### PR TITLE
feat: some `nargo expand` fixes related to function and method calls

### DIFF
--- a/tooling/nargo_cli/build.rs
+++ b/tooling/nargo_cli/build.rs
@@ -173,28 +173,16 @@ const TESTS_WITHOUT_STDOUT_CHECK: [&str; 0] = [];
 /// These tests are ignored because of existing bugs in `nargo expand`.
 /// As the bugs are fixed these tests should be removed from this list.
 /// (some are ignored on purpose for the same reason as `IGNORED_NARGO_EXPAND_EXECUTION_TESTS`)
-const IGNORED_NARGO_EXPAND_COMPILE_SUCCESS_EMPTY_TESTS: [&str; 24] = [
-    // bug
-    "alias_trait_method_call_multiple_candidates",
+const IGNORED_NARGO_EXPAND_COMPILE_SUCCESS_EMPTY_TESTS: [&str; 13] = [
     // bug
     "associated_type_bounds",
     // bug
     "enums",
     // There's no "src/main.nr" here so it's trickier to make this work
     "overlapping_dep_and_mod",
-    // bug
-    "primitive_trait_method_call_multiple_candidates",
     // this one works, but copying its `Nargo.toml` file to somewhere else doesn't work
     // because it references another project by a relative path
     "reexports",
-    // bug
-    "regression_7038",
-    // bug
-    "regression_7038_2",
-    // bug
-    "regression_7038_3",
-    // bug
-    "regression_7038_4",
     // bug
     "serialize_1",
     // bug
@@ -204,21 +192,11 @@ const IGNORED_NARGO_EXPAND_COMPILE_SUCCESS_EMPTY_TESTS: [&str; 24] = [
     // bug
     "serialize_4",
     // bug
-    "trait_allowed_item_name_matches",
-    // bug
-    "trait_default_implementation",
-    // bug
     "trait_function_calls",
     // bug
     "trait_method_mut_self",
     // bug
-    "trait_override_implementation",
-    // bug
     "trait_static_methods",
-    // bug
-    "type_trait_method_call_multiple_candidates",
-    // bug
-    "type_trait_method_call_multiple_candidates_with_turbofish",
     // There's no "src/main.nr" here so it's trickier to make this work
     "workspace_reexport_bug",
     // bug

--- a/tooling/nargo_cli/tests/snapshots/compile_success_empty/alias_trait_method_call_multiple_candidates/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_empty/alias_trait_method_call_multiple_candidates/execute__tests__expanded.snap
@@ -1,0 +1,38 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: expanded_code
+---
+use std::convert::From;
+
+struct MyU128 {
+    lo: Field,
+    hi: Field,
+}
+
+impl MyU128 {
+    pub fn from_u64s_le(lo: u64, hi: u64) -> Self {
+        Self { lo: lo as Field, hi: hi as Field }
+    }
+}
+
+impl From<u64> for MyU128 {
+    fn from(value: u64) -> Self {
+        Self::from_u64s_le(value, 0_u64)
+    }
+}
+
+impl From<u32> for MyU128 {
+    fn from(value: u32) -> Self {
+        Self::from(value as u64)
+    }
+}
+
+type MyU128Alias = MyU128;
+
+fn main() {
+    let x: u64 = 0_u64;
+    let mut small_int: MyU128 = MyU128::from(x);
+    assert(small_int.lo == (x as Field));
+    let u32_3: u32 = 3_u32;
+    assert(MyU128::from(u32_3).lo == 3_Field);
+}

--- a/tooling/nargo_cli/tests/snapshots/compile_success_empty/arithmetic_generics_move_constant_terms/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_empty/arithmetic_generics_move_constant_terms/execute__tests__expanded.snap
@@ -21,13 +21,13 @@ struct Point {
 
 impl<let N: u32> FromCallData<N, N - 2> for Point {
     fn from_calldata(calldata: [Field; N]) -> (Self, [Field; N - 2]) {
-        let (x, calldata): (Field, [Field; N - 1]) = FromCallData::from_calldata(calldata);
-        let (y, calldata): (Field, [Field; N - 2]) = FromCallData::from_calldata(calldata);
+        let (x, calldata): (Field, [Field; N - 1]) = Field::from_calldata(calldata);
+        let (y, calldata): (Field, [Field; N - 2]) = Field::from_calldata(calldata);
         (Self { x: x, y: y }, calldata)
     }
 }
 
 fn main() {
     let calldata: [Field; 2] = [1_Field, 2_Field];
-    let _: (Point, [Field; 2 - 2]) = FromCallData::from_calldata(calldata);
+    let _: (Point, [Field; 2 - 2]) = Point::from_calldata(calldata);
 }

--- a/tooling/nargo_cli/tests/snapshots/compile_success_empty/associated_types/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_empty/associated_types/execute__tests__expanded.snap
@@ -17,9 +17,9 @@ impl<let N: u32, T> Collection for [T; N] {
 
     fn cget(self, index: u32) -> Option<T> {
         if index < self.len() {
-            Option::some(self[index])
+            Option::<T>::some(self[index])
         } else {
-            Option::none()
+            Option::<T>::none()
         }
     }
 

--- a/tooling/nargo_cli/tests/snapshots/compile_success_empty/associated_types_implicit/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_empty/associated_types_implicit/execute__tests__expanded.snap
@@ -28,14 +28,14 @@ where
         T: Foo,
         <T as Foo>::Bar: Eq,
     {
-        Foo::foo(self.unwrap())
+        self.unwrap().foo()
     }
 }
 
 fn main() {
     let three: u64 = 3_u64;
     call_foo(three);
-    let x: Option<Option<u64>> = Option::some(Option::some(0_u64));
+    let x: Option<Option<u64>> = Option::<Option<u64>>::some(Option::<u64>::some(0_u64));
     let x_foo: u8 = x.foo();
     assert(x_foo == x_foo);
     assert(x.foo() == 0_u8);
@@ -46,6 +46,6 @@ where
     T: Foo,
     <T as Foo>::Bar: Eq,
 {
-    let y: <T as Foo>::Bar = Foo::foo(x);
+    let y: <T as Foo>::Bar = x.foo();
     assert(y == y);
 }

--- a/tooling/nargo_cli/tests/snapshots/compile_success_empty/derive_impl/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_empty/derive_impl/execute__tests__expanded.snap
@@ -37,7 +37,7 @@ struct Foo {
 
 impl Default for Foo {
     fn default() -> Self {
-        Self { x: Default::default(), y: Default::default() }
+        Self { x: Field::default(), y: Bar::default() }
     }
 }
 
@@ -71,5 +71,5 @@ comptime fn join(slice: [Quoted]) -> Quoted {
 }
 
 fn main() {
-    let _foo: Foo = Default::default();
+    let _foo: Foo = Foo::default();
 }

--- a/tooling/nargo_cli/tests/snapshots/compile_success_empty/field_or_integer_static_trait_method/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_empty/field_or_integer_static_trait_method/execute__tests__expanded.snap
@@ -20,9 +20,9 @@ impl Read for u32 {
 
 fn main() {
     let data: [Field; 1] = [1_Field];
-    let value: u32 = Read::read(data);
+    let value: u32 = u32::read(data);
     assert(value == 1_u32);
-    let value: Field = Read::read(data);
+    let value: Field = Field::read(data);
     assert(value == 10_Field);
 }
 

--- a/tooling/nargo_cli/tests/snapshots/compile_success_empty/function_attribute/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_empty/function_attribute/execute__tests__expanded.snap
@@ -25,5 +25,5 @@ comptime fn function_attr(_f: FunctionDefinition) -> Quoted {
 }
 
 fn main() {
-    let _: Foo = Default::default();
+    let _: Foo = Foo::default();
 }

--- a/tooling/nargo_cli/tests/snapshots/compile_success_empty/generic_trait_bounds/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_empty/generic_trait_bounds/execute__tests__expanded.snap
@@ -10,7 +10,7 @@ pub fn foo<T>(x: T)
 where
     T: Trait,
 {
-    Trait::foo(x);
+    x.foo();
 }
 
 pub struct Foo {}
@@ -20,7 +20,7 @@ impl Foo {
     where
         T: Trait,
     {
-        Trait::foo(x);
+        x.foo();
     }
 }
 
@@ -29,7 +29,7 @@ impl Trait2 for Foo {
     where
         T: Trait,
     {
-        Trait::foo(x);
+        x.foo();
     }
 }
 
@@ -39,7 +39,7 @@ trait Trait2 {
         T: Trait,
     {
         let _: Self = self;
-        Trait::foo(x);
+        x.foo();
     }
 }
 
@@ -50,7 +50,7 @@ impl<T> Bar<T> {
     where
         T: Trait,
     {
-        Trait::foo(x);
+        x.foo();
     }
 
     fn baz(self)
@@ -71,7 +71,7 @@ where
         U: Trait,
     {
         self.baz();
-        Trait::foo(x);
+        x.foo();
     }
 }
 

--- a/tooling/nargo_cli/tests/snapshots/compile_success_empty/impl_where_clause/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_empty/impl_where_clause/execute__tests__expanded.snap
@@ -12,7 +12,7 @@ impl<T> MyStruct<T> {
     where
         T: MyEq,
     {
-        (self.a == other.a) & MyEq::my_eq(self.b, other.b)
+        (self.a == other.a) & self.b.my_eq(other.b)
     }
 }
 

--- a/tooling/nargo_cli/tests/snapshots/compile_success_empty/inject_context_attribute/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_empty/inject_context_attribute/execute__tests__expanded.snap
@@ -49,7 +49,7 @@ comptime fn inject_context(f: FunctionDefinition) {
 comptime fn mapping_function(expr: Expr, f: FunctionDefinition) -> Option<Expr> {
     expr.as_function_call().and_then(|(name, arguments): (Expr, [Expr])| -> Option<Expr> {
         name
-            .resolve(Option::some(f))
+            .resolve(Option::<FunctionDefinition>::some(f))
             .as_function_definition()
             .and_then(|function_definition: FunctionDefinition| -> Option<Expr> {
                 if function_definition.has_named_attribute("inject_context") {
@@ -57,9 +57,9 @@ comptime fn mapping_function(expr: Expr, f: FunctionDefinition) -> Option<Expr> 
                         arguments.push_front(quote { _context }.as_expr().unwrap());
                     let arguments: Quoted =
                         arguments.map(|arg: Expr| -> Quoted arg.quoted()).join(quote { ,  });
-                    Option::some(quote { name(arguments) }.as_expr().unwrap())
+                    Option::<Expr>::some(quote { name(arguments) }.as_expr().unwrap())
                 } else {
-                    Option::none()
+                    Option::<Expr>::none()
                 }
             })
     })

--- a/tooling/nargo_cli/tests/snapshots/compile_success_empty/option/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_empty/option/execute__tests__expanded.snap
@@ -4,8 +4,8 @@ expression: expanded_code
 ---
 fn main() {
     let ten: Field = 10_Field;
-    let none: Option<Field> = Option::none();
-    let some: Option<Field> = Option::some(3_Field);
+    let none: Option<Field> = Option::<Field>::none();
+    let some: Option<Field> = Option::<Field>::some(3_Field);
     assert(none.is_none());
     assert(some.is_some());
     assert(some.unwrap() == 3_Field);
@@ -32,21 +32,24 @@ fn main() {
     assert(some.and(none).is_none());
     assert(some.and(some).is_some());
     let add1_u64: fn(Field) -> Option<u64> =
-        |value: Field| -> Option<u64> Option::some((value as u64) + 1_u64);
+        |value: Field| -> Option<u64> Option::<u64>::some((value as u64) + 1_u64);
     assert(none.and_then(|_value: Field| -> Option<Field> none).is_none());
     assert(none.and_then(add1_u64).is_none());
     assert(some.and_then(|_value: Field| -> Option<Field> none).is_none());
     assert(some.and_then(add1_u64).unwrap() == 4_u64);
-    assert(some.and_then(|x: Field| -> Option<Field> Option::some(x + ten)).unwrap() == 13_Field);
+    assert(
+        some.and_then(|x: Field| -> Option<Field> Option::<Field>::some(x + ten)).unwrap()
+            == 13_Field,
+    );
     assert(none.or(none).is_none());
     assert(none.or(some).is_some());
     assert(some.or(none).is_some());
     assert(some.or(some).is_some());
-    assert(none.or_else(|| -> Option<Field> Option::none()).is_none());
-    assert(none.or_else(|| -> Option<Field> Option::some(5_Field)).is_some());
-    assert(some.or_else(|| -> Option<Field> Option::none()).is_some());
-    assert(some.or_else(|| -> Option<Field> Option::some(5_Field)).is_some());
-    assert(some.or_else(|| -> Option<Field> Option::some(ten)).is_some());
+    assert(none.or_else(|| -> Option<Field> Option::<Field>::none()).is_none());
+    assert(none.or_else(|| -> Option<Field> Option::<Field>::some(5_Field)).is_some());
+    assert(some.or_else(|| -> Option<Field> Option::<Field>::none()).is_some());
+    assert(some.or_else(|| -> Option<Field> Option::<Field>::some(5_Field)).is_some());
+    assert(some.or_else(|| -> Option<Field> Option::<Field>::some(ten)).is_some());
     assert(none.xor(none).is_none());
     assert(none.xor(some).is_some());
     assert(some.xor(none).is_some());

--- a/tooling/nargo_cli/tests/snapshots/compile_success_empty/primitive_trait_method_call_multiple_candidates/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_empty/primitive_trait_method_call_multiple_candidates/execute__tests__expanded.snap
@@ -1,0 +1,10 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: expanded_code
+---
+fn main() {
+    let x: u64 = 0_u64;
+    let f: fn(u64) -> Field = Field::from;
+    let _: Field = f(x);
+    let _: str<3> = str::<3>::from([1_u8, 2_u8, 3_u8]);
+}

--- a/tooling/nargo_cli/tests/snapshots/compile_success_empty/regression_4635/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_empty/regression_4635/execute__tests__expanded.snap
@@ -52,13 +52,13 @@ where
     where
         T: FromField,
     {
-        Self { a: FromField::from_field(fields[0_u32]) }
+        Self { a: T::from_field(fields[0_u32]) }
     }
 }
 
 fn main() {
     let fields: [Field; 1] = [5_Field; 1];
-    let foo: MyStruct<AztecAddress> = Deserialize::<1>::deserialize(fields);
+    let foo: MyStruct<AztecAddress> = MyStruct::<AztecAddress>::deserialize(fields);
     let bar: AztecAddress = AztecAddress { inner: 5_Field };
     assert(foo.a == bar);
 }

--- a/tooling/nargo_cli/tests/snapshots/compile_success_empty/regression_5065/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_empty/regression_5065/execute__tests__expanded.snap
@@ -32,11 +32,11 @@ fn foo<T>() -> T
 where
     T: MyTrait,
 {
-    MyTrait::new()
+    T::new()
 }
 
 fn concise_regression() -> MyType {
-    Wrapper::new_wrapper(foo()).unwrap()
+    Wrapper::<MyType>::new_wrapper(foo()).unwrap()
 }
 
 fn main() {

--- a/tooling/nargo_cli/tests/snapshots/compile_success_empty/regression_7038/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_empty/regression_7038/execute__tests__expanded.snap
@@ -1,0 +1,50 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: expanded_code
+---
+trait BigNumTrait {}
+
+pub struct MyBigNum {}
+
+impl BigNumTrait for MyBigNum {}
+
+trait CurveParamsTrait<BigNum>
+where
+    BigNum: BigNumTrait,
+{
+    fn one()
+    where
+        BigNum: BigNumTrait;
+}
+
+pub struct BN254Params {}
+
+impl CurveParamsTrait<MyBigNum> for BN254Params {
+    fn one() {}
+}
+
+trait BigCurveTrait {
+    fn two();
+}
+
+pub struct BigCurve<BigNum, CurveParams> {}
+
+impl<BigNum, CurveParams> BigCurveTrait for BigCurve<BigNum, CurveParams>
+where
+    BigNum: BigNumTrait,
+    CurveParams: CurveParamsTrait<BigNum>,
+{
+    fn two()
+    where
+        BigNum: BigNumTrait,
+        CurveParams: CurveParamsTrait<BigNum>,
+    {
+        let _: () = CurveParams::one();
+    }
+}
+
+type BN254 = BigCurve<MyBigNum, BN254Params>;
+
+fn main() {
+    let _: () = BigCurve::<MyBigNum, BN254Params>::two();
+}

--- a/tooling/nargo_cli/tests/snapshots/compile_success_empty/regression_7038_2/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_empty/regression_7038_2/execute__tests__expanded.snap
@@ -1,0 +1,51 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: expanded_code
+---
+trait BigNumTrait {}
+
+pub struct MyBigNum {}
+
+impl BigNumTrait for MyBigNum {}
+
+trait CurveParamsTrait<BigNum>
+where
+    BigNum: BigNumTrait,
+{
+    fn one()
+    where
+        BigNum: BigNumTrait,
+    {}
+}
+
+pub struct BN254Params {}
+
+impl CurveParamsTrait<MyBigNum> for BN254Params {
+    fn one() {}
+}
+
+trait BigCurveTrait {
+    fn two();
+}
+
+pub struct BigCurve<BigNum, CurveParams> {}
+
+impl<BigNum, CurveParams> BigCurveTrait for BigCurve<BigNum, CurveParams>
+where
+    BigNum: BigNumTrait,
+    CurveParams: CurveParamsTrait<BigNum>,
+{
+    fn two()
+    where
+        BigNum: BigNumTrait,
+        CurveParams: CurveParamsTrait<BigNum>,
+    {
+        let _: () = CurveParams::one();
+    }
+}
+
+type BN254 = BigCurve<MyBigNum, BN254Params>;
+
+fn main() {
+    let _: () = BigCurve::<MyBigNum, BN254Params>::two();
+}

--- a/tooling/nargo_cli/tests/snapshots/compile_success_empty/regression_7038_3/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_empty/regression_7038_3/execute__tests__expanded.snap
@@ -1,0 +1,47 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: expanded_code
+---
+trait BigNumTrait {}
+
+pub struct MyBigNum {}
+
+impl BigNumTrait for MyBigNum {}
+
+trait CurveParamsTrait<BigNum> {
+    fn one()
+    where
+        BigNum: BigNumTrait;
+}
+
+pub struct BN254Params {}
+
+impl CurveParamsTrait<MyBigNum> for BN254Params {
+    fn one() {}
+}
+
+trait BigCurveTrait {
+    fn two();
+}
+
+pub struct BigCurve<BigNum, CurveParams> {}
+
+impl<BigNum, CurveParams> BigCurveTrait for BigCurve<BigNum, CurveParams>
+where
+    BigNum: BigNumTrait,
+    CurveParams: CurveParamsTrait<BigNum>,
+{
+    fn two()
+    where
+        BigNum: BigNumTrait,
+        CurveParams: CurveParamsTrait<BigNum>,
+    {
+        let _: () = CurveParams::one();
+    }
+}
+
+type BN254 = BigCurve<MyBigNum, BN254Params>;
+
+fn main() {
+    let _: () = BigCurve::<MyBigNum, BN254Params>::two();
+}

--- a/tooling/nargo_cli/tests/snapshots/compile_success_empty/regression_7038_4/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_empty/regression_7038_4/execute__tests__expanded.snap
@@ -1,0 +1,32 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: expanded_code
+---
+trait BigNumTrait {}
+
+trait CurveParamsTrait<BigNum> {
+    fn one()
+    where
+        BigNum: BigNumTrait;
+}
+
+pub struct MyBigNum {}
+
+impl BigNumTrait for MyBigNum {}
+
+pub struct Params {}
+
+impl CurveParamsTrait<MyBigNum> for Params {
+    fn one() {}
+}
+
+fn foo<C>()
+where
+    C: CurveParamsTrait<MyBigNum>,
+{
+    let _: () = C::one();
+}
+
+fn main() {
+    foo::<Params>();
+}

--- a/tooling/nargo_cli/tests/snapshots/compile_success_empty/slice_join/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_empty/slice_join/execute__tests__expanded.snap
@@ -16,11 +16,5 @@ fn append_three<T>(one: T, two: T, three: T) -> T
 where
     T: Append,
 {
-    Append::append(
-        Append::append(
-            Append::append(Append::append(Append::empty(), one), two),
-            three,
-        ),
-        Append::empty(),
-    )
+    T::empty().append(one).append(two).append(three).append(T::empty())
 }

--- a/tooling/nargo_cli/tests/snapshots/compile_success_empty/trait_allowed_item_name_matches/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_empty/trait_allowed_item_name_matches/execute__tests__expanded.snap
@@ -1,0 +1,29 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: expanded_code
+---
+pub trait Trait1 {
+    type Tralala;
+
+    let Tralala: u32;
+}
+
+pub trait Trait2 {
+    let Tralala: u32;
+
+    type Tralala;
+}
+
+pub trait Trait3 {
+    type Tralala;
+
+    fn Tralala();
+}
+
+pub trait Trait4 {
+    type Tralala;
+
+    fn Tralala();
+}
+
+fn main() {}

--- a/tooling/nargo_cli/tests/snapshots/compile_success_empty/trait_call_full_path/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_empty/trait_call_full_path/execute__tests__expanded.snap
@@ -17,7 +17,7 @@ mod foo {
 }
 
 fn main(x: Field) {
-    let _: Field = Trait::me(x);
-    let _: Field = Trait::me(x);
-    let _: Field = Trait::me(x);
+    let _: Field = x.me();
+    let _: Field = x.me();
+    let _: Field = x.me();
 }

--- a/tooling/nargo_cli/tests/snapshots/compile_success_empty/trait_default_implementation/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_empty/trait_default_implementation/execute__tests__expanded.snap
@@ -4,6 +4,10 @@ expression: expanded_code
 ---
 trait MyDefault {
     fn my_default(x: Field, y: Field) -> Self;
+
+    fn method2(x: Field) -> Field {
+        x
+    }
 }
 
 struct Foo {
@@ -15,9 +19,13 @@ impl MyDefault for Foo {
     fn my_default(x: Field, y: Field) -> Self {
         Self { bar: x, array: [x, y] }
     }
+
+    fn method2(x: Field) -> Field {
+        x
+    }
 }
 
-fn main(x: Field, y: Field) {
-    let first: Foo = Foo::my_default(x, y);
-    assert(first.bar == x);
+fn main(x: Field) {
+    let first: Field = Foo::method2(x);
+    assert(first == x);
 }

--- a/tooling/nargo_cli/tests/snapshots/compile_success_empty/trait_generics/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_empty/trait_generics/execute__tests__expanded.snap
@@ -15,7 +15,7 @@ where
     T: MyInto<U>,
     U: Eq,
 {
-    assert(MyInto::into(x) == u);
+    assert(x.into() == u);
 }
 
 trait MyInto<T> {
@@ -30,7 +30,7 @@ where
     where
         T: MyInto<U>,
     {
-        self.map(|x: T| -> U MyInto::into(x))
+        self.map(|x: T| -> U x.into())
     }
 }
 
@@ -60,7 +60,7 @@ fn sum<T, let M: u32>(data: T) -> Field
 where
     T: Serializable<M>,
 {
-    let serialized: [Field; M] = Serializable::serialize(data);
+    let serialized: [Field; M] = data.serialize();
     serialized.fold(0_Field, |acc: Field, elem: Field| -> Field { acc + elem })
 }
 
@@ -68,6 +68,6 @@ fn sum_static<T, let M: u32>(data: T) -> Field
 where
     T: Serializable<M>,
 {
-    let serialized: [Field; M] = Serializable::serialize(data);
+    let serialized: [Field; M] = data.serialize();
     serialized.fold(0_Field, |acc: Field, elem: Field| -> Field { acc + elem })
 }

--- a/tooling/nargo_cli/tests/snapshots/compile_success_empty/trait_impl_with_where_clause/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_empty/trait_impl_with_where_clause/execute__tests__expanded.snap
@@ -23,7 +23,7 @@ where
     {
         let mut ret: bool = true;
         for i in 0_u32..self.len() {
-            ret = ret & MyEq::my_eq(self[i], other[i]);
+            ret = ret & self[i].my_eq(other[i]);
         }
         ret
     }

--- a/tooling/nargo_cli/tests/snapshots/compile_success_empty/trait_override_implementation/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_empty/trait_override_implementation/execute__tests__expanded.snap
@@ -1,0 +1,87 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: expanded_code
+---
+trait MyDefault {
+    fn my_default(x: Field, y: Field) -> Self;
+
+    fn method2(x: Field) -> Field {
+        x
+    }
+}
+
+struct Foo {
+    bar: Field,
+    array: [Field; 2],
+}
+
+impl MyDefault for Foo {
+    fn my_default(x: Field, y: Field) -> Self {
+        Self { bar: x, array: [x, y] }
+    }
+
+    fn method2(x: Field) -> Field {
+        x * 3_Field
+    }
+}
+
+trait F {
+    fn f1(self) -> Field;
+
+    fn f2(_self: Self) -> Field {
+        2_Field
+    }
+
+    fn f3(_self: Self) -> Field {
+        3_Field
+    }
+
+    fn f4(_self: Self) -> Field {
+        4_Field
+    }
+
+    fn f5(_self: Self) -> Field {
+        5_Field
+    }
+}
+
+struct Bar {}
+
+impl F for Bar {
+    fn f1(_self: Self) -> Field {
+        10_Field
+    }
+
+    fn f2(_self: Self) -> Field {
+        2_Field
+    }
+
+    fn f3(_self: Self) -> Field {
+        30_Field
+    }
+
+    fn f4(_self: Self) -> Field {
+        4_Field
+    }
+
+    fn f5(_self: Self) -> Field {
+        50_Field
+    }
+}
+
+fn main(x: Field) {
+    let first: Field = Foo::method2(x);
+    assert(first == (3_Field * x));
+    let bar: Bar = Bar {};
+    assert(bar.f1() == 10_Field, "1");
+    assert(bar.f2() == 2_Field, "2");
+    assert(bar.f3() == 30_Field, "3");
+    assert(bar.f4() == 4_Field, "4");
+    assert(bar.f5() == 50_Field, "5");
+    let mut bar_mut: Bar = Bar {};
+    assert(bar_mut.f1() == 10_Field, "10");
+    assert(bar_mut.f2() == 2_Field, "12");
+    assert(bar_mut.f3() == 30_Field, "13");
+    assert(bar_mut.f4() == 4_Field, "14");
+    assert(bar_mut.f5() == 50_Field, "15");
+}

--- a/tooling/nargo_cli/tests/snapshots/compile_success_empty/trait_where_clause/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_empty/trait_where_clause/execute__tests__expanded.snap
@@ -67,7 +67,7 @@ fn assert_asd_eq_100<T>(t: T)
 where
     T: Asd,
 {
-    assert(Asd::asd(t) == 100_Field);
+    assert(t.asd() == 100_Field);
 }
 
 fn add_one_to_static_function<T>(t: T) -> Field

--- a/tooling/nargo_cli/tests/snapshots/compile_success_empty/turbofish_call_func_diff_types/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_empty/turbofish_call_func_diff_types/execute__tests__expanded.snap
@@ -6,12 +6,12 @@ use poseidon::{poseidon2::Poseidon2Hasher, poseidon::PoseidonHasher};
 use std::hash::Hasher;
 
 fn main(x: Field, y: pub Field) {
-    let mut hasher: PoseidonHasher = Default::default();
+    let mut hasher: PoseidonHasher = PoseidonHasher::default();
     hasher.write(x);
     hasher.write(y);
     let poseidon_expected_hash: Field = hasher.finish();
     assert(hash_simple_array::<PoseidonHasher>([x, y]) == poseidon_expected_hash);
-    let mut hasher: Poseidon2Hasher = Default::default();
+    let mut hasher: Poseidon2Hasher = Poseidon2Hasher::default();
     hasher.write(x);
     hasher.write(y);
     let poseidon2_expected_hash: Field = hasher.finish();
@@ -23,8 +23,8 @@ where
     H: Hasher,
     H: Default,
 {
-    let mut hasher: H = Default::default();
-    Hasher::write(&mut hasher, input[0_u32]);
-    Hasher::write(&mut hasher, input[1_u32]);
-    Hasher::finish(hasher)
+    let mut hasher: H = H::default();
+    hasher.write(input[0_u32]);
+    hasher.write(input[1_u32]);
+    hasher.finish()
 }

--- a/tooling/nargo_cli/tests/snapshots/compile_success_empty/type_path/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_empty/type_path/execute__tests__expanded.snap
@@ -5,8 +5,8 @@ expression: expanded_code
 fn main() {
     { Foo::static() };
     let _: Field = Field::from_be_bytes([1_u8]);
-    let _: () = Trait::method();
-    let _: [i32; 3] = Trait::method();
+    let _: () = <()>::method();
+    let _: [i32; 3] = <[i32; 3]>::method();
 }
 
 pub struct Foo {}

--- a/tooling/nargo_cli/tests/snapshots/compile_success_empty/type_trait_method_call_multiple_candidates/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_empty/type_trait_method_call_multiple_candidates/execute__tests__expanded.snap
@@ -1,0 +1,36 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: expanded_code
+---
+use std::convert::From;
+
+struct MyU128 {
+    lo: Field,
+    hi: Field,
+}
+
+impl MyU128 {
+    pub fn from_u64s_le(lo: u64, hi: u64) -> Self {
+        Self { lo: lo as Field, hi: hi as Field }
+    }
+}
+
+impl From<u64> for MyU128 {
+    fn from(value: u64) -> Self {
+        Self::from_u64s_le(value, 0_u64)
+    }
+}
+
+impl From<u32> for MyU128 {
+    fn from(value: u32) -> Self {
+        Self::from(value as u64)
+    }
+}
+
+fn main() {
+    let x: u64 = 0_u64;
+    let mut small_int: MyU128 = MyU128::from(x);
+    assert(small_int.lo == (x as Field));
+    let u32_3: u32 = 3_u32;
+    assert(MyU128::from(u32_3).lo == 3_Field);
+}

--- a/tooling/nargo_cli/tests/snapshots/compile_success_empty/type_trait_method_call_multiple_candidates_with_turbofish/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_empty/type_trait_method_call_multiple_candidates_with_turbofish/execute__tests__expanded.snap
@@ -1,0 +1,29 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: expanded_code
+---
+pub struct Struct<T> {
+    x: T,
+}
+
+impl From2<u64> for Struct<u64> {
+    fn from2(_: u64) -> Self {
+        Self { x: 0_u64 }
+    }
+}
+
+impl From2<u32> for Struct<u32> {
+    fn from2(_: u32) -> Self {
+        Self { x: 0_u32 }
+    }
+}
+
+pub trait From2<T> {
+    fn from2(input: T) -> Self;
+}
+
+fn main() {
+    let x: u32 = 1_u32;
+    let f: fn(u32) -> Struct<u32> = Struct::<u32>::from2;
+    let _: Struct<u32> = f(x);
+}

--- a/tooling/nargo_cli/tests/snapshots/compile_success_empty/vectors/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_empty/vectors/execute__tests__expanded.snap
@@ -5,7 +5,7 @@ expression: expanded_code
 use std::collections::vec::Vec;
 
 fn main(x: Field, y: pub Field) {
-    let mut vector: Vec<u32> = Vec::new();
+    let mut vector: Vec<u32> = Vec::<u32>::new();
     assert(vector.len() == 0_u32);
     for i in 0_u32..5_u32 {
         vector.push(i);
@@ -25,7 +25,7 @@ fn main(x: Field, y: pub Field) {
     assert(removed_elem == 2_u32);
     assert(vector.get(3_u32) == 3_u32);
     assert(vector.len() == 4_u32);
-    let mut inputs_vector: Vec<Field> = Vec::from_slice(&[x, y]);
+    let mut inputs_vector: Vec<Field> = Vec::<Field>::from_slice(&[x, y]);
     assert(inputs_vector.get(0_u32) == x);
     assert(inputs_vector.get(1_u32) == y);
 }

--- a/tooling/nargo_cli/tests/snapshots/compile_success_no_bug/databus_mapping_regression/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_no_bug/databus_mapping_regression/execute__tests__expanded.snap
@@ -17,7 +17,7 @@ where
     T: Empty,
     T: Eq,
 {
-    Eq::eq(item, Empty::empty())
+    item.eq(T::empty())
 }
 
 pub fn array_to_bounded_vec<T, let N: u32>(array: [T; N]) -> BoundedVec<T, N>
@@ -37,7 +37,7 @@ where
             }
         }
     };
-    BoundedVec::from_parts_unchecked(array, len)
+    BoundedVec::<T, N>::from_parts_unchecked(array, len)
 }
 
 global TX_SIZE: u32 = 5;

--- a/tooling/nargo_cli/tests/snapshots/compile_success_no_bug/noirc_frontend_tests_aliases_double_generic_alias_in_path/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_no_bug/noirc_frontend_tests_aliases_double_generic_alias_in_path/execute__tests__expanded.snap
@@ -15,5 +15,5 @@ type FooAlias1 = Foo<i32>;
 type FooAlias2 = FooAlias1;
 
 fn main() {
-    let _: Foo<i32> = Foo::new();
+    let _: Foo<i32> = Foo::<i32>::new();
 }

--- a/tooling/nargo_cli/tests/snapshots/compile_success_no_bug/noirc_frontend_tests_check_trait_implemented_for_all_t/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_no_bug/noirc_frontend_tests_check_trait_implemented_for_all_t/execute__tests__expanded.snap
@@ -30,7 +30,7 @@ where
         Self: Default2,
         Self: Eq2,
     {
-        Eq2::eq2(self, Default2::default2())
+        self.eq2(Self::default2())
     }
 }
 
@@ -46,7 +46,7 @@ impl Eq2 for Foo {
 
 impl Default2 for Foo {
     fn default2() -> Self {
-        Self { a: Default2::default2() }
+        Self { a: u64::default2() }
     }
 }
 

--- a/tooling/nargo_cli/tests/snapshots/compile_success_no_bug/noirc_frontend_tests_numeric_generic_in_trait_impl_with_extra_impl_generics/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_no_bug/noirc_frontend_tests_numeric_generic_in_trait_impl_with_extra_impl_generics/execute__tests__expanded.snap
@@ -21,7 +21,7 @@ where
     where
         T: Default2,
     {
-        Self { a: fields[0_u32], b: fields[1_u32], c: fields[2_u32], d: Default2::default2() }
+        Self { a: fields[0_u32], b: fields[1_u32], c: fields[2_u32], d: T::default2() }
     }
 }
 

--- a/tooling/nargo_cli/tests/snapshots/compile_success_no_bug/noirc_frontend_tests_regression_7088/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_no_bug/noirc_frontend_tests_regression_7088/execute__tests__expanded.snap
@@ -12,5 +12,5 @@ impl<let N: u32, let NumSegments: u32> U60Repr<N, NumSegments> {
 
 fn main() {
     let input: [Field; 6] = [0_Field; 6];
-    let _: U60Repr<3, 6> = U60Repr::new(input);
+    let _: U60Repr<3, 6> = U60Repr::<6 / 2, 6>::new(input);
 }

--- a/tooling/nargo_cli/tests/snapshots/compile_success_no_bug/noirc_frontend_tests_specify_function_types_with_turbofish/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_no_bug/noirc_frontend_tests_specify_function_types_with_turbofish/execute__tests__expanded.snap
@@ -23,7 +23,7 @@ where
     T: Default2,
     U: Default2,
 {
-    (Default2::default2(), Default2::default2())
+    (T::default2(), U::default2())
 }
 
 fn main() {

--- a/tooling/nargo_cli/tests/snapshots/compile_success_no_bug/noirc_frontend_tests_specify_method_types_with_turbofish/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_no_bug/noirc_frontend_tests_specify_method_types_with_turbofish/execute__tests__expanded.snap
@@ -21,7 +21,7 @@ impl<T> Foo<T> {
     where
         U: Default2,
     {
-        Default2::default2()
+        U::default2()
     }
 }
 

--- a/tooling/nargo_cli/tests/snapshots/compile_success_no_bug/noirc_frontend_tests_trait_constraint_on_tuple_type/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_no_bug/noirc_frontend_tests_trait_constraint_on_tuple_type/execute__tests__expanded.snap
@@ -10,7 +10,7 @@ pub fn bar<T, U, V>(x: (T, U), y: V) -> bool
 where
     (T, U): Foo<V>,
 {
-    Foo::foo(x, y)
+    x.foo(y)
 }
 
 fn main() {}

--- a/tooling/nargo_cli/tests/snapshots/compile_success_no_bug/noirc_frontend_tests_trait_constraint_on_tuple_type_pub_crate/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_no_bug/noirc_frontend_tests_trait_constraint_on_tuple_type_pub_crate/execute__tests__expanded.snap
@@ -10,7 +10,7 @@ pub fn bar<T, U, V>(x: (T, U), y: V) -> bool
 where
     (T, U): Foo<V>,
 {
-    Foo::foo(x, y)
+    x.foo(y)
 }
 
 fn main() {}

--- a/tooling/nargo_cli/tests/snapshots/compile_success_no_bug/noirc_frontend_tests_trait_impl_for_a_type_that_implements_another_trait/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_no_bug/noirc_frontend_tests_trait_impl_for_a_type_that_implements_another_trait/execute__tests__expanded.snap
@@ -24,7 +24,7 @@ where
     where
         Self: One,
     {
-        One::one(self) + 1_i32
+        self.one() + 1_i32
     }
 }
 
@@ -32,7 +32,7 @@ pub fn use_it<T>(t: T) -> i32
 where
     T: Two,
 {
-    Two::two(t)
+    t.two()
 }
 
 fn main() {}

--- a/tooling/nargo_cli/tests/snapshots/compile_success_no_bug/noirc_frontend_tests_trait_impl_for_a_type_that_implements_another_trait_with_another_impl_used/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_no_bug/noirc_frontend_tests_trait_impl_for_a_type_that_implements_another_trait_with_another_impl_used/execute__tests__expanded.snap
@@ -25,7 +25,7 @@ where
     where
         Self: One,
     {
-        One::one(self) + 1_i32
+        self.one() + 1_i32
     }
 }
 
@@ -37,7 +37,7 @@ impl Two for u32 {
 }
 
 pub fn use_it(t: u32) -> i32 {
-    Two::two(t)
+    t.two()
 }
 
 fn main() {}

--- a/tooling/nargo_cli/tests/snapshots/compile_success_no_bug/noirc_frontend_tests_traits_allows_renaming_trait_during_import/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_no_bug/noirc_frontend_tests_traits_allows_renaming_trait_during_import/execute__tests__expanded.snap
@@ -15,5 +15,5 @@ mod trait_mod {
 }
 
 fn main(x: Field) {
-    x.foo();
+    Field::foo(x);
 }

--- a/tooling/nargo_cli/tests/snapshots/compile_success_no_bug/noirc_frontend_tests_traits_calls_trait_method_if_it_is_in_scope_with_multiple_candidates_but_only_one_decided_by_generics/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_no_bug/noirc_frontend_tests_traits_calls_trait_method_if_it_is_in_scope_with_multiple_candidates_but_only_one_decided_by_generics/execute__tests__expanded.snap
@@ -24,5 +24,5 @@ trait Converter<N> {
 
 fn main() {
     let foo: Foo = Foo { inner: 42_Field };
-    let _: u32 = Converter::convert(foo);
+    let _: u32 = foo.convert();
 }

--- a/tooling/nargo_cli/tests/snapshots/compile_success_no_bug/noirc_frontend_tests_traits_does_not_error_if_impl_trait_constraint_is_satisfied_for_concrete_type/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_no_bug/noirc_frontend_tests_traits_does_not_error_if_impl_trait_constraint_is_satisfied_for_concrete_type/execute__tests__expanded.snap
@@ -15,7 +15,7 @@ where
         U: Greeter,
         T: Greeter,
     {
-        Greeter::greet(object);
+        object.greet();
     }
 }
 
@@ -32,7 +32,7 @@ impl Foo<SomeGreeter> for Bar {
     where
         U: Greeter,
     {
-        Greeter::greet(object);
+        object.greet();
     }
 }
 

--- a/tooling/nargo_cli/tests/snapshots/compile_success_no_bug/noirc_frontend_tests_traits_does_not_error_if_impl_trait_constraint_is_satisfied_for_type_variable/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_no_bug/noirc_frontend_tests_traits_does_not_error_if_impl_trait_constraint_is_satisfied_for_type_variable/execute__tests__expanded.snap
@@ -14,7 +14,7 @@ where
     where
         T: Greeter,
     {
-        Greeter::greet(object);
+        object.greet();
     }
 }
 
@@ -28,7 +28,7 @@ where
     where
         T: Greeter,
     {
-        Greeter::greet(object);
+        object.greet();
     }
 }
 

--- a/tooling/nargo_cli/tests/snapshots/compile_success_no_bug/noirc_frontend_tests_traits_regression_6314_double_inheritance/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_no_bug/noirc_frontend_tests_traits_regression_6314_double_inheritance/execute__tests__expanded.snap
@@ -34,7 +34,7 @@ fn baz<T>(x: T) -> T
 where
     T: Baz,
 {
-    Bar::bar(Foo::foo(x))
+    x.foo().bar()
 }
 
 fn main() {

--- a/tooling/nargo_cli/tests/snapshots/compile_success_no_bug/noirc_frontend_tests_traits_regression_6530/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_no_bug/noirc_frontend_tests_traits_regression_6530/execute__tests__expanded.snap
@@ -34,6 +34,6 @@ impl Into2<Field> for Foo {
 
 fn main() {
     let foo: Foo = Foo { inner: 0_Field };
-    let _: Field = Into2::into2(foo);
+    let _: Field = foo.into2();
     let _: Field = foo.into2();
 }

--- a/tooling/nargo_cli/tests/snapshots/compile_success_no_bug/noirc_frontend_tests_traits_renaming_trait_avoids_name_collisions/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_no_bug/noirc_frontend_tests_traits_renaming_trait_avoids_name_collisions/execute__tests__expanded.snap
@@ -17,5 +17,5 @@ mod trait_mod {
 pub struct Foo {}
 
 fn main(x: Field) {
-    x.foo();
+    Field::foo(x);
 }

--- a/tooling/nargo_cli/tests/snapshots/compile_success_no_bug/noirc_frontend_tests_traits_trait_inheritance/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_no_bug/noirc_frontend_tests_traits_trait_inheritance/execute__tests__expanded.snap
@@ -18,7 +18,7 @@ pub fn foo<T>(baz: T) -> (Field, Field, Field)
 where
     T: Baz,
 {
-    (Foo::foo(baz), Bar::bar(baz), Baz::baz(baz))
+    (baz.foo(), baz.bar(), baz.baz())
 }
 
 fn main() {}

--- a/tooling/nargo_cli/tests/snapshots/compile_success_no_bug/noirc_frontend_tests_traits_trait_inheritance_with_generics/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_no_bug/noirc_frontend_tests_traits_trait_inheritance_with_generics/execute__tests__expanded.snap
@@ -14,7 +14,7 @@ pub fn foo<T>(x: T) -> i32
 where
     T: Bar<i32>,
 {
-    Foo::foo(x)
+    x.foo()
 }
 
 fn main() {}

--- a/tooling/nargo_cli/tests/snapshots/compile_success_no_bug/noirc_frontend_tests_traits_trait_inheritance_with_generics_2/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_no_bug/noirc_frontend_tests_traits_trait_inheritance_with_generics_2/execute__tests__expanded.snap
@@ -14,7 +14,7 @@ pub fn foo<T>(x: T) -> i32
 where
     T: Bar<i32, i32>,
 {
-    Foo::foo(x)
+    x.foo()
 }
 
 fn main() {}

--- a/tooling/nargo_cli/tests/snapshots/compile_success_no_bug/noirc_frontend_tests_turbofish_turbofish_in_type_before_call_does_not_error/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_no_bug/noirc_frontend_tests_turbofish_turbofish_in_type_before_call_does_not_error/execute__tests__expanded.snap
@@ -13,5 +13,5 @@ impl<T> Foo<T> {
 }
 
 fn main() {
-    let _: Foo<i32> = Foo::new(1_i32);
+    let _: Foo<i32> = Foo::<i32>::new(1_i32);
 }

--- a/tooling/nargo_cli/tests/snapshots/compile_success_no_bug/noirc_frontend_tests_turbofish_use_generic_type_alias_with_partial_generics_with_turbofish_in_method_call_does_not_error/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_no_bug/noirc_frontend_tests_turbofish_use_generic_type_alias_with_partial_generics_with_turbofish_in_method_call_does_not_error/execute__tests__expanded.snap
@@ -16,5 +16,5 @@ impl<T, U> Foo<T, U> {
 type Bar<T> = Foo<T, i32>;
 
 fn main() {
-    let _: Foo<bool, i32> = Foo::new(true, 1_i32);
+    let _: Foo<bool, i32> = Foo::<bool, i32>::new(true, 1_i32);
 }

--- a/tooling/nargo_cli/tests/snapshots/compile_success_no_bug/noirc_frontend_tests_turbofish_use_generic_type_alias_with_turbofish_in_method_call_does_not_error/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_no_bug/noirc_frontend_tests_turbofish_use_generic_type_alias_with_turbofish_in_method_call_does_not_error/execute__tests__expanded.snap
@@ -13,7 +13,7 @@ impl<T> Foo<T> {
 type Bar<T> = Foo<T>;
 
 fn foo() -> Foo<i32> {
-    Foo::new()
+    Foo::<i32>::new()
 }
 
 fn main() {

--- a/tooling/nargo_cli/tests/snapshots/compile_success_no_bug/noirc_frontend_tests_use_type_alias_to_generic_concrete_type_in_method_call/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_no_bug/noirc_frontend_tests_use_type_alias_to_generic_concrete_type_in_method_call/execute__tests__expanded.snap
@@ -15,7 +15,7 @@ impl<T> Foo<T> {
 type Bar = Foo<i32>;
 
 fn foo() -> Bar {
-    Foo::new(1_i32)
+    Foo::<i32>::new(1_i32)
 }
 
 fn main() {

--- a/tooling/nargo_cli/tests/snapshots/compile_success_no_bug/noirc_frontend_tests_uses_self_type_inside_trait/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_no_bug/noirc_frontend_tests_uses_self_type_inside_trait/execute__tests__expanded.snap
@@ -21,5 +21,5 @@ impl Foo for Field {
 }
 
 fn main() {
-    let _: Field = Foo::foo();
+    let _: Field = Field::foo();
 }

--- a/tooling/nargo_cli/tests/snapshots/execution_success/a_1327_concrete_in_generic/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/a_1327_concrete_in_generic/execute__tests__expanded.snap
@@ -4,7 +4,7 @@ expression: expanded_code
 ---
 fn new_concrete_c_over_d() -> C<D> {
     let d_method_interface: MethodInterface<D> = get_d_method_interface();
-    C::new(d_method_interface)
+    C::<D>::new(d_method_interface)
 }
 
 struct B<T_C> {
@@ -54,7 +54,7 @@ fn get_d_method_interface() -> MethodInterface<D> {
 }
 
 fn main(input: Field) -> pub Field {
-    let b: B<C<D>> = B::new(new_concrete_c_over_d);
+    let b: B<C<D>> = B::<C<D>>::new(new_concrete_c_over_d);
     let c: C<D> = b.get_t_c();
     let d: D = D { d: input };
     let output: Field = c.call_method_of_t_d(d);

--- a/tooling/nargo_cli/tests/snapshots/execution_success/brillig_loop_size_regression/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/brillig_loop_size_regression/execute__tests__expanded.snap
@@ -9,11 +9,14 @@ struct EnumEmulation {
 }
 
 unconstrained fn main() -> pub Field {
-    let mut emulated_enum: EnumEmulation =
-        EnumEmulation { a: Option::some(1_Field), b: Option::none(), c: Option::none() };
+    let mut emulated_enum: EnumEmulation = EnumEmulation {
+        a: Option::<Field>::some(1_Field),
+        b: Option::<Field>::none(),
+        c: Option::<Field>::none(),
+    };
     for _ in 0_u32..1_u32 {
         assert(emulated_enum.a.unwrap() == 1_Field);
     }
-    emulated_enum.a = Option::some(2_Field);
+    emulated_enum.a = Option::<Field>::some(2_Field);
     emulated_enum.a.unwrap()
 }

--- a/tooling/nargo_cli/tests/snapshots/execution_success/brillig_rc_regression_6123/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/brillig_rc_regression_6123/execute__tests__expanded.snap
@@ -29,8 +29,10 @@ fn swap_items<T, let N: u32>(vec: &mut BoundedVec<T, N>, from_index: u32, to_ind
 }
 
 unconstrained fn main() {
-    let mut builder: Builder =
-        Builder { note_hashes: BoundedVec::new(), nullifiers: BoundedVec::new() };
+    let mut builder: Builder = Builder {
+        note_hashes: BoundedVec::<Field, 2>::new(),
+        nullifiers: BoundedVec::<Field, 2>::new(),
+    };
     builder.append_note_hashes_with_logs(2_u32);
     builder.nullifiers.set_unchecked(1_u32, 27_Field);
     let note_hashes: [Field; 2] = builder.note_hashes.storage();

--- a/tooling/nargo_cli/tests/snapshots/execution_success/derive/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/derive/execute__tests__expanded.snap
@@ -44,7 +44,7 @@ where
     where
         T: Default,
     {
-        Self { x: Default::default() }
+        Self { x: T::default() }
     }
 }
 
@@ -69,7 +69,7 @@ where
         H: Hasher,
         T: Hash,
     {
-        Hash::hash(_self.x, _state);
+        _self.x.hash(_state);
     }
 }
 
@@ -83,7 +83,7 @@ where
     {
         let mut result: std::cmp::Ordering = std::cmp::Ordering::equal();
         if result == std::cmp::Ordering::equal() {
-            result = Ord::cmp(_self.x, _other.x);
+            result = _self.x.cmp(_other.x);
         };
         result
     }
@@ -105,7 +105,11 @@ where
         A: Default,
         B: Default,
     {
-        Self { field1: Default::default(), field2: Default::default(), field3: Default::default() }
+        Self {
+            field1: A::default(),
+            field2: B::default(),
+            field3: MyOtherOtherStruct::<B>::default(),
+        }
     }
 }
 
@@ -135,8 +139,8 @@ where
         A: Hash,
         B: Hash,
     {
-        Hash::hash(_self.field1, _state);
-        Hash::hash(_self.field2, _state);
+        _self.field1.hash(_state);
+        _self.field2.hash(_state);
         _self.field3.hash(_state);
     }
 }
@@ -153,10 +157,10 @@ where
     {
         let mut result: std::cmp::Ordering = std::cmp::Ordering::equal();
         if result == std::cmp::Ordering::equal() {
-            result = Ord::cmp(_self.field1, _other.field1);
+            result = _self.field1.cmp(_other.field1);
         };
         if result == std::cmp::Ordering::equal() {
-            result = Ord::cmp(_self.field2, _other.field2);
+            result = _self.field2.cmp(_other.field2);
         };
         if result == std::cmp::Ordering::equal() {
             result = _self.field3.cmp(_other.field3);
@@ -196,9 +200,9 @@ impl Ord for EmptyStruct {
 fn main() {
     let s: MyStruct = MyStruct { my_field: 1_u32 };
     s.do_nothing();
-    let o: MyOtherStruct<Field, u32> = Default::default();
+    let o: MyOtherStruct<Field, u32> = MyOtherStruct::<Field, u32>::default();
     assert(o == o);
-    let o: MyOtherStruct<u8, [str<2>]> = Default::default();
+    let o: MyOtherStruct<u8, [str<2>]> = MyOtherStruct::<u8, [str<2>]>::default();
     assert(o == o);
     let o1: MyOtherStruct<u32, i8> = MyOtherStruct::<u32, i8> {
         field1: 12_u32,

--- a/tooling/nargo_cli/tests/snapshots/execution_success/generics/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/generics/execute__tests__expanded.snap
@@ -47,7 +47,8 @@ fn main(x: Field, y: Field) {
     foo(bar2);
     let int1: BigInt<1> = BigInt::<1> { limbs: [1_u32] };
     let int2: BigInt<1> = BigInt::<1> { limbs: [2_u32] };
-    let BigInt::<1> { limbs }: BigInt<1> = int1.second(int2).first(int1);
+    let BigInt::<1> { limbs }: BigInt<1> =
+        BigInt::<1>::first(BigInt::<1>::second(int1, int2), int1);
     assert(limbs == int2.limbs);
     assert(bar1.get_other() == bar1.other);
     let one: Field = x;

--- a/tooling/nargo_cli/tests/snapshots/execution_success/hashmap/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/hashmap/execute__tests__expanded.snap
@@ -27,8 +27,9 @@ global V_CMP: fn(Field, Field) -> bool = |a: Field, b: Field| -> bool a.lt(b);
 
 global KV_CMP: fn((K, V), (K, V)) -> bool = |a: (K, V), b: (K, V)| -> bool a.0.lt(b.0);
 
-global ALLOCATE_HASHMAP: fn() -> HashMap<K, V, 8, BuildHasherDefault<Poseidon2Hasher>> =
-    || -> HashMap<K, V, 8, BuildHasherDefault<Poseidon2Hasher>> Default::default();
+global ALLOCATE_HASHMAP: fn() -> HashMap<K, V, 8, BuildHasherDefault<Poseidon2Hasher>> = || -> HashMap<K, V, 8, BuildHasherDefault<Poseidon2Hasher>> {
+    HashMap::<Field, Field, 8, BuildHasherDefault<Poseidon2Hasher>>::default()
+};
 
 fn main(input: [Entry; 6]) {
     test_sequential(input[0_u32].key, input[0_u32].value);
@@ -202,13 +203,16 @@ type MyMap = HashMap<u8, u32, 10, BuildHasherDefault<Poseidon2Hasher>>;
 
 /// Tests examples from the stdlib hashmap documentation
 fn doc_tests() {
-    let hashmap: HashMap<u8, u32, 10, BuildHasherDefault<Poseidon2Hasher>> = Default::default();
-    assert(hashmap.is_empty());
-    let my_hasher: BuildHasherDefault<Poseidon2Hasher> = Default::default();
     let hashmap: HashMap<u8, u32, 10, BuildHasherDefault<Poseidon2Hasher>> =
-        HashMap::with_hasher(my_hasher);
+        HashMap::<u8, u32, 10, BuildHasherDefault<Poseidon2Hasher>>::default();
     assert(hashmap.is_empty());
-    let mut map: HashMap<Field, Field, 5, BuildHasherDefault<Poseidon2Hasher>> = Default::default();
+    let my_hasher: BuildHasherDefault<Poseidon2Hasher> =
+        BuildHasherDefault::<Poseidon2Hasher>::default();
+    let hashmap: HashMap<u8, u32, 10, BuildHasherDefault<Poseidon2Hasher>> =
+        HashMap::<u8, u32, 10, BuildHasherDefault<Poseidon2Hasher>>::with_hasher(my_hasher);
+    assert(hashmap.is_empty());
+    let mut map: HashMap<Field, Field, 5, BuildHasherDefault<Poseidon2Hasher>> =
+        HashMap::<Field, Field, 5, BuildHasherDefault<Poseidon2Hasher>>::default();
     map.insert(12_Field, 42_Field);
     assert(map.len() == 1_u32);
     get_example(map);
@@ -231,7 +235,7 @@ fn doc_tests() {
     map.remove(1_Field);
     assert(map.len() == 2_u32);
     let empty_map: HashMap<Field, Field, 42, BuildHasherDefault<Poseidon2Hasher>> =
-        Default::default();
+        HashMap::<Field, Field, 42, BuildHasherDefault<Poseidon2Hasher>>::default();
     assert(empty_map.len() == 0_u32);
     assert(empty_map.capacity() == 42_u32);
     assert(!map.is_empty());
@@ -246,8 +250,10 @@ fn doc_tests() {
     entries_examples(map);
     iter_examples(map);
     map.retain(|k: Field, v: Field| -> bool { (k != 0_Field) & (v != 0_Field) });
-    let mut map1: HashMap<Field, u64, 4, BuildHasherDefault<Poseidon2Hasher>> = Default::default();
-    let mut map2: HashMap<Field, u64, 4, BuildHasherDefault<Poseidon2Hasher>> = Default::default();
+    let mut map1: HashMap<Field, u64, 4, BuildHasherDefault<Poseidon2Hasher>> =
+        HashMap::<Field, u64, 4, BuildHasherDefault<Poseidon2Hasher>>::default();
+    let mut map2: HashMap<Field, u64, 4, BuildHasherDefault<Poseidon2Hasher>> =
+        HashMap::<Field, u64, 4, BuildHasherDefault<Poseidon2Hasher>>::default();
     map1.insert(1_Field, 2_u64);
     map1.insert(3_Field, 4_u64);
     map2.insert(3_Field, 4_u64);
@@ -296,7 +302,7 @@ fn iter_examples(mut map: HashMap<Field, Field, 5, BuildHasherDefault<Poseidon2H
 mod utils {
     pub(crate) fn cut<T, let N: u32, let M: u32>(input: BoundedVec<T, N>) -> [T; M] {
         assert(M < N, "M should be less than N.");
-        let mut new: BoundedVec<T, M> = BoundedVec::new();
+        let mut new: BoundedVec<T, M> = BoundedVec::<T, M>::new();
         for i in 0_u32..M {
             new.push(input.get(i));
         }

--- a/tooling/nargo_cli/tests/snapshots/execution_success/prelude/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/prelude/execute__tests__expanded.snap
@@ -3,8 +3,8 @@ source: tooling/nargo_cli/tests/execute.rs
 expression: expanded_code
 ---
 fn main() {
-    let _xs: Vec<Field> = Vec::new();
-    let _option: Option<Field> = Option::none();
+    let _xs: Vec<Field> = Vec::<Field>::new();
+    let _option: Option<Field> = Option::<Field>::none();
     print("42\n");
     println("42");
 }
@@ -13,8 +13,8 @@ mod a {
     use std::{collections::vec::Vec, option::Option};
 
     fn main() {
-        let _xs: Vec<Field> = Vec::new();
-        let _option: Option<Field> = Option::none();
+        let _xs: Vec<Field> = Vec::<Field>::new();
+        let _option: Option<Field> = Option::<Field>::none();
         print("42\n");
         println("42");
     }
@@ -22,8 +22,8 @@ mod a {
 
 mod b {
     fn main() {
-        let _xs: Vec<Field> = Vec::new();
-        let _option: Option<Field> = Option::none();
+        let _xs: Vec<Field> = Vec::<Field>::new();
+        let _option: Option<Field> = Option::<Field>::none();
         print("42\n");
         println("42");
     }

--- a/tooling/nargo_cli/tests/snapshots/execution_success/reference_only_used_as_alias/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/reference_only_used_as_alias/execute__tests__expanded.snap
@@ -84,7 +84,8 @@ unconstrained fn func(input: u32) {
 
 fn main(input: [Field; 4], randomness: Field, context_input: u32) {
     let b: [u32; 3] = [context_input, context_input, context_input];
-    let mut context: Context = Context { a: context_input, b: b, log_hashes: BoundedVec::new() };
+    let mut context: Context =
+        Context { a: context_input, b: b, log_hashes: BoundedVec::<LogHash, 4>::new() };
     let event0: ExampleEvent0 = ExampleEvent0 { value0: input[0_u32], value1: input[1_u32] };
     event0.emit(encode_event_with_randomness(&mut context, randomness));
 }

--- a/tooling/nargo_cli/tests/snapshots/execution_success/regression_11294/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/regression_11294/execute__tests__expanded.snap
@@ -61,7 +61,9 @@ impl PrivateKernelCircuitPublicInputsComposer {
         previous_kernel_public_inputs: PrivateKernelCircuitPublicInputs,
     ) -> Self {
         let mut public_inputs: PrivateKernelCircuitPublicInputsBuilder = PrivateKernelCircuitPublicInputsBuilder {
-            end: PrivateAccumulatedDataBuilder { private_call_stack: BoundedVec::new() },
+            end: PrivateAccumulatedDataBuilder {
+                private_call_stack: BoundedVec::<PrivateCallRequest, 8>::new(),
+            },
         };
         let start: PrivateAccumulatedData = previous_kernel_public_inputs.end;
         public_inputs.end.private_call_stack = array_to_bounded_vec(start.private_call_stack);
@@ -137,7 +139,7 @@ where
     T: Empty,
     T: Eq,
 {
-    Eq::eq(item, Empty::empty())
+    item.eq(T::empty())
 }
 
 pub fn array_length<T, let N: u32>(array: [T; N]) -> u32
@@ -169,5 +171,5 @@ where
     T: Eq,
 {
     let len: u32 = array_length(array);
-    BoundedVec::from_parts_unchecked(array, len)
+    BoundedVec::<T, N>::from_parts_unchecked(array, len)
 }

--- a/tooling/nargo_cli/tests/snapshots/execution_success/regression_4124/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/regression_4124/execute__tests__expanded.snap
@@ -41,6 +41,6 @@ impl<T> PublicMutable<T> {
 }
 
 fn main(value: Field) {
-    let ps: PublicMutable<Field> = PublicMutable::new(27_Field);
+    let ps: PublicMutable<Field> = PublicMutable::<Field>::new(27_Field);
     assert(ps.read() == value);
 }

--- a/tooling/nargo_cli/tests/snapshots/execution_success/regression_6674_3/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/regression_6674_3/execute__tests__expanded.snap
@@ -76,7 +76,7 @@ impl FixtureBuilder2 {
     }
 
     pub fn add_public_call_request(&mut self) {
-        self.public_call_requests.push(Counted::new(zeroed(), self.next_counter()));
+        self.public_call_requests.push(Counted::<Field>::new(zeroed(), self.next_counter()));
     }
 
     pub fn append_public_call_requests(&mut self, num: u32) {
@@ -126,11 +126,11 @@ pub struct PrivateKernelCircuitPublicInputsComposer {
 
 impl PrivateKernelCircuitPublicInputsComposer {
     pub unconstrained fn sort_ordered_values(&mut self) {
-        self.public_inputs.end.l2_to_l1_msgs = BoundedVec::from_parts_unchecked(
+        self.public_inputs.end.l2_to_l1_msgs = BoundedVec::<Field, 4>::from_parts_unchecked(
             sort_by_counter_desc(self.public_inputs.end.l2_to_l1_msgs.storage()),
             self.public_inputs.end.l2_to_l1_msgs.len(),
         );
-        self.public_inputs.end.public_call_requests = BoundedVec::from_parts_unchecked(
+        self.public_inputs.end.public_call_requests = BoundedVec::<Counted<Field>, 4>::from_parts_unchecked(
             sort_by_counter_desc(self.public_inputs.end.public_call_requests.storage()),
             self.public_inputs.end.public_call_requests.len(),
         );
@@ -141,8 +141,10 @@ impl PrivateKernelCircuitPublicInputsComposer {
     ) -> Self {
         let mut public_inputs: PrivateKernelCircuitPublicInputsBuilder = zeroed();
         let start: PrivateAccumulatedData = previous_kernel_public_inputs.end;
-        public_inputs.end.public_call_requests =
-            BoundedVec::from_parts(start.public_call_requests, start.public_call_requests.len());
+        public_inputs.end.public_call_requests = BoundedVec::<Counted<Field>, 4>::from_parts(
+            start.public_call_requests,
+            start.public_call_requests.len(),
+        );
         Self { public_inputs: public_inputs }
     }
 }
@@ -152,7 +154,7 @@ pub struct PrivateKernelCircuitPublicInputsBuilder {
 }
 
 fn vec_reverse<T, let N: u32>(vec: BoundedVec<T, N>) -> BoundedVec<T, N> {
-    let mut reversed: BoundedVec<T, N> = BoundedVec::new();
+    let mut reversed: BoundedVec<T, N> = BoundedVec::<T, N>::new();
     let len: u32 = vec.len();
     for i in 0_u32..N {
         if i < len {

--- a/tooling/nargo_cli/tests/snapshots/execution_success/slice_regex/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/slice_regex/execute__tests__expanded.snap
@@ -68,9 +68,9 @@ where
         T: Regex,
         U: Regex,
     {
-        let lhs_result: Match = Regex::find_match(self.0, input);
+        let lhs_result: Match = self.0.find_match(input);
         if lhs_result.succeeded {
-            let rhs_result: Match = Regex::find_match(self.1, lhs_result.leftover);
+            let rhs_result: Match = self.1.find_match(lhs_result.leftover);
             if rhs_result.succeeded {
                 Match {
                     succeeded: true,
@@ -101,7 +101,7 @@ where
         let mut result: Match = Match::empty(input);
         for _ in 0_u32..N {
             if result.succeeded {
-                let next_result: Match = Regex::find_match(self.inner, result.leftover);
+                let next_result: Match = self.inner.find_match(result.leftover);
                 result = Match {
                     succeeded: next_result.succeeded,
                     match_ends: result.match_ends + next_result.match_ends,
@@ -128,11 +128,11 @@ where
         T: Regex,
         U: Regex,
     {
-        let lhs_result: Match = Regex::find_match(self.lhs, input);
+        let lhs_result: Match = self.lhs.find_match(input);
         if lhs_result.succeeded {
             lhs_result
         } else {
-            Regex::find_match(self.rhs, input)
+            self.rhs.find_match(input)
         }
     }
 }

--- a/tooling/nargo_cli/tests/snapshots/execution_success/struct/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/struct/execute__tests__expanded.snap
@@ -24,7 +24,7 @@ impl Pair {
     }
 
     fn bar(self) -> Field {
-        self.foo().bar
+        Self::foo(self).bar
     }
 }
 

--- a/tooling/nargo_cli/tests/snapshots/execution_success/uhashmap/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/uhashmap/execute__tests__expanded.snap
@@ -24,8 +24,9 @@ global V_CMP: fn(Field, Field) -> bool = |a: Field, b: Field| -> bool a.lt(b);
 
 global KV_CMP: fn((K, V), (K, V)) -> bool = |a: (K, V), b: (K, V)| -> bool a.0.lt(b.0);
 
-global ALLOCATE_HASHMAP: fn() -> UHashMap<K, V, BuildHasherDefault<Poseidon2Hasher>> =
-    || -> UHashMap<K, V, BuildHasherDefault<Poseidon2Hasher>> Default::default();
+global ALLOCATE_HASHMAP: fn() -> UHashMap<K, V, BuildHasherDefault<Poseidon2Hasher>> = || -> UHashMap<K, V, BuildHasherDefault<Poseidon2Hasher>> {
+    UHashMap::<Field, Field, BuildHasherDefault<Poseidon2Hasher>>::default()
+};
 
 unconstrained fn main(input: [Entry; 6]) {
     test_sequential(input[0_u32].key, input[0_u32].value);
@@ -201,13 +202,16 @@ type MyMap = UHashMap<u8, u32, BuildHasherDefault<Poseidon2Hasher>>;
 
 /// Tests examples from the stdlib cthashmap documentation
 unconstrained fn doc_tests() {
-    let hashmap: UHashMap<u8, u32, BuildHasherDefault<Poseidon2Hasher>> = Default::default();
-    assert(hashmap.is_empty());
-    let my_hasher: BuildHasherDefault<Poseidon2Hasher> = Default::default();
     let hashmap: UHashMap<u8, u32, BuildHasherDefault<Poseidon2Hasher>> =
-        UHashMap::with_hasher(my_hasher);
+        UHashMap::<u8, u32, BuildHasherDefault<Poseidon2Hasher>>::default();
     assert(hashmap.is_empty());
-    let mut map: UHashMap<Field, Field, BuildHasherDefault<Poseidon2Hasher>> = Default::default();
+    let my_hasher: BuildHasherDefault<Poseidon2Hasher> =
+        BuildHasherDefault::<Poseidon2Hasher>::default();
+    let hashmap: UHashMap<u8, u32, BuildHasherDefault<Poseidon2Hasher>> =
+        UHashMap::<u8, u32, BuildHasherDefault<Poseidon2Hasher>>::with_hasher(my_hasher);
+    assert(hashmap.is_empty());
+    let mut map: UHashMap<Field, Field, BuildHasherDefault<Poseidon2Hasher>> =
+        UHashMap::<Field, Field, BuildHasherDefault<Poseidon2Hasher>>::default();
     map.insert(12_Field, 42_Field);
     assert(map.len() == 1_u32);
     get_example(map);
@@ -229,7 +233,8 @@ unconstrained fn doc_tests() {
     assert(map.len() == 3_u32);
     map.remove(1_Field);
     assert(map.len() == 2_u32);
-    let empty_map: UHashMap<Field, Field, BuildHasherDefault<Poseidon2Hasher>> = Default::default();
+    let empty_map: UHashMap<Field, Field, BuildHasherDefault<Poseidon2Hasher>> =
+        UHashMap::<Field, Field, BuildHasherDefault<Poseidon2Hasher>>::default();
     assert(empty_map.len() == 0_u32);
     println(empty_map.capacity());
     assert(!map.is_empty());
@@ -244,8 +249,10 @@ unconstrained fn doc_tests() {
     entries_examples(map);
     iter_examples(map);
     map.retain(|k: Field, v: Field| -> bool { (k != 0_Field) & (v != 0_Field) });
-    let mut map1: UHashMap<Field, u64, BuildHasherDefault<Poseidon2Hasher>> = Default::default();
-    let mut map2: UHashMap<Field, u64, BuildHasherDefault<Poseidon2Hasher>> = Default::default();
+    let mut map1: UHashMap<Field, u64, BuildHasherDefault<Poseidon2Hasher>> =
+        UHashMap::<Field, u64, BuildHasherDefault<Poseidon2Hasher>>::default();
+    let mut map2: UHashMap<Field, u64, BuildHasherDefault<Poseidon2Hasher>> =
+        UHashMap::<Field, u64, BuildHasherDefault<Poseidon2Hasher>>::default();
     map1.insert(1_Field, 2_u64);
     map1.insert(3_Field, 4_u64);
     map2.insert(3_Field, 4_u64);

--- a/tooling/nargo_expand/src/printer.rs
+++ b/tooling/nargo_expand/src/printer.rs
@@ -1119,6 +1119,17 @@ impl<'context, 'string> ItemPrinter<'context, 'string> {
         }
     }
 
+    fn pattern_is_self_or_underscore_self(&self, pattern: &HirPattern) -> bool {
+        match pattern {
+            HirPattern::Identifier(ident) => {
+                let definition = self.interner.definition(ident.id);
+                definition.name == "self" || definition.name == "_self"
+            }
+            HirPattern::Mutable(pattern, _) => self.pattern_is_self(pattern),
+            HirPattern::Tuple(..) | HirPattern::Struct(..) => false,
+        }
+    }
+
     fn module_def_id_name(&self, module_def_id: ModuleDefId) -> String {
         match module_def_id {
             ModuleDefId::ModuleId(module_id) => {

--- a/tooling/nargo_expand/src/printer/hir.rs
+++ b/tooling/nargo_expand/src/printer/hir.rs
@@ -64,7 +64,7 @@ impl ItemPrinter<'_, '_> {
     pub(super) fn show_hir_expression(&mut self, hir_expr: HirExpression, expr_id: ExprId) {
         match hir_expr {
             HirExpression::Ident(hir_ident, generics) => {
-                self.show_hir_ident(hir_ident);
+                self.show_hir_ident(hir_ident, Some(expr_id));
                 if let Some(generics) = generics {
                     let use_colons = true;
                     self.show_generic_types(&generics, use_colons);
@@ -386,19 +386,19 @@ impl ItemPrinter<'_, '_> {
             return false;
         };
 
-        // Is this `self.foo()` where `self` is currently a trait?
-        // If so, show it as `self.foo()` instead of `Self::foo(self)`.
-        let mut method_on_trait_self = false;
-
         // Special case: assumed trait method
         if let ImplKind::TraitMethod(trait_method) = hir_ident.impl_kind {
             if trait_method.assumed {
-                if let Type::NamedGeneric(NamedGeneric { name, .. }) = &trait_method.constraint.typ
-                {
-                    if name.to_string() == "Self" {
-                        method_on_trait_self = true;
-                    }
-                }
+                // Is this `self.foo()` where `self` is currently a trait?
+                // If so, show it as `self.foo()` instead of `Self::foo(self)`.
+                let method_on_trait_self =
+                    if let Type::NamedGeneric(NamedGeneric { name, .. }) =
+                        &trait_method.constraint.typ
+                    {
+                        name.to_string() == "Self"
+                    } else {
+                        false
+                    };
 
                 if !method_on_trait_self {
                     self.show_type(&trait_method.constraint.typ);
@@ -419,11 +419,6 @@ impl ItemPrinter<'_, '_> {
         // The function must have a self type
         let func_meta = self.interner.function_meta(&func_id);
 
-        // Don't do this for trait methods (refer to the trait name instead)
-        if func_meta.trait_id.is_some() && !method_on_trait_self {
-            return false;
-        }
-
         let Some(self_type) = &func_meta.self_type else {
             return false;
         };
@@ -433,12 +428,20 @@ impl ItemPrinter<'_, '_> {
             return false;
         }
 
+        let (first_param_patten, first_param_type, _) = &func_meta.parameters.0[0];
+
+        // The first parameter must be `self` or `_self`
+        if !self.pattern_is_self_or_underscore_self(first_param_patten) {
+            return false;
+        }
+
         // The first parameter must unify with the self type (as-is or after removing `&mut`)
-        let param_type = func_meta.parameters.0[0].1.follow_bindings();
-        let param_type = if let Type::Reference(typ, ..) = param_type { *typ } else { param_type };
+        let first_param_type = first_param_type.follow_bindings();
+        let first_param_type =
+            if let Type::Reference(typ, ..) = first_param_type { *typ } else { first_param_type };
 
         let mut bindings = TypeBindings::default();
-        if self_type.try_unify(&param_type, &mut bindings).is_err() {
+        if self_type.try_unify(&first_param_type, &mut bindings).is_err() {
             return false;
         }
 
@@ -518,7 +521,7 @@ impl ItemPrinter<'_, '_> {
             }
             HirStatement::For(hir_for_statement) => {
                 self.push_str("for ");
-                self.show_hir_ident(hir_for_statement.identifier);
+                self.show_hir_ident(hir_for_statement.identifier, None);
                 self.push_str(" in ");
                 self.show_hir_expression_id(hir_for_statement.start_range);
                 self.push_str("..");
@@ -622,7 +625,7 @@ impl ItemPrinter<'_, '_> {
     fn show_hir_lvalue(&mut self, lvalue: HirLValue) {
         match lvalue {
             HirLValue::Ident(hir_ident, _) => {
-                self.show_hir_ident(hir_ident);
+                self.show_hir_ident(hir_ident, None);
             }
             HirLValue::MemberAccess { object, field_name, field_index: _, typ: _, location: _ } => {
                 self.show_hir_lvalue(*object);
@@ -651,7 +654,7 @@ impl ItemPrinter<'_, '_> {
 
     fn show_hir_pattern(&mut self, pattern: HirPattern) {
         match pattern {
-            HirPattern::Identifier(hir_ident) => self.show_hir_ident(hir_ident),
+            HirPattern::Identifier(hir_ident) => self.show_hir_ident(hir_ident, None),
             HirPattern::Mutable(hir_pattern, _) => {
                 self.push_str("mut ");
                 self.show_hir_pattern(*hir_pattern);
@@ -687,28 +690,55 @@ impl ItemPrinter<'_, '_> {
     fn show_definition_id(&mut self, definition_id: DefinitionId) {
         let location = self.interner.definition(definition_id).location;
         let ident = HirIdent::non_trait_method(definition_id, location);
-        self.show_hir_ident(ident);
+        self.show_hir_ident(ident, None);
     }
 
-    fn show_hir_ident(&mut self, ident: HirIdent) {
+    fn show_hir_ident(&mut self, ident: HirIdent, expr_id: Option<ExprId>) {
         let definition = self.interner.definition(ident.id);
         match definition.kind {
             DefinitionKind::Function(func_id) => {
                 let func_meta = self.interner.function_meta(&func_id);
-                if func_meta.self_type.is_some() && func_meta.self_type == self.self_type {
+                let self_type = &func_meta.self_type;
+
+                if let Some(self_type) = self_type {
                     // No need to fully-qualify the function name if its self type is the current self type
-                    let name = self.interner.function_name(&func_id);
-                    self.push_str("Self::");
-                    self.push_str(name);
-                } else {
-                    let use_import = true;
-                    let visibility = self.interner.function_visibility(func_id);
-                    self.show_reference_to_module_def_id(
-                        ModuleDefId::FunctionId(func_id),
-                        visibility,
-                        use_import,
-                    );
+                    if Some(self_type) == self.self_type.as_ref() {
+                        let name = self.interner.function_name(&func_id);
+                        self.push_str("Self::");
+                        self.push_str(name);
+                        return;
+                    }
+
+                    // See if we can show this as `Self::method` by substitution instantiation type bindings for self_type
+                    if let Some(expr_id) = expr_id {
+                        if let Some(instantiation_bindings) =
+                            self.interner.try_get_instantiation_bindings(expr_id)
+                        {
+                            let self_type = self_type.substitute(instantiation_bindings);
+                            let unbound = if let Type::TypeVariable(type_var) = &self_type {
+                                type_var.borrow().is_unbound()
+                            } else {
+                                false
+                            };
+
+                            if !unbound {
+                                self.show_type_as_expression(&self_type);
+                                self.push_str("::");
+                                let name = self.interner.function_name(&func_id);
+                                self.push_str(name);
+                                return;
+                            }
+                        }
+                    }
                 }
+
+                let use_import = true;
+                let visibility = self.interner.function_visibility(func_id);
+                self.show_reference_to_module_def_id(
+                    ModuleDefId::FunctionId(func_id),
+                    visibility,
+                    use_import,
+                );
             }
             DefinitionKind::Global(global_id) => {
                 let global_info = self.interner.get_global(global_id);


### PR DESCRIPTION
# Description

## Problem

Part of #8281

## Summary

The core changes are on the first commit. The main change here is, when showing a HirIdent that corresponds to a function we now substitute instantiation bindings on `self` and show `self::method` if possible. That leads to more explicit generics showing up in some places, but I think that's acceptable (it shows more clearly what the compiler inferred, and could help with understanding code with the expansion).

## Additional Context

Still a few test programs don't expand to compilable code, but not many are left now!

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
