### PR TITLE
fix: validate numeric types when passing them to a FunctionBuilder

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/function_builder/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/function_builder/mod.rs
@@ -171,6 +171,7 @@ impl FunctionBuilder {
         value: impl Into<FieldElement>,
         typ: NumericType,
     ) -> ValueId {
+        validate_numeric_type(&typ);
         self.current_function.dfg.make_constant(value.into(), typ)
     }
 
@@ -300,6 +301,7 @@ impl FunctionBuilder {
     /// Insert a cast instruction at the end of the current block.
     /// Returns the result of the cast instruction.
     pub fn insert_cast(&mut self, value: ValueId, typ: NumericType) -> ValueId {
+        validate_numeric_type(&typ);
         self.insert_instruction(Instruction::Cast(value, typ), None).first()
     }
 
@@ -541,6 +543,28 @@ impl std::ops::Index<BasicBlockId> for FunctionBuilder {
 
     fn index(&self, id: BasicBlockId) -> &Self::Output {
         &self.current_function.dfg[id]
+    }
+}
+
+fn validate_numeric_type(typ: &NumericType) {
+    match &typ {
+        NumericType::Signed { bit_size } => match bit_size {
+            8 | 16 | 32 | 64 => (),
+            _ => {
+                panic!(
+                    "Invalid bit size for signed numeric type: {bit_size}. Expected one of 8, 16, 32 or 64."
+                );
+            }
+        },
+        NumericType::Unsigned { bit_size } => match bit_size {
+            1 | 8 | 16 | 32 | 64 | 128 => (),
+            _ => {
+                panic!(
+                    "Invalid bit size for unsigned numeric type: {bit_size}. Expected one of 1, 8, 16, 32, 64, or 128."
+                );
+            }
+        },
+        _ => (),
     }
 }
 

--- a/compiler/noirc_evaluator/src/ssa/parser/tests.rs
+++ b/compiler/noirc_evaluator/src/ssa/parser/tests.rs
@@ -40,7 +40,7 @@ fn test_empty_brillig_function() {
 
 #[test]
 fn test_return_integer() {
-    for typ in ["u1", "u8", "u16", "u32", "u64", "i1", "i8", "i16", "i32", "i64", "Field"] {
+    for typ in ["u1", "u8", "u16", "u32", "u64", "i8", "i16", "i32", "i64", "Field"] {
         let src = format!(
             "
             acir(inline) fn main f0 {{

--- a/tooling/ast_fuzzer/src/program/mod.rs
+++ b/tooling/ast_fuzzer/src/program/mod.rs
@@ -274,10 +274,12 @@ impl Context {
                 0 => Type::Bool,
                 1 => Type::Field,
                 2 => {
-                    // i1 is deprecated
+                    // i1 is deprecated, and i128 does not exist yet
                     let sign = *u.choose(&[Signedness::Signed, Signedness::Unsigned])?;
                     let sizes = IntegerBitSize::iter()
-                        .filter(|bs| !(sign.is_signed() && bs.bit_size() == 1))
+                        .filter(|bs| {
+                            !(sign.is_signed() && (bs.bit_size() == 1 || bs.bit_size() == 128))
+                        })
                         .collect::<Vec<_>>();
                     Type::Integer(sign, u.choose_iter(sizes)?)
                 }

--- a/tooling/ast_fuzzer/src/program/types.rs
+++ b/tooling/ast_fuzzer/src/program/types.rs
@@ -78,6 +78,14 @@ pub(crate) fn types_produced(typ: &Type) -> HashSet<Type> {
                 for size in IntegerBitSize::iter()
                     .filter(|size| size.bit_size() > integer_bit_size.bit_size())
                 {
+                    // We don't want to produce `i1` or `i128`
+                    if sign.is_signed()
+                        && (size == IntegerBitSize::One
+                            || size == IntegerBitSize::HundredTwentyEight)
+                    {
+                        continue;
+                    }
+
                     acc.insert(Type::Integer(*sign, size));
                 }
                 // There are `From<u*>` for Field


### PR DESCRIPTION
# Description

## Problem

Resolves #8082

## Summary



## Additional Context



## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
