### PR TITLE
fix(expand): show references to ModuleDefId recursing on parents

### DIFF
--- a/tooling/nargo_cli/build.rs
+++ b/tooling/nargo_cli/build.rs
@@ -151,7 +151,7 @@ const IGNORED_MINIMAL_EXECUTION_TESTS: [&str; 12] = [
 /// might not be worth it.
 /// Others are ignored because of existing bugs in `nargo expand`.
 /// As the bugs are fixed these tests should be removed from this list.
-const IGNORED_NARGO_EXPAND_EXECUTION_TESTS: [&str; 9] = [
+const IGNORED_NARGO_EXPAND_EXECUTION_TESTS: [&str; 6] = [
     // There's nothing special about this program but making it work with a custom entry would involve
     // having to parse the Nargo.toml file, etc., which is not worth it
     "custom_entry",
@@ -159,12 +159,6 @@ const IGNORED_NARGO_EXPAND_EXECUTION_TESTS: [&str; 9] = [
     "diamond_deps_0",
     // There's no "src/main.nr" here so it's trickier to make this work
     "overlapping_dep_and_mod",
-    // bug
-    "poseidonsponge_x5_254",
-    // bug
-    "regression_5045",
-    // bug
-    "regression_7744",
     // bug
     "trait_associated_constant",
     // There's no "src/main.nr" here so it's trickier to make this work
@@ -190,7 +184,8 @@ const IGNORED_NARGO_EXPAND_COMPILE_SUCCESS_EMPTY_TESTS: [&str; 24] = [
     "overlapping_dep_and_mod",
     // bug
     "primitive_trait_method_call_multiple_candidates",
-    // bug
+    // this one works, but copying its `Nargo.toml` file to somewhere else doesn't work
+    // because it references another project by a relative path
     "reexports",
     // bug
     "regression_7038",

--- a/tooling/nargo_cli/src/cli/expand_cmd/printer.rs
+++ b/tooling/nargo_cli/src/cli/expand_cmd/printer.rs
@@ -1074,10 +1074,7 @@ impl<'context, 'string> ItemPrinter<'context, 'string> {
         if module_def_id_parent_module != Some(self.module_id) {
             if let Some(module_def_id_parent_module) = module_def_id_parent_module {
                 let visibility = self
-                    .interner
-                    .try_module_attributes(&module_def_id_parent_module)
-                    .map(|attributes| attributes.visibility)
-                    .unwrap_or(ItemVisibility::Public);
+                    .module_def_id_visibility(ModuleDefId::ModuleId(module_def_id_parent_module));
                 self.show_reference_to_module_def_id(
                     ModuleDefId::ModuleId(module_def_id_parent_module),
                     visibility,

--- a/tooling/nargo_cli/src/cli/expand_cmd/printer.rs
+++ b/tooling/nargo_cli/src/cli/expand_cmd/printer.rs
@@ -15,10 +15,7 @@ use noirc_frontend::{
         stmt::{HirLetStatement, HirPattern},
         traits::{ResolvedTraitBound, TraitConstraint},
     },
-    modules::{
-        get_parent_module, module_def_id_is_visible, module_def_id_to_reference_id,
-        relative_module_full_path,
-    },
+    modules::{get_parent_module, module_def_id_is_visible, module_def_id_to_reference_id},
     node_interner::{FuncId, GlobalId, GlobalValue, NodeInterner, ReferenceId, TypeAliasId},
     shared::Visibility,
     token::{FunctionAttributeKind, LocatedToken, SecondaryAttribute, SecondaryAttributeKind},
@@ -1049,8 +1046,6 @@ impl<'context, 'string> ItemPrinter<'context, 'string> {
             }
         }
 
-        let mut reexport = None;
-
         let is_visible = module_def_id_is_visible(
             module_def_id,
             self.module_id,
@@ -1061,63 +1056,36 @@ impl<'context, 'string> ItemPrinter<'context, 'string> {
             self.dependencies,
         );
         if !is_visible {
-            reexport = self.interner.get_reexports(module_def_id).first();
-
-            // If we can't find a reexport for the main item, check if the parent module
-            // has a reexport, then use the item through that reexported module
-            if reexport.is_none() {
-                if let Some(module_def_id_parent_module) =
-                    get_parent_module(self.interner, module_def_id)
-                {
-                    let module_def_id_parent = ModuleDefId::ModuleId(module_def_id_parent_module);
-                    let visibility = self.module_def_id_visibility(module_def_id_parent);
-                    self.show_reference_to_module_def_id(
-                        module_def_id_parent,
-                        visibility,
-                        use_import,
-                    );
-                    self.push_str("::");
-                    let name = self.module_def_id_name(module_def_id);
-                    self.push_str(&name);
-                    return name;
-                }
+            if let Some(reexport) = self.interner.get_reexports(module_def_id).first() {
+                self.show_reference_to_module_def_id(
+                    ModuleDefId::ModuleId(reexport.module_id),
+                    reexport.visibility,
+                    true,
+                );
+                self.push_str("::");
+                self.push_str(reexport.name.as_str());
+                return reexport.name.to_string();
             }
         }
 
-        if let Some(reexport) = reexport {
-            self.show_reference_to_module_def_id(
-                ModuleDefId::ModuleId(reexport.module_id),
-                reexport.visibility,
-                true,
-            );
-            self.push_str("::");
-            self.push_str(reexport.name.as_str());
-            return reexport.name.to_string();
-        }
-
-        if let Some(full_path) = relative_module_full_path(
-            module_def_id,
-            self.module_id,
-            current_module_parent_id,
-            self.interner,
-        ) {
-            if !full_path.is_empty() {
-                // `relative_module_full_path` for a module returns the full path to that module
-                // so we need to remove the last segment
-                if matches!(module_def_id, ModuleDefId::ModuleId(..)) {
-                    let mut full_path = full_path.split("::").collect::<Vec<_>>();
-                    full_path.pop();
-                    let full_path = full_path.join("::");
-                    if !full_path.is_empty() {
-                        self.push_str(&full_path);
-                        self.push_str("::");
-                    }
-                } else {
-                    self.push_str(&full_path);
-                    self.push_str("::");
-                }
+        // Recurse on the parent module, but only if the parent module isn't the current module
+        // (if so, we can already reach the definition just by priting its name)
+        let module_def_id_parent_module = get_parent_module(self.interner, module_def_id);
+        if module_def_id_parent_module != Some(self.module_id) {
+            if let Some(module_def_id_parent_module) = module_def_id_parent_module {
+                let visibility = self
+                    .interner
+                    .try_module_attributes(&module_def_id_parent_module)
+                    .map(|attributes| attributes.visibility)
+                    .unwrap_or(ItemVisibility::Public);
+                self.show_reference_to_module_def_id(
+                    ModuleDefId::ModuleId(module_def_id_parent_module),
+                    visibility,
+                    use_import,
+                );
+                self.push_str("::");
             }
-        };
+        }
 
         let name = self.module_def_id_name(module_def_id);
         self.push_str(&name);

--- a/tooling/nargo_cli/tests/snapshots/compile_success_empty/nargo_expand_references/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_empty/nargo_expand_references/execute__tests__expanded.snap
@@ -29,7 +29,7 @@ mod test {
         use super::utils;
 
         pub fn use_utils() {
-            super::utils::func()
+            utils::func()
         }
     }
 

--- a/tooling/nargo_cli/tests/snapshots/compile_success_empty/poseidon2_simplification/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_empty/poseidon2_simplification/execute__tests__expanded.snap
@@ -5,7 +5,7 @@ expression: expanded_code
 use poseidon::poseidon2;
 
 fn main() {
-    let digest: Field = poseidon::poseidon2::Poseidon2::hash([0], 1);
+    let digest: Field = poseidon2::Poseidon2::hash([0], 1);
     let expected_digest: Field =
         -4219632353665391903210549416595966272614784286514361446092512556727311148272;
     assert(digest == expected_digest);

--- a/tooling/nargo_cli/tests/snapshots/compile_success_empty/reexports/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_empty/reexports/execute__tests__expanded.snap
@@ -1,0 +1,10 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: expanded_code
+---
+use reexporting_lib::{FooStruct, lib, MyStruct};
+
+fn main() {
+    let x: FooStruct = MyStruct { inner: 0 };
+    assert(lib::is_struct_zero(x));
+}

--- a/tooling/nargo_cli/tests/snapshots/compile_success_no_bug/noirc_frontend_tests_imports_warns_on_use_of_private_exported_item/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_no_bug/noirc_frontend_tests_imports_warns_on_use_of_private_exported_item/execute__tests__expanded.snap
@@ -15,5 +15,5 @@ mod foo {
 }
 
 fn main() {
-    crate::foo::bar::baz();
+    foo::bar::baz();
 }

--- a/tooling/nargo_cli/tests/snapshots/compile_success_no_bug/noirc_frontend_tests_uses_self_in_import/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_no_bug/noirc_frontend_tests_uses_self_in_import/execute__tests__expanded.snap
@@ -13,7 +13,7 @@ mod moo {
 }
 
 pub fn baz() -> i32 {
-    moo::bar::foo()
+    bar::foo()
 }
 
 fn main() {}

--- a/tooling/nargo_cli/tests/snapshots/compile_success_no_bug/noirc_frontend_tests_visibility_errors_if_trying_to_access_public_function_inside_private_module/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_no_bug/noirc_frontend_tests_visibility_errors_if_trying_to_access_public_function_inside_private_module/execute__tests__expanded.snap
@@ -9,5 +9,5 @@ mod foo {
 }
 
 fn main() {
-    crate::foo::bar::baz()
+    foo::bar::baz()
 }

--- a/tooling/nargo_cli/tests/snapshots/compile_success_no_bug/noirc_frontend_tests_visibility_errors_once_on_unused_import_that_is_not_accessible/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_no_bug/noirc_frontend_tests_visibility_errors_once_on_unused_import_that_is_not_accessible/execute__tests__expanded.snap
@@ -2,7 +2,7 @@
 source: tooling/nargo_cli/tests/execute.rs
 expression: expanded_code
 ---
-use crate::moo::Foo;
+use moo::Foo;
 
 mod moo {
     struct Foo {}

--- a/tooling/nargo_cli/tests/snapshots/execution_success/poseidonsponge_x5_254/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/poseidonsponge_x5_254/execute__tests__expanded.snap
@@ -1,0 +1,10 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: expanded_code
+---
+use poseidon::poseidon;
+
+fn main(x: [Field; 7]) {
+    let result: Field = poseidon::bn254::sponge(x);
+    assert(result == 3637726918731233354960448572465528704217843406233123660822069175839457651784);
+}

--- a/tooling/nargo_cli/tests/snapshots/execution_success/regression_5045/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/regression_5045/execute__tests__expanded.snap
@@ -1,0 +1,22 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: expanded_code
+---
+use std::embedded_curve_ops::{EmbeddedCurvePoint, EmbeddedCurveScalar};
+
+fn main(is_active: bool) {
+    let a: EmbeddedCurvePoint = EmbeddedCurvePoint {
+        x: -8519034168028805793603472410045416908800114122389094750979358290384607299995,
+        y: 2726875754519434671146873023426441956600113087238248464305840046775215989920,
+        is_infinite: false,
+    };
+    if is_active {
+        let bad: EmbeddedCurvePoint = EmbeddedCurvePoint { x: 0, y: 5, is_infinite: false };
+        let d: EmbeddedCurvePoint = bad.double();
+        let e: EmbeddedCurvePoint = std::embedded_curve_ops::multi_scalar_mul(
+            [a, bad],
+            [EmbeddedCurveScalar { lo: 1, hi: 0 }, EmbeddedCurveScalar { lo: 1, hi: 0 }],
+        );
+        assert(e.x != d.x);
+    }
+}

--- a/tooling/nargo_cli/tests/snapshots/execution_success/regression_7744/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/regression_7744/execute__tests__expanded.snap
@@ -1,0 +1,14 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: expanded_code
+---
+use std::embedded_curve_ops::{embedded_curve_add_unsafe, EmbeddedCurvePoint};
+
+fn main(is_active: bool) -> pub EmbeddedCurvePoint {
+    let bad: EmbeddedCurvePoint = EmbeddedCurvePoint { x: 0, y: 5, is_infinite: false };
+    if is_active {
+        embedded_curve_add_unsafe(bad, bad)
+    } else {
+        bad
+    }
+}


### PR DESCRIPTION
# Description

## Problem

Part of https://github.com/noir-lang/noir/issues/8281

## Summary

`nargo expand` didn't correctly produce references to items in some cases. To do this it relied on a function that didn't have access to the expander (a function used mainly for LSP) so it didn't know about existing imports, etc. Actually, in the end some logic was moved to be done more generally (previously it was only done if the item to reference wasn't visible).

## Additional Context

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
