### PR TITLE
fix(fuzz): Avoid negating `i8::MIN` into `i8::MAX+1` which won't compile

### DIFF
--- a/tooling/ast_fuzzer/fuzz/src/targets/orig_vs_morph.rs
+++ b/tooling/ast_fuzzer/fuzz/src/targets/orig_vs_morph.rs
@@ -300,6 +300,7 @@ mod rules {
     use crate::targets::orig_vs_morph::{VariableContext, helpers::reassign_ids};
 
     use super::helpers::{gen_expr, has_side_effect};
+    use acir::{AcirField, FieldElement};
     use arbitrary::Unstructured;
     use noir_ast_fuzzer::{expr, types};
     use noirc_frontend::{
@@ -429,7 +430,7 @@ mod rules {
                 if a.is_negative() && !b.is_negative() {
                     *b = SignedField::negative(b.absolute_value());
                 } else if !a.is_negative() && b.is_negative() {
-                    *b = SignedField::positive(b.absolute_value());
+                    *b = SignedField::positive(b.absolute_value() - FieldElement::one()); // -1 just to avoid the potential of going from e.g. i8 -128 to 128 where the maximum is 127.
                 }
 
                 let (op, c) = if *a >= *b {


### PR DESCRIPTION
# Description

## Problem\*

Resolves one of the issues with the AST fuzzer in https://github.com/noir-lang/noir/actions/runs/15748645365/job/44389551968

## Summary\*

When breaking up a number `a` into either `b + c` or `b - c`, I took a negation without considering that `-1 * MIN` won't fit into the type.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
