### PR TITLE
chore: switch to using insta for snapshot testing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3616,6 +3616,7 @@ dependencies = [
  "function_name",
  "fxhash",
  "im",
+ "insta",
  "iter-extended",
  "noirc_arena",
  "noirc_errors",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -196,6 +196,7 @@ tracing-web = "0.1.3"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter", "json"] }
 rust-embed = "6.6.0"
 petgraph = "0.6"
+insta = "1.42.2"
 
 [profile.dev]
 # This is required to be able to run `cargo test` in acvm_js due to the `locals exceeds maximum` error.

--- a/acvm-repo/acir/Cargo.toml
+++ b/acvm-repo/acir/Cargo.toml
@@ -47,7 +47,7 @@ fxhash.workspace = true
 criterion.workspace = true
 pprof.workspace = true
 num-bigint.workspace = true
-insta = "1.42.2"
+insta.workspace = true
 
 acir = { path = ".", features = ["arb"] } # Self to turn on `arb`.
 

--- a/compiler/noirc_frontend/Cargo.toml
+++ b/compiler/noirc_frontend/Cargo.toml
@@ -38,6 +38,7 @@ base64.workspace = true
 function_name = "0.3.0"
 proptest.workspace = true
 proptest-derive.workspace = true
+insta.workspace = true
 
 [features]
 bn254 = []

--- a/compiler/noirc_frontend/src/monomorphization/tests.rs
+++ b/compiler/noirc_frontend/src/monomorphization/tests.rs
@@ -116,17 +116,17 @@ fn simple_closure_with_no_captured_variables() {
 
     let program = get_monomorphized!(src, Expect::Success).unwrap();
     insta::assert_snapshot!(program, @r"
-    fn main$f0() -> Field {
-        let x$0 = 1;
-        let closure$3 = {
-            let closure_variable$2 = {
-                let env$1 = (x$l0);
+    fn main$f0() -> pub Field {
+        let x$l0 = 1;
+        let closure$l3 = {
+            let closure_variable$l2 = {
+                let env$l1 = (x$l0);
                 (env$l1, lambda$f1)
             };
             closure_variable$l2
         };
         {
-            let tmp$4 = closure$l3;
+            let tmp$l4 = closure$l3;
             tmp$l4.1(tmp$l4.0)
         }
     }

--- a/compiler/noirc_frontend/src/monomorphization/tests.rs
+++ b/compiler/noirc_frontend/src/monomorphization/tests.rs
@@ -1,14 +1,7 @@
 #![cfg(test)]
 use crate::{
-    check_monomorphization_error_using_features,
-    elaborator::UnstableFeature,
-    test_utils::{Expect, get_monomorphized},
+    check_monomorphization_error_using_features, elaborator::UnstableFeature, test_utils::Expect,
 };
-
-pub(crate) fn check_rewrite(src: &str, expected: &str, test_path: &str) {
-    let program = get_monomorphized(src, test_path, Expect::Success).unwrap();
-    assert!(format!("{}", program) == expected);
-}
 
 // NOTE: this will fail in CI when called twice within one test: test names must be unique
 #[macro_export]
@@ -121,23 +114,24 @@ fn simple_closure_with_no_captured_variables() {
     }
     "#;
 
-    let expected_rewrite = r#"fn main$f0() -> Field {
-    let x$0 = 1;
-    let closure$3 = {
-        let closure_variable$2 = {
-            let env$1 = (x$l0);
-            (env$l1, lambda$f1)
+    let program = get_monomorphized!(src, Expect::Success).unwrap();
+    insta::assert_snapshot!(program, @r"
+    fn main$f0() -> Field {
+        let x$0 = 1;
+        let closure$3 = {
+            let closure_variable$2 = {
+                let env$1 = (x$l0);
+                (env$l1, lambda$f1)
+            };
+            closure_variable$l2
         };
-        closure_variable$l2
-    };
-    {
-        let tmp$4 = closure$l3;
-        tmp$l4.1(tmp$l4.0)
+        {
+            let tmp$4 = closure$l3;
+            tmp$l4.1(tmp$l4.0)
+        }
     }
-}
-fn lambda$f1(mut env$l1: (Field)) -> Field {
-    env$l1.0
-}
-"#;
-    check_rewrite!(src, expected_rewrite);
+    fn lambda$f1(mut env$l1: (Field)) -> Field {
+        env$l1.0
+    }
+    ");
 }


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This PR switches us over to using insta.rs for snapshot testing the rewritten noir generated from ast.

## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
