### PR TITLE
chore: bump bignum timeout

### DIFF
--- a/EXTERNAL_NOIR_LIBRARIES.yml
+++ b/EXTERNAL_NOIR_LIBRARIES.yml
@@ -30,7 +30,7 @@ libraries:
     critical: true
   noir-bignum:
     repo: noir-lang/noir-bignum
-    timeout: 90
+    timeout: 600
     critical: true
   noir_bigcurve:
     repo: noir-lang/noir_bigcurve


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

https://github.com/noir-lang/noir-bignum/pull/157 added a bunch of heavy tests which increased the testing time for this library.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
