### PR TITLE
chore: Refactor `ConstrainEqFailed` to have `Option<String>` for `msg`

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/interpreter/errors.rs
+++ b/compiler/noirc_evaluator/src/ssa/interpreter/errors.rs
@@ -14,10 +14,22 @@ pub enum InterpreterError {
     /// These errors are all the result from malformed input SSA
     #[error("{0}")]
     Internal(InternalError),
-    #[error("constrain {lhs_id} == {rhs_id}{msg} failed:\n    {lhs} != {rhs}")]
-    ConstrainEqFailed { lhs: String, lhs_id: ValueId, rhs: String, rhs_id: ValueId, msg: String },
-    #[error("constrain {lhs_id} != {rhs_id}{msg} failed:\n    {lhs} == {rhs}")]
-    ConstrainNeFailed { lhs: String, lhs_id: ValueId, rhs: String, rhs_id: ValueId, msg: String },
+    #[error("constrain {lhs_id} == {rhs_id}{message} failed:\n    {lhs} != {rhs}", message = constraint_message(.msg))]
+    ConstrainEqFailed {
+        lhs: String,
+        lhs_id: ValueId,
+        rhs: String,
+        rhs_id: ValueId,
+        msg: Option<String>,
+    },
+    #[error("constrain {lhs_id} != {rhs_id}{message} failed:\n    {lhs} == {rhs}", message = constraint_message(.msg))]
+    ConstrainNeFailed {
+        lhs: String,
+        lhs_id: ValueId,
+        rhs: String,
+        rhs_id: ValueId,
+        msg: Option<String>,
+    },
     #[error("static_assert `{condition}` failed: {message}")]
     StaticAssertFailed { condition: ValueId, message: String },
     #[error(
@@ -176,4 +188,9 @@ pub enum InternalError {
     UnexpectedInput { name: &'static str, expected_type: &'static str, value: String },
     #[error("Error parsing `{name}` into `{expected_type}` from `{value}`: {error}")]
     ParsingError { name: &'static str, expected_type: &'static str, value: String, error: String },
+}
+
+/// Format the message of a `constrain` instruction so that we can print it.
+fn constraint_message(msg: &Option<String>) -> String {
+    msg.as_ref().map(|msg| format!(", \"{msg}\"")).unwrap_or_default()
 }

--- a/compiler/noirc_evaluator/src/ssa/interpreter/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/interpreter/mod.rs
@@ -511,9 +511,9 @@ impl<'ssa, W: Write> Interpreter<'ssa, W> {
                     let lhs_id = *lhs_id;
                     let rhs_id = *rhs_id;
                     let msg = if let Some(ConstrainError::StaticString(msg)) = constrain_error {
-                        format!(", \"{msg}\"")
+                        Some(msg.clone())
                     } else {
-                        "".to_string()
+                        None
                     };
                     return Err(InterpreterError::ConstrainEqFailed {
                         lhs,
@@ -534,9 +534,9 @@ impl<'ssa, W: Write> Interpreter<'ssa, W> {
                     let lhs_id = *lhs_id;
                     let rhs_id = *rhs_id;
                     let msg = if let Some(ConstrainError::StaticString(msg)) = constrain_error {
-                        format!(", \"{msg}\"")
+                        Some(msg.clone())
                     } else {
-                        "".to_string()
+                        None
                     };
                     return Err(InterpreterError::ConstrainNeFailed {
                         lhs,

--- a/tooling/ast_fuzzer/src/compare/interpreted.rs
+++ b/tooling/ast_fuzzer/src/compare/interpreted.rs
@@ -204,10 +204,10 @@ impl Comparable for ssa::interpreter::errors::InterpreterError {
             ) => {
                 // The removal of unreachable instructions evaluates constant binary operations and can replace
                 // e.g. a `mul` followed by a `range_check` with a `constrain true == false, "attempt to multiple with overflow"`
-                msg2.contains(msg1)
+                msg2.as_ref().is_some_and(|msg| msg == msg1)
             }
             (DivisionByZero { .. }, ConstrainEqFailed { msg, .. }) => {
-                msg.contains("attempt to divide by zero")
+                msg.as_ref().is_some_and(|msg| msg == "attempt to divide by zero")
             }
             (e1, e2) => {
                 // The format strings contain SSA instructions,


### PR DESCRIPTION
# Description

## Problem\*

Resolves the hacky way the formatting of `, "<msg>"` was achieved.

## Summary\*

Switch to using the intended way of `this_error` to format a field.

## Additional Context

The `msg` field of `ConstraintEqFailed` contained either `""` or e.g. `", \"attempt to multiply with overflow\""` which meant we had to use `msg.contains(other)` instead of `msg == other` to check it against other things.

## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
