### PR TITLE
chore(fuzz): Run fuzzing deterministically on CI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3414,6 +3414,7 @@ dependencies = [
  "noirc_abi",
  "noirc_evaluator",
  "noirc_frontend",
+ "proptest",
 ]
 
 [[package]]

--- a/tooling/ast_fuzzer/fuzz/Cargo.toml
+++ b/tooling/ast_fuzzer/fuzz/Cargo.toml
@@ -26,6 +26,7 @@ noir_ast_fuzzer = { path = ".." }
 [dev-dependencies]
 arbtest.workspace = true
 env_logger.workspace = true
+proptest.workspace = true
 
 
 [[bin]]

--- a/tooling/ast_fuzzer/fuzz/src/targets/mod.rs
+++ b/tooling/ast_fuzzer/fuzz/src/targets/mod.rs
@@ -6,10 +6,12 @@ pub mod pass_vs_prev;
 
 #[cfg(test)]
 mod tests {
-    use std::time::Duration;
+
+    use std::time::{Duration, Instant};
 
     use arbitrary::Unstructured;
     use color_eyre::eyre;
+    use proptest::prelude::*;
 
     pub fn seed_from_env() -> Option<u64> {
         let Ok(seed) = std::env::var("NOIR_ARBTEST_SEED") else { return None };
@@ -42,18 +44,55 @@ mod tests {
     pub fn fuzz_with_arbtest(f: impl Fn(&mut Unstructured) -> eyre::Result<()>) {
         let _ = env_logger::try_init();
 
-        let mut prop = arbtest::arbtest(|u| {
+        if let Some(seed) = seed_from_env() {
+            run_reproduce(f, seed);
+        } else {
+            run_deterministic(f);
+        }
+    }
+
+    /// Reproduce the result of a single seed.
+    fn run_reproduce(f: impl Fn(&mut Unstructured) -> eyre::Result<()>, seed: u64) {
+        arbtest::arbtest(|u| {
             f(u).unwrap();
             Ok(())
         })
-        .budget(Duration::from_secs(20))
-        .size_min(1 << 12)
-        .size_max(1 << 20);
+        .seed(seed)
+        .run();
+    }
 
-        if let Some(seed) = seed_from_env() {
-            prop = prop.seed(seed);
-        }
+    /// Run multiple tests with a deterministic RNG.
+    fn run_deterministic(f: impl Fn(&mut Unstructured) -> eyre::Result<()>) {
+        // Comptime tests run slower than others.
+        let start = Instant::now();
+        let timeout = Duration::from_secs(20);
 
-        prop.run();
+        let config = proptest::test_runner::Config {
+            cases: 1000,
+            failure_persistence: None,
+            ..Default::default()
+        };
+        let rng = proptest::test_runner::TestRng::deterministic_rng(config.rng_algorithm);
+        let mut runner = proptest::test_runner::TestRunner::new_with_rng(config, rng);
+
+        runner
+            .run(&seed_strategy(), |seed| {
+                if start.elapsed() < timeout {
+                    run_reproduce(&f, seed);
+                }
+                Ok(())
+            })
+            .unwrap();
+    }
+
+    /// Generate seeds for `arbtest` where the top 32 bits are random and the lower 32 bits represent the input size.
+    fn seed_strategy() -> proptest::strategy::BoxedStrategy<u64> {
+        let min_size: u32 = 1 << 12;
+        let max_size: u32 = 1 << 20;
+        (min_size..max_size)
+            .prop_flat_map(move |size| {
+                any::<u64>().prop_map(move |raw| (size as u64) | (raw << u32::BITS))
+            })
+            .boxed()
     }
 }


### PR DESCRIPTION
# Description

## Problem\*

Resolves flaky tests. 

## Summary\*

Changes the `cargo test -p noir_ast_fuzzer_fuzz arbtest` behaviour to:
* Use the deterministic `TestRunner` in `proptest` to generate seeds on CI, and run 1000 test cases, up to 20 seconds
* Use the current `arbtest` strategy locally to run tests for up to 20 seconds with randomised seeds
* Reproduce a single test result if `NOIR_ARBTEST_SEED` is present

This way the current "interface" does not change, but we get rid of the flakiness on CI.

## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
