### PR TITLE
fix(fuzz): Do not take a mutable reference over immutable vars which contain a mutable ref

### DIFF
--- a/tooling/ast_fuzzer/src/program/func.rs
+++ b/tooling/ast_fuzzer/src/program/func.rs
@@ -502,16 +502,21 @@ impl<'a> FunctionContext<'a> {
         max_depth: usize,
     ) -> arbitrary::Result<Option<TrackedExpression>> {
         if let Some(id) = self.choose_producer(u, typ)? {
-            let (mutable, src_name, src_type) = self.get_variable(&id).clone();
+            let (src_mutable, src_name, src_type) = self.get_variable(&id).clone();
             let ident_id = self.next_ident_id();
-            let src_expr = expr::ident(id, ident_id, mutable, src_name, src_type.clone());
+            let src_expr = expr::ident(id, ident_id, src_mutable, src_name, src_type.clone());
             let src_dyn = match id {
                 VariableId::Global(_) => false,
                 VariableId::Local(id) => self.is_dynamic(&id),
             };
-            if let Some(expr) =
-                self.gen_expr_from_source(u, (src_expr, src_dyn), &src_type, typ, max_depth)?
-            {
+            if let Some(expr) = self.gen_expr_from_source(
+                u,
+                (src_expr, src_dyn),
+                &src_type,
+                src_mutable,
+                typ,
+                max_depth,
+            )? {
                 return Ok(Some(expr));
             }
         } else {
@@ -558,6 +563,7 @@ impl<'a> FunctionContext<'a> {
         u: &mut Unstructured,
         (src_expr, src_dyn): TrackedExpression,
         src_type: &Type,
+        src_mutable: bool,
         tgt_type: &Type,
         max_depth: usize,
     ) -> arbitrary::Result<Option<TrackedExpression>> {
@@ -589,7 +595,7 @@ impl<'a> FunctionContext<'a> {
                 let expr = expr::deref(src_expr, tgt_type.clone());
                 Ok(Some((expr, src_dyn)))
             }
-            (_, Type::Reference(typ, true)) if typ.as_ref() == src_type => {
+            (_, Type::Reference(typ, true)) if typ.as_ref() == src_type && src_mutable => {
                 let expr = expr::ref_mut(src_expr, typ.as_ref().clone());
                 Ok(Some((expr, src_dyn)))
             }
@@ -626,6 +632,7 @@ impl<'a> FunctionContext<'a> {
                     u,
                     (item_expr, src_dyn || idx_dyn),
                     item_typ,
+                    src_mutable,
                     tgt_type,
                     max_depth,
                 )
@@ -639,6 +646,7 @@ impl<'a> FunctionContext<'a> {
                         u,
                         (item_expr, src_dyn),
                         item_type,
+                        src_mutable,
                         tgt_type,
                         max_depth,
                     )? {
@@ -1245,7 +1253,14 @@ impl<'a> FunctionContext<'a> {
         });
 
         // Derive the final result from the call, e.g. by casting, or accessing a member.
-        self.gen_expr_from_source(u, (call_expr, call_dyn), &return_type, typ, self.max_depth())
+        self.gen_expr_from_source(
+            u,
+            (call_expr, call_dyn),
+            &return_type,
+            true,
+            typ,
+            self.max_depth(),
+        )
     }
 
     /// Generate a call to a specific function, with arbitrary literals


### PR DESCRIPTION
# Description

## Problem\*

Resolves one of the errors in https://github.com/noir-lang/noir/actions/runs/15748645365/job/44389551968

## Summary\*

Fixes the AST generator to consider the mutability of the variable when it generates a target type from a source expression, and avoid taking a mutable reference over the non-mutable parts of an immutable variable, that might also contain a mutable ref. 

## Additional Context

To reproduce the error:
```shell
NOIR_AST_FUZZER_SEED=0x89a06e3200100000 cargo test -p noir_ast_fuzzer_fuzz comptime_vs_brillig 
```

What happened was that we had a type like this: `let d = (false, &mut false);` and we were looking to produce an `&mut bool`; we know `d` can produce it as `d.1`, so we chose `d` as the producer. However, the generator that considered how to produce `&mut bool` from `(bool, &mut bool)` thought that it can do `&mut <src>.0`, not knowing that the source in this case was not mutable.

## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
