### PR TITLE
chore(test): add panicking test for 'defunctionalize'

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/opt/defunctionalize.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/defunctionalize.rs
@@ -804,4 +804,26 @@ mod tests {
         "
         );
     }
+
+    // Expected to panic like:
+    // thread 'main' panicked at compiler/noirc_evaluator/src/ssa/opt/defunctionalize.rs:376:9:
+    // ICE: at least one variant should exist for a dynamic call Signature { params: [Numeric(Unsigned { bit_size: 32 })], returns: [Numeric(Unsigned { bit_size: 32 })] }
+    // note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+    #[test]
+    fn missing_fn() {
+        let src = "
+          brillig(inline) fn main f0 {
+            b0(v0: function, v1: u32):
+              v2 = call v0(v1) -> u32
+              return v2
+          }
+        ";
+
+        let ssa = Ssa::from_str(src).unwrap();
+        let ssa = ssa.defunctionalize();
+
+        assert_ssa_snapshot!(ssa, @r"
+        TODO
+        ");
+    }
 }


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

No function of type `v0: function` panics during `defunctionalize`

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
