### PR TITLE
fix: variable used in fmtstr inside lambda wasn't tracked as captured

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/patterns.rs
+++ b/compiler/noirc_frontend/src/elaborator/patterns.rs
@@ -759,44 +759,55 @@ impl Elaborator<'_> {
             let location = path.location;
             let ((hir_ident, var_scope_index), item) = self.get_ident_from_path(path);
 
-            if hir_ident.id != DefinitionId::dummy_id() {
-                match self.interner.definition(hir_ident.id).kind {
-                    DefinitionKind::Function(func_id) => {
-                        if let Some(current_item) = self.current_item {
-                            self.interner.add_function_dependency(current_item, func_id);
-                        }
-
-                        self.interner.add_function_reference(func_id, hir_ident.location);
-                    }
-                    DefinitionKind::Global(global_id) => {
-                        self.elaborate_global_if_unresolved(&global_id);
-                        if let Some(current_item) = self.current_item {
-                            self.interner.add_global_dependency(current_item, global_id);
-                        }
-
-                        self.interner.add_global_reference(global_id, hir_ident.location);
-                    }
-                    DefinitionKind::NumericGeneric(_, ref numeric_typ) => {
-                        // Initialize numeric generics to a polymorphic integer type in case
-                        // they're used in expressions. We must do this here since type_check_variable
-                        // does not check definition kinds and otherwise expects parameters to
-                        // already be typed.
-                        if self.interner.definition_type(hir_ident.id) == Type::Error {
-                            let type_var_kind = Kind::Numeric(numeric_typ.clone());
-                            let typ = self.type_variable_with_kind(type_var_kind);
-                            self.interner.push_definition_type(hir_ident.id, typ);
-                        }
-                    }
-                    DefinitionKind::Local(_) => {
-                        // only local variables can be captured by closures.
-                        self.resolve_local_variable(hir_ident.clone(), var_scope_index);
-
-                        self.interner.add_local_reference(hir_ident.id, location);
-                    }
-                }
-            }
+            self.handle_hir_ident(&hir_ident, var_scope_index, location);
 
             (hir_ident, item)
+        }
+    }
+
+    pub(crate) fn handle_hir_ident(
+        &mut self,
+        hir_ident: &HirIdent,
+        var_scope_index: usize,
+        location: Location,
+    ) {
+        if hir_ident.id == DefinitionId::dummy_id() {
+            return;
+        }
+
+        match self.interner.definition(hir_ident.id).kind {
+            DefinitionKind::Function(func_id) => {
+                if let Some(current_item) = self.current_item {
+                    self.interner.add_function_dependency(current_item, func_id);
+                }
+
+                self.interner.add_function_reference(func_id, hir_ident.location);
+            }
+            DefinitionKind::Global(global_id) => {
+                self.elaborate_global_if_unresolved(&global_id);
+                if let Some(current_item) = self.current_item {
+                    self.interner.add_global_dependency(current_item, global_id);
+                }
+
+                self.interner.add_global_reference(global_id, hir_ident.location);
+            }
+            DefinitionKind::NumericGeneric(_, ref numeric_typ) => {
+                // Initialize numeric generics to a polymorphic integer type in case
+                // they're used in expressions. We must do this here since type_check_variable
+                // does not check definition kinds and otherwise expects parameters to
+                // already be typed.
+                if self.interner.definition_type(hir_ident.id) == Type::Error {
+                    let type_var_kind = Kind::Numeric(numeric_typ.clone());
+                    let typ = self.type_variable_with_kind(type_var_kind);
+                    self.interner.push_definition_type(hir_ident.id, typ);
+                }
+            }
+            DefinitionKind::Local(_) => {
+                // only local variables can be captured by closures.
+                self.resolve_local_variable(hir_ident.clone(), var_scope_index);
+
+                self.interner.add_local_reference(hir_ident.id, location);
+            }
         }
     }
 

--- a/test_programs/compile_success_empty/lambda_captured_variable_because_of_fmtstr/Nargo.toml
+++ b/test_programs/compile_success_empty/lambda_captured_variable_because_of_fmtstr/Nargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "lambda_captured_variable_because_of_fmtstr"
+type = "bin"
+authors = [""]
+
+[dependencies]

--- a/test_programs/compile_success_empty/lambda_captured_variable_because_of_fmtstr/src/main.nr
+++ b/test_programs/compile_success_empty/lambda_captured_variable_because_of_fmtstr/src/main.nr
@@ -1,0 +1,7 @@
+fn main() {
+    comptime {
+        let captured = quote { };
+        let f = || { let _ = f"{captured}"; };
+        f();
+    }
+}

--- a/tooling/nargo_cli/tests/snapshots/compile_success_empty/lambda_captured_variable_because_of_fmtstr/execute__tests__force_brillig_false_inliner_0.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_empty/lambda_captured_variable_because_of_fmtstr/execute__tests__force_brillig_false_inliner_0.snap
@@ -1,0 +1,26 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: artifact
+---
+{
+  "noir_version": "[noir_version]",
+  "hash": "[hash]",
+  "abi": {
+    "parameters": [],
+    "return_type": null,
+    "error_types": {}
+  },
+  "bytecode": [
+    "func 0",
+    "current witness index : _0",
+    "private parameters indices : []",
+    "public parameters indices : []",
+    "return value indices : []"
+  ],
+  "debug_symbols": "XY5BCsQwCEXv4rqLWfcqw1BsaosgJtikMITefWyYQOlK/3/6tcJCc9km1jXuML4rzMYivE0SA2aO6m49B+hyykbkFty4byU00gyjFpEBDpTShvaE2mpGc/oagHTx6oErC13d+XGBge158UBjnIX+ci0abjR/Uyf942Qx0FKMrqTGPPsH",
+  "file_map": {},
+  "names": [
+    "main"
+  ],
+  "brillig_names": []
+}

--- a/tooling/nargo_cli/tests/snapshots/expand/compile_success_empty/lambda_captured_variable_because_of_fmtstr/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/expand/compile_success_empty/lambda_captured_variable_because_of_fmtstr/execute__tests__expanded.snap
@@ -1,0 +1,7 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: expanded_code
+---
+fn main() {
+    ()
+}


### PR DESCRIPTION
# Description

## Problem

Resolves #8166

## Summary

We were missing a similar treatment to what we do with local variables, but when elaborating format string interpolated identifiers.

I didn't know what name to use for the extracted logic, I went with `handle_hir_ident` but happy to give it a better name.

## Additional Context

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
