### PR TITLE
fix: Thread errors through remove_if_else instead of panicing when the value merger finds reference values

### DIFF
--- a/compiler/noirc_evaluator/src/errors.rs
+++ b/compiler/noirc_evaluator/src/errors.rs
@@ -66,9 +66,13 @@ pub enum RuntimeError {
         "Could not resolve some references to the array. All references must be resolved at compile time"
     )]
     UnknownReference { call_stack: CallStack },
-    #[error("Cannot return references from an if or match expression, or assignment within these expressions")]
+    #[error(
+        "Cannot return references from an if or match expression, or assignment within these expressions"
+    )]
     ReturnedReferenceFromDynamicIf { call_stack: CallStack },
-    #[error("Cannot return a function from an if or match expression, or assignment within these expressions")]
+    #[error(
+        "Cannot return a function from an if or match expression, or assignment within these expressions"
+    )]
     ReturnedFunctionFromDynamicIf { call_stack: CallStack },
 }
 
@@ -180,8 +184,8 @@ impl RuntimeError {
             | RuntimeError::UnconstrainedSliceReturnToConstrained { call_stack }
             | RuntimeError::UnconstrainedOracleReturnToConstrained { call_stack }
             | RuntimeError::UnknownReference { call_stack } => call_stack,
-            | RuntimeError::ReturnedReferenceFromDynamicIf { call_stack } => call_stack,
-            | RuntimeError::ReturnedFunctionFromDynamicIf { call_stack } => call_stack,
+            RuntimeError::ReturnedReferenceFromDynamicIf { call_stack } => call_stack,
+            RuntimeError::ReturnedFunctionFromDynamicIf { call_stack } => call_stack,
         }
     }
 }

--- a/compiler/noirc_evaluator/src/errors.rs
+++ b/compiler/noirc_evaluator/src/errors.rs
@@ -16,6 +16,8 @@ use thiserror::Error;
 use crate::ssa::ir::types::NumericType;
 use serde::{Deserialize, Serialize};
 
+pub type RtResult<T> = Result<T, RuntimeError>;
+
 #[derive(Debug, PartialEq, Eq, Clone, Error)]
 pub enum RuntimeError {
     #[error(transparent)]
@@ -64,6 +66,10 @@ pub enum RuntimeError {
         "Could not resolve some references to the array. All references must be resolved at compile time"
     )]
     UnknownReference { call_stack: CallStack },
+    #[error("Cannot return references from an if or match expression, or assignment within these expressions")]
+    ReturnedReferenceFromDynamicIf { call_stack: CallStack },
+    #[error("Cannot return a function from an if or match expression, or assignment within these expressions")]
+    ReturnedFunctionFromDynamicIf { call_stack: CallStack },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Hash)]
@@ -174,6 +180,8 @@ impl RuntimeError {
             | RuntimeError::UnconstrainedSliceReturnToConstrained { call_stack }
             | RuntimeError::UnconstrainedOracleReturnToConstrained { call_stack }
             | RuntimeError::UnknownReference { call_stack } => call_stack,
+            | RuntimeError::ReturnedReferenceFromDynamicIf { call_stack } => call_stack,
+            | RuntimeError::ReturnedFunctionFromDynamicIf { call_stack } => call_stack,
         }
     }
 }

--- a/compiler/noirc_evaluator/src/ssa.rs
+++ b/compiler/noirc_evaluator/src/ssa.rs
@@ -178,7 +178,7 @@ pub fn primary_passes(options: &SsaEvaluatorOptions) -> Vec<SsaPass> {
             move |ssa| ssa.inline_functions_with_no_predicates(options.inliner_aggressiveness),
             "Inlining",
         ),
-        SsaPass::new(Ssa::remove_if_else, "Remove IfElse"),
+        SsaPass::new_try(Ssa::remove_if_else, "Remove IfElse"),
         SsaPass::new(Ssa::purity_analysis, "Purity Analysis"),
         SsaPass::new(Ssa::fold_constants, "Constant Folding"),
         SsaPass::new(Ssa::flatten_basic_conditionals, "Simplify conditionals for unconstrained"),

--- a/compiler/noirc_evaluator/src/ssa/ir/dfg/simplify/call.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/dfg/simplify/call.rs
@@ -519,12 +519,17 @@ fn simplify_slice_push_back(
 
     let mut value_merger = ValueMerger::new(dfg, block, &mut slice_sizes, call_stack);
 
-    let new_slice = value_merger.merge_values(
+    let Ok(new_slice) = value_merger.merge_values(
         len_not_equals_capacity,
         len_equals_capacity,
         set_last_slice_value,
         new_slice,
-    );
+    ) else {
+        // If we were to percolate up the error here, it'd get to insert_instruction and eventually
+        // all of ssa. Instead we just choose not to simplify the slice call since this should
+        // be a rare case.
+        return SimplifyResult::None;
+    };
 
     SimplifyResult::SimplifiedToMultiple(vec![new_slice_length, new_slice])
 }

--- a/compiler/noirc_evaluator/src/ssa/opt/flatten_cfg.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/flatten_cfg.rs
@@ -1696,7 +1696,7 @@ mod test {
         let ssa = ssa
             .flatten_cfg()
             .mem2reg()
-            .remove_if_else()
+            .remove_if_else().unwrap()
             .fold_constants()
             .dead_instruction_elimination();
 

--- a/compiler/noirc_evaluator/src/ssa/opt/flatten_cfg.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/flatten_cfg.rs
@@ -1696,7 +1696,8 @@ mod test {
         let ssa = ssa
             .flatten_cfg()
             .mem2reg()
-            .remove_if_else().unwrap()
+            .remove_if_else()
+            .unwrap()
             .fold_constants()
             .dead_instruction_elimination();
 

--- a/compiler/noirc_evaluator/src/ssa/opt/flatten_cfg/value_merger.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/flatten_cfg/value_merger.rs
@@ -2,12 +2,15 @@ use acvm::{FieldElement, acir::AcirField};
 use fxhash::FxHashMap as HashMap;
 use noirc_errors::call_stack::CallStackId;
 
-use crate::ssa::ir::{
-    basic_block::BasicBlockId,
-    dfg::DataFlowGraph,
-    instruction::{ArrayOffset, BinaryOp, Instruction},
-    types::{NumericType, Type},
-    value::ValueId,
+use crate::{
+    errors::{RtResult, RuntimeError},
+    ssa::ir::{
+        basic_block::BasicBlockId,
+        dfg::DataFlowGraph,
+        instruction::{ArrayOffset, BinaryOp, Instruction},
+        types::{NumericType, Type},
+        value::ValueId,
+    },
 };
 
 pub(crate) struct ValueMerger<'a> {
@@ -45,28 +48,36 @@ impl<'a> ValueMerger<'a> {
         else_condition: ValueId,
         then_value: ValueId,
         else_value: ValueId,
-    ) -> ValueId {
+    ) -> RtResult<ValueId> {
         if then_value == else_value {
-            return then_value;
+            return Ok(then_value);
         }
 
         match self.dfg.type_of_value(then_value) {
-            Type::Numeric(_) => Self::merge_numeric_values(
+            Type::Numeric(_) => Ok(Self::merge_numeric_values(
                 self.dfg,
                 self.block,
                 then_condition,
                 else_condition,
                 then_value,
                 else_value,
-            ),
+            )),
             typ @ Type::Array(_, _) => {
                 self.merge_array_values(typ, then_condition, else_condition, then_value, else_value)
             }
             typ @ Type::Slice(_) => {
                 self.merge_slice_values(typ, then_condition, else_condition, then_value, else_value)
             }
-            Type::Reference(_) => panic!("Cannot return references from an if expression"),
-            Type::Function => panic!("Cannot return functions from an if expression"),
+            Type::Reference(_) => {
+                // FIXME: none of then_value, else_value, then_condition, or else_condition have
+                // non-empty call stacks
+                let call_stack = self.dfg.get_value_call_stack(then_value);
+                Err(RuntimeError::ReturnedReferenceFromDynamicIf { call_stack })
+            }
+            Type::Function => {
+                let call_stack = self.dfg.get_value_call_stack(then_value);
+                Err(RuntimeError::ReturnedFunctionFromDynamicIf { call_stack })
+            }
         }
     }
 
@@ -130,7 +141,7 @@ impl<'a> ValueMerger<'a> {
         else_condition: ValueId,
         then_value: ValueId,
         else_value: ValueId,
-    ) -> ValueId {
+    ) -> Result<ValueId, RuntimeError> {
         let mut merged = im::Vector::new();
 
         let (element_types, len) = match &typ {
@@ -149,7 +160,8 @@ impl<'a> ValueMerger<'a> {
                 let mut get_element = |array, typevars| {
                     let offset = ArrayOffset::None;
                     let get = Instruction::ArrayGet { array, index, offset };
-                    self.dfg
+                    self
+                        .dfg
                         .insert_instruction_and_results(get, self.block, typevars, self.call_stack)
                         .first()
                 };
@@ -162,14 +174,18 @@ impl<'a> ValueMerger<'a> {
                     else_condition,
                     then_element,
                     else_element,
-                ));
+                )?);
             }
         }
 
         let instruction = Instruction::MakeArray { elements: merged, typ };
-        self.dfg
-            .insert_instruction_and_results(instruction, self.block, None, self.call_stack)
-            .first()
+        let result = self.dfg.insert_instruction_and_results(
+            instruction,
+            self.block,
+            None,
+            self.call_stack,
+        );
+        Ok(result.first())
     }
 
     fn merge_slice_values(
@@ -179,7 +195,7 @@ impl<'a> ValueMerger<'a> {
         else_condition: ValueId,
         then_value_id: ValueId,
         else_value_id: ValueId,
-    ) -> ValueId {
+    ) -> Result<ValueId, RuntimeError> {
         let mut merged = im::Vector::new();
 
         let element_types = match &typ {
@@ -219,37 +235,36 @@ impl<'a> ValueMerger<'a> {
                     } else {
                         let offset = ArrayOffset::None;
                         let get = Instruction::ArrayGet { array, index, offset };
-                        self.dfg
-                            .insert_instruction_and_results(
-                                get,
-                                self.block,
-                                typevars,
-                                self.call_stack,
-                            )
-                            .first()
+                        let results = self.dfg.insert_instruction_and_results(
+                            get,
+                            self.block,
+                            typevars,
+                            self.call_stack,
+                        );
+                        results.first()
                     }
                 };
 
-                let then_element = get_element(
-                    then_value_id,
-                    typevars.clone(),
-                    then_len * element_types.len() as u32,
-                );
-                let else_element =
-                    get_element(else_value_id, typevars, else_len * element_types.len() as u32);
+                let len = then_len * element_types.len() as u32;
+                let then_element = get_element(then_value_id, typevars.clone(), len);
+
+                let len = else_len * element_types.len() as u32;
+                let else_element = get_element(else_value_id, typevars, len);
 
                 merged.push_back(self.merge_values(
                     then_condition,
                     else_condition,
                     then_element,
                     else_element,
-                ));
+                )?);
             }
         }
 
         let instruction = Instruction::MakeArray { elements: merged, typ };
         let call_stack = self.call_stack;
-        self.dfg.insert_instruction_and_results(instruction, self.block, None, call_stack).first()
+        let result =
+            self.dfg.insert_instruction_and_results(instruction, self.block, None, call_stack);
+        Ok(result.first())
     }
 
     /// Construct a dummy value to be attached to the smaller of two slices being merged.

--- a/compiler/noirc_evaluator/src/ssa/opt/flatten_cfg/value_merger.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/flatten_cfg/value_merger.rs
@@ -160,8 +160,7 @@ impl<'a> ValueMerger<'a> {
                 let mut get_element = |array, typevars| {
                     let offset = ArrayOffset::None;
                     let get = Instruction::ArrayGet { array, index, offset };
-                    self
-                        .dfg
+                    self.dfg
                         .insert_instruction_and_results(get, self.block, typevars, self.call_stack)
                         .first()
                 };
@@ -179,12 +178,8 @@ impl<'a> ValueMerger<'a> {
         }
 
         let instruction = Instruction::MakeArray { elements: merged, typ };
-        let result = self.dfg.insert_instruction_and_results(
-            instruction,
-            self.block,
-            None,
-            self.call_stack,
-        );
+        let result =
+            self.dfg.insert_instruction_and_results(instruction, self.block, None, self.call_stack);
         Ok(result.first())
     }
 

--- a/compiler/noirc_evaluator/src/ssa/opt/simple_optimization.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/simple_optimization.rs
@@ -1,10 +1,13 @@
-use crate::{errors::RtResult, ssa::ir::{
-    basic_block::BasicBlockId,
-    dfg::DataFlowGraph,
-    function::Function,
-    instruction::{Instruction, InstructionId},
-    value::{ValueId, ValueMapping},
-}};
+use crate::{
+    errors::RtResult,
+    ssa::ir::{
+        basic_block::BasicBlockId,
+        dfg::DataFlowGraph,
+        function::Function,
+        instruction::{Instruction, InstructionId},
+        value::{ValueId, ValueMapping},
+    },
+};
 
 impl Function {
     /// Performs a simple optimization according to the given callback.
@@ -27,7 +30,8 @@ impl Function {
         self.simple_reachable_blocks_optimization_result(move |context| {
             f(context);
             Ok(())
-        }).expect("`f` cannot error internally so this should be unreachable");
+        })
+        .expect("`f` cannot error internally so this should be unreachable");
     }
 
     /// Performs a simple optimization according to the given callback, returning early if
@@ -44,7 +48,10 @@ impl Function {
     ///
     /// `replace_value` can be used to replace a value with another one. This substitution will be
     /// performed in all subsequent instructions.
-    pub(crate) fn simple_reachable_blocks_optimization_result<F>(&mut self, mut f: F) -> RtResult<()>
+    pub(crate) fn simple_reachable_blocks_optimization_result<F>(
+        &mut self,
+        mut f: F,
+    ) -> RtResult<()>
     where
         F: FnMut(&mut SimpleOptimizationContext<'_, '_>) -> RtResult<()>,
     {


### PR DESCRIPTION
# Description

## Problem\*

Working towards https://github.com/noir-lang/noir/issues/8741
Unfortunately this does not 100% solve the issue. We issue a RuntimeError now but panic when reporting the error since the call stack is empty. It turns out none of the call stacks for then_value, else_value, then_condition, or else_condition have any call stacks. This PR is already quite large though so I thought I'd keep this one focused on just error handling.

## Summary\*

~~These changes are all just threading RuntimeError through more places in SSA to account for the fact we can now error when inserting instructions.~~ The above is still true but we only thread through remove_if_else now and fail to optimize slice_push_back instead of propagating up further.

## Additional Context

## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
