### PR TITLE
fix(fuzz): Use scoping for variable dynamism

### DIFF
--- a/tooling/ast_fuzzer/fuzz/src/targets/orig_vs_morph.rs
+++ b/tooling/ast_fuzzer/fuzz/src/targets/orig_vs_morph.rs
@@ -84,7 +84,7 @@ impl VariableContext {
     fn new(func: &Function) -> Self {
         let (next_local_id, next_ident_id) = rewrite::next_local_and_ident_id(func);
 
-        let locals = ScopeStack::new(
+        let locals = ScopeStack::from_variables(
             func.parameters
                 .iter()
                 .map(|(id, mutable, name, typ, _vis)| (*id, *mutable, name.clone(), typ.clone())),

--- a/tooling/ast_fuzzer/src/program/scope.rs
+++ b/tooling/ast_fuzzer/src/program/scope.rs
@@ -23,7 +23,7 @@ where
     K: Ord + Clone + Copy + Debug,
 {
     /// Create the initial scope from function parameters.
-    pub fn new(vars: impl Iterator<Item = (K, bool, Name, Type)>) -> Self {
+    pub fn from_variables(vars: impl Iterator<Item = (K, bool, Name, Type)>) -> Self {
         let mut scope = Self { variables: im::OrdMap::new(), producers: im::OrdMap::new() };
         for (id, mutable, name, typ) in vars {
             scope.add(id, mutable, name, typ);
@@ -144,25 +144,26 @@ where
 }
 
 /// Scope stack as we exit and enter blocks
-pub struct ScopeStack<K: Ord>(Vec<Scope<K>>);
+pub struct Stack<T>(Vec<T>);
 
-impl<K> ScopeStack<K>
-where
-    K: Ord + Clone + Copy + Debug,
-{
-    /// Create a stack from the base variables.
-    pub fn new(vars: impl Iterator<Item = (K, bool, Name, Type)>) -> Self {
-        Self(vec![Scope::new(vars)])
+impl<T: Clone> Stack<T> {
+    /// Create a stack from the base layer.
+    pub fn new(base: T) -> Self {
+        Self(vec![base])
     }
 
     /// The top scope in the stack.
-    pub fn current(&self) -> &Scope<K> {
+    pub fn current(&self) -> &T {
         self.0.last().expect("there is always the base layer")
+    }
+
+    /// The top scope in the stack.
+    pub fn current_mut(&mut self) -> &mut T {
+        self.0.last_mut().expect("there is always the base layer")
     }
 
     /// Push a new scope on top of the current one.
     pub fn enter(&mut self) {
-        // Instead of shallow cloning an immutable map, we could loop through layers when looking up variables.
         self.0.push(self.current().clone());
     }
 
@@ -170,6 +171,19 @@ where
     pub fn exit(&mut self) {
         self.0.pop();
         assert!(!self.0.is_empty(), "never pop the base layer");
+    }
+}
+
+/// Scope stack as we exit and enter blocks
+pub type ScopeStack<K> = Stack<Scope<K>>;
+
+impl<K> ScopeStack<K>
+where
+    K: Ord + Clone + Copy + Debug,
+{
+    /// Create a stack from the base variables.
+    pub fn from_variables(vars: impl Iterator<Item = (K, bool, Name, Type)>) -> Self {
+        Self(vec![Scope::from_variables(vars)])
     }
 
     /// Add a new variable to the current scope.
@@ -198,8 +212,9 @@ mod tests {
         let foo_type =
             Type::Tuple(vec![Type::Field, Type::Bool, Type::Array(4, Box::new(types::U32))]);
 
-        let mut stack =
-            ScopeStack::new([(LocalId(0), false, "foo".to_string(), foo_type)].into_iter());
+        let mut stack = ScopeStack::from_variables(
+            [(LocalId(0), false, "foo".to_string(), foo_type)].into_iter(),
+        );
 
         stack.enter();
         stack.add(LocalId(1), false, "bar".to_string(), Type::String(10));

--- a/tooling/ast_fuzzer/src/program/scope.rs
+++ b/tooling/ast_fuzzer/src/program/scope.rs
@@ -1,6 +1,6 @@
 use arbitrary::Unstructured;
 use noirc_frontend::monomorphization::ast::Type;
-use std::fmt::Debug;
+use std::{fmt::Debug, vec};
 
 use super::{Name, types};
 
@@ -171,6 +171,11 @@ impl<T: Clone> Stack<T> {
     pub fn exit(&mut self) {
         self.0.pop();
         assert!(!self.0.is_empty(), "never pop the base layer");
+    }
+
+    /// Iterate over the layers, starting the base layer.
+    pub fn iter_mut(&mut self) -> std::slice::IterMut<T> {
+        self.0.iter_mut()
     }
 }
 


### PR DESCRIPTION
# Description

## Problem\*

Resolves #9226

## Summary\*

Fixes the AST generator to use a scoping mechanism similar to the local variables to keep track of which variable is dynamic:
* When a variable is created, it is added to the current layer with its starting dynamism setting.
* When a new scope is entered, it inherits the parent scope dynamism.
* When the scope is exited, the dynamism settings of the top layer are removed.
* When a variable is assigned:
  * If it's dynamic, all ancestor scopes where it's present become dynamic
  * If it's no longer dynamic, only the current and potential future child scopes are affected

## Additional Context

The problem was that I only made a single set to collect all dynamic variables. When a variable got reassigned, and it was no longer dynamic, it was removed from this set. However, I forgot to consider that the reassignment might only happen within a scope, and outside that scope we wouldn't statically know whether the variable was dynamic or not.




## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
