### PR TITLE
chore(fuzz): Consider `RangeCheckFailed` equivalent to `ConstantDoesNotFitType` if the value matches

### DIFF
--- a/tooling/ast_fuzzer/src/compare/interpreted.rs
+++ b/tooling/ast_fuzzer/src/compare/interpreted.rs
@@ -132,6 +132,18 @@ impl Comparable for ssa::interpreter::errors::InterpreterError {
                 // To deal with this we ignore these errors as long as both passes fail the same way.
                 c1 == c2 && t1 == t2
             }
+            (
+                Internal(InternalError::ConstantDoesNotFitInType { constant, .. }),
+                RangeCheckFailed { value, .. } | RangeCheckFailedWithMessage { value, .. },
+            )
+            | (
+                RangeCheckFailed { value, .. } | RangeCheckFailedWithMessage { value, .. },
+                Internal(InternalError::ConstantDoesNotFitInType { constant, .. }),
+            ) => {
+                // The value should be a `NumericValue` display format, which is `<type> <value>`.
+                let value = value.split_once(' ').map(|(_, value)| value).unwrap_or(value);
+                value == constant.to_string()
+            }
             (Internal(_), _) | (_, Internal(_)) => {
                 // We should not get, or ignore, internal errors.
                 // They mean the interpreter got something unexpected that we need to fix.


### PR DESCRIPTION
# Description

## Problem\*

Resolves #8863 

## Summary\*

Relaxes the `Comparable` implementation for the SSA interpreter errors to consider the errors from a range check equivalent to the internal error we get when a constant does not fit into the intended type, as long as the value they mention is the same. This is because SSA passes might reorder some instructions that result in failure for the same reason, but with a different manifestation in the interpreter depending on which instruction comes first.

## Additional Context

This is a follow up for the discussion in https://github.com/noir-lang/noir/issues/8910 without going all the way to consider every failure equivalent. That would be too aggressive at the moment, because the SSA interpreter doesn't handle prints yet (I'll do that next).

## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
