### PR TITLE
chore: add some simple post-checks to certain SSA passes

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/opt/pure.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/pure.rs
@@ -49,8 +49,21 @@ impl Ssa {
             function.dfg.set_function_purities(purities.clone());
         }
 
+        purity_analysis_post_check(&self);
+
         self
     }
+}
+
+/// Post-check condition for [Function::remove_bit_shifts].
+///
+/// Returns `true` if:
+///   - all functions have a purity status attached to it.
+///
+/// Otherwise returns `false`.
+fn purity_analysis_post_check(ssa: &Ssa) -> bool {
+    // TODO: We have N different copies of the purity hashmap (one per function), ideally this would be deduplicated.
+    ssa.functions.iter().all(|(id, function)| function.dfg.purity_of(*id).is_some())
 }
 
 pub(crate) type FunctionPurities = HashMap<FunctionId, Purity>;


### PR DESCRIPTION
# Description

## Problem\*

From discussion with @michaeljklein 

## Summary\*

This PR adds some sanity checks to SSA passes so that, for instance,  the SSA pass to remove bitshifts does not leave behind any bitshifts in ACIR functions.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
