### PR TITLE
fix: enum match on integer type variable

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/enums.rs
+++ b/compiler/noirc_frontend/src/elaborator/enums.rs
@@ -907,7 +907,7 @@ impl<'elab, 'ctx> MatchCompiler<'elab, 'ctx> {
                 let (cases, fallback) = self.compile_int_cases(rows, branch_var)?;
                 Ok(HirMatch::Switch(branch_var, cases, Some(fallback)))
             }
-            Type::TypeVariable(typevar) if typevar.is_integer_or_field() => {
+            Type::TypeVariable(typevar) if typevar.is_integer() || typevar.is_integer_or_field() => {
                 let (cases, fallback) = self.compile_int_cases(rows, branch_var)?;
                 Ok(HirMatch::Switch(branch_var, cases, Some(fallback)))
             }

--- a/test_programs/compile_success_empty/enums/src/main.nr
+++ b/test_programs/compile_success_empty/enums/src/main.nr
@@ -151,3 +151,13 @@ struct MyStruct {
     x: i32,
     y: Field,
 }
+
+pub fn match_on_u32_type_var(a: u32) {
+    for i in 0..5 {
+        let _ = match i {
+            1 => "one",
+            2 => "two",
+            _ => "???",
+        };
+    }
+}


### PR DESCRIPTION
# Description

## Problem

Resolves #9109

## Summary

The methods `is_integer` and `is_integer_or_field` are a bit misleading... or, well, the second one doesn't imply the first one, and that's confusing. Maybe we should find some other name for "integer or field".

## Additional Context



## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
