### PR TITLE
fix: Create calls to `apply` before function values are changed to fields in defunctionalize

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/opt/defunctionalize.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/defunctionalize.rs
@@ -130,7 +130,7 @@ impl DefunctionalizationContext {
 
     /// Replaces any function calls using first-class function values with calls to the
     /// appropriate `apply` function. Note that this must be done before types are mutated
-    /// in `defunctionalize` since this uses the unmutated types to query apply functions.
+    /// in `defunctionalize` since this uses the pre-mutated types to query apply functions.
     fn replace_fist_class_calls_with_apply_function(&mut self, func: &mut Function) {
         for block_id in func.reachable_blocks() {
             let block = &mut func.dfg[block_id];


### PR DESCRIPTION
# Description

## Problem\*

Resolves https://github.com/noir-lang/noir/issues/8896
Resolves https://github.com/noir-lang/noir/issues/8897

## Summary\*

We had a couple of related issues from the variants map being keyed by function types before the `function -> field` mapping but then the apply_functions map being keyed after the mapping but still expecting this key change did not impact any values (it did).

I've fixed these two issues by:
- Keying ApplyFunctions by the unmodified function types
- Replacing `Instruction::Call`s with calls to apply functions _before_ any function values are changed to fields so that the types of the call instructions do not change and we can use the unmodified type we have in the map.

## Additional Context

The code example in https://github.com/noir-lang/noir/issues/8897 is leading to a panic during inlining but this is unrelated. I've added unit tests in defunctionalize for both issues.

## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
