### PR TITLE
chore(acir): Test whether the predicate has an effect on slice intrinsics

### DIFF
--- a/compiler/noirc_evaluator/src/acir/tests/intrinsics.rs
+++ b/compiler/noirc_evaluator/src/acir/tests/intrinsics.rs
@@ -21,7 +21,7 @@ fn slice_push_back_not_affected_by_predicate() {
         false,
     )[0];
     assert_eq!(func_with_pred.current_witness_index(), func_no_pred.current_witness_index());
-    assert_eq!(func_with_pred.opcodes(), func_no_pred.opcodes);
+    assert_eq!(func_with_pred.opcodes(), func_no_pred.opcodes());
 }
 
 #[test]
@@ -39,7 +39,7 @@ fn slice_push_front_not_affected_by_predicate() {
         false,
     )[0];
     assert_eq!(func_with_pred.current_witness_index(), func_no_pred.current_witness_index());
-    assert_eq!(func_with_pred.opcodes(), func_no_pred.opcodes);
+    assert_eq!(func_with_pred.opcodes(), func_no_pred.opcodes());
 }
 
 #[test]
@@ -57,7 +57,7 @@ fn slice_pop_back_not_affected_by_predicate() {
         false,
     )[0];
     assert_eq!(func_with_pred.current_witness_index(), func_no_pred.current_witness_index());
-    assert_eq!(func_with_pred.opcodes(), func_no_pred.opcodes);
+    assert_eq!(func_with_pred.opcodes(), func_no_pred.opcodes());
 }
 
 #[test]
@@ -75,7 +75,7 @@ fn slice_pop_front_not_affected_by_predicate() {
         false,
     )[0];
     assert_eq!(func_with_pred.current_witness_index(), func_no_pred.current_witness_index());
-    assert_eq!(func_with_pred.opcodes(), func_no_pred.opcodes);
+    assert_eq!(func_with_pred.opcodes(), func_no_pred.opcodes());
 }
 
 #[test]
@@ -93,7 +93,7 @@ fn slice_insert_affected_by_predicate() {
         false,
     )[0];
     assert_ne!(func_with_pred.current_witness_index(), func_no_pred.current_witness_index());
-    assert_ne!(func_with_pred.opcodes(), func_no_pred.opcodes);
+    assert_ne!(func_with_pred.opcodes(), func_no_pred.opcodes());
 }
 
 #[test]
@@ -111,7 +111,7 @@ fn slice_remove_affected_by_predicate() {
         false,
     )[0];
     assert_ne!(func_with_pred.current_witness_index(), func_no_pred.current_witness_index());
-    assert_ne!(func_with_pred.opcodes(), func_no_pred.opcodes);
+    assert_ne!(func_with_pred.opcodes(), func_no_pred.opcodes());
 }
 
 /// Helper method to set up the SSA for unit tests on whether slice intrinsics

--- a/compiler/noirc_evaluator/src/acir/tests/intrinsics.rs
+++ b/compiler/noirc_evaluator/src/acir/tests/intrinsics.rs
@@ -1,0 +1,162 @@
+use acvm::{FieldElement, acir::circuit::ExpressionWidth};
+
+use crate::{
+    acir::GeneratedAcir,
+    brillig::BrilligOptions,
+    ssa::{ir::instruction::Intrinsic, ssa_gen::Ssa},
+};
+
+#[test]
+fn slice_push_back_not_affected_by_predicate() {
+    let func_with_pred = &get_slice_intrinsic_acir(
+        "v9, v10",
+        &Intrinsic::SlicePushBack.to_string(),
+        ", Field 1, v4) -> (u32, [(Field, [Field; 2])])",
+        true,
+    )[0];
+    let func_no_pred = &get_slice_intrinsic_acir(
+        "v9, v10",
+        &Intrinsic::SlicePushBack.to_string(),
+        ", Field 1, v4) -> (u32, [(Field, [Field; 2])])",
+        false,
+    )[0];
+    assert_eq!(func_with_pred.current_witness_index(), func_no_pred.current_witness_index());
+    assert_eq!(func_with_pred.opcodes(), func_no_pred.opcodes);
+}
+
+#[test]
+fn slice_push_front_not_affected_by_predicate() {
+    let func_with_pred = &get_slice_intrinsic_acir(
+        "v9, v10",
+        &Intrinsic::SlicePushFront.to_string(),
+        ", Field 1, v4) -> (u32, [(Field, [Field; 2])])",
+        true,
+    )[0];
+    let func_no_pred = &get_slice_intrinsic_acir(
+        "v9, v10",
+        &Intrinsic::SlicePushFront.to_string(),
+        ", Field 1, v4) -> (u32, [(Field, [Field; 2])])",
+        false,
+    )[0];
+    assert_eq!(func_with_pred.current_witness_index(), func_no_pred.current_witness_index());
+    assert_eq!(func_with_pred.opcodes(), func_no_pred.opcodes);
+}
+
+#[test]
+fn slice_pop_back_not_affected_by_predicate() {
+    let func_with_pred = &get_slice_intrinsic_acir(
+        "v9, v10, v11, v12",
+        &Intrinsic::SlicePopBack.to_string(),
+        ") -> (u32, [(Field, [Field; 2])], Field, [Field; 2])",
+        true,
+    )[0];
+    let func_no_pred = &get_slice_intrinsic_acir(
+        "v9, v10, v11, v12",
+        &Intrinsic::SlicePopBack.to_string(),
+        ") -> (u32, [(Field, [Field; 2])], Field, [Field; 2])",
+        false,
+    )[0];
+    assert_eq!(func_with_pred.current_witness_index(), func_no_pred.current_witness_index());
+    assert_eq!(func_with_pred.opcodes(), func_no_pred.opcodes);
+}
+
+#[test]
+fn slice_pop_front_not_affected_by_predicate() {
+    let func_with_pred = &get_slice_intrinsic_acir(
+        "v9, v10, v11, v12",
+        &Intrinsic::SlicePopFront.to_string(),
+        ") -> (Field, [Field; 2], u32, [(Field, [Field; 2])])",
+        true,
+    )[0];
+    let func_no_pred = &get_slice_intrinsic_acir(
+        "v9, v10, v11, v12",
+        &Intrinsic::SlicePopFront.to_string(),
+        ") -> (Field, [Field; 2], u32, [(Field, [Field; 2])])",
+        false,
+    )[0];
+    assert_eq!(func_with_pred.current_witness_index(), func_no_pred.current_witness_index());
+    assert_eq!(func_with_pred.opcodes(), func_no_pred.opcodes);
+}
+
+#[test]
+fn slice_insert_affected_by_predicate() {
+    let func_with_pred = &get_slice_intrinsic_acir(
+        "v9, v10",
+        &Intrinsic::SliceInsert.to_string(),
+        ", u32 1, Field 1, v4) -> (u32, [(Field, [Field; 2])])",
+        true,
+    )[0];
+    let func_no_pred = &get_slice_intrinsic_acir(
+        "v9, v10",
+        &Intrinsic::SliceInsert.to_string(),
+        ", u32 1, Field 1, v4) -> (u32, [(Field, [Field; 2])])",
+        false,
+    )[0];
+    assert_ne!(func_with_pred.current_witness_index(), func_no_pred.current_witness_index());
+    assert_ne!(func_with_pred.opcodes(), func_no_pred.opcodes);
+}
+
+#[test]
+fn slice_remove_affected_by_predicate() {
+    let func_with_pred = &get_slice_intrinsic_acir(
+        "v9, v10, v11, v12",
+        &Intrinsic::SliceRemove.to_string(),
+        ", u32 1) -> (u32, [(Field, [Field; 2])], Field, [Field; 2])",
+        true,
+    )[0];
+    let func_no_pred = &get_slice_intrinsic_acir(
+        "v9, v10, v11, v12",
+        &Intrinsic::SliceRemove.to_string(),
+        ", u32 1) -> (u32, [(Field, [Field; 2])], Field, [Field; 2])",
+        false,
+    )[0];
+    assert_ne!(func_with_pred.current_witness_index(), func_no_pred.current_witness_index());
+    assert_ne!(func_with_pred.opcodes(), func_no_pred.opcodes);
+}
+
+/// Helper method to set up the SSA for unit tests on whether slice intrinsics
+/// are affected by the ACIR gen predicate.
+fn get_slice_intrinsic_src(
+    return_values: &str,
+    intrinsic_name: &str,
+    args_and_return_type: &str,
+    with_side_effects: bool,
+) -> String {
+    let side_effects = if with_side_effects { "enable_side_effects v1\n" } else { "" };
+    format!(
+        "
+    acir(inline) predicate_pure fn main f0 {{
+      b0(v0: u32, v1: u1):
+        v4 = make_array [Field 2, Field 3] : [Field; 2]
+        v5 = make_array [Field 1, v4] : [(Field, [Field; 2])]
+        v7 = array_set v5, index v0, value Field 4
+        {side_effects}
+        {return_values} = call {intrinsic_name}(u32 1, v7{args_and_return_type}
+        return
+    }}
+    "
+    )
+}
+
+/// Helper for fetching the ACIR for the SSA specified in [get_slice_intrinsic_src].
+/// This helper assumes we have a single main function we are testing against.
+fn get_slice_intrinsic_acir(
+    return_values: &str,
+    intrinsic_name: &str,
+    args_and_return_type: &str,
+    with_side_effects: bool,
+) -> Vec<GeneratedAcir<FieldElement>> {
+    let src = get_slice_intrinsic_src(
+        return_values,
+        intrinsic_name,
+        args_and_return_type,
+        with_side_effects,
+    );
+    let ssa = Ssa::from_str(&src).unwrap();
+    let brillig = ssa.to_brillig(&BrilligOptions::default());
+
+    let (acir_functions_with_pred, _brillig_functions, _, _) = ssa
+        .into_acir(&brillig, &BrilligOptions::default(), ExpressionWidth::default())
+        .expect("Should compile manually written SSA into ACIR");
+    acir_functions_with_pred
+}

--- a/compiler/noirc_evaluator/src/acir/tests/mod.rs
+++ b/compiler/noirc_evaluator/src/acir/tests/mod.rs
@@ -31,6 +31,8 @@ use crate::{
     },
 };
 
+mod intrinsics;
+
 fn build_basic_foo_with_return(
     builder: &mut FunctionBuilder,
     foo_id: FunctionId,


### PR DESCRIPTION
# Description

## Problem\*

Resolves https://github.com/noir-lang/noir/pull/8355#discussion_r2078441068

## Summary\*

So although this resolves the comment on #8355, this functionality can be tested in isolation without considering that PR at all. The following was done to determine whether a predicate affected a certain instruction:
1. Setup an SSA where there is only instruction after `EnableSideEffectIf` instruction on a dynamic predicate
2. Check the ACIR and final witness index for an SSA where that `EnableSideEffectIf` is in place and an SSA where there is no `EnableSideEffectIf`.
3.  If the instruction is meant to be unaffected by the predicate, check for equality. If the predicate is meant to have an affect, check for inequality.

For example we may have this SSA:
```
acir(inline) predicate_pure fn main f0 {
  b0(v0: u32, v1: u1):
    v4 = make_array [Field 2, Field 3] : [Field; 2]
    v6 = make_array [Field 1, v4] : [(Field, [Field; 2])]
    v8 = array_set v6, index v0, value Field 4
    enable_side_effects v1
    v11, v12 = call slice_push_back(u32 1, v8, Field 1, v4) -> (u32, [(Field, [Field; 2])])
    return
}
```
and we want to check that the ACIR generated is equivalent to this SSA:
```
acir(inline) predicate_pure fn main f0 {
  b0(v0: u32, v1: u1):
    v4 = make_array [Field 2, Field 3] : [Field; 2]
    v6 = make_array [Field 1, v4] : [(Field, [Field; 2])]
    v8 = array_set v6, index v0, value Field 4
    v11, v12 = call slice_push_back(u32 1, v8, Field 1, v4) -> (u32, [(Field, [Field; 2])])
    return
}
```

Composite types were used for setting up the slice tests. This was necessary to guarantee going that `slice_insert` and `slice_remove` were affected by the predicate.

## Additional Context

In general, I think this strategy of testing could be an effective simple way to test `requires_acir_gen_predicate` is in fact marked appropriately. We could expand it to the remaining intrinsic calls and instructions. If after a review we decide to go forward with these kinds of tests, I am happy to capture an issue for adding more ACIR gen predicate tests for the remaining instructions. 

The helper in this PR is specific to setting up slice intrinsic calls, however, it could definitely be expand to support all intrinsic calls, and even all instructions (perhaps we will want a new helper at that point). 

## Documentation\*

Check one:
- [X] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
