### PR TITLE
chore(fuzz): Display nightly fuzz status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@
 
 # The Noir Programming Language
 
+[![Non-deterministic fuzz tests](https://github.com/noir-lang/noir/actions/workflows/nightly-fuzz-test.yml/badge.svg)](https://github.com/noir-lang/noir/actions/workflows/nightly-fuzz-test.yml)
+
 Noir is a Domain Specific Language for SNARK proving systems. It has been designed to use any ACIR compatible proving system.
 
 **This implementation is in early development. It has not been reviewed or audited. It is not suitable to be used in production. Expect bugs!**


### PR DESCRIPTION
# Description

## Problem\*

We should make the status of nightly fuzzing visible somewhere.

## Summary\*

Adds a status badge to the README.

## Additional Context

Maybe some Slack notifications would be useful as well. As I understand the last person to edit the workflow gets an email notification, so I can keep an eye on it.

## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
