### PR TITLE
fix(ssa interpreter): Add out of bounds error

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/interpreter/errors.rs
+++ b/compiler/noirc_evaluator/src/ssa/interpreter/errors.rs
@@ -68,6 +68,8 @@ pub enum InterpreterError {
     BlackBoxError { name: String, reason: String },
     #[error("Reached the unreachable")]
     ReachedTheUnreachable,
+    #[error("Array index {index} is out of bounds for array of length {length}")]
+    IndexOutOfBounds { index: u32, length: u32 },
 }
 
 /// These errors can only result from interpreting malformed SSA

--- a/compiler/noirc_evaluator/src/ssa/interpreter/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/interpreter/mod.rs
@@ -879,7 +879,11 @@ impl<'ssa, W: Write> Interpreter<'ssa, W> {
             let array = self.lookup_array_or_slice(array, "array get")?;
             let index = self.lookup_u32(index, "array get index")?;
             let index = index - offset.to_u32();
-            array.elements.borrow()[index as usize].clone()
+            let elements = array.elements.borrow();
+            let element = elements.get(index as usize).ok_or_else(|| {
+                InterpreterError::IndexOutOfBounds { index, length: elements.len() as u32 }
+            })?;
+            element.clone()
         } else {
             let typ = self.dfg().type_of_value(result);
             Value::uninitialized(&typ, result)
@@ -908,6 +912,11 @@ impl<'ssa, W: Write> Interpreter<'ssa, W> {
 
             let should_mutate =
                 if self.in_unconstrained_context() { *array.rc.borrow() == 1 } else { mutable };
+
+            let len = array.elements.borrow().len();
+            if index as usize >= len {
+                return Err(InterpreterError::IndexOutOfBounds { index, length: len as u32 });
+            }
 
             if should_mutate {
                 array.elements.borrow_mut()[index as usize] = value;


### PR DESCRIPTION
# Description

## Problem\*

Resolves https://github.com/noir-lang/noir/issues/8539

## Summary\*

Adds out of bounds errors for ArrayGet and ArraySet instructions

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
