### PR TITLE
fix(ssa): Do not unroll loops in Brillig with a  constant back-edge value

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/opt/unrolling.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/unrolling.rs
@@ -225,6 +225,18 @@ impl Loops {
             if function.runtime().is_brillig() && !next_loop.is_small_loop(function, &self.cfg) {
                 continue;
             }
+
+            if next_loop.has_const_back_edge_induction_value(function) {
+                // Don't try to unroll this.
+                self.failed_to_unroll.insert(next_loop.header);
+                // If this Brillig, we can still evaluate this loop at runtime.
+                if function.runtime().is_acir() {
+                    unroll_errors
+                        .push(RuntimeError::UnknownLoopBound { call_stack: CallStack::new() });
+                }
+                continue;
+            }
+
             // If we've previously modified a block in this loop we need to refresh the context.
             // This happens any time we have nested loops.
             if next_loop.blocks.iter().any(|block| self.modified_blocks.contains(block)) {
@@ -282,6 +294,39 @@ impl Loop {
         }
 
         Self { header, back_edge_start, blocks }
+    }
+
+    /// Check that the loop does not end with a constant value passed to the header
+    /// from the back-edge, which would result in a loop we would never finish unrolling.
+    ///
+    /// This can happen if constraint folding replaces a value with what it's asserted
+    /// to equal, which doesn't even need to be a valid in the loop range.
+    ///
+    /// For example:
+    /// ```text
+    /// brillig(inline) predicate_pure fn main f0 {
+    ///   b0():
+    ///     jmp b1(u32 10)               // Pre-header
+    ///   b1(v0: u32):                   // Header
+    ///     v3 = lt v0, u32 20
+    ///     jmpif v3 then: b2, else: b3
+    ///   b2():                          // Back edge
+    ///     constrain v0 == u32 1        // Constrain the induction variable to a known value
+    ///     jmp b1(u32 2)                // `v1 = unchecked_add v0, u32 1; jmp b1(v1)` replaced by `jmp b1 (1+1)`
+    ///   b3():
+    ///     return
+    /// }
+    /// ```
+    fn has_const_back_edge_induction_value(&self, function: &Function) -> bool {
+        let back_edge = &function.dfg[self.back_edge_start];
+        let Some(TerminatorInstruction::Jmp { destination, arguments, .. }) =
+            back_edge.terminator()
+        else {
+            unreachable!("the back edge is expected to end in a `Jmp`");
+        };
+        assert_eq!(*destination, self.header, "back edge goes to the header");
+        assert_eq!(arguments.len(), 1);
+        function.dfg.get_numeric_constant(arguments[0]).is_some()
     }
 
     /// Find the lower bound of the loop in the pre-header and return it
@@ -1553,23 +1598,31 @@ mod tests {
         assert_eq!(errors.len(), 0, "All loops should be unrolled");
 
         // The SSA is expected to be unchanged
-        assert_ssa_snapshot!(ssa, @r#"
+        assert_normalized_ssa_equals(ssa, src);
+    }
+
+    #[test]
+    fn test_brillig_unroll_with_const_back_edge() {
+        // The loop is small enough that Brillig wants to unroll it,
+        // but the back edge passes a constant that would result in
+        // an infinite loop of attempting to unroll.
+        let src = "
         brillig(inline) predicate_pure fn main f0 {
           b0():
-            jmp b1(u32 0)
+            jmp b1(u32 10)
           b1(v0: u32):
-            v3 = lt v0, u32 5
+            v3 = lt v0, u32 12
             jmpif v3 then: b2, else: b3
           b2():
-            jmpif u1 1 then: b4, else: b5
+            constrain v0 == u32 1
+            jmp b1(u32 2)
           b3():
-            return u1 1
-          b4():
-            jmp b3()
-          b5():
-            v6 = unchecked_add v0, u32 1
-            jmp b1(v6)
+            return
         }
-        "#);
+        ";
+        let ssa = Ssa::from_str(src).unwrap();
+        let (ssa, errors) = try_unroll_loops(ssa);
+        assert_eq!(errors.len(), 0, "Unroll should have no errors");
+        assert_normalized_ssa_equals(ssa, src);
     }
 }

--- a/test_programs/compile_success_no_bug/regression_9165/Nargo.toml
+++ b/test_programs/compile_success_no_bug/regression_9165/Nargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "regression_9165"
+type = "bin"
+authors = [""]
+
+[dependencies]

--- a/test_programs/compile_success_no_bug/regression_9165/src/main.nr
+++ b/test_programs/compile_success_no_bug/regression_9165/src/main.nr
@@ -1,0 +1,11 @@
+unconstrained fn main() {
+    for idx_a in 4048979427..4048979430 {
+        assert(
+            idx_a
+                == match idx_a {
+                    198384605 => idx_a,
+                    _ => 3138276502,
+                },
+        );
+    }
+}


### PR DESCRIPTION
# Description

## Problem\*

Resolves #9165 

## Summary\*

Fixes the `unrolling` to inspect the induction variable in the back-edge of loops: if the value is a numeric constant, then trying to unroll would be futile. In Brillig we can skip such loops, while in ACIR we return an error.

## Additional Context

The way this happens is when during constraint folding we have a constraint on the induction variable that equates it to a known constant, for example:
```rust
brillig(inline) predicate_pure fn main f0 {
  b0():
    jmp b1(u32 10)
  b1(v0: u32):
    v3 = lt v0, u32 20  
    jmpif v3 then: b2, else: b3
  b2():
    constrain v0 == u32 1
    v6 = unchecked_add v0, u32 1
    jmp b1(v6)
  b3():
    return
}
```
If the `constrain` passes, then we know that the value of `v0` is 1, so the compiler replaces `v6` with 2:
```
  b2():
    constrain v0 == u32 1
    jmp b1(u32 2)
```
This does not make the program invalid in any way: _if_ the constraint was true, then 2 _is_ the next value for the loop variable, even thought the actual bounds were `[10, 20)`, which just means that at runtime (or even at compile time in a later pass), the constraint will fail, before we can run a loop with 2 as the induction value. 

However, the unrolling tracks the value of the induction and evaluates `lt v0, u32 20` at compile time to decide whether it needs to unroll another loop, and in that context, a `v0` that goes `10, 2, 2, 2, 2, ...` results in an infinite loop. 

In Brillig we can leave the loop as it is and let it fail at runtime. 

In ACIR this would be a problem: we _have_ to unroll the loop and we _could_ unroll it, if only constraint folding hadn't got rid of the `unchecked_add` which would increase the value. At the moment there is another unrolling pass before constraint folding though, so hopefully this does not happen in ACIR, because we'd have already unrolled the loops we were able to, but if it does, then we would have to come up with a way to limit what constraint folding can simplify.

## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
