### PR TITLE
fix(debugger): send idle at loop end + fix test

### DIFF
--- a/tooling/debugger/tests/debug.rs
+++ b/tooling/debugger/tests/debug.rs
@@ -144,6 +144,18 @@ mod tests {
             VecDeque::from(["foo(x);", "bar(y);", "fn bar(y: Field) {"]),
             VecDeque::from(["foo(x);", "bar(y);", "assert(y != 0);"]),
         ];
+
+        // Try to use relative paths if possible, otherwise the test breaks when run from the repository root
+        let at_filename = if let Ok(current_dir) = std::env::current_dir() {
+            if let Ok(stripped) = test_program_path.strip_prefix(current_dir) {
+                format!("At {}", stripped.display())
+            } else {
+                format!("At {}", test_program_dir)
+            }
+        } else {
+            format!("At {}", test_program_dir)
+        };
+
         for mut expected_lines in expected_lines_by_command {
             // While running the debugger, issue a "next" cmd,
             // which should run to the program to the next source line given
@@ -158,7 +170,6 @@ mod tests {
                 .exp_string(">")
                 .expect("Failed while waiting for debugger to step through program.");
 
-            let at_filename = format!("At {test_program_dir}");
             while let Some(expected_line) = expected_lines.pop_front() {
                 let line = loop {
                     let read_line = dbg_session.read_line().unwrap();

--- a/tooling/debugger/tests/debug.rs
+++ b/tooling/debugger/tests/debug.rs
@@ -146,15 +146,11 @@ mod tests {
         ];
 
         // Try to use relative paths if possible, otherwise the test breaks when run from the repository root
-        let at_filename = if let Ok(current_dir) = std::env::current_dir() {
-            if let Ok(stripped) = test_program_path.strip_prefix(current_dir) {
-                format!("At {}", stripped.display())
-            } else {
-                format!("At {}", test_program_dir)
-            }
-        } else {
-            format!("At {}", test_program_dir)
-        };
+        let at_filename = std::env::current_dir()
+            .ok()
+            .and_then(|dir| test_program_path.strip_prefix(&dir).ok())
+            .map(|stripped| format!("At {}", stripped.display()))
+            .unwrap_or_else(|| format!("At {}", test_program_dir));
 
         for mut expected_lines in expected_lines_by_command {
             // While running the debugger, issue a "next" cmd,


### PR DESCRIPTION
# Description

## Problem

Resolves https://github.com/AztecProtocol/aztec-packages/pull/13755#issuecomment-2823802201

## Summary

This PR has two fixes:
1. The debugger communicated over channels now since the last debugger PR. An "idle" status is expected after sending a command over one channel. The problem (I think) is that the "idle" status was reported **before** commands were processes instead of after.
2. A test was ignoring lines that matched "At {path}", but the debugger will try to use relative paths when possible so when the test ran from the top level, that line didn't match. Trying to use relative paths in the test fixes that (and this is the one that should unblock the merge on Aztec-Packages, but I fixed 1 first and then noticed the test was still failing, so...)

## Additional Context



## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
