### PR TITLE
chore(docs): Copy Type Coercions docs into v1.0.0-beta.8 versioned docs

### DIFF
--- a/docs/docs/noir/concepts/data_types/coercions.md
+++ b/docs/docs/noir/concepts/data_types/coercions.md
@@ -32,7 +32,7 @@ Note that:
 - `&T` requires the experimental `-Zownership` flag to be enabled.
 
 Examples:
-```noir
+```rust
 fn requires_slice(_slice: [Field]) {}
 comptime fn requires_ct_string(_s: CtString) {}
 

--- a/docs/versioned_docs/version-v1.0.0-beta.8/noir/concepts/data_types/coercions.md
+++ b/docs/versioned_docs/version-v1.0.0-beta.8/noir/concepts/data_types/coercions.md
@@ -32,7 +32,7 @@ Note that:
 - `&T` requires the experimental `-Zownership` flag to be enabled.
 
 Examples:
-```noir
+```rust
 fn requires_slice(_slice: [Field]) {}
 comptime fn requires_ct_string(_s: CtString) {}
 


### PR DESCRIPTION
# Description

## Problem\*

Resolves https://github.com/noir-lang/noir/issues/9296.

## Summary\*

- Copy Type Coercions docs into v1.0.0-beta.8's versioned docs
- Change syntax highlighting format of code example to Rust (as Noir doesn't get syntax highlighted in preview)

## Documentation\*

Check one:
- [ ] No documentation needed.
- [x] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
