### PR TITLE
chore: ensure `blake3` input length is less than 1024 bytes

### DIFF
--- a/acvm-repo/blackbox_solver/src/hash.rs
+++ b/acvm-repo/blackbox_solver/src/hash.rs
@@ -18,6 +18,12 @@ pub fn blake2s(inputs: &[u8]) -> Result<[u8; 32], BlackBoxResolutionError> {
 }
 
 pub fn blake3(inputs: &[u8]) -> Result<[u8; 32], BlackBoxResolutionError> {
+    if inputs.len() > 1024 {
+        return Err(BlackBoxResolutionError::Failed(
+            BlackBoxFunc::Blake3,
+            "the input length should be less than 1024 bytes".to_string(),
+        ));
+    }
     Ok(blake3::hash(inputs).into())
 }
 


### PR DESCRIPTION
# Description
BB does not behave correctly when the `blake3` input length is longer than 1024 bytes. 
This leads to programs that we can't generate the BB circuits for correctly. 
However, due to quirks in BB, this will only show up as a proof not being able to be verified. 
So I think it'd be a good idea to catch this in `stdlib`

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*



## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
