### PR TITLE
fix(fuzz): enable print in comptime_vs_brillig_direct

### DIFF
--- a/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
@@ -249,7 +249,7 @@ impl<'local, 'interner> Interpreter<'local, 'interner> {
     ) -> IResult<Value> {
         let attributes = self.elaborator.interner.function_attributes(&function);
         let func_attrs = &attributes.function()
-            .expect("all builtin functions must contain a function  attribute which contains the opcode which it links to").kind;
+            .expect("all builtin functions must contain a function attribute which contains the opcode which it links to").kind;
 
         if let Some(builtin) = func_attrs.builtin() {
             self.call_builtin(builtin.clone().as_str(), arguments, return_type, location)

--- a/tooling/ast_fuzzer/fuzz/src/targets/comptime_vs_brillig_direct.rs
+++ b/tooling/ast_fuzzer/fuzz/src/targets/comptime_vs_brillig_direct.rs
@@ -31,8 +31,6 @@ pub fn fuzz(u: &mut Unstructured) -> eyre::Result<()> {
         avoid_overflow: true,
         avoid_err_by_zero: true,
         avoid_constrain: true,
-        // At the moment prints aren't recognized by elaborator
-        avoid_print: true,
         // Use lower limits because of the interpreter, to avoid stack overflow
         max_loop_size: 5,
         max_recursive_calls: 5,


### PR DESCRIPTION
# Description

Turns out to use print bypassing nargo we just need to bring in the part of stdlib correctly declaring print oracle harnesses.

## Problem\*

Resolves #8973 

## Summary\*



## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
