### PR TITLE
chore: remove unnecessary double compilation

### DIFF
--- a/compiler/noirc_driver/src/lib.rs
+++ b/compiler/noirc_driver/src/lib.rs
@@ -174,10 +174,6 @@ pub struct CompileOptions {
     #[arg(long, default_value = "false")]
     pub pedantic_solving: bool,
 
-    /// Used internally to test for non-determinism in the compiler.
-    #[clap(long, hide = true)]
-    pub check_non_determinism: bool,
-
     /// Unstable features to enable for this current build
     #[arg(value_parser = clap::value_parser!(UnstableFeature))]
     #[clap(long, short = 'Z', value_delimiter = ',')]

--- a/tooling/nargo_cli/src/cli/compile_cmd.rs
+++ b/tooling/nargo_cli/src/cli/compile_cmd.rs
@@ -206,23 +206,6 @@ fn compile_programs(
             cached_program,
         )?;
 
-        if compile_options.check_non_determinism {
-            // As we compile the program again, disable comptime printing so we don't get duplicate output
-            let compile_options =
-                CompileOptions { disable_comptime_printing: true, ..compile_options.clone() };
-            let (program_two, _) = compile_program(
-                file_manager,
-                parsed_files,
-                workspace,
-                package,
-                &compile_options,
-                load_cached_program(package),
-            )?;
-            if fxhash::hash64(&program) != fxhash::hash64(&program_two) {
-                panic!("Non deterministic result compiling {}", package.name);
-            }
-        }
-
         // Choose the target width for the final, backend specific transformation.
         let target_width =
             get_target_width(package.expression_width, compile_options.expression_width);

--- a/tooling/nargo_cli/tests/execute.rs
+++ b/tooling/nargo_cli/tests/execute.rs
@@ -31,8 +31,6 @@ mod tests {
         nargo.arg("--program-dir").arg(test_program_dir);
         nargo.arg(test_command).arg("--force");
         nargo.arg("--inliner-aggressiveness").arg(inliner_aggressiveness.0.to_string());
-        // Check whether the test case is non-deterministic
-        nargo.arg("--check-non-determinism");
         // Allow more bytecode in exchange to catch illegal states.
         nargo.arg("--enable-brillig-debug-assertions");
 


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

After #7986, we're testing for non-determinism by checking against the build artifact snapshot. We can then avoid having to compile every program twice.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
