### PR TITLE
fix: better way to do LSP file overrides

### DIFF
--- a/tooling/lsp/src/requests/mod.rs
+++ b/tooling/lsp/src/requests/mod.rs
@@ -446,7 +446,7 @@ where
 
     // `path` might be a relative path so we canonicalize it to get an absolute path
     let path_buf = PathBuf::from(path);
-    let path_buf = path_buf.canonicalize().unwrap_or(path_buf);
+    let path_buf = std::path::absolute(path_buf.clone()).unwrap_or(path_buf);
 
     let uri = Url::from_file_path(path_buf.to_str()?).ok()?;
 

--- a/tooling/lsp/src/requests/workspace_symbol.rs
+++ b/tooling/lsp/src/requests/workspace_symbol.rs
@@ -11,7 +11,7 @@ use async_lsp::lsp_types::{
 };
 use fm::{FileManager, FileMap};
 use fuzzy_matcher::{FuzzyMatcher, skim::SkimMatcherV2};
-use nargo::{insert_all_files_under_path_into_file_manager, parse_all};
+use nargo::{insert_all_files_under_path, parse_all};
 use noirc_errors::{Location, Span};
 use noirc_frontend::{
     ast::{
@@ -42,7 +42,7 @@ pub(crate) fn on_workspace_symbol_request(
 
     // If the cache is not initialized yet, put all files in the workspace in the FileManager
     if !cache.initialized {
-        insert_all_files_under_path_into_file_manager(&mut file_manager, &root_path, &overrides);
+        insert_all_files_under_path(&mut file_manager, &root_path, &overrides);
         cache.initialized = true;
     }
 

--- a/tooling/nargo_cli/tests/snapshots/execution_success/traits_in_crates_1/execute__tests__force_brillig_false_inliner_-9223372036854775808.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/traits_in_crates_1/execute__tests__force_brillig_false_inliner_-9223372036854775808.snap
@@ -33,9 +33,9 @@ expression: artifact
     "return value indices : []",
     "EXPR [ (1, _0) (-1, _1) 10 ]"
   ],
-  "debug_symbols": "jZBNCoMwEIXvMmsXSUUoXqUUiXGUQEjCmAhFvHtHMVUXLV3Nz5tvHrwZOmzT0BjX+xHqxwwtGWvN0FivVTTe8XZeCshjEwmRV3DSmQqK0EWoXbK2gEnZtB2NQbmtRkWsigLQdVz5YW8srt1SHLT4jkpR7rCUB15defmDl/fMlyde/u1/qz58efF/8qS0oUtiIKBezyZFRrUW9xT75PQp1PgKWcmxB/Iau0S4vts0NngD",
+  "debug_symbols": "jZBNCoMwEIXvMmsXSUUoXqUUiXGUQEjCmAhFvHtHMVUXLV3Nz5tvHrwZOmzT0BjX+xHqxwwtGWvN0FivVTTe8XZeCshjEwmRV3DSmQqK0EWoXbK2gEnZtB2NQbmtRkWsigLQdVz5YW8srt1SHLT4jkpR7rCUB17dLrz8wct75ssT/7//rfrw5cX/yZPShi6JgYB6PZsUGdVa3FPsk9OnUOMrZCXHHshr7BLh+m7T2OAN",
   "file_map": {
-    "50": {
+    "52": {
       "source": "use crate1::MyTrait;\n\nfn main(x: Field, y: pub Field) {\n    let mut V = crate2::MyStruct { Q: x };\n    V.Add10();\n    assert(V.Q == y);\n}\n",
       "path": ""
     }

--- a/tooling/nargo_cli/tests/snapshots/execution_success/traits_in_crates_1/execute__tests__force_brillig_false_inliner_0.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/traits_in_crates_1/execute__tests__force_brillig_false_inliner_0.snap
@@ -33,9 +33,9 @@ expression: artifact
     "return value indices : []",
     "EXPR [ (1, _0) (-1, _1) 10 ]"
   ],
-  "debug_symbols": "jZBNCoMwEIXvMmsXSUUoXqUUiXGUQEjCmAhFvHtHMVUXLV3Nz5tvHrwZOmzT0BjX+xHqxwwtGWvN0FivVTTe8XZeCshjEwmRV3DSmQqK0EWoXbK2gEnZtB2NQbmtRkWsigLQdVz5YW8srt1SHLT4jkpR7rCUB15defmDl/fMlyde/u1/qz58efF/8qS0oUtiIKBezyZFRrUW9xT75PQp1PgKWcmxB/Iau0S4vts0NngD",
+  "debug_symbols": "jZBNCoMwEIXvMmsXSUUoXqUUiXGUQEjCmAhFvHtHMVUXLV3Nz5tvHrwZOmzT0BjX+xHqxwwtGWvN0FivVTTe8XZeCshjEwmRV3DSmQqK0EWoXbK2gEnZtB2NQbmtRkWsigLQdVz5YW8srt1SHLT4jkpR7rCUB17dLrz8wct75ssT/7//rfrw5cX/yZPShi6JgYB6PZsUGdVa3FPsk9OnUOMrZCXHHshr7BLh+m7T2OAN",
   "file_map": {
-    "50": {
+    "52": {
       "source": "use crate1::MyTrait;\n\nfn main(x: Field, y: pub Field) {\n    let mut V = crate2::MyStruct { Q: x };\n    V.Add10();\n    assert(V.Q == y);\n}\n",
       "path": ""
     }

--- a/tooling/nargo_cli/tests/snapshots/execution_success/traits_in_crates_1/execute__tests__force_brillig_false_inliner_9223372036854775807.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/traits_in_crates_1/execute__tests__force_brillig_false_inliner_9223372036854775807.snap
@@ -33,9 +33,9 @@ expression: artifact
     "return value indices : []",
     "EXPR [ (1, _0) (-1, _1) 10 ]"
   ],
-  "debug_symbols": "jZBNCoMwEIXvMmsXSUUoXqUUiXGUQEjCmAhFvHtHMVUXLV3Nz5tvHrwZOmzT0BjX+xHqxwwtGWvN0FivVTTe8XZeCshjEwmRV3DSmQqK0EWoXbK2gEnZtB2NQbmtRkWsigLQdVz5YW8srt1SHLT4jkpR7rCUB15defmDl/fMlyde/u1/qz58efF/8qS0oUtiIKBezyZFRrUW9xT75PQp1PgKWcmxB/Iau0S4vts0NngD",
+  "debug_symbols": "jZBNCoMwEIXvMmsXSUUoXqUUiXGUQEjCmAhFvHtHMVUXLV3Nz5tvHrwZOmzT0BjX+xHqxwwtGWvN0FivVTTe8XZeCshjEwmRV3DSmQqK0EWoXbK2gEnZtB2NQbmtRkWsigLQdVz5YW8srt1SHLT4jkpR7rCUB17dLrz8wct75ssT/7//rfrw5cX/yZPShi6JgYB6PZsUGdVa3FPsk9OnUOMrZCXHHshr7BLh+m7T2OAN",
   "file_map": {
-    "50": {
+    "52": {
       "source": "use crate1::MyTrait;\n\nfn main(x: Field, y: pub Field) {\n    let mut V = crate2::MyStruct { Q: x };\n    V.Add10();\n    assert(V.Q == y);\n}\n",
       "path": ""
     }

--- a/tooling/nargo_cli/tests/snapshots/execution_success/traits_in_crates_1/execute__tests__force_brillig_true_inliner_-9223372036854775808.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/traits_in_crates_1/execute__tests__force_brillig_true_inliner_-9223372036854775808.snap
@@ -40,14 +40,14 @@ expression: artifact
     "unconstrained func 0",
     "[Const { destination: Direct(2), bit_size: Integer(U32), value: 1 }, Const { destination: Direct(1), bit_size: Integer(U32), value: 32838 }, Const { destination: Direct(0), bit_size: Integer(U32), value: 3 }, Const { destination: Relative(3), bit_size: Integer(U32), value: 2 }, Const { destination: Relative(4), bit_size: Integer(U32), value: 0 }, CalldataCopy { destination_address: Direct(32836), size_address: Relative(3), offset_address: Relative(4) }, Mov { destination: Relative(1), source: Direct(32836) }, Mov { destination: Relative(2), source: Direct(32837) }, Call { location: 13 }, Call { location: 14 }, Const { destination: Relative(1), bit_size: Integer(U32), value: 32838 }, Const { destination: Relative(2), bit_size: Integer(U32), value: 0 }, Stop { return_data: HeapVector { pointer: Relative(1), size: Relative(2) } }, Return, Call { location: 22 }, Const { destination: Relative(3), bit_size: Field, value: 10 }, BinaryFieldOp { destination: Relative(4), op: Add, lhs: Relative(1), rhs: Relative(3) }, BinaryFieldOp { destination: Relative(1), op: Equals, lhs: Relative(4), rhs: Relative(2) }, JumpIf { condition: Relative(1), location: 21 }, Const { destination: Relative(3), bit_size: Integer(U32), value: 0 }, Trap { revert_data: HeapVector { pointer: Direct(1), size: Relative(3) } }, Return, Const { destination: Direct(32772), bit_size: Integer(U32), value: 30720 }, BinaryIntOp { destination: Direct(32771), op: LessThan, bit_size: U32, lhs: Direct(0), rhs: Direct(32772) }, JumpIf { condition: Direct(32771), location: 27 }, IndirectConst { destination_pointer: Direct(1), bit_size: Integer(U64), value: 17843811134343075018 }, Trap { revert_data: HeapVector { pointer: Direct(1), size: Direct(2) } }, Return]"
   ],
-  "debug_symbols": "jZHLDoMgEEX/ZdYsBGIf/krTGNSxISFoEJo0hn/v4KPqok03XIaZc2/CjNBgFR6ltm03QHEboXLaGP0oTVcrrztLryNk6eA5FIIBP81yhkKSXGa5TiJoUMbIYKVL7xATvLOjkF45tB4KG4xh8FQmTENDr+ykXjnqZgzQNqRk2GqD6RbZRmffUZ7JBeZ8w/Mjz3/w/LLycsfzv/NF/uHlIf9Olaq1O3xwTE5Oq8rgUrbB1ruuf/VrZ11Q77oam+AwOe22ROdNCCbO95jS3g==",
+  "debug_symbols": "jZHLDoMgEEX/ZdYsBGIf/krTGNSxISFoEJo0hn/v4KPqok03XIaZc2/CjNBgFR6ltm03QHEboXLaGP0oTVcrrztLryNk6eA5FIIBP81yhkKSXGa5TiJoUMbIYKVL7xATvLOjkF45tB4KG4xh8FQmTENDr+ykXjnqZgzQNqRk2GqD6RbZRmffUZ7JBeZ8w3Nx4PkPnl9WXu74//NF/uHlIf9Olaq1O3xwTE5Oq8rgUrbB1ruuf/VrZ11Q77oam+AwOe22ROdNCCbO95jS3g==",
   "file_map": {
     "50": {
-      "source": "use crate1::MyTrait;\n\nfn main(x: Field, y: pub Field) {\n    let mut V = crate2::MyStruct { Q: x };\n    V.Add10();\n    assert(V.Q == y);\n}\n",
+      "source": "pub trait MyTrait {\n    fn Add10(&mut self);\n}\n\nimpl MyTrait for crate2::MyStruct {\n    fn Add10(&mut self) {\n        self.Q += 10;\n    }\n}\n",
       "path": ""
     },
-    "51": {
-      "source": "pub trait MyTrait {\n    fn Add10(&mut self);\n}\n\nimpl MyTrait for crate2::MyStruct {\n    fn Add10(&mut self) {\n        self.Q += 10;\n    }\n}\n",
+    "52": {
+      "source": "use crate1::MyTrait;\n\nfn main(x: Field, y: pub Field) {\n    let mut V = crate2::MyStruct { Q: x };\n    V.Add10();\n    assert(V.Q == y);\n}\n",
       "path": ""
     }
   },

--- a/tooling/nargo_cli/tests/snapshots/execution_success/traits_in_crates_1/execute__tests__force_brillig_true_inliner_0.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/traits_in_crates_1/execute__tests__force_brillig_true_inliner_0.snap
@@ -40,14 +40,14 @@ expression: artifact
     "unconstrained func 0",
     "[Const { destination: Direct(2), bit_size: Integer(U32), value: 1 }, Const { destination: Direct(1), bit_size: Integer(U32), value: 32838 }, Const { destination: Direct(0), bit_size: Integer(U32), value: 3 }, Const { destination: Relative(3), bit_size: Integer(U32), value: 2 }, Const { destination: Relative(4), bit_size: Integer(U32), value: 0 }, CalldataCopy { destination_address: Direct(32836), size_address: Relative(3), offset_address: Relative(4) }, Mov { destination: Relative(1), source: Direct(32836) }, Mov { destination: Relative(2), source: Direct(32837) }, Call { location: 13 }, Call { location: 14 }, Const { destination: Relative(1), bit_size: Integer(U32), value: 32838 }, Const { destination: Relative(2), bit_size: Integer(U32), value: 0 }, Stop { return_data: HeapVector { pointer: Relative(1), size: Relative(2) } }, Return, Call { location: 22 }, Const { destination: Relative(3), bit_size: Field, value: 10 }, BinaryFieldOp { destination: Relative(4), op: Add, lhs: Relative(1), rhs: Relative(3) }, BinaryFieldOp { destination: Relative(1), op: Equals, lhs: Relative(4), rhs: Relative(2) }, JumpIf { condition: Relative(1), location: 21 }, Const { destination: Relative(3), bit_size: Integer(U32), value: 0 }, Trap { revert_data: HeapVector { pointer: Direct(1), size: Relative(3) } }, Return, Const { destination: Direct(32772), bit_size: Integer(U32), value: 30720 }, BinaryIntOp { destination: Direct(32771), op: LessThan, bit_size: U32, lhs: Direct(0), rhs: Direct(32772) }, JumpIf { condition: Direct(32771), location: 27 }, IndirectConst { destination_pointer: Direct(1), bit_size: Integer(U64), value: 17843811134343075018 }, Trap { revert_data: HeapVector { pointer: Direct(1), size: Direct(2) } }, Return]"
   ],
-  "debug_symbols": "jZHLDoMgEEX/ZdYsBGIf/krTGNSxISFoEJo0hn/v4KPqok03XIaZc2/CjNBgFR6ltm03QHEboXLaGP0oTVcrrztLryNk6eA5FIIBP81yhkKSXGa5TiJoUMbIYKVL7xATvLOjkF45tB4KG4xh8FQmTENDr+ykXjnqZgzQNqRk2GqD6RbZRmffUZ7JBeZ8w/Mjz3/w/LLycsfzv/NF/uHlIf9Olaq1O3xwTE5Oq8rgUrbB1ruuf/VrZ11Q77oam+AwOe22ROdNCCbO95jS3g==",
+  "debug_symbols": "jZHLDoMgEEX/ZdYsBGIf/krTGNSxISFoEJo0hn/v4KPqok03XIaZc2/CjNBgFR6ltm03QHEboXLaGP0oTVcrrztLryNk6eA5FIIBP81yhkKSXGa5TiJoUMbIYKVL7xATvLOjkF45tB4KG4xh8FQmTENDr+ykXjnqZgzQNqRk2GqD6RbZRmffUZ7JBeZ8w3Nx4PkPnl9WXu74//NF/uHlIf9Olaq1O3xwTE5Oq8rgUrbB1ruuf/VrZ11Q77oam+AwOe22ROdNCCbO95jS3g==",
   "file_map": {
     "50": {
-      "source": "use crate1::MyTrait;\n\nfn main(x: Field, y: pub Field) {\n    let mut V = crate2::MyStruct { Q: x };\n    V.Add10();\n    assert(V.Q == y);\n}\n",
+      "source": "pub trait MyTrait {\n    fn Add10(&mut self);\n}\n\nimpl MyTrait for crate2::MyStruct {\n    fn Add10(&mut self) {\n        self.Q += 10;\n    }\n}\n",
       "path": ""
     },
-    "51": {
-      "source": "pub trait MyTrait {\n    fn Add10(&mut self);\n}\n\nimpl MyTrait for crate2::MyStruct {\n    fn Add10(&mut self) {\n        self.Q += 10;\n    }\n}\n",
+    "52": {
+      "source": "use crate1::MyTrait;\n\nfn main(x: Field, y: pub Field) {\n    let mut V = crate2::MyStruct { Q: x };\n    V.Add10();\n    assert(V.Q == y);\n}\n",
       "path": ""
     }
   },

--- a/tooling/nargo_cli/tests/snapshots/execution_success/traits_in_crates_1/execute__tests__force_brillig_true_inliner_9223372036854775807.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/traits_in_crates_1/execute__tests__force_brillig_true_inliner_9223372036854775807.snap
@@ -40,14 +40,14 @@ expression: artifact
     "unconstrained func 0",
     "[Const { destination: Direct(2), bit_size: Integer(U32), value: 1 }, Const { destination: Direct(1), bit_size: Integer(U32), value: 32838 }, Const { destination: Direct(0), bit_size: Integer(U32), value: 3 }, Const { destination: Relative(3), bit_size: Integer(U32), value: 2 }, Const { destination: Relative(4), bit_size: Integer(U32), value: 0 }, CalldataCopy { destination_address: Direct(32836), size_address: Relative(3), offset_address: Relative(4) }, Mov { destination: Relative(1), source: Direct(32836) }, Mov { destination: Relative(2), source: Direct(32837) }, Call { location: 13 }, Call { location: 14 }, Const { destination: Relative(1), bit_size: Integer(U32), value: 32838 }, Const { destination: Relative(2), bit_size: Integer(U32), value: 0 }, Stop { return_data: HeapVector { pointer: Relative(1), size: Relative(2) } }, Return, Call { location: 22 }, Const { destination: Relative(3), bit_size: Field, value: 10 }, BinaryFieldOp { destination: Relative(4), op: Add, lhs: Relative(1), rhs: Relative(3) }, BinaryFieldOp { destination: Relative(1), op: Equals, lhs: Relative(4), rhs: Relative(2) }, JumpIf { condition: Relative(1), location: 21 }, Const { destination: Relative(3), bit_size: Integer(U32), value: 0 }, Trap { revert_data: HeapVector { pointer: Direct(1), size: Relative(3) } }, Return, Const { destination: Direct(32772), bit_size: Integer(U32), value: 30720 }, BinaryIntOp { destination: Direct(32771), op: LessThan, bit_size: U32, lhs: Direct(0), rhs: Direct(32772) }, JumpIf { condition: Direct(32771), location: 27 }, IndirectConst { destination_pointer: Direct(1), bit_size: Integer(U64), value: 17843811134343075018 }, Trap { revert_data: HeapVector { pointer: Direct(1), size: Direct(2) } }, Return]"
   ],
-  "debug_symbols": "jZHLDoMgEEX/ZdYsBGIf/krTGNSxISFoEJo0hn/v4KPqok03XIaZc2/CjNBgFR6ltm03QHEboXLaGP0oTVcrrztLryNk6eA5FIIBP81yhkKSXGa5TiJoUMbIYKVL7xATvLOjkF45tB4KG4xh8FQmTENDr+ykXjnqZgzQNqRk2GqD6RbZRmffUZ7JBeZ8w/Mjz3/w/LLycsfzv/NF/uHlIf9Olaq1O3xwTE5Oq8rgUrbB1ruuf/VrZ11Q77oam+AwOe22ROdNCCbO95jS3g==",
+  "debug_symbols": "jZHLDoMgEEX/ZdYsBGIf/krTGNSxISFoEJo0hn/v4KPqok03XIaZc2/CjNBgFR6ltm03QHEboXLaGP0oTVcrrztLryNk6eA5FIIBP81yhkKSXGa5TiJoUMbIYKVL7xATvLOjkF45tB4KG4xh8FQmTENDr+ykXjnqZgzQNqRk2GqD6RbZRmffUZ7JBeZ8w3Nx4PkPnl9WXu74//NF/uHlIf9Olaq1O3xwTE5Oq8rgUrbB1ruuf/VrZ11Q77oam+AwOe22ROdNCCbO95jS3g==",
   "file_map": {
     "50": {
-      "source": "use crate1::MyTrait;\n\nfn main(x: Field, y: pub Field) {\n    let mut V = crate2::MyStruct { Q: x };\n    V.Add10();\n    assert(V.Q == y);\n}\n",
+      "source": "pub trait MyTrait {\n    fn Add10(&mut self);\n}\n\nimpl MyTrait for crate2::MyStruct {\n    fn Add10(&mut self) {\n        self.Q += 10;\n    }\n}\n",
       "path": ""
     },
-    "51": {
-      "source": "pub trait MyTrait {\n    fn Add10(&mut self);\n}\n\nimpl MyTrait for crate2::MyStruct {\n    fn Add10(&mut self) {\n        self.Q += 10;\n    }\n}\n",
+    "52": {
+      "source": "use crate1::MyTrait;\n\nfn main(x: Field, y: pub Field) {\n    let mut V = crate2::MyStruct { Q: x };\n    V.Add10();\n    assert(V.Q == y);\n}\n",
       "path": ""
     }
   },

--- a/tooling/nargo_cli/tests/snapshots/execution_success/traits_in_crates_2/execute__tests__force_brillig_false_inliner_-9223372036854775808.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/traits_in_crates_2/execute__tests__force_brillig_false_inliner_-9223372036854775808.snap
@@ -33,9 +33,9 @@ expression: artifact
     "return value indices : []",
     "EXPR [ (1, _0) (-1, _1) 10 ]"
   ],
-  "debug_symbols": "jZBNCoMwEIXvMmsXieLGq5QiMY4SCEkYE6GId+8opuqipav5efPNg7dAj10aW+MGP0HzWKAjY60ZW+u1isY73i5rAXlsIyHyCi46U0ERugiNS9YWMCub9qMpKLfXqIhVUQC6nis/HIzFrVuLkxbfUSmqA5byxOs7L3/w8sOX9cmXf/uXdear6ub/5ElpQ7fEQECznc2KjOosHikOyelLqPEVspJjD+Q19olwe7drbPAG",
+  "debug_symbols": "jZBNCoMwEIXvMmsXieLGq5QiMY4SCEkYE6GId+8opuqipav5efPNg7dAj10aW+MGP0HzWKAjY60ZW+u1isY73i5rAXlsIyHyCi46U0ERugiNS9YWMCub9qMpKLfXqIhVUQC6nis/HIzFrVuLkxbfUSmqA5byxOvyxssfvPzwZX3y8m//ss58Vd38nzwpbeiWGAhotrNZkVGdxSPFITl9CTW+QlZy7IG8xj4Rbu92jQ3e",
   "file_map": {
-    "50": {
+    "52": {
       "source": "use crate1::MyTrait;\n\nfn main(x: Field, y: pub Field) {\n    let mut V = crate2::MyStruct { Q: x };\n    V.Add10();\n    assert(V.Q == y);\n}\n",
       "path": ""
     }

--- a/tooling/nargo_cli/tests/snapshots/execution_success/traits_in_crates_2/execute__tests__force_brillig_false_inliner_0.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/traits_in_crates_2/execute__tests__force_brillig_false_inliner_0.snap
@@ -33,9 +33,9 @@ expression: artifact
     "return value indices : []",
     "EXPR [ (1, _0) (-1, _1) 10 ]"
   ],
-  "debug_symbols": "jZBNCoMwEIXvMmsXieLGq5QiMY4SCEkYE6GId+8opuqipav5efPNg7dAj10aW+MGP0HzWKAjY60ZW+u1isY73i5rAXlsIyHyCi46U0ERugiNS9YWMCub9qMpKLfXqIhVUQC6nis/HIzFrVuLkxbfUSmqA5byxOs7L3/w8sOX9cmXf/uXdear6ub/5ElpQ7fEQECznc2KjOosHikOyelLqPEVspJjD+Q19olwe7drbPAG",
+  "debug_symbols": "jZBNCoMwEIXvMmsXieLGq5QiMY4SCEkYE6GId+8opuqipav5efPNg7dAj10aW+MGP0HzWKAjY60ZW+u1isY73i5rAXlsIyHyCi46U0ERugiNS9YWMCub9qMpKLfXqIhVUQC6nis/HIzFrVuLkxbfUSmqA5byxOvyxssfvPzwZX3y8m//ss58Vd38nzwpbeiWGAhotrNZkVGdxSPFITl9CTW+QlZy7IG8xj4Rbu92jQ3e",
   "file_map": {
-    "50": {
+    "52": {
       "source": "use crate1::MyTrait;\n\nfn main(x: Field, y: pub Field) {\n    let mut V = crate2::MyStruct { Q: x };\n    V.Add10();\n    assert(V.Q == y);\n}\n",
       "path": ""
     }

--- a/tooling/nargo_cli/tests/snapshots/execution_success/traits_in_crates_2/execute__tests__force_brillig_false_inliner_9223372036854775807.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/traits_in_crates_2/execute__tests__force_brillig_false_inliner_9223372036854775807.snap
@@ -33,9 +33,9 @@ expression: artifact
     "return value indices : []",
     "EXPR [ (1, _0) (-1, _1) 10 ]"
   ],
-  "debug_symbols": "jZBNCoMwEIXvMmsXieLGq5QiMY4SCEkYE6GId+8opuqipav5efPNg7dAj10aW+MGP0HzWKAjY60ZW+u1isY73i5rAXlsIyHyCi46U0ERugiNS9YWMCub9qMpKLfXqIhVUQC6nis/HIzFrVuLkxbfUSmqA5byxOs7L3/w8sOX9cmXf/uXdear6ub/5ElpQ7fEQECznc2KjOosHikOyelLqPEVspJjD+Q19olwe7drbPAG",
+  "debug_symbols": "jZBNCoMwEIXvMmsXieLGq5QiMY4SCEkYE6GId+8opuqipav5efPNg7dAj10aW+MGP0HzWKAjY60ZW+u1isY73i5rAXlsIyHyCi46U0ERugiNS9YWMCub9qMpKLfXqIhVUQC6nis/HIzFrVuLkxbfUSmqA5byxOvyxssfvPzwZX3y8m//ss58Vd38nzwpbeiWGAhotrNZkVGdxSPFITl9CTW+QlZy7IG8xj4Rbu92jQ3e",
   "file_map": {
-    "50": {
+    "52": {
       "source": "use crate1::MyTrait;\n\nfn main(x: Field, y: pub Field) {\n    let mut V = crate2::MyStruct { Q: x };\n    V.Add10();\n    assert(V.Q == y);\n}\n",
       "path": ""
     }

--- a/tooling/nargo_cli/tests/snapshots/execution_success/traits_in_crates_2/execute__tests__force_brillig_true_inliner_-9223372036854775808.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/traits_in_crates_2/execute__tests__force_brillig_true_inliner_-9223372036854775808.snap
@@ -40,14 +40,14 @@ expression: artifact
     "unconstrained func 0",
     "[Const { destination: Direct(2), bit_size: Integer(U32), value: 1 }, Const { destination: Direct(1), bit_size: Integer(U32), value: 32838 }, Const { destination: Direct(0), bit_size: Integer(U32), value: 3 }, Const { destination: Relative(3), bit_size: Integer(U32), value: 2 }, Const { destination: Relative(4), bit_size: Integer(U32), value: 0 }, CalldataCopy { destination_address: Direct(32836), size_address: Relative(3), offset_address: Relative(4) }, Mov { destination: Relative(1), source: Direct(32836) }, Mov { destination: Relative(2), source: Direct(32837) }, Call { location: 13 }, Call { location: 14 }, Const { destination: Relative(1), bit_size: Integer(U32), value: 32838 }, Const { destination: Relative(2), bit_size: Integer(U32), value: 0 }, Stop { return_data: HeapVector { pointer: Relative(1), size: Relative(2) } }, Return, Call { location: 22 }, Const { destination: Relative(3), bit_size: Field, value: 10 }, BinaryFieldOp { destination: Relative(4), op: Add, lhs: Relative(1), rhs: Relative(3) }, BinaryFieldOp { destination: Relative(1), op: Equals, lhs: Relative(4), rhs: Relative(2) }, JumpIf { condition: Relative(1), location: 21 }, Const { destination: Relative(3), bit_size: Integer(U32), value: 0 }, Trap { revert_data: HeapVector { pointer: Direct(1), size: Relative(3) } }, Return, Const { destination: Direct(32772), bit_size: Integer(U32), value: 30720 }, BinaryIntOp { destination: Direct(32771), op: LessThan, bit_size: U32, lhs: Direct(0), rhs: Direct(32772) }, JumpIf { condition: Direct(32771), location: 27 }, IndirectConst { destination_pointer: Direct(1), bit_size: Integer(U64), value: 17843811134343075018 }, Trap { revert_data: HeapVector { pointer: Direct(1), size: Direct(2) } }, Return]"
   ],
-  "debug_symbols": "jZHLDoMgEEX/ZdYsBGIf/krTGNSxISFoEJo0hn/v4KPqok03XIaZc2/CjNBgFR6ltm03QHEboXLaGP0oTVcrrztLryNk6eA5FIIBP81yhkKSXGa5TiJoUMbIYKVL7xATvLOjkF45tB4KG4xh8FQmTENDr+ykXjnqZgzQNqRk2GqD6RbZRmffUZ7JBeZ8w/Mjz3/w/MOLfOPF3/kiX3kpD/l3qlSt3eGDY3JyWlUGl7INtt51/atfO+uCetfV2ASHyWm3JTpvQjBxvseU9gY=",
+  "debug_symbols": "jZHLDoMgEEX/ZdYsBGIf/krTGNSxISFoEJo0hn/v4KPqok03XIaZc2/CjNBgFR6ltm03QHEboXLaGP0oTVcrrztLryNk6eA5FIIBP81yhkKSXGa5TiJoUMbIYKVL7xATvLOjkF45tB4KG4xh8FQmTENDr+ykXjnqZgzQNqRk2GqD6RbZRmffUZ7JBeZ8w3Nx4PkPnn94kW88/ztf5Csv5SH/TpWqtTt8cExOTqvK4FK2wda7rn/1a2ddUO+6GpvgMDnttkTnTQgmzveY0t4=",
   "file_map": {
-    "50": {
-      "source": "use crate1::MyTrait;\n\nfn main(x: Field, y: pub Field) {\n    let mut V = crate2::MyStruct { Q: x };\n    V.Add10();\n    assert(V.Q == y);\n}\n",
+    "51": {
+      "source": "pub struct MyStruct {\n    pub Q: Field,\n}\n\nimpl crate1::MyTrait for MyStruct {\n    fn Add10(&mut self) {\n        self.Q += 10;\n    }\n}\n",
       "path": ""
     },
     "52": {
-      "source": "pub struct MyStruct {\n    pub Q: Field,\n}\n\nimpl crate1::MyTrait for MyStruct {\n    fn Add10(&mut self) {\n        self.Q += 10;\n    }\n}\n",
+      "source": "use crate1::MyTrait;\n\nfn main(x: Field, y: pub Field) {\n    let mut V = crate2::MyStruct { Q: x };\n    V.Add10();\n    assert(V.Q == y);\n}\n",
       "path": ""
     }
   },

--- a/tooling/nargo_cli/tests/snapshots/execution_success/traits_in_crates_2/execute__tests__force_brillig_true_inliner_0.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/traits_in_crates_2/execute__tests__force_brillig_true_inliner_0.snap
@@ -40,14 +40,14 @@ expression: artifact
     "unconstrained func 0",
     "[Const { destination: Direct(2), bit_size: Integer(U32), value: 1 }, Const { destination: Direct(1), bit_size: Integer(U32), value: 32838 }, Const { destination: Direct(0), bit_size: Integer(U32), value: 3 }, Const { destination: Relative(3), bit_size: Integer(U32), value: 2 }, Const { destination: Relative(4), bit_size: Integer(U32), value: 0 }, CalldataCopy { destination_address: Direct(32836), size_address: Relative(3), offset_address: Relative(4) }, Mov { destination: Relative(1), source: Direct(32836) }, Mov { destination: Relative(2), source: Direct(32837) }, Call { location: 13 }, Call { location: 14 }, Const { destination: Relative(1), bit_size: Integer(U32), value: 32838 }, Const { destination: Relative(2), bit_size: Integer(U32), value: 0 }, Stop { return_data: HeapVector { pointer: Relative(1), size: Relative(2) } }, Return, Call { location: 22 }, Const { destination: Relative(3), bit_size: Field, value: 10 }, BinaryFieldOp { destination: Relative(4), op: Add, lhs: Relative(1), rhs: Relative(3) }, BinaryFieldOp { destination: Relative(1), op: Equals, lhs: Relative(4), rhs: Relative(2) }, JumpIf { condition: Relative(1), location: 21 }, Const { destination: Relative(3), bit_size: Integer(U32), value: 0 }, Trap { revert_data: HeapVector { pointer: Direct(1), size: Relative(3) } }, Return, Const { destination: Direct(32772), bit_size: Integer(U32), value: 30720 }, BinaryIntOp { destination: Direct(32771), op: LessThan, bit_size: U32, lhs: Direct(0), rhs: Direct(32772) }, JumpIf { condition: Direct(32771), location: 27 }, IndirectConst { destination_pointer: Direct(1), bit_size: Integer(U64), value: 17843811134343075018 }, Trap { revert_data: HeapVector { pointer: Direct(1), size: Direct(2) } }, Return]"
   ],
-  "debug_symbols": "jZHLDoMgEEX/ZdYsBGIf/krTGNSxISFoEJo0hn/v4KPqok03XIaZc2/CjNBgFR6ltm03QHEboXLaGP0oTVcrrztLryNk6eA5FIIBP81yhkKSXGa5TiJoUMbIYKVL7xATvLOjkF45tB4KG4xh8FQmTENDr+ykXjnqZgzQNqRk2GqD6RbZRmffUZ7JBeZ8w/Mjz3/w/MOLfOPF3/kiX3kpD/l3qlSt3eGDY3JyWlUGl7INtt51/atfO+uCetfV2ASHyWm3JTpvQjBxvseU9gY=",
+  "debug_symbols": "jZHLDoMgEEX/ZdYsBGIf/krTGNSxISFoEJo0hn/v4KPqok03XIaZc2/CjNBgFR6ltm03QHEboXLaGP0oTVcrrztLryNk6eA5FIIBP81yhkKSXGa5TiJoUMbIYKVL7xATvLOjkF45tB4KG4xh8FQmTENDr+ykXjnqZgzQNqRk2GqD6RbZRmffUZ7JBeZ8w3Nx4PkPnn94kW88/ztf5Csv5SH/TpWqtTt8cExOTqvK4FK2wda7rn/1a2ddUO+6GpvgMDnttkTnTQgmzveY0t4=",
   "file_map": {
-    "50": {
-      "source": "use crate1::MyTrait;\n\nfn main(x: Field, y: pub Field) {\n    let mut V = crate2::MyStruct { Q: x };\n    V.Add10();\n    assert(V.Q == y);\n}\n",
+    "51": {
+      "source": "pub struct MyStruct {\n    pub Q: Field,\n}\n\nimpl crate1::MyTrait for MyStruct {\n    fn Add10(&mut self) {\n        self.Q += 10;\n    }\n}\n",
       "path": ""
     },
     "52": {
-      "source": "pub struct MyStruct {\n    pub Q: Field,\n}\n\nimpl crate1::MyTrait for MyStruct {\n    fn Add10(&mut self) {\n        self.Q += 10;\n    }\n}\n",
+      "source": "use crate1::MyTrait;\n\nfn main(x: Field, y: pub Field) {\n    let mut V = crate2::MyStruct { Q: x };\n    V.Add10();\n    assert(V.Q == y);\n}\n",
       "path": ""
     }
   },

--- a/tooling/nargo_cli/tests/snapshots/execution_success/traits_in_crates_2/execute__tests__force_brillig_true_inliner_9223372036854775807.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/traits_in_crates_2/execute__tests__force_brillig_true_inliner_9223372036854775807.snap
@@ -40,14 +40,14 @@ expression: artifact
     "unconstrained func 0",
     "[Const { destination: Direct(2), bit_size: Integer(U32), value: 1 }, Const { destination: Direct(1), bit_size: Integer(U32), value: 32838 }, Const { destination: Direct(0), bit_size: Integer(U32), value: 3 }, Const { destination: Relative(3), bit_size: Integer(U32), value: 2 }, Const { destination: Relative(4), bit_size: Integer(U32), value: 0 }, CalldataCopy { destination_address: Direct(32836), size_address: Relative(3), offset_address: Relative(4) }, Mov { destination: Relative(1), source: Direct(32836) }, Mov { destination: Relative(2), source: Direct(32837) }, Call { location: 13 }, Call { location: 14 }, Const { destination: Relative(1), bit_size: Integer(U32), value: 32838 }, Const { destination: Relative(2), bit_size: Integer(U32), value: 0 }, Stop { return_data: HeapVector { pointer: Relative(1), size: Relative(2) } }, Return, Call { location: 22 }, Const { destination: Relative(3), bit_size: Field, value: 10 }, BinaryFieldOp { destination: Relative(4), op: Add, lhs: Relative(1), rhs: Relative(3) }, BinaryFieldOp { destination: Relative(1), op: Equals, lhs: Relative(4), rhs: Relative(2) }, JumpIf { condition: Relative(1), location: 21 }, Const { destination: Relative(3), bit_size: Integer(U32), value: 0 }, Trap { revert_data: HeapVector { pointer: Direct(1), size: Relative(3) } }, Return, Const { destination: Direct(32772), bit_size: Integer(U32), value: 30720 }, BinaryIntOp { destination: Direct(32771), op: LessThan, bit_size: U32, lhs: Direct(0), rhs: Direct(32772) }, JumpIf { condition: Direct(32771), location: 27 }, IndirectConst { destination_pointer: Direct(1), bit_size: Integer(U64), value: 17843811134343075018 }, Trap { revert_data: HeapVector { pointer: Direct(1), size: Direct(2) } }, Return]"
   ],
-  "debug_symbols": "jZHLDoMgEEX/ZdYsBGIf/krTGNSxISFoEJo0hn/v4KPqok03XIaZc2/CjNBgFR6ltm03QHEboXLaGP0oTVcrrztLryNk6eA5FIIBP81yhkKSXGa5TiJoUMbIYKVL7xATvLOjkF45tB4KG4xh8FQmTENDr+ykXjnqZgzQNqRk2GqD6RbZRmffUZ7JBeZ8w/Mjz3/w/MOLfOPF3/kiX3kpD/l3qlSt3eGDY3JyWlUGl7INtt51/atfO+uCetfV2ASHyWm3JTpvQjBxvseU9gY=",
+  "debug_symbols": "jZHLDoMgEEX/ZdYsBGIf/krTGNSxISFoEJo0hn/v4KPqok03XIaZc2/CjNBgFR6ltm03QHEboXLaGP0oTVcrrztLryNk6eA5FIIBP81yhkKSXGa5TiJoUMbIYKVL7xATvLOjkF45tB4KG4xh8FQmTENDr+ykXjnqZgzQNqRk2GqD6RbZRmffUZ7JBeZ8w3Nx4PkPnn94kW88/ztf5Csv5SH/TpWqtTt8cExOTqvK4FK2wda7rn/1a2ddUO+6GpvgMDnttkTnTQgmzveY0t4=",
   "file_map": {
-    "50": {
-      "source": "use crate1::MyTrait;\n\nfn main(x: Field, y: pub Field) {\n    let mut V = crate2::MyStruct { Q: x };\n    V.Add10();\n    assert(V.Q == y);\n}\n",
+    "51": {
+      "source": "pub struct MyStruct {\n    pub Q: Field,\n}\n\nimpl crate1::MyTrait for MyStruct {\n    fn Add10(&mut self) {\n        self.Q += 10;\n    }\n}\n",
       "path": ""
     },
     "52": {
-      "source": "pub struct MyStruct {\n    pub Q: Field,\n}\n\nimpl crate1::MyTrait for MyStruct {\n    fn Add10(&mut self) {\n        self.Q += 10;\n    }\n}\n",
+      "source": "use crate1::MyTrait;\n\nfn main(x: Field, y: pub Field) {\n    let mut V = crate2::MyStruct { Q: x };\n    V.Add10();\n    assert(V.Q == y);\n}\n",
       "path": ""
     }
   },


### PR DESCRIPTION
# Description

## Problem

Resolves #8670

## Summary

When you open a Noir file in LSP, and whenever you edit it, we cache that file's path and source code. Then when building a FileManager we pass these files as "overrides" so their contents are read from this cache instead of the filesystem. We do this so that even if you don't save a file, code that references that unsaved content works fine. This is how Rust Analyzer seem to work too (I'm not sure how they implemented it, though, but the exhibited behavior is that).

For overrides, what we used to do before this PR is traversing all files in the filesystem for the relevant packages and adding them to the FileManager, except that if there's an override for a path we'd use that override's source code. That works fine except when a file is deleted from the filesystem. In that case the override won't be added because we never find that path in the filesystem to be able to override it!

Initially I thought we could add the overrides at the end, at least those that we didn't find in the filesystem. The problem with that is that the override's FileID will end up being different than the one before the file was deleted, so things like "Go to definition", etc., which rely on FileIDs won't work well.

An alternative approach, which is what this PR does, is to first compute all the filenames that need to go into the FileManager. Those come from the filesystem, but also from the overrides. Then, to have a consistent FileID order, we can sort all of these filenames, and just then add them to the FileManager (considering overrides here too).

Here's how it works in Rust when you delete a file but continue editing it. Notice how we can still jump to that file from another file, and even if you add a new definition to the deleted file, it will be suggested in other files:

![lsp-rust](https://github.com/user-attachments/assets/f5c66df6-2d35-4d5b-96a3-01533eecb48b)

And now it works the same way in Noir LSP:

![lsp-noir](https://github.com/user-attachments/assets/62b21e8d-7211-4683-9e5b-607479d6925b)

## Additional Context



## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
