### PR TITLE
fix(SSA): don't use string literal if byte is "form feed" ('\f')

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/ir/printer.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/printer.rs
@@ -338,8 +338,12 @@ fn try_byte_array_to_string(elements: &Vector<ValueId>, dfg: &DataFlowGraph) -> 
         if element > 0xFF {
             return None;
         }
-        let byte = element as u8;
-        if byte.is_ascii_alphanumeric() || byte.is_ascii_punctuation() || byte.is_ascii_whitespace()
+        let byte: u8 = element as u8;
+        const FORM_FEED: u8 = 12; // This is the ASCII code for '\f', which isn't a valid escape sequence in strings
+        if byte != FORM_FEED
+            && (byte.is_ascii_alphanumeric()
+                || byte.is_ascii_punctuation()
+                || byte.is_ascii_whitespace())
         {
             string.push(byte as char);
         } else {

--- a/compiler/noirc_evaluator/src/ssa/parser/tests.rs
+++ b/compiler/noirc_evaluator/src/ssa/parser/tests.rs
@@ -127,6 +127,19 @@ fn test_make_byte_slice_with_string_literal() {
 }
 
 #[test]
+fn test_does_not_use_byte_array_literal_for_form_feed() {
+    // 12 is '\f', which isn't available in string literals (becuase in Rust it's the same)
+    let src = "
+        acir(inline) fn main f0 {
+          b0():
+            v1 = make_array [u8 12] : [u8; 1]
+            return v1
+        }
+        ";
+    assert_ssa_roundtrip(src);
+}
+
+#[test]
 fn test_block_parameters() {
     let src = "
         acir(inline) fn main f0 {

--- a/compiler/noirc_evaluator/src/ssa/parser/tests.rs
+++ b/compiler/noirc_evaluator/src/ssa/parser/tests.rs
@@ -128,7 +128,7 @@ fn test_make_byte_slice_with_string_literal() {
 
 #[test]
 fn test_does_not_use_byte_array_literal_for_form_feed() {
-    // 12 is '\f', which isn't available in string literals (becuase in Rust it's the same)
+    // 12 is '\f', which isn't available in string literals (because in Rust it's the same)
     let src = "
         acir(inline) fn main f0 {
           b0():


### PR DESCRIPTION
# Description

## Problem

Resolves #8651

## Summary



## Additional Context



## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
