### PR TITLE
: Update actions/setup-node from v3 to v4

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
         run: |
             cargo update --workspace
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: 20.18.3
           cache: 'yarn'


### PR DESCRIPTION
This PR updates the Node.js setup action to the latest version.
Updated actions/setup-node from @v3 to @v4

This is the only file in the repository that was still using the old version (v3). Updating it ensures consistency and up-to-date security across all workflows.
https://github.com/actions/setup-node/releases/tag/v4.4.0
