### PR TITLE
fix(comptime): Do not overflow on signed checked ops

### DIFF
--- a/compiler/noirc_frontend/src/hir/comptime/interpreter/infix.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter/infix.rs
@@ -45,14 +45,14 @@ pub(super) fn evaluate_infix(
 
     /// Generate matches for arithmetic operations on `Field` and integers.
     macro_rules! match_arithmetic {
-        (($lhs_value:ident as $lhs:ident $op:literal $rhs_value:ident as $rhs:ident) { field: $field_expr:expr, int: $int_expr:expr, }) => {
+        (($lhs_value:ident as $lhs:ident $op:literal $rhs_value:ident as $rhs:ident) { field: $field_expr:expr, int: $int_expr:expr, signed_int: $signed_int_expr:expr, }) => {
             match_values! {
                 ($lhs_value as $lhs $op $rhs_value as $rhs) {
                     (Field, Field) to Field => Some($field_expr),
-                    (I8,  I8)      to I8    => $int_expr,
-                    (I16, I16)     to I16   => $int_expr,
-                    (I32, I32)     to I32   => $int_expr,
-                    (I64, I64)     to I64   => $int_expr,
+                    (I8,  I8)      to I8    => $signed_int_expr,
+                    (I16, I16)     to I16   => $signed_int_expr,
+                    (I32, I32)     to I32   => $signed_int_expr,
+                    (I64, I64)     to I64   => $signed_int_expr,
                     (U8,  U8)      to U8    => $int_expr,
                     (U16, U16)     to U16   => $int_expr,
                     (U32, U32)     to U32   => $int_expr,
@@ -148,24 +148,28 @@ pub(super) fn evaluate_infix(
             (lhs_value as lhs "+" rhs_value as rhs) {
                 field: lhs + rhs,
                 int: lhs.checked_add(rhs),
+                signed_int: Some(lhs.wrapping_add(rhs)),
             }
         },
         BinaryOpKind::Subtract => match_arithmetic! {
             (lhs_value as lhs "-" rhs_value as rhs) {
                 field: lhs - rhs,
                 int: lhs.checked_sub(rhs),
+                signed_int: Some(lhs.wrapping_sub(rhs)),
             }
         },
         BinaryOpKind::Multiply => match_arithmetic! {
             (lhs_value as lhs "*" rhs_value as rhs) {
                 field: lhs * rhs,
                 int: lhs.checked_mul(rhs),
+                signed_int: Some(lhs.wrapping_mul(rhs)),
             }
         },
         BinaryOpKind::Divide => match_arithmetic! {
             (lhs_value as lhs "/" rhs_value as rhs) {
                 field: lhs / rhs,
                 int: lhs.checked_div(rhs),
+                signed_int: lhs.checked_div(rhs),
             }
         },
         BinaryOpKind::Equal => match_cmp! {

--- a/compiler/noirc_frontend/src/hir/comptime/tests.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/tests.rs
@@ -314,3 +314,133 @@ fn generic_functions() {
     let result = interpret(program);
     assert_eq!(result, Value::U8(2));
 }
+
+#[test]
+fn add_unsigned() {
+    let src = "
+    comptime fn main() -> pub u32 {
+        2 + 100
+    }
+    ";
+    let result = interpret(src);
+    assert_eq!(result, Value::U32(102));
+}
+
+#[test]
+fn add_signed() {
+    let src = "
+    comptime fn main() -> pub i32 {
+        2 + 100
+    }
+    ";
+    let result = interpret(src);
+    assert_eq!(result, Value::I32(102));
+}
+
+#[test]
+fn add_overflow_unsigned() {
+    let src = "
+    comptime fn main() -> pub u8 {
+        200 + 100
+    }
+    ";
+    let result = interpret_expect_error(src);
+    let InterpreterError::MathError { operator, .. } = result else {
+        panic!("Expected MathError");
+    };
+    assert_eq!(operator, "+");
+}
+
+#[test]
+fn sub_unsigned() {
+    let src = "
+    comptime fn main() -> pub u32 {
+        10101 - 101
+    }
+    ";
+    let result = interpret(src);
+    assert_eq!(result, Value::U32(10000));
+}
+
+#[test]
+fn sub_signed() {
+    let src = "
+    comptime fn main() -> pub i32 {
+        10101 - 10102
+    }
+    ";
+    let result = interpret(src);
+    assert_eq!(result, Value::I32(-1));
+}
+
+#[test]
+fn sub_underflow_unsigned() {
+    let src = "
+    comptime fn main() -> pub u32 {
+        0 - 10
+    }
+    ";
+    let result = interpret_expect_error(src);
+    let InterpreterError::MathError { operator, .. } = result else {
+        panic!("Expected MathError");
+    };
+    assert_eq!(operator, "-");
+}
+
+#[test]
+fn sub_underflow_signed() {
+    let src = "
+    comptime fn main() -> pub i8 {
+        -120 - 10
+    }
+    ";
+    let result = interpret(src);
+    assert_eq!(result, Value::I8(126));
+}
+
+#[test]
+fn mul_unsigned() {
+    let src = "
+    comptime fn main() -> pub u64 {
+        2 * 100
+    }
+    ";
+    let result = interpret(src);
+    assert_eq!(result, Value::U64(200));
+}
+
+#[test]
+fn mul_signed() {
+    let src = "
+    comptime fn main() -> pub i64 {
+        2 * -100
+    }
+    ";
+    let result = interpret(src);
+    assert_eq!(result, Value::I64(-200));
+}
+
+#[test]
+fn mul_overflow_unsigned() {
+    let src = "
+    comptime fn main() -> pub u8 {
+        128 * 2
+    }
+    ";
+    let result = interpret_expect_error(src);
+    let InterpreterError::MathError { operator, .. } = result else {
+        panic!("Expected MathError");
+    };
+    assert_eq!(operator, "*");
+}
+
+#[test]
+fn mul_overflow_signed() {
+    let src = "
+    comptime fn main() -> pub i8 {
+        127 * 2
+    }
+    ";
+    let result = interpret(src);
+    assert_eq!(result, Value::I8(-2));
+}


### PR DESCRIPTION
# Description

## Problem\*

Resolves https://github.com/noir-lang/noir/pull/8806#discussion_r2129493175

## Summary\*

Update the comptime interpreter to match the side effect (overflow) semantics of binary operations in the SSA. 

## Additional Context

## Documentation\*

Check one:
- [X] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
