### PR TITLE
feat: cache field inverses in brillig VM

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -838,6 +838,7 @@ version = "1.0.0-beta.4"
 dependencies = [
  "acir",
  "acvm_blackbox_solver",
+ "lru 0.14.0",
  "num-bigint",
  "num-traits",
  "thiserror 1.0.69",
@@ -3032,6 +3033,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f8cc7106155f10bdf99a6f379688f543ad6596a415375b36a59a054ceda1198"
+dependencies = [
+ "hashbrown 0.15.2",
+]
+
+[[package]]
 name = "lsp-types"
 version = "0.88.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3866,7 +3876,7 @@ checksum = "e238432a7881ec7164503ccc516c014bf009be7984cde1ba56837862543bdec3"
 dependencies = [
  "bitvec",
  "either",
- "lru",
+ "lru 0.12.5",
  "num-bigint",
  "num-integer",
  "num-modular",

--- a/acvm-repo/acvm/src/pwg/brillig.rs
+++ b/acvm-repo/acvm/src/pwg/brillig.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::{collections::HashMap, hash::Hash};
 
 use acir::{
     AcirField,
@@ -32,7 +32,7 @@ pub enum BrilligSolverStatus<F> {
 
 /// Specific solver for Brillig opcodes
 /// It maintains a Brillig VM that can execute the bytecode of the called brillig function
-pub struct BrilligSolver<'b, F, B: BlackBoxFunctionSolver<F>> {
+pub struct BrilligSolver<'b, F: Hash + Eq + PartialEq, B: BlackBoxFunctionSolver<F>> {
     vm: VM<'b, F, B>,
     acir_index: usize,
     /// This id references which Brillig function within the main ACIR program we are solving.

--- a/acvm-repo/acvm/src/pwg/mod.rs
+++ b/acvm-repo/acvm/src/pwg/mod.rs
@@ -74,8 +74,7 @@ impl<F> std::fmt::Display for ACVMStatus<F> {
     }
 }
 
-#[expect(clippy::large_enum_variant)]
-pub enum StepResult<'a, F, B: BlackBoxFunctionSolver<F>> {
+pub enum StepResult<'a, F: std::hash::Hash + Eq + PartialEq, B: BlackBoxFunctionSolver<F>> {
     Status(ACVMStatus<F>),
     IntoBrillig(BrilligSolver<'a, F, B>),
 }

--- a/acvm-repo/brillig_vm/Cargo.toml
+++ b/acvm-repo/brillig_vm/Cargo.toml
@@ -21,6 +21,7 @@ acvm_blackbox_solver.workspace = true
 num-bigint.workspace = true
 num-traits.workspace = true
 thiserror.workspace = true
+lru = "0.14.0"
 
 [features]
 bn254 = ["acir/bn254"]


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

Quick and dirty implementation of having the brillig VM maintain a cache of the 20 most recently seen fields which have been inverted. We then avoid continually inverting the same value in hot loops.

Testing to see the effect on performance.

## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
