### PR TITLE
fix(licm): Account for negative bounds when checking whether a loop executes 

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -155,6 +155,7 @@
         "kosaraju",
         "krate",
         "libc",
+        "LICM",
         "Linea",
         "lookback",
         "losslessly",

--- a/test_programs/compile_success_empty/signed_lower_loop_bound_regression_8858/Nargo.toml
+++ b/test_programs/compile_success_empty/signed_lower_loop_bound_regression_8858/Nargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "signed_lower_loop_bound_regression_8858"
+type = "bin"
+authors = [""]
+
+[dependencies]

--- a/test_programs/compile_success_empty/signed_lower_loop_bound_regression_8858/src/main.nr
+++ b/test_programs/compile_success_empty/signed_lower_loop_bound_regression_8858/src/main.nr
@@ -1,0 +1,6 @@
+fn main() {
+    let lower: i32 = -1;
+    for i in lower..0 {
+        assert(i >= (i + 0));
+    }
+}

--- a/tooling/nargo_cli/tests/snapshots/compile_success_empty/signed_lower_loop_bound_regression_8858/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_empty/signed_lower_loop_bound_regression_8858/execute__tests__expanded.snap
@@ -1,0 +1,10 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: expanded_code
+---
+fn main() {
+    let lower: i32 = -1;
+    for i in lower..0 {
+        assert(i >= (i + 0));
+    }
+}

--- a/tooling/nargo_cli/tests/snapshots/compile_success_empty/signed_lower_loop_bound_regression_8858/execute__tests__force_brillig_false_inliner_0.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_empty/signed_lower_loop_bound_regression_8858/execute__tests__force_brillig_false_inliner_0.snap
@@ -1,0 +1,26 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: artifact
+---
+{
+  "noir_version": "[noir_version]",
+  "hash": "[hash]",
+  "abi": {
+    "parameters": [],
+    "return_type": null,
+    "error_types": {}
+  },
+  "bytecode": [
+    "func 0",
+    "current witness index : _0",
+    "private parameters indices : []",
+    "public parameters indices : []",
+    "return value indices : []"
+  ],
+  "debug_symbols": "XY5BCsQwCEXv4rqLWfcqw1BsaosgJtikMITefWyYQOlK/3/6tcJCc9km1jXuML4rzMYivE0SA2aO6m49B+hyykbkFty4byU00gyjFpEBDpTShvaE2mpGc/oagHTx6oErC13d+XGBge158UBjnIX+ci0abjR/Uyf942Qx0FKMrqTGPPsH",
+  "file_map": {},
+  "names": [
+    "main"
+  ],
+  "brillig_names": []
+}


### PR DESCRIPTION
# Description

## Problem\*

Resolves #8858 

## Summary\*

We already have a pre-existing method `LoopInvariantContext::does_loop_body_execute` that appropriately handles negative loop bounds. We should use this method instead of `!upper.is_zero()`.

## Additional Context

## Documentation\*

Check one:
- [X] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
