### PR TITLE
fix(fuzz): Consider values returned from Brillig to ACIR as dynamic

### DIFF
--- a/docs/docs/noir/concepts/data_types/arrays.md
+++ b/docs/docs/noir/concepts/data_types/arrays.md
@@ -80,7 +80,7 @@ let slice : [[Field]] = &[];
 ## Dynamic Indexing
 
 Using constant indices of arrays will often be more efficient at runtime in constrained code.
-Indexing an array with non-constant indices (indices derived from the inputs to the program) is also
+Indexing an array with non-constant indices (indices derived from the inputs to the program, or returned from unconstrained functions) is also
 called "dynamic indexing" and incurs a slight runtime cost:
 
 ```rust


### PR DESCRIPTION
# Description

## Problem\*

Resolves #8930 

## Summary\*

Changes the fuzzer to not call Brillig functions to produce an index which is to be used with an array that contains references, as these values are opaque for the compiler in the ACIR function.

## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [x] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
