### PR TITLE
chore: Change AST fuzzer recursion limit

### DIFF
--- a/tooling/ast_fuzzer/src/lib.rs
+++ b/tooling/ast_fuzzer/src/lib.rs
@@ -30,8 +30,8 @@ pub struct Config {
     pub max_array_size: usize,
     /// Maximum size of for loop ranges, which affects unrolling in ACIR.
     pub max_loop_size: usize,
-    /// Maximum call depth for recursive calls.
-    pub max_call_depth: usize,
+    /// Maximum number of recursive calls to make at runtime.
+    pub max_recursive_calls: usize,
     /// Frequency of expressions, which produce a value.
     pub expr_freqs: Freqs,
     /// Frequency of statements in ACIR functions.
@@ -81,7 +81,7 @@ impl Default for Config {
             max_tuple_size: 5,
             max_array_size: 4,
             max_loop_size: 10,
-            max_call_depth: 5,
+            max_recursive_calls: 25,
             expr_freqs,
             stmt_freqs_acir,
             stmt_freqs_brillig,

--- a/tooling/ast_fuzzer/src/lib.rs
+++ b/tooling/ast_fuzzer/src/lib.rs
@@ -30,6 +30,8 @@ pub struct Config {
     pub max_array_size: usize,
     /// Maximum size of for loop ranges, which affects unrolling in ACIR.
     pub max_loop_size: usize,
+    /// Whether to choose the backstop for `loop` and `while` randomly.
+    pub vary_loop_size: bool,
     /// Maximum number of recursive calls to make at runtime.
     pub max_recursive_calls: usize,
     /// Frequency of expressions, which produce a value.
@@ -81,6 +83,7 @@ impl Default for Config {
             max_tuple_size: 5,
             max_array_size: 4,
             max_loop_size: 10,
+            vary_loop_size: true,
             max_recursive_calls: 25,
             expr_freqs,
             stmt_freqs_acir,

--- a/tooling/ast_fuzzer/src/program/expr.rs
+++ b/tooling/ast_fuzzer/src/program/expr.rs
@@ -277,8 +277,16 @@ pub(crate) fn if_else(
 }
 
 /// Assign a value to an identifier.
-pub(crate) fn assign(ident: Ident, expr: Expression) -> Expression {
+pub(crate) fn assign_ident(ident: Ident, expr: Expression) -> Expression {
     Expression::Assign(Assign { lvalue: LValue::Ident(ident), expression: Box::new(expr) })
+}
+
+/// Assign a value to a mutable reference.
+pub(crate) fn assign_ref(ident: Ident, expr: Expression) -> Expression {
+    let typ = ident.typ.clone();
+    let lvalue = LValue::Ident(ident);
+    let lvalue = LValue::Dereference { reference: Box::new(lvalue), element_type: typ };
+    Expression::Assign(Assign { lvalue, expression: Box::new(expr) })
 }
 
 /// Cast an expression to a target type.
@@ -310,6 +318,11 @@ pub(crate) fn equal(lhs: Expression, rhs: Expression) -> Expression {
 /// Dereference an expression into a target type
 pub(crate) fn deref(rhs: Expression, tgt_type: Type) -> Expression {
     unary(UnaryOp::Dereference { implicitly_added: false }, rhs, tgt_type)
+}
+
+/// Reference an expression as a target type
+pub(crate) fn ref_mut(rhs: Expression, tgt_type: Type) -> Expression {
+    unary(UnaryOp::Reference { mutable: true }, rhs, tgt_type)
 }
 
 /// Make a unary expression.

--- a/tooling/ast_fuzzer/src/program/func.rs
+++ b/tooling/ast_fuzzer/src/program/func.rs
@@ -1023,7 +1023,7 @@ fn test_loop() {
     let mut ctx = Context::default();
     ctx.config.max_loop_size = 10;
     ctx.config.vary_loop_size = false;
-    ctx.add_main_decl(&mut u);
+    ctx.gen_main_decl(&mut u);
     let mut fctx = FunctionContext::new(&mut ctx, FuncId(0));
     fctx.budget = 2;
     let loop_code = format!("{}", fctx.gen_loop(&mut u).unwrap()).replace(" ", "");
@@ -1049,7 +1049,7 @@ fn test_while() {
     let mut ctx = Context::default();
     ctx.config.max_loop_size = 10;
     ctx.config.vary_loop_size = false;
-    ctx.add_main_decl(&mut u);
+    ctx.gen_main_decl(&mut u);
     let mut fctx = FunctionContext::new(&mut ctx, FuncId(0));
     fctx.budget = 2;
     let while_code = format!("{}", fctx.gen_while(&mut u).unwrap()).replace(" ", "");

--- a/tooling/ast_fuzzer/src/program/func.rs
+++ b/tooling/ast_fuzzer/src/program/func.rs
@@ -931,7 +931,7 @@ impl<'a> FunctionContext<'a> {
         // Increment the index in the beginning of the body.
         expr::prepend(
             &mut loop_body,
-            expr::assign(
+            expr::assign_ident(
                 idx_ident,
                 expr::binary(idx_expr.clone(), BinaryOp::Add, expr::u32_literal(1)),
             ),
@@ -985,7 +985,7 @@ impl<'a> FunctionContext<'a> {
         // Increment the index in the beginning of the body.
         expr::prepend(
             &mut loop_body,
-            expr::assign(
+            expr::assign_ident(
                 idx_ident,
                 expr::binary(idx_expr.clone(), BinaryOp::Add, expr::u32_literal(1)),
             ),

--- a/tooling/ast_fuzzer/src/program/mod.rs
+++ b/tooling/ast_fuzzer/src/program/mod.rs
@@ -208,7 +208,7 @@ impl Context {
 
     /// As a post-processing step, identify recursive functions and add a call depth parameter to them.
     fn rewrite_functions(&mut self, u: &mut Unstructured) -> arbitrary::Result<()> {
-        rewrite::add_recursion_depth(self, u)
+        rewrite::add_recursion_limit(self, u)
     }
 
     /// Return the generated [Program].

--- a/tooling/ast_fuzzer/src/program/mod.rs
+++ b/tooling/ast_fuzzer/src/program/mod.rs
@@ -180,7 +180,7 @@ impl Context {
 
     /// Generate and add main (for testing)
     #[cfg(test)]
-    fn add_main_decl(&mut self, u: &mut Unstructured) {
+    fn gen_main_decl(&mut self, u: &mut Unstructured) {
         let d = self.gen_function_decl(u, 0).unwrap();
         self.function_declarations.insert(FuncId(0u32), d);
     }

--- a/tooling/ast_fuzzer/src/program/rewrite.rs
+++ b/tooling/ast_fuzzer/src/program/rewrite.rs
@@ -51,7 +51,7 @@ pub(crate) fn add_recursion_limit(
 
     // Rewrite recursive functions.
     for (func_id, unconstrained) in recursive_functions.iter() {
-        let func = ctx.functions.get_mut(&func_id).unwrap();
+        let func = ctx.functions.get_mut(func_id).unwrap();
         let is_main = *func_id == Program::main_id();
 
         // We'll need a new ID for variables or parameters. We could speed this up by
@@ -127,7 +127,7 @@ pub(crate) fn add_recursion_limit(
         }
 
         // Add the non-reference version of the parameter to the proxy function.
-        if let Some(proxy) = proxy_functions.get_mut(&func_id) {
+        if let Some(proxy) = proxy_functions.get_mut(func_id) {
             proxy.parameters.push((limit_id, true, limit_name.clone(), types::U32));
             // The body is just a call the the non-proxy function.
             proxy.body = Expression::Call(Call {

--- a/tooling/ast_fuzzer/src/program/rewrite.rs
+++ b/tooling/ast_fuzzer/src/program/rewrite.rs
@@ -106,21 +106,22 @@ pub(crate) fn add_recursion_limit(
             );
             let limit_expr = Expression::Ident(limit_ident.clone());
 
-            expr::replace(&mut func.body, |body| {
+            expr::replace(&mut func.body, |mut body| {
+                expr::prepend(
+                    &mut body,
+                    expr::assign_ref(
+                        limit_ident,
+                        expr::binary(
+                            expr::deref(limit_expr.clone(), types::U32),
+                            BinaryOpKind::Subtract,
+                            expr::u32_literal(1),
+                        ),
+                    ),
+                );
                 expr::if_else(
                     expr::equal(expr::deref(limit_expr.clone(), types::U32), expr::u32_literal(0)),
                     default_return,
-                    Expression::Block(vec![
-                        expr::assign_ref(
-                            limit_ident,
-                            expr::binary(
-                                expr::deref(limit_expr.clone(), types::U32),
-                                BinaryOpKind::Subtract,
-                                expr::u32_literal(1),
-                            ),
-                        ),
-                        body,
-                    ]),
+                    body,
                     func.return_type.clone(),
                 )
             });

--- a/tooling/ast_fuzzer/src/program/rewrite.rs
+++ b/tooling/ast_fuzzer/src/program/rewrite.rs
@@ -1,17 +1,17 @@
-use std::collections::{BTreeMap, HashSet};
+use std::collections::BTreeMap;
 
 use arbitrary::Unstructured;
 use im::HashMap;
+use nargo::errors::Location;
 use noirc_frontend::{
     ast::BinaryOpKind,
     monomorphization::ast::{
-        Call, Definition, Expression, FuncId, Function, IdentId, LocalId, Program, Type,
+        Call, Definition, Expression, FuncId, Function, Ident, IdentId, LocalId, Program, Type,
     },
-    shared::Visibility,
 };
 
 use super::{
-    Context, VariableId, expr, func, types,
+    Context, VariableId, expr, types,
     visitor::{visit_expr, visit_expr_mut},
 };
 
@@ -33,30 +33,25 @@ pub(crate) fn add_recursion_limit(
         .collect::<BTreeMap<_, _>>();
 
     // Create proxies for unconstrained recursive functions.
-    // let mut proxy_functions = HashMap::new();
-    // let mut next_func_id = FuncId(ctx.functions.len() as u32);
-
-    // for (id, func) in &ctx.functions {
-    //     if expr::has_call(&func.body) {
-    //         recursive_functions.insert(id);
-    //         if func.unconstrained && *id != Program::main_id() {
-    //             let mut proxy = func.clone();
-    //             proxy.id = next_func_id;
-    //             proxy.name =format!("{}_proxy", proxy.name);
-    //             proxy.body = Expression::Call(Call {})
-
-    //             next_func_id = FuncId(next_func_id.0 + 1);
-    //             proxy_functions.insert(id, )
-    //         }
-    //     }
-    // }
-
-    // Create proxy functions for the unconstrained recursive functions.
     // We could check whether they are called from ACIR, but that would require further traversals.
+    let mut proxy_functions = HashMap::new();
+    let mut next_func_id = FuncId(ctx.functions.len() as u32);
 
-    for (func_id, func) in
-        ctx.functions.iter_mut().filter(|(id, _)| recursive_functions.contains_key(id))
-    {
+    for (func_id, unconstrained) in &recursive_functions {
+        if !*unconstrained || *func_id == Program::main_id() {
+            continue;
+        }
+        let mut proxy = ctx.functions[func_id].clone();
+        proxy.id = next_func_id;
+        proxy.name = format!("{}_proxy", proxy.name);
+        // We will replace the body and update the params later.
+        proxy_functions.insert(*func_id, proxy);
+        next_func_id = FuncId(next_func_id.0 + 1);
+    }
+
+    // Rewrite recursive functions.
+    for (func_id, unconstrained) in recursive_functions.iter() {
+        let func = ctx.functions.get_mut(&func_id).unwrap();
         let is_main = *func_id == Program::main_id();
 
         // We'll need a new ID for variables or parameters. We could speed this up by
@@ -66,45 +61,64 @@ pub(crate) fn add_recursion_limit(
         // We wouldn't be able to add caching to `Program` without changing it, so eventually we'll need to look at the values
         // to do random mutations, or we have to pass back some meta along with `Program` and look it up there. For now we
         // traverse the AST to figure out what the next ID to use is.
-        let (next_local_id, next_ident_id) = next_local_and_ident_id(func);
+        let (mut next_local_id, mut next_ident_id) = next_local_and_ident_id(func);
 
-        let depth_id = LocalId(next_local_id);
-        let depth_name = "ctx_depth".to_string();
-        let depth_ident_id = IdentId(next_ident_id);
-        let depth_ident = expr::ident_inner(
-            VariableId::Local(depth_id),
-            depth_ident_id,
-            !is_main,
-            depth_name.clone(),
-            types::U32,
-        );
-        let depth_expr = Expression::Ident(depth_ident.clone());
-        let depth_decreased =
-            expr::binary(depth_expr.clone(), BinaryOpKind::Subtract, expr::u32_literal(1));
+        let mut next_local_id = || {
+            let id = next_local_id;
+            next_local_id += 1;
+            LocalId(id)
+        };
+
+        let mut next_ident_id = || {
+            let id = next_ident_id;
+            next_ident_id += 1;
+            IdentId(id)
+        };
+
+        let limit_name = "ctx_limit".to_string();
+        let limit_id = next_local_id();
+        let limit_var = VariableId::Local(limit_id);
 
         if is_main {
-            // In main we initialize the depth to its maximum value.
-            let init_depth = expr::let_var(
-                depth_id,
-                false,
-                depth_name,
-                expr::u32_literal(ctx.config.max_call_depth as u32),
+            // In main we initialize the limit to its maximum value.
+            let init_limit = expr::let_var(
+                limit_id,
+                true,
+                limit_name.clone(),
+                expr::u32_literal(ctx.config.max_recursive_calls as u32),
             );
-            expr::prepend(&mut func.body, init_depth);
+            expr::prepend(&mut func.body, init_limit);
         } else {
-            // In non-main we look at the depth and return a random value if it's zero,
+            // In non-main we look at the limit and return a random value if it's zero,
             // otherwise decrease it by one and continue with the original body.
-            func.parameters.push((depth_id, true, depth_name.clone(), types::U32));
-            func.func_sig.0.push(func::hir_param(true, &types::U32, Visibility::Private));
+            let limit_type = types::ref_mut(types::U32);
+            func.parameters.push((limit_id, false, limit_name.clone(), limit_type.clone()));
 
+            // Generate a random value to return.
             let default_return = expr::gen_literal(u, &func.return_type)?;
+
+            let limit_ident = expr::ident_inner(
+                limit_var,
+                next_ident_id(),
+                false,
+                limit_name.clone(),
+                limit_type,
+            );
+            let limit_expr = Expression::Ident(limit_ident.clone());
 
             expr::replace(&mut func.body, |body| {
                 expr::if_else(
-                    expr::equal(depth_expr.clone(), expr::u32_literal(0)),
+                    expr::equal(expr::deref(limit_expr.clone(), types::U32), expr::u32_literal(0)),
                     default_return,
                     Expression::Block(vec![
-                        expr::assign(depth_ident, depth_decreased.clone()),
+                        expr::assign_ref(
+                            limit_ident,
+                            expr::binary(
+                                expr::deref(limit_expr.clone(), types::U32),
+                                BinaryOpKind::Subtract,
+                                expr::u32_literal(1),
+                            ),
+                        ),
                         body,
                     ]),
                     func.return_type.clone(),
@@ -112,8 +126,59 @@ pub(crate) fn add_recursion_limit(
             });
         }
 
-        // Update calls to pass along the depth.
-        visit_expr_mut(&mut func.body, &mut |expr| {
+        // Add the non-reference version of the parameter to the proxy function.
+        if let Some(proxy) = proxy_functions.get_mut(&func_id) {
+            proxy.parameters.push((limit_id, true, limit_name.clone(), types::U32));
+            // The body is just a call the the non-proxy function.
+            proxy.body = Expression::Call(Call {
+                func: Box::new(Expression::Ident(Ident {
+                    location: None,
+                    definition: Definition::Function(*func_id),
+                    mutable: false,
+                    name: func.name.clone(),
+                    typ: Type::Function(
+                        func.parameters.iter().map(|p| p.3.clone()).collect(),
+                        Box::new(func.return_type.clone()),
+                        Box::new(Type::Unit),
+                        func.unconstrained,
+                    ),
+                    id: next_ident_id(),
+                })),
+                arguments: proxy
+                    .parameters
+                    .iter()
+                    .map(|(id, mutable, name, typ)| {
+                        if *id == limit_id {
+                            // Pass mutable reference to the limit.
+                            expr::ref_mut(
+                                expr::ident(
+                                    VariableId::Local(*id),
+                                    next_ident_id(),
+                                    *mutable,
+                                    name.clone(),
+                                    typ.clone(),
+                                ),
+                                typ.clone(),
+                            )
+                        } else {
+                            // Pass every other parameter as-is.
+                            expr::ident(
+                                VariableId::Local(*id),
+                                next_ident_id(),
+                                *mutable,
+                                name.clone(),
+                                typ.clone(),
+                            )
+                        }
+                    })
+                    .collect(),
+                return_type: proxy.return_type.clone(),
+                location: Location::dummy(),
+            });
+        }
+
+        // Update calls to pass along the limit and call the proxy if necessary.
+        visit_expr_mut(&mut func.body, &mut |expr: &mut Expression| {
             if let Expression::Call(call) = expr {
                 let Expression::Ident(func) = call.func.as_mut() else {
                     unreachable!("functions are called by ident");
@@ -122,17 +187,76 @@ pub(crate) fn add_recursion_limit(
                     unreachable!("function definition expected");
                 };
                 // If the callee isn't recursive, it won't have the extra parameter.
-                if !recursive_functions.contains(&func_id) {
+                let Some(callee_unconstrained) = recursive_functions.get(&func_id) else {
                     return true;
-                }
+                };
                 let Type::Function(param_types, _, _, _) = &mut func.typ else {
                     unreachable!("function type expected");
                 };
-                param_types.push(types::U32);
-                call.arguments.push(depth_expr.clone());
+                if *callee_unconstrained && !unconstrained {
+                    // Calling Brillig from ACIR: call the proxy.
+                    let Some(proxy) = proxy_functions.get(&func_id) else {
+                        unreachable!("expected to have a proxy");
+                    };
+                    func.name = proxy.name.clone();
+                    func.definition = Definition::Function(proxy.id);
+                    // Pass the limit by value.
+                    let limit_expr = if is_main {
+                        expr::ident(
+                            limit_var,
+                            next_ident_id(),
+                            true,
+                            limit_name.clone(),
+                            types::U32,
+                        )
+                    } else {
+                        expr::deref(
+                            expr::ident(
+                                limit_var,
+                                next_ident_id(),
+                                false,
+                                limit_name.clone(),
+                                types::ref_mut(types::U32),
+                            ),
+                            types::U32,
+                        )
+                    };
+                    param_types.push(types::U32);
+                    call.arguments.push(limit_expr);
+                } else {
+                    // Pass the limit by reference.
+                    let limit_type = types::ref_mut(types::U32);
+                    let limit_expr = if is_main {
+                        expr::ref_mut(
+                            expr::ident(
+                                limit_var,
+                                next_ident_id(),
+                                true,
+                                limit_name.clone(),
+                                types::U32,
+                            ),
+                            limit_type,
+                        )
+                    } else {
+                        expr::ident(
+                            limit_var,
+                            next_ident_id(),
+                            false,
+                            limit_name.clone(),
+                            limit_type,
+                        )
+                    };
+                    param_types.push(types::U32);
+                    call.arguments.push(limit_expr);
+                }
             }
             true
         });
+    }
+
+    // Append proxy functions.
+    for (_, proxy) in proxy_functions {
+        ctx.functions.insert(proxy.id, proxy);
     }
 
     Ok(())

--- a/tooling/ast_fuzzer/src/program/rewrite.rs
+++ b/tooling/ast_fuzzer/src/program/rewrite.rs
@@ -1,9 +1,12 @@
-use std::collections::HashSet;
+use std::collections::{BTreeMap, HashSet};
 
 use arbitrary::Unstructured;
+use im::HashMap;
 use noirc_frontend::{
     ast::BinaryOpKind,
-    monomorphization::ast::{Definition, Expression, Function, IdentId, LocalId, Program, Type},
+    monomorphization::ast::{
+        Call, Definition, Expression, FuncId, Function, IdentId, LocalId, Program, Type,
+    },
     shared::Visibility,
 };
 
@@ -12,27 +15,59 @@ use super::{
     visitor::{visit_expr, visit_expr_mut},
 };
 
-/// Find recursive functions and add a `ctx_depth` parameter to them.
-pub(crate) fn add_recursion_depth(
+/// Find recursive functions and add a `ctx_limit: &mut u32` parameter to them,
+/// which we use to limit the number of recursive calls. This is complicated by
+/// the fact that we cannot pass mutable references from ACIR to Brillig. To
+/// overcome that, we create a proxy function for unconstrained functions that
+/// take `mut ctx_limit: u32` instead, and pass it on as a mutable ref.
+pub(crate) fn add_recursion_limit(
     ctx: &mut Context,
     u: &mut Unstructured,
 ) -> arbitrary::Result<()> {
     // Collect recursive functions, ie. the ones which call other functions.
+    // Remember if they are unconstrained; those need proxies as well.
     let recursive_functions = ctx
         .functions
         .iter()
-        .filter_map(|(id, func)| expr::has_call(&func.body).then_some(*id))
-        .collect::<HashSet<_>>();
+        .filter_map(|(id, func)| expr::has_call(&func.body).then_some((*id, func.unconstrained)))
+        .collect::<BTreeMap<_, _>>();
+
+    // Create proxies for unconstrained recursive functions.
+    // let mut proxy_functions = HashMap::new();
+    // let mut next_func_id = FuncId(ctx.functions.len() as u32);
+
+    // for (id, func) in &ctx.functions {
+    //     if expr::has_call(&func.body) {
+    //         recursive_functions.insert(id);
+    //         if func.unconstrained && *id != Program::main_id() {
+    //             let mut proxy = func.clone();
+    //             proxy.id = next_func_id;
+    //             proxy.name =format!("{}_proxy", proxy.name);
+    //             proxy.body = Expression::Call(Call {})
+
+    //             next_func_id = FuncId(next_func_id.0 + 1);
+    //             proxy_functions.insert(id, )
+    //         }
+    //     }
+    // }
+
+    // Create proxy functions for the unconstrained recursive functions.
+    // We could check whether they are called from ACIR, but that would require further traversals.
 
     for (func_id, func) in
-        ctx.functions.iter_mut().filter(|(id, _)| recursive_functions.contains(id))
+        ctx.functions.iter_mut().filter(|(id, _)| recursive_functions.contains_key(id))
     {
         let is_main = *func_id == Program::main_id();
+
         // We'll need a new ID for variables or parameters. We could speed this up by
         // 1) caching this value in a "function meta" construct, or
-        // 2) using `u32::MAX`, but we wouldn't be able to add caching to `Program`,
-        // so eventually we'll need to look at the values to do random mutations.
+        // 2) using `u32::MAX`, but then we would be in a worse situation next time
+        // 3) draw values from `Context` instead of `FunctionContext`, which breaks continuity, but saves an extra traversal.
+        // We wouldn't be able to add caching to `Program` without changing it, so eventually we'll need to look at the values
+        // to do random mutations, or we have to pass back some meta along with `Program` and look it up there. For now we
+        // traverse the AST to figure out what the next ID to use is.
         let (next_local_id, next_ident_id) = next_local_and_ident_id(func);
+
         let depth_id = LocalId(next_local_id);
         let depth_name = "ctx_depth".to_string();
         let depth_ident_id = IdentId(next_ident_id);

--- a/tooling/ast_fuzzer/src/program/types.rs
+++ b/tooling/ast_fuzzer/src/program/types.rs
@@ -222,3 +222,8 @@ pub(crate) fn can_binary_op_return_from_input(op: &BinaryOp, input: &Type, outpu
         _ => false,
     }
 }
+
+/// Reference an expression into a target type
+pub(crate) fn ref_mut(typ: Type) -> Type {
+    Type::Reference(Box::new(typ), true)
+}


### PR DESCRIPTION
# Description

## Problem\*

Resolves intermittent slow tests in #8048 

## Summary\*

Replaces `mut ctx_depth: u32` with `ctx_limit: &mut u32`, to handle exponential cases similar to Fibonacci by limiting the overall number of recursive calls before shortcutting functions to return a random value, rather than allowing the maximum depth to be reached. 

The complication is that it's not possible to pass a mutable reference from ACIR to Brillig. To overcome this we: create a `func_{i}_proxy` for unconstrained functions, which takes `mut ctx_limit: u32` by value and passes it to `func_{i}` by reference.

## Additional Context

Here's an example of a function which was slow with `ctx_depth`, rewritten to use mutable references:

<details>
  <summary>Slow due to recursion</summary>

```rust
global G_A: [(Field, Field, bool, bool); 0] = [];
global G_B: [[u16; 0]; 3] = [[], [], []];
unconstrained fn main() -> pub (Field, Field, bool, bool) {
    let mut ctx_limit = 5;
    (210599614764714653382489015013312909866, (func_2(func_5("", &mut ctx_limit), if false {
        (!true)
    } else {
        func_5("", &mut ctx_limit)
    }) as Field), func_5(if true {
        ""
    } else {
        ""
    }, &mut ctx_limit), if func_5("", &mut ctx_limit) {
        (!func_5("", &mut ctx_limit))
    } else {
        if func_5(if (!false) {
            ""
        } else {
            func_4([("", false, 112173205673011516923171613784418000313, "ABC", -8147)], &mut ctx_limit).0
        }, &mut ctx_limit) {
            false
        } else {
            func_5("", &mut ctx_limit)
        }
    })
}
fn func_1(mut a: [[u16; 0]; 3], b: (Field, Field, bool, bool), mut c: Field) -> bool {
    b.2
}
unconstrained fn func_2(a: bool, mut b: bool) -> u16 {
    12744
}
fn func_3(a: bool, mut b: [str<0>; 3], mut c: [(u64, bool, u16, u32, bool); 2], ctx_limit: &mut u32) -> Field {
    if (*ctx_limit == 0) {
        -91272772969658566208753441772487222731
    } else {
        *ctx_limit = *ctx_limit - 1;
        if unsafe { func_5_proxy(if unsafe { func_5_proxy(b[0], *ctx_limit) } {
            unsafe { func_4_proxy([("", c[0].1, (a as Field), "IEF", 15837)], *ctx_limit) }.0
        } else {
            ""
        }, *ctx_limit) } {
            61819793148384237204158051638397851904
        } else {
            for idx_d in 8844 .. 8849 {
                if (if unsafe { func_5_proxy("", *ctx_limit) } {
                    51123439257234248396303652390047952106
                } else {
                    (unsafe { func_4_proxy([("", true, -332984236243826044317475693288591622591, "LGQ", 7313)], *ctx_limit) }.1.1 as u128)
                } <= (unsafe { func_2(false, c[0].4) } as u128)) {
                    c[0] = {
                        b = b;
                        let e = "S";
                        (12257872272973752653, true, 29144, (((c[1].2 % 9265) << 125) as u32), a)
                    };
                } else {
                    ()
                };
                ()
            };
            -214491953683494567084585875246146393402
        }
    }
}
unconstrained fn func_4_proxy(mut a: [(str<0>, bool, Field, str<3>, i16); 1], mut ctx_limit: u32) -> (str<0>, (i64, Field), [u16; 0]) {
    func_4(a, &mut ctx_limit)
}
unconstrained fn func_4(mut a: [(str<0>, bool, Field, str<3>, i16); 1], ctx_limit: &mut u32) -> (str<0>, (i64, Field), [u16; 0]) {
    if (*ctx_limit == 0) {
        ("", (-6198611486336017755, -158532646483603675733802980870644575904), [])
    } else {
        *ctx_limit = *ctx_limit - 1;
        (func_4(a, ctx_limit).0, (((a[0].4 >> if true {
            234
        } else {
            34
        }) as i64), (a[0].1 as Field)), if true {
            func_4(a, ctx_limit).2
        } else {
            G_B[0]
        })
    }
}
unconstrained fn func_5_proxy(mut a: str<0>, mut ctx_limit: u32) -> bool {
    func_5(a, &mut ctx_limit)
}
unconstrained fn func_5(mut a: str<0>, ctx_limit: &mut u32) -> bool {
    if (*ctx_limit == 0) {
        true
    } else {
        *ctx_limit = *ctx_limit - 1;
        if func_5(func_4([("", true, -68801463734466096185118923994098536602, "LJH", -16314)], ctx_limit).0, ctx_limit) {
            a = if func_5("", ctx_limit) {
                if func_5(a, ctx_limit) {
                    a = a;
                    {
                        let mut idx_b = 0;
                        loop {
                            if (idx_b == 10) {
                                break
                            } else {
                                idx_b = (idx_b + 1);
                                {
                                    let mut idx_c = 0;
                                    while func_5(a, ctx_limit) {
                                        if (idx_c == 10) {
                                            break
                                        } else {
                                            idx_c = (idx_c + 1);
                                            a = "";
                                        }
                                    }
                                };
                            }
                        }
                    };
                    a = a;
                };
                ""
            } else {
                a
            };
            true
        } else {
            false
        }
    }
}
```
</details>


## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
