### PR TITLE
chore(fuzz): AST generator to add `ctx_limit` to all functions

### DIFF
--- a/tooling/ast_fuzzer/src/program/tests.rs
+++ b/tooling/ast_fuzzer/src/program/tests.rs
@@ -196,7 +196,7 @@ fn test_recursion_limit_rewrite() {
     // - main passes the limit to foo by ref
     // - foo passes the limit to bar_proxy by value
     // - bar_proxy passes the limit to baz by ref
-    // - bar does not passes the limit to qux
+    // - bar passes the limit to qux, even though it's unused
     // - baz passes the limit to itself by ref
 
     let code = format!("{}", DisplayAstAsNoir(&program));
@@ -220,7 +220,7 @@ fn test_recursion_limit_rewrite() {
         } else {
             *ctx_limit = ((*ctx_limit) - 1);
             baz(ctx_limit);
-            qux()
+            qux(ctx_limit)
         }
     }
     unconstrained fn baz(ctx_limit: &mut u32) -> () {
@@ -231,13 +231,10 @@ fn test_recursion_limit_rewrite() {
             baz(ctx_limit)
         }
     }
-    unconstrained fn qux() -> () {
+    unconstrained fn qux(_ctx_limit: &mut u32) -> () {
     }
     unconstrained fn bar_proxy(mut ctx_limit: u32) -> () {
         bar((&mut ctx_limit))
-    }
-    unconstrained fn baz_proxy(mut ctx_limit: u32) -> () {
-        baz((&mut ctx_limit))
     }
     ");
 }


### PR DESCRIPTION
# Description

## Problem\*

Preparation for https://github.com/noir-lang/noir/issues/8484

## Summary\*

So far the `ctx_limit: &mut u32` parameter has only been added to functions which called other functions. Now it will be part of the signature of all functions except `main`.  

The PR also changes generation so only those Brillig functions which are called from ACIR get a `_proxy` variant, to reduce noise. We also stop generating ACIR functions if `main` is Brillig, because in code generated by the monomorphizer Brillig will only call other Brillig functions (apart from the #7279 problem). This is also to reduce noise. 

## Additional Context

In #8484 I want to pass function pointers as arguments in the generated AST. 

Say we had program like this:
```rust
fn main() -> u32 {
  baz(bar)
}
fn foo() -> u32 {
  1 
}
fn bar() -> u32 {
  2 + foo()
}
fn baz(f: fn() -> u32) -> u32 {
  3 + f()
}
```
`baz` can be called with `foo` or `bar`. 

According to the current rules, `foo` would be left alone, and `bar` would get a new `ctx_limit` parameter. But then `baz` could not take both functions as parameters any more: if we rewrite it into `fn baz(f: fn(&mut u32) -> u32, ctx_limit: &mut u32)` then it would only take `bar`, or we leave `f` alone and it can only take `bar`. 

Instead, if we change all functions to take `&mut u32`, we can pass both.

## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
