### PR TITLE
fix(interpreter): Do not overflow on signed checked ops

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/interpreter/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/interpreter/mod.rs
@@ -1025,19 +1025,32 @@ impl Interpreter<'_> {
         let dfg = self.dfg();
         let result = match binary.operator {
             BinaryOp::Add { unchecked: false } => {
-                apply_int_binop_opt!(dfg, lhs, rhs, binary, num_traits::CheckedAdd::checked_add)
+                if lhs.get_type().is_unsigned() {
+                    apply_int_binop_opt!(dfg, lhs, rhs, binary, num_traits::CheckedAdd::checked_add)
+                } else {
+                    apply_int_binop!(lhs, rhs, binary, num_traits::WrappingAdd::wrapping_add)
+                }
             }
             BinaryOp::Add { unchecked: true } => {
                 apply_int_binop!(lhs, rhs, binary, num_traits::WrappingAdd::wrapping_add)
             }
             BinaryOp::Sub { unchecked: false } => {
-                apply_int_binop_opt!(dfg, lhs, rhs, binary, num_traits::CheckedSub::checked_sub)
+                if lhs.get_type().is_unsigned() {
+                    apply_int_binop_opt!(dfg, lhs, rhs, binary, num_traits::CheckedSub::checked_sub)
+                } else {
+                    apply_int_binop!(lhs, rhs, binary, num_traits::WrappingSub::wrapping_sub)
+                }
             }
             BinaryOp::Sub { unchecked: true } => {
                 apply_int_binop!(lhs, rhs, binary, num_traits::WrappingSub::wrapping_sub)
             }
             BinaryOp::Mul { unchecked: false } => {
-                apply_int_binop_opt!(dfg, lhs, rhs, binary, num_traits::CheckedMul::checked_mul)
+                // Only unsigned multiplication has side effects
+                if lhs.get_type().is_unsigned() {
+                    apply_int_binop_opt!(dfg, lhs, rhs, binary, num_traits::CheckedMul::checked_mul)
+                } else {
+                    apply_int_binop!(lhs, rhs, binary, num_traits::WrappingMul::wrapping_mul)
+                }
             }
             BinaryOp::Mul { unchecked: true } => {
                 apply_int_binop!(lhs, rhs, binary, num_traits::WrappingMul::wrapping_mul)


### PR DESCRIPTION
# Description

## Problem\*

Resolves #8616 
Resolves #8621 

Does not fully resolve #8618, but both error with the same result now.

## Summary\*

We should not overflow on a signed add/sub/mul operation immediately. They are non side effectual and we leave checking their overflow to other instructions in the SSA.   

## Additional Context

## Documentation\*

Check one:
- [X] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
