### PR TITLE
add ssa_afl_fuzzer, export SSA parser and interpreter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5432,6 +5432,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "ssa_afl_fuzzer"
+version = "1.0.0-beta.4"
+dependencies = [
+ "afl",
+ "noirc_evaluator",
+]
+
+[[package]]
 name = "ssa_fuzzer_fuzz"
 version = "0.0.1"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ members = [
 
     "tooling/ssa_fuzzer",
     "tooling/ssa_fuzzer/fuzzer",
+    "tooling/ssa_afl_fuzzer", # cargo-afl fuzzer
     "utils/protobuf",
 ]
 default-members = [

--- a/compiler/noirc_evaluator/src/ssa.rs
+++ b/compiler/noirc_evaluator/src/ssa.rs
@@ -47,8 +47,11 @@ pub mod function_builder;
 pub mod interpreter;
 pub mod ir;
 pub(crate) mod opt;
-#[cfg(test)]
-pub(crate) mod parser;
+
+// TODO: only for testing?
+// #[cfg(test)]
+// pub(crate) mod parser;
+pub mod parser;
 pub mod ssa_gen;
 
 #[derive(Debug, Clone)]

--- a/compiler/noirc_evaluator/src/ssa/function_builder/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/function_builder/mod.rs
@@ -363,7 +363,8 @@ impl FunctionBuilder {
             .first()
     }
 
-    #[cfg(test)]
+    // TODO: used in fuzzing too
+    // #[cfg(test)]
     pub fn insert_mutable_array_set(
         &mut self,
         array: ValueId,

--- a/compiler/noirc_evaluator/src/ssa/interpreter/errors.rs
+++ b/compiler/noirc_evaluator/src/ssa/interpreter/errors.rs
@@ -10,7 +10,7 @@ pub(super) const MAX_SIGNED_BIT_SIZE: u32 = 64;
 pub(super) const MAX_UNSIGNED_BIT_SIZE: u32 = 128;
 
 #[derive(Debug, Error)]
-pub(crate) enum InterpreterError {
+pub enum InterpreterError {
     /// These errors are all the result from malformed input SSA
     #[error("{0}")]
     Internal(InternalError),
@@ -60,7 +60,7 @@ pub(crate) enum InterpreterError {
 
 /// These errors can only result from interpreting malformed SSA
 #[derive(Debug, Error)]
-pub(crate) enum InternalError {
+pub enum InternalError {
     #[error(
         "Argument count {arguments} to block {block} does not match the expected parameter count {parameters}"
     )]

--- a/compiler/noirc_evaluator/src/ssa/interpreter/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/interpreter/mod.rs
@@ -63,7 +63,7 @@ type IResults = IResult<Vec<Value>>;
 
 #[allow(unused)]
 impl Ssa {
-    pub(crate) fn interpret(&self, args: Vec<Value>) -> IResults {
+    pub fn interpret(&self, args: Vec<Value>) -> IResults {
         self.interpret_function(self.main_id, args)
     }
 

--- a/compiler/noirc_evaluator/src/ssa/interpreter/value.rs
+++ b/compiler/noirc_evaluator/src/ssa/interpreter/value.rs
@@ -12,7 +12,7 @@ use crate::ssa::ir::{
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) enum Value {
+pub enum Value {
     Numeric(NumericValue),
     Reference(ReferenceValue),
     ArrayOrSlice(ArrayValue),
@@ -22,7 +22,7 @@ pub(crate) enum Value {
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
-pub(crate) enum NumericValue {
+pub enum NumericValue {
     Field(FieldElement),
 
     U1(bool),
@@ -39,7 +39,7 @@ pub(crate) enum NumericValue {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct ReferenceValue {
+pub struct ReferenceValue {
     /// This is included mostly for debugging to distinguish different
     /// ReferenceValues which store the same element.
     pub original_id: ValueId,
@@ -51,7 +51,7 @@ pub(crate) struct ReferenceValue {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct ArrayValue {
+pub struct ArrayValue {
     pub elements: Shared<Vec<Value>>,
 
     /// The `Shared` type contains its own reference count but we need to track

--- a/compiler/noirc_evaluator/src/ssa/ir/map.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/map.rs
@@ -42,7 +42,9 @@ impl<T> Id<T> {
     /// be used for testing. Obtaining Ids in this way should be avoided
     /// as unlike DenseMap::push and SparseMap::push, the Ids created
     /// here are likely invalid for any particularly map.
-    #[cfg(test)]
+
+    // TODO: used for fuzzing
+    // #[cfg(test)]
     pub(crate) fn test_new(index: u32) -> Self {
         Self::new(index)
     }

--- a/compiler/noirc_evaluator/src/ssa/opt/remove_unreachable.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/remove_unreachable.rs
@@ -32,7 +32,8 @@ use crate::ssa::{
 
 impl Ssa {
     /// See [`remove_unreachable`][self] module for more information.
-    pub(crate) fn remove_unreachable_functions(mut self) -> Self {
+    // TODO: pub for fuzzing, otherwise pub(crate)
+    pub fn remove_unreachable_functions(mut self) -> Self {
         let mut reachable_functions = HashSet::default();
 
         // Go through all the functions, and if we have an entry point, extend the set of all

--- a/compiler/noirc_evaluator/src/ssa/parser/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/parser/mod.rs
@@ -41,6 +41,7 @@ impl FromStr for Ssa {
     }
 }
 
+#[allow(unused)]
 impl Ssa {
     /// Creates an Ssa object from the given string.
     pub(crate) fn from_str(src: &str) -> Result<Ssa, SsaErrorWithSource> {

--- a/tooling/ssa_afl_fuzzer/Cargo.toml
+++ b/tooling/ssa_afl_fuzzer/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "ssa_afl_fuzzer"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+afl = "*"
+noirc_evaluator.workspace = true
+
+[lints]
+workspace = true

--- a/tooling/ssa_afl_fuzzer/src/main.rs
+++ b/tooling/ssa_afl_fuzzer/src/main.rs
@@ -1,0 +1,38 @@
+#[macro_use]
+extern crate afl;
+extern crate noirc_evaluator;
+
+use std::str::FromStr;
+
+use noirc_evaluator::ssa::ssa_gen::Ssa;
+
+fn main() {
+    fuzz!(|data: &[u8]| {
+        if let Ok(src) = std::str::from_utf8(data) {
+            if let Ok(ssa) = Ssa::from_str(src) {
+                // re-parsing is easier than cloning
+                let other_ssa = Ssa::from_str(src).expect("expected repeated SSA parsing to succeed");
+                let other_ssa = other_ssa.remove_unreachable_functions();
+
+                let result = ssa.interpret(Vec::new());
+                let other_result = other_ssa.interpret(Vec::new());
+
+                // ensure both pass with the same result or both fail with the same error variant
+                match (result, other_result) {
+                    (Ok(result_ok), Ok(other_result_ok)) => {
+                        assert_eq!(result_ok, other_result_ok);
+                    }
+                    // check that the errors have the same discriminant (i.e. same enum variant)
+                    (Err(err), Err(other_err)) => {
+                        let disciminant = std::mem::discriminant(&err);
+                        let other_disciminant = std::mem::discriminant(&other_err);
+                        assert_eq!(disciminant, other_disciminant);
+                    }
+                    (result, other_result) => {
+                        panic!("results did not match when applying 'remove_unreachable_functions'!\n{:?}\n-----------\n{:?}", result, other_result)
+                    }
+                }
+            }
+        }
+    });
+}


### PR DESCRIPTION
# Description

## Problem\*

## Summary\*

https://github.com/noir-lang/noir/pull/8407 is focused on modifying the existing `ssa_fuzzer` while this PR is focused on a new AFL fuzzer using the SSA interpreter

## Additional Context

I'm basing this off of `sn/ssa_fuzzer_branching`, which is WIP, to get the latest support for CFG-related instructions

## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
