### PR TITLE
chore(ssa): Simplify truncate when the bit size we are truncating to is greater than the value's max bit size

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/ir/dfg/simplify.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/dfg/simplify.rs
@@ -141,7 +141,7 @@ pub(crate) fn simplify(
             try_optimize_array_set_from_previous_get(dfg, *array_id, *index_id, *value)
         }
         Instruction::Truncate { value, bit_size, max_bit_size } => {
-            if bit_size == max_bit_size {
+            if bit_size >= max_bit_size {
                 return SimplifiedTo(*value);
             }
             if let Some((numeric_constant, typ)) = dfg.get_numeric_constant_with_type(*value) {

--- a/compiler/noirc_evaluator/src/ssa/ir/dfg/simplify.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/dfg/simplify.rs
@@ -490,4 +490,25 @@ mod tests {
             assert_normalized_ssa_equals(ssa, &expected);
         }
     }
+
+    #[test]
+    fn truncate_to_bit_size_bigger_than_value_max_bit_size() {
+        let src = "
+        acir(inline) fn main f0 {
+          b0(v0: u8):
+            v1 = truncate v0 to 16 bits, max_bit_size: 8
+            v2 = cast v1 as u16
+            return v2
+        }
+        ";
+        let ssa = Ssa::from_str_simplifying(src).unwrap();
+
+        assert_ssa_snapshot!(ssa, @r"
+        acir(inline) fn main f0 {
+          b0(v0: u8):
+            v1 = cast v0 as u16
+            return v1
+        }
+        ");
+    }
 }


### PR DESCRIPTION
# Description

## Problem\*

No issue just something I noticed when looking at the Truncate simplification.

## Summary\*

If we are truncating to a `bit_size` but the `max_bit_size` is less than that value, we can return the value.

## Additional Context



## Documentation\*

Check one:
- [X] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
