### PR TITLE
fix: correct proptest Arbitrary for NumericType

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3568,7 +3568,6 @@ dependencies = [
  "num-traits",
  "petgraph",
  "proptest",
- "proptest-derive",
  "rayon",
  "serde",
  "serde_json",

--- a/compiler/noirc_evaluator/Cargo.toml
+++ b/compiler/noirc_evaluator/Cargo.toml
@@ -35,7 +35,6 @@ petgraph.workspace = true
 
 [dev-dependencies]
 proptest.workspace = true
-proptest-derive.workspace = true
 similar-asserts.workspace = true
 tracing-test = "0.2.5"
 num-traits.workspace = true

--- a/compiler/noirc_evaluator/src/ssa/ir/types.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/types.rs
@@ -115,7 +115,7 @@ mod props {
 
         fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
             let signed = prop_oneof!(Just(8), Just(16), Just(32), Just(64));
-            let unsigned = prop_oneof!(Just(8), Just(16), Just(32), Just(64), Just(128));
+            let unsigned = prop_oneof!(Just(1), Just(8), Just(16), Just(32), Just(64), Just(128));
             prop_oneof![
                 signed.prop_map(|bit_size| NumericType::Signed { bit_size }),
                 unsigned.prop_map(|bit_size| NumericType::Unsigned { bit_size }),

--- a/compiler/noirc_evaluator/src/ssa/ir/types.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/types.rs
@@ -15,7 +15,6 @@ use crate::ssa::ssa_gen::SSA_WORD_SIZE;
 /// Fields do not have a notion of ordering, so this distinction
 /// is reasonable.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Ord, PartialOrd, Serialize, Deserialize)]
-#[cfg_attr(test, derive(proptest_derive::Arbitrary))]
 pub enum NumericType {
     Signed { bit_size: u32 },
     Unsigned { bit_size: u32 },
@@ -97,6 +96,32 @@ impl NumericType {
                 _ => Ok(FieldElement::from(2u128.pow(*bit_size) - 1)),
             },
             other => Err(format!("Cannot get max value for type: {other}")),
+        }
+    }
+}
+
+#[cfg(test)]
+mod props {
+    use proptest::{
+        prelude::{Arbitrary, BoxedStrategy, Just, Strategy as _},
+        prop_oneof,
+    };
+
+    use super::NumericType;
+
+    impl Arbitrary for NumericType {
+        type Parameters = ();
+        type Strategy = BoxedStrategy<Self>;
+
+        fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
+            let signed = prop_oneof!(Just(8), Just(16), Just(32), Just(64));
+            let unsigned = prop_oneof!(Just(8), Just(16), Just(32), Just(64), Just(128));
+            prop_oneof![
+                signed.prop_map(|bit_size| NumericType::Signed { bit_size }),
+                unsigned.prop_map(|bit_size| NumericType::Unsigned { bit_size }),
+                Just(NumericType::NativeField),
+            ]
+            .boxed()
         }
     }
 }


### PR DESCRIPTION
# Description

## Problem

Resolves #7933

## Summary


## Additional Context

I'm not familiar with the proptest library so let me know if there's a more idiomatic way of doing this.

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
