### PR TITLE
chore!: disallow casting signed integers to field

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/types.rs
+++ b/compiler/noirc_frontend/src/elaborator/types.rs
@@ -1193,7 +1193,18 @@ impl Elaborator<'_> {
 
         match to {
             Type::Integer(sign, bits) => Type::Integer(sign, bits),
-            Type::FieldElement => Type::FieldElement,
+            Type::FieldElement => {
+                let is_signed = match from_follow_bindings {
+                    Type::Integer(Signedness::Signed, _) => true,
+                    Type::TypeVariable(ref var) => var.is_signed(),
+                    _ => false,
+                };
+                if is_signed {
+                    self.push_err(TypeCheckError::UnsupportedFieldCast { location });
+                }
+
+                Type::FieldElement
+            }
             Type::Bool => {
                 let from_is_numeric = match from_follow_bindings {
                     Type::Integer(..) | Type::FieldElement => true,

--- a/compiler/noirc_frontend/src/hir/type_check/errors.rs
+++ b/compiler/noirc_frontend/src/hir/type_check/errors.rs
@@ -86,6 +86,8 @@ pub enum TypeCheckError {
     UnconstrainedMismatch { item: String, expected: bool, location: Location },
     #[error("Only integer and Field types may be casted to")]
     UnsupportedCast { location: Location },
+    #[error("Only unsigned integer types may be casted to Field")]
+    UnsupportedFieldCast { location: Location },
     #[error("Index {index} is out of bounds for this tuple {lhs_type} of length {length}")]
     TupleIndexOutOfBounds { index: usize, lhs_type: Type, length: usize, location: Location },
     #[error("Variable `{name}` must be mutable to be assigned to")]
@@ -268,6 +270,7 @@ impl TypeCheckError {
             | TypeCheckError::GenericCountMismatch { location, .. }
             | TypeCheckError::UnconstrainedMismatch { location, .. }
             | TypeCheckError::UnsupportedCast { location }
+            | TypeCheckError::UnsupportedFieldCast { location }
             | TypeCheckError::TupleIndexOutOfBounds { location, .. }
             | TypeCheckError::VariableMustBeMutable { location, .. }
             | TypeCheckError::CannotMutateImmutableVariable { location, .. }
@@ -470,6 +473,7 @@ impl<'a> From<&'a TypeCheckError> for Diagnostic {
             TypeCheckError::ExpectedFunction { location, .. }
             | TypeCheckError::AccessUnknownMember { location, .. }
             | TypeCheckError::UnsupportedCast { location }
+            | TypeCheckError::UnsupportedFieldCast { location }
             | TypeCheckError::TupleIndexOutOfBounds { location, .. }
             | TypeCheckError::VariableMustBeMutable { location, .. }
             | TypeCheckError::CannotMutateImmutableVariable { location, .. }

--- a/compiler/noirc_frontend/src/hir_def/types.rs
+++ b/compiler/noirc_frontend/src/hir_def/types.rs
@@ -912,6 +912,16 @@ impl TypeVariable {
         }
     }
 
+    /// Check that if bound, it's a signed integer
+    pub fn is_signed(&self) -> bool {
+        match &*self.borrow() {
+            TypeBinding::Bound(binding) => {
+                matches!(binding.follow_bindings(), Type::Integer(Signedness::Signed, _))
+            }
+            _ => false,
+        }
+    }
+
     /// If value_level, only check for Type::FieldElement,
     /// else only check for a type-level FieldElement
     fn is_field_element(&self, value_level: bool) -> bool {

--- a/noir_stdlib/src/convert.nr
+++ b/noir_stdlib/src/convert.nr
@@ -169,7 +169,6 @@ comptime fn generate_as_primitive_impls(_: FunctionDefinition) -> Quoted {
         quote { i16 },
         quote { i32 },
         quote { i64 },
-        quote { Field },
     ];
 
     let mut impls = &[];
@@ -194,5 +193,41 @@ comptime fn generate_as_primitive_impls(_: FunctionDefinition) -> Quoted {
             );
         }
     }
+
+    let u_types =
+        [quote { bool }, quote { u8 }, quote { u16 }, quote { u32 }, quote { u64 }, quote { u128 }];
+
+    for type2 in u_types {
+        let body = quote { self as Field };
+
+        impls = impls.push_back(
+            quote {
+                impl AsPrimitive<Field> for $type2 {
+                    fn as_(self) -> Field {
+                        $body
+                    }
+                }
+            },
+        );
+    }
+
+    for type1 in u_types {
+        let body = if type1 == quote { bool } {
+            quote { self != 0 }
+        } else {
+            quote { self as $type1 }
+        };
+
+        impls = impls.push_back(
+            quote {
+                impl AsPrimitive<$type1> for Field {
+                    fn as_(self) -> $type1 {
+                        $body
+                    }
+                }
+            },
+        );
+    }
+
     impls.join(quote {})
 }

--- a/noir_stdlib/src/hash/mod.nr
+++ b/noir_stdlib/src/hash/mod.nr
@@ -271,7 +271,7 @@ impl Hash for i8 {
     where
         H: Hasher,
     {
-        H::write(state, self as Field);
+        H::write(state, self as u8 as Field);
     }
 }
 
@@ -280,7 +280,7 @@ impl Hash for i16 {
     where
         H: Hasher,
     {
-        H::write(state, self as Field);
+        H::write(state, self as u16 as Field);
     }
 }
 
@@ -289,7 +289,7 @@ impl Hash for i32 {
     where
         H: Hasher,
     {
-        H::write(state, self as Field);
+        H::write(state, self as u32 as Field);
     }
 }
 
@@ -298,7 +298,7 @@ impl Hash for i64 {
     where
         H: Hasher,
     {
-        H::write(state, self as Field);
+        H::write(state, self as u64 as Field);
     }
 }
 

--- a/noir_stdlib/src/ops/arith.nr
+++ b/noir_stdlib/src/ops/arith.nr
@@ -393,25 +393,29 @@ impl WrappingAdd for u128 {
 
 impl WrappingAdd for i8 {
     fn wrapping_add(self: i8, y: i8) -> i8 {
-        wrapping_add_hlp(self, y)
+        let x = self as u8;
+        x.wrapping_add(y as u8) as i8
     }
 }
 
 impl WrappingAdd for i16 {
     fn wrapping_add(self: i16, y: i16) -> i16 {
-        wrapping_add_hlp(self, y)
+        let x = self as u16;
+        x.wrapping_add(y as u16) as i16
     }
 }
 
 impl WrappingAdd for i32 {
     fn wrapping_add(self: i32, y: i32) -> i32 {
-        wrapping_add_hlp(self, y)
+        let x = self as u32;
+        x.wrapping_add(y as u32) as i32
     }
 }
 
 impl WrappingAdd for i64 {
     fn wrapping_add(self: i64, y: i64) -> i64 {
-        wrapping_add_hlp(self, y)
+        let x = self as u64;
+        x.wrapping_add(y as u64) as i64
     }
 }
 impl WrappingAdd for Field {
@@ -462,24 +466,28 @@ impl WrappingSub for u128 {
 
 impl WrappingSub for i8 {
     fn wrapping_sub(self: i8, y: i8) -> i8 {
-        wrapping_sub_hlp(self, y) as i8
+        let x = self as u8;
+        x.wrapping_sub(y as u8) as i8
     }
 }
 
 impl WrappingSub for i16 {
     fn wrapping_sub(self: i16, y: i16) -> i16 {
-        wrapping_sub_hlp(self, y) as i16
+        let x = self as u16;
+        x.wrapping_sub(y as u16) as i16
     }
 }
 
 impl WrappingSub for i32 {
     fn wrapping_sub(self: i32, y: i32) -> i32 {
-        wrapping_sub_hlp(self, y) as i32
+        let x = self as u32;
+        x.wrapping_sub(y as u32) as i32
     }
 }
 impl WrappingSub for i64 {
     fn wrapping_sub(self: i64, y: i64) -> i64 {
-        wrapping_sub_hlp(self, y) as i64
+        let x = self as u64;
+        x.wrapping_sub(y as u64) as i64
     }
 }
 impl WrappingSub for Field {
@@ -525,25 +533,29 @@ impl WrappingMul for u64 {
 
 impl WrappingMul for i8 {
     fn wrapping_mul(self: i8, y: i8) -> i8 {
-        wrapping_mul_hlp(self, y)
+        let x = self as u8;
+        x.wrapping_mul(y as u8) as i8
     }
 }
 
 impl WrappingMul for i16 {
     fn wrapping_mul(self: i16, y: i16) -> i16 {
-        wrapping_mul_hlp(self, y)
+        let x = self as u16;
+        x.wrapping_mul(y as u16) as i16
     }
 }
 
 impl WrappingMul for i32 {
     fn wrapping_mul(self: i32, y: i32) -> i32 {
-        wrapping_mul_hlp(self, y)
+        let x = self as u32;
+        x.wrapping_mul(y as u32) as i32
     }
 }
 
 impl WrappingMul for i64 {
     fn wrapping_mul(self: i64, y: i64) -> i64 {
-        wrapping_mul_hlp(self, y)
+        let x = self as u64;
+        x.wrapping_mul(y as u64) as i64
     }
 }
 


### PR DESCRIPTION
# Description

## Problem\*

As discussed, we disallow casting signed integers to Field. This is because the current implementation is not coherent:
-1_i8 as Field resulted in 255 instead of -1.
However changing this behaviour has too many impact before the 1.0 release.

## Summary\*
Casting a signed integer to a Field is forbidden


## Additional Context



## Documentation\*

Check one:
- [X] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
