### PR TITLE
fix: top-level item in dependency isn't always visible

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/path_resolution.rs
+++ b/compiler/noirc_frontend/src/elaborator/path_resolution.rs
@@ -468,7 +468,11 @@ impl Elaborator<'_> {
             });
         }
 
-        let plain_or_crate = matches!(path.kind, PathKind::Plain | PathKind::Crate);
+        let first_segment_is_always_visible = match path.kind {
+            PathKind::Crate => true,
+            PathKind::Plain => importing_module == starting_module,
+            PathKind::Dep | PathKind::Super | PathKind::Resolved(_) => false,
+        };
 
         // The current module and module ID as we resolve path segments
         let mut current_module_id = starting_module;
@@ -551,7 +555,7 @@ impl Elaborator<'_> {
 
             // If the path is plain or crate, the first segment will always refer to
             // something that's visible from the current module.
-            if !((plain_or_crate && index == 0)
+            if !((first_segment_is_always_visible && index == 0)
                 || item_in_module_is_visible(
                     self.def_maps,
                     importing_module,

--- a/compiler/noirc_frontend/src/hir/resolution/import.rs
+++ b/compiler/noirc_frontend/src/hir/resolution/import.rs
@@ -323,7 +323,11 @@ impl<'def_maps, 'usage_tracker, 'references_tracker>
             });
         }
 
-        let plain_or_crate = matches!(path.kind, PathKind::Plain | PathKind::Crate);
+        let first_segment_is_always_visible = match path.kind {
+            PathKind::Crate => true,
+            PathKind::Plain => self.importing_module == starting_module,
+            PathKind::Dep | PathKind::Super | PathKind::Resolved(_) => false,
+        };
 
         // The current module and module ID as we resolve path segments
         let mut current_module_id = starting_module;
@@ -375,9 +379,7 @@ impl<'def_maps, 'usage_tracker, 'references_tracker>
                 ModuleDefId::GlobalId(_) => panic!("globals cannot be in the type namespace"),
             };
 
-            // If the path is plain or crate, the first segment will always refer to
-            // something that's visible from the current module.
-            if !((plain_or_crate && index == 0)
+            if !((first_segment_is_always_visible && index == 0)
                 || self.item_in_module_is_visible(current_module_id, visibility))
             {
                 errors.push(PathResolutionError::Private(last_ident.clone()));

--- a/test_programs/compile_failure/access_private_dependency_item/Nargo.toml
+++ b/test_programs/compile_failure/access_private_dependency_item/Nargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "access_private_dependency_item"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.33.0"
+
+[dependencies]
+foo = { path = "./foo" }

--- a/test_programs/compile_failure/access_private_dependency_item/foo/Nargo.toml
+++ b/test_programs/compile_failure/access_private_dependency_item/foo/Nargo.toml
@@ -1,0 +1,5 @@
+[package]
+name = "foo"
+type = "lib"
+authors = [""]
+compiler_version = ">=0.31.0"

--- a/test_programs/compile_failure/access_private_dependency_item/foo/src/lib.nr
+++ b/test_programs/compile_failure/access_private_dependency_item/foo/src/lib.nr
@@ -1,0 +1,3 @@
+mod bar {
+    pub fn baz() {}
+}

--- a/test_programs/compile_failure/access_private_dependency_item/src/main.nr
+++ b/test_programs/compile_failure/access_private_dependency_item/src/main.nr
@@ -1,0 +1,6 @@
+use foo::bar::baz;
+
+fn main() {
+    foo::bar::baz();
+    baz();
+}

--- a/tooling/nargo_cli/tests/snapshots/compile_failure/access_private_dependency_item/execute__tests__stderr.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_failure/access_private_dependency_item/execute__tests__stderr.snap
@@ -1,0 +1,19 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: stderr
+---
+error: bar is private and not visible from the current module
+  ┌─ src/main.nr:1:10
+  │
+1 │ use foo::bar::baz;
+  │          --- bar is private
+  │
+
+error: bar is private and not visible from the current module
+  ┌─ src/main.nr:4:10
+  │
+4 │     foo::bar::baz();
+  │          --- bar is private
+  │
+
+Aborting due to 2 previous errors


### PR DESCRIPTION
# Description

## Problem

Resolves #9277

## Summary

When there's a path `foo::bar::baz`, it's guaranteed that `foo` is always visible from where we are at. That's what the code did. However, that logic of "is this is first segment?" was also triggered when dependencies were solved. For example if we have `some_dependency::foo::bar::baz`, the code would first solve `some_dependency`, then solve `foo::bar::baz` starting from that dependency. In that case it's no longer true that the first segment is always visible.

## Additional Context

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
