### PR TITLE
chore(nargo): extract common functions

### DIFF
--- a/tooling/nargo/src/ops/compile.rs
+++ b/tooling/nargo/src/ops/compile.rs
@@ -1,9 +1,10 @@
 use fm::FileManager;
 use noirc_driver::{
-    CompilationResult, CompileOptions, CompiledContract, CompiledProgram, link_to_debug_crate,
+    CompilationResult, CompileOptions, CompiledContract, CompiledProgram, CrateId, check_crate,
+    link_to_debug_crate,
 };
 use noirc_frontend::debug::DebugInstrumenter;
-use noirc_frontend::hir::ParsedFiles;
+use noirc_frontend::hir::{Context, ParsedFiles};
 
 use crate::errors::CompileError;
 use crate::prepare_package;
@@ -150,4 +151,15 @@ pub fn report_errors<T>(
     );
 
     Ok(t)
+}
+
+/// Run the lexing, parsing, name resolution, and type checking passes and report any warnings
+/// and errors found.
+pub fn check_crate_and_report_errors(
+    context: &mut Context,
+    crate_id: CrateId,
+    options: &CompileOptions,
+) -> Result<(), CompileError> {
+    let result = check_crate(context, crate_id, options);
+    report_errors(result, &context.file_manager, options.deny_warnings, options.silence_warnings)
 }

--- a/tooling/nargo/src/ops/mod.rs
+++ b/tooling/nargo/src/ops/mod.rs
@@ -1,7 +1,7 @@
 pub use self::check::check_program;
 pub use self::compile::{
-    collect_errors, compile_contract, compile_program, compile_program_with_debug_instrumenter,
-    compile_workspace, report_errors,
+    check_crate_and_report_errors, collect_errors, compile_contract, compile_program,
+    compile_program_with_debug_instrumenter, compile_workspace, report_errors,
 };
 pub use self::optimize::{optimize_contract, optimize_program};
 pub use self::transform::{transform_contract, transform_program};

--- a/tooling/nargo_cli/src/cli/check_cmd.rs
+++ b/tooling/nargo_cli/src/cli/check_cmd.rs
@@ -4,17 +4,15 @@ use clap::Args;
 use fm::FileManager;
 use iter_extended::btree_map;
 use nargo::{
-    errors::CompileError, insert_all_files_for_workspace_into_file_manager, ops::report_errors,
-    package::Package, parse_all, prepare_package, workspace::Workspace,
+    errors::CompileError, insert_all_files_for_workspace_into_file_manager,
+    ops::check_crate_and_report_errors, package::Package, parse_all, prepare_package,
+    workspace::Workspace,
 };
 use nargo_toml::PackageSelection;
 use noir_artifact_cli::fs::artifact::write_to_file;
 use noirc_abi::{AbiParameter, AbiType, MAIN_RETURN_NAME};
-use noirc_driver::{CompileOptions, CrateId, check_crate, compute_function_abi};
-use noirc_frontend::{
-    hir::{Context, ParsedFiles},
-    monomorphization::monomorphize,
-};
+use noirc_driver::{CompileOptions, check_crate, compute_function_abi};
+use noirc_frontend::{hir::ParsedFiles, monomorphization::monomorphize};
 
 use super::{LockType, PackageOptions, WorkspaceCommand};
 
@@ -149,17 +147,6 @@ fn create_input_toml_template(
     }
 
     toml::to_string(&map).unwrap()
-}
-
-/// Run the lexing, parsing, name resolution, and type checking passes and report any warnings
-/// and errors found.
-pub(crate) fn check_crate_and_report_errors(
-    context: &mut Context,
-    crate_id: CrateId,
-    options: &CompileOptions,
-) -> Result<(), CompileError> {
-    let result = check_crate(context, crate_id, options);
-    report_errors(result, &context.file_manager, options.deny_warnings, options.silence_warnings)
 }
 
 #[cfg(test)]

--- a/tooling/nargo_cli/src/cli/export_cmd.rs
+++ b/tooling/nargo_cli/src/cli/export_cmd.rs
@@ -1,5 +1,5 @@
 use nargo::errors::CompileError;
-use nargo::ops::report_errors;
+use nargo::ops::{check_crate_and_report_errors, report_errors};
 use noir_artifact_cli::fs::artifact::save_program_to_file;
 use noirc_errors::CustomDiagnostic;
 use noirc_frontend::hir::ParsedFiles;
@@ -17,8 +17,6 @@ use noirc_driver::{CompileOptions, CompiledProgram, compile_no_check};
 use clap::Args;
 
 use crate::errors::CliError;
-
-use super::check_cmd::check_crate_and_report_errors;
 
 use super::{LockType, PackageOptions, WorkspaceCommand};
 

--- a/tooling/nargo_cli/src/cli/fuzz_cmd.rs
+++ b/tooling/nargo_cli/src/cli/fuzz_cmd.rs
@@ -6,7 +6,7 @@ use clap::Args;
 use fm::FileManager;
 use nargo::{
     FuzzExecutionConfig, FuzzFolderConfig, insert_all_files_for_workspace_into_file_manager,
-    ops::FuzzingRunStatus,
+    ops::{FuzzingRunStatus, check_crate_and_report_errors},
     package::{CrateName, Package},
     parse_all, prepare_package,
     workspace::Workspace,
@@ -18,7 +18,7 @@ use noirc_frontend::hir::{FunctionNameMatch, ParsedFiles};
 use rayon::prelude::{ParallelBridge, ParallelIterator};
 use termcolor::{Color, ColorChoice, ColorSpec, StandardStream, WriteColor};
 
-use crate::{cli::check_cmd::check_crate_and_report_errors, errors::CliError};
+use crate::errors::CliError;
 
 use super::{LockType, PackageOptions, WorkspaceCommand};
 use noir_artifact_cli::fs::inputs::write_inputs_to_file;

--- a/tooling/nargo_cli/src/cli/test_cmd.rs
+++ b/tooling/nargo_cli/src/cli/test_cmd.rs
@@ -14,14 +14,18 @@ use clap::Args;
 use fm::FileManager;
 use formatters::{Formatter, JsonFormatter, PrettyFormatter, TerseFormatter};
 use nargo::{
-    foreign_calls::DefaultForeignCallBuilder, insert_all_files_for_workspace_into_file_manager,
-    ops::TestStatus, package::Package, parse_all, prepare_package, workspace::Workspace,
+    foreign_calls::DefaultForeignCallBuilder,
+    insert_all_files_for_workspace_into_file_manager,
+    ops::{TestStatus, check_crate_and_report_errors},
+    package::Package,
+    parse_all, prepare_package,
+    workspace::Workspace,
 };
 use nargo_toml::PackageSelection;
 use noirc_driver::{CompileOptions, check_crate};
 use noirc_frontend::hir::{FunctionNameMatch, ParsedFiles};
 
-use crate::{cli::check_cmd::check_crate_and_report_errors, errors::CliError};
+use crate::errors::CliError;
 
 use super::{LockType, PackageOptions, WorkspaceCommand};
 


### PR DESCRIPTION
# Description
- extract logic of mapping a `OpcodeResolutionError` to an `ExecutionError` from `nargo::ops::execute::execute_circuit` into a new function `nargo::errors::execution_error_from` - so that it can be used in other places without repeating logic
- move `check_crate_and_report_errors` from `check_cmd` to `nargo::ops::compile` since it was being used in different commands

## Additional Context

- The new `execution_error_from` is necessary for the debugger

## Documentation\*

Check one:
- [X] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
