### PR TITLE
feat: added 1, -1 case for inversions in brillig

### DIFF
--- a/acvm-repo/brillig_vm/src/arithmetic.rs
+++ b/acvm-repo/brillig_vm/src/arithmetic.rs
@@ -52,6 +52,10 @@ pub(crate) fn evaluate_binary_field_op<F: AcirField>(
         BinaryFieldOp::Div => {
             if b.is_zero() {
                 return Err(BrilligArithmeticError::DivisionByZero);
+            } else if b.is_one() {
+                MemoryValue::new_field(a)
+            } else if b == -F::one() {
+                MemoryValue::new_field(-a)
             } else {
                 MemoryValue::new_field(a / b)
             }


### PR DESCRIPTION
# Description
do not invert elements when they're 1 or -1

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*



## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
