### PR TITLE
docs: fix small typo

### DIFF
--- a/docs/docs/getting_started/setting_up_shell_completions.md
+++ b/docs/docs/getting_started/setting_up_shell_completions.md
@@ -20,7 +20,7 @@ If you have `oh-my-zsh` installed, you might already have a directory of automat
 If not, first create it:
 
 ```bash
-mkdir -p ~/.oh-my-zsh/completions`
+mkdir -p ~/.oh-my-zsh/completions
 ```
 
 Then copy the completion script to that directory:


### PR DESCRIPTION
# Description
Remove backtick character in creating completion directory command.

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*



## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
