### PR TITLE
fix(docs): bar -> foo correction

### DIFF
--- a/docs/docs/noir/modules_packages_crates/modules.md
+++ b/docs/docs/noir/modules_packages_crates/modules.md
@@ -175,12 +175,12 @@ fn from_foo() {}
 Filename : `src/foo/bar.nr`
 
 ```rust
-// Same as bar::from_foo
+// Same as foo::from_foo
 use super::from_foo; 
 
 fn from_bar() {
-    from_foo();        // invokes super::from_foo(), which is bar::from_foo()
-    super::from_foo(); // also invokes bar::from_foo()
+    from_foo();        // invokes super::from_foo(), which is foo::from_foo()
+    super::from_foo(); // also invokes foo::from_foo()
 }
 ```
 


### PR DESCRIPTION
# Description

I noticed that the docs referenced `bar::from_foo()` when this function is from the parent module `foo.nr` 

Let me know if I am misunderstanding!

## Problem\*

Comments reference function from child module rather than parent module.

## Documentation\*

https://noir-lang.org/docs/noir/modules_packages_crates/modules#referencing-a-parent-module

Check one:
- [ ] No documentation needed.
- [ -] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

