### PR TITLE
fix(ssa): Empty array of higher order functions

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/ir/types.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/types.rs
@@ -185,6 +185,11 @@ impl Type {
         Type::Numeric(NumericType::NativeField)
     }
 
+    /// Returns whether the `Type` represents a [native field numeric type][NumericType::NativeField].
+    pub fn is_field(&self) -> bool {
+        matches!(self, Type::Numeric(NumericType::NativeField))
+    }
+
     /// Creates the type of an array's length.
     pub fn length_type() -> Type {
         Type::unsigned(SSA_WORD_SIZE)

--- a/test_programs/execution_failure/lambda_from_empty_array/Nargo.toml
+++ b/test_programs/execution_failure/lambda_from_empty_array/Nargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "lambda_from_empty_array"
+type = "bin"
+authors = [""]
+
+[dependencies]

--- a/test_programs/execution_failure/lambda_from_empty_array/src/main.nr
+++ b/test_programs/execution_failure/lambda_from_empty_array/src/main.nr
@@ -1,0 +1,6 @@
+fn main() {
+    // Still panics when there are no other lambdas
+    // This should fail either way as we are attempting to access an empty array at zero
+    let lambdas: [fn(()) -> (); 0] = [];
+    lambdas[0](());
+}


### PR DESCRIPTION
# Description

## Problem\*

Builds upon https://github.com/noir-lang/noir/pull/8674

Resolves the final panic in the linked issue that is slightly separate from lambdas in arrays:
```
fn main() {
    let lambdas: [fn(()) -> (); 0] = [];
    lambdas[0](());
}
```

## Summary\*

This is the SSA for the above snippet pre-DIE:
```text
acir(inline) fn main f0 {
  b0():
    v0 = make_array [] : [Field; 0]
    constrain u1 0 == u1 1, "Index out of bounds"
    v4 = array_get v0, index u32 0 -> Field
    call v4()
    return
}
```
If we leave `call v4()` this leads to issues in the underconstrained check and then during ACIR as function pointers are not supported. Also, the fact that we still have a function as a value means that there are no function variants and we should be able to safely remove this function. 

We now have this final SSA:
```
acir(inline) predicate_pure fn main f0 {
  b0():
    constrain u1 0 == u1 1, "Index out of bounds"
    return
}
```
This matches the final SSA and behavior of an empty array:
```noir
fn main() {
    let x = [];
    x[0];
}
```

## Additional Context

I'm not really sure in what other case we may have a function value which is an instruction. This seems like the only case. However, I'm not a huge fan of this solution as it makes assumptions across passes. I think a better solution would be to simply error out on accessing an empty array at compile-time https://github.com/noir-lang/noir/issues/8676.

## Documentation\*

Check one:
- [X] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
