### PR TITLE
chore(SSA): restrict `shr` and `shl` right-hand side to u8

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/ir/dfg.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/dfg.rs
@@ -233,17 +233,41 @@ impl DataFlowGraph {
 
     fn validate_instruction(&self, instruction: &Instruction) {
         match instruction {
-            Instruction::Binary(Binary { lhs, rhs: _, operator: BinaryOp::Lt }) => {
-                // Assume rhs_type is the same as lhs_type
+            Instruction::Binary(Binary { lhs, rhs, operator }) => {
                 let lhs_type = self.type_of_value(*lhs);
-                if matches!(lhs_type, Type::Numeric(NumericType::NativeField)) {
-                    panic!("Cannot use `lt` with field elements");
-                }
-            }
-            Instruction::Binary(Binary { lhs: _, rhs, operator: BinaryOp::Shr }) => {
                 let rhs_type = self.type_of_value(*rhs);
-                if !matches!(rhs_type, Type::Numeric(NumericType::Unsigned { bit_size: 8 })) {
-                    panic!("Right-hand side of `shr` must be u8");
+                match operator {
+                    BinaryOp::Lt => {
+                        if lhs_type != rhs_type {
+                            panic!(
+                                "Left-hand side and right-hand side of `lt` must have the same type"
+                            );
+                        }
+
+                        if matches!(lhs_type, Type::Numeric(NumericType::NativeField)) {
+                            panic!("Cannot use `lt` with field elements");
+                        }
+                    }
+                    BinaryOp::Shl => {
+                        if !matches!(rhs_type, Type::Numeric(NumericType::Unsigned { bit_size: 8 }))
+                        {
+                            panic!("Right-hand side of `shl` must be u8");
+                        }
+                    }
+                    BinaryOp::Shr => {
+                        if !matches!(rhs_type, Type::Numeric(NumericType::Unsigned { bit_size: 8 }))
+                        {
+                            panic!("Right-hand side of `shr` must be u8");
+                        }
+                    }
+                    _ => {
+                        if lhs_type != rhs_type {
+                            panic!(
+                                "Left-hand side and right-hand side of `{}` must have the same type",
+                                operator
+                            );
+                        }
+                    }
                 }
             }
             Instruction::ArrayGet { index, .. } | Instruction::ArraySet { index, .. } => {
@@ -951,6 +975,47 @@ mod tests {
         acir(inline) impure fn main f0 {
           b0():
             v2 = lt Field 1, Field 2
+            return
+        }
+        ";
+        let _ = Ssa::from_str(src);
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "Left-hand side and right-hand side of `add` must have the same type"
+    )]
+    fn disallows_binary_add_with_different_types() {
+        let src = "
+        acir(inline) fn main f0 {
+          b0():
+            v2 = add Field 1, i32 2
+            return
+        }
+        ";
+        let _ = Ssa::from_str(src);
+    }
+
+    #[test]
+    #[should_panic(expected = "Right-hand side of `shr` must be u8")]
+    fn disallows_shr_with_non_u8() {
+        let src = "
+        acir(inline) fn main f0 {
+          b0():
+            v2 = shr u32 1, u16 1
+            return
+        }
+        ";
+        let _ = Ssa::from_str(src);
+    }
+
+    #[test]
+    #[should_panic(expected = "Right-hand side of `shl` must be u8")]
+    fn disallows_shl_with_non_u8() {
+        let src = "
+        acir(inline) fn main f0 {
+          b0():
+            v2 = shl u32 1, u16 1
             return
         }
         ";

--- a/compiler/noirc_evaluator/src/ssa/ir/dfg.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/dfg.rs
@@ -240,6 +240,12 @@ impl DataFlowGraph {
                     panic!("Cannot use `lt` with field elements");
                 }
             }
+            Instruction::Binary(Binary { lhs: _, rhs, operator: BinaryOp::Shr }) => {
+                let rhs_type = self.type_of_value(*rhs);
+                if !matches!(rhs_type, Type::Numeric(NumericType::Unsigned { bit_size: 8 })) {
+                    panic!("Right-hand side of `shr` must be u8");
+                }
+            }
             Instruction::ArrayGet { index, .. } | Instruction::ArraySet { index, .. } => {
                 let index_type = self.type_of_value(*index);
                 if !matches!(index_type, Type::Numeric(NumericType::Unsigned { bit_size: 32 })) {

--- a/compiler/noirc_evaluator/src/ssa/opt/constant_folding.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/constant_folding.rs
@@ -1368,7 +1368,7 @@ mod test {
                 v2 = lt u32 1000, v0
                 jmpif v2 then: b1, else: b2
               b1():
-                v4 = shl v0, u32 1
+                v4 = shl v0, u8 1
                 v5 = lt v0, v4
                 constrain v5 == u1 1
                 jmp b2()
@@ -1376,7 +1376,7 @@ mod test {
                 v7 = lt u32 1000, v0
                 jmpif v7 then: b3, else: b4
               b3():
-                v8 = shl v0, u32 1
+                v8 = shl v0, u8 1
                 v9 = lt v0, v8
                 constrain v9 == u1 1
                 jmp b4()
@@ -1395,10 +1395,10 @@ mod test {
         brillig(inline) fn main f0 {
           b0(v0: u32):
             v2 = lt u32 1000, v0
-            v4 = shl v0, u32 1
+            v4 = shl v0, u8 1
             jmpif v2 then: b1, else: b2
           b1():
-            v5 = shl v0, u32 1
+            v5 = shl v0, u8 1
             v6 = lt v0, v5
             constrain v6 == u1 1
             jmp b2()

--- a/compiler/noirc_evaluator/src/ssa/parser/tests.rs
+++ b/compiler/noirc_evaluator/src/ssa/parser/tests.rs
@@ -454,12 +454,23 @@ fn test_binary() {
         "and",
         "or",
         "xor",
-        "shl",
-        "shr",
         "unchecked_add",
         "unchecked_sub",
         "unchecked_mul",
     ] {
+        let src = format!(
+            "
+            acir(inline) fn main f0 {{
+              b0(v0: u32, v1: u32):
+                v2 = {op} v0, v1
+                return
+            }}
+            "
+        );
+        assert_ssa_roundtrip(&src);
+    }
+
+    for op in ["shl", "shr"] {
         let src = format!(
             "
             acir(inline) fn main f0 {{

--- a/compiler/noirc_evaluator/src/ssa/parser/tests.rs
+++ b/compiler/noirc_evaluator/src/ssa/parser/tests.rs
@@ -463,7 +463,7 @@ fn test_binary() {
         let src = format!(
             "
             acir(inline) fn main f0 {{
-              b0(v0: u32, v1: u32):
+              b0(v0: u32, v1: u8):
                 v2 = {op} v0, v1
                 return
             }}


### PR DESCRIPTION
# Description

## Problem

Resolves #8544

## Summary

Also added a check that for other binary operations the types of lhs and rhs is the same.

## Additional Context



## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
