### PR TITLE
chore: add timeouts to rust CI

### DIFF
--- a/.github/workflows/test-rust-workspace-msrv.yml
+++ b/.github/workflows/test-rust-workspace-msrv.yml
@@ -64,6 +64,7 @@ jobs:
     name: "Run tests (partition ${{matrix.partition}})"
     runs-on: ubuntu-22.04
     needs: [build-test-artifacts]
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test-rust-workspace.yml
+++ b/.github/workflows/test-rust-workspace.yml
@@ -51,6 +51,7 @@ jobs:
     name: "Run tests (partition ${{matrix.partition}})"
     runs-on: ubuntu-22.04
     needs: [build-test-artifacts]
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

I noticed that we weren't enforcing a timeout here on a separate PR.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
