### PR TITLE
feat: remove `len` argument from `poseidon2_permutation`

### DIFF
--- a/acvm-repo/acir/src/circuit/opcodes/black_box_function_call.rs
+++ b/acvm-repo/acir/src/circuit/opcodes/black_box_function_call.rs
@@ -246,9 +246,6 @@ pub enum BlackBoxFuncCall<F> {
         inputs: Vec<FunctionInput<F>>,
         /// Permuted state
         outputs: Vec<Witness>,
-        /// State length (in number of field elements)
-        /// It is the length of inputs and outputs vectors
-        len: u32,
     },
     /// Applies the SHA-256 compression function to the input message
     ///
@@ -706,11 +703,9 @@ mod arb {
             let case_big_int_to_le_bytes = (any::<u32>(), witness_vec.clone())
                 .prop_map(|(input, outputs)| BlackBoxFuncCall::BigIntToLeBytes { input, outputs });
 
-            let case_poseidon2_permutation = (input_vec.clone(), witness_vec.clone(), any::<u32>())
-                .prop_map(|(inputs, outputs, len)| BlackBoxFuncCall::Poseidon2Permutation {
-                    inputs,
-                    outputs,
-                    len,
+            let case_poseidon2_permutation =
+                (input_vec.clone(), witness_vec.clone()).prop_map(|(inputs, outputs)| {
+                    BlackBoxFuncCall::Poseidon2Permutation { inputs, outputs }
                 });
 
             let case_sha256_compression = (input_arr_16, input_arr_8, witness_arr_8).prop_map(

--- a/acvm-repo/acir/src/proto/acir/circuit.proto
+++ b/acvm-repo/acir/src/proto/acir/circuit.proto
@@ -201,7 +201,6 @@ message BlackBoxFuncCall {
   message Poseidon2Permutation {
     repeated FunctionInput inputs = 1;
     repeated native.Witness outputs = 2;
-    uint32 len = 3;
   }
   message Sha256Compression {
     repeated FunctionInput inputs = 1;

--- a/acvm-repo/acir/src/proto/brillig.proto
+++ b/acvm-repo/acir/src/proto/brillig.proto
@@ -286,7 +286,6 @@ message BlackBoxOp {
   message Poseidon2Permutation {
     HeapVector message = 1;
     HeapArray output = 2;
-    MemoryAddress len = 3;
   }
   message Sha256Compression {
     HeapArray input = 1;

--- a/acvm-repo/acir/src/proto/convert/acir.rs
+++ b/acvm-repo/acir/src/proto/convert/acir.rs
@@ -390,11 +390,10 @@ where
                     outputs: Self::encode_vec(outputs),
                 })
             }
-            opcodes::BlackBoxFuncCall::Poseidon2Permutation { inputs, outputs, len } => {
+            opcodes::BlackBoxFuncCall::Poseidon2Permutation { inputs, outputs } => {
                 Value::Poseidon2Permutation(Poseidon2Permutation {
                     inputs: Self::encode_vec(inputs),
                     outputs: Self::encode_vec(outputs),
-                    len: *len,
                 })
             }
             opcodes::BlackBoxFuncCall::Sha256Compression { inputs, hash_values, outputs } => {
@@ -530,7 +529,6 @@ where
                         Ok(opcodes::BlackBoxFuncCall::Poseidon2Permutation {
                             inputs: Self::decode_vec_wrap(&v.inputs, "inputs")?,
                             outputs: Self::decode_vec_wrap(&v.outputs, "outputs")?,
-                            len: v.len,
                         })
                     }
                     Value::Sha256Compression(v) => {

--- a/acvm-repo/acir/src/proto/convert/brillig.rs
+++ b/acvm-repo/acir/src/proto/convert/brillig.rs
@@ -578,11 +578,10 @@ impl<F> ProtoCodec<brillig::BlackBoxOp, BlackBoxOp> for ProtoSchema<F> {
                     output: Self::encode_some(output),
                 })
             }
-            brillig::BlackBoxOp::Poseidon2Permutation { message, output, len } => {
+            brillig::BlackBoxOp::Poseidon2Permutation { message, output } => {
                 Value::Poseidon2Permutation(Poseidon2Permutation {
                     message: Self::encode_some(message),
                     output: Self::encode_some(output),
-                    len: Self::encode_some(len),
                 })
             }
             brillig::BlackBoxOp::Sha256Compression { input, hash_values, output } => {
@@ -690,7 +689,6 @@ impl<F> ProtoCodec<brillig::BlackBoxOp, BlackBoxOp> for ProtoSchema<F> {
             Value::Poseidon2Permutation(v) => Ok(brillig::BlackBoxOp::Poseidon2Permutation {
                 message: Self::decode_some_wrap(&v.message, "message")?,
                 output: Self::decode_some_wrap(&v.output, "output")?,
-                len: Self::decode_some_wrap(&v.len, "len")?,
             }),
             Value::Sha256Compression(v) => Ok(brillig::BlackBoxOp::Sha256Compression {
                 input: Self::decode_some_wrap(&v.input, "input")?,

--- a/acvm-repo/acvm/src/compiler/transformers/mod.rs
+++ b/acvm-repo/acvm/src/compiler/transformers/mod.rs
@@ -471,7 +471,7 @@ where
             BlackBoxFuncCall::BigIntToLeBytes { input: _, outputs } => {
                 self.fold_many(outputs.iter());
             }
-            BlackBoxFuncCall::Poseidon2Permutation { inputs, outputs, len: _ } => {
+            BlackBoxFuncCall::Poseidon2Permutation { inputs, outputs } => {
                 self.fold_inputs(inputs.as_slice());
                 self.fold_many(outputs.iter());
             }

--- a/acvm-repo/acvm/src/pwg/blackbox/hash.rs
+++ b/acvm-repo/acvm/src/pwg/blackbox/hash.rs
@@ -111,25 +111,14 @@ pub(crate) fn solve_poseidon2_permutation_opcode<F: AcirField>(
     initial_witness: &mut WitnessMap<F>,
     inputs: &[FunctionInput<F>],
     outputs: &[Witness],
-    len: u32,
 ) -> Result<(), OpcodeResolutionError<F>> {
-    if len as usize != inputs.len() {
+    if inputs.len() != outputs.len() {
         return Err(OpcodeResolutionError::BlackBoxFunctionFailed(
             acir::BlackBoxFunc::Poseidon2Permutation,
             format!(
-                "the number of inputs does not match specified length. {} != {}",
+                "the input and output sizes are not consistent. {} != {}",
                 inputs.len(),
-                len
-            ),
-        ));
-    }
-    if len as usize != outputs.len() {
-        return Err(OpcodeResolutionError::BlackBoxFunctionFailed(
-            acir::BlackBoxFunc::Poseidon2Permutation,
-            format!(
-                "the number of outputs does not match specified length. {} != {}",
-                outputs.len(),
-                len
+                outputs.len()
             ),
         ));
     }
@@ -140,7 +129,7 @@ pub(crate) fn solve_poseidon2_permutation_opcode<F: AcirField>(
         .map(|input| input_to_value(initial_witness, *input))
         .collect::<Result<_, _>>()?;
 
-    let state = backend.poseidon2_permutation(&state, len)?;
+    let state = backend.poseidon2_permutation(&state)?;
 
     // Write witness assignments
     for (output_witness, value) in outputs.iter().zip(state.into_iter()) {

--- a/acvm-repo/acvm/src/pwg/blackbox/mod.rs
+++ b/acvm-repo/acvm/src/pwg/blackbox/mod.rs
@@ -166,8 +166,8 @@ pub(crate) fn solve<F: AcirField>(
         BlackBoxFuncCall::Sha256Compression { inputs, hash_values, outputs } => {
             solve_sha_256_permutation_opcode(initial_witness, inputs, hash_values, outputs)
         }
-        BlackBoxFuncCall::Poseidon2Permutation { inputs, outputs, len } => {
-            solve_poseidon2_permutation_opcode(backend, initial_witness, inputs, outputs, *len)
+        BlackBoxFuncCall::Poseidon2Permutation { inputs, outputs } => {
+            solve_poseidon2_permutation_opcode(backend, initial_witness, inputs, outputs)
         }
     }
 }

--- a/acvm-repo/blackbox_solver/src/curve_specific_solver.rs
+++ b/acvm-repo/blackbox_solver/src/curve_specific_solver.rs
@@ -23,11 +23,7 @@ pub trait BlackBoxFunctionSolver<F> {
         input2_y: &F,
         input2_infinite: &F,
     ) -> Result<(F, F, F), BlackBoxResolutionError>;
-    fn poseidon2_permutation(
-        &self,
-        inputs: &[F],
-        len: u32,
-    ) -> Result<Vec<F>, BlackBoxResolutionError>;
+    fn poseidon2_permutation(&self, inputs: &[F]) -> Result<Vec<F>, BlackBoxResolutionError>;
 }
 
 // pedantic_solving: bool
@@ -73,11 +69,7 @@ impl<F> BlackBoxFunctionSolver<F> for StubbedBlackBoxSolver {
     ) -> Result<(F, F, F), BlackBoxResolutionError> {
         Err(Self::fail(BlackBoxFunc::EmbeddedCurveAdd))
     }
-    fn poseidon2_permutation(
-        &self,
-        _inputs: &[F],
-        _len: u32,
-    ) -> Result<Vec<F>, BlackBoxResolutionError> {
+    fn poseidon2_permutation(&self, _inputs: &[F]) -> Result<Vec<F>, BlackBoxResolutionError> {
         Err(Self::fail(BlackBoxFunc::Poseidon2Permutation))
     }
 }

--- a/acvm-repo/bn254_blackbox_solver/src/lib.rs
+++ b/acvm-repo/bn254_blackbox_solver/src/lib.rs
@@ -54,8 +54,7 @@ impl BlackBoxFunctionSolver<FieldElement> for Bn254BlackBoxSolver {
     fn poseidon2_permutation(
         &self,
         inputs: &[FieldElement],
-        len: u32,
     ) -> Result<Vec<FieldElement>, BlackBoxResolutionError> {
-        poseidon2_permutation(inputs, len)
+        poseidon2_permutation(inputs)
     }
 }

--- a/acvm-repo/brillig/src/black_box.rs
+++ b/acvm-repo/brillig/src/black_box.rs
@@ -56,7 +56,7 @@ pub enum BlackBoxOp {
     BigIntToLeBytes { input: MemoryAddress, output: HeapVector },
     /// Applies the Poseidon2 permutation function to the given state,
     /// outputting the permuted state.
-    Poseidon2Permutation { message: HeapVector, output: HeapArray, len: MemoryAddress },
+    Poseidon2Permutation { message: HeapVector, output: HeapArray },
     /// Applies the SHA-256 compression function to the input message
     Sha256Compression { input: HeapArray, hash_values: HeapArray, output: HeapArray },
     /// Returns a decomposition in `num_limbs` limbs of the given input over the given radix.

--- a/acvm-repo/brillig_vm/src/black_box.rs
+++ b/acvm-repo/brillig_vm/src/black_box.rs
@@ -268,11 +268,10 @@ pub(crate) fn evaluate_black_box<F: AcirField, Solver: BlackBoxFunctionSolver<F>
             memory.write_slice(memory.read_ref(output.pointer), &values);
             Ok(())
         }
-        BlackBoxOp::Poseidon2Permutation { message, output, len } => {
+        BlackBoxOp::Poseidon2Permutation { message, output } => {
             let input = read_heap_vector(memory, message);
             let input: Vec<F> = input.iter().map(|x| x.expect_field().unwrap()).collect();
-            let len = memory.read(*len).expect_u32().unwrap();
-            let result = solver.poseidon2_permutation(&input, len)?;
+            let result = solver.poseidon2_permutation(&input)?;
             let mut values = Vec::new();
             for i in result {
                 values.push(MemoryValue::new_field(i));

--- a/compiler/noirc_evaluator/src/acir/acir_context/generated_acir/mod.rs
+++ b/compiler/noirc_evaluator/src/acir/acir_context/generated_acir/mod.rs
@@ -336,7 +336,6 @@ impl<F: AcirField> GeneratedAcir<F> {
             BlackBoxFunc::Poseidon2Permutation => BlackBoxFuncCall::Poseidon2Permutation {
                 inputs: function_inputs[0].clone(),
                 outputs,
-                len: constant_inputs[0].to_u128() as u32,
             },
             BlackBoxFunc::Sha256Compression => BlackBoxFuncCall::Sha256Compression {
                 inputs: function_inputs[0]

--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_black_box.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_black_box.rs
@@ -345,10 +345,8 @@ pub(crate) fn convert_black_box_call<F: AcirField + DebugToString, Registers: Re
             }
         }
         BlackBoxFunc::Poseidon2Permutation => {
-            if let (
-                [message, BrilligVariable::SingleAddr(state_len)],
-                [BrilligVariable::BrilligArray(result_array)],
-            ) = (function_arguments, function_results)
+            if let ([message], [BrilligVariable::BrilligArray(result_array)]) =
+                (function_arguments, function_results)
             {
                 let message_vector = convert_array_or_vector(brillig_context, *message, bb_func);
                 let output_heap_array =
@@ -357,7 +355,6 @@ pub(crate) fn convert_black_box_call<F: AcirField + DebugToString, Registers: Re
                 brillig_context.black_box_op_instruction(BlackBoxOp::Poseidon2Permutation {
                     message: message_vector,
                     output: output_heap_array,
-                    len: state_len.address,
                 });
 
                 brillig_context.deallocate_heap_vector(message_vector);

--- a/compiler/noirc_evaluator/src/brillig/brillig_ir.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_ir.rs
@@ -357,7 +357,6 @@ pub(crate) mod tests {
         fn poseidon2_permutation(
             &self,
             _inputs: &[FieldElement],
-            _len: u32,
         ) -> Result<Vec<FieldElement>, BlackBoxResolutionError> {
             Ok(vec![0_u128.into(), 1_u128.into(), 2_u128.into(), 3_u128.into()])
         }

--- a/compiler/noirc_evaluator/src/brillig/brillig_ir/debug_show.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_ir/debug_show.rs
@@ -397,12 +397,11 @@ impl DebugShow {
                     output
                 );
             }
-            BlackBoxOp::Poseidon2Permutation { message, output, len } => {
+            BlackBoxOp::Poseidon2Permutation { message, output } => {
                 debug_println!(
                     self.enable_debug_trace,
-                    "  POSEIDON2_PERMUTATION {} {} -> {}",
+                    "  POSEIDON2_PERMUTATION {} -> {}",
                     message,
-                    len,
                     output
                 );
             }

--- a/compiler/noirc_evaluator/src/ssa/interpreter/intrinsics.rs
+++ b/compiler/noirc_evaluator/src/ssa/interpreter/intrinsics.rs
@@ -342,15 +342,12 @@ impl Interpreter<'_> {
                     }))
                 }
                 acvm::acir::BlackBoxFunc::Poseidon2Permutation => {
-                    check_argument_count(args, 2, intrinsic)?;
+                    check_argument_count(args, 1, intrinsic)?;
                     let inputs = self
                         .lookup_vec_field(args[0], "call Poseidon2Permutation BlackBox (inputs)")?;
-                    let length =
-                        self.lookup_u32(args[1], "call Poseidon2Permutation BlackBox (length)")?;
                     let solver = bn254_blackbox_solver::Bn254BlackBoxSolver(false);
-                    let result = solver
-                        .poseidon2_permutation(&inputs, length)
-                        .map_err(Self::convert_error)?;
+                    let result =
+                        solver.poseidon2_permutation(&inputs).map_err(Self::convert_error)?;
                     let result = Value::array_from_iter(result, NumericType::NativeField)?;
                     Ok(vec![result])
                 }

--- a/compiler/noirc_evaluator/src/ssa/ir/dfg/simplify/call/blackbox.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/dfg/simplify/call/blackbox.rs
@@ -205,8 +205,8 @@ pub(super) fn simplify_poseidon2_permutation(
     block: BasicBlockId,
     call_stack: CallStackId,
 ) -> SimplifyResult {
-    match (dfg.get_array_constant(arguments[0]), dfg.get_numeric_constant(arguments[1])) {
-        (Some((state, _)), Some(state_length)) if array_is_constant(dfg, &state) => {
+    match dfg.get_array_constant(arguments[0]) {
+        Some((state, _)) if array_is_constant(dfg, &state) => {
             let state: Vec<FieldElement> = state
                 .iter()
                 .map(|id| {
@@ -215,11 +215,7 @@ pub(super) fn simplify_poseidon2_permutation(
                 })
                 .collect();
 
-            let Some(state_length) = state_length.try_to_u32() else {
-                return SimplifyResult::None;
-            };
-
-            let Ok(new_state) = solver.poseidon2_permutation(&state, state_length) else {
+            let Ok(new_state) = solver.poseidon2_permutation(&state) else {
                 return SimplifyResult::None;
             };
 

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter/foreign.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter/foreign.rs
@@ -359,14 +359,13 @@ fn poseidon2_permutation(
     location: Location,
     pedantic_solving: bool,
 ) -> IResult<Value> {
-    let (input, state_length) = check_two_arguments(arguments, location)?;
+    let input = check_one_argument(arguments, location)?;
 
     let (input, typ) = get_array_map(interner, input, get_field)?;
     let input = vecmap(input, SignedField::to_field_element);
-    let state_length = get_u32(state_length)?;
 
     let fields = Bn254BlackBoxSolver(pedantic_solving)
-        .poseidon2_permutation(&input, state_length)
+        .poseidon2_permutation(&input)
         .map_err(|error| InterpreterError::BlackBoxError(error, location))?;
 
     let array = fields.into_iter().map(|f| Value::Field(SignedField::positive(f))).collect();

--- a/noir_stdlib/src/hash/mod.nr
+++ b/noir_stdlib/src/hash/mod.nr
@@ -137,7 +137,7 @@ pub fn hash_to_field(inputs: [Field]) -> Field {
 }
 
 #[foreign(poseidon2_permutation)]
-pub fn poseidon2_permutation<let N: u32>(_input: [Field; N], _state_length: u32) -> [Field; N] {}
+pub fn poseidon2_permutation<let N: u32>(input: [Field; N]) -> [Field; N] {}
 
 // Generic hashing support.
 // Partially ported and impacted by rust.

--- a/tooling/lsp/src/solver.rs
+++ b/tooling/lsp/src/solver.rs
@@ -40,8 +40,7 @@ impl BlackBoxFunctionSolver<acvm::FieldElement> for WrapperSolver {
     fn poseidon2_permutation(
         &self,
         inputs: &[acvm::FieldElement],
-        len: u32,
     ) -> Result<Vec<acvm::FieldElement>, acvm::BlackBoxResolutionError> {
-        self.0.poseidon2_permutation(inputs, len)
+        self.0.poseidon2_permutation(inputs)
     }
 }


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

I'm not sure why this argument was added but it doesn't really give us anything as we can get the state length from looking at the type of the `inputs` argument. I've then removed this from the definition of the `poseidon2_permutation` opcode.

## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
