### PR TITLE
fix(ssa): Do not inline simple recursive functions

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/opt/inlining.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/inlining.rs
@@ -94,6 +94,9 @@ impl Ssa {
         self
     }
 
+    /// Inline "simple" functions.
+    /// A simple function being a function with one or less instructions.
+    /// Simple functions are still restricted to not inlined if they are recursive or marked with no predicates.
     pub(crate) fn inline_simple_functions(mut self: Ssa) -> Ssa {
         let should_inline_call = |callee: &Function| {
             if let RuntimeType::Acir(_) = callee.runtime() {
@@ -112,10 +115,32 @@ impl Ssa {
             }
 
             // Only inline functions with 0 or 1 instructions
-            entry_block.instructions().len() <= 1
+            if entry_block.instructions().len() > 1 {
+                return false;
+            }
+
+            let instructions = callee.dfg[entry_block_id].instructions();
+            if instructions.is_empty() {
+                return true;
+            }
+
+            // Check whether the only instruction is a recursive call, which prevents inlining the callee.
+            // This special check is done here to avoid performing the entire inline info computation.
+            // The inline info computation contains extra logic and requires passing over every function.
+            // which we can avoid in when inlining simple functions.
+            let only_instruction = callee.dfg[entry_block_id].instructions()[0];
+            if let Instruction::Call { func, .. } = callee.dfg[only_instruction] {
+                let Value::Function(func_id) = callee.dfg[func] else {
+                    return true;
+                };
+
+                func_id != callee.id()
+            } else {
+                true
+            }
         };
 
-        self.functions = btree_map(self.functions.iter(), |(id, function)| {
+        self.functions = btree_map(&self.functions, |(id, function)| {
             (*id, function.inlined(&self, &should_inline_call))
         });
 

--- a/test_programs/execution_failure/simple_infinite_recursive_function/Nargo.toml
+++ b/test_programs/execution_failure/simple_infinite_recursive_function/Nargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "simple_infinite_recursive_function"
+type = "bin"
+authors = [""]
+
+[dependencies]

--- a/test_programs/execution_failure/simple_infinite_recursive_function/src/main.nr
+++ b/test_programs/execution_failure/simple_infinite_recursive_function/src/main.nr
@@ -1,0 +1,14 @@
+fn main() {
+    // Safety: testing context
+    unsafe {
+        foo();
+    }
+}
+
+unconstrained fn foo() {
+    bar();
+}
+
+unconstrained fn bar() {
+    bar();
+}

--- a/test_programs/execution_failure/simple_infinite_recursive_lambda/Nargo.toml
+++ b/test_programs/execution_failure/simple_infinite_recursive_lambda/Nargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "simple_infinite_recursive_lambda"
+type = "bin"
+authors = [""]
+
+[dependencies]

--- a/test_programs/execution_failure/simple_infinite_recursive_lambda/src/main.nr
+++ b/test_programs/execution_failure/simple_infinite_recursive_lambda/src/main.nr
@@ -1,4 +1,5 @@
 fn main() {
+    // Safety: testing context
     unsafe {
         foo(bar);
     }

--- a/test_programs/execution_failure/simple_infinite_recursive_lambda/src/main.nr
+++ b/test_programs/execution_failure/simple_infinite_recursive_lambda/src/main.nr
@@ -1,0 +1,15 @@
+fn main() {
+    unsafe {
+        foo(bar);
+    }
+}
+
+unconstrained fn foo<Env>(f: fn[Env]()) {
+    f();
+    f();
+}
+
+fn bar() {
+    bar();
+    bar();
+}

--- a/test_programs/execution_failure/simple_infinite_recursive_lambda/src/main.nr
+++ b/test_programs/execution_failure/simple_infinite_recursive_lambda/src/main.nr
@@ -5,12 +5,12 @@ fn main() {
     }
 }
 
-unconstrained fn foo<Env>(f: fn[Env]()) {
+unconstrained fn foo<Env>(f: unconstrained fn[Env]()) {
     f();
     f();
 }
 
-fn bar() {
+unconstrained fn bar() {
     bar();
     bar();
 }


### PR DESCRIPTION
# Description

## Problem\*

Resolves #8078

## Summary\*

We were not taking into account whether the single instruction a single function has may be a recursive call.

I chose to add a special check for this inside of `inline_simple_functions` rather than computing the `InlineInfos` as done in `inline_functions` and `inline_functions_with_no_predicates`. The simple functions check can avoid running through every function to compute the inline infos when we can just directly check the single instruction that we have. 

## Additional Context

I added a test similar to what is in #8081 but that test is failing due to different reasons than #8078. If we were appropriately marking `bar` as unconstrained input it would not be appropriately inlined and execute with a stack overflow as expected.

## Documentation\*

Check one:
- [X] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
