### PR TITLE
feat: Fuzz the inliner aggressiveness along with the AST

### DIFF
--- a/tooling/ast_fuzzer/fuzz/src/lib.rs
+++ b/tooling/ast_fuzzer/fuzz/src/lib.rs
@@ -105,8 +105,11 @@ where
                 .serialize(&inputs.input_map, &inputs.abi)
                 .unwrap_or_else(|e| format!("failed to serialize inputs: {e}"))
         );
-        eprintln!("---\nProgram 1:\n{}", inputs.ssa1.program);
-        eprintln!("---\nProgram 2:\n{}", inputs.ssa2.program);
+        eprintln!("---\nOptions 1:\n{:?}", inputs.ssa1.options);
+        eprintln!("---\nProgram 1:\n{}", inputs.ssa1.artifact.program);
+
+        eprintln!("---\nOptions 2:\n{:?}", inputs.ssa2.options);
+        eprintln!("---\nProgram 2:\n{}", inputs.ssa2.artifact.program);
 
         // Returning it as-is, so we can see the error message at the bottom as well.
         Err(report)

--- a/tooling/ast_fuzzer/fuzz/src/targets/init_vs_final.rs
+++ b/tooling/ast_fuzzer/fuzz/src/targets/init_vs_final.rs
@@ -24,10 +24,10 @@ pub fn fuzz(u: &mut Unstructured) -> eyre::Result<()> {
     let inputs = ComparePasses::arb(
         u,
         config,
-        |u, program| {
-            let options = CompareOptions::arbitrary(u)?;
+        |_u, program| {
             // We want to do the minimum possible amount of SSA passes. Brillig can get away with fewer than ACIR,
             // because ACIR needs unrolling of loops for example, so we treat everything as Brillig.
+            let options = CompareOptions::default();
             let ssa = create_ssa_with_passes_or_die(
                 change_all_functions_into_unconstrained(program),
                 &options.onto(default_ssa_options()),

--- a/tooling/ast_fuzzer/fuzz/src/targets/init_vs_final.rs
+++ b/tooling/ast_fuzzer/fuzz/src/targets/init_vs_final.rs
@@ -4,14 +4,13 @@
 use crate::{
     compare_results, create_ssa_or_die, create_ssa_with_passes_or_die, default_ssa_options,
 };
-use arbitrary::Unstructured;
+use arbitrary::{Arbitrary, Unstructured};
 use color_eyre::eyre;
-use noir_ast_fuzzer::compare::ComparePasses;
+use noir_ast_fuzzer::compare::{CompareOptions, ComparePasses};
 use noir_ast_fuzzer::{Config, change_all_functions_into_unconstrained, compare::CompareResult};
 use noirc_evaluator::ssa::minimal_passes;
 
 pub fn fuzz(u: &mut Unstructured) -> eyre::Result<()> {
-    let options = default_ssa_options();
     let passes = minimal_passes();
     let config = Config {
         // Try to avoid using overflowing operations; see below for the reason.
@@ -25,13 +24,25 @@ pub fn fuzz(u: &mut Unstructured) -> eyre::Result<()> {
     let inputs = ComparePasses::arb(
         u,
         config,
-        |program| {
+        |u, program| {
+            let options = CompareOptions::arbitrary(u)?;
             // We want to do the minimum possible amount of SSA passes. Brillig can get away with fewer than ACIR,
             // because ACIR needs unrolling of loops for example, so we treat everything as Brillig.
-            let program = change_all_functions_into_unconstrained(program);
-            create_ssa_with_passes_or_die(program, &options, &passes, |_| vec![], Some("init"))
+            let ssa = create_ssa_with_passes_or_die(
+                change_all_functions_into_unconstrained(program),
+                &options.onto(default_ssa_options()),
+                &passes,
+                |_| vec![],
+                Some("init"),
+            );
+            Ok((ssa, options))
         },
-        |program| create_ssa_or_die(program, &options, Some("final")),
+        |u, program| {
+            let options = CompareOptions::arbitrary(u)?;
+            let ssa =
+                create_ssa_or_die(program, &options.onto(default_ssa_options()), Some("final"));
+            Ok((ssa, options))
+        },
     )?;
 
     let result = inputs.exec()?;

--- a/tooling/ast_fuzzer/fuzz/src/targets/orig_vs_mutant.rs
+++ b/tooling/ast_fuzzer/fuzz/src/targets/orig_vs_mutant.rs
@@ -2,21 +2,21 @@
 //! execution result does not change.
 
 use crate::{compare_results, create_ssa_or_die, default_ssa_options};
-use arbitrary::Unstructured;
+use arbitrary::{Arbitrary, Unstructured};
 use color_eyre::eyre;
 use noir_ast_fuzzer::Config;
-use noir_ast_fuzzer::compare::CompareMutants;
+use noir_ast_fuzzer::compare::{CompareMutants, CompareOptions};
 
 pub fn fuzz(u: &mut Unstructured) -> eyre::Result<()> {
-    let options = default_ssa_options();
     let inputs = CompareMutants::arb(
         u,
         Config::default(),
-        |_u, program| {
+        |u, program| {
+            let options = CompareOptions::arbitrary(u)?;
             // TODO(#7875): Perform random mutations
-            Ok(program.clone())
+            Ok((program, options))
         },
-        |program| create_ssa_or_die(program, &options, None),
+        |program, options| create_ssa_or_die(program, &options.onto(default_ssa_options()), None),
     )?;
 
     let result = inputs.exec()?;

--- a/tooling/ast_fuzzer/src/compare.rs
+++ b/tooling/ast_fuzzer/src/compare.rs
@@ -1,11 +1,11 @@
 use acir::{FieldElement, native_types::WitnessStack};
 use acvm::pwg::{OpcodeResolutionError, ResolvedAssertionPayload};
-use arbitrary::Unstructured;
+use arbitrary::{Arbitrary, Unstructured};
 use bn254_blackbox_solver::Bn254BlackBoxSolver;
 use color_eyre::eyre::{self, WrapErr, bail};
 use nargo::{NargoError, errors::ExecutionError, foreign_calls::DefaultForeignCallBuilder};
 use noirc_abi::{Abi, InputMap, input_parser::InputValue};
-use noirc_evaluator::ssa::SsaProgramArtifact;
+use noirc_evaluator::ssa::{SsaEvaluatorOptions, SsaProgramArtifact};
 use noirc_frontend::monomorphization::ast::Program;
 
 use crate::{Config, arb_inputs, arb_program, program_abi};
@@ -17,6 +17,28 @@ pub struct ExecOutput {
 }
 
 type ExecResult = (Result<WitnessStack<FieldElement>, NargoError<FieldElement>>, String);
+
+/// Subset of [SsaEvaluatorOptions] that we want to vary.
+///
+/// It exists to reduce noise in the printed results, compared to showing the full `SsaEvaluatorOptions`.
+#[derive(Debug, Clone)]
+pub struct CompareOptions {
+    pub inliner_aggressiveness: i64,
+}
+
+impl Arbitrary<'_> for CompareOptions {
+    fn arbitrary(u: &mut Unstructured<'_>) -> arbitrary::Result<Self> {
+        Ok(Self { inliner_aggressiveness: *u.choose(&[i64::MIN, 0, i64::MAX])? })
+    }
+}
+
+impl CompareOptions {
+    /// Copy fields into an [SsaEvaluatorOptions] instance.
+    pub fn onto(&self, mut options: SsaEvaluatorOptions) -> SsaEvaluatorOptions {
+        options.inliner_aggressiveness = self.inliner_aggressiveness;
+        options
+    }
+}
 
 /// Possible outcomes of the differential execution of two equivalent programs.
 ///
@@ -124,13 +146,31 @@ impl CompareResult {
         }
     }
 }
+
+pub struct CompareArtifact {
+    pub options: CompareOptions,
+    pub artifact: SsaProgramArtifact,
+}
+
+impl CompareArtifact {
+    fn new(artifact: SsaProgramArtifact, options: CompareOptions) -> Self {
+        Self { artifact, options }
+    }
+}
+
+impl From<(SsaProgramArtifact, CompareOptions)> for CompareArtifact {
+    fn from((artifact, options): (SsaProgramArtifact, CompareOptions)) -> Self {
+        Self::new(artifact, options)
+    }
+}
+
 /// Compare the execution of different SSA representations of equivalent program(s).
 pub struct CompareSsa<P> {
     pub program: P,
     pub abi: Abi,
     pub input_map: InputMap,
-    pub ssa1: SsaProgramArtifact,
-    pub ssa2: SsaProgramArtifact,
+    pub ssa1: CompareArtifact,
+    pub ssa2: CompareArtifact,
 }
 
 impl<P> CompareSsa<P> {
@@ -158,8 +198,8 @@ impl<P> CompareSsa<P> {
             (res, print)
         };
 
-        let (res1, print1) = do_exec(&self.ssa1.program);
-        let (res2, print2) = do_exec(&self.ssa2.program);
+        let (res1, print1) = do_exec(&self.ssa1.artifact.program);
+        let (res2, print2) = do_exec(&self.ssa2.artifact.program);
 
         CompareResult::new(&self.abi, (res1, print1), (res2, print2))
     }
@@ -173,16 +213,23 @@ impl CompareSsa<Program> {
     pub fn arb(
         u: &mut Unstructured,
         c: Config,
-        f: impl FnOnce(Program) -> SsaProgramArtifact,
-        g: impl FnOnce(Program) -> SsaProgramArtifact,
+        f: impl FnOnce(
+            &mut Unstructured,
+            Program,
+        ) -> arbitrary::Result<(SsaProgramArtifact, CompareOptions)>,
+        g: impl FnOnce(
+            &mut Unstructured,
+            Program,
+        ) -> arbitrary::Result<(SsaProgramArtifact, CompareOptions)>,
     ) -> arbitrary::Result<Self> {
         let program = arb_program(u, c)?;
         let abi = program_abi(&program);
 
-        let ssa1 = f(program.clone());
-        let ssa2 = g(program.clone());
+        let ssa1 = CompareArtifact::from(f(u, program.clone())?);
+        let ssa2 = CompareArtifact::from(g(u, program.clone())?);
 
-        let input_map = arb_inputs(u, &ssa1.program, &abi)?;
+        let input_program = &ssa1.artifact.program;
+        let input_map = arb_inputs(u, input_program, &abi)?;
 
         Ok(Self { program, abi, input_map, ssa1, ssa2 })
     }
@@ -192,23 +239,30 @@ impl CompareSsa<Program> {
 pub type CompareMutants = CompareSsa<(Program, Program)>;
 
 impl CompareMutants {
-    /// Generate a random AST and compile it into SSA in two different ways.
+    /// Generate a random AST, a random mutation of it, then compile both into SSA with the same options.
     pub fn arb(
         u: &mut Unstructured,
         c: Config,
-        f: impl Fn(&mut Unstructured, Program) -> arbitrary::Result<Program>,
-        g: impl Fn(Program) -> SsaProgramArtifact,
+        f: impl Fn(&mut Unstructured, Program) -> arbitrary::Result<(Program, CompareOptions)>,
+        g: impl Fn(Program, &CompareOptions) -> SsaProgramArtifact,
     ) -> arbitrary::Result<Self> {
         let program1 = arb_program(u, c)?;
-        let program2 = f(u, program1.clone())?;
+        let (program2, options) = f(u, program1.clone())?;
         let abi = program_abi(&program1);
 
-        let ssa1 = g(program1.clone());
-        let ssa2 = g(program2.clone());
+        let ssa1 = g(program1.clone(), &options);
+        let ssa2 = g(program2.clone(), &options);
 
-        let input_map = arb_inputs(u, &ssa1.program, &abi)?;
+        let input_program = &ssa1.program;
+        let input_map = arb_inputs(u, input_program, &abi)?;
 
-        Ok(Self { program: (program1, program2), abi, input_map, ssa1, ssa2 })
+        Ok(Self {
+            program: (program1, program2),
+            abi,
+            input_map,
+            ssa1: CompareArtifact::new(ssa1, options.clone()),
+            ssa2: CompareArtifact::new(ssa2, options),
+        })
     }
 }
 

--- a/tooling/ast_fuzzer/src/compare.rs
+++ b/tooling/ast_fuzzer/src/compare.rs
@@ -21,15 +21,9 @@ type ExecResult = (Result<WitnessStack<FieldElement>, NargoError<FieldElement>>,
 /// Subset of [SsaEvaluatorOptions] that we want to vary.
 ///
 /// It exists to reduce noise in the printed results, compared to showing the full `SsaEvaluatorOptions`.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct CompareOptions {
     pub inliner_aggressiveness: i64,
-}
-
-impl Default for CompareOptions {
-    fn default() -> Self {
-        Self { inliner_aggressiveness: 0 }
-    }
 }
 
 impl Arbitrary<'_> for CompareOptions {

--- a/tooling/ast_fuzzer/src/compare.rs
+++ b/tooling/ast_fuzzer/src/compare.rs
@@ -26,6 +26,12 @@ pub struct CompareOptions {
     pub inliner_aggressiveness: i64,
 }
 
+impl Default for CompareOptions {
+    fn default() -> Self {
+        Self { inliner_aggressiveness: 0 }
+    }
+}
+
 impl Arbitrary<'_> for CompareOptions {
     fn arbitrary(u: &mut Unstructured<'_>) -> arbitrary::Result<Self> {
         Ok(Self { inliner_aggressiveness: *u.choose(&[i64::MIN, 0, i64::MAX])? })


### PR DESCRIPTION
# Description

## Problem\*

Resolves #8260 

## Summary\*

Created a `CompareOptions` struct, currently with only the `inliner_aggressiveness` field, which is randomised during fuzzing so that we can compare ACIR vs Brillig with both having arbitrary inlining settings, and similarly the minimal pipeline vs the final, varying the setting of the latter.

## Additional Context

We could add a separate target that compares the program to itself with a different pipeline setting, but I figured the ACIR vs Brillig case should cover it, since ACIR has to inline everything anyway.

## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
