### PR TITLE
chore: Add `GITHUB_TOKEN` to more workflow steps

### DIFF
--- a/.github/workflows/reports.yml
+++ b/.github/workflows/reports.yml
@@ -36,6 +36,8 @@ jobs:
       - name: Run ACVM benchmarks
         run: |
           cargo bench -p acvm -- --output-format bencher | tee acvm-bench.txt
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Store ACVM benchmarks result
         uses: benchmark-action/github-action-benchmark@4de1bed97a47495fc4c5404952da0499e31f5c29

--- a/.github/workflows/rustdoc.yml
+++ b/.github/workflows/rustdoc.yml
@@ -33,6 +33,8 @@ jobs:
 
       - name: Build docs
         run: cargo doc --no-deps --document-private-items --workspace
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Add redirect
         run: echo '<meta http-equiv="refresh" content="0;url=nargo/index.html">' > target/doc/index.html

--- a/.github/workflows/test-js-packages.yml
+++ b/.github/workflows/test-js-packages.yml
@@ -99,6 +99,8 @@ jobs:
 
       - name: Build noir-execute
         run: cargo build --package noir_artifact_cli --release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Package artifacts
         run: |

--- a/.github/workflows/test-rust-workspace-arm64.yml
+++ b/.github/workflows/test-rust-workspace-arm64.yml
@@ -39,6 +39,8 @@ jobs:
 
       - name: Build and archive tests
         run: cargo nextest archive --workspace --features noirc_frontend/nextest --archive-file nextest-archive-arm64.tar.zst
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload archive to workflow
         uses: actions/upload-artifact@v4

--- a/.github/workflows/test-rust-workspace-msrv.yml
+++ b/.github/workflows/test-rust-workspace-msrv.yml
@@ -53,6 +53,8 @@ jobs:
 
       - name: Build and archive tests
         run: cargo nextest archive --workspace --archive-file nextest-archive.tar.zst
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload archive to workflow
         uses: actions/upload-artifact@v4

--- a/.github/workflows/test-rust-workspace.yml
+++ b/.github/workflows/test-rust-workspace.yml
@@ -40,6 +40,8 @@ jobs:
 
       - name: Build and archive tests
         run: cargo nextest archive --workspace --features noirc_frontend/nextest --archive-file nextest-archive.tar.zst
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload archive to workflow
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
# Description

## Problem\*

Fixes https://github.com/noir-lang/noir/actions/runs/14418135582

## Summary\*

Adds `GITHUB_TOKEN` env to more `cargo` commands to intermittent API limiting.

## Additional Context

This is because of https://github.com/noir-lang/noir/pull/7513

We don't plan to use protobuf at the moment, although it can be selected by the user in https://github.com/noir-lang/noir/pull/7716 which could be used by someone who wants to bootstrap their side of the stack from the protobuf schemas, but I thought that if we wanted to keep the bytecode model we use internally separate from the DTOs (which protobuf achieves, but the reflection based approach does not), we might want to look at using https://docs.rs/prost-reflect/latest/prost_reflect/ to write some kind of custom format that utilises the number tags specified in the protobuf schema. 

For example we could have two ways to transfer data:
* to targets that support protobuf: Noir model -> protobuf -> compressed artifact -> protobuf -> reader model
* to targets like Barretenberg that don't do protobuf: Noir model -> protobuf -> reflect message -> arrays of tuples of number tag and content -> msgpack -> compressed artifact -> msgpack -> reader model generated from protobuf schema

The idea with the second approach would be that we maintain a separate DTO structure in the form of protobuf, which forces us good hygiene about handling backwards compatibility with the number tagging, but then we generate C++ code to read those _without_ having to add protobuf as a dependency to Barretenberg, which didn't work because of the restrictions on Wasm.

## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
