### PR TITLE
fix(ssa-interpreter): Return error if slice length is 0 during popping

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/interpreter/intrinsics.rs
+++ b/compiler/noirc_evaluator/src/ssa/interpreter/intrinsics.rs
@@ -542,7 +542,7 @@ impl<W: Write> Interpreter<'_, W> {
         let mut slice_elements = slice.elements.borrow().to_vec();
         let element_types = slice.element_types.clone();
 
-        if slice_elements.is_empty() {
+        if slice_elements.is_empty() || length == 0 {
             let instruction = "slice_pop_back";
             return Err(InterpreterError::PoppedFromEmptySlice { slice: args[1], instruction });
         }
@@ -566,7 +566,7 @@ impl<W: Write> Interpreter<'_, W> {
         let mut slice_elements = slice.elements.borrow().to_vec();
         let element_types = slice.element_types.clone();
 
-        if slice_elements.is_empty() {
+        if slice_elements.is_empty() || length == 0 {
             let instruction = "slice_pop_front";
             return Err(InterpreterError::PoppedFromEmptySlice { slice: args[1], instruction });
         }


### PR DESCRIPTION
# Description

## Problem\*

Resolves #9267

## Summary\*

Return `InterpreterError::PoppedFromEmptySlice` if the `length` is 0 even if the slice does have elements.

## Additional Context

The initial SSA calls the popping function with 0 length and non-empty slice. Works for ACIR ~and Brillig~ 🤷 

## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
