### PR TITLE
fix(docs): fix proof splitting script in solidity guide

### DIFF
--- a/docs/docs/how_to/how-to-solidity-verifier.mdx
+++ b/docs/docs/how_to/how-to-solidity-verifier.mdx
@@ -141,10 +141,10 @@ Barretenberg attaches the public inputs to the proof, which in this case it's no
 PROOF_HEX=$(cat ./target/proof | od -An -v -t x1 | tr -d $' \n' | sed 's/^.\{8\}//')
 
 NUM_PUBLIC_INPUTS=2
-HEX_PUBLIC_INPUTS=${PROOF_HEX:192:$((32 * $NUM_PUBLIC_INPUTS * 2))}
+HEX_PUBLIC_INPUTS=${PROOF_HEX:0:$((32 * $NUM_PUBLIC_INPUTS * 2))}
 SPLIT_HEX_PUBLIC_INPUTS=$(sed -e 's/.\{64\}/0x&,/g' <<<$HEX_PUBLIC_INPUTS)
 
-PROOF_WITHOUT_PUBLIC_INPUTS="${PROOF_HEX:0:192}${PROOF_HEX:$((192 + $NUM_PUBLIC_INPUTS * 32 * 2))}"
+PROOF_WITHOUT_PUBLIC_INPUTS="${PROOF_HEX:$((NUM_PUBLIC_INPUTS * 32 * 2))}"
 
 echo 0x$PROOF_WITHOUT_PUBLIC_INPUTS
 echo [$SPLIT_HEX_PUBLIC_INPUTS]

--- a/docs/versioned_docs/version-1.0.0-beta.4/how_to/how-to-solidity-verifier.mdx
+++ b/docs/versioned_docs/version-1.0.0-beta.4/how_to/how-to-solidity-verifier.mdx
@@ -141,10 +141,10 @@ Barretenberg attaches the public inputs to the proof, which in this case it's no
 PROOF_HEX=$(cat ./target/proof | od -An -v -t x1 | tr -d $' \n' | sed 's/^.\{8\}//')
 
 NUM_PUBLIC_INPUTS=2
-HEX_PUBLIC_INPUTS=${PROOF_HEX:192:$((32 * $NUM_PUBLIC_INPUTS * 2))}
+HEX_PUBLIC_INPUTS=${PROOF_HEX:0:$((32 * $NUM_PUBLIC_INPUTS * 2))}
 SPLIT_HEX_PUBLIC_INPUTS=$(sed -e 's/.\{64\}/0x&,/g' <<<$HEX_PUBLIC_INPUTS)
 
-PROOF_WITHOUT_PUBLIC_INPUTS="${PROOF_HEX:0:192}${PROOF_HEX:$((192 + $NUM_PUBLIC_INPUTS * 32 * 2))}"
+PROOF_WITHOUT_PUBLIC_INPUTS="${PROOF_HEX:$((NUM_PUBLIC_INPUTS * 32 * 2))}"
 
 echo 0x$PROOF_WITHOUT_PUBLIC_INPUTS
 echo [$SPLIT_HEX_PUBLIC_INPUTS]

--- a/docs/versioned_docs/version-v1.0.0-beta.2/how_to/how-to-solidity-verifier.mdx
+++ b/docs/versioned_docs/version-v1.0.0-beta.2/how_to/how-to-solidity-verifier.mdx
@@ -141,10 +141,10 @@ Barretenberg attaches the public inputs to the proof, which in this case it's no
 PROOF_HEX=$(cat ./target/proof | od -An -v -t x1 | tr -d $' \n' | sed 's/^.\{8\}//')
 
 NUM_PUBLIC_INPUTS=2
-HEX_PUBLIC_INPUTS=${PROOF_HEX:192:$((32 * $NUM_PUBLIC_INPUTS * 2))}
+HEX_PUBLIC_INPUTS=${PROOF_HEX:0:$((32 * $NUM_PUBLIC_INPUTS * 2))}
 SPLIT_HEX_PUBLIC_INPUTS=$(sed -e 's/.\{64\}/0x&,/g' <<<$HEX_PUBLIC_INPUTS)
 
-PROOF_WITHOUT_PUBLIC_INPUTS="${PROOF_HEX:0:192}${PROOF_HEX:$((192 + $NUM_PUBLIC_INPUTS * 32 * 2))}"
+PROOF_WITHOUT_PUBLIC_INPUTS="${PROOF_HEX:$((NUM_PUBLIC_INPUTS * 32 * 2))}"
 
 echo 0x$PROOF_WITHOUT_PUBLIC_INPUTS
 echo [$SPLIT_HEX_PUBLIC_INPUTS]

--- a/docs/versioned_docs/version-v1.0.0-beta.3/how_to/how-to-solidity-verifier.mdx
+++ b/docs/versioned_docs/version-v1.0.0-beta.3/how_to/how-to-solidity-verifier.mdx
@@ -141,10 +141,10 @@ Barretenberg attaches the public inputs to the proof, which in this case it's no
 PROOF_HEX=$(cat ./target/proof | od -An -v -t x1 | tr -d $' \n' | sed 's/^.\{8\}//')
 
 NUM_PUBLIC_INPUTS=2
-HEX_PUBLIC_INPUTS=${PROOF_HEX:192:$((32 * $NUM_PUBLIC_INPUTS * 2))}
+HEX_PUBLIC_INPUTS=${PROOF_HEX:0:$((32 * $NUM_PUBLIC_INPUTS * 2))}
 SPLIT_HEX_PUBLIC_INPUTS=$(sed -e 's/.\{64\}/0x&,/g' <<<$HEX_PUBLIC_INPUTS)
 
-PROOF_WITHOUT_PUBLIC_INPUTS="${PROOF_HEX:0:192}${PROOF_HEX:$((192 + $NUM_PUBLIC_INPUTS * 32 * 2))}"
+PROOF_WITHOUT_PUBLIC_INPUTS="${PROOF_HEX:$((NUM_PUBLIC_INPUTS * 32 * 2))}"
 
 echo 0x$PROOF_WITHOUT_PUBLIC_INPUTS
 echo [$SPLIT_HEX_PUBLIC_INPUTS]


### PR DESCRIPTION
# Description

## Problem\*

Fix proof split script to match bb 0.82.2 in solidity verifier docs


## Summary\*



## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
