### PR TITLE
chore: Adjust the frequency of 'for' statements in ACIR fuzz generation

### DIFF
--- a/tooling/ast_fuzzer/src/lib.rs
+++ b/tooling/ast_fuzzer/src/lib.rs
@@ -82,7 +82,7 @@ impl Default for Config {
             ("drop", 0), // The `ownership` module says it will insert `Drop` and `Clone`.
             ("assign", 30),
             ("if", 10),
-            ("for", 18),
+            ("for", 22),
             ("let", 25),
             ("call", 5),
         ]);


### PR DESCRIPTION
# Description

## Problem\*

Resolves CI failures such as https://github.com/noir-lang/noir/actions/runs/15443832433/job/43470438910?pr=8772

## Summary\*

On CI the frequency of `"for"` seems to be on the low side. It's expected to be around 10 percent, fall between 8 and 12, but comes out as 7. Adjusted it higher based on a few local runs.

## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
