### PR TITLE
chore: don't use `set_value_from_id` in `remove_truncate_after_range_checks`

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/ir/dfg.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/dfg.rs
@@ -389,7 +389,7 @@ impl DataFlowGraph {
     pub(crate) fn replace_values_in_block(
         &mut self,
         block: BasicBlockId,
-        values_to_replace: &std::collections::HashMap<ValueId, ValueId>,
+        values_to_replace: &HashMap<ValueId, ValueId>,
     ) {
         if values_to_replace.is_empty() {
             return;

--- a/compiler/noirc_evaluator/src/ssa/opt/remove_truncate_after_range_check.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/remove_truncate_after_range_check.rs
@@ -93,7 +93,7 @@ mod tests {
           b0(v0: Field):
             range_check v0 to 64 bits // This is to make sure we keep the smallest one
             range_check v0 to 32 bits
-            jmp b1()
+            jmp b1() // Make sure the optimization is applied across blocks
           b1():
             v1 = truncate v0 to 32 bits, max_bit_size: 254
             return v1

--- a/compiler/noirc_evaluator/src/ssa/opt/remove_truncate_after_range_check.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/remove_truncate_after_range_check.rs
@@ -21,11 +21,15 @@ impl Ssa {
 
 impl Function {
     pub(crate) fn remove_truncate_after_range_check(&mut self) {
-        for block in self.reachable_blocks() {
+        let mut values_to_replace = HashMap::<ValueId, ValueId>::default();
+
+        let blocks = self.reachable_blocks();
+        for block in &blocks {
+            let block = *block;
+
             // Keeps the minimum bit size a value was range-checked against
             let mut range_checks: HashMap<ValueId, u32> = HashMap::default();
             let mut instructions_to_remove = HashSet::default();
-            let mut values_to_replace = HashMap::<ValueId, ValueId>::default();
 
             for instruction_id in self.dfg[block].instructions() {
                 let instruction = &self.dfg[*instruction_id];
@@ -70,9 +74,9 @@ impl Function {
             self.dfg[block]
                 .instructions_mut()
                 .retain(|instruction| !instructions_to_remove.contains(instruction));
-
-            self.dfg.replace_values_in_block(block, &values_to_replace);
         }
+
+        self.dfg.replace_values_in_blocks(blocks.into_iter(), &values_to_replace);
     }
 }
 

--- a/compiler/noirc_evaluator/src/ssa/opt/remove_truncate_after_range_check.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/remove_truncate_after_range_check.rs
@@ -1,4 +1,5 @@
-use im::{HashMap, HashSet};
+use fxhash::FxHashMap as HashMap;
+use fxhash::FxHashSet as HashSet;
 
 use crate::ssa::{
     ir::{function::Function, instruction::Instruction, value::ValueId},
@@ -22,9 +23,9 @@ impl Function {
     pub(crate) fn remove_truncate_after_range_check(&mut self) {
         for block in self.reachable_blocks() {
             // Keeps the minimum bit size a value was range-checked against
-            let mut range_checks: HashMap<ValueId, u32> = HashMap::new();
-            let mut instructions_to_remove = HashSet::new();
-            let mut values_to_replace = std::collections::HashMap::<ValueId, ValueId>::new();
+            let mut range_checks: HashMap<ValueId, u32> = HashMap::default();
+            let mut instructions_to_remove = HashSet::default();
+            let mut values_to_replace = HashMap::<ValueId, ValueId>::default();
 
             for instruction_id in self.dfg[block].instructions() {
                 let instruction = &self.dfg[*instruction_id];

--- a/compiler/noirc_evaluator/src/ssa/opt/remove_truncate_after_range_check.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/remove_truncate_after_range_check.rs
@@ -24,7 +24,7 @@ impl Function {
             // Keeps the minimum bit size a value was range-checked against
             let mut range_checks: HashMap<ValueId, u32> = HashMap::new();
             let mut instructions_to_remove = HashSet::new();
-            let mut values_to_replace = HashMap::<ValueId, ValueId>::new();
+            let mut values_to_replace = std::collections::HashMap::<ValueId, ValueId>::new();
 
             for instruction_id in self.dfg[block].instructions() {
                 let instruction = &self.dfg[*instruction_id];
@@ -70,9 +70,7 @@ impl Function {
                 .instructions_mut()
                 .retain(|instruction| !instructions_to_remove.contains(instruction));
 
-            for (old_value, new_value) in values_to_replace {
-                self.dfg.set_value_from_id(old_value, new_value);
-            }
+            self.dfg.replace_values_in_block(block, &values_to_replace);
         }
     }
 }


### PR DESCRIPTION

# Description

## Problem

Slowly trying to migrate away from `set_value_from_id`

## Summary


## Additional Context



## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
