### PR TITLE
chore: improve checking of github urls in `noir_wasm`

### DIFF
--- a/compiler/wasm/src/noir/dependencies/github-dependency-resolver.ts
+++ b/compiler/wasm/src/noir/dependencies/github-dependency-resolver.ts
@@ -32,7 +32,7 @@ export class GithubDependencyResolver implements DependencyResolver {
   async resolveDependency(_pkg: Package, dependency: DependencyConfig): Promise<Dependency | null> {
     // TODO accept ssh urls?
     // TODO github authentication?
-    if (!('git' in dependency) || !dependency.git.startsWith('https://github.com')) {
+    if (!('git' in dependency) || new URL(dependency.git).hostname != 'github.com') {
       return null;
     }
 


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This PR addresses a false positive security alert warning of incomplete sanitation of urls. Any malicious urls which get through this check will be caught by `resolveGithubCodeArchive` however there's no reason to not do the secure check everywhere.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
