### PR TITLE
chore(docs): Remove outdated BigInt library reference

### DIFF
--- a/docs/docs/noir/concepts/data_types/index.md
+++ b/docs/docs/noir/concepts/data_types/index.md
@@ -119,8 +119,3 @@ Noir can usually infer the type of the variable from the context, so specifying 
 ```rust
 let a: [_; 4] = foo(b);
 ```
- 
-
-### BigInt
-
-You can achieve BigInt functionality using the [Noir BigInt](https://github.com/shuklaayush/noir-bigint) library.

--- a/docs/versioned_docs/version-v0.36.0/noir/concepts/data_types/index.md
+++ b/docs/versioned_docs/version-v0.36.0/noir/concepts/data_types/index.md
@@ -119,8 +119,3 @@ Noir can usually infer the type of the variable from the context, so specifying 
 ```rust
 let a: [_; 4] = foo(b);
 ```
- 
-
-### BigInt
-
-You can achieve BigInt functionality using the [Noir BigInt](https://github.com/shuklaayush/noir-bigint) library.

--- a/docs/versioned_docs/version-v1.0.0-beta.0/noir/concepts/data_types/index.md
+++ b/docs/versioned_docs/version-v1.0.0-beta.0/noir/concepts/data_types/index.md
@@ -119,8 +119,3 @@ Noir can usually infer the type of the variable from the context, so specifying 
 ```rust
 let a: [_; 4] = foo(b);
 ```
- 
-
-### BigInt
-
-You can achieve BigInt functionality using the [Noir BigInt](https://github.com/shuklaayush/noir-bigint) library.

--- a/docs/versioned_docs/version-v1.0.0-beta.1/noir/concepts/data_types/index.md
+++ b/docs/versioned_docs/version-v1.0.0-beta.1/noir/concepts/data_types/index.md
@@ -119,8 +119,3 @@ Noir can usually infer the type of the variable from the context, so specifying 
 ```rust
 let a: [_; 4] = foo(b);
 ```
- 
-
-### BigInt
-
-You can achieve BigInt functionality using the [Noir BigInt](https://github.com/shuklaayush/noir-bigint) library.

--- a/docs/versioned_docs/version-v1.0.0-beta.2/noir/concepts/data_types/index.md
+++ b/docs/versioned_docs/version-v1.0.0-beta.2/noir/concepts/data_types/index.md
@@ -119,8 +119,3 @@ Noir can usually infer the type of the variable from the context, so specifying 
 ```rust
 let a: [_; 4] = foo(b);
 ```
- 
-
-### BigInt
-
-You can achieve BigInt functionality using the [Noir BigInt](https://github.com/shuklaayush/noir-bigint) library.

--- a/docs/versioned_docs/version-v1.0.0-beta.3/noir/concepts/data_types/index.md
+++ b/docs/versioned_docs/version-v1.0.0-beta.3/noir/concepts/data_types/index.md
@@ -119,8 +119,3 @@ Noir can usually infer the type of the variable from the context, so specifying 
 ```rust
 let a: [_; 4] = foo(b);
 ```
- 
-
-### BigInt
-
-You can achieve BigInt functionality using the [Noir BigInt](https://github.com/shuklaayush/noir-bigint) library.


### PR DESCRIPTION
# Description

## Summary\*

Remove references to the outdated community BigInt library https://github.com/shuklaayush/noir-bigint.

## Documentation\*

Check one:
- [ ] No documentation needed.
- [x] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
