### PR TITLE
fix(interpreter): Return -1 for shr signed overflow

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/interpreter/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/interpreter/mod.rs
@@ -1091,7 +1091,17 @@ impl Interpreter<'_> {
                 }
             }
             BinaryOp::Shr => {
-                let zero = || NumericValue::zero(lhs.get_type());
+                // let zero = || NumericValue::zero(lhs.get_type());
+                // let zero = || NumericValue::zero(lhs.get_type());
+
+                let fallback = || {
+                    if lhs.get_type().is_unsigned() {
+                        NumericValue::zero(lhs.get_type())
+                    } else {
+                        NumericValue::neg_one(lhs.get_type())
+                    }
+                };
+
                 let Some(rhs) = rhs.as_u8() else {
                     let rhs = rhs.to_string();
                     return Err(internal(InternalError::RhsOfBitShiftShouldBeU8 {
@@ -1111,15 +1121,15 @@ impl Interpreter<'_> {
                         }));
                     }
                     U1(value) => U1(if rhs == 0 { value } else { false }),
-                    U8(value) => value.checked_shr(rhs).map(U8).unwrap_or_else(zero),
-                    U16(value) => value.checked_shr(rhs).map(U16).unwrap_or_else(zero),
-                    U32(value) => value.checked_shr(rhs).map(U32).unwrap_or_else(zero),
-                    U64(value) => value.checked_shr(rhs).map(U64).unwrap_or_else(zero),
-                    U128(value) => value.checked_shr(rhs).map(U128).unwrap_or_else(zero),
-                    I8(value) => value.checked_shr(rhs).map(I8).unwrap_or_else(zero),
-                    I16(value) => value.checked_shr(rhs).map(I16).unwrap_or_else(zero),
-                    I32(value) => value.checked_shr(rhs).map(I32).unwrap_or_else(zero),
-                    I64(value) => value.checked_shr(rhs).map(I64).unwrap_or_else(zero),
+                    U8(value) => value.checked_shr(rhs).map(U8).unwrap_or_else(fallback),
+                    U16(value) => value.checked_shr(rhs).map(U16).unwrap_or_else(fallback),
+                    U32(value) => value.checked_shr(rhs).map(U32).unwrap_or_else(fallback),
+                    U64(value) => value.checked_shr(rhs).map(U64).unwrap_or_else(fallback),
+                    U128(value) => value.checked_shr(rhs).map(U128).unwrap_or_else(fallback),
+                    I8(value) => value.checked_shr(rhs).map(I8).unwrap_or_else(fallback),
+                    I16(value) => value.checked_shr(rhs).map(I16).unwrap_or_else(fallback),
+                    I32(value) => value.checked_shr(rhs).map(I32).unwrap_or_else(fallback),
+                    I64(value) => value.checked_shr(rhs).map(I64).unwrap_or_else(fallback),
                 }
             }
         };

--- a/compiler/noirc_evaluator/src/ssa/interpreter/value.rs
+++ b/compiler/noirc_evaluator/src/ssa/interpreter/value.rs
@@ -7,6 +7,7 @@ use noirc_frontend::Shared;
 use crate::ssa::ir::{
     function::FunctionId,
     instruction::Intrinsic,
+    integer::IntegerConstant,
     types::{CompositeType, NumericType, Type},
     value::ValueId,
 };
@@ -254,6 +255,13 @@ impl NumericValue {
 
     pub(crate) fn zero(typ: NumericType) -> Self {
         Self::from_constant(FieldElement::zero(), typ).expect("zero should fit in every type")
+    }
+
+    pub(crate) fn neg_one(typ: NumericType) -> Self {
+        let neg_one = IntegerConstant::Signed { value: -1, bit_size: typ.bit_size() };
+        let (neg_one_constant, typ) = neg_one.into_numeric_constant();
+        Self::from_constant(neg_one_constant, typ)
+            .unwrap_or_else(|_| panic!("Negative one cannot fit in {typ}"))
     }
 
     pub(crate) fn as_field(&self) -> Option<FieldElement> {

--- a/compiler/noirc_evaluator/src/ssa/opt/remove_bit_shifts.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/remove_bit_shifts.rs
@@ -230,7 +230,7 @@ impl Context<'_, '_, '_> {
         );
         let minus_one_or_zero =
             self.insert_binary(minus_one, BinaryOp::Mul { unchecked: true }, lhs_sign_as_int);
-        // -1, or 0 if lhs is positve or if there is no overflow
+        // -1, or 0 if lhs is positive or if there is no overflow
         let one = self.numeric_constant(FieldElement::one(), lhs_typ);
         let no_overflow = self.insert_binary(
             one,

--- a/compiler/noirc_frontend/src/hir/comptime/tests.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/tests.rs
@@ -79,13 +79,13 @@ fn interpret_helper(src: &str) -> Result<Value, InterpreterError> {
     })
 }
 
-fn interpret(src: &str) -> Value {
+pub(super) fn interpret(src: &str) -> Value {
     interpret_helper(src).unwrap_or_else(|error| {
         panic!("Expected interpreter to exit successfully, but found {error:?}")
     })
 }
 
-fn interpret_expect_error(src: &str) -> InterpreterError {
+pub(super) fn interpret_expect_error(src: &str) -> InterpreterError {
     interpret_helper(src).expect_err("Expected interpreter to error")
 }
 


### PR DESCRIPTION
# Description

## Problem\*

Resolves https://github.com/noir-lang/noir/pull/8806#issuecomment-2950199379 

Follow-up to https://github.com/noir-lang/noir/pull/8805. We updated the comptime interpreter 

## Summary\*

Fallback to -1 when we have an overflowing shift right in the SSA interpreter to match functionality in comptime and in ACIR/Brillig.

## Additional Context



## Documentation\*

Check one:
- [X] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
