### PR TITLE
fix: parenthesized pattern, and correct 1-element tuple printing

### DIFF
--- a/compiler/noirc_frontend/src/ast/statement.rs
+++ b/compiler/noirc_frontend/src/ast/statement.rs
@@ -567,6 +567,7 @@ pub enum Pattern {
     Mutable(Box<Pattern>, Location, /*is_synthesized*/ bool),
     Tuple(Vec<Pattern>, Location),
     Struct(Path, Vec<(Ident, Pattern)>, Location),
+    Parenthesized(Box<Pattern>, Location),
     Interned(InternedPattern, Location),
 }
 
@@ -580,6 +581,7 @@ impl Pattern {
             Pattern::Mutable(_, location, _)
             | Pattern::Tuple(_, location)
             | Pattern::Struct(_, _, location)
+            | Pattern::Parenthesized(_, location)
             | Pattern::Interned(_, location) => *location,
         }
     }
@@ -624,6 +626,7 @@ impl Pattern {
                     location: *location,
                 })
             }
+            Pattern::Parenthesized(pattern, _) => pattern.try_as_expression(interner),
             Pattern::Interned(id, _) => interner.get_pattern(*id).try_as_expression(interner),
         }
     }
@@ -989,6 +992,9 @@ impl Display for Pattern {
             Pattern::Struct(typename, fields, _) => {
                 let fields = vecmap(fields, |(name, pattern)| format!("{name}: {pattern}"));
                 write!(f, "{} {{ {} }}", typename, fields.join(", "))
+            }
+            Pattern::Parenthesized(pattern, _) => {
+                write!(f, "({})", pattern)
             }
             Pattern::Interned(_, _) => {
                 write!(f, "?Interned")

--- a/compiler/noirc_frontend/src/ast/visitor.rs
+++ b/compiler/noirc_frontend/src/ast/visitor.rs
@@ -519,6 +519,10 @@ pub trait Visitor {
         true
     }
 
+    fn visit_parenthesized_pattern(&mut self, _: &Pattern, _: Span) -> bool {
+        true
+    }
+
     fn visit_interned_pattern(&mut self, _: &InternedPattern, _: Span) {}
 
     fn visit_secondary_attribute(
@@ -1622,6 +1626,11 @@ impl Pattern {
                     for (_, pattern) in fields {
                         pattern.accept(visitor);
                     }
+                }
+            }
+            Pattern::Parenthesized(pattern, location) => {
+                if visitor.visit_parenthesized_pattern(pattern, location.span) {
+                    pattern.accept(visitor);
                 }
             }
             Pattern::Interned(id, location) => {

--- a/compiler/noirc_frontend/src/debug/mod.rs
+++ b/compiler/noirc_frontend/src/debug/mod.rs
@@ -730,6 +730,9 @@ fn pattern_vars(pattern: &ast::Pattern) -> Vec<(ast::Ident, bool)> {
                 stack.extend(pids.iter().map(|(_, pattern)| (pattern, is_mut)));
                 vars.extend(pids.iter().map(|(id, _)| (id.clone(), false)));
             }
+            ast::Pattern::Parenthesized(pattern, _) => {
+                stack.push_back((pattern, false));
+            }
             ast::Pattern::Interned(_, _) => (),
         }
     }
@@ -756,6 +759,9 @@ fn pattern_to_string(pattern: &ast::Pattern) -> String {
                     .collect::<Vec<_>>()
                     .join(", "),
             )
+        }
+        ast::Pattern::Parenthesized(pattern, _) => {
+            format!("({})", pattern_to_string(pattern.as_ref()))
         }
         ast::Pattern::Interned(_, _) => "?Interned".to_string(),
     }

--- a/compiler/noirc_frontend/src/elaborator/patterns.rs
+++ b/compiler/noirc_frontend/src/elaborator/patterns.rs
@@ -170,6 +170,14 @@ impl Elaborator<'_> {
                     new_definitions,
                 )
             }
+            Pattern::Parenthesized(pattern, _) => self.elaborate_pattern_mut(
+                *pattern,
+                expected_type,
+                definition,
+                mutable,
+                new_definitions,
+                warn_if_unused,
+            ),
             Pattern::Interned(id, _) => {
                 let pattern = self.interner.get_pattern(id).clone();
                 self.elaborate_pattern_mut(

--- a/compiler/noirc_frontend/src/hir/comptime/display.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/display.rs
@@ -952,21 +952,25 @@ fn remove_interned_in_generic_type_args(
 fn remove_interned_in_pattern(interner: &NodeInterner, pattern: Pattern) -> Pattern {
     match pattern {
         Pattern::Identifier(_) => pattern,
-        Pattern::Mutable(pattern, span, is_synthesized) => Pattern::Mutable(
+        Pattern::Mutable(pattern, location, is_synthesized) => Pattern::Mutable(
             Box::new(remove_interned_in_pattern(interner, *pattern)),
-            span,
+            location,
             is_synthesized,
         ),
-        Pattern::Tuple(patterns, span) => Pattern::Tuple(
+        Pattern::Tuple(patterns, location) => Pattern::Tuple(
             vecmap(patterns, |pattern| remove_interned_in_pattern(interner, pattern)),
-            span,
+            location,
         ),
-        Pattern::Struct(path, patterns, span) => {
+        Pattern::Struct(path, patterns, location) => {
             let patterns = vecmap(patterns, |(name, pattern)| {
                 (name, remove_interned_in_pattern(interner, pattern))
             });
-            Pattern::Struct(path, patterns, span)
+            Pattern::Struct(path, patterns, location)
         }
+        Pattern::Parenthesized(pattern, location) => Pattern::Parenthesized(
+            Box::new(remove_interned_in_pattern(interner, *pattern)),
+            location,
+        ),
         Pattern::Interned(id, _) => interner.get_pattern(id).clone(),
     }
 }

--- a/compiler/noirc_frontend/src/hir/comptime/display.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/display.rs
@@ -385,7 +385,11 @@ impl Display for ValuePrinter<'_, '_> {
             Value::Closure(..) => write!(f, "(closure)"),
             Value::Tuple(fields) => {
                 let fields = vecmap(fields, |field| field.display(self.interner).to_string());
-                write!(f, "({})", fields.join(", "))
+                if fields.len() == 1 {
+                    write!(f, "({},)", fields[0])
+                } else {
+                    write!(f, "({})", fields.join(", "))
+                }
             }
             Value::Struct(fields, typ) => {
                 let typename = match typ.follow_bindings() {

--- a/compiler/noirc_frontend/src/hir_def/types.rs
+++ b/compiler/noirc_frontend/src/hir_def/types.rs
@@ -1021,7 +1021,11 @@ impl std::fmt::Display for Type {
             }
             Type::Tuple(elements) => {
                 let elements = vecmap(elements, ToString::to_string);
-                write!(f, "({})", elements.join(", "))
+                if elements.len() == 1 {
+                    write!(f, "({},)", elements[0])
+                } else {
+                    write!(f, "({})", elements.join(", "))
+                }
             }
             Type::Bool => write!(f, "bool"),
             Type::String(len) => write!(f, "str<{len}>"),

--- a/compiler/noirc_frontend/src/tests.rs
+++ b/compiler/noirc_frontend/src/tests.rs
@@ -3027,7 +3027,7 @@ fn do_not_infer_partial_global_types() {
         pub global FORMATTED_VALUE: str<5> = "there";
         pub global FMT_STR: fmtstr<_, _> = f"hi {FORMATTED_VALUE}";
                    ^^^^^^^ Globals must have a specified type
-                                           ~~~~~~~~~~~~~~~~~~~~~~~ Inferred type is `fmtstr<20, (str<5>)>`
+                                           ~~~~~~~~~~~~~~~~~~~~~~~ Inferred type is `fmtstr<20, (str<5>,)>`
         pub global TUPLE_WITH_MULTIPLE: ([str<_>], [[Field; _]; 3]) = 
                    ^^^^^^^^^^^^^^^^^^^ Globals must have a specified type
             (&["hi"], [[]; 3]);

--- a/compiler/noirc_printable_type/src/lib.rs
+++ b/compiler/noirc_printable_type/src/lib.rs
@@ -187,6 +187,9 @@ fn to_string<F: AcirField>(value: &PrintableValue<F>, typ: &PrintableType) -> Op
                     output.push_str(", ");
                 }
             }
+            if types.len() == 1 {
+                output.push(',');
+            }
             output.push(')');
         }
 
@@ -487,6 +490,31 @@ mod tests {
         let display =
             PrintableValueDisplay::<FieldElement>::FmtString(template.to_string(), values);
         assert_eq!(display.to_string(), expected);
+    }
+
+    #[test]
+    fn one_element_tuple_to_string() {
+        let value = PrintableValue::<FieldElement>::Vec {
+            array_elements: vec![PrintableValue::Field(1_u128.into())],
+            is_slice: false,
+        };
+        let typ = PrintableType::Tuple { types: vec![PrintableType::Field] };
+        let string = to_string(&value, &typ);
+        assert_eq!(string.unwrap(), "(0x01,)");
+    }
+
+    #[test]
+    fn two_elements_tuple_to_string() {
+        let value = PrintableValue::<FieldElement>::Vec {
+            array_elements: vec![
+                PrintableValue::Field(1_u128.into()),
+                PrintableValue::Field(2_u128.into()),
+            ],
+            is_slice: false,
+        };
+        let typ = PrintableType::Tuple { types: vec![PrintableType::Field, PrintableType::Field] };
+        let string = to_string(&value, &typ);
+        assert_eq!(string.unwrap(), "(0x01, 0x02)");
     }
 
     proptest! {

--- a/test_programs/compile_failure/noirc_frontend_tests_do_not_infer_partial_global_types/stderr.txt
+++ b/test_programs/compile_failure/noirc_frontend_tests_do_not_infer_partial_global_types/stderr.txt
@@ -16,7 +16,7 @@ error: Globals must have a specified type
   ┌─ src/main.nr:8:20
   │
 8 │         pub global FMT_STR: fmtstr<_, _> = f"hi {FORMATTED_VALUE}";
-  │                    -------                 ----------------------- Inferred type is `fmtstr<20, (str<5>)>`
+  │                    -------                 ----------------------- Inferred type is `fmtstr<20, (str<5>,)>`
   │
 
 error: Globals must have a specified type

--- a/tooling/lsp/src/requests/completion.rs
+++ b/tooling/lsp/src/requests/completion.rs
@@ -546,6 +546,9 @@ impl<'a> NodeFinder<'a> {
                     self.collect_local_variables(pattern);
                 }
             }
+            Pattern::Parenthesized(pattern, _) => {
+                self.collect_local_variables(pattern);
+            }
             Pattern::Interned(..) => (),
         }
     }
@@ -1100,7 +1103,9 @@ impl<'a> NodeFinder<'a> {
                     }
                 }
             }
-            Pattern::Mutable(pattern, ..) => self.try_set_self_type(pattern),
+            Pattern::Mutable(pattern, ..) | Pattern::Parenthesized(pattern, _) => {
+                self.try_set_self_type(pattern)
+            }
             Pattern::Tuple(..) | Pattern::Struct(..) | Pattern::Interned(..) => (),
         }
     }

--- a/tooling/lsp/src/requests/completion.rs
+++ b/tooling/lsp/src/requests/completion.rs
@@ -1104,7 +1104,7 @@ impl<'a> NodeFinder<'a> {
                 }
             }
             Pattern::Mutable(pattern, ..) | Pattern::Parenthesized(pattern, _) => {
-                self.try_set_self_type(pattern)
+                self.try_set_self_type(pattern);
             }
             Pattern::Tuple(..) | Pattern::Struct(..) | Pattern::Interned(..) => (),
         }

--- a/tooling/lsp/src/requests/inlay_hint.rs
+++ b/tooling/lsp/src/requests/inlay_hint.rs
@@ -465,6 +465,9 @@ fn push_type_parts(typ: &Type, parts: &mut Vec<InlayHintLabelPart>, files: &File
                     parts.push(string_part(", "));
                 }
             }
+            if types.len() == 1 {
+                parts.push(string_part(","));
+            }
             parts.push(string_part(")"));
         }
         Type::DataType(struct_type, generics) => {

--- a/tooling/lsp/src/with_file.rs
+++ b/tooling/lsp/src/with_file.rs
@@ -126,6 +126,10 @@ fn pattern_with_file(pattern: Pattern, file: FileId) -> Pattern {
             }),
             location_with_file(location, file),
         ),
+        Pattern::Parenthesized(pattern, location) => Pattern::Parenthesized(
+            Box::new(pattern_with_file(*pattern, file)),
+            location_with_file(location, file),
+        ),
         Pattern::Interned(interned_pattern, location) => {
             Pattern::Interned(interned_pattern, location_with_file(location, file))
         }

--- a/tooling/nargo_fmt/src/formatter/global.rs
+++ b/tooling/nargo_fmt/src/formatter/global.rs
@@ -53,8 +53,11 @@ impl ChunkFormatter<'_, '_> {
 
                 *pattern
             }
-            Pattern::Tuple(..) | Pattern::Struct(..) | Pattern::Interned(..) => {
-                unreachable!("Global pattern cannot be a tuple, struct or interned")
+            Pattern::Tuple(..)
+            | Pattern::Struct(..)
+            | Pattern::Parenthesized(..)
+            | Pattern::Interned(..) => {
+                unreachable!("Global pattern cannot be a tuple, struct, parenthesized or interned")
             }
         };
 

--- a/tooling/nargo_fmt/src/formatter/pattern.rs
+++ b/tooling/nargo_fmt/src/formatter/pattern.rs
@@ -94,6 +94,11 @@ impl Formatter<'_> {
 
                 self.format_chunk_group(group);
             }
+            Pattern::Parenthesized(pattern, _) => {
+                self.write_left_paren();
+                self.format_pattern(*pattern);
+                self.write_right_paren();
+            }
             Pattern::Interned(..) => {
                 unreachable!("Should not be present in the AST")
             }
@@ -141,6 +146,13 @@ mod tests {
     fn format_tuple_pattern_one_element() {
         let src = "fn foo( (  x  ,    ) : i32) {}";
         let expected = "fn foo((x,): i32) {}\n";
+        assert_format(src, expected);
+    }
+
+    #[test]
+    fn format_parenthesized_pattern_one_element() {
+        let src = "fn foo( (  x      ) : i32) {}";
+        let expected = "fn foo((x): i32) {}\n";
         assert_format(src, expected);
     }
 


### PR DESCRIPTION
# Description

## Problem

Resolves #8475
Resolves #8476

## Summary

The first commit introduces a new pattern, the parenthesized pattern, which is when you do `let (x) = ...;`, which is similar to `let x = ...;`, but previously was parsed as a 1-element tuple. This is to match Rust's syntax and semantic.

The rest of the commits make sure that printing 1-element tuples in several contexts always includes a trailing comma.

## Additional Context



## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
