### PR TITLE
feat(greybox_fuzzer): Parallel fuzz tests

### DIFF
--- a/EXTERNAL_NOIR_LIBRARIES.yml
+++ b/EXTERNAL_NOIR_LIBRARIES.yml
@@ -76,7 +76,7 @@ libraries:
     repo: AztecProtocol/aztec-packages
     ref: *AZ_COMMIT
     path: noir-projects/aztec-nr
-    timeout: 60
+    timeout: 70
     critical: false
   noir_contracts:
     repo: AztecProtocol/aztec-packages

--- a/docs/docs/tooling/testing.md
+++ b/docs/docs/tooling/testing.md
@@ -88,7 +88,7 @@ fn test_basic(a: Field, b: Field) {
     assert(a + b == b + a);
 }
 ```
-The test above is not expected to fail. By default, the fuzzer will run for 10 seconds and use 100000 executions (whichever comes first). All available threads will be used for each fuzz test.
+The test above is not expected to fail. By default, the fuzzer will run for 1 seconds and use 100000 executions (whichever comes first). All available threads will be used for each fuzz test.
 The fuzz tests also work with `#[test(should_fail)]` and `#[test(should_fail_with = "<the reason for failure>")]`. For example:
 
 ```rust

--- a/docs/docs/tooling/testing.md
+++ b/docs/docs/tooling/testing.md
@@ -134,9 +134,9 @@ There are some fuzzing-specific options that can be used with `nargo test`:
           If given, store the failing input in the given folder
 
       --fuzz-timeout <FUZZ_TIMEOUT>
-          Maximum time in seconds to spend fuzzing (default: 10 seconds)
+          Maximum time in seconds to spend fuzzing (default: 1 second)
 
-          [default: 10]
+          [default: 1]
 
       --fuzz-max-executions <FUZZ_MAX_EXECUTIONS>
           Maximum number of executions to run for each fuzz test (default: 100000)

--- a/docs/docs/tooling/testing.md
+++ b/docs/docs/tooling/testing.md
@@ -88,7 +88,7 @@ fn test_basic(a: Field, b: Field) {
     assert(a + b == b + a);
 }
 ```
-The test above is not expected to fail. By default, the fuzzer will run for 1 seconds and use 100000 executions (whichever comes first). All available threads will be used for each fuzz test.
+The test above is not expected to fail. By default, the fuzzer will run for 1 second and use 100000 executions (whichever comes first). All available threads will be used for each fuzz test.
 The fuzz tests also work with `#[test(should_fail)]` and `#[test(should_fail_with = "<the reason for failure>")]`. For example:
 
 ```rust

--- a/docs/docs/tooling/testing.md
+++ b/docs/docs/tooling/testing.md
@@ -77,3 +77,75 @@ fn test_bridgekeeper() {
     main(32);
 }
 ```
+
+### Fuzz tests
+
+You can write fuzzing harnesses that will run on `nargo test` by using the decorator `#[test]` with a function that has arguments. For example:
+
+```rust
+#[test]
+fn test_basic(a: Field, b: Field) {
+    assert(a + b == b + a);
+}
+```
+The test above is not expected to fail. By default, the fuzzer will run for 10 seconds and use 100000 executions (whichever comes first). All available threads will be used for each fuzz test.
+The fuzz tests also work with `#[test(should_fail)]` and `#[test(should_fail_with = "<the reason for failure>")]`. For example:
+
+```rust
+#[test(should_fail)]
+fn test_should_fail(a: [bool; 32]) {
+    let mut or_sum= false;
+    for i in 0..32 {
+        or_sum=or_sum|(a[i]==((i&1)as bool));
+    }
+    assert(!or_sum);
+}
+```
+or
+
+```rust
+#[test(should_fail_with = "This is the message that will be checked for")]
+fn fuzz_should_fail_with(a: [bool; 32]) {
+    let mut or_sum= false;
+    for i in 0..32 {
+        or_sum=or_sum|(a[i]==((i&1)as bool));
+    }
+    assert(or_sum);
+    assert(false, "This is the message that will be checked for");
+}
+```
+
+The underlying fuzzing mechanism is described in the [Fuzzing](../tooling/fuzzing) documentation.
+
+There are some fuzzing-specific options that can be used with `nargo test`:
+       --no-fuzz
+          Do not run fuzz tests (tests that have arguments)
+
+      --only-fuzz
+          Only run fuzz tests (tests that have arguments)
+
+      --corpus-dir <CORPUS_DIR>
+          If given, load/store fuzzer corpus from this folder
+
+      --minimized-corpus-dir <MINIMIZED_CORPUS_DIR>
+          If given, perform corpus minimization instead of fuzzing and store results in the given folder
+
+      --fuzzing-failure-dir <FUZZING_FAILURE_DIR>
+          If given, store the failing input in the given folder
+
+      --fuzz-timeout <FUZZ_TIMEOUT>
+          Maximum time in seconds to spend fuzzing (default: 10 seconds)
+
+          [default: 10]
+
+      --fuzz-max-executions <FUZZ_MAX_EXECUTIONS>
+          Maximum number of executions to run for each fuzz test (default: 100000)
+
+          [default: 100000]
+
+      --fuzz-show-progress
+          Show progress of fuzzing (default: false)
+
+
+By default, the fuzzing corpus is saved in a temporary directory, but this can be changed. This allows you to resume fuzzing from the same corpus if the process is interrupted, if you want to run continuous fuzzing on your corpus, or if you want to use previous failures for regression testing.
+

--- a/tooling/nargo_cli/src/cli/test_cmd.rs
+++ b/tooling/nargo_cli/src/cli/test_cmd.rs
@@ -97,8 +97,8 @@ pub(crate) struct TestCommand {
     #[arg(long)]
     fuzzing_failure_dir: Option<String>,
 
-    /// Maximum time in seconds to spend fuzzing (default: 10 seconds)
-    #[arg(long, default_value_t = 10)]
+    /// Maximum time in seconds to spend fuzzing (default: 1 seconds)
+    #[arg(long, default_value_t = 1)]
     fuzz_timeout: u64,
 
     /// Maximum number of executions to run for each fuzz test (default: 100000)


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

Fuzzing tests are now run after the main tests and each fuzzing test uses parallelisation internally instead of just being assigned 1 thread. The limits have also been changed to 100k executions and 1 second.

## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [x] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
