### PR TITLE
fix: support recursive call to main function in SSA parser

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/parser/into_ssa.rs
+++ b/compiler/noirc_evaluator/src/ssa/parser/into_ssa.rs
@@ -91,6 +91,9 @@ impl Translator {
         // Map function names to their IDs so calls can be resolved
         let mut function_id_counter = 1;
         let mut functions = HashMap::new();
+
+        functions.insert(main_function.internal_name.clone(), main_id);
+
         for function in &parsed_ssa.functions {
             let function_id = FunctionId::new(function_id_counter);
             function_id_counter += 1;

--- a/compiler/noirc_evaluator/src/ssa/parser/tests.rs
+++ b/compiler/noirc_evaluator/src/ssa/parser/tests.rs
@@ -272,6 +272,18 @@ fn test_call_intrinsic() {
 }
 
 #[test]
+fn test_recursive_call_to_main_function() {
+    let src = "
+        acir(inline) fn main f0 {
+          b0(v0: Field):
+            call f0(v0)
+            return
+        }
+        ";
+    assert_ssa_roundtrip(src);
+}
+
+#[test]
 fn test_cast() {
     let src = "
         acir(inline) fn main f0 {


### PR DESCRIPTION
# Description

## Problem

Resolves #8737

## Summary

There was already forward-declarations for functions, except that an entry was missing for the main function (because it's handled a bit differently).

## Additional Context



## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
