### PR TITLE
fix: do not mutate arrays later copied inside other arrays

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/opt/array_set.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/array_set.rs
@@ -233,7 +233,7 @@ mod tests {
         // from and cloned in a loop. If the array is inadvertently marked mutable, and is cloned in a previous iteration
         // of the loop, its clone will also be altered.
         let src = "
-            acir(inline) fn main f0 {
+            brillig(inline) fn main f0 {
               b0():
                 v2 = make_array [Field 0, Field 0, Field 0, Field 0, Field 0] : [Field; 5]
                 v3 = make_array [v2, v2] : [[Field; 5]; 2]


### PR DESCRIPTION
# Description

## Problem\*

Resolves #8563

## Summary\*
One array was mutated in place by the array_set optimisation, while it was copied into another array.
I added a check for arrays used inside make_array, treating it similarly to an array_get.




## Additional Context
I still need to add a (small) unit test.


## Documentation\*

Check one:
- [X] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
