### PR TITLE
feat: allow specifying fuzz-related dirs when invoking `nargo test`

### DIFF
--- a/tooling/nargo/src/ops/mod.rs
+++ b/tooling/nargo/src/ops/mod.rs
@@ -11,7 +11,7 @@ pub use self::fuzz::{
     FuzzExecutionConfig, FuzzFolderConfig, FuzzingRunStatus, run_fuzzing_harness,
 };
 pub use self::test::{
-    TestStatus, check_expected_failure_message, fuzz_test, run_or_fuzz_test, run_test,
+    FuzzConfig, TestStatus, check_expected_failure_message, fuzz_test, run_or_fuzz_test, run_test,
     test_status_program_compile_fail, test_status_program_compile_pass,
 };
 

--- a/tooling/nargo/src/ops/test.rs
+++ b/tooling/nargo/src/ops/test.rs
@@ -47,7 +47,12 @@ impl TestStatus {
     }
 }
 
+pub struct FuzzConfig {
+    pub folder_config: FuzzFolderConfig,
+}
+
 /// Runs a test function. This will either run the test or fuzz it, depending on whether the function has arguments.
+#[allow(clippy::too_many_arguments)]
 pub fn run_or_fuzz_test<'a, W, B, F, E>(
     blackbox_solver: &B,
     context: &mut Context,
@@ -55,6 +60,7 @@ pub fn run_or_fuzz_test<'a, W, B, F, E>(
     output: W,
     package_name: String,
     config: &CompileOptions,
+    fuzz_config: FuzzConfig,
     build_foreign_call_executor: F,
 ) -> TestStatus
 where
@@ -69,6 +75,7 @@ where
             test_function,
             package_name,
             config,
+            fuzz_config,
             build_foreign_call_executor,
         )
     } else {
@@ -186,6 +193,7 @@ pub fn fuzz_test<'a, B, F, E>(
     test_function: &TestFunction,
     package_name: String,
     config: &CompileOptions,
+    fuzz_config: FuzzConfig,
     build_foreign_call_executor: F,
 ) -> TestStatus
 where
@@ -199,6 +207,7 @@ where
             test_function,
             package_name,
             config,
+            fuzz_config,
             build_foreign_call_executor,
         ),
         Err(err) => test_status_program_compile_fail(err, test_function),
@@ -210,6 +219,7 @@ fn fuzz_test_impl<'a, B, F, E>(
     test_function: &TestFunction,
     package_name: String,
     config: &CompileOptions,
+    fuzz_config: FuzzConfig,
     build_foreign_call_executor: F,
 ) -> TestStatus
 where
@@ -227,14 +237,26 @@ where
     let location = test_function.location;
     let fuzzing_harness = FuzzingHarness { id, scope, location };
 
-    let corpus_dir = tempfile::tempdir().expect("Couldn't create temporary directory");
-    let fuzzing_failure_dir = tempfile::tempdir().expect("Couldn't create temporary directory");
+    let mut temporary_dirs_to_delete = Vec::new();
 
-    // TODO: allow configuring this. See https://github.com/noir-lang/noir/issues/8214
+    let mut config_or_temporary_dir = |dir: Option<String>| match dir {
+        Some(ref dir) => PathBuf::from(dir),
+        None => {
+            let corpus_dir = tempfile::tempdir().expect("Couldn't create temporary directory");
+            let corpus_dir = corpus_dir.into_path();
+            temporary_dirs_to_delete.push(corpus_dir.clone());
+            corpus_dir
+        }
+    };
+
+    let corpus_dir = config_or_temporary_dir(fuzz_config.folder_config.corpus_dir);
+    let fuzzing_failure_dir =
+        config_or_temporary_dir(fuzz_config.folder_config.fuzzing_failure_dir);
+
     let fuzz_folder_config = FuzzFolderConfig {
-        corpus_dir: Some(corpus_dir.path().to_string_lossy().to_string()),
-        minimized_corpus_dir: None,
-        fuzzing_failure_dir: Some(fuzzing_failure_dir.path().to_string_lossy().to_string()),
+        corpus_dir: Some(corpus_dir.to_string_lossy().to_string()),
+        fuzzing_failure_dir: Some(fuzzing_failure_dir.to_string_lossy().to_string()),
+        minimized_corpus_dir: fuzz_config.folder_config.minimized_corpus_dir,
     };
     // TODO: allow configuring this. See https://github.com/noir-lang/noir/issues/8214
     let fuzz_execution_config =
@@ -252,6 +274,11 @@ where
         &fuzz_execution_config,
         build_foreign_call_executor,
     );
+
+    for temporary_dir_to_delete in temporary_dirs_to_delete {
+        // Not a big deal if we can't delete a temporary directory
+        let _ = std::fs::remove_dir_all(temporary_dir_to_delete);
+    }
 
     match fuzz_result {
         FuzzingRunStatus::ExecutionPass | FuzzingRunStatus::MinimizationPass => TestStatus::Pass,


### PR DESCRIPTION
# Description

## Problem

Part of #8214

## Summary



## Additional Context



## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
