### PR TITLE
chore(fuzz): Call function pointers

### DIFF
--- a/tooling/ast_fuzzer/src/lib.rs
+++ b/tooling/ast_fuzzer/src/lib.rs
@@ -60,6 +60,8 @@ pub struct Config {
     pub avoid_large_int_literals: bool,
     /// Avoid using loop control (break/continue).
     pub avoid_loop_control: bool,
+    /// Avoid using function pointers in parameters.
+    pub avoid_lambdas: bool,
     /// Only use comptime friendly expressions.
     pub comptime_friendly: bool,
 }
@@ -117,6 +119,7 @@ impl Default for Config {
             avoid_large_int_literals: false,
             avoid_negative_int_literals: false,
             avoid_loop_control: false,
+            avoid_lambdas: false,
             comptime_friendly: false,
         }
     }

--- a/tooling/ast_fuzzer/src/lib.rs
+++ b/tooling/ast_fuzzer/src/lib.rs
@@ -119,7 +119,8 @@ impl Default for Config {
             avoid_large_int_literals: false,
             avoid_negative_int_literals: false,
             avoid_loop_control: false,
-            avoid_lambdas: false,
+            // TODO(#8543): Allow lambdas when ICE is fixed.
+            avoid_lambdas: true,
             comptime_friendly: false,
         }
     }

--- a/tooling/ast_fuzzer/src/program/func.rs
+++ b/tooling/ast_fuzzer/src/program/func.rs
@@ -192,10 +192,8 @@ impl<'a> FunctionContext<'a> {
             if !can_call(id, decl.unconstrained, *callee_id, callee_decl.unconstrained) {
                 continue;
             }
-            call_targets.insert(
-                CallableId::Global(*callee_id),
-                types::types_produced(&callee_decl.return_type),
-            );
+            let produces = types::types_produced(&callee_decl.return_type);
+            call_targets.insert(CallableId::Global(*callee_id), produces);
         }
 
         // Consider function pointers as callable; they are already filtered during construction.
@@ -203,7 +201,8 @@ impl<'a> FunctionContext<'a> {
             let Type::Function(_, return_type, _, _) = typ else {
                 continue;
             };
-            call_targets.insert(CallableId::Local(*callee_id), types::types_produced(&return_type));
+            let produces = types::types_produced(return_type);
+            call_targets.insert(CallableId::Local(*callee_id), produces);
         }
 
         Self {

--- a/tooling/ast_fuzzer/src/program/func.rs
+++ b/tooling/ast_fuzzer/src/program/func.rs
@@ -985,7 +985,7 @@ impl<'a> FunctionContext<'a> {
 
         let callee_id = *u.choose_iter(opts)?;
         let callee_ident = self.function_ident(callee_id);
-        let (param_types, return_type) = self.function_types(callee_id);
+        let (param_types, return_type) = self.callable_signature(callee_id);
 
         // Generate an expression for each argument.
         let mut args = Vec::new();
@@ -1249,8 +1249,8 @@ impl<'a> FunctionContext<'a> {
         }
     }
 
-    /// Get the parameter types and return type of a function.
-    fn function_types(&self, callee_id: CallableId) -> (Vec<Type>, Type) {
+    /// Get the parameter types and return type of a callable function.
+    fn callable_signature(&self, callee_id: CallableId) -> (Vec<Type>, Type) {
         match callee_id {
             CallableId::Global(id) => {
                 let decl = self.ctx.function_decl(id);

--- a/tooling/ast_fuzzer/src/program/mod.rs
+++ b/tooling/ast_fuzzer/src/program/mod.rs
@@ -77,6 +77,14 @@ pub(crate) enum VariableId {
     Global(GlobalId),
 }
 
+/// ID of a function we can call, either as a pointer in a local variable,
+/// or directly as a global function.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub(crate) enum CallableId {
+    Local(LocalId),
+    Global(FuncId),
+}
+
 /// Name of a variable.
 type Name = String;
 

--- a/tooling/ast_fuzzer/src/program/mod.rs
+++ b/tooling/ast_fuzzer/src/program/mod.rs
@@ -189,7 +189,7 @@ impl Context {
             || bool::arbitrary(u)?;
 
         // Which existing functions we could receive as parameters.
-        let func_param_candidates: Vec<FuncId> = if is_main {
+        let func_param_candidates: Vec<FuncId> = if is_main || self.config.avoid_lambdas {
             // Main cannot receive function parameters from outside.
             vec![]
         } else {

--- a/tooling/ast_fuzzer/src/program/rewrite/limit.rs
+++ b/tooling/ast_fuzzer/src/program/rewrite/limit.rs
@@ -426,8 +426,7 @@ impl<'a> LimitContext<'a> {
         }
         if let Some(proxy) = proxy_functions.get_mut(&self.func_id) {
             for (_, _, _, param_type, _) in proxy.parameters.iter_mut() {
-                // Proxies will only be called from ACIR
-                modify_function_pointer_param_type(param_type, false);
+                modify_function_pointer_param_type(param_type, self.func.unconstrained);
             }
         }
     }

--- a/tooling/ast_fuzzer/src/program/rewrite/mod.rs
+++ b/tooling/ast_fuzzer/src/program/rewrite/mod.rs
@@ -1,0 +1,46 @@
+use noirc_frontend::monomorphization::ast::{Expression, Function, Program};
+
+use super::visitor::visit_expr;
+
+mod limit;
+
+pub(crate) use limit::add_recursion_limit;
+
+/// Find the next local ID and ident IDs (in that order) that we can use to add
+/// variables to a [Function] during mutations.
+fn next_local_and_ident_id(func: &Function) -> (u32, u32) {
+    let mut next_local_id = func.parameters.iter().map(|p| p.0.0 + 1).max().unwrap_or_default();
+    let mut next_ident_id = 0;
+
+    visit_expr(&func.body, &mut |expr| {
+        let local_id = match expr {
+            Expression::Let(let_) => Some(let_.id),
+            Expression::For(for_) => Some(for_.index_variable),
+            Expression::Ident(ident) => {
+                next_ident_id = next_ident_id.max(ident.id.0 + 1);
+                None
+            }
+            _ => None,
+        };
+        if let Some(id) = local_id {
+            next_local_id = next_local_id.max(id.0 + 1);
+        }
+        true
+    });
+    (next_local_id, next_ident_id)
+}
+
+/// Turn all ACIR functions into Brillig functions.
+///
+/// This is more involved than flipping the `unconstrained` property because of the
+/// "ownership analysis", which can only run on a function once.
+pub fn change_all_functions_into_unconstrained(mut program: Program) -> Program {
+    for f in program.functions.iter_mut() {
+        if f.unconstrained {
+            continue;
+        }
+        f.unconstrained = true;
+        f.handle_ownership();
+    }
+    program
+}

--- a/tooling/ast_fuzzer/tests/smoke.rs
+++ b/tooling/ast_fuzzer/tests/smoke.rs
@@ -27,7 +27,10 @@ fn arb_program_can_be_executed() {
     let maybe_seed = seed_from_env();
 
     let mut prop = arbtest(|u| {
-        let program = arb_program(u, Config::default())?;
+        // TODO(#8543): Allow lambdas when ICE is fixed.
+        let config = Config { avoid_lambdas: true, ..Default::default() };
+
+        let program = arb_program(u, config)?;
         let abi = program_abi(&program);
 
         let options = ssa::SsaEvaluatorOptions {

--- a/tooling/ast_fuzzer/tests/smoke.rs
+++ b/tooling/ast_fuzzer/tests/smoke.rs
@@ -27,9 +27,7 @@ fn arb_program_can_be_executed() {
     let maybe_seed = seed_from_env();
 
     let mut prop = arbtest(|u| {
-        // TODO(#8543): Allow lambdas when ICE is fixed.
-        let config = Config { avoid_lambdas: true, ..Default::default() };
-
+        let config = Config::default();
         let program = arb_program(u, config)?;
         let abi = program_abi(&program);
 


### PR DESCRIPTION
# Description

## Problem\*

Resolves #8484

## Summary\*

Call and pass on function pointers in code generated by the AST fuzzer. 

I refactored the `rewrite` module in the fuzzer because it was difficult to see what was going on, and also needed recursion.

Blocked by ICE in https://github.com/noir-lang/noir/issues/8543 
For now I added a flag to turn lambdas off in the smoke test for now so we can merge this and not fail on aztec-packages.

## Additional Context

Here's an example, generated by the following sample:
```shell
NOIR_ARBTEST_SEED=0x5824e5b200100000 cargo test -p noir_ast_fuzzer --test smoke 
```

It shows the `&mut u32` or `u32` added to the function pointers in the parameters
```rust
...
unconstrained fn main(a: i64, b: call_data(1) i64, c: i64) -> pub ((i64, i64), (bool, bool, bool, i64), u64, i16, Field) {
    let mut ctx_limit = 25;
        let d = if (c > func_3(false, func_2, (&mut ctx_limit))) {
    ...
}
unconstrained fn func_1(mut a: u128, ctx_limit: &mut u32) -> (bool, bool, bool, i64) {
    ...
}
unconstrained fn func_2(a: unconstrained fn(u128, &mut u32) -> (bool, bool, bool, i64), ctx_limit: &mut u32) -> str<0> {
    ...
                        (func_3(true, func_2, ctx_limit) * G_A)
   ...
}
unconstrained fn func_3(mut a: bool, mut b: unconstrained fn(unconstrained fn(u128, &mut u32) -> (bool, bool, bool, i64), &mut u32) -> str<0>, ctx_limit: &mut u32) -> i64 {
    ...
        func_3(false, b, ctx_limit)
    ...
}
fn func_4(mut a: ((i64, i64), (bool, bool, bool, i64), u64, i16, Field), mut b: (i64, i64), ctx_limit: &mut u32) -> ((bool, bool, bool, i64), [u64; 3]) {
    ...
}
fn func_5(a: unconstrained fn(u128, u32) -> (bool, bool, bool, i64), mut b: ((i64, i64), (bool, bool, bool, i64), u64, i16, Field), mut c: Field, ctx_limit: &mut u32) -> str<1> {
                ... 
                a((b.2 as u128), (*ctx_limit)) }.1 as Field)
            ...
}
unconstrained fn func_1_proxy(mut a: u128, mut ctx_limit: u32) -> (bool, bool, bool, i64) {
    func_1(a, (&mut ctx_limit))
}
unconstrained fn func_2_proxy(a: unconstrained fn(u128, &mut u32) -> (bool, bool, bool, i64), mut ctx_limit: u32) -> str<0> {
    func_2(a, (&mut ctx_limit))
}
unconstrained fn func_3_proxy(mut a: bool, mut b: unconstrained fn(unconstrained fn(u128, &mut u32) -> (bool, bool, bool, i64), &mut u32) -> str<0>, mut ctx_limit: u32) -> i64 {
    func_3(a, b, (&mut ctx_limit))
}


```

## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
