### PR TITLE
fix: differentiate between function and field arguments properly in defunctionalize pass

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/opt/defunctionalize.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/defunctionalize.rs
@@ -635,8 +635,11 @@ fn defunctionalize_post_check(func: &Function) {
                 let function = &func.dfg[*target_func];
 
                 assert!(
-                    matches!(function, Value::Function(_)),
-                    "Call instructions should only call functions, not function values. Got '{function:?}' in instruction {instruction_id} of block {block_id} in function {} {}",
+                    matches!(
+                        function,
+                        Value::Function(_) | Value::ForeignFunction(_) | Value::Intrinsic(_)
+                    ),
+                    "Call instructions should only call functions, foreign functions, and intrinsics, not function values. Got '{function:?}' in instruction {instruction_id} of block {block_id} in function {} {}",
                     func.name(),
                     func.id()
                 );


### PR DESCRIPTION
…

# Description

## Problem\*

Resolves #8896 

## Summary\*

Chucking this up as a draft, expecting tests to not pass in general. I think that the main defunctionalize loop needs some unpicking to ensure that we do things in the correct order.

## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
