### PR TITLE
chore(test): Add more tests for the removal of unused functions

### DIFF
--- a/test_programs/execution_success/function_ref/Nargo.toml
+++ b/test_programs/execution_success/function_ref/Nargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "function_ref"
+type = "bin"
+authors = [""]
+
+[dependencies]

--- a/test_programs/execution_success/function_ref/Prover.toml
+++ b/test_programs/execution_success/function_ref/Prover.toml
@@ -1,0 +1,2 @@
+c = true
+return = "bar"

--- a/test_programs/execution_success/function_ref/src/main.nr
+++ b/test_programs/execution_success/function_ref/src/main.nr
@@ -1,0 +1,15 @@
+fn main(c: bool) -> pub str<3> {
+    let mut f = foo;
+    if c {
+        f = bar;
+    }
+    f()
+}
+
+fn foo() -> str<3> {
+    "foo"
+}
+
+fn bar() -> str<3> {
+    "bar"
+}

--- a/test_programs/execution_success/function_ref/stdout.txt
+++ b/test_programs/execution_success/function_ref/stdout.txt
@@ -1,0 +1,1 @@
+[function_ref] Circuit output: String("bar")

--- a/tooling/nargo_cli/tests/snapshots/execution_success/function_ref/execute__tests__force_brillig_false_inliner_-9223372036854775808.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/function_ref/execute__tests__force_brillig_false_inliner_-9223372036854775808.snap
@@ -1,0 +1,57 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: artifact
+---
+{
+  "noir_version": "[noir_version]",
+  "hash": "[hash]",
+  "abi": {
+    "parameters": [
+      {
+        "name": "c",
+        "type": {
+          "kind": "boolean"
+        },
+        "visibility": "private"
+      }
+    ],
+    "return_type": {
+      "abi_type": {
+        "kind": "string",
+        "length": 3
+      },
+      "visibility": "public"
+    },
+    "error_types": {}
+  },
+  "bytecode": [
+    "func 0",
+    "current witness index : _5",
+    "private parameters indices : [_0]",
+    "public parameters indices : []",
+    "return value indices : [_1, _2, _3]",
+    "BLACKBOX::RANGE [(_0, 1)] []",
+    "BRILLIG CALL func 0: inputs: [Single(Expression { mul_terms: [], linear_combinations: [(1, Witness(0))], q_c: 0 })], outputs: [Simple(Witness(4))]",
+    "EXPR [ (1, _0, _4) (1, _5) -1 ]",
+    "EXPR [ (1, _0, _5) 0 ]",
+    "EXPR [ (-1, _0, _5) (1, _0) (1, _5) -1 ]",
+    "EXPR [ (1, _1) (-4, _5) -98 ]",
+    "EXPR [ (1, _2) (-14, _5) -97 ]",
+    "EXPR [ (1, _3) (3, _5) -114 ]",
+    "unconstrained func 0",
+    "[Const { destination: Direct(21), bit_size: Integer(U32), value: 1 }, Const { destination: Direct(20), bit_size: Integer(U32), value: 0 }, CalldataCopy { destination_address: Direct(0), size_address: Direct(21), offset_address: Direct(20) }, Const { destination: Direct(2), bit_size: Field, value: 0 }, BinaryFieldOp { destination: Direct(3), op: Equals, lhs: Direct(0), rhs: Direct(2) }, JumpIf { condition: Direct(3), location: 8 }, Const { destination: Direct(1), bit_size: Field, value: 1 }, BinaryFieldOp { destination: Direct(0), op: Div, lhs: Direct(1), rhs: Direct(0) }, Stop { return_data: HeapVector { pointer: Direct(20), size: Direct(21) } }]"
+  ],
+  "debug_symbols": "dZDBDoMgDIbfpWcO6uZBX2VZDGI1JA2QCksW47uvEt3cwctf2p+vpSwwYJ+mzrrRz9A+FujZEtmpI290tN5JdVkVHGkXGVFKcPKFCprRRWhdIlLw0pTypTlol2PULG6hAN0gURqOlnA7repHF9doU+1sU3/hWuinZNpY/nsvlNCWCqqst6x30XVrz1b3hPtWY3LmtGR8h8M5viGwNzgkxm1A9mTkBw==",
+  "file_map": {
+    "50": {
+      "source": "fn main(c: bool) -> pub str<3> {\n    let mut f = foo;\n    if c {\n        f = bar;\n    }\n    f()\n}\n\nfn foo() -> str<3> {\n    \"foo\"\n}\n\nfn bar() -> str<3> {\n    \"bar\"\n}\n",
+      "path": ""
+    }
+  },
+  "names": [
+    "main"
+  ],
+  "brillig_names": [
+    "directive_invert"
+  ]
+}

--- a/tooling/nargo_cli/tests/snapshots/execution_success/function_ref/execute__tests__force_brillig_false_inliner_0.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/function_ref/execute__tests__force_brillig_false_inliner_0.snap
@@ -1,0 +1,57 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: artifact
+---
+{
+  "noir_version": "[noir_version]",
+  "hash": "[hash]",
+  "abi": {
+    "parameters": [
+      {
+        "name": "c",
+        "type": {
+          "kind": "boolean"
+        },
+        "visibility": "private"
+      }
+    ],
+    "return_type": {
+      "abi_type": {
+        "kind": "string",
+        "length": 3
+      },
+      "visibility": "public"
+    },
+    "error_types": {}
+  },
+  "bytecode": [
+    "func 0",
+    "current witness index : _5",
+    "private parameters indices : [_0]",
+    "public parameters indices : []",
+    "return value indices : [_1, _2, _3]",
+    "BLACKBOX::RANGE [(_0, 1)] []",
+    "BRILLIG CALL func 0: inputs: [Single(Expression { mul_terms: [], linear_combinations: [(1, Witness(0))], q_c: 0 })], outputs: [Simple(Witness(4))]",
+    "EXPR [ (1, _0, _4) (1, _5) -1 ]",
+    "EXPR [ (1, _0, _5) 0 ]",
+    "EXPR [ (-1, _0, _5) (1, _0) (1, _5) -1 ]",
+    "EXPR [ (1, _1) (-4, _5) -98 ]",
+    "EXPR [ (1, _2) (-14, _5) -97 ]",
+    "EXPR [ (1, _3) (3, _5) -114 ]",
+    "unconstrained func 0",
+    "[Const { destination: Direct(21), bit_size: Integer(U32), value: 1 }, Const { destination: Direct(20), bit_size: Integer(U32), value: 0 }, CalldataCopy { destination_address: Direct(0), size_address: Direct(21), offset_address: Direct(20) }, Const { destination: Direct(2), bit_size: Field, value: 0 }, BinaryFieldOp { destination: Direct(3), op: Equals, lhs: Direct(0), rhs: Direct(2) }, JumpIf { condition: Direct(3), location: 8 }, Const { destination: Direct(1), bit_size: Field, value: 1 }, BinaryFieldOp { destination: Direct(0), op: Div, lhs: Direct(1), rhs: Direct(0) }, Stop { return_data: HeapVector { pointer: Direct(20), size: Direct(21) } }]"
+  ],
+  "debug_symbols": "dZDBDoMgDIbfpWcO6uZBX2VZDGI1JA2QCksW47uvEt3cwctf2p+vpSwwYJ+mzrrRz9A+FujZEtmpI290tN5JdVkVHGkXGVFKcPKFCprRRWhdIlLw0pTypTlol2PULG6hAN0gURqOlnA7repHF9doU+1sU3/hWuinZNpY/nsvlNCWCqqst6x30XVrz1b3hPtWY3LmtGR8h8M5viGwNzgkxm1A9mTkBw==",
+  "file_map": {
+    "50": {
+      "source": "fn main(c: bool) -> pub str<3> {\n    let mut f = foo;\n    if c {\n        f = bar;\n    }\n    f()\n}\n\nfn foo() -> str<3> {\n    \"foo\"\n}\n\nfn bar() -> str<3> {\n    \"bar\"\n}\n",
+      "path": ""
+    }
+  },
+  "names": [
+    "main"
+  ],
+  "brillig_names": [
+    "directive_invert"
+  ]
+}

--- a/tooling/nargo_cli/tests/snapshots/execution_success/function_ref/execute__tests__force_brillig_false_inliner_9223372036854775807.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/function_ref/execute__tests__force_brillig_false_inliner_9223372036854775807.snap
@@ -1,0 +1,57 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: artifact
+---
+{
+  "noir_version": "[noir_version]",
+  "hash": "[hash]",
+  "abi": {
+    "parameters": [
+      {
+        "name": "c",
+        "type": {
+          "kind": "boolean"
+        },
+        "visibility": "private"
+      }
+    ],
+    "return_type": {
+      "abi_type": {
+        "kind": "string",
+        "length": 3
+      },
+      "visibility": "public"
+    },
+    "error_types": {}
+  },
+  "bytecode": [
+    "func 0",
+    "current witness index : _5",
+    "private parameters indices : [_0]",
+    "public parameters indices : []",
+    "return value indices : [_1, _2, _3]",
+    "BLACKBOX::RANGE [(_0, 1)] []",
+    "BRILLIG CALL func 0: inputs: [Single(Expression { mul_terms: [], linear_combinations: [(1, Witness(0))], q_c: 0 })], outputs: [Simple(Witness(4))]",
+    "EXPR [ (1, _0, _4) (1, _5) -1 ]",
+    "EXPR [ (1, _0, _5) 0 ]",
+    "EXPR [ (-1, _0, _5) (1, _0) (1, _5) -1 ]",
+    "EXPR [ (1, _1) (-4, _5) -98 ]",
+    "EXPR [ (1, _2) (-14, _5) -97 ]",
+    "EXPR [ (1, _3) (3, _5) -114 ]",
+    "unconstrained func 0",
+    "[Const { destination: Direct(21), bit_size: Integer(U32), value: 1 }, Const { destination: Direct(20), bit_size: Integer(U32), value: 0 }, CalldataCopy { destination_address: Direct(0), size_address: Direct(21), offset_address: Direct(20) }, Const { destination: Direct(2), bit_size: Field, value: 0 }, BinaryFieldOp { destination: Direct(3), op: Equals, lhs: Direct(0), rhs: Direct(2) }, JumpIf { condition: Direct(3), location: 8 }, Const { destination: Direct(1), bit_size: Field, value: 1 }, BinaryFieldOp { destination: Direct(0), op: Div, lhs: Direct(1), rhs: Direct(0) }, Stop { return_data: HeapVector { pointer: Direct(20), size: Direct(21) } }]"
+  ],
+  "debug_symbols": "dZDBDoMgDIbfpWcO6uZBX2VZDGI1JA2QCksW47uvEt3cwctf2p+vpSwwYJ+mzrrRz9A+FujZEtmpI290tN5JdVkVHGkXGVFKcPKFCprRRWhdIlLw0pTypTlol2PULG6hAN0gURqOlnA7repHF9doU+1sU3/hWuinZNpY/nsvlNCWCqqst6x30XVrz1b3hPtWY3LmtGR8h8M5viGwNzgkxm1A9mTkBw==",
+  "file_map": {
+    "50": {
+      "source": "fn main(c: bool) -> pub str<3> {\n    let mut f = foo;\n    if c {\n        f = bar;\n    }\n    f()\n}\n\nfn foo() -> str<3> {\n    \"foo\"\n}\n\nfn bar() -> str<3> {\n    \"bar\"\n}\n",
+      "path": ""
+    }
+  },
+  "names": [
+    "main"
+  ],
+  "brillig_names": [
+    "directive_invert"
+  ]
+}

--- a/tooling/nargo_cli/tests/snapshots/execution_success/function_ref/execute__tests__force_brillig_true_inliner_-9223372036854775808.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/function_ref/execute__tests__force_brillig_true_inliner_-9223372036854775808.snap
@@ -1,0 +1,55 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: artifact
+---
+{
+  "noir_version": "[noir_version]",
+  "hash": "[hash]",
+  "abi": {
+    "parameters": [
+      {
+        "name": "c",
+        "type": {
+          "kind": "boolean"
+        },
+        "visibility": "private"
+      }
+    ],
+    "return_type": {
+      "abi_type": {
+        "kind": "string",
+        "length": 3
+      },
+      "visibility": "public"
+    },
+    "error_types": {
+      "17843811134343075018": {
+        "error_kind": "string",
+        "string": "Stack too deep"
+      }
+    }
+  },
+  "bytecode": [
+    "func 0",
+    "current witness index : _3",
+    "private parameters indices : [_0]",
+    "public parameters indices : []",
+    "return value indices : [_1, _2, _3]",
+    "BRILLIG CALL func 0: inputs: [Single(Expression { mul_terms: [], linear_combinations: [(1, Witness(0))], q_c: 0 })], outputs: [Array([Witness(1), Witness(2), Witness(3)])]",
+    "unconstrained func 0",
+    "[Const { destination: Direct(2), bit_size: Integer(U32), value: 1 }, Const { destination: Direct(1), bit_size: Integer(U32), value: 32840 }, Const { destination: Direct(0), bit_size: Integer(U32), value: 3 }, Const { destination: Relative(2), bit_size: Integer(U32), value: 1 }, Const { destination: Relative(3), bit_size: Integer(U32), value: 0 }, CalldataCopy { destination_address: Direct(32836), size_address: Relative(2), offset_address: Relative(3) }, Cast { destination: Direct(32836), source: Direct(32836), bit_size: Integer(U1) }, Mov { destination: Relative(1), source: Direct(32836) }, Call { location: 20 }, Call { location: 21 }, BinaryIntOp { destination: Relative(2), op: Add, bit_size: U32, lhs: Relative(1), rhs: Direct(2) }, Const { destination: Relative(3), bit_size: Integer(U32), value: 32837 }, Const { destination: Relative(4), bit_size: Integer(U32), value: 3 }, Mov { destination: Direct(32771), source: Relative(2) }, Mov { destination: Direct(32772), source: Relative(3) }, Mov { destination: Direct(32773), source: Relative(4) }, Call { location: 71 }, Const { destination: Relative(2), bit_size: Integer(U32), value: 32837 }, Const { destination: Relative(3), bit_size: Integer(U32), value: 3 }, Stop { return_data: HeapVector { pointer: Relative(2), size: Relative(3) } }, Return, Call { location: 82 }, Mov { destination: Relative(2), source: Direct(1) }, BinaryIntOp { destination: Direct(1), op: Add, bit_size: U32, lhs: Direct(1), rhs: Direct(2) }, Const { destination: Relative(3), bit_size: Field, value: 1 }, Store { destination_pointer: Relative(2), source: Relative(3) }, Const { destination: Relative(4), bit_size: Field, value: 2 }, JumpIf { condition: Relative(1), location: 29 }, Jump { location: 31 }, Store { destination_pointer: Relative(2), source: Relative(4) }, Jump { location: 31 }, Load { destination: Relative(5), source_pointer: Relative(2) }, BinaryFieldOp { destination: Relative(2), op: Equals, lhs: Relative(5), rhs: Relative(3) }, JumpIf { condition: Relative(2), location: 55 }, Jump { location: 35 }, BinaryFieldOp { destination: Relative(2), op: Equals, lhs: Relative(5), rhs: Relative(4) }, JumpIf { condition: Relative(2), location: 39 }, Const { destination: Relative(3), bit_size: Integer(U32), value: 0 }, Trap { revert_data: HeapVector { pointer: Direct(1), size: Relative(3) } }, Const { destination: Relative(2), bit_size: Integer(U8), value: 98 }, Const { destination: Relative(3), bit_size: Integer(U8), value: 97 }, Const { destination: Relative(4), bit_size: Integer(U8), value: 114 }, Mov { destination: Relative(5), source: Direct(1) }, Const { destination: Relative(6), bit_size: Integer(U32), value: 4 }, BinaryIntOp { destination: Direct(1), op: Add, bit_size: U32, lhs: Direct(1), rhs: Relative(6) }, IndirectConst { destination_pointer: Relative(5), bit_size: Integer(U32), value: 1 }, BinaryIntOp { destination: Relative(6), op: Add, bit_size: U32, lhs: Relative(5), rhs: Direct(2) }, Mov { destination: Relative(7), source: Relative(6) }, Store { destination_pointer: Relative(7), source: Relative(2) }, BinaryIntOp { destination: Relative(7), op: Add, bit_size: U32, lhs: Relative(7), rhs: Direct(2) }, Store { destination_pointer: Relative(7), source: Relative(3) }, BinaryIntOp { destination: Relative(7), op: Add, bit_size: U32, lhs: Relative(7), rhs: Direct(2) }, Store { destination_pointer: Relative(7), source: Relative(4) }, Mov { destination: Relative(1), source: Relative(5) }, Jump { location: 70 }, Const { destination: Relative(2), bit_size: Integer(U8), value: 102 }, Const { destination: Relative(3), bit_size: Integer(U8), value: 111 }, Mov { destination: Relative(4), source: Direct(1) }, Const { destination: Relative(5), bit_size: Integer(U32), value: 4 }, BinaryIntOp { destination: Direct(1), op: Add, bit_size: U32, lhs: Direct(1), rhs: Relative(5) }, IndirectConst { destination_pointer: Relative(4), bit_size: Integer(U32), value: 1 }, BinaryIntOp { destination: Relative(5), op: Add, bit_size: U32, lhs: Relative(4), rhs: Direct(2) }, Mov { destination: Relative(6), source: Relative(5) }, Store { destination_pointer: Relative(6), source: Relative(2) }, BinaryIntOp { destination: Relative(6), op: Add, bit_size: U32, lhs: Relative(6), rhs: Direct(2) }, Store { destination_pointer: Relative(6), source: Relative(3) }, BinaryIntOp { destination: Relative(6), op: Add, bit_size: U32, lhs: Relative(6), rhs: Direct(2) }, Store { destination_pointer: Relative(6), source: Relative(3) }, Mov { destination: Relative(1), source: Relative(4) }, Jump { location: 70 }, Return, BinaryIntOp { destination: Direct(32775), op: Add, bit_size: U32, lhs: Direct(32771), rhs: Direct(32773) }, Mov { destination: Direct(32776), source: Direct(32771) }, Mov { destination: Direct(32777), source: Direct(32772) }, BinaryIntOp { destination: Direct(32778), op: Equals, bit_size: U32, lhs: Direct(32776), rhs: Direct(32775) }, JumpIf { condition: Direct(32778), location: 81 }, Load { destination: Direct(32774), source_pointer: Direct(32776) }, Store { destination_pointer: Direct(32777), source: Direct(32774) }, BinaryIntOp { destination: Direct(32776), op: Add, bit_size: U32, lhs: Direct(32776), rhs: Direct(2) }, BinaryIntOp { destination: Direct(32777), op: Add, bit_size: U32, lhs: Direct(32777), rhs: Direct(2) }, Jump { location: 74 }, Return, Const { destination: Direct(32772), bit_size: Integer(U32), value: 30720 }, BinaryIntOp { destination: Direct(32771), op: LessThan, bit_size: U32, lhs: Direct(0), rhs: Direct(32772) }, JumpIf { condition: Direct(32771), location: 87 }, IndirectConst { destination_pointer: Direct(1), bit_size: Integer(U64), value: 17843811134343075018 }, Trap { revert_data: HeapVector { pointer: Direct(1), size: Direct(2) } }, Return]"
+  ],
+  "debug_symbols": "lZLNjoMgFIXf5a5ZiO3Fn1dpjEHFhoSgoTrJxPjuAz11xi5m0Y2fcP3ODVc2Gky33lvrx+lB9W2jLljn7L11U68XO/m4u1GWHpecainowoACCqAEKqpzQdcMkEAOXIArwIACCqAEkMJIYaQwUhgew2N4DI/hKXgKnoKn0F2hu0KKQopKKfsu6DhzuwRj0pFPQ4ijmXUwfqHar84J+tJufX70mLV/ctEhVjNBxg+RMXC0zqS3XfzZ2f9qlb/cin9lfrfl53YTV7q34e2X7iknWN0581qOq+9P1eV7PirHlZjD1JthDSYlne5FHE4hRSkbQTLu3MpclEWzp84/",
+  "file_map": {
+    "50": {
+      "source": "fn main(c: bool) -> pub str<3> {\n    let mut f = foo;\n    if c {\n        f = bar;\n    }\n    f()\n}\n\nfn foo() -> str<3> {\n    \"foo\"\n}\n\nfn bar() -> str<3> {\n    \"bar\"\n}\n",
+      "path": ""
+    }
+  },
+  "names": [
+    "main"
+  ],
+  "brillig_names": [
+    "main"
+  ]
+}

--- a/tooling/nargo_cli/tests/snapshots/execution_success/function_ref/execute__tests__force_brillig_true_inliner_0.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/function_ref/execute__tests__force_brillig_true_inliner_0.snap
@@ -1,0 +1,55 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: artifact
+---
+{
+  "noir_version": "[noir_version]",
+  "hash": "[hash]",
+  "abi": {
+    "parameters": [
+      {
+        "name": "c",
+        "type": {
+          "kind": "boolean"
+        },
+        "visibility": "private"
+      }
+    ],
+    "return_type": {
+      "abi_type": {
+        "kind": "string",
+        "length": 3
+      },
+      "visibility": "public"
+    },
+    "error_types": {
+      "17843811134343075018": {
+        "error_kind": "string",
+        "string": "Stack too deep"
+      }
+    }
+  },
+  "bytecode": [
+    "func 0",
+    "current witness index : _3",
+    "private parameters indices : [_0]",
+    "public parameters indices : []",
+    "return value indices : [_1, _2, _3]",
+    "BRILLIG CALL func 0: inputs: [Single(Expression { mul_terms: [], linear_combinations: [(1, Witness(0))], q_c: 0 })], outputs: [Array([Witness(1), Witness(2), Witness(3)])]",
+    "unconstrained func 0",
+    "[Const { destination: Direct(2), bit_size: Integer(U32), value: 1 }, Const { destination: Direct(1), bit_size: Integer(U32), value: 32840 }, Const { destination: Direct(0), bit_size: Integer(U32), value: 3 }, Const { destination: Relative(2), bit_size: Integer(U32), value: 1 }, Const { destination: Relative(3), bit_size: Integer(U32), value: 0 }, CalldataCopy { destination_address: Direct(32836), size_address: Relative(2), offset_address: Relative(3) }, Cast { destination: Direct(32836), source: Direct(32836), bit_size: Integer(U1) }, Mov { destination: Relative(1), source: Direct(32836) }, Call { location: 20 }, Call { location: 21 }, BinaryIntOp { destination: Relative(2), op: Add, bit_size: U32, lhs: Relative(1), rhs: Direct(2) }, Const { destination: Relative(3), bit_size: Integer(U32), value: 32837 }, Const { destination: Relative(4), bit_size: Integer(U32), value: 3 }, Mov { destination: Direct(32771), source: Relative(2) }, Mov { destination: Direct(32772), source: Relative(3) }, Mov { destination: Direct(32773), source: Relative(4) }, Call { location: 71 }, Const { destination: Relative(2), bit_size: Integer(U32), value: 32837 }, Const { destination: Relative(3), bit_size: Integer(U32), value: 3 }, Stop { return_data: HeapVector { pointer: Relative(2), size: Relative(3) } }, Return, Call { location: 82 }, Mov { destination: Relative(2), source: Direct(1) }, BinaryIntOp { destination: Direct(1), op: Add, bit_size: U32, lhs: Direct(1), rhs: Direct(2) }, Const { destination: Relative(3), bit_size: Field, value: 1 }, Store { destination_pointer: Relative(2), source: Relative(3) }, Const { destination: Relative(4), bit_size: Field, value: 2 }, JumpIf { condition: Relative(1), location: 29 }, Jump { location: 31 }, Store { destination_pointer: Relative(2), source: Relative(4) }, Jump { location: 31 }, Load { destination: Relative(5), source_pointer: Relative(2) }, BinaryFieldOp { destination: Relative(2), op: Equals, lhs: Relative(5), rhs: Relative(3) }, JumpIf { condition: Relative(2), location: 55 }, Jump { location: 35 }, BinaryFieldOp { destination: Relative(2), op: Equals, lhs: Relative(5), rhs: Relative(4) }, JumpIf { condition: Relative(2), location: 39 }, Const { destination: Relative(3), bit_size: Integer(U32), value: 0 }, Trap { revert_data: HeapVector { pointer: Direct(1), size: Relative(3) } }, Const { destination: Relative(2), bit_size: Integer(U8), value: 98 }, Const { destination: Relative(3), bit_size: Integer(U8), value: 97 }, Const { destination: Relative(4), bit_size: Integer(U8), value: 114 }, Mov { destination: Relative(5), source: Direct(1) }, Const { destination: Relative(6), bit_size: Integer(U32), value: 4 }, BinaryIntOp { destination: Direct(1), op: Add, bit_size: U32, lhs: Direct(1), rhs: Relative(6) }, IndirectConst { destination_pointer: Relative(5), bit_size: Integer(U32), value: 1 }, BinaryIntOp { destination: Relative(6), op: Add, bit_size: U32, lhs: Relative(5), rhs: Direct(2) }, Mov { destination: Relative(7), source: Relative(6) }, Store { destination_pointer: Relative(7), source: Relative(2) }, BinaryIntOp { destination: Relative(7), op: Add, bit_size: U32, lhs: Relative(7), rhs: Direct(2) }, Store { destination_pointer: Relative(7), source: Relative(3) }, BinaryIntOp { destination: Relative(7), op: Add, bit_size: U32, lhs: Relative(7), rhs: Direct(2) }, Store { destination_pointer: Relative(7), source: Relative(4) }, Mov { destination: Relative(1), source: Relative(5) }, Jump { location: 70 }, Const { destination: Relative(2), bit_size: Integer(U8), value: 102 }, Const { destination: Relative(3), bit_size: Integer(U8), value: 111 }, Mov { destination: Relative(4), source: Direct(1) }, Const { destination: Relative(5), bit_size: Integer(U32), value: 4 }, BinaryIntOp { destination: Direct(1), op: Add, bit_size: U32, lhs: Direct(1), rhs: Relative(5) }, IndirectConst { destination_pointer: Relative(4), bit_size: Integer(U32), value: 1 }, BinaryIntOp { destination: Relative(5), op: Add, bit_size: U32, lhs: Relative(4), rhs: Direct(2) }, Mov { destination: Relative(6), source: Relative(5) }, Store { destination_pointer: Relative(6), source: Relative(2) }, BinaryIntOp { destination: Relative(6), op: Add, bit_size: U32, lhs: Relative(6), rhs: Direct(2) }, Store { destination_pointer: Relative(6), source: Relative(3) }, BinaryIntOp { destination: Relative(6), op: Add, bit_size: U32, lhs: Relative(6), rhs: Direct(2) }, Store { destination_pointer: Relative(6), source: Relative(3) }, Mov { destination: Relative(1), source: Relative(4) }, Jump { location: 70 }, Return, BinaryIntOp { destination: Direct(32775), op: Add, bit_size: U32, lhs: Direct(32771), rhs: Direct(32773) }, Mov { destination: Direct(32776), source: Direct(32771) }, Mov { destination: Direct(32777), source: Direct(32772) }, BinaryIntOp { destination: Direct(32778), op: Equals, bit_size: U32, lhs: Direct(32776), rhs: Direct(32775) }, JumpIf { condition: Direct(32778), location: 81 }, Load { destination: Direct(32774), source_pointer: Direct(32776) }, Store { destination_pointer: Direct(32777), source: Direct(32774) }, BinaryIntOp { destination: Direct(32776), op: Add, bit_size: U32, lhs: Direct(32776), rhs: Direct(2) }, BinaryIntOp { destination: Direct(32777), op: Add, bit_size: U32, lhs: Direct(32777), rhs: Direct(2) }, Jump { location: 74 }, Return, Const { destination: Direct(32772), bit_size: Integer(U32), value: 30720 }, BinaryIntOp { destination: Direct(32771), op: LessThan, bit_size: U32, lhs: Direct(0), rhs: Direct(32772) }, JumpIf { condition: Direct(32771), location: 87 }, IndirectConst { destination_pointer: Direct(1), bit_size: Integer(U64), value: 17843811134343075018 }, Trap { revert_data: HeapVector { pointer: Direct(1), size: Direct(2) } }, Return]"
+  ],
+  "debug_symbols": "lZLNjoMgFIXf5a5ZiO3Fn1dpjEHFhoSgoTrJxPjuAz11xi5m0Y2fcP3ODVc2Gky33lvrx+lB9W2jLljn7L11U68XO/m4u1GWHpecainowoACCqAEKqpzQdcMkEAOXIArwIACCqAEkMJIYaQwUhgew2N4DI/hKXgKnoKn0F2hu0KKQopKKfsu6DhzuwRj0pFPQ4ijmXUwfqHar84J+tJufX70mLV/ctEhVjNBxg+RMXC0zqS3XfzZ2f9qlb/cin9lfrfl53YTV7q34e2X7iknWN0581qOq+9P1eV7PirHlZjD1JthDSYlne5FHE4hRSkbQTLu3MpclEWzp84/",
+  "file_map": {
+    "50": {
+      "source": "fn main(c: bool) -> pub str<3> {\n    let mut f = foo;\n    if c {\n        f = bar;\n    }\n    f()\n}\n\nfn foo() -> str<3> {\n    \"foo\"\n}\n\nfn bar() -> str<3> {\n    \"bar\"\n}\n",
+      "path": ""
+    }
+  },
+  "names": [
+    "main"
+  ],
+  "brillig_names": [
+    "main"
+  ]
+}

--- a/tooling/nargo_cli/tests/snapshots/execution_success/function_ref/execute__tests__force_brillig_true_inliner_9223372036854775807.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/function_ref/execute__tests__force_brillig_true_inliner_9223372036854775807.snap
@@ -1,0 +1,55 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: artifact
+---
+{
+  "noir_version": "[noir_version]",
+  "hash": "[hash]",
+  "abi": {
+    "parameters": [
+      {
+        "name": "c",
+        "type": {
+          "kind": "boolean"
+        },
+        "visibility": "private"
+      }
+    ],
+    "return_type": {
+      "abi_type": {
+        "kind": "string",
+        "length": 3
+      },
+      "visibility": "public"
+    },
+    "error_types": {
+      "17843811134343075018": {
+        "error_kind": "string",
+        "string": "Stack too deep"
+      }
+    }
+  },
+  "bytecode": [
+    "func 0",
+    "current witness index : _3",
+    "private parameters indices : [_0]",
+    "public parameters indices : []",
+    "return value indices : [_1, _2, _3]",
+    "BRILLIG CALL func 0: inputs: [Single(Expression { mul_terms: [], linear_combinations: [(1, Witness(0))], q_c: 0 })], outputs: [Array([Witness(1), Witness(2), Witness(3)])]",
+    "unconstrained func 0",
+    "[Const { destination: Direct(2), bit_size: Integer(U32), value: 1 }, Const { destination: Direct(1), bit_size: Integer(U32), value: 32840 }, Const { destination: Direct(0), bit_size: Integer(U32), value: 3 }, Const { destination: Relative(2), bit_size: Integer(U32), value: 1 }, Const { destination: Relative(3), bit_size: Integer(U32), value: 0 }, CalldataCopy { destination_address: Direct(32836), size_address: Relative(2), offset_address: Relative(3) }, Cast { destination: Direct(32836), source: Direct(32836), bit_size: Integer(U1) }, Mov { destination: Relative(1), source: Direct(32836) }, Call { location: 20 }, Call { location: 21 }, BinaryIntOp { destination: Relative(2), op: Add, bit_size: U32, lhs: Relative(1), rhs: Direct(2) }, Const { destination: Relative(3), bit_size: Integer(U32), value: 32837 }, Const { destination: Relative(4), bit_size: Integer(U32), value: 3 }, Mov { destination: Direct(32771), source: Relative(2) }, Mov { destination: Direct(32772), source: Relative(3) }, Mov { destination: Direct(32773), source: Relative(4) }, Call { location: 71 }, Const { destination: Relative(2), bit_size: Integer(U32), value: 32837 }, Const { destination: Relative(3), bit_size: Integer(U32), value: 3 }, Stop { return_data: HeapVector { pointer: Relative(2), size: Relative(3) } }, Return, Call { location: 82 }, Mov { destination: Relative(2), source: Direct(1) }, BinaryIntOp { destination: Direct(1), op: Add, bit_size: U32, lhs: Direct(1), rhs: Direct(2) }, Const { destination: Relative(3), bit_size: Field, value: 1 }, Store { destination_pointer: Relative(2), source: Relative(3) }, Const { destination: Relative(4), bit_size: Field, value: 2 }, JumpIf { condition: Relative(1), location: 29 }, Jump { location: 31 }, Store { destination_pointer: Relative(2), source: Relative(4) }, Jump { location: 31 }, Load { destination: Relative(5), source_pointer: Relative(2) }, BinaryFieldOp { destination: Relative(2), op: Equals, lhs: Relative(5), rhs: Relative(3) }, JumpIf { condition: Relative(2), location: 55 }, Jump { location: 35 }, BinaryFieldOp { destination: Relative(2), op: Equals, lhs: Relative(5), rhs: Relative(4) }, JumpIf { condition: Relative(2), location: 39 }, Const { destination: Relative(3), bit_size: Integer(U32), value: 0 }, Trap { revert_data: HeapVector { pointer: Direct(1), size: Relative(3) } }, Const { destination: Relative(2), bit_size: Integer(U8), value: 98 }, Const { destination: Relative(3), bit_size: Integer(U8), value: 97 }, Const { destination: Relative(4), bit_size: Integer(U8), value: 114 }, Mov { destination: Relative(5), source: Direct(1) }, Const { destination: Relative(6), bit_size: Integer(U32), value: 4 }, BinaryIntOp { destination: Direct(1), op: Add, bit_size: U32, lhs: Direct(1), rhs: Relative(6) }, IndirectConst { destination_pointer: Relative(5), bit_size: Integer(U32), value: 1 }, BinaryIntOp { destination: Relative(6), op: Add, bit_size: U32, lhs: Relative(5), rhs: Direct(2) }, Mov { destination: Relative(7), source: Relative(6) }, Store { destination_pointer: Relative(7), source: Relative(2) }, BinaryIntOp { destination: Relative(7), op: Add, bit_size: U32, lhs: Relative(7), rhs: Direct(2) }, Store { destination_pointer: Relative(7), source: Relative(3) }, BinaryIntOp { destination: Relative(7), op: Add, bit_size: U32, lhs: Relative(7), rhs: Direct(2) }, Store { destination_pointer: Relative(7), source: Relative(4) }, Mov { destination: Relative(1), source: Relative(5) }, Jump { location: 70 }, Const { destination: Relative(2), bit_size: Integer(U8), value: 102 }, Const { destination: Relative(3), bit_size: Integer(U8), value: 111 }, Mov { destination: Relative(4), source: Direct(1) }, Const { destination: Relative(5), bit_size: Integer(U32), value: 4 }, BinaryIntOp { destination: Direct(1), op: Add, bit_size: U32, lhs: Direct(1), rhs: Relative(5) }, IndirectConst { destination_pointer: Relative(4), bit_size: Integer(U32), value: 1 }, BinaryIntOp { destination: Relative(5), op: Add, bit_size: U32, lhs: Relative(4), rhs: Direct(2) }, Mov { destination: Relative(6), source: Relative(5) }, Store { destination_pointer: Relative(6), source: Relative(2) }, BinaryIntOp { destination: Relative(6), op: Add, bit_size: U32, lhs: Relative(6), rhs: Direct(2) }, Store { destination_pointer: Relative(6), source: Relative(3) }, BinaryIntOp { destination: Relative(6), op: Add, bit_size: U32, lhs: Relative(6), rhs: Direct(2) }, Store { destination_pointer: Relative(6), source: Relative(3) }, Mov { destination: Relative(1), source: Relative(4) }, Jump { location: 70 }, Return, BinaryIntOp { destination: Direct(32775), op: Add, bit_size: U32, lhs: Direct(32771), rhs: Direct(32773) }, Mov { destination: Direct(32776), source: Direct(32771) }, Mov { destination: Direct(32777), source: Direct(32772) }, BinaryIntOp { destination: Direct(32778), op: Equals, bit_size: U32, lhs: Direct(32776), rhs: Direct(32775) }, JumpIf { condition: Direct(32778), location: 81 }, Load { destination: Direct(32774), source_pointer: Direct(32776) }, Store { destination_pointer: Direct(32777), source: Direct(32774) }, BinaryIntOp { destination: Direct(32776), op: Add, bit_size: U32, lhs: Direct(32776), rhs: Direct(2) }, BinaryIntOp { destination: Direct(32777), op: Add, bit_size: U32, lhs: Direct(32777), rhs: Direct(2) }, Jump { location: 74 }, Return, Const { destination: Direct(32772), bit_size: Integer(U32), value: 30720 }, BinaryIntOp { destination: Direct(32771), op: LessThan, bit_size: U32, lhs: Direct(0), rhs: Direct(32772) }, JumpIf { condition: Direct(32771), location: 87 }, IndirectConst { destination_pointer: Direct(1), bit_size: Integer(U64), value: 17843811134343075018 }, Trap { revert_data: HeapVector { pointer: Direct(1), size: Direct(2) } }, Return]"
+  ],
+  "debug_symbols": "lZLNjoMgFIXf5a5ZiO3Fn1dpjEHFhoSgoTrJxPjuAz11xi5m0Y2fcP3ODVc2Gky33lvrx+lB9W2jLljn7L11U68XO/m4u1GWHpecainowoACCqAEKqpzQdcMkEAOXIArwIACCqAEkMJIYaQwUhgew2N4DI/hKXgKnoKn0F2hu0KKQopKKfsu6DhzuwRj0pFPQ4ijmXUwfqHar84J+tJufX70mLV/ctEhVjNBxg+RMXC0zqS3XfzZ2f9qlb/cin9lfrfl53YTV7q34e2X7iknWN0581qOq+9P1eV7PirHlZjD1JthDSYlne5FHE4hRSkbQTLu3MpclEWzp84/",
+  "file_map": {
+    "50": {
+      "source": "fn main(c: bool) -> pub str<3> {\n    let mut f = foo;\n    if c {\n        f = bar;\n    }\n    f()\n}\n\nfn foo() -> str<3> {\n    \"foo\"\n}\n\nfn bar() -> str<3> {\n    \"bar\"\n}\n",
+      "path": ""
+    }
+  },
+  "names": [
+    "main"
+  ],
+  "brillig_names": [
+    "main"
+  ]
+}

--- a/tooling/nargo_cli/tests/snapshots/expand/execution_success/function_ref/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/expand/execution_success/function_ref/execute__tests__expanded.snap
@@ -1,0 +1,17 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: expanded_code
+---
+fn main(c: bool) -> pub str<3> {
+    let mut f: fn() -> str<3> = foo;
+    if c { f = bar; };
+    f()
+}
+
+fn foo() -> str<3> {
+    "foo"
+}
+
+fn bar() -> str<3> {
+    "bar"
+}


### PR DESCRIPTION
# Description

## Problem\*

Part of https://github.com/noir-lang/noir/issues/8218

## Summary\*

Adds tests that would fail if the `remove_unreachable_functions` did not consider function references as reachable.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
