### PR TITLE
chore: bump external pinned commits

### DIFF
--- a/.github/benchmark_projects.yml
+++ b/.github/benchmark_projects.yml
@@ -1,4 +1,4 @@
-define: &AZ_COMMIT a1f94c3a1c244834601e3048953cad9047c69835
+define: &AZ_COMMIT d0dccf50800b33605b7525cc31b171ff434ab1d8
 projects:
   private-kernel-inner:
     repo: AztecProtocol/aztec-packages

--- a/.github/benchmark_projects.yml
+++ b/.github/benchmark_projects.yml
@@ -48,7 +48,7 @@ projects:
     compilation-timeout: 20
     execution-timeout: 0.75
     compilation-memory-limit: 1500
-    execution-memory-limit: 500
+    execution-memory-limit: 550
   rollup-block-root-empty:
     repo: AztecProtocol/aztec-packages
     ref: *AZ_COMMIT

--- a/EXTERNAL_NOIR_LIBRARIES.yml
+++ b/EXTERNAL_NOIR_LIBRARIES.yml
@@ -1,4 +1,4 @@
-define: &AZ_COMMIT a1f94c3a1c244834601e3048953cad9047c69835
+define: &AZ_COMMIT d0dccf50800b33605b7525cc31b171ff434ab1d8
 libraries:
   noir_check_shuffle:
     repo: noir-lang/noir_check_shuffle


### PR DESCRIPTION

Automated update of the pinned commit of [aztec-packages](https://github.com/AztecProtocol/aztec-packages) repository against which we run benchmarks.
