### PR TITLE
fix: Typo in filtering of types that can be used in `main`

### DIFF
--- a/tooling/ast_fuzzer/src/program/mod.rs
+++ b/tooling/ast_fuzzer/src/program/mod.rs
@@ -345,7 +345,7 @@ impl Context {
                 .types
                 .iter()
                 .filter(|typ| !is_global || types::can_be_global(typ))
-                .filter(|typ| !is_main || !types::can_be_main(typ))
+                .filter(|typ| !is_main || types::can_be_main(typ))
                 .filter(|typ| types::type_depth(typ) <= max_depth)
                 .filter(|typ| !is_frontend_friendly || !self.should_avoid_literals(typ))
                 .collect::<Vec<_>>();


### PR DESCRIPTION
# Description

## Problem\*

Resolves a typo in filtering logic

## Summary\*

Fixes `!is_main || !types::can_be_main(typ)` to be `!is_main || types::can_be_main(typ)`. 

## Additional Context

The impact isn't huge, because it only filters the use of types that exist at the time already, which, when we pick parameters for `main`, is only the globals. In other words, we did not exclusively use anathema types for `main`. 

(I think I originally wanted to write `!is_main || !types::is_zero_length(typ)` before I changed my mind to match `can_be_global`, but didn't notice the `!` I already laid down 🤦 )

## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
