### PR TITLE
chore: repro for very strange bug

### DIFF
--- a/noir_stdlib/src/convert.nr
+++ b/noir_stdlib/src/convert.nr
@@ -175,23 +175,24 @@ comptime fn generate_as_primitive_impls(_: FunctionDefinition) -> Quoted {
     let mut impls = &[];
     for type1 in types {
         for type2 in types {
-            let body = if type1 == type2 {
-                quote { self }
-            } else if type1 == quote { bool } {
-                quote { self != 0 }
-            } else {
-                quote { self as $type1 }
-            };
+            // Uncomment one, the serialize_1 program compiles.
+            // Uncomment two, it doesn't compile anymore.
+            // Uncomment three, it compiles again.
+            // Uncomment four, it still compiles.
+            // let a1 = quote {};
+            // let a2 = quote {};
+            // let a3 = quote {};
+            // let a4 = quote {};
 
-            let as_primitive_impl = quote {
+            impls = impls.push_back(
+                quote {
                 impl AsPrimitive<$type1> for $type2 {
                     fn as_(self) -> $type1 {
-                        $body
+                        $crate::default::Default::default()
                     }
                 }
-            };
-
-            impls = impls.push_back(as_primitive_impl);
+            },
+            );
         }
     }
     impls.join(quote {})


### PR DESCRIPTION
# Description

## Problem

The compiler fails to compile a program if we add/remove unused variables.

## Summary

If we compile the `serialize_1` as it is in this PR, it fails to compile. But if we uncomment the `let a1 = quote {};` variable, it compiles.

Note that if it's `let a1 = 1;` then it **doesn't** compile. For some reason if we use `quote {}` it compiles.

Then, if we keep uncomment variables the program will compile or not compile. It seems a bit random.

This makes me think there's a bug somewhere in the comptime code. We already [observed](https://github.com/noir-lang/noir/issues/8545#issuecomment-2887599812) that if some code is generated via macros instead of written by hand then it might lead to slower compilation, when it shouldn't, so maybe all of these things are related. I wonder if something is leaking from the comptime interpreter that's modifying something outside of it, some global state (or bindings, type vars, not sure).

---

Another way: instead of uncommenting any of those variables, add this to `lib.nr` for the standard library:

```noir
fn foo() {
    comptime {
        let _ = quote {};
    }
}
```

then the code compiles.

## Additional Context



## Documentation

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
