### PR TITLE
chore: Use FxHashMap for TypeBindings

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/comptime.rs
+++ b/compiler/noirc_frontend/src/elaborator/comptime.rs
@@ -249,7 +249,7 @@ impl<'context> Elaborator<'context> {
         arguments.insert(0, (item, location));
 
         let value = interpreter
-            .call_function(function, arguments, TypeBindings::new(), location)
+            .call_function(function, arguments, TypeBindings::default(), location)
             .map_err(CompilationError::from)?;
 
         self.debug_comptime(location, |interner| value.display(interner).to_string());

--- a/compiler/noirc_frontend/src/elaborator/mod.rs
+++ b/compiler/noirc_frontend/src/elaborator/mod.rs
@@ -1395,7 +1395,7 @@ impl<'context> Elaborator<'context> {
 
         let impl_trait = the_trait.name.to_string();
 
-        let mut bindings = TypeBindings::new();
+        let mut bindings = TypeBindings::default();
         bind_ordered_generics(
             &the_trait.generics,
             &trait_impl.resolved_trait_generics,
@@ -1455,7 +1455,7 @@ impl<'context> Elaborator<'context> {
 
         let impl_trait = the_trait.name.to_string();
 
-        let mut bindings = TypeBindings::new();
+        let mut bindings = TypeBindings::default();
         bind_ordered_generics(
             &the_trait.generics,
             &trait_impl.resolved_trait_generics,

--- a/compiler/noirc_frontend/src/elaborator/patterns.rs
+++ b/compiler/noirc_frontend/src/elaborator/patterns.rs
@@ -588,7 +588,7 @@ impl Elaborator<'_> {
             && definition.is_some_and(DefinitionInfo::is_comptime_local);
         let definition_kind = definition.as_ref().map(|definition| definition.kind.clone());
 
-        let mut bindings = TypeBindings::new();
+        let mut bindings = TypeBindings::default();
 
         // Resolve any generics if we the variable we have resolved is a function
         // and if the turbofish operator was used.
@@ -973,7 +973,7 @@ impl Elaborator<'_> {
         expr_id: ExprId,
         generics: Option<Vec<Type>>,
     ) -> Type {
-        let bindings = TypeBindings::new();
+        let bindings = TypeBindings::default();
         self.type_check_variable_with_bindings(ident, expr_id, generics, bindings)
     }
 

--- a/compiler/noirc_frontend/src/elaborator/traits.rs
+++ b/compiler/noirc_frontend/src/elaborator/traits.rs
@@ -368,7 +368,7 @@ fn check_function_type_matches_expected_type(
     trait_name: &str,
     errors: &mut Vec<TypeCheckError>,
 ) {
-    let mut bindings = TypeBindings::new();
+    let mut bindings = TypeBindings::default();
     if let (
         Type::Function(params_a, ret_a, env_a, unconstrained_a),
         Type::Function(params_b, ret_b, env_b, unconstrained_b),

--- a/compiler/noirc_frontend/src/elaborator/types.rs
+++ b/compiler/noirc_frontend/src/elaborator/types.rs
@@ -953,7 +953,7 @@ impl Elaborator<'_> {
         expected: &Type,
         make_error: impl FnOnce() -> TypeCheckError,
     ) {
-        let mut bindings = TypeBindings::new();
+        let mut bindings = TypeBindings::default();
         if actual.try_unify(expected, &mut bindings).is_err() {
             let error: CompilationError = make_error().into();
             self.push_err(error);
@@ -2311,7 +2311,7 @@ impl Elaborator<'_> {
         trait_bound: &ResolvedTraitBound,
         parent_trait_bound: &ResolvedTraitBound,
     ) -> ResolvedTraitBound {
-        let mut bindings = TypeBindings::new();
+        let mut bindings = TypeBindings::default();
         self.bind_generics_from_trait_bound(trait_bound, &mut bindings);
         ResolvedTraitBound {
             trait_generics: parent_trait_bound.trait_generics.map(|typ| typ.substitute(&bindings)),

--- a/compiler/noirc_frontend/src/hir/comptime/tests.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/tests.rs
@@ -1,6 +1,5 @@
 #![cfg(test)]
 
-use std::collections::HashMap;
 use std::path::PathBuf;
 
 use fm::{FileId, FileManager};
@@ -76,7 +75,7 @@ fn interpret_helper(src: &str) -> Result<Value, InterpreterError> {
     with_interpreter(src, |interpreter, main, errors| {
         assert_eq!(errors.len(), 0);
         let no_location = Location::dummy();
-        interpreter.call_function(main, Vec::new(), HashMap::new(), no_location)
+        interpreter.call_function(main, Vec::new(), Default::default(), no_location)
     })
 }
 

--- a/compiler/noirc_frontend/src/hir_def/types.rs
+++ b/compiler/noirc_frontend/src/hir_def/types.rs
@@ -1,9 +1,6 @@
-use std::{
-    borrow::Cow,
-    cell::RefCell,
-    collections::{BTreeSet, HashMap},
-    rc::Rc,
-};
+use std::{borrow::Cow, cell::RefCell, collections::BTreeSet, rc::Rc};
+
+use fxhash::FxHashMap as HashMap;
 
 #[cfg(test)]
 use proptest_derive::Arbitrary;
@@ -243,7 +240,7 @@ impl Kind {
 
             // Kind::Numeric unifies along its Type argument
             (Kind::Numeric(lhs), Kind::Numeric(rhs)) => {
-                let mut bindings = TypeBindings::new();
+                let mut bindings = TypeBindings::default();
                 let unifies = lhs.try_unify(rhs, &mut bindings).is_ok();
                 if unifies {
                     Type::apply_type_bindings(bindings);
@@ -1790,7 +1787,7 @@ impl Type {
     /// (including try_unify) are almost always preferred over Type::eq as unification
     /// will correctly handle generic types.
     pub fn unify(&self, expected: &Type) -> Result<(), UnificationError> {
-        let mut bindings = TypeBindings::new();
+        let mut bindings = TypeBindings::default();
 
         self.try_unify(expected, &mut bindings).map(|()| {
             // Commit any type bindings on success
@@ -2062,7 +2059,7 @@ impl Type {
         errors: &mut Vec<TypeCheckError>,
         make_error: impl FnOnce() -> TypeCheckError,
     ) {
-        let mut bindings = TypeBindings::new();
+        let mut bindings = TypeBindings::default();
 
         if let Ok(()) = self.try_unify(expected, &mut bindings) {
             Type::apply_type_bindings(bindings);
@@ -2134,7 +2131,7 @@ impl Type {
             if let Some(as_slice) = interner.lookup_direct_method(&this, "as_slice", true) {
                 // Still have to ensure the element types match.
                 // Don't need to issue an error here if not, it will be done in unify_with_coercions
-                let mut bindings = TypeBindings::new();
+                let mut bindings = TypeBindings::default();
                 if element1.try_unify(element2, &mut bindings).is_ok() {
                     convert_array_expression_to_slice(expression, this, target, as_slice, interner);
                     Self::apply_type_bindings(bindings);
@@ -2155,7 +2152,7 @@ impl Type {
         {
             // Still have to ensure the element types match.
             // Don't need to issue an error here if not, it will be done in unify_with_coercions
-            let mut bindings = TypeBindings::new();
+            let mut bindings = TypeBindings::default();
             if this_elem.try_unify(target_elem, &mut bindings).is_ok() {
                 Self::apply_type_bindings(bindings);
                 return true;
@@ -2338,7 +2335,7 @@ impl Type {
                 let instantiated = typ.force_substitute(&replacements);
                 (instantiated, replacements)
             }
-            other => (other.clone(), HashMap::new()),
+            other => (other.clone(), HashMap::default()),
         }
     }
 
@@ -2375,7 +2372,7 @@ impl Type {
                 let instantiated = typ.substitute(&replacements);
                 (instantiated, replacements)
             }
-            other => (other.clone(), HashMap::new()),
+            other => (other.clone(), HashMap::default()),
         }
     }
 

--- a/compiler/noirc_frontend/src/hir_def/types/arithmetic.rs
+++ b/compiler/noirc_frontend/src/hir_def/types/arithmetic.rs
@@ -1,3 +1,4 @@
+use fxhash::FxHashMap as HashMap;
 use std::collections::BTreeMap;
 
 use acvm::{AcirField, FieldElement};

--- a/compiler/noirc_frontend/src/hir_def/types/arithmetic.rs
+++ b/compiler/noirc_frontend/src/hir_def/types/arithmetic.rs
@@ -1,4 +1,3 @@
-use fxhash::FxHashMap as HashMap;
 use std::collections::BTreeMap;
 
 use acvm::{AcirField, FieldElement};

--- a/compiler/noirc_frontend/src/monomorphization/mod.rs
+++ b/compiler/noirc_frontend/src/monomorphization/mod.rs
@@ -2512,7 +2512,7 @@ pub fn perform_impl_bindings(
     impl_method: node_interner::FuncId,
     location: Location,
 ) -> Result<TypeBindings, InterpreterError> {
-    let mut bindings = TypeBindings::new();
+    let mut bindings = TypeBindings::default();
 
     if let Some(trait_method) = trait_method {
         let the_trait = interner.get_trait(trait_method.trait_id);

--- a/compiler/noirc_frontend/src/node_interner.rs
+++ b/compiler/noirc_frontend/src/node_interner.rs
@@ -1526,7 +1526,7 @@ impl NodeInterner {
         trait_generics: &[Type],
         trait_associated_types: &[NamedType],
     ) -> Result<(TraitImplKind, TypeBindings, TypeBindings), ImplSearchErrorKind> {
-        let mut bindings = TypeBindings::new();
+        let mut bindings = TypeBindings::default();
         let (impl_kind, instantiation_bindings) = self.lookup_trait_implementation_helper(
             object_type,
             trait_id,
@@ -2299,7 +2299,7 @@ impl NodeInterner {
         trait_impl_generics: &[Type],
         impl_self_type: Type,
     ) -> TypeBindings {
-        let mut bindings = TypeBindings::new();
+        let mut bindings = TypeBindings::default();
         let the_trait = self.get_trait(trait_id);
         let trait_generics = the_trait.generics.clone();
 

--- a/tooling/nargo_cli/src/cli/expand_cmd/printer/hir.rs
+++ b/tooling/nargo_cli/src/cli/expand_cmd/printer/hir.rs
@@ -432,7 +432,7 @@ impl ItemPrinter<'_, '_, '_> {
         let param_type = func_meta.parameters.0[0].1.follow_bindings();
         let param_type = if let Type::Reference(typ, ..) = param_type { *typ } else { param_type };
 
-        let mut bindings = TypeBindings::new();
+        let mut bindings = TypeBindings::default();
         if self_type.try_unify(&param_type, &mut bindings).is_err() {
             return false;
         }


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

Minor speedup, not expected to be noticeable. Broken out of the optimize canonicalize change.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
