### PR TITLE
feat: disallow emitting multiple `MemoryInit` opcodes for the same block

### DIFF
--- a/acvm-repo/acvm/src/compiler/simulator.rs
+++ b/acvm-repo/acvm/src/compiler/simulator.rs
@@ -104,8 +104,7 @@ impl CircuitSimulator {
                         return false;
                     }
                 }
-                self.initialized_blocks.insert(*block_id);
-                true
+                self.initialized_blocks.insert(*block_id)
             }
             Opcode::BrilligCall { id: _, inputs, outputs, predicate } => {
                 for input in inputs {
@@ -311,6 +310,28 @@ mod tests {
                 },
             ],
             BTreeSet::from([Witness(1)]),
+            PublicInputs::default(),
+        );
+
+        assert!(!CircuitSimulator::default().check_circuit(&circuit));
+    }
+
+    #[test]
+    fn reports_false_when_attempting_to_reinitialize_memory_block() {
+        let circuit = test_circuit(
+            vec![
+                Opcode::MemoryInit {
+                    block_id: BlockId(0),
+                    init: vec![Witness(0)],
+                    block_type: BlockType::Memory,
+                },
+                Opcode::MemoryInit {
+                    block_id: BlockId(0),
+                    init: vec![Witness(0)],
+                    block_type: BlockType::Memory,
+                },
+            ],
+            BTreeSet::from([Witness(0)]),
             PublicInputs::default(),
         );
 


### PR DESCRIPTION
# Description

## Problem\*

Resolves #8288 

## Summary\*

I'm not sure how barretenberg would handle this but if we emit two of these instructions for the same block id then there's a 99% chance that it's a bug.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
