### PR TITLE
feat: add `--fuzz-timeout` to `nargo test` options

### DIFF
--- a/tooling/nargo/src/ops/test.rs
+++ b/tooling/nargo/src/ops/test.rs
@@ -49,6 +49,7 @@ impl TestStatus {
 
 pub struct FuzzConfig {
     pub folder_config: FuzzFolderConfig,
+    pub execution_config: FuzzExecutionConfig,
 }
 
 /// Runs a test function. This will either run the test or fuzz it, depending on whether the function has arguments.
@@ -258,9 +259,7 @@ where
         fuzzing_failure_dir: Some(fuzzing_failure_dir.to_string_lossy().to_string()),
         minimized_corpus_dir: fuzz_config.folder_config.minimized_corpus_dir,
     };
-    // TODO: allow configuring this. See https://github.com/noir-lang/noir/issues/8214
-    let fuzz_execution_config =
-        FuzzExecutionConfig { timeout: 1, num_threads: 1, show_progress: false };
+    let fuzz_execution_config = fuzz_config.execution_config;
 
     // TODO: show output?
     let show_output = false;

--- a/tooling/nargo_cli/src/cli/test_cmd.rs
+++ b/tooling/nargo_cli/src/cli/test_cmd.rs
@@ -14,7 +14,7 @@ use clap::Args;
 use fm::FileManager;
 use formatters::{Formatter, JsonFormatter, PrettyFormatter, TerseFormatter};
 use nargo::{
-    FuzzFolderConfig,
+    FuzzExecutionConfig, FuzzFolderConfig,
     foreign_calls::DefaultForeignCallBuilder,
     insert_all_files_for_workspace_into_file_manager,
     ops::{FuzzConfig, TestStatus, check_crate_and_report_errors},
@@ -92,6 +92,10 @@ pub(crate) struct TestCommand {
     /// If given, store the failing input in the given folder
     #[arg(long)]
     fuzzing_failure_dir: Option<String>,
+
+    /// Maximum time in seconds to spend fuzzing (default: 1 second)
+    #[arg(long, default_value_t = 1)]
+    fuzz_timeout: u64,
 }
 
 impl WorkspaceCommand for TestCommand {
@@ -560,6 +564,11 @@ impl<'a> TestRunner<'a> {
                 corpus_dir: self.args.corpus_dir.clone(),
                 minimized_corpus_dir: self.args.minimized_corpus_dir.clone(),
                 fuzzing_failure_dir: self.args.fuzzing_failure_dir.clone(),
+            },
+            execution_config: FuzzExecutionConfig {
+                num_threads: 1,
+                timeout: self.args.fuzz_timeout,
+                show_progress: false,
             },
         };
 


### PR DESCRIPTION
# Description

## Problem

Part of #8214

## Summary

I let the default timeout be 1 second. The original issue says 10 seconds but I think that's too long if tests are supposed to pass. But let me know otherwise! (additionally: 1 second was the default value before this PR too, though just for `nargo test`).

## Additional Context



## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
