### PR TITLE
chore(docs): Add links to ACIR and source reference docs

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -68,6 +68,16 @@ export default {
           position: 'right',
         },
         {
+          href: 'https://noir-lang.github.io/noir/docs/acir/circuit/index.html',
+          label: 'ACIR reference',
+          position: 'right',
+        },
+        {
+          href: 'https://noir-lang.github.io/noir/docs/nargo/index.html',
+          label: 'Source reference',
+          position: 'right',
+        },
+        {
           type: 'docsVersionDropdown',
           position: 'left',
           dropdownActiveClassDisabled: true,


### PR DESCRIPTION
# Description

Adds external links to the ACIR and nargo source docs on the navbar.

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*



## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
