### PR TITLE
feat: use `asm` feature flag in arkworks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,7 +117,7 @@ ark-bls12-381 = { version = "^0.5.0", default-features = false, features = [
 ] }
 ark-grumpkin = { version = "^0.5.0", default-features = false }
 ark-ec = { version = "^0.5.0", default-features = false }
-ark-ff = { version = "^0.5.0", default-features = false }
+ark-ff = { version = "^0.5.0", default-features = false, features = ["asm"] }
 ark-std = { version = "^0.5.0", default-features = false }
 
 # Misc utils crates


### PR DESCRIPTION
# Description

## Problem\*

Resolves #4754 

## Summary\*

This PR switches us over to using some of the optimized assembly implementations of arkworks logic for free performance.

## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
