### PR TITLE
chore: Support printing the AST without variable IDs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3616,6 +3616,7 @@ dependencies = [
  "function_name",
  "fxhash",
  "im",
+ "insta",
  "iter-extended",
  "noirc_arena",
  "noirc_errors",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3302,6 +3302,7 @@ dependencies = [
  "color-eyre",
  "libfuzzer-sys",
  "noir_ast_fuzzer",
+ "noirc_abi",
  "noirc_evaluator",
  "noirc_frontend",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -196,6 +196,7 @@ tracing-web = "0.1.3"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter", "json"] }
 rust-embed = "6.6.0"
 petgraph = "0.6"
+insta = "1.42.2"
 
 [profile.dev]
 # This is required to be able to run `cargo test` in acvm_js due to the `locals exceeds maximum` error.

--- a/acvm-repo/acir/Cargo.toml
+++ b/acvm-repo/acir/Cargo.toml
@@ -47,7 +47,7 @@ fxhash.workspace = true
 criterion.workspace = true
 pprof.workspace = true
 num-bigint.workspace = true
-insta = "1.42.2"
+insta.workspace = true
 
 acir = { path = ".", features = ["arb"] } # Self to turn on `arb`.
 

--- a/compiler/noirc_frontend/Cargo.toml
+++ b/compiler/noirc_frontend/Cargo.toml
@@ -38,6 +38,7 @@ base64.workspace = true
 function_name = "0.3.0"
 proptest.workspace = true
 proptest-derive.workspace = true
+insta.workspace = true
 
 [features]
 bn254 = []

--- a/compiler/noirc_frontend/src/monomorphization/ast.rs
+++ b/compiler/noirc_frontend/src/monomorphization/ast.rs
@@ -443,14 +443,7 @@ impl std::ops::IndexMut<FuncId> for Program {
 
 impl std::fmt::Display for Program {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let mut printer = super::printer::AstPrinter::default();
-        for (id, global) in &self.globals {
-            printer.print_global(id, global, f)?;
-        }
-        for function in &self.functions {
-            printer.print_function(function, f)?;
-        }
-        Ok(())
+        super::printer::AstPrinter::default().print_program(self, f)
     }
 }
 

--- a/compiler/noirc_frontend/src/monomorphization/ast.rs
+++ b/compiler/noirc_frontend/src/monomorphization/ast.rs
@@ -449,7 +449,7 @@ impl std::fmt::Display for Program {
 
 impl std::fmt::Display for Function {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        super::printer::AstPrinter::default().print_function(self, f)
+        super::printer::AstPrinter::default().print_function(self, None, f)
     }
 }
 

--- a/compiler/noirc_frontend/src/monomorphization/printer.rs
+++ b/compiler/noirc_frontend/src/monomorphization/printer.rs
@@ -3,7 +3,7 @@
 use crate::ast::UnaryOp;
 
 use super::ast::{
-    Definition, Expression, FuncId, Function, GlobalId, LValue, LocalId, Type, While,
+    Definition, Expression, FuncId, Function, GlobalId, LValue, LocalId, Program, Type, While,
 };
 use iter_extended::vecmap;
 use std::fmt::{Display, Formatter};
@@ -11,7 +11,7 @@ use std::fmt::{Display, Formatter};
 #[derive(Debug)]
 pub struct AstPrinter {
     indent_level: u32,
-    show_id: bool,
+    pub show_id: bool,
 }
 
 impl Default for AstPrinter {
@@ -35,6 +35,16 @@ impl AstPrinter {
 
     fn fmt_func(&self, name: &str, id: FuncId) -> String {
         self.fmt_ident(name, &Definition::Function(id))
+    }
+
+    pub fn print_program(&mut self, program: &Program, f: &mut Formatter) -> std::fmt::Result {
+        for (id, global) in &program.globals {
+            self.print_global(id, global, f)?;
+        }
+        for function in &program.functions {
+            self.print_function(function, f)?;
+        }
+        Ok(())
     }
 
     pub fn print_global(

--- a/compiler/noirc_frontend/src/monomorphization/tests.rs
+++ b/compiler/noirc_frontend/src/monomorphization/tests.rs
@@ -1,14 +1,7 @@
 #![cfg(test)]
 use crate::{
-    check_monomorphization_error_using_features,
-    elaborator::UnstableFeature,
-    test_utils::{Expect, get_monomorphized},
+    check_monomorphization_error_using_features, elaborator::UnstableFeature, test_utils::Expect,
 };
-
-pub(crate) fn check_rewrite(src: &str, expected: &str, test_path: &str) {
-    let program = get_monomorphized(src, test_path, Expect::Success).unwrap();
-    assert!(format!("{}", program) == expected);
-}
 
 // NOTE: this will fail in CI when called twice within one test: test names must be unique
 #[macro_export]
@@ -121,23 +114,24 @@ fn simple_closure_with_no_captured_variables() {
     }
     "#;
 
-    let expected_rewrite = r#"fn main$f0() -> Field {
-    let x$0 = 1;
-    let closure$3 = {
-        let closure_variable$2 = {
-            let env$1 = (x$l0);
-            (env$l1, lambda$f1)
+    let program = get_monomorphized!(src, Expect::Success).unwrap();
+    insta::assert_snapshot!(program, @r"
+    fn main$f0() -> pub Field {
+        let x$l0 = 1;
+        let closure$l3 = {
+            let closure_variable$l2 = {
+                let env$l1 = (x$l0);
+                (env$l1, lambda$f1)
+            };
+            closure_variable$l2
         };
-        closure_variable$l2
-    };
-    {
-        let tmp$4 = closure$l3;
-        tmp$l4.1(tmp$l4.0)
+        {
+            let tmp$l4 = closure$l3;
+            tmp$l4.1(tmp$l4.0)
+        }
     }
-}
-fn lambda$f1(mut env$l1: (Field)) -> Field {
-    env$l1.0
-}
-"#;
-    check_rewrite!(src, expected_rewrite);
+    fn lambda$f1(mut env$l1: (Field)) -> Field {
+        env$l1.0
+    }
+    ");
 }

--- a/tooling/ast_fuzzer/examples/sample.rs
+++ b/tooling/ast_fuzzer/examples/sample.rs
@@ -4,7 +4,7 @@
 //! cargo run -p noir_ast_fuzzer --example sample
 //! ```
 use arbitrary::Unstructured;
-use noir_ast_fuzzer::{Config, arb_program};
+use noir_ast_fuzzer::{Config, DisplayAstAsNoir, arb_program};
 use rand::RngCore;
 
 fn main() {
@@ -18,5 +18,5 @@ fn main() {
 
     let program = arb_program(&mut u, Config::default()).expect("arb_program");
 
-    println!("{program}");
+    println!("{}", DisplayAstAsNoir(&program));
 }

--- a/tooling/ast_fuzzer/fuzz/Cargo.toml
+++ b/tooling/ast_fuzzer/fuzz/Cargo.toml
@@ -16,6 +16,7 @@ color-eyre.workspace = true
 libfuzzer-sys.workspace = true
 
 acir.workspace = true
+noirc_abi.workspace = true
 noirc_evaluator.workspace = true
 noirc_frontend.workspace = true
 

--- a/tooling/ast_fuzzer/fuzz/src/lib.rs
+++ b/tooling/ast_fuzzer/fuzz/src/lib.rs
@@ -2,6 +2,7 @@ use acir::circuit::ExpressionWidth;
 use color_eyre::eyre;
 use noir_ast_fuzzer::DisplayAstAsNoir;
 use noir_ast_fuzzer::compare::{CompareResult, CompareSsa};
+use noirc_abi::input_parser::Format;
 use noirc_evaluator::{
     brillig::BrilligOptions,
     ssa::{self, SsaEvaluatorOptions, SsaProgramArtifact},
@@ -72,7 +73,12 @@ where
         for (i, ast) in asts(inputs).into_iter().enumerate() {
             eprintln!("AST {}:\n{}", i + 1, DisplayAstAsNoir(ast));
         }
-        eprintln!("Inputs:\n{:?}", inputs.input_map);
+        eprintln!(
+            "Inputs:\n{}---",
+            Format::Toml
+                .serialize(&inputs.input_map, &inputs.abi)
+                .unwrap_or_else(|e| format!("failed to serialize inputs: {e}"))
+        );
         eprintln!("Program 1:\n{}", inputs.ssa1.program);
         eprintln!("Program 2:\n{}", inputs.ssa2.program);
     }

--- a/tooling/ast_fuzzer/fuzz/src/lib.rs
+++ b/tooling/ast_fuzzer/fuzz/src/lib.rs
@@ -1,5 +1,6 @@
 use acir::circuit::ExpressionWidth;
 use color_eyre::eyre;
+use noir_ast_fuzzer::DisplayAstAsNoir;
 use noir_ast_fuzzer::compare::{CompareResult, CompareSsa};
 use noirc_evaluator::{
     brillig::BrilligOptions,
@@ -44,7 +45,7 @@ pub fn create_ssa_or_die(
     // and print the AST, then resume the panic, because
     // `Program` has a `RefCell` in it, which is not unwind safe.
     if show_ast() {
-        eprintln!("---\n{program}\n---");
+        eprintln!("---\n{}\n---", DisplayAstAsNoir(&program));
     }
 
     ssa::create_program(program, options).unwrap_or_else(|e| {
@@ -69,7 +70,7 @@ where
 
     if res.is_err() {
         for (i, ast) in asts(inputs).into_iter().enumerate() {
-            eprintln!("AST {}:\n{}", i + 1, ast);
+            eprintln!("AST {}:\n{}", i + 1, DisplayAstAsNoir(ast));
         }
         eprintln!("Inputs:\n{:?}", inputs.input_map);
         eprintln!("Program 1:\n{}", inputs.ssa1.program);

--- a/tooling/ast_fuzzer/fuzz/src/lib.rs
+++ b/tooling/ast_fuzzer/fuzz/src/lib.rs
@@ -71,16 +71,16 @@ where
 
     if res.is_err() {
         for (i, ast) in asts(inputs).into_iter().enumerate() {
-            eprintln!("AST {}:\n{}", i + 1, DisplayAstAsNoir(ast));
+            eprintln!("---\nAST {}:\n{}", i + 1, DisplayAstAsNoir(ast));
         }
         eprintln!(
-            "Inputs:\n{}---",
+            "---\nInputs:\n{}",
             Format::Toml
                 .serialize(&inputs.input_map, &inputs.abi)
                 .unwrap_or_else(|e| format!("failed to serialize inputs: {e}"))
         );
-        eprintln!("Program 1:\n{}", inputs.ssa1.program);
-        eprintln!("Program 2:\n{}", inputs.ssa2.program);
+        eprintln!("---\nProgram 1:\n{}", inputs.ssa1.program);
+        eprintln!("---\nProgram 2:\n{}", inputs.ssa2.program);
     }
 
     res.map(|_| ())

--- a/tooling/ast_fuzzer/src/lib.rs
+++ b/tooling/ast_fuzzer/src/lib.rs
@@ -5,8 +5,8 @@ mod program;
 
 pub use abi::program_abi;
 pub use input::arb_inputs;
-pub use program::arb_program;
 use program::freq::Freqs;
+pub use program::{DisplayAstAsNoir, arb_program};
 
 /// AST generation configuration.
 #[derive(Debug, Clone)]

--- a/tooling/ast_fuzzer/src/program/mod.rs
+++ b/tooling/ast_fuzzer/src/program/mod.rs
@@ -141,20 +141,23 @@ impl Context {
             });
         }
 
+        let return_type = self.gen_type(u, self.config.max_depth, false)?;
+        let return_visibility = if is_main {
+            if types::is_unit(&return_type) {
+                Visibility::Private
+            } else {
+                if u.ratio(4, 5)? { Visibility::Public } else { Visibility::ReturnData }
+            }
+        } else {
+            Visibility::Private
+        };
+
         let decl = FunctionDeclaration {
             name: if is_main { "main".to_string() } else { format!("func_{i}") },
             params,
             param_visibilities,
-            return_type: self.gen_type(u, self.config.max_depth, false)?,
-            return_visibility: if is_main {
-                match u.choose_index(5)? {
-                    0 | 1 => Visibility::Public,
-                    2 | 3 => Visibility::Private,
-                    _ => Visibility::ReturnData,
-                }
-            } else {
-                Visibility::Private
-            },
+            return_type,
+            return_visibility,
             inline_type: if is_main {
                 InlineType::default()
             } else {

--- a/tooling/ast_fuzzer/src/program/mod.rs
+++ b/tooling/ast_fuzzer/src/program/mod.rs
@@ -7,8 +7,9 @@ use strum::IntoEnumIterator;
 use arbitrary::{Arbitrary, Unstructured};
 use noirc_frontend::{
     ast::IntegerBitSize,
-    monomorphization::ast::{
-        Expression, FuncId, Function, GlobalId, InlineType, LocalId, Program, Type,
+    monomorphization::{
+        ast::{Expression, FuncId, Function, GlobalId, InlineType, LocalId, Program, Type},
+        printer::AstPrinter,
     },
     shared::{Signedness, Visibility},
 };
@@ -297,6 +298,18 @@ fn make_name(mut id: usize, is_global: bool) -> String {
     name.reverse();
     let name = name.into_iter().collect::<String>();
     if is_global { format!("G_{}", name) } else { name }
+}
+
+/// Wrapper around `Program` that prints the AST as close to being able to
+/// copy-paste it as a Noir program as we can get.
+pub struct DisplayAstAsNoir<'a>(pub &'a Program);
+
+impl std::fmt::Display for DisplayAstAsNoir<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut printer = AstPrinter::default();
+        printer.show_id = false;
+        printer.print_program(self.0, f)
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
# Description

## Problem\*

Resolves #7978 

## Summary\*

Adds some customisation options to the `AstPrinter` to try to keep the printed code closer to Noir by not printing e.g. `a$l1` for a local variable but simply `a`. This saves us the trouble of having to get rid of all those IDs when we're trying to turn an AST printed when the fuzzer failed into a Noir integration test.

The printer now also shows the _main return visibility_ of the program, because Noir always complains if we try to return a value without `pub`. The generator will no longer generate private non-unit return types for `main`.

The PR also changes the display of input values when a program fails to TOML, so it's easier to paste into `Prover.toml`. 

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
