### PR TITLE
fix: warn if no double colon on generic type in type path

### DIFF
--- a/compiler/noirc_frontend/src/ast/mod.rs
+++ b/compiler/noirc_frontend/src/ast/mod.rs
@@ -297,7 +297,7 @@ impl std::fmt::Display for UnresolvedTypeData {
             Expression(expression) => expression.fmt(f),
             Bool => write!(f, "bool"),
             String(len) => write!(f, "str<{len}>"),
-            FormatString(len, elements) => write!(f, "fmt<{len}, {elements}"),
+            FormatString(len, elements) => write!(f, "fmtstr<{len}, {elements}>"),
             Function(args, ret, env, unconstrained) => {
                 if *unconstrained {
                     write!(f, "unconstrained ")?;

--- a/compiler/noirc_frontend/src/parser/errors.rs
+++ b/compiler/noirc_frontend/src/parser/errors.rs
@@ -127,6 +127,8 @@ pub enum ParserErrorReason {
     LogicalAnd,
     #[error("Trait bounds are not allowed here")]
     TraitBoundsNotAllowedHere,
+    #[error("Missing double colon before generic arguments")]
+    MissingDoubleColon,
 }
 
 /// Represents a parsing error, or a parsing error in the making.
@@ -324,6 +326,10 @@ impl<'a> From<&'a ParserError> for Diagnostic {
                 ParserErrorReason::MissingAngleBrackets => {
                     let secondary = "Types that don't start with an identifier need to be surrounded with angle brackets: `<`, `>`".to_string();
                     Diagnostic::simple_error(format!("{reason}"), secondary, error.location())
+                }
+                ParserErrorReason::MissingDoubleColon => {
+                    let secondary = String::new();
+                    Diagnostic::simple_warning(format!("{reason}"), secondary, error.location())
                 }
                 ParserErrorReason::LogicalAnd => {
                     let primary = "Noir has no logical-and (&&) operator since short-circuiting is much less efficient when compiling to circuits".to_string();

--- a/tooling/nargo_fmt/src/formatter/expression.rs
+++ b/tooling/nargo_fmt/src/formatter/expression.rs
@@ -399,7 +399,37 @@ impl ChunkFormatter<'_, '_> {
                 formatter.write_token(Token::Less);
             }
 
-            formatter.format_type(type_path.typ);
+            // Special handling so that `str<N>::foo` is formatted as `str::<N>::foo` (and similarly for `fmtstr`)
+            match type_path.typ.typ {
+                UnresolvedTypeData::String(length) => {
+                    formatter.write_keyword(Keyword::String);
+                    formatter.skip_comments_and_whitespace();
+                    if formatter.is_at(Token::DoubleColon) {
+                        formatter.write_token(Token::DoubleColon);
+                    } else {
+                        formatter.write("::");
+                    }
+                    formatter.write_token(Token::Less);
+                    formatter.format_type_expression(length);
+                    formatter.write_token(Token::Greater);
+                }
+                UnresolvedTypeData::FormatString(length, element) => {
+                    formatter.write_keyword(Keyword::FormatString);
+                    formatter.skip_comments_and_whitespace();
+                    if formatter.is_at(Token::DoubleColon) {
+                        formatter.write_token(Token::DoubleColon);
+                    } else {
+                        formatter.write("::");
+                    }
+                    formatter.write_token(Token::Less);
+                    formatter.format_type_expression(length);
+                    formatter.write_token(Token::Comma);
+                    formatter.write_space();
+                    formatter.format_type(*element);
+                    formatter.write_token(Token::Greater);
+                }
+                _ => formatter.format_type(type_path.typ),
+            }
 
             if nameless {
                 formatter.write_token(Token::Greater);
@@ -2141,6 +2171,34 @@ global y = 1;
     fn format_type_path_with_array_type() {
         let src = "global x = < [ i32 ; 3 ] > :: max  ;";
         let expected = "global x = <[i32; 3]>::max;\n";
+        assert_format(src, expected);
+    }
+
+    #[test]
+    fn format_type_path_for_str_with_colons() {
+        let src = "global x = str :: < N > :: max  ;";
+        let expected = "global x = str::<N>::max;\n";
+        assert_format(src, expected);
+    }
+
+    #[test]
+    fn format_type_path_for_str_missing_colons() {
+        let src = "global x = str < N > :: max  ;";
+        let expected = "global x = str::<N>::max;\n";
+        assert_format(src, expected);
+    }
+
+    #[test]
+    fn format_type_path_for_fmtstr_with_colons() {
+        let src = "global x = fmtstr :: < A , B > :: max  ;";
+        let expected = "global x = fmtstr::<A, B>::max;\n";
+        assert_format(src, expected);
+    }
+
+    #[test]
+    fn format_type_path_for_fmtstr_missing_colons() {
+        let src = "global x = fmtstr < A , B > :: max  ;";
+        let expected = "global x = fmtstr::<A, B>::max;\n";
         assert_format(src, expected);
     }
 


### PR DESCRIPTION
# Description

## Problem

Related to #8470

## Summary

This is valid Noir code:

```noir
fn foo<let N: u32>(fields: [Field; N]) -> str<N> {
    str<N>::from(fields.map(|value| value as u8))
}
```

However, the syntax `str<N>` is inconsistent with the rest of the language. For example for a `Vec` you'd write `Vec::<N>::from(...)`, that is, with colons between `Vec` and `<`.

This PR will now parse:
- `str::<N>::from` as correct syntax (same with `fmtstr`)
- warn if there's no `::` between `str` and `<` (only in a TypePath)
- have the formatter fix the incorrect syntax to the new syntax, so the upgrade path is easy (just run `nargo fmt` on your project)

After this is merged we can fix the syntax in Aztec-Packages, then https://github.com/noir-lang/noir/pull/8470 wouldn't produce errors in Aztec-Packages anymore.

## Additional Context



## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
