### PR TITLE
fix: unify type from elaborator and from comptime value

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/expressions.rs
+++ b/compiler/noirc_frontend/src/elaborator/expressions.rs
@@ -1241,13 +1241,19 @@ impl Elaborator<'_> {
         location: Location,
         target_type: Option<&Type>,
     ) -> (ExprId, Type) {
-        let (block, _typ) = self.elaborate_in_comptime_context(|this| {
+        let (block, typ) = self.elaborate_in_comptime_context(|this| {
             this.elaborate_block_expression(block, target_type)
         });
 
         let mut interpreter = self.setup_interpreter();
         let value = interpreter.evaluate_block(block);
-        let (id, typ) = self.inline_comptime_value(value, location);
+        let (id, comptime_typ) = self.inline_comptime_value(value, location);
+
+        self.unify(&comptime_typ, &typ, || TypeCheckError::TypeMismatch {
+            expected_typ: typ.to_string(),
+            expr_typ: comptime_typ.to_string(),
+            expr_location: location,
+        });
 
         let location = self.interner.id_location(id);
         self.debug_comptime(location, |interner| {

--- a/compiler/noirc_frontend/src/elaborator/patterns.rs
+++ b/compiler/noirc_frontend/src/elaborator/patterns.rs
@@ -602,7 +602,14 @@ impl Elaborator<'_> {
             // (the error will make no sense, it will say that a non-comptime variable was referenced at runtime
             // but that's not true)
             if value.is_ok() {
-                let (id, typ) = self.inline_comptime_value(value, location);
+                let (id, comptime_typ) = self.inline_comptime_value(value, location);
+
+                self.unify(&comptime_typ, &typ, || TypeCheckError::TypeMismatch {
+                    expected_typ: typ.to_string(),
+                    expr_typ: comptime_typ.to_string(),
+                    expr_location: location,
+                });
+
                 self.debug_comptime(location, |interner| id.to_display_ast(interner).kind);
                 (id, typ)
             } else {

--- a/compiler/noirc_frontend/src/elaborator/statements.rs
+++ b/compiler/noirc_frontend/src/elaborator/statements.rs
@@ -610,11 +610,17 @@ impl Elaborator<'_> {
 
     fn elaborate_comptime_statement(&mut self, statement: Statement) -> (HirStatement, Type) {
         let location = statement.location;
-        let (hir_statement, _typ) =
+        let (hir_statement, typ) =
             self.elaborate_in_comptime_context(|this| this.elaborate_statement(statement));
         let mut interpreter = self.setup_interpreter();
         let value = interpreter.evaluate_statement(hir_statement);
-        let (expr, typ) = self.inline_comptime_value(value, location);
+        let (expr, comptime_typ) = self.inline_comptime_value(value, location);
+
+        self.unify(&comptime_typ, &typ, || TypeCheckError::TypeMismatch {
+            expected_typ: typ.to_string(),
+            expr_typ: comptime_typ.to_string(),
+            expr_location: location,
+        });
 
         let location = self.interner.id_location(hir_statement);
         self.debug_comptime(location, |interner| expr.to_display_ast(interner).kind);

--- a/test_programs/compile_failure/comptime_expression_wrong_type/Nargo.toml
+++ b/test_programs/compile_failure/comptime_expression_wrong_type/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "comptime_expression_wrong_type"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.34.0"
+
+[dependencies]

--- a/test_programs/compile_failure/comptime_expression_wrong_type/src/main.nr
+++ b/test_programs/compile_failure/comptime_expression_wrong_type/src/main.nr
@@ -1,0 +1,10 @@
+fn main() -> pub i64 {
+    let x: i64 = comptime {
+        func_1(1) 
+    };
+    x
+}
+
+fn func_1(b: i32) -> i32 {
+    b                                                                                                                                                             
+}

--- a/test_programs/compile_failure/comptime_expression_wrong_type/stderr.txt
+++ b/test_programs/compile_failure/comptime_expression_wrong_type/stderr.txt
@@ -1,23 +1,9 @@
-warning: Unnecessary `unsafe` block
-  ┌─ src/main.nr:3:9
-  │
-3 │         unsafe { func_1(1) }
-  │         ------
-  │
-
-warning: Unsafe block must have a safety comment above it
-  ┌─ src/main.nr:3:9
-  │
-3 │         unsafe { func_1(1) }
-  │         ------ The comment must start with the "Safety: " word
-  │
-
 error: Expected type i64, found type i32
   ┌─ src/main.nr:2:18
   │  
 2 │       let x: i64 = comptime {
   │ ╭──────────────────'
-3 │ │         unsafe { func_1(1) }
+3 │ │         func_1(1) 
 4 │ │     };
   │ ╰─────'
   │  

--- a/test_programs/compile_failure/comptime_statement_wrong_type/Nargo.toml
+++ b/test_programs/compile_failure/comptime_statement_wrong_type/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "comptime_statement_wrong_type"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.34.0"
+
+[dependencies]

--- a/test_programs/compile_failure/comptime_statement_wrong_type/src/main.nr
+++ b/test_programs/compile_failure/comptime_statement_wrong_type/src/main.nr
@@ -1,0 +1,9 @@
+fn main() -> pub i64 {
+    comptime {
+        func_1(1)
+    }
+}
+
+fn func_1(b: i32) -> i32 {
+    b                                                                                                                                                             
+}

--- a/test_programs/compile_failure/comptime_statement_wrong_type_field/Nargo.toml
+++ b/test_programs/compile_failure/comptime_statement_wrong_type_field/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "comptime_statement_wrong_type_field"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.34.0"
+
+[dependencies]

--- a/test_programs/compile_failure/comptime_statement_wrong_type_field/src/main.nr
+++ b/test_programs/compile_failure/comptime_statement_wrong_type_field/src/main.nr
@@ -1,0 +1,9 @@
+fn main() -> pub i64 {
+    comptime {
+        func_1(1)
+    }
+}
+
+fn func_1(b: Field) -> Field {
+    b                                                                                                                                                             
+}

--- a/test_programs/compile_failure/comptime_statement_wrong_type_field/stderr.txt
+++ b/test_programs/compile_failure/comptime_statement_wrong_type_field/stderr.txt
@@ -1,4 +1,4 @@
-error: expected type i64, found type i32
+error: expected type i64, found type Field
   ┌─ src/main.nr:1:18
   │  
 1 │   fn main() -> pub i64 {
@@ -6,7 +6,7 @@ error: expected type i64, found type i32
 2 │ ╭     comptime {
 3 │ │         func_1(1)
 4 │ │     }
-  │ ╰─────' i32 returned here
+  │ ╰─────' Field returned here
   │  
 
 Aborting due to 1 previous error


### PR DESCRIPTION
# Description

## Problem

Resolves https://github.com/noir-lang/noir/issues/8340

## Summary

Yet another approach. The problem with the two previous approaches were:
1. When only taking the type of the elaborator we were discarding the type of the comptime value. Then it seems somewhere along the road there's a type mismatch (I didn't debug this, to be honest)
2. Turning `Value::I32` into "1 as i32" works, but for "Value::Field" it's a bit trickier. If we have `[1, 2, 3]`, each of those will end up being `Value::Field`, but if the target type is `[i32; 3]` then we can't turn `[1, 2, 3]` into `[1 as Field, 2 as Field, 3 as Field]` as that doesn't compile.

In this PR we just unify the type we got from the Elaborator with the type we get from the comptime value... which, if it holds integers, should be a polymorphic integer (unless casts are used, etc.). Then the "untyped" literals will work fine.

## Additional Context



## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
