### PR TITLE
chore: replace array operation on 0-len arrays with side effect assertion

### DIFF
--- a/test_programs/execution_success/regression_8874/Nargo.toml
+++ b/test_programs/execution_success/regression_8874/Nargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "regression_8874"
+type = "bin"
+authors = [""]
+
+[dependencies]

--- a/test_programs/execution_success/regression_8874/Prover.toml
+++ b/test_programs/execution_success/regression_8874/Prover.toml
@@ -1,0 +1,2 @@
+print = false
+i = 5

--- a/test_programs/execution_success/regression_8874/src/main.nr
+++ b/test_programs/execution_success/regression_8874/src/main.nr
@@ -1,0 +1,7 @@
+fn main(print: bool, i: u32) {
+    let array: [u32; 0] = [];
+
+    if print {
+        println(array[i]);
+    }
+}


### PR DESCRIPTION
# Description

## Problem\*

Related to #8874

## Summary\*
Array operations on 0-length arrays are replaced by an assertion on the 'side-effects-enabled'


## Additional Context
I tried to do it with a ssa pass, but it seemed overkill for an uncommon case (it cannot use the 'simple optimisation' pass) . I end up doing this transformation directly in acir-gen.


## Documentation\*

Check one:
- [X] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
