### PR TITLE
fix: use enable_side_effects for u128 multiplication overflow checks

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/opt/simple_optimization.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/simple_optimization.rs
@@ -1,3 +1,5 @@
+use acvm::FieldElement;
+
 use crate::{
     errors::RtResult,
     ssa::ir::{
@@ -5,6 +7,7 @@ use crate::{
         dfg::DataFlowGraph,
         function::Function,
         instruction::{Instruction, InstructionId},
+        types::NumericType,
         value::{ValueId, ValueMapping},
     },
 };
@@ -56,24 +59,27 @@ impl Function {
         F: FnMut(&mut SimpleOptimizationContext<'_, '_>) -> RtResult<()>,
     {
         let mut values_to_replace = ValueMapping::default();
-
+        let mut enable_side_effects =
+            self.dfg.make_constant(FieldElement::from(1_u128), NumericType::bool());
         for block_id in self.reachable_blocks() {
             let instruction_ids = self.dfg[block_id].take_instructions();
             self.dfg[block_id].instructions_mut().reserve(instruction_ids.len());
             for instruction_id in &instruction_ids {
                 let instruction_id = *instruction_id;
-
+                let instruction = &mut self.dfg[instruction_id];
                 if !values_to_replace.is_empty() {
-                    let instruction = &mut self.dfg[instruction_id];
                     instruction.replace_values(&values_to_replace);
                 }
-
+                if let Instruction::EnableSideEffectsIf { condition } = instruction {
+                    enable_side_effects = *condition;
+                }
                 let mut context = SimpleOptimizationContext {
                     block_id,
                     instruction_id,
                     dfg: &mut self.dfg,
                     values_to_replace: &mut values_to_replace,
                     insert_current_instruction_at_callback_end: true,
+                    enable_side_effects,
                 };
                 f(&mut context)?;
 
@@ -95,6 +101,7 @@ pub(crate) struct SimpleOptimizationContext<'dfg, 'mapping> {
     pub(crate) block_id: BasicBlockId,
     pub(crate) instruction_id: InstructionId,
     pub(crate) dfg: &'dfg mut DataFlowGraph,
+    pub(crate) enable_side_effects: ValueId,
     values_to_replace: &'mapping mut ValueMapping,
     insert_current_instruction_at_callback_end: bool,
 }


### PR DESCRIPTION
# Description

## Problem\*

Resolves #9099 

## Summary\*
u128 overflow checks take the current 'enable_side_effects' into account so that the check is disabled if there if side effects are disabled as well.


## Additional Context



## Documentation\*

Check one:
- [X] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
