### PR TITLE
chore: Incorrect clippy warning blocking PRs

### DIFF
--- a/tooling/nargo_cli/src/cli/mod.rs
+++ b/tooling/nargo_cli/src/cli/mod.rs
@@ -189,6 +189,7 @@ fn read_workspace(
 }
 
 /// "with_workspace", but use a dummy workspace when 'debug_compile_stdin' is enabled
+#[allow(clippy::field_reassign_with_default)]
 fn compile_with_maybe_dummy_workspace(
     cmd: compile_cmd::CompileCommand,
     config: NargoConfig,
@@ -198,6 +199,8 @@ fn compile_with_maybe_dummy_workspace(
 
         // dummy root dir
         let root_dir = PathBuf::new();
+        // This `PackageMetadata::default()` is leading to a clippy error but the suggested solution
+        // is invalid because the fields are private
         let mut package = PackageMetadata::default();
         package.name = Some(package_name.clone());
         package.package_type = Some("bin".into());


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

Unblocks https://github.com/noir-lang/noir/pull/8793 and presumably other PRs from a clippy warning which can't be fixed due to it suggesting using private fields of a struct

## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
