### PR TITLE
chore: Mark `sparse_array` and `noir_json_parser` as non-critical

### DIFF
--- a/EXTERNAL_NOIR_LIBRARIES.yml
+++ b/EXTERNAL_NOIR_LIBRARIES.yml
@@ -47,11 +47,11 @@ libraries:
   sparse_array:
     repo: noir-lang/sparse_array
     timeout: 3
-    critical: true
+    critical: false
   noir_json_parser:
     repo: noir-lang/noir_json_parser
     timeout: 12
-    critical: true
+    critical: false
   sha256:
     repo: noir-lang/sha256
     timeout: 3


### PR DESCRIPTION
# Description

## Problem\*

Resolves https://github.com/noir-lang/noir/issues/9281.

## Summary\*

Update criticality statuses of `sparse_array` and `noir_json_parser` to non-critical in https://github.com/noir-lang/noir/blob/master/EXTERNAL_NOIR_LIBRARIES.yml.

## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
