### PR TITLE
fix: replace values in data_bus too

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/function_builder/data_bus.rs
+++ b/compiler/noirc_evaluator/src/ssa/function_builder/data_bus.rs
@@ -3,7 +3,7 @@ use std::{collections::BTreeMap, sync::Arc};
 use crate::ssa::ir::{
     function::RuntimeType,
     types::{NumericType, Type},
-    value::ValueId,
+    value::{ValueId, resolve_value},
 };
 use acvm::FieldElement;
 use fxhash::FxHashMap as HashMap;
@@ -92,6 +92,12 @@ impl DataBus {
             })
             .collect();
         DataBus { call_data, return_data: self.return_data.map(&mut f) }
+    }
+
+    pub(crate) fn replace_values(&mut self, values_to_replace: &HashMap<ValueId, ValueId>) {
+        if !values_to_replace.is_empty() {
+            self.map_values_mut(|value_id| resolve_value(values_to_replace, value_id));
+        }
     }
 
     /// Updates the databus values in place with the provided function

--- a/compiler/noirc_evaluator/src/ssa/ir/dfg.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/dfg.rs
@@ -389,7 +389,7 @@ impl DataFlowGraph {
         block: BasicBlockId,
         values_to_replace: &HashMap<ValueId, ValueId>,
     ) {
-        if self[block].terminator().is_some() {
+        if !values_to_replace.is_empty() && self[block].terminator().is_some() {
             self[block]
                 .unwrap_terminator_mut()
                 .map_values_mut(|value_id| resolve_value(values_to_replace, value_id));

--- a/compiler/noirc_evaluator/src/ssa/ir/value.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/value.rs
@@ -73,7 +73,7 @@ impl Value {
     }
 }
 
-pub(super) fn resolve_value(
+pub(crate) fn resolve_value(
     values_to_replace: &HashMap<ValueId, ValueId>,
     value_id: ValueId,
 ) -> ValueId {

--- a/compiler/noirc_evaluator/src/ssa/opt/as_slice_length.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/as_slice_length.rs
@@ -66,6 +66,8 @@ impl Function {
             *self.dfg[block].instructions_mut() = instruction_ids;
             self.dfg.replace_values_in_block_terminator(block, &values_to_replace);
         }
+
+        self.dfg.data_bus.replace_values(&values_to_replace);
     }
 }
 

--- a/compiler/noirc_evaluator/src/ssa/opt/remove_truncate_after_range_check.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/remove_truncate_after_range_check.rs
@@ -77,6 +77,8 @@ impl Function {
             *self.dfg[block].instructions_mut() = instruction_ids;
             self.dfg.replace_values_in_block_terminator(block, &values_to_replace);
         }
+
+        self.dfg.data_bus.replace_values(&values_to_replace);
     }
 }
 


### PR DESCRIPTION
# Description

## Problem

Slowly trying to migrate away from `set_value_from_id`

## Summary

I don't know if this is needed in these passes, but it's better to do it for completeness (I noticed `FunctionInserter` does this in some passes).

## Additional Context

Once this is merged I'll also do this in the other open PRs before merging them.

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
