### PR TITLE
chore: redo typo PR by GarmashAlex

### DIFF
--- a/tooling/ast_fuzzer/fuzz/README.md
+++ b/tooling/ast_fuzzer/fuzz/README.md
@@ -1,6 +1,6 @@
 # AST fuzz targets
 
-This crate was created by `cargo fuzz init`. See more in https://rust-fuzz.github.io/book/cargo-fuzz/
+This crate was created by `cargo fuzz init`. See more in https://rust-fuzz.github.io/book/cargo-fuzz.html
 
 You can list the available targets with `cargo fuzz list`.
 


### PR DESCRIPTION
Thanks GarmashAlex for https://github.com/noir-lang/noir/pull/8324. Our policy is to redo typo changes to dissuade metric farming. This is an automated script.