### PR TITLE
refactor: simplify boolean comparisons and improve clarity

### DIFF
--- a/docs/scripts/preprocess/include_code.js
+++ b/docs/scripts/preprocess/include_code.js
@@ -153,7 +153,7 @@ function doExtractCodeSnippet(filePath, identifier, useCurrent) {
             }
           }
         } else {
-          if (matchFound === true) {
+          if (matchFound) {
             throw new Error(`Duplicate for regex ${regex} and identifier ${identifier}`);
           }
           matchFound = true;

--- a/noir_stdlib/src/array/check_shuffle.nr
+++ b/noir_stdlib/src/array/check_shuffle.nr
@@ -21,7 +21,7 @@ where
                 continue;
             }
         }
-        assert(found == true, "check_shuffle, lhs and rhs arrays do not contain equivalent values");
+        assert(found, "check_shuffle, lhs and rhs arrays do not contain equivalent values");
     }
 
     shuffle_indices

--- a/test_programs/compile_success_empty/conditional_regression_579/src/main.nr
+++ b/test_programs/compile_success_empty/conditional_regression_579/src/main.nr
@@ -19,7 +19,7 @@ impl MyStruct579 {
 fn test(flag: bool) -> MyStruct579 {
     let mut my_struct = MyStruct579::new([0; 2]);
 
-    if flag == true {
+    if flag {
         my_struct = MyStruct579::new([1; 2]);
     }
     my_struct

--- a/test_programs/execution_success/loop/src/main.nr
+++ b/test_programs/execution_success/loop/src/main.nr
@@ -9,7 +9,7 @@ fn main(six_as_u32: u32) {
 
     // Safety: testing context
     unsafe {
-        assert(basic_break() == true)
+        assert(basic_break())
     }
 }
 

--- a/test_programs/execution_success/pred_eq/src/main.nr
+++ b/test_programs/execution_success/pred_eq/src/main.nr
@@ -1,4 +1,4 @@
 fn main(x: Field, y: Field) {
     let p = x == y;
-    assert(p == true);
+    assert(p);
 }

--- a/test_programs/execution_success/struct/src/main.nr
+++ b/test_programs/execution_success/struct/src/main.nr
@@ -61,8 +61,8 @@ fn main(x: Field, y: Field) {
     assert(p.first.array[0] != p.first.array[1]);
     // Nested structs
     let (struct_from_tuple, a_bool) = test_struct_in_tuple(true, x, y);
-    assert(struct_from_tuple.my_bool == true);
-    assert(a_bool == true);
+    assert(struct_from_tuple.my_bool);
+    assert(a_bool);
     assert(struct_from_tuple.my_int == 5);
     assert(struct_from_tuple.my_nest.a == 0);
     // Regression test for issue #670

--- a/tooling/nargo_fmt/tests/expected/struct.nr
+++ b/tooling/nargo_fmt/tests/expected/struct.nr
@@ -58,8 +58,8 @@ fn main(x: Field, y: Field) {
 
     // Nested structs
     let (struct_from_tuple, a_bool) = test_struct_in_tuple(true, x, y);
-    assert(struct_from_tuple.my_bool == true);
-    assert(a_bool == true);
+    assert(struct_from_tuple.my_bool);
+    assert(a_bool);
     assert(struct_from_tuple.my_int == 5);
     assert(struct_from_tuple.my_nest.a == 0);
 

--- a/tooling/nargo_fmt/tests/input/struct.nr
+++ b/tooling/nargo_fmt/tests/input/struct.nr
@@ -62,8 +62,8 @@ fn main(x: Field, y: Field) {
 
     // Nested structs
     let (struct_from_tuple, a_bool) = test_struct_in_tuple(true,x,y);
-    assert(struct_from_tuple.my_bool == true);
-    assert(a_bool == true);
+    assert(struct_from_tuple.my_bool);
+    assert(a_bool);
     assert(struct_from_tuple.my_int == 5);
     assert(struct_from_tuple.my_nest.a == 0);
 


### PR DESCRIPTION
# Description

## Problem\*
Multiple code segments used redundant comparisons like == true or == false, which clutter readability and go against idiomatic style.

## Summary\*

- Replaced == true and == false with direct boolean usage (e.g., if flag == true → if flag).

- Updated several assert(...) == true statements to cleaner assert(...).

- Simplified conditionals across Noir standard library and test programs.

- Improved error messaging and removed redundant logic in a JS preprocessor.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
