### PR TITLE
fix(parser): avoid using `Location::dummy()`

### DIFF
--- a/compiler/noirc_frontend/src/parser/parser/function.rs
+++ b/compiler/noirc_frontend/src/parser/parser/function.rs
@@ -223,8 +223,8 @@ impl Parser<'_> {
             );
 
             let visibility = Visibility::Private;
-            let typ =
-                UnresolvedType { typ: UnresolvedTypeData::Error, location: Location::dummy() };
+            let location = self.location_at_previous_token_end();
+            let typ = UnresolvedType { typ: UnresolvedTypeData::Error, location };
             (visibility, typ)
         } else {
             (
@@ -328,7 +328,7 @@ fn empty_function(location: Location) -> FunctionDefinitionWithOptionalBody {
         body: None,
         location: Location::new(span, location.file),
         where_clause: Vec::new(),
-        return_type: FunctionReturnType::Default(Location::dummy()),
+        return_type: FunctionReturnType::Default(Location::new(span, location.file)),
         return_visibility: Visibility::Private,
     }
 }

--- a/compiler/noirc_frontend/src/parser/parser/global.rs
+++ b/compiler/noirc_frontend/src/parser/parser/global.rs
@@ -27,13 +27,11 @@ impl Parser<'_> {
 
         let Some(ident) = self.eat_ident() else {
             self.eat_semicolon();
+            let location = self.location_at_previous_token_end();
             return LetStatement {
                 pattern: ident_to_pattern(Ident::default(), mutable),
-                r#type: UnresolvedType {
-                    typ: UnresolvedTypeData::Unspecified,
-                    location: Location::dummy(),
-                },
-                expression: Expression { kind: ExpressionKind::Error, location: Location::dummy() },
+                r#type: UnresolvedType { typ: UnresolvedTypeData::Unspecified, location },
+                expression: Expression { kind: ExpressionKind::Error, location },
                 attributes,
                 comptime,
                 is_global_let,
@@ -48,7 +46,8 @@ impl Parser<'_> {
             self.parse_expression_or_error()
         } else {
             self.push_error(ParserErrorReason::GlobalWithoutValue, pattern.location());
-            Expression { kind: ExpressionKind::Error, location: Location::dummy() }
+            let location = self.location_at_previous_token_end();
+            Expression { kind: ExpressionKind::Error, location }
         };
 
         self.eat_semicolon_or_error();

--- a/compiler/noirc_frontend/src/parser/parser/impls.rs
+++ b/compiler/noirc_frontend/src/parser/parser/impls.rs
@@ -155,19 +155,18 @@ impl Parser<'_> {
         let Some(name) = self.eat_ident() else {
             self.expected_identifier();
             self.eat_semicolons();
+            let location = self.location_at_previous_token_end();
             return Some(TraitImplItemKind::Type {
                 name: Ident::default(),
-                alias: UnresolvedType {
-                    typ: UnresolvedTypeData::Error,
-                    location: Location::dummy(),
-                },
+                alias: UnresolvedType { typ: UnresolvedTypeData::Error, location },
             });
         };
 
         let alias = if self.eat_assign() {
             self.parse_type_or_error()
         } else {
-            UnresolvedType { typ: UnresolvedTypeData::Error, location: Location::dummy() }
+            let location = self.location_at_previous_token_end();
+            UnresolvedType { typ: UnresolvedTypeData::Error, location }
         };
 
         self.eat_semicolon_or_error();
@@ -195,7 +194,8 @@ impl Parser<'_> {
             self.parse_expression_or_error()
         } else {
             self.expected_token(Token::Assign);
-            Expression { kind: ExpressionKind::Error, location: Location::dummy() }
+            let location = self.location_at_previous_token_end();
+            Expression { kind: ExpressionKind::Error, location }
         };
 
         self.eat_semicolon_or_error();

--- a/compiler/noirc_frontend/src/parser/parser/statement.rs
+++ b/compiler/noirc_frontend/src/parser/parser/statement.rs
@@ -365,13 +365,11 @@ impl Parser<'_> {
     }
 
     fn empty_for_loop(&mut self, identifier: Ident, start_location: Location) -> ForLoopStatement {
+        let location = self.location_at_previous_token_end();
         ForLoopStatement {
             identifier,
-            range: ForRange::Array(Expression {
-                kind: ExpressionKind::Error,
-                location: Location::dummy(),
-            }),
-            block: Expression { kind: ExpressionKind::Error, location: Location::dummy() },
+            range: ForRange::Array(Expression { kind: ExpressionKind::Error, location }),
+            block: Expression { kind: ExpressionKind::Error, location },
             location: self.location_since(start_location),
         }
     }

--- a/compiler/noirc_frontend/src/parser/parser/traits.rs
+++ b/compiler/noirc_frontend/src/parser/parser/traits.rs
@@ -204,7 +204,8 @@ impl Parser<'_> {
             self.parse_type_or_error()
         } else {
             self.expected_token(Token::Colon);
-            UnresolvedType { typ: UnresolvedTypeData::Unspecified, location: Location::dummy() }
+            let location = self.location_at_previous_token_end();
+            UnresolvedType { typ: UnresolvedTypeData::Unspecified, location }
         };
 
         let default_value =

--- a/compiler/noirc_frontend/src/parser/parser/type_alias.rs
+++ b/compiler/noirc_frontend/src/parser/parser/type_alias.rs
@@ -16,11 +16,12 @@ impl Parser<'_> {
     ) -> NoirTypeAlias {
         let Some(name) = self.eat_ident() else {
             self.expected_identifier();
+            let location = self.location_at_previous_token_end();
             return NoirTypeAlias {
                 visibility,
                 name: Ident::default(),
                 generics: Vec::new(),
-                typ: UnresolvedType { typ: UnresolvedTypeData::Error, location: Location::dummy() },
+                typ: UnresolvedType { typ: UnresolvedTypeData::Error, location },
                 location: start_location,
             };
         };
@@ -37,7 +38,10 @@ impl Parser<'_> {
                 visibility,
                 name,
                 generics,
-                typ: UnresolvedType { typ: UnresolvedTypeData::Error, location: Location::dummy() },
+                typ: UnresolvedType {
+                    typ: UnresolvedTypeData::Error,
+                    location: self.location_at_previous_token_end(),
+                },
                 location,
             };
         }


### PR DESCRIPTION
# Description

## Problem

While working on another thing I noticed that LSP Document Symbol would crash on this code:

```noir
trait Bar {
    let N;
}
```

That is, an associated constant without a type. The reason it crashed is that the Document Symbol logic eventually relied on a dummy location.

## Summary

Here all references to `Location::dummy` are replaced with a location right where the parser is currently is (an empty span at the last token end) which should prevent these crashes. I didn't add tests for these as they are many and in general locations aren't tested by the parser, but I verified the crash no longer happens.

## Additional Context



## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
