### PR TITLE
fix: Allow more slack in AST calibration for CI

### DIFF
--- a/tooling/ast_fuzzer/tests/calibration.rs
+++ b/tooling/ast_fuzzer/tests/calibration.rs
@@ -41,7 +41,7 @@ fn arb_program_freqs_in_expected_range() {
         program_count += 1;
         Ok(())
     })
-    .budget_ms(1000)
+    .budget_ms(2000)
     .size_min(1 << 12)
     .size_max(1 << 20);
 
@@ -61,9 +61,10 @@ fn arb_program_freqs_in_expected_range() {
         }
     }
 
+    // Sum of frequencies normalized to 100, as it appears in the printout above.
     let freq_100 = |unconstrained, group: &str, keys: &[&str]| {
-        keys.iter().map(|key| counts[&unconstrained][group][key]).sum::<usize>() * 100
-            / counts[&unconstrained][group].values().sum::<usize>()
+        let total = counts[&unconstrained][group].values().sum::<usize>();
+        keys.iter().map(|key| counts[&unconstrained][group][key] * 100 / total).sum::<usize>()
     };
 
     // Assert relative frequencies
@@ -71,9 +72,10 @@ fn arb_program_freqs_in_expected_range() {
     let loops_b = freq_100(true, "stmt", &["for", "loop", "while"]);
     let break_b = freq_100(true, "stmt", &["break"]);
 
-    assert!((9..=11).contains(&loops_a), "ACIR loops: {loops_a}");
-    assert!((loops_a - 1..=loops_a + 1).contains(&loops_b), "Brillig loops: {loops_b}");
-    assert!(break_b >= loops_b, "Brillig should break out of loops: {break_b}");
+    let loop_range = 8..=12;
+    assert!(loop_range.contains(&loops_a), "ACIR loops should be ~10: {loops_a}");
+    assert!(loop_range.contains(&loops_b), "Brillig loops should be ~10: {loops_b}");
+    assert!(break_b >= loops_b, "Brillig should break out of loops: {break_b} >= {loops_b}");
 }
 
 /// Classify the expression into "expr" or "stmt" for frequency settings.


### PR DESCRIPTION
# Description

## Problem\*

Resolves flaky test failures on CI when the observed frequency of Brillig loops fell out of the 9-11 range.

## Summary\*

Changes the expected range of loops to be 8-12 in 100, and the collection duration to be 2s, to give CI more time to stabilise.

## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
