### PR TITLE
fix: Create SSA interpreter arguments from scratch for each invocation

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/interpreter/value.rs
+++ b/compiler/noirc_evaluator/src/ssa/interpreter/value.rs
@@ -13,6 +13,7 @@ use crate::ssa::ir::{
 
 use super::IResult;
 
+/// Be careful when using `Clone`: the `ArrayValue` is backed by a `Shared` data structure.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Value {
     Numeric(NumericValue),

--- a/tooling/ast_fuzzer/fuzz/src/lib.rs
+++ b/tooling/ast_fuzzer/fuzz/src/lib.rs
@@ -176,7 +176,7 @@ pub fn compare_results_interpreted(
         eprintln!(
             "---\nSSA Inputs:\n{}",
             inputs
-                .input_values
+                .input_values()
                 .iter()
                 .enumerate()
                 .map(|(i, v)| format!("{i}: {v}"))


### PR DESCRIPTION
# Description

## Problem\*

Resolves https://github.com/noir-lang/noir/issues/8754

## Summary\*

The SSA interpreter `Value` is `Clone` but the arrays share their underlying storage with their clones. This meant that the inputs I prepared for it were modified after the first pass, affecting the second pass.

## Additional Context

This affects the `pass_vs_prev` fuzz target and the `nargo interpret` command, and comes out where `main` has a `mut` array parameter, which it modifies.

## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
