### PR TITLE
feat: SSA interpreter checks return value

### DIFF
--- a/tooling/ast_fuzzer/src/compare/interpreted.rs
+++ b/tooling/ast_fuzzer/src/compare/interpreted.rs
@@ -194,7 +194,7 @@ pub fn input_values_to_ssa(abi: &Abi, input_map: &InputMap) -> Vec<Value> {
 /// Convert one ABI encoded input to what the SSA interpreter expects.
 ///
 /// Tuple types are returned flattened.
-fn input_value_to_ssa(typ: &AbiType, input: &InputValue) -> Vec<Value> {
+pub fn input_value_to_ssa(typ: &AbiType, input: &InputValue) -> Vec<Value> {
     use ssa::interpreter::value::{ArrayValue, NumericValue, Value};
     use ssa::ir::types::Type;
     let array_value = |elements: Vec<Vec<Value>>, types: Vec<Type>| {

--- a/tooling/ast_fuzzer/src/compare/mod.rs
+++ b/tooling/ast_fuzzer/src/compare/mod.rs
@@ -17,7 +17,8 @@ pub use compiled::{
 };
 pub use comptime::CompareComptime;
 pub use interpreted::{
-    CompareInterpreted, CompareInterpretedResult, ComparePass, input_values_to_ssa,
+    CompareInterpreted, CompareInterpretedResult, ComparePass, input_value_to_ssa,
+    input_values_to_ssa,
 };
 
 #[derive(Clone, Debug, PartialEq)]

--- a/tooling/ast_fuzzer/src/lib.rs
+++ b/tooling/ast_fuzzer/src/lib.rs
@@ -11,7 +11,7 @@ mod input;
 mod program;
 
 pub use abi::program_abi;
-pub use compare::input_values_to_ssa;
+pub use compare::{input_value_to_ssa, input_values_to_ssa};
 pub use input::arb_inputs;
 use program::freq::Freqs;
 pub use program::{DisplayAstAsNoir, DisplayAstAsNoirComptime, arb_program, arb_program_comptime};


### PR DESCRIPTION
# Description

## Problem

No issue, but I think @aakoshh mentioned this as a potential improvements.

This will also be useful to run `nargo interpret` on all execution_success test programs, combined with #8882.

## Summary

For example, given this program:

```noir
fn main() -> pub Field {
    0
}
```

and this Prover.toml:

```toml
return = 1
```

running `nargo interpret` we get this output:

```
--- Interpreter result after Initial SSA:
Ok([Numeric(Field(0))])
---
Error: interpreter produced an unexpected result.
Expected result: [Numeric(Field(1))]
Actual result:   [Numeric(Field(0))]
```

## Additional Context



## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
