### PR TITLE
fix: handle return_data in the interpreter SSA CLI

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/interpreter/value.rs
+++ b/compiler/noirc_evaluator/src/ssa/interpreter/value.rs
@@ -158,7 +158,7 @@ impl Value {
         Self::Numeric(NumericValue::U1(value))
     }
 
-    pub(crate) fn array(elements: Vec<Value>, element_types: Vec<Type>) -> Self {
+    pub fn array(elements: Vec<Value>, element_types: Vec<Type>) -> Self {
         Self::ArrayOrSlice(ArrayValue {
             elements: Shared::new(elements),
             rc: Shared::new(1),

--- a/compiler/noirc_evaluator/src/ssa/ir/function.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/function.rs
@@ -231,6 +231,10 @@ impl Function {
             }
         })
     }
+
+    pub fn has_data_bus_return_data(&self) -> bool {
+        self.dfg.data_bus.return_data.is_some()
+    }
 }
 
 impl Clone for Function {

--- a/tooling/nargo_cli/build.rs
+++ b/tooling/nargo_cli/build.rs
@@ -119,17 +119,9 @@ const TESTS_WITH_EXPECTED_WARNINGS: [&str; 5] = [
 
 /// `nargo interpret` ignored tests, either because they don't currently work or
 /// becuase they are too slow to run.
-const IGNORED_INTERPRET_EXECUTION_TESTS: [&str; 5] = [
+const IGNORED_INTERPRET_EXECUTION_TESTS: [&str; 1] = [
     // slow
     "regression_4709",
-    // wrong result
-    "databus",
-    // panic: index out of bounds
-    "databus_composite_calldata",
-    // wrong result
-    "databus_two_calldata",
-    // wrong result
-    "databus_two_calldata_simple",
 ];
 
 /// These tests are ignored because making them work involves a more complex test code that

--- a/tooling/nargo_cli/src/cli/interpret_cmd.rs
+++ b/tooling/nargo_cli/src/cli/interpret_cmd.rs
@@ -17,6 +17,7 @@ use noirc_errors::CustomDiagnostic;
 use noirc_evaluator::brillig::BrilligOptions;
 use noirc_evaluator::ssa::interpreter::InterpreterOptions;
 use noirc_evaluator::ssa::interpreter::value::Value;
+use noirc_evaluator::ssa::ir::types::{NumericType, Type};
 use noirc_evaluator::ssa::ssa_gen::{Ssa, generate_ssa};
 use noirc_evaluator::ssa::{SsaEvaluatorOptions, SsaLogging, primary_passes};
 use noirc_frontend::debug::DebugInstrumenter;
@@ -107,6 +108,21 @@ pub(crate) fn run(args: InterpretCommand, workspace: Workspace) -> Result<(), Cl
         // Generate the initial SSA.
         let mut ssa = generate_ssa(program)
             .map_err(|e| CliError::Generic(format!("failed to generate SSA: {e}")))?;
+
+        // If the main function returns `return_data`, the values are returned in a flattened array.
+        // So, we change the expected return value by flattening it as well.
+        // Ideally we'd have the interpreter return the data in the correct shape. However, doing
+        // that would be replicating some logic which is unrelated to SSA. For the purpose of SSA
+        // correctness, it's enough if we make sure the flattened values match.
+        let ssa_return = ssa_return.map(|ssa_return| {
+            let main_function = &ssa.functions[&ssa.main_id];
+            if main_function.has_data_bus_return_data() {
+                let values = flatten_values(ssa_return);
+                vec![Value::array(values, vec![Type::Numeric(NumericType::NativeField)])]
+            } else {
+                ssa_return
+            }
+        });
 
         let interpreter_options = InterpreterOptions { trace: args.trace };
 
@@ -275,4 +291,27 @@ fn print_and_interpret_ssa(
 ) -> Result<(), CliError> {
     print_ssa(options, ssa, msg);
     interpret_ssa(passes_to_interpret, ssa, msg, args, return_value, interpreter_options)
+}
+
+fn flatten_values(values: Vec<Value>) -> Vec<Value> {
+    let mut flattened_values = Vec::new();
+    for value in values {
+        flatten_value(value, &mut flattened_values);
+    }
+    flattened_values
+}
+
+fn flatten_value(value: Value, flattened_values: &mut Vec<Value>) {
+    match value {
+        Value::ArrayOrSlice(array_value) => {
+            for value in array_value.elements.borrow().iter() {
+                flatten_value(value.clone(), flattened_values);
+            }
+        }
+        Value::Numeric(..)
+        | Value::Reference(..)
+        | Value::Function(..)
+        | Value::Intrinsic(..)
+        | Value::ForeignFunction(..) => flattened_values.push(value),
+    }
 }


### PR DESCRIPTION
# Description

## Problem

Resolves #8450

## Summary

Now the SSA interpreter CLI won't fail against an expected return value if the main function returns `return_data`. This is done by flattening all values in the expected return value. See the comment in the code for an explanation of why I decided to do it that way.

## Additional Context


## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
