### PR TITLE
fix: add handling for u128 infix ops in interpreter

### DIFF
--- a/compiler/noirc_frontend/src/hir/comptime/interpreter/infix.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter/infix.rs
@@ -57,6 +57,7 @@ pub(super) fn evaluate_infix(
                     (U16, U16)     to U16   => $int_expr,
                     (U32, U32)     to U32   => $int_expr,
                     (U64, U64)     to U64   => $int_expr,
+                    (U128, U128)   to U128  => $int_expr,
                 }
             }
         };
@@ -77,6 +78,7 @@ pub(super) fn evaluate_infix(
                     (U16, U16)     to Bool => Some($expr),
                     (U32, U32)     to Bool => Some($expr),
                     (U64, U64)     to Bool => Some($expr),
+                    (U128, U128)   to Bool => Some($expr),
                 }
             }
         };
@@ -96,6 +98,7 @@ pub(super) fn evaluate_infix(
                     (U16, U16)     to U16  => Some($expr),
                     (U32, U32)     to U32  => Some($expr),
                     (U64, U64)     to U64  => Some($expr),
+                    (U128, U128)   to U128  => Some($expr),
                 }
             }
         };
@@ -114,6 +117,7 @@ pub(super) fn evaluate_infix(
                     (U16, U16)     to U16  => $expr,
                     (U32, U32)     to U32  => $expr,
                     (U64, U64)     to U64  => $expr,
+                    (U128, U128)   to U128 => $expr,
                 }
             }
         };
@@ -132,6 +136,7 @@ pub(super) fn evaluate_infix(
                     (U16, U8)      to U16  => $expr,
                     (U32, U8)      to U32  => $expr,
                     (U64, U8)      to U64  => $expr,
+                    (U128, U8)     to U128  => $expr,
                 }
             }
         };
@@ -200,5 +205,24 @@ pub(super) fn evaluate_infix(
         BinaryOpKind::Modulo => match_integer! {
             (lhs_value as lhs "%" rhs_value as rhs) => lhs.checked_rem(rhs)
         },
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::{BinaryOpKind, HirBinaryOp, Location, Value};
+
+    use super::evaluate_infix;
+
+    #[test]
+    /// See: https://github.com/noir-lang/noir/issues/8391
+    fn regression_8391() {
+        let lhs = Value::U128(340282366920938463463374607431768211455);
+        let rhs = Value::U128(2);
+        let operator = HirBinaryOp { kind: BinaryOpKind::Divide, location: Location::dummy() };
+        let location = Location::dummy();
+        let result = evaluate_infix(lhs, rhs, operator, location).unwrap();
+
+        assert_eq!(result, Value::U128(170141183460469231731687303715884105727));
     }
 }


### PR DESCRIPTION
# Description

## Problem\*

Resolves #8391 

## Summary\*

Looks like these match arms never got added when the u128 type was added.

## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
