### PR TITLE
chore: make ssa_fuzzer tests actually fuzz

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3580,7 +3580,7 @@ dependencies = [
  "noirc_driver",
  "noirc_evaluator",
  "noirc_frontend",
- "rand 0.8.5",
+ "proptest",
  "serde",
  "thiserror 1.0.69",
 ]

--- a/tooling/ssa_fuzzer/Cargo.toml
+++ b/tooling/ssa_fuzzer/Cargo.toml
@@ -21,8 +21,9 @@ acvm.workspace = true
 thiserror.workspace = true
 libfuzzer-sys = { workspace = true, features = ["arbitrary-derive"] }
 serde.workspace = true
+
 [dev-dependencies]
-rand.workspace = true
+proptest.workspace = true
 
 [features]
 bn254 = ["noirc_frontend/bn254"]


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

Followup to #9113 which updates these tests from testing a single input to fuzzing the full range of inputs. It also expands the acceptable range of inputs so that it doesn't require that execution succeeds, just that it matches rust behaviour.

## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
