### PR TITLE
fix: SSA pass print filter to include the count

### DIFF
--- a/compiler/noirc_evaluator/src/ssa.rs
+++ b/compiler/noirc_evaluator/src/ssa.rs
@@ -612,6 +612,7 @@ impl SsaBuilder {
     fn print(mut self, msg: &str) -> Self {
         // Count the number of times we have seen this message.
         let cnt = self.passed.entry(msg.to_string()).and_modify(|cnt| *cnt += 1).or_insert(1);
+        let msg = format!("{msg} ({cnt})");
 
         // Always normalize if we are going to print at least one of the passes
         if !matches!(self.ssa_logging, SsaLogging::None) {
@@ -628,8 +629,9 @@ impl SsaBuilder {
                 msg.to_lowercase().contains(string)
             }
         };
+
         if print_ssa_pass {
-            println!("After {msg} ({cnt}):\n{}", self.ssa);
+            println!("After {msg}:\n{}", self.ssa);
         }
         self
     }


### PR DESCRIPTION
# Description

## Problem\*

Resolves an issue introduced by https://github.com/noir-lang/noir/pull/8035

## Summary\*

The ` ({cnt})` part was not included in the SSA message based print filtering, so trying to filter `--show-ssa-pass "My Pass (1)"` did not work, only `--show-ssa-pass "My Pass"`.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
