### PR TITLE
fix: print slice composite types surrounded by parentheses

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/ir/types.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/types.rs
@@ -315,7 +315,11 @@ impl std::fmt::Display for Type {
             }
             Type::Slice(element) => {
                 let elements = vecmap(element.iter(), |element| element.to_string());
-                write!(f, "[{}]", elements.join(", "))
+                if elements.len() == 1 {
+                    write!(f, "[{}]", elements.join(", "))
+                } else {
+                    write!(f, "[({})]", elements.join(", "))
+                }
             }
             Type::Function => write!(f, "function"),
         }

--- a/compiler/noirc_evaluator/src/ssa/parser/tests.rs
+++ b/compiler/noirc_evaluator/src/ssa/parser/tests.rs
@@ -90,6 +90,19 @@ fn test_make_composite_array() {
 }
 
 #[test]
+fn test_make_composite_slice() {
+    let src = "
+        acir(inline) predicate_pure fn main f0 {
+          b0():
+            v2 = make_array [Field 2, Field 3] : [Field; 2]
+            v4 = make_array [Field 1, v2] : [(Field, [Field; 2])]
+            return v4
+        }
+        ";
+    assert_ssa_roundtrip(src);
+}
+
+#[test]
 fn test_make_byte_array_with_string_literal() {
     let src = "
         acir(inline) fn main f0 {


### PR DESCRIPTION
# Description

## Problem

Resolves #8408

## Summary

Let me know if composite types shouldn't be surrounded by parentheses. It's something I already did for arrays a long time ago (when writing the SSA parser, or maybe even before that).

## Additional Context

I can't remember why I added those parentheses, it was maybe for clarity or to avoid an ambiguity.

Then I just tried to generate SSA for this code:

```noir
fn main() {
    let _ = [(); 4];
}
```

The result is:

```noir
acir(inline) fn main f0 {
  b0():
    v0 = make_array [] : [(); 4]
    return
}
```

I guess without those `()` it would look like `[; 4]` so we'd have to assume, when parsing, that if no type comes it's an empty list... but maybe that makes it harder to distinguish between that and a mistake.

I think back when I implemented the SSA parser I wasn't sure what all types were, so when parsing parameters `b0: Field, b1: Field`, if we allowed composite types in the parameters it would be harder to parse because we see `Field, ...` and we don't know if another type comes. Well, composite types aren't allowed in parameters, but in the end using parentheses is maybe clearer and more consistent.

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
