### PR TITLE
Ab/nargo expands reexports correctly implemented

### DIFF
--- a/test_programs/compile_success_empty/nargo_expand_references/Nargo.toml
+++ b/test_programs/compile_success_empty/nargo_expand_references/Nargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "nargo_expand_references"
+type = "bin"
+authors = [""]
+
+[dependencies]

--- a/test_programs/compile_success_empty/nargo_expand_references/src/main.nr
+++ b/test_programs/compile_success_empty/nargo_expand_references/src/main.nr
@@ -1,0 +1,41 @@
+mod foo {
+    mod bar {
+        pub mod baz {
+            pub fn func() {}
+
+            pub mod qux {
+                pub fn func() {}
+            }
+
+            mod one {
+                pub mod two {
+                    pub fn func() {}
+                }
+            }
+
+            pub use one::two;
+        }
+    }
+
+    pub use bar::baz;
+}
+
+mod test {
+    mod nested {
+        use super::utils;
+
+        pub fn use_utils() {
+            utils::func()
+        }
+    }
+
+    mod utils {
+        pub fn func() {}
+    }
+}
+
+fn main() {
+    foo::baz::func();
+    foo::baz::qux::func();
+    foo::baz::two::func();
+}

--- a/tooling/nargo_cli/src/cli/expand_cmd/printer.rs
+++ b/tooling/nargo_cli/src/cli/expand_cmd/printer.rs
@@ -1037,6 +1037,15 @@ impl<'context, 'string> ItemPrinter<'context, 'string> {
         }
 
         let current_module_parent_id = self.module_id.parent(self.def_maps);
+
+        // Check if module_def_id is the current module's parent
+        if let ModuleDefId::ModuleId(module_id) = module_def_id {
+            if current_module_parent_id == Some(module_id) {
+                self.push_str("super");
+                return "super".to_string();
+            }
+        }
+
         let mut reexport = None;
 
         let is_visible = module_def_id_is_visible(

--- a/tooling/nargo_cli/tests/snapshots/compile_success_empty/nargo_expand_references/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_empty/nargo_expand_references/execute__tests__expanded.snap
@@ -1,0 +1,45 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: expanded_code
+---
+mod foo {
+    pub use bar::baz;
+
+    mod bar {
+        pub mod baz {
+            pub use one::two;
+
+            pub fn func() {}
+
+            pub mod qux {
+                pub fn func() {}
+            }
+
+            mod one {
+                pub mod two {
+                    pub fn func() {}
+                }
+            }
+        }
+    }
+}
+
+mod test {
+    mod nested {
+        use super::utils;
+
+        pub fn use_utils() {
+            super::utils::func()
+        }
+    }
+
+    mod utils {
+        pub fn func() {}
+    }
+}
+
+fn main() {
+    foo::baz::func();
+    foo::baz::qux::func();
+    foo::baz::two::func();
+}

--- a/tooling/nargo_cli/tests/snapshots/compile_success_empty/nargo_expand_references/execute__tests__force_brillig_false_inliner_0.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_empty/nargo_expand_references/execute__tests__force_brillig_false_inliner_0.snap
@@ -1,0 +1,26 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: artifact
+---
+{
+  "noir_version": "[noir_version]",
+  "hash": "[hash]",
+  "abi": {
+    "parameters": [],
+    "return_type": null,
+    "error_types": {}
+  },
+  "bytecode": [
+    "func 0",
+    "current witness index : _0",
+    "private parameters indices : []",
+    "public parameters indices : []",
+    "return value indices : []"
+  ],
+  "debug_symbols": "XY5BCsQwCEXv4rqLWfcqw1BsaosgJtikMITefWyYQOlK/3/6tcJCc9km1jXuML4rzMYivE0SA2aO6m49B+hyykbkFty4byU00gyjFpEBDpTShvaE2mpGc/oagHTx6oErC13d+XGBge158UBjnIX+ci0abjR/Uyf942Qx0FKMrqTGPPsH",
+  "file_map": {},
+  "names": [
+    "main"
+  ],
+  "brillig_names": []
+}


### PR DESCRIPTION
# Description

## Problem

Follow-up to #8374

## Summary

It turns out reexports in `nargo expand` worked in some cases but not in all cases. @aakoshh shows me that it didn't work well in the `easy_private_voting` contract when referencing items inside `protocol_types`, which is reexported from `aztec`. With this PR now it works and I included a test with all the scenarios where it wasn't correctly working before.

## Additional Context



## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
