### PR TITLE
fix: replace one more path pattern when producing stderr.txt

### DIFF
--- a/tooling/nargo_cli/tests/execute.rs
+++ b/tooling/nargo_cli/tests/execute.rs
@@ -63,7 +63,15 @@ mod tests {
     }
 
     fn delete_test_program_dir_occurrences(string: String, test_program_dir: &Path) -> String {
+        // Assuming `test_program_dir` is "/projects/noir/test_programs/compile_failure/some_program"...
+
+        // `test_program_base_dir` is "/projects/noir/test_programs"
         let test_program_base_dir = test_program_dir.parent().unwrap().parent().unwrap();
+
+        // `root_dir` is "/projects/noir"
+        let root_dir = test_program_base_dir.parent().unwrap();
+
+        // Here we turn the paths into strings and ensure they end with a `/`
         let mut test_program_base_dir = test_program_base_dir.to_string_lossy().to_string();
         if !test_program_base_dir.ends_with('/') {
             test_program_base_dir.push('/');
@@ -74,12 +82,25 @@ mod tests {
             test_program_dir.push('/');
         }
 
-        // We replace both test_program_dir (test_programs/compile_failure/foo) and its ancestor
-        // (test_programs) because in some cases some programs refer to other programs in `test_programs`.
+        // `test_program_dir_without_root is "test_programs/compile_failure".
+        // This one is needed because tests might run from the root of the project and paths
+        // will end up starting with "test_programs/compile_failure/...".
+        let test_program_dir_without_root =
+            test_program_dir.strip_prefix(&root_dir.to_string_lossy().to_string()).unwrap();
+        let test_program_dir_without_root = test_program_dir_without_root
+            .strip_prefix('/')
+            .unwrap_or(test_program_dir_without_root);
+
+        // We replace all of these:
+        // - test_program_dir ("/projects/noir/test_programs/compile_failure/foo")
+        // - test_program_base_dir ("/projects/noir/test_programs")
+        // - test_program_dir_without_root ("test_programs/compile_failure")
         string
             .lines()
             .map(|line| {
-                line.replace(&test_program_dir, "").replace(&test_program_base_dir, "../../")
+                line.replace(&test_program_dir, "")
+                    .replace(&test_program_base_dir, "../../")
+                    .replace(test_program_dir_without_root, "")
             })
             .collect::<Vec<String>>()
             .join("\n")


### PR DESCRIPTION
# Description

## Problem

Should unblock https://github.com/AztecProtocol/aztec-packages/pull/12995

## Summary

It seems tests in Aztec-Packages run from the root directory via something like `target/debug/deps/execute-16a6287606ef3464 test_name` so the currently directory isn't inside `nargo_cli`, which is what I assumed would happen. So this PR takes that into account.

## Additional Context

I was able to reproduce this locally and checked that this change fixes the issue according to how tests run in Aztec-Packages CI.

Tests could theoretically run from other directories and maybe it will fail too. I'm not sure what the logic would be to clear up these paths, maybe we'd need to use a regex... but if tests in Aztec-Packages are always going to run from the root directory then this should be good enough.

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
