### PR TITLE
chore: document ssa `inline_simple_functions`

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/opt/inlining.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/inlining.rs
@@ -1208,4 +1208,25 @@ mod test {
         }
         ");
     }
+
+    #[test]
+    fn does_not_inline_simple_function_that_calls_itself() {
+        let src = "
+        acir(inline) fn main f0 {
+          b0(v0: Field):
+            v1 = call f1(v0) -> Field
+            return v1
+        }
+
+        acir(inline) fn foo f1 {
+          b0(v0: Field):
+            v1 = call f1(v0) -> Field
+            return v1
+        }
+        ";
+        let ssa = Ssa::from_str(src).unwrap();
+
+        let ssa = ssa.inline_simple_functions();
+        assert_normalized_ssa_equals(ssa, src);
+    }
 }

--- a/compiler/noirc_evaluator/src/ssa/opt/inlining.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/inlining.rs
@@ -807,212 +807,121 @@ impl<'function> PerFunctionContext<'function> {
 mod test {
     use std::cmp::max;
 
-    use acvm::{FieldElement, acir::AcirField};
-    use noirc_frontend::monomorphization::ast::InlineType;
-
     use crate::{
         assert_ssa_snapshot,
         ssa::{
             Ssa,
-            function_builder::FunctionBuilder,
-            ir::{
-                basic_block::BasicBlockId,
-                function::RuntimeType,
-                instruction::{BinaryOp, Intrinsic, TerminatorInstruction},
-                map::Id,
-                types::{NumericType, Type},
-            },
-            opt::inlining::inline_info::compute_bottom_up_order,
+            opt::{assert_normalized_ssa_equals, inlining::inline_info::compute_bottom_up_order},
         },
     };
 
     #[test]
     fn basic_inlining() {
-        // fn foo {
-        //   b0():
-        //     v0 = call bar()
-        //     return v0
-        // }
-        // fn bar {
-        //   b0():
-        //     return 72
-        // }
-        let foo_id = Id::test_new(0);
-        let mut builder = FunctionBuilder::new("foo".into(), foo_id);
+        let src = "
+        acir(inline) fn foo f0 {
+          b0():
+            v1 = call f1() -> Field
+            return v1
+        }
 
-        let bar_id = Id::test_new(1);
-        let bar = builder.import_function(bar_id);
-        let results = builder.insert_call(bar, Vec::new(), vec![Type::field()]).to_vec();
-        builder.terminate_with_return(results);
-
-        builder.new_function("bar".into(), bar_id, InlineType::default());
-        let expected_return = 72u128;
-        let seventy_two = builder.field_constant(expected_return);
-        builder.terminate_with_return(vec![seventy_two]);
-
-        let ssa = builder.finish();
-        assert_eq!(ssa.functions.len(), 2);
-
-        let inlined = ssa.inline_functions(i64::MAX);
-        assert_eq!(inlined.functions.len(), 1);
+        acir(inline) fn bar f1 {
+          b0():
+            return Field 72
+        }
+        ";
+        let ssa = Ssa::from_str(src).unwrap();
+        let ssa = ssa.inline_functions(i64::MAX);
+        assert_ssa_snapshot!(ssa, @r"
+        acir(inline) fn foo f0 {
+          b0():
+            return Field 72
+        }
+        ");
     }
 
     #[test]
     fn complex_inlining() {
         // This SSA is from issue #1327 which previously failed to inline properly
-        //
-        // fn main f0 {
-        //   b0(v0: Field):
-        //     v7 = call f2(f1)
-        //     v13 = call f3(v7)
-        //     v16 = call v13(v0)
-        //     return v16
-        // }
-        // fn square f1 {
-        //   b0(v0: Field):
-        //     v2 = mul v0, v0
-        //     return v2
-        // }
-        // fn id1 f2 {
-        //   b0(v0: function):
-        //     return v0
-        // }
-        // fn id2 f3 {
-        //   b0(v0: function):
-        //     return v0
-        // }
-        let main_id = Id::test_new(0);
-        let square_id = Id::test_new(1);
-        let id1_id = Id::test_new(2);
-        let id2_id = Id::test_new(3);
+        let src = "
+        acir(inline) fn main f0 {
+          b0(v0: Field):
+            v4 = call f2(f1) -> function
+            v5 = call f3(v4) -> function
+            v6 = call v5(v0) -> Field
+            return v6
+        }
 
-        // Compiling main
-        let mut builder = FunctionBuilder::new("main".into(), main_id);
-        let main_v0 = builder.add_parameter(Type::field());
+        acir(inline) fn square f1 {
+          b0(v0: Field):
+            v1 = mul v0, v0
+            return v1
+        }
 
-        let main_f1 = builder.import_function(square_id);
-        let main_f2 = builder.import_function(id1_id);
-        let main_f3 = builder.import_function(id2_id);
+        acir(inline) fn id1 f2 {
+          b0(v0: function):
+            return v0
+        }
 
-        let main_v7 = builder.insert_call(main_f2, vec![main_f1], vec![Type::Function])[0];
-        let main_v13 = builder.insert_call(main_f3, vec![main_v7], vec![Type::Function])[0];
-        let main_v16 = builder.insert_call(main_v13, vec![main_v0], vec![Type::field()])[0];
-        builder.terminate_with_return(vec![main_v16]);
+        acir(inline) fn id2 f3 {
+          b0(v0: function):
+            return v0
+        }
+        ";
+        let ssa = Ssa::from_str(src).unwrap();
 
-        // Compiling square f1
-        builder.new_function("square".into(), square_id, InlineType::default());
-        let square_v0 = builder.add_parameter(Type::field());
-        let square_v2 =
-            builder.insert_binary(square_v0, BinaryOp::Mul { unchecked: false }, square_v0);
-        builder.terminate_with_return(vec![square_v2]);
-
-        // Compiling id1 f2
-        builder.new_function("id1".into(), id1_id, InlineType::default());
-        let id1_v0 = builder.add_parameter(Type::Function);
-        builder.terminate_with_return(vec![id1_v0]);
-
-        // Compiling id2 f3
-        builder.new_function("id2".into(), id2_id, InlineType::default());
-        let id2_v0 = builder.add_parameter(Type::Function);
-        builder.terminate_with_return(vec![id2_v0]);
-
-        // Done, now we test that we can successfully inline all functions.
-        let ssa = builder.finish();
-        assert_eq!(ssa.functions.len(), 4);
-
-        let inlined = ssa.inline_functions(i64::MAX);
-        assert_eq!(inlined.functions.len(), 1);
+        let ssa = ssa.inline_functions(i64::MAX);
+        assert_ssa_snapshot!(ssa, @r"
+        acir(inline) fn main f0 {
+          b0(v0: Field):
+            v1 = mul v0, v0
+            return v1
+        }
+        ");
     }
 
     #[test]
     fn recursive_functions() {
-        // fn main f0 {
-        //   b0():
-        //     v0 = call factorial(Field 5)
-        //     return v0
-        // }
-        // fn factorial f1 {
-        //   b0(v0: Field):
-        //     v1 = lt v0, Field 1
-        //     jmpif v1, then: b1, else: b2
-        //   b1():
-        //     return Field 1
-        //   b2():
-        //     v2 = sub v0, Field 1
-        //     v3 = call factorial(v2)
-        //     v4 = mul v0, v3
-        //     return v4
-        // }
-        let main_id = Id::test_new(0);
-        let mut builder = FunctionBuilder::new("main".into(), main_id);
-
-        let factorial_id = Id::test_new(1);
-        let factorial = builder.import_function(factorial_id);
-
-        let five = builder.field_constant(5u128);
-        let results = builder.insert_call(factorial, vec![five], vec![Type::field()]).to_vec();
-        builder.terminate_with_return(results);
-
-        builder.new_function("factorial".into(), factorial_id, InlineType::default());
-        let b1 = builder.insert_block();
-        let b2 = builder.insert_block();
-
-        let one = builder.field_constant(1u128);
-
-        let v0 = builder.add_parameter(Type::field());
-        let v1 = builder.insert_binary(v0, BinaryOp::Lt, one);
-        builder.terminate_with_jmpif(v1, b1, b2);
-
-        builder.switch_to_block(b1);
-        builder.terminate_with_return(vec![one]);
-
-        builder.switch_to_block(b2);
-        let factorial_id = builder.import_function(factorial_id);
-        let v2 = builder.insert_binary(v0, BinaryOp::Sub { unchecked: false }, one);
-        let v3 = builder.insert_call(factorial_id, vec![v2], vec![Type::field()])[0];
-        let v4 = builder.insert_binary(v0, BinaryOp::Mul { unchecked: false }, v3);
-        builder.terminate_with_return(vec![v4]);
-
-        let ssa = builder.finish();
-        assert_eq!(ssa.functions.len(), 2);
-
-        // Expected SSA:
-        //
-        // fn main f2 {
-        //   b0():
-        //     jmp b1()
-        //   b1():
-        //     jmp b2()
-        //   b2():
-        //     jmp b3()
-        //   b3():
-        //     jmp b4()
-        //   b4():
-        //     jmp b5()
-        //   b5():
-        //     jmp b6()
-        //   b6():
-        //     return Field 120
-        // }
-        let inlined = ssa.inline_functions(i64::MAX);
-        assert_eq!(inlined.functions.len(), 1);
-
-        let main = inlined.main();
-        let b6_id: BasicBlockId = Id::test_new(6);
-        let b6 = &main.dfg[b6_id];
-
-        match b6.terminator() {
-            Some(TerminatorInstruction::Return { return_values, .. }) => {
-                assert_eq!(return_values.len(), 1);
-                let value = main
-                    .dfg
-                    .get_numeric_constant(return_values[0])
-                    .expect("Expected a constant for the return value")
-                    .to_u128();
-                assert_eq!(value, 120);
-            }
-            other => unreachable!("Unexpected terminator {other:?}"),
+        let src = "
+        acir(inline) fn main f0 {
+          b0():
+            v2 = call f1(Field 5) -> Field
+            return v2
         }
+
+        acir(inline) fn factorial f1 {
+          b0(v1: Field):
+            v2 = lt v1, Field 1
+            jmpif v2 then: b1, else: b2
+          b1():
+            return Field 1
+          b2():
+            v4 = sub v1, Field 1
+            v5 = call f1(v4) -> Field
+            v6 = mul v1, v5
+            return v6
+        }
+        ";
+        let ssa = Ssa::from_str(src).unwrap();
+
+        let ssa = ssa.inline_functions(i64::MAX);
+        assert_ssa_snapshot!(ssa, @r"
+        acir(inline) fn main f0 {
+          b0():
+            jmp b1()
+          b1():
+            jmp b2()
+          b2():
+            jmp b3()
+          b3():
+            jmp b4()
+          b4():
+            jmp b5()
+          b5():
+            jmp b6()
+          b6():
+            return Field 120
+        }
+        ");
     }
 
     #[test]
@@ -1021,77 +930,35 @@ mod test {
         // terminated by returns are badly tracked. As a result, the continuation of a source
         // block after a call instruction could but inlined into a block that's already been
         // terminated, producing an incorrect order and orphaning successors.
+        let src = "
+        acir(inline) fn main f0 {
+          b0(v0: u1):
+            jmpif v0 then: b1, else: b2
+          b1():
+            jmp b3(Field 1)
+          b2():
+            jmp b3(Field 2)
+          b3(v3: Field):
+            call assert_constant(v3)
+            return
+        }
+        ";
+        let ssa = Ssa::from_str(src).unwrap();
 
-        // fn main f0 {
-        //   b0(v0: u1):
-        //     v2 = call f1(v0)
-        //     call assert_constant(v2)
-        //     return
-        // }
-        // fn inner1 f1 {
-        //   b0(v0: u1):
-        //     v2 = call f2(v0)
-        //     return v2
-        // }
-        // fn inner2 f2 {
-        //   b0(v0: u1):
-        //     jmpif v0 then: b1, else: b2
-        //   b1():
-        //     jmp b3(Field 1)
-        //   b3(v3: Field):
-        //     return v3
-        //   b2():
-        //     jmp b3(Field 2)
-        // }
-        let main_id = Id::test_new(0);
-        let mut builder = FunctionBuilder::new("main".into(), main_id);
-
-        let main_cond = builder.add_parameter(Type::bool());
-        let inner1_id = Id::test_new(1);
-        let inner1 = builder.import_function(inner1_id);
-        let main_v2 = builder.insert_call(inner1, vec![main_cond], vec![Type::field()])[0];
-        let assert_constant = builder.import_intrinsic_id(Intrinsic::AssertConstant);
-        builder.insert_call(assert_constant, vec![main_v2], vec![]);
-        builder.terminate_with_return(vec![]);
-
-        builder.new_function("inner1".into(), inner1_id, InlineType::default());
-        let inner1_cond = builder.add_parameter(Type::bool());
-        let inner2_id = Id::test_new(2);
-        let inner2 = builder.import_function(inner2_id);
-        let inner1_v2 = builder.insert_call(inner2, vec![inner1_cond], vec![Type::field()])[0];
-        builder.terminate_with_return(vec![inner1_v2]);
-
-        builder.new_function("inner2".into(), inner2_id, InlineType::default());
-        let inner2_cond = builder.add_parameter(Type::bool());
-        let then_block = builder.insert_block();
-        let else_block = builder.insert_block();
-        let join_block = builder.insert_block();
-        builder.terminate_with_jmpif(inner2_cond, then_block, else_block);
-        builder.switch_to_block(then_block);
-        let one = builder.field_constant(FieldElement::one());
-        builder.terminate_with_jmp(join_block, vec![one]);
-        builder.switch_to_block(else_block);
-        let two = builder.field_constant(FieldElement::from(2_u128));
-        builder.terminate_with_jmp(join_block, vec![two]);
-        let join_param = builder.add_block_parameter(join_block, Type::field());
-        builder.switch_to_block(join_block);
-        builder.terminate_with_return(vec![join_param]);
-
-        let ssa = builder.finish().inline_functions(i64::MAX);
-        // Expected result:
-        // fn main f3 {
-        //   b0(v0: u1):
-        //     jmpif v0 then: b1, else: b2
-        //   b1():
-        //     jmp b3(Field 1)
-        //   b3(v3: Field):
-        //     call assert_constant(v3)
-        //     return
-        //   b2():
-        //     jmp b3(Field 2)
-        // }
-        let main = ssa.main();
-        assert_eq!(main.reachable_blocks().len(), 4);
+        let ssa = ssa.inline_functions(i64::MAX);
+        assert_ssa_snapshot!(ssa, @r"
+        acir(inline) fn main f0 {
+          b0(v0: u1):
+            jmpif v0 then: b1, else: b2
+          b1():
+            jmp b3(Field 1)
+          b2():
+            jmp b3(Field 2)
+          b3(v1: Field):
+            call assert_constant(v1)
+            return
+        }
+        ");
     }
 
     #[test]
@@ -1119,90 +986,68 @@ mod test {
 
     #[test]
     fn inliner_disabled() {
-        // brillig fn foo {
-        //   b0():
-        //     v0 = call bar()
-        //     return v0
-        // }
-        // brillig fn bar {
-        //   b0():
-        //     return 72
-        // }
-        let foo_id = Id::test_new(0);
-        let mut builder = FunctionBuilder::new("foo".into(), foo_id);
-        builder.set_runtime(RuntimeType::Brillig(InlineType::default()));
+        let src = "
+        brillig(inline) fn foo f0 {
+          b0():
+            v1 = call f1() -> Field
+            return v1
+        }
 
-        let bar_id = Id::test_new(1);
-        let bar = builder.import_function(bar_id);
-        let results = builder.insert_call(bar, Vec::new(), vec![Type::field()]).to_vec();
-        builder.terminate_with_return(results);
-
-        builder.new_brillig_function("bar".into(), bar_id, InlineType::default());
-        let expected_return = 72u128;
-        let seventy_two = builder.field_constant(expected_return);
-        builder.terminate_with_return(vec![seventy_two]);
-
-        let ssa = builder.finish();
-        assert_eq!(ssa.functions.len(), 2);
-
-        let inlined = ssa.inline_functions(i64::MIN);
+        brillig(inline) fn bar f1 {
+          b0():
+            return Field 72
+        }
+        ";
+        let ssa = Ssa::from_str(src).unwrap();
+        let ssa = ssa.inline_functions(i64::MIN);
         // No inlining has happened
-        assert_eq!(inlined.functions.len(), 2);
+        assert_normalized_ssa_equals(ssa, src);
     }
 
     #[test]
     fn conditional_inlining() {
         // In this example we call a larger brillig function 3 times so the inliner refuses to inline the function.
-        // brillig fn foo {
-        //   b0():
-        //     v0 = call bar()
-        //     v1 = call bar()
-        //     v2 = call bar()
-        //     return v0
-        // }
-        // brillig fn bar {
-        //   b0():
-        //     jmpif 1 then: b1, else: b2
-        //   b1():
-        //     jmp b3(Field 1)
-        //   b3(v3: Field):
-        //     return v3
-        //   b2():
-        //     jmp b3(Field 2)
-        // }
-        let foo_id = Id::test_new(0);
-        let mut builder = FunctionBuilder::new("foo".into(), foo_id);
-        builder.set_runtime(RuntimeType::Brillig(InlineType::default()));
+        let src = "
+        brillig(inline) fn foo f0 {
+          b0():
+            v1 = call f1() -> Field
+            v2 = call f1() -> Field
+            v3 = call f1() -> Field
+            return v1
+        }
 
-        let bar_id = Id::test_new(1);
-        let bar = builder.import_function(bar_id);
-        let v0 = builder.insert_call(bar, Vec::new(), vec![Type::field()]).to_vec();
-        let _v1 = builder.insert_call(bar, Vec::new(), vec![Type::field()]).to_vec();
-        let _v2 = builder.insert_call(bar, Vec::new(), vec![Type::field()]).to_vec();
-        builder.terminate_with_return(v0);
+        brillig(inline) fn bar f1 {
+          b0():
+            jmpif u1 1 then: b1, else: b2
+          b1():
+            jmp b3(Field 1)
+          b2():
+            jmp b3(Field 2)
+          b3(v3: Field):
+            return v3
+        }
+        ";
+        let ssa = Ssa::from_str(src).unwrap();
 
-        builder.new_brillig_function("bar".into(), bar_id, InlineType::default());
-        let bar_v0 = builder.numeric_constant(1_usize, NumericType::bool());
-        let then_block = builder.insert_block();
-        let else_block = builder.insert_block();
-        let join_block = builder.insert_block();
-        builder.terminate_with_jmpif(bar_v0, then_block, else_block);
-        builder.switch_to_block(then_block);
-        let one = builder.field_constant(FieldElement::one());
-        builder.terminate_with_jmp(join_block, vec![one]);
-        builder.switch_to_block(else_block);
-        let two = builder.field_constant(FieldElement::from(2_u128));
-        builder.terminate_with_jmp(join_block, vec![two]);
-        let join_param = builder.add_block_parameter(join_block, Type::field());
-        builder.switch_to_block(join_block);
-        builder.terminate_with_return(vec![join_param]);
-
-        let ssa = builder.finish();
-        assert_eq!(ssa.functions.len(), 2);
-
-        let inlined = ssa.inline_functions(0);
-        // No inlining has happened
-        assert_eq!(inlined.functions.len(), 2);
+        let ssa = ssa.inline_functions(0);
+        // No inlining has happened in f0
+        assert_ssa_snapshot!(ssa, @r"
+        brillig(inline) fn foo f0 {
+          b0():
+            v1 = call f1() -> Field
+            v2 = call f1() -> Field
+            v3 = call f1() -> Field
+            return v1
+        }
+        brillig(inline) fn bar f1 {
+          b0():
+            jmp b1()
+          b1():
+            jmp b2(Field 1)
+          b2(v0: Field):
+            return v0
+        }
+        ");
     }
 
     #[test]

--- a/compiler/noirc_evaluator/src/ssa/opt/inlining.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/inlining.rs
@@ -94,8 +94,9 @@ impl Ssa {
         self
     }
 
-    /// Inline "simple" functions.
-    /// A simple function being a function with one or less instructions.
+    /// An SSA pass that inlines calls to "simple" functions. That is, the contents of the called
+    /// function is put directly into the caller's body.
+    /// A simple function is a function with one or less instructions.
     /// Simple functions are still restricted to not inlined if they are recursive or marked with no predicates.
     pub(crate) fn inline_simple_functions(mut self: Ssa) -> Ssa {
         let should_inline_call = |callee: &Function| {


### PR DESCRIPTION
# Description

## Problem

Resolves #8155

## Summary

In reality this already had some docs but I wrote a bit more to make it clear what inlining is. The docs aren't long but with the tests in the file it should be clear what's going on. I also added a test for the recursive case.

I also took this opportunity to transform some SSA tests to use the SSA parser.

## Additional Context

I wonder if this `inline_simple_functions` pass should be moved to its own file as it doesn't rely on the other methods (though it's a form of inlining so maybe it makes sense for all to be in the same file?)

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
