### PR TITLE
fix(ssa): Map terminator instructions after constant folding 

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/opt/constant_folding.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/constant_folding.rs
@@ -234,9 +234,9 @@ impl<'brillig> Context<'brillig> {
         &mut self,
         function: &mut Function,
         dom: &mut DominatorTree,
-        block: BasicBlockId,
+        block_id: BasicBlockId,
     ) {
-        let instructions = function.dfg[block].take_instructions();
+        let instructions = function.dfg[block_id].take_instructions();
 
         // Default side effect condition variable with an enabled state.
         let mut side_effects_enabled_var =
@@ -246,12 +246,22 @@ impl<'brillig> Context<'brillig> {
             self.fold_constants_into_instruction(
                 function,
                 dom,
-                block,
+                block_id,
                 instruction_id,
                 &mut side_effects_enabled_var,
             );
         }
-        self.block_queue.extend(function.dfg[block].successors());
+
+        let cache = self.get_constraint_map(side_effects_enabled_var);
+        // Map a terminator in place, replacing any ValueId in the terminator with the
+        // resolved version of that value id from the simplification cache's internal value mapping.
+        let mut terminator = function.dfg[block_id].take_terminator();
+        terminator.map_values_mut(|value| {
+            Self::resolve_cache(block_id, &mut function.dfg, dom, self.get_constraint_map(side_effects_enabled_var), value)
+        });
+        function.dfg[block_id].set_terminator(terminator);
+
+        self.block_queue.extend(function.dfg[block_id].successors());
     }
 
     fn fold_constants_into_instruction(
@@ -334,6 +344,31 @@ impl<'brillig> Context<'brillig> {
         };
     }
 
+    // Alternate between resolving `value_id` in the `dfg` and checking to see if the resolved value
+    // has been constrained to be equal to some simpler value in the current block.
+    //
+    // This allows us to reach a stable final `ValueId` for each instruction input as we add more
+    // constraints to the cache.
+    fn resolve_cache(
+        block: BasicBlockId,
+        dfg: &DataFlowGraph,
+        dom: &mut DominatorTree,
+        cache: &HashMap<ValueId, SimplificationCache>,
+        value_id: ValueId,
+    ) -> ValueId {
+        let resolved_id = dfg.resolve(value_id);
+        match cache.get(&resolved_id) {
+            Some(simplification_cache) => {
+                if let Some(simplified) = simplification_cache.get(block, dom) {
+                    Self::resolve_cache(block, dfg, dom, cache, simplified)
+                } else {
+                    resolved_id
+                }
+            }
+            None => resolved_id,
+        }
+    }
+
     /// Fetches an [`Instruction`] by its [`InstructionId`] and fully resolves its inputs.
     fn resolve_instruction(
         instruction_id: InstructionId,
@@ -344,34 +379,9 @@ impl<'brillig> Context<'brillig> {
     ) -> Instruction {
         let mut instruction = dfg[instruction_id].clone();
 
-        // Alternate between resolving `value_id` in the `dfg` and checking to see if the resolved value
-        // has been constrained to be equal to some simpler value in the current block.
-        //
-        // This allows us to reach a stable final `ValueId` for each instruction input as we add more
-        // constraints to the cache.
-        fn resolve_cache(
-            block: BasicBlockId,
-            dfg: &DataFlowGraph,
-            dom: &mut DominatorTree,
-            cache: &HashMap<ValueId, SimplificationCache>,
-            value_id: ValueId,
-        ) -> ValueId {
-            let resolved_id = dfg.resolve(value_id);
-            match cache.get(&resolved_id) {
-                Some(simplification_cache) => {
-                    if let Some(simplified) = simplification_cache.get(block, dom) {
-                        resolve_cache(block, dfg, dom, cache, simplified)
-                    } else {
-                        resolved_id
-                    }
-                }
-                None => resolved_id,
-            }
-        }
-
         // Resolve any inputs to ensure that we're comparing like-for-like instructions.
         instruction.map_values_mut(|value_id| {
-            resolve_cache(block, dfg, dom, constraint_simplification_mapping, value_id)
+            Self::resolve_cache(block, dfg, dom, constraint_simplification_mapping, value_id)
         });
         instruction.map_values(|v| dfg.resolve(v))
     }

--- a/cspell.json
+++ b/cspell.json
@@ -62,6 +62,7 @@
         "compinit",
         "comptime",
         "concat",
+        "cond",
         "cpus",
         "cranelift",
         "critesjosh",

--- a/test_programs/execution_success/double_neg_cond_bool_input/Nargo.toml
+++ b/test_programs/execution_success/double_neg_cond_bool_input/Nargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "double_neg_cond_bool_input"
+type = "bin"
+authors = [""]
+
+[dependencies]

--- a/test_programs/execution_success/double_neg_cond_bool_input/src/main.nr
+++ b/test_programs/execution_success/double_neg_cond_bool_input/src/main.nr
@@ -1,0 +1,7 @@
+unconstrained fn main(a: bool) -> pub Field {
+    if ((!a) > (!a)) {
+        (-(-(a as Field)))
+    } else {
+        (-(-(a as Field)))
+    }
+}

--- a/test_programs/execution_success/double_neg_cond_global_var/Nargo.toml
+++ b/test_programs/execution_success/double_neg_cond_global_var/Nargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "double_neg_cond_global_var"
+type = "bin"
+authors = [""]
+
+[dependencies]

--- a/test_programs/execution_success/double_neg_cond_global_var/src/main.nr
+++ b/test_programs/execution_success/double_neg_cond_global_var/src/main.nr
@@ -1,0 +1,22 @@
+// Regression from issue #7964 (https://github.com/noir-lang/noir/issues/7964)
+global G_A: bool = false;
+fn main(a: Field) -> pub Field {
+    if (
+        (
+            if (!G_A) {
+                if (!G_A) {
+                    (a as u128)
+                } else {
+                    (a as u128)
+                }
+            } else {
+                (a as u128)
+            }
+                <= (a as u128)
+        ) as bool
+    ) {
+        (-(-a))
+    } else {
+        (-(-a))
+    }
+}


### PR DESCRIPTION
…ant folding

# Description

## Problem\*

Resolves #7964 

I noticed the supplied program in the issue would not fail when I had `--show-ssa` activated. Looking at the SSA we can see the jmpif condition is simplified from instructions to a constant value during constant folding:
```
After Purity Analysis (2nd):
g0 = u1 0

brillig(inline) predicate_pure fn main f0 {
  b0(v1: Field):
    v3 = truncate v1 to 128 bits, max_bit_size: 254
    v4 = cast v3 as u128
    v5 = truncate v1 to 128 bits, max_bit_size: 254
    v6 = cast v5 as u128
    v7 = lt v6, v4
    v8 = not v7
    jmpif v7 then: b1, else: b2
  b1():
    v12 = sub Field 0, v1
    v13 = sub Field 0, v12
    jmp b3(v13)
  b2():
    v10 = sub Field 0, v1
    v11 = sub Field 0, v10
    jmp b3(v11)
  b3(v2: Field):
    return v2
}

After Constant Folding:
g0 = u1 0

brillig(inline) predicate_pure fn main f0 {
  b0(v1: Field):
    v3 = truncate v1 to 128 bits, max_bit_size: 254
    v4 = cast v3 as u128
    jmpif u1 0 then: b1, else: b2
  b1():
    v8 = sub Field 0, v1
    v9 = sub Field 0, v8
    jmp b3(v9)
  b2():
    v6 = sub Field 0, v1
    v7 = sub Field 0, v6
    jmp b3(v7)
  b3(v2: Field):
    return v2
}
```
The fact that the instruction ID is missing made me think to check whether we were resolving the terminators of blocks during constant folding.

## Summary\*

I simply added logic similar to `map_terminator_in_place` that exists on the `FunctionInserter`. I had tried to make some sort of the shared method on `BasicBlock` or `Function` but `resolve_cache` needs to borrow the dfg which runs into issues with the borrow checker. Thus, just setting and mapping the terminator during the pass felt simplest.

## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
