### PR TITLE
fix: throw error if foreign call returns the wrong number of fields

### DIFF
--- a/acvm-repo/brillig/src/opcodes.rs
+++ b/acvm-repo/brillig/src/opcodes.rs
@@ -84,6 +84,18 @@ impl HeapValueType {
     pub fn field() -> HeapValueType {
         HeapValueType::Simple(BitSize::Field)
     }
+
+    pub fn flattened_size(&self) -> usize {
+        match self {
+            HeapValueType::Simple(_) => 1,
+            HeapValueType::Array { value_types, size } => {
+                value_types.iter().map(|t| t.flattened_size()).sum::<usize>() * size
+            }
+            HeapValueType::Vector { value_types } => {
+                value_types.iter().map(|t| t.flattened_size()).sum()
+            }
+        }
+    }
 }
 
 /// A fixed-sized array starting from a Brillig memory location.


### PR DESCRIPTION
# Description

## Problem\*

Resolves https://aztecprotocol.slack.com/archives/C04QF64EDNV/p1753216370658889

## Summary\*

This PR adds more validation on foreign call return results to throw an error if we get a differing number of values from the user.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
