### PR TITLE
fix: fix visibility of methods in `std::meta`

### DIFF
--- a/noir_stdlib/src/meta/typ.nr
+++ b/noir_stdlib/src/meta/typ.nr
@@ -94,7 +94,7 @@ impl Type {
     /// If this is a mutable reference type `&mut T`, returns the mutable type `T`.
     #[builtin(type_as_mutable_reference)]
     // docs:start:as_mutable_reference
-    comptime fn as_mutable_reference(self) -> Option<Type> {}
+    pub comptime fn as_mutable_reference(self) -> Option<Type> {}
     // docs:end:as_mutable_reference
 
     /// If this is a slice type, return the element type of the slice.
@@ -187,7 +187,7 @@ impl Type {
     /// Returns `true` if this type is the unit `()` type.
     #[builtin(type_is_unit)]
     // docs:start:is_unit
-    comptime fn is_unit(self) -> bool {}
+    pub comptime fn is_unit(self) -> bool {}
     // docs:end:is_unit
 }
 

--- a/noir_stdlib/src/meta/unresolved_type.nr
+++ b/noir_stdlib/src/meta/unresolved_type.nr
@@ -6,19 +6,19 @@ impl UnresolvedType {
     /// If this is a mutable reference type `&mut T`, returns the mutable type `T`.
     #[builtin(unresolved_type_as_mutable_reference)]
     // docs:start:as_mutable_reference
-    comptime fn as_mutable_reference(self) -> Option<UnresolvedType> {}
+    pub comptime fn as_mutable_reference(self) -> Option<UnresolvedType> {}
     // docs:end:as_mutable_reference
 
     /// If this is a slice `&[T]`, returns the element type `T`.
     #[builtin(unresolved_type_as_slice)]
     // docs:start:as_slice
-    comptime fn as_slice(self) -> Option<UnresolvedType> {}
+    pub comptime fn as_slice(self) -> Option<UnresolvedType> {}
     // docs:end:as_slice
 
     /// Returns `true` if this type is `bool`.
     #[builtin(unresolved_type_is_bool)]
     // docs:start:is_bool
-    comptime fn is_bool(self) -> bool {}
+    pub comptime fn is_bool(self) -> bool {}
     // docs:end:is_bool
 
     /// Returns true if this type refers to the `Field` type.
@@ -30,6 +30,6 @@ impl UnresolvedType {
     /// Returns true if this type is the unit `()` type.
     #[builtin(unresolved_type_is_unit)]
     // docs:start:is_unit
-    comptime fn is_unit(self) -> bool {}
+    pub comptime fn is_unit(self) -> bool {}
     // docs:end:is_unit
 }


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

There's a number of documented methods which look like they're intended to be public but are marked as private here. This PR marks them as public.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
