### PR TITLE
fix(fuzz): Ignore `-0` vs `0` in parsing roundtrip

### DIFF
--- a/tooling/ast_fuzzer/tests/mono.rs
+++ b/tooling/ast_fuzzer/tests/mono.rs
@@ -94,9 +94,18 @@ fn monomorphize_snippet(source: String) -> Result<Program, Vec<CustomDiagnostic>
     Ok(program)
 }
 
+/// Get rid of superficial differences.
 fn sanitize(src: &str) -> String {
-    // Sometimes `;` is removed, or duplicated.
-    src.replace(";", "").replace("{}", "()").replace("--", "")
+    src
+        // Sometimes `;` is removed, or duplicated.
+        .replace(";", "")
+        // Sometimes a unit value is printed as () other times as {}
+        .replace("{}", "()")
+        // Double negation is removed during parsing
+        .replace("--", "")
+        // Negative zero is parsed as zero
+        // (NB we don't want to avoid generating -0, because there were bugs related to it).
+        .replace("-0", "0")
 }
 
 fn split_functions(src: &str) -> Vec<String> {


### PR DESCRIPTION
# Description

## Problem\*

Resolves the test failure in https://github.com/noir-lang/noir/actions/runs/16321067297/job/46099671705?pr=9221#step:6:1587

## Summary\*

Treat `-0` as `0` in the parsing and monomorphization roundtrip test. 

## Additional Context

To replicate the failure:
```shell
NOIR_AST_FUZZER_SEED=0x5be5e27a00001900 cargo test -p noir_ast_fuzzer --test mono
```

My initial thought was to tweak the AST generator not to produce `-0` in the first place, but then I remembered we had a [0 != -0 bug](https://github.com/noir-lang/noir/issues/8498), so we should rather keep it, and just ignore it in the test. Actually the fix for that bug is probably what caused this test failure, but we probably shouldn't assume that it can never happen again.

## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
