### PR TITLE
chore: bump bb to 0.84.0

### DIFF
--- a/compiler/integration-tests/package.json
+++ b/compiler/integration-tests/package.json
@@ -13,7 +13,7 @@
     "lint": "NODE_NO_WARNINGS=1 eslint . --max-warnings 0"
   },
   "dependencies": {
-    "@aztec/bb.js": "0.82.0",
+    "@aztec/bb.js": "0.84.0",
     "@noir-lang/noir_js": "workspace:*",
     "@noir-lang/noir_wasm": "workspace:*",
     "@nomicfoundation/hardhat-chai-matchers": "^2.0.8",

--- a/examples/prove_and_verify/prove_and_verify.sh
+++ b/examples/prove_and_verify/prove_and_verify.sh
@@ -11,4 +11,4 @@ $BACKEND prove -b ./target/hello_world.json -w ./target/witness.gz -o ./proofs
 
 # TODO: backend should automatically generate vk if necessary.
 $BACKEND write_vk -b ./target/hello_world.json -o ./target
-$BACKEND verify -k ./target/vk -p ./proofs/proof
+$BACKEND verify -k ./target/vk -p ./proofs/proof -i ./proofs/public_inputs

--- a/examples/recursion/generate_recursive_proof.sh
+++ b/examples/recursion/generate_recursive_proof.sh
@@ -3,21 +3,19 @@ set -eu
 
 BACKEND=${BACKEND:-bb}
 
+# Execute and prove inner circuit (sum)
+mkdir -p ./target/sum
 nargo execute sum_witness --package sum
+$BACKEND prove -b ./target/sum.json -w ./target/sum_witness.gz --init_kzg_accumulator --output_format bytes_and_fields -o ./target/sum
 
-# Once we have generated our inner proof, we must use this to generate inputs to `recurse_leaf``
-$BACKEND write_vk -b ./target/sum.json -o ./target --init_kzg_accumulator --output_format fields
-mv ./target/vk_fields.json ./target/sum_vk_as_fields
+# Generate vk for inner circuit
+$BACKEND write_vk -b ./target/sum.json -o ./target/sum --init_kzg_accumulator --output_format fields
 
-VK_AS_FIELDS=$(jq -r '.[0:]' ./target/sum_vk_as_fields)
+# Prepare Prover.toml for recurse_leaf
+PROOF_AS_FIELDS=$(jq -r '.[0:]' ./target/sum/proof_fields.json)
+PUBLIC_INPUTS_AS_FIELDS=$(jq -r '.[0:]' ./target/sum/public_inputs_fields.json)
+VK_AS_FIELDS=$(jq -r '.[0:]' ./target/sum/vk_fields.json)
 VK_HASH="0x0"
-
-FULL_PROOF_AS_FIELDS="$($BACKEND prove -b ./target/sum.json -w ./target/sum_witness.gz --init_kzg_accumulator --output_format fields -o -)"
-
-echo $FULL_PROOF_AS_FIELDS | jq 'length'
-# sum has 3 public inputs
-PUBLIC_INPUTS=$(echo $FULL_PROOF_AS_FIELDS | jq -r '.[:3]')
-PROOF_AS_FIELDS=$(echo $FULL_PROOF_AS_FIELDS | jq -r '.[3:]')
 
 RECURSE_LEAF_PROVER_TOML=./recurse_leaf/Prover.toml
 echo -n "" > $RECURSE_LEAF_PROVER_TOML
@@ -25,45 +23,37 @@ echo "num = 2" > $RECURSE_LEAF_PROVER_TOML
 echo "key_hash = $VK_HASH" >> $RECURSE_LEAF_PROVER_TOML
 echo "verification_key = $VK_AS_FIELDS"  >> $RECURSE_LEAF_PROVER_TOML
 echo "proof = $PROOF_AS_FIELDS" >> $RECURSE_LEAF_PROVER_TOML
-echo "public_inputs = $PUBLIC_INPUTS" >> $RECURSE_LEAF_PROVER_TOML
+echo "public_inputs = $PUBLIC_INPUTS_AS_FIELDS" >> $RECURSE_LEAF_PROVER_TOML
+
 
 # We can now execute and prove `recurse_leaf`
-
 nargo execute recurse_leaf_witness --package recurse_leaf
 
-$BACKEND prove -b ./target/recurse_leaf.json -w ./target/recurse_leaf_witness.gz -o ./target --init_kzg_accumulator
-mv ./target/proof ./target/recurse_leaf_proof
+mkdir -p ./target/leaf
+$BACKEND prove -b ./target/recurse_leaf.json -w ./target/recurse_leaf_witness.gz --output_format bytes_and_fields --init_kzg_accumulator -o ./target/leaf
+$BACKEND write_vk -b ./target/recurse_leaf.json --output_format bytes_and_fields --init_kzg_accumulator -o ./target/leaf
 
-# Let's do a sanity check that the proof we've generated so far is valid.
-$BACKEND write_vk -b ./target/recurse_leaf.json -o ./target --init_kzg_accumulator
-mv ./target/vk ./target/recurse_leaf_key
-$BACKEND verify -p ./target/recurse_leaf_proof -k ./target/recurse_leaf_key
+# Sanity check
+$BACKEND verify -k ./target/leaf/vk -p ./target/leaf/proof  -i ./target/leaf/public_inputs
 
 # Now we generate the final `recurse_node` proof similarly to how we did for `recurse_leaf`.
-$BACKEND write_vk -b ./target/recurse_leaf.json --output_format fields -o ./target --init_kzg_accumulator
-mv ./target/vk_fields.json ./target/recurse_leaf_vk_as_fields
-VK_AS_FIELDS=$(jq -r '.[0:]' ./target/recurse_leaf_vk_as_fields)
-
-FULL_PROOF_AS_FIELDS="$($BACKEND prove -b ./target/recurse_leaf.json -w ./target/recurse_leaf_witness.gz --honk_recursion 1 --init_kzg_accumulator --output_format fields -o -)"
-# recurse_leaf has 4 public inputs (excluding aggregation object)
-PUBLIC_INPUTS=$(echo $FULL_PROOF_AS_FIELDS | jq -r '.[:4]')
-PROOF_AS_FIELDS=$(echo $FULL_PROOF_AS_FIELDS | jq -r '.[4:]')
+PROOF_AS_FIELDS=$(jq -r '.[0:]' ./target/leaf/proof_fields.json)
+PUBLIC_INPUTS_AS_FIELDS=$(jq -r '.[0:]' ./target/leaf/public_inputs_fields.json)
+VK_AS_FIELDS=$(jq -r '.[0:]' ./target/leaf/vk_fields.json)
 
 RECURSE_NODE_PROVER_TOML=./recurse_node/Prover.toml
 echo -n "" > $RECURSE_NODE_PROVER_TOML
 echo "key_hash = $VK_HASH" >> $RECURSE_NODE_PROVER_TOML
 echo "verification_key = $VK_AS_FIELDS"  >> $RECURSE_NODE_PROVER_TOML
 echo "proof = $PROOF_AS_FIELDS" >> $RECURSE_NODE_PROVER_TOML
-echo "public_inputs = $PUBLIC_INPUTS" >> $RECURSE_NODE_PROVER_TOML
+echo "public_inputs = $PUBLIC_INPUTS_AS_FIELDS" >> $RECURSE_NODE_PROVER_TOML
 
 # We can now execute and prove `recurse_node`
 
 nargo execute recurse_node_witness --package recurse_node
-$BACKEND prove -b ./target/recurse_node.json -w ./target/recurse_node_witness.gz -o ./target --honk_recursion 1 --init_kzg_accumulator
-mv ./target/proof ./target/recurse_node_proof
 
-# We finally verify that the generated recursive proof is valid.
-$BACKEND write_vk -b ./target/recurse_node.json -o ./target --honk_recursion 1 --init_kzg_accumulator
-mv ./target/vk ./target/recurse_node_key
+mkdir -p ./target/node
+$BACKEND prove -b ./target/recurse_node.json -w ./target/recurse_node_witness.gz -o ./target/node --init_kzg_accumulator
+$BACKEND write_vk -b ./target/recurse_node.json -o ./target/node --init_kzg_accumulator
 
-$BACKEND verify -p ./target/recurse_node_proof -k ./target/recurse_node_key
+$BACKEND verify -k ./target/node/vk -p ./target/node/proof  -i ./target/node/public_inputs

--- a/scripts/install_bb.sh
+++ b/scripts/install_bb.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-VERSION="0.82.0"
+VERSION="0.84.0"
 
 BBUP_PATH=~/.bb/bbup
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -238,9 +238,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aztec/bb.js@npm:0.82.0":
-  version: 0.82.0
-  resolution: "@aztec/bb.js@npm:0.82.0"
+"@aztec/bb.js@npm:0.84.0":
+  version: 0.84.0
+  resolution: "@aztec/bb.js@npm:0.84.0"
   dependencies:
     comlink: "npm:^4.4.1"
     commander: "npm:^12.1.0"
@@ -250,7 +250,7 @@ __metadata:
     tslib: "npm:^2.4.0"
   bin:
     bb.js: dest/node/main.js
-  checksum: 10/4b4e6e32168a5dcdff70db237dda26567c16800422721e0482403581a310a98dc2f53b179ce87a2acf138ffd9ab47b0e3a2d8027787a84ba28a12d3f02b60f14
+  checksum: 10/cdb8c88746795e4f3f334341cc7f3915152465eabb3863fbb5fa60661fcafeffe0d3998822137b395de6453829fedf49532dae136c8ce1bdb2612d8be5631dc3
   languageName: node
   linkType: hard
 
@@ -18766,7 +18766,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "integration-tests@workspace:compiler/integration-tests"
   dependencies:
-    "@aztec/bb.js": "npm:0.82.0"
+    "@aztec/bb.js": "npm:0.84.0"
     "@noir-lang/noir_js": "workspace:*"
     "@noir-lang/noir_wasm": "workspace:*"
     "@nomicfoundation/hardhat-chai-matchers": "npm:^2.0.8"


### PR DESCRIPTION
# Description

## Problem\*

bump bb to 0.84.0

## Summary\*

bb `0.84.0` saves proof and publicInputs as separate files

## Additional Context

Will update the docs in a separate PR

## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
