### PR TITLE
chore: redo typo PR by dedyshkaPexto

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -88,7 +88,7 @@ export default {
           items: [
             {
               label: 'Noir Forum',
-              href: 'https://discourse.aztec.network/c/noir/7',
+              href: 'https://forum.aztec.network/c/noir/7',
             },
             {
               label: 'Twitter',


### PR DESCRIPTION
Thanks dedyshkaPexto for https://github.com/noir-lang/noir/pull/8327. Our policy is to redo typo changes to dissuade metric farming. This is an automated script.