### PR TITLE
chore: remove override for zero length inputs

### DIFF
--- a/compiler/noirc_frontend/src/hir_def/types.rs
+++ b/compiler/noirc_frontend/src/hir_def/types.rs
@@ -1311,7 +1311,7 @@ impl Type {
             }
 
             Type::Array(length, element) => {
-                (Self::should_allow_zero_sized_input() || self.array_or_string_len_is_not_zero())
+                self.array_or_string_len_is_not_zero()
                     && length.is_valid_for_program_input()
                     && element.is_valid_for_program_input()
             }
@@ -1332,14 +1332,6 @@ impl Type {
                 lhs.is_valid_for_program_input() && rhs.is_valid_for_program_input()
             }
         }
-    }
-
-    /// Check if it is okay to allow for zero-sized input (e..g zero-sized arrays) to a program.
-    /// This behavior is not well defined and is banned by default.
-    /// However, this ban is a breaking change for some dependent projects so this override
-    /// is provided until those projects migrate away from using zero-sized array input (e.g. <https://github.com/AztecProtocol/aztec-packages/issues/14388>).
-    fn should_allow_zero_sized_input() -> bool {
-        std::env::var("ALLOW_EMPTY_INPUT").ok().map(|v| v == "1" || v == "true").unwrap_or_default()
     }
 
     /// Empty arrays and strings (which are arrays under the hood) are disallowed


### PR DESCRIPTION
# Description

## Problem\*


## Summary\*

This PR reverts #8568 as aztec-packages has been updated to remove these zero length inputs.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
