### PR TITLE
fix: check "negate with overflow" in comptime code

### DIFF
--- a/compiler/noirc_frontend/src/hir/comptime/errors.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/errors.rs
@@ -126,8 +126,11 @@ pub enum InterpreterError {
         operator: &'static str,
         location: Location,
     },
-    MathError {
+    InfixMathError {
         operator: &'static str,
+        location: Location,
+    },
+    PrefixMathError {
         location: Location,
     },
     CastToNonNumericType {
@@ -301,7 +304,8 @@ impl InterpreterError {
             | InterpreterError::TypeUnsupported { location, .. }
             | InterpreterError::InvalidValueForUnary { location, .. }
             | InterpreterError::InvalidValuesForBinary { location, .. }
-            | InterpreterError::MathError { location, .. }
+            | InterpreterError::InfixMathError { location, .. }
+            | InterpreterError::PrefixMathError { location, .. }
             | InterpreterError::CastToNonNumericType { location, .. }
             | InterpreterError::NonStructInConstructor { location, .. }
             | InterpreterError::NonEnumInConstructor { location, .. }
@@ -504,7 +508,7 @@ impl<'a> From<&'a InterpreterError> for CustomDiagnostic {
                 let msg = format!("No implementation for `{lhs}` {operator} `{rhs}`");
                 CustomDiagnostic::simple_error(msg, String::new(), *location)
             }
-            InterpreterError::MathError { operator, location } => {
+            InterpreterError::InfixMathError { operator, location } => {
                 let msg = if *operator == "/" {
                     "Attempt to divide by zero".to_string()
                 } else {
@@ -518,6 +522,10 @@ impl<'a> From<&'a InterpreterError> for CustomDiagnostic {
                     };
                     format!("Attempt to {operator} with overflow")
                 };
+                CustomDiagnostic::simple_error(msg, String::new(), *location)
+            }
+            InterpreterError::PrefixMathError { location } => {
+                let msg = "Attempt to negate with overflow".to_string();
                 CustomDiagnostic::simple_error(msg, String::new(), *location)
             }
             InterpreterError::CastToNonNumericType { typ, location } => {

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
@@ -1595,10 +1595,22 @@ fn evaluate_prefix_with_value(rhs: Value, operator: UnaryOp, location: Location)
     match operator {
         UnaryOp::Minus => match rhs {
             Value::Field(value) => Ok(Value::Field(-value)),
-            Value::I8(value) => Ok(Value::I8(-value)),
-            Value::I16(value) => Ok(Value::I16(-value)),
-            Value::I32(value) => Ok(Value::I32(-value)),
-            Value::I64(value) => Ok(Value::I64(-value)),
+            Value::I8(value) => value
+                .checked_neg()
+                .map(Value::I8)
+                .ok_or_else(|| InterpreterError::PrefixMathError { location }),
+            Value::I16(value) => value
+                .checked_neg()
+                .map(Value::I16)
+                .ok_or_else(|| InterpreterError::PrefixMathError { location }),
+            Value::I32(value) => value
+                .checked_neg()
+                .map(Value::I32)
+                .ok_or_else(|| InterpreterError::PrefixMathError { location }),
+            Value::I64(value) => value
+                .checked_neg()
+                .map(Value::I64)
+                .ok_or_else(|| InterpreterError::PrefixMathError { location }),
             Value::U8(value) => Ok(Value::U8(0 - value)),
             Value::U16(value) => Ok(Value::U16(0 - value)),
             Value::U32(value) => Ok(Value::U32(0 - value)),

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter/infix.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter/infix.rs
@@ -21,7 +21,7 @@ pub(super) fn evaluate_infix(
         InterpreterError::InvalidValuesForBinary { lhs, rhs, location, operator }
     };
 
-    let math_error = |operator| InterpreterError::MathError { location, operator };
+    let math_error = |operator| InterpreterError::InfixMathError { location, operator };
 
     /// Generate matches that can promote the type of one side to the other if they are compatible.
     macro_rules! match_values {
@@ -280,7 +280,7 @@ mod test {
         "#;
 
         let err = interpret_expect_error(src);
-        let InterpreterError::MathError { operator, .. } = err else {
+        let InterpreterError::InfixMathError { operator, .. } = err else {
             panic!("Expected overflow error");
         };
         assert_eq!(operator, "<<");
@@ -295,7 +295,7 @@ mod test {
         "#;
 
         let err = interpret_expect_error(src);
-        let InterpreterError::MathError { operator, .. } = err else {
+        let InterpreterError::InfixMathError { operator, .. } = err else {
             panic!("Expected overflow error");
         };
         assert_eq!(operator, "<<");
@@ -414,7 +414,7 @@ mod test {
             }
         "#;
         let result = interpret_expect_error(src);
-        assert!(matches!(result, InterpreterError::MathError { operator: "/", location: _ }));
+        assert!(matches!(result, InterpreterError::InfixMathError { operator: "/", location: _ }));
     }
 
     #[test]
@@ -425,7 +425,7 @@ mod test {
             }
         "#;
         let result = interpret_expect_error(src);
-        assert!(matches!(result, InterpreterError::MathError { operator: "/", location: _ }));
+        assert!(matches!(result, InterpreterError::InfixMathError { operator: "/", location: _ }));
     }
 
     #[test]

--- a/test_programs/compile_failure/comptime_negate_with_overflow/Nargo.toml
+++ b/test_programs/compile_failure/comptime_negate_with_overflow/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "comptime_negate_with_overflow"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.33.0"
+
+[dependencies]

--- a/test_programs/compile_failure/comptime_negate_with_overflow/src/main.nr
+++ b/test_programs/compile_failure/comptime_negate_with_overflow/src/main.nr
@@ -1,0 +1,6 @@
+fn main() {
+    comptime {
+        let i: i8 = -(128 as i8);
+        println(i);
+    }
+}

--- a/tooling/nargo_cli/tests/snapshots/compile_failure/comptime_negate_with_overflow/execute__tests__stderr.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_failure/comptime_negate_with_overflow/execute__tests__stderr.snap
@@ -1,0 +1,19 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: stderr
+---
+warning: Casting value of type Field to a smaller type (i8)
+  ┌─ src/main.nr:3:23
+  │
+3 │         let i: i8 = -(128 as i8);
+  │                       --------- casting untyped value (128) to a type with a maximum size (127) that's smaller than it
+  │
+
+error: Attempt to negate with overflow
+  ┌─ src/main.nr:3:21
+  │
+3 │         let i: i8 = -(128 as i8);
+  │                     ------------
+  │
+
+Aborting due to 1 previous error


### PR DESCRIPTION
# Description

## Problem

Resolves #8870

## Summary



## Additional Context



## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
