### PR TITLE
chore(ssa_fuzzer): taking witnesses from program

### DIFF
--- a/tooling/ssa_fuzzer/fuzzer/src/fuzz_lib/base_context.rs
+++ b/tooling/ssa_fuzzer/fuzzer/src/fuzz_lib/base_context.rs
@@ -3,7 +3,6 @@ use super::instruction::Instruction;
 use super::instruction::InstructionBlock;
 use super::options::{ProgramContextOptions, SsaBlockOptions};
 use acvm::FieldElement;
-use acvm::acir::native_types::Witness;
 use libfuzzer_sys::arbitrary;
 use libfuzzer_sys::arbitrary::Arbitrary;
 use noir_ssa_fuzzer::{
@@ -77,8 +76,6 @@ pub(crate) struct FuzzerContext {
     stored_variables_for_block: HashMap<BasicBlockId, HashMap<ValueType, Vec<TypedValue>>>,
     /// Hashmap of stored blocks
     stored_blocks: HashMap<BasicBlockId, StoredBlock>,
-    /// Whether the program is executed in constants
-    is_constant: bool,
     /// Options of the program context
     context_options: ProgramContextOptions,
     /// Number of instructions inserted in the program
@@ -129,7 +126,6 @@ impl FuzzerContext {
             instruction_blocks,
             stored_variables_for_block: HashMap::new(),
             stored_blocks: HashMap::new(),
-            is_constant: false,
             context_options,
             inserted_instructions_count: 0,
             inserted_ssa_blocks_count: 0,
@@ -184,7 +180,6 @@ impl FuzzerContext {
             instruction_blocks,
             stored_variables_for_block: HashMap::new(),
             stored_blocks: HashMap::new(),
-            is_constant: true,
             context_options,
             inserted_instructions_count: 0,
             inserted_ssa_blocks_count: 0,

--- a/tooling/ssa_fuzzer/fuzzer/src/fuzz_lib/base_context.rs
+++ b/tooling/ssa_fuzzer/fuzzer/src/fuzz_lib/base_context.rs
@@ -864,22 +864,6 @@ impl FuzzerContext {
             .finalize_block_with_return(&mut self.acir_builder, &mut self.brillig_builder);
     }
 
-    /// Returns witnesses for ACIR and Brillig
-    /// If program does not have any instructions, it terminated with the last witness
-    /// Resulting WitnessStack of programs contains only variables and return value
-    /// If we inserted some instructions, WitnessStack contains return value, so we return the last one
-    /// If we are checking constant folding, the witness stack will only contain the return value, so we return Witness(0)
-    pub(crate) fn get_return_witnesses(&self) -> (Witness, Witness) {
-        if self.is_constant {
-            (Witness(0), Witness(0))
-        } else {
-            (
-                Witness(super::NUMBER_OF_VARIABLES_INITIAL),
-                Witness(super::NUMBER_OF_VARIABLES_INITIAL),
-            )
-        }
-    }
-
     /// Returns programs for ACIR and Brillig
     pub(crate) fn get_programs(
         self,

--- a/tooling/ssa_fuzzer/fuzzer/src/fuzz_lib/fuzzer.rs
+++ b/tooling/ssa_fuzzer/fuzzer/src/fuzz_lib/fuzzer.rs
@@ -146,7 +146,7 @@ impl Fuzzer {
                             "ACIR compiled and successfully executed, \
                             but brillig compilation failed. Execution result of \
                             acir only {:?}. Brillig compilation failed with: {:?}",
-                            acir_result[&acir_return_witness], brillig_error
+                            acir_result[acir_return_witness], brillig_error
                         );
                     }
                     Err(acir_error) => {
@@ -166,7 +166,7 @@ impl Fuzzer {
                             "Brillig compiled and successfully executed, \
                             but ACIR compilation failed. Execution result of \
                             brillig only {:?}. ACIR compilation failed with: {:?}",
-                            brillig_result[&brillig_return_witness], acir_error
+                            brillig_result[brillig_return_witness], acir_error
                         );
                     }
                     Err(brillig_error) => {

--- a/tooling/ssa_fuzzer/fuzzer/src/fuzz_lib/options.rs
+++ b/tooling/ssa_fuzzer/fuzzer/src/fuzz_lib/options.rs
@@ -108,6 +108,7 @@ impl Default for FuzzerCommandOptions {
     }
 }
 
+#[derive(Clone)]
 pub struct FuzzerOptions {
     pub constrain_idempotent_morphing_enabled: bool,
     pub constant_execution_enabled: bool,
@@ -130,6 +131,20 @@ impl Default for FuzzerOptions {
             max_iterations_num: 1000,
             instruction_options: InstructionOptions::default(),
             fuzzer_command_options: FuzzerCommandOptions::default(),
+        }
+    }
+}
+
+impl From<&FuzzerOptions> for ProgramContextOptions {
+    fn from(options: &FuzzerOptions) -> ProgramContextOptions {
+        ProgramContextOptions {
+            idempotent_morphing_enabled: false,
+            compile_options: options.compile_options.clone(),
+            max_ssa_blocks_num: options.max_ssa_blocks_num,
+            max_instructions_num: options.max_instructions_num,
+            instruction_options: options.instruction_options,
+            fuzzer_command_options: options.fuzzer_command_options,
+            max_iterations_num: options.max_iterations_num,
         }
     }
 }


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*
1) Added ProgramContextOptions from FuzzerOptions
2) Got rid of taking return witness as NUMBER_OF_VARIABLES_INITIAL or 0 for constant mode 


## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
