### PR TITLE
feat: AST fuzzer compare result between minimum and full SSA pipeline

### DIFF
--- a/tooling/ast_fuzzer/fuzz/fuzz_targets/acir_vs_brillig.rs
+++ b/tooling/ast_fuzzer/fuzz/fuzz_targets/acir_vs_brillig.rs
@@ -1,9 +1,12 @@
 //! Compare the execution of random ASTs between the normal execution
 //! vs when everything is forced to be Brillig.
-
+//!
+//! ```text
+//! cargo +nightly fuzz run acir_vs_brillig
+//! ```
 #![no_main]
 
-use color_eyre::eyre::{self, Context};
+use color_eyre::eyre;
 use libfuzzer_sys::arbitrary::Unstructured;
 use libfuzzer_sys::fuzz_target;
 use noir_ast_fuzzer::Config;
@@ -19,9 +22,8 @@ fn fuzz(u: &mut Unstructured) -> eyre::Result<()> {
     let inputs = CompareMutants::arb(
         u,
         Config::default(),
-        |_u, program| {
+        |_u, mut program| {
             // Change every function to be unconstrained.
-            let mut program = program.clone();
             for f in program.functions.iter_mut() {
                 f.unconstrained = true;
             }
@@ -30,7 +32,7 @@ fn fuzz(u: &mut Unstructured) -> eyre::Result<()> {
         |program| create_ssa_or_die(program, &options, None),
     )?;
 
-    let result = inputs.exec().wrap_err("exec")?;
+    let result = inputs.exec()?;
 
     compare_results(&inputs, &result, |inputs| [&inputs.program.0, &inputs.program.1])
 }

--- a/tooling/ast_fuzzer/fuzz/fuzz_targets/init_vs_final.rs
+++ b/tooling/ast_fuzzer/fuzz/fuzz_targets/init_vs_final.rs
@@ -1,15 +1,20 @@
 //! Compare the execution of random ASTs between the initial SSA
 //! (or as close as we can stay to the initial state)
 //! and the fully optimized version.
+//!
+//! ```text
+//! cargo +nightly fuzz run init_vs_final
+//! ```
 #![no_main]
 
-use color_eyre::eyre::{self, Context};
+use color_eyre::eyre;
 use libfuzzer_sys::arbitrary::Unstructured;
 use libfuzzer_sys::fuzz_target;
 use noir_ast_fuzzer::Config;
 use noir_ast_fuzzer::compare::ComparePasses;
-use noir_ast_fuzzer_fuzz::{compare_results, create_ssa_or_die, default_ssa_options};
-use noirc_evaluator::ssa;
+use noir_ast_fuzzer_fuzz::{
+    compare_results, create_ssa_or_die, create_ssa_with_passes_or_die, default_ssa_options,
+};
 
 fuzz_target!(|data: &[u8]| {
     fuzz(&mut Unstructured::new(data)).unwrap();
@@ -18,28 +23,22 @@ fuzz_target!(|data: &[u8]| {
 fn fuzz(u: &mut Unstructured) -> eyre::Result<()> {
     let options = default_ssa_options();
 
-    // TODO(#7873): What we really want is to do the minimum number of passes on the SSA to leave it as close to the initial SSA as possible.
-    // For now just test with min/max inliner aggressiveness.
     let inputs = ComparePasses::arb(
         u,
         Config::default(),
-        |program| {
-            create_ssa_or_die(
-                program,
-                &ssa::SsaEvaluatorOptions { inliner_aggressiveness: i64::MIN, ..options.clone() },
-                Some("init"),
-            )
+        |mut program| {
+            // We won't do any SSA passes at all, but for that to have a chance to work,
+            // we have to execute everything as Brillig, because ACIR needs some minimal
+            // passes such as unrolling.
+            for f in program.functions.iter_mut() {
+                f.unconstrained = true;
+            }
+            create_ssa_with_passes_or_die(program, &options, &[], |_| Vec::new(), Some("init"))
         },
-        |program| {
-            create_ssa_or_die(
-                program,
-                &ssa::SsaEvaluatorOptions { inliner_aggressiveness: i64::MAX, ..options.clone() },
-                Some("final"),
-            )
-        },
+        |program| create_ssa_or_die(program, &options, Some("final")),
     )?;
 
-    let result = inputs.exec().wrap_err("exec")?;
+    let result = inputs.exec()?;
 
     compare_results(&inputs, &result, |inputs| [&inputs.program])
 }

--- a/tooling/ast_fuzzer/fuzz/fuzz_targets/orig_vs_mutant.rs
+++ b/tooling/ast_fuzzer/fuzz/fuzz_targets/orig_vs_mutant.rs
@@ -1,8 +1,12 @@
 //! Perform random equivalence mutations on the AST and check that the
 //! execution result does not change.
+//!
+//! ```text
+//! cargo +nightly fuzz run orig_vs_mutant
+//! ```
 #![no_main]
 
-use color_eyre::eyre::{self, Context};
+use color_eyre::eyre;
 use libfuzzer_sys::arbitrary::Unstructured;
 use libfuzzer_sys::fuzz_target;
 use noir_ast_fuzzer::Config;
@@ -25,7 +29,7 @@ fn fuzz(u: &mut Unstructured) -> eyre::Result<()> {
         |program| create_ssa_or_die(program, &options, None),
     )?;
 
-    let result = inputs.exec().wrap_err("exec")?;
+    let result = inputs.exec()?;
 
     compare_results(&inputs, &result, |inputs| [&inputs.program.0, &inputs.program.1])
 }

--- a/tooling/ast_fuzzer/fuzz/src/lib.rs
+++ b/tooling/ast_fuzzer/fuzz/src/lib.rs
@@ -64,8 +64,7 @@ where
     // and print the AST, then resume the panic, because
     // `Program` has a `RefCell` in it, which is not unwind safe.
     if show_ast() {
-        // Showing the AST as-is, in case we have problem with IDs.
-        eprintln!("---\n{}\n---", program);
+        eprintln!("---\n{}\n---", DisplayAstAsNoir(&program));
     }
 
     ssa::create_program_with_passes(program, options, primary, secondary).unwrap_or_else(|e| {

--- a/tooling/ast_fuzzer/src/compare.rs
+++ b/tooling/ast_fuzzer/src/compare.rs
@@ -197,11 +197,11 @@ impl CompareMutants {
     pub fn arb(
         u: &mut Unstructured,
         c: Config,
-        f: impl Fn(&mut Unstructured, &Program) -> arbitrary::Result<Program>,
+        f: impl Fn(&mut Unstructured, Program) -> arbitrary::Result<Program>,
         g: impl Fn(Program) -> SsaProgramArtifact,
     ) -> arbitrary::Result<Self> {
         let program1 = arb_program(u, c)?;
-        let program2 = f(u, &program1)?;
+        let program2 = f(u, program1.clone())?;
         let abi = program_abi(&program1);
 
         let ssa1 = g(program1.clone());


### PR DESCRIPTION
# Description

## Problem\*

Resolves #8034

## Summary\*

Changes the `init_vs_final` fuzz target to do no, or minimum amount of SSA passes. (So far it compared min vs max inlining).

## Additional Context

```shell
cd tooling/ast_fuzzer
cargo +nightly fuzz run init_vs_final
```

For now I'm trying to figure out how minimal the SSA passes can be. A crash can be investigated with for example:

```shell
❯ NOIR_AST_FUZZER_SHOW_AST=1 cargo +nightly -q fuzz run init_vs_final fuzz/artifacts/init_vs_final/crash-adc83b19e793491b1c6ea0fd8b46cd9f32e592fc
...
---
global G_A: bool = false;
global G_B: bool = false;
unconstrained fn main() -> pub bool {
    (!(!G_A))
}

---

thread '<unnamed>' panicked at compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_block.rs:1794:25:
ICE: Global value not found in cache v0
```

## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
