### PR TITLE
chore: remove redundant associated constant lookup

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/patterns.rs
+++ b/compiler/noirc_frontend/src/elaborator/patterns.rs
@@ -679,14 +679,8 @@ impl Elaborator<'_> {
 
         let location = variable.location;
         let name = variable.segments[1].ident.as_str();
-
-        let Some(self_type) = &self.self_type else {
-            return None;
-        };
-
-        let Some(trait_impl_id) = &self.current_trait_impl else {
-            return None;
-        };
+        let self_type = self.self_type.as_ref()?;
+        let trait_impl_id = &self.current_trait_impl?;
 
         // Check the `Self::AssociatedConstant` case when inside a trait impl
         if let Some((definition_id, numeric_type)) =


### PR DESCRIPTION
# Description

## Problem

Now that #9041 is merged there's one code path that isn't reached anymore (now this is done in a different way).

## Summary



## Additional Context



## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
