### PR TITLE
feat(debug): Print ssa locations along with ssa

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3710,6 +3710,7 @@ dependencies = [
  "bn254_blackbox_solver",
  "cfg-if",
  "chrono",
+ "fm",
  "function_name",
  "fxhash",
  "im",

--- a/compiler/noirc_driver/src/lib.rs
+++ b/compiler/noirc_driver/src/lib.rs
@@ -796,7 +796,7 @@ pub fn compile_no_check(
                 &context.file_manager,
             )?
         } else {
-            create_program(program, &ssa_evaluator_options, &context.file_manager)?
+            create_program(program, &ssa_evaluator_options, Some(&context.file_manager))?
         };
 
     let abi = gen_abi(context, &main_function, return_visibility, error_types);

--- a/compiler/noirc_driver/src/lib.rs
+++ b/compiler/noirc_driver/src/lib.rs
@@ -790,9 +790,13 @@ pub fn compile_no_check(
 
     let SsaProgramArtifact { program, debug, warnings, names, brillig_names, error_types, .. } =
         if options.minimal_ssa {
-            create_program_with_minimal_passes(program, &ssa_evaluator_options)?
+            create_program_with_minimal_passes(
+                program,
+                &ssa_evaluator_options,
+                &context.file_manager,
+            )?
         } else {
-            create_program(program, &ssa_evaluator_options)?
+            create_program(program, &ssa_evaluator_options, &context.file_manager)?
         };
 
     let abi = gen_abi(context, &main_function, return_visibility, error_types);

--- a/compiler/noirc_evaluator/Cargo.toml
+++ b/compiler/noirc_evaluator/Cargo.toml
@@ -34,6 +34,7 @@ cfg-if.workspace = true
 smallvec = { version = "1.13.2", features = ["serde"] }
 vec-collections = "0.4.3"
 petgraph.workspace = true
+fm.workspace = true
 
 [dev-dependencies]
 proptest.workspace = true

--- a/compiler/noirc_evaluator/src/acir/tests/mod.rs
+++ b/compiler/noirc_evaluator/src/acir/tests/mod.rs
@@ -560,7 +560,6 @@ fn brillig_stdlib_calls_with_regular_brillig_call() {
     let ssa = builder.finish();
     // We need to generate  Brillig artifacts for the regular Brillig function and pass them to the ACIR generation pass.
     let brillig = ssa.to_brillig(&BrilligOptions::default());
-    println!("{}", ssa);
 
     let (acir_functions, brillig_functions, _, _) = ssa
         .generate_entry_point_index()
@@ -645,7 +644,6 @@ fn brillig_stdlib_calls_with_multiple_acir_calls() {
     let ssa = builder.finish();
     // We need to generate  Brillig artifacts for the regular Brillig function and pass them to the ACIR generation pass.
     let brillig = ssa.to_brillig(&BrilligOptions::default());
-    println!("{}", ssa);
 
     let (acir_functions, brillig_functions, _, _) = ssa
         .generate_entry_point_index()

--- a/compiler/noirc_evaluator/src/ssa.rs
+++ b/compiler/noirc_evaluator/src/ssa.rs
@@ -767,7 +767,7 @@ impl<'local> SsaBuilder<'local> {
         };
 
         if print_ssa_pass {
-            println!("After {msg}:\n{}", self.ssa.print_with_files(self.files));
+            println!("After {msg}:\n{}", self.ssa.print_with(self.files));
         }
         self
     }

--- a/compiler/noirc_evaluator/src/ssa.rs
+++ b/compiler/noirc_evaluator/src/ssa.rs
@@ -653,7 +653,9 @@ pub struct SsaBuilder<'local> {
     /// List of SSA pass message fragments that we want to skip, for testing purposes.
     pub skip_passes: Vec<String>,
 
-    pub files: &'local fm::FileManager,
+    /// Providing a file manager is optional - if provided it can be used to print source
+    /// locations along with each ssa instructions when debugging.
+    pub files: Option<&'local fm::FileManager>,
 }
 
 impl<'local> SsaBuilder<'local> {
@@ -674,14 +676,15 @@ impl<'local> SsaBuilder<'local> {
             let ssa_path = emit_ssa.with_extension("ssa.json");
             write_to_file(&serde_json::to_vec(&ssa).unwrap(), &ssa_path);
         }
-        Ok(Self::from_ssa(ssa, ssa_logging, print_codegen_timings, files).print("Initial SSA"))
+        Ok(Self::from_ssa(ssa, ssa_logging, print_codegen_timings, Some(files))
+            .print("Initial SSA"))
     }
 
     pub fn from_ssa(
         ssa: Ssa,
         ssa_logging: SsaLogging,
         print_codegen_timings: bool,
-        files: &'local fm::FileManager,
+        files: Option<&'local fm::FileManager>,
     ) -> Self {
         Self {
             ssa_logging,

--- a/compiler/noirc_evaluator/src/ssa.rs
+++ b/compiler/noirc_evaluator/src/ssa.rs
@@ -358,7 +358,7 @@ pub fn optimize_into_acir<S>(
     options: &SsaEvaluatorOptions,
     primary: &[SsaPass],
     secondary: S,
-    files: &fm::FileManager,
+    files: Option<&fm::FileManager>,
 ) -> Result<ArtifactsAndWarnings, RuntimeError>
 where
     S: for<'b> Fn(&'b Brillig) -> Vec<SsaPass<'b>>,
@@ -443,7 +443,7 @@ impl SsaProgramArtifact {
 pub fn create_program(
     program: Program,
     options: &SsaEvaluatorOptions,
-    files: &fm::FileManager,
+    files: Option<&fm::FileManager>,
 ) -> Result<SsaProgramArtifact, RuntimeError> {
     create_program_with_passes(program, options, &primary_passes(options), secondary_passes, files)
 }
@@ -465,7 +465,7 @@ pub fn create_program_with_minimal_passes(
             func.name
         );
     }
-    create_program_with_passes(program, options, &minimal_passes(), |_| vec![], files)
+    create_program_with_passes(program, options, &minimal_passes(), |_| vec![], Some(files))
 }
 
 /// Compiles the [`Program`] into [`ACIR`][acvm::acir::circuit::Program] by running it through
@@ -476,7 +476,7 @@ pub fn create_program_with_passes<S>(
     options: &SsaEvaluatorOptions,
     primary: &[SsaPass],
     secondary: S,
-    files: &fm::FileManager,
+    files: Option<&fm::FileManager>,
 ) -> Result<SsaProgramArtifact, RuntimeError>
 where
     S: for<'b> Fn(&'b Brillig) -> Vec<SsaPass<'b>>,
@@ -664,7 +664,7 @@ impl<'local> SsaBuilder<'local> {
         ssa_logging: SsaLogging,
         print_codegen_timings: bool,
         emit_ssa: &Option<PathBuf>,
-        files: &'local fm::FileManager,
+        files: Option<&'local fm::FileManager>,
     ) -> Result<Self, RuntimeError> {
         let ssa = ssa_gen::generate_ssa(program)?;
         if let Some(emit_ssa) = emit_ssa {
@@ -676,8 +676,7 @@ impl<'local> SsaBuilder<'local> {
             let ssa_path = emit_ssa.with_extension("ssa.json");
             write_to_file(&serde_json::to_vec(&ssa).unwrap(), &ssa_path);
         }
-        Ok(Self::from_ssa(ssa, ssa_logging, print_codegen_timings, Some(files))
-            .print("Initial SSA"))
+        Ok(Self::from_ssa(ssa, ssa_logging, print_codegen_timings, files).print("Initial SSA"))
     }
 
     pub fn from_ssa(

--- a/compiler/noirc_evaluator/src/ssa.rs
+++ b/compiler/noirc_evaluator/src/ssa.rs
@@ -287,6 +287,7 @@ where
     let ssa_gen_span_guard = ssa_gen_span.enter();
     let mut builder = builder.with_skip_passes(options.skip_passes.clone()).run_passes(primary)?;
     let passed = std::mem::take(&mut builder.passed);
+    let files = builder.files;
     let mut ssa = builder.finish();
 
     let mut ssa_level_warnings = vec![];
@@ -300,12 +301,16 @@ where
     let ssa_gen_span = span!(Level::TRACE, "ssa_generation");
     let ssa_gen_span_guard = ssa_gen_span.enter();
 
-    let mut ssa =
-        SsaBuilder::from_ssa(ssa, options.ssa_logging.clone(), options.print_codegen_timings)
-            .with_passed(passed)
-            .with_skip_passes(options.skip_passes.clone())
-            .run_passes(&secondary(&brillig))?
-            .finish();
+    let mut ssa = SsaBuilder::from_ssa(
+        ssa,
+        options.ssa_logging.clone(),
+        options.print_codegen_timings,
+        files,
+    )
+    .with_passed(passed)
+    .with_skip_passes(options.skip_passes.clone())
+    .run_passes(&secondary(&brillig))?
+    .finish();
 
     if !options.skip_underconstrained_check {
         ssa_level_warnings.extend(time(
@@ -353,6 +358,7 @@ pub fn optimize_into_acir<S>(
     options: &SsaEvaluatorOptions,
     primary: &[SsaPass],
     secondary: S,
+    files: &fm::FileManager,
 ) -> Result<ArtifactsAndWarnings, RuntimeError>
 where
     S: for<'b> Fn(&'b Brillig) -> Vec<SsaPass<'b>>,
@@ -362,6 +368,7 @@ where
         options.ssa_logging.clone(),
         options.print_codegen_timings,
         &options.emit_ssa,
+        files,
     )?;
 
     optimize_ssa_builder_into_acir(builder, options, primary, secondary)
@@ -436,8 +443,9 @@ impl SsaProgramArtifact {
 pub fn create_program(
     program: Program,
     options: &SsaEvaluatorOptions,
+    files: &fm::FileManager,
 ) -> Result<SsaProgramArtifact, RuntimeError> {
-    create_program_with_passes(program, options, &primary_passes(options), secondary_passes)
+    create_program_with_passes(program, options, &primary_passes(options), secondary_passes, files)
 }
 
 /// Compiles the [`Program`] into [`ACIR`][acvm::acir::circuit::Program] using the minimum amount of SSA passes.
@@ -448,6 +456,7 @@ pub fn create_program(
 pub fn create_program_with_minimal_passes(
     program: Program,
     options: &SsaEvaluatorOptions,
+    files: &fm::FileManager,
 ) -> Result<SsaProgramArtifact, RuntimeError> {
     for func in &program.functions {
         assert!(
@@ -456,7 +465,7 @@ pub fn create_program_with_minimal_passes(
             func.name
         );
     }
-    create_program_with_passes(program, options, &minimal_passes(), |_| vec![])
+    create_program_with_passes(program, options, &minimal_passes(), |_| vec![], files)
 }
 
 /// Compiles the [`Program`] into [`ACIR`][acvm::acir::circuit::Program] by running it through
@@ -467,6 +476,7 @@ pub fn create_program_with_passes<S>(
     options: &SsaEvaluatorOptions,
     primary: &[SsaPass],
     secondary: S,
+    files: &fm::FileManager,
 ) -> Result<SsaProgramArtifact, RuntimeError>
 where
     S: for<'b> Fn(&'b Brillig) -> Vec<SsaPass<'b>>,
@@ -480,7 +490,7 @@ where
     let ArtifactsAndWarnings(
         (generated_acirs, generated_brillig, brillig_function_names, error_types),
         ssa_level_warnings,
-    ) = optimize_into_acir(program, options, primary, secondary)?;
+    ) = optimize_into_acir(program, options, primary, secondary, files)?;
 
     assert_eq!(
         generated_acirs.len(),
@@ -630,7 +640,7 @@ fn split_public_and_private_inputs(
 }
 
 // This is just a convenience object to bundle the ssa with `print_ssa_passes` for debug printing.
-pub struct SsaBuilder {
+pub struct SsaBuilder<'local> {
     /// The SSA being built; it is the input and the output of every pass ran by the builder.
     pub ssa: Ssa,
     /// Options to control which SSA passes to print.
@@ -642,14 +652,17 @@ pub struct SsaBuilder {
     pub passed: HashMap<String, usize>,
     /// List of SSA pass message fragments that we want to skip, for testing purposes.
     pub skip_passes: Vec<String>,
+
+    pub files: &'local fm::FileManager,
 }
 
-impl SsaBuilder {
+impl<'local> SsaBuilder<'local> {
     pub fn from_program(
         program: Program,
         ssa_logging: SsaLogging,
         print_codegen_timings: bool,
         emit_ssa: &Option<PathBuf>,
+        files: &'local fm::FileManager,
     ) -> Result<Self, RuntimeError> {
         let ssa = ssa_gen::generate_ssa(program)?;
         if let Some(emit_ssa) = emit_ssa {
@@ -661,14 +674,20 @@ impl SsaBuilder {
             let ssa_path = emit_ssa.with_extension("ssa.json");
             write_to_file(&serde_json::to_vec(&ssa).unwrap(), &ssa_path);
         }
-        Ok(Self::from_ssa(ssa, ssa_logging, print_codegen_timings).print("Initial SSA"))
+        Ok(Self::from_ssa(ssa, ssa_logging, print_codegen_timings, files).print("Initial SSA"))
     }
 
-    pub fn from_ssa(ssa: Ssa, ssa_logging: SsaLogging, print_codegen_timings: bool) -> Self {
+    pub fn from_ssa(
+        ssa: Ssa,
+        ssa_logging: SsaLogging,
+        print_codegen_timings: bool,
+        files: &'local fm::FileManager,
+    ) -> Self {
         Self {
             ssa_logging,
             print_codegen_timings,
             ssa,
+            files,
             passed: Default::default(),
             skip_passes: Default::default(),
         }
@@ -745,7 +764,7 @@ impl SsaBuilder {
         };
 
         if print_ssa_pass {
-            println!("After {msg}:\n{}", self.ssa);
+            println!("After {msg}:\n{}", self.ssa.print_with_files(self.files));
         }
         self
     }

--- a/compiler/noirc_evaluator/src/ssa/ir/printer.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/printer.rs
@@ -32,7 +32,7 @@ impl Ssa {
         Printer { ssa: self, fm: None }
     }
 
-    pub fn print_with_files<'local>(
+    pub fn print_with<'local>(
         &'local self,
         files: Option<&'local fm::FileManager>,
     ) -> Printer<'local> {

--- a/compiler/noirc_evaluator/src/ssa/ir/printer.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/printer.rs
@@ -28,15 +28,15 @@ pub struct Printer<'local> {
 }
 
 impl Ssa {
-    pub fn print_without_files<'local>(&'local self) -> Printer<'local> {
+    pub fn print_without_locations<'local>(&'local self) -> Printer<'local> {
         Printer { ssa: self, fm: None }
     }
 
     pub fn print_with_files<'local>(
         &'local self,
-        files: &'local fm::FileManager,
+        files: Option<&'local fm::FileManager>,
     ) -> Printer<'local> {
-        Printer { ssa: self, fm: Some(files) }
+        Printer { ssa: self, fm: files }
     }
 }
 
@@ -424,15 +424,15 @@ fn display_constrain_error(
 ) -> Result {
     match error {
         ConstrainError::StaticString(assert_message_string) => {
-            writeln!(f, ", {assert_message_string:?}")
+            write!(f, ", {assert_message_string:?}")
         }
         ConstrainError::Dynamic(_, is_string, values) => {
             if let Some(constant_string) =
                 try_to_extract_string_from_error_payload(*is_string, values, dfg)
             {
-                writeln!(f, ", {constant_string:?}")
+                write!(f, ", {constant_string:?}")
             } else {
-                writeln!(f, ", data {}", value_list(dfg, values))
+                write!(f, ", data {}", value_list(dfg, values))
             }
         }
     }

--- a/compiler/noirc_evaluator/src/ssa/ir/printer.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/printer.rs
@@ -28,7 +28,7 @@ pub struct Printer<'local> {
 }
 
 impl Ssa {
-    pub fn print_without_locations<'local>(&'local self) -> Printer<'local> {
+    pub fn print_without_locations(&self) -> Printer {
         Printer { ssa: self, fm: None }
     }
 
@@ -40,7 +40,7 @@ impl Ssa {
     }
 }
 
-impl<'local> Display for Printer<'local> {
+impl Display for Printer<'_> {
     fn fmt(&self, f: &mut Formatter) -> Result {
         let globals = (*self.ssa.functions[&self.ssa.main_id].dfg.globals).clone();
         let globals_dfg = DataFlowGraph::from(globals);

--- a/compiler/noirc_evaluator/src/ssa/opt/defunctionalize.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/defunctionalize.rs
@@ -1318,7 +1318,6 @@ mod tests {
 
         let ssa = Ssa::from_str(src).unwrap();
         let ssa = ssa.defunctionalize();
-        println!("{}", ssa);
 
         assert_ssa_snapshot!(ssa, @r"
         acir(inline) fn main f0 {

--- a/compiler/noirc_evaluator/src/ssa/opt/hint.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/hint.rs
@@ -24,8 +24,7 @@ mod tests {
             skip_passes: Default::default(),
         };
 
-        let builder = SsaBuilder::from_ssa(ssa, options.ssa_logging.clone(), false);
-
+        let builder = SsaBuilder::from_ssa(ssa, options.ssa_logging.clone(), false, None);
         Ok(builder.run_passes(&primary_passes(options))?.finish())
     }
 

--- a/compiler/noirc_evaluator/src/ssa/opt/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/mod.rs
@@ -64,10 +64,10 @@ pub(crate) fn assert_normalized_ssa_equals(mut ssa: super::Ssa, expected: &str) 
 
     ssa.normalize_ids();
 
-    let ssa = ssa.to_string();
+    let ssa = ssa.print_without_locations().to_string();
     let ssa = ssa.trim_end();
 
-    let expected_ssa = expected_ssa.to_string();
+    let expected_ssa = expected_ssa.print_without_locations().to_string();
     let expected_ssa = expected_ssa.trim_end();
 
     if ssa == expected_ssa {
@@ -112,6 +112,7 @@ macro_rules! assert_ssa_snapshot {
         #[allow(unused_mut)]
         let mut mut_ssa = $ssa;
         mut_ssa.normalize_ids();
-        insta::assert_snapshot!(mut_ssa, $($arg)*)
+        let ssa_string = mut_ssa.print_without_locations().to_string();
+        insta::assert_snapshot!(ssa_string, $($arg)*)
     };
 }

--- a/compiler/noirc_evaluator/src/ssa/opt/unrolling.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/unrolling.rs
@@ -1328,7 +1328,7 @@ mod tests {
         let (ssa, errors) = try_unroll_loops(ssa);
         assert_eq!(errors.len(), 0, "Unroll should have no errors");
         // Check that it's still the original
-        assert_normalized_ssa_equals(ssa, parse_ssa().to_string().as_str());
+        assert_normalized_ssa_equals(ssa, &parse_ssa().print_without_locations().to_string());
     }
 
     #[test]
@@ -1336,7 +1336,8 @@ mod tests {
         let ssa = brillig_unroll_test_case();
         let ssa = ssa.unroll_loops_iteratively(Some(-90)).unwrap();
         // Check that it's still the original
-        assert_normalized_ssa_equals(ssa, brillig_unroll_test_case().to_string().as_str());
+        let expected = brillig_unroll_test_case();
+        assert_normalized_ssa_equals(ssa, &expected.print_without_locations().to_string());
     }
 
     #[test]

--- a/compiler/noirc_evaluator/src/ssa/parser/tests.rs
+++ b/compiler/noirc_evaluator/src/ssa/parser/tests.rs
@@ -7,7 +7,7 @@ use crate::{
 
 fn assert_ssa_roundtrip(src: &str) {
     let ssa = Ssa::from_str(src).unwrap();
-    let ssa = ssa.to_string();
+    let ssa = ssa.print_without_locations().to_string();
     let ssa = trim_leading_whitespace_from_lines(&ssa);
     let src = trim_leading_whitespace_from_lines(src);
     if ssa != src {

--- a/compiler/noirc_evaluator/src/ssa/ssa_gen/program.rs
+++ b/compiler/noirc_evaluator/src/ssa/ssa_gen/program.rs
@@ -131,7 +131,7 @@ mod test {
         let ssa = builder.finish();
         let serialized_ssa = &serde_json::to_string(&ssa).unwrap();
         let deserialized_ssa: Ssa = serde_json::from_str(serialized_ssa).unwrap();
-        let actual_string = format!("{}", deserialized_ssa);
+        let actual_string = format!("{}", deserialized_ssa.print_without_locations());
 
         let expected_string = "acir(inline) fn main f0 {\n  \
         b0(v0: Field):\n    \

--- a/tooling/ast_fuzzer/fuzz/src/lib.rs
+++ b/tooling/ast_fuzzer/fuzz/src/lib.rs
@@ -77,12 +77,14 @@ where
         eprintln!("---\n{}\n---", DisplayAstAsNoir(&program));
     }
 
-    ssa::create_program_with_passes(program, options, primary, secondary).unwrap_or_else(|e| {
-        panic!(
-            "failed to compile program: {}{e}",
-            msg.map(|s| format!("{s}: ")).unwrap_or_default()
-        )
-    })
+    ssa::create_program_with_passes(program, options, primary, secondary, None).unwrap_or_else(
+        |e| {
+            panic!(
+                "failed to compile program: {}{e}",
+                msg.map(|s| format!("{s}: ")).unwrap_or_default()
+            )
+        },
+    )
 }
 
 /// Compare the execution result and print the inputs if the result is a failure.
@@ -193,11 +195,15 @@ pub fn compare_results_interpreted(
 
         eprintln!(
             "---\nSSA 1 after step {} ({}):\n{}",
-            inputs.ssa1.step, inputs.ssa1.msg, inputs.ssa1.ssa
+            inputs.ssa1.step,
+            inputs.ssa1.msg,
+            inputs.ssa2.ssa.print_without_locations()
         );
         eprintln!(
             "---\nSSA 2 after step {} ({}):\n{}",
-            inputs.ssa2.step, inputs.ssa2.msg, inputs.ssa2.ssa
+            inputs.ssa2.step,
+            inputs.ssa2.msg,
+            inputs.ssa2.ssa.print_without_locations()
         );
 
         // Returning it as-is, so we can see the error message at the bottom as well.

--- a/tooling/ast_fuzzer/src/compare/interpreted.rs
+++ b/tooling/ast_fuzzer/src/compare/interpreted.rs
@@ -93,7 +93,7 @@ impl CompareInterpreted {
             "SSA after step {} ({}):\n{}\n",
             self.ssa1.step,
             self.ssa1.msg,
-            self.ssa1.ssa.print_without_files()
+            self.ssa1.ssa.print_without_locations()
         );
 
         // Interpret an SSA with a fresh copy of the input values.

--- a/tooling/ast_fuzzer/src/compare/interpreted.rs
+++ b/tooling/ast_fuzzer/src/compare/interpreted.rs
@@ -89,7 +89,12 @@ impl CompareInterpreted {
                 .collect::<Vec<_>>()
                 .join("\n")
         );
-        log::debug!("SSA after step {} ({}):\n{}\n", self.ssa1.step, self.ssa1.msg, self.ssa1.ssa);
+        log::debug!(
+            "SSA after step {} ({}):\n{}\n",
+            self.ssa1.step,
+            self.ssa1.msg,
+            self.ssa1.ssa.print_without_files()
+        );
 
         // Interpret an SSA with a fresh copy of the input values.
         let interpret = |ssa: &Ssa| ssa.interpret(Value::snapshot_args(&self.ssa_args));

--- a/tooling/ast_fuzzer/tests/parser.rs
+++ b/tooling/ast_fuzzer/tests/parser.rs
@@ -76,12 +76,13 @@ fn arb_ssa_roundtrip() {
         ssa1.normalize_ids();
 
         // Print to str and parse back.
-        let ssa2 = Ssa::from_str_no_validation(&ssa1.to_string()).unwrap_or_else(|e| {
-            let msg = passes.last().map(|p| p.msg()).unwrap_or("Initial SSA");
-            print_ast_and_panic(&format!(
-                "Could not parse SSA after step {last_pass} ({msg}): \n{e:?}"
-            ))
-        });
+        let ssa2 = Ssa::from_str_no_validation(&ssa1.print_without_locations().to_string())
+            .unwrap_or_else(|e| {
+                let msg = passes.last().map(|p| p.msg()).unwrap_or("Initial SSA");
+                print_ast_and_panic(&format!(
+                    "Could not parse SSA after step {last_pass} ({msg}): \n{e:?}"
+                ))
+            });
 
         // Not everything is populated by the parser, and unfortunately serializing to JSON doesn't work either.
         for (func_id, func1) in ssa1.functions {

--- a/tooling/ast_fuzzer/tests/smoke.rs
+++ b/tooling/ast_fuzzer/tests/smoke.rs
@@ -59,7 +59,7 @@ fn arb_program_can_be_executed() {
             eprintln!("{}", DisplayAstAsNoir(&program));
         }
 
-        let ssa = ssa::create_program(program.clone(), &options)
+        let ssa = ssa::create_program(program.clone(), &options, None)
             .unwrap_or_else(|e| print_ast_and_panic(&format!("Failed to compile program: {e}")));
 
         let inputs = arb_inputs(u, &ssa.program, &abi)?;

--- a/tooling/nargo_cli/examples/ssa_pass_impact.rs
+++ b/tooling/nargo_cli/examples/ssa_pass_impact.rs
@@ -275,12 +275,17 @@ fn collect_ssa_before_and_after(
     let mut last_msg = "Initial";
 
     for (i, pass) in passes.iter().enumerate() {
-        let before = pass.msg().contains(name).then(|| format!("{ssa}"));
+        let before =
+            pass.msg().contains(name).then(|| format!("{}", ssa.print_without_locations()));
         ssa = pass.run(ssa)?;
         if let Some(before) = before {
             pairs.push(SsaBeforeAndAfter {
                 before: SsaPrint { step: i, msg: last_msg.to_string(), ssa: before },
-                after: SsaPrint { step: i + 1, msg: pass.msg().to_string(), ssa: format!("{ssa}") },
+                after: SsaPrint {
+                    step: i + 1,
+                    msg: pass.msg().to_string(),
+                    ssa: format!("{}", ssa.print_without_locations()),
+                },
             });
         }
         last_msg = pass.msg();

--- a/tooling/nargo_cli/src/cli/interpret_cmd.rs
+++ b/tooling/nargo_cli/src/cli/interpret_cmd.rs
@@ -283,6 +283,7 @@ fn interpret_ssa(
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 fn print_and_interpret_ssa(
     options: &SsaEvaluatorOptions,
     passes_to_interpret: &[String],

--- a/tooling/nargo_cli/src/cli/interpret_cmd.rs
+++ b/tooling/nargo_cli/src/cli/interpret_cmd.rs
@@ -253,7 +253,7 @@ fn print_ssa(options: &SsaEvaluatorOptions, ssa: &mut Ssa, msg: &str, fm: &FileM
     };
     if print {
         ssa.normalize_ids();
-        println!("After {msg}:\n{}", ssa.print_with_files(fm));
+        println!("After {msg}:\n{}", ssa.print_with_files(Some(fm)));
     }
 }
 

--- a/tooling/nargo_cli/src/cli/interpret_cmd.rs
+++ b/tooling/nargo_cli/src/cli/interpret_cmd.rs
@@ -253,7 +253,7 @@ fn print_ssa(options: &SsaEvaluatorOptions, ssa: &mut Ssa, msg: &str, fm: &FileM
     };
     if print {
         ssa.normalize_ids();
-        println!("After {msg}:\n{}", ssa.print_with_files(Some(fm)));
+        println!("After {msg}:\n{}", ssa.print_with(Some(fm)));
     }
 }
 

--- a/tooling/nargo_cli/src/cli/interpret_cmd.rs
+++ b/tooling/nargo_cli/src/cli/interpret_cmd.rs
@@ -135,6 +135,7 @@ pub(crate) fn run(args: InterpretCommand, workspace: Workspace) -> Result<(), Cl
             &ssa_args,
             &ssa_return,
             interpreter_options,
+            &file_manager,
         )?;
 
         // Run SSA passes in the pipeline and interpret the ones we are interested in.
@@ -157,6 +158,7 @@ pub(crate) fn run(args: InterpretCommand, workspace: Workspace) -> Result<(), Cl
                 &ssa_args,
                 &ssa_return,
                 interpreter_options,
+                &file_manager,
             )?;
         }
     }
@@ -243,7 +245,7 @@ fn msg_matches(patterns: &[String], msg: &str) -> bool {
     patterns.iter().any(|p| msg.contains(&p.to_lowercase()))
 }
 
-fn print_ssa(options: &SsaEvaluatorOptions, ssa: &mut Ssa, msg: &str) {
+fn print_ssa(options: &SsaEvaluatorOptions, ssa: &mut Ssa, msg: &str, fm: &FileManager) {
     let print = match options.ssa_logging {
         SsaLogging::All => true,
         SsaLogging::None => false,
@@ -251,7 +253,7 @@ fn print_ssa(options: &SsaEvaluatorOptions, ssa: &mut Ssa, msg: &str) {
     };
     if print {
         ssa.normalize_ids();
-        println!("After {msg}:\n{ssa}");
+        println!("After {msg}:\n{}", ssa.print_with_files(fm));
     }
 }
 
@@ -289,8 +291,9 @@ fn print_and_interpret_ssa(
     args: &[Value],
     return_value: &Option<Vec<Value>>,
     interpreter_options: InterpreterOptions,
+    fm: &FileManager,
 ) -> Result<(), CliError> {
-    print_ssa(options, ssa, msg);
+    print_ssa(options, ssa, msg, fm);
     interpret_ssa(passes_to_interpret, ssa, msg, args, return_value, interpreter_options)
 }
 

--- a/tooling/ssa_executor/src/compiler.rs
+++ b/tooling/ssa_executor/src/compiler.rs
@@ -57,6 +57,7 @@ pub fn optimize_ssa_into_acir(
             print_codegen_timings: options.print_codegen_timings,
             passed: HashMap::new(),
             skip_passes: vec![],
+            files: None,
         };
         optimize_ssa_builder_into_acir(
             builder,

--- a/tooling/ssa_fuzzer/src/compiler.rs
+++ b/tooling/ssa_fuzzer/src/compiler.rs
@@ -18,7 +18,7 @@ fn optimize_into_acir_and_validate(
     options: SsaEvaluatorOptions,
 ) -> Result<ArtifactsAndWarnings, RuntimeError> {
     let ssa = builder.finish();
-    log::debug!("SSA: {:}", ssa);
+    log::debug!("SSA: {:}", ssa.print_without_locations());
     optimize_ssa_into_acir(ssa, options)
 }
 

--- a/tooling/ssa_verification/src/acir_instruction_builder.rs
+++ b/tooling/ssa_verification/src/acir_instruction_builder.rs
@@ -86,7 +86,7 @@ impl InstructionArtifacts {
         let second_variable_type = Self::get_type(second_variable);
         let ssa = binary_function(op, first_variable_type, second_variable_type);
         let serialized_ssa = &serde_json::to_string(&ssa).unwrap();
-        let formatted_ssa = format!("{}", ssa);
+        let formatted_ssa = format!("{}", ssa.print_without_locations());
 
         let program = ssa_to_acir_program(ssa);
         let serialized_program = AcirProgram::serialize_program(&program);
@@ -118,7 +118,7 @@ impl InstructionArtifacts {
 
     fn new_by_ssa(ssa: Ssa, instruction_name: String, variable: &Variable) -> Self {
         let serialized_ssa = &serde_json::to_string(&ssa).unwrap();
-        let formatted_ssa = format!("{}", ssa);
+        let formatted_ssa = format!("{}", ssa.print_without_locations());
 
         let program = ssa_to_acir_program(ssa);
         let serialized_program = AcirProgram::serialize_program(&program);
@@ -239,6 +239,7 @@ fn ssa_to_acir_program(ssa: Ssa) -> AcirProgram<FieldElement> {
         print_codegen_timings: false,
         passed: HashMap::default(),
         skip_passes: vec![],
+        files: None,
     };
     let ssa_evaluator_options = SsaEvaluatorOptions {
         ssa_logging: SsaLogging::None,


### PR DESCRIPTION
# Description

## Problem\*

Resolves https://github.com/noir-lang/noir/issues/8983

## Summary\*

Prints the top (last) function in the callstack and the source line along with each SSA instruction to help finding where instructions originate from when printing larger files.

This requires we pass a `FileManager` when printing SSA now if you want the debug comments. For ease of debugging, you can still print SSA without this though and we just won't print out the source lines.

## Additional Context

Before this PR (lambda_from_dynamic_if test):

```
After Dead Instruction Elimination - ACIR (1) (step 45):
acir(inline) impure fn main f0 {
  b0(v0: u32):
    v2 = eq v0, u32 0
    v3 = not v2
    v5 = eq v0, u32 1
    v6 = unchecked_mul v3, v5
    v7 = not v5 // src/main.nr:12
    v8 = unchecked_mul v3, v7
    v10 = make_array b"!"
    constrain u1 0 == v8, data v10, Field 0
    v13 = cast v6 as Field
    v15 = mul v13, Field 9
    enable_side_effects u1 1
    v17 = cast v2 as Field
    v18 = cast v3 as Field
    v20 = mul v17, Field 8
    v21 = mul v18, v15
    v22 = add v20, v21
    v23 = eq v22, Field 8
    v26 = make_array b"hi"
    enable_side_effects v23
    call f3(u1 1, v26)
    v28 = not v23
    v29 = eq v22, Field 9
    v30 = unchecked_mul v28, v29
    v34 = make_array b"bye"
    enable_side_effects v30
    ...
```

After this PR:

```
After Dead Instruction Elimination - ACIR (1) (step 45):
acir(inline) impure fn main f0 {
  b0(v0: u32):
    v2 = eq v0, u32 0           // src/main.nr:10
    v3 = not v2         // src/main.nr:10
    v5 = eq v0, u32 1           // src/main.nr:12
    v6 = unchecked_mul v3, v5           // src/main.nr:12
    v7 = not v5         // src/main.nr:12
    v8 = unchecked_mul v3, v7           // src/main.nr:12
    v10 = make_array b"!"               // src/main.nr:12
    constrain u1 0 == v8, data v10, Field 0             // std/panic.nr:2
    v13 = cast v6 as Field
    v15 = mul v13, Field 9
    enable_side_effects u1 1
    v17 = cast v2 as Field
    v18 = cast v3 as Field
    v20 = mul v17, Field 8
    v21 = mul v18, v15
    v22 = add v20, v21
    v23 = eq v22, Field 8               // src/main.nr:17
    v26 = make_array b"hi"              // std/lib.nr:34
    enable_side_effects v23             // src/main.nr:17
    call f3(u1 1, v26)          // std/lib.nr:40
    v28 = not v23               // src/main.nr:17
    v29 = eq v22, Field 9               // src/main.nr:17
    v30 = unchecked_mul v28, v29                // src/main.nr:17
    v34 = make_array b"bye"             // std/panic.nr:2
    enable_side_effects v30             // src/main.nr:17
    ...
```

So now the source file and line is given on the side in a comment after two tab characters. We can also clearly see how the value merger doesn't insert any locations for the instructions it inserts.

## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
