### PR TITLE
chore(debug): Toggle SSA locations when printing SSA 

### DIFF
--- a/compiler/noirc_driver/src/lib.rs
+++ b/compiler/noirc_driver/src/lib.rs
@@ -79,6 +79,11 @@ pub struct CompileOptions {
     #[arg(long, hide = true)]
     pub show_ssa_pass: Vec<String>,
 
+    /// Do not emit source file locations when emitting debug information for the SSA IR to stdout.
+    /// By default, source file locations will be shown.
+    #[arg(long)]
+    pub no_ssa_locations: bool,
+
     /// Only show the SSA and ACIR for the contract function with a given name.
     #[arg(long, hide = true)]
     pub show_contract_fn: Option<String>,
@@ -796,7 +801,11 @@ pub fn compile_no_check(
                 &context.file_manager,
             )?
         } else {
-            create_program(program, &ssa_evaluator_options, Some(&context.file_manager))?
+            create_program(
+                program,
+                &ssa_evaluator_options,
+                if options.no_ssa_locations { None } else { Some(&context.file_manager) },
+            )?
         };
 
     let abi = gen_abi(context, &main_function, return_visibility, error_types);

--- a/compiler/noirc_driver/src/lib.rs
+++ b/compiler/noirc_driver/src/lib.rs
@@ -81,7 +81,7 @@ pub struct CompileOptions {
 
     /// Do not emit source file locations when emitting debug information for the SSA IR to stdout.
     /// By default, source file locations will be shown.
-    #[arg(long)]
+    #[arg(long, hide = true)]
     pub no_ssa_locations: bool,
 
     /// Only show the SSA and ACIR for the contract function with a given name.


### PR DESCRIPTION
# Description

## Problem\*

No issue, just something I would like post https://github.com/noir-lang/noir/pull/9001.

Sometimes I like to write small programs in Noir so that I can print their SSA and then transfer it to SSA unit tests. To do this always having SSA locations adds some extra friction, especially when indents don't perfectly line up. 

## Summary\*

I simply added a new compiler options `no_ssa_locations` to determine whether we pass a file manager during `compile_no_check`. 

I debated expanding our `SsaLogging` enum to a struct to contain more settings, but as this print detail was already being toggled through an optional file manager I felt adding a compile option was simpler and touched less code. 

Running on `test_programs/assert_statement`:
The default `nargo compile --show-ssa`:
```
acir(inline) predicate_pure fn main f0 {
  b0(v0: Field, v1: Field):
    constrain v0 == v1, "x and y are not equal"         // src/main.nr:5:12
    return
}
```
With `nargo execute --show-ssa --no-ssa-locations`:
```
acir(inline) predicate_pure fn main f0 {
  b0(v0: Field, v1: Field):
    constrain v0 == v1, "x and y are not equal"
    return
}
```

## Additional Context

## Documentation\*

Check one:
- [X] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
