### PR TITLE
chore: add regression test for panic encountered in bigcurve library.

### DIFF
--- a/test_programs/execution_panic/regression_8210/Nargo.toml
+++ b/test_programs/execution_panic/regression_8210/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "regression_8210"
+type = "bin"
+authors = [""]
+
+[dependencies]
+bignum = {tag = "v0.7.0", git = "https://github.com/noir-lang/noir-bignum"}

--- a/test_programs/execution_panic/regression_8210/Nargo.toml
+++ b/test_programs/execution_panic/regression_8210/Nargo.toml
@@ -4,4 +4,3 @@ type = "bin"
 authors = [""]
 
 [dependencies]
-bignum = {tag = "v0.7.0", git = "https://github.com/noir-lang/noir-bignum"}

--- a/test_programs/execution_panic/regression_8210/src/main.nr
+++ b/test_programs/execution_panic/regression_8210/src/main.nr
@@ -1,0 +1,7 @@
+
+use bignum::{BigNum, BN254_Fq};
+
+fn main() {
+    BN254_Fq::zero().modulus_bits();
+}
+

--- a/test_programs/execution_panic/regression_8210/src/main.nr
+++ b/test_programs/execution_panic/regression_8210/src/main.nr
@@ -1,16 +1,14 @@
-
 // https://github.com/noir-lang/noir/issues/8210
 fn main() {
     (42 as Field).bar();
 }
-
 
 trait Foo {
     let BAR: u32;
 
     fn bar(_: Self) -> u32 {
         Foo::BAR
-    }  
+    }
 }
 
 impl Foo for Field {

--- a/test_programs/execution_panic/regression_8210/src/main.nr
+++ b/test_programs/execution_panic/regression_8210/src/main.nr
@@ -1,6 +1,8 @@
 
 use bignum::{BigNum, BN254_Fq};
 
+
+// https://github.com/noir-lang/noir/issues/8210
 fn main() {
     BN254_Fq::zero().modulus_bits();
 }

--- a/test_programs/execution_panic/regression_8210/src/main.nr
+++ b/test_programs/execution_panic/regression_8210/src/main.nr
@@ -1,9 +1,18 @@
 
-use bignum::{BigNum, BN254_Fq};
-
-
 // https://github.com/noir-lang/noir/issues/8210
 fn main() {
-    BN254_Fq::zero().modulus_bits();
+    (42 as Field).bar();
 }
 
+
+trait Foo {
+    let BAR: u32;
+
+    fn bar(_: Self) -> u32 {
+        Foo::BAR
+    }  
+}
+
+impl Foo for Field {
+    let BAR: u32 = 254;
+}


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This PR adds a minimal reproduction for the panics being experienced in https://github.com/noir-lang/noir_bigcurve/pull/46

The issue for this panic is https://github.com/noir-lang/noir/issues/8210


## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
