### PR TITLE
fix: use temporary dirs when fuzzing during `nargo test`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3171,6 +3171,7 @@ dependencies = [
  "rayon",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror 1.0.69",
  "tokio",
  "tracing",

--- a/tooling/nargo/Cargo.toml
+++ b/tooling/nargo/Cargo.toml
@@ -23,6 +23,7 @@ noirc_printable_type.workspace = true
 iter-extended.workspace = true
 jsonrpsee.workspace = true
 rayon.workspace = true
+tempfile.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
 serde.workspace = true

--- a/tooling/nargo/src/ops/test.rs
+++ b/tooling/nargo/src/ops/test.rs
@@ -227,11 +227,14 @@ where
     let location = test_function.location;
     let fuzzing_harness = FuzzingHarness { id, scope, location };
 
+    let corpus_dir = tempfile::tempdir().expect("Couldn't create temporary directory");
+    let fuzzing_failure_dir = tempfile::tempdir().expect("Couldn't create temporary directory");
+
     // TODO: allow configuring this. See https://github.com/noir-lang/noir/issues/8214
     let fuzz_folder_config = FuzzFolderConfig {
-        corpus_dir: None,
+        corpus_dir: Some(corpus_dir.path().to_string_lossy().to_string()),
         minimized_corpus_dir: None,
-        fuzzing_failure_dir: None,
+        fuzzing_failure_dir: Some(fuzzing_failure_dir.path().to_string_lossy().to_string()),
     };
     // TODO: allow configuring this. See https://github.com/noir-lang/noir/issues/8214
     let fuzz_execution_config =
@@ -249,6 +252,7 @@ where
         &fuzz_execution_config,
         build_foreign_call_executor,
     );
+
     match fuzz_result {
         FuzzingRunStatus::ExecutionPass | FuzzingRunStatus::MinimizationPass => TestStatus::Pass,
         FuzzingRunStatus::CorpusFailure { message } => {


### PR DESCRIPTION
# Description

## Problem

Should fix https://github.com/AztecProtocol/aztec-packages/issues/13921

## Summary



## Additional Context



## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
