### PR TITLE
fix: Execution and proving discrepancy in ecdsa

### DIFF
--- a/acvm-repo/blackbox_solver/src/ecdsa/secp256k1.rs
+++ b/acvm-repo/blackbox_solver/src/ecdsa/secp256k1.rs
@@ -27,7 +27,7 @@ pub(super) fn verify_signature(
     let point = EncodedPoint::from_affine_coordinates(
         public_key_x_bytes.into(),
         public_key_y_bytes.into(),
-        true,
+        false,
     );
 
     let pubkey = PublicKey::from_encoded_point(&point);
@@ -107,6 +107,15 @@ mod secp256k1_tests {
         let valid = verify_signature(&HASHED_MESSAGE, &PUB_KEY_X, &PUB_KEY_Y, &SIGNATURE);
 
         assert!(valid);
+    }
+
+    #[test]
+    fn rejects_signature_that_doesnt_have_the_full_y_coordinate() {
+        let mut pub_key_y_bytes = [0u8; 32];
+        pub_key_y_bytes[31] = PUB_KEY_Y[31];
+        let valid = verify_signature(&HASHED_MESSAGE, &PUB_KEY_X, &pub_key_y_bytes, &SIGNATURE);
+
+        assert!(!valid);
     }
 
     #[test]

--- a/acvm-repo/blackbox_solver/src/ecdsa/secp256r1.rs
+++ b/acvm-repo/blackbox_solver/src/ecdsa/secp256r1.rs
@@ -27,7 +27,7 @@ pub(super) fn verify_signature(
     let point = EncodedPoint::from_affine_coordinates(
         public_key_x_bytes.into(),
         public_key_y_bytes.into(),
-        true,
+        false,
     );
 
     let pubkey = PublicKey::from_encoded_point(&point);
@@ -103,6 +103,15 @@ mod secp256r1_tests {
         let valid = verify_signature(&HASHED_MESSAGE, &PUB_KEY_X, &PUB_KEY_Y, &SIGNATURE);
 
         assert!(valid);
+    }
+
+    #[test]
+    fn rejects_signature_that_doesnt_have_the_full_y_coordinate() {
+        let mut pub_key_y_bytes = [0u8; 32];
+        pub_key_y_bytes[31] = PUB_KEY_Y[31];
+        let valid = verify_signature(&HASHED_MESSAGE, &PUB_KEY_X, &pub_key_y_bytes, &SIGNATURE);
+
+        assert!(!valid);
     }
 
     #[test]


### PR DESCRIPTION
# Description

## Problem\*

ECDSA checked compressed point representation instead of full during nargo execute.
## Summary\*



## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
