### PR TITLE
chore: Document type coercions

### DIFF
--- a/docs/docs/noir/concepts/data_types/coercions.md
+++ b/docs/docs/noir/concepts/data_types/coercions.md
@@ -1,0 +1,55 @@
+---
+title: Type Coercions
+description:
+  Noir's various type coercions
+keywords:
+  [
+    noir,
+    types,
+    coercions,
+    casts,
+  ]
+sidebar_position: 11
+---
+
+When one type is required in Noir code but a different type is given, the compiler will typically issue
+a type error. There are a few cases however where the compiler will instead automatically perform a
+type coercion. These are typically limited to a few type pairs where converting from one to the other
+will not sacrifice performance or correctness. Currently, Noir will will try to perform the following
+type coercions:
+
+| Actual Type   | Expected Type               |
+| ------------- | --------------------------- |
+| `[T; N]`      | `[T]`                       |
+| `fn(..) -> R` | `unconstrained fn(..) -> R` |
+| `str<N>`      | `CtString`                  |
+| `&mut T`      | `&T`                        |
+
+Note that:
+- Conversions are only from the actual type to the expected type, never the other way around.
+- Conversions are only performed on the outermost type, they're never performed within a nested type.
+- `CtString` is a compile-time only type, so this conversion is only valid in [comptime code](../../concepts/comptime.md).
+- `&T` requires the experimental `-Zownership` flag to be enabled.
+
+Examples:
+```noir
+fn requires_slice(_slice: [Field]) {}
+comptime fn requires_ct_string(_s: CtString) {}
+
+fn main() {
+    let array: [Field; 4] = [1, 2, 3, 4];
+
+    // Ok - array is converted to a slice
+    requires_slice(array);
+    // equivalent to:
+    requires_slice(array.as_slice());
+
+    // coerce a constrained function to an unconstrained one:
+    let f: unconstrained fn([Field]) = requires_slice;
+
+    comptime {
+        // Passing a str<6> where a CtString is expected
+        requires_ct_string("hello!")
+    }
+}
+```


### PR DESCRIPTION
# Description

## Problem\*

Resolves https://github.com/noir-lang/noir/issues/9036

## Summary\*



## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [x] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
