### PR TITLE
chore(fuzz): Do not use zero length types in the main input output

### DIFF
--- a/tooling/ast_fuzzer/src/program/func.rs
+++ b/tooling/ast_fuzzer/src/program/func.rs
@@ -715,7 +715,7 @@ impl<'a> FunctionContext<'a> {
         // Generate a type or choose an existing one.
         let max_depth = self.max_depth();
         let comptime_friendly = self.is_comptime_friendly();
-        let typ = self.ctx.gen_type(u, max_depth, false, true, comptime_friendly)?;
+        let typ = self.ctx.gen_type(u, max_depth, false, false, true, comptime_friendly)?;
         let expr = self.gen_expr(u, &typ, max_depth, Flags::TOP)?;
         let mutable = bool::arbitrary(u)?;
         Ok(self.let_var(mutable, typ, expr, true))

--- a/tooling/ast_fuzzer/src/program/mod.rs
+++ b/tooling/ast_fuzzer/src/program/mod.rs
@@ -133,8 +133,14 @@ impl Context {
         u: &mut Unstructured,
         i: usize,
     ) -> arbitrary::Result<(Name, Type, Expression)> {
-        let typ =
-            self.gen_type(u, self.config.max_depth, true, false, self.config.comptime_friendly)?;
+        let typ = self.gen_type(
+            u,
+            self.config.max_depth,
+            true,
+            false,
+            false,
+            self.config.comptime_friendly,
+        )?;
         // By the time we get to the monomorphized AST the compiler will have already turned
         // complex global expressions into literals.
         let val = expr::gen_literal(u, &typ)?;
@@ -172,6 +178,7 @@ impl Context {
                 u,
                 self.config.max_depth,
                 false,
+                is_main,
                 false,
                 self.config.comptime_friendly,
             )?;
@@ -189,8 +196,15 @@ impl Context {
             params.push((id, is_mutable, name, typ, visibility));
         }
 
-        let return_type =
-            self.gen_type(u, self.config.max_depth, false, false, self.config.comptime_friendly)?;
+        let return_type = self.gen_type(
+            u,
+            self.config.max_depth,
+            false,
+            is_main,
+            false,
+            self.config.comptime_friendly,
+        )?;
+
         let return_visibility = if is_main {
             if types::is_unit(&return_type) {
                 Visibility::Private
@@ -321,6 +335,7 @@ impl Context {
         u: &mut Unstructured,
         max_depth: usize,
         is_global: bool,
+        is_main: bool,
         is_frontend_friendly: bool,
         is_comptime_friendly: bool,
     ) -> arbitrary::Result<Type> {
@@ -330,6 +345,7 @@ impl Context {
                 .types
                 .iter()
                 .filter(|typ| !is_global || types::can_be_global(typ))
+                .filter(|typ| !is_main || !types::can_be_main(typ))
                 .filter(|typ| types::type_depth(typ) <= max_depth)
                 .filter(|typ| !is_frontend_friendly || !self.should_avoid_literals(typ))
                 .collect::<Vec<_>>();
@@ -378,6 +394,7 @@ impl Context {
                                 u,
                                 max_depth - 1,
                                 is_global,
+                                is_main,
                                 is_frontend_friendly,
                                 is_comptime_friendly,
                             )
@@ -392,6 +409,7 @@ impl Context {
                         u,
                         max_depth - 1,
                         is_global,
+                        is_main,
                         is_frontend_friendly,
                         is_comptime_friendly,
                     )?;
@@ -399,7 +417,11 @@ impl Context {
                 }
                 _ => unreachable!("unexpected arbitrary type index"),
             };
-            if !is_global || types::can_be_global(&typ) {
+            // Looping is kinda dangerous, we could get stuck if we run out of randomness,
+            // so we have to make sure the first type on the list is acceptable.
+            if is_global && !types::can_be_global(&typ) || is_main && !types::can_be_main(&typ) {
+                continue;
+            } else {
                 break;
             }
         }

--- a/tooling/ast_fuzzer/src/program/types.rs
+++ b/tooling/ast_fuzzer/src/program/types.rs
@@ -35,6 +35,18 @@ pub(crate) fn can_be_global(typ: &Type) -> bool {
     )
 }
 
+/// Check if a type can be used in the `main` function.
+///
+/// We decided we will avoid 0 length arrays in the main inputs and outputs, because we don't generate
+/// witnesses for them anyway, and they are tricky to handle consistently when they can be regular inputs
+/// as well as part of the databus. They are not expected in real programs as they don't do anything useful.
+pub(crate) fn can_be_main(typ: &Type) -> bool {
+    match typ {
+        Type::Array(size, _) | Type::String(size) => *size > 0,
+        _ => true,
+    }
+}
+
 /// Collect all the sub-types produced by a type.
 ///
 /// It's like a _power set_ of the type.


### PR DESCRIPTION
# Description

## Problem\*

Resolves us having to deal with https://github.com/noir-lang/noir/issues/8451 and constantly being pinged from smoke tests failing in aztec-packages such as http://ci.aztec-labs.com/3ecfe93088757b18

## Summary\*

0 length arrays and strings produce no witnesses, but the code generated for them currently differs when they are in the databus vs when they are accessed as normal variables. When they are accessed as both, we run into problems. 

Since they are not expected in real programs, we can save ourselves jumping through hoops if we disallow them altogether. Expecting that to happen, this PR changes the AST fuzzer to stop using these types in the input and output of `main`. 

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
