### PR TITLE
fix!: indexing arrays with non-u32 is now an error

### DIFF
--- a/compiler/noirc_frontend/src/hir/resolution/errors.rs
+++ b/compiler/noirc_frontend/src/hir/resolution/errors.rs
@@ -810,7 +810,7 @@ impl<'a> From<&'a ResolverError> for Diagnostic {
                 )
             },
             ResolverError::NonU32Index { location } => {
-                Diagnostic::simple_warning(
+                Diagnostic::simple_error(
                     "Indexing an array or slice with a type other than `u32` is deprecated and will soon be an error".to_string(), 
                     String::new(),
                     *location,


### PR DESCRIPTION
# Description

## Problem

Resolves https://github.com/noir-lang/noir/issues/7795

## Summary

Alternative to #7804 that's easier to merge against master without getting conflicts. The code here isn't the best one to implement it, but it's the simplest to avoid merge conflicts. This PR is mainly to see which external repos use non-u32 indexes.

## Additional Context



## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
