### PR TITLE
chore(debug): Add trait constraint to string helper

### DIFF
--- a/compiler/noirc_frontend/src/hir_def/traits.rs
+++ b/compiler/noirc_frontend/src/hir_def/traits.rs
@@ -4,6 +4,7 @@ use rustc_hash::FxHashMap as HashMap;
 use crate::ResolvedGeneric;
 use crate::ast::{Ident, ItemVisibility, NoirFunction};
 use crate::hir::type_check::generics::TraitGenerics;
+use crate::node_interner::NodeInterner;
 use crate::{
     Generics, Type, TypeBindings, TypeVariable,
     graph::CrateId,
@@ -119,6 +120,15 @@ impl TraitConstraint {
     pub fn apply_bindings(&mut self, type_bindings: &TypeBindings) {
         self.typ = self.typ.substitute(type_bindings);
         self.trait_bound.apply_bindings(type_bindings);
+    }
+
+    pub fn to_string(&self, interner: &NodeInterner) -> String {
+        interner.trait_constraint_string(
+            &self.typ,
+            self.trait_bound.trait_id,
+            &self.trait_bound.trait_generics.ordered,
+            &self.trait_bound.trait_generics.named,
+        )
     }
 }
 

--- a/compiler/noirc_frontend/src/node_interner.rs
+++ b/compiler/noirc_frontend/src/node_interner.rs
@@ -1487,6 +1487,30 @@ impl NodeInterner {
         trait_impls.collect()
     }
 
+    #[allow(unused)]
+    pub fn trait_constraint_string(
+        &self,
+        object_type: &Type,
+        trait_id: TraitId,
+        trait_generics: &[Type],
+        trait_associated_types: &[NamedType],
+    ) -> String {
+        let name = self.get_trait(trait_id).name.to_string();
+        let mut generics = vecmap(trait_generics, |t| format!("{t:?}")).join(", ");
+        let associated =
+            vecmap(trait_associated_types, |t| format!("{}: {:?}", t.name, t.typ)).join(", ");
+
+        if !generics.is_empty() && !associated.is_empty() {
+            generics += ", ";
+            generics += &associated;
+        }
+
+        if !generics.is_empty() {
+            generics = format!("<{generics}>");
+        }
+        format!("{object_type:?}: {name}{generics}")
+    }
+
     /// If the given function belongs to a trait impl, return its trait method id.
     /// Otherwise, return None.
     pub fn get_trait_method_id(&self, function: FuncId) -> Option<TraitMethodId> {


### PR DESCRIPTION
# Description

## Problem\*

No issue. This was just the easiest part to break out from my debugging on https://github.com/noir-lang/noir/pull/9041

## Summary\*

Provides an easy way to convert a `TraitConstraint` (or its constituent parts) to a string.

I often find myself rewriting this or a similar helper when debugging so it'd be nice to just always have it.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
