### PR TITLE
chore: push names into circuit/brillig bytecode

### DIFF
--- a/acvm-repo/acir/benches/serialization.rs
+++ b/acvm-repo/acir/benches/serialization.rs
@@ -31,6 +31,7 @@ fn sample_program(num_opcodes: usize) -> Program<FieldElement> {
 
     Program {
         functions: vec![Circuit {
+            name: "main".to_string(),
             current_witness_index: 4000,
             opcodes: assert_zero_opcodes.to_vec(),
             expression_width: ExpressionWidth::Bounded { width: 4 },

--- a/acvm-repo/acir/src/circuit/brillig.rs
+++ b/acvm-repo/acir/src/circuit/brillig.rs
@@ -56,6 +56,7 @@ pub enum BrilligOutputs {
 #[derive(Clone, PartialEq, Eq, Serialize, Deserialize, Default, Debug, Hash)]
 #[cfg_attr(feature = "arb", derive(proptest_derive::Arbitrary))]
 pub struct BrilligBytecode<F> {
+    pub name: String,
     pub bytecode: Vec<BrilligOpcode<F>>,
 }
 

--- a/acvm-repo/acir/src/circuit/mod.rs
+++ b/acvm-repo/acir/src/circuit/mod.rs
@@ -54,6 +54,7 @@ pub struct Program<F: AcirField> {
 #[derive(Clone, PartialEq, Eq, Serialize, Deserialize, Default, Hash)]
 #[cfg_attr(feature = "arb", derive(proptest_derive::Arbitrary))]
 pub struct Circuit<F: AcirField> {
+    pub name: String,
     /// current_witness_index is the highest witness index in the circuit. The next witness to be added to this circuit
     /// will take on this value. (The value is cached here as an optimization.)
     pub current_witness_index: u32,
@@ -445,6 +446,7 @@ mod tests {
     #[test]
     fn serialization_roundtrip() {
         let circuit = Circuit {
+            name: "main".to_string(),
             current_witness_index: 5,
             expression_width: ExpressionWidth::Unbounded,
             opcodes: vec![and_opcode::<FieldElement>(), range_opcode()],
@@ -470,6 +472,7 @@ mod tests {
     #[test]
     fn test_serialize() {
         let circuit = Circuit {
+            name: "main".to_string(),
             current_witness_index: 0,
             expression_width: ExpressionWidth::Unbounded,
             opcodes: vec![
@@ -516,6 +519,7 @@ mod tests {
     #[test]
     fn circuit_display_snapshot() {
         let circuit = Circuit {
+            name: "main".to_string(),
             current_witness_index: 3,
             expression_width: ExpressionWidth::Unbounded,
             opcodes: vec![

--- a/acvm-repo/acir/src/proto/acir/circuit.proto
+++ b/acvm-repo/acir/src/proto/acir/circuit.proto
@@ -5,13 +5,14 @@ package acvm.acir.circuit;
 import "acir/native.proto";
 
 message Circuit {
-  uint32 current_witness_index = 1;
-  repeated Opcode opcodes = 2;
-  ExpressionWidth expression_width = 3;
-  repeated native.Witness private_parameters = 4;
-  repeated native.Witness public_parameters = 5;
-  repeated native.Witness return_values = 6;
-  repeated AssertMessage assert_messages = 7;
+  string name = 1;
+  uint32 current_witness_index = 2;
+  repeated Opcode opcodes = 3;
+  ExpressionWidth expression_width = 4;
+  repeated native.Witness private_parameters = 5;
+  repeated native.Witness public_parameters = 6;
+  repeated native.Witness return_values = 7;
+  repeated AssertMessage assert_messages = 8;
 }
 
 message ExpressionWidth {

--- a/acvm-repo/acir/src/proto/brillig.proto
+++ b/acvm-repo/acir/src/proto/brillig.proto
@@ -4,7 +4,10 @@ package acvm.brillig;
 
 import "acir/native.proto";
 
-message BrilligBytecode { repeated BrilligOpcode bytecode = 1; }
+message BrilligBytecode { 
+  string name = 1;
+  repeated BrilligOpcode bytecode = 2;
+}
 
 message BrilligOpcode {
   oneof value {

--- a/acvm-repo/acir/src/proto/convert/acir.rs
+++ b/acvm-repo/acir/src/proto/convert/acir.rs
@@ -19,6 +19,7 @@ use super::ProtoSchema;
 impl<F: AcirField> ProtoCodec<circuit::Circuit<F>, Circuit> for ProtoSchema<F> {
     fn encode(value: &circuit::Circuit<F>) -> Circuit {
         Circuit {
+            name: value.name.clone(),
             current_witness_index: value.current_witness_index,
             opcodes: Self::encode_vec(&value.opcodes),
             expression_width: Self::encode_some(&value.expression_width),
@@ -31,6 +32,7 @@ impl<F: AcirField> ProtoCodec<circuit::Circuit<F>, Circuit> for ProtoSchema<F> {
 
     fn decode(value: &Circuit) -> eyre::Result<circuit::Circuit<F>> {
         Ok(circuit::Circuit {
+            name: value.name.clone(),
             current_witness_index: value.current_witness_index,
             opcodes: Self::decode_vec_wrap(&value.opcodes, "opcodes")?,
             expression_width: Self::decode_some_wrap(&value.expression_width, "expression_width")?,

--- a/acvm-repo/acir/src/proto/convert/brillig.rs
+++ b/acvm-repo/acir/src/proto/convert/brillig.rs
@@ -17,11 +17,12 @@ impl<F: AcirField> ProtoCodec<circuit::brillig::BrilligBytecode<F>, BrilligBytec
     for ProtoSchema<F>
 {
     fn encode(value: &circuit::brillig::BrilligBytecode<F>) -> BrilligBytecode {
-        BrilligBytecode { bytecode: Self::encode_vec(&value.bytecode) }
+        BrilligBytecode { name: value.name.clone(), bytecode: Self::encode_vec(&value.bytecode) }
     }
 
     fn decode(value: &BrilligBytecode) -> eyre::Result<circuit::brillig::BrilligBytecode<F>> {
         Ok(circuit::brillig::BrilligBytecode {
+            name: value.name.clone(),
             bytecode: Self::decode_vec_wrap(&value.bytecode, "bytecode")?,
         })
     }

--- a/acvm-repo/acir/tests/test_program_serialization.rs
+++ b/acvm-repo/acir/tests/test_program_serialization.rs
@@ -99,6 +99,7 @@ fn simple_brillig_foreign_call() {
     let one_usize = MemoryAddress::direct(2);
 
     let brillig_bytecode = BrilligBytecode {
+        name: "main".to_string(),
         bytecode: vec![
             brillig::Opcode::Const {
                 destination: zero_usize,
@@ -172,6 +173,7 @@ fn complex_brillig_foreign_call() {
     let a_plus_b_plus_c_times_2 = Witness(8);
 
     let brillig_bytecode = BrilligBytecode {
+        name: "main".to_string(),
         bytecode: vec![
             brillig::Opcode::Const {
                 destination: MemoryAddress::direct(0),

--- a/acvm-repo/acvm/src/compiler/optimizers/merge_expressions.rs
+++ b/acvm-repo/acvm/src/compiler/optimizers/merge_expressions.rs
@@ -335,6 +335,7 @@ mod tests {
         private_parameters.insert(Witness(0));
 
         let circuit = Circuit {
+            name: "main".to_string(),
             current_witness_index: 1,
             expression_width: ExpressionWidth::Bounded { width: 4 },
             opcodes,
@@ -373,6 +374,7 @@ mod tests {
         return_values.insert(Witness(2));
 
         let circuit = Circuit {
+            name: "main".to_string(),
             current_witness_index: 2,
             expression_width: ExpressionWidth::Bounded { width: 4 },
             opcodes,
@@ -432,6 +434,7 @@ mod tests {
         private_parameters.insert(Witness(0));
         private_parameters.insert(Witness(1));
         let circuit = Circuit {
+            name: "main".to_string(),
             current_witness_index: 5,
             expression_width: ExpressionWidth::Bounded { width: 4 },
             opcodes,

--- a/acvm-repo/acvm/src/compiler/optimizers/redundant_range.rs
+++ b/acvm-repo/acvm/src/compiler/optimizers/redundant_range.rs
@@ -252,6 +252,7 @@ mod tests {
             .collect();
 
         Circuit {
+            name: "main".to_string(),
             current_witness_index: 1,
             expression_width: ExpressionWidth::Bounded { width: 4 },
             opcodes,

--- a/acvm-repo/acvm/src/compiler/simulator.rs
+++ b/acvm-repo/acvm/src/compiler/simulator.rs
@@ -207,6 +207,7 @@ mod tests {
         public_parameters: PublicInputs,
     ) -> Circuit<FieldElement> {
         Circuit {
+            name: "main".to_string(),
             current_witness_index: 1,
             expression_width: ExpressionWidth::Bounded { width: 4 },
             opcodes,

--- a/acvm-repo/acvm/tests/solver.rs
+++ b/acvm-repo/acvm/tests/solver.rs
@@ -129,6 +129,7 @@ fn inversion_brillig_oracle_equivalence() {
     let three_usize = MemoryAddress::direct(5);
 
     let brillig_bytecode = BrilligBytecode {
+        name: "main".to_string(),
         bytecode: vec![
             BrilligOpcode::Const {
                 destination: zero_usize,
@@ -281,6 +282,7 @@ fn double_inversion_brillig_oracle() {
     };
 
     let brillig_bytecode = BrilligBytecode {
+        name: "main".to_string(),
         bytecode: vec![
             BrilligOpcode::Const {
                 destination: zero_usize,
@@ -405,6 +407,7 @@ fn oracle_dependent_execution() {
     let four_usize = MemoryAddress::direct(6);
 
     let brillig_bytecode = BrilligBytecode {
+        name: "main".to_string(),
         bytecode: vec![
             BrilligOpcode::Const {
                 destination: zero_usize,
@@ -548,6 +551,7 @@ fn brillig_oracle_predicate() {
     };
 
     let brillig_bytecode = BrilligBytecode {
+        name: "main".to_string(),
         bytecode: vec![
             BrilligOpcode::Const {
                 destination: MemoryAddress::direct(0),
@@ -696,6 +700,7 @@ fn unsatisfied_opcode_resolved_brillig() {
     };
 
     let brillig_bytecode = BrilligBytecode {
+        name: "main".to_string(),
         bytecode: vec![
             BrilligOpcode::Const {
                 destination: MemoryAddress::direct(0),

--- a/compiler/noirc_driver/src/contract.rs
+++ b/compiler/noirc_driver/src/contract.rs
@@ -56,10 +56,4 @@ pub struct ContractFunction {
     pub bytecode: Program<FieldElement>,
 
     pub debug: Vec<DebugInfo>,
-
-    /// Names of the functions in the program. These are used for more informative debugging and benchmarking.
-    pub names: Vec<String>,
-
-    /// Names of the unconstrained functions in the program.
-    pub brillig_names: Vec<String>,
 }

--- a/compiler/noirc_driver/src/lib.rs
+++ b/compiler/noirc_driver/src/lib.rs
@@ -664,8 +664,6 @@ fn compile_contract_inner(
             bytecode: function.program,
             debug: function.debug,
             is_unconstrained: modifiers.is_unconstrained,
-            names: function.names,
-            brillig_names: function.brillig_names,
         });
     }
 
@@ -798,20 +796,15 @@ pub fn compile_no_check(
     let return_visibility = program.return_visibility();
     let ssa_evaluator_options = options.as_ssa_options(context.package_build_path.clone());
 
-    let SsaProgramArtifact { program, debug, warnings, names, brillig_names, error_types, .. } =
-        if options.minimal_ssa {
-            create_program_with_minimal_passes(
-                program,
-                &ssa_evaluator_options,
-                &context.file_manager,
-            )?
-        } else {
-            create_program(
-                program,
-                &ssa_evaluator_options,
-                if options.no_ssa_locations { None } else { Some(&context.file_manager) },
-            )?
-        };
+    let SsaProgramArtifact { program, debug, warnings, error_types, .. } = if options.minimal_ssa {
+        create_program_with_minimal_passes(program, &ssa_evaluator_options, &context.file_manager)?
+    } else {
+        create_program(
+            program,
+            &ssa_evaluator_options,
+            if options.no_ssa_locations { None } else { Some(&context.file_manager) },
+        )?
+    };
 
     let abi = gen_abi(context, &main_function, return_visibility, error_types);
     let file_map = filter_relevant_files(&debug, &context.file_manager);
@@ -824,8 +817,6 @@ pub fn compile_no_check(
         file_map,
         noir_version: NOIR_ARTIFACT_VERSION_STRING.to_string(),
         warnings,
-        names,
-        brillig_names,
     })
 }
 

--- a/compiler/noirc_driver/src/program.rs
+++ b/compiler/noirc_driver/src/program.rs
@@ -27,8 +27,4 @@ pub struct CompiledProgram {
     pub debug: Vec<DebugInfo>,
     pub file_map: BTreeMap<FileId, DebugFile>,
     pub warnings: Vec<SsaReport>,
-    /// Names of the functions in the program. These are used for more informative debugging and benchmarking.
-    pub names: Vec<String>,
-    /// Names of the unconstrained functions in the program.
-    pub brillig_names: Vec<String>,
 }

--- a/compiler/noirc_evaluator/src/acir/ssa.rs
+++ b/compiler/noirc_evaluator/src/acir/ssa.rs
@@ -17,7 +17,6 @@ use super::{Context, GeneratedAcir, SharedContext, acir_context::BrilligStdLib};
 pub type Artifacts = (
     Vec<GeneratedAcir<FieldElement>>,
     Vec<BrilligBytecode<FieldElement>>,
-    Vec<String>,
     BTreeMap<ErrorSelector, HirType>,
 );
 
@@ -87,11 +86,11 @@ pub(super) fn codegen_acir(
         }
     }
 
-    let (brillig_bytecode, brillig_names) = shared_context
+    let brillig_bytecode = shared_context
         .generated_brillig
         .into_iter()
-        .map(|brillig| (BrilligBytecode { bytecode: brillig.byte_code }, brillig.name))
-        .unzip();
+        .map(|brillig| BrilligBytecode { name: brillig.name, bytecode: brillig.byte_code })
+        .collect();
 
-    Ok((acirs, brillig_bytecode, brillig_names, ssa.error_selector_to_type))
+    Ok((acirs, brillig_bytecode, ssa.error_selector_to_type))
 }

--- a/compiler/noirc_evaluator/src/acir/tests/intrinsics.rs
+++ b/compiler/noirc_evaluator/src/acir/tests/intrinsics.rs
@@ -155,7 +155,7 @@ fn get_slice_intrinsic_acir(
     let ssa = Ssa::from_str(&src).unwrap();
     let brillig = ssa.to_brillig(&BrilligOptions::default());
 
-    let (acir_functions_with_pred, _brillig_functions, _, _) = ssa
+    let (acir_functions_with_pred, _brillig_functions, _) = ssa
         .into_acir(&brillig, &BrilligOptions::default(), ExpressionWidth::default())
         .expect("Should compile manually written SSA into ACIR");
     acir_functions_with_pred

--- a/compiler/noirc_evaluator/src/acir/tests/mod.rs
+++ b/compiler/noirc_evaluator/src/acir/tests/mod.rs
@@ -118,7 +118,7 @@ fn basic_call_with_outputs_assert(inline_type: InlineType) {
 
     let ssa = builder.finish().generate_entry_point_index();
 
-    let (acir_functions, _, _, _) = ssa
+    let (acir_functions, _, _) = ssa
         .into_acir(&Brillig::default(), &BrilligOptions::default(), ExpressionWidth::default())
         .expect("Should compile manually written SSA into ACIR");
     // Expected result:
@@ -223,7 +223,7 @@ fn call_output_as_next_call_input(inline_type: InlineType) {
 
     let ssa = builder.finish();
 
-    let (acir_functions, _, _, _) = ssa
+    let (acir_functions, _, _) = ssa
         .generate_entry_point_index()
         .into_acir(&Brillig::default(), &BrilligOptions::default(), ExpressionWidth::default())
         .expect("Should compile manually written SSA into ACIR");
@@ -325,7 +325,7 @@ fn basic_nested_call(inline_type: InlineType) {
 
     let ssa = builder.finish().generate_entry_point_index();
 
-    let (acir_functions, _, _, _) = ssa
+    let (acir_functions, _, _) = ssa
         .into_acir(&Brillig::default(), &BrilligOptions::default(), ExpressionWidth::default())
         .expect("Should compile manually written SSA into ACIR");
 
@@ -445,7 +445,7 @@ fn multiple_brillig_calls_one_bytecode() {
     let ssa = builder.finish();
     let brillig = ssa.to_brillig(&BrilligOptions::default());
 
-    let (acir_functions, brillig_functions, _, _) = ssa
+    let (acir_functions, brillig_functions, _) = ssa
         .generate_entry_point_index()
         .into_acir(&brillig, &BrilligOptions::default(), ExpressionWidth::default())
         .expect("Should compile manually written SSA into ACIR");
@@ -493,7 +493,7 @@ fn multiple_brillig_stdlib_calls() {
 
     // The Brillig bytecode we insert for the stdlib is hardcoded so we do not need to provide any
     // Brillig artifacts to the ACIR gen pass.
-    let (acir_functions, brillig_functions, _, _) = ssa
+    let (acir_functions, brillig_functions, _) = ssa
         .generate_entry_point_index()
         .into_acir(&Brillig::default(), &BrilligOptions::default(), ExpressionWidth::default())
         .expect("Should compile manually written SSA into ACIR");
@@ -561,7 +561,7 @@ fn brillig_stdlib_calls_with_regular_brillig_call() {
     // We need to generate  Brillig artifacts for the regular Brillig function and pass them to the ACIR generation pass.
     let brillig = ssa.to_brillig(&BrilligOptions::default());
 
-    let (acir_functions, brillig_functions, _, _) = ssa
+    let (acir_functions, brillig_functions, _) = ssa
         .generate_entry_point_index()
         .into_acir(&brillig, &BrilligOptions::default(), ExpressionWidth::default())
         .expect("Should compile manually written SSA into ACIR");
@@ -645,7 +645,7 @@ fn brillig_stdlib_calls_with_multiple_acir_calls() {
     // We need to generate  Brillig artifacts for the regular Brillig function and pass them to the ACIR generation pass.
     let brillig = ssa.to_brillig(&BrilligOptions::default());
 
-    let (acir_functions, brillig_functions, _, _) = ssa
+    let (acir_functions, brillig_functions, _) = ssa
         .generate_entry_point_index()
         .into_acir(&brillig, &BrilligOptions::default(), ExpressionWidth::default())
         .expect("Should compile manually written SSA into ACIR");
@@ -749,7 +749,7 @@ fn unchecked_mul_should_not_have_range_check() {
     let ssa = Ssa::from_str(src).unwrap();
     let brillig = ssa.to_brillig(&BrilligOptions::default());
 
-    let (mut acir_functions, _brillig_functions, _, _) = ssa
+    let (mut acir_functions, _brillig_functions, _) = ssa
         .into_acir(&brillig, &BrilligOptions::default(), ExpressionWidth::default())
         .expect("Should compile manually written SSA into ACIR");
 
@@ -787,7 +787,7 @@ fn does_not_generate_memory_blocks_without_dynamic_accesses() {
     let ssa = Ssa::from_str(src).unwrap();
     let brillig = ssa.to_brillig(&BrilligOptions::default());
 
-    let (acir_functions, _brillig_functions, _, _) = ssa
+    let (acir_functions, _brillig_functions, _) = ssa
         .into_acir(&brillig, &BrilligOptions::default(), ExpressionWidth::default())
         .expect("Should compile manually written SSA into ACIR");
 
@@ -873,7 +873,7 @@ fn properly_constrains_quotient_when_truncating_fields() {
     let malicious_brillig_stdlib =
         BrilligStdLib { quotient: malicious_quotient, ..BrilligStdLib::default() };
 
-    let (acir_functions, brillig_functions, _, _) = codegen_acir(
+    let (acir_functions, brillig_functions, _) = codegen_acir(
         ssa,
         &Brillig::default(),
         malicious_brillig_stdlib,
@@ -917,7 +917,7 @@ fn do_not_overflow_with_constant_constrain_neq() {
     let ssa = Ssa::from_str(src).unwrap();
     let brillig = ssa.to_brillig(&BrilligOptions::default());
 
-    let (acir_functions, _brillig_functions, _, _) = ssa
+    let (acir_functions, _brillig_functions, _) = ssa
         .into_acir(&brillig, &BrilligOptions::default(), ExpressionWidth::default())
         .expect("Should compile manually written SSA into ACIR");
 

--- a/compiler/noirc_evaluator/src/ssa/artifact.rs
+++ b/compiler/noirc_evaluator/src/ssa/artifact.rs
@@ -13,29 +13,18 @@ pub struct SsaProgramArtifact {
     pub program: Program<FieldElement>,
     pub debug: Vec<DebugInfo>,
     pub warnings: Vec<SsaReport>,
-    pub names: Vec<String>,
-    pub brillig_names: Vec<String>,
     pub error_types: BTreeMap<ErrorSelector, ErrorType>,
 }
 
 impl SsaProgramArtifact {
     pub fn new(
         functions: Vec<SsaCircuitArtifact>,
-        brillig_names: Vec<String>,
         unconstrained_functions: Vec<BrilligBytecode<FieldElement>>,
         error_types: BTreeMap<ErrorSelector, ErrorType>,
         warnings: Vec<SsaReport>,
     ) -> Self {
-        assert_eq!(brillig_names.len(), unconstrained_functions.len());
         let program = Program { functions: Vec::default(), unconstrained_functions };
-        let mut this = Self {
-            program,
-            debug: Vec::default(),
-            warnings,
-            names: Vec::default(),
-            brillig_names,
-            error_types,
-        };
+        let mut this = Self { program, debug: Vec::default(), warnings, error_types };
 
         for function in functions {
             this.add_circuit(function);
@@ -48,7 +37,6 @@ impl SsaProgramArtifact {
         self.program.functions.push(circuit_artifact.circuit);
         self.debug.push(circuit_artifact.debug_info);
         self.warnings.append(&mut circuit_artifact.warnings);
-        self.names.push(circuit_artifact.name);
         // Acir and brillig both generate new error types, so we need to merge them
         // With the ones found during ssa generation.
         self.error_types.extend(circuit_artifact.error_types);
@@ -56,7 +44,6 @@ impl SsaProgramArtifact {
 }
 
 pub struct SsaCircuitArtifact {
-    pub name: String,
     pub circuit: Circuit<FieldElement>,
     pub debug_info: DebugInfo,
     pub warnings: Vec<SsaReport>,

--- a/compiler/noirc_evaluator/src/ssa/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/mod.rs
@@ -402,10 +402,8 @@ pub fn combine_artifacts(
     debug_functions: DebugFunctions,
     debug_types: DebugTypes,
 ) -> SsaProgramArtifact {
-    let ArtifactsAndWarnings(
-        (generated_acirs, generated_brillig, brillig_function_names, error_types),
-        ssa_level_warnings,
-    ) = artifacts;
+    let ArtifactsAndWarnings((generated_acirs, generated_brillig, error_types), ssa_level_warnings) =
+        artifacts;
 
     assert_eq!(
         generated_acirs.len(),
@@ -432,13 +430,7 @@ pub fn combine_artifacts(
         .map(|(selector, hir_type)| (selector, ErrorType::Dynamic(hir_type)))
         .collect();
 
-    SsaProgramArtifact::new(
-        functions,
-        brillig_function_names,
-        generated_brillig,
-        error_types,
-        ssa_level_warnings,
-    )
+    SsaProgramArtifact::new(functions, generated_brillig, error_types, ssa_level_warnings)
 }
 
 fn resolve_function_signature(func_sig: &FunctionSignature) -> Vec<(u32, Visibility)> {
@@ -477,6 +469,7 @@ pub fn convert_generated_acir_into_circuit(
     let return_values = PublicInputs(return_witnesses.iter().copied().collect());
 
     let circuit = Circuit {
+        name,
         current_witness_index,
         expression_width: ExpressionWidth::Unbounded,
         opcodes,
@@ -508,7 +501,6 @@ pub fn convert_generated_acir_into_circuit(
     debug_info.update_acir(transformation_map);
 
     SsaCircuitArtifact {
-        name,
         circuit: optimized_circuit,
         debug_info,
         warnings,

--- a/tooling/debugger/src/context.rs
+++ b/tooling/debugger/src/context.rs
@@ -1106,6 +1106,7 @@ mod tests {
         let w_x = Witness(1);
 
         let brillig_bytecode = BrilligBytecode {
+            name: "main".to_string(),
             bytecode: vec![
                 BrilligOpcode::Const {
                     destination: MemoryAddress::direct(1),
@@ -1262,6 +1263,7 @@ mod tests {
 
         // This Brillig block is equivalent to: z = x + y
         let brillig_bytecode = BrilligBytecode {
+            name: "main".to_string(),
             bytecode: vec![
                 BrilligOpcode::Const {
                     destination: MemoryAddress::direct(0),
@@ -1379,9 +1381,12 @@ mod tests {
     #[test]
     fn test_address_debug_location_mapping() {
         let solver = StubbedBlackBoxSolver::default();
-        let brillig_one =
-            BrilligBytecode { bytecode: vec![BrilligOpcode::Return, BrilligOpcode::Return] };
+        let brillig_one = BrilligBytecode {
+            name: "one".to_string(),
+            bytecode: vec![BrilligOpcode::Return, BrilligOpcode::Return],
+        };
         let brillig_two = BrilligBytecode {
+            name: "two".to_string(),
             bytecode: vec![BrilligOpcode::Return, BrilligOpcode::Return, BrilligOpcode::Return],
         };
 

--- a/tooling/nargo/src/ops/check.rs
+++ b/tooling/nargo/src/ops/check.rs
@@ -5,11 +5,11 @@ use noirc_errors::CustomDiagnostic;
 /// Run each function through a circuit simulator to check that they are solvable.
 #[tracing::instrument(level = "trace", skip_all)]
 pub fn check_program(compiled_program: &CompiledProgram) -> Result<(), ErrorsAndWarnings> {
-    for (i, circuit) in compiled_program.program.functions.iter().enumerate() {
+    for circuit in &compiled_program.program.functions {
         let mut simulator = CircuitSimulator::default();
         if !simulator.check_circuit(circuit) {
             let diag = CustomDiagnostic::from_message(
-                &format!("Circuit \"{}\" is not solvable", compiled_program.names[i]),
+                &format!("Circuit \"{}\" is not solvable", circuit.name),
                 fm::FileId::dummy(),
             );
             return Err(vec![diag]);

--- a/tooling/noirc_artifacts/src/contract.rs
+++ b/tooling/noirc_artifacts/src/contract.rs
@@ -87,9 +87,6 @@ pub struct ContractFunctionArtifact {
         deserialize_with = "ProgramDebugInfo::deserialize_compressed_base64_json"
     )]
     pub debug_symbols: ProgramDebugInfo,
-    #[serde(default)] // For backwards compatibility (it was missing).
-    pub names: Vec<String>,
-    pub brillig_names: Vec<String>,
 }
 
 impl ContractFunctionArtifact {
@@ -106,8 +103,6 @@ impl ContractFunctionArtifact {
             debug: self.debug_symbols.debug_infos,
             file_map,
             warnings: Vec::new(),
-            names: self.names,
-            brillig_names: self.brillig_names,
         }
     }
 }
@@ -121,8 +116,6 @@ impl From<ContractFunction> for ContractFunctionArtifact {
             custom_attributes: func.custom_attributes,
             abi: func.abi,
             bytecode: func.bytecode,
-            names: func.names,
-            brillig_names: func.brillig_names,
             debug_symbols: ProgramDebugInfo { debug_infos: func.debug },
         }
     }

--- a/tooling/noirc_artifacts/src/program.rs
+++ b/tooling/noirc_artifacts/src/program.rs
@@ -37,10 +37,6 @@ pub struct ProgramArtifact {
 
     /// Map of file Id to the source code so locations in debug info can be mapped to source code they point to.
     pub file_map: BTreeMap<FileId, DebugFile>,
-
-    pub names: Vec<String>,
-    /// Names of the unconstrained functions in the program.
-    pub brillig_names: Vec<String>,
 }
 
 impl From<CompiledProgram> for ProgramArtifact {
@@ -52,8 +48,6 @@ impl From<CompiledProgram> for ProgramArtifact {
             bytecode: compiled_program.program,
             debug_symbols: ProgramDebugInfo { debug_infos: compiled_program.debug },
             file_map: compiled_program.file_map,
-            names: compiled_program.names,
-            brillig_names: compiled_program.brillig_names,
         }
     }
 }
@@ -68,8 +62,6 @@ impl From<ProgramArtifact> for CompiledProgram {
             debug: program.debug_symbols.debug_infos,
             file_map: program.file_map,
             warnings: vec![],
-            names: program.names,
-            brillig_names: program.brillig_names,
         }
     }
 }

--- a/tooling/noirc_artifacts_info/src/lib.rs
+++ b/tooling/noirc_artifacts_info/src/lib.rs
@@ -2,7 +2,7 @@ use acvm::acir::circuit::ExpressionWidth;
 use iter_extended::vecmap;
 use noirc_artifacts::program::ProgramArtifact;
 use prettytable::{Row, row, table};
-use rayon::iter::{IndexedParallelIterator, IntoParallelIterator, ParallelIterator};
+use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use serde::Serialize;
 
 #[derive(Debug, Default, Serialize)]
@@ -65,18 +65,14 @@ pub fn count_opcodes_and_gates_in_program(
         .bytecode
         .functions
         .into_par_iter()
-        .enumerate()
-        .map(|(i, function)| FunctionInfo {
-            name: compiled_program.names[i].clone(),
-            opcodes: function.opcodes.len(),
-        })
+        .map(|function| FunctionInfo { name: function.name, opcodes: function.opcodes.len() })
         .collect();
 
-    let opcodes_len: Vec<usize> = compiled_program
+    let unconstrained_info: Vec<FunctionInfo> = compiled_program
         .bytecode
         .unconstrained_functions
         .iter()
-        .map(|func| func.bytecode.len())
+        .map(|func| FunctionInfo { name: func.name.clone(), opcodes: func.bytecode.len() })
         .collect();
     let unconstrained_functions_opcodes = compiled_program
         .bytecode
@@ -84,13 +80,6 @@ pub fn count_opcodes_and_gates_in_program(
         .into_par_iter()
         .map(|function| function.bytecode.len())
         .sum();
-    let unconstrained_info: Vec<FunctionInfo> = compiled_program
-        .brillig_names
-        .clone()
-        .iter()
-        .zip(opcodes_len)
-        .map(|(name, len)| FunctionInfo { name: name.clone(), opcodes: len })
-        .collect();
 
     ProgramInfo {
         package_name,

--- a/tooling/profiler/src/cli/execution_flamegraph_cmd.rs
+++ b/tooling/profiler/src/cli/execution_flamegraph_cmd.rs
@@ -234,7 +234,7 @@ mod tests {
             hash: 27,
             abi: noirc_abi::Abi::default(),
             bytecode: Program {
-                functions: vec![Circuit::default()],
+                functions: vec![Circuit { name: "main".to_string(), ..Default::default() }],
                 unconstrained_functions: vec![
                     BrilligBytecode::default(),
                     BrilligBytecode::default(),
@@ -242,8 +242,6 @@ mod tests {
             },
             debug_symbols: ProgramDebugInfo { debug_infos: vec![DebugInfo::default()] },
             file_map: BTreeMap::default(),
-            names: vec!["main".to_string()],
-            brillig_names: Vec::new(),
         };
 
         // Write the artifact to a file

--- a/tooling/profiler/src/cli/gates_flamegraph_cmd.rs
+++ b/tooling/profiler/src/cli/gates_flamegraph_cmd.rs
@@ -66,8 +66,6 @@ fn run_with_provider<Provider: GatesProvider, Generator: FlamegraphGenerator>(
     let backend_gates_response =
         gates_provider.get_gates(artifact_path).context("Error querying backend for gates")?;
 
-    let function_names = std::mem::take(&mut program.names);
-
     let bytecode = std::mem::take(&mut program.bytecode);
 
     let debug_artifact: DebugArtifact = program.into();
@@ -79,9 +77,9 @@ fn run_with_provider<Provider: GatesProvider, Generator: FlamegraphGenerator>(
         // We can have repeated names if there are functions with the same name in different
         // modules or functions that use generics. Thus, add the unique function index as a suffix.
         let function_name = if num_functions > 1 {
-            format!("{}_{}", function_names[func_idx].as_str(), func_idx)
+            format!("{}_{}", circuit.name, func_idx)
         } else {
-            function_names[func_idx].to_owned()
+            circuit.name.to_owned()
         };
 
         println!(
@@ -185,11 +183,12 @@ mod tests {
             noir_version: "0.0.0".to_string(),
             hash: 27,
             abi: noirc_abi::Abi::default(),
-            bytecode: Program { functions: vec![Circuit::default()], ..Program::default() },
+            bytecode: Program {
+                functions: vec![Circuit { name: "main".to_string(), ..Circuit::default() }],
+                ..Program::default()
+            },
             debug_symbols: ProgramDebugInfo { debug_infos: vec![DebugInfo::default()] },
             file_map: BTreeMap::default(),
-            names: vec!["main".to_string()],
-            brillig_names: Vec::new(),
         };
 
         // Write the artifact to a file

--- a/tooling/profiler/src/cli/opcodes_flamegraph_cmd.rs
+++ b/tooling/profiler/src/cli/opcodes_flamegraph_cmd.rs
@@ -46,9 +46,6 @@ fn run_with_generator<Generator: FlamegraphGenerator>(
     let mut program =
         read_program_from_file(artifact_path).context("Error reading program from file")?;
 
-    let acir_names = std::mem::take(&mut program.names);
-    let brillig_names = std::mem::take(&mut program.brillig_names);
-
     let bytecode = std::mem::take(&mut program.bytecode);
 
     let debug_artifact: DebugArtifact = program.into();
@@ -57,9 +54,9 @@ fn run_with_generator<Generator: FlamegraphGenerator>(
         // We can have repeated names if there are functions with the same name in different
         // modules or functions that use generics. Thus, add the unique function index as a suffix.
         let function_name = if bytecode.functions.len() > 1 {
-            format!("{}_{}", acir_names[func_idx].as_str(), func_idx)
+            format!("{}_{}", circuit.name.as_str(), func_idx)
         } else {
-            acir_names[func_idx].to_owned()
+            circuit.name.to_owned()
         };
 
         println!("Opcode count for {}: {}", function_name, circuit.opcodes.len());
@@ -101,8 +98,7 @@ fn run_with_generator<Generator: FlamegraphGenerator>(
 
         // We can have repeated names if there are functions with the same name in different
         // modules or functions that use generics. Thus, add the unique function index as a suffix.
-        let function_name =
-            format!("{}_{}", brillig_names[brillig_fn_index].as_str(), brillig_fn_index);
+        let function_name = format!("{}_{}", brillig_bytecode.name.as_str(), brillig_fn_index);
 
         println!("Opcode count for {}_brillig: {}", function_name, brillig_bytecode.bytecode.len());
 
@@ -200,11 +196,12 @@ mod tests {
             noir_version: "0.0.0".to_string(),
             hash: 27,
             abi: noirc_abi::Abi::default(),
-            bytecode: Program { functions: vec![Circuit::default()], ..Program::default() },
+            bytecode: Program {
+                functions: vec![Circuit { name: "main".to_string(), ..Default::default() }],
+                ..Program::default()
+            },
             debug_symbols: ProgramDebugInfo { debug_infos: vec![DebugInfo::default()] },
             file_map: BTreeMap::default(),
-            names: vec!["main".to_string()],
-            brillig_names: Vec::new(),
         };
 
         // Write the artifact to a file
@@ -253,17 +250,19 @@ mod tests {
             hash: 27,
             abi: noirc_abi::Abi::default(),
             bytecode: Program {
-                functions: vec![Circuit { opcodes: acir, ..Circuit::default() }],
+                functions: vec![Circuit {
+                    name: "main".to_string(),
+                    opcodes: acir,
+                    ..Circuit::default()
+                }],
                 unconstrained_functions: vec![
-                    BrilligBytecode::default(),
-                    BrilligBytecode::default(),
-                    BrilligBytecode::default(),
+                    BrilligBytecode { name: "main".to_string(), ..Default::default() },
+                    BrilligBytecode { name: "main".to_string(), ..Default::default() },
+                    BrilligBytecode { name: "main_1".to_string(), ..Default::default() },
                 ],
             },
             debug_symbols: ProgramDebugInfo { debug_infos: vec![DebugInfo::default()] },
             file_map: BTreeMap::default(),
-            names: vec!["main".to_string()],
-            brillig_names: vec!["main".to_string(), "main".to_string(), "main_1".to_string()],
         };
 
         // Write the artifact to a file

--- a/tooling/ssa_executor/src/compiler.rs
+++ b/tooling/ssa_executor/src/compiler.rs
@@ -76,14 +76,13 @@ pub fn compile_from_artifacts(artifacts: ArtifactsAndWarnings) -> CompiledProgra
         .map(|acir| vec![(acir.input_witnesses.len() as u32, Visibility::Private)])
         .collect();
 
-    let SsaProgramArtifact { program, debug, warnings, names, brillig_names, .. } =
-        combine_artifacts(
-            artifacts,
-            &dummy_arg_info,
-            BTreeMap::new(),
-            BTreeMap::new(),
-            BTreeMap::new(),
-        );
+    let SsaProgramArtifact { program, debug, warnings, .. } = combine_artifacts(
+        artifacts,
+        &dummy_arg_info,
+        BTreeMap::new(),
+        BTreeMap::new(),
+        BTreeMap::new(),
+    );
     let file_map = BTreeMap::new();
     CompiledProgram {
         hash: 1, // const hash, doesn't matter in this case
@@ -93,8 +92,6 @@ pub fn compile_from_artifacts(artifacts: ArtifactsAndWarnings) -> CompiledProgra
         file_map,
         noir_version: NOIR_ARTIFACT_VERSION_STRING.to_string(),
         warnings,
-        names,
-        brillig_names,
     }
 }
 

--- a/tooling/ssa_verification/src/acir_instruction_builder.rs
+++ b/tooling/ssa_verification/src/acir_instruction_builder.rs
@@ -246,7 +246,7 @@ fn ssa_to_acir_program(ssa: Ssa) -> AcirProgram<FieldElement> {
         enable_brillig_constraints_check_lookback: false,
         skip_passes: vec![],
     };
-    let (acir_functions, brillig, _, _) = match optimize_ssa_builder_into_acir(
+    let (acir_functions, brillig, _) = match optimize_ssa_builder_into_acir(
         builder,
         &ssa_evaluator_options,
         &primary_passes(&ssa_evaluator_options),


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This PR changes each circuit or brillig bytecode to have a name attached to it. This makes it easier to access the names when inspecting the artifact and avoids us from having to pass them around externally to the circuits.

## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
