### PR TITLE
chore: Switch to `protoc_bin_vendored`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,7 +24,7 @@ dependencies = [
  "proptest-derive",
  "prost",
  "prost-build",
- "protoc-prebuilt",
+ "protoc-bin-vendored",
  "regex",
  "rmp-serde",
  "rmpv",
@@ -4515,14 +4515,61 @@ dependencies = [
 ]
 
 [[package]]
-name = "protoc-prebuilt"
-version = "0.3.0"
+name = "protoc-bin-vendored"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d85d4641fe3b8c6e853dfd09fe35379bc6b6e66bd692ac29ed4f7087de69ed5"
+checksum = "dd89a830d0eab2502c81a9b8226d446a52998bb78e5e33cb2637c0cdd6068d99"
 dependencies = [
- "ureq",
- "zip",
+ "protoc-bin-vendored-linux-aarch_64",
+ "protoc-bin-vendored-linux-ppcle_64",
+ "protoc-bin-vendored-linux-x86_32",
+ "protoc-bin-vendored-linux-x86_64",
+ "protoc-bin-vendored-macos-aarch_64",
+ "protoc-bin-vendored-macos-x86_64",
+ "protoc-bin-vendored-win32",
 ]
+
+[[package]]
+name = "protoc-bin-vendored-linux-aarch_64"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f563627339f1653ea1453dfbcb4398a7369b768925eb14499457aeaa45afe22c"
+
+[[package]]
+name = "protoc-bin-vendored-linux-ppcle_64"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5025c949a02cd3b60c02501dd0f348c16e8fff464f2a7f27db8a9732c608b746"
+
+[[package]]
+name = "protoc-bin-vendored-linux-x86_32"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c9500ce67d132c2f3b572504088712db715755eb9adf69d55641caa2cb68a07"
+
+[[package]]
+name = "protoc-bin-vendored-linux-x86_64"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5462592380cefdc9f1f14635bcce70ba9c91c1c2464c7feb2ce564726614cc41"
+
+[[package]]
+name = "protoc-bin-vendored-macos-aarch_64"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c637745681b68b4435484543667a37606c95ddacf15e917710801a0877506030"
+
+[[package]]
+name = "protoc-bin-vendored-macos-x86_64"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38943f3c90319d522f94a6dfd4a134ba5e36148b9506d2d9723a82ebc57c8b55"
+
+[[package]]
+name = "protoc-bin-vendored-win32"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dc55d7dec32ecaf61e0bd90b3d2392d721a28b95cfd23c3e176eccefbeab2f2"
 
 [[package]]
 name = "quick-error"
@@ -6197,21 +6244,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
 
 [[package]]
-name = "ureq"
-version = "2.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
-dependencies = [
- "base64",
- "log",
- "once_cell",
- "rustls",
- "rustls-pki-types",
- "url",
- "webpki-roots 0.26.11",
-]
-
-[[package]]
 name = "url"
 version = "2.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6452,24 +6484,6 @@ name = "webpki-root-certs"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01a83f7e1a9f8712695c03eabe9ed3fbca0feff0152f33f12593e5a6303cb1a4"
-dependencies = [
- "rustls-pki-types",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "0.26.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
-dependencies = [
- "webpki-roots 1.0.0",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2853738d1cc4f2da3a225c18ec6c3721abb31961096e9dbf5ab35fa88b19cfdb"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -6942,18 +6956,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.102",
-]
-
-[[package]]
-name = "zip"
-version = "0.6.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "760394e246e4c28189f19d488c058bf16f564016aefac5d32bb1f3b51d5e9261"
-dependencies = [
- "byteorder",
- "crc32fast",
- "crossbeam-utils",
- "flate2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -162,7 +162,8 @@ pprof = { version = "^0.15.0", features = ["flamegraph", "criterion"] }
 # Protobuf
 prost = "0.13"
 prost-build = "0.13"
-protoc-prebuilt = "0.3"
+protoc-bin-vendored = "3.1.0"
+
 
 # MessagePack
 rmp = "0.8.14"
@@ -184,7 +185,7 @@ url = "2.5.4"
 base64 = "^0.22.1"
 fxhash = "0.2.1"
 build-data = "^0.3.3"
-bincode =  { version = "^2.0.1", features = ["serde"] }
+bincode = { version = "^2.0.1", features = ["serde"] }
 hex = "0.4.2"
 const_format = "0.2.30"
 lazy_static = "1.4"

--- a/acvm-repo/acir/Cargo.toml
+++ b/acvm-repo/acir/Cargo.toml
@@ -38,7 +38,7 @@ proptest-derive = { workspace = true, optional = true }
 
 [build-dependencies]
 prost-build.workspace = true
-protoc-prebuilt.workspace = true
+protoc-bin-vendored.workspace = true
 
 [dev-dependencies]
 serde_json = "1.0"

--- a/acvm-repo/acir/build.rs
+++ b/acvm-repo/acir/build.rs
@@ -1,9 +1,19 @@
 use std::path::Path;
 
 fn main() {
-    let (protoc_bin, include_dir) =
-        protoc_prebuilt::init("29.3").expect("failed to initialize protoc");
+    // This version downloads a configurable protoc version during the build, a separate one each time our code changes.
+    // Despite having the GITHUB_TOKEN, it often gets throttles on CI when lots of builds are running.
+    //
+    // let (protoc_bin, include_dir) =
+    //     protoc_prebuilt::init("29.3").expect("failed to initialize protoc");
 
+    // This version downloads a version of protoc bundled in the library,
+    // which looks like just another Rust dependency, so shouldn't cause API rate limit issues.
+    let protoc_bin = protoc_bin_vendored::protoc_bin_path().expect("can't find protoc for this OS");
+    let include_dir =
+        protoc_bin_vendored::include_path().expect("can't find protobuf includes for this OS");
+
+    // Set the path to the bin so `prost_build` can find it.
     #[allow(unsafe_code)]
     unsafe {
         std::env::set_var("PROTOC", protoc_bin);


### PR DESCRIPTION
# Description

## Problem\*

Resolves the annoying API rate limits we are still getting on CI when downloading `protoc`.

## Summary\*

Switches from using https://docs.rs/protoc-prebuilt/latest/protoc_prebuilt/ to https://crates.io/crates/protoc-bin-vendored

## Additional Context

With this crate we are getting the version of `protoc` which is bundled in the library, probably 25.x, instead of 29.x used so far. If that's not good enough we need to cater for downloading with Github Workflow actions.

## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
