### PR TITLE
chore: redo typo PR by osrm

### DIFF
--- a/docs/docs/how_to/using-devcontainers.mdx
+++ b/docs/docs/how_to/using-devcontainers.mdx
@@ -77,7 +77,7 @@ Github comes with a default codespace and you can use it to code your own devcon
 
 This will pull the new image and build it, so it could take a minute or so
 
-#### 8. Done!   
+#### 7. Done!   
 Just wait for the build to finish, and there's your easy Noir environment. Some examples of how to use it can be found in the [awesome-noir](https://github.com/noir-lang/awesome-noir?tab=readme-ov-file#boilerplates) repository.
 
 ## How do I use it?


### PR DESCRIPTION
Thanks osrm for https://github.com/noir-lang/noir/pull/8832. Our policy is to redo typo changes to dissuade metric farming. This is an automated script.