### PR TITLE
fix: always use u32 to index arrays in stdlib

### DIFF
--- a/noir_stdlib/src/hash/poseidon/mod.nr
+++ b/noir_stdlib/src/hash/poseidon/mod.nr
@@ -129,11 +129,11 @@ fn absorb<let T: u32, let N: u32, let X: u32, let O: u32>(
     pos_conf: PoseidonConfig<T, N, X>,
     // Initial state; usually [0; O]
     mut state: [Field; T],
-    rate: Field,
-    capacity: Field,
+    rate: u32,
+    capacity: u32,
     msg: [Field; O], // Arbitrary length message
 ) -> [Field; T] {
-    assert_eq(pos_conf.t, rate + capacity);
+    assert_eq(pos_conf.t, (rate + capacity) as Field);
 
     let mut i = 0;
 


### PR DESCRIPTION
# Description

## Problem

Part of #7795

## Summary



## Additional Context



## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
