### PR TITLE
feat(fuzz): Generate Match expressions and statements

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/ssa_gen/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/ssa_gen/mod.rs
@@ -774,7 +774,7 @@ impl FunctionContext<'_> {
     }
 
     fn codegen_match(&mut self, match_expr: &ast::Match) -> Result<Values, RuntimeError> {
-        let variable = self.lookup(match_expr.variable_to_match);
+        let variable = self.lookup(match_expr.variable_to_match.0);
 
         // Any matches with only a single case we don't need to check the tag at all.
         // Note that this includes all matches on struct / tuple values.
@@ -962,7 +962,7 @@ impl FunctionContext<'_> {
             "Expected enum variant to contain a value for each variant argument"
         );
 
-        for (value, arg) in variant.into_iter().zip(&case.arguments) {
+        for (value, (arg, _)) in variant.into_iter().zip(&case.arguments) {
             self.define(*arg, value);
         }
     }
@@ -978,7 +978,7 @@ impl FunctionContext<'_> {
             "Expected field length to match constructor argument count"
         );
 
-        for (value, arg) in fields.into_iter().zip(&case.arguments) {
+        for (value, (arg, _)) in fields.into_iter().zip(&case.arguments) {
             self.define(*arg, value);
         }
     }

--- a/compiler/noirc_frontend/src/monomorphization/ast.rs
+++ b/compiler/noirc_frontend/src/monomorphization/ast.rs
@@ -305,7 +305,7 @@ pub struct If {
 
 #[derive(Debug, Clone, Hash)]
 pub struct Match {
-    pub variable_to_match: LocalId,
+    pub variable_to_match: (LocalId, String),
     pub cases: Vec<MatchCase>,
     pub default_case: Option<Box<Expression>>,
     pub typ: Type,
@@ -314,7 +314,7 @@ pub struct Match {
 #[derive(Debug, Clone, Hash)]
 pub struct MatchCase {
     pub constructor: Constructor,
-    pub arguments: Vec<LocalId>,
+    pub arguments: Vec<(LocalId, String)>,
     pub branch: Expression,
 }
 

--- a/compiler/noirc_frontend/src/monomorphization/printer.rs
+++ b/compiler/noirc_frontend/src/monomorphization/printer.rs
@@ -63,6 +63,10 @@ impl AstPrinter {
         self.fmt_ident(name, &Definition::Function(id))
     }
 
+    fn fmt_match(&self, name: &str, id: LocalId) -> String {
+        if self.show_id { format!("${}", id.0) } else { self.fmt_local(name, id) }
+    }
+
     pub fn print_program(&mut self, program: &Program, f: &mut Formatter) -> std::fmt::Result {
         for (id, global) in &program.globals {
             self.print_global(id, global, f)?;
@@ -430,13 +434,14 @@ impl AstPrinter {
         match_expr: &super::ast::Match,
         f: &mut Formatter,
     ) -> Result<(), std::fmt::Error> {
-        write!(f, "match ${} {{", match_expr.variable_to_match.0)?;
+        let (var_id, var_name) = &match_expr.variable_to_match;
+        write!(f, "match {} {{", self.fmt_match(var_name, *var_id))?;
         self.indent_level += 1;
         self.next_line(f)?;
 
         for (i, case) in match_expr.cases.iter().enumerate() {
             write!(f, "{}", case.constructor)?;
-            let args = vecmap(&case.arguments, |arg| format!("${}", arg.0)).join(", ");
+            let args = vecmap(&case.arguments, |(id, name)| self.fmt_match(name, *id)).join(", ");
             if !args.is_empty() {
                 write!(f, "({args})")?;
             }

--- a/compiler/noirc_frontend/src/ownership/last_uses.rs
+++ b/compiler/noirc_frontend/src/ownership/last_uses.rs
@@ -381,7 +381,7 @@ impl LastUseContext {
         let match_id = self.next_if_or_match_id();
 
         for (i, case) in match_expr.cases.iter().enumerate() {
-            for argument in &case.arguments {
+            for (argument, _) in &case.arguments {
                 self.declare_variable(*argument);
             }
 

--- a/tooling/ast_fuzzer/src/lib.rs
+++ b/tooling/ast_fuzzer/src/lib.rs
@@ -45,6 +45,8 @@ pub struct Config {
     pub vary_loop_size: bool,
     /// Maximum number of recursive calls to make at runtime.
     pub max_recursive_calls: usize,
+    /// Maximum number of match cases.
+    pub max_match_cases: usize,
     /// Frequency of expressions, which produce a value.
     pub expr_freqs: Freqs,
     /// Frequency of statements in ACIR functions.
@@ -80,6 +82,7 @@ impl Default for Config {
             ("unary", 10),
             ("binary", 20),
             ("if", 15),
+            ("match", 15),
             ("block", 30),
             ("vars", 25),
             ("literal", 5),
@@ -88,6 +91,7 @@ impl Default for Config {
         let stmt_freqs_acir = Freqs::new(&[
             ("assign", 30),
             ("if", 10),
+            ("match", 10),
             ("for", 22),
             ("let", 25),
             ("call", 5),
@@ -98,6 +102,7 @@ impl Default for Config {
             ("continue", 20),
             ("assign", 30),
             ("if", 10),
+            ("match", 10),
             ("for", 15),
             ("loop", 15),
             ("while", 15),
@@ -119,6 +124,7 @@ impl Default for Config {
             max_loop_size: 10,
             vary_loop_size: true,
             max_recursive_calls: 25,
+            max_match_cases: 3,
             expr_freqs,
             stmt_freqs_acir,
             stmt_freqs_brillig,

--- a/tooling/ast_fuzzer/src/program/types.rs
+++ b/tooling/ast_fuzzer/src/program/types.rs
@@ -52,6 +52,11 @@ pub fn can_be_main(typ: &Type) -> bool {
     }
 }
 
+/// Check if a variable with a given type can be used in a match.
+pub fn can_be_matched(typ: &Type) -> bool {
+    matches!(typ, Type::Unit | Type::Bool | Type::Field | Type::Integer(_, _) | Type::Tuple(_))
+}
+
 /// Collect all the sub-types produced by a type.
 ///
 /// It's like a _power set_ of the type.


### PR DESCRIPTION
# Description

## Problem\*

Resolves #7926 

## Summary\*

Implement `match` statements in the AST generator.

## Additional Context

We are generating the what a match statement looks like in the monomorphized AST, but doing so without having in mind a full match statement in Noir, rather, just doing a single layer. 

For example take this program:
```rust
global G: (u32, u32) = (2, 3);
fn main() -> pub u8 {
  match G {
    (2, _) => 1, 
    (_, 3) => 2, 
    (4, _) => 3, 
    _ => 4
  }
}
```
It turns into the following AST:
```
global G$g0: (u32, u32) = (2, 3);
fn main$f0() -> pub u8 {
    {
        let internal variable$l0 = G$g0;
        match $0 {
            ($1, $2) => match $1 {
                2 => {
                    let _$l3 = internal_match_variable_1$l2;
                    1
                },
                4 => match $2 {
                    3 => {
                        let _$l4 = internal_match_variable_0$l1;
                        2
                    },
                    _ => {
                        let _$l5 = internal_match_variable_1$l2;
                        3
                    },
                },
                _ => match $2 {
                    3 => {
                        let _$l6 = internal_match_variable_0$l1;
                        2
                    },
                    _ => {
                        let _$l7 = internal variable$l0;
                        4
                    },
                },
            },
        }
    }
}
```

So, it's a series of simpler match statements, on one variable at a time. The AST generator generates only one random match, which can be:
* a bool variable against `true`, `false`, `_`
* a numeric variable against some random values and `_` (wanted to do ranges but the frontend doesn't parse them)
* a tuple gets matched and individual fields introduced as local variables

I added support for variable names in the `Match` so that I can print a parseable AST.

## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
