### PR TITLE
chore: reenable fuzzing tests in CI

### DIFF
--- a/tooling/ast_fuzzer/fuzz/src/targets/acir_vs_brillig.rs
+++ b/tooling/ast_fuzzer/fuzz/src/targets/acir_vs_brillig.rs
@@ -46,7 +46,6 @@ pub fn fuzz(u: &mut Unstructured) -> eyre::Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use crate::targets::tests::is_running_in_ci;
 
     /// ```ignore
     /// NOIR_ARBTEST_SEED=0x6819c61400001000 \
@@ -55,10 +54,6 @@ mod tests {
     /// ```
     #[test]
     fn fuzz_with_arbtest() {
-        if is_running_in_ci() {
-            // TODO: Investigate function missing purity status failures.
-            return;
-        }
         crate::targets::tests::fuzz_with_arbtest(super::fuzz);
     }
 }

--- a/tooling/ast_fuzzer/fuzz/src/targets/comptime_vs_brillig.rs
+++ b/tooling/ast_fuzzer/fuzz/src/targets/comptime_vs_brillig.rs
@@ -50,7 +50,6 @@ pub fn fuzz(u: &mut Unstructured) -> eyre::Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use crate::targets::tests::is_running_in_ci;
 
     /// ```ignore
     /// NOIR_ARBTEST_SEED=0x6819c61400001000 \
@@ -59,10 +58,6 @@ mod tests {
     /// ```
     #[test]
     fn fuzz_with_arbtest() {
-        if is_running_in_ci() {
-            // #8511
-            return;
-        }
         crate::targets::tests::fuzz_with_arbtest(super::fuzz);
     }
 }

--- a/tooling/ast_fuzzer/fuzz/src/targets/orig_vs_morph.rs
+++ b/tooling/ast_fuzzer/fuzz/src/targets/orig_vs_morph.rs
@@ -354,8 +354,6 @@ mod rules {
 
 #[cfg(test)]
 mod tests {
-    use crate::targets::tests::is_running_in_ci;
-
     /// ```ignore
     /// NOIR_ARBTEST_SEED=0xb2fb5f0b00100000 \
     /// NOIR_AST_FUZZER_SHOW_AST=1 \
@@ -363,10 +361,6 @@ mod tests {
     /// ```
     #[test]
     fn fuzz_with_arbtest() {
-        if is_running_in_ci() {
-            // TODO: Investigate function missing purity status failures.
-            return;
-        }
         crate::targets::tests::fuzz_with_arbtest(super::fuzz);
     }
 }


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

A few of these were disabled for addressed issues (#8511, function purity postcheck). They all worked when testing locally a couple times.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
