### PR TITLE
fix(parser): do not use `Ident::default()`

### DIFF
--- a/compiler/noirc_frontend/src/ast/statement.rs
+++ b/compiler/noirc_frontend/src/ast/statement.rs
@@ -179,7 +179,7 @@ impl StatementKind {
     }
 }
 
-#[derive(Eq, Debug, Clone, Default)]
+#[derive(Eq, Debug, Clone)]
 pub struct Ident(Located<String>);
 
 impl PartialEq<Ident> for Ident {

--- a/compiler/noirc_frontend/src/parser/parser.rs
+++ b/compiler/noirc_frontend/src/parser/parser.rs
@@ -530,11 +530,10 @@ impl<'a> Parser<'a> {
     }
 
     fn location_at_previous_token_end(&self) -> Location {
-        Location::new(self.span_at_previous_token_end(), self.previous_token_location.file)
-    }
-
-    fn span_at_previous_token_end(&self) -> Span {
-        Span::from(self.previous_token_location.span.end()..self.previous_token_location.span.end())
+        let span_at_previous_token_end = Span::from(
+            self.previous_token_location.span.end()..self.previous_token_location.span.end(),
+        );
+        Location::new(span_at_previous_token_end, self.previous_token_location.file)
     }
 
     fn expected_identifier(&mut self) {

--- a/compiler/noirc_frontend/src/parser/parser.rs
+++ b/compiler/noirc_frontend/src/parser/parser.rs
@@ -536,6 +536,10 @@ impl<'a> Parser<'a> {
         Location::new(span_at_previous_token_end, self.previous_token_location.file)
     }
 
+    fn empty_ident_at_previous_token_end(&self) -> Ident {
+        Ident::new(String::new(), self.location_at_previous_token_end())
+    }
+
     fn expected_identifier(&mut self) {
         self.expected_label(ParsingRuleLabel::Identifier);
     }

--- a/compiler/noirc_frontend/src/parser/parser/enums.rs
+++ b/compiler/noirc_frontend/src/parser/parser/enums.rs
@@ -119,6 +119,8 @@ impl Parser<'_> {
 
 #[cfg(test)]
 mod tests {
+    use insta::assert_snapshot;
+
     use crate::{
         ast::{IntegerBitSize, NoirEnumeration, UnresolvedGeneric, UnresolvedTypeData},
         parse_program_with_dummy_file,
@@ -258,6 +260,6 @@ mod tests {
 
         assert_eq!(errors.len(), 1);
         let error = &errors[0];
-        assert_eq!(error.to_string(), "Expected an identifier but found '42'");
+        assert_snapshot!(error.to_string(), @"Expected an identifier but found '42'");
     }
 }

--- a/compiler/noirc_frontend/src/parser/parser/enums.rs
+++ b/compiler/noirc_frontend/src/parser/parser/enums.rs
@@ -26,7 +26,7 @@ impl Parser<'_> {
         let Some(name) = self.eat_ident() else {
             self.expected_identifier();
             return self.empty_enum(
-                Ident::default(),
+                self.empty_ident_at_previous_token_end(),
                 attributes,
                 visibility,
                 Vec::new(),

--- a/compiler/noirc_frontend/src/parser/parser/expression.rs
+++ b/compiler/noirc_frontend/src/parser/parser/expression.rs
@@ -1015,6 +1015,7 @@ impl Parser<'_> {
 
 #[cfg(test)]
 mod tests {
+    use insta::assert_snapshot;
     use strum::IntoEnumIterator;
 
     use crate::{
@@ -1281,7 +1282,7 @@ mod tests {
         let mut parser = Parser::for_str_with_dummy_file(&src);
         parser.parse_expression();
         let error = get_single_error(&parser.errors, span);
-        assert_eq!(error.to_string(), "Expected an expression but found end of input");
+        assert_snapshot!(error.to_string(), @"Expected an expression but found end of input");
     }
 
     #[test]
@@ -1653,7 +1654,7 @@ mod tests {
         let expr = parser.parse_expression_or_error();
 
         let error = get_single_error(&parser.errors, span);
-        assert_eq!(error.to_string(), "Expected a ':' but found '='");
+        assert_snapshot!(error.to_string(), @"Expected a ':' but found '='");
 
         let ExpressionKind::Constructor(mut constructor) = expr.kind else {
             panic!("Expected constructor");
@@ -1681,7 +1682,7 @@ mod tests {
         let expr = parser.parse_expression_or_error();
 
         let error = get_single_error(&parser.errors, span);
-        assert_eq!(error.to_string(), "Expected a ':' but found '::'");
+        assert_snapshot!(error.to_string(), @"Expected a ':' but found '::'");
 
         let ExpressionKind::Constructor(mut constructor) = expr.kind else {
             panic!("Expected constructor");
@@ -1719,7 +1720,7 @@ mod tests {
         assert_eq!(expr.to_string(), "1");
 
         let error = get_single_error(&parser.errors, span);
-        assert_eq!(error.to_string(), "Expected an identifier but found '2'");
+        assert_snapshot!(error.to_string(), @"Expected an identifier but found '2'");
     }
 
     #[test]
@@ -1747,7 +1748,7 @@ mod tests {
         assert_eq!(expr.to_string(), "2");
 
         let error = get_single_error(&parser.errors, span);
-        assert_eq!(error.to_string(), "Expected an identifier but found '2'");
+        assert_snapshot!(error.to_string(), @"Expected an identifier but found '2'");
     }
 
     #[test]
@@ -1821,7 +1822,7 @@ mod tests {
         let mut parser = Parser::for_str_with_dummy_file(&src);
         parser.parse_expression();
         let error = get_single_error(&parser.errors, span);
-        assert_eq!(error.to_string(), "Expected a type but found end of input");
+        assert_snapshot!(error.to_string(), @"Expected a type but found end of input");
     }
 
     #[test]

--- a/compiler/noirc_frontend/src/parser/parser/function.rs
+++ b/compiler/noirc_frontend/src/parser/parser/function.rs
@@ -346,6 +346,8 @@ fn empty_body() -> BlockExpression {
 
 #[cfg(test)]
 mod tests {
+    use insta::assert_snapshot;
+
     use crate::{
         ast::{
             ExpressionKind, IntegerBitSize, ItemVisibility, NoirFunction, StatementKind,
@@ -506,7 +508,7 @@ mod tests {
         assert_eq!(noir_function.parameters().len(), 1);
 
         let error = get_single_error(&errors, span);
-        assert_eq!(error.to_string(), "Expected a pattern but found '1'");
+        assert_snapshot!(error.to_string(), @"Expected a pattern but found '1'");
     }
 
     #[test]
@@ -542,7 +544,7 @@ mod tests {
         assert_eq!(noir_function.parameters().len(), 2);
 
         let error = get_single_error(&errors, span);
-        assert_eq!(error.to_string(), "Expected a type but found ','");
+        assert_snapshot!(error.to_string(), @"Expected a type but found ','");
     }
 
     #[test]
@@ -575,7 +577,7 @@ mod tests {
         let (src, span) = get_source_with_error_span(src);
         let (mut module, errors) = parse_program_with_dummy_file(&src);
         let error = get_single_error(&errors, span);
-        assert_eq!(error.to_string(), "Expected a type but found 'mut'");
+        assert_snapshot!(error.to_string(), @"Expected a type but found 'mut'");
 
         assert_eq!(module.items.len(), 1);
         let item = module.items.remove(0);
@@ -660,7 +662,7 @@ mod tests {
         let _ = parser.parse_program();
 
         let error = get_single_error(&parser.errors, span);
-        assert_eq!(error.to_string(), "Unexpected 'struct', expected one of 'where', '{', '->'");
+        assert_snapshot!(error.to_string(), @"Unexpected 'struct', expected one of 'where', '{', '->'");
     }
 
     #[test]
@@ -674,7 +676,7 @@ mod tests {
         let _ = parser.parse_program();
 
         let error = get_single_error(&parser.errors, span);
-        assert_eq!(error.to_string(), "Unexpected 'struct', expected one of 'where', '{'");
+        assert_snapshot!(error.to_string(), @"Unexpected 'struct', expected one of 'where', '{'");
     }
 
     #[test]
@@ -688,7 +690,7 @@ mod tests {
         let _ = parser.parse_program();
 
         let error = get_single_error(&parser.errors, span);
-        assert_eq!(error.to_string(), "Expected a '{' but found 'struct'");
+        assert_snapshot!(error.to_string(), @"Expected a '{' but found 'struct'");
     }
 
     #[test]
@@ -702,6 +704,6 @@ mod tests {
         let _ = parser.parse_program();
 
         let error = get_single_error(&parser.errors, span);
-        assert_eq!(error.to_string(), "Expected an identifier but found '('");
+        assert_snapshot!(error.to_string(), @"Expected an identifier but found '('");
     }
 }

--- a/compiler/noirc_frontend/src/parser/parser/function.rs
+++ b/compiler/noirc_frontend/src/parser/parser/function.rs
@@ -89,7 +89,7 @@ impl Parser<'_> {
     ) -> FunctionDefinitionWithOptionalBody {
         let Some(name) = self.eat_ident() else {
             self.expected_identifier();
-            return empty_function(self.previous_token_location);
+            return empty_function(self.location_at_previous_token_end());
         };
 
         let generics = self.parse_generics_allowing_trait_bounds();
@@ -320,15 +320,14 @@ impl Parser<'_> {
 }
 
 fn empty_function(location: Location) -> FunctionDefinitionWithOptionalBody {
-    let span = Span::from(location.span.end()..location.span.end());
     FunctionDefinitionWithOptionalBody {
-        name: Ident::default(),
+        name: Ident::new(String::new(), location),
         generics: Vec::new(),
         parameters: Vec::new(),
         body: None,
-        location: Location::new(span, location.file),
+        location,
         where_clause: Vec::new(),
-        return_type: FunctionReturnType::Default(Location::new(span, location.file)),
+        return_type: FunctionReturnType::Default(location),
         return_visibility: Visibility::Private,
     }
 }

--- a/compiler/noirc_frontend/src/parser/parser/global.rs
+++ b/compiler/noirc_frontend/src/parser/parser/global.rs
@@ -69,6 +69,7 @@ fn ident_to_pattern(ident: Ident, mutable: bool) -> Pattern {
 #[cfg(test)]
 mod tests {
     use acvm::FieldElement;
+    use insta::assert_snapshot;
 
     use crate::{
         ast::{
@@ -169,7 +170,7 @@ mod tests {
         let (src, span) = get_source_with_error_span(src);
         let (_, errors) = parse_program_with_dummy_file(&src);
         let error = get_single_error(&errors, span);
-        assert_eq!(error.to_string(), "Expected a ';' but found end of input");
+        assert_snapshot!(error.to_string(), @"Expected a ';' but found end of input");
     }
 
     #[test]

--- a/compiler/noirc_frontend/src/parser/parser/global.rs
+++ b/compiler/noirc_frontend/src/parser/parser/global.rs
@@ -28,8 +28,9 @@ impl Parser<'_> {
         let Some(ident) = self.eat_ident() else {
             self.eat_semicolon();
             let location = self.location_at_previous_token_end();
+            let ident = self.empty_ident_at_previous_token_end();
             return LetStatement {
-                pattern: ident_to_pattern(Ident::default(), mutable),
+                pattern: ident_to_pattern(ident, mutable),
                 r#type: UnresolvedType { typ: UnresolvedTypeData::Unspecified, location },
                 expression: Expression { kind: ExpressionKind::Error, location },
                 attributes,

--- a/compiler/noirc_frontend/src/parser/parser/impls.rs
+++ b/compiler/noirc_frontend/src/parser/parser/impls.rs
@@ -2,7 +2,7 @@ use noirc_errors::Location;
 
 use crate::{
     ast::{
-        Documented, Expression, ExpressionKind, Ident, ItemVisibility, NoirFunction, NoirTraitImpl,
+        Documented, Expression, ExpressionKind, ItemVisibility, NoirFunction, NoirTraitImpl,
         TraitImplItem, TraitImplItemKind, TypeImpl, UnresolvedGeneric, UnresolvedType,
         UnresolvedTypeData,
     },
@@ -156,10 +156,9 @@ impl Parser<'_> {
             self.expected_identifier();
             self.eat_semicolons();
             let location = self.location_at_previous_token_end();
-            return Some(TraitImplItemKind::Type {
-                name: Ident::default(),
-                alias: UnresolvedType { typ: UnresolvedTypeData::Error, location },
-            });
+            let name = self.empty_ident_at_previous_token_end();
+            let alias = UnresolvedType { typ: UnresolvedTypeData::Error, location };
+            return Some(TraitImplItemKind::Type { name, alias });
         };
 
         let alias = if self.eat_assign() {
@@ -184,7 +183,7 @@ impl Parser<'_> {
             Some(name) => name,
             None => {
                 self.expected_identifier();
-                Ident::default()
+                self.empty_ident_at_previous_token_end()
             }
         };
 

--- a/compiler/noirc_frontend/src/parser/parser/impls.rs
+++ b/compiler/noirc_frontend/src/parser/parser/impls.rs
@@ -234,6 +234,8 @@ impl Parser<'_> {
 
 #[cfg(test)]
 mod tests {
+    use insta::assert_snapshot;
+
     use crate::{
         ast::{
             ItemVisibility, NoirTraitImpl, Pattern, TraitImplItemKind, TypeImpl, UnresolvedTypeData,
@@ -548,7 +550,7 @@ mod tests {
         assert_eq!(type_impl.methods.len(), 1);
 
         let error = get_single_error(&errors, span);
-        assert_eq!(error.to_string(), "Expected a function but found 'hello'");
+        assert_snapshot!(error.to_string(), @"Expected a function but found 'hello'");
     }
 
     #[test]
@@ -568,7 +570,7 @@ mod tests {
         assert_eq!(trait_imp.items.len(), 1);
 
         let error = get_single_error(&errors, span);
-        assert_eq!(error.to_string(), "Expected a trait impl item but found 'hello'");
+        assert_snapshot!(error.to_string(), @"Expected a trait impl item but found 'hello'");
     }
 
     #[test]

--- a/compiler/noirc_frontend/src/parser/parser/item.rs
+++ b/compiler/noirc_frontend/src/parser/parser/item.rs
@@ -261,6 +261,8 @@ impl<'a> Parser<'a> {
 
 #[cfg(test)]
 mod tests {
+    use insta::assert_snapshot;
+
     use crate::{
         parse_program_with_dummy_file,
         parser::{
@@ -279,7 +281,7 @@ mod tests {
         let (module, errors) = parse_program_with_dummy_file(&src);
         assert_eq!(module.items.len(), 2);
         let error = get_single_error(&errors, span);
-        assert_eq!(error.to_string(), "Expected an item but found 'hello'");
+        assert_snapshot!(error.to_string(), @"Expected an item but found 'hello'");
     }
 
     #[test]
@@ -292,7 +294,7 @@ mod tests {
         let (module, errors) = parse_program_with_dummy_file(&src);
         assert_eq!(module.items.len(), 1);
         let error = get_single_error(&errors, span);
-        assert_eq!(error.to_string(), "Expected a '}' but found end of input");
+        assert_snapshot!(error.to_string(), @"Expected a '}' but found end of input");
     }
 
     #[test]

--- a/compiler/noirc_frontend/src/parser/parser/item_visibility.rs
+++ b/compiler/noirc_frontend/src/parser/parser/item_visibility.rs
@@ -36,6 +36,8 @@ impl Parser<'_> {
 
 #[cfg(test)]
 mod tests {
+    use insta::assert_snapshot;
+
     use crate::{
         ast::ItemVisibility,
         parser::{
@@ -73,7 +75,7 @@ mod tests {
         let visibility = parser.parse_item_visibility();
         assert_eq!(visibility, ItemVisibility::Public);
         let error = get_single_error(&parser.errors, span);
-        assert_eq!(error.to_string(), "Expected a 'crate' but found end of input");
+        assert_snapshot!(error.to_string(), @"Expected a 'crate' but found end of input");
     }
 
     #[test]
@@ -87,7 +89,7 @@ mod tests {
         let visibility = parser.parse_item_visibility();
         assert_eq!(visibility, ItemVisibility::Public);
         let error = get_single_error(&parser.errors, span);
-        assert_eq!(error.to_string(), "Expected a 'crate' but found 'hello'");
+        assert_snapshot!(error.to_string(), @"Expected a 'crate' but found 'hello'");
     }
     #[test]
     fn parses_public_visibility_missing_paren_after_pub_crate() {
@@ -100,7 +102,7 @@ mod tests {
         let visibility = parser.parse_item_visibility();
         assert_eq!(visibility, ItemVisibility::PublicCrate);
         let error = get_single_error(&parser.errors, span);
-        assert_eq!(error.to_string(), "Expected a ')' but found end of input");
+        assert_snapshot!(error.to_string(), @"Expected a ')' but found end of input");
     }
 
     #[test]

--- a/compiler/noirc_frontend/src/parser/parser/module.rs
+++ b/compiler/noirc_frontend/src/parser/parser/module.rs
@@ -1,7 +1,7 @@
 use noirc_errors::Location;
 
 use crate::{
-    ast::{Ident, ItemVisibility, ModuleDeclaration},
+    ast::{ItemVisibility, ModuleDeclaration},
     parser::{ItemKind, ParsedSubModule},
     token::{Attribute, Token},
 };
@@ -23,7 +23,7 @@ impl Parser<'_> {
             self.expected_identifier();
             return ItemKind::ModuleDecl(ModuleDeclaration {
                 visibility,
-                ident: Ident::default(),
+                ident: self.empty_ident_at_previous_token_end(),
                 outer_attributes,
                 has_semicolon: false,
             });

--- a/compiler/noirc_frontend/src/parser/parser/path.rs
+++ b/compiler/noirc_frontend/src/parser/parser/path.rs
@@ -219,6 +219,8 @@ impl Parser<'_> {
 #[cfg(test)]
 mod tests {
 
+    use insta::assert_snapshot;
+
     use crate::{
         ast::{Path, PathKind},
         parser::{
@@ -352,6 +354,6 @@ mod tests {
         assert!(path.is_none());
 
         let error = get_single_error(&parser.errors, span);
-        assert_eq!(error.to_string(), "Expected an identifier but found end of input");
+        assert_snapshot!(error.to_string(), @"Expected an identifier but found end of input");
     }
 }

--- a/compiler/noirc_frontend/src/parser/parser/pattern.rs
+++ b/compiler/noirc_frontend/src/parser/parser/pattern.rs
@@ -249,6 +249,8 @@ impl Parser<'_> {
 #[cfg(test)]
 mod tests {
 
+    use insta::assert_snapshot;
+
     use crate::{
         ast::Pattern,
         parser::{
@@ -355,7 +357,7 @@ mod tests {
         let pattern = parser.parse_pattern_or_error();
 
         let error = get_single_error(&parser.errors, span);
-        assert_eq!(error.to_string(), "Expected a ':' but found '='");
+        assert_snapshot!(error.to_string(), @"Expected a ':' but found '='");
 
         let Pattern::Struct(path, mut patterns, _) = pattern else {
             panic!("Expected a struct pattern")

--- a/compiler/noirc_frontend/src/parser/parser/statement.rs
+++ b/compiler/noirc_frontend/src/parser/parser/statement.rs
@@ -466,6 +466,8 @@ impl Parser<'_> {
 
 #[cfg(test)]
 mod tests {
+    use insta::assert_snapshot;
+
     use crate::{
         ast::{ExpressionKind, ForRange, LValue, Statement, StatementKind, UnresolvedTypeData},
         parser::{
@@ -772,7 +774,7 @@ mod tests {
         let statement = parser.parse_statement_or_error();
         assert!(matches!(statement.kind, StatementKind::Let(..)));
         let error = get_single_error(&parser.errors, span);
-        assert_eq!(error.to_string(), "Expected a statement but found ']'");
+        assert_snapshot!(error.to_string(), @"Expected a statement but found ']'");
     }
 
     #[test]

--- a/compiler/noirc_frontend/src/parser/parser/statement.rs
+++ b/compiler/noirc_frontend/src/parser/parser/statement.rs
@@ -264,7 +264,7 @@ impl Parser<'_> {
 
         let Some(identifier) = self.eat_ident() else {
             self.expected_identifier();
-            let identifier = Ident::default();
+            let identifier = self.empty_ident_at_previous_token_end();
             return Some(self.empty_for_loop(identifier, start_location));
         };
 

--- a/compiler/noirc_frontend/src/parser/parser/structs.rs
+++ b/compiler/noirc_frontend/src/parser/parser/structs.rs
@@ -128,6 +128,8 @@ impl Parser<'_> {
 
 #[cfg(test)]
 mod tests {
+    use insta::assert_snapshot;
+
     use crate::{
         ast::{IntegerBitSize, NoirStruct, UnresolvedGeneric, UnresolvedTypeData},
         parse_program_with_dummy_file,
@@ -272,6 +274,6 @@ mod tests {
         assert_eq!(noir_struct.fields.len(), 1);
 
         let error = get_single_error(&errors, span);
-        assert_eq!(error.to_string(), "Expected an identifier but found '42'");
+        assert_snapshot!(error.to_string(), @"Expected an identifier but found '42'");
     }
 }

--- a/compiler/noirc_frontend/src/parser/parser/structs.rs
+++ b/compiler/noirc_frontend/src/parser/parser/structs.rs
@@ -23,7 +23,7 @@ impl Parser<'_> {
         let Some(name) = self.eat_ident() else {
             self.expected_identifier();
             return self.empty_struct(
-                Ident::default(),
+                self.empty_ident_at_previous_token_end(),
                 attributes,
                 visibility,
                 Vec::new(),

--- a/compiler/noirc_frontend/src/parser/parser/traits.rs
+++ b/compiler/noirc_frontend/src/parser/parser/traits.rs
@@ -177,7 +177,7 @@ impl Parser<'_> {
             Some(name) => name,
             None => {
                 self.expected_identifier();
-                Ident::default()
+                self.empty_ident_at_previous_token_end()
             }
         };
 
@@ -196,7 +196,7 @@ impl Parser<'_> {
             Some(name) => name,
             None => {
                 self.expected_identifier();
-                Ident::default()
+                self.empty_ident_at_previous_token_end()
             }
         };
 
@@ -272,7 +272,7 @@ fn empty_trait(
     location: Location,
 ) -> NoirTrait {
     NoirTrait {
-        name: Ident::default(),
+        name: Ident::new(String::new(), location),
         generics: Vec::new(),
         bounds: Vec::new(),
         where_clause: Vec::new(),

--- a/compiler/noirc_frontend/src/parser/parser/type_alias.rs
+++ b/compiler/noirc_frontend/src/parser/parser/type_alias.rs
@@ -1,7 +1,7 @@
 use noirc_errors::Location;
 
 use crate::{
-    ast::{Ident, ItemVisibility, NoirTypeAlias, UnresolvedType, UnresolvedTypeData},
+    ast::{ItemVisibility, NoirTypeAlias, UnresolvedType, UnresolvedTypeData},
     token::Token,
 };
 
@@ -19,7 +19,7 @@ impl Parser<'_> {
             let location = self.location_at_previous_token_end();
             return NoirTypeAlias {
                 visibility,
-                name: Ident::default(),
+                name: self.empty_ident_at_previous_token_end(),
                 generics: Vec::new(),
                 typ: UnresolvedType { typ: UnresolvedTypeData::Error, location },
                 location: start_location,

--- a/compiler/noirc_frontend/src/parser/parser/types.rs
+++ b/compiler/noirc_frontend/src/parser/parser/types.rs
@@ -472,6 +472,7 @@ impl Parser<'_> {
 mod tests {
     use std::collections::BTreeMap;
 
+    use insta::assert_snapshot;
     use proptest::prelude::*;
     use strum::IntoEnumIterator;
 
@@ -707,7 +708,7 @@ mod tests {
         let mut parser = Parser::for_str_with_dummy_file(&src);
         parser.parse_type();
         let error = get_single_error(&parser.errors, span);
-        assert_eq!(error.to_string(), "Expected a ']' but found end of input");
+        assert_snapshot!(error.to_string(), @"Expected a ']' but found end of input");
     }
 
     #[test]

--- a/compiler/noirc_frontend/src/parser/parser/use_tree.rs
+++ b/compiler/noirc_frontend/src/parser/parser/use_tree.rs
@@ -111,7 +111,7 @@ impl Parser<'_> {
             }
             UseTree {
                 prefix,
-                kind: UseTreeKind::Path(Ident::default(), None),
+                kind: UseTreeKind::Path(self.empty_ident_at_previous_token_end(), None),
                 location: self.location_since(start_location),
             }
         } else {


### PR DESCRIPTION
# Description

## Problem

Similar to #8178, `Ident::default()` ends up using a default/dummy location that would sometimes crash the LSP server.

## Summary

One case where it crashed was if you had code like this:

```noir
#[test]
fn () {
    let x = 1;
    let y = 2;
}
```

The name is missing. In my case that happens when I rename the function: I use VIM mode so the command first removes the entire name and lets me type a new one.

The error happened because in this case the parser ended up using `Ident::default()` for the name, and when LSP tried to use that location it crashed.

In addition to this I improved the error message shown in this case. Previously it would not continue parsing the function and error on each successive token. Now the parser will assume the function definition continues if a `(` or `<` comes next.

Finally, checking the error messages now use `assert_snapshot!` which will be handy if we later change/improve the produced error messages.

## Additional Context

I'm trying to fix these LSP bugs as soon as I find them because I usually left them for later, but then I couldn't remember how to trigger them.

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
