### PR TITLE
chore(ci): avoid running fuzzer tests in the merge queue

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,10 @@
+[profile.ci]
+# Do not cancel the test run on the first failure.
+fail-fast = false
+
+[profile.merge-queue]
+# fail fast to kick from merge queue faster.
+fail-fast = true
+
+# Disable fuzzing to avoid flakiness
+default-filter = "not package(noir_ast_fuzzer_fuzz)"

--- a/.github/workflows/test-rust-workspace-arm64.yml
+++ b/.github/workflows/test-rust-workspace-arm64.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Install nextest
         uses: taiki-e/install-action@v2
         with:
-          tool: nextest@0.9.67
+          tool: nextest@0.9.88
 
       - name: Download archive
         uses: actions/download-artifact@v4

--- a/.github/workflows/test-rust-workspace-arm64.yml
+++ b/.github/workflows/test-rust-workspace-arm64.yml
@@ -79,7 +79,7 @@ jobs:
           RUST_MIN_STACK=8388608 \
           cargo nextest run --archive-file nextest-archive-arm64.tar.zst \
             --partition count:${{ matrix.partition }}/4 \
-            --no-fail-fast
+            --profile ci
 
   # This is a job which depends on all test jobs and reports the overall status.
   # This allows us to add/remove test jobs without having to update the required workflows.

--- a/.github/workflows/test-rust-workspace-arm64.yml
+++ b/.github/workflows/test-rust-workspace-arm64.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Install nextest
         uses: taiki-e/install-action@v2
         with:
-          tool: nextest@0.9.67
+          tool: nextest@0.9.88
 
       - name: Build and archive tests
         run: cargo nextest archive --workspace --features noirc_frontend/nextest --archive-file nextest-archive-arm64.tar.zst

--- a/.github/workflows/test-rust-workspace-msrv.yml
+++ b/.github/workflows/test-rust-workspace-msrv.yml
@@ -82,7 +82,7 @@ jobs:
       - name: Install nextest
         uses: taiki-e/install-action@v2
         with:
-          tool: nextest@0.9.67
+          tool: nextest@0.9.88
 
       - name: Download archive
         uses: actions/download-artifact@v4

--- a/.github/workflows/test-rust-workspace-msrv.yml
+++ b/.github/workflows/test-rust-workspace-msrv.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Install nextest
         uses: taiki-e/install-action@v2
         with:
-          tool: nextest@0.9.67
+          tool: nextest@0.9.88
 
       - name: Build and archive tests
         run: cargo nextest archive --workspace --archive-file nextest-archive.tar.zst

--- a/.github/workflows/test-rust-workspace-msrv.yml
+++ b/.github/workflows/test-rust-workspace-msrv.yml
@@ -93,7 +93,7 @@ jobs:
           RUST_MIN_STACK=8388608 \
           cargo nextest run --archive-file nextest-archive.tar.zst \
             --partition count:${{ matrix.partition }}/4 \
-            --no-fail-fast
+            --profile ci
 
   # This is a job which depends on all test jobs and reports the overall status.
   # This allows us to add/remove test jobs without having to update the required workflows.

--- a/.github/workflows/test-rust-workspace.yml
+++ b/.github/workflows/test-rust-workspace.yml
@@ -83,7 +83,7 @@ jobs:
             --partition count:${{ matrix.partition }}/4 \
             --profile $NEXTEST_PROFILE
         env:
-          NEXTEST_PROFILE: ${{ (github.event_name == 'merge_group' && "merge-queue") || "ci" }}
+          NEXTEST_PROFILE: ${{ (github.event_name == 'merge_group' && 'merge-queue') || 'ci' }}
 
   # This is a job which depends on all test jobs and reports the overall status.
   # This allows us to add/remove test jobs without having to update the required workflows.

--- a/.github/workflows/test-rust-workspace.yml
+++ b/.github/workflows/test-rust-workspace.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Install nextest
         uses: taiki-e/install-action@v2
         with:
-          tool: nextest@0.9.67
+          tool: nextest@0.9.88
 
       - name: Download archive
         uses: actions/download-artifact@v4

--- a/.github/workflows/test-rust-workspace.yml
+++ b/.github/workflows/test-rust-workspace.yml
@@ -77,10 +77,13 @@ jobs:
           name: nextest-archive
       - name: Run tests
         run: |
+          echo "Running with profile: $NEXTEST_PROFILE"
           RUST_MIN_STACK=8388608 \
           cargo nextest run --archive-file nextest-archive.tar.zst \
             --partition count:${{ matrix.partition }}/4 \
-            --no-fail-fast
+            --profile $NEXTEST_PROFILE
+        env:
+          NEXTEST_PROFILE: ${{ (github.event_name == 'merge_group' && "merge-queue") || "ci" }}
 
   # This is a job which depends on all test jobs and reports the overall status.
   # This allows us to add/remove test jobs without having to update the required workflows.

--- a/.github/workflows/test-rust-workspace.yml
+++ b/.github/workflows/test-rust-workspace.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Install nextest
         uses: taiki-e/install-action@v2
         with:
-          tool: nextest@0.9.67
+          tool: nextest@0.9.88
 
       - name: Build and archive tests
         run: cargo nextest archive --workspace --features noirc_frontend/nextest --archive-file nextest-archive.tar.zst


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This PR disables running the fuzzer in the merge queue as it's just causing unnecessary friction as people need to push an otherwise good PR back in to the queue.


## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
