### PR TITLE
fix(ssa): Swap Brillig index shift and DIE in minimal pipeline

### DIFF
--- a/compiler/noirc_evaluator/src/ssa.rs
+++ b/compiler/noirc_evaluator/src/ssa.rs
@@ -228,7 +228,7 @@ pub fn secondary_passes(brillig: &Brillig) -> Vec<SsaPass> {
         // It could happen that we inlined all calls to a given brillig function.
         // In that case it's unused so we can remove it. This is what we check next.
         SsaPass::new(Ssa::remove_unreachable_functions, "Removing Unreachable Functions"),
-        SsaPass::new(Ssa::dead_instruction_elimination_acir, "Dead Instruction Elimination"),
+        SsaPass::new(Ssa::dead_instruction_elimination_acir, "Dead Instruction Elimination - ACIR"),
     ]
 }
 

--- a/compiler/noirc_evaluator/src/ssa.rs
+++ b/compiler/noirc_evaluator/src/ssa.rs
@@ -207,7 +207,10 @@ pub fn primary_passes(options: &SsaEvaluatorOptions) -> Vec<SsaPass> {
         // We can safely place the pass before DIE as that pass only removes instructions.
         // We also need DIE's tracking of used globals in case the array get transformations
         // end up using an existing constant from the globals space.
+        // This pass might result in otherwise unused global constant becoming used,
+        // because the creation of shifted index constants can reuse their IDs.
         SsaPass::new(Ssa::brillig_array_get_and_set, "Brillig Array Get and Set Optimizations"),
+        // Perform another DIE pass to update the used globals after offsetting Brillig indexes.
         SsaPass::new(Ssa::dead_instruction_elimination, "Dead Instruction Elimination"),
         // A function can be potentially unreachable post-DIE if all calls to that function were removed.
         SsaPass::new(Ssa::remove_unreachable_functions, "Removing Unreachable Functions"),

--- a/compiler/noirc_evaluator/src/ssa.rs
+++ b/compiler/noirc_evaluator/src/ssa.rs
@@ -249,8 +249,8 @@ pub fn minimal_passes() -> Vec<SsaPass<'static>> {
         // panics later, when we are looking for global allocations.
         SsaPass::new(Ssa::remove_unreachable_functions, "Removing Unreachable Functions"),
         // We need to add an offset to constant array indices in Brillig.
-        // This can change which globals are used, because it shifts index constants,
-        // which might result in the (re)use of global constants.
+        // This can change which globals are used, because constant creation might result
+        // in the (re)use of otherwise unused global values.
         SsaPass::new(Ssa::brillig_array_get_and_set, "Brillig Array Get and Set Optimizations"),
         // We need a DIE pass to populate `used_globals`, otherwise it will panic later.
         SsaPass::new(Ssa::dead_instruction_elimination, "Dead Instruction Elimination"),

--- a/compiler/noirc_evaluator/src/ssa.rs
+++ b/compiler/noirc_evaluator/src/ssa.rs
@@ -248,10 +248,12 @@ pub fn minimal_passes() -> Vec<SsaPass<'static>> {
         // which was called in the AST not being called in the SSA. Such functions would cause
         // panics later, when we are looking for global allocations.
         SsaPass::new(Ssa::remove_unreachable_functions, "Removing Unreachable Functions"),
+        // We need to add an offset to constant array indices in Brillig.
+        // This can change which globals are used, because it shifts index constants,
+        // which might result in the (re)use of global constants.
+        SsaPass::new(Ssa::brillig_array_get_and_set, "Brillig Array Get and Set Optimizations"),
         // We need a DIE pass to populate `used_globals`, otherwise it will panic later.
         SsaPass::new(Ssa::dead_instruction_elimination, "Dead Instruction Elimination"),
-        // We need to add an offset to constant array indices in Brillig.
-        SsaPass::new(Ssa::brillig_array_get_and_set, "Brillig Array Get and Set Optimizations"),
     ]
 }
 

--- a/tooling/nargo_cli/build.rs
+++ b/tooling/nargo_cli/build.rs
@@ -126,7 +126,7 @@ const IGNORED_INTERPRET_EXECUTION_TESTS: [&str; 1] = [
 ];
 
 /// `nargo execute --minimal-ssa` ignored tests
-const IGNORED_MINIMAL_EXECUTION_TESTS: [&str; 13] = [
+const IGNORED_MINIMAL_EXECUTION_TESTS: [&str; 12] = [
     // internal error: entered unreachable code: unsupported function call type Intrinsic(AssertConstant)
     // These tests contain calls to `assert_constant`, which are evaluated and removed in the full SSA
     // pipeline, but in the minimal they are untouched, and trying to remove them causes a failure because
@@ -141,8 +141,6 @@ const IGNORED_MINIMAL_EXECUTION_TESTS: [&str; 13] = [
     "pedersen_commitment",
     "simple_shield",
     "strings",
-    // ICE: Global value not found in cache v0
-    "integer_array_indexing",
     // The minimum SSA pipeline only works with Brillig: \'zeroed_lambda\' needs to be unconstrained
     "lambda_from_dynamic_if",
     // This relies on maximum inliner setting


### PR DESCRIPTION
# Description

## Problem\*

Resolves #8941

## Summary\*

Changes the order of "Dead Instruction Elimination" and "Brillig Array Get and Set Optimizations" in the `--minimal-ssa` pipeline to do the DIE as the last step. 

The reason is the Brillig array index optimisations shift constant indexes by an offset, and then insert the new constants into the DFG; when that happens the DFG tries to reuse existing constants and return their IDs, and these constants can come from the global as well as local values. If it comes from a global, it can mark a global value as _used_ even when it wasn't otherwise referenced. 

The DIE pass gathers used global values, but in the minimal pipeline it came before the index offsets, so it worked with stale data. 

## Additional Context

I don't know if this is an intended reuse, I suppose it might save some allocations the Brillig VM if we reuse global values, although it seems dubious if this is the _only_ use of a global value. Nevertheless, swapping the order doesn't seem to have any detrimental effect.

## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
