### PR TITLE
fix: Call the ownership analysis

### DIFF
--- a/compiler/noirc_frontend/src/lib.rs
+++ b/compiler/noirc_frontend/src/lib.rs
@@ -26,7 +26,7 @@ pub mod lexer;
 pub mod locations;
 pub mod monomorphization;
 pub mod node_interner;
-pub(crate) mod ownership;
+pub mod ownership;
 pub mod parser;
 pub mod resolve_locations;
 pub mod shared;

--- a/compiler/noirc_frontend/src/monomorphization/printer.rs
+++ b/compiler/noirc_frontend/src/monomorphization/printer.rs
@@ -23,11 +23,12 @@ pub struct AstPrinter {
     indent_level: u32,
     in_unconstrained: bool,
     pub show_id: bool,
+    pub show_clone_and_drop: bool,
 }
 
 impl Default for AstPrinter {
     fn default() -> Self {
-        Self { indent_level: 0, in_unconstrained: false, show_id: true }
+        Self { indent_level: 0, in_unconstrained: false, show_id: true, show_clone_and_drop: true }
     }
 }
 
@@ -177,11 +178,17 @@ impl AstPrinter {
             Expression::Continue => write!(f, "continue"),
             Expression::Clone(expr) => {
                 self.print_expr(expr, f)?;
-                write!(f, ".clone()")
+                if self.show_clone_and_drop {
+                    write!(f, ".clone()")?;
+                }
+                Ok(())
             }
             Expression::Drop(expr) => {
                 self.print_expr(expr, f)?;
-                write!(f, ".drop()")
+                if self.show_clone_and_drop {
+                    write!(f, ".drop()")?;
+                }
+                Ok(())
             }
         }
     }

--- a/compiler/noirc_frontend/src/ownership/mod.rs
+++ b/compiler/noirc_frontend/src/ownership/mod.rs
@@ -50,7 +50,7 @@ mod tests;
 impl Program {
     /// Perform "ownership analysis".
     ///
-    /// See [noirc_frontend::ownership] for details.
+    /// See [ownership](crate::ownership) for details.
     ///
     /// This should only be called once, before converting to SSA.
     pub fn handle_ownership(mut self) -> Self {
@@ -64,7 +64,7 @@ impl Program {
 impl Function {
     /// Perform "ownership analysis".
     ///
-    /// See [noirc_frontend::ownership] for details.
+    /// See [ownership](crate::ownership) for details.
     ///
     /// This should only be called on a function once.
     pub fn handle_ownership(&mut self) {

--- a/compiler/noirc_frontend/src/ownership/mod.rs
+++ b/compiler/noirc_frontend/src/ownership/mod.rs
@@ -48,13 +48,28 @@ mod last_uses;
 mod tests;
 
 impl Program {
-    pub(crate) fn handle_ownership(mut self) -> Self {
-        let mut context = Context { variables_to_move: Default::default() };
-
+    /// Perform "ownership analysis".
+    ///
+    /// See [noirc_frontend::ownership] for details.
+    ///
+    /// This should only be called once, before converting to SSA.
+    pub fn handle_ownership(mut self) -> Self {
         for function in self.functions.iter_mut() {
-            context.handle_ownership_in_function(function);
+            function.handle_ownership();
         }
         self
+    }
+}
+
+impl Function {
+    /// Perform "ownership analysis".
+    ///
+    /// See [noirc_frontend::ownership] for details.
+    ///
+    /// This should only be called on a function once.
+    pub fn handle_ownership(&mut self) {
+        let mut context = Context { variables_to_move: Default::default() };
+        context.handle_ownership_in_function(self);
     }
 }
 

--- a/tooling/ast_fuzzer/fuzz/src/targets/acir_vs_brillig.rs
+++ b/tooling/ast_fuzzer/fuzz/src/targets/acir_vs_brillig.rs
@@ -4,6 +4,7 @@ use crate::{compare_results, create_ssa_or_die, default_ssa_options};
 use arbitrary::Unstructured;
 use color_eyre::eyre;
 use noir_ast_fuzzer::Config;
+use noir_ast_fuzzer::change_all_functions_into_unconstrained;
 use noir_ast_fuzzer::compare::CompareMutants;
 
 pub fn fuzz(u: &mut Unstructured) -> eyre::Result<()> {
@@ -17,13 +18,7 @@ pub fn fuzz(u: &mut Unstructured) -> eyre::Result<()> {
     let inputs = CompareMutants::arb(
         u,
         config,
-        |_u, mut program| {
-            // Change every function to be unconstrained.
-            for f in program.functions.iter_mut() {
-                f.unconstrained = true;
-            }
-            Ok(program)
-        },
+        |_u, program| Ok(change_all_functions_into_unconstrained(program)),
         |program| create_ssa_or_die(program, &options, None),
     )?;
 

--- a/tooling/ast_fuzzer/src/lib.rs
+++ b/tooling/ast_fuzzer/src/lib.rs
@@ -7,7 +7,10 @@ pub use abi::program_abi;
 pub use input::arb_inputs;
 use program::freq::Freqs;
 pub use program::visitor::{visit_expr, visit_expr_mut};
-pub use program::{DisplayAstAsNoir, DisplayAstAsNoirComptime, arb_program, arb_program_comptime};
+pub use program::{
+    DisplayAstAsNoir, DisplayAstAsNoirComptime, arb_program, arb_program_comptime,
+    change_all_functions_into_unconstrained,
+};
 
 /// AST generation configuration.
 #[derive(Debug, Clone)]
@@ -61,7 +64,7 @@ impl Default for Config {
             ("call", 15),
         ]);
         let stmt_freqs_acir = Freqs::new(&[
-            ("drop", 3),
+            ("drop", 0), // The `ownership` module says it will insert `Drop` and `Clone`.
             ("assign", 30),
             ("if", 10),
             ("for", 18),
@@ -69,7 +72,7 @@ impl Default for Config {
             ("call", 5),
         ]);
         let stmt_freqs_brillig = Freqs::new(&[
-            ("drop", 5),
+            ("drop", 0),
             ("break", 20),
             ("continue", 20),
             ("assign", 30),

--- a/tooling/ast_fuzzer/src/program/func.rs
+++ b/tooling/ast_fuzzer/src/program/func.rs
@@ -735,6 +735,11 @@ impl<'a> FunctionContext<'a> {
     }
 
     /// Drop a local variable, if we have anything to drop.
+    ///
+    /// The `ownership` module has a comment saying it will be the only one inserting `Clone` and `Drop`,
+    /// so this shouldn't be needed unless a user can do it via a `drop`-like method.
+    ///
+    /// Leaving it here for reference, but its frequency is adjusted to be 0.
     fn gen_drop(&mut self, u: &mut Unstructured) -> arbitrary::Result<Option<Expression>> {
         if self.locals.current().is_empty() {
             return Ok(None);

--- a/tooling/ast_fuzzer/src/program/mod.rs
+++ b/tooling/ast_fuzzer/src/program/mod.rs
@@ -405,6 +405,7 @@ impl std::fmt::Display for DisplayAstAsNoir<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut printer = AstPrinter::default();
         printer.show_id = false;
+        printer.show_clone_and_drop = false;
         printer.print_program(self.0, f)
     }
 }
@@ -420,6 +421,7 @@ impl std::fmt::Display for DisplayAstAsNoirComptime<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut printer = AstPrinter::default();
         printer.show_id = false;
+        printer.show_clone_and_drop = false;
         for function in &self.0.functions {
             let mut fpo = FunctionPrintOptions::default();
             if function.id == Program::main_id() {

--- a/tooling/ast_fuzzer/src/program/rewrite.rs
+++ b/tooling/ast_fuzzer/src/program/rewrite.rs
@@ -286,3 +286,18 @@ fn next_local_and_ident_id(func: &Function) -> (u32, u32) {
     });
     (next_local_id, next_ident_id)
 }
+
+/// Turn all ACIR functions into Brillig functions.
+///
+/// This is more involved then flipping the `unconstrained` property because of the
+/// "ownership analysis", which can only run on a function once.
+pub fn change_all_functions_into_unconstrained(mut program: Program) -> Program {
+    for f in program.functions.iter_mut() {
+        if f.unconstrained {
+            continue;
+        }
+        f.unconstrained = true;
+        f.handle_ownership();
+    }
+    program
+}

--- a/tooling/ast_fuzzer/tests/calibration.rs
+++ b/tooling/ast_fuzzer/tests/calibration.rs
@@ -87,7 +87,8 @@ fn classify(expr: &Expression) -> Option<(&'static str, &'static str)> {
         | Expression::ExtractTupleField(_, _)
         | Expression::Index(_)
         | Expression::Semi(_)
-        | Expression::Clone(_) => {
+        | Expression::Clone(_)
+        | Expression::Drop(_) => {
             return None;
         }
         Expression::Literal(_) => ("expr", "literal"),
@@ -105,7 +106,6 @@ fn classify(expr: &Expression) -> Option<(&'static str, &'static str)> {
         Expression::Let(_) => ("stmt", "let"),
         Expression::Constrain(_, _, _) => ("stmt", "constrain"),
         Expression::Assign(_) => ("stmt", "assign"),
-        Expression::Drop(_) => ("stmt", "drop"),
         Expression::Break => ("stmt", "break"),
         Expression::Continue => ("stmt", "continue"),
     };


### PR DESCRIPTION
# Description

## Problem\*

Resolves #8240

## Summary\*

Makes `Program::handle_ownership` public and calls it in `Context::finalize` to insert `Clone` into `unconstrained` functions where necessary. Added a `change_functions_into_unconstrained` to flip the `unconstrained` flag in every function of a `Program` and run the `handle_ownership` on them, which can now also be called on `Function`. 

## Additional Context

### Where to do it

I went back and forth between calling `handle_ownership` in `Context::finalize`, versus calling it in `create_ssa_or_die`. I thought we might have _rewrites_ in the future which could result in this method having to run again on an unconstrained function (where it would panic). In the end I put it in `finalize`, because that way the `CompareSsa::program` field contains an AST which is as close as possible to what we will execute, which could avoid some confusion in debugging. 

We might not want to show `.clone()` and `.drop()` in prints, because they are are not valid Noir code, but at least we would see them if we wanted to compare the AST to what `nargo` is doing, without further hidden steps happening during SSA conversion.

### Drop
The `ownership` module contains this comment:

> Clones & Drops are only inserted by this pass so we can assume any code they

However, I don't see `Drop` being inserted. Maybe it's reserved for the future. For now I adjusted the frequency of `"drop"` to 0 but left `gen_drop` in, although I expect we can remove it in the future, unless an explicit `drop` function will be available.

## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
