### PR TITLE
chore: remove noir-lang/noir_rsa from external libraries

### DIFF
--- a/.github/critical_libraries_status/noir-lang/noir_rsa/.failures.jsonl
+++ b/.github/critical_libraries_status/noir-lang/noir_rsa/.failures.jsonl
@@ -1,4 +1,0 @@
-{"suite":"noir_rsa","name":"rsa::tests::smoke_test"}
-{"suite":"noir_rsa","name":"rsa::tests::test_verify_sha256_pkcs1v15_1024"}
-{"suite":"noir_rsa","name":"rsa::tests::test_verify_sha256_pkcs1v15_2048"}
-{"suite":"noir_rsa","name":"rsa::tests::test_verify_sha256_pkcs1v15_2048_exponent_3"}

--- a/EXTERNAL_NOIR_LIBRARIES.yml
+++ b/EXTERNAL_NOIR_LIBRARIES.yml
@@ -48,10 +48,6 @@ libraries:
     repo: noir-lang/sparse_array
     timeout: 3
     critical: true
-  noir_rsa:
-    repo: noir-lang/noir_rsa
-    timeout: 4
-    critical: true
   noir_json_parser:
     repo: noir-lang/noir_json_parser
     timeout: 12


### PR DESCRIPTION
# Description

## Problem

The library is archived and it won't compile anymore with some breaking changes that are going to happen with the language.

## Summary



## Additional Context



## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
