### PR TITLE
fix: ignore types from inlining comptime values, use elaborator's ones

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/expressions.rs
+++ b/compiler/noirc_frontend/src/elaborator/expressions.rs
@@ -1241,13 +1241,13 @@ impl Elaborator<'_> {
         location: Location,
         target_type: Option<&Type>,
     ) -> (ExprId, Type) {
-        let (block, _typ) = self.elaborate_in_comptime_context(|this| {
+        let (block, typ) = self.elaborate_in_comptime_context(|this| {
             this.elaborate_block_expression(block, target_type)
         });
 
         let mut interpreter = self.setup_interpreter();
         let value = interpreter.evaluate_block(block);
-        let (id, typ) = self.inline_comptime_value(value, location);
+        let (id, _typ) = self.inline_comptime_value(value, location);
 
         let location = self.interner.id_location(id);
         self.debug_comptime(location, |interner| {

--- a/compiler/noirc_frontend/src/elaborator/patterns.rs
+++ b/compiler/noirc_frontend/src/elaborator/patterns.rs
@@ -602,7 +602,7 @@ impl Elaborator<'_> {
             // (the error will make no sense, it will say that a non-comptime variable was referenced at runtime
             // but that's not true)
             if value.is_ok() {
-                let (id, typ) = self.inline_comptime_value(value, location);
+                let (id, _typ) = self.inline_comptime_value(value, location);
                 self.debug_comptime(location, |interner| id.to_display_ast(interner).kind);
                 (id, typ)
             } else {

--- a/compiler/noirc_frontend/src/elaborator/statements.rs
+++ b/compiler/noirc_frontend/src/elaborator/statements.rs
@@ -610,11 +610,11 @@ impl Elaborator<'_> {
 
     fn elaborate_comptime_statement(&mut self, statement: Statement) -> (HirStatement, Type) {
         let location = statement.location;
-        let (hir_statement, _typ) =
+        let (hir_statement, typ) =
             self.elaborate_in_comptime_context(|this| this.elaborate_statement(statement));
         let mut interpreter = self.setup_interpreter();
         let value = interpreter.evaluate_statement(hir_statement);
-        let (expr, typ) = self.inline_comptime_value(value, location);
+        let (expr, _typ) = self.inline_comptime_value(value, location);
 
         let location = self.interner.id_location(hir_statement);
         self.debug_comptime(location, |interner| expr.to_display_ast(interner).kind);

--- a/test_programs/compile_failure/comptime_expression_wrong_type/Nargo.toml
+++ b/test_programs/compile_failure/comptime_expression_wrong_type/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "comptime_expression_wrong_type"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.34.0"
+
+[dependencies]

--- a/test_programs/compile_failure/comptime_expression_wrong_type/src/main.nr
+++ b/test_programs/compile_failure/comptime_expression_wrong_type/src/main.nr
@@ -1,0 +1,10 @@
+fn main() -> pub i64 {
+    let x: i64 = comptime {
+        unsafe { func_1(1) }
+    };
+    x
+}
+
+unconstrained fn func_1(b: i32) -> i32 {
+    b                                                                                                                                                             
+}

--- a/test_programs/compile_failure/comptime_statement_wrong_type/Nargo.toml
+++ b/test_programs/compile_failure/comptime_statement_wrong_type/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "comptime_statement_wrong_type"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.34.0"
+
+[dependencies]

--- a/test_programs/compile_failure/comptime_statement_wrong_type/src/main.nr
+++ b/test_programs/compile_failure/comptime_statement_wrong_type/src/main.nr
@@ -1,0 +1,9 @@
+fn main() -> pub i64 {
+    comptime {
+        unsafe { func_1(1) }
+    }
+}
+
+unconstrained fn func_1(b: i32) -> i32 {
+    b                                                                                                                                                             
+}


### PR DESCRIPTION
# Description

## Problem

Resolves #8340

## Summary

For example, given this code:

```noir
fn main() -> pub i64 {
    comptime {
        1 as i32
    }
}
```

The compiler would see `comptime { 1 as i32 }`. The type of `1 as i32` is `i32`. But the compiler also interprets `1 as i32` and gets a "1" signed field comptime value. Then it turns that comptime value into an Expression (we get a literal), then it types that (we get a polymorphic integer) and that type was given to the `comptime` block. That polymorphic integer matches fine with `i64`, that's why we didn't previously get an error.

Now, the type from the comptime value is ignored, and the one from the Elaborator is used. I think in all cases the one in the Elaborator should be "stronger".

## Additional Context

I'm thinking now an alternative could be for `Value::into_expression` to carry the type information. For example if we have `Value::I32`, `into_expression` would return the value wrapped in a `Cast`... though trying that, for a `Cast` we need an UnresolvedType, so doing that is a bit cumbersome. (trying this in #8350)

It would be nice to have typed literals like in Rust, for example `1_i32`. Then we could turn `Value::I32` into that literal without needing a cast.

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
