### PR TITLE
fix: update external lib commit tdd.nr

### DIFF
--- a/EXTERNAL_NOIR_LIBRARIES.yml
+++ b/EXTERNAL_NOIR_LIBRARIES.yml
@@ -141,7 +141,7 @@ libraries:
     critical: false
   tdd:
     repo: teddav/tdd.nr
-    ref: 4bebfb361f2e5175d23376645310eecca96749a5
+    ref: c5c2d8ed9d9c7dc73346bb0bd7884f871bd16236
     timeout: 20
     critical: false
   zkpassport_rsa:


### PR DESCRIPTION
Updating the commit for the external lib [tdd.nr](https://github.com/teddav/tdd.nr), due to a breaking change in Noir: https://github.com/noir-lang/noir/pull/8804#issuecomment-2949260604