### PR TITLE
fix(ssa): Type check ToRadix and ToBits intrinsic calls

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/validation/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/validation/mod.rs
@@ -150,19 +150,26 @@ impl<'f> Validator<'f> {
             }
             Instruction::Call { func, arguments } => {
                 if let Value::Intrinsic(intrinsic) = &dfg[*func] {
-                    let value_typ = dfg.type_of_value(arguments[0]);
-                    assert!(matches!(value_typ, Type::Numeric(NumericType::NativeField)));
+                    match intrinsic {
+                        Intrinsic::ToRadix(_) => {
+                            assert_eq!(arguments.len(), 2);
 
-                    if matches!(intrinsic, Intrinsic::ToRadix(_)) {
-                        assert_eq!(arguments.len(), 2);
-                        let radix_typ = dfg.type_of_value(arguments[1]);
-                        assert!(matches!(
-                            radix_typ,
-                            Type::Numeric(NumericType::Unsigned { bit_size: 32 })
-                        ));
-                    } else {
-                        // Intrinsic::ToBits always has a set radix
-                        assert_eq!(arguments.len(), 1);
+                            let value_typ = dfg.type_of_value(arguments[0]);
+                            assert!(matches!(value_typ, Type::Numeric(NumericType::NativeField)));
+
+                            let radix_typ = dfg.type_of_value(arguments[1]);
+                            assert!(matches!(
+                                radix_typ,
+                                Type::Numeric(NumericType::Unsigned { bit_size: 32 })
+                            ));
+                        }
+                        Intrinsic::ToBits(_) => {
+                            // Intrinsic::ToBits always has a set radix
+                            assert_eq!(arguments.len(), 1);
+                            let value_typ = dfg.type_of_value(arguments[0]);
+                            assert!(matches!(value_typ, Type::Numeric(NumericType::NativeField)));
+                        }
+                        _ => {}
                     }
                 }
             }


### PR DESCRIPTION
# Description

## Problem\*

Resolves #8517 

Builds upon #8765 

## Summary\*

We simply now type check calls to the ToRadix and ToBits intrinsics that their first arguments is a field type and the second argument is an unsigned 32 bit integer.

## Additional Context

## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [X] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
