### PR TITLE
Af/8606 capture comptime print

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/comptime.rs
+++ b/compiler/noirc_frontend/src/elaborator/comptime.rs
@@ -89,6 +89,7 @@ impl<'context> Elaborator<'context> {
             self.def_maps,
             self.usage_tracker,
             self.crate_graph,
+            self.interpreter_output,
             self.crate_id,
             self.interpreter_call_stack.clone(),
             self.options,

--- a/compiler/noirc_frontend/src/elaborator/mod.rs
+++ b/compiler/noirc_frontend/src/elaborator/mod.rs
@@ -1,4 +1,5 @@
 use std::{
+    cell::RefCell,
     collections::{BTreeMap, BTreeSet},
     rc::Rc,
 };
@@ -122,6 +123,7 @@ pub struct Elaborator<'context> {
     pub(crate) def_maps: &'context mut DefMaps,
     pub(crate) usage_tracker: &'context mut UsageTracker,
     pub(crate) crate_graph: &'context CrateGraph,
+    pub(crate) interpreter_output: &'context Option<Rc<RefCell<dyn std::io::Write>>>,
 
     unsafe_block_status: UnsafeBlockStatus,
     current_loop: Option<Loop>,
@@ -272,6 +274,7 @@ impl<'context> Elaborator<'context> {
         def_maps: &'context mut DefMaps,
         usage_tracker: &'context mut UsageTracker,
         crate_graph: &'context CrateGraph,
+        interpreter_output: &'context Option<Rc<RefCell<dyn std::io::Write>>>,
         crate_id: CrateId,
         interpreter_call_stack: im::Vector<Location>,
         options: ElaboratorOptions<'context>,
@@ -284,6 +287,7 @@ impl<'context> Elaborator<'context> {
             def_maps,
             usage_tracker,
             crate_graph,
+            interpreter_output,
             unsafe_block_status: UnsafeBlockStatus::NotInUnsafeBlock,
             current_loop: None,
             generics: Vec::new(),
@@ -316,6 +320,7 @@ impl<'context> Elaborator<'context> {
             &mut context.def_maps,
             &mut context.usage_tracker,
             &context.crate_graph,
+            &context.interpreter_output,
             crate_id,
             im::Vector::new(),
             options,

--- a/compiler/noirc_frontend/src/hir/mod.rs
+++ b/compiler/noirc_frontend/src/hir/mod.rs
@@ -19,6 +19,7 @@ use fm::{FileId, FileManager};
 use iter_extended::vecmap;
 use noirc_errors::Location;
 use std::borrow::Cow;
+use std::cell::RefCell;
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::path::PathBuf;
 use std::rc::Rc;
@@ -52,6 +53,9 @@ pub struct Context<'file_manager, 'parsed_files> {
     pub parsed_files: Cow<'parsed_files, ParsedFiles>,
 
     pub package_build_path: PathBuf,
+
+    /// Writer for comptime prints.
+    pub interpreter_output: Option<Rc<RefCell<dyn std::io::Write>>>,
 }
 
 #[derive(Debug)]
@@ -73,6 +77,7 @@ impl Context<'_, '_> {
             debug_instrumenter: DebugInstrumenter::default(),
             parsed_files: Cow::Owned(parsed_files),
             package_build_path: PathBuf::default(),
+            interpreter_output: Some(Rc::new(RefCell::new(std::io::stdout()))),
         }
     }
 
@@ -90,6 +95,7 @@ impl Context<'_, '_> {
             debug_instrumenter: DebugInstrumenter::default(),
             parsed_files: Cow::Borrowed(parsed_files),
             package_build_path: PathBuf::default(),
+            interpreter_output: Some(Rc::new(RefCell::new(std::io::stdout()))),
         }
     }
 
@@ -284,6 +290,10 @@ impl Context<'_, '_> {
     }
 
     pub fn disable_comptime_printing(&mut self) {
-        self.def_interner.disable_comptime_printing = true;
+        self.interpreter_output = None;
+    }
+
+    pub fn set_comptime_printing(&mut self, output: Rc<RefCell<dyn std::io::Write>>) {
+        self.interpreter_output = Some(output);
     }
 }

--- a/compiler/noirc_frontend/src/node_interner.rs
+++ b/compiler/noirc_frontend/src/node_interner.rs
@@ -226,9 +226,6 @@ pub struct NodeInterner {
     /// Determins whether to run in LSP mode. In LSP mode references are tracked.
     pub(crate) lsp_mode: bool,
 
-    /// Whether to avoid comptime println from producing output
-    pub(crate) disable_comptime_printing: bool,
-
     /// Store the location of the references in the graph.
     /// Edges are directed from reference nodes to referenced nodes.
     /// For example:
@@ -709,7 +706,6 @@ impl Default for NodeInterner {
             interned_unresolved_type_datas: Default::default(),
             interned_patterns: Default::default(),
             lsp_mode: false,
-            disable_comptime_printing: false,
             location_indices: LocationIndices::default(),
             reference_graph: petgraph::graph::DiGraph::new(),
             reference_graph_indices: HashMap::default(),

--- a/tooling/ast_fuzzer/src/compare/comptime.rs
+++ b/tooling/ast_fuzzer/src/compare/comptime.rs
@@ -1,7 +1,8 @@
 //! Compare an arbitrary AST executed as Noir with the comptime
 //! interpreter vs compiled into bytecode and ran through a VM.
-use std::collections::BTreeMap;
 use std::path::Path;
+use std::rc::Rc;
+use std::{cell::RefCell, collections::BTreeMap};
 
 use arbitrary::Unstructured;
 use bn254_blackbox_solver::Bn254BlackBoxSolver;
@@ -40,11 +41,14 @@ fn prepare_snippet(source: String) -> (Context<'static, 'static>, CrateId) {
 /// Use `force_brillig` to test it as an unconstrained function without having to change the code.
 /// This is useful for methods that use the `runtime::is_unconstrained()` method to change their behavior.
 /// (copied from nargo_cli/tests/common.rs)
-fn prepare_and_compile_snippet(
+fn prepare_and_compile_snippet<W: std::io::Write + 'static>(
     source: String,
     force_brillig: bool,
-) -> CompilationResult<CompiledProgram> {
+    output: W,
+) -> CompilationResult<(CompiledProgram, W)> {
+    let output = Rc::new(RefCell::new(output));
     let (mut context, root_crate_id) = prepare_snippet(source);
+    context.set_comptime_printing(output.clone());
     let options = CompileOptions {
         force_brillig,
         silence_warnings: true,
@@ -52,7 +56,10 @@ fn prepare_and_compile_snippet(
         skip_brillig_constraints_check: true,
         ..Default::default()
     };
-    compile_main(&mut context, root_crate_id, &options, None)
+    let (program, warnings) = compile_main(&mut context, root_crate_id, &options, None)?;
+    drop(context);
+    let output = Rc::into_inner(output).expect("context is gone").into_inner();
+    Ok(((program, output), warnings))
 }
 
 /// Compare the execution of a Noir program in pure comptime (via interpreter)
@@ -68,8 +75,12 @@ pub struct CompareComptime {
 impl CompareComptime {
     /// Execute the Noir code and the SSA, then compare the results.
     pub fn exec(&self) -> eyre::Result<CompareCompiledResult> {
-        let program1 = match prepare_and_compile_snippet(self.source.clone(), self.force_brillig) {
-            Ok((program, _)) => program,
+        let program1 = match prepare_and_compile_snippet(
+            self.source.clone(),
+            self.force_brillig,
+            std::io::empty(),
+        ) {
+            Ok(((program, _), _)) => program,
             Err(e) => panic!("failed to compile program:\n{}\n{e:?}", self.source),
         };
 
@@ -199,6 +210,6 @@ unconstrained fn func_1_proxy(mut ctx_limit: u32) -> ((str<2>, str<2>, bool, str
 }
         "#;
 
-        let _ = prepare_and_compile_snippet(src.to_string(), false);
+        let _ = prepare_and_compile_snippet(src.to_string(), false, std::io::stdout());
     }
 }

--- a/tooling/ast_fuzzer/src/program/func.rs
+++ b/tooling/ast_fuzzer/src/program/func.rs
@@ -718,14 +718,6 @@ impl<'a> FunctionContext<'a> {
         }
 
         if self.unconstrained() {
-            // For now only try prints in unconstrained code, were we don't need to create a proxy.
-            // We don't use this in comptime because comptime prints to stdout which is currently not captured.
-            if freq.enabled_when("print", !self.is_comptime_friendly()) {
-                if let Some(e) = self.gen_print(u)? {
-                    return Ok(e);
-                }
-            }
-
             // Get loop out of the way quick, as it's always disabled for ACIR.
             if freq.enabled_when("loop", self.budget > 1) {
                 return self.gen_loop(u);
@@ -741,6 +733,13 @@ impl<'a> FunctionContext<'a> {
 
             if freq.enabled_when("continue", self.in_loop && !self.ctx.config.avoid_loop_control) {
                 return Ok(Expression::Continue);
+            }
+
+            // For now only try prints in unconstrained code, were we don't need to create a proxy.
+            if freq.enabled("print") {
+                if let Some(e) = self.gen_print(u)? {
+                    return Ok(e);
+                }
             }
         }
 


### PR DESCRIPTION
# Description

## Problem\*

Resolves #8606

## Summary\*

Adds an `interpreter_output` to `Context` which is accessed by the comptime `Interpreter` through the `Elaborator` to do the printing. The field holds a trait object which implements `std::io::Write`; we use dynamic dispatch to access it for writing.

In the fuzz test tests the content goes in a byte vector and is used to compare the output from the interpreter with the real execution. DRAFT because the formats are different.

## Additional Context

I started off by adding a generic `W: std::io::Write`, and borrowing a mutable reference to it through the `Elaborator`, but the number of places I had to add it was huge relative to how little I expect comptime printing to be used. I thought the performance impact of dynamic dispatch should be negligible, as this is most likely used for debugging, and this way the code churn is kept to a minimum. 

I ended up using `Rc<RefCell<dyn std::io::Write>>` so that the we can share the ownership over something writeable between the test and the `Context` without losing type information, which is what would happen if we used `Box` and passed it over to `Context`, then took it back. 

## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
