### PR TITLE
chore: add pre- and post-check on `array_set` optimization pass

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/opt/array_set.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/array_set.rs
@@ -43,7 +43,7 @@ fn array_set_optimization_pre_check(func: &Function) {
         let instruction_ids = func.dfg[block_id].instructions();
         for instruction_id in instruction_ids {
             if matches!(func.dfg[*instruction_id], Instruction::ArraySet { mutable: true, .. }) {
-                panic!("IfElse instruction exists before `array_set_optimization` pass");
+                panic!("mutable ArraySet instruction exists before `array_set_optimization` pass");
             }
         }
     }


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This PR adds some pre- and post-checks to the array_set optimization pass to ensure that we're not calling it more than once or on brillig functions.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
