### PR TITLE
chore: fix failing test on MacOS

### DIFF
--- a/tooling/nargo_cli/tests/hello_world.rs
+++ b/tooling/nargo_cli/tests/hello_world.rs
@@ -21,7 +21,11 @@ fn hello_world_example() {
     cmd.arg("new").arg(project_name);
     cmd.assert().success().stdout(predicate::str::contains(format!(
         "Project successfully created! It is located at {}",
-        project_dir.display()
+        // Note: on MacOS `test_dir` will be something like `/var/folders/...` but when asking
+        // what's the current dir it will be `/private/var/folders/...`, and that's what
+        // the command output will include. That's why we use `current_dir` here instead of
+        // relying on `test_dir` or `project_dir` above.
+        std::env::current_dir().unwrap().join(project_name).display()
     )));
 
     project_dir.child("src").assert(predicate::path::is_dir());


### PR DESCRIPTION
# Description

## Problem

Running the tests on arm64 currently fail because of one test.

## Summary

This test actually always failed for me (I have a Mac) but always thought that test didn't run in CI.

See the comment in the PR's code for the fix. I have no idea why Mac does this...

## Additional Context



## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
