### PR TITLE
fix: don't use relative path in nargo_cli build script

### DIFF
--- a/test_programs/compile_failure/dep_impl_primitive/stderr.txt
+++ b/test_programs/compile_failure/dep_impl_primitive/stderr.txt
@@ -6,7 +6,7 @@ warning: unused import bad_impl
   │
 
 error: Non-struct type used in impl
-  ┌─ ../../test_libraries/bad_impl/src/lib.nr:1:6
+  ┌─ test_programs/test_libraries/bad_impl/src/lib.nr:1:6
   │
 1 │ impl Field {
   │      ----- Only struct types may have implementation methods

--- a/test_programs/compile_failure/invalid_dependency_name/stderr.txt
+++ b/test_programs/compile_failure/invalid_dependency_name/stderr.txt
@@ -1,1 +1,1 @@
-Invalid package name `bad-name` found in ../../test_libraries/bad_name/Nargo.toml
+Invalid package name `bad-name` found in test_programs/test_libraries/bad_name/Nargo.toml

--- a/tooling/nargo_cli/tests/execute.rs
+++ b/tooling/nargo_cli/tests/execute.rs
@@ -99,7 +99,7 @@ mod tests {
             .lines()
             .map(|line| {
                 line.replace(&test_program_dir, "")
-                    .replace(&test_program_base_dir, "../../")
+                    .replace(&test_program_base_dir, "test_programs/")
                     .replace(test_program_dir_without_root, "")
             })
             .collect::<Vec<String>>()


### PR DESCRIPTION
# Description

## Problem

Resolves https://github.com/noir-lang/noir/pull/7970#issuecomment-2789617899

## Summary



## Additional Context



## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
