### PR TITLE
chore(test): Replicate comptime stack overflow in a test

### DIFF
--- a/tooling/ast_fuzzer/src/compare/comptime.rs
+++ b/tooling/ast_fuzzer/src/compare/comptime.rs
@@ -129,3 +129,73 @@ impl HasPrograms for CompareComptime {
         vec![&self.program]
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::prepare_and_compile_snippet;
+
+    #[test]
+    fn test_prepare_and_compile_snippet() {
+        let src = r#"
+fn main() -> pub ((str<2>, str<2>, bool, str<2>), bool, [str<2>; 3]) {
+    comptime {
+        let mut ctx_limit = 25;
+        unsafe { func_1_proxy(ctx_limit) }
+    }
+}
+unconstrained fn func_1(ctx_limit: &mut u32) -> ((str<2>, str<2>, bool, str<2>), bool, [str<2>; 3]) {
+    if ((*ctx_limit) == 0) {
+        (("BD", "GT", false, "EV"), false, ["LJ", "BB", "CE"])
+    } else {
+        *ctx_limit = ((*ctx_limit) - 1);
+        let g = if true {
+            let f = {
+                {
+                    let mut idx_a = 0;
+                    loop {
+                        if (idx_a == 4) {
+                            break
+                        } else {
+                            idx_a = (idx_a + 1);
+                            let mut e = if true {
+                                if func_1(ctx_limit).0.2 {
+                                    {
+                                        let b = 38;
+                                        {
+                                            let mut c = false;
+                                            let d = if c {
+                                                c = false;
+                                                [("ZO", "AF", false, "NY"), ("HJ", "NF", c, "RV"), ("SN", "VK", true, "QJ")]
+                                            } else {
+                                                [("SN", "YR", (b != (27 >> b)), "LS"), ("SW", "ZQ", false, "TQ"), ("AD", "YD", c, "EF")]
+                                            };
+                                            (d[1].3, d[1].1, (!c), "LO")
+                                        }
+                                    }
+                                } else {
+                                    ("HF", "WQ", true, "FZ")
+                                }
+                            } else {
+                                ("YP", "CH", true, "ZG")
+                            };
+                            e = (e.1, "NU", e.2, e.0);
+                        }
+                    }
+                };
+                true
+            };
+            (("HW", "EI", true, "IY"), (!false), ["TO", "WI", "PC"])
+        } else {
+            (("OX", "CE", true, "OV"), false, ["OS", "DT", "CH"])
+        };
+        g
+    }
+}
+unconstrained fn func_1_proxy(mut ctx_limit: u32) -> ((str<2>, str<2>, bool, str<2>), bool, [str<2>; 3]) {
+    func_1((&mut ctx_limit))
+}
+        "#;
+
+        let _ = prepare_and_compile_snippet(src.to_string(), false);
+    }
+}


### PR DESCRIPTION
# Description

## Problem\*

Resolves an issue frequently mentioned by @rkarabut, that the comptime vs brillig fuzzer gets stack overflow.

## Summary\*

I ran the following test after adding a few prints to check how far it gets before it gets a stack overflow, and printed the source that caused it. 
```shell
cargo test -p noir_ast_fuzzer_fuzz comptime_vs_brillig -- --nocapture
```

We get this:
```
thread 'targets::comptime_vs_brillig::tests::fuzz_with_arbtest' has overflowed its stack
fatal runtime error: stack overflow
```

It turned out it was during the call to `prepare_and_compile_snippet`. I added a unit test with one of the offending examples. 

I cannot replicate this stack overflow with `nargo`.

## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
