### PR TITLE
chore: remove unreachable functions after inlining simple functions

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/opt/inline_simple_functions.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/inline_simple_functions.rs
@@ -71,7 +71,7 @@ impl Ssa {
             (*id, function.inlined(&self, &should_inline_call))
         });
 
-        self
+        self.remove_unreachable_functions()
     }
 }
 
@@ -112,10 +112,6 @@ mod test {
           b0(v0: Field):
             v1 = add v0, v0
             return v1
-        }
-        acir(inline) fn foo f1 {
-          b0(v0: Field):
-            return v0
         }
         ");
     }
@@ -160,14 +156,10 @@ mod test {
         assert_ssa_snapshot!(&mut ssa, @r"
         acir(inline) fn main f0 {
           b0(v0: Field):
-            v2 = call f2(v0) -> Field
+            v2 = call f1(v0) -> Field
             return v2
         }
-        acir(inline) fn foo f1 {
-          b0(v0: Field):
-            return v0
-        }
-        acir(inline) fn bar f2 {
+        acir(inline) fn bar f1 {
           b0(v0: Field):
             v1 = add v0, v0
             return v1
@@ -178,15 +170,6 @@ mod test {
         ssa = ssa.inline_simple_functions();
         assert_ssa_snapshot!(ssa, @r"
         acir(inline) fn main f0 {
-          b0(v0: Field):
-            v1 = add v0, v0
-            return v1
-        }
-        acir(inline) fn foo f1 {
-          b0(v0: Field):
-            return v0
-        }
-        acir(inline) fn bar f2 {
           b0(v0: Field):
             v1 = add v0, v0
             return v1
@@ -221,11 +204,6 @@ mod test {
             v3 = add v0, Field 1
             v4 = add v2, v3
             return v4
-        }
-        acir(inline) fn foo f1 {
-          b0(v0: Field):
-            v2 = add v0, Field 1
-            return v2
         }
         ");
     }


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

In aztec-packages we have a glut of small functions which hang around in the SSA for a long time after being inlined. This PR integrates the `remove_unreachable_functions` pass into the `inline_simple_functions` pass so we can remove these asap.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
