### PR TITLE
fix(parser): error on missing function body

### DIFF
--- a/compiler/noirc_frontend/src/parser/errors.rs
+++ b/compiler/noirc_frontend/src/parser/errors.rs
@@ -248,7 +248,7 @@ impl std::fmt::Display for ParserError {
         } else {
             let expected = expected.iter().map(ToString::to_string).collect::<Vec<_>>().join(", ");
 
-            write!(f, "Unexpected {:?}, expected one of {}{}", self.found, expected, reason_str)
+            write!(f, "Unexpected '{}', expected one of {}{}", self.found, expected, reason_str)
         }
     }
 }

--- a/test_programs/compile_failure/builtin_function_declaration/src/main.nr
+++ b/test_programs/compile_failure/builtin_function_declaration/src/main.nr
@@ -2,7 +2,7 @@
 
 // This would otherwise be a perfectly valid declaration of the `to_le_bits` builtin function
 #[builtin(to_le_bits)]
-fn to_le_bits<let N: u32>(_x: Field) -> [u1: N] {}
+fn to_le_bits<let N: u32>(_x: Field) -> [u1; N] {}
 
 fn main(x: Field) -> pub u1 {
     let bits: [u1; 100] = to_le_bits(x);

--- a/test_programs/compile_failure/builtin_function_declaration/stderr.txt
+++ b/test_programs/compile_failure/builtin_function_declaration/stderr.txt
@@ -1,57 +1,8 @@
 error: Definition of low-level function outside of standard library
   ┌─ src/main.nr:5:4
   │
-5 │ fn to_le_bits<let N: u32>(_x: Field) -> [u1: N] {}
+5 │ fn to_le_bits<let N: u32>(_x: Field) -> [u1; N] {}
   │    ---------- Usage of the `#[foreign]` or `#[builtin]` function attributes are not allowed outside of the Noir standard library
   │
 
-error: Expected type [u1; 100], found type [u1]
-  ┌─ src/main.nr:8:27
-  │
-8 │     let bits: [u1; 100] = to_le_bits(x);
-  │                           -------------
-  │
-
-error: Expected a ']' but found ':'
-  ┌─ src/main.nr:5:44
-  │
-5 │ fn to_le_bits<let N: u32>(_x: Field) -> [u1: N] {}
-  │                                            -
-  │
-
-error: Expected an item but found ':'
-  ┌─ src/main.nr:5:44
-  │
-5 │ fn to_le_bits<let N: u32>(_x: Field) -> [u1: N] {}
-  │                                            -
-  │
-
-error: Expected an item but found 'N'
-  ┌─ src/main.nr:5:46
-  │
-5 │ fn to_le_bits<let N: u32>(_x: Field) -> [u1: N] {}
-  │                                              -
-  │
-
-error: Expected an item but found ']'
-  ┌─ src/main.nr:5:47
-  │
-5 │ fn to_le_bits<let N: u32>(_x: Field) -> [u1: N] {}
-  │                                               -
-  │
-
-error: Expected an item but found '{'
-  ┌─ src/main.nr:5:49
-  │
-5 │ fn to_le_bits<let N: u32>(_x: Field) -> [u1: N] {}
-  │                                                 -
-  │
-
-error: Expected an item but found '}'
-  ┌─ src/main.nr:5:50
-  │
-5 │ fn to_le_bits<let N: u32>(_x: Field) -> [u1: N] {}
-  │                                                  -
-  │
-
-Aborting due to 8 previous errors
+Aborting due to 1 previous error


### PR DESCRIPTION
# Description

## Problem

Resolves #7997

## Summary

The issue was that when the parser didn't find `{ ... }` for a function, it would return an empty body but not error. Without an error the formatter tried to format it and panicked. Now the parser will produce an error in this case.

## Additional Context

Also fixes a syntax error in a test.

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
