### PR TITLE
chore: let `nargo test` write to stdout, not stderr

### DIFF
--- a/tooling/nargo_cli/src/cli/test_cmd/formatters.rs
+++ b/tooling/nargo_cli/src/cli/test_cmd/formatters.rs
@@ -100,7 +100,7 @@ impl Formatter for PrettyFormatter {
         deny_warnings: bool,
         silence_warnings: bool,
     ) -> std::io::Result<()> {
-        let writer = StandardStream::stderr(ColorChoice::Always);
+        let writer = stdout();
         let mut writer = writer.lock();
 
         let is_slow = test_result.time_to_run >= Duration::from_secs(30);
@@ -174,7 +174,7 @@ impl Formatter for PrettyFormatter {
         _deny_warnings: bool,
         _silence_warnings: bool,
     ) -> std::io::Result<()> {
-        let writer = StandardStream::stderr(ColorChoice::Always);
+        let writer = stdout();
         let mut writer = writer.lock();
 
         let failed_tests: Vec<_> = test_results
@@ -257,7 +257,7 @@ impl Formatter for TerseFormatter {
         _deny_warnings: bool,
         _silence_warnings: bool,
     ) -> std::io::Result<()> {
-        let writer = StandardStream::stderr(ColorChoice::Always);
+        let writer = stdout();
         let mut writer = writer.lock();
 
         match &test_result.status {
@@ -299,7 +299,7 @@ impl Formatter for TerseFormatter {
         deny_warnings: bool,
         silence_warnings: bool,
     ) -> std::io::Result<()> {
-        let writer = StandardStream::stderr(ColorChoice::Always);
+        let writer = stdout();
         let mut writer = writer.lock();
 
         if !test_results.is_empty() {
@@ -539,4 +539,8 @@ pub(crate) fn diagnostic_to_string(
     }
 
     message
+}
+
+fn stdout() -> StandardStream {
+    StandardStream::stdout(ColorChoice::Always)
 }


### PR DESCRIPTION
# Description

## Problem

Resolves #7924

## Summary



## Additional Context



## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
