### PR TITLE
chore: Replace all SSA interpreter panics with error variants

### DIFF
--- a/compiler/noirc_evaluator/src/errors.rs
+++ b/compiler/noirc_evaluator/src/errors.rs
@@ -13,7 +13,7 @@ use noirc_errors::{CustomDiagnostic, Location, call_stack::CallStack};
 use noirc_frontend::signed_field::SignedField;
 use thiserror::Error;
 
-use crate::ssa::ir::{basic_block::BasicBlockId, types::NumericType, value::ValueId};
+use crate::ssa::ir::types::NumericType;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, PartialEq, Eq, Clone, Error)]
@@ -66,15 +66,6 @@ pub enum RuntimeError {
         "Could not resolve some references to the array. All references must be resolved at compile time"
     )]
     UnknownReference { call_stack: CallStack },
-    #[error("Argument count {arguments} to block {block} does not match the expected parameter count {parameters}")]
-    BlockArgumentCountMismatch { block: BasicBlockId, arguments: usize, parameters: usize },
-    #[error("Block {block} is missing the terminator instruction")]
-    BlockMissingTerminator { block: BasicBlockId },
-    #[error("constrain {lhs_id} == {rhs_id} failed:\n    {lhs} != {rhs}")]
-    ConstrainEqFailed { lhs: String, lhs_id: ValueId, rhs: String, rhs_id: ValueId },
-    #[error("constrain {lhs_id} != {rhs_id} failed:\n    {lhs} == {rhs}")]
-    ConstrainNeFailed { lhs: String, lhs_id: ValueId, rhs: String, rhs_id: ValueId },
-    FailedRangeConstraint 
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Hash)]

--- a/compiler/noirc_evaluator/src/errors.rs
+++ b/compiler/noirc_evaluator/src/errors.rs
@@ -13,7 +13,7 @@ use noirc_errors::{CustomDiagnostic, Location, call_stack::CallStack};
 use noirc_frontend::signed_field::SignedField;
 use thiserror::Error;
 
-use crate::ssa::ir::types::NumericType;
+use crate::ssa::ir::{basic_block::BasicBlockId, types::NumericType, value::ValueId};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, PartialEq, Eq, Clone, Error)]
@@ -66,6 +66,15 @@ pub enum RuntimeError {
         "Could not resolve some references to the array. All references must be resolved at compile time"
     )]
     UnknownReference { call_stack: CallStack },
+    #[error("Argument count {arguments} to block {block} does not match the expected parameter count {parameters}")]
+    BlockArgumentCountMismatch { block: BasicBlockId, arguments: usize, parameters: usize },
+    #[error("Block {block} is missing the terminator instruction")]
+    BlockMissingTerminator { block: BasicBlockId },
+    #[error("constrain {lhs_id} == {rhs_id} failed:\n    {lhs} != {rhs}")]
+    ConstrainEqFailed { lhs: String, lhs_id: ValueId, rhs: String, rhs_id: ValueId },
+    #[error("constrain {lhs_id} != {rhs_id} failed:\n    {lhs} == {rhs}")]
+    ConstrainNeFailed { lhs: String, lhs_id: ValueId, rhs: String, rhs_id: ValueId },
+    FailedRangeConstraint 
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Hash)]

--- a/compiler/noirc_evaluator/src/ssa/interpreter/errors.rs
+++ b/compiler/noirc_evaluator/src/ssa/interpreter/errors.rs
@@ -1,0 +1,93 @@
+use crate::ssa::ir::{basic_block::BasicBlockId, instruction::BinaryOp, value::ValueId};
+use thiserror::Error;
+
+pub(super) const MAX_SIGNED_BIT_SIZE: u32 = 64;
+pub(super) const MAX_UNSIGNED_BIT_SIZE: u32 = 128;
+
+#[derive(Debug, Error)]
+pub(crate) enum InterpreterError {
+    #[error(
+        "Argument count {arguments} to block {block} does not match the expected parameter count {parameters}"
+    )]
+    BlockArgumentCountMismatch { block: BasicBlockId, arguments: usize, parameters: usize },
+    #[error("Block {block} is missing the terminator instruction")]
+    BlockMissingTerminator { block: BasicBlockId },
+    #[error("constrain {lhs_id} == {rhs_id} failed:\n    {lhs} != {rhs}")]
+    ConstrainEqFailed { lhs: String, lhs_id: ValueId, rhs: String, rhs_id: ValueId },
+    #[error("constrain {lhs_id} != {rhs_id} failed:\n    {lhs} == {rhs}")]
+    ConstrainNeFailed { lhs: String, lhs_id: ValueId, rhs: String, rhs_id: ValueId },
+    #[error(
+        "Range check of {value_id} = {value} failed.\n  Max bits allowed by range check = {max_bits}\n  Actual bit count = {actual_bits}"
+    )]
+    RangeCheckFailed { value: String, value_id: ValueId, actual_bits: u32, max_bits: u32 },
+    #[error(
+        "Range check of {value_id} = {value} failed.\n  Max bits allowed by range check = {max_bits}\n  Actual bit count = {actual_bits}\n  {message}"
+    )]
+    RangeCheckFailedWithMessage {
+        value: String,
+        value_id: ValueId,
+        actual_bits: u32,
+        max_bits: u32,
+        message: String,
+    },
+    #[error("Call to unknown foreign function {name}")]
+    UnknownForeignFunctionCall { name: String },
+    #[error("Cannot call non-function value {value_id} = {value}")]
+    CalledNonFunction { value: String, value_id: ValueId },
+    // Note that we don't need to display the value_id because displaying a reference
+    // value shows the original value id anyway
+    #[error("Reference value `{value}` passed from a constrained to an unconstrained function")]
+    ReferenceValueCrossedUnconstrainedBoundary { value: String },
+    #[error("Reference value `{value}` loaded before it was first stored to")]
+    UninitializedReferenceValueLoaded { value: String },
+    #[error(
+        "Mismatched types in binary operator: `{operator} {lhs_id}, {rhs_id}`  ({operator} {lhs}, {rhs})"
+    )]
+    MismatchedTypesInBinaryOperator {
+        lhs_id: ValueId,
+        lhs: String,
+        operator: BinaryOp,
+        rhs_id: ValueId,
+        rhs: String,
+    },
+    #[error("Division by zero: `div {lhs_id}, {rhs_id}`  ({lhs} / {rhs})")]
+    DivisionByZero { lhs_id: ValueId, lhs: String, rhs_id: ValueId, rhs: String },
+    #[error("Unsupported operator `{operator}` for type `{typ}`")]
+    UnsupportedOperatorForType { operator: &'static str, typ: &'static str },
+    #[error(
+        "Invalid bit size of `{bit_size}` given to truncate, maximum size allowed for unsigned values is {MAX_UNSIGNED_BIT_SIZE}"
+    )]
+    InvalidUnsignedTruncateBitSize { bit_size: u32 },
+    #[error(
+        "Invalid bit size of `{bit_size}` given to truncate, maximum size allowed for signed values is {MAX_SIGNED_BIT_SIZE}"
+    )]
+    InvalidSignedTruncateBitSize { bit_size: u32 },
+    #[error("Rhs of `{operator}` should be a u32 but found `{rhs_id} = {rhs}`")]
+    RhsOfBitShiftShouldBeU32 { operator: &'static str, rhs_id: ValueId, rhs: String },
+    #[error(
+        "Expected {expected_type} value in {instruction} but instead found `{value_id} = {value}`"
+    )]
+    TypeError {
+        value_id: ValueId,
+        value: String,
+        expected_type: &'static str,
+        instruction: &'static str,
+    },
+    #[error("Underflow in dec_rc when decrementing reference count of `{value_id} = {value}`")]
+    DecRcUnderflow { value_id: ValueId, value: String },
+    #[error(
+        "Erroneously incremented reference count of value `{value_id} = {value}` from 0 back to 1"
+    )]
+    IncRcRevive { value_id: ValueId, value: String },
+    #[error("An overflow occurred while evaluating {instruction}")]
+    Overflow { instruction: String },
+    #[error(
+        "Function {function} ({function_name}) returned {actual} argument(s) but it was expected to return {expected}"
+    )]
+    FunctionReturnedIncorrectArgCount {
+        function: ValueId,
+        function_name: String,
+        expected: usize,
+        actual: usize,
+    },
+}

--- a/compiler/noirc_evaluator/src/ssa/interpreter/errors.rs
+++ b/compiler/noirc_evaluator/src/ssa/interpreter/errors.rs
@@ -90,4 +90,16 @@ pub(crate) enum InterpreterError {
         expected: usize,
         actual: usize,
     },
+    #[error(
+        "if-else instruction with then condition `{then_condition_id}` and else condition `{else_condition_id}` has both branches as true. This should be impossible except for malformed SSA code"
+    )]
+    DoubleTrueIfElse { then_condition_id: ValueId, else_condition_id: ValueId },
+    #[error(
+        "`truncate {value_id} to 0 bits, max_bit_size: {max_bit_size}` has invalid bit size 0. This should only be possible in malformed SSA."
+    )]
+    TruncateToZeroBits { value_id: ValueId, max_bit_size: u32 },
+    #[error(
+        "`range_check {value_id} to 0 bits` has invalid bit size 0. This should only be possible in malformed SSA."
+    )]
+    RangeCheckToZeroBits { value_id: ValueId },
 }

--- a/compiler/noirc_evaluator/src/ssa/interpreter/tests/instructions.rs
+++ b/compiler/noirc_evaluator/src/ssa/interpreter/tests/instructions.rs
@@ -5,7 +5,7 @@ use noirc_frontend::Shared;
 
 use crate::ssa::{
     interpreter::{
-        NumericValue, Value,
+        InterpreterError, NumericValue, Value,
         tests::{expect_value, expect_values},
         value::ReferenceValue,
     },
@@ -31,11 +31,9 @@ fn add() {
     assert_eq!(value, Value::Numeric(NumericValue::I32(102)));
 }
 
-/// TODO: Replace panic with error
 #[test]
-#[should_panic(expected = "called `Option::unwrap()` on a `None` value")]
 fn add_overflow() {
-    expect_error(
+    let error = expect_error(
         "
         acir(inline) fn main f0 {
           b0():
@@ -44,6 +42,7 @@ fn add_overflow() {
         }
     ",
     );
+    assert!(matches!(error, InterpreterError::Overflow { .. }))
 }
 
 #[test]
@@ -73,11 +72,9 @@ fn sub() {
     assert_eq!(value, Value::Numeric(NumericValue::I32(10000)));
 }
 
-/// TODO: Replace panic with error
 #[test]
-#[should_panic(expected = "called `Option::unwrap()` on a `None` value")]
 fn sub_underflow() {
-    expect_error(
+    let error = expect_error(
         "
         acir(inline) fn main f0 {
           b0():
@@ -86,6 +83,7 @@ fn sub_underflow() {
         }
     ",
     );
+    assert!(matches!(error, InterpreterError::Overflow { .. }))
 }
 
 #[test]
@@ -116,11 +114,9 @@ fn mul() {
     assert_eq!(value, Value::Numeric(NumericValue::U64(200)));
 }
 
-/// TODO: Replace panic with error
 #[test]
-#[should_panic(expected = "called `Option::unwrap()` on a `None` value")]
 fn mul_overflow() {
-    expect_error(
+    let error = expect_error(
         "
         acir(inline) fn main f0 {
           b0():
@@ -129,6 +125,7 @@ fn mul_overflow() {
         }
     ",
     );
+    assert!(matches!(error, InterpreterError::Overflow { .. }))
 }
 
 #[test]
@@ -159,11 +156,9 @@ fn div() {
     assert_eq!(value, Value::Numeric(NumericValue::I16(64)));
 }
 
-/// TODO: Replace panic with error
 #[test]
-#[should_panic(expected = "Field division by zero")]
 fn div_zero() {
-    expect_error(
+    let error = expect_error(
         "
         acir(inline) fn main f0 {
           b0():
@@ -172,6 +167,7 @@ fn div_zero() {
         }
     ",
     );
+    assert!(matches!(error, InterpreterError::DivisionByZero { .. }))
 }
 
 #[test]
@@ -188,11 +184,9 @@ fn r#mod() {
     assert_eq!(value, Value::Numeric(NumericValue::I64(2)));
 }
 
-/// TODO: Replace panic with error
 #[test]
-#[should_panic(expected = "called `Option::unwrap()` on a `None` value")]
 fn mod_zero() {
-    expect_error(
+    let error = expect_error(
         "
         acir(inline) fn main f0 {
           b0():
@@ -201,6 +195,8 @@ fn mod_zero() {
         }
     ",
     );
+    dbg!(&error);
+    assert!(matches!(error, InterpreterError::DivisionByZero { .. }))
 }
 
 #[test]
@@ -304,11 +300,10 @@ fn shl() {
     assert_eq!(value, Value::from_constant(12_u128.into(), NumericType::unsigned(8)));
 }
 
-#[test]
-#[should_panic]
 /// shl should overflow if the rhs is greater than the bit count
+#[test]
 fn shl_overflow() {
-    expect_error(
+    let error = expect_error(
         "
         acir(inline) fn main f0 {
           b0():
@@ -317,6 +312,7 @@ fn shl_overflow() {
         }
     ",
     );
+    assert!(matches!(error, InterpreterError::Overflow { .. }));
 }
 
 #[test]
@@ -477,9 +473,8 @@ fn range_check() {
 }
 
 #[test]
-#[should_panic]
 fn range_check_fail() {
-    expect_error(
+    let error = expect_error(
         "
         acir(inline) fn main f0 {
           b0():
@@ -488,6 +483,7 @@ fn range_check_fail() {
         }
     ",
     );
+    assert!(matches!(error, InterpreterError::RangeCheckFailed { .. }));
 }
 
 #[test]

--- a/compiler/noirc_evaluator/src/ssa/interpreter/tests/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/interpreter/tests/mod.rs
@@ -4,15 +4,12 @@ use std::sync::Arc;
 
 use acvm::{AcirField, FieldElement};
 
-use crate::{
-    errors::RuntimeError,
-    ssa::{
-        interpreter::value::NumericValue,
-        ir::types::{NumericType, Type},
-    },
+use crate::ssa::{
+    interpreter::value::NumericValue,
+    ir::types::{NumericType, Type},
 };
 
-use super::{Ssa, Value};
+use super::{InterpreterError, Ssa, Value};
 
 mod instructions;
 
@@ -33,7 +30,7 @@ fn expect_value(src: &str) -> Value {
 }
 
 #[track_caller]
-fn expect_error(src: &str) -> RuntimeError {
+fn expect_error(src: &str) -> InterpreterError {
     let ssa = Ssa::from_str(src).unwrap();
     ssa.interpret(Vec::new()).unwrap_err()
 }

--- a/compiler/noirc_evaluator/src/ssa/interpreter/value.rs
+++ b/compiler/noirc_evaluator/src/ssa/interpreter/value.rs
@@ -111,16 +111,16 @@ impl Value {
         }
     }
 
-    pub(crate) fn as_reference(&self) -> Option<&ReferenceValue> {
+    pub(crate) fn as_reference(&self) -> Option<ReferenceValue> {
         match self {
-            Value::Reference(value) => Some(value),
+            Value::Reference(value) => Some(value.clone()),
             _ => None,
         }
     }
 
-    pub(crate) fn as_array_or_slice(&self) -> Option<&ArrayValue> {
+    pub(crate) fn as_array_or_slice(&self) -> Option<ArrayValue> {
         match self {
-            Value::ArrayOrSlice(value) => Some(value),
+            Value::ArrayOrSlice(value) => Some(value.clone()),
             _ => None,
         }
     }

--- a/compiler/noirc_evaluator/src/ssa/ir/printer.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/printer.rs
@@ -190,7 +190,7 @@ fn display_instruction_inner(
 
     match instruction {
         Instruction::Binary(binary) => {
-            writeln!(f, "{} {}, {}", binary.operator, show(binary.lhs), show(binary.rhs))
+            writeln!(f, "{}", display_binary(binary, dfg))
         }
         Instruction::Cast(lhs, typ) => writeln!(f, "cast {} as {typ}", show(*lhs)),
         Instruction::Not(rhs) => writeln!(f, "not {}", show(*rhs)),
@@ -305,6 +305,10 @@ fn display_instruction_inner(
         }
         Instruction::Noop => writeln!(f, "nop"),
     }
+}
+
+pub(crate) fn display_binary(binary: &super::instruction::Binary, dfg: &DataFlowGraph) -> String {
+    format!("{} {}, {}", binary.operator, value(dfg, binary.lhs), value(dfg, binary.rhs))
 }
 
 fn try_byte_array_to_string(elements: &Vector<ValueId>, dfg: &DataFlowGraph) -> Option<String> {


### PR DESCRIPTION
# Description

## Problem\*

Resolves https://github.com/noir-lang/noir/issues/8284

## Summary\*

Removes almost all panics in the SSA interpreter, replacing them with somewhat detailed error messages to help find the SSA instruction in question.

Not all panics were removed - the only ones kept were a few which should not be possible in even malformed code. E.g. the `.expect()` that the call-stack is non-empty or the `unreachable!` when evaluating binary operators on cases that are already handled by the early return.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
