### PR TITLE
fix(fuzz): Consider `==` turning into `!=` equivalent

### DIFF
--- a/tooling/ast_fuzzer/src/compare/interpreted.rs
+++ b/tooling/ast_fuzzer/src/compare/interpreted.rs
@@ -173,11 +173,22 @@ impl Comparable for ssa::interpreter::errors::InterpreterError {
             | (
                 ConstrainNeFailed { lhs: _lhs1, rhs: _rhs1, msg: msg1, .. },
                 ConstrainNeFailed { lhs: _lhs2, rhs: _rhs2, msg: msg2, .. },
+            )
+            | (
+                ConstrainNeFailed { lhs: _lhs1, rhs: _rhs1, msg: msg1, .. },
+                ConstrainEqFailed { lhs: _lhs2, rhs: _rhs2, msg: msg2, .. },
+            )
+            | (
+                ConstrainEqFailed { lhs: _lhs1, rhs: _rhs1, msg: msg1, .. },
+                ConstrainNeFailed { lhs: _lhs2, rhs: _rhs2, msg: msg2, .. },
             ) => {
-                // The sides might be flipped: `u1 0 == u1 1` vs `u1 1 == u1 0`.
-                // Unfortunately we often see the type change as well, which makes it more difficult to compare,
-                // for example `Field 313339671284855045676773137498590239475 != Field 0` vs `u128 313339671284855045676773137498590239475 != u128 0`,
-                // or `i64 -1615928006 != i64 -5568658583620095790` vs `u64 18446744072093623610 != u64 12878085490089455826`
+                // The `lhs` and `rhs` might change during passes, making direct comparison difficult:
+                // * the sides might be flipped: `u1 0 == u1 1` vs `u1 1 == u1 0`
+                // * the condition might be flipped: `u1 true != u1 false` vs `Field 0 == Field 0`
+                // * types could change:
+                //      * `Field 313339671284855045676773137498590239475 != Field 0` vs `u128 313339671284855045676773137498590239475 != u128 0`
+                //      * `i64 -1615928006 != i64 -5568658583620095790` vs `u64 18446744072093623610 != u64 12878085490089455826`
+                // So instead of reasoning about the `lhs` and `rhs` formats, let's just compare the message so we know it's the same constraint:
                 // (lhs1 == lhs2 && rhs1 == rhs2 || lhs1 == rhs2 && rhs1 == lhs2) && msg1 == msg2
                 msg1 == msg2
             }


### PR DESCRIPTION
# Description

## Problem\*

Fixes a fuzzing error in https://github.com/noir-lang/noir/actions/runs/15892240538/job/44816776896

## Summary\*

Changes the `Comparable` implementation for the SSA interpreter errors to consider `ConstrainEqFailed` and `ConstrainNeFailed` equivalents, as long as the message is the same.

## Additional Context

Some SSA pass turned a `constrain false == true` into a `constrain 0 != 0`. 

## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
