### PR TITLE
fix(ssa): Loop range with u1

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/opt/unrolling.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/unrolling.rs
@@ -342,8 +342,24 @@ impl Loop {
                 // `for i in 0..1` is turned into:
                 // b1(v0: u32):
                 //   v12 = eq v0, u32 0
-                //   jmpif v12 then: b3, else: b2
+                //   jmpif v12 then: b2, else: b3
                 function.dfg.get_numeric_constant(*rhs).map(|c| c + FieldElement::one())
+            }
+            Instruction::Not(_) => {
+                // We simplify equality operations with booleans like `(boolean == false)` into `!boolean`.
+                // Thus, using a u1 in a loop bound can possibly lead to a Not instruction
+                // as a loop header's jump condition.
+                //
+                // `for i in 0..1` is turned into:
+                //  b1(v0: u1):
+                //    v2 = eq v0, u32 0
+                //    jmpif v2 then: b2, else: b3
+                //
+                // Which is further simplified into:
+                //  b1(v0: u1):
+                //    v2 = not v0
+                //    jmpif v2 then: b2, else: b3
+                Some(true.into())
             }
             other => panic!("Unexpected instruction in header: {other:?}"),
         }

--- a/test_programs/compile_success_empty/loop_over_u1_range/Nargo.toml
+++ b/test_programs/compile_success_empty/loop_over_u1_range/Nargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "loop_over_u1_range"
+type = "bin"
+authors = [""]
+
+[dependencies]

--- a/test_programs/compile_success_empty/loop_over_u1_range/src/main.nr
+++ b/test_programs/compile_success_empty/loop_over_u1_range/src/main.nr
@@ -1,9 +1,9 @@
 fn main() {
     let zero: u1 = 0;
-    for _ in zero..zero { }
+    for _ in zero..zero {}
 
     let one: u1 = 1;
-    for _ in one..one { }
+    for _ in one..one {}
 
-    for _ in zero..one { }
+    for _ in zero..one {}
 }

--- a/test_programs/compile_success_empty/loop_over_u1_range/src/main.nr
+++ b/test_programs/compile_success_empty/loop_over_u1_range/src/main.nr
@@ -1,0 +1,9 @@
+fn main() {
+    let zero: u1 = 0;
+    for _ in zero..zero { }
+
+    let one: u1 = 1;
+    for _ in one..one { }
+
+    for _ in zero..one { }
+}

--- a/tooling/nargo_cli/tests/snapshots/compile_success_empty/loop_over_u1_range/execute__tests__force_brillig_false_inliner_0.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_empty/loop_over_u1_range/execute__tests__force_brillig_false_inliner_0.snap
@@ -1,0 +1,20 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: artifact
+---
+{
+  "noir_version": "[noir_version]",
+  "hash": "[hash]",
+  "abi": {
+    "parameters": [],
+    "return_type": null,
+    "error_types": {}
+  },
+  "bytecode": "H4sIAAAAAAAA/5XDsQkAAADCMAv+f7PuTgaCFm19Arunwj5IAAAA",
+  "debug_symbols": "XYxLCoAwDAXvkrUn8Coi0k9aAqEpsRWk9O5+cCFdzhveNPBoa9woBdlhXhqwOFNI0k2tT2CVmCluw3wYJWMZPww1uZ8tZ8bhn1Uc+qr4lF7X134B",
+  "file_map": {},
+  "names": [
+    "main"
+  ],
+  "brillig_names": []
+}


### PR DESCRIPTION
# Description

## Problem\*

Resolves #8107 

## Summary\*

We simplify equality operations with booleans like `(boolean == false)` into `!boolean`.
Thus, using a u1 in a loop bound can possibly lead to a Not instruction
as a loop header's jump condition.

Where `x: u1`, `for i in 0..x` is turned into:
```
 b1(v0: u1):
   v2 = eq v0, u32 0
   jmpif v2 then: b2, else: b3
```
Which is further simplified into:
```
 b1(v0: u1):
   v2 = not v0
   jmpif v2 then: b2, else: b3
```

We handle Not instructions as the loop header condition when fetching the upper const bound now.

## Additional Context



## Documentation\*

Check one:
- [X] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
