### PR TITLE
chore: minor fix for docs

### DIFF
--- a/docs/docs/how_to/using-devcontainers.mdx
+++ b/docs/docs/how_to/using-devcontainers.mdx
@@ -77,7 +77,7 @@ Github comes with a default codespace and you can use it to code your own devcon
 
 This will pull the new image and build it, so it could take a minute or so
 
-#### 8. Done!   
+#### 7. Done!   
 Just wait for the build to finish, and there's your easy Noir environment. Some examples of how to use it can be found in the [awesome-noir](https://github.com/noir-lang/awesome-noir?tab=readme-ov-file#boilerplates) repository.
 
 ## How do I use it?


### PR DESCRIPTION
# Description
The number 7 was skipped (6 was followed by 8).
This PR removes the extra 8 and renumbers the final item as 7.

## Problem\*

Resolves https://github.com/noir-lang/noir/issues/5807

## Summary\*
Fixes the incorrect list numbering by ensuring sequential order (1 through 7).



## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
