### PR TITLE
fix: parse AsTraitPath in type expressions

### DIFF
--- a/test_programs/compile_success_empty/as_trait_path_type_expression/Nargo.toml
+++ b/test_programs/compile_success_empty/as_trait_path_type_expression/Nargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "as_trait_path_type_expression"
+type = "bin"
+authors = [""]
+
+[dependencies]

--- a/test_programs/compile_success_empty/as_trait_path_type_expression/src/main.nr
+++ b/test_programs/compile_success_empty/as_trait_path_type_expression/src/main.nr
@@ -1,0 +1,14 @@
+use std::mem::zeroed;
+
+trait Trait {
+    let N: u32;
+}
+
+impl Trait for Field {
+    let N: u32 = 10;
+}
+
+fn main() {
+    let something: [Field; <Field as Trait>::N] = zeroed();
+    assert_eq(something.len(), <Field as Trait>::N);
+}

--- a/tooling/nargo_cli/build.rs
+++ b/tooling/nargo_cli/build.rs
@@ -178,7 +178,7 @@ const TESTS_WITHOUT_STDOUT_CHECK: [&str; 0] = [];
 /// These tests are ignored because of existing bugs in `nargo expand`.
 /// As the bugs are fixed these tests should be removed from this list.
 /// (some are ignored on purpose for the same reason as `IGNORED_NARGO_EXPAND_EXECUTION_TESTS`)
-const IGNORED_NARGO_EXPAND_COMPILE_SUCCESS_EMPTY_TESTS: [&str; 10] = [
+const IGNORED_NARGO_EXPAND_COMPILE_SUCCESS_EMPTY_TESTS: [&str; 9] = [
     // bug
     "associated_type_bounds",
     // bug
@@ -198,8 +198,6 @@ const IGNORED_NARGO_EXPAND_COMPILE_SUCCESS_EMPTY_TESTS: [&str; 10] = [
     "workspace_reexport_bug",
     // bug
     "type_trait_method_call_multiple_candidates",
-    // bug
-    "alias_trait_method_call_multiple_candidates",
 ];
 
 /// These tests are ignored because of existing bugs in `nargo expand`.

--- a/tooling/nargo_cli/build.rs
+++ b/tooling/nargo_cli/build.rs
@@ -178,7 +178,7 @@ const TESTS_WITHOUT_STDOUT_CHECK: [&str; 0] = [];
 /// These tests are ignored because of existing bugs in `nargo expand`.
 /// As the bugs are fixed these tests should be removed from this list.
 /// (some are ignored on purpose for the same reason as `IGNORED_NARGO_EXPAND_EXECUTION_TESTS`)
-const IGNORED_NARGO_EXPAND_COMPILE_SUCCESS_EMPTY_TESTS: [&str; 9] = [
+const IGNORED_NARGO_EXPAND_COMPILE_SUCCESS_EMPTY_TESTS: [&str; 8] = [
     // bug
     "associated_type_bounds",
     // bug
@@ -196,8 +196,6 @@ const IGNORED_NARGO_EXPAND_COMPILE_SUCCESS_EMPTY_TESTS: [&str; 9] = [
     "trait_static_methods",
     // There's no "src/main.nr" here so it's trickier to make this work
     "workspace_reexport_bug",
-    // bug
-    "type_trait_method_call_multiple_candidates",
 ];
 
 /// These tests are ignored because of existing bugs in `nargo expand`.

--- a/tooling/nargo_cli/build.rs
+++ b/tooling/nargo_cli/build.rs
@@ -178,7 +178,7 @@ const TESTS_WITHOUT_STDOUT_CHECK: [&str; 0] = [];
 /// These tests are ignored because of existing bugs in `nargo expand`.
 /// As the bugs are fixed these tests should be removed from this list.
 /// (some are ignored on purpose for the same reason as `IGNORED_NARGO_EXPAND_EXECUTION_TESTS`)
-const IGNORED_NARGO_EXPAND_COMPILE_SUCCESS_EMPTY_TESTS: [&str; 14] = [
+const IGNORED_NARGO_EXPAND_COMPILE_SUCCESS_EMPTY_TESTS: [&str; 10] = [
     // bug
     "associated_type_bounds",
     // bug
@@ -188,14 +188,6 @@ const IGNORED_NARGO_EXPAND_COMPILE_SUCCESS_EMPTY_TESTS: [&str; 14] = [
     // this one works, but copying its `Nargo.toml` file to somewhere else doesn't work
     // because it references another project by a relative path
     "reexports",
-    // bug
-    "serialize_1",
-    // bug
-    "serialize_2",
-    // bug
-    "serialize_3",
-    // bug
-    "serialize_4",
     // bug
     "trait_function_calls",
     // bug
@@ -223,8 +215,6 @@ const IGNORED_NARGO_EXPAND_COMPILE_SUCCESS_NO_BUG_TESTS: [&str; 10] = [
     "noirc_frontend_tests_traits_accesses_associated_type_inside_trait_impl_using_self",
     "noirc_frontend_tests_traits_accesses_associated_type_inside_trait_using_self",
     "noirc_frontend_tests_u32_globals_as_sizes_in_types",
-    // "noirc_frontend_tests_traits_as_trait_path_called_multiple_times_for_different_t_1",
-    // "noirc_frontend_tests_traits_as_trait_path_called_multiple_times_for_different_t_2",
 ];
 
 const IGNORED_NARGO_EXPAND_COMPILE_SUCCESS_WITH_BUG_TESTS: [&str; 1] =

--- a/tooling/nargo_cli/tests/snapshots/compile_success_empty/as_trait_path_type_expression/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_empty/as_trait_path_type_expression/execute__tests__expanded.snap
@@ -1,0 +1,18 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: expanded_code
+---
+use std::mem::zeroed;
+
+trait Trait {
+    let N: u32;
+}
+
+impl Trait for Field {
+    let N: u32 = 10;
+}
+
+fn main() {
+    let something: [Field; 10] = zeroed();
+    assert(something.len() == <Field as Trait>::N);
+}

--- a/tooling/nargo_cli/tests/snapshots/compile_success_empty/as_trait_path_type_expression/execute__tests__force_brillig_false_inliner_0.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_empty/as_trait_path_type_expression/execute__tests__force_brillig_false_inliner_0.snap
@@ -1,0 +1,26 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: artifact
+---
+{
+  "noir_version": "[noir_version]",
+  "hash": "[hash]",
+  "abi": {
+    "parameters": [],
+    "return_type": null,
+    "error_types": {}
+  },
+  "bytecode": [
+    "func 0",
+    "current witness index : _0",
+    "private parameters indices : []",
+    "public parameters indices : []",
+    "return value indices : []"
+  ],
+  "debug_symbols": "XY5BCsQwCEXv4rqLWfcqw1BsaosgJtikMITefWyYQOlK/3/6tcJCc9km1jXuML4rzMYivE0SA2aO6m49B+hyykbkFty4byU00gyjFpEBDpTShvaE2mpGc/oagHTx6oErC13d+XGBge158UBjnIX+ci0abjR/Uyf942Qx0FKMrqTGPPsH",
+  "file_map": {},
+  "names": [
+    "main"
+  ],
+  "brillig_names": []
+}

--- a/tooling/nargo_cli/tests/snapshots/compile_success_empty/serialize_1/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_empty/serialize_1/execute__tests__expanded.snap
@@ -68,6 +68,7 @@ impl Serialize for Field {
 }
 
 fn main() {
-    let x: (Field, [Field; 3]) = (1_Field, [2_Field, 3_Field, 4_Field]);
-    assert(x.serialize().len() == 4_u32);
+    let x: (((Field, [Field; 3]), [Field; 4]), Field) =
+        (((1_Field, [2_Field, 3_Field, 4_Field]), [5_Field, 6_Field, 7_Field, 8_Field]), 9_Field);
+    assert(x.serialize().len() == 9_u32);
 }

--- a/tooling/nargo_cli/tests/snapshots/compile_success_empty/serialize_2/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_empty/serialize_2/execute__tests__expanded.snap
@@ -5,63 +5,27 @@ expression: expanded_code
 trait Serialize {
     let Size: u32;
 
-    fn serialize(self) -> [Field; Size];
-}
-
-impl<A, B> Serialize for (A, B) where A: Serialize, B: Serialize {
-    type Size = <A as Serialize>::Size + <B as Serialize>::Size;
-
-    fn serialize(self) -> [Field; <A as Serialize>::Size + <B as Serialize>::Size] where A: Serialize, B: Serialize {
-        let mut array: [Field; <A as Serialize>::Size + <B as Serialize>::Size] = std::mem::zeroed();
-        let a: [Field; <A as Serialize>::Size] = Serialize::serialize(self.0);
-        let b: [Field; <B as Serialize>::Size] = Serialize::serialize(self.1);
-        for i in 0..a.len() {
-            array[i] = a[i];
-        };
-        for i in 0..b.len() {
-            {
-                let i_3793: u32 = i + a.len();
-                array[i_3793] = b[i];
-            }
-        };
-        array
-    }
-}
-
-impl<let N: u32, T> Serialize for [T; N] where T: Serialize {
-    type Size = N * <T as Serialize>::Size;
-
-    fn serialize(self) -> [Field; N * <T as Serialize>::Size] where T: Serialize {
-        let mut array: [Field; N * <T as Serialize>::Size] = std::mem::zeroed();
-        let mut array_i: Field = 0;
-        {
-            let ___i0: Self = self;
-            for ___i1 in 0..___i0.len() {
-                let elem: T = ___i0[___i1];
-                {
-                    let elem_fields: [Field; <T as Serialize>::Size] = Serialize::serialize(elem);
-                    for i in 0..elem_fields.len() {
-                        array[array_i] = elem_fields[i];
-                        array_i = array_i + 1;
-                    }
-                }
-            }
-        };
-        array
-    }
+    fn serialize(self);
 }
 
 impl Serialize for Field {
     let Size: u32 = 1;
 
-    fn serialize(self) -> [Self; 1] {
-        [self]
+    fn serialize(self) {}
+}
+
+impl<A> Serialize for (A,)
+where
+    A: Serialize,
+{
+    let Size: u32 = <A as Serialize>::Size;
+
+    fn serialize(self) {
+        self.0.serialize();
     }
 }
 
 fn main() {
-    let x: (((Field, [Field; 3]), [Field; 4]), Field) = (((1, [2, 3, 4]), [5, 6, 7, 8]), 9);
-    assert(x.serialize().len() == 9);
+    let x: ((Field,),) = ((1_Field,),);
+    x.serialize();
 }
-
-// Warning: the generated code has syntax errors

--- a/tooling/nargo_cli/tests/snapshots/compile_success_empty/serialize_3/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_empty/serialize_3/execute__tests__expanded.snap
@@ -5,30 +5,43 @@ expression: expanded_code
 trait Serialize {
     let Size: u32;
 
-    fn serialize(self);
+    fn serialize(self) -> [Field; Size];
+}
+
+impl<A, B> Serialize for (A, B)
+where
+    A: Serialize,
+    B: Serialize,
+{
+    let Size: u32 = <A as Serialize>::Size + <B as Serialize>::Size;
+
+    fn serialize(self) -> [Field; <A as Serialize>::Size + <B as Serialize>::Size] {
+        let _: [Field; <A as Serialize>::Size] = self.0.serialize();
+        [0_Field; <A as Serialize>::Size + <B as Serialize>::Size]
+    }
+}
+
+impl<let N: u32, T> Serialize for [T; N]
+where
+    T: Serialize,
+{
+    let Size: u32 = N * <T as Serialize>::Size;
+
+    fn serialize(self) -> [Field; N * <T as Serialize>::Size] {
+        [0_Field; N * <T as Serialize>::Size]
+    }
 }
 
 impl Serialize for Field {
     let Size: u32 = 1;
 
-    fn serialize(self) {}
-}
-
-impl<A> Serialize for (A,)
-where
-    A: Serialize,
-{
-    type Size = <A as Serialize>::Size;
-
-    fn serialize(self)
-    where
-        A: Serialize,
-    {
-        Serialize::serialize(self.0);
+    fn serialize(self) -> [Self; 1] {
+        [self]
     }
 }
 
 fn main() {
-    let x: ((Field,),) = ((1,),);
-    x.serialize();
+    let x: (((Field, [Field; 3]), [Field; 4]), Field) =
+        (((1_Field, [2_Field, 3_Field, 4_Field]), [5_Field, 6_Field, 7_Field, 8_Field]), 9_Field);
+    assert(x.serialize().len() == 9_u32);
 }

--- a/tooling/nargo_fmt/src/formatter/type_expression.rs
+++ b/tooling/nargo_fmt/src/formatter/type_expression.rs
@@ -23,8 +23,8 @@ impl Formatter<'_> {
                 self.write_space();
                 self.format_type_expression(*rhs);
             }
-            UnresolvedTypeExpression::AsTraitPath(..) => {
-                unreachable!("Should not be present in the AST")
+            UnresolvedTypeExpression::AsTraitPath(as_trait_path) => {
+                self.format_as_trait_path(*as_trait_path);
             }
         }
 

--- a/tooling/nargo_fmt/src/formatter/types.rs
+++ b/tooling/nargo_fmt/src/formatter/types.rs
@@ -354,4 +354,11 @@ mod tests {
         let expected = "<Field as foo::Bar>::baz";
         assert_format_type(src, expected);
     }
+
+    #[test]
+    fn format_as_trait_path_type_expression() {
+        let src = "[ Field ; < Field as foo :: Bar> :: baz ]";
+        let expected = "[Field; <Field as foo::Bar>::baz]";
+        assert_format_type(src, expected);
+    }
 }


### PR DESCRIPTION
# Description

## Problem

Resolves #5794

## Summary

I don't know if I missed this while porting the old parser.

That said, this currently doesn't work if `AsTraitPath` is used in a function signature. That is, this doesn't compile:

```noir
use std::mem::zeroed;

trait Trait {
    let N: u32;
}

impl Trait for Field {
    let N: u32 = 10;
}

fn main() {}

fn foo(x: [Field; <Field as Trait>::N]) {} // No matching impl found for `Field: Trait<N = _>`
```

I think the reason is that function signatures are checked before impls are processed, not sure. In any case this PR at least makes the use case in the linked issue work.

## Additional Context



## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
