### PR TITLE
fix: constraints on Self cannot be assumed inside a trait impl

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/mod.rs
+++ b/compiler/noirc_frontend/src/elaborator/mod.rs
@@ -1308,6 +1308,13 @@ impl<'context> Elaborator<'context> {
         trait_bound: &ResolvedTraitBound,
         starting_trait_id: TraitId,
     ) {
+        // If there's a constraint on self, like `Self: Trait`, and we are inside a trait impl,
+        // there's no need to add it as an assumed impl because that impl shouldn't be assumed
+        // (it's either defined or not)
+        if self.current_trait_impl.is_some() && Some(object) == self.self_type.as_ref() {
+            return;
+        }
+
         let trait_id = trait_bound.trait_id;
         let generics = trait_bound.trait_generics.clone();
 

--- a/test_programs/compile_success_empty/regression_8597/Nargo.toml
+++ b/test_programs/compile_success_empty/regression_8597/Nargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "regression_8597"
+type = "bin"
+authors = [""]
+
+[dependencies]

--- a/test_programs/compile_success_empty/regression_8597/src/main.nr
+++ b/test_programs/compile_success_empty/regression_8597/src/main.nr
@@ -1,0 +1,27 @@
+trait Foo {
+    fn to_be_implemented(self) -> Field;
+
+    fn method_that_already_exists(self, other: Self) -> Field
+    where
+        Self: Eq,
+    {
+        if self.eq(other) {
+            self.to_be_implemented()
+        } else {
+            0
+        }
+    }
+}
+
+#[derive(Eq)]
+pub struct Bar {
+    a: Field,
+}
+
+impl Foo for Bar {
+    fn to_be_implemented(self) -> Field {
+        self.a
+    }
+}
+
+fn main() {}

--- a/tooling/nargo_cli/tests/snapshots/compile_success_empty/regression_8597/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_empty/regression_8597/execute__tests__expanded.snap
@@ -1,0 +1,47 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: expanded_code
+---
+trait Foo {
+    fn to_be_implemented(self) -> Field;
+
+    fn method_that_already_exists(self, other: Self) -> Field
+    where
+        Self: Eq,
+    {
+        if Eq::eq(self, other) {
+            self.to_be_implemented()
+        } else {
+            0
+        }
+    }
+}
+
+pub struct Bar {
+    a: Field,
+}
+
+impl Eq for Bar {
+    fn eq(_self: Self, _other: Self) -> bool {
+        _self.a == _other.a
+    }
+}
+
+impl Foo for Bar {
+    fn to_be_implemented(self) -> Field {
+        self.a
+    }
+
+    fn method_that_already_exists(self, other: Self) -> Field
+    where
+        Self: Eq,
+    {
+        if self.eq(other) {
+            self.to_be_implemented()
+        } else {
+            0
+        }
+    }
+}
+
+fn main() {}

--- a/tooling/nargo_cli/tests/snapshots/compile_success_empty/regression_8597/execute__tests__force_brillig_false_inliner_0.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_empty/regression_8597/execute__tests__force_brillig_false_inliner_0.snap
@@ -1,0 +1,26 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: artifact
+---
+{
+  "noir_version": "[noir_version]",
+  "hash": "[hash]",
+  "abi": {
+    "parameters": [],
+    "return_type": null,
+    "error_types": {}
+  },
+  "bytecode": [
+    "func 0",
+    "current witness index : _0",
+    "private parameters indices : []",
+    "public parameters indices : []",
+    "return value indices : []"
+  ],
+  "debug_symbols": "XY5BCsQwCEXv4rqLWfcqw1BsaosgJtikMITefWyYQOlK/3/6tcJCc9km1jXuML4rzMYivE0SA2aO6m49B+hyykbkFty4byU00gyjFpEBDpTShvaE2mpGc/oagHTx6oErC13d+XGBge158UBjnIX+ci0abjR/Uyf942Qx0FKMrqTGPPsH",
+  "file_map": {},
+  "names": [
+    "main"
+  ],
+  "brillig_names": []
+}


### PR DESCRIPTION
# Description

## Problem

Resolves #8597

## Summary

I _think_ the change here makes sense but I'm a bit hesitant about it.

## Additional Context

If this is okay, maybe the logic should also be applied when we are inside an `impl` (we should never assume `Self` has a trait impl unless we are inside a trait, in which case we don't know what `Self` is)

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
