### PR TITLE
chore: Remove references to the deprecated grants program

### DIFF
--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -23,10 +23,6 @@ When submitting an issue, please include as much detail as possible about the er
 
 Noir is still very new and there are many cryptographic primitives that we have yet to build that will be useful for the community. If you have other ideas, please reach out on the [Noir Discord](https://discord.gg/YpCUTkzTC7) to discuss. You can find the current list of requested primitives in the [issues section](https://github.com/noir-lang/noir/labels/noir-stdlib) marked with the label `noir-stdlib`.
 
-## Funding Opportunities
-
-Aztec is offering grants to people and teams that want to use, test or build Noir. You can find more information about the grants program [here](https://aztec.network/grants).
-
 ## Full-time Contributors
 
 Aztec is hiring a wide variety of software engineers, so if you would like to work on Noir full-time consider applying for an [open role](https://aztec-labs.com/jobs).


### PR DESCRIPTION
# Description

## Problem\*

The grants program has been deprecated. All links or mentions to it should be removed to minimize community confusions.

## Summary\*

Removes the "Funding Opportunities" section in SUPPORT.md that's basically just linking to https://aztec.network/grants.

## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
