### PR TITLE
chore(fuzz): Use `nextest` to run nightly fuzz test

### DIFF
--- a/.github/workflows/nightly-fuzz-test.yml
+++ b/.github/workflows/nightly-fuzz-test.yml
@@ -31,7 +31,13 @@ jobs:
         with:
           targets: x86_64-unknown-linux-gnu
 
+      - name: Install nextest
+        uses: taiki-e/install-action@v2
+        with:
+          tool: nextest@0.9.88
+
       - name: Run tests
-        run: cargo test -p noir_ast_fuzzer_fuzz
+        run: cargo nextest run -p noir_ast_fuzzer_fuzz --no-fail-fast
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUST_MIN_STACK: 8388608


### PR DESCRIPTION
# Description

## Problem\*

Yesterday's nightly fuzz test [had a stack overflow](https://github.com/noir-lang/noir/actions/runs/15723142109/job/44307763601). Since I used `cargo test`, it causes the whole testing process to exit, so if 1 out of the 5 targets has the stack overflow, we don't learn the outcome of the other 4. 

## Summary\*

Changes the nightly fuzz test to use `nextest`, which runs tests in a sub-process and should not fail if one of them crashes with stack overflow. 

## Additional Context

I tried to reproduce locally and did get a failure once (in `min_vs_orig`, like on CI), but then haven't managed to get the error again while logging the ASTs at the same time, to ferret out the program that causes it. 

Tested it locally like this:
```shell
NOIR_AST_FUZZER_BUDGET_SECS=60 NOIR_AST_FUZZER_FORCE_NON_DETERMINISTIC=1 cargo nextest run -p noir_ast_fuzzer_fuzz --no-fail-fast
```

## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
