### PR TITLE
fix(fuzz): Use an inline block to circumvent negation with overflow

### DIFF
--- a/compiler/noirc_frontend/src/monomorphization/printer.rs
+++ b/compiler/noirc_frontend/src/monomorphization/printer.rs
@@ -249,7 +249,9 @@ impl AstPrinter {
             }
             super::ast::Literal::Integer(x, typ, _) => {
                 if self.show_type_of_int_literal {
-                    write!(f, "{x} as {typ}")
+                    // Unfortunately this doesn't work: `-128 as i8` panics with `attempt to negate with overflow` because it first treats `128` as `u8`.
+                    //write!(f, "{x} as {typ}")
+                    write!(f, "{{ let x: {typ} = {x}; x }}")
                 } else {
                     x.fmt(f)
                 }


### PR DESCRIPTION
# Description

## Problem\*

Workaround for #8870 
This was one of the issues holding up https://github.com/noir-lang/noir/pull/8872

## Summary\*

Changes the behaviour of `show_type_of_int_literal` in the AST printer to create an inline block to provide unequivocal type information for integer literals from being e.g. `-128 as i8` to `{ let x: i8 = -128; x }`. 

## Additional Context

This is highly unreadable, but it's only used for `comptime_vs_brillig`, where we print an AST and parse it back for comptime execution. Differences in execution result from the frontend inferring different type than what the AST we run through Brillig did. 

It's not trying to figure out where annotations are needed (unlike the `needs_type_inference_from_literal` used to display `let`s), it's all or nothing.

For example here's different version of the same code:

Unannotated:
```rust
unconstrained fn main() -> pub (i8, [i32; 2], i32, i32, bool) {
    let mut ctx_limit: u32 = 5;
    func_1_proxy(-181866008458986137272760665451993875826, ([-1432091493, 1826177408, -641393292, 924821601], [104, -60, 110, -128]), ctx_limit)
}
```

"Annotated" with `as`:
```rust
    fn main() -> pub (i8, [i32; 2], i32, i32, bool) {
        comptime {
            let mut ctx_limit: u32 = 5 as u32;
            unsafe { func_1_proxy(-181866008458986137272760665451993875826 as Field, ([-1432091493 as i32, 1826177408 as i32, -641393292 as i32, 924821601 as i32], [104 as i8, -60 as i8, 110 as i8, -128 as i8]), ctx_limit) }
        }
    }
```

Using inline blocks:
```rust
    fn main() -> pub (i8, [i32; 2], i32, i32, bool) {
        comptime {
            let mut ctx_limit: u32 = { let x: u32 = 5; x };
            unsafe { func_1_proxy({ let x: Field = -181866008458986137272760665451993875826; x }, ([{ let x: i32 = -1432091493; x }, { let x: i32 = 1826177408; x }, { let x: i32 = -641393292; x }, { let x: i32 = 924821601; x }], [{ let x: i8 = 104; x }, { let x: i8 = -60; x }, { let x: i8 = 110; x }, { let x: i8 = -128; x }]), ctx_limit) }
        }
    }
```

It should only be around until https://github.com/noir-lang/noir/issues/8759

## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
