### PR TITLE
chore: don't use `set_value_from_id` in `simplify_cfg`

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/ir/dfg.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/dfg.rs
@@ -383,6 +383,30 @@ impl DataFlowGraph {
         self.instructions[id] = instruction;
     }
 
+    /// Replaces values in the given block according to the given HashMap.
+    pub(crate) fn replace_values_in_block(
+        &mut self,
+        block: BasicBlockId,
+        values_to_replace: &HashMap<ValueId, ValueId>,
+    ) {
+        self.replace_values_in_block_instructions(block, values_to_replace);
+        self.replace_values_in_block_terminator(block, values_to_replace);
+    }
+
+    /// Replaces values in the given block instructions according to the given HashMap.
+    pub(crate) fn replace_values_in_block_instructions(
+        &mut self,
+        block: BasicBlockId,
+        values_to_replace: &HashMap<ValueId, ValueId>,
+    ) {
+        let instruction_ids = self.blocks[block].take_instructions();
+        for instruction_id in &instruction_ids {
+            let instruction = &mut self[*instruction_id];
+            instruction.replace_values(values_to_replace);
+        }
+        *self[block].instructions_mut() = instruction_ids;
+    }
+
     /// Replaces values in the given block terminator (if it has any) according to the given HashMap.
     pub(crate) fn replace_values_in_block_terminator(
         &mut self,

--- a/compiler/noirc_evaluator/src/ssa/opt/simplify_cfg.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/simplify_cfg.rs
@@ -9,6 +9,7 @@
 //!    only 1 successor then (2) also will be applied.
 //!
 //! Currently, 1 and 4 are unimplemented.
+use fxhash::FxHashMap as HashMap;
 use std::collections::HashSet;
 
 use acvm::acir::AcirField;
@@ -19,7 +20,7 @@ use crate::ssa::{
         cfg::ControlFlowGraph,
         function::{Function, RuntimeType},
         instruction::{Instruction, TerminatorInstruction},
-        value::Value,
+        value::{Value, ValueId},
     },
     ssa_gen::Ssa,
 };
@@ -49,12 +50,17 @@ impl Function {
     /// be inlined into their predecessor.
     pub(crate) fn simplify_function(&mut self) {
         let mut cfg = ControlFlowGraph::with_function(self);
+        let mut values_to_replace = HashMap::default();
         let mut stack = vec![self.entry_block()];
         let mut visited = HashSet::new();
 
         while let Some(block) = stack.pop() {
             if visited.insert(block) {
                 stack.extend(self.dfg[block].successors().filter(|block| !visited.contains(block)));
+            }
+
+            if !values_to_replace.is_empty() {
+                self.dfg.replace_values_in_block_instructions(block, &values_to_replace);
             }
 
             check_for_negated_jmpif_condition(self, block, &mut cfg);
@@ -70,7 +76,7 @@ impl Function {
                 drop(predecessors);
 
                 // If the block has only 1 predecessor, we can safely remove its block parameters
-                remove_block_parameters(self, block, predecessor);
+                remove_block_parameters(self, block, predecessor, &mut values_to_replace);
 
                 // Note: this function relies on `remove_block_parameters` being called first.
                 // Otherwise the inlined block will refer to parameters that no longer exist.
@@ -84,6 +90,15 @@ impl Function {
 
                 check_for_double_jmp(self, block, &mut cfg);
             }
+
+            if !values_to_replace.is_empty() {
+                self.dfg.replace_values_in_block_terminator(block, &values_to_replace);
+            }
+        }
+
+        // Values from previous blocks might need to be replaced
+        for block in self.reachable_blocks() {
+            self.dfg.replace_values_in_block(block, &values_to_replace);
         }
     }
 }
@@ -246,6 +261,7 @@ fn remove_block_parameters(
     function: &mut Function,
     block: BasicBlockId,
     predecessor: BasicBlockId,
+    values_to_replace: &mut HashMap<ValueId, ValueId>,
 ) {
     let block = &mut function.dfg[block];
 
@@ -264,7 +280,7 @@ fn remove_block_parameters(
 
         assert_eq!(block_params.len(), jump_args.len());
         for (param, arg) in block_params.iter().zip(jump_args) {
-            function.dfg.set_value_from_id(*param, arg);
+            values_to_replace.insert(*param, arg);
         }
     }
 }


### PR DESCRIPTION
# Description

## Problem

Slowly trying to migrate away from `set_value_from_id`

## Summary

This one is a bit different from the other ones in that it seems that blocks are merged and so sometimes after we determined that we need to replace, say, `v1` for `v0`, we need to do this replacement in a previous block. I'm not sure exactly why, though, but without doing this an SSA test fails (and likely many more tests fail and the behavior is wrong).

## Additional Context

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
