### PR TITLE
feat(greybox_fuzzer): Maximum executions parameter added

### DIFF
--- a/docs/docs/tooling/fuzzing.md
+++ b/docs/docs/tooling/fuzzing.md
@@ -79,7 +79,7 @@ Additional fuzzing-specific options include:
       --timeout <TIMEOUT>
           Maximum time in seconds to spend fuzzing per harness (default: no timeout)
       --max-executions <MAX_EXECUTIONS>
-          Maximum number of executions of ACIR and Brillig per harness(default: no limit)
+          Maximum number of executions of ACIR and Brillig per harness (default: no limit)
 
 `--show-output` and `--oracle-resolver` can be used in the same way as with regular execution and testing.
 It is recommended to use `--skip-underconstrained-check` to increase compilation speed.

--- a/docs/docs/tooling/fuzzing.md
+++ b/docs/docs/tooling/fuzzing.md
@@ -78,6 +78,8 @@ Additional fuzzing-specific options include:
           Only run harnesses that match exactly
       --timeout <TIMEOUT>
           Maximum time in seconds to spend fuzzing per harness (default: no timeout)
+      --max-executions <MAX_EXECUTIONS>
+          Maximum number of executions of ACIR and Brillig per harness(default: no limit)
 
 `--show-output` and `--oracle-resolver` can be used in the same way as with regular execution and testing.
 It is recommended to use `--skip-underconstrained-check` to increase compilation speed.

--- a/tooling/nargo/src/ops/fuzz.rs
+++ b/tooling/nargo/src/ops/fuzz.rs
@@ -32,6 +32,8 @@ pub struct FuzzExecutionConfig {
     pub timeout: u64,
     /// Whether to output progress to stdout or not.
     pub show_progress: bool,
+    /// Maximum number of executions of ACIR and Brillig (default: no limit)
+    pub max_executions: usize,
 }
 
 /// Folder configuration for fuzzing
@@ -208,6 +210,7 @@ where
                     num_threads: fuzz_execution_config.num_threads,
                     timeout: fuzz_execution_config.timeout,
                     show_progress: fuzz_execution_config.show_progress,
+                    max_executions: fuzz_execution_config.max_executions,
                 },
                 failure_configuration,
                 FuzzedExecutorFolderConfiguration {

--- a/tooling/nargo_cli/src/cli/fuzz_cmd.rs
+++ b/tooling/nargo_cli/src/cli/fuzz_cmd.rs
@@ -72,6 +72,10 @@ pub(crate) struct FuzzCommand {
     /// Maximum time in seconds to spend fuzzing (default: no timeout)
     #[arg(long)]
     timeout: Option<u64>,
+
+    /// Maximum number of executions of ACIR and Brillig per harness(default: no limit)
+    #[arg(long)]
+    max_executions: Option<usize>,
 }
 impl WorkspaceCommand for FuzzCommand {
     fn package_selection(&self) -> PackageSelection {
@@ -156,6 +160,7 @@ pub(crate) fn run(args: FuzzCommand, workspace: Workspace) -> Result<(), CliErro
         timeout: args.timeout.unwrap_or(0),
         num_threads: args.num_threads,
         show_progress: true,
+        max_executions: args.max_executions.unwrap_or(0),
     };
 
     let fuzzing_reports: Vec<Vec<(String, FuzzingRunStatus)>> = workspace

--- a/tooling/nargo_cli/src/cli/fuzz_cmd.rs
+++ b/tooling/nargo_cli/src/cli/fuzz_cmd.rs
@@ -70,11 +70,11 @@ pub(crate) struct FuzzCommand {
     oracle_resolver: Option<String>,
 
     /// Maximum time in seconds to spend fuzzing (default: no timeout)
-    #[arg(long, default_value = 0)]
+    #[arg(long, default_value = "0")]
     timeout: u64,
 
     /// Maximum number of executions of ACIR and Brillig per harness (default: no limit)
-    #[arg(long, default_value = 0)]
+    #[arg(long, default_value = "0")]
     max_executions: usize,
 }
 impl WorkspaceCommand for FuzzCommand {

--- a/tooling/nargo_cli/src/cli/fuzz_cmd.rs
+++ b/tooling/nargo_cli/src/cli/fuzz_cmd.rs
@@ -73,7 +73,7 @@ pub(crate) struct FuzzCommand {
     #[arg(long)]
     timeout: Option<u64>,
 
-    /// Maximum number of executions of ACIR and Brillig per harness(default: no limit)
+    /// Maximum number of executions of ACIR and Brillig per harness (default: no limit)
     #[arg(long)]
     max_executions: Option<usize>,
 }

--- a/tooling/nargo_cli/src/cli/fuzz_cmd.rs
+++ b/tooling/nargo_cli/src/cli/fuzz_cmd.rs
@@ -70,12 +70,12 @@ pub(crate) struct FuzzCommand {
     oracle_resolver: Option<String>,
 
     /// Maximum time in seconds to spend fuzzing (default: no timeout)
-    #[arg(long)]
-    timeout: Option<u64>,
+    #[arg(long, default_value = 0)]
+    timeout: u64,
 
     /// Maximum number of executions of ACIR and Brillig per harness (default: no limit)
-    #[arg(long)]
-    max_executions: Option<usize>,
+    #[arg(long, default_value = 0)]
+    max_executions: usize,
 }
 impl WorkspaceCommand for FuzzCommand {
     fn package_selection(&self) -> PackageSelection {
@@ -157,10 +157,10 @@ pub(crate) fn run(args: FuzzCommand, workspace: Workspace) -> Result<(), CliErro
         fuzzing_failure_dir: args.fuzzing_failure_dir,
     };
     let fuzz_execution_config = FuzzExecutionConfig {
-        timeout: args.timeout.unwrap_or(0),
+        timeout: args.timeout,
         num_threads: args.num_threads,
         show_progress: true,
-        max_executions: args.max_executions.unwrap_or(0),
+        max_executions: args.max_executions,
     };
 
     let fuzzing_reports: Vec<Vec<(String, FuzzingRunStatus)>> = workspace

--- a/tooling/nargo_cli/src/cli/test_cmd.rs
+++ b/tooling/nargo_cli/src/cli/test_cmd.rs
@@ -569,6 +569,7 @@ impl<'a> TestRunner<'a> {
                 num_threads: 1,
                 timeout: self.args.fuzz_timeout,
                 show_progress: false,
+                max_executions: 0,
             },
         };
 


### PR DESCRIPTION
# Description

## Problem\*



## Summary\*

It is now possible to limit fuzzing not just by time, but also by the number of executions. It should come in handy with fuzz tests.

## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [x] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
