### PR TITLE
fix: don't check for overflow when rhs is zero

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/ssa_gen/context.rs
+++ b/compiler/noirc_evaluator/src/ssa/ssa_gen/context.rs
@@ -366,6 +366,13 @@ impl<'a> FunctionContext<'a> {
         operator: BinaryOpKind,
         location: Location,
     ) -> ValueId {
+        // If the rhs is zero there's never an overflow chance
+        let rhs_value = self.builder.current_function.dfg.get_numeric_constant(rhs);
+        let rhs_is_zero = rhs_value.is_some_and(|rhs| rhs.is_zero());
+        if rhs_is_zero {
+            return result;
+        }
+
         let result_type = self.builder.current_function.dfg.type_of_value(result).unwrap_numeric();
         match result_type {
             NumericType::Signed { bit_size } => {


### PR DESCRIPTION
# Description

## Problem

Resolves #8833

## Summary

There's already a simplification that will turn `x - 0` into `x`. However, when creating the initial SSA we insert an overflow check after some binary operations, even if those binary operations end up being simplified. I thought about not inserting the overflow check when the instruction is simplified, but we don't know what it was simplified to or, well, we could check if it's a binary, etc., but it would be a bit bug-prone to do that.

## Additional Context

I'm not sure how to test this.

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
