### PR TITLE
fix(LSP): suggest generic type methods

### DIFF
--- a/tooling/lsp/src/requests/completion.rs
+++ b/tooling/lsp/src/requests/completion.rs
@@ -344,9 +344,10 @@ impl<'a> NodeFinder<'a> {
                 ModuleDefId::ModuleId(id) => module_id = id,
                 ModuleDefId::TypeId(type_id) => {
                     let data_type = self.interner.get_type(type_id);
+                    let generics = data_type.borrow().generic_types();
                     self.complete_enum_variants_without_parameters(&data_type.borrow(), &prefix);
                     self.complete_type_methods(
-                        &Type::DataType(data_type, vec![]),
+                        &Type::DataType(data_type, generics),
                         &prefix,
                         FunctionKind::Any,
                         function_completion_kind,

--- a/tooling/lsp/src/requests/completion.rs
+++ b/tooling/lsp/src/requests/completion.rs
@@ -14,6 +14,7 @@ use completion_items::{
 };
 use convert_case::{Case, Casing};
 use fm::{FileId, FileMap, PathString};
+use iter_extended::vecmap;
 use kinds::{FunctionCompletionKind, FunctionKind, RequestedItems};
 use noirc_errors::{Location, Span};
 use noirc_frontend::{
@@ -344,7 +345,11 @@ impl<'a> NodeFinder<'a> {
                 ModuleDefId::ModuleId(id) => module_id = id,
                 ModuleDefId::TypeId(type_id) => {
                     let data_type = self.interner.get_type(type_id);
-                    let generics = data_type.borrow().generic_types();
+                    // Use `Type::Error` for the generics since they unify with anything, to get methods from all impls.
+                    // We could use fresh type variables instead, but we have a non-mutable NodeInterner here.
+                    // Note: ideally we'd also use any turbofish for `generics`, but at least Rust Analyzer seems
+                    // to ignore them and offers all methods from all impls, so for now we do the same.
+                    let generics = vecmap(&data_type.borrow().generics, |_| Type::Error);
                     self.complete_enum_variants_without_parameters(&data_type.borrow(), &prefix);
                     self.complete_type_methods(
                         &Type::DataType(data_type, generics),

--- a/tooling/lsp/src/requests/completion/tests.rs
+++ b/tooling/lsp/src/requests/completion/tests.rs
@@ -1225,6 +1225,47 @@ mod completion_tests {
     }
 
     #[test]
+    async fn test_suggests_generic_struct_methods_after_colons() {
+        let src = r#"
+            struct Some<T> {
+            }
+
+            impl<T> Some<T> {
+                fn foobar(self, x: i32) {}
+                fn foobar2(&mut self, x: i32) {}
+                fn foobar3(y: i32) {}
+            }
+
+            fn foo() {
+                Some::>|<
+            }
+        "#;
+        assert_completion(
+            src,
+            vec![
+                completion_item_with_sort_text(
+                    function_completion_item(
+                        "foobar(…)",
+                        "foobar(${1:self}, ${2:x})",
+                        "fn(self, i32)",
+                    ),
+                    self_mismatch_sort_text(),
+                ),
+                completion_item_with_sort_text(
+                    function_completion_item(
+                        "foobar2(…)",
+                        "foobar2(${1:self}, ${2:x})",
+                        "fn(&mut self, i32)",
+                    ),
+                    self_mismatch_sort_text(),
+                ),
+                function_completion_item("foobar3(…)", "foobar3(${1:y})", "fn(i32)"),
+            ],
+        )
+        .await;
+    }
+
+    #[test]
     async fn test_suggests_struct_behind_alias_methods_after_dot() {
         let src = r#"
             struct Some {

--- a/tooling/lsp/src/requests/completion/tests.rs
+++ b/tooling/lsp/src/requests/completion/tests.rs
@@ -1266,6 +1266,50 @@ mod completion_tests {
     }
 
     #[test]
+    async fn test_suggests_generic_struct_with_turbofish_methods_after_colons() {
+        let src = r#"
+            struct Some<T> {
+            }
+
+            impl Some<i32> {
+                fn foobar(self, x: i32) {}
+                fn foobar2(&mut self, x: i32) {}
+            }
+
+            impl Some<i64> {
+                fn foobar3(y: i32) {}
+            }
+
+            fn foo() {
+                Some::<i32>::>|<
+            }
+        "#;
+        assert_completion(
+            src,
+            vec![
+                completion_item_with_sort_text(
+                    function_completion_item(
+                        "foobar(…)",
+                        "foobar(${1:self}, ${2:x})",
+                        "fn(self, i32)",
+                    ),
+                    self_mismatch_sort_text(),
+                ),
+                completion_item_with_sort_text(
+                    function_completion_item(
+                        "foobar2(…)",
+                        "foobar2(${1:self}, ${2:x})",
+                        "fn(&mut self, i32)",
+                    ),
+                    self_mismatch_sort_text(),
+                ),
+                function_completion_item("foobar3(…)", "foobar3(${1:y})", "fn(i32)"),
+            ],
+        )
+        .await;
+    }
+
+    #[test]
     async fn test_suggests_struct_behind_alias_methods_after_dot() {
         let src = r#"
             struct Some {


### PR DESCRIPTION
# Description

## Problem

No issue, but something I noticed while coding.

## Summary

LSP didn't offer any suggestions for `Option::`. I think it used to, maybe it stopped working at some point, likely because there wasn't a test for exactly that.

This PR adds a regression test and also fixes the issue.

Before:

![lsp-complete-option-methods-bad](https://github.com/user-attachments/assets/05273167-8b7b-4608-9c17-56144b3343bf)

After:

![lsp-complete-option-methods-good](https://github.com/user-attachments/assets/2f7b9adf-a2ab-4dfb-bc9f-400a49fbd205)


## Additional Context



## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
