### PR TITLE
fix: Fix comptime casts of negative integer to field

### DIFF
--- a/compiler/noirc_frontend/src/hir/comptime/interpreter/cast.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter/cast.rs
@@ -249,10 +249,11 @@ mod tests {
             // Widen
             (Value::I8(127), unsigned(SixtyFour), Value::U64(127)),
             (Value::I8(127), signed(SixtyFour), Value::I64(127)),
-            // Widen negative: zero extend
+            // Widen signed->unsigned: sign extend
             (Value::I8(-1), unsigned(Sixteen), Value::U16(65535)),
             (Value::I8(-100), unsigned(Sixteen), Value::U16(65436)),
             // Casting a negative integer to a field always results in a positive value
+            // This is the only case we zero-extend signed integers instead of sign-extending them
             (Value::I8(-1), Type::FieldElement, Value::Field(SignedField::positive(255u32))),
             // Widen negative: sign extend
             (Value::I8(-1), signed(Sixteen), Value::I16(-1)),


### PR DESCRIPTION
# Description

## Problem\*

A test case I was using for https://github.com/noir-lang/noir/pull/8669 was incorrect. It stated we expect `-1_u8 as Field == -1` while the rest of our code base uses `-1_u8 as Field = 255`

## Summary\*

Not sure how I missed this originally but the problem is given above. We always zero-extend which casting to fields regardless of whether the source was signed or not.

There is something to be said about this being unintuitive. Even for existing languages casting a signed value to an unsigned one still sign-extends it.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
