### PR TITLE
chore: box `AsTraitPath` and `TypePath` in `ExpressionKind`

### DIFF
--- a/compiler/noirc_frontend/src/ast/expression.rs
+++ b/compiler/noirc_frontend/src/ast/expression.rs
@@ -42,8 +42,8 @@ pub enum ExpressionKind {
     Unquote(Box<Expression>),
     Comptime(BlockExpression, Location),
     Unsafe(UnsafeExpression),
-    AsTraitPath(AsTraitPath),
-    TypePath(TypePath),
+    AsTraitPath(Box<AsTraitPath>),
+    TypePath(Box<TypePath>),
 
     // This variant is only emitted when inlining the result of comptime
     // code. It is used to translate function values back into the AST while

--- a/compiler/noirc_frontend/src/ast/mod.rs
+++ b/compiler/noirc_frontend/src/ast/mod.rs
@@ -562,9 +562,7 @@ impl UnresolvedTypeExpression {
                 };
                 Ok(UnresolvedTypeExpression::BinaryOperation(lhs, op, rhs, expr.location))
             }
-            ExpressionKind::AsTraitPath(path) => {
-                Ok(UnresolvedTypeExpression::AsTraitPath(Box::new(path)))
-            }
+            ExpressionKind::AsTraitPath(path) => Ok(UnresolvedTypeExpression::AsTraitPath(path)),
             ExpressionKind::Parenthesized(expr) => Self::from_expr_helper(*expr),
             _ => Err(expr),
         }

--- a/compiler/noirc_frontend/src/elaborator/expressions.rs
+++ b/compiler/noirc_frontend/src/elaborator/expressions.rs
@@ -99,9 +99,9 @@ impl Elaborator<'_> {
                 (HirExpression::Error, Type::Error)
             }
             ExpressionKind::AsTraitPath(path) => {
-                return self.elaborate_as_trait_path(path);
+                return self.elaborate_as_trait_path(*path);
             }
-            ExpressionKind::TypePath(path) => return self.elaborate_type_path(path),
+            ExpressionKind::TypePath(path) => return self.elaborate_type_path(*path),
         };
         let id = self.interner.push_expr(hir_expr);
         self.interner.push_expr_location(id, expr.location);

--- a/compiler/noirc_frontend/src/parser/parser/expression.rs
+++ b/compiler/noirc_frontend/src/parser/parser/expression.rs
@@ -399,11 +399,11 @@ impl Parser<'_> {
         let typ = self.parse_type_or_error();
         if self.eat_keyword(Keyword::As) {
             let as_trait_path = self.parse_as_trait_path_for_type_after_as_keyword(typ);
-            Some(ExpressionKind::AsTraitPath(as_trait_path))
+            Some(ExpressionKind::AsTraitPath(Box::new(as_trait_path)))
         } else {
             self.eat_or_error(Token::Greater);
             let type_path = self.parse_type_path_expr_for_type(typ);
-            Some(ExpressionKind::TypePath(type_path))
+            Some(ExpressionKind::TypePath(Box::new(type_path)))
         }
     }
 
@@ -677,7 +677,7 @@ impl Parser<'_> {
         let typ = UnresolvedType { typ, location };
 
         if self.at(Token::DoubleColon) {
-            Some(ExpressionKind::TypePath(self.parse_type_path_expr_for_type(typ)))
+            Some(ExpressionKind::TypePath(Box::new(self.parse_type_path_expr_for_type(typ))))
         } else {
             // This is the case when we find `Field` or `i32` but `::` doesn't follow it.
             self.push_error(ParserErrorReason::ExpectedValueFoundBuiltInType { typ }, location);
@@ -882,7 +882,7 @@ impl Parser<'_> {
 
                 self.push_error(ParserErrorReason::MissingAngleBrackets, location);
 
-                return Some(ExpressionKind::TypePath(type_path));
+                return Some(ExpressionKind::TypePath(Box::new(type_path)));
             }
 
             return Some(ExpressionKind::Literal(Literal::Unit));

--- a/tooling/lsp/src/with_file.rs
+++ b/tooling/lsp/src/with_file.rs
@@ -676,10 +676,10 @@ fn expression_kind_with_file(kind: ExpressionKind, file: FileId) -> ExpressionKi
             })
         }
         ExpressionKind::AsTraitPath(as_trait_path) => {
-            ExpressionKind::AsTraitPath(as_trait_path_with_file(as_trait_path, file))
+            ExpressionKind::AsTraitPath(Box::new(as_trait_path_with_file(*as_trait_path, file)))
         }
         ExpressionKind::TypePath(type_path) => {
-            ExpressionKind::TypePath(type_path_with_file(type_path, file))
+            ExpressionKind::TypePath(Box::new(type_path_with_file(*type_path, file)))
         }
         ExpressionKind::Resolved(..)
         | ExpressionKind::Interned(..)

--- a/tooling/nargo_fmt/src/formatter/expression.rs
+++ b/tooling/nargo_fmt/src/formatter/expression.rs
@@ -105,10 +105,10 @@ impl ChunkFormatter<'_, '_> {
                 ));
             }
             ExpressionKind::AsTraitPath(as_trait_path) => {
-                group.text(self.chunk(|formatter| formatter.format_as_trait_path(as_trait_path)));
+                group.text(self.chunk(|formatter| formatter.format_as_trait_path(*as_trait_path)));
             }
             ExpressionKind::TypePath(type_path) => {
-                group.group(self.format_type_path(type_path));
+                group.group(self.format_type_path(*type_path));
             }
             ExpressionKind::Resolved(..)
             | ExpressionKind::Interned(..)


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

`StatementOrExpressionOrLValue` is screaming at me for being over a kilobyte in size. This PR shrinks it down to being 416 bytes so we don't need to move so much memory around all the time.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
