### PR TITLE
feat: add better handling for follow-on optimizations in `simplify_cfg`

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/opt/simplify_cfg.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/simplify_cfg.rs
@@ -95,7 +95,7 @@ impl Function {
                 // optimizations performed after this point on the same block should check if
                 // the inlining here was successful before continuing.
                 if try_inline_into_predecessor(self, &mut cfg, block, predecessor) {
-                    stack.push(block);
+                    stack.push(predecessor);
                 };
             } else {
                 drop(predecessors);


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This PR modifies the `simplify_cfg` pass so it's more likely to catch further simplifications which are uncovered. This is done by pushing the current block back onto the stack if we've successfully simplified it.

I've also added an explicit check for unreachable blocks which may exist on the stack (e.g. an orphaned block from a constant condition jmpif) so we can ensure that its successors are removed and we don't consider it any further.
## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
