### PR TITLE
chore: add SSA interpreter test for higher order functions

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/interpreter/tests/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/interpreter/tests/mod.rs
@@ -240,7 +240,7 @@ fn without_defunctionalize() {
         vec![Value::from_constant(0_u128.into(), NumericType::bool())],
     );
 
-    assert!(values.len() == 0);
+    assert!(values.is_empty());
 }
 
 #[test]

--- a/compiler/noirc_evaluator/src/ssa/interpreter/tests/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/interpreter/tests/mod.rs
@@ -192,6 +192,60 @@ fn loads_passed_to_a_call() {
 }
 
 #[test]
+fn without_defunctionalize() {
+    let src = "
+  acir(inline) fn main f0 {
+    b0(v0: u1):
+      v1 = allocate -> &mut function
+      store f1 at v1
+      jmpif v0 then: b1, else: b2
+    b1():
+      call f2(v1, f1)
+      jmp b3()
+    b2():
+      call f2(v1, f3)
+      jmp b3()
+    b3():
+      v5 = load v1 -> function
+      v7 = call f4(v5) -> u1
+      constrain v7 == u1 1
+      return
+  }
+  acir(inline) fn f f1 {
+    b0(v0: u8):
+      v2 = eq v0, u8 0
+      return v2
+  }
+  acir(inline) fn bar f2 {
+    b0(v0: &mut function, v1: function):
+      store v1 at v0
+      return
+  }
+  acir(inline) fn g f3 {
+    b0(v0: u8):
+      v2 = eq v0, u8 1
+      return v2
+  }
+  acir(inline) fn foo f4 {
+    b0(v0: function):
+      v2 = call v0(u8 0) -> u1
+      v4 = call v0(u8 1) -> u1
+      v5 = eq v2, v4
+      v6 = not v5
+      return v6
+  }
+      ";
+    let values = expect_values_with_args(
+        src,
+        vec![
+            Value::from_constant(0_u128.into(), NumericType::bool()),
+        ],
+    );
+
+    assert!(values.len() == 0);
+}
+
+#[test]
 fn keep_repeat_loads_with_alias_store() {
     let src = "
     acir(inline) fn main f0 {

--- a/compiler/noirc_evaluator/src/ssa/interpreter/tests/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/interpreter/tests/mod.rs
@@ -237,9 +237,7 @@ fn without_defunctionalize() {
       ";
     let values = expect_values_with_args(
         src,
-        vec![
-            Value::from_constant(0_u128.into(), NumericType::bool()),
-        ],
+        vec![Value::from_constant(0_u128.into(), NumericType::bool())],
     );
 
     assert!(values.len() == 0);


### PR DESCRIPTION
and mutable references to functions

# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

Made a quick test of how the interpreter handles higher-order functions, based on the `After initial SSA` output:
```noir
fn f(x: u8) -> bool {
    x == 0
}
fn g(x: u8) -> bool {
    x == 1
}

fn foo(fg: fn(u8) -> bool) -> bool {
    fg(0) != fg(1)
}

fn bar(f: &mut (fn(u8) -> bool), g: fn(u8) -> bool) {
    *f = g;
}

fn main(b: bool) {
    let mut h = f;
    if b {
        bar(&mut h, f);
    } else {
        bar(&mut h, g);
    }
    assert(foo(h));
}
```

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
