### PR TITLE
fix(fuzz): Avoid overflowing binary ops in "no dynamic" mode

### DIFF
--- a/tooling/ast_fuzzer/src/program/func.rs
+++ b/tooling/ast_fuzzer/src/program/func.rs
@@ -726,11 +726,14 @@ impl<'a> FunctionContext<'a> {
         max_depth: usize,
     ) -> arbitrary::Result<Option<TrackedExpression>> {
         // Collect the operations can return the expected type.
+        // Avoid operations that can fail in no-dynamic mode, otherwise they will be considered non-constant indexes.
         let ops = BinaryOp::iter()
             .filter(|op| {
                 types::can_binary_op_return(op, typ)
-                    && (!self.ctx.config.avoid_overflow || !types::can_binary_op_overflow(op))
-                    && (!self.ctx.config.avoid_err_by_zero || !types::can_binary_op_err_by_zero(op))
+                    && (!self.ctx.config.avoid_overflow && !self.in_no_dynamic
+                        || !types::can_binary_op_overflow(op))
+                    && (!self.ctx.config.avoid_err_by_zero && !self.in_no_dynamic
+                        || !types::can_binary_op_err_by_zero(op))
             })
             .collect::<Vec<_>>();
 


### PR DESCRIPTION
# Description

## Problem\*

Workaround for https://github.com/noir-lang/noir/issues/8995

## Summary\*

When the AST code generator is in "no dynamic" mode, avoid binary operations that can fail, otherwise we will get a compilation error saying that we are trying to index an array with a non-constant expression, which is true from the compiler perspective, but fell outside the mechanism implemented to prevent this kind of indexing, which only tracked whether variables came from either program inputs or unconstrained environment.

## Additional Context

To replicate the error in the ticket:
```shell
NOIR_AST_FUZZER_SHOW_AST=1 NOIR_AST_FUZZER_SEED=0xcfb2f7da00100000 cargo test -p noir_ast_fuzzer_fuzz min_vs_full
```


## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
