### PR TITLE
fix(ssa_fuzzer): fix panic if compiler removed return value

### DIFF
--- a/tooling/ssa_fuzzer/src/runner.rs
+++ b/tooling/ssa_fuzzer/src/runner.rs
@@ -29,6 +29,12 @@ pub fn run_and_compare(
 
     let return_witnesses_acir = &acir_program.functions[0].return_values;
     let return_witnesses_brillig = &brillig_program.functions[0].return_values;
+    if return_witnesses_acir.0.is_empty() && return_witnesses_brillig.0.is_empty() {
+        return CompareResults::BothFailed(
+            "The function does not return anything".into(),
+            "The function does not return anything".into(),
+        );
+    }
     assert_eq!(return_witnesses_acir.0.len(), 1, "Multiple return value witnesses encountered");
     assert_eq!(return_witnesses_brillig.0.len(), 1, "Multiple return value witnesses encountered");
     let return_witness_acir: &Witness = return_witnesses_acir.0.first().unwrap();


### PR DESCRIPTION
# Description

## Problem\*
The following SSA
```text
acir(inline) fn main f0 {
  b0(v0: i32, v1: i32, v2: u64, v3: i32, v4: u1, v5: u1, v6: u1):
    jmp b1()
  b1():
    v7 = or v0, v3
    v9 = mod v7, i32 0
    v10 = cast v4 as u8
    return v10
}
```
compiles into 
```text
acir(inline) predicate_pure fn main f0 {
  b0(v0: i32, v1: i32, v2: u64, v3: i32, v4: u1, v5: u1, v6: u1):
    v7 = or v0, v3
    v9 = mod v7, i32 0
    constrain u1 0 == u1 1, "attempt to calculate the remainder with a divisor of zero"
    unreachable
}
```
so the number of return values is 0 

## Summary\*



## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
