### PR TITLE
chore: use BTreeMap for TypeBindings

### DIFF
--- a/compiler/noirc_frontend/src/hir_def/types.rs
+++ b/compiler/noirc_frontend/src/hir_def/types.rs
@@ -1,6 +1,9 @@
-use std::{borrow::Cow, cell::RefCell, collections::BTreeSet, rc::Rc};
-
-use fxhash::FxHashMap as HashMap;
+use std::{
+    borrow::Cow,
+    cell::RefCell,
+    collections::{BTreeMap, BTreeSet},
+    rc::Rc,
+};
 
 #[cfg(test)]
 use proptest_derive::Arbitrary;
@@ -334,7 +337,7 @@ pub enum QuotedType {
 /// A list of (TypeVariableId, Kind)'s to bind to a type. Storing the
 /// TypeVariable in addition to the matching TypeVariableId allows
 /// the binding to later be undone if needed.
-pub type TypeBindings = HashMap<TypeVariableId, (TypeVariable, Kind, Type)>;
+pub type TypeBindings = BTreeMap<TypeVariableId, (TypeVariable, Kind, Type)>;
 
 /// Represents a struct or enum type in the type system. Each instance of this
 /// rust struct will be shared across all Type::DataType variants that represent
@@ -589,10 +592,7 @@ impl DataType {
         Some((name, args))
     }
 
-    fn get_fields_substitutions(
-        &self,
-        generic_args: &[Type],
-    ) -> HashMap<TypeVariableId, (TypeVariable, Kind, Type)> {
+    fn get_fields_substitutions(&self, generic_args: &[Type]) -> TypeBindings {
         assert_eq!(self.generics.len(), generic_args.len());
 
         self.generics
@@ -2352,7 +2352,7 @@ impl Type {
                 let instantiated = typ.force_substitute(&replacements);
                 (instantiated, replacements)
             }
-            other => (other.clone(), HashMap::default()),
+            other => (other.clone(), TypeBindings::default()),
         }
     }
 
@@ -2389,7 +2389,7 @@ impl Type {
                 let instantiated = typ.substitute(&replacements);
                 (instantiated, replacements)
             }
-            other => (other.clone(), HashMap::default()),
+            other => (other.clone(), TypeBindings::default()),
         }
     }
 


### PR DESCRIPTION
# Description

## Problem

Related to https://github.com/noir-lang/noir/issues/8780

## Summary

This is just a PR to prove that if we change the implementation of `TypeBindings` to be sorted by `TypeVariableId`, many programs stops to compile. This means that the order of the type bindings apparently matters.

I'd suggest, if this doesn't degrade performance, we could keep this going forward to get predictable results... that is, once we find why the order here matters.

## Additional Context

Before this PR, `TypeBindings` are an alias of `FxHashMap`. It seems this map always has a consistent order given the same keys. For example if we insert the keys 0, 1 and 2, the order ends up being 0, 1 and 2. If we insert the keys 2, 3 and 4 the order ends up being 4, 2 and 3. That would explain why adding seemingly unrelated code changes the behavior: there are new type variables, and the order type variables end up in the map end up being different.

Another note: this seems to only matter for the serialize programs, which rely on associated constants. So maybe the issue is around how associated constants are related to bindings, and not with the order of bindings.

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
