### PR TITLE
chore: only follow bindings on interface to `arithmetic` module

### DIFF
--- a/compiler/noirc_frontend/src/hir_def/types.rs
+++ b/compiler/noirc_frontend/src/hir_def/types.rs
@@ -1803,8 +1803,7 @@ impl Type {
             }
         }
 
-        let could_be_checked_cast = false;
-        match self.canonicalize_helper(could_be_checked_cast, run_simplifications) {
+        match self.canonicalize_with_simplifications( run_simplifications) {
             Type::Constant(x, constant_kind) => {
                 if kind.unifies(&constant_kind) {
                     kind.ensure_value_fits(x, location)

--- a/compiler/noirc_frontend/src/hir_def/types.rs
+++ b/compiler/noirc_frontend/src/hir_def/types.rs
@@ -1803,7 +1803,7 @@ impl Type {
             }
         }
 
-        match self.canonicalize_with_simplifications( run_simplifications) {
+        match self.canonicalize_with_simplifications(run_simplifications) {
             Type::Constant(x, constant_kind) => {
                 if kind.unifies(&constant_kind) {
                     kind.ensure_value_fits(x, location)

--- a/compiler/noirc_frontend/src/hir_def/types/arithmetic.rs
+++ b/compiler/noirc_frontend/src/hir_def/types/arithmetic.rs
@@ -30,6 +30,13 @@ impl Type {
         }
     }
 
+    pub(crate) fn canonicalize_with_simplifications(
+        &self,
+        run_simplifications: bool,
+    ) -> Type {
+        self.follow_bindings().canonicalize_helper(false, run_simplifications)
+    }
+
     /// Only simplify constants and drop/skip any CheckedCast's
     pub(crate) fn canonicalize_checked(&self) -> Type {
         self.follow_bindings().canonicalize_checked_helper()
@@ -48,7 +55,7 @@ impl Type {
         let found_checked_cast = true;
         let run_simplifications = true;
         // We expect `self` to have already called `follow_bindings`
-        self.canonicalize_helper_helper(found_checked_cast, run_simplifications)
+        self.canonicalize_helper(found_checked_cast, run_simplifications)
     }
 
     /// If `found_checked_cast`, then drop additional CheckedCast's
@@ -59,23 +66,7 @@ impl Type {
     ///
     /// Otherwise also attempt try_simplify_partial_constants, sort_commutative,
     /// and other simplifications
-    pub(crate) fn canonicalize_helper(
-        &self,
-        found_checked_cast: bool,
-        run_simplifications: bool,
-    ) -> Type {
-        self.follow_bindings().canonicalize_helper_helper(found_checked_cast, run_simplifications)
-    }
-
-    /// If `found_checked_cast`, then drop additional CheckedCast's
-    ///
-    /// If `run_simplifications` is false, then only:
-    /// - Attempt to evaluate each sub-expression to a constant
-    /// - Drop nested CheckedCast's
-    ///
-    /// Otherwise also attempt try_simplify_partial_constants, sort_commutative,
-    /// and other simplifications
-    fn canonicalize_helper_helper(
+    fn canonicalize_helper(
         &self,
         found_checked_cast: bool,
         run_simplifications: bool,

--- a/compiler/noirc_frontend/src/hir_def/types/arithmetic.rs
+++ b/compiler/noirc_frontend/src/hir_def/types/arithmetic.rs
@@ -32,8 +32,14 @@ impl Type {
 
     /// Only simplify constants and drop/skip any CheckedCast's
     pub(crate) fn canonicalize_checked(&self) -> Type {
+        self.follow_bindings().canonicalize_checked_helper()
+    }
+
+    /// Only simplify constants and drop/skip any CheckedCast's
+    fn canonicalize_checked_helper(&self) -> Type {
         let found_checked_cast = true;
         let skip_simplifications = false;
+        // We expect `self` to have already called `follow_bindings`
         self.canonicalize_helper(found_checked_cast, skip_simplifications)
     }
 
@@ -41,12 +47,13 @@ impl Type {
     fn canonicalize_unchecked(&self) -> Type {
         let found_checked_cast = true;
         let run_simplifications = true;
-        self.canonicalize_helper(found_checked_cast, run_simplifications)
+        // We expect `self` to have already called `follow_bindings`
+        self.canonicalize_helper_helper(found_checked_cast, run_simplifications)
     }
 
-    /// If found_checked_cast, then drop additional CheckedCast's
+    /// If `found_checked_cast`, then drop additional CheckedCast's
     ///
-    /// If run_simplifications is false, then only:
+    /// If `run_simplifications` is false, then only:
     /// - Attempt to evaluate each sub-expression to a constant
     /// - Drop nested CheckedCast's
     ///
@@ -57,7 +64,23 @@ impl Type {
         found_checked_cast: bool,
         run_simplifications: bool,
     ) -> Type {
-        match self.follow_bindings() {
+        self.follow_bindings().canonicalize_helper_helper(found_checked_cast, run_simplifications)
+    }
+
+    /// If `found_checked_cast`, then drop additional CheckedCast's
+    ///
+    /// If `run_simplifications` is false, then only:
+    /// - Attempt to evaluate each sub-expression to a constant
+    /// - Drop nested CheckedCast's
+    ///
+    /// Otherwise also attempt try_simplify_partial_constants, sort_commutative,
+    /// and other simplifications
+    fn canonicalize_helper_helper(
+        &self,
+        found_checked_cast: bool,
+        run_simplifications: bool,
+    ) -> Type {
+        match self {
             Type::InfixExpr(lhs, op, rhs, inversion) => {
                 let kind = lhs.infix_kind(&rhs);
                 let dummy_location = Location::dummy();
@@ -82,28 +105,28 @@ impl Type {
                 let rhs = rhs.canonicalize_helper(found_checked_cast, run_simplifications);
 
                 if !run_simplifications {
-                    return Type::InfixExpr(Box::new(lhs), op, Box::new(rhs), inversion);
+                    return Type::InfixExpr(Box::new(lhs), *op, Box::new(rhs), *inversion);
                 }
 
-                if let Some(result) = Self::try_simplify_non_constants_in_lhs(&lhs, op, &rhs) {
+                if let Some(result) = Self::try_simplify_non_constants_in_lhs(&lhs, *op, &rhs) {
                     return result.canonicalize_unchecked();
                 }
 
-                if let Some(result) = Self::try_simplify_non_constants_in_rhs(&lhs, op, &rhs) {
+                if let Some(result) = Self::try_simplify_non_constants_in_rhs(&lhs, *op, &rhs) {
                     return result.canonicalize_unchecked();
                 }
 
                 // Try to simplify partially constant expressions in the form `(N op1 C1) op2 C2`
                 // where C1 and C2 are constants that can be combined (e.g. N + 5 - 3 = N + 2)
-                if let Some(result) = Self::try_simplify_partial_constants(&lhs, op, &rhs) {
+                if let Some(result) = Self::try_simplify_partial_constants(&lhs, *op, &rhs) {
                     return result.canonicalize_unchecked();
                 }
 
                 if op.is_commutative() {
-                    return Self::sort_commutative(&lhs, op, &rhs);
+                    return Self::sort_commutative(&lhs, *op, &rhs);
                 }
 
-                Type::InfixExpr(Box::new(lhs), op, Box::new(rhs), inversion)
+                Type::InfixExpr(Box::new(lhs), *op, Box::new(rhs), *inversion)
             }
             Type::CheckedCast { from, to } => {
                 let inner_found_checked_cast = true;
@@ -117,7 +140,7 @@ impl Type {
 
                 Type::CheckedCast { from: Box::new(from), to: Box::new(to) }
             }
-            other => other,
+            other => other.clone(),
         }
     }
 
@@ -195,10 +218,10 @@ impl Type {
         op: BinaryTypeOperator,
         rhs: &Type,
     ) -> Option<Type> {
-        match lhs.follow_bindings() {
+        match lhs {
             Type::CheckedCast { from, to } => {
                 // Apply operation directly to `from` while attempting simplification to `to`.
-                let from = Type::infix_expr(from, op, Box::new(rhs.clone()));
+                let from = Type::infix_expr(from.clone(), op, Box::new(rhs.clone()));
                 let to = Self::try_simplify_non_constants_in_lhs(&to, op, rhs)?;
                 Some(Type::CheckedCast { from: Box::new(from), to: Box::new(to) })
             }
@@ -206,13 +229,13 @@ impl Type {
                 // Note that this is exact, syntactic equality, not unification.
                 // `rhs` is expected to already be in canonical form.
                 if l_op.approx_inverse() != Some(op)
-                    || l_op == BinaryTypeOperator::Division
+                    || *l_op == BinaryTypeOperator::Division
                     || l_rhs.canonicalize_unchecked() != *rhs
                 {
                     return None;
                 }
 
-                Some(*l_lhs)
+                Some(*l_lhs.clone())
             }
             _ => None,
         }
@@ -232,17 +255,17 @@ impl Type {
         op: BinaryTypeOperator,
         rhs: &Type,
     ) -> Option<Type> {
-        match rhs.follow_bindings() {
+        match rhs {
             Type::CheckedCast { from, to } => {
                 // Apply operation directly to `from` while attempting simplification to `to`.
-                let from = Type::infix_expr(Box::new(lhs.clone()), op, from);
+                let from = Type::infix_expr(Box::new(lhs.clone()), op, from.clone());
                 let to = Self::try_simplify_non_constants_in_rhs(lhs, op, &to)?;
                 Some(Type::CheckedCast { from: Box::new(from), to: Box::new(to) })
             }
             Type::InfixExpr(r_lhs, r_op, r_rhs, _) => {
                 // `N / (M * N)` should be simplified to `1 / M`, but we only handle
                 // simplifying to `M` in this function.
-                if op == BinaryTypeOperator::Division && r_op == BinaryTypeOperator::Multiplication
+                if op == BinaryTypeOperator::Division && *r_op == BinaryTypeOperator::Multiplication
                 {
                     return None;
                 }
@@ -253,7 +276,7 @@ impl Type {
                     return None;
                 }
 
-                Some(*r_lhs)
+                Some(*r_lhs.clone())
             }
             _ => None,
         }

--- a/compiler/noirc_frontend/src/hir_def/types/arithmetic.rs
+++ b/compiler/noirc_frontend/src/hir_def/types/arithmetic.rs
@@ -30,10 +30,7 @@ impl Type {
         }
     }
 
-    pub(crate) fn canonicalize_with_simplifications(
-        &self,
-        run_simplifications: bool,
-    ) -> Type {
+    pub(crate) fn canonicalize_with_simplifications(&self, run_simplifications: bool) -> Type {
         self.follow_bindings().canonicalize_helper(false, run_simplifications)
     }
 
@@ -66,11 +63,7 @@ impl Type {
     ///
     /// Otherwise also attempt try_simplify_partial_constants, sort_commutative,
     /// and other simplifications
-    fn canonicalize_helper(
-        &self,
-        found_checked_cast: bool,
-        run_simplifications: bool,
-    ) -> Type {
+    fn canonicalize_helper(&self, found_checked_cast: bool, run_simplifications: bool) -> Type {
         match self {
             Type::InfixExpr(lhs, op, rhs, inversion) => {
                 let kind = lhs.infix_kind(&rhs);

--- a/compiler/noirc_frontend/src/hir_def/types/arithmetic.rs
+++ b/compiler/noirc_frontend/src/hir_def/types/arithmetic.rs
@@ -66,7 +66,7 @@ impl Type {
     fn canonicalize_helper(&self, found_checked_cast: bool, run_simplifications: bool) -> Type {
         match self {
             Type::InfixExpr(lhs, op, rhs, inversion) => {
-                let kind = lhs.infix_kind(&rhs);
+                let kind = lhs.infix_kind(rhs);
                 let dummy_location = Location::dummy();
                 // evaluate_to_field_element also calls canonicalize so if we just called
                 // `self.evaluate_to_field_element(..)` we'd get infinite recursion.
@@ -206,7 +206,7 @@ impl Type {
             Type::CheckedCast { from, to } => {
                 // Apply operation directly to `from` while attempting simplification to `to`.
                 let from = Type::infix_expr(from.clone(), op, Box::new(rhs.clone()));
-                let to = Self::try_simplify_non_constants_in_lhs(&to, op, rhs)?;
+                let to = Self::try_simplify_non_constants_in_lhs(to, op, rhs)?;
                 Some(Type::CheckedCast { from: Box::new(from), to: Box::new(to) })
             }
             Type::InfixExpr(l_lhs, l_op, l_rhs, _) => {
@@ -243,7 +243,7 @@ impl Type {
             Type::CheckedCast { from, to } => {
                 // Apply operation directly to `from` while attempting simplification to `to`.
                 let from = Type::infix_expr(Box::new(lhs.clone()), op, from.clone());
-                let to = Self::try_simplify_non_constants_in_rhs(lhs, op, &to)?;
+                let to = Self::try_simplify_non_constants_in_rhs(lhs, op, to)?;
                 Some(Type::CheckedCast { from: Box::new(from), to: Box::new(to) })
             }
             Type::InfixExpr(r_lhs, r_op, r_rhs, _) => {


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This PR removes the call to `follow_bindings` which happens multiple times on the same type per `canonicalize` call. This method does a large amount of cloning and a single call goes through the full `Type` structure. We can then call `follow_bindings` once on the entrypoint and consider all bindings as having been followed after that.

I've done a small amount of reworking of this module so that all the `pub(crate)` methods call `follow_bindings` so an external consumer of the module doesn't need to manually call `follow_bindings` themselves.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
