### PR TITLE
chore: Add fmtstr to coercions list

### DIFF
--- a/docs/docs/noir/concepts/data_types/coercions.md
+++ b/docs/docs/noir/concepts/data_types/coercions.md
@@ -18,12 +18,13 @@ type coercion. These are typically limited to a few type pairs where converting 
 will not sacrifice performance or correctness. Currently, Noir will will try to perform the following
 type coercions:
 
-| Actual Type   | Expected Type               |
-| ------------- | --------------------------- |
-| `[T; N]`      | `[T]`                       |
-| `fn(..) -> R` | `unconstrained fn(..) -> R` |
-| `str<N>`      | `CtString`                  |
-| `&mut T`      | `&T`                        |
+| Actual Type    | Expected Type               |
+| -------------- | --------------------------- |
+| `[T; N]`       | `[T]`                       |
+| `fn(..) -> R`  | `unconstrained fn(..) -> R` |
+| `str<N>`       | `CtString`                  |
+| `fmtstr<N, T>` | `CtString`                  |
+| `&mut T`       | `&T`                        |
 
 Note that:
 - Conversions are only from the actual type to the expected type, never the other way around.

--- a/docs/versioned_docs/version-v1.0.0-beta.8/noir/concepts/data_types/coercions.md
+++ b/docs/versioned_docs/version-v1.0.0-beta.8/noir/concepts/data_types/coercions.md
@@ -18,12 +18,13 @@ type coercion. These are typically limited to a few type pairs where converting 
 will not sacrifice performance or correctness. Currently, Noir will will try to perform the following
 type coercions:
 
-| Actual Type   | Expected Type               |
-| ------------- | --------------------------- |
-| `[T; N]`      | `[T]`                       |
-| `fn(..) -> R` | `unconstrained fn(..) -> R` |
-| `str<N>`      | `CtString`                  |
-| `&mut T`      | `&T`                        |
+| Actual Type    | Expected Type               |
+| -------------- | --------------------------- |
+| `[T; N]`       | `[T]`                       |
+| `fn(..) -> R`  | `unconstrained fn(..) -> R` |
+| `str<N>`       | `CtString`                  |
+| `fmtstr<N, T>` | `CtString`                  |
+| `&mut T`       | `&T`                        |
 
 Note that:
 - Conversions are only from the actual type to the expected type, never the other way around.


### PR DESCRIPTION
# Description

## Problem\*

Resolves https://github.com/noir-lang/noir/pull/9292#discussion_r2225895989

## Summary\*

Adds a missed coercion with fmtstr to the coercions docs

## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [x] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
