### PR TITLE
chore: interpret all execution_success programs

### DIFF
--- a/compiler/noirc_driver/src/abi_gen.rs
+++ b/compiler/noirc_driver/src/abi_gen.rs
@@ -23,7 +23,7 @@ use noirc_frontend::{
 
 /// Arranges a function signature and a generated circuit's return witnesses into a
 /// `noirc_abi::Abi`.
-pub(super) fn gen_abi(
+pub fn gen_abi(
     context: &Context,
     func_id: &FuncId,
     return_visibility: Visibility,

--- a/compiler/noirc_driver/src/lib.rs
+++ b/compiler/noirc_driver/src/lib.rs
@@ -38,6 +38,7 @@ mod stdlib;
 
 use debug::filter_relevant_files;
 
+pub use abi_gen::gen_abi;
 pub use contract::{CompiledContract, CompiledContractOutputs, ContractFunction};
 pub use debug::DebugFile;
 pub use noirc_frontend::graph::{CrateId, CrateName};
@@ -793,7 +794,7 @@ pub fn compile_no_check(
             create_program(program, &ssa_evaluator_options)?
         };
 
-    let abi = abi_gen::gen_abi(context, &main_function, return_visibility, error_types);
+    let abi = gen_abi(context, &main_function, return_visibility, error_types);
     let file_map = filter_relevant_files(&debug, &context.file_manager);
 
     Ok(CompiledProgram {

--- a/tooling/nargo_cli/build.rs
+++ b/tooling/nargo_cli/build.rs
@@ -42,6 +42,8 @@ fn main() {
     generate_compile_success_with_bug_tests(&mut test_file, &test_dir);
     generate_compile_failure_tests(&mut test_file, &test_dir);
 
+    generate_interpret_execution_success_tests(&mut test_file, &test_dir);
+
     generate_fuzzing_failure_tests(&mut test_file, &test_dir);
 
     generate_nargo_expand_execution_success_tests(&mut test_file, &test_dir);
@@ -113,6 +115,56 @@ const TESTS_WITH_EXPECTED_WARNINGS: [&str; 5] = [
     "comptime_enums",
     // Testing unreachable instructions
     "brillig_continue_break",
+];
+
+/// `nargo interpret` ignored tests, either because they don't currently work or
+/// becuase they are too slow to run.
+const IGNORED_INTERPRET_EXECUTION_TESTS: [&str; 43] = [
+    // slow
+    "regression_4709",
+    // bug
+    "array_dynamic_nested_blackbox_input",
+    "array_oob_regression_7965",
+    "array_oob_regression_7975",
+    "as_witness",
+    "brillig_block_parameter_liveness",
+    "brillig_cow",
+    "brillig_cow_regression",
+    "databus",
+    "databus_composite_calldata",
+    "databus_two_calldata",
+    "databus_two_calldata_simple",
+    "fold_numeric_generic_poseidon",
+    "global_array_rc_regression_8259",
+    "hash_to_field",
+    "hashmap",
+    "inline_decompose_hint_brillig_call",
+    "multi_scalar_mul",
+    "nested_array_dynamic",
+    "nested_if_then_block_same_cond",
+    "no_predicates_numeric_generic_poseidon",
+    "pedersen_commitment",
+    "ram_blowup_regression",
+    "regression_11294",
+    "regression_3889",
+    "regression_4088",
+    "regression_5252",
+    "regression_7128",
+    "regression_7612",
+    "regression_7744",
+    "regression_8174",
+    "regression_struct_array_conditional",
+    "signed_div",
+    "simple_shield",
+    "slice_loop",
+    "struct_array_inputs",
+    "struct_fields_ordering",
+    "struct_inputs",
+    "to_be_bytes",
+    "to_le_bytes",
+    "tuple_inputs",
+    "uhashmap",
+    "unrolling_regression_8333",
 ];
 
 /// These tests are ignored because making them work involves a more complex test code that
@@ -381,6 +433,7 @@ fn test_{test_name}() {{
     )
     .expect("Could not write templated test file.");
 }
+
 fn generate_execution_success_tests(test_file: &mut File, test_data_dir: &Path) {
     let test_type = "execution_success";
     let test_cases = read_test_cases(test_data_dir, test_type);
@@ -694,6 +747,41 @@ fn generate_compile_failure_tests(test_file: &mut File, test_data_dir: &Path) {
             "compile",
             "compile_failure(nargo, test_program_dir);",
             &MatrixConfig::default(),
+        );
+    }
+    writeln!(test_file, "}}").unwrap();
+}
+
+fn generate_interpret_execution_success_tests(test_file: &mut File, test_data_dir: &Path) {
+    let test_type = "execution_success";
+    let test_cases = read_test_cases(test_data_dir, test_type);
+
+    writeln!(
+        test_file,
+        "mod interpret_{test_type} {{
+        use super::*;
+    "
+    )
+    .unwrap();
+    for (test_name, test_dir) in test_cases {
+        if IGNORED_INTERPRET_EXECUTION_TESTS.contains(&test_name.as_str()) {
+            continue;
+        }
+
+        let test_dir = test_dir.display();
+
+        generate_test_cases(
+            test_file,
+            &test_name,
+            &test_dir,
+            "interpret",
+            "interpret_execution_success(nargo);",
+            &MatrixConfig {
+                vary_brillig: !IGNORED_BRILLIG_TESTS.contains(&test_name.as_str()),
+                vary_inliner: true,
+                min_inliner: min_inliner(&test_name),
+                max_inliner: max_inliner(&test_name),
+            },
         );
     }
     writeln!(test_file, "}}").unwrap();

--- a/tooling/nargo_cli/build.rs
+++ b/tooling/nargo_cli/build.rs
@@ -119,7 +119,7 @@ const TESTS_WITH_EXPECTED_WARNINGS: [&str; 5] = [
 
 /// `nargo interpret` ignored tests, either because they don't currently work or
 /// becuase they are too slow to run.
-const IGNORED_INTERPRET_EXECUTION_TESTS: [&str; 43] = [
+const IGNORED_INTERPRET_EXECUTION_TESTS: [&str; 35] = [
     // slow
     "regression_4709",
     // bug
@@ -128,7 +128,6 @@ const IGNORED_INTERPRET_EXECUTION_TESTS: [&str; 43] = [
     "array_oob_regression_7975",
     "as_witness",
     "brillig_block_parameter_liveness",
-    "brillig_cow",
     "brillig_cow_regression",
     "databus",
     "databus_composite_calldata",
@@ -137,33 +136,26 @@ const IGNORED_INTERPRET_EXECUTION_TESTS: [&str; 43] = [
     "fold_numeric_generic_poseidon",
     "global_array_rc_regression_8259",
     "hash_to_field",
-    "hashmap",
     "inline_decompose_hint_brillig_call",
     "multi_scalar_mul",
-    "nested_array_dynamic",
     "nested_if_then_block_same_cond",
     "no_predicates_numeric_generic_poseidon",
-    "pedersen_commitment",
     "ram_blowup_regression",
     "regression_11294",
     "regression_3889",
-    "regression_4088",
     "regression_5252",
     "regression_7128",
     "regression_7612",
     "regression_7744",
     "regression_8174",
     "regression_struct_array_conditional",
-    "signed_div",
     "simple_shield",
     "slice_loop",
     "struct_array_inputs",
-    "struct_fields_ordering",
     "struct_inputs",
     "to_be_bytes",
     "to_le_bytes",
     "tuple_inputs",
-    "uhashmap",
     "unrolling_regression_8333",
 ];
 

--- a/tooling/nargo_cli/build.rs
+++ b/tooling/nargo_cli/build.rs
@@ -122,40 +122,73 @@ const TESTS_WITH_EXPECTED_WARNINGS: [&str; 5] = [
 const IGNORED_INTERPRET_EXECUTION_TESTS: [&str; 35] = [
     // slow
     "regression_4709",
-    // bug
+    // panic: index out of bounds
     "array_dynamic_nested_blackbox_input",
+    // gives a different result with `--force-brillig`
     "array_oob_regression_7965",
+    // gives a different result with `--force-brillig`
     "array_oob_regression_7975",
+    // panic: FunctionReturnedIncorrectArgCount
     "as_witness",
+    // wrong result
     "brillig_block_parameter_liveness",
+    // panic: BlockArgumentCountMismatch
     "brillig_cow_regression",
+    // wrong result
     "databus",
+    // panic: index out of bounds
     "databus_composite_calldata",
+    // wrong result
     "databus_two_calldata",
+    // wrong result
     "databus_two_calldata_simple",
+    // panic: IntrinsicArgumentCountMismatch
     "fold_numeric_generic_poseidon",
+    // gives a different result with `--force-brillig`
     "global_array_rc_regression_8259",
+    // panic: IntrinsicArgumentCountMismatch
     "hash_to_field",
+    // panic: Internal(TypeError)
     "inline_decompose_hint_brillig_call",
+    // panic: Internal(TypeError)
     "multi_scalar_mul",
+    // gives a different result with `--force-brillig`
     "nested_if_then_block_same_cond",
+    // panic: IntrinsicArgumentCountMismatch
     "no_predicates_numeric_generic_poseidon",
+    // panic: IntrinsicArgumentCountMismatch
     "ram_blowup_regression",
+    // panic: index out of bounds
     "regression_11294",
+    // panic: Internal(TypeError)
     "regression_3889",
+    // panic: IntrinsicArgumentCountMismatch
     "regression_5252",
+    // panic: IntrinsicArgumentCountMismatch
     "regression_7128",
+    // panic: index out of bounds
     "regression_7612",
+    // gives a wrong result
     "regression_7744",
+    // gives a wrong result
     "regression_8174",
+    // panic: index out of bounds
     "regression_struct_array_conditional",
+    // panic Internal(TypeError)
     "simple_shield",
+    // panic: index out of bounds
     "slice_loop",
+    // panic: index out of bounds
     "struct_array_inputs",
+    // panic: BlockArgumentCountMismatch
     "struct_inputs",
+    // panic: IntrinsicArgumentCountMismatch
     "to_be_bytes",
+    // panic: IntrinsicArgumentCountMismatch
     "to_le_bytes",
+    // panic: BlockArgumentCountMismatch
     "tuple_inputs",
+    // panic: IntrinsicArgumentCountMismatch
     "unrolling_regression_8333",
 ];
 

--- a/tooling/nargo_cli/tests/execute.rs
+++ b/tooling/nargo_cli/tests/execute.rs
@@ -322,6 +322,10 @@ mod tests {
         })
     }
 
+    fn interpret_execution_success(mut nargo: Command) {
+        nargo.assert().success();
+    }
+
     fn nargo_expand_execute(test_program_dir: PathBuf) {
         // First run `nargo execute` on the original code to get the output
         let mut nargo = Command::cargo_bin("nargo").unwrap();

--- a/tooling/noirc_abi/src/errors.rs
+++ b/tooling/noirc_abi/src/errors.rs
@@ -26,7 +26,7 @@ pub enum InputParserError {
         FieldElement::modulus()
     )]
     InputExceedsFieldModulus { arg_name: String, value: String },
-    #[error("cannot parse value {0} into {1:?}")]
+    #[error("cannot parse value `{0}` into {1:?}")]
     AbiTypeMismatch(String, AbiType),
     #[error("Expected argument `{0}`, but none was found")]
     MissingArgument(String),

--- a/tooling/noirc_abi/src/errors.rs
+++ b/tooling/noirc_abi/src/errors.rs
@@ -26,8 +26,8 @@ pub enum InputParserError {
         FieldElement::modulus()
     )]
     InputExceedsFieldModulus { arg_name: String, value: String },
-    #[error("cannot parse value into {0:?}")]
-    AbiTypeMismatch(AbiType),
+    #[error("cannot parse value {0} into {1:?}")]
+    AbiTypeMismatch(String, AbiType),
     #[error("Expected argument `{0}`, but none was found")]
     MissingArgument(String),
 }

--- a/tooling/noirc_abi/src/input_parser/json.rs
+++ b/tooling/noirc_abi/src/input_parser/json.rs
@@ -120,7 +120,12 @@ impl JsonTypes {
                 JsonTypes::Array(fields)
             }
 
-            _ => return Err(InputParserError::AbiTypeMismatch(abi_type.clone())),
+            _ => {
+                return Err(InputParserError::AbiTypeMismatch(
+                    format!("{value:?}"),
+                    abi_type.clone(),
+                ));
+            }
         };
         Ok(json_value)
     }
@@ -212,7 +217,12 @@ impl InputValue {
                 InputValue::Vec(tuple_fields)
             }
 
-            (_, _) => return Err(InputParserError::AbiTypeMismatch(param_type.clone())),
+            (value, _) => {
+                return Err(InputParserError::AbiTypeMismatch(
+                    format!("{value:?}"),
+                    param_type.clone(),
+                ));
+            }
         };
 
         Ok(input_value)

--- a/tooling/noirc_abi/src/input_parser/toml.rs
+++ b/tooling/noirc_abi/src/input_parser/toml.rs
@@ -118,7 +118,12 @@ impl TomlTypes {
                 TomlTypes::Array(fields)
             }
 
-            _ => return Err(InputParserError::AbiTypeMismatch(abi_type.clone())),
+            _ => {
+                return Err(InputParserError::AbiTypeMismatch(
+                    format!("{value:?}"),
+                    abi_type.clone(),
+                ));
+            }
         };
         Ok(toml_value)
     }
@@ -197,7 +202,12 @@ impl InputValue {
                 InputValue::Vec(tuple_fields)
             }
 
-            (_, _) => return Err(InputParserError::AbiTypeMismatch(param_type.clone())),
+            (value, _) => {
+                return Err(InputParserError::AbiTypeMismatch(
+                    format!("{value:?}"),
+                    param_type.clone(),
+                ));
+            }
         };
 
         Ok(input_value)

--- a/tooling/noirc_abi_wasm/test/browser/errors.test.ts
+++ b/tooling/noirc_abi_wasm/test/browser/errors.test.ts
@@ -16,7 +16,9 @@ it('errors when an integer input overflows', async () => {
 it('errors when passing a field in place of an array', async () => {
   const { abi, inputs } = await import('../shared/field_as_array');
 
-  expect(() => abiEncode(abi, inputs)).to.throw('cannot parse value `String("1")` into Array { length: 2, typ: Field }');
+  expect(() => abiEncode(abi, inputs)).to.throw(
+    'cannot parse value `String("1")` into Array { length: 2, typ: Field }',
+  );
 });
 
 it('errors when passing an array in place of a field', async () => {

--- a/tooling/noirc_abi_wasm/test/browser/errors.test.ts
+++ b/tooling/noirc_abi_wasm/test/browser/errors.test.ts
@@ -16,11 +16,11 @@ it('errors when an integer input overflows', async () => {
 it('errors when passing a field in place of an array', async () => {
   const { abi, inputs } = await import('../shared/field_as_array');
 
-  expect(() => abiEncode(abi, inputs)).to.throw('cannot parse value into Array { length: 2, typ: Field }');
+  expect(() => abiEncode(abi, inputs)).to.throw('cannot parse value `String("1")` into Array { length: 2, typ: Field }');
 });
 
 it('errors when passing an array in place of a field', async () => {
   const { abi, inputs } = await import('../shared/array_as_field');
 
-  expect(() => abiEncode(abi, inputs)).to.throw('cannot parse value into Field');
+  expect(() => abiEncode(abi, inputs)).to.throw('cannot parse value `Array([String("1"), String("2")])` into Field');
 });

--- a/tooling/noirc_abi_wasm/test/node/errors.test.ts
+++ b/tooling/noirc_abi_wasm/test/node/errors.test.ts
@@ -12,11 +12,11 @@ it('errors when an integer input overflows', async () => {
 it('errors when passing a field in place of an array', async () => {
   const { abi, inputs } = await import('../shared/field_as_array');
 
-  expect(() => abiEncode(abi, inputs)).to.throw('cannot parse value into Array { length: 2, typ: Field }');
+  expect(() => abiEncode(abi, inputs)).to.throw('cannot parse value `String("1")` into Array { length: 2, typ: Field }');
 });
 
 it('errors when passing an array in place of a field', async () => {
   const { abi, inputs } = await import('../shared/array_as_field');
 
-  expect(() => abiEncode(abi, inputs)).to.throw('cannot parse value into Field');
+  expect(() => abiEncode(abi, inputs)).to.throw('cannot parse value `Array([String("1"), String("2")])` into Field');
 });

--- a/tooling/noirc_abi_wasm/test/node/errors.test.ts
+++ b/tooling/noirc_abi_wasm/test/node/errors.test.ts
@@ -12,7 +12,9 @@ it('errors when an integer input overflows', async () => {
 it('errors when passing a field in place of an array', async () => {
   const { abi, inputs } = await import('../shared/field_as_array');
 
-  expect(() => abiEncode(abi, inputs)).to.throw('cannot parse value `String("1")` into Array { length: 2, typ: Field }');
+  expect(() => abiEncode(abi, inputs)).to.throw(
+    'cannot parse value `String("1")` into Array { length: 2, typ: Field }',
+  );
 });
 
 it('errors when passing an array in place of a field', async () => {


### PR DESCRIPTION
# Description

## Problem

No issue, but will help us improve the interpreter.

## Summary

Runs `nargo interpret` against all execution_success test programs, except a few that currently don't work well.

Also fixes one issue where the ABI was built in a way that doesn't match how it's built everywhere else (this made some tests fail, which were around 43, and then the number got down to 35).

I decided to not keep fixing issues here as there seem to be a few of them. Some of them might be easier to fix (like the "IntrinsicArgumentCountMismatch" ones), but in any case we can probably fix them in follow-up PRs.

## Additional Context

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
