### PR TITLE
feat: print initialization witnesses and show all blackbox witnesses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,6 +15,7 @@ dependencies = [
  "criterion",
  "flate2",
  "fxhash",
+ "insta",
  "noir_protobuf",
  "num-bigint",
  "pprof",
@@ -2572,6 +2573,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "insta"
+version = "1.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50259abbaa67d11d2bcafc7ba1d094ed7a0c70e3ce893f0d0997f73558cb3084"
+dependencies = [
+ "console",
+ "linked-hash-map",
+ "once_cell",
+ "pin-project",
+ "similar",
+]
+
+[[package]]
 name = "is-terminal"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2889,6 +2903,12 @@ dependencies = [
  "num-bigint",
  "thiserror",
 ]
+
+[[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"

--- a/acvm-repo/acir/Cargo.toml
+++ b/acvm-repo/acir/Cargo.toml
@@ -46,6 +46,7 @@ fxhash.workspace = true
 criterion.workspace = true
 pprof.workspace = true
 num-bigint.workspace = true
+insta = "1.42.2"
 
 acir = { path = ".", features = ["arb"] } # Self to turn on `arb`.
 

--- a/cspell.json
+++ b/cspell.json
@@ -128,6 +128,7 @@
         "indexmap",
         "injective",
         "Inlines",
+        "insta",
         "instrumenter",
         "interner",
         "interners",


### PR DESCRIPTION
# Description

## Problem\*

Resolves #7904
Resolves #7918 

## Summary\*

This PR starts work on #7902 by adding missing info from memory init and blackbox opcodes.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
