### PR TITLE
docs: fix parameter name inconsistency in profiler usage

### DIFF
--- a/docs/docs/tooling/profiler.md
+++ b/docs/docs/tooling/profiler.md
@@ -118,7 +118,7 @@ The profiler also enables developers to generate a flamegraph of the unconstrain
 
 Let's take our initial program and simply add an `unconstrained` modifier before main (e.g. `unconstrained fn main`). Then run the following command:
 ```sh
-noir-profiler execution-opcodes --artifact-name ./target/program.json --prover_toml_path Prover.toml --output ./target
+noir-profiler execution-opcodes --artifact-path ./target/program.json --prover_toml_path Prover.toml --output ./target
 ```
 This matches the `opcodes` command, except that now we need to accept a `Prover.toml` file to profile execution with a specific set of inputs.
 


### PR DESCRIPTION
# Description

I noticed that the parameter `--artifact-name` was used in the profiler command, but based on other parts of the documentation, it seems like the correct name should be `--artifact-path`.

## Additional Context

This change ensures consistency throughout the guide and aligns with the other examples that use `--artifact-path`.

## Documentation\*

Check one:
- [ ] No documentation needed.
- [x] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
