### PR TITLE
chore: Add expected bigcurve failure

### DIFF
--- a/.github/critical_libraries_status/noir-lang/noir_bigcurve/.failures.jsonl
+++ b/.github/critical_libraries_status/noir-lang/noir_bigcurve/.failures.jsonl
@@ -1,0 +1,1 @@
+{"suite":"noir_bigcurve","name":"utils::derive_offset_generators::test_compute_and_print_offset_generators"}

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 </div>
 
 
+
 # The Noir Programming Language
 
 [![Non-deterministic fuzz tests](https://github.com/noir-lang/noir/actions/workflows/nightly-fuzz-test.yml/badge.svg)](https://github.com/noir-lang/noir/actions/workflows/nightly-fuzz-test.yml)

--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@
 </div>
 
 
-
 # The Noir Programming Language
 
 [![Non-deterministic fuzz tests](https://github.com/noir-lang/noir/actions/workflows/nightly-fuzz-test.yml/badge.svg)](https://github.com/noir-lang/noir/actions/workflows/nightly-fuzz-test.yml)


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

Adds an expected failure to the CI for our external bigcurve test while we are working on fixing assumed trait constraints to unblock other PRs.

## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
