### PR TITLE
chore: move a couple of test_utils functions into a module

### DIFF
--- a/tooling/ast_fuzzer/src/compare/comptime.rs
+++ b/tooling/ast_fuzzer/src/compare/comptime.rs
@@ -19,9 +19,11 @@ use noirc_driver::{
 };
 use noirc_errors::CustomDiagnostic;
 use noirc_evaluator::ssa::SsaProgramArtifact;
-use noirc_frontend::elaborator::ElaboratorError;
+use noirc_frontend::elaborator::test_utils::ElaboratorError;
 use noirc_frontend::hir::def_collector::dc_crate::CompilationError;
-use noirc_frontend::{elaborator::interpret, hir::Context, monomorphization::ast::Program};
+use noirc_frontend::{
+    elaborator::test_utils::interpret, hir::Context, monomorphization::ast::Program,
+};
 
 use super::{CompareArtifact, CompareCompiledResult, CompareOptions, HasPrograms};
 use crate::compare::compiled::ExecResult;


### PR DESCRIPTION
# Description

## Problem

The current code would give a warning saying that the `InterpreterError` import was unused, because it was only used if `test_utils` was enabled. I considered changing the usage to a fully-qualified path but maybe it's better to put everything inside its own module so that imports need to be defined again and they don't clash with the non-gated module.

## Summary



## Additional Context



## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
