### PR TITLE
lets see the effect

### DIFF
--- a/compiler/noirc_evaluator/src/acir/acir_context/mod.rs
+++ b/compiler/noirc_evaluator/src/acir/acir_context/mod.rs
@@ -1555,9 +1555,6 @@ impl<F: AcirField, B: BlackBoxFunctionSolver<F>> AcirContext<F, B> {
             }
             Some(optional_value) => {
                 let mut values = Vec::new();
-                if let AcirValue::DynamicArray(_) = optional_value {
-                    unreachable!("Dynamic array should already be initialized");
-                }
                 self.initialize_array_inner(&mut values, optional_value)?;
                 values
             }

--- a/compiler/noirc_evaluator/src/acir/arrays.rs
+++ b/compiler/noirc_evaluator/src/acir/arrays.rs
@@ -243,13 +243,6 @@ impl Context<'_> {
             // as if the predicate were true. This is as if the predicate were to resolve to false then
             // the result should not affect the rest of circuit execution.
             let value = array[index].clone();
-            // An `Array` might contain a `DynamicArray`, however if we define the result this way,
-            // we would bypass the array initialization and the handling of dynamic values that
-            // happens in `array_get_value`. Rather than repeat it here, let the non-special-case
-            // handling take over by returning `false`.
-            if matches!(value, AcirValue::DynamicArray(_)) {
-                return Ok(false);
-            }
             self.define_result(dfg, instruction, value);
             Ok(true)
         }


### PR DESCRIPTION
# Description

## Problem\*

I want to see the effect of removing the panic in `initialize_array` as https://github.com/noir-lang/noir/pull/9259 looks to have led to some timing regressions. 

## Summary\*



## Additional Context



## Documentation\*

Check one:
- [X] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
