### PR TITLE
chore(docs): Fix aes128 encrypt example 

### DIFF
--- a/docs/docs/noir/standard_library/cryptographic_primitives/ciphers.mdx
+++ b/docs/docs/noir/standard_library/cryptographic_primitives/ciphers.mdx
@@ -20,7 +20,7 @@ fn main() {
     let input: [u8; 4] = [0, 12, 3, 15] // Random bytes, will be padded to 16 bytes.
     let iv: [u8; 16] = [0; 16]; // Initialisation vector
     let key: [u8; 16] = [0; 16] // AES key
-    let ciphertext = std::aes128::aes128_encrypt(inputs.as_bytes(), iv.as_bytes(), key.as_bytes()); // In this case, the output length will be 16 bytes.
+    let ciphertext = std::aes128::aes128_encrypt(inputs, iv, key); // In this case, the output length will be 16 bytes.
 }
 ```
 


### PR DESCRIPTION
# Description
Fix `aes128_encrypt` example by removing `as_bytes` in cypher docs.

## Problem\*
Current `aes128_encrypt` example compilation fails because of invalid parameters(because of `as_bytes` usage). parameters should be passed as it is.

Resolves <!-- Link to GitHub Issue -->

## Summary\*



## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
