### PR TITLE
chore: bump external pinned commits

### DIFF
--- a/.github/benchmark_projects.yml
+++ b/.github/benchmark_projects.yml
@@ -15,7 +15,7 @@ projects:
     path: noir-projects/noir-protocol-circuits/crates/private-kernel-tail
     num_runs: 5
     timeout: 4
-    compilation-timeout: 1.5
+    compilation-timeout: 3
     execution-timeout: 0.04
     compilation-memory-limit: 250
     execution-memory-limit: 230
@@ -83,7 +83,7 @@ projects:
     path: noir-projects/noir-protocol-circuits/crates/rollup-merge
     num_runs: 5
     timeout: 300
-    compilation-timeout: 1.5
+    compilation-timeout: 4
     execution-timeout: 0.01
     compilation-memory-limit: 450
     execution-memory-limit: 450

--- a/.github/benchmark_projects.yml
+++ b/.github/benchmark_projects.yml
@@ -1,4 +1,4 @@
-define: &AZ_COMMIT 841f13f189e3191ef6f4852130d61c370a20a991
+define: &AZ_COMMIT 801a120d940fe3b0068eb770d57124d426e0f2b1
 projects:
   private-kernel-inner:
     repo: AztecProtocol/aztec-packages

--- a/EXTERNAL_NOIR_LIBRARIES.yml
+++ b/EXTERNAL_NOIR_LIBRARIES.yml
@@ -95,7 +95,7 @@ libraries:
     repo: AztecProtocol/aztec-packages
     ref: *AZ_COMMIT
     path: noir-projects/noir-protocol-circuits/crates/private-kernel-lib
-    timeout: 250
+    timeout: 300
     critical: false
   protocol_circuits_reset_kernel_lib:
     repo: AztecProtocol/aztec-packages
@@ -107,7 +107,7 @@ libraries:
     repo: AztecProtocol/aztec-packages
     ref: *AZ_COMMIT
     path: noir-projects/noir-protocol-circuits/crates/types
-    timeout: 100
+    timeout: 150
     critical: false
   protocol_circuits_rollup_lib:
     repo: AztecProtocol/aztec-packages

--- a/EXTERNAL_NOIR_LIBRARIES.yml
+++ b/EXTERNAL_NOIR_LIBRARIES.yml
@@ -1,4 +1,4 @@
-define: &AZ_COMMIT 841f13f189e3191ef6f4852130d61c370a20a991
+define: &AZ_COMMIT 801a120d940fe3b0068eb770d57124d426e0f2b1
 libraries:
   noir_check_shuffle:
     repo: noir-lang/noir_check_shuffle


### PR DESCRIPTION

Automated update of the pinned commit of [aztec-packages](https://github.com/AztecProtocol/aztec-packages) repository against which we run benchmarks.
