### PR TITLE
chore!: avoid serializing fields as strings

### DIFF
--- a/acvm-repo/acir_field/src/field_element.rs
+++ b/acvm-repo/acir_field/src/field_element.rs
@@ -69,7 +69,7 @@ impl<T: PrimeField> Serialize for FieldElement<T> {
     where
         S: serde::Serializer,
     {
-        self.to_hex().serialize(serializer)
+        self.to_be_bytes().serialize(serializer)
     }
 }
 
@@ -79,10 +79,7 @@ impl<'de, T: PrimeField> Deserialize<'de> for FieldElement<T> {
         D: serde::Deserializer<'de>,
     {
         let s: Cow<'de, str> = Deserialize::deserialize(deserializer)?;
-        match Self::from_hex(&s) {
-            Some(value) => Ok(value),
-            None => Err(serde::de::Error::custom(format!("Invalid hex for FieldElement: {s}",))),
-        }
+        Ok(Self::from_be_bytes_reduce(&s.as_bytes()))
     }
 }
 


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This PR avoids serializing field elements through their string representations but as pure bytes.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
