### PR TITLE
fix: branch and squash merge steps fixed

### DIFF
--- a/scripts/redo-typo-pr.sh
+++ b/scripts/redo-typo-pr.sh
@@ -6,35 +6,37 @@ set -eux
 ORIGINAL_PR_NUMBER=$1
 REPO='noir-lang/noir'
 NEW_BRANCH="chore/typo-redo-$ORIGINAL_PR_NUMBER"
-AUTHOR=`gh pr view $ORIGINAL_PR_NUMBER --json author --jq '.author.login'`
+AUTHOR=$(gh pr view $ORIGINAL_PR_NUMBER --json author --jq '.author.login')
 
 # Step 1: Checkout the PR locally
 echo "Checking out PR #$ORIGINAL_PR_NUMBER"
 gh pr checkout $ORIGINAL_PR_NUMBER --branch "typo-pr-branch"
 
-# Step 2: Create squash commit on master
-echo "Squashing PR branch onto master"
-git checkout master
+# Step 2: Create new branch from master for squash commit
+echo "Creating new local branch $NEW_BRANCH from master"
+git checkout -b $NEW_BRANCH master
+
+# Step 3: Squash merge the PR branch onto the new branch
+echo "Squashing PR branch onto $NEW_BRANCH"
 git merge "typo-pr-branch" --squash
 
-# Step 3: Commit squash commit to new branch
-echo "Creating new local branch $NEW_BRANCH"
-git checkout -b $NEW_BRANCH
-git commit -a -m "chore: redo typo PR"
+# Step 4: Commit squash changes
+echo "Committing squash commit"
+git commit -m "chore: redo typo PR"
 
-# Step 4: Push the new branch to GitHub
+# Step 5: Push the new branch to GitHub
 echo "Pushing new branch $NEW_BRANCH to GitHub"
 git push origin $NEW_BRANCH
 
-# Step 5: create a new pull request
+# Step 6: Create a new pull request
 echo "Creating a new pull request for $NEW_BRANCH"
 gh pr create --base master --head $NEW_BRANCH --title "chore: redo typo PR by $AUTHOR" --body "Thanks $AUTHOR for https://github.com/$REPO/pull/$ORIGINAL_PR_NUMBER. Our policy is to redo typo changes to dissuade metric farming. This is an automated script."
 
-# Step 6: Close the original PR
+# Step 7: Close the original PR
 echo "Closing original PR #$ORIGINAL_PR_NUMBER"
 gh pr close $ORIGINAL_PR_NUMBER
 
-# Step 7: Delete the temporary branch
+# Step 8: Delete the temporary branch
 git branch -D typo-pr-branch
 
 echo "Script completed."


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

I fixed the flow by creating the new branch directly from master before doing the squash merge. The squash merge now happens on the new branch with a proper commit message. Also replaced backticks with \$(...) and reordered the steps for better clarity.

## Additional Context

Should make the process smoother and easier to follow.

## Documentation\*

Check one:

* [x] No documentation needed.
* [ ] Documentation included in this PR.
* [ ] **\[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

* [x] I have tested the changes locally.
* [ ] I have formatted the changes with [[Prettier](https://prettier.io/)](https://prettier.io/) and/or `cargo fmt` on default settings.