### PR TITLE
chore(docs): add forgotten import to RPC example

### DIFF
--- a/docs/docs/tooling/fuzzer.md
+++ b/docs/docs/tooling/fuzzer.md
@@ -166,6 +166,7 @@ You can create a simple python server to resolve the oracle (you'll have to inst
 
 ```python
 from werkzeug.serving import run_simple
+from werkzeug.wrappers import Response, Request
 
 from jsonrpc import JSONRPCResponseManager, dispatcher
 


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*



## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
