### PR TITLE
fix: Detect ABI change of fuzzing harnesses

### DIFF
--- a/tooling/greybox_fuzzer/src/mutation/mod.rs
+++ b/tooling/greybox_fuzzer/src/mutation/mod.rs
@@ -31,6 +31,7 @@ pub struct InputMutator {
     full_dictionary: FullDictionary,
 }
 
+pub use dictionary::add_elements_from_input_map_to_vector_without_abi;
 const MUTATION_LOG_MIN: u32 = 0;
 const MUTATION_LOG_MAX: u32 = 5;
 /// NodeWeight determines the probability of mutating a particular object
@@ -76,6 +77,11 @@ impl InputMutator {
     /// Fill the dictionary with values from an interesting input
     pub fn update_dictionary(&mut self, testcase: &InputMap) {
         self.full_dictionary.update(&self.abi, testcase);
+    }
+
+    /// Update the dictionary with values from a vector of field elements
+    pub fn update_dictionary_from_vector(&mut self, elements: &[FieldElement]) {
+        self.full_dictionary.update_from_vector(elements);
     }
 
     /// Count weights of each element recursively (complex structures return a vector of weights of their most basic elements)


### PR DESCRIPTION
# Description

## Problem\*

Changing a fuzzing harness with an existing corpus could lead to panics, if former elements couldn't be cast to appropriate types. 

## Summary\*

Before fuzzing with the starting corpus we now try to decode all testcases with the current ABI. If a testcase fails, then we collect parse it for dictionary elements.
For example, if you first fuzz 

```rust
#[fuzz(should_fail)]
fn fuzz_main(x: Field, y: u64, z: u64) {
    
     let prod=y*z;
     assert(y<0x100000000);
     assert(z<0x100000000);
     assert(prod-0xdeadbeefdeadbeef<0xdeadbeef);
     assert(x==0xdeadbeefdeadbeefdeadbeefdeadbeef);
 }
```
and find a failure (`nargo fuzz`), after changing to 
```rust
#[fuzz(should_fail)]
fn fuzz_main(x: u64, y: u64, z: u64) {
    
    let prod=y*z;
    assert(x<0x100000000);
    assert(y<0x100000000);
    assert(z<0x100000000);
    assert(prod-0xdeadbeefdeadbeef<0xdeadbeef);
}
```
The fuzzer will inform you that the ABI has changed and will almost immediately find a failing testcase, because it already has useful values that it needs to put into `y` and `z`
## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
