### PR TITLE
chore: nicer way to show nargo interpret results

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/interpreter/tests/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/interpreter/tests/mod.rs
@@ -3,6 +3,7 @@
 use std::sync::Arc;
 
 use acvm::{AcirField, FieldElement};
+use insta::assert_snapshot;
 
 use crate::ssa::{
     interpreter::value::NumericValue,
@@ -158,10 +159,10 @@ fn run_flattened_function() {
     let v1 = Value::array(v1_elements, v1_element_types);
 
     let result = expect_value_with_args(src, vec![Value::bool(true), v1.clone()]);
-    assert_eq!(result.to_string(), "rc1 [u1 false, u1 false]");
+    assert_snapshot!(result.to_string(), @"rc1 [u1 0, u1 0]");
 
     let result = expect_value_with_args(src, vec![Value::bool(false), v1]);
-    assert_eq!(result.to_string(), "rc1 [u1 false, u1 true]");
+    assert_snapshot!(result.to_string(), @"rc1 [u1 0, u1 1]");
 }
 
 #[test]

--- a/compiler/noirc_evaluator/src/ssa/interpreter/value.rs
+++ b/compiler/noirc_evaluator/src/ssa/interpreter/value.rs
@@ -399,7 +399,7 @@ impl std::fmt::Display for NumericValue {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             NumericValue::Field(value) => write!(f, "Field {value}"),
-            NumericValue::U1(value) => write!(f, "u1 {value}"),
+            NumericValue::U1(value) => write!(f, "u1 {}", if *value { "1" } else { "0" }),
             NumericValue::U8(value) => write!(f, "u8 {value}"),
             NumericValue::U16(value) => write!(f, "u16 {value}"),
             NumericValue::U32(value) => write!(f, "u32 {value}"),
@@ -425,11 +425,41 @@ impl std::fmt::Display for ReferenceValue {
 
 impl std::fmt::Display for ArrayValue {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let elements = self.elements.borrow();
-        let elements = vecmap(elements.iter(), ToString::to_string).join(", ");
+        let rc = self.rc.borrow();
 
         let is_slice = if self.is_slice { "&" } else { "" };
-        write!(f, "rc{} {is_slice}[{elements}]", self.rc.borrow())
+        write!(f, "rc{rc} {is_slice}[")?;
+
+        let length = self.elements.borrow().len() / self.element_types.len();
+        if length == 0 {
+            // We show an array length zero like `[T; 0]` or `[(T1, T2, ...); 0]`
+            let element_types = if self.element_types.len() == 1 {
+                self.element_types[0].to_string()
+            } else {
+                let element_types =
+                    vecmap(self.element_types.iter(), ToString::to_string).join(", ");
+                format!("({element_types})")
+            };
+            write!(f, "{element_types}; {length}")?;
+        } else {
+            // Otherwise we show the elements, but try to group them if the element type is a composite type
+            // (that way the element types can be inferred from the elements)
+            let element_types_len = self.element_types.len();
+            for (index, element) in self.elements.borrow().iter().enumerate() {
+                if index > 0 {
+                    write!(f, ", ")?;
+                }
+                if element_types_len > 1 && index % element_types_len == 0 {
+                    write!(f, "(")?;
+                }
+                write!(f, "{element}")?;
+                if element_types_len > 1 && index % element_types_len == element_types_len - 1 {
+                    write!(f, ")")?;
+                }
+            }
+        }
+
+        write!(f, "]")
     }
 }
 

--- a/tooling/ast_fuzzer/src/compare/interpreted.rs
+++ b/tooling/ast_fuzzer/src/compare/interpreted.rs
@@ -191,7 +191,7 @@ impl Comparable for ssa::interpreter::errors::InterpreterError {
             ) => {
                 // The `lhs` and `rhs` might change during passes, making direct comparison difficult:
                 // * the sides might be flipped: `u1 0 == u1 1` vs `u1 1 == u1 0`
-                // * the condition might be flipped: `u1 true != u1 false` vs `Field 0 == Field 0`
+                // * the condition might be flipped: `u1 1 != u1 0` vs `Field 0 == Field 0`
                 // * types could change:
                 //      * `Field 313339671284855045676773137498590239475 != Field 0` vs `u128 313339671284855045676773137498590239475 != u128 0`
                 //      * `i64 -1615928006 != i64 -5568658583620095790` vs `u64 18446744072093623610 != u64 12878085490089455826`


### PR DESCRIPTION
# Description

## Problem

No issue, just something I noticed.

## Summary

For this program:

```noir
fn main() -> pub [(Field, Field); 2] {
    [(1, 2), (3, 4)]
}
```

`nargo interpret` would show this:

```
--- Interpreter result after Verifying no dynamic array indices to reference value elements (step 39):
Ok([ArrayOrSlice(ArrayValue { elements: Shared(RefCell { value: [Numeric(Field(1)), Numeric(Field(2)), Numeric(Field(3)), Numeric(Field(4))] }), rc: Shared(RefCell { value: 1 }), element_types: [Numeric(NativeField), Numeric(NativeField)], is_slice: false })])
```

which is... fine! I was about to change it by implementing a nicer `Display` for `Value` but that was already implemented, we just weren't using it. Together with improving how arrays are shown, the new output is:

```
--- Interpreter result after Verifying no dynamic array indices to reference value elements (step 39):
Ok(rc1 [(Field 1, Field 2), (Field 3, Field 4)])
```

In the case of an empty array, it's shown as `[(Field, Field); 0]` so the element types can be seen (when there are values, the values are grouped according to element types, if needed, so the element types can be inferred from those values).

## Additional Context

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
