### PR TITLE
chore: disable noncritical workflow steps which fail on external prs

### DIFF
--- a/.github/benchmark_projects.yml
+++ b/.github/benchmark_projects.yml
@@ -56,8 +56,8 @@ projects:
     cannot_execute: true
     num_runs: 5
     timeout: 60
-    compilation-timeout: 2
-    compilation-memory-limit: 450
+    compilation-timeout: 25
+    compilation-memory-limit: 1500
   rollup-block-root-single-tx:
     repo: AztecProtocol/aztec-packages
     ref: *AZ_COMMIT
@@ -65,17 +65,17 @@ projects:
     cannot_execute: true
     num_runs: 1
     timeout: 60
-    compilation-timeout: 180
-    compilation-memory-limit: 8000
+    compilation-timeout: 200
+    compilation-memory-limit: 10000
   rollup-block-root:
     repo: AztecProtocol/aztec-packages
     ref: *AZ_COMMIT
     path: noir-projects/noir-protocol-circuits/crates/rollup-block-root
     num_runs: 1
     timeout: 60
-    compilation-timeout: 150
+    compilation-timeout: 200
     execution-timeout: 40
-    compilation-memory-limit: 8000
+    compilation-memory-limit: 10000
     execution-memory-limit: 1900
   rollup-merge:
     repo: AztecProtocol/aztec-packages

--- a/.github/workflows/reports.yml
+++ b/.github/workflows/reports.yml
@@ -144,7 +144,8 @@ jobs:
           summaryQuantile: 0.9 # only display the 10% most significant circuit size diffs in the summary (defaults to 20%)
 
       - name: Add gates diff to sticky comment
-        if: github.event_name == 'pull_request' || github.event_name == 'pull_request_target'
+        # We don't run this step on external PRs
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           # delete the comment in case changes no longer impact circuit sizes

--- a/.github/workflows/test-js-packages.yml
+++ b/.github/workflows/test-js-packages.yml
@@ -675,6 +675,8 @@ jobs:
           jq --slurp '. | flatten' ./reports/* | tee test_bench.json
 
       - name: Store benchmark result
+        # We don't run this step on external PRs
+        if: github.event.pull_request.head.repo.full_name == github.repository
         uses: benchmark-action/github-action-benchmark@4de1bed97a47495fc4c5404952da0499e31f5c29
         with:
           name: "Test Suite Duration"


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

These parts of CI fail on external PRs as we restrict access to the relevant access token permissions. This results in a decent amount of confusion for external contributors so it's worth adding a couple of lines to just skip these steps in these situations rather than just letting them fail.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
