### PR TITLE
chore: avoid need to rebuild after running tests

### DIFF
--- a/tooling/nargo_cli/tests/execute.rs
+++ b/tooling/nargo_cli/tests/execute.rs
@@ -134,8 +134,8 @@ mod tests {
         force_brillig: ForceBrillig,
         inliner: Inliner,
     ) {
-        let target_dir = test_program_dir
-            .join(format!("target_force_brillig_{}_inliner_{}", force_brillig.0, inliner.0));
+        let target_dir = tempfile::tempdir().unwrap().into_path();
+
         nargo.arg(format!("--target-dir={}", target_dir.to_string_lossy()));
 
         nargo.assert().success();


### PR DESCRIPTION
# Description

## Problem\*

Resolves #8351 

## Summary\*

This shifts us from having target directory inside of `test_programs` to it being a designated temp directory. This avoids the need for us to rebuild after running the tests as we're no longer writing to the `test_programs` directory.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
