### PR TITLE
chore(fuzz): enable constrain operations for comptime_vs_brillig_direct

### DIFF
--- a/tooling/ast_fuzzer/fuzz/src/targets/comptime_vs_brillig_direct.rs
+++ b/tooling/ast_fuzzer/fuzz/src/targets/comptime_vs_brillig_direct.rs
@@ -26,8 +26,6 @@ pub fn fuzz(u: &mut Unstructured) -> eyre::Result<()> {
         comptime_friendly: true,
         // Force brillig, to generate loops that the interpreter can do but ACIR cannot.
         force_brillig: true,
-        // Avoid constraints for now
-        avoid_constrain: true,
         // Use lower limits because of the interpreter, to avoid stack overflow
         max_loop_size: 5,
         max_recursive_calls: 5,


### PR DESCRIPTION
# Description

By now constraints can be included seemingly with no issues.

## Problem\*

## Summary\*



## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
