### PR TITLE
feat(cli): Add `nargo interpret` command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3249,6 +3249,7 @@ dependencies = [
  "nargo_fmt",
  "nargo_toml",
  "noir_artifact_cli",
+ "noir_ast_fuzzer",
  "noir_debugger",
  "noir_lsp",
  "noirc_abi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,6 +106,7 @@ noirc_artifacts_info = { path = "tooling/noirc_artifacts_info" }
 noir_artifact_cli = { path = "tooling/artifact_cli" }
 noir_protobuf = { path = "utils/protobuf" }
 noir_ssa_executor = { path = "tooling/ssa_executor" }
+noir_ast_fuzzer = { path = "tooling/ast_fuzzer" }
 
 # Arkworks
 ark-bn254 = { version = "^0.5.0", default-features = false, features = [

--- a/tooling/ast_fuzzer/src/compare/interpreted.rs
+++ b/tooling/ast_fuzzer/src/compare/interpreted.rs
@@ -160,7 +160,7 @@ impl Comparable for ssa::interpreter::value::Value {
 }
 
 /// Convert the ABI encoded inputs to what the SSA interpreter expects.
-fn input_values_to_ssa(abi: &Abi, input_map: &InputMap) -> Vec<ssa::interpreter::value::Value> {
+pub fn input_values_to_ssa(abi: &Abi, input_map: &InputMap) -> Vec<ssa::interpreter::value::Value> {
     let mut inputs = Vec::new();
     for param in &abi.parameters {
         let input = &input_map

--- a/tooling/ast_fuzzer/src/compare/mod.rs
+++ b/tooling/ast_fuzzer/src/compare/mod.rs
@@ -16,7 +16,9 @@ pub use compiled::{
     CompareArtifact, CompareCompiled, CompareCompiledResult, CompareMorph, ComparePipelines,
 };
 pub use comptime::CompareComptime;
-pub use interpreted::{CompareInterpreted, CompareInterpretedResult, ComparePass};
+pub use interpreted::{
+    CompareInterpreted, CompareInterpretedResult, ComparePass, input_values_to_ssa,
+};
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct ExecOutput<T> {

--- a/tooling/ast_fuzzer/src/lib.rs
+++ b/tooling/ast_fuzzer/src/lib.rs
@@ -9,6 +9,7 @@ mod input;
 mod program;
 
 pub use abi::program_abi;
+pub use compare::input_values_to_ssa;
 pub use input::arb_inputs;
 use program::freq::Freqs;
 pub use program::{DisplayAstAsNoir, DisplayAstAsNoirComptime, arb_program, arb_program_comptime};

--- a/tooling/nargo_cli/Cargo.toml
+++ b/tooling/nargo_cli/Cargo.toml
@@ -44,12 +44,14 @@ nargo_toml.workspace = true
 noir_lsp.workspace = true
 noir_artifact_cli.workspace = true
 noir_debugger.workspace = true
+noirc_evaluator.workspace = true
 noirc_driver = { workspace = true, features = ["bn254"] }
 noirc_frontend = { workspace = true, features = ["bn254"] }
 noirc_abi.workspace = true
 noirc_errors.workspace = true
 noirc_artifacts.workspace = true
 noirc_artifacts_info.workspace = true
+noir_ast_fuzzer.workspace = true
 acvm = { workspace = true, features = ["bn254"] }
 bn254_blackbox_solver.workspace = true
 toml.workspace = true

--- a/tooling/nargo_cli/src/cli/compile_cmd.rs
+++ b/tooling/nargo_cli/src/cli/compile_cmd.rs
@@ -111,7 +111,7 @@ fn watch_workspace(workspace: &Workspace, compile_options: &CompileOptions) -> n
 }
 
 /// Parse all files in the workspace.
-fn parse_workspace(
+pub fn parse_workspace(
     workspace: &Workspace,
     debug_compile_stdin: Option<String>,
 ) -> (FileManager, ParsedFiles) {

--- a/tooling/nargo_cli/src/cli/interpret_cmd.rs
+++ b/tooling/nargo_cli/src/cli/interpret_cmd.rs
@@ -1,0 +1,224 @@
+//! Use the SSA Interpreter to execute a SSA after a certain pass.
+
+use acvm::acir::circuit::ExpressionWidth;
+use fm::{FileId, FileManager};
+use nargo::constants::PROVER_INPUT_FILE;
+use nargo::ops::report_errors;
+use nargo::package::Package;
+use nargo::workspace::Workspace;
+use nargo_toml::PackageSelection;
+use noirc_driver::{CompilationResult, CompileOptions};
+
+use clap::Args;
+use noirc_errors::CustomDiagnostic;
+use noirc_evaluator::brillig::BrilligOptions;
+use noirc_evaluator::ssa::ssa_gen::{Ssa, generate_ssa};
+use noirc_evaluator::ssa::{SsaEvaluatorOptions, SsaLogging, primary_passes};
+use noirc_frontend::debug::DebugInstrumenter;
+use noirc_frontend::hir::ParsedFiles;
+use noirc_frontend::monomorphization::ast::Program;
+use noirc_frontend::monomorphization::{monomorphize, monomorphize_debug};
+
+use crate::errors::CliError;
+
+use super::compile_cmd::parse_workspace;
+use super::{LockType, PackageOptions, WorkspaceCommand};
+
+/// Compile the program and interpret the SSA after each pass,
+/// printing the results to the console.
+#[derive(Debug, Clone, Args)]
+pub(super) struct InterpretCommand {
+    #[clap(flatten)]
+    pub(super) package_options: PackageOptions,
+
+    #[clap(flatten)]
+    pub(super) compile_options: CompileOptions,
+
+    /// The name of the TOML file which contains the ABI encoded inputs.
+    #[clap(long, short, default_value = PROVER_INPUT_FILE)]
+    prover_name: String,
+
+    /// The name of the SSA passes we want to interpret the results at.
+    ///
+    /// When nothing is specified, the SSA is interpreted after all passes.
+    #[clap(long)]
+    ssa_pass: Vec<String>,
+}
+
+impl WorkspaceCommand for InterpretCommand {
+    fn package_selection(&self) -> PackageSelection {
+        self.package_options.package_selection()
+    }
+
+    fn lock_type(&self) -> LockType {
+        // Does not write any artifacts.
+        LockType::Shared
+    }
+}
+
+pub(crate) fn run(args: InterpretCommand, workspace: Workspace) -> Result<(), CliError> {
+    let (file_manager, parsed_files) = parse_workspace(&workspace, None);
+    let binary_packages = workspace.into_iter().filter(|package| package.is_binary());
+
+    let ssa_options = to_ssa_options(&args.compile_options);
+    let ssa_passes = primary_passes(&ssa_options);
+
+    for package in binary_packages {
+        // Compile into monomorphized AST
+        let program_result = compile_into_program(
+            &file_manager,
+            &parsed_files,
+            &workspace,
+            package,
+            &args.compile_options,
+        );
+
+        // Report warnings and get the AST, or exit if the compilation failed.
+        let program = report_errors(
+            program_result,
+            &file_manager,
+            args.compile_options.deny_warnings,
+            args.compile_options.silence_warnings,
+        )?;
+
+        // Parse the inputs and convert them to what the SSA interpreter expects.
+        let abi = noir_ast_fuzzer::program_abi(&program);
+        let prover_file = package.root_dir.join(&args.prover_name).with_extension("toml");
+        let (prover_input, _) =
+            noir_artifact_cli::fs::inputs::read_inputs_from_file(&prover_file, &abi)?;
+        let ssa_input = noir_ast_fuzzer::input_values_to_ssa(&abi, &prover_input);
+
+        // Generate the initial SSA.
+        let mut ssa = generate_ssa(program)
+            .map_err(|e| CliError::Generic(format!("failed to generate SSA: {e}")))?;
+
+        print_and_interpret_ssa(&ssa_options, &args.ssa_pass, &mut ssa, "Initial SSA", &ssa_input);
+
+        // Run all SSA passes that match the filter, printing the result after each step.
+        for (i, ssa_pass) in ssa_passes.iter().enumerate() {
+            let msg = format!("{} (step {})", ssa_pass.msg(), i + 1);
+
+            if msg_matches(&args.compile_options.skip_ssa_pass, &msg) {
+                continue;
+            }
+
+            ssa = ssa_pass
+                .run(ssa)
+                .map_err(|e| CliError::Generic(format!("failed to run SSA pass {msg}: {e}")))?;
+
+            print_and_interpret_ssa(&ssa_options, &args.ssa_pass, &mut ssa, &msg, &ssa_input);
+        }
+    }
+    Ok(())
+}
+
+/// Compile the source code into the monomorphized AST, which is one step before SSA passes.
+///
+/// This isn't exposed through the `nargo` library operations at the moment, so this is a
+/// bit of copy pasting from the functions that normally produce an artifact.
+fn compile_into_program(
+    file_manager: &FileManager,
+    parsed_files: &ParsedFiles,
+    workspace: &Workspace,
+    package: &Package,
+    options: &CompileOptions,
+) -> CompilationResult<Program> {
+    let (mut context, crate_id) = nargo::prepare_package(file_manager, parsed_files, package);
+    if options.disable_comptime_printing {
+        context.disable_comptime_printing();
+    }
+    context.debug_instrumenter = DebugInstrumenter::default();
+    context.package_build_path = workspace.package_build_path(package);
+    noirc_driver::link_to_debug_crate(&mut context, crate_id);
+    let (_, warnings) = noirc_driver::check_crate(&mut context, crate_id, options)?;
+
+    let main_id = context.get_main_function(&crate_id).ok_or_else(|| {
+        let err = CustomDiagnostic::from_message(
+            "cannot compile crate into a program as it does not contain a `main` function",
+            FileId::default(),
+        );
+        vec![err]
+    })?;
+
+    let force_unconstrained = options.force_brillig || options.minimal_ssa;
+
+    let monomorphize_result = if options.instrument_debug {
+        monomorphize_debug(
+            main_id,
+            &mut context.def_interner,
+            &context.debug_instrumenter,
+            force_unconstrained,
+        )
+    } else {
+        monomorphize(main_id, &mut context.def_interner, force_unconstrained)
+    };
+
+    let program = monomorphize_result.map_err(|error| vec![CustomDiagnostic::from(error)])?;
+
+    if options.show_monomorphized {
+        println!("{program}");
+    }
+
+    Ok((program, warnings))
+}
+
+fn to_ssa_options(options: &CompileOptions) -> SsaEvaluatorOptions {
+    SsaEvaluatorOptions {
+        ssa_logging: if !options.show_ssa_pass.is_empty() {
+            SsaLogging::Contains(options.show_ssa_pass.clone())
+        } else if options.show_ssa {
+            SsaLogging::All
+        } else {
+            SsaLogging::None
+        },
+        brillig_options: BrilligOptions::default(),
+        print_codegen_timings: false,
+        expression_width: ExpressionWidth::default(),
+        emit_ssa: None,
+        skip_underconstrained_check: true,
+        enable_brillig_constraints_check_lookback: false,
+        skip_brillig_constraints_check: true,
+        inliner_aggressiveness: options.inliner_aggressiveness,
+        max_bytecode_increase_percent: options.max_bytecode_increase_percent,
+        skip_passes: options.skip_ssa_pass.clone(),
+    }
+}
+
+fn msg_matches(patterns: &[String], msg: &str) -> bool {
+    patterns.iter().any(|p| msg.contains(p))
+}
+
+fn print_ssa(options: &SsaEvaluatorOptions, ssa: &mut Ssa, msg: &str) {
+    let print = match options.ssa_logging {
+        SsaLogging::All => true,
+        SsaLogging::None => false,
+        SsaLogging::Contains(ref ps) => msg_matches(ps, msg),
+    };
+    if print {
+        ssa.normalize_ids();
+        println!("After {msg}:\n{ssa}");
+    }
+}
+
+fn interpret_ssa(
+    passes_to_interpret: &[String],
+    ssa: &Ssa,
+    msg: &str,
+    args: &[noirc_evaluator::ssa::interpreter::value::Value],
+) {
+    if passes_to_interpret.is_empty() || msg_matches(passes_to_interpret, msg) {
+        let result = ssa.interpret(args.into());
+        println!("--- Interpreter result after {msg}:\n{result:?}\n---");
+    }
+}
+
+fn print_and_interpret_ssa(
+    options: &SsaEvaluatorOptions,
+    passes_to_interpret: &[String],
+    ssa: &mut Ssa,
+    msg: &str,
+    args: &[noirc_evaluator::ssa::interpreter::value::Value],
+) {
+    print_ssa(options, ssa, msg);
+    interpret_ssa(passes_to_interpret, ssa, msg, args);
+}

--- a/tooling/nargo_cli/src/cli/interpret_cmd.rs
+++ b/tooling/nargo_cli/src/cli/interpret_cmd.rs
@@ -185,7 +185,8 @@ fn to_ssa_options(options: &CompileOptions) -> SsaEvaluatorOptions {
 }
 
 fn msg_matches(patterns: &[String], msg: &str) -> bool {
-    patterns.iter().any(|p| msg.contains(p))
+    let msg = msg.to_lowercase();
+    patterns.iter().any(|p| msg.contains(&p.to_lowercase()))
 }
 
 fn print_ssa(options: &SsaEvaluatorOptions, ssa: &mut Ssa, msg: &str) {

--- a/tooling/nargo_cli/src/cli/interpret_cmd.rs
+++ b/tooling/nargo_cli/src/cli/interpret_cmd.rs
@@ -94,7 +94,7 @@ pub(crate) fn run(args: InterpretCommand, workspace: Workspace) -> Result<(), Cl
 
         print_and_interpret_ssa(&ssa_options, &args.ssa_pass, &mut ssa, "Initial SSA", &ssa_input);
 
-        // Run all SSA passes that match the filter, printing the result after each step.
+        // Run SSA passes in the pipeline and interpret the ones we are interested in.
         for (i, ssa_pass) in ssa_passes.iter().enumerate() {
             let msg = format!("{} (step {})", ssa_pass.msg(), i + 1);
 

--- a/tooling/nargo_cli/src/cli/mod.rs
+++ b/tooling/nargo_cli/src/cli/mod.rs
@@ -101,6 +101,7 @@ enum NargoCommand {
     Fmt(fmt_cmd::FormatCommand),
     #[command(alias = "build")]
     Compile(compile_cmd::CompileCommand),
+    #[command(hide = true)]
     Interpret(interpret_cmd::InterpretCommand),
     New(new_cmd::NewCommand),
     Init(init_cmd::InitCommand),

--- a/tooling/nargo_cli/src/cli/mod.rs
+++ b/tooling/nargo_cli/src/cli/mod.rs
@@ -29,6 +29,7 @@ mod fuzz_cmd;
 mod generate_completion_script_cmd;
 mod info_cmd;
 mod init_cmd;
+mod interpret_cmd;
 mod lsp_cmd;
 mod new_cmd;
 mod test_cmd;
@@ -100,6 +101,7 @@ enum NargoCommand {
     Fmt(fmt_cmd::FormatCommand),
     #[command(alias = "build")]
     Compile(compile_cmd::CompileCommand),
+    Interpret(interpret_cmd::InterpretCommand),
     New(new_cmd::NewCommand),
     Init(init_cmd::InitCommand),
     Execute(execute_cmd::ExecuteCommand),
@@ -145,6 +147,7 @@ pub(crate) fn start_cli() -> eyre::Result<()> {
         NargoCommand::Init(args) => init_cmd::run(args, config),
         NargoCommand::Check(args) => with_workspace(args, config, check_cmd::run),
         NargoCommand::Compile(args) => compile_with_maybe_dummy_workspace(args, config),
+        NargoCommand::Interpret(args) => with_workspace(args, config, interpret_cmd::run),
         NargoCommand::Debug(args) => with_workspace(args, config, debug_cmd::run),
         NargoCommand::Execute(args) => with_workspace(args, config, execute_cmd::run),
         NargoCommand::Export(args) => with_workspace(args, config, export_cmd::run),


### PR DESCRIPTION
# Description

## Problem\*

@guipublic said he would like to use the SSA interpreter to evaluate the SSA at a certain point in the pipeline to debug some issue. 

This is related to https://github.com/noir-lang/noir/issues/8503 , but instead of working on a stand-alone SSA snippet where we would have to come up with some input format as well, it taps into the existing flow of `nargo`, dealing with Noir source code and TOML/JSON input, which I thought was a low hanging fruit and fits into our typical workflow.

## Summary\*

Adds a new `nargo interpret` command compiles the source code, looks for binary packages, parses their `Prover.toml` file, then uses the SSA Interpreter to evaluate the SSA after each pass, according to the `--ssa-pass` filter, which can accept multiple passes, similar to `--show-ssa-pass`. 

At the moment it only considers the `primary` passes, it doesn't do the `secondary` like the normal flow. 

## Additional Context

I added a reference from `nargo_cli` to:
* `noirc_evaluator`: so that I can access the interpreter
* `noir_ast_fuzzer`: so that I can turn ABI inputs into SSA interpreter values

We could migrate some of the stuff from the AST fuzzer into the libraries, but I thought it could be done as a follow up, to keep the code churn to a minimum. 

The new command also has quite a lot of boilerplate due to having to compile from source into monomorphized AST, which isn't exposed by the compiler library as a flow. In this it is similar to what I had to do in #8393 

Example:
```console
❯ cargo run -q -p nargo_cli -- interpret --silence-warnings --ssa-pass Flattening --ssa-pass "Removing bit shifts" 
--- Interpreter result after Flattening (step 17):
Ok([Numeric(U8(78))])
---
--- Interpreter result after Removing Bit Shifts (step 18):
Err(Internal(ConstantDoesNotFitInType { constant: -409655725810913393472212215421341542392503380204074161341709628484773418406, typ: Unsigned { bit_size: 64 } }))
---
```

The options include all the `CompileOptions`, such as `--force-brillig` and `--show-ssa`, plus some from `execute`:
```console
❯ cargo run -q -p nargo_cli -- interpret --help
Compile the program and interpret the SSA after each pass, printing the results to the console

Usage: nargo interpret [OPTIONS]

Options:
      --package <PACKAGE>
          The name of the package to run the command on. By default run on the first one found moving up along the ancestors of the current directory

      --workspace
          Run on all packages in the workspace

      ...

  -p, --prover-name <PROVER_NAME>
          The name of the TOML file which contains the ABI encoded inputs
          
          [default: Prover]

      --ssa-pass <SSA_PASS>
          The name of the SSA passes we want to interpret the results at.
          
          When nothing is specified, the SSA is interpreted after all passes.

  -h, --help
          Print help (see a summary with '-h')

```
Options which only affect ACIR or Brillig generation are ignored.

The command itself is hidden, like the SSA options in general. 

## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
