### PR TITLE
chore: enforce `clippy::uninlined_format_args`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,6 +79,7 @@ unused_must_use = "warn"
 [workspace.lints.clippy]
 semicolon_if_nothing_returned = "warn"
 result_large_err = "allow"
+uninlined_format_args = "warn"
 
 [workspace.dependencies]
 

--- a/acvm-repo/acir/src/circuit/mod.rs
+++ b/acvm-repo/acir/src/circuit/mod.rs
@@ -371,11 +371,11 @@ impl<F: AcirField> std::fmt::Debug for Circuit<F> {
 impl<F: AcirField> std::fmt::Display for Program<F> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         for (func_index, function) in self.functions.iter().enumerate() {
-            writeln!(f, "func {}", func_index)?;
-            writeln!(f, "{}", function)?;
+            writeln!(f, "func {func_index}")?;
+            writeln!(f, "{function}")?;
         }
         for (func_index, function) in self.unconstrained_functions.iter().enumerate() {
-            writeln!(f, "unconstrained func {}", func_index)?;
+            writeln!(f, "unconstrained func {func_index}")?;
             writeln!(f, "{:?}", function.bytecode)?;
         }
         Ok(())

--- a/acvm-repo/acir/src/circuit/opcodes.rs
+++ b/acvm-repo/acir/src/circuit/opcodes.rs
@@ -172,7 +172,7 @@ impl<F: AcirField> std::fmt::Display for Opcode<F> {
             Opcode::MemoryInit { block_id, init, block_type: databus } => {
                 match databus {
                     BlockType::Memory => write!(f, "INIT ")?,
-                    BlockType::CallData(id) => write!(f, "INIT CALLDATA {} ", id)?,
+                    BlockType::CallData(id) => write!(f, "INIT CALLDATA {id} ")?,
                     BlockType::ReturnData => write!(f, "INIT RETURNDATA ")?, // cSpell:disable-line
                 }
                 let witnesses =
@@ -182,20 +182,20 @@ impl<F: AcirField> std::fmt::Display for Opcode<F> {
             // We keep the display for a BrilligCall and circuit Call separate as they
             // are distinct in their functionality and we should maintain this separation for debugging.
             Opcode::BrilligCall { id, inputs, outputs, predicate } => {
-                write!(f, "BRILLIG CALL func {}: ", id)?;
+                write!(f, "BRILLIG CALL func {id}: ")?;
                 if let Some(pred) = predicate {
                     writeln!(f, "PREDICATE = {pred}")?;
                 }
-                write!(f, "inputs: {:?}, ", inputs)?;
-                write!(f, "outputs: {:?}", outputs)
+                write!(f, "inputs: {inputs:?}, ")?;
+                write!(f, "outputs: {outputs:?}")
             }
             Opcode::Call { id, inputs, outputs, predicate } => {
-                write!(f, "CALL func {}: ", id)?;
+                write!(f, "CALL func {id}: ")?;
                 if let Some(pred) = predicate {
                     writeln!(f, "PREDICATE = {pred}")?;
                 }
-                write!(f, "inputs: {:?}, ", inputs)?;
-                write!(f, "outputs: {:?}", outputs)
+                write!(f, "inputs: {inputs:?}, ")?;
+                write!(f, "outputs: {outputs:?}")
             }
         }
     }

--- a/acvm-repo/acir/src/circuit/opcodes/black_box_function_call.rs
+++ b/acvm-repo/acir/src/circuit/opcodes/black_box_function_call.rs
@@ -76,7 +76,7 @@ impl<F: AcirField> FunctionInput<F> {
             Ok(FunctionInput { input: ConstantOrWitnessEnum::Constant(value), num_bits: max_bits })
         } else {
             let value_num_bits = value.num_bits();
-            let value = format!("{}", value);
+            let value = format!("{value}");
             Err(InvalidInputBitSize { value, value_num_bits, max_bits })
         }
     }

--- a/acvm-repo/acir/src/lib.rs
+++ b/acvm-repo/acir/src/lib.rs
@@ -565,7 +565,7 @@ mod reflection {
         #[allow(dead_code)]
         fn msgpack_fields(&mut self, name: &str, fields: impl Iterator<Item = String>) {
             let fields = fields.collect::<Vec<_>>().join(", ");
-            let code = format!("MSGPACK_FIELDS({});", fields);
+            let code = format!("MSGPACK_FIELDS({fields});");
             self.add_code(name, &code);
         }
 

--- a/acvm-repo/acir_field/src/field_element.rs
+++ b/acvm-repo/acir_field/src/field_element.rs
@@ -259,7 +259,7 @@ impl<F: PrimeField> AcirField for FieldElement<F> {
         let value = hex_str.strip_prefix("0x").unwrap_or(hex_str);
         // Values of odd length require an additional "0" prefix
         let sanitized_value =
-            if value.len() % 2 == 0 { value.to_string() } else { format!("0{}", value) };
+            if value.len() % 2 == 0 { value.to_string() } else { format!("0{value}") };
         let hex_as_bytes = hex::decode(sanitized_value).ok()?;
         Some(FieldElement::from_be_bytes_reduce(&hex_as_bytes))
     }

--- a/acvm-repo/acvm_js/src/execute.rs
+++ b/acvm-repo/acvm_js/src/execute.rs
@@ -291,7 +291,7 @@ impl<'a, B: BlackBoxFunctionSolver<FieldElement>> ProgramExecutor<'a, B> {
                                     ("Assertion failed".to_string(), Some(raw_payload))
                                 }
                                 ResolvedAssertionPayload::String(message) => {
-                                    (format!("Assertion failed: {}", message), None)
+                                    (format!("Assertion failed: {message}"), None)
                                 }
                             },
                             _ => (error.to_string(), None),
@@ -331,7 +331,7 @@ impl<'a, B: BlackBoxFunctionSolver<FieldElement>> ProgramExecutor<'a, B> {
                                 call_resolved_outputs.push(*return_value);
                             } else {
                                 // TODO: look at changing this call stack from None
-                                return Err(JsExecutionError::new(format!("Failed to read from solved witness of ACIR call at witness {}", return_witness_index), None, None, None, None).into());
+                                return Err(JsExecutionError::new(format!("Failed to read from solved witness of ACIR call at witness {return_witness_index}"), None, None, None, None).into());
                             }
                         }
                         acvm.resolve_pending_acir_call(call_resolved_outputs);

--- a/acvm-repo/acvm_js/src/js_execution_error.rs
+++ b/acvm-repo/acvm_js/src/js_execution_error.rs
@@ -50,7 +50,7 @@ impl JsExecutionError {
             Some(call_stack) => {
                 let js_array = Array::new();
                 for loc in call_stack {
-                    js_array.push(&JsValue::from(format!("{}", loc)));
+                    js_array.push(&JsValue::from(format!("{loc}")));
                 }
                 js_array.into()
             }

--- a/acvm-repo/acvm_js/src/js_witness_map.rs
+++ b/acvm-repo/acvm_js/src/js_witness_map.rs
@@ -95,7 +95,7 @@ pub(crate) fn js_value_to_field_element(js_value: JsValue) -> Result<FieldElemen
     let hex_str = js_value.as_string().ok_or("failed to parse field element from non-string")?;
 
     FieldElement::from_hex(&hex_str)
-        .ok_or_else(|| format!("Invalid hex string: '{}'", hex_str).into())
+        .ok_or_else(|| format!("Invalid hex string: '{hex_str}'").into())
 }
 
 pub(crate) fn field_element_to_js_string(field_element: &FieldElement) -> JsString {

--- a/acvm-repo/blackbox_solver/src/bigint.rs
+++ b/acvm-repo/blackbox_solver/src/bigint.rs
@@ -67,7 +67,7 @@ impl BigIntSolver {
     ) -> Result<(), BlackBoxResolutionError> {
         if self.pedantic_solving {
             if !self.is_valid_modulus(modulus) {
-                panic!("--pedantic-solving: bigint_from_bytes: disallowed modulus {:?}", modulus);
+                panic!("--pedantic-solving: bigint_from_bytes: disallowed modulus {modulus:?}");
             }
             if inputs.len() > modulus.len() {
                 panic!(
@@ -232,8 +232,7 @@ fn all_allowed_bigint_moduli_are_prime() {
             Primality::Probable(probability) => {
                 if probability < 0.90 {
                     panic!(
-                        "not all allowed_bigint_moduli are prime within the allowed probability: {} < 0.90",
-                        probability
+                        "not all allowed_bigint_moduli are prime within the allowed probability: {probability} < 0.90"
                     );
                 }
             }

--- a/acvm-repo/bn254_blackbox_solver/src/embedded_curve_ops.rs
+++ b/acvm-repo/bn254_blackbox_solver/src/embedded_curve_ops.rs
@@ -96,7 +96,7 @@ pub fn embedded_curve_add(
             if point == ark_grumpkin::Affine::zero() {
                 return Err(BlackBoxResolutionError::Failed(
                     BlackBoxFunc::EmbeddedCurveAdd,
-                    format!("Infinite input: embedded_curve_add({}, {})", point1, point2),
+                    format!("Infinite input: embedded_curve_add({point1}, {point2})"),
                 ));
             }
         }

--- a/acvm-repo/brillig_vm/src/black_box.rs
+++ b/acvm-repo/brillig_vm/src/black_box.rs
@@ -353,26 +353,22 @@ pub(crate) fn evaluate_black_box<F: AcirField, Solver: BlackBoxFunctionSolver<F>
 
             assert!(
                 radix >= BigUint::from(2u32) && radix <= BigUint::from(256u32),
-                "Radix out of the valid range [2,256]. Value: {}",
-                radix
+                "Radix out of the valid range [2,256]. Value: {radix}"
             );
 
             assert!(
                 num_limbs >= 1 || input == BigUint::from(0u32),
-                "Input value {} is not zero but number of limbs is zero.",
-                input
+                "Input value {input} is not zero but number of limbs is zero."
             );
 
             assert!(
                 !output_bits || radix == BigUint::from(2u32),
-                "Radix {} is not equal to 2 and bit mode is activated.",
-                radix
+                "Radix {radix} is not equal to 2 and bit mode is activated."
             );
 
             if (input.bits() as u32) > max_bit_size {
                 return Err(BlackBoxResolutionError::AssertFailed(format!(
-                    "Field failed to decompose into specified {} limbs",
-                    num_limbs
+                    "Field failed to decompose into specified {num_limbs} limbs"
                 )));
             }
             for i in (0..num_limbs).rev() {

--- a/acvm-repo/brillig_vm/src/lib.rs
+++ b/acvm-repo/brillig_vm/src/lib.rs
@@ -886,8 +886,7 @@ impl<'a, F: AcirField, B: BlackBoxFunctionSolver<F>> VM<'a, F, B> {
             self.memory.write(destination, memory_value);
         } else {
             return Err(format!(
-                "Foreign call result value {} does not fit in bit size {:?}",
-                value, value_bit_size
+                "Foreign call result value {value} does not fit in bit size {value_bit_size:?}"
             ));
         }
         Ok(())
@@ -919,8 +918,7 @@ impl<'a, F: AcirField, B: BlackBoxFunctionSolver<F>> VM<'a, F, B> {
             self.memory.write_slice(destination, &memory_values);
         } else {
             return Err(format!(
-                "Foreign call result values {:?} do not match expected bit sizes",
-                values,
+                "Foreign call result values {values:?} do not match expected bit sizes",
             ));
         }
         Ok(())
@@ -974,8 +972,7 @@ impl<'a, F: AcirField, B: BlackBoxFunctionSolver<F>> VM<'a, F, B> {
                             }
                             HeapValueType::Vector { .. } => {
                                 return Err(format!(
-                                    "Unsupported returned type in foreign calls {:?}",
-                                    typ
+                                    "Unsupported returned type in foreign calls {typ:?}"
                                 ));
                             }
                         }
@@ -984,7 +981,7 @@ impl<'a, F: AcirField, B: BlackBoxFunctionSolver<F>> VM<'a, F, B> {
                 Ok(())
             }
             HeapValueType::Vector { .. } => {
-                Err(format!("Unsupported returned type in foreign calls {:?}", value_type))
+                Err(format!("Unsupported returned type in foreign calls {value_type:?}"))
             }
         }
     }

--- a/acvm-repo/brillig_vm/src/memory.rs
+++ b/acvm-repo/brillig_vm/src/memory.rs
@@ -205,13 +205,13 @@ impl<F: AcirField> MemoryValue<F> {
 impl<F: std::fmt::Display> std::fmt::Display for MemoryValue<F> {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> Result<(), ::std::fmt::Error> {
         match self {
-            MemoryValue::Field(value) => write!(f, "{}: field", value),
-            MemoryValue::U1(value) => write!(f, "{}: u1", value),
-            MemoryValue::U8(value) => write!(f, "{}: u8", value),
-            MemoryValue::U16(value) => write!(f, "{}: u16", value),
-            MemoryValue::U32(value) => write!(f, "{}: u32", value),
-            MemoryValue::U64(value) => write!(f, "{}: u64", value),
-            MemoryValue::U128(value) => write!(f, "{}: u128", value),
+            MemoryValue::Field(value) => write!(f, "{value}: field"),
+            MemoryValue::U1(value) => write!(f, "{value}: u1"),
+            MemoryValue::U8(value) => write!(f, "{value}: u8"),
+            MemoryValue::U16(value) => write!(f, "{value}: u16"),
+            MemoryValue::U32(value) => write!(f, "{value}: u32"),
+            MemoryValue::U64(value) => write!(f, "{value}: u64"),
+            MemoryValue::U128(value) => write!(f, "{value}: u128"),
         }
     }
 }

--- a/compiler/noirc_evaluator/src/acir/acir_context/generated_acir/mod.rs
+++ b/compiler/noirc_evaluator/src/acir/acir_context/generated_acir/mod.rs
@@ -352,8 +352,7 @@ impl<F: AcirField> GeneratedAcir<F> {
         let radix_range = 2..=256;
         assert!(
             radix_range.contains(&radix),
-            "ICE: Radix must be in the range 2..=256, but found: {:?}",
-            radix
+            "ICE: Radix must be in the range 2..=256, but found: {radix:?}"
         );
         let radix_big = BigUint::from(radix);
         assert_eq!(

--- a/compiler/noirc_evaluator/src/acir/arrays.rs
+++ b/compiler/noirc_evaluator/src/acir/arrays.rs
@@ -676,7 +676,7 @@ impl Context<'_> {
             }
             _ => Err(InternalError::Unexpected {
                 expected: "AcirValue::DynamicArray or AcirValue::Array".to_owned(),
-                found: format!("{:?}", array_acir_value),
+                found: format!("{array_acir_value:?}"),
                 call_stack: self.acir_context.get_call_stack(),
             }
             .into()),

--- a/compiler/noirc_evaluator/src/acir/mod.rs
+++ b/compiler/noirc_evaluator/src/acir/mod.rs
@@ -423,7 +423,7 @@ impl<'a> Context<'a> {
                     } else {
                         return Err(InternalError::Unexpected {
                             expected: "Block params should be an array".to_owned(),
-                            found: format!("Instead got {:?}", typ),
+                            found: format!("Instead got {typ:?}"),
                             call_stack: self.acir_context.get_call_stack(),
                         }
                         .into());

--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/constant_allocation.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/constant_allocation.rs
@@ -101,7 +101,7 @@ impl ConstantAllocation {
 
     fn decide_allocation_points(&mut self, func: &Function) {
         for (constant_id, usage_in_blocks) in self.constant_usage.iter() {
-            let block_ids: Vec<_> = usage_in_blocks.iter().map(|(block_id, _)| *block_id).collect();
+            let block_ids: Vec<_> = usage_in_blocks.keys().copied().collect();
 
             let allocation_point = self.decide_allocation_point(*constant_id, &block_ids, func);
 

--- a/compiler/noirc_evaluator/src/brillig/brillig_ir/artifact.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_ir/artifact.rs
@@ -86,13 +86,13 @@ impl std::fmt::Display for LabelType {
         match self {
             LabelType::Function(function_id, block_id) => {
                 if let Some(block_id) = block_id {
-                    write!(f, "Function({:?}, {:?})", function_id, block_id)
+                    write!(f, "Function({function_id:?}, {block_id:?})")
                 } else {
-                    write!(f, "Function({:?})", function_id)
+                    write!(f, "Function({function_id:?})")
                 }
             }
             LabelType::Entrypoint => write!(f, "Entrypoint"),
-            LabelType::Procedure(procedure_id) => write!(f, "Procedure({:?})", procedure_id),
+            LabelType::Procedure(procedure_id) => write!(f, "Procedure({procedure_id:?})"),
             LabelType::GlobalInit(function_id) => {
                 write!(f, "Globals Initialization({function_id:?})")
             }

--- a/compiler/noirc_evaluator/src/brillig/brillig_ir/debug_show.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_ir/debug_show.rs
@@ -32,8 +32,8 @@ impl DebugToString for MemoryAddress {
             "StackPointer".into()
         } else {
             match self {
-                MemoryAddress::Direct(address) => format!("M{}", address),
-                MemoryAddress::Relative(offset) => format!("S{}", offset),
+                MemoryAddress::Direct(address) => format!("M{address}"),
+                MemoryAddress::Relative(offset) => format!("S{offset}"),
             }
         }
     }

--- a/compiler/noirc_evaluator/src/brillig/brillig_ir/instructions.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_ir/instructions.rs
@@ -391,9 +391,7 @@ impl<F: AcirField + DebugToString, Registers: RegisterAllocator> BrilligContext<
     fn constant(&mut self, result: MemoryAddress, bit_size: u32, constant: F, indirect: bool) {
         assert!(
             bit_size >= constant.num_bits(),
-            "Constant {} does not fit in bit size {}",
-            constant,
-            bit_size
+            "Constant {constant} does not fit in bit size {bit_size}"
         );
         if indirect {
             self.push_opcode(BrilligOpcode::IndirectConst {
@@ -489,7 +487,7 @@ impl From<BrilligBinaryOp> for BinaryFieldOp {
             BrilligBinaryOp::Equals => BinaryFieldOp::Equals,
             BrilligBinaryOp::LessThan => BinaryFieldOp::LessThan,
             BrilligBinaryOp::LessThanEquals => BinaryFieldOp::LessThanEquals,
-            _ => panic!("Unsupported operation: {:?} on a field", operation),
+            _ => panic!("Unsupported operation: {operation:?} on a field"),
         }
     }
 }
@@ -509,7 +507,7 @@ impl From<BrilligBinaryOp> for BinaryIntOp {
             BrilligBinaryOp::Xor => BinaryIntOp::Xor,
             BrilligBinaryOp::Shl => BinaryIntOp::Shl,
             BrilligBinaryOp::Shr => BinaryIntOp::Shr,
-            _ => panic!("Unsupported operation: {:?} on an integer", operation),
+            _ => panic!("Unsupported operation: {operation:?} on an integer"),
         }
     }
 }

--- a/compiler/noirc_evaluator/src/ssa/checks/check_for_underconstrained_values.rs
+++ b/compiler/noirc_evaluator/src/ssa/checks/check_for_underconstrained_values.rs
@@ -434,8 +434,7 @@ impl DependencyContext {
                             self.update_children(&[*value_id], &results);
                         } else {
                             panic!(
-                                "load instruction {} has attempted to access previously unused memory location",
-                                instruction
+                                "load instruction {instruction} has attempted to access previously unused memory location"
                             );
                         }
                     }

--- a/compiler/noirc_evaluator/src/ssa/interpreter/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/interpreter/mod.rs
@@ -236,7 +236,7 @@ impl<'ssa, W: Write> Interpreter<'ssa, W> {
                 Some(TerminatorInstruction::Jmp { destination, arguments: jump_args, .. }) => {
                     block_id = *destination;
                     if self.options.trace {
-                        println!("jump to {}", block_id);
+                        println!("jump to {block_id}");
                     }
                     arguments = self.lookup_all(jump_args)?;
                 }
@@ -252,7 +252,7 @@ impl<'ssa, W: Write> Interpreter<'ssa, W> {
                         *else_destination
                     };
                     if self.options.trace {
-                        println!("jump to {}", block_id);
+                        println!("jump to {block_id}");
                     }
                     arguments = Vec::new();
                 }

--- a/compiler/noirc_evaluator/src/ssa/ir/printer.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/printer.rs
@@ -57,7 +57,7 @@ impl Display for Printer<'_> {
                     panic!("Value::Global should only be in the function dfg");
                 }
                 Value::Function(id) => {
-                    writeln!(f, "{}", id)?;
+                    writeln!(f, "{id}")?;
                 }
                 _ => panic!("Expected only numeric constant or instruction"),
             };
@@ -229,7 +229,7 @@ fn display_instruction_buffer(
         if in_global_space {
             value_list = value_list.replace('v', "g");
         }
-        write!(buffer, "{} = ", value_list).map_err(|_| ())?;
+        write!(buffer, "{value_list} = ").map_err(|_| ())?;
     }
 
     display_instruction_inner(dfg, &dfg[instruction], results, in_global_space, &mut buffer)
@@ -276,7 +276,7 @@ fn write_location_information(
             else {
                 return Ok(());
             };
-            write!(buffer, ":{}", column_number)?;
+            write!(buffer, ":{column_number}")?;
         }
     }
     Ok(())
@@ -388,9 +388,9 @@ fn display_instruction_inner(
             {
                 if let Some(string) = try_byte_array_to_string(elements, dfg) {
                     if is_slice {
-                        return write!(f, "make_array &b{:?}", string);
+                        return write!(f, "make_array &b{string:?}");
                     } else {
-                        return write!(f, "make_array b{:?}", string);
+                        return write!(f, "make_array b{string:?}");
                     }
                 }
             }
@@ -405,7 +405,7 @@ fn display_instruction_inner(
                 if in_global_space {
                     value = value.replace('v', "g");
                 }
-                write!(f, "{}", value)?;
+                write!(f, "{value}")?;
             }
 
             write!(f, "] : {typ}")

--- a/compiler/noirc_evaluator/src/ssa/ir/types.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/types.rs
@@ -63,12 +63,12 @@ impl NumericType {
             NumericType::Unsigned { bit_size } => {
                 let max = if bit_size == 128 { u128::MAX } else { 2u128.pow(bit_size) - 1 };
                 if value.is_negative() {
-                    return Some(format!("0..={}", max));
+                    return Some(format!("0..={max}"));
                 }
                 if value.absolute_value() <= max.into() {
                     None
                 } else {
-                    Some(format!("0..={}", max))
+                    Some(format!("0..={max}"))
                 }
             }
             NumericType::Signed { bit_size } => {
@@ -78,7 +78,7 @@ impl NumericType {
                 if value.absolute_value() <= target_max.into() {
                     None
                 } else {
-                    Some(format!("-{}..={}", min, max))
+                    Some(format!("-{min}..={max}"))
                 }
             }
             NumericType::NativeField => None,

--- a/compiler/noirc_evaluator/src/ssa/opt/assert_constant.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/assert_constant.rs
@@ -182,7 +182,7 @@ fn evaluate_static_assert(
                 panic!("ICE: missing foreign call inputs")
             }
             TryFromParamsError::ParsingError(error) => {
-                panic!("ICE: could not decode printable type {:?}", error)
+                panic!("ICE: could not decode printable type {error:?}")
             }
         },
     };

--- a/compiler/noirc_evaluator/src/ssa/opt/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/mod.rs
@@ -54,7 +54,7 @@ pub(crate) fn assert_normalized_ssa_equals(mut ssa: super::Ssa, expected: &str) 
     let mut expected_ssa = match Ssa::from_str(&expected) {
         Ok(ssa) => ssa,
         Err(err) => {
-            panic!("`expected` argument of `assert_ssa_equals` is not valid SSA:\n{:?}", err)
+            panic!("`expected` argument of `assert_ssa_equals` is not valid SSA:\n{err:?}")
         }
     };
 

--- a/compiler/noirc_evaluator/src/ssa/parser/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/parser/mod.rs
@@ -93,7 +93,7 @@ impl Debug for SsaErrorWithSource {
                 writeln!(f)?;
             }
 
-            writeln!(f, "{}", line)?;
+            writeln!(f, "{line}")?;
 
             if has_error {
                 let offset = span.start() as usize - byte;

--- a/compiler/noirc_evaluator/src/ssa/parser/tests.rs
+++ b/compiler/noirc_evaluator/src/ssa/parser/tests.rs
@@ -11,7 +11,7 @@ fn assert_ssa_roundtrip(src: &str) {
     let ssa = trim_leading_whitespace_from_lines(&ssa);
     let src = trim_leading_whitespace_from_lines(src);
     if ssa != src {
-        println!("Expected:\n~~~\n{}\n~~~\nGot:\n~~~\n{}\n~~~", src, ssa);
+        println!("Expected:\n~~~\n{src}\n~~~\nGot:\n~~~\n{ssa}\n~~~");
         similar_asserts::assert_eq!(ssa, src);
     }
 }

--- a/compiler/noirc_evaluator/src/ssa/parser/token.rs
+++ b/compiler/noirc_evaluator/src/ssa/parser/token.rs
@@ -79,12 +79,12 @@ impl Token {
 impl Display for Token {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Token::Ident(ident) => write!(f, "{}", ident),
-            Token::Int(int) => write!(f, "{}", int),
+            Token::Ident(ident) => write!(f, "{ident}"),
+            Token::Int(int) => write!(f, "{int}"),
             Token::Str(string) => write!(f, "{string:?}"),
             Token::ByteStr(string) => write!(f, "{string:?}"),
-            Token::Keyword(keyword) => write!(f, "{}", keyword),
-            Token::IntType(int_type) => write!(f, "{}", int_type),
+            Token::Keyword(keyword) => write!(f, "{keyword}"),
+            Token::IntType(int_type) => write!(f, "{int_type}"),
             Token::Assign => write!(f, "="),
             Token::LeftParen => write!(f, "("),
             Token::RightParen => write!(f, ")"),
@@ -107,7 +107,7 @@ impl Display for Token {
 
 impl std::fmt::Debug for Token {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self)
+        write!(f, "{self}")
     }
 }
 

--- a/compiler/noirc_evaluator/src/ssa/validation/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/validation/mod.rs
@@ -173,8 +173,7 @@ impl<'f> Validator<'f> {
                     _ => {
                         if lhs_type != rhs_type {
                             panic!(
-                                "Left-hand side and right-hand side of `{}` must have the same type",
-                                operator
+                                "Left-hand side and right-hand side of `{operator}` must have the same type"
                             );
                         }
                     }

--- a/compiler/noirc_frontend/src/ast/expression.rs
+++ b/compiler/noirc_frontend/src/ast/expression.rs
@@ -796,7 +796,7 @@ impl Display for TypePath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}::{}", self.typ, self.item)?;
         if let Some(turbofish) = &self.turbofish {
-            write!(f, "::{}", turbofish)?;
+            write!(f, "::{turbofish}")?;
         }
         Ok(())
     }

--- a/compiler/noirc_frontend/src/ast/statement.rs
+++ b/compiler/noirc_frontend/src/ast/statement.rs
@@ -901,7 +901,7 @@ impl Display for StatementKind {
             StatementKind::Expression(expression) => expression.fmt(f),
             StatementKind::Assign(assign) => assign.fmt(f),
             StatementKind::For(for_loop) => for_loop.fmt(f),
-            StatementKind::Loop(block, _) => write!(f, "loop {}", block),
+            StatementKind::Loop(block, _) => write!(f, "loop {block}"),
             StatementKind::While(while_) => {
                 write!(f, "while {} {}", while_.condition, while_.body)
             }
@@ -996,7 +996,7 @@ impl Display for Pattern {
                 write!(f, "{} {{ {} }}", typename, fields.join(", "))
             }
             Pattern::Parenthesized(pattern, _) => {
-                write!(f, "({})", pattern)
+                write!(f, "({pattern})")
             }
             Pattern::Interned(_, _) => {
                 write!(f, "?Interned")

--- a/compiler/noirc_frontend/src/ast/traits.rs
+++ b/compiler/noirc_frontend/src/ast/traits.rs
@@ -144,12 +144,12 @@ impl Display for NoirTrait {
 
         if self.is_alias {
             let bounds = vecmap(&self.bounds, |bound| bound.to_string()).join(" + ");
-            return write!(f, " = {};", bounds);
+            return write!(f, " = {bounds};");
         }
 
         if !self.bounds.is_empty() {
             let bounds = vecmap(&self.bounds, |bound| bound.to_string()).join(" + ");
-            write!(f, ": {}", bounds)?;
+            write!(f, ": {bounds}")?;
         }
 
         let where_clause = vecmap(&self.where_clause, ToString::to_string);

--- a/compiler/noirc_frontend/src/elaborator/lints.rs
+++ b/compiler/noirc_frontend/src/elaborator/lints.rs
@@ -224,7 +224,7 @@ pub(crate) fn check_integer_literal_fits_its_type(
                     return Some(TypeCheckError::IntegerLiteralDoesNotFitItsType {
                         expr: value,
                         ty: typ.clone(),
-                        range: format!("0..={}", max),
+                        range: format!("0..={max}"),
                         location,
                     });
                 }
@@ -241,7 +241,7 @@ pub(crate) fn check_integer_literal_fits_its_type(
                     return Some(TypeCheckError::IntegerLiteralDoesNotFitItsType {
                         expr: value,
                         ty: typ.clone(),
-                        range: format!("-{}..={}", min, max),
+                        range: format!("-{min}..={max}"),
                         location,
                     });
                 }

--- a/compiler/noirc_frontend/src/hir/comptime/display.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/display.rs
@@ -457,7 +457,7 @@ impl Display for ValuePrinter<'_, '_> {
                 let generic_string = if generic_string.is_empty() {
                     generic_string
                 } else {
-                    format!("<{}>", generic_string)
+                    format!("<{generic_string}>")
                 };
 
                 let where_clause = vecmap(&trait_impl.where_clause, |trait_constraint| {
@@ -467,7 +467,7 @@ impl Display for ValuePrinter<'_, '_> {
                 let where_clause = if where_clause.is_empty() {
                     where_clause
                 } else {
-                    format!(" where {}", where_clause)
+                    format!(" where {where_clause}")
                 };
 
                 write!(
@@ -487,11 +487,11 @@ impl Display for ValuePrinter<'_, '_> {
                 }
             }
             Value::Zeroed(typ) => write!(f, "(zeroed {typ})"),
-            Value::Type(typ) => write!(f, "{}", typ),
+            Value::Type(typ) => write!(f, "{typ}"),
             Value::Expr(expr) => match expr.as_ref() {
                 ExprValue::Expression(expr) => {
                     let expr = remove_interned_in_expression_kind(self.interner, expr.clone());
-                    write!(f, "{}", expr)
+                    write!(f, "{expr}")
                 }
                 ExprValue::Statement(statement) => {
                     write!(

--- a/compiler/noirc_frontend/src/hir/comptime/errors.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/errors.rs
@@ -352,14 +352,14 @@ impl InterpreterError {
     }
 
     pub(crate) fn debug_evaluate_comptime(expr: impl Display, location: Location) -> Self {
-        let mut formatted_result = format!("{}", expr);
+        let mut formatted_result = format!("{expr}");
         // if multi-line, display on a separate line from the message
         if formatted_result.contains('\n') {
             formatted_result.insert(0, '\n');
         }
         let diagnostic = CustomDiagnostic::simple_info(
             "`comptime` expression ran:".to_string(),
-            format!("After evaluation: {}", formatted_result),
+            format!("After evaluation: {formatted_result}"),
             location,
         );
         InterpreterError::DebugEvaluateComptime { diagnostic, location }

--- a/compiler/noirc_frontend/src/hir/comptime/hir_to_display_ast.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/hir_to_display_ast.rs
@@ -427,7 +427,7 @@ impl Type {
             Type::TypeVariable(binding) => match &*binding.borrow() {
                 TypeBinding::Bound(typ) => return typ.to_display_ast(),
                 TypeBinding::Unbound(id, type_var_kind) => {
-                    let name = format!("var_{:?}_{}", type_var_kind, id);
+                    let name = format!("var_{type_var_kind:?}_{id}");
                     let path =
                         Path::from_single(name, Location::new(Span::empty(0), FileId::dummy()));
                     let expression = UnresolvedTypeExpression::Variable(path);

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
@@ -1453,14 +1453,14 @@ impl<'local, 'interner> Interpreter<'local, 'interner> {
             // the connection. If we use `eprintln!` not only it doesn't crash, but the output
             // appears in the "Noir Language Server" output window in case you want to see it.
             if print_newline {
-                eprintln!("{}", contents);
+                eprintln!("{contents}");
             } else {
-                eprint!("{}", contents);
+                eprint!("{contents}");
             }
         } else if print_newline {
-            writeln!(output, "{}", contents).expect("write should succeed");
+            writeln!(output, "{contents}").expect("write should succeed");
         } else {
-            write!(output, "{}", contents).expect("write should succeed");
+            write!(output, "{contents}").expect("write should succeed");
         }
 
         Ok(Value::Unit)

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
@@ -347,7 +347,7 @@ fn static_assert(
         Ok(Value::Unit)
     } else {
         failing_constraint(
-            format!("static_assert failed: {}", message).clone(),
+            format!("static_assert failed: {message}").clone(),
             location,
             call_stack,
         )
@@ -387,7 +387,7 @@ fn type_def_add_attribute(
     let (self_argument, attribute) = check_two_arguments(arguments, location)?;
     let attribute_location = attribute.1;
     let attribute = get_str(interner, attribute)?;
-    let attribute = format!("#[{}]", attribute);
+    let attribute = format!("#[{attribute}]");
     let mut parser = Parser::for_str(&attribute, attribute_location.file);
     let Some((Attribute::Secondary(attribute), _span)) = parser.parse_attribute() else {
         return Err(InterpreterError::InvalidAttribute {
@@ -2427,7 +2427,7 @@ fn function_def_add_attribute(
     let (self_argument, attribute) = check_two_arguments(arguments, location)?;
     let attribute_location = attribute.1;
     let attribute = get_str(interpreter.elaborator.interner, attribute)?;
-    let attribute = format!("#[{}]", attribute);
+    let attribute = format!("#[{attribute}]");
     let mut parser = Parser::for_str(&attribute, attribute_location.file);
     let Some((attribute, _span)) = parser.parse_attribute() else {
         return Err(InterpreterError::InvalidAttribute {

--- a/compiler/noirc_frontend/src/hir/def_collector/dc_crate.rs
+++ b/compiler/noirc_frontend/src/hir/def_collector/dc_crate.rs
@@ -220,13 +220,13 @@ impl CompilationError {
 impl std::fmt::Display for CompilationError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            CompilationError::ParseError(error) => write!(f, "{}", error),
-            CompilationError::DefinitionError(error) => write!(f, "{}", error),
-            CompilationError::ResolverError(error) => write!(f, "{}", error),
-            CompilationError::TypeError(error) => write!(f, "{}", error),
-            CompilationError::InterpreterError(error) => write!(f, "{:?}", error),
-            CompilationError::DebugComptimeScopeNotFound(error, _) => write!(f, "{:?}", error),
-            CompilationError::ComptimeError(error) => write!(f, "{:?}", error),
+            CompilationError::ParseError(error) => write!(f, "{error}"),
+            CompilationError::DefinitionError(error) => write!(f, "{error}"),
+            CompilationError::ResolverError(error) => write!(f, "{error}"),
+            CompilationError::TypeError(error) => write!(f, "{error}"),
+            CompilationError::InterpreterError(error) => write!(f, "{error:?}"),
+            CompilationError::DebugComptimeScopeNotFound(error, _) => write!(f, "{error:?}"),
+            CompilationError::ComptimeError(error) => write!(f, "{error:?}"),
         }
     }
 }

--- a/compiler/noirc_frontend/src/hir/def_collector/errors.rs
+++ b/compiler/noirc_frontend/src/hir/def_collector/errors.rs
@@ -260,7 +260,7 @@ impl<'a> From<&'a DefCollectorErrorKind> for Diagnostic {
                 *location,
             ),
             DefCollectorErrorKind::ImplIsStricterThanTrait { constraint_typ, constraint_name, constraint_generics, constraint_location, trait_method_name, trait_method_location } => {
-                let constraint = format!("{}{}", constraint_name, constraint_generics);
+                let constraint = format!("{constraint_name}{constraint_generics}");
 
                 let mut diag = Diagnostic::simple_error(
                     "impl has stricter requirements than trait".to_string(),

--- a/compiler/noirc_frontend/src/hir/resolution/import.rs
+++ b/compiler/noirc_frontend/src/hir/resolution/import.rs
@@ -119,7 +119,7 @@ impl<'a> From<&'a PathResolutionError> for CustomDiagnostic {
                 CustomDiagnostic::simple_error(error.to_string(), String::new(), ident.location())
             }
             PathResolutionError::UnresolvedWithPossibleTraitsToImport { ident, traits } => {
-                let mut traits = vecmap(traits, |trait_name| format!("`{}`", trait_name));
+                let mut traits = vecmap(traits, |trait_name| format!("`{trait_name}`"));
                 traits.sort();
                 CustomDiagnostic::simple_error(
                     error.to_string(),
@@ -131,7 +131,7 @@ impl<'a> From<&'a PathResolutionError> for CustomDiagnostic {
                 )
             }
             PathResolutionError::MultipleTraitsInScope { ident, traits } => {
-                let mut traits = vecmap(traits, |trait_name| format!("`{}`", trait_name));
+                let mut traits = vecmap(traits, |trait_name| format!("`{trait_name}`"));
                 traits.sort();
                 CustomDiagnostic::simple_error(
                     error.to_string(),

--- a/compiler/noirc_frontend/src/hir_def/types.rs
+++ b/compiler/noirc_frontend/src/hir_def/types.rs
@@ -282,7 +282,7 @@ impl std::fmt::Display for Kind {
             Kind::Normal => write!(f, "normal"),
             Kind::Integer => write!(f, "int"),
             Kind::IntegerOrField => write!(f, "intOrField"),
-            Kind::Numeric(typ) => write!(f, "numeric {}", typ),
+            Kind::Numeric(typ) => write!(f, "numeric {typ}"),
         }
     }
 }
@@ -1003,7 +1003,7 @@ impl std::fmt::Display for Type {
                         Kind::Numeric(_typ) => write!(f, "_"),
                     },
                     TypeBinding::Bound(binding) => {
-                        write!(f, "{}", binding)
+                        write!(f, "{binding}")
                     }
                 }
             }
@@ -1024,7 +1024,7 @@ impl std::fmt::Display for Type {
                 }
             }
             Type::TraitAsType(_id, name, generics) => {
-                write!(f, "impl {}{}", name, generics)
+                write!(f, "impl {name}{generics}")
             }
             Type::Tuple(elements) => {
                 let elements = vecmap(elements, ToString::to_string);
@@ -1072,7 +1072,7 @@ impl std::fmt::Display for Type {
             Type::Reference(element, _) => {
                 write!(f, "&{element}")
             }
-            Type::Quoted(quoted) => write!(f, "{}", quoted),
+            Type::Quoted(quoted) => write!(f, "{quoted}"),
             Type::InfixExpr(lhs, op, rhs, _) => {
                 let this = self.canonicalize_checked();
 
@@ -2748,17 +2748,17 @@ impl std::fmt::Debug for Type {
                 let binding = &var.1;
                 if let TypeBinding::Unbound(_, type_var_kind) = &*binding.borrow() {
                     match type_var_kind {
-                        Kind::Any | Kind::Normal => write!(f, "{:?}", var),
-                        Kind::IntegerOrField => write!(f, "IntOrField{:?}", binding),
-                        Kind::Integer => write!(f, "Int{:?}", binding),
-                        Kind::Numeric(typ) => write!(f, "Numeric({:?}: {:?})", binding, typ),
+                        Kind::Any | Kind::Normal => write!(f, "{var:?}"),
+                        Kind::IntegerOrField => write!(f, "IntOrField{binding:?}"),
+                        Kind::Integer => write!(f, "Int{binding:?}"),
+                        Kind::Numeric(typ) => write!(f, "Numeric({binding:?}: {typ:?})"),
                     }
                 } else {
                     write!(f, "{}", binding.borrow())
                 }
             }
             Type::DataType(s, args) => {
-                let args = vecmap(args, |arg| format!("{:?}", arg));
+                let args = vecmap(args, |arg| format!("{arg:?}"));
                 if args.is_empty() {
                     write!(f, "{}", s.borrow())
                 } else {
@@ -2766,16 +2766,16 @@ impl std::fmt::Debug for Type {
                 }
             }
             Type::Alias(alias, args) => {
-                let args = vecmap(args, |arg| format!("{:?}", arg));
+                let args = vecmap(args, |arg| format!("{arg:?}"));
                 if args.is_empty() {
                     write!(f, "{}", alias.borrow())
                 } else {
                     write!(f, "{}<{}>", alias.borrow(), args.join(", "))
                 }
             }
-            Type::TraitAsType(_id, name, generics) => write!(f, "impl {}{:?}", name, generics),
+            Type::TraitAsType(_id, name, generics) => write!(f, "impl {name}{generics:?}"),
             Type::Tuple(elements) => {
-                let elements = vecmap(elements, |arg| format!("{:?}", arg));
+                let elements = vecmap(elements, |arg| format!("{arg:?}"));
                 if elements.len() == 1 {
                     write!(f, "({},)", elements[0])
                 } else {
@@ -2789,18 +2789,18 @@ impl std::fmt::Debug for Type {
             }
             Type::Unit => write!(f, "()"),
             Type::Error => write!(f, "error"),
-            Type::CheckedCast { to, .. } => write!(f, "{:?}", to),
+            Type::CheckedCast { to, .. } => write!(f, "{to:?}"),
             Type::NamedGeneric(NamedGeneric { type_var, name, .. }) => match type_var.kind() {
                 Kind::Any | Kind::Normal | Kind::Integer | Kind::IntegerOrField => {
-                    write!(f, "{}{:?}", name, type_var)
+                    write!(f, "{name}{type_var:?}")
                 }
                 Kind::Numeric(typ) => {
-                    write!(f, "({} : {}){:?}", name, typ, type_var)
+                    write!(f, "({name} : {typ}){type_var:?}")
                 }
             },
-            Type::Constant(x, kind) => write!(f, "({}: {})", x, kind),
+            Type::Constant(x, kind) => write!(f, "({x}: {kind})"),
             Type::Forall(typevars, typ) => {
-                let typevars = vecmap(typevars, |var| format!("{:?}", var));
+                let typevars = vecmap(typevars, |var| format!("{var:?}"));
                 write!(f, "forall {}. {:?}", typevars.join(" "), typ)
             }
             Type::Function(args, ret, env, unconstrained) => {
@@ -2813,7 +2813,7 @@ impl std::fmt::Debug for Type {
                     _ => format!(" with env {env:?}"),
                 };
 
-                let args = vecmap(args.iter(), |arg| format!("{:?}", arg));
+                let args = vecmap(args.iter(), |arg| format!("{arg:?}"));
 
                 write!(f, "fn({}) -> {ret:?}{closure_env_text}", args.join(", "))
             }
@@ -2823,7 +2823,7 @@ impl std::fmt::Debug for Type {
             Type::Reference(element, true) => {
                 write!(f, "&mut {element:?}")
             }
-            Type::Quoted(quoted) => write!(f, "{}", quoted),
+            Type::Quoted(quoted) => write!(f, "{quoted}"),
             Type::InfixExpr(lhs, op, rhs, _) => write!(f, "({lhs:?} {op} {rhs:?})"),
         }
     }

--- a/compiler/noirc_frontend/src/lexer/lexer.rs
+++ b/compiler/noirc_frontend/src/lexer/lexer.rs
@@ -1555,8 +1555,7 @@ mod tests {
                             }
                             Err(err) => {
                                 panic!(
-                                    "Unexpected lexer error found {:?} for input string {:?}",
-                                    err, big_list_program_str
+                                    "Unexpected lexer error found {err:?} for input string {big_list_program_str:?}"
                                 )
                             }
                         }

--- a/compiler/noirc_frontend/src/lexer/token.rs
+++ b/compiler/noirc_frontend/src/lexer/token.rs
@@ -381,10 +381,10 @@ impl Display for FmtStrFragment {
                     .replace('\0', "\\0")
                     .replace('\'', "\\'")
                     .replace('\"', "\\\"");
-                write!(f, "{}", string)
+                write!(f, "{string}")
             }
             FmtStrFragment::Interpolation(string, _) => {
-                write!(f, "{{{}}}", string)
+                write!(f, "{{{string}}}")
             }
         }
     }
@@ -1137,7 +1137,7 @@ impl SecondaryAttributeKind {
             SecondaryAttributeKind::Deprecated(Some(note)) => {
                 format!("deprecated({note:?})")
             }
-            SecondaryAttributeKind::Tag(contents) => format!("'{}", contents),
+            SecondaryAttributeKind::Tag(contents) => format!("'{contents}"),
             SecondaryAttributeKind::Meta(meta) => meta.to_string(),
             SecondaryAttributeKind::ContractLibraryMethod => "contract_library_method".to_string(),
             SecondaryAttributeKind::Export => "export".to_string(),

--- a/compiler/noirc_frontend/src/modules.rs
+++ b/compiler/noirc_frontend/src/modules.rs
@@ -205,9 +205,9 @@ pub fn module_def_id_relative_path(
 
     let path = if defining_module.is_some() || !matches!(module_def_id, ModuleDefId::ModuleId(..)) {
         if let Some(reexport_name) = &intermediate_name {
-            format!("{}::{}::{}", module_path, reexport_name, name)
+            format!("{module_path}::{reexport_name}::{name}")
         } else {
-            format!("{}::{}", module_path, name)
+            format!("{module_path}::{name}")
         }
     } else {
         module_path.clone()

--- a/compiler/noirc_frontend/src/monomorphization/printer.rs
+++ b/compiler/noirc_frontend/src/monomorphization/printer.rs
@@ -55,7 +55,7 @@ impl Default for AstPrinter {
 
 impl AstPrinter {
     fn fmt_ident(&self, name: &str, definition: &Definition) -> String {
-        if self.show_id { format!("{}${}", name, definition) } else { name.to_string() }
+        if self.show_id { format!("{name}${definition}") } else { name.to_string() }
     }
 
     fn fmt_local(&self, name: &str, id: LocalId) -> String {
@@ -628,7 +628,7 @@ impl Display for Definition {
         match self {
             Definition::Local(id) => write!(f, "l{}", id.0),
             Definition::Global(id) => write!(f, "g{}", id.0),
-            Definition::Function(id) => write!(f, "f{}", id),
+            Definition::Function(id) => write!(f, "f{id}"),
             Definition::Builtin(name) => write!(f, "{name}"),
             Definition::LowLevel(name) => write!(f, "{name}"),
             Definition::Oracle(name) => write!(f, "{name}"),

--- a/compiler/noirc_frontend/src/parser/errors.rs
+++ b/compiler/noirc_frontend/src/parser/errors.rs
@@ -91,7 +91,7 @@ pub enum ParserErrorReason {
     #[error(
         "Wrong number of arguments for attribute `{}`. Expected {}, found {}",
         name,
-        if min == max { min.to_string() } else { format!("between {} and {}", min, max) },
+        if min == max { min.to_string() } else { format!("between {min} and {max}") },
         found
     )]
     WrongNumberOfAttributeArguments { name: String, min: usize, max: usize, found: usize },
@@ -205,7 +205,7 @@ impl std::fmt::Display for ParserError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let token_to_string = |token: &Token| match token {
             Token::EOF => token.to_string(),
-            _ => format!("'{}'", token),
+            _ => format!("'{token}'"),
         };
 
         let reason_str: String = if self.reason.is_none() {

--- a/compiler/noirc_frontend/src/parser/mod.rs
+++ b/compiler/noirc_frontend/src/parser/mod.rs
@@ -190,7 +190,7 @@ impl std::fmt::Display for ItemKind {
                 }
                 c.fmt(f)
             }
-            ItemKind::InnerAttribute(a) => write!(f, "#![{}]", a),
+            ItemKind::InnerAttribute(a) => write!(f, "#![{a}]"),
         }
     }
 }

--- a/compiler/noirc_frontend/src/parser/parser/tests.rs
+++ b/compiler/noirc_frontend/src/parser/parser/tests.rs
@@ -27,7 +27,7 @@ pub(super) fn get_single_error(errors: &[ParserError], expected_span: Span) -> &
 
     if errors.len() > 1 {
         for error in errors {
-            println!("{}", error);
+            println!("{error}");
         }
         panic!("Expected one error, found {} errors (printed above)", errors.len());
     }
@@ -49,7 +49,7 @@ pub(super) fn expect_no_errors(errors: &[ParserError]) {
     }
 
     for error in errors {
-        println!("{}", error);
+        println!("{error}");
     }
     panic!("Expected no errors, found {} errors (printed above)", errors.len());
 }

--- a/compiler/noirc_frontend/src/tests.rs
+++ b/compiler/noirc_frontend/src/tests.rs
@@ -203,7 +203,7 @@ fn check_errors_with_options(
         let secondary = error
             .secondaries
             .first()
-            .unwrap_or_else(|| panic!("Expected {:?} to have a secondary label", error));
+            .unwrap_or_else(|| panic!("Expected {error:?} to have a secondary label"));
         let span = secondary.location.span;
         let message = &error.message;
 

--- a/compiler/noirc_frontend/src/tests/arithmetic_generics.rs
+++ b/compiler/noirc_frontend/src/tests/arithmetic_generics.rs
@@ -91,14 +91,14 @@ fn arithmetic_generics_checked_cast_zeros() {
                 assert!(matches!(*from.clone(), Type::InfixExpr { .. }));
                 assert!(matches!(*to.clone(), Type::InfixExpr { .. }));
             }
-            _ => panic!("unexpected length: {:?}", length),
+            _ => panic!("unexpected length: {length:?}"),
         }
         assert!(matches!(
             err,
             TypeCheckError::FailingBinaryOp { op: BinaryTypeOperator::Modulo, lhs: 0, rhs: 0, .. }
         ));
     } else {
-        panic!("unexpected error: {:?}", monomorphization_error);
+        panic!("unexpected error: {monomorphization_error:?}");
     }
 }
 
@@ -134,17 +134,17 @@ fn arithmetic_generics_checked_cast_indirect_zeros() {
                 assert!(matches!(*from.clone(), Type::InfixExpr { .. }));
                 assert!(matches!(*to.clone(), Type::InfixExpr { .. }));
             }
-            _ => panic!("unexpected length: {:?}", length),
+            _ => panic!("unexpected length: {length:?}"),
         }
         match err {
             TypeCheckError::ModuloOnFields { lhs, rhs, .. } => {
                 assert_eq!(lhs.clone(), FieldElement::zero());
                 assert_eq!(rhs.clone(), FieldElement::zero());
             }
-            _ => panic!("expected ModuloOnFields, but found: {:?}", err),
+            _ => panic!("expected ModuloOnFields, but found: {err:?}"),
         }
     } else {
-        panic!("unexpected error: {:?}", monomorphization_error);
+        panic!("unexpected error: {monomorphization_error:?}");
     }
 }
 

--- a/compiler/noirc_frontend/src/tests/name_shadowing.rs
+++ b/compiler/noirc_frontend/src/tests/name_shadowing.rs
@@ -412,7 +412,7 @@ fn test_name_shadowing() {
             if !cases_to_skip.contains(&(i, j)) {
                 let modified_src = src.replace(x, y);
                 let errors = get_program_errors(&modified_src, &format!("name_shadowing_{i}_{j}"));
-                assert!(!errors.is_empty(), "Expected errors, got: {:?}", errors);
+                assert!(!errors.is_empty(), "Expected errors, got: {errors:?}");
             }
         }
     }

--- a/compiler/noirc_printable_type/src/lib.rs
+++ b/compiler/noirc_printable_type/src/lib.rs
@@ -128,7 +128,7 @@ fn to_string<F: AcirField>(value: &PrintableValue<F>, typ: &PrintableType) -> Op
             }
         }
         (PrintableValue::Field(_), PrintableType::Function { arguments, return_type, .. }) => {
-            output.push_str(&format!("<<fn({:?}) -> {:?}>>", arguments, return_type,));
+            output.push_str(&format!("<<fn({arguments:?}) -> {return_type:?}>>",));
         }
         (_, PrintableType::Reference { mutable: false, .. }) => {
             output.push_str("<<ref>>");
@@ -246,7 +246,7 @@ fn write_template_replacing_interpolations(
 
         // Write the interpolation
         if let Some(string) = replacement() {
-            write!(fmt, "{}", string)?;
+            write!(fmt, "{string}")?;
         } else {
             return Err(std::fmt::Error);
         }

--- a/tooling/artifact_cli/src/execution.rs
+++ b/tooling/artifact_cli/src/execution.rs
@@ -84,13 +84,13 @@ pub fn save_and_check_witness(
     witness_dir: Option<&Path>,
     witness_name: Option<&str>,
 ) -> Result<(), CliError> {
-    println!("[{}] Circuit witness successfully solved", circuit_name);
+    println!("[{circuit_name}] Circuit witness successfully solved");
     // Save first, so that we can potentially look at the output if the expectations fail.
     if let Some(witness_dir) = witness_dir {
         save_witness(&results.witness_stack, circuit_name, witness_dir, witness_name)?;
     }
     if let Some(ref return_value) = results.return_values.actual_return {
-        println!("[{}] Circuit output: {return_value:?}", circuit_name);
+        println!("[{circuit_name}] Circuit output: {return_value:?}");
     }
     check_witness(circuit, results.return_values)
 }

--- a/tooling/ast_fuzzer/src/program/mod.rs
+++ b/tooling/ast_fuzzer/src/program/mod.rs
@@ -566,7 +566,7 @@ fn make_name(mut id: usize, is_global: bool) -> String {
     }
     name.reverse();
     let name = name.into_iter().collect::<String>();
-    if is_global { format!("G_{}", name) } else { name }
+    if is_global { format!("G_{name}") } else { name }
 }
 
 /// Wrapper around `Program` that prints the AST as close to being able to

--- a/tooling/ast_fuzzer/src/program/scope.rs
+++ b/tooling/ast_fuzzer/src/program/scope.rs
@@ -114,7 +114,7 @@ where
 
     /// Get a variable in scope.
     pub fn get_variable(&self, id: &K) -> &Variable {
-        self.variables.get(id).unwrap_or_else(|| panic!("variable doesn't exist: {:?}", id))
+        self.variables.get(id).unwrap_or_else(|| panic!("variable doesn't exist: {id:?}"))
     }
 }
 

--- a/tooling/debugger/src/dap.rs
+++ b/tooling/debugger/src/dap.rs
@@ -495,7 +495,7 @@ impl<'a, R: Read, W: Write, B: BlackBoxFunctionSolver<FieldElement>> DapSession<
                     };
                 }
                 let breakpoint_address = self.context.debug_location_to_address(&location);
-                let instruction_reference = format!("{}", breakpoint_address);
+                let instruction_reference = format!("{breakpoint_address}");
                 let breakpoint_id = self.get_next_breakpoint_id();
                 breakpoints_to_set.push((location, breakpoint_id));
                 Breakpoint {

--- a/tooling/debugger/src/repl.rs
+++ b/tooling/debugger/src/repl.rs
@@ -357,14 +357,13 @@ impl<'a> AsyncReplDebugger<'a> {
             match &opcode {
                 Opcode::BrilligCall { id, inputs, outputs, .. } => {
                     println!(
-                        "{:>2}:{:>3} {:2} BRILLIG CALL id={} inputs={:?}",
-                        circuit_id, acir_index, marker, id, inputs
+                        "{circuit_id:>2}:{acir_index:>3} {marker:2} BRILLIG CALL id={id} inputs={inputs:?}"
                     );
-                    println!("          |       outputs={:?}", outputs);
+                    println!("          |       outputs={outputs:?}");
                     let bytecode = &self.unconstrained_functions[id.as_usize()].bytecode;
                     print_brillig_bytecode(acir_index, bytecode, *id);
                 }
-                _ => println!("{:>2}:{:>3} {:2} {:?}", circuit_id, acir_index, marker, opcode),
+                _ => println!("{circuit_id:>2}:{acir_index:>3} {marker:2} {opcode:?}"),
             }
         }
     }
@@ -383,10 +382,10 @@ impl<'a> AsyncReplDebugger<'a> {
         let best_location = context.find_opcode_at_current_file_line(line_number);
         match best_location {
             Some(location) => {
-                println!("Added breakpoint at line {}", line_number);
+                println!("Added breakpoint at line {line_number}");
                 Self::add_breakpoint_at(context, location);
             }
-            None => println!("No opcode at line {}", line_number),
+            None => println!("No opcode at line {line_number}"),
         }
     }
 
@@ -406,10 +405,10 @@ impl<'a> AsyncReplDebugger<'a> {
             }
             DebugCommandResult::Ok => (),
             DebugCommandResult::BreakpointReached(location) => {
-                println!("Stopped at breakpoint in opcode {}", location);
+                println!("Stopped at breakpoint in opcode {location}");
             }
             DebugCommandResult::Error(error) => {
-                println!("ERROR: {}", error);
+                println!("ERROR: {error}");
             }
         }
     }
@@ -425,7 +424,7 @@ impl<'a> AsyncReplDebugger<'a> {
                 false
             }
             DebugCommandResult::Error(ref error) => {
-                println!("ERROR: {}", error);
+                println!("ERROR: {error}");
                 self.show_current_vm_status(context);
                 false
             }
@@ -454,7 +453,7 @@ impl<'a> AsyncReplDebugger<'a> {
 
     fn show_witness(context: &mut Context<'_>, index: u32) {
         if let Some(value) = context.get_witness_map().get_index(index) {
-            println!("_{} = {value}", index);
+            println!("_{index} = {value}");
         }
     }
 
@@ -466,7 +465,7 @@ impl<'a> AsyncReplDebugger<'a> {
 
         let witness = Witness::from(index);
         _ = context.overwrite_witness(witness, field_value);
-        println!("_{} = {value}", index);
+        println!("_{index} = {value}");
     }
 
     fn show_brillig_memory(context: &mut Context<'_>) {
@@ -490,7 +489,7 @@ impl<'a> AsyncReplDebugger<'a> {
                     continue;
                 }
             }
-            println!("{index} = {}", value);
+            println!("{index} = {value}");
         }
     }
     fn write_brillig_memory(context: &mut Context<'_>, index: usize, value: String, bit_size: u32) {
@@ -519,7 +518,7 @@ impl<'a> AsyncReplDebugger<'a> {
             for (var_name, value, var_type) in frame.variables.iter() {
                 let printable_value =
                     PrintableValueDisplay::Plain((*value).clone(), (*var_type).clone());
-                println!("  {var_name}:{var_type:?} = {}", printable_value);
+                println!("  {var_name}:{var_type:?} = {printable_value}");
             }
         }
     }

--- a/tooling/debugger/src/source_code_printer.rs
+++ b/tooling/debugger/src/source_code_printer.rs
@@ -81,7 +81,7 @@ fn print_content(
 ) {
     if raw_source_printing {
         if cursor == "->" && highlight.is_some() {
-            println!("{}", content);
+            println!("{content}");
         }
         return;
     }

--- a/tooling/debugger/tests/debug.rs
+++ b/tooling/debugger/tests/debug.rs
@@ -150,7 +150,7 @@ mod tests {
             .ok()
             .and_then(|dir| test_program_path.strip_prefix(&dir).ok())
             .map(|stripped| format!("At {}", stripped.display()))
-            .unwrap_or_else(|| format!("At {}", test_program_dir));
+            .unwrap_or_else(|| format!("At {test_program_dir}"));
 
         for mut expected_lines in expected_lines_by_command {
             // While running the debugger, issue a "next" cmd,
@@ -181,9 +181,7 @@ mod tests {
                 let line_expected_to_contain = expected_line.trim();
                 assert!(
                     ascii_line.contains(line_expected_to_contain),
-                    "{:?}\ndid not contain\n{:?}",
-                    ascii_line,
-                    line_expected_to_contain,
+                    "{ascii_line:?}\ndid not contain\n{line_expected_to_contain:?}",
                 );
             }
         }

--- a/tooling/greybox_fuzzer/src/corpus.rs
+++ b/tooling/greybox_fuzzer/src/corpus.rs
@@ -120,7 +120,7 @@ impl CorpusFileManager {
                 continue;
             }
             let source = std::fs::read_to_string(path.as_path())
-                .unwrap_or_else(|_| panic!("could not read file {:?} into string", path));
+                .unwrap_or_else(|_| panic!("could not read file {path:?} into string"));
 
             let parsed_source = parse_json(&source, &self.abi).map_err(|parsing_error| {
                 format!("Error while parsing file {:?}: {:?}", path.as_os_str(), parsing_error)

--- a/tooling/greybox_fuzzer/src/lib.rs
+++ b/tooling/greybox_fuzzer/src/lib.rs
@@ -1014,10 +1014,10 @@ impl<
             }) => {
                 let reason = match acir_failed {
                     true => {
-                        format!("ACIR failed while brillig executed with no issues: {}", status)
+                        format!("ACIR failed while brillig executed with no issues: {status}")
                     }
                     false => {
-                        format!("brillig failed while ACIR executed with no issues: {}", status)
+                        format!("brillig failed while ACIR executed with no issues: {status}")
                     }
                 };
 
@@ -1307,11 +1307,11 @@ fn display_starting_info(
     if minimize_corpus {
         write!(writer, "Attempting to minimize corpus for fuzzing harness ")?;
         writer.set_color(ColorSpec::new().set_fg(Some(Color::Blue)))?;
-        write!(writer, "{}", fuzzing_harness_name)?;
+        write!(writer, "{fuzzing_harness_name}")?;
         writer.reset()?;
         write!(writer, " of package ")?;
         writer.set_color(ColorSpec::new().set_fg(Some(Color::Blue)))?;
-        writeln!(writer, "{}", package_name)?;
+        writeln!(writer, "{package_name}")?;
         writer.reset()?;
         write!(writer, "Corpus path: \"")?;
         writer.set_color(ColorSpec::new().set_fg(Some(Color::Blue)))?;
@@ -1330,11 +1330,11 @@ fn display_starting_info(
     } else {
         write!(writer, "Starting fuzzing with harness ")?;
         writer.set_color(ColorSpec::new().set_fg(Some(Color::Blue)))?;
-        write!(writer, "{}", fuzzing_harness_name)?;
+        write!(writer, "{fuzzing_harness_name}")?;
         writer.reset()?;
         write!(writer, " of package ")?;
         writer.set_color(ColorSpec::new().set_fg(Some(Color::Blue)))?;
-        writeln!(writer, "{}", package_name)?;
+        writeln!(writer, "{package_name}")?;
         writer.reset()?;
         write!(writer, "Corpus path: \"")?;
         writer.set_color(ColorSpec::new().set_fg(Some(Color::Blue)))?;
@@ -1344,17 +1344,17 @@ fn display_starting_info(
     }
     write!(writer, "seed: ")?;
     writer.set_color(ColorSpec::new().set_fg(Some(Color::Blue)))?;
-    write!(writer, "{:#016x}", seed)?;
+    write!(writer, "{seed:#016x}")?;
     writer.reset()?;
 
     write!(writer, ", starting_corpus_size: ")?;
     writer.set_color(ColorSpec::new().set_fg(Some(Color::Blue)))?;
-    write!(writer, "{}", starting_corpus_size)?;
+    write!(writer, "{starting_corpus_size}")?;
     writer.reset()?;
 
     write!(writer, ", num_threads: ")?;
     writer.set_color(ColorSpec::new().set_fg(Some(Color::Blue)))?;
-    writeln!(writer, "{}", num_threads)?;
+    writeln!(writer, "{num_threads}")?;
     writer.reset()?;
 
     if abi_change_detected {
@@ -1388,7 +1388,7 @@ fn display_metrics(metrics: &Metrics) -> Result<(), std::io::Error> {
         } else if x > microseconds_in_millisecond {
             format!("{}ms", x / microseconds_in_millisecond)
         } else {
-            format!("{}us", x)
+            format!("{x}us")
         }
     };
     let format_count = |x: usize| {
@@ -1402,7 +1402,7 @@ fn display_metrics(metrics: &Metrics) -> Result<(), std::io::Error> {
         } else if x > thousand {
             format!("{}k", x / thousand)
         } else {
-            format!("{}", x)
+            format!("{x}")
         }
     };
     if metrics.found_new_with_acir_brillig || metrics.found_new_with_brillig {

--- a/tooling/lsp/src/lib.rs
+++ b/tooling/lsp/src/lib.rs
@@ -278,7 +278,7 @@ pub(crate) fn resolve_workspace_for_source_path(file_path: &Path) -> Result<Work
         ) {
             Ok(workspace) => return Ok(workspace),
             Err(error) => {
-                eprintln!("Error while processing {:?}: {}", toml_path, error);
+                eprintln!("Error while processing {toml_path:?}: {error}");
             }
         }
     }
@@ -289,15 +289,14 @@ pub(crate) fn resolve_workspace_for_source_path(file_path: &Path) -> Result<Work
         .and_then(|file_name_os_str| file_name_os_str.to_str())
     else {
         return Err(LspError::WorkspaceResolutionError(format!(
-            "Could not resolve parent folder for file: {:?}",
-            file_path
+            "Could not resolve parent folder for file: {file_path:?}"
         )));
     };
 
     let crate_name = match CrateName::from_str(parent_folder) {
         Ok(name) => name,
         Err(error) => {
-            eprintln!("{}", error);
+            eprintln!("{error}");
             CrateName::from_str("root").unwrap()
         }
     };

--- a/tooling/lsp/src/requests/code_action/implement_missing_members.rs
+++ b/tooling/lsp/src/requests/code_action/implement_missing_members.rs
@@ -104,9 +104,9 @@ impl CodeActionFinder<'_> {
 
         for (name, generic) in associated_types {
             if let Kind::Numeric(typ) = generic.kind() {
-                stubs.push(format!("{}let {}: {};\n", indent_string, name, typ));
+                stubs.push(format!("{indent_string}let {name}: {typ};\n"));
             } else {
-                stubs.push(format!("{}type {};\n", indent_string, name));
+                stubs.push(format!("{indent_string}type {name};\n"));
             }
         }
 
@@ -125,7 +125,7 @@ impl CodeActionFinder<'_> {
                 self.module_id,
                 indent + 4,
             );
-            generator.set_body(format!("panic(f\"Implement {}\")", name));
+            generator.set_body(format!("panic(f\"Implement {name}\")"));
 
             let stub = generator.generate();
             stubs.push(stub);

--- a/tooling/lsp/src/requests/code_action/import_or_qualify.rs
+++ b/tooling/lsp/src/requests/code_action/import_or_qualify.rs
@@ -79,7 +79,7 @@ impl CodeActionFinder<'_> {
     }
 
     fn push_import_code_action(&mut self, full_path: &str) {
-        let title = format!("Import {}", full_path);
+        let title = format!("Import {full_path}");
 
         let text_edits = use_completion_item_additional_text_edits(
             UseCompletionItemAdditionTextEditsRequest {
@@ -110,8 +110,8 @@ impl CodeActionFinder<'_> {
         prefix.pop();
         let prefix = prefix.join("::");
 
-        let title = format!("Qualify as {}", full_path);
-        let text_edit = TextEdit { range, new_text: format!("{}::", prefix) };
+        let title = format!("Qualify as {full_path}");
+        let text_edit = TextEdit { range, new_text: format!("{prefix}::") };
 
         let code_action = self.new_quick_fix(title, text_edit);
         self.code_actions.push(code_action);

--- a/tooling/lsp/src/requests/code_action/import_trait.rs
+++ b/tooling/lsp/src/requests/code_action/import_trait.rs
@@ -117,7 +117,7 @@ impl CodeActionFinder<'_> {
             return;
         };
 
-        let title = format!("Import {}", full_path);
+        let title = format!("Import {full_path}");
 
         let text_edits = use_completion_item_additional_text_edits(
             UseCompletionItemAdditionTextEditsRequest {

--- a/tooling/lsp/src/requests/code_action/remove_unused_import.rs
+++ b/tooling/lsp/src/requests/code_action/remove_unused_import.rs
@@ -142,7 +142,7 @@ fn use_tree_to_string(use_tree: UseTree, visibility: ItemVisibility, nesting: us
     let string = if nesting > 0 && string.contains('\n') {
         // If the import is nested in a module, we just formatted it without indents so we need to add them.
         let indent = " ".repeat(nesting * 4);
-        string.lines().map(|line| format!("{}{}", indent, line)).collect::<Vec<_>>().join("\n")
+        string.lines().map(|line| format!("{indent}{line}")).collect::<Vec<_>>().join("\n")
     } else {
         string
     };

--- a/tooling/lsp/src/requests/code_action/tests.rs
+++ b/tooling/lsp/src/requests/code_action/tests.rs
@@ -69,7 +69,7 @@ pub(crate) async fn assert_code_action(title: &str, src: &str, expected: &str) {
 
     let result = apply_text_edits(&src.replace(">|<", ""), text_edits);
     if result != expected {
-        println!("Expected:\n```\n{}\n```\n\nGot:\n```\n{}\n```", expected, result);
+        println!("Expected:\n```\n{expected}\n```\n\nGot:\n```\n{result}\n```");
         assert_eq!(result, expected);
     }
 }

--- a/tooling/lsp/src/requests/completion.rs
+++ b/tooling/lsp/src/requests/completion.rs
@@ -1042,9 +1042,9 @@ impl<'a> NodeFinder<'a> {
         for name in attributes {
             if name_matches(name, prefix) {
                 self.completion_items.push(snippet_completion_item(
-                    format!("{}(…)", name),
+                    format!("{name}(…)"),
                     CompletionItemKind::METHOD,
-                    format!("{}(${{1:name}})", name),
+                    format!("{name}(${{1:name}})"),
                     None,
                 ));
             }
@@ -1204,7 +1204,7 @@ impl<'a> NodeFinder<'a> {
                 continue;
             }
 
-            let label = if module.has_semicolon { name.to_string() } else { format!("{};", name) };
+            let label = if module.has_semicolon { name.to_string() } else { format!("{name};") };
             self.completion_items.push(simple_completion_item(
                 label,
                 CompletionItemKind::MODULE,

--- a/tooling/lsp/src/requests/completion/auto_import.rs
+++ b/tooling/lsp/src/requests/completion/auto_import.rs
@@ -84,7 +84,7 @@ impl NodeFinder<'_> {
                     };
 
                     let mut label_details = completion_item.label_details.unwrap();
-                    label_details.detail = Some(format!("(use {})", full_path));
+                    label_details.detail = Some(format!("(use {full_path})"));
                     completion_item.label_details = Some(label_details);
                     completion_item.additional_text_edits =
                         Some(use_completion_item_additional_text_edits(

--- a/tooling/lsp/src/requests/completion/completion_items.rs
+++ b/tooling/lsp/src/requests/completion/completion_items.rs
@@ -322,8 +322,8 @@ impl NodeFinder<'_> {
             false
         };
         let description = func_meta_type_to_string(func_meta, name, func_self_type.is_some());
-        let name = if self_prefix { format!("self.{}", name) } else { name.clone() };
-        let name = if is_macro_call { format!("{}!", name) } else { name };
+        let name = if self_prefix { format!("self.{name}") } else { name.clone() };
+        let name = if is_macro_call { format!("{name}!") } else { name };
         let name = &name;
         let mut has_arguments = false;
 
@@ -345,12 +345,12 @@ impl NodeFinder<'_> {
 
                 if insert_text.ends_with("()") {
                     let label =
-                        if skip_first_argument { name.to_string() } else { format!("{}()", name) };
+                        if skip_first_argument { name.to_string() } else { format!("{name}()") };
                     simple_completion_item(label, kind, Some(description.clone()))
                 } else {
                     has_arguments = true;
                     snippet_completion_item(
-                        format!("{}(…)", name),
+                        format!("{name}(…)"),
                         kind,
                         insert_text,
                         Some(description.clone()),
@@ -436,9 +436,9 @@ impl NodeFinder<'_> {
                 self.interner,
             )?
         };
-        let full_path = format!("{}::{}", module_full_path, trait_name);
+        let full_path = format!("{module_full_path}::{trait_name}");
         let mut label_details = completion_item.label_details.clone().unwrap();
-        label_details.detail = Some(format!("(use {})", full_path));
+        label_details.detail = Some(format!("(use {full_path})"));
         completion_item.label_details = Some(label_details);
         completion_item.additional_text_edits = Some(use_completion_item_additional_text_edits(
             UseCompletionItemAdditionTextEditsRequest {

--- a/tooling/lsp/src/requests/hover.rs
+++ b/tooling/lsp/src/requests/hover.rs
@@ -249,7 +249,7 @@ mod hover_tests {
             "workspace",
             "two/src/lib.nr",
             Position { line: 51, character: 8 },
-            &format!("    let x: BoundedVec<SubOneStruct, 3>\n\nGo to [SubOneStruct](file://{}#L4,12-4,24)", workspace_on_src_lib_path),
+            &format!("    let x: BoundedVec<SubOneStruct, 3>\n\nGo to [SubOneStruct](file://{workspace_on_src_lib_path}#L4,12-4,24)"),
         )
         .await;
     }

--- a/tooling/lsp/src/requests/hover/from_reference.rs
+++ b/tooling/lsp/src/requests/hover/from_reference.rs
@@ -310,7 +310,7 @@ fn format_global(id: GlobalId, args: &ProcessRequestCallbackArgs) -> String {
     string.push_str("global ");
     string.push_str(global_info.ident.as_str());
     string.push_str(": ");
-    string.push_str(&format!("{}", typ));
+    string.push_str(&format!("{typ}"));
 
     if let GlobalValue::Resolved(value) = &global_info.value {
         if let Some(value) = value_to_string(value) {
@@ -473,7 +473,7 @@ fn format_function(id: FuncId, args: &ProcessRequestCallbackArgs) -> String {
         }
 
         if enum_variant.is_some() {
-            string.push_str(&format!("{}", typ));
+            string.push_str(&format!("{typ}"));
         } else {
             format_pattern(pattern, args.interner, &mut string);
 
@@ -483,7 +483,7 @@ fn format_function(id: FuncId, args: &ProcessRequestCallbackArgs) -> String {
                 if matches!(visibility, Visibility::Public) {
                     string.push_str("pub ");
                 }
-                string.push_str(&format!("{}", typ));
+                string.push_str(&format!("{typ}"));
             }
         }
 
@@ -500,7 +500,7 @@ fn format_function(id: FuncId, args: &ProcessRequestCallbackArgs) -> String {
             Type::Unit => (),
             _ => {
                 string.push_str(" -> ");
-                string.push_str(&format!("{}", return_type));
+                string.push_str(&format!("{return_type}"));
             }
         }
 
@@ -600,7 +600,7 @@ fn format_local(id: DefinitionId, args: &ProcessRequestCallbackArgs) -> String {
     string.push_str(&definition_info.name);
     if !matches!(typ, Type::Error) {
         string.push_str(": ");
-        string.push_str(&format!("{}", typ));
+        string.push_str(&format!("{typ}"));
     }
 
     string.push_str(&go_to_type_links(&typ, args.interner, args.files));

--- a/tooling/lsp/src/requests/inlay_hint.rs
+++ b/tooling/lsp/src/requests/inlay_hint.rs
@@ -144,7 +144,7 @@ impl<'a> InlayHintCollector<'a> {
             text_edits: if editable {
                 Some(vec![TextEdit {
                     range: Range { start: location.range.end, end: location.range.end },
-                    new_text: format!(": {}", typ),
+                    new_text: format!(": {typ}"),
                 }])
             } else {
                 None
@@ -275,7 +275,7 @@ impl<'a> InlayHintCollector<'a> {
     }
 
     fn push_parameter_hint(&mut self, position: Position, str: &str) {
-        self.push_text_hint(position, format!("{}: ", str));
+        self.push_text_hint(position, format!("{str}: "));
     }
 
     fn push_text_hint(&mut self, position: Position, str: String) {

--- a/tooling/lsp/src/requests/mod.rs
+++ b/tooling/lsp/src/requests/mod.rs
@@ -355,7 +355,7 @@ fn read_format_config(file_path: Option<&Path>) -> Config {
         Some(file_path) => match Config::read(file_path) {
             Ok(config) => config,
             Err(err) => {
-                eprintln!("{}", err);
+                eprintln!("{err}");
                 Config::default()
             }
         },
@@ -393,12 +393,12 @@ fn position_to_location(
 ) -> Result<noirc_errors::Location, ResponseError> {
     let file_id = files.get_file_id(file_path).ok_or(ResponseError::new(
         ErrorCode::REQUEST_FAILED,
-        format!("Could not find file in file manager. File path: {:?}", file_path),
+        format!("Could not find file in file manager. File path: {file_path:?}"),
     ))?;
     let byte_index = position_to_byte_index(files, file_id, position).map_err(|err| {
         ResponseError::new(
             ErrorCode::REQUEST_FAILED,
-            format!("Could not convert position to byte index. Error: {:?}", err),
+            format!("Could not convert position to byte index. Error: {err:?}"),
         )
     })?;
 

--- a/tooling/lsp/src/requests/rename.rs
+++ b/tooling/lsp/src/requests/rename.rs
@@ -112,8 +112,7 @@ mod rename_tests {
                 let extra_in_ranges: Vec<_> =
                     ranges.iter().filter(|range| !changes.contains(range)).collect();
                 panic!(
-                    "Rename locations did not match.\nThese renames were not found: {:?}\nThese renames should not have been found: {:?}",
-                    extra_in_ranges, extra_in_changes
+                    "Rename locations did not match.\nThese renames were not found: {extra_in_ranges:?}\nThese renames should not have been found: {extra_in_changes:?}"
                 );
             }
             assert_eq!(changes, ranges);

--- a/tooling/lsp/src/requests/signature_help/tests.rs
+++ b/tooling/lsp/src/requests/signature_help/tests.rs
@@ -47,7 +47,7 @@ mod signature_help_tests {
 
     fn check_label(signature_label: &str, parameter_label: &ParameterLabel, expected_string: &str) {
         let ParameterLabel::LabelOffsets(offsets) = parameter_label else {
-            panic!("Expected label to be LabelOffsets, got {:?}", parameter_label);
+            panic!("Expected label to be LabelOffsets, got {parameter_label:?}");
         };
 
         assert_eq!(&signature_label[offsets[0] as usize..offsets[1] as usize], expected_string);

--- a/tooling/lsp/src/requests/workspace_symbol.rs
+++ b/tooling/lsp/src/requests/workspace_symbol.rs
@@ -56,7 +56,7 @@ pub(crate) fn on_workspace_symbol_request(
             file_manager.add_file_with_source(path.as_path(), source.to_string());
         } else {
             let source = std::fs::read_to_string(path.as_path())
-                .unwrap_or_else(|_| panic!("could not read file {:?} into string", path));
+                .unwrap_or_else(|_| panic!("could not read file {path:?} into string"));
             file_manager.add_file_with_source(path.as_path(), source);
         }
     }
@@ -262,7 +262,7 @@ mod tests {
         .unwrap();
 
         let WorkspaceSymbolResponse::Nested(symbols) = response else {
-            panic!("Expected Nested response, got {:?}", response);
+            panic!("Expected Nested response, got {response:?}");
         };
 
         assert_eq!(symbols.len(), 8);

--- a/tooling/lsp/src/test_utils.rs
+++ b/tooling/lsp/src/test_utils.rs
@@ -42,7 +42,7 @@ pub(crate) async fn init_lsp_server(directory: &str) -> (LspState, Url) {
 /// Searches for all instances of `search_string` in file `file_name` and returns a list of their locations.
 pub(crate) fn search_in_file(filename: &str, search_string: &str) -> Vec<Range> {
     let file_contents = std::fs::read_to_string(filename)
-        .unwrap_or_else(|_| panic!("Couldn't read file {}", filename));
+        .unwrap_or_else(|_| panic!("Couldn't read file {filename}"));
     let file_lines: Vec<&str> = file_contents.lines().collect();
     file_lines
         .iter()

--- a/tooling/lsp/src/use_segment_positions.rs
+++ b/tooling/lsp/src/use_segment_positions.rs
@@ -247,7 +247,7 @@ pub(crate) fn use_completion_item_additional_text_edits(
             if let Some(lsp_location) = to_lsp_location(request.files, request.file, span) {
                 let range = lsp_location.range;
                 vec![TextEdit {
-                    new_text: format!("::{{self, {}}}", name),
+                    new_text: format!("::{{self, {name}}}"),
                     range: Range { start: range.end, end: range.end },
                 }]
             } else {
@@ -282,7 +282,7 @@ pub(crate) fn use_completion_item_additional_text_edits(
                         range: Range { start: range.start, end: range.start },
                     },
                     TextEdit {
-                        new_text: format!(", {}}}", name),
+                        new_text: format!(", {name}}}"),
                         range: Range { start: range.end, end: range.end },
                     },
                 ]
@@ -308,7 +308,7 @@ pub(crate) fn use_completion_item_additional_text_edits(
             {
                 let range = lsp_location.range;
                 vec![TextEdit {
-                    new_text: if list_is_empty { name } else { format!("{}, ", name) },
+                    new_text: if list_is_empty { name } else { format!("{name}, ") },
                     range: Range { start: range.start, end: range.start },
                 }]
             } else {

--- a/tooling/nargo/src/foreign_calls/mocker.rs
+++ b/tooling/nargo/src/foreign_calls/mocker.rs
@@ -102,7 +102,7 @@ where
             Some(ForeignCall::SetMockParams) => {
                 let (id, params) = Self::extract_mock_id(&foreign_call.inputs)?;
                 self.find_mock_by_id_mut(id)
-                    .unwrap_or_else(|| panic!("Unknown mock id {}", id))
+                    .unwrap_or_else(|| panic!("Unknown mock id {id}"))
                     .params = Some(params.to_vec());
 
                 Ok(ForeignCallResult::default())
@@ -110,7 +110,7 @@ where
             Some(ForeignCall::GetMockLastParams) => {
                 let (id, _) = Self::extract_mock_id(&foreign_call.inputs)?;
                 let mock =
-                    self.find_mock_by_id(id).unwrap_or_else(|| panic!("Unknown mock id {}", id));
+                    self.find_mock_by_id(id).unwrap_or_else(|| panic!("Unknown mock id {id}"));
 
                 let last_called_params = mock
                     .last_called_params
@@ -122,7 +122,7 @@ where
             Some(ForeignCall::SetMockReturns) => {
                 let (id, params) = Self::extract_mock_id(&foreign_call.inputs)?;
                 self.find_mock_by_id_mut(id)
-                    .unwrap_or_else(|| panic!("Unknown mock id {}", id))
+                    .unwrap_or_else(|| panic!("Unknown mock id {id}"))
                     .result = ForeignCallResult { values: params.to_vec() };
 
                 Ok(ForeignCallResult::default())
@@ -133,7 +133,7 @@ where
                     params[0].unwrap_field().try_to_u64().expect("Invalid bit size of times");
 
                 self.find_mock_by_id_mut(id)
-                    .unwrap_or_else(|| panic!("Unknown mock id {}", id))
+                    .unwrap_or_else(|| panic!("Unknown mock id {id}"))
                     .times_left = Some(times);
 
                 Ok(ForeignCallResult::default())
@@ -146,7 +146,7 @@ where
             Some(ForeignCall::GetTimesCalled) => {
                 let (id, _) = Self::extract_mock_id(&foreign_call.inputs)?;
                 let mock =
-                    self.find_mock_by_id(id).unwrap_or_else(|| panic!("Unknown mock id {}", id));
+                    self.find_mock_by_id(id).unwrap_or_else(|| panic!("Unknown mock id {id}"));
                 let times_called = mock.times_called;
                 Ok(ForeignCallResult::from(F::from(times_called)))
             }

--- a/tooling/nargo/src/foreign_calls/rpc.rs
+++ b/tooling/nargo/src/foreign_calls/rpc.rs
@@ -249,7 +249,7 @@ mod tests {
         let server = Server::builder().build("127.0.0.1:0").await?;
         let addr = server.local_addr()?;
         let handle = server.start(OracleResolverImpl.into_rpc());
-        let url = format!("http://{}", addr);
+        let url = format!("http://{addr}");
         // In this test we don't care about doing shutdown so let's it run forever.
         tokio::spawn(handle.stopped());
         Ok(url)

--- a/tooling/nargo/src/lib.rs
+++ b/tooling/nargo/src/lib.rs
@@ -127,7 +127,7 @@ fn insert_all_files_into_file_manager(
             src.to_string()
         } else {
             std::fs::read_to_string(filename.as_path())
-                .unwrap_or_else(|_| panic!("could not read file {:?} into string", filename))
+                .unwrap_or_else(|_| panic!("could not read file {filename:?} into string"))
         };
 
         file_manager.add_file_with_source(filename.as_path(), source);

--- a/tooling/nargo/src/ops/debug.rs
+++ b/tooling/nargo/src/ops/debug.rs
@@ -35,7 +35,7 @@ pub fn get_test_function_for_debug(
 
     let (test_name, test_function) = match test_functions {
         matchings if matchings.is_empty() => {
-            return Err(format!("`{}` does not match with any test function", test_name));
+            return Err(format!("`{test_name}` does not match with any test function"));
         }
         matchings if matchings.len() == 1 => matchings.into_iter().next().unwrap(),
         matchings => {
@@ -53,7 +53,7 @@ pub fn get_test_function_for_debug(
             if exact_match_op.len() == 1 {
                 exact_match_op.into_iter().next().unwrap()
             } else {
-                return Err(format!("`{}` matches with more than one test function", test_name));
+                return Err(format!("`{test_name}` matches with more than one test function"));
             }
         }
     };

--- a/tooling/nargo_cli/src/cli/dap_cmd.rs
+++ b/tooling/nargo_cli/src/cli/dap_cmd.rs
@@ -101,10 +101,9 @@ fn find_workspace(project_folder: &str, package: Option<&str>) -> Option<Workspa
 fn workspace_not_found_error_msg(project_folder: &str, package: Option<&str>) -> String {
     match package {
         Some(pkg) => format!(
-            r#"Noir Debugger could not load program from {}, package {}"#,
-            project_folder, pkg
+            r#"Noir Debugger could not load program from {project_folder}, package {pkg}"#
         ),
-        None => format!(r#"Noir Debugger could not load program from {}"#, project_folder),
+        None => format!(r#"Noir Debugger could not load program from {project_folder}"#),
     }
 }
 
@@ -234,9 +233,9 @@ fn loop_uninitialized_dap<R: Read, W: Write>(
                     .and_then(|v| v.as_str())
                     .map(String::from);
 
-                eprintln!("Project folder: {}", project_folder);
+                eprintln!("Project folder: {project_folder}");
                 eprintln!("Package: {}", package.unwrap_or("(default)"));
-                eprintln!("Prover name: {}", prover_name);
+                eprintln!("Prover name: {prover_name}");
 
                 let compile_options = compile_options_for_debugging(
                     generate_acir,

--- a/tooling/nargo_cli/src/cli/debug_cmd.rs
+++ b/tooling/nargo_cli/src/cli/debug_cmd.rs
@@ -277,7 +277,7 @@ fn decode_and_save_program_witness(
         &witness_stack.peek().expect("Should have at least one witness on the stack").witness;
 
     if let (_, Some(return_value)) = abi.decode(main_witness)? {
-        println!("[{}] Circuit output: {return_value:?}", package_name);
+        println!("[{package_name}] Circuit output: {return_value:?}");
     }
 
     if let Some(witness_name) = target_witness_name {

--- a/tooling/nargo_cli/src/cli/fuzz_cmd.rs
+++ b/tooling/nargo_cli/src/cli/fuzz_cmd.rs
@@ -494,13 +494,13 @@ fn display_fuzzing_report_and_store(
 
     if !status.failed() {
         writer.set_color(ColorSpec::new().set_fg(Some(Color::Green))).expect("Failed to set color");
-        write!(writer, "{} passed (didn't find any issues)", fuzzing_harness_name)
+        write!(writer, "{fuzzing_harness_name} passed (didn't find any issues)")
             .expect("Failed to write to stderr");
         writer.reset().expect("Failed to reset writer");
         writeln!(writer).expect("Failed to write to stderr");
     } else {
         writer.set_color(ColorSpec::new().set_fg(Some(Color::Red))).expect("Failed to set color");
-        write!(writer, "{} failed", fuzzing_harness_name).expect("Failed to write to stderr");
+        write!(writer, "{fuzzing_harness_name} failed").expect("Failed to write to stderr");
         writer.reset().expect("Failed to reset writer");
     }
 

--- a/tooling/nargo_cli/src/cli/test_cmd/formatters.rs
+++ b/tooling/nargo_cli/src/cli/test_cmd/formatters.rs
@@ -184,14 +184,14 @@ impl Formatter for PrettyFormatter {
 
         if !failed_tests.is_empty() {
             writeln!(writer)?;
-            writeln!(writer, "[{}] Failures:", package_name)?;
+            writeln!(writer, "[{package_name}] Failures:")?;
             for failed_test in failed_tests {
-                writeln!(writer, "     {}", failed_test)?;
+                writeln!(writer, "     {failed_test}")?;
             }
             writeln!(writer)?;
         }
 
-        write!(writer, "[{}] ", package_name)?;
+        write!(writer, "[{package_name}] ")?;
 
         let count_all = test_results.len();
         let count_failed =
@@ -284,7 +284,7 @@ impl Formatter for TerseFormatter {
         const MAX_TESTS_PER_LINE: usize = 88;
 
         if current_test_count % MAX_TESTS_PER_LINE == 0 && current_test_count < total_test_count {
-            writeln!(writer, " {}/{}", current_test_count, total_test_count)?;
+            writeln!(writer, " {current_test_count}/{total_test_count}")?;
         }
 
         Ok(())
@@ -350,14 +350,14 @@ impl Formatter for TerseFormatter {
 
         if !failed_tests.is_empty() {
             writeln!(writer)?;
-            writeln!(writer, "[{}] Failures:", package_name)?;
+            writeln!(writer, "[{package_name}] Failures:")?;
             for failed_test in failed_tests {
-                writeln!(writer, "     {}", failed_test)?;
+                writeln!(writer, "     {failed_test}")?;
             }
             writeln!(writer)?;
         }
 
-        write!(writer, "[{}] ", package_name)?;
+        write!(writer, "[{package_name}] ")?;
 
         let count_all = test_results.len();
         let count_failed =

--- a/tooling/nargo_expand/src/printer.rs
+++ b/tooling/nargo_expand/src/printer.rs
@@ -821,18 +821,17 @@ impl<'context, 'string> ItemPrinter<'context, 'string> {
             Value::U32(value) => self.push_str(&value.to_string()),
             Value::U64(value) => self.push_str(&value.to_string()),
             Value::U128(value) => self.push_str(&value.to_string()),
-            Value::String(string) => self.push_str(&format!("{:?}", string)),
+            Value::String(string) => self.push_str(&format!("{string:?}")),
             Value::FormatString(string, _typ) => {
                 // Note: at this point the format string was already expanded so we can't recover the original
                 // interpolation and this will result in a compile-error. But... the expanded code is meant
                 // to be browsed, not compiled.
-                self.push_str(&format!("f{:?}", string));
+                self.push_str(&format!("f{string:?}"));
             }
             Value::CtString(string) => {
                 let std = if self.crate_id.is_stdlib() { "std" } else { "crate" };
                 self.push_str(&format!(
-                    "{}::meta::ctstring::AsCtString::as_ctstring({:?})",
-                    std, string
+                    "{std}::meta::ctstring::AsCtString::as_ctstring({string:?})"
                 ));
             }
             Value::Function(func_id, ..) => {

--- a/tooling/nargo_expand/src/printer/hir.rs
+++ b/tooling/nargo_expand/src/printer/hir.rs
@@ -579,7 +579,7 @@ impl ItemPrinter<'_, '_> {
                 self.push_str(&typ.to_string());
             }
             HirLiteral::Str(string) => {
-                self.push_str(&format!("{:?}", string));
+                self.push_str(&format!("{string:?}"));
             }
             HirLiteral::FmtStr(fmt_str_fragments, _expr_ids, _) => {
                 self.push_str("f\"");

--- a/tooling/nargo_fmt/src/formatter.rs
+++ b/tooling/nargo_fmt/src/formatter.rs
@@ -305,7 +305,7 @@ impl<'a> Formatter<'a> {
         if let Some(token) = token {
             match token {
                 Ok(token) => token.into_spanned_token(),
-                Err(err) => panic!("Expected lexer not to error, but got: {:?}", err),
+                Err(err) => panic!("Expected lexer not to error, but got: {err:?}"),
             }
         } else {
             SpannedToken::new(Token::EOF, Default::default())

--- a/tooling/nargo_fmt/src/formatter/expression.rs
+++ b/tooling/nargo_fmt/src/formatter/expression.rs
@@ -343,7 +343,7 @@ impl ChunkFormatter<'_, '_> {
             '(' => ')',
             '{' => '}',
             '[' => ']',
-            _ => panic!("Unexpected delimiter: {}", delimiter_start),
+            _ => panic!("Unexpected delimiter: {delimiter_start}"),
         };
 
         // We use the current token rather than the Tokens we got from `Token::Quote` because

--- a/tooling/nargo_fmt/src/formatter/types.rs
+++ b/tooling/nargo_fmt/src/formatter/types.rs
@@ -167,10 +167,10 @@ mod tests {
     use crate::Config;
 
     fn assert_format_type(src: &str, expected: &str) {
-        let module_src = format!("type X = {};", src);
+        let module_src = format!("type X = {src};");
         let (parsed_module, errors) = parser::parse_program_with_dummy_file(&module_src);
         if !errors.is_empty() {
-            panic!("Expected no errors, got: {:?}", errors);
+            panic!("Expected no errors, got: {errors:?}");
         }
         let result = crate::format(&module_src, parsed_module, &Config::default());
         let type_result = &result["type X = ".len()..];
@@ -179,7 +179,7 @@ mod tests {
 
         let (parsed_module, errors) = parser::parse_program_with_dummy_file(&result);
         if !errors.is_empty() {
-            panic!("Expected no errors in idempotent check, got: {:?}", errors);
+            panic!("Expected no errors in idempotent check, got: {errors:?}");
         }
         let result = crate::format(&result, parsed_module, &Config::default());
         let type_result = &result["type X = ".len()..];

--- a/tooling/nargo_fmt/src/formatter/use_tree_merge.rs
+++ b/tooling/nargo_fmt/src/formatter/use_tree_merge.rs
@@ -137,7 +137,7 @@ impl Segment {
         if other == Segment::SelfReference {
             self
         } else {
-            Segment::Plain(format!("{}::{}", self, other))
+            Segment::Plain(format!("{self}::{other}"))
         }
     }
 
@@ -158,7 +158,7 @@ impl Display for Segment {
             Segment::Crate => write!(f, "crate"),
             Segment::Super => write!(f, "super"),
             Segment::Dep => write!(f, "dep"),
-            Segment::Plain(s) => write!(f, "{}", s),
+            Segment::Plain(s) => write!(f, "{s}"),
             Segment::SelfReference => write!(f, "self"),
         }
     }
@@ -278,7 +278,7 @@ fn merge_imports_in_tree(imports: Vec<UseTree>, mut tree: &mut ImportTree) {
         match import.kind {
             UseTreeKind::Path(ident, alias) => {
                 if let Some(alias) = alias {
-                    tree = tree.insert(Segment::Plain(format!("{} as {}", ident, alias)));
+                    tree = tree.insert(Segment::Plain(format!("{ident} as {alias}")));
                     tree.insert(Segment::SelfReference);
                 } else if ident.as_str() == "self" {
                     tree.insert(Segment::SelfReference);

--- a/tooling/nargo_fmt/src/lib.rs
+++ b/tooling/nargo_fmt/src/lib.rs
@@ -66,11 +66,11 @@ pub(crate) fn assert_format_with_config(src: &str, expected: &str, config: Confi
     let (parsed_module, errors) = parser::parse_program_with_dummy_file(src);
     let errors: Vec<_> = errors.into_iter().filter(|error| !error.is_warning()).collect();
     if !errors.is_empty() {
-        panic!("Expected no errors, got: {:?}", errors);
+        panic!("Expected no errors, got: {errors:?}");
     }
     let result = format(src, parsed_module, &config);
     if result != expected {
-        println!("Expected:\n~~~\n{}\n~~~\nGot:\n~~~\n{}\n~~~", expected, result);
+        println!("Expected:\n~~~\n{expected}\n~~~\nGot:\n~~~\n{result}\n~~~");
     }
 
     similar_asserts::assert_eq!(result, expected);
@@ -79,11 +79,11 @@ pub(crate) fn assert_format_with_config(src: &str, expected: &str, config: Confi
     let (parsed_module, errors) = parser::parse_program_with_dummy_file(src);
     let errors: Vec<_> = errors.into_iter().filter(|error| !error.is_warning()).collect();
     if !errors.is_empty() {
-        panic!("Expected no errors in idempotent check, got: {:?}", errors);
+        panic!("Expected no errors in idempotent check, got: {errors:?}");
     }
     let result = format(src, parsed_module, &config);
     if result != expected {
-        println!("Expected (idempotent):\n~~~\n{}\n~~~\nGot:\n~~~\n{}\n~~~", expected, result);
+        println!("Expected (idempotent):\n~~~\n{expected}\n~~~\nGot:\n~~~\n{result}\n~~~");
     }
     similar_asserts::assert_eq!(result, expected, "idempotent check failed");
 }

--- a/tooling/nargo_toml/src/lib.rs
+++ b/tooling/nargo_toml/src/lib.rs
@@ -491,7 +491,7 @@ fn resolve_package_from_toml(
         for toml in processed {
             cycle = cycle || toml == str_path;
             if cycle {
-                message += &format!("{} referencing ", toml);
+                message += &format!("{toml} referencing ");
             }
         }
         message += str_path;

--- a/tooling/noirc_abi_wasm/src/js_witness_map.rs
+++ b/tooling/noirc_abi_wasm/src/js_witness_map.rs
@@ -54,7 +54,7 @@ pub(crate) fn js_value_to_field_element(js_value: JsValue) -> Result<FieldElemen
     let hex_str = js_value.as_string().ok_or("failed to parse field element from non-string")?;
 
     FieldElement::from_hex(&hex_str)
-        .ok_or_else(|| format!("Invalid hex string: '{}'", hex_str).into())
+        .ok_or_else(|| format!("Invalid hex string: '{hex_str}'").into())
 }
 
 pub(crate) fn field_element_to_js_string(field_element: &FieldElement) -> JsString {

--- a/tooling/noirc_artifacts_info/src/lib.rs
+++ b/tooling/noirc_artifacts_info/src/lib.rs
@@ -24,7 +24,7 @@ pub struct ProgramInfo {
 impl From<ProgramInfo> for Vec<Row> {
     fn from(program_info: ProgramInfo) -> Self {
         let expression_width = if let Some(expression_width) = program_info.expression_width {
-            format!("{:?}", expression_width)
+            format!("{expression_width:?}")
         } else {
             "N/A".to_string()
         };

--- a/tooling/profiler/src/cli/gates_flamegraph_cmd.rs
+++ b/tooling/profiler/src/cli/gates_flamegraph_cmd.rs
@@ -105,9 +105,9 @@ fn run_with_provider<Provider: GatesProvider, Generator: FlamegraphGenerator>(
             .collect();
 
         let output_filename = if let Some(output_filename) = &output_filename {
-            format!("{}_{}_gates.svg", output_filename, function_name)
+            format!("{output_filename}_{function_name}_gates.svg")
         } else {
-            format!("{}_gates.svg", function_name)
+            format!("{function_name}_gates.svg")
         };
         flamegraph_generator.generate_flamegraph(
             samples,

--- a/tooling/profiler/src/cli/opcodes_flamegraph_cmd.rs
+++ b/tooling/profiler/src/cli/opcodes_flamegraph_cmd.rs
@@ -128,7 +128,7 @@ fn run_with_generator<Generator: FlamegraphGenerator>(
             artifact_path.to_str().unwrap(),
             &function_name,
             &Path::new(&output_path)
-                .join(Path::new(&format!("{}_brillig_opcodes.svg", function_name))),
+                .join(Path::new(&format!("{function_name}_brillig_opcodes.svg"))),
         )?;
     }
 

--- a/tooling/profiler/src/flamegraph.rs
+++ b/tooling/profiler/src/flamegraph.rs
@@ -112,7 +112,7 @@ impl FlamegraphGenerator for InfernoFlamegraphGenerator {
         let mut options = Options::default();
         options.hash = true;
         options.deterministic = true;
-        options.title = format!("Artifact: {}, Function: {}", artifact_name, function_name);
+        options.title = format!("Artifact: {artifact_name}, Function: {function_name}");
         options.frame_height = 24;
         options.color_diffusion = true;
         options.min_width = 0.0;
@@ -245,7 +245,7 @@ fn location_to_callsite_label<'files>(
 
     let (line, column) = line_and_column_from_span(source.as_ref(), &location.span);
 
-    format!("{}:{}:{}::{}", filename, line, column, code_slice)
+    format!("{filename}:{line}:{column}::{code_slice}")
 }
 
 fn add_locations_to_folded_stack_items(

--- a/tooling/profiler/src/opcode_formatter.rs
+++ b/tooling/profiler/src/opcode_formatter.rs
@@ -106,7 +106,7 @@ fn format_brillig_opcode_kind<F>(opcode: &BrilligOpcode<F>) -> String {
         BrilligOpcode::ConditionalMov { .. } => "cmov".to_string(),
         BrilligOpcode::Const { .. } => "const".to_string(),
         BrilligOpcode::IndirectConst { .. } => "iconst".to_string(),
-        BrilligOpcode::ForeignCall { function, .. } => format!("foreign_call({})", function),
+        BrilligOpcode::ForeignCall { function, .. } => format!("foreign_call({function})"),
         BrilligOpcode::Jump { .. } => "jump".to_string(),
         BrilligOpcode::JumpIf { .. } => "jump_if".to_string(),
         BrilligOpcode::JumpIfNot { .. } => "jump_if_not".to_string(),

--- a/tooling/ssa_executor/src/compiler.rs
+++ b/tooling/ssa_executor/src/compiler.rs
@@ -24,11 +24,11 @@ pub fn optimize_ssa_into_acir(
 
     std::panic::set_hook(Box::new(move |panic_info| {
         let message = if let Some(s) = panic_info.payload().downcast_ref::<&str>() {
-            format!("Panic: {}", s)
+            format!("Panic: {s}")
         } else if let Some(s) = panic_info.payload().downcast_ref::<String>() {
-            format!("Panic: {}", s)
+            format!("Panic: {s}")
         } else {
-            format!("Unknown panic: {:?}", panic_info)
+            format!("Unknown panic: {panic_info:?}")
         };
 
         if let Some(location) = panic_info.location() {
@@ -59,7 +59,7 @@ pub fn optimize_ssa_into_acir(
         Err(_) => {
             let error_msg = panic_message.lock().unwrap().clone();
             Err(RuntimeError::InternalError(InternalError::General {
-                message: format!("Panic occurred: {}", error_msg),
+                message: format!("Panic occurred: {error_msg}"),
                 call_stack: CallStack::default(),
             }))
         }

--- a/tooling/ssa_executor/src/lib.rs
+++ b/tooling/ssa_executor/src/lib.rs
@@ -26,12 +26,11 @@ pub fn execute_ssa(
             match compiled_program {
                 Ok(compiled_program) => execute_single(&compiled_program.program, initial_witness),
                 Err(e) => Err(SsaExecutionError::SsaCompilationFailed(format!(
-                    "SSA compilation failed: {:?}",
-                    e
+                    "SSA compilation failed: {e:?}"
                 ))),
             }
         }
-        Err(e) => Err(SsaExecutionError::SsaParsingFailed(format!("SSA parsing failed: {:?}", e))),
+        Err(e) => Err(SsaExecutionError::SsaParsingFailed(format!("SSA parsing failed: {e:?}"))),
     }
 }
 
@@ -132,8 +131,8 @@ mod tests {
         let brillig_result =
             execute_ssa(brillig_ssa.to_string(), witness_map, CompileOptions::default());
         match (acir_result, brillig_result) {
-            (Err(acir), Ok(_brillig)) => panic!("Acir failed with: {}, brillig succeeded", acir),
-            (Ok(_acir), Err(brillig)) => panic!("Acir succeeded, brillig failed: {}", brillig),
+            (Err(acir), Ok(_brillig)) => panic!("Acir failed with: {acir}, brillig succeeded"),
+            (Ok(_acir), Err(brillig)) => panic!("Acir succeeded, brillig failed: {brillig}"),
             _ => {}
         }
     }

--- a/tooling/ssa_fuzzer/fuzzer/src/fuzz_lib/base_context.rs
+++ b/tooling/ssa_fuzzer/fuzzer/src/fuzz_lib/base_context.rs
@@ -783,7 +783,7 @@ impl FuzzerContext {
     /// so to merge blocks we need to merge every branch separately
     fn merge_one_block(&mut self, block_id: BasicBlockId) -> StoredBlock {
         let block = &self.stored_blocks[&block_id];
-        log::debug!("merging block {:?}", block_id);
+        log::debug!("merging block {block_id:?}");
         let block_end = self.end_of_block(block_id);
         if let Some(block_end) = block_end {
             return self.stored_blocks[&block_end].clone();
@@ -815,7 +815,7 @@ impl FuzzerContext {
         let cycle_info: Vec<_> = self.cycle_bodies_to_iters_ids.keys().cloned().collect();
         for body_id in cycle_info {
             let iter_id = self.cycle_bodies_to_iters_ids[&body_id].block_iter_id;
-            log::debug!("body_id: {:?}, iter_id: {:?}", body_id, iter_id);
+            log::debug!("body_id: {body_id:?}, iter_id: {iter_id:?}");
             self.switch_to_block(body_id);
             self.insert_jmp_instruction(iter_id, vec![]);
         }

--- a/tooling/ssa_fuzzer/fuzzer/src/fuzz_lib/fuzz_target_lib.rs
+++ b/tooling/ssa_fuzzer/fuzzer/src/fuzz_lib/fuzz_target_lib.rs
@@ -111,7 +111,7 @@ pub(crate) fn fuzz_target(data: FuzzerData, options: FuzzerOptions) -> Option<Fi
     let (witness_map, values, types) = initialize_witness_map(&data);
 
     // to triage
-    log::debug!("initial_witness: {:?}", witness_map);
+    log::debug!("initial_witness: {witness_map:?}");
     log::debug!("commands: {:?}", data.commands);
 
     let mut fuzzer = Fuzzer::new(types, values, data.blocks, options);
@@ -195,7 +195,7 @@ mod tests {
         let result = fuzz_target(data, FuzzerOptions::default());
         // we expect that this program failed to execute
         if let Some(result) = result {
-            panic!("Program executed successfully with result: {:?}", result);
+            panic!("Program executed successfully with result: {result:?}");
         }
     }
 

--- a/tooling/ssa_fuzzer/fuzzer/src/fuzz_lib/fuzzer.rs
+++ b/tooling/ssa_fuzzer/fuzzer/src/fuzz_lib/fuzzer.rs
@@ -143,7 +143,7 @@ impl Fuzzer {
                 non_constant_result, result_with_constrains,
                 "Non-constant and idempotent morphing contexts should return the same result"
             );
-            log::debug!("result_with_constrains: {:?}", result_with_constrains);
+            log::debug!("result_with_constrains: {result_with_constrains:?}");
         }
         non_constant_result
     }
@@ -158,8 +158,8 @@ impl Fuzzer {
         let (acir_program, brillig_program) = match (acir_program, brillig_program) {
             (Ok(acir), Ok(brillig)) => (acir, brillig),
             (Err(acir_error), Err(brillig_error)) => {
-                log::debug!("ACIR compilation error: {:?}", acir_error);
-                log::debug!("Brillig compilation error: {:?}", brillig_error);
+                log::debug!("ACIR compilation error: {acir_error:?}");
+                log::debug!("Brillig compilation error: {brillig_error:?}");
                 log::debug!("ACIR and Brillig compilation failed");
                 return None;
             }
@@ -175,8 +175,8 @@ impl Fuzzer {
                         );
                     }
                     Err(acir_error) => {
-                        log::debug!("ACIR execution error: {:?}", acir_error);
-                        log::debug!("Brillig compilation error: {:?}", brillig_error);
+                        log::debug!("ACIR execution error: {acir_error:?}");
+                        log::debug!("Brillig compilation error: {brillig_error:?}");
                         return None;
                     }
                 }
@@ -193,8 +193,8 @@ impl Fuzzer {
                         );
                     }
                     Err(brillig_error) => {
-                        log::debug!("Brillig execution error: {:?}", brillig_error);
-                        log::debug!("ACIR compilation error: {:?}", acir_error);
+                        log::debug!("Brillig execution error: {brillig_error:?}");
+                        log::debug!("ACIR compilation error: {acir_error:?}");
                         return None;
                     }
                 }
@@ -202,31 +202,28 @@ impl Fuzzer {
         };
         let comparison_result =
             run_and_compare(&acir_program.program, &brillig_program.program, initial_witness);
-        log::debug!("Comparison result: {:?}", comparison_result);
+        log::debug!("Comparison result: {comparison_result:?}");
         match comparison_result {
             CompareResults::Agree(result) => Some(result),
             CompareResults::Disagree(acir_return_value, brillig_return_value) => {
                 panic!(
                     "ACIR and Brillig programs returned different results: \
-                    ACIR returned {:?}, Brillig returned {:?}",
-                    acir_return_value, brillig_return_value
+                    ACIR returned {acir_return_value:?}, Brillig returned {brillig_return_value:?}"
                 );
             }
             CompareResults::AcirFailed(acir_error, brillig_return_value) => {
                 panic!(
-                    "ACIR execution failed with error: {:?}, Brillig returned {:?}",
-                    acir_error, brillig_return_value
+                    "ACIR execution failed with error: {acir_error:?}, Brillig returned {brillig_return_value:?}"
                 );
             }
             CompareResults::BrilligFailed(brillig_error, acir_return_value) => {
                 panic!(
-                    "Brillig execution failed with error: {:?}, ACIR returned {:?}",
-                    brillig_error, acir_return_value
+                    "Brillig execution failed with error: {brillig_error:?}, ACIR returned {acir_return_value:?}"
                 );
             }
             CompareResults::BothFailed(acir_error, brillig_error) => {
-                log::debug!("ACIR execution error: {:?}", acir_error);
-                log::debug!("Brillig execution error: {:?}", brillig_error);
+                log::debug!("ACIR execution error: {acir_error:?}");
+                log::debug!("Brillig execution error: {brillig_error:?}");
                 None
             }
         }

--- a/tooling/ssa_fuzzer/src/builder.rs
+++ b/tooling/ssa_fuzzer/src/builder.rs
@@ -62,7 +62,7 @@ impl FuzzerBuilder {
             Ok(result) => match result {
                 Ok(result) => Ok(result),
                 Err(e) => {
-                    Err(FuzzerBuilderError::RuntimeError(format!("Compilation error {:?}", e)))
+                    Err(FuzzerBuilderError::RuntimeError(format!("Compilation error {e:?}")))
                 }
             },
             Err(_) => Err(FuzzerBuilderError::RuntimeError("Compilation panicked".to_string())),

--- a/tooling/ssa_fuzzer/src/lib.rs
+++ b/tooling/ssa_fuzzer/src/lib.rs
@@ -101,26 +101,22 @@ mod tests {
             CompareResults::Agree(result) => result,
             CompareResults::Disagree(acir_result, brillig_result) => {
                 panic!(
-                    "ACIR and Brillig results disagree: ACIR: {}, Brillig: {}, lhs: {}, rhs: {}",
-                    acir_result, brillig_result, lhs, rhs
+                    "ACIR and Brillig results disagree: ACIR: {acir_result}, Brillig: {brillig_result}, lhs: {lhs}, rhs: {rhs}"
                 );
             }
             CompareResults::BothFailed(acir_error, brillig_error) => {
                 panic!(
-                    "Both ACIR and Brillig failed: ACIR: {}, Brillig: {}, lhs: {}, rhs: {}",
-                    acir_error, brillig_error, lhs, rhs
+                    "Both ACIR and Brillig failed: ACIR: {acir_error}, Brillig: {brillig_error}, lhs: {lhs}, rhs: {rhs}"
                 );
             }
             CompareResults::AcirFailed(acir_error, brillig_result) => {
                 panic!(
-                    "ACIR failed: ACIR: {}, Brillig: {}, lhs: {}, rhs: {}",
-                    acir_error, brillig_result, lhs, rhs
+                    "ACIR failed: ACIR: {acir_error}, Brillig: {brillig_result}, lhs: {lhs}, rhs: {rhs}"
                 );
             }
             CompareResults::BrilligFailed(brillig_error, acir_result) => {
                 panic!(
-                    "Brillig failed: Brillig: {}, ACIR: {}, lhs: {}, rhs: {}",
-                    brillig_error, acir_result, lhs, rhs
+                    "Brillig failed: Brillig: {brillig_error}, ACIR: {acir_result}, lhs: {lhs}, rhs: {rhs}"
                 );
             }
         }

--- a/tooling/ssa_verification/src/main.rs
+++ b/tooling/ssa_verification/src/main.rs
@@ -58,7 +58,7 @@ fn save_artifacts(all_artifacts: Vec<InstructionArtifacts>, dir: &str) {
         match save_to_file(&ungzip(acir), &filename) {
             Ok(_) => (),
             Err(error) => {
-                eprintln!("Error saving data: {}", error);
+                eprintln!("Error saving data: {error}");
                 std::process::exit(1);
             }
         }


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This applies the new clippy style suggestions which rust-analyzer is shouting at me for. I've updated the cargo.toml config to enforce these in CI.


## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
