### PR TITLE
fix(brillig_vm): Remove slice padding for foreign call inputs

### DIFF
--- a/acvm-repo/brillig/src/opcodes.rs
+++ b/acvm-repo/brillig/src/opcodes.rs
@@ -84,6 +84,31 @@ impl HeapValueType {
     pub fn field() -> HeapValueType {
         HeapValueType::Simple(BitSize::Field)
     }
+
+    /// Returns the total number of field elements required to represent this type in memory
+    pub fn flattened_size(&self) -> usize {
+        match self {
+            HeapValueType::Simple(_) => 1,
+
+            HeapValueType::Array { value_types, size } => {
+                // Recursively compute the flattened size of all value types
+                let element_size: usize = value_types
+                    .iter()
+                    .map(|ty| ty.flattened_size())
+                    .sum();
+
+                element_size * size
+            }
+
+            // The size of a vector is stored separately and should be handled by the caller of this method
+            HeapValueType::Vector { value_types } => {
+                value_types
+                    .iter()
+                    .map(|ty| ty.flattened_size())
+                    .sum()
+            }
+        }
+    }
 }
 
 /// A fixed-sized array starting from a Brillig memory location.

--- a/acvm-repo/brillig_vm/src/lib.rs
+++ b/acvm-repo/brillig_vm/src/lib.rs
@@ -525,10 +525,39 @@ impl<'a, F: AcirField, B: BlackBoxFunctionSolver<F>> VM<'a, F, B> {
                     // resolved inputs back to the caller. Once the caller pushes to `foreign_call_results`,
                     // they can then make another call to the VM that starts at this opcode
                     // but has the necessary results to proceed with execution.
+                    let mut previous_input: Option<ForeignCallParam<F>> = None;
                     let resolved_inputs = inputs
                         .iter()
                         .zip(input_value_types)
-                        .map(|(input, input_type)| self.get_memory_values(*input, input_type))
+                        .map(|(input, input_type)| {
+                            let mut input = self.get_memory_values(*input, input_type);
+
+                            match input_type {
+                                HeapValueType::Vector { .. } => {
+                                    if let Some(ForeignCallParam::Single(value)) = previous_input {
+                                        // Cut off slices with their semantic length, 
+                                        // They may have a capacity which could be higher than their semantic length.
+                                        let flattened_size = input_type.flattened_size();
+                                        let fields = input.fields();
+                                        let value_as_usize = value.to_u128() as usize;
+                                        input = ForeignCallParam::Array(fields[0..(value_as_usize * flattened_size)].to_vec());
+                                    }
+
+                                    previous_input = None;
+                                }
+                                HeapValueType::Simple(BitSize::Integer(IntegerBitSize::U32)) => {
+                                    // If we have a single u32 we may have a slice representation, so store this input.
+                                    // On the next iteration, if we have a vector then we know we have the dynamic length 
+                                    // for that slice. 
+                                    previous_input = Some(input.clone());
+                                }
+                                _ => {
+                                    // Do nothing otherwise
+                                    previous_input = None;
+                                }
+                            }
+                            input
+                        })
                         .collect::<Vec<_>>();
                     return self.wait_for_foreign_call(function.clone(), resolved_inputs);
                 }
@@ -681,14 +710,9 @@ impl<'a, F: AcirField, B: BlackBoxFunctionSolver<F>> VM<'a, F, B> {
             ) => {
                 let start = self.memory.read_ref(pointer_index);
                 let size = self.memory.read(size_index).to_usize();
-                // Prefix slices with their capacity, which could be higher than their semantic length.
-                let mut values = vec![F::from(size)];
-                values.extend(
-                    self.read_slice_of_values_from_memory(start, size, value_types)
+                self.read_slice_of_values_from_memory(start, size, value_types)
                         .into_iter()
-                        .map(|mem_value| mem_value.to_field()),
-                );
-                values.into()
+                        .map(|mem_value| mem_value.to_field()).collect::<Vec<_>>().into()
             }
             _ => {
                 unreachable!("Unexpected value type {value_type:?} for input {input:?}");


### PR DESCRIPTION
# Description

## Problem\*

Alternative to https://github.com/noir-lang/noir/pull/9288

## Summary\*



## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
