### PR TITLE
chore: redo typo PR by donatik27

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
         run: |
             cargo update --workspace
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: 20.18.3
           cache: 'yarn'

--- a/acvm-repo/acir/src/circuit/opcodes/black_box_function_call.rs
+++ b/acvm-repo/acir/src/circuit/opcodes/black_box_function_call.rs
@@ -158,6 +158,12 @@ pub enum BlackBoxFuncCall<F> {
     ///       For more context regarding malleability you can reference BIP 0062.
     ///     - the hash of the message, as a vector of bytes
     /// - output: 0 for failure and 1 for success
+    ///
+    /// Expected backend behavior:
+    /// - The backend MAY fail to prove this opcode if the public key is not on the secp256k1 curve.
+    ///    - Otherwise the backend MUST constrain the output to be false.
+    /// - The backend MUST constrain the output to be false if `s` is not normalized.
+    /// - The backend MUST constrain the output to match the signature's validity.
     EcdsaSecp256k1 {
         public_key_x: Box<[FunctionInput<F>; 32]>,
         public_key_y: Box<[FunctionInput<F>; 32]>,


### PR DESCRIPTION
Thanks donatik27 for https://github.com/noir-lang/noir/pull/9003. Our policy is to redo typo changes to dissuade metric farming. This is an automated script.