### PR TITLE
feat: better error message on unicode whitespace that isn't ascii whitespace

### DIFF
--- a/compiler/noirc_frontend/src/lexer/errors.rs
+++ b/compiler/noirc_frontend/src/lexer/errors.rs
@@ -211,9 +211,9 @@ impl LexerErrorKind {
 
                 let primary = format!("Unknown start of token: \\u{{{:x}}}", (*char as u32));
                 let secondary = match char_name {
-                    Some(name) => format!("Unicode character '{char}' ({name}) looks like space, but is it not"),
+                    Some(name) => format!("Unicode character '{char}' ({name}) looks like ' ' (Space), but is it not"),
                     None => {
-                        format!("Unicode character '{char}' looks like space ' ' (Space), but is it not")
+                        format!("Unicode character '{char}' looks like ' ' (Space), but is it not")
                     }
                 };
                 (primary, secondary, *location)

--- a/compiler/noirc_frontend/src/lexer/lexer.rs
+++ b/compiler/noirc_frontend/src/lexer/lexer.rs
@@ -176,6 +176,7 @@ impl<'a> Lexer<'a> {
             Some('#') => self.eat_attribute_start(),
             Some(ch)
                 if ch.is_whitespace()
+                    // These aren't unicode whitespace but look like '' so they are also misleading
                     || ch == '\u{180E}'
                     || ch == '\u{200B}'
                     || ch == '\u{200C}'

--- a/compiler/noirc_frontend/src/lexer/lexer.rs
+++ b/compiler/noirc_frontend/src/lexer/lexer.rs
@@ -174,8 +174,24 @@ impl<'a> Lexer<'a> {
             Some('r') => self.eat_raw_string_or_alpha_numeric(),
             Some('q') => self.eat_quote_or_alpha_numeric(),
             Some('#') => self.eat_attribute_start(),
+            Some(ch)
+                if ch.is_whitespace()
+                    || ch == '\u{180E}'
+                    || ch == '\u{200B}'
+                    || ch == '\u{200C}'
+                    || ch == '\u{200D}'
+                    || ch == '\u{2060}'
+                    || ch == '\u{FEFF}' =>
+            {
+                let span = Span::from(self.position..self.position + 1);
+                let location = Location::new(span, self.file_id);
+                self.next_char();
+                Err(LexerErrorKind::UnicodeCharacterLooksLikeSpaceButIsItNot { char: ch, location })
+            }
             Some(ch) if ch.is_ascii_alphanumeric() || ch == '_' => self.eat_alpha_numeric(ch),
             Some(ch) => {
+                dbg!(ch);
+
                 // We don't report invalid tokens in the source as errors until parsing to
                 // avoid reporting the error twice. See the note on Token::Invalid's documentation for details.
                 Ok(Token::Invalid(ch).into_single_span(self.position))
@@ -1628,5 +1644,15 @@ mod tests {
                 "Expected NonAsciiComment error"
             );
         }
+    }
+
+    #[test]
+    fn errors_on_non_unicode_whitespace() {
+        let str = "\u{0085}";
+        let mut lexer = Lexer::new_with_dummy_file(str);
+        assert!(matches!(
+            lexer.next_token(),
+            Err(LexerErrorKind::UnicodeCharacterLooksLikeSpaceButIsItNot { .. })
+        ));
     }
 }


### PR DESCRIPTION
# Description

## Problem

Resolves #5163

## Summary

Here's an example error we get now:

```
error: Unknown start of token: \u{a0}
  ┌─ src/main.nr:3:16
  │
3 │     if true {}   else { // Placing "} else {" on the same line causes the issue
  │                - Unicode character ' ' (No-Break Space) looks like ' ' (Space), but is it not
```

This is similar to what Rust outputs.

## Additional Context

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
