### PR TITLE
fix(mem2reg): Look for aliases in `jmp` arguments

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/opt/mem2reg.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/mem2reg.rs
@@ -680,6 +680,16 @@ impl<'f> PerFunctionContext<'f> {
                     }
                 }
 
+                // Treat parameters passed to another block as if they were return values.
+                for arg in arguments {
+                    let arg_type = self.inserter.function.dfg.type_of_value(*arg);
+                    if Self::contains_references(&arg_type) {
+                        references.for_each_alias_of(*arg, |_, alias| {
+                            self.instruction_input_references.insert(alias);
+                        });
+                    }
+                }
+
                 // Set the aliases of the parameters
                 for (_, aliased_params) in arg_set {
                     for param in aliased_params.iter() {

--- a/test_programs/execution_success/regression_9119/Nargo.toml
+++ b/test_programs/execution_success/regression_9119/Nargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "regression_9119"
+type = "bin"
+authors = [""]
+
+[dependencies]

--- a/test_programs/execution_success/regression_9119/Prover.toml
+++ b/test_programs/execution_success/regression_9119/Prover.toml
@@ -1,0 +1,2 @@
+c = false
+return = true

--- a/test_programs/execution_success/regression_9119/src/main.nr
+++ b/test_programs/execution_success/regression_9119/src/main.nr
@@ -1,0 +1,8 @@
+unconstrained fn main(c: bool) -> pub bool {
+    let b = if c {
+        [(&mut true, 1)]
+    } else {
+        [(&mut true, 1)]
+    };
+    *b[0].0
+}

--- a/tooling/nargo_cli/tests/snapshots/execution_success/regression_9119/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/regression_9119/execute__tests__expanded.snap
@@ -1,0 +1,12 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: expanded_code
+---
+unconstrained fn main(c: bool) -> pub bool {
+    let b: [(&mut bool, Field); 1] = if c {
+        [(&mut true, 1_Field)]
+    } else {
+        [(&mut true, 1_Field)]
+    };
+    *b[0_u32].0
+}

--- a/tooling/nargo_cli/tests/snapshots/execution_success/regression_9119/execute__tests__force_brillig_false_inliner_-9223372036854775808.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/regression_9119/execute__tests__force_brillig_false_inliner_-9223372036854775808.snap
@@ -1,0 +1,54 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: artifact
+---
+{
+  "noir_version": "[noir_version]",
+  "hash": "[hash]",
+  "abi": {
+    "parameters": [
+      {
+        "name": "c",
+        "type": {
+          "kind": "boolean"
+        },
+        "visibility": "private"
+      }
+    ],
+    "return_type": {
+      "abi_type": {
+        "kind": "boolean"
+      },
+      "visibility": "public"
+    },
+    "error_types": {
+      "17843811134343075018": {
+        "error_kind": "string",
+        "string": "Stack too deep"
+      }
+    }
+  },
+  "bytecode": [
+    "func 0",
+    "current witness index : _1",
+    "private parameters indices : [_0]",
+    "public parameters indices : []",
+    "return value indices : [_1]",
+    "BRILLIG CALL func 0: inputs: [Single(Expression { mul_terms: [], linear_combinations: [(1, Witness(0))], q_c: 0 })], outputs: [Simple(Witness(1))]",
+    "unconstrained func 0",
+    "[Const { destination: Direct(2), bit_size: Integer(U32), value: 1 }, Const { destination: Direct(1), bit_size: Integer(U32), value: 32838 }, Const { destination: Direct(0), bit_size: Integer(U32), value: 3 }, Const { destination: Relative(2), bit_size: Integer(U32), value: 1 }, Const { destination: Relative(3), bit_size: Integer(U32), value: 0 }, CalldataCopy { destination_address: Direct(32836), size_address: Relative(2), offset_address: Relative(3) }, Cast { destination: Direct(32836), source: Direct(32836), bit_size: Integer(U1) }, Mov { destination: Relative(1), source: Direct(32836) }, Call { location: 14 }, Call { location: 15 }, Mov { destination: Direct(32837), source: Relative(1) }, Const { destination: Relative(2), bit_size: Integer(U32), value: 32837 }, Const { destination: Relative(3), bit_size: Integer(U32), value: 1 }, Stop { return_data: HeapVector { pointer: Relative(2), size: Relative(3) } }, Return, Call { location: 53 }, Const { destination: Relative(3), bit_size: Integer(U1), value: 1 }, Const { destination: Relative(4), bit_size: Field, value: 1 }, JumpIf { condition: Relative(1), location: 34 }, Jump { location: 20 }, Mov { destination: Relative(1), source: Direct(1) }, BinaryIntOp { destination: Direct(1), op: Add, bit_size: U32, lhs: Direct(1), rhs: Direct(2) }, Store { destination_pointer: Relative(1), source: Relative(3) }, Mov { destination: Relative(3), source: Direct(1) }, Const { destination: Relative(5), bit_size: Integer(U32), value: 3 }, BinaryIntOp { destination: Direct(1), op: Add, bit_size: U32, lhs: Direct(1), rhs: Relative(5) }, IndirectConst { destination_pointer: Relative(3), bit_size: Integer(U32), value: 1 }, BinaryIntOp { destination: Relative(5), op: Add, bit_size: U32, lhs: Relative(3), rhs: Direct(2) }, Mov { destination: Relative(6), source: Relative(5) }, Store { destination_pointer: Relative(6), source: Relative(1) }, BinaryIntOp { destination: Relative(6), op: Add, bit_size: U32, lhs: Relative(6), rhs: Direct(2) }, Store { destination_pointer: Relative(6), source: Relative(4) }, Mov { destination: Relative(2), source: Relative(3) }, Jump { location: 48 }, Mov { destination: Relative(1), source: Direct(1) }, BinaryIntOp { destination: Direct(1), op: Add, bit_size: U32, lhs: Direct(1), rhs: Direct(2) }, Store { destination_pointer: Relative(1), source: Relative(3) }, Mov { destination: Relative(3), source: Direct(1) }, Const { destination: Relative(5), bit_size: Integer(U32), value: 3 }, BinaryIntOp { destination: Direct(1), op: Add, bit_size: U32, lhs: Direct(1), rhs: Relative(5) }, IndirectConst { destination_pointer: Relative(3), bit_size: Integer(U32), value: 1 }, BinaryIntOp { destination: Relative(5), op: Add, bit_size: U32, lhs: Relative(3), rhs: Direct(2) }, Mov { destination: Relative(6), source: Relative(5) }, Store { destination_pointer: Relative(6), source: Relative(1) }, BinaryIntOp { destination: Relative(6), op: Add, bit_size: U32, lhs: Relative(6), rhs: Direct(2) }, Store { destination_pointer: Relative(6), source: Relative(4) }, Mov { destination: Relative(2), source: Relative(3) }, Jump { location: 48 }, Const { destination: Relative(1), bit_size: Integer(U32), value: 1 }, BinaryIntOp { destination: Relative(4), op: Add, bit_size: U32, lhs: Relative(2), rhs: Relative(1) }, Load { destination: Relative(3), source_pointer: Relative(4) }, Load { destination: Relative(1), source_pointer: Relative(3) }, Return, Const { destination: Direct(32772), bit_size: Integer(U32), value: 30720 }, BinaryIntOp { destination: Direct(32771), op: LessThan, bit_size: U32, lhs: Direct(0), rhs: Direct(32772) }, JumpIf { condition: Direct(32771), location: 58 }, IndirectConst { destination_pointer: Direct(1), bit_size: Integer(U64), value: 17843811134343075018 }, Trap { revert_data: HeapVector { pointer: Direct(1), size: Direct(2) } }, Return]"
+  ],
+  "debug_symbols": "nZLNisMgEIDfxbOH+NcmeZVSgklMEcQEGxeW4Lvv6CTb9lAovcynjt8Mg25kNH28ddZP8520l430wTpnb52bB73a2cPpRqocOERGCWcIjhCk5QCJUIgT4oyoEU2BqBAMcS5VRI1oCiQ2kthIYiMpEBKhEOAJQFOgKgR4IiVKjhG6NRiTJ3iaCSZddDB+Ja2PzlHyo10sl+6L9oWrDpCtKDF+BELByTqTV4k+7Oq9WqvdrU//svrYZlzsOuPyG180hy/Fi3+FnR5seHnjlCsFq3tn9u0U/fCUXX+XI3P8kSXMgxljMLnS46MwiBclqKqvKXf7Aw==",
+  "file_map": {
+    "50": {
+      "source": "unconstrained fn main(c: bool) -> pub bool {\n    let b = if c {\n        [(&mut true, 1)]\n    } else {\n        [(&mut true, 1)]\n    };\n    *b[0].0\n}\n",
+      "path": ""
+    }
+  },
+  "names": [
+    "main"
+  ],
+  "brillig_names": [
+    "main"
+  ]
+}

--- a/tooling/nargo_cli/tests/snapshots/execution_success/regression_9119/execute__tests__force_brillig_false_inliner_0.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/regression_9119/execute__tests__force_brillig_false_inliner_0.snap
@@ -1,0 +1,54 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: artifact
+---
+{
+  "noir_version": "[noir_version]",
+  "hash": "[hash]",
+  "abi": {
+    "parameters": [
+      {
+        "name": "c",
+        "type": {
+          "kind": "boolean"
+        },
+        "visibility": "private"
+      }
+    ],
+    "return_type": {
+      "abi_type": {
+        "kind": "boolean"
+      },
+      "visibility": "public"
+    },
+    "error_types": {
+      "17843811134343075018": {
+        "error_kind": "string",
+        "string": "Stack too deep"
+      }
+    }
+  },
+  "bytecode": [
+    "func 0",
+    "current witness index : _1",
+    "private parameters indices : [_0]",
+    "public parameters indices : []",
+    "return value indices : [_1]",
+    "BRILLIG CALL func 0: inputs: [Single(Expression { mul_terms: [], linear_combinations: [(1, Witness(0))], q_c: 0 })], outputs: [Simple(Witness(1))]",
+    "unconstrained func 0",
+    "[Const { destination: Direct(2), bit_size: Integer(U32), value: 1 }, Const { destination: Direct(1), bit_size: Integer(U32), value: 32838 }, Const { destination: Direct(0), bit_size: Integer(U32), value: 3 }, Const { destination: Relative(2), bit_size: Integer(U32), value: 1 }, Const { destination: Relative(3), bit_size: Integer(U32), value: 0 }, CalldataCopy { destination_address: Direct(32836), size_address: Relative(2), offset_address: Relative(3) }, Cast { destination: Direct(32836), source: Direct(32836), bit_size: Integer(U1) }, Mov { destination: Relative(1), source: Direct(32836) }, Call { location: 14 }, Call { location: 15 }, Mov { destination: Direct(32837), source: Relative(1) }, Const { destination: Relative(2), bit_size: Integer(U32), value: 32837 }, Const { destination: Relative(3), bit_size: Integer(U32), value: 1 }, Stop { return_data: HeapVector { pointer: Relative(2), size: Relative(3) } }, Return, Call { location: 53 }, Const { destination: Relative(3), bit_size: Integer(U1), value: 1 }, Const { destination: Relative(4), bit_size: Field, value: 1 }, JumpIf { condition: Relative(1), location: 34 }, Jump { location: 20 }, Mov { destination: Relative(1), source: Direct(1) }, BinaryIntOp { destination: Direct(1), op: Add, bit_size: U32, lhs: Direct(1), rhs: Direct(2) }, Store { destination_pointer: Relative(1), source: Relative(3) }, Mov { destination: Relative(3), source: Direct(1) }, Const { destination: Relative(5), bit_size: Integer(U32), value: 3 }, BinaryIntOp { destination: Direct(1), op: Add, bit_size: U32, lhs: Direct(1), rhs: Relative(5) }, IndirectConst { destination_pointer: Relative(3), bit_size: Integer(U32), value: 1 }, BinaryIntOp { destination: Relative(5), op: Add, bit_size: U32, lhs: Relative(3), rhs: Direct(2) }, Mov { destination: Relative(6), source: Relative(5) }, Store { destination_pointer: Relative(6), source: Relative(1) }, BinaryIntOp { destination: Relative(6), op: Add, bit_size: U32, lhs: Relative(6), rhs: Direct(2) }, Store { destination_pointer: Relative(6), source: Relative(4) }, Mov { destination: Relative(2), source: Relative(3) }, Jump { location: 48 }, Mov { destination: Relative(1), source: Direct(1) }, BinaryIntOp { destination: Direct(1), op: Add, bit_size: U32, lhs: Direct(1), rhs: Direct(2) }, Store { destination_pointer: Relative(1), source: Relative(3) }, Mov { destination: Relative(3), source: Direct(1) }, Const { destination: Relative(5), bit_size: Integer(U32), value: 3 }, BinaryIntOp { destination: Direct(1), op: Add, bit_size: U32, lhs: Direct(1), rhs: Relative(5) }, IndirectConst { destination_pointer: Relative(3), bit_size: Integer(U32), value: 1 }, BinaryIntOp { destination: Relative(5), op: Add, bit_size: U32, lhs: Relative(3), rhs: Direct(2) }, Mov { destination: Relative(6), source: Relative(5) }, Store { destination_pointer: Relative(6), source: Relative(1) }, BinaryIntOp { destination: Relative(6), op: Add, bit_size: U32, lhs: Relative(6), rhs: Direct(2) }, Store { destination_pointer: Relative(6), source: Relative(4) }, Mov { destination: Relative(2), source: Relative(3) }, Jump { location: 48 }, Const { destination: Relative(1), bit_size: Integer(U32), value: 1 }, BinaryIntOp { destination: Relative(4), op: Add, bit_size: U32, lhs: Relative(2), rhs: Relative(1) }, Load { destination: Relative(3), source_pointer: Relative(4) }, Load { destination: Relative(1), source_pointer: Relative(3) }, Return, Const { destination: Direct(32772), bit_size: Integer(U32), value: 30720 }, BinaryIntOp { destination: Direct(32771), op: LessThan, bit_size: U32, lhs: Direct(0), rhs: Direct(32772) }, JumpIf { condition: Direct(32771), location: 58 }, IndirectConst { destination_pointer: Direct(1), bit_size: Integer(U64), value: 17843811134343075018 }, Trap { revert_data: HeapVector { pointer: Direct(1), size: Direct(2) } }, Return]"
+  ],
+  "debug_symbols": "nZLNisMgEIDfxbOH+NcmeZVSgklMEcQEGxeW4Lvv6CTb9lAovcynjt8Mg25kNH28ddZP8520l430wTpnb52bB73a2cPpRqocOERGCWcIjhCk5QCJUIgT4oyoEU2BqBAMcS5VRI1oCiQ2kthIYiMpEBKhEOAJQFOgKgR4IiVKjhG6NRiTJ3iaCSZddDB+Ja2PzlHyo10sl+6L9oWrDpCtKDF+BELByTqTV4k+7Oq9WqvdrU//svrYZlzsOuPyG180hy/Fi3+FnR5seHnjlCsFq3tn9u0U/fCUXX+XI3P8kSXMgxljMLnS46MwiBclqKqvKXf7Aw==",
+  "file_map": {
+    "50": {
+      "source": "unconstrained fn main(c: bool) -> pub bool {\n    let b = if c {\n        [(&mut true, 1)]\n    } else {\n        [(&mut true, 1)]\n    };\n    *b[0].0\n}\n",
+      "path": ""
+    }
+  },
+  "names": [
+    "main"
+  ],
+  "brillig_names": [
+    "main"
+  ]
+}

--- a/tooling/nargo_cli/tests/snapshots/execution_success/regression_9119/execute__tests__force_brillig_false_inliner_9223372036854775807.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/regression_9119/execute__tests__force_brillig_false_inliner_9223372036854775807.snap
@@ -1,0 +1,54 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: artifact
+---
+{
+  "noir_version": "[noir_version]",
+  "hash": "[hash]",
+  "abi": {
+    "parameters": [
+      {
+        "name": "c",
+        "type": {
+          "kind": "boolean"
+        },
+        "visibility": "private"
+      }
+    ],
+    "return_type": {
+      "abi_type": {
+        "kind": "boolean"
+      },
+      "visibility": "public"
+    },
+    "error_types": {
+      "17843811134343075018": {
+        "error_kind": "string",
+        "string": "Stack too deep"
+      }
+    }
+  },
+  "bytecode": [
+    "func 0",
+    "current witness index : _1",
+    "private parameters indices : [_0]",
+    "public parameters indices : []",
+    "return value indices : [_1]",
+    "BRILLIG CALL func 0: inputs: [Single(Expression { mul_terms: [], linear_combinations: [(1, Witness(0))], q_c: 0 })], outputs: [Simple(Witness(1))]",
+    "unconstrained func 0",
+    "[Const { destination: Direct(2), bit_size: Integer(U32), value: 1 }, Const { destination: Direct(1), bit_size: Integer(U32), value: 32838 }, Const { destination: Direct(0), bit_size: Integer(U32), value: 3 }, Const { destination: Relative(2), bit_size: Integer(U32), value: 1 }, Const { destination: Relative(3), bit_size: Integer(U32), value: 0 }, CalldataCopy { destination_address: Direct(32836), size_address: Relative(2), offset_address: Relative(3) }, Cast { destination: Direct(32836), source: Direct(32836), bit_size: Integer(U1) }, Mov { destination: Relative(1), source: Direct(32836) }, Call { location: 14 }, Call { location: 15 }, Mov { destination: Direct(32837), source: Relative(1) }, Const { destination: Relative(2), bit_size: Integer(U32), value: 32837 }, Const { destination: Relative(3), bit_size: Integer(U32), value: 1 }, Stop { return_data: HeapVector { pointer: Relative(2), size: Relative(3) } }, Return, Call { location: 53 }, Const { destination: Relative(3), bit_size: Integer(U1), value: 1 }, Const { destination: Relative(4), bit_size: Field, value: 1 }, JumpIf { condition: Relative(1), location: 34 }, Jump { location: 20 }, Mov { destination: Relative(1), source: Direct(1) }, BinaryIntOp { destination: Direct(1), op: Add, bit_size: U32, lhs: Direct(1), rhs: Direct(2) }, Store { destination_pointer: Relative(1), source: Relative(3) }, Mov { destination: Relative(3), source: Direct(1) }, Const { destination: Relative(5), bit_size: Integer(U32), value: 3 }, BinaryIntOp { destination: Direct(1), op: Add, bit_size: U32, lhs: Direct(1), rhs: Relative(5) }, IndirectConst { destination_pointer: Relative(3), bit_size: Integer(U32), value: 1 }, BinaryIntOp { destination: Relative(5), op: Add, bit_size: U32, lhs: Relative(3), rhs: Direct(2) }, Mov { destination: Relative(6), source: Relative(5) }, Store { destination_pointer: Relative(6), source: Relative(1) }, BinaryIntOp { destination: Relative(6), op: Add, bit_size: U32, lhs: Relative(6), rhs: Direct(2) }, Store { destination_pointer: Relative(6), source: Relative(4) }, Mov { destination: Relative(2), source: Relative(3) }, Jump { location: 48 }, Mov { destination: Relative(1), source: Direct(1) }, BinaryIntOp { destination: Direct(1), op: Add, bit_size: U32, lhs: Direct(1), rhs: Direct(2) }, Store { destination_pointer: Relative(1), source: Relative(3) }, Mov { destination: Relative(3), source: Direct(1) }, Const { destination: Relative(5), bit_size: Integer(U32), value: 3 }, BinaryIntOp { destination: Direct(1), op: Add, bit_size: U32, lhs: Direct(1), rhs: Relative(5) }, IndirectConst { destination_pointer: Relative(3), bit_size: Integer(U32), value: 1 }, BinaryIntOp { destination: Relative(5), op: Add, bit_size: U32, lhs: Relative(3), rhs: Direct(2) }, Mov { destination: Relative(6), source: Relative(5) }, Store { destination_pointer: Relative(6), source: Relative(1) }, BinaryIntOp { destination: Relative(6), op: Add, bit_size: U32, lhs: Relative(6), rhs: Direct(2) }, Store { destination_pointer: Relative(6), source: Relative(4) }, Mov { destination: Relative(2), source: Relative(3) }, Jump { location: 48 }, Const { destination: Relative(1), bit_size: Integer(U32), value: 1 }, BinaryIntOp { destination: Relative(4), op: Add, bit_size: U32, lhs: Relative(2), rhs: Relative(1) }, Load { destination: Relative(3), source_pointer: Relative(4) }, Load { destination: Relative(1), source_pointer: Relative(3) }, Return, Const { destination: Direct(32772), bit_size: Integer(U32), value: 30720 }, BinaryIntOp { destination: Direct(32771), op: LessThan, bit_size: U32, lhs: Direct(0), rhs: Direct(32772) }, JumpIf { condition: Direct(32771), location: 58 }, IndirectConst { destination_pointer: Direct(1), bit_size: Integer(U64), value: 17843811134343075018 }, Trap { revert_data: HeapVector { pointer: Direct(1), size: Direct(2) } }, Return]"
+  ],
+  "debug_symbols": "nZLNisMgEIDfxbOH+NcmeZVSgklMEcQEGxeW4Lvv6CTb9lAovcynjt8Mg25kNH28ddZP8520l430wTpnb52bB73a2cPpRqocOERGCWcIjhCk5QCJUIgT4oyoEU2BqBAMcS5VRI1oCiQ2kthIYiMpEBKhEOAJQFOgKgR4IiVKjhG6NRiTJ3iaCSZddDB+Ja2PzlHyo10sl+6L9oWrDpCtKDF+BELByTqTV4k+7Oq9WqvdrU//svrYZlzsOuPyG180hy/Fi3+FnR5seHnjlCsFq3tn9u0U/fCUXX+XI3P8kSXMgxljMLnS46MwiBclqKqvKXf7Aw==",
+  "file_map": {
+    "50": {
+      "source": "unconstrained fn main(c: bool) -> pub bool {\n    let b = if c {\n        [(&mut true, 1)]\n    } else {\n        [(&mut true, 1)]\n    };\n    *b[0].0\n}\n",
+      "path": ""
+    }
+  },
+  "names": [
+    "main"
+  ],
+  "brillig_names": [
+    "main"
+  ]
+}

--- a/tooling/nargo_cli/tests/snapshots/execution_success/regression_9119/execute__tests__force_brillig_true_inliner_-9223372036854775808.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/regression_9119/execute__tests__force_brillig_true_inliner_-9223372036854775808.snap
@@ -1,0 +1,54 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: artifact
+---
+{
+  "noir_version": "[noir_version]",
+  "hash": "[hash]",
+  "abi": {
+    "parameters": [
+      {
+        "name": "c",
+        "type": {
+          "kind": "boolean"
+        },
+        "visibility": "private"
+      }
+    ],
+    "return_type": {
+      "abi_type": {
+        "kind": "boolean"
+      },
+      "visibility": "public"
+    },
+    "error_types": {
+      "17843811134343075018": {
+        "error_kind": "string",
+        "string": "Stack too deep"
+      }
+    }
+  },
+  "bytecode": [
+    "func 0",
+    "current witness index : _1",
+    "private parameters indices : [_0]",
+    "public parameters indices : []",
+    "return value indices : [_1]",
+    "BRILLIG CALL func 0: inputs: [Single(Expression { mul_terms: [], linear_combinations: [(1, Witness(0))], q_c: 0 })], outputs: [Simple(Witness(1))]",
+    "unconstrained func 0",
+    "[Const { destination: Direct(2), bit_size: Integer(U32), value: 1 }, Const { destination: Direct(1), bit_size: Integer(U32), value: 32838 }, Const { destination: Direct(0), bit_size: Integer(U32), value: 3 }, Const { destination: Relative(2), bit_size: Integer(U32), value: 1 }, Const { destination: Relative(3), bit_size: Integer(U32), value: 0 }, CalldataCopy { destination_address: Direct(32836), size_address: Relative(2), offset_address: Relative(3) }, Cast { destination: Direct(32836), source: Direct(32836), bit_size: Integer(U1) }, Mov { destination: Relative(1), source: Direct(32836) }, Call { location: 14 }, Call { location: 15 }, Mov { destination: Direct(32837), source: Relative(1) }, Const { destination: Relative(2), bit_size: Integer(U32), value: 32837 }, Const { destination: Relative(3), bit_size: Integer(U32), value: 1 }, Stop { return_data: HeapVector { pointer: Relative(2), size: Relative(3) } }, Return, Call { location: 53 }, Const { destination: Relative(3), bit_size: Integer(U1), value: 1 }, Const { destination: Relative(4), bit_size: Field, value: 1 }, JumpIf { condition: Relative(1), location: 34 }, Jump { location: 20 }, Mov { destination: Relative(1), source: Direct(1) }, BinaryIntOp { destination: Direct(1), op: Add, bit_size: U32, lhs: Direct(1), rhs: Direct(2) }, Store { destination_pointer: Relative(1), source: Relative(3) }, Mov { destination: Relative(3), source: Direct(1) }, Const { destination: Relative(5), bit_size: Integer(U32), value: 3 }, BinaryIntOp { destination: Direct(1), op: Add, bit_size: U32, lhs: Direct(1), rhs: Relative(5) }, IndirectConst { destination_pointer: Relative(3), bit_size: Integer(U32), value: 1 }, BinaryIntOp { destination: Relative(5), op: Add, bit_size: U32, lhs: Relative(3), rhs: Direct(2) }, Mov { destination: Relative(6), source: Relative(5) }, Store { destination_pointer: Relative(6), source: Relative(1) }, BinaryIntOp { destination: Relative(6), op: Add, bit_size: U32, lhs: Relative(6), rhs: Direct(2) }, Store { destination_pointer: Relative(6), source: Relative(4) }, Mov { destination: Relative(2), source: Relative(3) }, Jump { location: 48 }, Mov { destination: Relative(1), source: Direct(1) }, BinaryIntOp { destination: Direct(1), op: Add, bit_size: U32, lhs: Direct(1), rhs: Direct(2) }, Store { destination_pointer: Relative(1), source: Relative(3) }, Mov { destination: Relative(3), source: Direct(1) }, Const { destination: Relative(5), bit_size: Integer(U32), value: 3 }, BinaryIntOp { destination: Direct(1), op: Add, bit_size: U32, lhs: Direct(1), rhs: Relative(5) }, IndirectConst { destination_pointer: Relative(3), bit_size: Integer(U32), value: 1 }, BinaryIntOp { destination: Relative(5), op: Add, bit_size: U32, lhs: Relative(3), rhs: Direct(2) }, Mov { destination: Relative(6), source: Relative(5) }, Store { destination_pointer: Relative(6), source: Relative(1) }, BinaryIntOp { destination: Relative(6), op: Add, bit_size: U32, lhs: Relative(6), rhs: Direct(2) }, Store { destination_pointer: Relative(6), source: Relative(4) }, Mov { destination: Relative(2), source: Relative(3) }, Jump { location: 48 }, Const { destination: Relative(1), bit_size: Integer(U32), value: 1 }, BinaryIntOp { destination: Relative(4), op: Add, bit_size: U32, lhs: Relative(2), rhs: Relative(1) }, Load { destination: Relative(3), source_pointer: Relative(4) }, Load { destination: Relative(1), source_pointer: Relative(3) }, Return, Const { destination: Direct(32772), bit_size: Integer(U32), value: 30720 }, BinaryIntOp { destination: Direct(32771), op: LessThan, bit_size: U32, lhs: Direct(0), rhs: Direct(32772) }, JumpIf { condition: Direct(32771), location: 58 }, IndirectConst { destination_pointer: Direct(1), bit_size: Integer(U64), value: 17843811134343075018 }, Trap { revert_data: HeapVector { pointer: Direct(1), size: Direct(2) } }, Return]"
+  ],
+  "debug_symbols": "nZLNisMgEIDfxbOH+NcmeZVSgklMEcQEGxeW4Lvv6CTb9lAovcynjt8Mg25kNH28ddZP8520l430wTpnb52bB73a2cPpRqocOERGCWcIjhCk5QCJUIgT4oyoEU2BqBAMcS5VRI1oCiQ2kthIYiMpEBKhEOAJQFOgKgR4IiVKjhG6NRiTJ3iaCSZddDB+Ja2PzlHyo10sl+6L9oWrDpCtKDF+BELByTqTV4k+7Oq9WqvdrU//svrYZlzsOuPyG180hy/Fi3+FnR5seHnjlCsFq3tn9u0U/fCUXX+XI3P8kSXMgxljMLnS46MwiBclqKqvKXf7Aw==",
+  "file_map": {
+    "50": {
+      "source": "unconstrained fn main(c: bool) -> pub bool {\n    let b = if c {\n        [(&mut true, 1)]\n    } else {\n        [(&mut true, 1)]\n    };\n    *b[0].0\n}\n",
+      "path": ""
+    }
+  },
+  "names": [
+    "main"
+  ],
+  "brillig_names": [
+    "main"
+  ]
+}

--- a/tooling/nargo_cli/tests/snapshots/execution_success/regression_9119/execute__tests__force_brillig_true_inliner_0.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/regression_9119/execute__tests__force_brillig_true_inliner_0.snap
@@ -1,0 +1,54 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: artifact
+---
+{
+  "noir_version": "[noir_version]",
+  "hash": "[hash]",
+  "abi": {
+    "parameters": [
+      {
+        "name": "c",
+        "type": {
+          "kind": "boolean"
+        },
+        "visibility": "private"
+      }
+    ],
+    "return_type": {
+      "abi_type": {
+        "kind": "boolean"
+      },
+      "visibility": "public"
+    },
+    "error_types": {
+      "17843811134343075018": {
+        "error_kind": "string",
+        "string": "Stack too deep"
+      }
+    }
+  },
+  "bytecode": [
+    "func 0",
+    "current witness index : _1",
+    "private parameters indices : [_0]",
+    "public parameters indices : []",
+    "return value indices : [_1]",
+    "BRILLIG CALL func 0: inputs: [Single(Expression { mul_terms: [], linear_combinations: [(1, Witness(0))], q_c: 0 })], outputs: [Simple(Witness(1))]",
+    "unconstrained func 0",
+    "[Const { destination: Direct(2), bit_size: Integer(U32), value: 1 }, Const { destination: Direct(1), bit_size: Integer(U32), value: 32838 }, Const { destination: Direct(0), bit_size: Integer(U32), value: 3 }, Const { destination: Relative(2), bit_size: Integer(U32), value: 1 }, Const { destination: Relative(3), bit_size: Integer(U32), value: 0 }, CalldataCopy { destination_address: Direct(32836), size_address: Relative(2), offset_address: Relative(3) }, Cast { destination: Direct(32836), source: Direct(32836), bit_size: Integer(U1) }, Mov { destination: Relative(1), source: Direct(32836) }, Call { location: 14 }, Call { location: 15 }, Mov { destination: Direct(32837), source: Relative(1) }, Const { destination: Relative(2), bit_size: Integer(U32), value: 32837 }, Const { destination: Relative(3), bit_size: Integer(U32), value: 1 }, Stop { return_data: HeapVector { pointer: Relative(2), size: Relative(3) } }, Return, Call { location: 53 }, Const { destination: Relative(3), bit_size: Integer(U1), value: 1 }, Const { destination: Relative(4), bit_size: Field, value: 1 }, JumpIf { condition: Relative(1), location: 34 }, Jump { location: 20 }, Mov { destination: Relative(1), source: Direct(1) }, BinaryIntOp { destination: Direct(1), op: Add, bit_size: U32, lhs: Direct(1), rhs: Direct(2) }, Store { destination_pointer: Relative(1), source: Relative(3) }, Mov { destination: Relative(3), source: Direct(1) }, Const { destination: Relative(5), bit_size: Integer(U32), value: 3 }, BinaryIntOp { destination: Direct(1), op: Add, bit_size: U32, lhs: Direct(1), rhs: Relative(5) }, IndirectConst { destination_pointer: Relative(3), bit_size: Integer(U32), value: 1 }, BinaryIntOp { destination: Relative(5), op: Add, bit_size: U32, lhs: Relative(3), rhs: Direct(2) }, Mov { destination: Relative(6), source: Relative(5) }, Store { destination_pointer: Relative(6), source: Relative(1) }, BinaryIntOp { destination: Relative(6), op: Add, bit_size: U32, lhs: Relative(6), rhs: Direct(2) }, Store { destination_pointer: Relative(6), source: Relative(4) }, Mov { destination: Relative(2), source: Relative(3) }, Jump { location: 48 }, Mov { destination: Relative(1), source: Direct(1) }, BinaryIntOp { destination: Direct(1), op: Add, bit_size: U32, lhs: Direct(1), rhs: Direct(2) }, Store { destination_pointer: Relative(1), source: Relative(3) }, Mov { destination: Relative(3), source: Direct(1) }, Const { destination: Relative(5), bit_size: Integer(U32), value: 3 }, BinaryIntOp { destination: Direct(1), op: Add, bit_size: U32, lhs: Direct(1), rhs: Relative(5) }, IndirectConst { destination_pointer: Relative(3), bit_size: Integer(U32), value: 1 }, BinaryIntOp { destination: Relative(5), op: Add, bit_size: U32, lhs: Relative(3), rhs: Direct(2) }, Mov { destination: Relative(6), source: Relative(5) }, Store { destination_pointer: Relative(6), source: Relative(1) }, BinaryIntOp { destination: Relative(6), op: Add, bit_size: U32, lhs: Relative(6), rhs: Direct(2) }, Store { destination_pointer: Relative(6), source: Relative(4) }, Mov { destination: Relative(2), source: Relative(3) }, Jump { location: 48 }, Const { destination: Relative(1), bit_size: Integer(U32), value: 1 }, BinaryIntOp { destination: Relative(4), op: Add, bit_size: U32, lhs: Relative(2), rhs: Relative(1) }, Load { destination: Relative(3), source_pointer: Relative(4) }, Load { destination: Relative(1), source_pointer: Relative(3) }, Return, Const { destination: Direct(32772), bit_size: Integer(U32), value: 30720 }, BinaryIntOp { destination: Direct(32771), op: LessThan, bit_size: U32, lhs: Direct(0), rhs: Direct(32772) }, JumpIf { condition: Direct(32771), location: 58 }, IndirectConst { destination_pointer: Direct(1), bit_size: Integer(U64), value: 17843811134343075018 }, Trap { revert_data: HeapVector { pointer: Direct(1), size: Direct(2) } }, Return]"
+  ],
+  "debug_symbols": "nZLNisMgEIDfxbOH+NcmeZVSgklMEcQEGxeW4Lvv6CTb9lAovcynjt8Mg25kNH28ddZP8520l430wTpnb52bB73a2cPpRqocOERGCWcIjhCk5QCJUIgT4oyoEU2BqBAMcS5VRI1oCiQ2kthIYiMpEBKhEOAJQFOgKgR4IiVKjhG6NRiTJ3iaCSZddDB+Ja2PzlHyo10sl+6L9oWrDpCtKDF+BELByTqTV4k+7Oq9WqvdrU//svrYZlzsOuPyG180hy/Fi3+FnR5seHnjlCsFq3tn9u0U/fCUXX+XI3P8kSXMgxljMLnS46MwiBclqKqvKXf7Aw==",
+  "file_map": {
+    "50": {
+      "source": "unconstrained fn main(c: bool) -> pub bool {\n    let b = if c {\n        [(&mut true, 1)]\n    } else {\n        [(&mut true, 1)]\n    };\n    *b[0].0\n}\n",
+      "path": ""
+    }
+  },
+  "names": [
+    "main"
+  ],
+  "brillig_names": [
+    "main"
+  ]
+}

--- a/tooling/nargo_cli/tests/snapshots/execution_success/regression_9119/execute__tests__force_brillig_true_inliner_9223372036854775807.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/regression_9119/execute__tests__force_brillig_true_inliner_9223372036854775807.snap
@@ -1,0 +1,54 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: artifact
+---
+{
+  "noir_version": "[noir_version]",
+  "hash": "[hash]",
+  "abi": {
+    "parameters": [
+      {
+        "name": "c",
+        "type": {
+          "kind": "boolean"
+        },
+        "visibility": "private"
+      }
+    ],
+    "return_type": {
+      "abi_type": {
+        "kind": "boolean"
+      },
+      "visibility": "public"
+    },
+    "error_types": {
+      "17843811134343075018": {
+        "error_kind": "string",
+        "string": "Stack too deep"
+      }
+    }
+  },
+  "bytecode": [
+    "func 0",
+    "current witness index : _1",
+    "private parameters indices : [_0]",
+    "public parameters indices : []",
+    "return value indices : [_1]",
+    "BRILLIG CALL func 0: inputs: [Single(Expression { mul_terms: [], linear_combinations: [(1, Witness(0))], q_c: 0 })], outputs: [Simple(Witness(1))]",
+    "unconstrained func 0",
+    "[Const { destination: Direct(2), bit_size: Integer(U32), value: 1 }, Const { destination: Direct(1), bit_size: Integer(U32), value: 32838 }, Const { destination: Direct(0), bit_size: Integer(U32), value: 3 }, Const { destination: Relative(2), bit_size: Integer(U32), value: 1 }, Const { destination: Relative(3), bit_size: Integer(U32), value: 0 }, CalldataCopy { destination_address: Direct(32836), size_address: Relative(2), offset_address: Relative(3) }, Cast { destination: Direct(32836), source: Direct(32836), bit_size: Integer(U1) }, Mov { destination: Relative(1), source: Direct(32836) }, Call { location: 14 }, Call { location: 15 }, Mov { destination: Direct(32837), source: Relative(1) }, Const { destination: Relative(2), bit_size: Integer(U32), value: 32837 }, Const { destination: Relative(3), bit_size: Integer(U32), value: 1 }, Stop { return_data: HeapVector { pointer: Relative(2), size: Relative(3) } }, Return, Call { location: 53 }, Const { destination: Relative(3), bit_size: Integer(U1), value: 1 }, Const { destination: Relative(4), bit_size: Field, value: 1 }, JumpIf { condition: Relative(1), location: 34 }, Jump { location: 20 }, Mov { destination: Relative(1), source: Direct(1) }, BinaryIntOp { destination: Direct(1), op: Add, bit_size: U32, lhs: Direct(1), rhs: Direct(2) }, Store { destination_pointer: Relative(1), source: Relative(3) }, Mov { destination: Relative(3), source: Direct(1) }, Const { destination: Relative(5), bit_size: Integer(U32), value: 3 }, BinaryIntOp { destination: Direct(1), op: Add, bit_size: U32, lhs: Direct(1), rhs: Relative(5) }, IndirectConst { destination_pointer: Relative(3), bit_size: Integer(U32), value: 1 }, BinaryIntOp { destination: Relative(5), op: Add, bit_size: U32, lhs: Relative(3), rhs: Direct(2) }, Mov { destination: Relative(6), source: Relative(5) }, Store { destination_pointer: Relative(6), source: Relative(1) }, BinaryIntOp { destination: Relative(6), op: Add, bit_size: U32, lhs: Relative(6), rhs: Direct(2) }, Store { destination_pointer: Relative(6), source: Relative(4) }, Mov { destination: Relative(2), source: Relative(3) }, Jump { location: 48 }, Mov { destination: Relative(1), source: Direct(1) }, BinaryIntOp { destination: Direct(1), op: Add, bit_size: U32, lhs: Direct(1), rhs: Direct(2) }, Store { destination_pointer: Relative(1), source: Relative(3) }, Mov { destination: Relative(3), source: Direct(1) }, Const { destination: Relative(5), bit_size: Integer(U32), value: 3 }, BinaryIntOp { destination: Direct(1), op: Add, bit_size: U32, lhs: Direct(1), rhs: Relative(5) }, IndirectConst { destination_pointer: Relative(3), bit_size: Integer(U32), value: 1 }, BinaryIntOp { destination: Relative(5), op: Add, bit_size: U32, lhs: Relative(3), rhs: Direct(2) }, Mov { destination: Relative(6), source: Relative(5) }, Store { destination_pointer: Relative(6), source: Relative(1) }, BinaryIntOp { destination: Relative(6), op: Add, bit_size: U32, lhs: Relative(6), rhs: Direct(2) }, Store { destination_pointer: Relative(6), source: Relative(4) }, Mov { destination: Relative(2), source: Relative(3) }, Jump { location: 48 }, Const { destination: Relative(1), bit_size: Integer(U32), value: 1 }, BinaryIntOp { destination: Relative(4), op: Add, bit_size: U32, lhs: Relative(2), rhs: Relative(1) }, Load { destination: Relative(3), source_pointer: Relative(4) }, Load { destination: Relative(1), source_pointer: Relative(3) }, Return, Const { destination: Direct(32772), bit_size: Integer(U32), value: 30720 }, BinaryIntOp { destination: Direct(32771), op: LessThan, bit_size: U32, lhs: Direct(0), rhs: Direct(32772) }, JumpIf { condition: Direct(32771), location: 58 }, IndirectConst { destination_pointer: Direct(1), bit_size: Integer(U64), value: 17843811134343075018 }, Trap { revert_data: HeapVector { pointer: Direct(1), size: Direct(2) } }, Return]"
+  ],
+  "debug_symbols": "nZLNisMgEIDfxbOH+NcmeZVSgklMEcQEGxeW4Lvv6CTb9lAovcynjt8Mg25kNH28ddZP8520l430wTpnb52bB73a2cPpRqocOERGCWcIjhCk5QCJUIgT4oyoEU2BqBAMcS5VRI1oCiQ2kthIYiMpEBKhEOAJQFOgKgR4IiVKjhG6NRiTJ3iaCSZddDB+Ja2PzlHyo10sl+6L9oWrDpCtKDF+BELByTqTV4k+7Oq9WqvdrU//svrYZlzsOuPyG180hy/Fi3+FnR5seHnjlCsFq3tn9u0U/fCUXX+XI3P8kSXMgxljMLnS46MwiBclqKqvKXf7Aw==",
+  "file_map": {
+    "50": {
+      "source": "unconstrained fn main(c: bool) -> pub bool {\n    let b = if c {\n        [(&mut true, 1)]\n    } else {\n        [(&mut true, 1)]\n    };\n    *b[0].0\n}\n",
+      "path": ""
+    }
+  },
+  "names": [
+    "main"
+  ],
+  "brillig_names": [
+    "main"
+  ]
+}

--- a/tooling/nargo_cli/tests/snapshots/execution_success/regression_9119/execute__tests__stdout.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/regression_9119/execute__tests__stdout.snap
@@ -1,0 +1,5 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: stdout
+---
+[regression_9119] Circuit output: Field(1)


### PR DESCRIPTION
# Description

## Problem\*

Resolves #9119 

## Summary\*

Handle the case when a value passed in the `jmp` arguments contains references, so those references don't get their stores removed.

## Additional Context

This handles the case where an array with references is returned from an `if` expression in Brillig, which the compiler does not reject, unlike with ACIR.

The problematic SSA looked like this:
```rust
After Inlining (step 6):
brillig(inline) fn main f0 {
  b0(v0: u1):
    jmpif v0 then: b1, else: b2
  b1():
    v6 = allocate -> &mut u1
    store u1 1 at v6
    v7 = make_array [v6, Field 1] : [(&mut u1, Field); 1]	// src/main.nr:3:22
    jmp b3(v7)
  b2():
    v2 = allocate -> &mut u1                      	// src/main.nr:3:22
    store u1 1 at v2                              	// src/main.nr:3:22
    v5 = make_array [v2, Field 1] : [(&mut u1, Field); 1]	// src/main.nr:5:22
    jmp b3(v5)
  b3(v1: [(&mut u1, Field); 1]):
    v9 = array_get v1, index u32 0 -> &mut u1     	// src/main.nr:7:6
    v10 = load v9 -> u1                           	// src/main.nr:7:6
    return v10
}

--- Interpreter result after Inlining (step 6):
Ok([Numeric(U1(true))])
---

After Mem2Reg (step 7):
brillig(inline) fn main f0 {
  b0(v0: u1):
    jmpif v0 then: b1, else: b2
  b1():
    v5 = allocate -> &mut u1
    v6 = make_array [v5, Field 1] : [(&mut u1, Field); 1]	// src/main.nr:3:22
    jmp b3(v6)
  b2():
    v2 = allocate -> &mut u1                      	// src/main.nr:3:22
    v4 = make_array [v2, Field 1] : [(&mut u1, Field); 1]	// src/main.nr:5:22
    jmp b3(v4)
  b3(v1: [(&mut u1, Field); 1]):
    v8 = array_get v1, index u32 0 -> &mut u1     	// src/main.nr:7:6
    v9 = load v8 -> u1                            	// src/main.nr:7:6
    return v9
}

--- Interpreter result after Mem2Reg (step 7):
Err(Internal(UninitializedReferenceValueLoaded { value: "*v5 = None" }))
---
```

Initially I used the `instruction_inputs`, following the example of the return terminator. I tried to just extend the logic already present in `// Add an alias for each reference parameter` to any type that contains a reference, but that wasn't enough for the integration test. 

Then I took another look and saw that we collect the `all_terminator_values`. In this case that contains arrays `v5` and `v7`, however that did not prevent the removal of the store for their elements `v2` and `v6`, because `v2` is an alias of `v5`, but `v5` is not an alias of `v2`, and we only looked whether any alias of `v2` was in `all_terminator_value`, but did not consider that something that `v2` is an alias of is there.

## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
