### PR TITLE
feat: add `--program-output-file` to `nargo compile`

### DIFF
--- a/compiler/noirc_driver/src/lib.rs
+++ b/compiler/noirc_driver/src/lib.rs
@@ -25,7 +25,7 @@ use noirc_frontend::monomorphization::{
 use noirc_frontend::node_interner::{FuncId, GlobalId, TypeId};
 use noirc_frontend::token::SecondaryAttribute;
 use std::collections::HashMap;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use tracing::info;
 
 mod abi_gen;
@@ -186,6 +186,10 @@ pub struct CompileOptions {
     /// Used internally to avoid comptime println from producing output
     #[arg(long, hide = true)]
     pub disable_comptime_printing: bool,
+
+    /// Used internally to choose a different file to store the program artifact
+    #[arg(long, hide = true)]
+    pub program_output_file: Option<PathBuf>,
 }
 
 pub fn parse_expression_width(input: &str) -> Result<ExpressionWidth, std::io::Error> {
@@ -715,7 +719,8 @@ pub fn compile_no_check(
         || options.force_brillig
         || options.show_ssa
         || options.show_ssa_pass.is_some()
-        || options.emit_ssa;
+        || options.emit_ssa
+        || options.program_output_file.is_some();
 
     // Hash the AST program, which is going to be used to fingerprint the compilation artifact.
     let hash = fxhash::hash64(&program);

--- a/tooling/nargo_cli/src/cli/compile_cmd.rs
+++ b/tooling/nargo_cli/src/cli/compile_cmd.rs
@@ -10,7 +10,7 @@ use nargo::workspace::Workspace;
 use nargo::{insert_all_files_for_workspace_into_file_manager, parse_all};
 use nargo_toml::PackageSelection;
 use noir_artifact_cli::fs::artifact::{
-    read_program_from_file, save_contract_to_file, save_program_to_file,
+    read_program_from_file, save_contract_to_file, save_program_to_dir, save_program_to_file,
 };
 use noirc_driver::DEFAULT_EXPRESSION_WIDTH;
 use noirc_driver::NOIR_ARTIFACT_VERSION_STRING;
@@ -246,8 +246,13 @@ fn compile_programs(
         // Check solvability.
         nargo::ops::check_program(&program)?;
         // Overwrite the build artifacts with the final circuit, which includes the backend specific transformations.
-        save_program_to_file(&program.into(), &package.name, &workspace.target_directory_path())
-            .expect("failed to save program");
+        if let Some(output_file) = &compile_options.program_output_file {
+            save_program_to_file(&program.into(), output_file.clone())
+                .expect("failed to save program");
+        } else {
+            save_program_to_dir(&program.into(), &package.name, &workspace.target_directory_path())
+                .expect("failed to save program");
+        }
 
         Ok(((), warnings))
     };

--- a/tooling/nargo_cli/src/cli/export_cmd.rs
+++ b/tooling/nargo_cli/src/cli/export_cmd.rs
@@ -1,6 +1,6 @@
 use nargo::errors::CompileError;
 use nargo::ops::report_errors;
-use noir_artifact_cli::fs::artifact::save_program_to_file;
+use noir_artifact_cli::fs::artifact::save_program_to_dir;
 use noirc_errors::CustomDiagnostic;
 use noirc_frontend::hir::ParsedFiles;
 use rayon::prelude::*;
@@ -98,7 +98,7 @@ fn compile_exported_functions(
 
     let export_dir = workspace.export_directory_path();
     for (function_name, program) in exported_programs {
-        save_program_to_file(&program.into(), &function_name.parse().unwrap(), &export_dir)?;
+        save_program_to_dir(&program.into(), &function_name.parse().unwrap(), &export_dir)?;
     }
     Ok(())
 }

--- a/tooling/profiler/src/cli/execution_flamegraph_cmd.rs
+++ b/tooling/profiler/src/cli/execution_flamegraph_cmd.rs
@@ -247,7 +247,7 @@ mod tests {
         };
 
         // Write the artifact to a file
-        let artifact_path = noir_artifact_cli::fs::artifact::save_program_to_file(
+        let artifact_path = noir_artifact_cli::fs::artifact::save_program_to_dir(
             &artifact,
             &CrateName::from_str("test").unwrap(),
             temp_dir.path(),


### PR DESCRIPTION
# Description

## Problem

Towards #7949

## Summary

When test programs run for a given options matrix they all generate artifacts with the same final destination. It's all good when `nargo compile` runs because there's a lock, but... after `nargo compile` finishes the lock is gone. What I need to do for snapshots is to read that artifact, but another `nargo compile` run in the same directory might start running, so we'd need an extra lock to prevent this.

Alternatively, we could allow specifying the output file and have each option in the matrix use a different file. Then there's no conflict. I think this is simpler. Plus, in any case, I wanted to store these separate artifacts in a directory that's not `target` because that's in `.gitignore` (I plan to use `test_target` for these artifacts).

## Additional Context

I made this a hidden option because I don't know if it's generally useful.

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
