### PR TITLE
chore: bumping external libraries

### DIFF
--- a/EXTERNAL_NOIR_LIBRARIES.yml
+++ b/EXTERNAL_NOIR_LIBRARIES.yml
@@ -135,12 +135,12 @@ libraries:
     critical: false
   noir_jwt:
     repo: zkemail/noir-jwt
-    ref: d461d01b24432c42c17a149e7075974b2a7bce3d
+    ref: 899ff2ca9ec196bc80be6dbe87fcb8ed721695b7
     timeout: 20
     critical: false
   zkemail:
     repo: zkemail/zkemail.nr
-    ref: 07053e865447b3167b670f9167f256e971fdb5c8
+    ref: 0a2cc39293fea71cdd0beaff8928abf54e555a36
     path: lib
     timeout: 20
     critical: false


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This PR bumps the commits of the noir jwt library so that we can compile it and run tests.

## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
