### PR TITLE
fix: Use `u32` in `RepeatedValue` example in generics docs

### DIFF
--- a/docs/docs/noir/concepts/generics.md
+++ b/docs/docs/noir/concepts/generics.md
@@ -53,7 +53,7 @@ struct will be of a certain generic type. In this case `value` is of type `T`.
 ```rust
 struct RepeatedValue<T> {
     value: T,
-    count: Field,
+    count: u32,
 }
 
 impl<T> RepeatedValue<T> {


### PR DESCRIPTION
# Description

## Problem\*

Resolves https://github.com/noir-lang/noir/issues/9268

## Summary\*



## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [x] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
