### PR TITLE
fix(fmt): correctly format mixed secondary attributes and doc comments

### DIFF
--- a/tooling/nargo_fmt/src/formatter/attribute.rs
+++ b/tooling/nargo_fmt/src/formatter/attribute.rs
@@ -27,9 +27,13 @@ impl Formatter<'_> {
     }
 
     pub(super) fn format_secondary_attributes(&mut self, attributes: Vec<SecondaryAttribute>) {
+        // Attributes and doc comments can be mixed, so between each attribute
+        // we format potential doc comments
         for attribute in attributes {
+            self.format_outer_doc_comments();
             self.format_secondary_attribute(attribute);
         }
+        self.format_outer_doc_comments();
     }
 
     fn format_attribute(&mut self, attribute: Attribute) {

--- a/tooling/nargo_fmt/src/formatter/doc_comments.rs
+++ b/tooling/nargo_fmt/src/formatter/doc_comments.rs
@@ -111,4 +111,12 @@ mod tests {
 ";
         assert_format(src, expected);
     }
+
+    #[test]
+    fn format_struct_outer_doc_comment_after_attribute() {
+        let src = "#[derive(Eq)]
+/// A struct
+struct Foo {}\n";
+        assert_format(src, src);
+    }
 }


### PR DESCRIPTION
# Description

## Problem

Resolves #8719

## Summary



## Additional Context



## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
