### PR TITLE
fix: avoid logging all unused params in DIE pass

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/opt/die/prune_dead_parameters.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/die/prune_dead_parameters.rs
@@ -55,7 +55,7 @@ use crate::ssa::{
 
 impl Ssa {
     /// See [`prune_dead_parameters`][self] module for more information.
-    #[tracing::instrument(level = "trace", skip(self))]
+    #[tracing::instrument(level = "trace", skip_all)]
     pub(crate) fn prune_dead_parameters(
         mut self,
         unused_parameters: &HashMap<FunctionId, HashMap<BasicBlockId, Vec<ValueId>>>,


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

We're currently printing a huge number of elements which isn't really useful.

## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
