### PR TITLE
chore: use insta snapshots for ssa tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3594,6 +3594,7 @@ dependencies = [
  "function_name",
  "fxhash",
  "im",
+ "insta",
  "iter-extended",
  "noirc_errors",
  "noirc_frontend",

--- a/compiler/noirc_evaluator/Cargo.toml
+++ b/compiler/noirc_evaluator/Cargo.toml
@@ -40,6 +40,7 @@ tracing-test = "0.2.5"
 num-traits.workspace = true
 test-case.workspace = true
 function_name = "0.3.0"
+insta.workspace = true
 noirc_frontend = { workspace = true, features = ["test_utils"] }
 
 [features]

--- a/compiler/noirc_evaluator/src/ssa/ir/dfg/simplify.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/dfg/simplify.rs
@@ -440,7 +440,10 @@ fn try_optimize_array_set_from_previous_get(
 
 #[cfg(test)]
 mod tests {
-    use crate::ssa::{opt::assert_normalized_ssa_equals, ssa_gen::Ssa};
+    use crate::{
+        assert_ssa_snapshot,
+        ssa::{opt::assert_normalized_ssa_equals, ssa_gen::Ssa},
+    };
 
     #[test]
     fn removes_range_constraints_on_constants() {
@@ -456,14 +459,13 @@ mod tests {
         ";
         let ssa = Ssa::from_str_simplifying(src).unwrap();
 
-        let expected = "
+        assert_ssa_snapshot!(ssa, @r"
         acir(inline) fn main f0 {
           b0(v0: Field):
             range_check Field 256 to 8 bits
             return
         }
-        ";
-        assert_normalized_ssa_equals(ssa, expected);
+        ");
     }
 
     #[test]

--- a/compiler/noirc_evaluator/src/ssa/ir/dfg/simplify/call.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/dfg/simplify/call.rs
@@ -740,7 +740,7 @@ fn simplify_derive_generators(
 
 #[cfg(test)]
 mod tests {
-    use crate::ssa::{Ssa, opt::assert_normalized_ssa_equals};
+    use crate::{assert_ssa_snapshot, ssa::Ssa};
 
     #[test]
     fn simplify_derive_generators_has_correct_type() {
@@ -757,14 +757,13 @@ mod tests {
             "#;
         let ssa = Ssa::from_str_simplifying(src).unwrap();
 
-        let expected = r#"
-            brillig(inline) fn main func {
-              block():
-                separator = make_array b"DEFAULT_DOMAIN_SEPARATOR"
-                result = make_array [Field 3728882899078719075161482178784387565366481897740339799480980287259621149274, Field -9903063709032878667290627648209915537972247634463802596148419711785767431332, u1 0] : [(Field, Field, u1); 1]
-                return result
-            }
-            "#;
-        assert_normalized_ssa_equals(ssa, expected);
+        assert_ssa_snapshot!(ssa, @r#"
+        brillig(inline) fn main f0 {
+          b0():
+            v15 = make_array b"DEFAULT_DOMAIN_SEPARATOR"
+            v19 = make_array [Field 3728882899078719075161482178784387565366481897740339799480980287259621149274, Field -9903063709032878667290627648209915537972247634463802596148419711785767431332, u1 0] : [(Field, Field, u1); 1]
+            return v19
+        }
+        "#);
     }
 }

--- a/compiler/noirc_evaluator/src/ssa/ir/dfg/simplify/call/blackbox.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/dfg/simplify/call/blackbox.rs
@@ -358,8 +358,8 @@ pub(super) fn simplify_signature(
 #[cfg(feature = "bn254")]
 #[cfg(test)]
 mod multi_scalar_mul {
+    use crate::assert_ssa_snapshot;
     use crate::ssa::Ssa;
-    use crate::ssa::opt::assert_normalized_ssa_equals;
 
     #[cfg(feature = "bn254")]
     #[test]
@@ -374,16 +374,7 @@ mod multi_scalar_mul {
             }"#;
         let ssa = Ssa::from_str_simplifying(src).unwrap();
 
-        let expected_src = r#"
-            acir(inline) fn main f0 {
-              b0():
-                v3 = make_array [Field 2, Field 3, Field 5, Field 5] : [Field; 4]
-                v7 = make_array [Field 1, Field 17631683881184975370165255887551781615748388533673675138860, Field 0, Field 1, Field 17631683881184975370165255887551781615748388533673675138860, Field 0] : [Field; 6]
-                v10 = make_array [Field 1478523918288173385110236399861791147958001875200066088686689589556927843200, Field 700144278551281040379388961242974992655630750193306467120985766322057145630, u1 0] : [(Field, Field, u1); 1]
-                return v10
-            }
-            "#;
-        assert_normalized_ssa_equals(ssa, expected_src);
+        assert_ssa_snapshot!(ssa, @"");
     }
 
     #[cfg(feature = "bn254")]
@@ -402,18 +393,7 @@ mod multi_scalar_mul {
             }"#;
         let ssa = Ssa::from_str_simplifying(src).unwrap();
         //First point is zero, second scalar is zero, so we should be left with the scalar mul of the last point.
-        let expected_src = r#"
-            acir(inline) fn main f0 {
-              b0(v0: Field, v1: Field):
-                v3 = make_array [v0, Field 0, Field 0, Field 0, v0, Field 0] : [Field; 6]
-                v5 = make_array [Field 0, Field 0, Field 1, v0, v1, Field 0, Field 1, v0, Field 0] : [Field; 9]
-                v6 = make_array [v0, Field 0] : [Field; 2]
-                v7 = make_array [Field 1, v0, Field 0] : [Field; 3]
-                v9 = call multi_scalar_mul(v7, v6) -> [Field; 3]
-                return v9
-            }
-            "#;
-        assert_normalized_ssa_equals(ssa, expected_src);
+        assert_ssa_snapshot!(ssa, @"");
     }
 
     #[cfg(feature = "bn254")]
@@ -430,25 +410,14 @@ mod multi_scalar_mul {
             }"#;
         let ssa = Ssa::from_str_simplifying(src).unwrap();
         //First and last scalar/point are constant, so we should be left with the msm of the middle point and the folded constant point
-        let expected_src = r#"
-            acir(inline) fn main f0 {
-              b0(v0: Field, v1: Field):
-                v5 = make_array [Field 1, Field 0, v0, Field 0, Field 2, Field 0] : [Field; 6]
-                v7 = make_array [Field 1, Field 17631683881184975370165255887551781615748388533673675138860, Field 0, v0, v1, Field 0, Field 1, Field 17631683881184975370165255887551781615748388533673675138860, Field 0] : [Field; 9]
-                v8 = make_array [v0, Field 0, Field 1, Field 0] : [Field; 4]
-                v12 = make_array [v0, v1, Field 0, Field -3227352362257037263902424173275354266044964400219754872043023745437788450996, Field 8902249110305491597038405103722863701255802573786510474664632793109847672620, u1 0] : [Field; 6]
-                v14 = call multi_scalar_mul(v12, v8) -> [Field; 3]
-                return v14
-            }
-            "#;
-        assert_normalized_ssa_equals(ssa, expected_src);
+        assert_ssa_snapshot!(ssa, @"");
     }
 }
 
 #[cfg(test)]
 mod sha256_compression {
+    use crate::assert_ssa_snapshot;
     use crate::ssa::Ssa;
-    use crate::ssa::opt::assert_normalized_ssa_equals;
 
     #[test]
     fn is_optimized_out_with_constant_arguments() {
@@ -461,15 +430,14 @@ mod sha256_compression {
                 return v2
             }"#;
         let ssa = Ssa::from_str_simplifying(src).unwrap();
-        let expected_src = r#"
-            acir(inline) fn main f0 {
-              b0():
-                v1 = make_array [u32 0, u32 0, u32 0, u32 0, u32 0, u32 0, u32 0, u32 0] : [u32; 8]
-                v2 = make_array [u32 0, u32 0, u32 0, u32 0, u32 0, u32 0, u32 0, u32 0, u32 0, u32 0, u32 0, u32 0, u32 0, u32 0, u32 0, u32 0] : [u32; 16]
-                v11 = make_array [u32 2091193876, u32 1113340840, u32 3461668143, u32 3254913767, u32 3068490961, u32 2551409935, u32 2927503052, u32 3205228454] : [u32; 8]
-                return v11
-            }
-            "#;
-        assert_normalized_ssa_equals(ssa, expected_src);
+        assert_ssa_snapshot!(ssa, @r"
+        acir(inline) fn main f0 {
+          b0():
+            v1 = make_array [u32 0, u32 0, u32 0, u32 0, u32 0, u32 0, u32 0, u32 0] : [u32; 8]
+            v2 = make_array [u32 0, u32 0, u32 0, u32 0, u32 0, u32 0, u32 0, u32 0, u32 0, u32 0, u32 0, u32 0, u32 0, u32 0, u32 0, u32 0] : [u32; 16]
+            v11 = make_array [u32 2091193876, u32 1113340840, u32 3461668143, u32 3254913767, u32 3068490961, u32 2551409935, u32 2927503052, u32 3205228454] : [u32; 8]
+            return v11
+        }
+        ");
     }
 }

--- a/compiler/noirc_evaluator/src/ssa/ir/dfg/simplify/call/blackbox.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/dfg/simplify/call/blackbox.rs
@@ -374,7 +374,15 @@ mod multi_scalar_mul {
             }"#;
         let ssa = Ssa::from_str_simplifying(src).unwrap();
 
-        assert_ssa_snapshot!(ssa, @"");
+        assert_ssa_snapshot!(ssa, @r"
+        acir(inline) fn main f0 {
+          b0():
+            v3 = make_array [Field 2, Field 3, Field 5, Field 5] : [Field; 4]
+            v7 = make_array [Field 1, Field 17631683881184975370165255887551781615748388533673675138860, Field 0, Field 1, Field 17631683881184975370165255887551781615748388533673675138860, Field 0] : [Field; 6]
+            v11 = make_array [Field 1478523918288173385110236399861791147958001875200066088686689589556927843200, Field 700144278551281040379388961242974992655630750193306467120985766322057145630, u1 0] : [(Field, Field, u1); 1]
+            return v11
+        }
+        ");
     }
 
     #[cfg(feature = "bn254")]
@@ -393,7 +401,17 @@ mod multi_scalar_mul {
             }"#;
         let ssa = Ssa::from_str_simplifying(src).unwrap();
         //First point is zero, second scalar is zero, so we should be left with the scalar mul of the last point.
-        assert_ssa_snapshot!(ssa, @"");
+        assert_ssa_snapshot!(ssa, @r"
+        acir(inline) fn main f0 {
+          b0(v0: Field, v1: Field):
+            v3 = make_array [v0, Field 0, Field 0, Field 0, v0, Field 0] : [Field; 6]
+            v5 = make_array [Field 0, Field 0, Field 1, v0, v1, Field 0, Field 1, v0, Field 0] : [Field; 9]
+            v6 = make_array [v0, Field 0] : [Field; 2]
+            v7 = make_array [Field 1, v0, Field 0] : [Field; 3]
+            v9 = call multi_scalar_mul(v7, v6) -> [Field; 3]
+            return v9
+        }
+        ");
     }
 
     #[cfg(feature = "bn254")]
@@ -410,7 +428,17 @@ mod multi_scalar_mul {
             }"#;
         let ssa = Ssa::from_str_simplifying(src).unwrap();
         //First and last scalar/point are constant, so we should be left with the msm of the middle point and the folded constant point
-        assert_ssa_snapshot!(ssa, @"");
+        assert_ssa_snapshot!(ssa, @r"
+        acir(inline) fn main f0 {
+          b0(v0: Field, v1: Field):
+            v5 = make_array [Field 1, Field 0, v0, Field 0, Field 2, Field 0] : [Field; 6]
+            v7 = make_array [Field 1, Field 17631683881184975370165255887551781615748388533673675138860, Field 0, v0, v1, Field 0, Field 1, Field 17631683881184975370165255887551781615748388533673675138860, Field 0] : [Field; 9]
+            v8 = make_array [v0, Field 0, Field 1, Field 0] : [Field; 4]
+            v12 = make_array [v0, v1, Field 0, Field -3227352362257037263902424173275354266044964400219754872043023745437788450996, Field 8902249110305491597038405103722863701255802573786510474664632793109847672620, u1 0] : [Field; 6]
+            v14 = call multi_scalar_mul(v12, v8) -> [Field; 3]
+            return v14
+        }
+        ");
     }
 }
 

--- a/compiler/noirc_evaluator/src/ssa/ir/dfg/simplify/constrain.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/dfg/simplify/constrain.rs
@@ -183,7 +183,7 @@ pub(super) fn decompose_constrain(
 
 #[cfg(test)]
 mod tests {
-    use crate::ssa::{opt::assert_normalized_ssa_equals, ssa_gen::Ssa};
+    use crate::{assert_ssa_snapshot, ssa::ssa_gen::Ssa};
 
     #[test]
     fn simplifies_assertions_that_squared_values_are_equal_to_zero() {
@@ -197,15 +197,14 @@ mod tests {
         ";
         let ssa = Ssa::from_str_simplifying(src).unwrap();
 
-        let expected = "
+        assert_ssa_snapshot!(ssa, @r"
         acir(inline) fn main f0 {
           b0(v0: Field):
             v1 = mul v0, v0
             constrain v0 == Field 0
             return
         }
-        ";
-        assert_normalized_ssa_equals(ssa, expected);
+        ");
     }
 
     #[test]
@@ -221,13 +220,12 @@ mod tests {
 
         let ssa = Ssa::from_str_simplifying(src).unwrap();
 
-        let expected = "
+        assert_ssa_snapshot!(ssa, @r"
         acir(inline) predicate_pure fn main f0 {
           b0(v0: u8):
             return v0
         }
-        ";
-        assert_normalized_ssa_equals(ssa, expected);
+        ");
     }
 
     #[test]
@@ -247,18 +245,17 @@ mod tests {
             ";
         let ssa = Ssa::from_str_simplifying(src).unwrap();
 
-        let expected = "
-            acir(inline) fn main f0 {
-              b0(v0: u1, v1: u1, v2: u1):
-                v3 = mul v0, v1
-                v4 = not v2
-                v5 = mul v3, v4
-                constrain v0 == u1 1
-                constrain v1 == u1 1
-                constrain v2 == u1 0
-                return
-            }
-            ";
-        assert_normalized_ssa_equals(ssa, expected);
+        assert_ssa_snapshot!(ssa, @r"
+        acir(inline) fn main f0 {
+          b0(v0: u1, v1: u1, v2: u1):
+            v3 = mul v0, v1
+            v4 = not v2
+            v5 = mul v3, v4
+            constrain v0 == u1 1
+            constrain v1 == u1 1
+            constrain v2 == u1 0
+            return
+        }
+        ");
     }
 }

--- a/compiler/noirc_evaluator/src/ssa/opt/as_slice_length.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/as_slice_length.rs
@@ -78,7 +78,7 @@ fn replace_known_slice_lengths(
 
 #[cfg(test)]
 mod test {
-    use crate::ssa::opt::assert_normalized_ssa_equals;
+    use crate::assert_ssa_snapshot;
 
     use super::Ssa;
 
@@ -95,14 +95,13 @@ mod test {
             ";
         let ssa = Ssa::from_str(src).unwrap();
 
-        let expected = "
-            acir(inline) fn main f0 {
-              b0(v0: [Field; 3]):
-                v2, v3 = call as_slice(v0) -> (u32, [Field])
-                return u32 3
-            }
-            ";
         let ssa = ssa.as_slice_optimization();
-        assert_normalized_ssa_equals(ssa, expected);
+        assert_ssa_snapshot!(ssa, @r"
+        acir(inline) fn main f0 {
+          b0(v0: [Field; 3]):
+            v2, v3 = call as_slice(v0) -> (u32, [Field])
+            return u32 3
+        }
+        ");
     }
 }

--- a/compiler/noirc_evaluator/src/ssa/opt/basic_conditional.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/basic_conditional.rs
@@ -387,7 +387,10 @@ impl Context<'_> {
 
 #[cfg(test)]
 mod test {
-    use crate::ssa::{Ssa, opt::assert_normalized_ssa_equals};
+    use crate::{
+        assert_ssa_snapshot,
+        ssa::{Ssa, opt::assert_normalized_ssa_equals},
+    };
 
     #[test]
     fn basic_jmpif() {
@@ -407,22 +410,20 @@ mod test {
         let ssa = Ssa::from_str(src).unwrap();
         assert_eq!(ssa.main().reachable_blocks().len(), 4);
 
-        let expected = "
-            brillig(inline) fn foo f0 {
-              b0(v0: u32):
-                v2 = eq v0, u32 0
-                v3 = not v2
-                v4 = cast v2 as u32
-                v5 = cast v3 as u32
-                v7 = unchecked_mul v4, u32 3
-                v9 = unchecked_mul v5, u32 5
-                v10 = unchecked_add v7, v9
-                return v10
-            }
-            ";
-
         let ssa = ssa.flatten_basic_conditionals();
-        assert_normalized_ssa_equals(ssa, expected);
+        assert_ssa_snapshot!(ssa, @r"
+        brillig(inline) fn foo f0 {
+          b0(v0: u32):
+            v2 = eq v0, u32 0
+            v3 = not v2
+            v4 = cast v2 as u32
+            v5 = cast v3 as u32
+            v7 = unchecked_mul v4, u32 3
+            v9 = unchecked_mul v5, u32 5
+            v10 = unchecked_add v7, v9
+            return v10
+        }
+        ");
     }
 
     #[test]
@@ -486,7 +487,9 @@ mod test {
         let ssa = Ssa::from_str(src).unwrap();
         assert_eq!(ssa.main().reachable_blocks().len(), 10);
 
-        let expected = "
+        let ssa = ssa.flatten_basic_conditionals();
+        assert_eq!(ssa.main().reachable_blocks().len(), 4);
+        assert_ssa_snapshot!(ssa, @r"
         brillig(inline) fn foo f0 {
           b0(v0: u32):
             v3 = eq v0, u32 5
@@ -517,10 +520,6 @@ mod test {
           b3(v1: u32):
             return v1
         }
-            ";
-
-        let ssa = ssa.flatten_basic_conditionals();
-        assert_eq!(ssa.main().reachable_blocks().len(), 4);
-        assert_normalized_ssa_equals(ssa, expected);
+        ");
     }
 }

--- a/compiler/noirc_evaluator/src/ssa/opt/brillig_array_gets.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/brillig_array_gets.rs
@@ -84,7 +84,7 @@ impl Function {
 
 #[cfg(test)]
 mod tests {
-    use crate::ssa::opt::assert_normalized_ssa_equals;
+    use crate::{assert_ssa_snapshot, ssa::opt::assert_normalized_ssa_equals};
 
     use super::Ssa;
 
@@ -101,15 +101,13 @@ mod tests {
         let ssa = Ssa::from_str(src).unwrap();
         let ssa = ssa.brillig_array_gets();
 
-        let expected = "
+        assert_ssa_snapshot!(ssa, @r"
         brillig(inline) fn main f0 {
           b0(v0: [Field; 3]):
             v2 = array_get v0, index u32 1 -> Field
             return v2
         }
-        ";
-
-        assert_normalized_ssa_equals(ssa, expected);
+        ");
     }
 
     #[test]
@@ -155,14 +153,12 @@ mod tests {
         let ssa = Ssa::from_str(src).unwrap();
         let ssa = ssa.brillig_array_gets();
 
-        let expected = "
+        assert_ssa_snapshot!(ssa, @r"
         brillig(inline) fn main f0 {
           b0(v0: [Field]):
             v2 = array_get v0, index u32 3 -> Field
             return v2
         }
-        ";
-
-        assert_normalized_ssa_equals(ssa, expected);
+        ");
     }
 }

--- a/compiler/noirc_evaluator/src/ssa/opt/brillig_entry_points.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/brillig_entry_points.rs
@@ -296,7 +296,8 @@ pub(crate) fn build_inner_call_to_entry_points(
 
 #[cfg(test)]
 mod tests {
-    use crate::ssa::opt::assert_normalized_ssa_equals;
+
+    use crate::assert_ssa_snapshot;
 
     use super::Ssa;
 
@@ -343,11 +344,11 @@ mod tests {
         let ssa = ssa.remove_unreachable_functions();
 
         // We expect `inner_func` to be duplicated
-        let expected = "
+        assert_ssa_snapshot!(ssa, @r"
         g0 = Field 1
         g1 = Field 2
         g2 = Field 3
-        
+
         acir(inline) fn main f0 {
           b0(v3: Field, v4: Field):
             call f1(v3, v4)
@@ -384,8 +385,7 @@ mod tests {
             constrain v6 == Field 4
             return
         }
-        ";
-        assert_normalized_ssa_equals(ssa, expected);
+        ");
     }
 
     #[test]
@@ -438,10 +438,10 @@ mod tests {
         let ssa = ssa.remove_unreachable_functions();
 
         // We expect both `inner_func` and `nested_inner_func` to be duplicated
-        let expected = "
+        assert_ssa_snapshot!(ssa, @r"
         g0 = Field 2
         g1 = Field 3
-        
+
         acir(inline) fn main f0 {
           b0(v2: Field, v3: Field):
             call f1(v2, v3)
@@ -494,8 +494,7 @@ mod tests {
             call f5(v2, v3)
             return
         }
-        ";
-        assert_normalized_ssa_equals(ssa, expected);
+        ");
     }
 
     #[test]
@@ -550,11 +549,11 @@ mod tests {
         let ssa = ssa.brillig_entry_point_analysis();
 
         // We expect `entry_point_one_global` and `entry_point_one_diff_global` to be duplicated
-        let expected = "
+        assert_ssa_snapshot!(ssa, @r"
         g0 = Field 2
         g1 = Field 3
         g2 = Field 1
-        
+
         acir(inline) fn main f0 {
           b0(v3: Field, v4: Field):
             call f1(v3, v4)
@@ -604,7 +603,6 @@ mod tests {
             constrain v6 == Field 4
             return
         }
-        ";
-        assert_normalized_ssa_equals(ssa, expected);
+        ");
     }
 }

--- a/compiler/noirc_evaluator/src/ssa/opt/check_u128_mul_overflow.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/check_u128_mul_overflow.rs
@@ -134,7 +134,10 @@ fn check_u128_mul_overflow(
 
 #[cfg(test)]
 mod tests {
-    use crate::ssa::{opt::assert_normalized_ssa_equals, ssa_gen::Ssa};
+    use crate::{
+        assert_ssa_snapshot,
+        ssa::{opt::assert_normalized_ssa_equals, ssa_gen::Ssa},
+    };
 
     #[test]
     fn does_not_insert_check_if_lhs_is_less_than_two_pow_64() {
@@ -177,7 +180,8 @@ mod tests {
         ";
         let ssa = Ssa::from_str(src).unwrap();
 
-        let expected = r#"
+        let ssa = ssa.check_u128_mul_overflow();
+        assert_ssa_snapshot!(ssa, @r#"
         acir(inline) fn main f0 {
           b0(v0: u128):
             v2 = mul v0, u128 18446744073709551617
@@ -185,10 +189,7 @@ mod tests {
             constrain v4 == u128 0, "attempt to multiply with overflow"
             return
         }
-        "#;
-
-        let ssa = ssa.check_u128_mul_overflow();
-        assert_normalized_ssa_equals(ssa, expected);
+        "#);
     }
 
     #[test]
@@ -202,7 +203,8 @@ mod tests {
         ";
         let ssa = Ssa::from_str(src).unwrap();
 
-        let expected = r#"
+        let ssa = ssa.check_u128_mul_overflow();
+        assert_ssa_snapshot!(ssa, @r#"
         acir(inline) fn main f0 {
           b0(v0: u128):
             v2 = mul u128 18446744073709551617, v0
@@ -210,10 +212,7 @@ mod tests {
             constrain v4 == u128 0, "attempt to multiply with overflow"
             return
         }
-        "#;
-
-        let ssa = ssa.check_u128_mul_overflow();
-        assert_normalized_ssa_equals(ssa, expected);
+        "#);
     }
 
     #[test]
@@ -227,7 +226,8 @@ mod tests {
         ";
         let ssa = Ssa::from_str(src).unwrap();
 
-        let expected = r#"
+        let ssa = ssa.check_u128_mul_overflow();
+        assert_ssa_snapshot!(ssa, @r#"
         acir(inline) fn main f0 {
           b0(v0: u128, v1: u128):
             v2 = mul v0, v1
@@ -237,10 +237,7 @@ mod tests {
             constrain v6 == u128 0, "attempt to multiply with overflow"
             return
         }
-        "#;
-
-        let ssa = ssa.check_u128_mul_overflow();
-        assert_normalized_ssa_equals(ssa, expected);
+        "#);
     }
 
     #[test]
@@ -254,18 +251,16 @@ mod tests {
         ";
         let ssa = Ssa::from_str(src).unwrap();
 
+        let ssa = ssa.check_u128_mul_overflow();
         // The multiplication remains, but it will be later removed by DIE
-        let expected = r#"
+        assert_ssa_snapshot!(ssa, @r#"
         acir(inline) fn main f0 {
           b0():
             v2 = mul u128 18446744073709551617, u128 18446744073709551616
             constrain u128 1 == u128 0, "attempt to multiply with overflow"
             return
         }
-        "#;
-
-        let ssa = ssa.check_u128_mul_overflow();
-        assert_normalized_ssa_equals(ssa, expected);
+        "#);
     }
 
     #[test]

--- a/compiler/noirc_evaluator/src/ssa/opt/constant_folding.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/constant_folding.rs
@@ -934,6 +934,7 @@ mod test {
     use noirc_frontend::monomorphization::ast::InlineType;
 
     use crate::{
+        assert_ssa_snapshot,
         brillig::BrilligOptions,
         ssa::{
             Ssa,
@@ -1343,35 +1344,33 @@ mod test {
             }
         ";
         let ssa = Ssa::from_str(src).unwrap();
+        let ssa = ssa.fold_constants_using_constraints();
 
         // v4 has been hoisted, although:
         // - v5 has not yet been removed since it was encountered earlier in the program
         // - v8 hasn't been recognized as a duplicate of v6 yet since they still reference v4 and
         //   v5 respectively
-        let expected = "
-            brillig(inline) fn main f0 {
-              b0(v0: u32):
-                v2 = lt u32 1000, v0
-                v4 = shl v0, u32 1
-                jmpif v2 then: b1, else: b2
-              b1():
-                v5 = shl v0, u32 1
-                v6 = lt v0, v5
-                constrain v6 == u1 1
-                jmp b2()
-              b2():
-                jmpif v2 then: b3, else: b4
-              b3():
-                v8 = lt v0, v4
-                constrain v8 == u1 1
-                jmp b4()
-              b4():
-                return
-            }
-        ";
-
-        let ssa = ssa.fold_constants_using_constraints();
-        assert_normalized_ssa_equals(ssa, expected);
+        assert_ssa_snapshot!(ssa, @r"
+        brillig(inline) fn main f0 {
+          b0(v0: u32):
+            v2 = lt u32 1000, v0
+            v4 = shl v0, u32 1
+            jmpif v2 then: b1, else: b2
+          b1():
+            v5 = shl v0, u32 1
+            v6 = lt v0, v5
+            constrain v6 == u1 1
+            jmp b2()
+          b2():
+            jmpif v2 then: b3, else: b4
+          b3():
+            v8 = lt v0, v4
+            constrain v8 == u1 1
+            jmp b4()
+          b4():
+            return
+        }
+        ");
     }
 
     #[test]
@@ -1392,15 +1391,14 @@ mod test {
         let ssa = Ssa::from_str(src).unwrap();
         let brillig = ssa.to_brillig(&BrilligOptions::default());
 
-        let expected = "
-            acir(inline) fn main f0 {
-              b0():
-                return Field 5
-            }
-            ";
         let ssa = ssa.fold_constants_with_brillig(&brillig);
         let ssa = ssa.remove_unreachable_functions();
-        assert_normalized_ssa_equals(ssa, expected);
+        assert_ssa_snapshot!(ssa, @r"
+        acir(inline) fn main f0 {
+          b0():
+            return Field 5
+        }
+        ");
     }
 
     #[test]
@@ -1421,15 +1419,14 @@ mod test {
         let ssa = Ssa::from_str(src).unwrap();
         let brillig = ssa.to_brillig(&BrilligOptions::default());
 
-        let expected = "
-            acir(inline) fn main f0 {
-              b0():
-                return Field 5
-            }
-            ";
         let ssa = ssa.fold_constants_with_brillig(&brillig);
         let ssa = ssa.remove_unreachable_functions();
-        assert_normalized_ssa_equals(ssa, expected);
+        assert_ssa_snapshot!(ssa, @r"
+        acir(inline) fn main f0 {
+          b0():
+            return Field 5
+        }
+        ");
     }
 
     #[test]
@@ -1450,15 +1447,14 @@ mod test {
         let ssa = Ssa::from_str(src).unwrap();
         let brillig = ssa.to_brillig(&BrilligOptions::default());
 
-        let expected = "
-            acir(inline) fn main f0 {
-              b0():
-                return i32 5
-            }
-            ";
         let ssa = ssa.fold_constants_with_brillig(&brillig);
         let ssa = ssa.remove_unreachable_functions();
-        assert_normalized_ssa_equals(ssa, expected);
+        assert_ssa_snapshot!(ssa, @r"
+        acir(inline) fn main f0 {
+          b0():
+            return i32 5
+        }
+        ");
     }
 
     #[test]
@@ -1479,16 +1475,15 @@ mod test {
         let ssa = Ssa::from_str(src).unwrap();
         let brillig = ssa.to_brillig(&BrilligOptions::default());
 
-        let expected = "
-            acir(inline) fn main f0 {
-              b0():
-                v3 = make_array [Field 2, Field 3, Field 4] : [Field; 3]
-                return v3
-            }
-            ";
         let ssa = ssa.fold_constants_with_brillig(&brillig);
         let ssa = ssa.remove_unreachable_functions();
-        assert_normalized_ssa_equals(ssa, expected);
+        assert_ssa_snapshot!(ssa, @r"
+        acir(inline) fn main f0 {
+          b0():
+            v3 = make_array [Field 2, Field 3, Field 4] : [Field; 3]
+            return v3
+        }
+        ");
     }
 
     #[test]
@@ -1509,16 +1504,15 @@ mod test {
         let ssa = Ssa::from_str(src).unwrap();
         let brillig = ssa.to_brillig(&BrilligOptions::default());
 
-        let expected = "
-            acir(inline) fn main f0 {
-              b0():
-                v4 = make_array [Field 2, i32 3, Field 4, i32 5] : [(Field, i32); 2]
-                return v4
-            }
-            ";
         let ssa = ssa.fold_constants_with_brillig(&brillig);
         let ssa = ssa.remove_unreachable_functions();
-        assert_normalized_ssa_equals(ssa, expected);
+        assert_ssa_snapshot!(ssa, @r"
+        acir(inline) fn main f0 {
+          b0():
+            v4 = make_array [Field 2, i32 3, Field 4, i32 5] : [(Field, i32); 2]
+            return v4
+        }
+        ");
     }
 
     #[test]
@@ -1546,16 +1540,15 @@ mod test {
         let ssa = ssa.brillig_array_gets();
         let brillig = ssa.to_brillig(&BrilligOptions::default());
 
-        let expected = "
-            acir(inline) fn main f0 {
-              b0():
-                v2 = make_array [Field 2, Field 3] : [Field; 2]
-                return Field 5
-            }
-            ";
         let ssa = ssa.fold_constants_with_brillig(&brillig);
         let ssa = ssa.remove_unreachable_functions();
-        assert_normalized_ssa_equals(ssa, expected);
+        assert_ssa_snapshot!(ssa, @r"
+        acir(inline) fn main f0 {
+          b0():
+            v2 = make_array [Field 2, Field 3] : [Field; 2]
+            return Field 5
+        }
+        ");
     }
 
     #[test]
@@ -1580,18 +1573,16 @@ mod test {
         let used_globals_map = std::mem::take(&mut ssa.used_globals);
         let brillig = ssa.to_brillig_with_globals(&BrilligOptions::default(), used_globals_map);
 
-        let expected = "
+        let ssa = ssa.fold_constants_with_brillig(&brillig);
+        let ssa = ssa.remove_unreachable_functions();
+        assert_ssa_snapshot!(ssa, @r"
         g0 = Field 2
 
         acir(inline) fn main f0 {
           b0():
             return Field 5
         }
-        ";
-
-        let ssa = ssa.fold_constants_with_brillig(&brillig);
-        let ssa = ssa.remove_unreachable_functions();
-        assert_normalized_ssa_equals(ssa, expected);
+        ");
     }
 
     #[test]
@@ -1622,18 +1613,16 @@ mod test {
         let used_globals_map = std::mem::take(&mut ssa.used_globals);
         let brillig = ssa.to_brillig_with_globals(&BrilligOptions::default(), used_globals_map);
 
-        let expected = "
+        let ssa = ssa.fold_constants_with_brillig(&brillig);
+        let ssa = ssa.remove_unreachable_functions();
+        assert_ssa_snapshot!(ssa, @r"
         g0 = Field 2
 
         acir(inline) fn main f0 {
           b0():
             return Field 5
         }
-        ";
-
-        let ssa = ssa.fold_constants_with_brillig(&brillig);
-        let ssa = ssa.remove_unreachable_functions();
-        assert_normalized_ssa_equals(ssa, expected);
+        ");
     }
 
     #[test]
@@ -1726,7 +1715,9 @@ mod test {
         }
         ";
         let ssa = Ssa::from_str(src).unwrap();
-        let expected = "
+
+        let ssa = ssa.fold_constants_using_constraints();
+        assert_ssa_snapshot!(ssa, @r"
         brillig(inline) fn main f0 {
           b0(v0: Field, v1: Field, v2: u1):
             v5 = call to_be_radix(v0, u32 256) -> [u8; 1]
@@ -1738,9 +1729,7 @@ mod test {
             inc_rc v8
             return
         }
-        ";
-        let ssa = ssa.fold_constants_using_constraints();
-        assert_normalized_ssa_equals(ssa, expected);
+        ");
     }
 
     #[test]
@@ -1776,16 +1765,15 @@ mod test {
         ";
         let ssa = Ssa::from_str(src).unwrap();
 
-        let expected = "
+        let ssa = ssa.fold_constants_using_constraints();
+        assert_ssa_snapshot!(ssa, @r"
         acir(inline) fn main f0 {
           b0(v0: [Field; 3], v1: u32, v2: Field):
             enable_side_effects u1 1
             v4 = array_set v0, index v1, value v2
             return v2
         }
-        ";
-        let ssa = ssa.fold_constants_using_constraints();
-        assert_normalized_ssa_equals(ssa, expected);
+        ");
     }
 
     #[test]
@@ -1805,7 +1793,9 @@ mod test {
         }
         ";
 
-        let expected = "
+        let ssa = Ssa::from_str(src).unwrap();
+        let ssa = ssa.purity_analysis().fold_constants_using_constraints();
+        assert_ssa_snapshot!(ssa, @r"
         acir(inline) predicate_pure fn main f0 {
           b0(v0: Field):
             v2 = call f1(v0) -> Field
@@ -1816,11 +1806,7 @@ mod test {
           b0(v0: Field):
             return v0
         }
-        ";
-
-        let ssa = Ssa::from_str(src).unwrap();
-        let ssa = ssa.purity_analysis().fold_constants_using_constraints();
-        assert_normalized_ssa_equals(ssa, expected);
+        ");
     }
 
     #[test]
@@ -1922,7 +1908,7 @@ mod test {
         let ssa = Ssa::from_str(src).unwrap();
         let ssa = ssa.fold_constants();
 
-        let expected = "
+        assert_ssa_snapshot!(ssa, @r"
         acir(inline) fn main f0 {
           b0(v0: u32, v1: u32, v2: u1):
             enable_side_effects v2
@@ -1932,7 +1918,6 @@ mod test {
             v6 = div v1, u32 2
             return
         }
-        ";
-        assert_normalized_ssa_equals(ssa, expected);
+        ");
     }
 }

--- a/compiler/noirc_evaluator/src/ssa/opt/defunctionalize.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/defunctionalize.rs
@@ -439,7 +439,7 @@ fn build_return_block(
 
 #[cfg(test)]
 mod tests {
-    use crate::ssa::opt::assert_normalized_ssa_equals;
+    use crate::assert_ssa_snapshot;
 
     use super::Ssa;
 
@@ -479,50 +479,49 @@ mod tests {
         let ssa = Ssa::from_str(src).unwrap();
         let ssa = ssa.defunctionalize();
 
-        let expected = "
-          brillig(inline) fn main f0 {
-            b0(v0: u32):
-              v3 = call f1(Field 2, v0) -> u32
-              v5 = add v0, u32 1
-              v6 = eq v3, v5
-              constrain v3 == v5
-              v8 = call f1(Field 3, v0) -> u32
-              v9 = add v0, u32 1
-              v10 = eq v8, v9
-              constrain v8 == v9
-              return
-          }
-          brillig(inline) fn wrapper f1 {
-            b0(v0: Field, v1: u32):
-              v3 = call f4(v0, v1) -> u32
-              return v3
-          }
-          brillig(inline) fn increment f2 {
-            b0(v0: u32):
-              v2 = add v0, u32 1
-              return v2
-          }
-          brillig(inline) fn increment_acir f3 {
-            b0(v0: u32):
-              v2 = add v0, u32 1
-              return v2
-          }
-          brillig(inline_always) fn apply f4 {
-            b0(v0: Field, v1: u32):
-              v4 = eq v0, Field 2
-              jmpif v4 then: b2, else: b1
-            b1():
-              constrain v0 == Field 3
-              v9 = call f3(v1) -> u32
-              jmp b3(v9)
-            b2():
-              v6 = call f2(v1) -> u32
-              jmp b3(v6)
-            b3(v2: u32):
-              return v2
-          }
-        ";
-        assert_normalized_ssa_equals(ssa, expected);
+        assert_ssa_snapshot!(ssa, @r"
+        brillig(inline) fn main f0 {
+          b0(v0: u32):
+            v3 = call f1(Field 2, v0) -> u32
+            v5 = add v0, u32 1
+            v6 = eq v3, v5
+            constrain v3 == v5
+            v8 = call f1(Field 3, v0) -> u32
+            v9 = add v0, u32 1
+            v10 = eq v8, v9
+            constrain v8 == v9
+            return
+        }
+        brillig(inline) fn wrapper f1 {
+          b0(v0: Field, v1: u32):
+            v3 = call f4(v0, v1) -> u32
+            return v3
+        }
+        brillig(inline) fn increment f2 {
+          b0(v0: u32):
+            v2 = add v0, u32 1
+            return v2
+        }
+        brillig(inline) fn increment_acir f3 {
+          b0(v0: u32):
+            v2 = add v0, u32 1
+            return v2
+        }
+        brillig(inline_always) fn apply f4 {
+          b0(v0: Field, v1: u32):
+            v4 = eq v0, Field 2
+            jmpif v4 then: b2, else: b1
+          b1():
+            constrain v0 == Field 3
+            v9 = call f3(v1) -> u32
+            jmp b3(v9)
+          b2():
+            v6 = call f2(v1) -> u32
+            jmp b3(v6)
+          b3(v2: u32):
+            return v2
+        }
+        ");
     }
 
     #[test]

--- a/compiler/noirc_evaluator/src/ssa/opt/hint.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/hint.rs
@@ -3,12 +3,10 @@ mod tests {
     use acvm::acir::circuit::ExpressionWidth;
 
     use crate::{
+        assert_ssa_snapshot,
         brillig::BrilligOptions,
         errors::RuntimeError,
-        ssa::{
-            Ssa, SsaBuilder, SsaEvaluatorOptions, SsaLogging, opt::assert_normalized_ssa_equals,
-            optimize_all,
-        },
+        ssa::{Ssa, SsaBuilder, SsaEvaluatorOptions, SsaLogging, optimize_all},
     };
 
     fn run_all_passes(ssa: Ssa) -> Result<Ssa, RuntimeError> {
@@ -84,23 +82,20 @@ mod tests {
           }
         ";
 
-        // After Array Set Optimizations:
-        let expected = "
-          acir(inline) impure fn main f0 {
-            b0(v0: u32):
-              constrain u32 50 == v0
-              v4 = call black_box(u32 10) -> u32
-              v5 = add v4, v4
-              v6 = add v5, v4
-              v7 = add v6, v4
-              v8 = add v7, v4
-              constrain v8 == u32 50
-              return
-          }
-        ";
-
         let ssa = Ssa::from_str(src).unwrap();
         let ssa = run_all_passes(ssa).unwrap();
-        assert_normalized_ssa_equals(ssa, expected);
+        assert_ssa_snapshot!(ssa, @r"
+        acir(inline) impure fn main f0 {
+          b0(v0: u32):
+            constrain u32 50 == v0
+            v4 = call black_box(u32 10) -> u32
+            v5 = add v4, v4
+            v6 = add v5, v4
+            v7 = add v6, v4
+            v8 = add v7, v4
+            constrain v8 == u32 50
+            return
+        }
+        ");
     }
 }

--- a/compiler/noirc_evaluator/src/ssa/opt/inlining.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/inlining.rs
@@ -787,18 +787,15 @@ mod test {
     use acvm::{FieldElement, acir::AcirField};
     use noirc_frontend::monomorphization::ast::InlineType;
 
-    use crate::ssa::{
-        Ssa,
-        function_builder::FunctionBuilder,
-        ir::{
+    use crate::{assert_ssa_snapshot, ssa::{
+        function_builder::FunctionBuilder, ir::{
             basic_block::BasicBlockId,
             function::RuntimeType,
             instruction::{BinaryOp, Intrinsic, TerminatorInstruction},
             map::Id,
             types::{NumericType, Type},
-        },
-        opt::{assert_normalized_ssa_equals, inlining::inline_info::compute_bottom_up_order},
-    };
+        }, opt::inlining::inline_info::compute_bottom_up_order, Ssa
+    }};
 
     #[test]
     fn basic_inlining() {
@@ -1288,7 +1285,8 @@ mod test {
         ";
         let ssa = Ssa::from_str(src).unwrap();
 
-        let expected = "
+        let ssa = ssa.inline_simple_functions();
+        assert_ssa_snapshot!(ssa, @r"
         acir(inline) fn main f0 {
           b0(v0: Field):
             v1 = add v0, v0
@@ -1298,10 +1296,7 @@ mod test {
           b0(v0: Field):
             return v0
         }
-        ";
-
-        let ssa = ssa.inline_simple_functions();
-        assert_normalized_ssa_equals(ssa, expected);
+        ");
     }
 
     #[test]
@@ -1323,7 +1318,8 @@ mod test {
         ";
         let ssa = Ssa::from_str(src).unwrap();
 
-        let expected = "
+        let ssa = ssa.inline_simple_functions();
+        assert_ssa_snapshot!(ssa, @r"
         acir(inline) fn main f0 {
           b0(v0: Field):
             v2 = add v0, Field 1
@@ -1336,9 +1332,6 @@ mod test {
             v2 = add v0, Field 1
             return v2
         }
-        ";
-
-        let ssa = ssa.inline_simple_functions();
-        assert_normalized_ssa_equals(ssa, expected);
+        ");
     }
 }

--- a/compiler/noirc_evaluator/src/ssa/opt/inlining.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/inlining.rs
@@ -787,15 +787,21 @@ mod test {
     use acvm::{FieldElement, acir::AcirField};
     use noirc_frontend::monomorphization::ast::InlineType;
 
-    use crate::{assert_ssa_snapshot, ssa::{
-        function_builder::FunctionBuilder, ir::{
-            basic_block::BasicBlockId,
-            function::RuntimeType,
-            instruction::{BinaryOp, Intrinsic, TerminatorInstruction},
-            map::Id,
-            types::{NumericType, Type},
-        }, opt::inlining::inline_info::compute_bottom_up_order, Ssa
-    }};
+    use crate::{
+        assert_ssa_snapshot,
+        ssa::{
+            Ssa,
+            function_builder::FunctionBuilder,
+            ir::{
+                basic_block::BasicBlockId,
+                function::RuntimeType,
+                instruction::{BinaryOp, Intrinsic, TerminatorInstruction},
+                map::Id,
+                types::{NumericType, Type},
+            },
+            opt::inlining::inline_info::compute_bottom_up_order,
+        },
+    };
 
     #[test]
     fn basic_inlining() {

--- a/compiler/noirc_evaluator/src/ssa/opt/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/mod.rs
@@ -79,3 +79,12 @@ pub(crate) fn assert_normalized_ssa_equals(mut ssa: super::Ssa, expected: &str) 
     println!("Got:\n~~~\n{ssa}\n~~~");
     similar_asserts::assert_eq!(expected_ssa, ssa);
 }
+
+#[macro_export]
+macro_rules! assert_ssa_snapshot {
+    ($ssa:expr, $($arg:tt)*) => {
+        let mut mut_ssa = $ssa;
+        mut_ssa.normalize_ids();
+        insta::assert_snapshot!(mut_ssa, $($arg)*)
+    };
+}

--- a/compiler/noirc_evaluator/src/ssa/opt/remove_truncate_after_range_check.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/remove_truncate_after_range_check.rs
@@ -79,7 +79,10 @@ impl Function {
 
 #[cfg(test)]
 mod tests {
-    use crate::ssa::{opt::assert_normalized_ssa_equals, ssa_gen::Ssa};
+    use crate::{
+        assert_ssa_snapshot,
+        ssa::{opt::assert_normalized_ssa_equals, ssa_gen::Ssa},
+    };
 
     #[test]
     fn removes_truncate_after_range_check_with_same_bit_size() {
@@ -94,18 +97,15 @@ mod tests {
         ";
 
         let ssa = Ssa::from_str(src).unwrap();
-
-        let expected = "
+        let ssa = ssa.remove_truncate_after_range_check();
+        assert_ssa_snapshot!(ssa, @r"
         acir(inline) predicate_pure fn main f0 {
           b0(v0: Field):
             range_check v0 to 64 bits
             range_check v0 to 32 bits
             return v0
         }
-        ";
-
-        let ssa = ssa.remove_truncate_after_range_check();
-        assert_normalized_ssa_equals(ssa, expected);
+        ");
     }
 
     #[test]
@@ -120,17 +120,14 @@ mod tests {
         ";
 
         let ssa = Ssa::from_str(src).unwrap();
-
-        let expected = "
+        let ssa = ssa.remove_truncate_after_range_check();
+        assert_ssa_snapshot!(ssa, @r"
         acir(inline) predicate_pure fn main f0 {
           b0(v0: Field):
             range_check v0 to 16 bits
             return v0
         }
-        ";
-
-        let ssa = ssa.remove_truncate_after_range_check();
-        assert_normalized_ssa_equals(ssa, expected);
+        ");
     }
 
     #[test]

--- a/compiler/noirc_evaluator/src/ssa/opt/remove_unreachable.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/remove_unreachable.rs
@@ -85,7 +85,7 @@ fn used_functions(func: &Function) -> BTreeSet<FunctionId> {
 
 #[cfg(test)]
 mod tests {
-    use crate::ssa::opt::assert_normalized_ssa_equals;
+    use crate::assert_ssa_snapshot;
 
     use super::Ssa;
 
@@ -115,21 +115,20 @@ mod tests {
         let ssa = Ssa::from_str(src).unwrap();
         let ssa = ssa.remove_unreachable_functions();
 
-        let expected = "
-          brillig(inline) fn main f0 {
-            b0(v0: u32):
-              v2 = call f1(v0) -> u32
-              v4 = add v0, u32 1
-              v5 = eq v2, v4
-              constrain v2 == v4
-              return
-          }
-          brillig(inline) fn increment f1 {
-            b0(v0: u32):
-              v2 = add v0, u32 1
-              return v2
-          }
-        ";
-        assert_normalized_ssa_equals(ssa, expected);
+        assert_ssa_snapshot!(ssa, @r"
+        brillig(inline) fn main f0 {
+          b0(v0: u32):
+            v2 = call f1(v0) -> u32
+            v4 = add v0, u32 1
+            v5 = eq v2, v4
+            constrain v2 == v4
+            return
+        }
+        brillig(inline) fn increment f1 {
+          b0(v0: u32):
+            v2 = add v0, u32 1
+            return v2
+        }
+        ");
     }
 }

--- a/compiler/noirc_evaluator/src/ssa/opt/simplify_cfg.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/simplify_cfg.rs
@@ -294,15 +294,18 @@ fn try_inline_into_predecessor(
 
 #[cfg(test)]
 mod test {
-    use crate::ssa::{
-        Ssa,
-        function_builder::FunctionBuilder,
-        ir::{
-            instruction::{BinaryOp, TerminatorInstruction},
-            map::Id,
-            types::Type,
+    use crate::{
+        assert_ssa_snapshot,
+        ssa::{
+            Ssa,
+            function_builder::FunctionBuilder,
+            ir::{
+                instruction::{BinaryOp, TerminatorInstruction},
+                map::Id,
+                types::Type,
+            },
+            opt::assert_normalized_ssa_equals,
         },
-        opt::assert_normalized_ssa_equals,
     };
     use acvm::acir::AcirField;
 
@@ -437,7 +440,7 @@ mod test {
         }";
         let ssa = Ssa::from_str(src).unwrap();
 
-        let expected = "
+        assert_ssa_snapshot!(ssa.simplify_cfg(), @r"
         brillig(inline) fn main f0 {
           b0(v0: u1):
             v1 = allocate -> &mut Field
@@ -452,8 +455,8 @@ mod test {
             v6 = eq v5, Field 2
             constrain v5 == Field 2
             return
-        }";
-        assert_normalized_ssa_equals(ssa.simplify_cfg(), expected);
+        }
+        ");
     }
 
     #[test]

--- a/compiler/noirc_evaluator/src/ssa/opt/unrolling.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/unrolling.rs
@@ -1032,6 +1032,7 @@ mod tests {
     use acvm::FieldElement;
     use test_case::test_case;
 
+    use crate::assert_ssa_snapshot;
     use crate::errors::RuntimeError;
     use crate::ssa::{Ssa, ir::value::ValueId, opt::assert_normalized_ssa_equals};
 
@@ -1085,7 +1086,13 @@ mod tests {
         ";
         let ssa = Ssa::from_str(src).unwrap();
 
-        let expected = "
+        // The final block count is not 1 because unrolling creates some unnecessary jmps.
+        // If a simplify cfg pass is ran afterward, the expected block count will be 1.
+        let (ssa, errors) = try_unroll_loops(ssa);
+        assert_eq!(errors.len(), 0, "All loops should be unrolled");
+        assert_eq!(ssa.main().reachable_blocks().len(), 5);
+
+        assert_ssa_snapshot!(ssa, @r"
         acir(inline) fn main f0 {
           b0():
             constrain u1 0 == Field 1
@@ -1110,15 +1117,7 @@ mod tests {
           b4():
             jmp b1()
         }
-        ";
-
-        // The final block count is not 1 because unrolling creates some unnecessary jmps.
-        // If a simplify cfg pass is ran afterward, the expected block count will be 1.
-        let (ssa, errors) = try_unroll_loops(ssa);
-        assert_eq!(errors.len(), 0, "All loops should be unrolled");
-        assert_eq!(ssa.main().reachable_blocks().len(), 5);
-
-        assert_normalized_ssa_equals(ssa, expected);
+        ");
     }
 
     // Test that the pass can still be run on loops which fail to unroll properly
@@ -1217,9 +1216,13 @@ mod tests {
     fn test_brillig_unroll_small_loop() {
         let ssa = brillig_unroll_test_case();
 
+        let (ssa, errors) = try_unroll_loops(ssa);
+        assert_eq!(errors.len(), 0, "Unroll should have no errors");
+        assert_eq!(ssa.main().reachable_blocks().len(), 2, "The loop should be unrolled");
+
         // Expectation taken by compiling the Noir program as ACIR,
         // ie. by removing the `unconstrained` from `main`.
-        let expected = "
+        assert_ssa_snapshot!(ssa, @r"
         brillig(inline) fn main f0 {
           b0(v0: u32):
             v1 = allocate -> &mut u32
@@ -1242,13 +1245,7 @@ mod tests {
             constrain v13 == v0
             return
         }
-        ";
-
-        let (ssa, errors) = try_unroll_loops(ssa);
-        assert_eq!(errors.len(), 0, "Unroll should have no errors");
-        assert_eq!(ssa.main().reachable_blocks().len(), 2, "The loop should be unrolled");
-
-        assert_normalized_ssa_equals(ssa, expected);
+        ");
     }
 
     /// Test that we can unroll the loop in the ticket if we don't have too many iterations.
@@ -1260,8 +1257,7 @@ mod tests {
         assert_eq!(errors.len(), 0, "Unroll should have no errors");
         assert_eq!(ssa.main().reachable_blocks().len(), 2, "The loop should be unrolled");
 
-        // The IDs are shifted by one compared to what the ACIR version printed.
-        let expected = "
+        assert_ssa_snapshot!(ssa, @r"
         brillig(inline) fn main f0 {
           b0(v0: [u64; 6]):
             inc_rc v0
@@ -1290,8 +1286,7 @@ mod tests {
             dec_rc v0
             return v20
         }
-        ";
-        assert_normalized_ssa_equals(ssa, expected);
+        ");
     }
 
     /// Test that with more iterations it's not unrolled.


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

Follow on from #7984 .

This PR adds an example of using insta for our snapshot testing in SSA passes. I've created a `assert_ssa_snapshot!` macro which will automatically normalize the SSA before snapshotting it for devex.

I'd really recommend having a quick read of https://insta.rs/docs/quickstart/ if you're not familiar.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
