### PR TITLE
fix: disallow trait associated constants to have a default value

### DIFF
--- a/compiler/noirc_frontend/src/ast/traits.rs
+++ b/compiler/noirc_frontend/src/ast/traits.rs
@@ -45,7 +45,6 @@ pub enum TraitItem {
     Constant {
         name: Ident,
         typ: UnresolvedType,
-        default_value: Option<Expression>,
     },
     Type {
         name: Ident,
@@ -207,15 +206,7 @@ impl Display for TraitItem {
 
                 if let Some(body) = body { write!(f, "{body}") } else { write!(f, ";") }
             }
-            TraitItem::Constant { name, typ, default_value } => {
-                write!(f, "let {name}: {typ}")?;
-
-                if let Some(default_value) = default_value {
-                    write!(f, "{default_value};")
-                } else {
-                    write!(f, ";")
-                }
-            }
+            TraitItem::Constant { name, typ } => write!(f, "let {name}: {typ};"),
             TraitItem::Type { name, bounds } => {
                 if bounds.is_empty() {
                     write!(f, "type {name};")

--- a/compiler/noirc_frontend/src/ast/visitor.rs
+++ b/compiler/noirc_frontend/src/ast/visitor.rs
@@ -123,12 +123,7 @@ pub trait Visitor {
         true
     }
 
-    fn visit_trait_item_constant(
-        &mut self,
-        _name: &Ident,
-        _typ: &UnresolvedType,
-        _default_value: &Option<Expression>,
-    ) -> bool {
+    fn visit_trait_item_constant(&mut self, _name: &Ident, _typ: &UnresolvedType) -> bool {
         true
     }
 
@@ -793,13 +788,9 @@ impl TraitItem {
                     }
                 }
             }
-            TraitItem::Constant { name, typ, default_value } => {
-                if visitor.visit_trait_item_constant(name, typ, default_value) {
+            TraitItem::Constant { name, typ } => {
+                if visitor.visit_trait_item_constant(name, typ) {
                     typ.accept(visitor);
-
-                    if let Some(default_value) = default_value {
-                        default_value.accept(visitor);
-                    }
                 }
             }
             TraitItem::Type { name, bounds } => {

--- a/compiler/noirc_frontend/src/hir/def_collector/dc_mod.rs
+++ b/compiler/noirc_frontend/src/hir/def_collector/dc_mod.rs
@@ -602,7 +602,7 @@ impl ModCollector<'_> {
                             }
                         }
                     }
-                    TraitItem::Constant { name, typ, default_value: _ } => {
+                    TraitItem::Constant { name, typ } => {
                         let global_id = context.def_interner.push_empty_global(
                             name.clone(),
                             trait_id.0.local_id,

--- a/compiler/noirc_frontend/src/parser/parser/traits.rs
+++ b/compiler/noirc_frontend/src/parser/parser/traits.rs
@@ -213,12 +213,9 @@ impl Parser<'_> {
             UnresolvedType { typ: UnresolvedTypeData::Unspecified, location }
         };
 
-        let default_value =
-            if self.eat_assign() { Some(self.parse_expression_or_error()) } else { None };
-
         self.eat_semicolon_or_error();
 
-        Some(TraitItem::Constant { name, typ, default_value })
+        Some(TraitItem::Constant { name, typ })
     }
 
     /// TraitFunction = Modifiers Function
@@ -510,17 +507,16 @@ mod tests {
 
     #[test]
     fn parse_trait_with_constant() {
-        let src = "trait Foo { let x: Field = 1; }";
+        let src = "trait Foo { let x: Field; }";
         let mut noir_trait = parse_trait_no_errors(src);
         assert_eq!(noir_trait.items.len(), 1);
 
         let item = noir_trait.items.remove(0).item;
-        let TraitItem::Constant { name, typ, default_value } = item else {
+        let TraitItem::Constant { name, typ } = item else {
             panic!("Expected constant");
         };
         assert_eq!(name.to_string(), "x");
         assert_eq!(typ.to_string(), "Field");
-        assert_eq!(default_value.unwrap().to_string(), "1");
         assert!(!noir_trait.is_alias);
     }
 

--- a/tooling/lsp/src/requests/document_symbol.rs
+++ b/tooling/lsp/src/requests/document_symbol.rs
@@ -327,17 +327,12 @@ impl Visitor for DocumentSymbolCollector<'_> {
         false
     }
 
-    fn visit_trait_item_constant(
-        &mut self,
-        name: &Ident,
-        typ: &UnresolvedType,
-        default_value: &Option<Expression>,
-    ) -> bool {
+    fn visit_trait_item_constant(&mut self, name: &Ident, typ: &UnresolvedType) -> bool {
         if name.is_empty() {
             return false;
         }
 
-        self.collect_in_constant(name, typ, default_value.as_ref());
+        self.collect_in_constant(name, typ, None);
         false
     }
 

--- a/tooling/lsp/src/with_file.rs
+++ b/tooling/lsp/src/with_file.rs
@@ -277,10 +277,9 @@ fn trait_item_with_file(item: TraitItem, file: FileId) -> TraitItem {
             where_clause: unresolved_trait_constraints_with_file(where_clause, file),
             body: body.map(|body| block_expression_with_file(body, file)),
         },
-        TraitItem::Constant { name, typ, default_value } => TraitItem::Constant {
+        TraitItem::Constant { name, typ } => TraitItem::Constant {
             name: ident_with_file(name, file),
             typ: unresolved_type_with_file(typ, file),
-            default_value: default_value.map(|value| expression_with_file(value, file)),
         },
         TraitItem::Type { name, bounds } => TraitItem::Type {
             name: ident_with_file(name, file),

--- a/tooling/nargo_fmt/src/formatter/traits.rs
+++ b/tooling/nargo_fmt/src/formatter/traits.rs
@@ -111,13 +111,13 @@ impl Formatter<'_> {
                 };
                 self.format_function_impl(func);
             }
-            TraitItem::Constant { name, typ, default_value } => {
+            TraitItem::Constant { name, typ } => {
                 let pattern = Pattern::Identifier(name);
                 let chunks = self.chunk_formatter().format_let_or_global(
                     Keyword::Let,
                     pattern,
                     typ,
-                    default_value,
+                    None,
                     Vec::new(), // Attributes
                 );
                 self.write_indentation();


### PR DESCRIPTION
# Description

## Problem

Resolves #9138

## Summary



## Additional Context



## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
