### PR TITLE
feat(ssa): Initial validation module

### DIFF
--- a/compiler/noirc_evaluator/src/ssa.rs
+++ b/compiler/noirc_evaluator/src/ssa.rs
@@ -49,6 +49,7 @@ pub mod ir;
 pub(crate) mod opt;
 pub mod parser;
 pub mod ssa_gen;
+pub(crate) mod validation;
 
 #[derive(Debug, Clone)]
 pub enum SsaLogging {

--- a/compiler/noirc_evaluator/src/ssa/function_builder/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/function_builder/mod.rs
@@ -28,6 +28,7 @@ use super::{
     },
     opt::pure::FunctionPurities,
     ssa_gen::Ssa,
+    validation::validate_function,
 };
 
 /// The per-function context for each ssa function being generated.
@@ -524,7 +525,7 @@ impl FunctionBuilder {
 
     fn validate_ssa(functions: &[Function]) {
         for function in functions {
-            function.assert_valid();
+            validate_function(function);
         }
     }
 }

--- a/compiler/noirc_evaluator/src/ssa/ir/function.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/function.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 
 use super::basic_block::BasicBlockId;
 use super::dfg::{DataFlowGraph, GlobalsGraph};
-use super::instruction::{BinaryOp, Instruction, TerminatorInstruction};
+use super::instruction::TerminatorInstruction;
 use super::map::Id;
 use super::types::{NumericType, Type};
 use super::value::{Value, ValueId};
@@ -230,89 +230,6 @@ impl Function {
                 None
             }
         })
-    }
-
-    /// Asserts that the [`Function`] is well formed.
-    ///
-    /// Panics on malformed functions.
-    pub(crate) fn assert_valid(&self) {
-        self.assert_single_return_block();
-        self.validate_signed_arithmetic_invariants();
-    }
-
-    /// Checks that the function has only one return block.
-    fn assert_single_return_block(&self) {
-        let reachable_blocks = self.reachable_blocks();
-
-        // We assume that all functions have a single block which terminates with a `return` instruction.
-        let return_blocks: BTreeSet<_> = reachable_blocks
-            .iter()
-            .filter(|block| {
-                // All blocks must have a terminator instruction of some sort.
-                let terminator = self.dfg[**block].terminator().unwrap_or_else(|| {
-                    panic!("Function {} has no terminator in block {block}", self.id())
-                });
-                matches!(terminator, TerminatorInstruction::Return { .. })
-            })
-            .collect();
-        if return_blocks.len() > 1 {
-            panic!("Function {} has multiple return blocks {return_blocks:?}", self.id())
-        }
-    }
-
-    /// Validates that any checked signed add/sub is followed by the expected truncate.
-    fn validate_signed_arithmetic_invariants(&self) {
-        // State for tracking the last signed binary addition/subtraction
-        let mut signed_binary_op = None;
-        for block in self.reachable_blocks() {
-            for instruction in self.dfg[block].instructions() {
-                match &self.dfg[*instruction] {
-                    Instruction::Binary(binary) => {
-                        signed_binary_op = None;
-
-                        match binary.operator {
-                            // We are only validating addition/subtraction
-                            BinaryOp::Add { unchecked: false }
-                            | BinaryOp::Sub { unchecked: false } => {}
-                            // Otherwise, move onto the next instruction
-                            _ => continue,
-                        }
-
-                        // Assume rhs_type is the same as lhs_type
-                        let lhs_type = self.dfg.type_of_value(binary.lhs);
-                        if let Type::Numeric(NumericType::Signed { bit_size }) = lhs_type {
-                            let results = self.dfg.instruction_results(*instruction);
-                            signed_binary_op = Some((bit_size, results[0]));
-                        }
-                    }
-                    Instruction::Truncate { value, bit_size, max_bit_size } => {
-                        let Some((signed_op_bit_size, signed_op_res)) = signed_binary_op.take()
-                        else {
-                            continue;
-                        };
-                        assert_eq!(
-                            *bit_size, signed_op_bit_size,
-                            "ICE: Correct truncate must follow the result of a checked signed add/sub"
-                        );
-                        assert_eq!(
-                            *max_bit_size,
-                            *bit_size + 1,
-                            "ICE: Correct truncate must follow the result of a checked signed add/sub"
-                        );
-                        assert_eq!(
-                            *value, signed_op_res,
-                            "ICE: Correct truncate must follow the result of a checked signed add/sub"
-                        );
-                    }
-                    _ => {
-                        signed_binary_op = None;
-                    }
-                }
-            }
-        }
-        if signed_binary_op.is_some() {
-            panic!("ICE: Truncate must follow the result of a checked signed add/sub");
-        }
     }
 }
 

--- a/compiler/noirc_evaluator/src/ssa/parser/into_ssa.rs
+++ b/compiler/noirc_evaluator/src/ssa/parser/into_ssa.rs
@@ -16,6 +16,7 @@ use crate::ssa::{
         value::ValueId,
     },
     opt::pure::FunctionPurities,
+    validation::validate_function,
 };
 
 use super::{
@@ -558,7 +559,7 @@ impl Translator {
         ssa.normalize_ids();
 
         for function in ssa.functions.values() {
-            function.assert_valid();
+            validate_function(function);
         }
 
         ssa

--- a/compiler/noirc_evaluator/src/ssa/validation/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/validation/mod.rs
@@ -1,0 +1,272 @@
+use fxhash::FxHashSet as HashSet;
+
+use crate::ssa::ir::instruction::TerminatorInstruction;
+
+use super::ir::{
+    function::Function,
+    instruction::{BinaryOp, Instruction, InstructionId},
+    types::{NumericType, Type},
+    value::ValueId,
+};
+
+struct Validator<'f> {
+    function: &'f Function,
+    // State for truncate-after-signed-sub validation
+    // Stores: Option<(bit_size, result)>
+    signed_binary_op: Option<(u32, ValueId)>,
+}
+
+impl<'f> Validator<'f> {
+    fn new(function: &'f Function) -> Self {
+        Self { function, signed_binary_op: None }
+    }
+
+    fn start_function(&mut self) {
+        self.validate_single_return_block();
+        // Reset any state needed at start, if any
+        self.signed_binary_op = None;
+    }
+
+    fn visit_instruction(&mut self, instruction: InstructionId) {
+        self.validate_truncate_after_signed_sub(instruction);
+    }
+
+    fn finish_function(&mut self) {
+        if self.signed_binary_op.is_some() {
+            panic!("ICE: Truncate must follow the result of a checked signed add/sub");
+        }
+    }
+
+    /// Validates that any checked signed add/sub is followed by the expected truncate.
+    fn validate_truncate_after_signed_sub(&mut self, instruction: InstructionId) {
+        let dfg = &self.function.dfg;
+        match &dfg[instruction] {
+            Instruction::Binary(binary) => {
+                self.signed_binary_op = None;
+
+                match binary.operator {
+                    // Only validating checked addition/subtraction
+                    BinaryOp::Add { unchecked: false } | BinaryOp::Sub { unchecked: false } => {}
+                    // Otherwise, move onto the next instruction
+                    _ => return,
+                }
+
+                // Assumes rhs_type is the same as lhs_type
+                let lhs_type = dfg.type_of_value(binary.lhs);
+                if let Type::Numeric(NumericType::Signed { bit_size }) = lhs_type {
+                    let results = dfg.instruction_results(instruction);
+                    self.signed_binary_op = Some((bit_size, results[0]));
+                }
+            }
+            Instruction::Truncate { value, bit_size, max_bit_size } => {
+                let Some((signed_op_bit_size, signed_op_res)) = self.signed_binary_op.take() else {
+                    return;
+                };
+                assert_eq!(
+                    *bit_size, signed_op_bit_size,
+                    "ICE: Correct truncate must follow the result of a checked signed add/sub"
+                );
+                assert_eq!(
+                    *max_bit_size,
+                    *bit_size + 1,
+                    "ICE: Correct truncate must follow the result of a checked signed add/sub"
+                );
+                assert_eq!(
+                    *value, signed_op_res,
+                    "ICE: Correct truncate must follow the result of a checked signed add/sub"
+                );
+            }
+            _ => {
+                self.signed_binary_op = None;
+            }
+        }
+    }
+
+    // Validates there is exactly one return block
+    fn validate_single_return_block(&self) {
+        let reachable_blocks = self.function.reachable_blocks();
+
+        let return_blocks: HashSet<_> = reachable_blocks
+            .iter()
+            .filter(|block| {
+                let terminator = self.function.dfg[**block].terminator().unwrap_or_else(|| {
+                    panic!("Function {} has no terminator in block {block}", self.function.id())
+                });
+                matches!(terminator, TerminatorInstruction::Return { .. })
+            })
+            .collect();
+
+        if return_blocks.len() > 1 {
+            panic!("Function {} has multiple return blocks {return_blocks:?}", self.function.id())
+        }
+    }
+}
+
+/// Validates that the [Function] is well formed.
+///
+/// Panics on malformed functions.
+pub(crate) fn validate_function(function: &Function) {
+    let mut validator = Validator::new(function);
+
+    validator.start_function();
+
+    for block in function.reachable_blocks() {
+        for instruction in function.dfg[block].instructions() {
+            validator.visit_instruction(*instruction);
+        }
+    }
+
+    validator.finish_function();
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::ssa::ssa_gen::Ssa;
+
+    #[test]
+    #[should_panic(expected = "ICE: Truncate must follow the result of a checked signed add/sub")]
+    fn lone_signed_sub_acir() {
+        let src = r"
+        acir(inline) pure fn main f0 {
+          b0(v0: i16, v1: i16):
+            v2 = sub v0, v1
+            return v2
+        }
+        ";
+
+        let _ = Ssa::from_str(src);
+    }
+
+    #[test]
+    #[should_panic(expected = "ICE: Truncate must follow the result of a checked signed add/sub")]
+    fn lone_signed_sub_brillig() {
+        // This matches the test above we just want to make sure it holds in the Brillig runtime as well as ACIR
+        let src = r"
+        brillig(inline) pure fn main f0 {
+          b0(v0: i16, v1: i16):
+            v2 = sub v0, v1
+            return v2
+        }
+        ";
+
+        let _ = Ssa::from_str(src);
+    }
+
+    #[test]
+    #[should_panic(expected = "ICE: Truncate must follow the result of a checked signed add/sub")]
+    fn lone_signed_add_acir() {
+        let src = r"
+        acir(inline) pure fn main f0 {
+          b0(v0: i16, v1: i16):
+            v2 = add v0, v1
+            return v2
+        }
+        ";
+
+        let _ = Ssa::from_str(src);
+    }
+
+    #[test]
+    #[should_panic(expected = "ICE: Truncate must follow the result of a checked signed add/sub")]
+    fn lone_signed_add_brillig() {
+        let src = r"
+        brillig(inline) pure fn main f0 {
+          b0(v0: i16, v1: i16):
+            v2 = add v0, v1
+            return v2
+        }
+        ";
+
+        let _ = Ssa::from_str(src);
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "ICE: Correct truncate must follow the result of a checked signed add/sub"
+    )]
+    fn signed_sub_bad_truncate_bit_size() {
+        let src = r"
+        acir(inline) pure fn main f0 {
+          b0(v0: i16, v1: i16):
+            v2 = sub v0, v1
+            v3 = truncate v2 to 32 bits, max_bit_size: 33
+            return v3
+        }
+        ";
+
+        let _ = Ssa::from_str(src);
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "ICE: Correct truncate must follow the result of a checked signed add/sub"
+    )]
+    fn signed_sub_bad_truncate_max_bit_size() {
+        let src = r"
+        acir(inline) pure fn main f0 {
+          b0(v0: i16, v1: i16):
+            v2 = sub v0, v1
+            v3 = truncate v2 to 16 bits, max_bit_size: 18
+            return v3
+        }
+        ";
+
+        let _ = Ssa::from_str(src);
+    }
+
+    #[test]
+    fn truncate_follows_signed_sub_acir() {
+        let src = r"
+        acir(inline) pure fn main f0 {
+          b0(v0: i16, v1: i16):
+            v2 = sub v0, v1
+            v3 = truncate v2 to 16 bits, max_bit_size: 17
+            return v3
+        }
+        ";
+
+        let _ = Ssa::from_str(src);
+    }
+
+    #[test]
+    fn truncate_follows_signed_sub_brillig() {
+        let src = r"
+        brillig(inline) pure fn main f0 {
+          b0(v0: i16, v1: i16):
+            v2 = sub v0, v1
+            v3 = truncate v2 to 16 bits, max_bit_size: 17
+            return v3
+        }
+        ";
+
+        let _ = Ssa::from_str(src);
+    }
+
+    #[test]
+    fn truncate_follows_signed_add_acir() {
+        let src = r"
+        acir(inline) pure fn main f0 {
+          b0(v0: i16, v1: i16):
+            v2 = add v0, v1
+            v3 = truncate v2 to 16 bits, max_bit_size: 17
+            return v3
+        }
+        ";
+
+        let _ = Ssa::from_str(src);
+    }
+
+    #[test]
+    fn truncate_follows_signed_add_brillig() {
+        let src = r"
+        brillig(inline) pure fn main f0 {
+          b0(v0: i16, v1: i16):
+            v2 = add v0, v1
+            v3 = truncate v2 to 16 bits, max_bit_size: 17
+            return v3
+        }
+        ";
+
+        let _ = Ssa::from_str(src);
+    }
+}


### PR DESCRIPTION
# Description

## Problem\*

Working towards https://github.com/noir-lang/noir/issues/8705. It has multiple sub-issues so once those are resolved I think we could close the issue. 

## Summary\*

This PR simply makes an initial validation module that moves over some of our assertions on `Function` to a separate `Validator` struct. This felt like the simplest solution for our current validation plans. We can then expand this validator in the future as needed (e.g. extra state like the CFG and DominatorTree). 

## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [X] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
