### PR TITLE
chore(test): Allow lambdas in fuzzing

### DIFF
--- a/compiler/noirc_evaluator/src/ssa.rs
+++ b/compiler/noirc_evaluator/src/ssa.rs
@@ -238,12 +238,12 @@ pub fn secondary_passes(brillig: &Brillig) -> Vec<SsaPass> {
 /// In the future, we can potentially execute the actual initial version using the SSA interpreter.
 pub fn minimal_passes() -> Vec<SsaPass<'static>> {
     vec![
+        // We need to get rid of function pointer parameters, otherwise they cause panic in Brillig generation.
+        SsaPass::new(Ssa::defunctionalize, "Defunctionalization"),
         // Even the initial SSA generation can result in optimizations that leave a function
         // which was called in the AST not being called in the SSA. Such functions would cause
         // panics later, when we are looking for global allocations.
         SsaPass::new(Ssa::remove_unreachable_functions, "Removing Unreachable Functions"),
-        // We need to get rid of function pointer parameters, otherwise they cause panic in Brillig generation.
-        SsaPass::new(Ssa::defunctionalize, "Defunctionalization"),
         // We need a DIE pass to populate `used_globals`, otherwise it will panic later.
         SsaPass::new(Ssa::dead_instruction_elimination, "Dead Instruction Elimination"),
         // We need to add an offset to constant array indices in Brillig.

--- a/compiler/noirc_evaluator/src/ssa.rs
+++ b/compiler/noirc_evaluator/src/ssa.rs
@@ -242,6 +242,8 @@ pub fn minimal_passes() -> Vec<SsaPass<'static>> {
         // which was called in the AST not being called in the SSA. Such functions would cause
         // panics later, when we are looking for global allocations.
         SsaPass::new(Ssa::remove_unreachable_functions, "Removing Unreachable Functions"),
+        // We need to get rid of function pointer parameters, otherwise they cause panic in Brillig generation.
+        SsaPass::new(Ssa::defunctionalize, "Defunctionalization"),
         // We need a DIE pass to populate `used_globals`, otherwise it will panic later.
         SsaPass::new(Ssa::dead_instruction_elimination, "Dead Instruction Elimination"),
         // We need to add an offset to constant array indices in Brillig.

--- a/tooling/ast_fuzzer/fuzz/src/targets/acir_vs_brillig.rs
+++ b/tooling/ast_fuzzer/fuzz/src/targets/acir_vs_brillig.rs
@@ -46,8 +46,6 @@ pub fn fuzz(u: &mut Unstructured) -> eyre::Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use crate::targets::tests::is_running_in_ci;
-
     /// ```ignore
     /// NOIR_ARBTEST_SEED=0x6819c61400001000 \
     /// NOIR_AST_FUZZER_SHOW_AST=1 \
@@ -55,10 +53,6 @@ mod tests {
     /// ```
     #[test]
     fn fuzz_with_arbtest() {
-        if is_running_in_ci() {
-            // TODO: Investigate stack overflow and disagreements.
-            return;
-        }
         crate::targets::tests::fuzz_with_arbtest(super::fuzz);
     }
 }

--- a/tooling/ast_fuzzer/src/lib.rs
+++ b/tooling/ast_fuzzer/src/lib.rs
@@ -119,8 +119,7 @@ impl Default for Config {
             avoid_large_int_literals: false,
             avoid_negative_int_literals: false,
             avoid_loop_control: false,
-            // TODO(#8543): Allow lambdas when ICE is fixed.
-            avoid_lambdas: true,
+            avoid_lambdas: false,
             comptime_friendly: false,
         }
     }


### PR DESCRIPTION
# Description

## Problem\*

Follow up for https://github.com/noir-lang/noir/pull/8573

## Summary\*

Stop avoiding lambdas in AST fuzzing.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
