### PR TITLE
fix(ssa): Experiment with removing the last stores optimization in mem2reg

### DIFF
--- a/test_programs/execution_success/regression_8739/Nargo.toml
+++ b/test_programs/execution_success/regression_8739/Nargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "regression_8739"
+type = "bin"
+authors = [""]
+
+[dependencies]

--- a/test_programs/execution_success/regression_8739/src/main.nr
+++ b/test_programs/execution_success/regression_8739/src/main.nr
@@ -1,0 +1,15 @@
+fn main() {
+    // Safety: testing context
+    unsafe {
+        func_2()
+    }
+}
+unconstrained fn func_2() {
+    let mut a: [&mut bool; 1] = [(&mut true)];
+    let mut idx_b: u32 = 0;
+    while (*a[0]) {
+        if (idx_b == 0) {
+            break;
+        }
+    }
+}


### PR DESCRIPTION
# Description

## Problem\*

As as an alternative to https://github.com/noir-lang/noir/pull/8743 I just want to see the effects of removing this optimization where we remove the remaining last stores.

## Summary\*



## Additional Context



## Documentation\*

Check one:
- [X] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
