### PR TITLE
fix(fuzz): Prevent breaking/continuing out from let blocks in the AST fuzzer

### DIFF
--- a/tooling/ast_fuzzer/fuzz/src/targets/comptime_vs_brillig.rs
+++ b/tooling/ast_fuzzer/fuzz/src/targets/comptime_vs_brillig.rs
@@ -21,8 +21,6 @@ pub fn fuzz(u: &mut Unstructured) -> eyre::Result<()> {
         avoid_err_by_zero: true,
         // and it gets old to have to edit u128 to fit into u32 for the frontend to parse
         avoid_large_int_literals: true,
-        // Avoid break/continue (until #8382 is merged)
-        avoid_loop_control: true,
         // Has to only use expressions valid in comptime
         comptime_friendly: true,
         // Force brillig

--- a/tooling/ast_fuzzer/fuzz/src/targets/comptime_vs_brillig.rs
+++ b/tooling/ast_fuzzer/fuzz/src/targets/comptime_vs_brillig.rs
@@ -21,6 +21,8 @@ pub fn fuzz(u: &mut Unstructured) -> eyre::Result<()> {
         avoid_err_by_zero: true,
         // and it gets old to have to edit u128 to fit into u32 for the frontend to parse
         avoid_large_int_literals: true,
+        // Avoid break/continue
+        avoid_loop_control: true,
         // Has to only use expressions valid in comptime
         comptime_friendly: true,
         // Force brillig

--- a/tooling/ast_fuzzer/src/program/func.rs
+++ b/tooling/ast_fuzzer/src/program/func.rs
@@ -758,7 +758,14 @@ impl<'a> FunctionContext<'a> {
         let max_depth = self.max_depth();
         let comptime_friendly = self.is_comptime_friendly();
         let typ = self.ctx.gen_type(u, max_depth, false, false, true, comptime_friendly)?;
+
+        // Temporarily set in_loop to false to disallow breaking/continuing out
+        // of the let blocks (which would lead to frontend errors when reversing
+        // the AST into Noir)
+        let was_in_loop = std::mem::replace(&mut self.in_loop, false);
         let expr = self.gen_expr(u, &typ, max_depth, Flags::TOP)?;
+        self.in_loop = was_in_loop;
+
         let mutable = bool::arbitrary(u)?;
         Ok(self.let_var(mutable, typ, expr, true))
     }


### PR DESCRIPTION
# Description

While generating loops, the fuzzer would often place `break` inside a let stament in a loop, leading to https://github.com/noir-lang/noir/issues/8629. This should be a quick fix for these appearances.

## Problem\*


## Summary\*



## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
