### PR TITLE
Replace TODO with actual check for source directory existence in `Package.getEntryPointPath`

### DIFF
--- a/compiler/wasm/src/noir/package.ts
+++ b/compiler/wasm/src/noir/package.ts
@@ -1,5 +1,6 @@
 import { parse } from '@ltd/j-toml';
 import { join } from 'path';
+import { existsSync } from 'fs';
 
 import { FileManager } from './file-manager/file-manager';
 import { DependencyConfig, PackageConfig, parseNoirPackageConfig } from '../types/noir_package_config';
@@ -75,7 +76,11 @@ export class Package {
       default:
         throw new Error(`Unknown package type: ${this.getType()}`);
     }
-    // TODO check that `src` exists
+    // Ensure the source directory exists before resolving entrypoint
+    if (!existsSync(this.#srcPath)) {
+      throw new Error(`Source directory does not exist: ${this.#srcPath}`);
+    }
+
     return join(this.#srcPath, entrypoint);
   }
 


### PR DESCRIPTION
#### Problem\*

Previously, there was a `// TODO check that 'src' exists` comment in the `getEntryPointPath` method of the `Package` class. This meant that if the expected `src` directory was missing, it could lead to unexpected runtime errors when resolving the package entrypoint.

#### Summary\*

This PR resolves the TODO by introducing a runtime check using `fs.existsSync`. Now, when `getEntryPointPath` is called, it will throw an explicit error if the `src` directory does not exist.

```ts
if (!existsSync(this.#srcPath)) {
  throw new Error(`Source directory does not exist: ${this.#srcPath}`);
}
```

The comment was also updated to reflect this behavior:
```ts
// Ensure the source directory exists before resolving entrypoint
```

This makes the package resolution more robust and improves developer feedback during local development or integration.

#### Additional Context

This is a minimal and safe change, using standard Node.js `fs` utilities. No logic beyond the existence check was introduced.

---

### Documentation\*

- [x] No documentation needed.

---

### PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) or other applicable tools.
