### PR TITLE
fix: when macro parse error happens, discard warnings; also preserve unquoted token locations

### DIFF
--- a/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
@@ -554,7 +554,7 @@ impl<'local, 'interner> Interpreter<'local, 'interner> {
             HirExpression::Match(match_) => todo!("Evaluate match in comptime code"),
             HirExpression::Tuple(tuple) => self.evaluate_tuple(tuple),
             HirExpression::Lambda(lambda) => self.evaluate_lambda(lambda, id),
-            HirExpression::Quote(tokens) => self.evaluate_quote(tokens, id),
+            HirExpression::Quote(tokens) => self.evaluate_quote(tokens),
             HirExpression::Unsafe(block) => self.evaluate_block(block),
             HirExpression::EnumConstructor(constructor) => {
                 self.evaluate_enum_constructor(constructor, id)
@@ -1097,9 +1097,8 @@ impl<'local, 'interner> Interpreter<'local, 'interner> {
         Ok(Value::Closure(Box::new(closure)))
     }
 
-    fn evaluate_quote(&mut self, mut tokens: Tokens, expr_id: ExprId) -> IResult<Value> {
-        let location = self.elaborator.interner.expr_location(&expr_id);
-        let tokens = self.substitute_unquoted_values_into_tokens(tokens, location)?;
+    fn evaluate_quote(&mut self, mut tokens: Tokens) -> IResult<Value> {
+        let tokens = self.substitute_unquoted_values_into_tokens(tokens)?;
         Ok(Value::Quoted(Rc::new(tokens)))
     }
 

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin/builtin_helpers.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin/builtin_helpers.rs
@@ -529,8 +529,9 @@ pub(super) fn parse_tokens<'a, T, F>(
 where
     F: FnOnce(&mut Parser<'a>) -> T,
 {
-    Parser::for_tokens(quoted).parse_result(parsing_function).map_err(|mut errors| {
-        let error = Box::new(errors.swap_remove(0));
+    Parser::for_tokens(quoted).parse_result(parsing_function).map_err(|errors| {
+        let error = errors.into_iter().find(|error| !error.is_warning()).unwrap();
+        let error = Box::new(error);
         let tokens = tokens_to_string(&tokens, interner);
         InterpreterError::FailedToParseMacro { error, tokens, rule, location }
     })

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter/unquote.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter/unquote.rs
@@ -1,5 +1,3 @@
-use noirc_errors::Location;
-
 use crate::{
     hir::comptime::errors::IResult,
     token::{LocatedToken, Token, Tokens},
@@ -14,7 +12,6 @@ impl Interpreter<'_, '_> {
     pub(super) fn substitute_unquoted_values_into_tokens(
         &mut self,
         tokens: Tokens,
-        location: Location,
     ) -> IResult<Vec<LocatedToken>> {
         let mut new_tokens = Vec::with_capacity(tokens.0.len());
 
@@ -22,7 +19,7 @@ impl Interpreter<'_, '_> {
             match token.token() {
                 Token::UnquoteMarker(id) => {
                     let value = self.evaluate(*id)?;
-                    let tokens = value.into_tokens(self.elaborator.interner, location)?;
+                    let tokens = value.into_tokens(self.elaborator.interner, token.location())?;
                     new_tokens.extend(tokens);
                 }
                 _ => new_tokens.push(token),

--- a/compiler/noirc_frontend/src/hir/comptime/value.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/value.rs
@@ -286,8 +286,9 @@ impl Value {
 
                         Ok(expr)
                     }
-                    Err(mut errors) => {
-                        let error = Box::new(errors.swap_remove(0));
+                    Err(errors) => {
+                        let error = errors.into_iter().find(|error| !error.is_warning()).unwrap();
+                        let error = Box::new(error);
                         let rule = "an expression";
                         let tokens = tokens_to_string(&tokens, elaborator.interner);
                         Err(InterpreterError::FailedToParseMacro { error, tokens, rule, location })
@@ -670,8 +671,9 @@ where
             }
             Ok(expr)
         }
-        Err(mut errors) => {
-            let error = Box::new(errors.swap_remove(0));
+        Err(errors) => {
+            let error = errors.into_iter().find(|error| !error.is_warning()).unwrap();
+            let error = Box::new(error);
             let tokens = tokens_to_string(&tokens, elaborator.interner);
             Err(InterpreterError::FailedToParseMacro { error, tokens, rule, location })
         }

--- a/test_programs/compile_failure/comptime_error_on_macro_expansion/Nargo.toml
+++ b/test_programs/compile_failure/comptime_error_on_macro_expansion/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "comptime_error_on_macro_expansion_1"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.31.0"
+
+[dependencies]

--- a/test_programs/compile_failure/comptime_error_on_macro_expansion/src/main.nr
+++ b/test_programs/compile_failure/comptime_error_on_macro_expansion/src/main.nr
@@ -1,0 +1,42 @@
+mod other;
+use other::expr;
+
+#[foo]
+comptime fn foo(_: FunctionDefinition) -> Quoted {
+    quote {
+        pub fn generated_by_foo() {
+            1 + "a";
+        }
+    }
+}
+
+#[bar]
+comptime fn bar(_: FunctionDefinition) -> Quoted {
+    let expr = expr();
+    quote {
+        pub fn generated_by_bar() {
+            $expr;
+        }
+    }
+}
+
+#[derive_bn254_impl]
+pub struct BN254 {}
+
+comptime fn derive_bn254_impl(s: TypeDefinition) -> Quoted {
+    let typ = s.as_type();
+    quote {
+        impl BN254 {
+            fn one() {}
+
+            fn mul<let NScalarSlices: u32>(self, scalar: ScalarField<NScalarSlices>) -> Self {
+                unconstrained_function();
+                crate::mul_with_hint($typ, scalar, transcript)
+            }
+        }
+    }
+}
+
+pub unconstrained fn unconstrained_function() {}
+
+fn main() {}

--- a/test_programs/compile_failure/comptime_error_on_macro_expansion/src/other.nr
+++ b/test_programs/compile_failure/comptime_error_on_macro_expansion/src/other.nr
@@ -1,0 +1,3 @@
+pub comptime fn expr() -> Quoted {
+    quote { 1 + "a" }
+}

--- a/tooling/nargo_cli/tests/snapshots/compile_failure/comptime_error_on_macro_expansion/execute__tests__stderr.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_failure/comptime_error_on_macro_expansion/execute__tests__stderr.snap
@@ -1,0 +1,76 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: stderr
+---
+warning: Unused expression result of type str<1>
+  ┌─ src/main.nr:4:1
+  │
+4 │ #[foo]
+  │ ------ While running this function attribute
+  ·
+8 │             1 + "a";
+  │             -------
+  │
+
+warning: Unused expression result of type str<1>
+   ┌─ src/other.nr:2:13
+   │
+ 2 │     quote { 1 + "a" }
+   │             -
+   │
+   ┌─ src/main.nr:13:1
+   │
+13 │ #[bar]
+   │ ------ While running this function attribute
+   │
+
+error: Types in a binary operation should match, but found Field and str<1>
+  ┌─ src/main.nr:4:1
+  │
+4 │ #[foo]
+  │ ------ While running this function attribute
+  ·
+8 │             1 + "a";
+  │             -------
+  │
+
+error: Types in a binary operation should match, but found Field and str<1>
+   ┌─ src/other.nr:2:13
+   │
+ 2 │     quote { 1 + "a" }
+   │             -
+   │
+   ┌─ src/main.nr:13:1
+   │
+13 │ #[bar]
+   │ ------ While running this function attribute
+   │
+
+error: Expected value, found built-in type `(resolved type)`
+   ┌─ src/main.nr:23:1
+   │  
+23 │   #[derive_bn254_impl]
+   │   -------------------- Failed to parse macro's token stream into top-level item
+   ·  
+28 │ ╭     quote {
+29 │ │         impl BN254 {
+30 │ │             fn one() {}
+31 │ │ 
+   · │
+36 │ │         }
+37 │ │     }
+   │ ╰─────'
+   │  
+   = The resulting token stream was: (stream starts on next line)
+       impl BN254 {
+         fn one() {
+             
+         }
+         fn mul < let NScalarSlices: u32 > (self, scalar: ScalarField < NScalarSlices > ) -> Self {
+             unconstrained_function();
+             crate::mul_with_hint(BN254, scalar, transcript)
+         }
+     }
+   = To avoid this error in the future, try adding input validation to your macro. Erroring out early with an `assert` can be a good way to provide a user-friendly error message
+
+Aborting due to 3 previous errors

--- a/tooling/nargo_cli/tests/snapshots/compile_failure/comptime_error_on_macro_expansion/execute__tests__stderr.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_failure/comptime_error_on_macro_expansion/execute__tests__stderr.snap
@@ -48,19 +48,13 @@ error: Types in a binary operation should match, but found Field and str<1>
 
 error: Expected value, found built-in type `(resolved type)`
    ┌─ src/main.nr:23:1
-   │  
-23 │   #[derive_bn254_impl]
-   │   -------------------- Failed to parse macro's token stream into top-level item
-   ·  
-28 │ ╭     quote {
-29 │ │         impl BN254 {
-30 │ │             fn one() {}
-31 │ │ 
-   · │
-36 │ │         }
-37 │ │     }
-   │ ╰─────'
-   │  
+   │
+23 │ #[derive_bn254_impl]
+   │ -------------------- Failed to parse macro's token stream into top-level item
+   ·
+34 │                 crate::mul_with_hint($typ, scalar, transcript)
+   │                                       ---
+   │
    = The resulting token stream was: (stream starts on next line)
        impl BN254 {
          fn one() {

--- a/tooling/nargo_cli/tests/snapshots/compile_failure/comptime_parse_all_tokens/execute__tests__stderr.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_failure/comptime_parse_all_tokens/execute__tests__stderr.snap
@@ -9,7 +9,7 @@ error: Expected an identifier, `crate`, `dep` or `super` but found '(type)'
   │ ------ Failed to parse macro's token stream into top-level item
   ·
 8 │     quote { use $t; }
-  │     -----------------
+  │                  -
   │
   = The resulting token stream was: (stream starts on next line)
       use Field;


### PR DESCRIPTION
# Description

## Problem

No issue, just something confusing mentioned over Slack that could be improved.

## Summary

Two things here:
1. When a macro parse error happened we'd show the just first error. The issue was that in the list of "errors" warnings could exist too. So here we discard warnings and truly show the first error. (Maybe ideally we'd show all errors and warnings here but I'm not sure how we'd show that as a result of a macro expansion, so I did the minimum thing to improve the situation without introducing a large change).
2. The location of the `$expr` token ended up being the location of the `quote` expression that held it, making errors point to that entire quote (as can be seen in the second commit). This was likely done before everything started holding a Location instead of a Span. The second improvement here is to preserve those token locations. The third commit shows how the error improves.

In the actual code with the confusing error message, this is what we initially saw in VSCode:

![image](https://github.com/user-attachments/assets/09606f74-dc40-4304-b238-9a46613a41bb)

This is the warning caused by not being able to parse the macro.

Once that was fixed (first commit), we got this error:

![image](https://github.com/user-attachments/assets/24753aa3-21ca-4b1b-a438-044cd56a68a1)

It actually continues above and below that: it's the entire `quote { ... }` that has the error.

With the third commit we get this error:

![image](https://github.com/user-attachments/assets/e25ad555-4c7b-47d4-8078-10f08e567689)

with the error being "Expected value, found built-in type `(resolved type)`". So now it's much clearer where's the error.

## Additional Context



## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
