### PR TITLE
chore(ci): Do not run ast_fuzzer orig vs. morph in ci

### DIFF
--- a/tooling/ast_fuzzer/fuzz/src/targets/acir_vs_brillig.rs
+++ b/tooling/ast_fuzzer/fuzz/src/targets/acir_vs_brillig.rs
@@ -46,6 +46,8 @@ pub fn fuzz(u: &mut Unstructured) -> eyre::Result<()> {
 
 #[cfg(test)]
 mod tests {
+    use crate::targets::tests::is_running_in_ci;
+
     /// ```ignore
     /// NOIR_ARBTEST_SEED=0x6819c61400001000 \
     /// NOIR_AST_FUZZER_SHOW_AST=1 \
@@ -53,6 +55,10 @@ mod tests {
     /// ```
     #[test]
     fn fuzz_with_arbtest() {
+        if is_running_in_ci() {
+            // TODO: Investigate function missing purity status failures.
+            return;
+        }
         crate::targets::tests::fuzz_with_arbtest(super::fuzz);
     }
 }

--- a/tooling/ast_fuzzer/fuzz/src/targets/orig_vs_morph.rs
+++ b/tooling/ast_fuzzer/fuzz/src/targets/orig_vs_morph.rs
@@ -354,6 +354,8 @@ mod rules {
 
 #[cfg(test)]
 mod tests {
+    use crate::targets::tests::is_running_in_ci;
+
     /// ```ignore
     /// NOIR_ARBTEST_SEED=0xb2fb5f0b00100000 \
     /// NOIR_AST_FUZZER_SHOW_AST=1 \
@@ -361,6 +363,10 @@ mod tests {
     /// ```
     #[test]
     fn fuzz_with_arbtest() {
+        if is_running_in_ci() {
+            // TODO: Investigate function missing purity status failures.
+            return;
+        }
         crate::targets::tests::fuzz_with_arbtest(super::fuzz);
     }
 }


### PR DESCRIPTION
# Description

## Problem\*

Resolves https://github.com/noir-lang/noir/pull/8452#issuecomment-2901736666

This fuzzer test is failing on all several PRs non-deterministically.

## Summary\*

Just blocks the test in CI for now, we can bring it back later once the failures are resolved.

## Additional Context

## Documentation\*

Check one:
- [X] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
