### PR TITLE
chore: Don't use i1 in the AST fuzzer

### DIFF
--- a/tooling/ast_fuzzer/src/program/mod.rs
+++ b/tooling/ast_fuzzer/src/program/mod.rs
@@ -273,10 +273,14 @@ impl Context {
                 // 4 leaf types
                 0 => Type::Bool,
                 1 => Type::Field,
-                2 => Type::Integer(
-                    *u.choose(&[Signedness::Signed, Signedness::Unsigned])?,
-                    u.choose_iter(IntegerBitSize::iter())?,
-                ),
+                2 => {
+                    // i1 is deprecated
+                    let sign = *u.choose(&[Signedness::Signed, Signedness::Unsigned])?;
+                    let sizes = IntegerBitSize::iter()
+                        .filter(|bs| !(sign.is_signed() && bs.bit_size() == 1))
+                        .collect::<Vec<_>>();
+                    Type::Integer(sign, u.choose_iter(sizes)?)
+                }
                 3 => Type::String(u.int_in_range(0..=self.config.max_array_size)? as u32),
                 // 2 composite types
                 4 | 5 => {

--- a/tooling/ast_fuzzer/src/program/types.rs
+++ b/tooling/ast_fuzzer/src/program/types.rs
@@ -215,7 +215,7 @@ pub(crate) fn can_binary_op_return_from_input(op: &BinaryOp, input: &Type, outpu
             // i128 is not a type a user can define, and the truncation that gets added after binary operations to
             // limit it to 129 bits results in division by zero during compilation.
             (op.is_arithmetic() && size != 1 && size != 128 && size_in <= size_out)
-                || op.is_bitshift() && size != 128
+                || op.is_bitshift() && size != 128 && !(size == 1 && sign_in.is_signed())
                 || op.is_bitwise()
         }
         (Type::Reference(typ, _), _) => can_binary_op_return_from_input(op, typ, output),


### PR DESCRIPTION
# Description

## Problem\*

Consequence of https://github.com/noir-lang/noir/pull/8172
It would mean we don't have to deal with https://github.com/noir-lang/noir/issues/8198

## Summary\*

Stops choosing `i1` as a type for variables, since it's no longer a type the user can use in Noir.

## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
