### PR TITLE
chore: shrink `Statement` enum by boxing large data fields

### DIFF
--- a/compiler/noirc_frontend/src/ast/statement.rs
+++ b/compiler/noirc_frontend/src/ast/statement.rs
@@ -170,7 +170,7 @@ impl StatementKind {
     ) -> StatementKind {
         StatementKind::Let(LetStatement {
             pattern,
-            r#type,
+            r#type: Box::new(r#type),
             expression,
             comptime: false,
             is_global_let: false,
@@ -539,7 +539,7 @@ impl Display for PathSegment {
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct LetStatement {
     pub pattern: Pattern,
-    pub r#type: UnresolvedType,
+    pub r#type: Box<UnresolvedType>,
     pub expression: Expression,
     pub attributes: Vec<SecondaryAttribute>,
 
@@ -569,7 +569,7 @@ pub enum Pattern {
     Identifier(Ident),
     Mutable(Box<Pattern>, Location, /*is_synthesized*/ bool),
     Tuple(Vec<Pattern>, Location),
-    Struct(Path, Vec<(Ident, Pattern)>, Location),
+    Struct(Box<Path>, Vec<(Ident, Pattern)>, Location),
     Parenthesized(Box<Pattern>, Location),
     Interned(InternedPattern, Location),
 }
@@ -620,7 +620,7 @@ impl Pattern {
                 }
                 Some(Expression {
                     kind: ExpressionKind::Constructor(Box::new(ConstructorExpression {
-                        typ: UnresolvedType::from_path(path.clone()),
+                        typ: UnresolvedType::from_path(*path.clone()),
                         fields,
                     })),
                     location: *location,
@@ -853,7 +853,7 @@ impl ForRange {
                 let for_loop = Statement {
                     kind: StatementKind::For(ForLoopStatement {
                         identifier: fresh_identifier,
-                        range: ForRange::range(start_range, end_range),
+                        range: Box::new(ForRange::range(start_range, end_range)),
                         block: new_block,
                         location: for_loop_location,
                     }),
@@ -875,7 +875,7 @@ impl ForRange {
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct ForLoopStatement {
     pub identifier: Ident,
-    pub range: ForRange,
+    pub range: Box<ForRange>,
     pub block: Expression,
     pub location: Location,
 }
@@ -1000,7 +1000,7 @@ impl Display for Pattern {
 
 impl Display for ForLoopStatement {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let range = match &self.range {
+        let range = match &*self.range {
             ForRange::Range(bounds) => {
                 format!(
                     "{}{}{}",

--- a/compiler/noirc_frontend/src/elaborator/patterns.rs
+++ b/compiler/noirc_frontend/src/elaborator/patterns.rs
@@ -163,7 +163,7 @@ impl Elaborator<'_> {
                 HirPattern::Tuple(fields, location)
             }
             Pattern::Struct(name, fields, location) => {
-                let name = self.validate_path(name);
+                let name = self.validate_path(*name);
                 self.elaborate_struct_pattern(
                     name,
                     fields,

--- a/compiler/noirc_frontend/src/elaborator/statements.rs
+++ b/compiler/noirc_frontend/src/elaborator/statements.rs
@@ -92,7 +92,7 @@ impl Elaborator<'_> {
         global_id: Option<GlobalId>,
     ) -> (HirStatement, Type) {
         let type_contains_unspecified = let_stmt.r#type.contains_unspecified();
-        let annotated_type = self.resolve_inferred_type(let_stmt.r#type);
+        let annotated_type = self.resolve_inferred_type(*let_stmt.r#type);
 
         let pattern_location = let_stmt.pattern.location();
         let expr_location = let_stmt.expression.location;
@@ -192,7 +192,7 @@ impl Elaborator<'_> {
     }
 
     pub(super) fn elaborate_for(&mut self, for_loop: ForLoopStatement) -> (HirStatement, Type) {
-        let (start, end) = match for_loop.range {
+        let (start, end) = match *for_loop.range {
             ForRange::Range(bounds) => bounds.into_half_open(),
             ForRange::Array(_) => {
                 let for_stmt =

--- a/compiler/noirc_frontend/src/hir/comptime/display.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/display.rs
@@ -785,7 +785,7 @@ fn remove_interned_in_statement_kind(
         StatementKind::Let(let_statement) => StatementKind::Let(LetStatement {
             pattern: remove_interned_in_pattern(interner, let_statement.pattern),
             expression: remove_interned_in_expression(interner, let_statement.expression),
-            r#type: remove_interned_in_unresolved_type(interner, let_statement.r#type),
+            r#type: Box::new(remove_interned_in_unresolved_type(interner, *let_statement.r#type)),
             ..let_statement
         }),
         StatementKind::Expression(expr) => {
@@ -796,16 +796,16 @@ fn remove_interned_in_statement_kind(
             expression: remove_interned_in_expression(interner, assign.expression),
         }),
         StatementKind::For(for_loop) => StatementKind::For(ForLoopStatement {
-            range: match for_loop.range {
+            range: match *for_loop.range {
                 ForRange::Range(ForBounds { start, end, inclusive }) => {
-                    ForRange::Range(ForBounds {
+                    Box::new(ForRange::Range(ForBounds {
                         start: remove_interned_in_expression(interner, start),
                         end: remove_interned_in_expression(interner, end),
                         inclusive,
-                    })
+                    }))
                 }
                 ForRange::Array(expr) => {
-                    ForRange::Array(remove_interned_in_expression(interner, expr))
+                    Box::new(ForRange::Array(remove_interned_in_expression(interner, expr)))
                 }
             },
             block: remove_interned_in_expression(interner, for_loop.block),

--- a/compiler/noirc_frontend/src/hir/comptime/hir_to_display_ast.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/hir_to_display_ast.rs
@@ -41,10 +41,10 @@ impl HirStatement {
             }),
             HirStatement::For(for_stmt) => StatementKind::For(ForLoopStatement {
                 identifier: for_stmt.identifier.to_display_ast(interner),
-                range: ForRange::range(
+                range: Box::new(ForRange::range(
                     for_stmt.start_range.to_display_ast(interner),
                     for_stmt.end_range.to_display_ast(interner),
-                ),
+                )),
                 block: for_stmt.block.to_display_ast(interner),
                 location,
             }),
@@ -338,7 +338,7 @@ impl HirPattern {
                 };
                 // The name span is lost here
                 let path = Path::from_single(name, *location);
-                Pattern::Struct(path, patterns, *location)
+                Pattern::Struct(Box::new(path), patterns, *location)
             }
         }
     }

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
@@ -1827,7 +1827,7 @@ fn expr_as_for(
 ) -> IResult<Value> {
     expr_as(interner, arguments, return_type, location, |expr| {
         if let ExprValue::Statement(StatementKind::For(for_statement)) = expr {
-            if let ForRange::Array(array) = for_statement.range {
+            if let ForRange::Array(array) = *for_statement.range {
                 let token = Token::Ident(for_statement.identifier.into_string());
                 let token = LocatedToken::new(token, location);
                 let identifier = Value::Quoted(Rc::new(vec![token]));
@@ -1852,7 +1852,7 @@ fn expr_as_for_range(
 ) -> IResult<Value> {
     expr_as(interner, arguments, return_type, location, |expr| {
         if let ExprValue::Statement(StatementKind::For(for_statement)) = expr {
-            if let ForRange::Range(bounds) = for_statement.range {
+            if let ForRange::Range(bounds) = *for_statement.range {
                 let (from, to) = bounds.into_half_open();
                 let token = Token::Ident(for_statement.identifier.into_string());
                 let token = LocatedToken::new(token, location);

--- a/compiler/noirc_frontend/src/parser/parser/global.rs
+++ b/compiler/noirc_frontend/src/parser/parser/global.rs
@@ -31,7 +31,7 @@ impl Parser<'_> {
             let ident = self.unknown_ident_at_previous_token_end();
             return LetStatement {
                 pattern: ident_to_pattern(ident, mutable),
-                r#type: UnresolvedType { typ: UnresolvedTypeData::Unspecified, location },
+                r#type: Box::new(UnresolvedType { typ: UnresolvedTypeData::Unspecified, location }),
                 expression: Expression { kind: ExpressionKind::Error, location },
                 attributes,
                 comptime,
@@ -53,7 +53,14 @@ impl Parser<'_> {
 
         self.eat_semicolon_or_error();
 
-        LetStatement { pattern, r#type: typ, expression, attributes, comptime, is_global_let }
+        LetStatement {
+            pattern,
+            r#type: Box::new(typ),
+            expression,
+            attributes,
+            comptime,
+            is_global_let,
+        }
     }
 }
 

--- a/compiler/noirc_frontend/src/parser/parser/pattern.rs
+++ b/compiler/noirc_frontend/src/parser/parser/pattern.rs
@@ -202,7 +202,7 @@ impl Parser<'_> {
             Self::parse_struct_pattern_field,
         );
 
-        Pattern::Struct(path, fields, self.location_since(start_location))
+        Pattern::Struct(Box::new(path), fields, self.location_since(start_location))
     }
 
     fn parse_struct_pattern_field(&mut self) -> Option<(Ident, Pattern)> {

--- a/compiler/noirc_frontend/src/parser/parser/statement.rs
+++ b/compiler/noirc_frontend/src/parser/parser/statement.rs
@@ -291,7 +291,7 @@ impl Parser<'_> {
 
         Some(ForLoopStatement {
             identifier,
-            range,
+            range: Box::new(range),
             block,
             location: self.location_since(start_location),
         })
@@ -368,7 +368,7 @@ impl Parser<'_> {
         let location = self.location_at_previous_token_end();
         ForLoopStatement {
             identifier,
-            range: ForRange::Array(Expression { kind: ExpressionKind::Error, location }),
+            range: Box::new(ForRange::Array(Expression { kind: ExpressionKind::Error, location })),
             block: Expression { kind: ExpressionKind::Error, location },
             location: self.location_since(start_location),
         }
@@ -455,7 +455,7 @@ impl Parser<'_> {
 
         Some(LetStatement {
             pattern,
-            r#type,
+            r#type: Box::new(r#type),
             expression,
             attributes,
             comptime: false,
@@ -601,7 +601,7 @@ mod tests {
             panic!("Expected for loop");
         };
         assert_eq!(for_loop.identifier.to_string(), "i");
-        let ForRange::Array(expr) = for_loop.range else {
+        let ForRange::Array(expr) = *for_loop.range else {
             panic!("Expected array");
         };
         assert_eq!(expr.to_string(), "x");
@@ -615,7 +615,7 @@ mod tests {
             panic!("Expected for loop");
         };
         assert_eq!(for_loop.identifier.to_string(), "i");
-        let ForRange::Range(bounds) = for_loop.range else {
+        let ForRange::Range(bounds) = *for_loop.range else {
             panic!("Expected range");
         };
         assert_eq!(bounds.start.to_string(), "0");
@@ -631,7 +631,7 @@ mod tests {
             panic!("Expected for loop");
         };
         assert_eq!(for_loop.identifier.to_string(), "i");
-        let ForRange::Range(bounds) = for_loop.range else {
+        let ForRange::Range(bounds) = *for_loop.range else {
             panic!("Expected range");
         };
         assert_eq!(bounds.start.to_string(), "0");
@@ -650,7 +650,7 @@ mod tests {
             panic!("Expected for loop");
         };
         assert_eq!(for_loop.identifier.to_string(), "i");
-        assert!(matches!(for_loop.range, ForRange::Array(..)));
+        assert!(matches!(*for_loop.range, ForRange::Array(..)));
     }
 
     #[test]

--- a/tooling/lsp/src/with_file.rs
+++ b/tooling/lsp/src/with_file.rs
@@ -96,7 +96,7 @@ fn module_declaration_with_file(module: ModuleDeclaration, file: FileId) -> Modu
 fn let_statement_with_file(let_statement: LetStatement, file: FileId) -> LetStatement {
     LetStatement {
         pattern: pattern_with_file(let_statement.pattern, file),
-        r#type: unresolved_type_with_file(let_statement.r#type, file),
+        r#type: Box::new(unresolved_type_with_file(*let_statement.r#type, file)),
         expression: expression_with_file(let_statement.expression, file),
         attributes: secondary_attributes_with_file(let_statement.attributes, file),
         comptime: let_statement.comptime,
@@ -120,7 +120,7 @@ fn pattern_with_file(pattern: Pattern, file: FileId) -> Pattern {
             Pattern::Tuple(patterns_with_file(patterns, file), location_with_file(location, file))
         }
         Pattern::Struct(path, items, location) => Pattern::Struct(
-            path_with_file(path, file),
+            Box::new(path_with_file(*path, file)),
             vecmap(items, |(ident, pattern)| {
                 (ident_with_file(ident, file), pattern_with_file(pattern, file))
             }),
@@ -913,7 +913,7 @@ fn statement_kind_with_file(kind: StatementKind, file: FileId) -> StatementKind 
 fn for_loop_statement_with_file(for_loop: ForLoopStatement, file: FileId) -> ForLoopStatement {
     ForLoopStatement {
         identifier: ident_with_file(for_loop.identifier, file),
-        range: for_range_with_file(for_loop.range, file),
+        range: Box::new(for_range_with_file(*for_loop.range, file)),
         block: expression_with_file(for_loop.block, file),
         location: location_with_file(for_loop.location, file),
     }

--- a/tooling/nargo_fmt/src/formatter/global.rs
+++ b/tooling/nargo_fmt/src/formatter/global.rs
@@ -64,7 +64,7 @@ impl ChunkFormatter<'_, '_> {
         group.group(self.format_let_or_global(
             Keyword::Global,
             pattern,
-            let_statement.r#type,
+            *let_statement.r#type,
             Some(let_statement.expression),
             Vec::new(), // Attributes
         ));

--- a/tooling/nargo_fmt/src/formatter/pattern.rs
+++ b/tooling/nargo_fmt/src/formatter/pattern.rs
@@ -74,7 +74,7 @@ impl ChunkFormatter<'_, '_> {
                 let mut inner_group = ChunkGroup::new();
 
                 inner_group.text(self.chunk(|formatter| {
-                    formatter.format_path(path);
+                    formatter.format_path(*path);
                     formatter.write_space();
                     formatter.write_left_brace();
                 }));

--- a/tooling/nargo_fmt/src/formatter/statement.rs
+++ b/tooling/nargo_fmt/src/formatter/statement.rs
@@ -112,7 +112,7 @@ impl ChunkFormatter<'_, '_> {
         self.format_let_or_global(
             Keyword::Let,
             let_statement.pattern,
-            let_statement.r#type,
+            *let_statement.r#type,
             Some(let_statement.expression),
             let_statement.attributes,
         )
@@ -245,7 +245,7 @@ impl ChunkFormatter<'_, '_> {
             formatter.write_space();
         }));
 
-        match for_loop.range {
+        match *for_loop.range {
             ForRange::Range(for_bounds) => {
                 self.format_expression(for_bounds.start, &mut group);
                 group.text(self.chunk(|formatter| {


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

Testing to see effects on memory usage vs compile time.

## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
