### PR TITLE
feat: `nargo expand` for LSP

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3503,6 +3503,7 @@ dependencies = [
  "fxhash",
  "iter-extended",
  "nargo",
+ "nargo_expand",
  "nargo_fmt",
  "nargo_toml",
  "noirc_driver",

--- a/tooling/lsp/Cargo.toml
+++ b/tooling/lsp/Cargo.toml
@@ -16,6 +16,7 @@ workspace = true
 acvm.workspace = true
 codespan-lsp.workspace = true
 nargo = { workspace = true, features = ["rpc"] }
+nargo_expand.workspace = true
 nargo_fmt.workspace = true
 nargo_toml.workspace = true
 noirc_driver.workspace = true

--- a/tooling/lsp/src/lib.rs
+++ b/tooling/lsp/src/lib.rs
@@ -80,6 +80,8 @@ use solver::WrapperSolver;
 use types::{NargoTest, NargoTestId, Position, Range, Url, notification, request};
 use with_file::parsed_module_with_file;
 
+use crate::{requests::on_expand_request, types::request::NargoExpand};
+
 #[derive(Debug, Error)]
 pub enum LspError {
     /// Error while Resolving Workspace.
@@ -170,6 +172,7 @@ impl NargoLspService {
             .request::<SignatureHelpRequest, _>(on_signature_help_request)
             .request::<CodeActionRequest, _>(on_code_action_request)
             .request::<WorkspaceSymbolRequest, _>(on_workspace_symbol_request)
+            .request::<NargoExpand, _>(on_expand_request)
             .notification::<notification::Initialized>(on_initialized)
             .notification::<notification::DidChangeConfiguration>(on_did_change_configuration)
             .notification::<notification::DidOpenTextDocument>(on_did_open_text_document)

--- a/tooling/lsp/src/requests/code_action.rs
+++ b/tooling/lsp/src/requests/code_action.rs
@@ -67,7 +67,7 @@ pub(crate) fn on_code_action_request(
                     byte_range,
                     args.crate_id,
                     args.def_maps,
-                    args.dependencies,
+                    args.dependencies(),
                     args.interner,
                     args.usage_tracker,
                 );

--- a/tooling/lsp/src/requests/completion.rs
+++ b/tooling/lsp/src/requests/completion.rs
@@ -86,7 +86,7 @@ pub(crate) fn on_completion_request(
                     byte,
                     args.crate_id,
                     args.def_maps,
-                    args.dependencies,
+                    args.dependencies(),
                     args.interner,
                 );
                 finder.find(&parsed_module)

--- a/tooling/lsp/src/requests/expand.rs
+++ b/tooling/lsp/src/requests/expand.rs
@@ -1,0 +1,26 @@
+use std::future;
+
+use async_lsp::{ResponseError, lsp_types::TextDocumentPositionParams};
+use nargo_expand::get_expanded_crate;
+
+use crate::{
+    LspState,
+    requests::process_request,
+    types::{NargoExpandParams, NargoExpandResult},
+};
+
+pub(crate) fn on_expand_request(
+    state: &mut LspState,
+    params: NargoExpandParams,
+) -> impl Future<Output = Result<NargoExpandResult, ResponseError>> + use<> {
+    let text_document_position_params = TextDocumentPositionParams {
+        text_document: params.text_document,
+        position: params.position,
+    };
+
+    let result = process_request(state, text_document_position_params, |args| {
+        get_expanded_crate(args.crate_id, args.crate_graph, args.def_maps, args.interner)
+    });
+
+    future::ready(result)
+}

--- a/tooling/lsp/src/requests/hover/from_reference.rs
+++ b/tooling/lsp/src/requests/hover/from_reference.rs
@@ -85,7 +85,7 @@ fn format_module(id: ModuleId, args: &ProcessRequestCallbackArgs) -> Option<Stri
     let mut string = String::new();
 
     if id.local_id == crate_root {
-        let dep = args.dependencies.iter().find(|dep| dep.crate_id == id.krate)?;
+        let dep = args.dependencies().iter().find(|dep| dep.crate_id == id.krate)?;
         string.push_str("    crate ");
         string.push_str(&dep.name.to_string());
     } else {
@@ -682,8 +682,13 @@ fn format_parent_module_from_module_id(
     args: &ProcessRequestCallbackArgs,
     string: &mut String,
 ) -> bool {
-    let full_path =
-        module_full_path(module, args.interner, args.crate_id, &args.crate_name, args.dependencies);
+    let full_path = module_full_path(
+        module,
+        args.interner,
+        args.crate_id,
+        &args.crate_name,
+        args.dependencies(),
+    );
     if full_path.is_empty() {
         return false;
     }

--- a/tooling/lsp/src/types.rs
+++ b/tooling/lsp/src/types.rs
@@ -1,7 +1,8 @@
 use async_lsp::lsp_types::{
     CodeActionOptions, CompletionOptions, DeclarationCapability, DefinitionOptions,
     DocumentSymbolOptions, HoverOptions, InlayHintOptions, OneOf, ReferencesOptions, RenameOptions,
-    SignatureHelpOptions, TypeDefinitionProviderCapability, WorkspaceSymbolOptions,
+    SignatureHelpOptions, TextDocumentIdentifier, TypeDefinitionProviderCapability,
+    WorkspaceSymbolOptions,
 };
 use noirc_frontend::graph::CrateName;
 use serde::{Deserialize, Serialize};
@@ -16,6 +17,8 @@ pub(crate) use async_lsp::lsp_types::{
 
 pub(crate) mod request {
     use async_lsp::lsp_types::{InitializeParams, request::Request};
+
+    use crate::types::{NargoExpandParams, NargoExpandResult};
 
     use super::{
         InitializeResult, NargoTestRunParams, NargoTestRunResult, NargoTestsParams,
@@ -50,6 +53,14 @@ pub(crate) mod request {
         type Params = NargoTestsParams;
         type Result = NargoTestsResult;
         const METHOD: &'static str = "nargo/tests";
+    }
+
+    #[derive(Debug)]
+    pub(crate) struct NargoExpand;
+    impl Request for NargoExpand {
+        type Params = NargoExpandParams;
+        type Result = NargoExpandResult;
+        const METHOD: &'static str = "nargo/expand";
     }
 }
 
@@ -244,6 +255,15 @@ pub(crate) struct NargoTestRunResult {
     pub(crate) result: String,
     pub(crate) message: Option<String>,
 }
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct NargoExpandParams {
+    pub(crate) text_document: TextDocumentIdentifier,
+    pub(crate) position: Position,
+}
+
+pub(crate) type NargoExpandResult = String;
 
 pub(crate) type CodeLensResult = Option<Vec<CodeLens>>;
 pub(crate) type GotoDefinitionResult = Option<async_lsp::lsp_types::GotoDefinitionResponse>;

--- a/tooling/nargo_cli/src/cli/expand_cmd.rs
+++ b/tooling/nargo_cli/src/cli/expand_cmd.rs
@@ -71,5 +71,5 @@ fn get_expanded_package_or_error(
 
     check_crate_and_report_errors(&mut context, crate_id, compile_options)?;
 
-    Ok(get_expanded_crate(&context, crate_id))
+    Ok(get_expanded_crate(crate_id, &context.crate_graph, &context.def_maps, &context.def_interner))
 }

--- a/tooling/nargo_expand/src/lib.rs
+++ b/tooling/nargo_expand/src/lib.rs
@@ -1,7 +1,11 @@
+use std::collections::BTreeMap;
+
 use nargo_fmt::ImportsGranularity;
 use noirc_driver::CrateId;
 use noirc_frontend::{
-    hir::{Context, def_map::ModuleId},
+    graph::CrateGraph,
+    hir::def_map::{CrateDefMap, ModuleId},
+    node_interner::NodeInterner,
     parse_program_with_dummy_file,
 };
 
@@ -11,24 +15,24 @@ mod items;
 mod printer;
 
 /// Returns the expanded code for the given crate.
-/// Note that `context` must have `activate_lsp_mode` called on it before invoking this function.
-pub fn get_expanded_crate(context: &Context, crate_id: CrateId) -> String {
-    let root_module_id = context.def_maps[&crate_id].root();
+/// Note that `context` that holds the crate graph, def maps and interner
+/// must have `activate_lsp_mode` called on it before invoking this function.
+pub fn get_expanded_crate(
+    crate_id: CrateId,
+    crate_graph: &CrateGraph,
+    def_maps: &BTreeMap<CrateId, CrateDefMap>,
+    interner: &NodeInterner,
+) -> String {
+    let root_module_id = def_maps[&crate_id].root();
     let module_id = ModuleId { krate: crate_id, local_id: root_module_id };
 
-    let mut builder = ItemBuilder::new(crate_id, &context.def_interner, &context.def_maps);
+    let mut builder = ItemBuilder::new(crate_id, interner, def_maps);
     let item = builder.build_module(module_id);
 
-    let dependencies = &context.crate_graph[context.root_crate_id()].dependencies;
+    let dependencies = &crate_graph[crate_id].dependencies;
 
     let mut string = String::new();
-    let mut printer = ItemPrinter::new(
-        crate_id,
-        &context.def_interner,
-        &context.def_maps,
-        dependencies,
-        &mut string,
-    );
+    let mut printer = ItemPrinter::new(crate_id, interner, def_maps, dependencies, &mut string);
     printer.show_item(item);
 
     let (parsed_module, errors) = parse_program_with_dummy_file(&string);


### PR DESCRIPTION
# Description

## Problem

No issue, just something nice to have: allow invoking `nargo expand` via LSP.

## Summary

Goes together with https://github.com/noir-lang/vscode-noir/pull/104

## Additional Context



## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
