### PR TITLE
chore: bump external pinned commits

### DIFF
--- a/.github/benchmark_projects.yml
+++ b/.github/benchmark_projects.yml
@@ -1,4 +1,4 @@
-define: &AZ_COMMIT 278661f67ce4d444b068b331971a5bb3e2a2461f
+define: &AZ_COMMIT 369f60c69d94f2a689c387ab2c6fcf3b5fb64c20
 projects:
   private-kernel-inner:
     repo: AztecProtocol/aztec-packages

--- a/EXTERNAL_NOIR_LIBRARIES.yml
+++ b/EXTERNAL_NOIR_LIBRARIES.yml
@@ -1,4 +1,4 @@
-define: &AZ_COMMIT 278661f67ce4d444b068b331971a5bb3e2a2461f
+define: &AZ_COMMIT 369f60c69d94f2a689c387ab2c6fcf3b5fb64c20
 libraries:
   noir_check_shuffle:
     repo: noir-lang/noir_check_shuffle


### PR DESCRIPTION

Automated update of the pinned commit of [aztec-packages](https://github.com/AztecProtocol/aztec-packages) repository against which we run benchmarks.
