### PR TITLE
chore(fuzz): Capture printed output in `comptime_vs_brillig_direct`

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/mod.rs
+++ b/compiler/noirc_frontend/src/elaborator/mod.rs
@@ -2413,6 +2413,10 @@ impl Visitor for RemoveGenericsAppearingInTypeVisitor<'_> {
 
 #[cfg(feature = "test_utils")]
 pub mod test_utils {
+    use std::cell::RefCell;
+    use std::io::Write;
+    use std::rc::Rc;
+
     use crate::hir::comptime::InterpreterError;
     use crate::{hir::def_collector::dc_crate::CompilationError, parser::ParserError};
 
@@ -2429,8 +2433,9 @@ pub mod test_utils {
     /// Interpret source code using the elaborator, without
     /// parsing and compiling it with nargo, converting
     /// the result into a monomorphized AST expression.
-    pub fn interpret(
+    pub fn interpret<W: Write + 'static>(
         src: &str,
+        output: Rc<RefCell<W>>,
     ) -> Result<crate::monomorphization::ast::Expression, ElaboratorError> {
         use crate::elaborator::ElaboratorOptions;
         use crate::monomorphization::{Monomorphizer, debug_types::DebugTypeTracker};
@@ -2463,6 +2468,7 @@ pub mod test_utils {
         let parsed_files = ParsedFiles::new();
         let mut context = Context::new(file_manager, parsed_files);
         context.def_interner.populate_dummy_operator_traits();
+        context.set_comptime_printing(output);
 
         let krate = context.crate_graph.add_crate_root(FileId::dummy());
 

--- a/tooling/ast_fuzzer/src/program/func.rs
+++ b/tooling/ast_fuzzer/src/program/func.rs
@@ -1575,52 +1575,60 @@ impl<'a> FunctionContext<'a> {
     }
 }
 
-#[test]
-fn test_loop() {
-    let mut u = Unstructured::new(&[0u8; 1]);
-    let mut ctx = Context::default();
-    ctx.config.max_loop_size = 10;
-    ctx.config.vary_loop_size = false;
-    ctx.gen_main_decl(&mut u);
-    let mut fctx = FunctionContext::new(&mut ctx, FuncId(0));
-    fctx.budget = 2;
-    let loop_code = format!("{}", fctx.gen_loop(&mut u).unwrap()).replace(" ", "");
+#[cfg(test)]
+mod tests {
+    use arbitrary::Unstructured;
+    use noirc_frontend::monomorphization::ast::FuncId;
 
-    assert!(
-        loop_code.starts_with(
-            &r#"{
+    use crate::program::{Context, FunctionContext};
+
+    #[test]
+    fn test_loop() {
+        let mut u = Unstructured::new(&[0u8; 1]);
+        let mut ctx = Context::default();
+        ctx.config.max_loop_size = 10;
+        ctx.config.vary_loop_size = false;
+        ctx.gen_main_decl(&mut u);
+        let mut fctx = FunctionContext::new(&mut ctx, FuncId(0));
+        fctx.budget = 2;
+        let loop_code = format!("{}", fctx.gen_loop(&mut u).unwrap()).replace(" ", "");
+
+        assert!(
+            loop_code.starts_with(
+                &r#"{
     let mut idx_a$l0 = 0;
     loop {
         if (idx_a$l0 == 10) {
             break
         } else {
             idx_a$l0 = (idx_a$l0 + 1);"#
-                .replace(" ", "")
-        )
-    );
-}
+                    .replace(" ", "")
+            )
+        );
+    }
 
-#[test]
-fn test_while() {
-    let mut u = Unstructured::new(&[0u8; 1]);
-    let mut ctx = Context::default();
-    ctx.config.max_loop_size = 10;
-    ctx.config.vary_loop_size = false;
-    ctx.gen_main_decl(&mut u);
-    let mut fctx = FunctionContext::new(&mut ctx, FuncId(0));
-    fctx.budget = 2;
-    let while_code = format!("{}", fctx.gen_while(&mut u).unwrap()).replace(" ", "");
+    #[test]
+    fn test_while() {
+        let mut u = Unstructured::new(&[0u8; 1]);
+        let mut ctx = Context::default();
+        ctx.config.max_loop_size = 10;
+        ctx.config.vary_loop_size = false;
+        ctx.gen_main_decl(&mut u);
+        let mut fctx = FunctionContext::new(&mut ctx, FuncId(0));
+        fctx.budget = 2;
+        let while_code = format!("{}", fctx.gen_while(&mut u).unwrap()).replace(" ", "");
 
-    assert!(
-        while_code.starts_with(
-            &r#"{
+        assert!(
+            while_code.starts_with(
+                &r#"{
     let mut idx_a$l0 = 0;
     while (!false) {
         if (idx_a$l0 == 10) {
             break
         } else {
             idx_a$l0 = (idx_a$l0 + 1)"#
-                .replace(" ", "")
-        )
-    );
+                    .replace(" ", "")
+            )
+        );
+    }
 }


### PR DESCRIPTION
# Description

## Problem\*

Resolves something I noticed in testing, which is that the `comptime_vs_brillig_direct` target prints to the stdout during testing since https://github.com/noir-lang/noir/pull/9045

## Summary\*

Adds an `output` to the `interpret` method and captures it in the test, so now it doesn't go to stdout and it also gets compared with the Brillig runtime output.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
