### PR TITLE
feat(profiler): Replace println! with tracing macros for improved logging

### DIFF
--- a/tooling/profiler/Cargo.toml
+++ b/tooling/profiler/Cargo.toml
@@ -37,6 +37,7 @@ noir_artifact_cli.workspace = true
 thiserror.workspace = true
 
 # Logs
+tracing.workspace = true
 tracing-subscriber.workspace = true
 tracing-appender = "0.2.3"
 

--- a/tooling/profiler/src/cli/execution_flamegraph_cmd.rs
+++ b/tooling/profiler/src/cli/execution_flamegraph_cmd.rs
@@ -17,7 +17,7 @@ use crate::opcode_formatter::format_brillig_opcode;
 use bn254_blackbox_solver::Bn254BlackBoxSolver;
 use noirc_artifacts::debug::DebugArtifact;
 
-/// Generates a flamegraph mapping Brillig opcodes to source code.
+/// Generates a flamegraph mapping unconstrained Noir execution to source code.
 #[derive(Debug, Clone, Args)]
 pub(crate) struct ExecutionFlamegraphCommand {
     /// The path to the artifact JSON file
@@ -78,7 +78,6 @@ fn run_with_generator(
 
     let initial_witness = program.abi.encode(&inputs_map, None)?;
 
-    debug!("Executing...");
     info!("Executing program...");
 
     let solved_witness_stack_err = nargo::ops::execute_program_with_profiling(
@@ -107,9 +106,6 @@ fn run_with_generator(
         }
     };
 
-    debug!("Executed");
-    info!("Execution complete");
-
     if print_sample_count {
         // We use `println!` directly here to ensure the output goes to stdout
         // and is not affected by log filtering levels
@@ -120,7 +116,6 @@ fn run_with_generator(
     // We place this logging output before the transforming and collection of the samples.
     // This is done because large traces can take some time, and can make it look
     // as if the profiler has stalled.
-    debug!("Generating flamegraph for {} samples...", profiling_samples.len());
     info!("Generating flamegraph for {} samples...", profiling_samples.len());
 
     let profiling_samples: Vec<BrilligExecutionSample> = profiling_samples
@@ -156,7 +151,6 @@ fn run_with_generator(
         &Path::new(output_path).join(Path::new(&format!("{}_brillig_trace.svg", "main"))),
     )?;
 
-    debug!("Generated flamegraph");
     info!("Flamegraph generation complete");
 
     Ok(())

--- a/tooling/profiler/src/cli/execution_flamegraph_cmd.rs
+++ b/tooling/profiler/src/cli/execution_flamegraph_cmd.rs
@@ -69,7 +69,7 @@ fn run_with_generator(
     ensure_brillig_entry_point(&program)?;
 
     if !print_sample_count && output_path.is_none() {
-        return report_error("Missing --output <o> argument for when building a flamegraph")
+        return report_error("Missing --output <OUTPUT> argument for when building a flamegraph")
             .map_err(Into::into);
     }
 

--- a/tooling/profiler/src/cli/gates_flamegraph_cmd.rs
+++ b/tooling/profiler/src/cli/gates_flamegraph_cmd.rs
@@ -3,6 +3,7 @@ use std::path::{Path, PathBuf};
 use acir::circuit::OpcodeLocation;
 use clap::Args;
 use color_eyre::eyre::{self, Context};
+use tracing::info;
 
 use noir_artifact_cli::fs::artifact::read_program_from_file;
 use noirc_artifacts::debug::DebugArtifact;
@@ -84,7 +85,7 @@ fn run_with_provider<Provider: GatesProvider, Generator: FlamegraphGenerator>(
             function_names[func_idx].to_owned()
         };
 
-        println!(
+        info!(
             "Opcode count: {}, Total gates by opcodes: {}, Circuit size: {}",
             func_gates.acir_opcodes,
             func_gates.gates_per_opcode.iter().sum::<usize>(),

--- a/tooling/profiler/src/cli/opcodes_flamegraph_cmd.rs
+++ b/tooling/profiler/src/cli/opcodes_flamegraph_cmd.rs
@@ -73,7 +73,7 @@ fn run_with_generator<Generator: FlamegraphGenerator>(
             &debug_artifact,
             artifact_path.to_str().unwrap(),
             &function_name,
-            &Path::new(output_path).join(Path::new(&format!("{}_opcodes.svg", function_name))),
+            &Path::new(output_path).join(Path::new(&format!("{}_acir_opcodes.svg", function_name))),
         )?;
     }
 

--- a/tooling/profiler/src/cli/opcodes_flamegraph_cmd.rs
+++ b/tooling/profiler/src/cli/opcodes_flamegraph_cmd.rs
@@ -1,9 +1,9 @@
 use std::path::{Path, PathBuf};
 
+use acir::AcirField;
 use acir::circuit::Circuit;
 use acir::circuit::Opcode;
 use acir::circuit::OpcodeLocation;
-use acir::AcirField;
 use acir::circuit::brillig::BrilligFunctionId;
 use clap::Args;
 use color_eyre::eyre::{self, Context};
@@ -47,8 +47,8 @@ fn run_with_generator<Generator: FlamegraphGenerator>(
 ) -> eyre::Result<()> {
     info!("Reading program from {:?}", artifact_path);
 
-    let mut program =
-        read_program_from_file(artifact_path).with_context(|| "Could not read program from file")?;
+    let mut program = read_program_from_file(artifact_path)
+        .with_context(|| "Could not read program from file")?;
 
     let acir_names = std::mem::take(&mut program.names);
     let brillig_names = std::mem::take(&mut program.brillig_names);
@@ -57,7 +57,9 @@ fn run_with_generator<Generator: FlamegraphGenerator>(
     let debug_artifact = DebugArtifact::from(program);
 
     // Generate flamegraph for ACIR opcodes for each function in the program
-    for (acir_fn_index, (circuit, function_name)) in bytecode.functions.iter().zip(acir_names).enumerate() {
+    for (acir_fn_index, (circuit, function_name)) in
+        bytecode.functions.iter().zip(acir_names).enumerate()
+    {
         let circuit_samples = generate_acir_flamegraph_samples(circuit, &function_name);
 
         info!("Opcode count for {}: {}", function_name, circuit.opcodes.len());


### PR DESCRIPTION
# Description

## Problem\*

Resolves https://github.com/noir-lang/noir/issues/7586

## Summary\*

Replaced println! statements with appropriate tracing macros in the profiler tooling to provide more consistent logging experience and ensure logs respect the configured log level. Specifically:
- Removed verbose flag from execution_flamegraph_cmd
- Replaced println! with tracing::info! and tracing::debug! macros
- Fixed OpcodeLocation structure usage to match current API
- Added proper generic parameter for AcirField in related functions

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
