### PR TITLE
chore(acir): Test that `BLACKBOX::RANGE` display the number of bits 

### DIFF
--- a/acvm-repo/acir/src/circuit/opcodes.rs
+++ b/acvm-repo/acir/src/circuit/opcodes.rs
@@ -245,4 +245,16 @@ mod tests {
             @"BLACKBOX::XOR [(_0, 32), (_1, 32)] [_3]"
         );
     }
+
+    #[test]
+    fn range_display_snapshot() {
+        let range: Opcode<FieldElement> = Opcode::BlackBoxFuncCall(BlackBoxFuncCall::RANGE {
+            input: FunctionInput::witness(0.into(), 32),
+        });
+
+        insta::assert_snapshot!(
+            range.to_string(),
+            @"BLACKBOX::RANGE [(_0, 32)] []"
+        )
+    }
 }


### PR DESCRIPTION
# Description

## Problem\*

Resolves #7903 

## Summary\*

This was actually resolved by https://github.com/noir-lang/noir/pull/7919 but I am adding a test here. 

## Additional Context



## Documentation\*

Check one:
- [X] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
