### PR TITLE
fix: bind self generic type in trait calls via a concrete type in more cases

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/path_resolution.rs
+++ b/compiler/noirc_frontend/src/elaborator/path_resolution.rs
@@ -49,7 +49,7 @@ pub(crate) enum PathResolutionItem {
     /// A function call on a type that resolves to a trait method, for example `SomeType::from(...)`
     /// or `SomeType::<A, B>::from(..).`. The main difference from `TraitFunction` is that this
     /// holds the self type, in this case `SomeType`.
-    TypeTraitFunction(Type, TraitId, Option<Turbofish>, FuncId),
+    TypeTraitFunction(Type, TraitId, FuncId),
     /// A function call on a primitive type, for example `u64::from(...)` or `u64::<A, B>::from(..)`.
     PrimitiveFunction(PrimitiveType, Option<Turbofish>, FuncId),
 }
@@ -62,7 +62,7 @@ impl PathResolutionItem {
             | PathResolutionItem::SelfMethod(func_id)
             | PathResolutionItem::TypeAliasFunction(_, _, func_id)
             | PathResolutionItem::TraitFunction(_, _, func_id)
-            | PathResolutionItem::TypeTraitFunction(_, _, _, func_id)
+            | PathResolutionItem::TypeTraitFunction(_, _, func_id)
             | PathResolutionItem::PrimitiveFunction(_, _, func_id) => Some(*func_id),
             PathResolutionItem::Module(..)
             | PathResolutionItem::Type(..)

--- a/compiler/noirc_frontend/src/tests/traits.rs
+++ b/compiler/noirc_frontend/src/tests/traits.rs
@@ -1239,32 +1239,6 @@ fn calls_trait_method_using_struct_name_when_multiple_impls_exist() {
 
 #[named]
 #[test]
-fn calls_trait_method_using_struct_name_when_multiple_impls_exist_and_errors_turbofish() {
-    let src = r#"
-    trait From2<T> {
-        fn from2(input: T) -> Self;
-    }
-    struct U60Repr {}
-    impl From2<[Field; 3]> for U60Repr {
-        fn from2(_: [Field; 3]) -> Self {
-            U60Repr {}
-        }
-    }
-    impl From2<Field> for U60Repr {
-        fn from2(_: Field) -> Self {
-            U60Repr {}
-        }
-    }
-    fn main() {
-        let _ = U60Repr::<Field>::from2([1, 2, 3]);
-                                        ^^^^^^^^^ Expected type Field, found type [Field; 3]
-    }
-    "#;
-    check_errors!(src);
-}
-
-#[named]
-#[test]
 fn as_trait_path_in_expression() {
     let src = r#"
         fn main() {

--- a/test_programs/compile_success_empty/alias_trait_method_call_multiple_candidates/Nargo.toml
+++ b/test_programs/compile_success_empty/alias_trait_method_call_multiple_candidates/Nargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "alias_trait_method_call_multiple_candidates"
+type = "bin"
+authors = [""]
+
+[dependencies]

--- a/test_programs/compile_success_empty/alias_trait_method_call_multiple_candidates/src/main.nr
+++ b/test_programs/compile_success_empty/alias_trait_method_call_multiple_candidates/src/main.nr
@@ -1,0 +1,34 @@
+use dep::std::convert::From;
+
+struct MyU128 {
+    lo: Field,
+    hi: Field,
+}
+
+impl MyU128 {
+    pub fn from_u64s_le(lo: u64, hi: u64) -> MyU128 {
+        MyU128 { lo: lo as Field, hi: hi as Field }
+    }
+}
+
+impl From<u64> for MyU128 {
+    fn from(value: u64) -> MyU128 {
+        MyU128::from_u64s_le(value, 0)
+    }
+}
+
+impl From<u32> for MyU128 {
+    fn from(value: u32) -> MyU128 {
+        MyU128::from(value as u64)
+    }
+}
+
+type MyU128Alias = MyU128;
+
+fn main() {
+    let x: u64 = 0;
+    let mut small_int = MyU128Alias::from(x);
+    assert(small_int.lo == x as Field);
+    let u32_3: u32 = 3;
+    assert(MyU128::from(u32_3).lo == 3);
+}

--- a/test_programs/compile_success_empty/primitive_trait_method_call_multiple_candidates/Nargo.toml
+++ b/test_programs/compile_success_empty/primitive_trait_method_call_multiple_candidates/Nargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "primitive_trait_method_call_multiple_candidates"
+type = "bin"
+authors = [""]
+
+[dependencies]

--- a/test_programs/compile_success_empty/primitive_trait_method_call_multiple_candidates/src/main.nr
+++ b/test_programs/compile_success_empty/primitive_trait_method_call_multiple_candidates/src/main.nr
@@ -1,0 +1,7 @@
+fn main() {
+    let x: u64 = 0;
+    let f = Field::from;
+    let _ = f(x);
+
+    let _ = str::from([1, 2, 3]);
+}

--- a/test_programs/compile_success_empty/type_trait_method_call_multiple_candidates_with_turbofish/Nargo.toml
+++ b/test_programs/compile_success_empty/type_trait_method_call_multiple_candidates_with_turbofish/Nargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "type_trait_method_call_multiple_candidates_with_turbofish"
+type = "bin"
+authors = [""]
+
+[dependencies]

--- a/test_programs/compile_success_empty/type_trait_method_call_multiple_candidates_with_turbofish/src/main.nr
+++ b/test_programs/compile_success_empty/type_trait_method_call_multiple_candidates_with_turbofish/src/main.nr
@@ -1,0 +1,25 @@
+pub struct Struct<T> {
+    pub x: T,
+}
+
+pub trait From2<T> {
+    fn from2(input: T) -> Self;
+}
+
+impl From2<u64> for Struct<u64> {
+    fn from2(_: u64) -> Struct<u64> {
+        Struct { x: 0 }
+    }
+}
+
+impl From2<u32> for Struct<u32> {
+    fn from2(_: u32) -> Struct<u32> {
+        Struct { x: 0 }
+    }
+}
+
+fn main() {
+    let x = 1;
+    let f = Struct::<u32>::from2;
+    let _ = f(x);
+}

--- a/tooling/nargo_cli/build.rs
+++ b/tooling/nargo_cli/build.rs
@@ -147,7 +147,9 @@ const TESTS_WITHOUT_STDOUT_CHECK: [&str; 0] = [];
 /// These tests are ignored because of existing bugs in `nargo expand`.
 /// As the bugs are fixed these tests should be removed from this list.
 /// (some are ignored on purpose for the same reason as `IGNORED_NARGO_EXPAND_EXECUTION_TESTS`)
-const IGNORED_NARGO_EXPAND_COMPILE_SUCCESS_EMPTY_TESTS: [&str; 22] = [
+const IGNORED_NARGO_EXPAND_COMPILE_SUCCESS_EMPTY_TESTS: [&str; 23] = [
+    // bug
+    "alias_trait_method_call_multiple_candidates",
     // bug
     "associated_type_bounds",
     // bug

--- a/tooling/nargo_cli/build.rs
+++ b/tooling/nargo_cli/build.rs
@@ -147,7 +147,7 @@ const TESTS_WITHOUT_STDOUT_CHECK: [&str; 0] = [];
 /// These tests are ignored because of existing bugs in `nargo expand`.
 /// As the bugs are fixed these tests should be removed from this list.
 /// (some are ignored on purpose for the same reason as `IGNORED_NARGO_EXPAND_EXECUTION_TESTS`)
-const IGNORED_NARGO_EXPAND_COMPILE_SUCCESS_EMPTY_TESTS: [&str; 21] = [
+const IGNORED_NARGO_EXPAND_COMPILE_SUCCESS_EMPTY_TESTS: [&str; 22] = [
     // bug
     "associated_type_bounds",
     // bug
@@ -186,6 +186,8 @@ const IGNORED_NARGO_EXPAND_COMPILE_SUCCESS_EMPTY_TESTS: [&str; 21] = [
     "trait_static_methods",
     // bug
     "type_trait_method_call_multiple_candidates",
+    // bug
+    "type_trait_method_call_multiple_candidates_with_turbofish",
     // There's no "src/main.nr" here so it's trickier to make this work
     "workspace_reexport_bug",
     // bug

--- a/tooling/nargo_cli/build.rs
+++ b/tooling/nargo_cli/build.rs
@@ -147,7 +147,7 @@ const TESTS_WITHOUT_STDOUT_CHECK: [&str; 0] = [];
 /// These tests are ignored because of existing bugs in `nargo expand`.
 /// As the bugs are fixed these tests should be removed from this list.
 /// (some are ignored on purpose for the same reason as `IGNORED_NARGO_EXPAND_EXECUTION_TESTS`)
-const IGNORED_NARGO_EXPAND_COMPILE_SUCCESS_EMPTY_TESTS: [&str; 23] = [
+const IGNORED_NARGO_EXPAND_COMPILE_SUCCESS_EMPTY_TESTS: [&str; 24] = [
     // bug
     "alias_trait_method_call_multiple_candidates",
     // bug
@@ -156,6 +156,8 @@ const IGNORED_NARGO_EXPAND_COMPILE_SUCCESS_EMPTY_TESTS: [&str; 23] = [
     "enums",
     // There's no "src/main.nr" here so it's trickier to make this work
     "overlapping_dep_and_mod",
+    // bug
+    "primitive_trait_method_call_multiple_candidates",
     // bug
     "reexports",
     // bug

--- a/tooling/nargo_cli/tests/snapshots/compile_success_empty/alias_trait_method_call_multiple_candidates/execute__tests__force_brillig_false_inliner_0.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_empty/alias_trait_method_call_multiple_candidates/execute__tests__force_brillig_false_inliner_0.snap
@@ -1,0 +1,26 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: artifact
+---
+{
+  "noir_version": "[noir_version]",
+  "hash": "[hash]",
+  "abi": {
+    "parameters": [],
+    "return_type": null,
+    "error_types": {}
+  },
+  "bytecode": [
+    "func 0",
+    "current witness index : _0",
+    "private parameters indices : []",
+    "public parameters indices : []",
+    "return value indices : []"
+  ],
+  "debug_symbols": "XY5BCsQwCEXv4rqLWfcqw1BsaosgJtikMITefWyYQOlK/3/6tcJCc9km1jXuML4rzMYivE0SA2aO6m49B+hyykbkFty4byU00gyjFpEBDpTShvaE2mpGc/oagHTx6oErC13d+XGBge158UBjnIX+ci0abjR/Uyf942Qx0FKMrqTGPPsH",
+  "file_map": {},
+  "names": [
+    "main"
+  ],
+  "brillig_names": []
+}

--- a/tooling/nargo_cli/tests/snapshots/compile_success_empty/primitive_trait_method_call_multiple_candidates/execute__tests__force_brillig_false_inliner_0.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_empty/primitive_trait_method_call_multiple_candidates/execute__tests__force_brillig_false_inliner_0.snap
@@ -1,0 +1,26 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: artifact
+---
+{
+  "noir_version": "[noir_version]",
+  "hash": "[hash]",
+  "abi": {
+    "parameters": [],
+    "return_type": null,
+    "error_types": {}
+  },
+  "bytecode": [
+    "func 0",
+    "current witness index : _0",
+    "private parameters indices : []",
+    "public parameters indices : []",
+    "return value indices : []"
+  ],
+  "debug_symbols": "XY5BCsQwCEXv4rqLWfcqw1BsaosgJtikMITefWyYQOlK/3/6tcJCc9km1jXuML4rzMYivE0SA2aO6m49B+hyykbkFty4byU00gyjFpEBDpTShvaE2mpGc/oagHTx6oErC13d+XGBge158UBjnIX+ci0abjR/Uyf942Qx0FKMrqTGPPsH",
+  "file_map": {},
+  "names": [
+    "main"
+  ],
+  "brillig_names": []
+}

--- a/tooling/nargo_cli/tests/snapshots/compile_success_empty/type_trait_method_call_multiple_candidates_with_turbofish/execute__tests__force_brillig_false_inliner_0.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_empty/type_trait_method_call_multiple_candidates_with_turbofish/execute__tests__force_brillig_false_inliner_0.snap
@@ -1,0 +1,26 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: artifact
+---
+{
+  "noir_version": "[noir_version]",
+  "hash": "[hash]",
+  "abi": {
+    "parameters": [],
+    "return_type": null,
+    "error_types": {}
+  },
+  "bytecode": [
+    "func 0",
+    "current witness index : _0",
+    "private parameters indices : []",
+    "public parameters indices : []",
+    "return value indices : []"
+  ],
+  "debug_symbols": "XY5BCsQwCEXv4rqLWfcqw1BsaosgJtikMITefWyYQOlK/3/6tcJCc9km1jXuML4rzMYivE0SA2aO6m49B+hyykbkFty4byU00gyjFpEBDpTShvaE2mpGc/oagHTx6oErC13d+XGBge158UBjnIX+ci0abjR/Uyf942Qx0FKMrqTGPPsH",
+  "file_map": {},
+  "names": [
+    "main"
+  ],
+  "brillig_names": []
+}


### PR DESCRIPTION
# Description

## Problem

Follow-up to https://github.com/noir-lang/noir/pull/8825

## Summary

Follow-up to the recent PR for handling some remaining cases, mainly when `self` is a type alias or a primitive type.

## Additional Context


## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
