### PR TITLE
fix(codegen): look at struct args (generics) when generating structs

### DIFF
--- a/tooling/noir_codegen/package.json
+++ b/tooling/noir_codegen/package.json
@@ -35,7 +35,7 @@
     "dev": "tsc-multi --watch",
     "build": "tsc",
     "test": "yarn test:codegen && yarn test:node && yarn test:clean",
-    "test:codegen": "${NARGO:-nargo} export --program-dir=./test/test_lib && tsx src/main.ts ./test/test_lib/export/** --out-dir ./test/codegen",
+    "test:codegen": "rm -rf ./test/test_lib/export && ${NARGO:-nargo} export --program-dir=./test/test_lib && tsx src/main.ts ./test/test_lib/export/** --out-dir ./test/codegen",
     "test:node": "mocha --timeout 25000 --exit --config ./.mocharc.json",
     "test:clean": "rm -rf ./test/codegen ./test/test_lib/export",
     "prettier": "prettier 'src/**/*.ts'",

--- a/tooling/noir_codegen/src/utils/abi_type_with_generics.ts
+++ b/tooling/noir_codegen/src/utils/abi_type_with_generics.ts
@@ -60,63 +60,44 @@ export type AbiTypeWithGenerics =
  * Maps an ABI type to an ABI type with generics.
  * This performs pure type conversion, and does not generate any bindings.
  */
-export function mapAbiTypeToAbiTypeWithGenerics(
-  abiType: AbiType,
-  allTypes: AbiTypeWithGenerics[],
-): AbiTypeWithGenerics {
-  let returnedType: AbiTypeWithGenerics;
+export function mapAbiTypeToAbiTypeWithGenerics(abiType: AbiType): AbiTypeWithGenerics {
   switch (abiType.kind) {
     case 'field':
     case 'boolean':
     case 'string':
     case 'integer':
-      returnedType = abiType;
-      break;
-    case 'array': {
-      const type = mapAbiTypeToAbiTypeWithGenerics(abiType.type, allTypes);
-      returnedType = {
+      return abiType;
+    case 'array':
+      return {
         kind: 'array',
         length: abiType.length,
-        type,
+        type: mapAbiTypeToAbiTypeWithGenerics(abiType.type),
       };
-      break;
-    }
     case 'struct': {
       const structType = {
         path: abiType.path,
-        fields: abiType.fields.map(function (field) {
-          const type = mapAbiTypeToAbiTypeWithGenerics(field.type, allTypes);
-          return {
-            name: field.name,
-            type,
-          };
-        }),
+        fields: abiType.fields.map((field) => ({
+          name: field.name,
+          type: mapAbiTypeToAbiTypeWithGenerics(field.type),
+        })),
         generics: [],
       };
-      returnedType = {
+      return {
         kind: 'struct',
         structType,
         args: [],
       };
-      break;
     }
     case 'tuple':
-      returnedType = {
+      return {
         kind: 'tuple',
-        fields: abiType.fields.map(function (field) {
-          const type = mapAbiTypeToAbiTypeWithGenerics(field, allTypes);
-          allTypes.push(type);
-          return type;
-        }),
+        fields: abiType.fields.map(mapAbiTypeToAbiTypeWithGenerics),
       };
-      break;
     default: {
       const exhaustiveCheck: never = abiType;
       throw new Error(`Unhandled abi type: ${exhaustiveCheck}`);
     }
   }
-  allTypes.push(returnedType);
-  return returnedType;
 }
 
 /**

--- a/tooling/noir_codegen/src/utils/abi_type_with_generics.ts
+++ b/tooling/noir_codegen/src/utils/abi_type_with_generics.ts
@@ -131,9 +131,12 @@ export function findAllStructsInType(abiType: AbiTypeWithGenerics): Struct[] {
   let lastStructs = findStructsInType(abiType);
   while (lastStructs.length > 0) {
     allStructs = allStructs.concat(lastStructs);
-    lastStructs = lastStructs.flatMap((struct) =>
-      struct.structType.fields.flatMap((field) => findStructsInType(field.type)),
-    );
+    lastStructs = lastStructs.flatMap(function (struct) {
+      const fieldStructTypes = struct.structType.fields.flatMap((field) => findStructsInType(field.type));
+      const argsStructTypes = struct.args.flatMap(findAllStructsInType);
+      const structTypes = fieldStructTypes.concat(argsStructTypes);
+      return structTypes;
+    });
   }
   return allStructs;
 }

--- a/tooling/noir_codegen/src/utils/typings_generator.ts
+++ b/tooling/noir_codegen/src/utils/typings_generator.ts
@@ -99,11 +99,13 @@ export class TypingsGenerator {
     // Map all the types used in the ABIs to the demonomorphized types
     for (const { abi, circuitName, artifact } of circuits) {
       const params = abi.parameters.map((param) => {
-        const type = mapAbiTypeToAbiTypeWithGenerics(param.type, this.allTypes);
+        const type = mapAbiTypeToAbiTypeWithGenerics(param.type);
+        this.allTypes.push(type);
         return { name: param.name, type };
       });
       if (abi.return_type) {
-        const returnType = mapAbiTypeToAbiTypeWithGenerics(abi.return_type.abi_type, this.allTypes);
+        const returnType = mapAbiTypeToAbiTypeWithGenerics(abi.return_type.abi_type);
+        this.allTypes.push(returnType);
         this.demonomorphizedAbis.push({ circuitName, params, returnType, artifact });
       } else {
         this.demonomorphizedAbis.push({ circuitName, params, artifact });

--- a/tooling/noir_codegen/test/index.test.ts
+++ b/tooling/noir_codegen/test/index.test.ts
@@ -4,13 +4,10 @@ import { expect } from 'chai';
 import {
   exported_function_foo,
   exported_function_baz,
-  exported_function_parent,
   MyStruct,
   u64,
   u32,
   ForeignCallHandler,
-  Parent,
-  Child,
 } from './codegen/index.js';
 
 it('codegens a callable function', async () => {
@@ -118,19 +115,4 @@ it('allows passing a custom foreign call handler', async () => {
 it('codegens a callable argless function', async () => {
   const val: u64 = await exported_function_baz();
   expect(val).to.be.eq('0x01');
-});
-
-it('codegens types for generic arguments', async () => {
-  const a: Parent<Child> = {
-    inner: {
-      value: '1',
-    },
-    counter: '2',
-  };
-  const b: Parent<u32> = {
-    inner: '3',
-    counter: '4',
-  };
-  const val: u32 = await exported_function_parent(a, b);
-  expect(val).to.be.eq('0x0a'); // 1 + 2 + 3 + 4 = 10
 });

--- a/tooling/noir_codegen/test/index.test.ts
+++ b/tooling/noir_codegen/test/index.test.ts
@@ -4,7 +4,10 @@ import { expect } from 'chai';
 import {
   exported_function_foo,
   exported_function_baz,
+  exported_function_parent,
   MyStruct,
+  Parent,
+  Child,
   u64,
   u32,
   ForeignCallHandler,
@@ -115,4 +118,20 @@ it('allows passing a custom foreign call handler', async () => {
 it('codegens a callable argless function', async () => {
   const val: u64 = await exported_function_baz();
   expect(val).to.be.eq('0x01');
+});
+
+
+it('codegens types for generic arguments', async () => {
+  const a: Parent<Child> = {
+    inner: {
+      value: '1',
+    },
+    counter: '2',
+  };
+  const b: Parent<u32> = {
+    inner: '3',
+    counter: '4',
+  };
+  const val: u32 = await exported_function_parent(a, b);
+  expect(val).to.be.eq('0x0a'); // 1 + 2 + 3 + 4 = 10
 });

--- a/tooling/noir_codegen/test/index.test.ts
+++ b/tooling/noir_codegen/test/index.test.ts
@@ -120,7 +120,6 @@ it('codegens a callable argless function', async () => {
   expect(val).to.be.eq('0x01');
 });
 
-
 it('codegens types for generic arguments', async () => {
   const a: Parent<Child> = {
     inner: {

--- a/tooling/noir_codegen/test/test_lib/src/lib.nr
+++ b/tooling/noir_codegen/test/test_lib/src/lib.nr
@@ -36,3 +36,17 @@ fn exported_function_bar(my_struct: NestedStruct<1, 2, 3, u64>) -> (u64) {
 fn exported_function_baz() -> u64 {
     1
 }
+
+pub struct Parent<T> {
+    inner: T,
+    counter: u32,
+}
+
+pub struct Child {
+    value: u32,
+}
+
+#[export]
+fn exported_function_parent(a: Parent<Child>, b: Parent<u32>) -> u32 {
+    a.counter + a.inner.value + b.counter + b.inner
+}

--- a/tooling/noir_codegen/test/test_lib/src/lib.nr
+++ b/tooling/noir_codegen/test/test_lib/src/lib.nr
@@ -36,17 +36,3 @@ fn exported_function_bar(my_struct: NestedStruct<1, 2, 3, u64>) -> (u64) {
 fn exported_function_baz() -> u64 {
     1
 }
-
-pub struct Parent<T> {
-    inner: T,
-    counter: u32,
-}
-
-pub struct Child {
-    value: u32,
-}
-
-#[export]
-fn exported_function_parent(a: Parent<Child>, b: Parent<u32>) -> u32 {
-    a.counter + a.inner.value + b.counter + b.inner
-}


### PR DESCRIPTION
# Description

## Problem

Resolves #9044

## Summary

The fix in the previous PR was wrong. Nested structs were generated. It's just that at one point generic struct field types get replaced with bindings, and the bindings (possibly structs) end up in an `args` field. So what was missing is taking a look at `args` to find more structs to generate.

## Additional Context

I added `rm -rf ./test/test_lib/export` to the test script because otherwise when you made changed to the Noir code some old code might remain there and error, and it can be a bit misleading.

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
