### PR TITLE
fix: Impl associated types can get out of order

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/trait_impls.rs
+++ b/compiler/noirc_frontend/src/elaborator/trait_impls.rs
@@ -152,6 +152,7 @@ impl Elaborator<'_> {
         // First get the general trait to impl bindings.
         // Then we'll need to add the bindings for this specific method.
         let self_type = self.self_type.as_ref().unwrap().clone();
+
         let mut bindings =
             self.interner.trait_to_impl_bindings(trait_id, impl_id, trait_impl_generics, self_type);
 

--- a/compiler/noirc_frontend/src/parser/parser/traits.rs
+++ b/compiler/noirc_frontend/src/parser/parser/traits.rs
@@ -188,7 +188,7 @@ impl Parser<'_> {
         Some(TraitItem::Type { name, bounds })
     }
 
-    /// TraitConstant = 'let' identifier ':' Type ( '=' Expression ) ';'
+    /// TraitConstant = 'let' identifier ':' Type ( '=' Expression )? ';'
     fn parse_trait_constant(&mut self) -> Option<TraitItem> {
         if !self.eat_keyword(Keyword::Let) {
             return None;

--- a/test_programs/compile_failure/regression_8485/Nargo.toml
+++ b/test_programs/compile_failure/regression_8485/Nargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "regression_8485"
+type = "bin"
+authors = [""]
+
+[dependencies]

--- a/test_programs/compile_failure/regression_8485/src/main.nr
+++ b/test_programs/compile_failure/regression_8485/src/main.nr
@@ -1,0 +1,47 @@
+pub trait Deserialize {
+    let N: u32;
+
+    fn deserialize(fields: [Field; Self::N]) -> Self;
+}
+
+pub struct PrivateCallInterface<T> {
+  return_type: T
+}
+
+pub struct PrivateVoidCallInterface {
+  return_type: ()
+}
+
+trait SuperCallInterface where Self::T: Deserialize<N = Self::M> {
+    type T;
+    let M: u32;
+
+    fn call(self) -> Self::T;
+}
+
+impl<T> SuperCallInterface for PrivateCallInterface<T>
+    where T: Deserialize
+{
+    type T = T;
+    let M: u32 = <T as Deserialize>::N;
+
+    fn call(self) -> T {
+        let preimage: [Field; Self::M] = std::mem::zeroed();
+
+        let returns: T = T::deserialize(preimage);
+        returns
+    }
+}
+
+// Removing this impl fixes the panic despite this type being unused
+impl SuperCallInterface<()> for PrivateVoidCallInterface {
+    let M: u32 = 0;
+
+    fn call(self) -> () {
+        ()
+    }
+}
+
+unconstrained fn main() {
+  let _should_be_field = PrivateCallInterface {return_type: 1}.call();
+}

--- a/tooling/nargo_cli/tests/snapshots/compile_failure/regression_8485/execute__tests__stderr.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_failure/regression_8485/execute__tests__stderr.snap
@@ -1,0 +1,60 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: stderr
+---
+error: SuperCallInterface expects 0 generics but 1 was given
+   ┌─ src/main.nr:37:6
+   │
+37 │ impl SuperCallInterface<()> for PrivateVoidCallInterface {
+   │      ------------------
+   │
+
+error: `SuperCallInterface` is missing the associated type `T`
+   ┌─ src/main.nr:37:6
+   │
+37 │ impl SuperCallInterface<()> for PrivateVoidCallInterface {
+   │      ------------------
+   │
+
+error: No matching impl found for `Field: Deserialize<N = _>`
+   ┌─ src/main.nr:46:26
+   │
+46 │   let _should_be_field = PrivateCallInterface {return_type: 1}.call();
+   │                          ------------------------------------------ No impl for `Field: Deserialize<N = _>`
+   │
+
+error: Type annotation needed
+   ┌─ src/main.nr:46:26
+   │
+46 │   let _should_be_field = PrivateCallInterface {return_type: 1}.call();
+   │                          ------------------------------------------ Could not determine the value of the generic argument `<T as Deserialize>::N` declared on the struct `PrivateCallInterface`
+   │
+
+error: The trait bound `T: Deserialize<N = M>` is not satisfied
+   ┌─ src/main.nr:15:41
+   │
+15 │ trait SuperCallInterface where Self::T: Deserialize<N = Self::M> {
+   │                                         ----------- required by this bound in `SuperCallInterface`
+   ·
+22 │ impl<T> SuperCallInterface for PrivateCallInterface<T>
+   │                                ----------------------- The trait `Deserialize<N = M>` is not implemented for `T`
+   │
+
+error: The trait bound `T: Deserialize<N = M>` is not satisfied
+   ┌─ src/main.nr:15:41
+   │
+15 │ trait SuperCallInterface where Self::T: Deserialize<N = Self::M> {
+   │                                         ----------- required by this bound in `SuperCallInterface`
+   ·
+37 │ impl SuperCallInterface<()> for PrivateVoidCallInterface {
+   │                                 ------------------------ The trait `Deserialize<N = M>` is not implemented for `T`
+   │
+
+error: Expected type fn(PrivateVoidCallInterface) -> _, found type fn(PrivateVoidCallInterface) -> ()
+   ┌─ src/main.nr:40:8
+   │
+40 │     fn call(self) -> () {
+   │        ----
+   │
+
+Aborting due to 7 previous errors


### PR DESCRIPTION
# Description

## Problem\*

Resolves https://github.com/noir-lang/noir/issues/8485

## Summary\*

In some cases the associated types of an impl can get out of order, particularly in the presence of programs with other errors in them such as just not having all associated types to begin with (Although they are filled in with Type::Error this can be out of order). It seemed better to sort them when we need them then continue to rely on them being in order everywhere.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
