### PR TITLE
feat: optimize get_value_max_num_bits to take into account multiplications

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/ir/dfg.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/dfg.rs
@@ -540,7 +540,7 @@ impl DataFlowGraph {
                 let value_bit_size = self.type_of_value(value).bit_size();
                 match self[instruction] {
                     Instruction::Cast(original_value, _) => {
-                        let original_bit_size = self.get_value_max_num_bits(original_value);
+                        let original_bit_size = self.type_of_value(original_value).bit_size();
                         // We might have cast e.g. `u1` to `u8` to be able to do arithmetic,
                         // in which case we want to recover the original smaller bit size;
                         // OTOH if we cast down, then we don't need the higher original size.

--- a/compiler/noirc_evaluator/src/ssa/ir/dfg.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/dfg.rs
@@ -540,7 +540,7 @@ impl DataFlowGraph {
                 let value_bit_size = self.type_of_value(value).bit_size();
                 match self[instruction] {
                     Instruction::Cast(original_value, _) => {
-                        let original_bit_size = self.type_of_value(original_value).bit_size();
+                        let original_bit_size = self.get_value_max_num_bits(original_value);
                         // We might have cast e.g. `u1` to `u8` to be able to do arithmetic,
                         // in which case we want to recover the original smaller bit size;
                         // OTOH if we cast down, then we don't need the higher original size.

--- a/compiler/noirc_evaluator/src/ssa/ir/dfg.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/dfg.rs
@@ -546,30 +546,9 @@ impl DataFlowGraph {
                         // OTOH if we cast down, then we don't need the higher original size.
                         value_bit_size.min(original_bit_size)
                     }
-                    _ => value_bit_size,
-                }
-            }
-
-            Value::NumericConstant { constant, .. } => constant.num_bits(),
-            _ => self.type_of_value(value).bit_size(),
-        }
-    }
-
-    pub(crate) fn get_value_max_num_bits_2(&self, value: ValueId) -> u32 {
-        match self[value] {
-            Value::Instruction { instruction, .. } => {
-                let value_bit_size = self.type_of_value(value).bit_size();
-                match self[instruction] {
-                    Instruction::Cast(original_value, _) => {
-                        let original_bit_size = self.get_value_max_num_bits(original_value);
-                        // We might have cast e.g. `u1` to `u8` to be able to do arithmetic,
-                        // in which case we want to recover the original smaller bit size;
-                        // OTOH if we cast down, then we don't need the higher original size.
-                        value_bit_size.min(original_bit_size)
-                    }
                     Instruction::Binary(Binary { lhs, operator: BinaryOp::Mul { .. }, rhs })
-                        if self.get_value_max_num_bits(lhs) == 1
-                            && self.get_value_max_num_bits(rhs) == 1 =>
+                        if self.type_of_value(lhs).bit_size() == 1
+                            && self.type_of_value(rhs).bit_size() == 1 =>
                     {
                         // When multiplying two values, if their bitsize is 1 then the result's bitsize will be 1 too
                         1

--- a/compiler/noirc_evaluator/src/ssa/ir/instruction/binary.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/instruction/binary.rs
@@ -93,8 +93,8 @@ impl Binary {
         bit_size: u32,
     ) -> Option<&'static str> {
         // We try to optimize away operations that are guaranteed not to overflow
-        let max_lhs_bits = dfg.get_value_max_num_bits(self.lhs);
-        let max_rhs_bits = dfg.get_value_max_num_bits(self.rhs);
+        let max_lhs_bits = dfg.get_value_max_num_bits_2(self.lhs);
+        let max_rhs_bits = dfg.get_value_max_num_bits_2(self.rhs);
 
         let msg = match self.operator {
             BinaryOp::Add { unchecked: false } => {

--- a/compiler/noirc_evaluator/src/ssa/ir/instruction/binary.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/instruction/binary.rs
@@ -93,8 +93,8 @@ impl Binary {
         bit_size: u32,
     ) -> Option<&'static str> {
         // We try to optimize away operations that are guaranteed not to overflow
-        let max_lhs_bits = dfg.get_value_max_num_bits_2(self.lhs);
-        let max_rhs_bits = dfg.get_value_max_num_bits_2(self.rhs);
+        let max_lhs_bits = dfg.get_value_max_num_bits(self.lhs);
+        let max_rhs_bits = dfg.get_value_max_num_bits(self.rhs);
 
         let msg = match self.operator {
             BinaryOp::Add { unchecked: false } => {


### PR DESCRIPTION
# Description

## Problem

No issue, just a common operation I noticed in the bignum library that we could maybe optimize.

## Summary

If we have code like this:

```noir
fn main(x: u1, z: u32) -> pub u32 {
    let m = x as u32;
    z * m
}
```

then we don't check for overflow in that multiplication because we know `m` was casted from `u1` which can only be 0 or 1.

If we have code like this:

```noir
fn main(x: u1, y: u1, z: u32) -> pub u32 {
    let x = x as u32;
    let y = y as u32;
    let m = x * y;
    z * m
}
```

then we shouldn't need to check for overflow either as we know `x * y` can be 1 or 0. However, there was no such check in our code so that's what this PR does.

## Additional Context

I also made the cast case recurse so that if you cast a multiplication to `u32`, we'll check the max bitsize of that multiplication according to these rules.

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
