### PR TITLE
chore: Show the step number in the SSA message

### DIFF
--- a/compiler/noirc_evaluator/src/ssa.rs
+++ b/compiler/noirc_evaluator/src/ssa.rs
@@ -701,8 +701,9 @@ impl SsaBuilder {
         F: FnOnce(Ssa) -> Result<Ssa, RuntimeError>,
     {
         // Count the number of times we have seen this message.
-        let cnt = self.passed.entry(msg.to_string()).and_modify(|cnt| *cnt += 1).or_insert(1);
-        let msg = format!("{msg} ({cnt})");
+        let cnt = *self.passed.entry(msg.to_string()).and_modify(|cnt| *cnt += 1).or_insert(1);
+        let step = self.passed.values().sum::<usize>();
+        let msg = format!("{msg} ({cnt}) (step {step})");
 
         // See if we should skip this pass, including the count, so we can skip the n-th occurrence of a step.
         let skip = self.skip_passes.iter().any(|s| msg.contains(s));


### PR DESCRIPTION
# Description

## Problem\*

Resolves having to scroll up and down the SSA trying to find a particular pass.

## Summary\*

Adds the overall step number to the SSA "After" message, so we can refer to a step by absolute position and look up a step in the pipeline a bit easier when we're looking at console output.

```console
❯ cargo run -q -p nargo_cli -- compile --silence-warnings --force --show-ssa-pass Simple --show-ssa-pass Defunct
After Initial SSA:
brillig(inline) fn main f0 {
...
After Dead Instruction Elimination (3) (step 43):
brillig(inline) predicate_pure fn main f0 {
  b0():
    return
}
```

In the above example `(3) (step 43)` means this is the 3rd occurrence of the DIE pass, and overall this is the 43rd SSA pass. 

## Additional Context

The output from `cargo test -p noir_ast_fuzzer_fuzz pass_vs_prev` and #8647 include a _step_ number along with the _message_. If we want to look up the state of the SSA before/after this step in an overall output we get from `--show-ssa`, we either have to know where the pass is, or use string search in a text editor to find it. By including the step count in the output of `--show-ssa`, it should be easier to find the step in a large console output by scrolling down and looking for the number, because we always see where we are relative to what we are looking for.

### Implementation notes

The reason we're not printing something like "step 4 of 43" is because the `SsaBuilder` doesn't necessarily know how many steps we are going to execute.

And the reason for deriving the count from the `Map` that contains how many times a specific message was encountered, rather than maintaining a separate counter, is so that we don't have to _take_ another stateful variable to give to the `SsaBuilder` used to execute the secondary pipeline.

## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
