### PR TITLE
fix(acir): Check whether opcodes were laid down for non-equality check before fetching payload locations

### DIFF
--- a/compiler/noirc_evaluator/src/acir/acir_context/mod.rs
+++ b/compiler/noirc_evaluator/src/acir/acir_context/mod.rs
@@ -499,8 +499,20 @@ impl<F: AcirField, B: BlackBoxFunctionSolver<F>> AcirContext<F, B> {
     ) -> Result<(), RuntimeError> {
         let diff_var = self.sub_var(lhs, rhs)?;
 
+        let old_opcodes_len = self.acir_ir.opcodes().len();
         let _ = self.inv_var(diff_var, predicate)?;
         if let Some(payload) = assert_message {
+            // Non-equality can potentially be a no-op if we have all constant
+            // inputs that we know satisfy the non-equality check.
+            // If a no-op non-equality check were to then add an assertion payload
+            // opcode location based upon `GeneratedAcir::last_acir_opcode_location`,
+            // it would be pointing at the previous opcode location.
+            // This at best leads to a mismatch in assertion payload opcode locations
+            // and at worst an attempt to subtract with overflow if the non-equality
+            // check is the first opcode.
+            if self.acir_ir.opcodes().len() - old_opcodes_len == 0 {
+                return Ok(());
+            }
             self.acir_ir
                 .assertion_payloads
                 .insert(self.acir_ir.last_acir_opcode_location(), payload);

--- a/compiler/noirc_evaluator/src/acir/mod.rs
+++ b/compiler/noirc_evaluator/src/acir/mod.rs
@@ -2856,4 +2856,29 @@ mod test {
 
         assert!(matches!(acvm.solve(), ACVMStatus::Failure::<FieldElement>(_)));
     }
+
+    #[test]
+    fn do_not_overflow_with_constant_constrain_neq() {
+        // Test that we appropriately fetch the assertion payload opcode location.
+        // We expect this constrain neq to be simplified and not lay down any opcodes. 
+        // As the constrain neq is the first opcode, if we do not fetch the last opcode
+        // location correctly we can potentially trigger an overflow. 
+        let src = r#"
+        acir(inline) predicate_pure fn main f0 {
+          b0():
+            constrain Field 1 != Field 0, ""
+            return
+        }
+        "#;
+
+        let ssa = Ssa::from_str(src).unwrap();
+        let brillig = ssa.to_brillig(&BrilligOptions::default());
+
+        let (acir_functions, _brillig_functions, _, _) = ssa
+            .into_acir(&brillig, &BrilligOptions::default(), ExpressionWidth::default())
+            .expect("Should compile manually written SSA into ACIR");
+
+        assert_eq!(acir_functions.len(), 1);
+        assert!(acir_functions[0].opcodes().is_empty());
+    }
 }

--- a/test_programs/compile_success_empty/brillig_call_from_acir_constant_input/Nargo.toml
+++ b/test_programs/compile_success_empty/brillig_call_from_acir_constant_input/Nargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "brillig_call_from_acir_constant_input"
+type = "bin"
+authors = [""]
+
+[dependencies]

--- a/test_programs/compile_success_empty/brillig_call_from_acir_constant_input/src/main.nr
+++ b/test_programs/compile_success_empty/brillig_call_from_acir_constant_input/src/main.nr
@@ -1,0 +1,20 @@
+// Regression from issue #7372: (https://github.com/noir-lang/noir/issues/7372)
+fn main() {
+    bar(0)
+}
+
+pub unconstrained fn foo(input: Field) -> Field {
+    (input == 0) as Field
+}
+
+pub fn bar(input: Field) {
+    // Safety: test
+    let output = unsafe { foo(input) };
+
+    // This test requires an assert message.
+    // Non-equality can potentially be a no-op during ACIR gen. 
+    // We want to make sure that we are appropriately indexing our 
+    // assertion payload opcode location in the case our first opcode
+    // is constraining non-equality and resulted in a no-op.
+    assert(output != 0, "");
+}

--- a/tooling/nargo_cli/tests/snapshots/compile_success_empty/brillig_call_from_acir_constant_input/execute__tests__force_brillig_false_inliner_0.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_empty/brillig_call_from_acir_constant_input/execute__tests__force_brillig_false_inliner_0.snap
@@ -1,0 +1,25 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: artifact
+---
+{
+  "noir_version": "[noir_version]",
+  "hash": "[hash]",
+  "abi": {
+    "parameters": [],
+    "return_type": null,
+    "error_types": {
+      "3117886703346944619": {
+        "error_kind": "string",
+        "string": ""
+      }
+    }
+  },
+  "bytecode": "H4sIAAAAAAAA/5XDsQkAAADCMAv+f7PuTgaCFm19Arunwj5IAAAA",
+  "debug_symbols": "XYxLCoAwDAXvkrUn8Coi0k9aAqEpsRWk9O5+cCFdzhveNPBoa9woBdlhXhqwOFNI0k2tT2CVmCluw3wYJWMZPww1uZ8tZ8bhn1Uc+qr4lF7X134B",
+  "file_map": {},
+  "names": [
+    "main"
+  ],
+  "brillig_names": []
+}


### PR DESCRIPTION
… for neq

# Description

## Problem\*

Resolves #7372 

This is the SSA in the leadup to ACIR gen where the overflow is triggered:
<details><summary>Details</summary>
<p>

```
After Dead Instruction Elimination (2):
acir(inline) predicate_pure fn main f0 {
  b0():
    v2 = call f1(Field 0) -> Field
    constrain v2 != Field 0, ""
    return
}
brillig(inline) predicate_pure fn foo f1 {
  b0(v0: Field):
    v2 = eq v0, Field 0
    v3 = cast v2 as Field
    return v3
}

After Inlining Brillig Calls (1):
acir(inline) predicate_pure fn main f0 {
  b0():
    constrain Field 1 != Field 0, ""
    return
}
brillig(inline) predicate_pure fn foo f1 {
  b0(v0: Field):
    v2 = eq v0, Field 0
    v3 = cast v2 as Field
    return v3
}

After Removing Unreachable Functions (4):
acir(inline) predicate_pure fn main f0 {
  b0():
    constrain Field 1 != Field 0, ""
    return
}

After Dead Instruction Elimination (3):
acir(inline) predicate_pure fn main f0 {
  b0():
    constrain Field 1 != Field 0, ""
    return
}
```

</p>
</details> 

The issue boils down to that inversion (which is used by our neq check internally) can potentially be a no-op in ACIR. As we have a constant non equality check, the first SSA instruction is in fact a no-op. When we then go to write the assertion payload location we use [GeneratedAcir::last_acir_opcode_location](https://github.com/noir-lang/noir/blob/master/compiler/noirc_evaluator/src/acir/acir_context/generated_acir/mod.rs#L645C1-L647C6). This causes us to subtract with an overflow as we are doing `0 - 1`. 

## Summary\*

I simply now check before fetching a payload location whether any opcodes were actually laid down. If they were not, we skip adding an assertion payload as we know that the neq check passed.

`constrain Field 1 != Field 0, ""` makes it down to ACIR gen and is not simplified during constant folding as it only appears after inlining Brillig calls with constant inputs. This is most likely a rare case but important to handle nonetheless. 

The current logic also means we are adding assertion payloads for any neq var check even when we they are no-ops during ACIR gen. This shouldn't affect very many assertion payloads, but is a nice side benefit either way.

## Additional Context

## Documentation\*

Check one:
- [X] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
