### PR TITLE
chore: remove uneeded references to FileId

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/comptime.rs
+++ b/compiler/noirc_frontend/src/elaborator/comptime.rs
@@ -359,17 +359,12 @@ impl<'context> Elaborator<'context> {
     ) {
         self.with_elaborate_reason(ElaborateReason::RunningAttribute(location), |elaborator| {
             for item in items {
-                elaborator.add_item(item, generated_items, location);
+                elaborator.add_item(item, generated_items);
             }
         });
     }
 
-    pub(crate) fn add_item(
-        &mut self,
-        item: Item,
-        generated_items: &mut CollectedItems,
-        location: Location,
-    ) {
+    pub(crate) fn add_item(&mut self, item: Item, generated_items: &mut CollectedItems) {
         match item.kind {
             ItemKind::Function(function) => {
                 let module_id = self.module_id();
@@ -385,7 +380,6 @@ impl<'context> Elaborator<'context> {
                 ) {
                     let functions = vec![(self.local_module, id, function)];
                     generated_items.functions.push(UnresolvedFunctions {
-                        file_id: location.file,
                         functions,
                         trait_id: None,
                         self_type: None,
@@ -398,12 +392,10 @@ impl<'context> Elaborator<'context> {
                         self.interner,
                         &mut trait_impl,
                         self.crate_id,
-                        location.file,
                         self.local_module,
                     );
 
                 generated_items.trait_impls.push(UnresolvedTraitImpl {
-                    file_id: location.file,
                     module_id: self.local_module,
                     r#trait: trait_impl.r#trait,
                     object_type: trait_impl.object_type,
@@ -428,7 +420,6 @@ impl<'context> Elaborator<'context> {
                     self.usage_tracker,
                     Documented::new(global, item.doc_comments),
                     visibility,
-                    location.file,
                     self.local_module,
                     self.crate_id,
                 );
@@ -457,7 +448,6 @@ impl<'context> Elaborator<'context> {
                     self.def_maps.get_mut(&self.crate_id).unwrap(),
                     self.usage_tracker,
                     Documented::new(enum_def, item.doc_comments),
-                    location.file,
                     self.local_module,
                     self.crate_id,
                     &mut self.errors,
@@ -471,7 +461,6 @@ impl<'context> Elaborator<'context> {
                     self.interner,
                     generated_items,
                     r#impl,
-                    location.file,
                     module,
                     &mut self.errors,
                 );

--- a/compiler/noirc_frontend/src/elaborator/enums.rs
+++ b/compiler/noirc_frontend/src/elaborator/enums.rs
@@ -160,7 +160,6 @@ impl Elaborator<'_> {
             name.clone(),
             type_id.local_module_id(),
             type_id.krate(),
-            name.location().file,
             Vec::new(),
             false,
             false,

--- a/compiler/noirc_frontend/src/elaborator/mod.rs
+++ b/compiler/noirc_frontend/src/elaborator/mod.rs
@@ -1566,7 +1566,6 @@ impl<'context> Elaborator<'context> {
                 typ: self_type.clone(),
                 trait_id,
                 trait_generics,
-                file: trait_impl.file_id,
                 where_clause,
                 methods,
             });

--- a/compiler/noirc_frontend/src/elaborator/traits.rs
+++ b/compiler/noirc_frontend/src/elaborator/traits.rs
@@ -184,7 +184,7 @@ impl Elaborator<'_> {
                     functions.push(TraitFunction {
                         name: name.clone(),
                         typ: Type::Forall(generics, Box::new(function_type)),
-                        location: Location::new(name.span(), unresolved_trait.file_id),
+                        location: name.location(),
                         default_impl,
                         default_impl_module_id: unresolved_trait.module_id,
                         trait_constraints: func_meta.trait_constraints.clone(),

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
@@ -2795,7 +2795,7 @@ fn module_add_item(
         let mut generated_items = CollectedItems::default();
 
         for top_level_statement in top_level_statements {
-            elaborator.add_item(top_level_statement, &mut generated_items, location);
+            elaborator.add_item(top_level_statement, &mut generated_items);
         }
 
         if !generated_items.is_empty() {

--- a/compiler/noirc_frontend/src/hir/def_collector/dc_crate.rs
+++ b/compiler/noirc_frontend/src/hir/def_collector/dc_crate.rs
@@ -42,7 +42,6 @@ use std::vec;
 /// Stores all of the unresolved functions in a particular file/mod
 #[derive(Clone)]
 pub struct UnresolvedFunctions {
-    pub file_id: FileId,
     pub functions: Vec<(LocalModuleId, FuncId, NoirFunction)>,
     pub trait_id: Option<TraitId>,
 
@@ -61,20 +60,17 @@ impl UnresolvedFunctions {
 }
 
 pub struct UnresolvedStruct {
-    pub file_id: FileId,
     pub module_id: LocalModuleId,
     pub struct_def: NoirStruct,
 }
 
 pub struct UnresolvedEnum {
-    pub file_id: FileId,
     pub module_id: LocalModuleId,
     pub enum_def: NoirEnumeration,
 }
 
 #[derive(Clone)]
 pub struct UnresolvedTrait {
-    pub file_id: FileId,
     pub module_id: LocalModuleId,
     pub crate_id: CrateId,
     pub trait_def: NoirTrait,
@@ -83,7 +79,6 @@ pub struct UnresolvedTrait {
 }
 
 pub struct UnresolvedTraitImpl {
-    pub file_id: FileId,
     pub module_id: LocalModuleId,
     pub r#trait: UnresolvedType,
     pub object_type: UnresolvedType,
@@ -107,14 +102,12 @@ pub struct UnresolvedTraitImpl {
 
 #[derive(Clone)]
 pub struct UnresolvedTypeAlias {
-    pub file_id: FileId,
     pub module_id: LocalModuleId,
     pub type_alias_def: NoirTypeAlias,
 }
 
 #[derive(Debug, Clone)]
 pub struct UnresolvedGlobal {
-    pub file_id: FileId,
     pub module_id: LocalModuleId,
     pub global_id: GlobalId,
     pub stmt_def: LetStatement,

--- a/compiler/noirc_frontend/src/hir_def/traits.rs
+++ b/compiler/noirc_frontend/src/hir_def/traits.rs
@@ -9,7 +9,6 @@ use crate::{
     graph::CrateId,
     node_interner::{FuncId, TraitId, TraitMethodId},
 };
-use fm::FileId;
 use noirc_errors::{Location, Span};
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -94,7 +93,6 @@ pub struct TraitImpl {
     /// before the impl as a whole is finished resolving.
     pub trait_generics: Vec<Type>,
 
-    pub file: FileId,
     pub methods: Vec<FuncId>, // methods[i] is the implementation of trait.methods[i] for Type typ
 
     /// The where clause, if present, contains each trait requirement which must

--- a/compiler/noirc_frontend/src/node_interner.rs
+++ b/compiler/noirc_frontend/src/node_interner.rs
@@ -3,7 +3,6 @@ use std::fmt;
 use std::hash::Hash;
 use std::marker::Copy;
 
-use fm::FileId;
 use iter_extended::vecmap;
 use noirc_arena::{Arena, Index};
 use noirc_errors::{Location, Span};
@@ -791,16 +790,14 @@ impl NodeInterner {
     pub fn new_type(
         &mut self,
         name: Ident,
-        span: Span,
+        location: Location,
         attributes: Vec<SecondaryAttribute>,
         generics: Generics,
         krate: CrateId,
         local_id: LocalModuleId,
-        file_id: FileId,
     ) -> TypeId {
         let type_id = TypeId(ModuleId { krate, local_id });
 
-        let location = Location::new(span, file_id);
         let new_type = DataType::new(type_id, name, location, generics);
         self.data_types.insert(type_id, Shared::new(new_type));
         self.type_attributes.insert(type_id, attributes);
@@ -891,13 +888,12 @@ impl NodeInterner {
         local_id: LocalModuleId,
         crate_id: CrateId,
         let_statement: StmtId,
-        file: FileId,
         attributes: Vec<SecondaryAttribute>,
         mutable: bool,
         comptime: bool,
     ) -> GlobalId {
         let id = GlobalId(self.globals.len());
-        let location = Location::new(ident.span(), file);
+        let location = ident.location();
         let name = ident.to_string();
 
         let definition_id =
@@ -928,7 +924,6 @@ impl NodeInterner {
         name: Ident,
         local_id: LocalModuleId,
         crate_id: CrateId,
-        file: FileId,
         attributes: Vec<SecondaryAttribute>,
         mutable: bool,
         comptime: bool,
@@ -936,8 +931,8 @@ impl NodeInterner {
         let statement = self.push_stmt(HirStatement::Error);
         let location = name.location();
 
-        let id = self
-            .push_global(name, local_id, crate_id, statement, file, attributes, mutable, comptime);
+        let id =
+            self.push_global(name, local_id, crate_id, statement, attributes, mutable, comptime);
         self.push_stmt_location(statement, location);
         id
     }

--- a/compiler/noirc_frontend/src/resolve_locations.rs
+++ b/compiler/noirc_frontend/src/resolve_locations.rs
@@ -187,7 +187,8 @@ impl NodeInterner {
             .iter()
             .find(|shared_trait_impl| {
                 let trait_impl = shared_trait_impl.1.borrow();
-                trait_impl.file == location.file && trait_impl.ident.span().contains(&location.span)
+                trait_impl.ident.location().file == location.file
+                    && trait_impl.ident.span().contains(&location.span)
             })
             .and_then(|shared_trait_impl| {
                 let trait_impl = shared_trait_impl.1.borrow();


### PR DESCRIPTION
# Description

## Problem

While working on something else I noticed we were passing `FileId` around and creating `Location` instances from an `Ident`'s span. However, `Ident` now carries a location so in all cases we can take the `Location` from it, and it's actually a bit more accurate.

## Summary

Removes some `FileId` from some structs and methods.

## Additional Context

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
