### PR TITLE
chore: remove BrilligOpcode::JumpIfNot

### DIFF
--- a/acvm-repo/acir/src/proto/brillig.proto
+++ b/acvm-repo/acir/src/proto/brillig.proto
@@ -12,7 +12,7 @@ message BrilligOpcode {
     BinaryIntOp binary_int_op = 2;
     Not not = 3;
     Cast cast = 4;
-    JumpIfNot jump_if_not = 5;
+    JumpIfNot jump_if_not = 5 [deprecated=true];
     JumpIf jump_if = 6;
     Jump jump = 7;
     CalldataCopy calldata_copy = 8;

--- a/acvm-repo/acir/src/proto/convert/brillig.rs
+++ b/acvm-repo/acir/src/proto/convert/brillig.rs
@@ -59,10 +59,6 @@ impl<F: AcirField> ProtoCodec<brillig::Opcode<F>, BrilligOpcode> for ProtoSchema
                 source: Self::encode_some(source),
                 bit_size: Self::encode_some(bit_size),
             }),
-            brillig::Opcode::JumpIfNot { condition, location } => Value::JumpIfNot(JumpIfNot {
-                condition: Self::encode_some(condition),
-                location: Self::encode(location),
-            }),
             brillig::Opcode::JumpIf { condition, location } => Value::JumpIf(JumpIf {
                 condition: Self::encode_some(condition),
                 location: Self::encode(location),
@@ -166,10 +162,7 @@ impl<F: AcirField> ProtoCodec<brillig::Opcode<F>, BrilligOpcode> for ProtoSchema
                 source: Self::decode_some_wrap(&v.source, "source")?,
                 bit_size: Self::decode_some_wrap(&v.bit_size, "bit_size")?,
             }),
-            Value::JumpIfNot(v) => Ok(brillig::Opcode::JumpIfNot {
-                condition: Self::decode_some_wrap(&v.condition, "condition")?,
-                location: Self::decode_wrap(&v.location, "location")?,
-            }),
+            Value::JumpIfNot(_) => Err(eyre::Report::msg("JumpIfNot is deprecated")),
             Value::JumpIf(v) => Ok(brillig::Opcode::JumpIf {
                 condition: Self::decode_some_wrap(&v.condition, "condition")?,
                 location: Self::decode_wrap(&v.location, "location")?,

--- a/acvm-repo/brillig/src/opcodes.rs
+++ b/acvm-repo/brillig/src/opcodes.rs
@@ -241,12 +241,6 @@ pub enum BrilligOpcode<F> {
         source: MemoryAddress,
         bit_size: BitSize,
     },
-    /// Sets the program counter to the value of `location` if
-    /// the value at the `condition` address is zero.
-    JumpIfNot {
-        condition: MemoryAddress,
-        location: Label,
-    },
     /// Sets the program counter to the value of `location`
     /// If the value at `condition` is non-zero
     JumpIf {

--- a/compiler/noirc_evaluator/src/brillig/brillig_ir/artifact.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_ir/artifact.rs
@@ -267,12 +267,7 @@ impl<F: Clone + std::fmt::Debug> BrilligArtifact<F> {
 
     /// Returns true if the opcode is a jump instruction
     fn is_jmp_instruction(instruction: &BrilligOpcode<F>) -> bool {
-        matches!(
-            instruction,
-            BrilligOpcode::JumpIfNot { .. }
-                | BrilligOpcode::JumpIf { .. }
-                | BrilligOpcode::Jump { .. }
-        )
+        matches!(instruction, BrilligOpcode::JumpIf { .. } | BrilligOpcode::Jump { .. })
     }
 
     /// Adds a label in the bytecode to specify where this block's
@@ -311,15 +306,6 @@ impl<F: Clone + std::fmt::Debug> BrilligArtifact<F> {
 
                     self.byte_code[*location_of_jump] =
                         BrilligOpcode::Jump { location: resolved_location };
-                }
-                BrilligOpcode::JumpIfNot { condition, location } => {
-                    assert_eq!(
-                        location, 0,
-                        "location is not zero, which means that the jump label does not need resolving"
-                    );
-
-                    self.byte_code[*location_of_jump] =
-                        BrilligOpcode::JumpIfNot { condition, location: resolved_location };
                 }
                 BrilligOpcode::JumpIf { condition, location } => {
                     assert_eq!(

--- a/tooling/greybox_fuzzer/src/coverage.rs
+++ b/tooling/greybox_fuzzer/src/coverage.rs
@@ -658,8 +658,7 @@ pub fn analyze_brillig_program_before_fuzzing(
     for (opcode_index, opcode) in fuzzed_brillig_function.bytecode.iter().enumerate() {
         match opcode {
             // Conditional branching
-            &BrilligOpcode::JumpIf { location, .. }
-            | &BrilligOpcode::JumpIfNot { location, .. } => {
+            &BrilligOpcode::JumpIf { location, .. } => {
                 feature_to_index_map.insert((opcode_index, location), total_features);
                 feature_to_index_map.insert((opcode_index, opcode_index + 1), total_features + 1);
                 coverage_items.push(BrilligCoverageItemRange::Branch(BranchCoverageRange {

--- a/tooling/profiler/src/opcode_formatter.rs
+++ b/tooling/profiler/src/opcode_formatter.rs
@@ -109,7 +109,6 @@ fn format_brillig_opcode_kind<F>(opcode: &BrilligOpcode<F>) -> String {
         BrilligOpcode::ForeignCall { function, .. } => format!("foreign_call({})", function),
         BrilligOpcode::Jump { .. } => "jump".to_string(),
         BrilligOpcode::JumpIf { .. } => "jump_if".to_string(),
-        BrilligOpcode::JumpIfNot { .. } => "jump_if_not".to_string(),
         BrilligOpcode::Load { .. } => "load".to_string(),
         BrilligOpcode::Mov { .. } => "mov".to_string(),
         BrilligOpcode::Return => "return".to_string(),


### PR DESCRIPTION
# Description

## Problem

Resolves #7882

## Summary

It seems the opcode was unused, unless I'm mistaken. The only place it was crated was when decoding from protobuf... can that happen without us generating that opcode from Noir?

## Additional Context

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
