### PR TITLE
fix(frontend): Override to allow empty array input

### DIFF
--- a/compiler/noirc_frontend/src/hir_def/types.rs
+++ b/compiler/noirc_frontend/src/hir_def/types.rs
@@ -1299,7 +1299,7 @@ impl Type {
             }
 
             Type::Array(length, element) => {
-                self.array_or_string_len_is_not_zero()
+                (Self::should_allow_zero_sized_input() || self.array_or_string_len_is_not_zero())
                     && length.is_valid_for_program_input()
                     && element.is_valid_for_program_input()
             }
@@ -1320,6 +1320,14 @@ impl Type {
                 lhs.is_valid_for_program_input() && rhs.is_valid_for_program_input()
             }
         }
+    }
+
+    /// Check if it is okay to allow for zero-sized input (e..g zero-sized arrays) to a program.
+    /// This behavior is not well defined and is banned by default.
+    /// However, this ban is a breaking change for some dependent projects so this override
+    /// is provided until those projects migrate away from using zero-sized array input (e.g. https://github.com/AztecProtocol/aztec-packages/issues/14388).
+    fn should_allow_zero_sized_input() -> bool {
+        std::env::var("ALLOW_EMPTY_INPUT").ok().map(|v| v == "1" || v == "true").unwrap_or_default()
     }
 
     /// Empty arrays and strings (which are arrays under the hood) are disallowed

--- a/compiler/noirc_frontend/src/hir_def/types.rs
+++ b/compiler/noirc_frontend/src/hir_def/types.rs
@@ -1325,7 +1325,7 @@ impl Type {
     /// Check if it is okay to allow for zero-sized input (e..g zero-sized arrays) to a program.
     /// This behavior is not well defined and is banned by default.
     /// However, this ban is a breaking change for some dependent projects so this override
-    /// is provided until those projects migrate away from using zero-sized array input (e.g. https://github.com/AztecProtocol/aztec-packages/issues/14388).
+    /// is provided until those projects migrate away from using zero-sized array input (e.g. <https://github.com/AztecProtocol/aztec-packages/issues/14388>).
     fn should_allow_zero_sized_input() -> bool {
         std::env::var("ALLOW_EMPTY_INPUT").ok().map(|v| v == "1" || v == "true").unwrap_or_default()
     }


### PR DESCRIPTION
# Description

## Problem\*

Resolves #8565 

## Summary\*

I have tested locally that I can compile the `noir-protocol-circuits` zero variants by prefixing a call to `nargo` with `ALLOW_EMPTY_INPUT=1`.

I went with an environment variable as it felt like the least instructive hot fix (e.g. threading a compilation flag or a patch on aztec-packages felt more complicated that simply providing an override).

## Additional Context

Once https://github.com/AztecProtocol/aztec-packages/issues/14388 is resolved we can remove this environment variable.

## Documentation\*

Check one:
- [ ] No documentation needed.
- [X] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
