### PR TITLE
fix: Merge `replacement_type` and `is_function_type` in `defunctionalization`

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/opt/defunctionalize.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/defunctionalize.rs
@@ -625,7 +625,9 @@ fn defunctionalize_post_check(func: &Function) {
 /// Return what type a function value type should be replaced with:
 /// * Global functions are replaced with a `Field`.
 /// * Function references are replaced with a reference to the replacement type of the underlying type, recursively.
-/// * Other types need no replacement.
+/// * Array and slices that contain function types are handled recursively.
+///
+/// If the type doesn't need replacement, `None` is returned.
 fn replacement_type(typ: &Type) -> Option<Type> {
     match typ {
         Type::Function => Some(Type::field()),
@@ -642,6 +644,9 @@ fn replacement_type(typ: &Type) -> Option<Type> {
     }
 }
 
+/// Take a list of types that might need replacement.
+/// Replaces the ones that need replacement, leaving all others as-is.
+/// If no type needs replacement, `None` is returned.
 fn replacement_types(types: &[Type]) -> Option<Vec<Type>> {
     let mut type_reps = Vec::new();
     let mut has_rep = false;

--- a/compiler/noirc_evaluator/src/ssa/opt/defunctionalize.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/defunctionalize.rs
@@ -243,22 +243,8 @@ fn remove_first_class_functions_in_instruction(
             *arg = map_value(*arg);
         }
     } else if let Instruction::MakeArray { typ, .. } = instruction {
-        match typ {
-            Type::Array(element_types, len) => {
-                let new_element_types = element_types
-                    .iter()
-                    .map(|typ| replacement_type(typ).unwrap_or_else(|| typ.clone()))
-                    .collect::<Vec<_>>();
-                *typ = Type::Array(Arc::new(new_element_types), *len);
-            }
-            Type::Slice(element_types) => {
-                let new_element_types = element_types
-                    .iter()
-                    .map(|typ| replacement_type(typ).unwrap_or_else(|| typ.clone()))
-                    .collect::<Vec<_>>();
-                *typ = Type::Slice(Arc::new(new_element_types));
-            }
-            _ => {}
+        if let Some(rep) = replacement_type(typ) {
+            *typ = rep;
         }
         instruction.map_values_mut(map_value);
 

--- a/compiler/noirc_evaluator/src/ssa/opt/defunctionalize.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/defunctionalize.rs
@@ -245,23 +245,17 @@ fn remove_first_class_functions_in_instruction(
     } else if let Instruction::MakeArray { typ, .. } = instruction {
         match typ {
             Type::Array(element_types, len) => {
-                let new_element_types =
-                    element_types
-                        .iter()
-                        .map(|typ| {
-                            if matches!(typ, Type::Function) { Type::field() } else { typ.clone() }
-                        })
-                        .collect::<Vec<_>>();
+                let new_element_types = element_types
+                    .iter()
+                    .map(|typ| replacement_type(typ).unwrap_or_else(|| typ.clone()))
+                    .collect::<Vec<_>>();
                 *typ = Type::Array(Arc::new(new_element_types), *len);
             }
             Type::Slice(element_types) => {
-                let new_element_types =
-                    element_types
-                        .iter()
-                        .map(|typ| {
-                            if matches!(typ, Type::Function) { Type::field() } else { typ.clone() }
-                        })
-                        .collect::<Vec<_>>();
+                let new_element_types = element_types
+                    .iter()
+                    .map(|typ| replacement_type(typ).unwrap_or_else(|| typ.clone()))
+                    .collect::<Vec<_>>();
                 *typ = Type::Slice(Arc::new(new_element_types));
             }
             _ => {}

--- a/compiler/noirc_evaluator/src/ssa/opt/defunctionalize.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/defunctionalize.rs
@@ -648,17 +648,22 @@ fn replacement_type(typ: &Type) -> Option<Type> {
 /// Replaces the ones that need replacement, leaving all others as-is.
 /// If no type needs replacement, `None` is returned.
 fn replacement_types(types: &[Type]) -> Option<Vec<Type>> {
-    let mut type_reps = Vec::new();
+    let mut reps = Vec::new();
     let mut has_rep = false;
     for typ in types {
         let rep = replacement_type(typ);
         has_rep |= rep.is_some();
-        type_reps.push((typ, rep));
+        reps.push(rep);
     }
     if !has_rep {
         None
     } else {
-        Some(type_reps.into_iter().map(|(typ, rep)| rep.unwrap_or_else(|| typ.clone())).collect())
+        Some(
+            reps.into_iter()
+                .zip(types)
+                .map(|(rep, typ)| rep.unwrap_or_else(|| typ.clone()))
+                .collect(),
+        )
     }
 }
 

--- a/compiler/noirc_evaluator/src/ssa/opt/defunctionalize.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/defunctionalize.rs
@@ -130,8 +130,8 @@ impl DefunctionalizationContext {
             let parameters = block.take_parameters();
             for parameter in &parameters {
                 let typ = &func.dfg.type_of_value(*parameter);
-                if is_function_type(typ) {
-                    func.dfg.set_type_of_value(*parameter, replacement_type(typ));
+                if let Some(rep) = replacement_type(typ) {
+                    func.dfg.set_type_of_value(*parameter, rep);
                 }
             }
 
@@ -160,8 +160,8 @@ impl DefunctionalizationContext {
                 #[allow(clippy::unnecessary_to_owned)] // clippy is wrong here
                 for result in func.dfg.instruction_results(instruction_id).to_vec() {
                     let typ = &func.dfg.type_of_value(result);
-                    if is_function_type(typ) {
-                        func.dfg.set_type_of_value(result, replacement_type(typ));
+                    if let Some(rep) = replacement_type(typ) {
+                        func.dfg.set_type_of_value(result, rep);
                     }
                 }
 
@@ -280,7 +280,7 @@ fn remove_first_class_functions_in_instruction(
 /// Returns none if the given value was not a function or doesn't need to be mapped.
 fn map_function_to_field(func: &mut Function, value: ValueId) -> Option<ValueId> {
     let typ = func.dfg[value].get_type();
-    if is_function_type(typ.as_ref()) {
+    if let Some(rep) = replacement_type(typ.as_ref()) {
         match &func.dfg[value] {
             // If the value is a static function, transform it to the function id
             Value::Function(id) => {
@@ -289,7 +289,7 @@ fn map_function_to_field(func: &mut Function, value: ValueId) -> Option<ValueId>
             }
             // If the value is a function used as value, just change the type of it
             Value::Instruction { .. } | Value::Param { .. } => {
-                func.dfg.set_type_of_value(value, replacement_type(typ.as_ref()));
+                func.dfg.set_type_of_value(value, rep);
             }
             _ => (),
         }
@@ -424,15 +424,15 @@ fn create_apply_functions(ssa: &mut Ssa, variants_map: Variants) -> ApplyFunctio
         // Update the shared function signature of the higher-order function variants
         // to replace any function passed as a value to a numeric field type.
         for param in &mut signature.params {
-            if is_function_type(param) {
-                *param = replacement_type(param);
+            if let Some(rep) = replacement_type(param) {
+                *param = rep;
             }
         }
 
         // Update the return value types as we did for the signature parameters above.
         for ret in &mut signature.returns {
-            if is_function_type(ret) {
-                *ret = replacement_type(ret);
+            if let Some(rep) = replacement_type(ret) {
+                *ret = rep;
             }
         }
 
@@ -619,7 +619,7 @@ fn defunctionalize_post_check(func: &Function) {
                 panic!("unexpected parameter value: {value:?}");
             };
             assert!(
-                !is_function_type(typ),
+                replacement_type(typ).is_none(),
                 "Blocks are not expected to take function parameters any more. Got '{typ}' in param {param} of block {block_id} in function {} {}",
                 func.name(),
                 func.id()
@@ -628,19 +628,17 @@ fn defunctionalize_post_check(func: &Function) {
     }
 }
 
-fn is_function_type(typ: &Type) -> bool {
+/// Return what type a function value type should be replaced with:
+/// * Global functions are replaced with a `Field`.
+/// * Function references are replaced with a reference to the replacement type of the underlying type, recursively.
+/// * Other types need no replacement.
+fn replacement_type(typ: &Type) -> Option<Type> {
     match typ {
-        Type::Function => true,
-        Type::Reference(typ) => is_function_type(typ),
-        _ => false,
-    }
-}
-
-fn replacement_type(typ: &Type) -> Type {
-    if matches!(typ, Type::Reference(_)) {
-        Type::Reference(Arc::new(Type::field()))
-    } else {
-        Type::field()
+        Type::Function => Some(Type::field()),
+        Type::Reference(typ) => {
+            replacement_type(typ.as_ref()).map(|typ| Type::Reference(Arc::new(typ)))
+        }
+        _ => None,
     }
 }
 


### PR DESCRIPTION
# Description

## Problem\*

Resolves the following audit issues:
* [Array and slice types with deeply nested function types are not fully updated](https://audithub.veridise.com/app/organizations/85/projects/277/project-viewer?bpt=1&version=433&issue=21)
* [Missing/incorrect cases when replacing function types](https://audithub.veridise.com/app/organizations/85/projects/277/project-viewer?bpt=1&version=433&issue=18)

## Summary\*

* Removes `is_function_type` and changes `replacement_type` to return an `Option`, so there is no need for guarding the latter with the former. 
* Makes `replacement_type` recursive. 
* Uses `replacement_type` to handle types in arrays and slices.
* Extends `replacement_type` to consider arrays/slices that contain types with functions, recursively.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
