### PR TITLE
fix(expand): output safety comment before statements

### DIFF
--- a/tooling/nargo_cli/src/cli/expand_cmd/printer/hir.rs
+++ b/tooling/nargo_cli/src/cli/expand_cmd/printer/hir.rs
@@ -231,8 +231,7 @@ impl ItemPrinter<'_, '_, '_> {
                 self.show_quoted(&tokens.0);
             }
             HirExpression::Unsafe(hir_block_expression) => {
-                self.push_str("// Safety: comment added by `nargo expand`\n");
-                self.write_indent();
+                // The safety comment was already outputted for the enclosing statement
                 self.push_str("unsafe ");
                 self.show_hir_block_expression(hir_block_expression);
             }
@@ -486,31 +485,24 @@ impl ItemPrinter<'_, '_, '_> {
     }
 
     fn show_hir_statement(&mut self, statement: HirStatement) {
+        // A safety comment can be put before a statement and it applies to any `unsafe`
+        // expression inside it. Here we check if the statment has `unsafe` in it and
+        // put a safety comment right before it. When printing an `Unsafe` expression
+        // we'll never include a safety comment at that point.
+        let has_unsafe = self.statement_has_unsafe(&statement);
+        if has_unsafe {
+            self.push_str("// Safety: comment added by `nargo expand`\n");
+            self.write_indent();
+        }
+
         match statement {
             HirStatement::Let(hir_let_statement) => {
-                // If this is `let ... = unsafe { }` then show the unsafe comment on top of `let`
-                if let HirExpression::Unsafe(_) =
-                    self.interner.expression(&hir_let_statement.expression)
-                {
-                    self.push_str("// Safety: comment added by `nargo expand`\n");
-                    self.write_indent();
-                }
-
                 self.push_str("let ");
                 self.show_hir_pattern(hir_let_statement.pattern);
                 self.push_str(": ");
                 self.show_type(&hir_let_statement.r#type);
                 self.push_str(" = ");
-
-                if let HirExpression::Unsafe(block_expression) =
-                    self.interner.expression(&hir_let_statement.expression)
-                {
-                    self.push_str("unsafe ");
-                    self.show_hir_block_expression(block_expression);
-                } else {
-                    self.show_hir_expression_id(hir_let_statement.expression);
-                }
-
+                self.show_hir_expression_id(hir_let_statement.expression);
                 self.push(';');
             }
             HirStatement::Assign(hir_assign_statement) => {
@@ -735,6 +727,146 @@ impl ItemPrinter<'_, '_, '_> {
                 let name = name.replace(['$', ' '], "___");
 
                 self.push_str(&name);
+            }
+        }
+    }
+
+    fn statement_id_has_unsafe(&self, stmt_id: StmtId) -> bool {
+        let statement = self.interner.statement(&stmt_id);
+        self.statement_has_unsafe(&statement)
+    }
+
+    fn statement_has_unsafe(&self, statement: &HirStatement) -> bool {
+        match statement {
+            HirStatement::Let(hir_let_statement) => {
+                self.expression_id_has_unsafe(hir_let_statement.expression)
+            }
+            HirStatement::Assign(hir_assign_statement) => {
+                self.expression_id_has_unsafe(hir_assign_statement.expression)
+            }
+            HirStatement::For(hir_for_statement) => {
+                // We don't check the block, as the block consists of statements and we
+                // can put the safety comment on top of the ones that have unsafe
+                self.expression_id_has_unsafe(hir_for_statement.start_range)
+                    || self.expression_id_has_unsafe(hir_for_statement.end_range)
+            }
+            HirStatement::Loop(expr_id) => self.expression_id_has_unsafe(*expr_id),
+            HirStatement::While(expr_id, expr_id2) => {
+                self.expression_id_has_unsafe(*expr_id) || self.expression_id_has_unsafe(*expr_id2)
+            }
+            HirStatement::Break => false,
+            HirStatement::Continue => false,
+            HirStatement::Expression(expr_id) => self.expression_id_has_unsafe(*expr_id),
+            HirStatement::Semi(expr_id) => self.expression_id_has_unsafe(*expr_id),
+            HirStatement::Comptime(stmt_id) => self.statement_id_has_unsafe(*stmt_id),
+            HirStatement::Error => false,
+        }
+    }
+
+    fn expression_id_has_unsafe(&self, expr_id: ExprId) -> bool {
+        let hir_expr = self.interner.expression(&expr_id);
+        self.expression_has_unsafe(hir_expr)
+    }
+
+    fn expression_has_unsafe(&self, expr: HirExpression) -> bool {
+        match expr {
+            HirExpression::Ident(..) => false,
+            HirExpression::Literal(hir_literal) => match hir_literal {
+                HirLiteral::Array(hir_array_literal) | HirLiteral::Slice(hir_array_literal) => {
+                    match hir_array_literal {
+                        HirArrayLiteral::Standard(expr_ids) => {
+                            expr_ids.iter().any(|expr_id| self.expression_id_has_unsafe(*expr_id))
+                        }
+                        HirArrayLiteral::Repeated { repeated_element, length: _ } => {
+                            self.expression_id_has_unsafe(repeated_element)
+                        }
+                    }
+                }
+                HirLiteral::FmtStr(_, expr_ids, _) => {
+                    expr_ids.iter().any(|expr_id| self.expression_id_has_unsafe(*expr_id))
+                }
+                HirLiteral::Bool(_)
+                | HirLiteral::Integer(..)
+                | HirLiteral::Str(_)
+                | HirLiteral::Unit => false,
+            },
+            HirExpression::Block(_) => {
+                // A block consists of statements so if any of those have `unsafe`, those
+                // should have the safety comment, not this wrapping statement
+                false
+            }
+            HirExpression::Prefix(hir_prefix_expression) => {
+                self.expression_id_has_unsafe(hir_prefix_expression.rhs)
+            }
+            HirExpression::Infix(hir_infix_expression) => {
+                self.expression_id_has_unsafe(hir_infix_expression.lhs)
+                    || self.expression_id_has_unsafe(hir_infix_expression.rhs)
+            }
+            HirExpression::Index(hir_index_expression) => {
+                self.expression_id_has_unsafe(hir_index_expression.collection)
+                    || self.expression_id_has_unsafe(hir_index_expression.index)
+            }
+            HirExpression::Constructor(hir_constructor_expression) => hir_constructor_expression
+                .fields
+                .iter()
+                .any(|(_, expr_id)| self.expression_id_has_unsafe(*expr_id)),
+            HirExpression::EnumConstructor(hir_enum_constructor_expression) => {
+                hir_enum_constructor_expression
+                    .arguments
+                    .iter()
+                    .any(|expr_id| self.expression_id_has_unsafe(*expr_id))
+            }
+            HirExpression::MemberAccess(hir_member_access) => {
+                self.expression_id_has_unsafe(hir_member_access.lhs)
+            }
+            HirExpression::Call(hir_call_expression) => {
+                self.expression_id_has_unsafe(hir_call_expression.func)
+                    || hir_call_expression
+                        .arguments
+                        .iter()
+                        .any(|expr_id| self.expression_id_has_unsafe(*expr_id))
+            }
+            HirExpression::Constrain(hir_constrain_expression) => {
+                self.expression_id_has_unsafe(hir_constrain_expression.0)
+                    || hir_constrain_expression
+                        .2
+                        .is_some_and(|expr_id| self.expression_id_has_unsafe(expr_id))
+            }
+            HirExpression::Cast(hir_cast_expression) => {
+                self.expression_id_has_unsafe(hir_cast_expression.lhs)
+            }
+            HirExpression::If(hir_if_expression) => {
+                self.expression_id_has_unsafe(hir_if_expression.condition)
+                    || self.expression_id_has_unsafe(hir_if_expression.consequence)
+                    || hir_if_expression
+                        .alternative
+                        .is_some_and(|expr_id| self.expression_id_has_unsafe(expr_id))
+            }
+            HirExpression::Match(hir_match) => self.hir_match_has_unsafe(&hir_match),
+            HirExpression::Tuple(expr_ids) => {
+                expr_ids.iter().any(|expr_id| self.expression_id_has_unsafe(*expr_id))
+            }
+            HirExpression::Lambda(hir_lambda) => self.expression_id_has_unsafe(hir_lambda.body),
+            HirExpression::Quote(..) | HirExpression::Unquote(..) => false,
+            HirExpression::Unsafe(..) => true,
+            HirExpression::Error => false,
+        }
+    }
+
+    fn hir_match_has_unsafe(&self, hir_match: &HirMatch) -> bool {
+        match hir_match {
+            HirMatch::Success(expr_id) => self.expression_id_has_unsafe(*expr_id),
+            HirMatch::Failure { .. } => false,
+            HirMatch::Guard { cond, body, otherwise } => {
+                self.expression_id_has_unsafe(*cond)
+                    || self.expression_id_has_unsafe(*body)
+                    || self.hir_match_has_unsafe(otherwise)
+            }
+            HirMatch::Switch(_, cases, hir_match) => {
+                cases.iter().any(|case| self.hir_match_has_unsafe(&case.body))
+                    || hir_match
+                        .as_ref()
+                        .is_some_and(|hir_match| self.hir_match_has_unsafe(hir_match))
             }
         }
     }

--- a/tooling/nargo_cli/tests/snapshots/expand/execution_success/uhashmap/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/expand/execution_success/uhashmap/execute__tests__expanded.snap
@@ -266,9 +266,8 @@ fn entries_examples(map: UHashMap<Field, Field, BuildHasherDefault<Poseidon2Hash
         for ___i1 in 0..___i0.len() {
             let key: Field = ___i0[___i1];
             {
-                let value: Field =
-                    // Safety: comment added by `nargo expand`
-                    unsafe { map.get(key) }.unwrap_unchecked();
+                // Safety: comment added by `nargo expand`
+                let value: Field = unsafe { map.get(key) }.unwrap_unchecked();
                 println(f"{key} -> {value}");
             }
         }


### PR DESCRIPTION
# Description

## Problem

Resolves #8371

## Summary

Now safety comments will always be added before statements, never in the middle of expressions.

For this program:

```noir
global G_A: [u16; 3] = [33700, 47314, 35095];
global G_B: [u16; 3] = [59890, 17417, 14409];
fn main(a: [u16; 3], b: [bool; 1]) -> pub bool {
    // Safety: testing context
    if unsafe { func_1(G_B, true) }[(((a[0] as u32) % (G_B[2] as u32)) % 1)] {
        // Safety: testing context
        let c = unsafe { func_1(a, b[0]) };
        b[0]
    } else {
        ((a[((a[0] as u32) % 3)] as u32) > ((24993 % G_A[1]) as u32))
    }
}
unconstrained fn func_1(a: [u16; 3], b: bool) -> [bool; 1] {
    [false]
}
```

the output of `nargo expand` is now:

```noir
global G_A: [u16; 3] = [33700, 47314, 35095];

global G_B: [u16; 3] = [59890, 17417, 14409];

fn main(a: [u16; 3], b: [bool; 1]) -> pub bool {
    // Safety: comment added by `nargo expand`
    if unsafe { func_1(G_B, true) }[((a[0] as u32) % (G_B[2] as u32)) % 1] {
        // Safety: comment added by `nargo expand`
        let c: [bool; 1] = unsafe { func_1(a, b[0]) };
        b[0]
    } else {
        (a[(a[0] as u32) % 3] as u32) > ((24993 % G_A[1]) as u32)
    }
}

unconstrained fn func_1(a: [u16; 3], b: bool) -> [bool; 1] {
    [false]
}
```

## Additional Context

In a next PR I'll try to preserve safety comments in the AST so we can output those instead of a generated comment.

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
