### PR TITLE
fix(fuzz): fix wrong source listing order for comptime

### DIFF
--- a/tooling/ast_fuzzer/fuzz/src/lib.rs
+++ b/tooling/ast_fuzzer/fuzz/src/lib.rs
@@ -143,8 +143,8 @@ pub fn compare_results_comptime(
         eprintln!("{report:#}");
 
         // Showing the AST as Noir so we can easily create integration tests.
-        eprintln!("---\nAST:\n{}", DisplayAstAsNoir(&inputs.program));
         eprintln!("---\nComptime source:\n{}", &inputs.source);
+        eprintln!("---\nAST:\n{}", DisplayAstAsNoir(&inputs.program));
 
         eprintln!("---\nCompile options:\n{:?}", inputs.ssa.options);
         eprintln!("---\nCompiled program:\n{}", inputs.ssa.artifact.program);


### PR DESCRIPTION
# Description

"Left program failed" would in fact indicate comptime failure, and comptime source came after AST listing in the report, which was confusing. Fixed 

## Problem\*

## Summary\*



## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
