### PR TITLE
fix: use correct meta attribute names in contract custom attributes

### DIFF
--- a/compiler/noirc_driver/src/lib.rs
+++ b/compiler/noirc_driver/src/lib.rs
@@ -594,7 +594,9 @@ fn compile_contract_inner(
             .iter()
             .filter_map(|attr| match &attr.kind {
                 SecondaryAttributeKind::Tag(contents) => Some(contents.clone()),
-                SecondaryAttributeKind::Meta(attribute) => Some(attribute.to_string()),
+                SecondaryAttributeKind::Meta(meta_attribute) => {
+                    context.def_interner.get_meta_attribute_name(meta_attribute)
+                }
                 _ => None,
             })
             .collect();

--- a/compiler/noirc_driver/src/lib.rs
+++ b/compiler/noirc_driver/src/lib.rs
@@ -497,16 +497,19 @@ pub fn compile_contract(
 fn read_contract(context: &Context, module_id: ModuleId, name: String) -> Contract {
     let module = context.module(module_id);
 
-    let functions = module
+    let mut functions: Vec<(ContractFunctionMeta, &str)> = module
         .value_definitions()
         .filter_map(|id| {
             id.as_function().map(|function_id| {
+                let name = context.def_interner.function_name(&function_id);
                 let attrs = context.def_interner.function_attributes(&function_id);
                 let is_entry_point = attrs.is_contract_entry_point();
-                ContractFunctionMeta { function_id, is_entry_point }
+                (ContractFunctionMeta { function_id, is_entry_point }, name)
             })
         })
         .collect();
+    functions.sort_by_key(|(_, name)| *name);
+    let functions = vecmap(functions, |(function, _)| function);
 
     let mut outputs = ContractOutputs { structs: HashMap::new(), globals: HashMap::new() };
 

--- a/compiler/noirc_driver/src/lib.rs
+++ b/compiler/noirc_driver/src/lib.rs
@@ -497,19 +497,16 @@ pub fn compile_contract(
 fn read_contract(context: &Context, module_id: ModuleId, name: String) -> Contract {
     let module = context.module(module_id);
 
-    let mut functions: Vec<(ContractFunctionMeta, &str)> = module
+    let functions: Vec<ContractFunctionMeta> = module
         .value_definitions()
         .filter_map(|id| {
             id.as_function().map(|function_id| {
-                let name = context.def_interner.function_name(&function_id);
                 let attrs = context.def_interner.function_attributes(&function_id);
                 let is_entry_point = attrs.is_contract_entry_point();
-                (ContractFunctionMeta { function_id, is_entry_point }, name)
+                ContractFunctionMeta { function_id, is_entry_point }
             })
         })
         .collect();
-    functions.sort_by_key(|(_, name)| *name);
-    let functions = vecmap(functions, |(function, _)| function);
 
     let mut outputs = ContractOutputs { structs: HashMap::new(), globals: HashMap::new() };
 

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin/builtin_helpers.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin/builtin_helpers.rs
@@ -9,10 +9,9 @@ use crate::elaborator::Elaborator;
 use crate::hir::comptime::display::tokens_to_string;
 use crate::hir::comptime::value::unwrap_rc;
 use crate::hir::def_collector::dc_crate::CompilationError;
-use crate::hir_def::expr::HirExpression;
 use crate::lexer::Lexer;
 use crate::parser::{Parser, ParserError};
-use crate::token::{LocatedToken, MetaAttributeName, SecondaryAttributeKind};
+use crate::token::{LocatedToken, SecondaryAttributeKind};
 use crate::{DataType, Kind, Shared};
 use crate::{
     QuotedType, Type,
@@ -608,15 +607,7 @@ fn secondary_attribute_name(
             let token = lexer.next()?.ok()?;
             if let Token::Ident(ident) = token.into_token() { Some(ident) } else { None }
         }
-        SecondaryAttributeKind::Meta(meta) => match &meta.name {
-            MetaAttributeName::Path(path) => Some(path.last_name().to_string()),
-            MetaAttributeName::Resolved(expr_id) => {
-                let HirExpression::Ident(ident, _) = interner.expression(expr_id) else {
-                    return None;
-                };
-                interner.try_definition(ident.id).map(|def| def.name.clone())
-            }
-        },
+        SecondaryAttributeKind::Meta(meta) => interner.get_meta_attribute_name(meta),
         SecondaryAttributeKind::Abi(_) => Some("abi".to_string()),
         SecondaryAttributeKind::Varargs => Some("varargs".to_string()),
         SecondaryAttributeKind::UseCallersScope => Some("use_callers_scope".to_string()),

--- a/compiler/noirc_frontend/src/hir/def_map/item_scope.rs
+++ b/compiler/noirc_frontend/src/hir/def_map/item_scope.rs
@@ -2,14 +2,15 @@ use super::{ModuleDefId, ModuleId, namespace::PerNs};
 use crate::ast::{Ident, ItemVisibility};
 use crate::node_interner::{FuncId, TraitId};
 
-use std::collections::{HashMap, hash_map::Entry};
+use std::collections::{BTreeMap, btree_map};
+use std::collections::{HashMap, hash_map};
 
 type Scope = HashMap<Option<TraitId>, (ModuleDefId, ItemVisibility, bool /*is_prelude*/)>;
 
 #[derive(Default, Debug, PartialEq, Eq)]
 pub struct ItemScope {
-    types: HashMap<Ident, Scope>,
-    values: HashMap<Ident, Scope>,
+    types: BTreeMap<Ident, Scope>,
+    values: BTreeMap<Ident, Scope>,
 
     defs: Vec<ModuleDefId>,
 }
@@ -38,10 +39,10 @@ impl ItemScope {
         trait_id: Option<TraitId>,
         is_prelude: bool,
     ) -> Result<(), (Ident, Ident)> {
-        let add_item = |map: &mut HashMap<Ident, Scope>| {
-            if let Entry::Occupied(mut o) = map.entry(name.clone()) {
+        let add_item = |map: &mut BTreeMap<Ident, Scope>| {
+            if let btree_map::Entry::Occupied(mut o) = map.entry(name.clone()) {
                 let trait_hashmap = o.get_mut();
-                if let Entry::Occupied(mut n) = trait_hashmap.entry(trait_id) {
+                if let hash_map::Entry::Occupied(mut n) = trait_hashmap.entry(trait_id) {
                     // Generally we want to reject having two of the same ident in the same namespace.
                     // The exception to this is when we're explicitly importing something
                     // which exists in the Noir stdlib prelude.
@@ -120,7 +121,7 @@ impl ItemScope {
     pub fn find_name(&self, name: &Ident) -> PerNs {
         // Names, not associated with traits are searched first. If not found, we search for name, coming from a trait.
         // If we find only one name from trait, we return it. If there are multiple traits, providing the same name, we return None.
-        let find_name_in = |a: &HashMap<Ident, Scope>| {
+        let find_name_in = |a: &BTreeMap<Ident, Scope>| {
             if let Some(t) = a.get(name) {
                 if let Some(tt) = t.get(&None) {
                     Some(*tt)
@@ -156,11 +157,11 @@ impl ItemScope {
         self.defs.clone()
     }
 
-    pub fn types(&self) -> &HashMap<Ident, Scope> {
+    pub fn types(&self) -> &BTreeMap<Ident, Scope> {
         &self.types
     }
 
-    pub fn values(&self) -> &HashMap<Ident, Scope> {
+    pub fn values(&self) -> &BTreeMap<Ident, Scope> {
         &self.values
     }
 

--- a/compiler/noirc_frontend/src/node_interner.rs
+++ b/compiler/noirc_frontend/src/node_interner.rs
@@ -26,6 +26,8 @@ use crate::hir::type_check::generics::TraitGenerics;
 use crate::hir_def::traits::NamedType;
 use crate::hir_def::traits::ResolvedTraitBound;
 use crate::locations::AutoImportEntry;
+use crate::token::MetaAttribute;
+use crate::token::MetaAttributeName;
 
 use crate::GenericTypeVars;
 use crate::Generics;
@@ -2344,6 +2346,18 @@ impl NodeInterner {
 
     pub fn get_trait_reexports(&self, trait_id: TraitId) -> &[Reexport] {
         self.get_reexports(ModuleDefId::TraitId(trait_id))
+    }
+
+    pub fn get_meta_attribute_name(&self, meta: &MetaAttribute) -> Option<String> {
+        match &meta.name {
+            MetaAttributeName::Path(path) => Some(path.last_name().to_string()),
+            MetaAttributeName::Resolved(expr_id) => {
+                let HirExpression::Ident(ident, _) = self.expression(expr_id) else {
+                    return None;
+                };
+                self.try_definition(ident.id).map(|def| def.name.clone())
+            }
+        }
     }
 }
 

--- a/test_programs/compile_success_contract/contract_with_comptime_attributes/Nargo.toml
+++ b/test_programs/compile_success_contract/contract_with_comptime_attributes/Nargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "contract_with_comptime_attributes"
+type = "contract"
+authors = [""]
+
+[dependencies]

--- a/test_programs/compile_success_contract/contract_with_comptime_attributes/src/main.nr
+++ b/test_programs/compile_success_contract/contract_with_comptime_attributes/src/main.nr
@@ -1,0 +1,19 @@
+pub contract SomeContract {
+    #[super::add_utility]
+    fn fn1() {}
+
+}
+
+comptime fn utility(f: FunctionDefinition) -> () {
+    f.add_attribute("'custom")
+}
+
+comptime fn add_utility(_: FunctionDefinition) -> Quoted {
+    let utility = utility;
+
+    quote {
+        #[$utility]
+        fn fn2() {
+        }
+    }
+}

--- a/tooling/nargo_cli/build.rs
+++ b/tooling/nargo_cli/build.rs
@@ -482,7 +482,7 @@ fn generate_compile_success_contract_tests(test_file: &mut File, test_data_dir: 
             &test_name,
             &test_dir,
             "compile",
-            "compile_success_contract(nargo);",
+            "compile_success_contract(nargo, test_program_dir, force_brillig, inliner_aggressiveness);",
             &MatrixConfig::default(),
         );
     }

--- a/tooling/nargo_cli/tests/execute.rs
+++ b/tooling/nargo_cli/tests/execute.rs
@@ -378,7 +378,7 @@ mod tests {
         let artifact_file = fs::File::open(&artifact_filename).unwrap();
         let artifact: ContractArtifact = serde_json::from_reader(artifact_file).unwrap();
 
-        let _ = fs::remove_dir_all(target_dir);
+        fs::remove_dir_all(target_dir).expect("Could not remove target dir");
 
         let test_name = test_program_dir.file_name().unwrap().to_string_lossy().to_string();
 

--- a/tooling/nargo_cli/tests/execute.rs
+++ b/tooling/nargo_cli/tests/execute.rs
@@ -3,6 +3,8 @@
 mod tests {
     // Some of these imports are consumed by the injected tests
     use assert_cmd::prelude::*;
+    use insta::internals::Redaction;
+    use noirc_artifacts::contract::ContractArtifact;
     use noirc_artifacts::program::ProgramArtifact;
     use predicates::prelude::*;
     use serde::Deserialize;
@@ -259,8 +261,25 @@ mod tests {
         );
     }
 
-    fn compile_success_contract(mut nargo: Command) {
+    fn compile_success_contract(
+        mut nargo: Command,
+        test_program_dir: PathBuf,
+        force_brillig: ForceBrillig,
+        inliner: Inliner,
+    ) {
+        let target_dir = test_program_dir
+            .join(format!("target_force_brillig_{}_inliner_{}", force_brillig.0, inliner.0));
+        nargo.arg(format!("--target-dir={}", target_dir.to_string_lossy()));
+
         nargo.assert().success().stderr(predicate::str::contains("warning:").not());
+
+        check_contract_artifact(
+            "compile_success_contract",
+            &test_program_dir,
+            &target_dir,
+            force_brillig,
+            inliner,
+        );
     }
 
     fn compile_success_no_bug(mut nargo: Command) {
@@ -341,16 +360,47 @@ mod tests {
             insta::assert_json_snapshot!(snapshot_name, artifact, {
                 ".noir_version" => "[noir_version]",
                 ".hash" => "[hash]",
-                ".file_map.**.path" => insta::dynamic_redaction(|value, _path| {
-                    // Some paths are absolute: clear those out.
-                    let value = value.as_str().expect("Expected a string value in a path entry");
-                    if value.starts_with("/") {
-                        String::new()
-                    } else {
-                        value.to_string()
-                    }
-                }),
+                ".file_map.**.path" => file_map_path_redaction(),
             })
+        })
+    }
+
+    fn check_contract_artifact(
+        prefix: &'static str,
+        test_program_dir: &Path,
+        target_dir: &PathBuf,
+        force_brillig: ForceBrillig,
+        inliner: Inliner,
+    ) {
+        let artifact_filename =
+            find_program_artifact_in_dir(target_dir).expect("Expected an artifact to exist");
+
+        let artifact_file = fs::File::open(&artifact_filename).unwrap();
+        let artifact: ContractArtifact = serde_json::from_reader(artifact_file).unwrap();
+
+        let _ = fs::remove_dir_all(target_dir);
+
+        let test_name = test_program_dir.file_name().unwrap().to_string_lossy().to_string();
+
+        let snapshot_name = format!("force_brillig_{}_inliner_{}", force_brillig.0, inliner.0);
+        insta::with_settings!(
+            {
+                snapshot_path => format!("./snapshots/{prefix}/{test_name}")
+            },
+            {
+            insta::assert_json_snapshot!(snapshot_name, artifact, {
+                ".noir_version" => "[noir_version]",
+                ".functions[].hash" => "[hash]",
+                ".file_map.**.path" => file_map_path_redaction(),
+            })
+        })
+    }
+
+    fn file_map_path_redaction() -> Redaction {
+        insta::dynamic_redaction(|value, _path| {
+            // Some paths are absolute: clear those out.
+            let value = value.as_str().expect("Expected a string value in a path entry");
+            if value.starts_with("/") { String::new() } else { value.to_string() }
         })
     }
 

--- a/tooling/nargo_cli/tests/snapshots/compile_success_contract/abi_attribute/execute__tests__force_brillig_false_inliner_0.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_contract/abi_attribute/execute__tests__force_brillig_false_inliner_0.snap
@@ -1,0 +1,37 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: artifact
+---
+{
+  "noir_version": "[noir_version]",
+  "name": "Foo",
+  "functions": [],
+  "outputs": {
+    "structs": {
+      "bar": [
+        {
+          "kind": "struct",
+          "path": "Foo::Bar",
+          "fields": [
+            {
+              "name": "inner",
+              "type": {
+                "kind": "field"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "globals": {
+      "foo": [
+        {
+          "kind": "integer",
+          "sign": false,
+          "value": "000000000000000000000000000000000000000000000000000000000000002a"
+        }
+      ]
+    }
+  },
+  "file_map": {}
+}

--- a/tooling/nargo_cli/tests/snapshots/compile_success_contract/contract_with_comptime_attributes/execute__tests__force_brillig_false_inliner_0.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_contract/contract_with_comptime_attributes/execute__tests__force_brillig_false_inliner_0.snap
@@ -11,7 +11,7 @@ expression: artifact
       "hash": "[hash]",
       "is_unconstrained": false,
       "custom_attributes": [
-        "super::add_utility"
+        "add_utility"
       ],
       "abi": {
         "parameters": [],
@@ -30,7 +30,7 @@ expression: artifact
       "hash": "[hash]",
       "is_unconstrained": false,
       "custom_attributes": [
-        "(quoted)",
+        "utility",
         "custom"
       ],
       "abi": {

--- a/tooling/nargo_cli/tests/snapshots/compile_success_contract/contract_with_comptime_attributes/execute__tests__force_brillig_false_inliner_0.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_contract/contract_with_comptime_attributes/execute__tests__force_brillig_false_inliner_0.snap
@@ -1,0 +1,54 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: artifact
+---
+{
+  "noir_version": "[noir_version]",
+  "name": "SomeContract",
+  "functions": [
+    {
+      "name": "fn1",
+      "hash": "[hash]",
+      "is_unconstrained": false,
+      "custom_attributes": [
+        "super::add_utility"
+      ],
+      "abi": {
+        "parameters": [],
+        "return_type": null,
+        "error_types": {}
+      },
+      "bytecode": "H4sIAAAAAAAA/5XDsQkAAADCMAv+f7PuTgaCFm19Arunwj5IAAAA",
+      "debug_symbols": "XY5BCsQwCEXv4rqLWfcqw1BsaosgJtikMITefWyYQOlK/3/6tcJCc9km1jXuML4rzMYivE0SA2aO6m49B+hyykbkFty4byU00gyjFpEBDpTShvaE2mpGc/oagHTx6oErC13d+XGBge158UBjnIX+ci0abjR/Uyf942Qx0FKMrqTGPPsH",
+      "names": [
+        "fn1"
+      ],
+      "brillig_names": []
+    },
+    {
+      "name": "fn2",
+      "hash": "[hash]",
+      "is_unconstrained": false,
+      "custom_attributes": [
+        "(quoted)",
+        "custom"
+      ],
+      "abi": {
+        "parameters": [],
+        "return_type": null,
+        "error_types": {}
+      },
+      "bytecode": "H4sIAAAAAAAA/5XDsQkAAADCMAv+f7PuTgaCFm19Arunwj5IAAAA",
+      "debug_symbols": "XY5BCsQwCEXv4rqLWfcqw1BsaosgJtikMITefWyYQOlK/3/6tcJCc9km1jXuML4rzMYivE0SA2aO6m49B+hyykbkFty4byU00gyjFpEBDpTShvaE2mpGc/oagHTx6oErC13d+XGBge158UBjnIX+ci0abjR/Uyf942Qx0FKMrqTGPPsH",
+      "names": [
+        "fn2"
+      ],
+      "brillig_names": []
+    }
+  ],
+  "outputs": {
+    "structs": {},
+    "globals": {}
+  },
+  "file_map": {}
+}

--- a/tooling/nargo_cli/tests/snapshots/compile_success_contract/contract_with_impl/execute__tests__force_brillig_false_inliner_0.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_contract/contract_with_impl/execute__tests__force_brillig_false_inliner_0.snap
@@ -1,0 +1,14 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: artifact
+---
+{
+  "noir_version": "[noir_version]",
+  "name": "Foo",
+  "functions": [],
+  "outputs": {
+    "structs": {},
+    "globals": {}
+  },
+  "file_map": {}
+}

--- a/tooling/nargo_cli/tests/snapshots/compile_success_contract/fold_non_contract_method/execute__tests__force_brillig_false_inliner_0.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_contract/fold_non_contract_method/execute__tests__force_brillig_false_inliner_0.snap
@@ -1,0 +1,111 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: artifact
+---
+{
+  "noir_version": "[noir_version]",
+  "name": "Foo",
+  "functions": [
+    {
+      "name": "double",
+      "hash": "[hash]",
+      "is_unconstrained": false,
+      "custom_attributes": [],
+      "abi": {
+        "parameters": [
+          {
+            "name": "x",
+            "type": {
+              "kind": "field"
+            },
+            "visibility": "private"
+          }
+        ],
+        "return_type": {
+          "abi_type": {
+            "kind": "field"
+          },
+          "visibility": "public"
+        },
+        "error_types": {}
+      },
+      "bytecode": "H4sIAAAAAAAA/62QsQ2AMAwEMWIgO7aJ3bEKEc7+IyCUFFEKGjjp9cVLVzwsDeiZWXsfvRl3kcgpiOnE5MUURctuZKSmVzLmMLHsxTM6CQdVdY7aGF34DYL/XPi4tuGLGXjZbl/bHHBEAQAA",
+      "debug_symbols": "dY/RCoMwDEX/Jc99GIyB81fGkFijFEJaYisM8d8XRTcZ7Cm9OT2XdoaO2jI0Qfo4Qv2YodXAHIaGo8ccoth2XhwcsclKZCs4cbMSKkmGWgqzgwm5bJfGhLLNjGr04oCks2mFfWBaT4v72pf/alXt7v36kW9mPy2hD/r73gk1YMu0x76IP9H8Sgc5/ps0euqK0tq0Met+Aw==",
+      "names": [
+        "double"
+      ],
+      "brillig_names": []
+    },
+    {
+      "name": "times_40",
+      "hash": "[hash]",
+      "is_unconstrained": false,
+      "custom_attributes": [],
+      "abi": {
+        "parameters": [
+          {
+            "name": "x",
+            "type": {
+              "kind": "field"
+            },
+            "visibility": "private"
+          }
+        ],
+        "return_type": {
+          "abi_type": {
+            "kind": "field"
+          },
+          "visibility": "public"
+        },
+        "error_types": {}
+      },
+      "bytecode": "H4sIAAAAAAAA/7WR0QrDIAxFq2z/k5ikJm/7lUnT//+ErZ0FkT7N9sBFkHCJxzj9iDUbz29CzUFo5tr7nVc9YQxsO+PF3aHpIpiZPSdHwjckKyrAUmZFRVFZkhK5smYrlsGQyXEVI193lnjdXrDt9egkTyfi+884m+2dDb4z3+UfBvnH2cEHq8+0wPECAAA=",
+      "debug_symbols": "zZDBCoMwDIbfJWcPnduY81WGSK1RCqUtsR0M6buvFXV6GIOxw05p8vcL7TdCi43va6k7M0B5G6EhqZTsa2UEd9LoOB1DBktbO0KMI9jkkbKcUDsotVcqgztXfro0WK6n6jjFlGWAuo01LuykwnQK2Ytm79GcFTOcH64rfv6Gz487voodF5J2PwYG5SGkdSR5o3C20HktNlLcwy7Jos2SEdh6wrRuytID/1XqZZVSnD5L+ZGPKjwB",
+      "names": [
+        "times_40",
+        "times_10"
+      ],
+      "brillig_names": []
+    },
+    {
+      "name": "triple",
+      "hash": "[hash]",
+      "is_unconstrained": false,
+      "custom_attributes": [],
+      "abi": {
+        "parameters": [
+          {
+            "name": "x",
+            "type": {
+              "kind": "field"
+            },
+            "visibility": "private"
+          }
+        ],
+        "return_type": {
+          "abi_type": {
+            "kind": "field"
+          },
+          "visibility": "public"
+        },
+        "error_types": {}
+      },
+      "bytecode": "H4sIAAAAAAAA/62QsQ2AMAwEMWIgO7aJ3bEKEc7+IyAgRZSCBk56ffHSFQ/TA7SMzK231oyrSOQUxLRj8mKKomU1MlLTIxlzmFj24hmdhIOqOke9id6F3yD4z4WXa+m+GIGX7QSI948TRAEAAA==",
+      "debug_symbols": "dY/RCoMwDEX/Jc990DEZ+CtjSKxRCqEtsRWG+O+LopsMfEpvTs+lnaGjNg+N830YoX7O0IpjdkPDwWJywet2XgwcsUlCpCs4cbUiCvkEtc/MBibkvF0aI/ptJhSlhQHynU4t7B3TelrMzy6u1fL+2OWyun31Sv2XJrRO/l88oThsmfbYZ29PNL3jQY4fRwmWuiy0Nm1Muz8=",
+      "names": [
+        "triple"
+      ],
+      "brillig_names": []
+    }
+  ],
+  "outputs": {
+    "structs": {},
+    "globals": {}
+  },
+  "file_map": {
+    "50": {
+      "source": "contract Foo {\n    use crate::times_10;\n\n    fn double(x: Field) -> pub Field {\n        x * 2\n    }\n    fn triple(x: Field) -> pub Field {\n        x * 3\n    }\n    fn times_40(x: Field) -> pub Field {\n        times_10(x) * 4\n    }\n}\n\n#[fold]\nfn times_10(x: Field) -> Field {\n    x * 10\n}\n",
+      "path": ""
+    }
+  }
+}

--- a/tooling/nargo_cli/tests/snapshots/compile_success_contract/non_entry_point_method/execute__tests__force_brillig_false_inliner_0.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_contract/non_entry_point_method/execute__tests__force_brillig_false_inliner_0.snap
@@ -1,0 +1,14 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: artifact
+---
+{
+  "noir_version": "[noir_version]",
+  "name": "Foo",
+  "functions": [],
+  "outputs": {
+    "structs": {},
+    "globals": {}
+  },
+  "file_map": {}
+}

--- a/tooling/nargo_cli/tests/snapshots/compile_success_contract/simple_contract/execute__tests__force_brillig_false_inliner_0.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_contract/simple_contract/execute__tests__force_brillig_false_inliner_0.snap
@@ -1,0 +1,105 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: artifact
+---
+{
+  "noir_version": "[noir_version]",
+  "name": "Foo",
+  "functions": [
+    {
+      "name": "double",
+      "hash": "[hash]",
+      "is_unconstrained": false,
+      "custom_attributes": [],
+      "abi": {
+        "parameters": [
+          {
+            "name": "x",
+            "type": {
+              "kind": "field"
+            },
+            "visibility": "private"
+          }
+        ],
+        "return_type": {
+          "abi_type": {
+            "kind": "field"
+          },
+          "visibility": "public"
+        },
+        "error_types": {}
+      },
+      "bytecode": "H4sIAAAAAAAA/62QsQ2AMAwEMWIgO7aJ3bEKEc7+IyCUFFEKGjjp9cVLVzwsDeiZWXsfvRl3kcgpiOnE5MUURctuZKSmVzLmMLHsxTM6CQdVdY7aGF34DYL/XPi4tuGLGXjZbl/bHHBEAQAA",
+      "debug_symbols": "dY/RCoMwDEX/Jc99GIM58FfGkFijFEJaYisM8d8XRTcZ7Cm9OT2XdoaO2jI0Qfo4Qv2YodXAHIaGo8ccoth2XhwcsclKZCs4cbMSKkmGWgqzgwm5bJfGhLLNjGr04oCks2mFfWBaT4v72pf/anXd3er+kW9mPy2hD/r73gk1YMu0x76IP9H8Sgc5/ps0euqK0tq0Met+Aw==",
+      "names": [
+        "double"
+      ],
+      "brillig_names": []
+    },
+    {
+      "name": "quadruple",
+      "hash": "[hash]",
+      "is_unconstrained": false,
+      "custom_attributes": [],
+      "abi": {
+        "parameters": [
+          {
+            "name": "x",
+            "type": {
+              "kind": "field"
+            },
+            "visibility": "private"
+          }
+        ],
+        "return_type": {
+          "abi_type": {
+            "kind": "field"
+          },
+          "visibility": "public"
+        },
+        "error_types": {}
+      },
+      "bytecode": "H4sIAAAAAAAA/62QsQ2AMAwECWIgO7YTu2MVojj7j4CAFFEKGjjp9cVLV3xYHkLPzNp7702QmD1HR8IDohUVYClJUVFUalQiV9ZsxTIYMjk2MfJ2U0cXfAPDfy64XNvwxUx42U76ES6ERAEAAA==",
+      "debug_symbols": "dY/RCoMwDEX/Jc99UMZA/JUxJNYohdCW2ApD/PdFsZsM9pTenJ5Lu8JAfZ4658cwQ/tYoRfH7KaOg8XkgtftuhkosUtCpCu4cLUiCvkErc/MBhbkfFyaI/pjJhSllQHyg04tHB3TftrM167+q3VzO+W6aT76Xf2nJrROfl+8oDjsmc44Zm8vNL1iIeXHUYKlIQvtTQfT7jc=",
+      "names": [
+        "quadruple"
+      ],
+      "brillig_names": []
+    },
+    {
+      "name": "triple",
+      "hash": "[hash]",
+      "is_unconstrained": false,
+      "custom_attributes": [],
+      "abi": {
+        "parameters": [
+          {
+            "name": "x",
+            "type": {
+              "kind": "field"
+            },
+            "visibility": "private"
+          }
+        ],
+        "return_type": {
+          "abi_type": {
+            "kind": "field"
+          },
+          "visibility": "public"
+        },
+        "error_types": {}
+      },
+      "bytecode": "H4sIAAAAAAAA/62QsQ2AMAwEMWIgO7aJ3bEKEc7+IyAgRZSCBk56ffHSFQ/TA7SMzK231oyrSOQUxLRj8mKKomU1MlLTIxlzmFj24hmdhIOqOke9id6F3yD4z4WXa+m+GIGX7QSI948TRAEAAA==",
+      "debug_symbols": "dY/RCoMwDEX/Jc99UGF78FfGkFijFEJbYisM8d8XxW4y2FN6c3ou7QoD9XnqnB/DDO1jhV4cs5s6DhaTC16362agxC4Jka7gwtWKKOQTtD4zG1iQ83FpjuiPmVCUVgbIDzq1cHRM+2kzX7v6r9ZNfcp1c//oN/WfmtA6+X3xguKwZzrjmL290PSKhZQfRwmWhiy0Nx1Mu98=",
+      "names": [
+        "triple"
+      ],
+      "brillig_names": []
+    }
+  ],
+  "outputs": {
+    "structs": {},
+    "globals": {}
+  },
+  "file_map": {}
+}


### PR DESCRIPTION
# Description

## Problem

Resolves #8255

## Summary

To do this:
- I wanted a test for this and one thing we can do is to start capturing snapshots of contract artifacts, which is what I did here (second commit)
- However, when I did that I noticed the output of functions was not deterministic. So the first commit makes it deterministic by sorting by function name.
- The third commit is the actual fix to the issue, and you can see in the diff how "(quoted)" changed to "utility" (and also how "super::add_utility" changed to "add_utility"), proving that the fix works 😊 

## Additional Context



## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
