### PR TITLE
fix: Fix nondeterminsm on aarch64 vs amd64

### DIFF
--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/constant_allocation.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/constant_allocation.rs
@@ -1,7 +1,8 @@
 //! This module analyzes the usage of constants in a given function and decides an allocation point for them.
 //! The allocation point will be the common dominator of all the places where the constant is used.
 //! By allocating in the common dominator, we can cache the constants for all subsequent uses.
-use fxhash::{FxHashMap as HashMap, FxHashSet as HashSet};
+
+use std::collections::{BTreeMap, BTreeSet};
 
 use crate::ssa::ir::{
     basic_block::BasicBlockId,
@@ -16,7 +17,7 @@ use crate::ssa::ir::{
 
 use super::variable_liveness::{collect_variables_of_value, variables_used_in_instruction};
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub(crate) enum InstructionLocation {
     Instruction(InstructionId),
     Terminator,
@@ -24,10 +25,10 @@ pub(crate) enum InstructionLocation {
 
 #[derive(Default)]
 pub(crate) struct ConstantAllocation {
-    constant_usage: HashMap<ValueId, HashMap<BasicBlockId, Vec<InstructionLocation>>>,
-    allocation_points: HashMap<BasicBlockId, HashMap<InstructionLocation, Vec<ValueId>>>,
+    constant_usage: BTreeMap<ValueId, BTreeMap<BasicBlockId, Vec<InstructionLocation>>>,
+    allocation_points: BTreeMap<BasicBlockId, BTreeMap<InstructionLocation, Vec<ValueId>>>,
     dominator_tree: DominatorTree,
-    blocks_within_loops: HashSet<BasicBlockId>,
+    blocks_within_loops: BTreeSet<BasicBlockId>,
 }
 
 impl ConstantAllocation {
@@ -37,8 +38,8 @@ impl ConstantAllocation {
         let mut dominator_tree = DominatorTree::with_cfg_and_post_order(&cfg, &post_order);
         let blocks_within_loops = find_all_blocks_within_loops(func, &cfg, &mut dominator_tree);
         let mut instance = ConstantAllocation {
-            constant_usage: HashMap::default(),
-            allocation_points: HashMap::default(),
+            constant_usage: BTreeMap::default(),
+            allocation_points: BTreeMap::default(),
             dominator_tree,
             blocks_within_loops,
         };
@@ -164,7 +165,7 @@ impl ConstantAllocation {
         current_block
     }
 
-    pub(crate) fn get_constants(&self) -> HashSet<ValueId> {
+    pub(crate) fn get_constants(&self) -> BTreeSet<ValueId> {
         self.constant_usage.keys().copied().collect()
     }
 }
@@ -178,8 +179,8 @@ fn find_all_blocks_within_loops(
     func: &Function,
     cfg: &ControlFlowGraph,
     dominator_tree: &mut DominatorTree,
-) -> HashSet<BasicBlockId> {
-    let mut blocks_in_loops = HashSet::default();
+) -> BTreeSet<BasicBlockId> {
+    let mut blocks_in_loops = BTreeSet::default();
     for block_id in func.reachable_blocks() {
         let block = &func.dfg[block_id];
         let successors = block.successors();
@@ -199,8 +200,8 @@ fn find_blocks_in_loop(
     header: BasicBlockId,
     back_edge_start: BasicBlockId,
     cfg: &ControlFlowGraph,
-) -> HashSet<BasicBlockId> {
-    let mut blocks = HashSet::default();
+) -> BTreeSet<BasicBlockId> {
+    let mut blocks = BTreeSet::default();
     blocks.insert(header);
 
     let mut insert = |block, stack: &mut Vec<BasicBlockId>| {


### PR DESCRIPTION
# Description

## Problem\*

Quick fix to an issue discovered in aztec testnet. 
We were having nondeterministic contract builds between aarch64 and amd64 builds of the noir compiler, reproduced locally. The iterators generated from the FxHashMaps/FxHashSets used in constant_allocation were yielding differently ordered items. I did log the insertions and the input was in the same order (if the insertion ordering was nondeterministic the iteration order is expected to be nondeterministic) so I have no idea what was creating the nondeterminism there. 

Switched to a BTreeMap/BTreeSet in that file and nondeterminism is gone.

## Summary\*



## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
