### PR TITLE
fix: some nargo expand fixes

### DIFF
--- a/compiler/noirc_frontend/src/hir/comptime/display.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/display.rs
@@ -216,10 +216,16 @@ impl<'interner> TokenPrettyPrinter<'interner> {
             }
             Token::InternedCrate(_) => write!(f, "$crate"),
             Token::UnquoteMarker(id) => {
-                if self.preserve_unquote_markers {
-                    write!(f, "$")?;
-                }
                 let value = Value::TypedExpr(TypedExpr::ExprId(*id));
+                let last_was_alphanumeric = if self.preserve_unquote_markers {
+                    if last_was_alphanumeric {
+                        write!(f, " ")?;
+                    }
+                    write!(f, "$")?;
+                    false
+                } else {
+                    last_was_alphanumeric
+                };
                 self.print_value(&value, last_was_alphanumeric, f)
             }
             Token::Keyword(..) | Token::Ident(..) | Token::Int(..) | Token::Bool(..) => {

--- a/test_programs/compile_success_empty/comptime_trait_constraint_method/Nargo.toml
+++ b/test_programs/compile_success_empty/comptime_trait_constraint_method/Nargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "comptime_trait_constraint_method"
+type = "bin"
+authors = [""]
+
+[dependencies]

--- a/test_programs/compile_success_empty/comptime_trait_constraint_method/src/main.nr
+++ b/test_programs/compile_success_empty/comptime_trait_constraint_method/src/main.nr
@@ -1,0 +1,28 @@
+mod moo {
+    pub trait Trait {
+        fn trait_method(self);
+    }
+
+    impl Trait for Field {
+        fn trait_method(self) {}
+    }
+
+    pub comptime fn attr(_: FunctionDefinition) -> Quoted {
+        let trait_constraint = quote { Trait }.as_trait_constraint();
+        let field = quote { Field }.as_type();
+        let trait_impl = field.get_trait_impl(trait_constraint).unwrap();
+        let method = trait_impl.methods()[0].as_typed_expr();
+        let x = 1;
+        quote {
+            pub fn bar() {
+                let _ = $x;
+                $method(1);
+            }
+        }
+    }
+}
+
+#[moo::attr]
+fn main() {
+    bar();
+}

--- a/tooling/nargo_cli/tests/snapshots/compile_success_contract/contract_with_comptime_attributes/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_contract/contract_with_comptime_attributes/execute__tests__expanded.snap
@@ -16,7 +16,7 @@ comptime fn utility(f: FunctionDefinition) {
 comptime fn add_utility(_: FunctionDefinition) -> Quoted {
     let utility: fn(FunctionDefinition) = utility;
     quote {
-        #[utility]fn fn2() {
+        #[$utility]fn fn2() {
             
         }
     }

--- a/tooling/nargo_cli/tests/snapshots/compile_success_empty/comptime_attribute/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_empty/comptime_attribute/execute__tests__expanded.snap
@@ -6,7 +6,7 @@ mod moo {
     pub comptime fn add_fn(f: FunctionDefinition, name: Quoted) -> Quoted {
         assert(f.has_named_attribute("add_fn"));
         quote {
-            pub fn name() {
+            pub fn $name() {
                 
             }
         }
@@ -20,7 +20,7 @@ mod moo {
 comptime fn add_foo(_: Module) -> Quoted {
     let func: fn(FunctionDefinition, Quoted) -> Quoted = moo::add_fn;
     quote {
-        #[func(quote {
+        #[$func(quote {
             bar
         })]pub fn foo() {
             

--- a/tooling/nargo_cli/tests/snapshots/compile_success_empty/comptime_attribute_coercions/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_empty/comptime_attribute_coercions/execute__tests__expanded.snap
@@ -5,7 +5,7 @@ expression: expanded_code
 comptime fn foo(_: FunctionDefinition, slice: [u8], _str1: CtString, _str2: CtString) -> Quoted {
     quote {
         fn bar() -> [u8] {
-            slice
+            $slice
         }
     }
 }

--- a/tooling/nargo_cli/tests/snapshots/compile_success_empty/comptime_fmt_strings/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_empty/comptime_fmt_strings/execute__tests__expanded.snap
@@ -17,5 +17,5 @@ comptime fn glue(x: Quoted, y: Quoted) -> Quoted {
 fn hello_world() {}
 
 comptime fn call(x: Quoted) -> Quoted {
-    quote { x() }
+    quote { $x() }
 }

--- a/tooling/nargo_cli/tests/snapshots/compile_success_empty/comptime_function_definition/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_empty/comptime_function_definition/execute__tests__expanded.snap
@@ -108,7 +108,7 @@ mod test_as_typed_expr_1 {
         let func: TypedExpr = method.as_typed_expr();
         quote {
             pub fn bar() -> i32 {
-                func(1)
+                $func(1)
             }
         }
     }
@@ -136,7 +136,7 @@ mod test_as_typed_expr_2 {
             pub fn bar() -> u32 {
                 // Safety: test program
                 unsafe {
-                    func([1, 2, 3, 0])
+                    $func([1, 2, 3, 0])
                 }
             }
         }
@@ -169,7 +169,7 @@ mod test_as_typed_expr_3 {
             pub fn bar() -> u32 {
                 // Safety: test program
                 comptime {
-                    func(([1, 2, 3, 0], "a"))
+                    $func(([1, 2, 3, 0], "a"))
                 }
             }
         }
@@ -186,7 +186,7 @@ mod test_as_typed_expr_3 {
 
 mod test_as_typed_expr_4 {
     comptime fn foo(f: TypedExpr) -> Quoted {
-        quote { f() }
+        quote { $f() }
     }
 
     fn bar() -> Field {

--- a/tooling/nargo_cli/tests/snapshots/compile_success_empty/comptime_trait_constraint_method/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_empty/comptime_trait_constraint_method/execute__tests__expanded.snap
@@ -1,0 +1,36 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: expanded_code
+---
+mod moo {
+    pub trait Trait {
+        fn trait_method(self);
+    }
+
+    impl Trait for Field {
+        fn trait_method(self) {}
+    }
+
+    pub comptime fn attr(_: FunctionDefinition) -> Quoted {
+        let trait_constraint: TraitConstraint = quote { Trait }.as_trait_constraint();
+        let field: Type = quote { Field }.as_type();
+        let trait_impl: TraitImpl = field.get_trait_impl(trait_constraint).unwrap();
+        let method: TypedExpr = trait_impl.methods()[0_u32].as_typed_expr();
+        let x: Field = 1_Field;
+        quote {
+            pub fn bar() {
+                let _ = $x;
+                $method(1);
+            }
+        }
+    }
+}
+
+pub fn bar() {
+    let _: Field = 1_Field;
+    <Field as moo::Trait>::trait_method(1_Field);
+}
+
+fn main() {
+    bar();
+}

--- a/tooling/nargo_cli/tests/snapshots/compile_success_empty/comptime_trait_constraint_method/execute__tests__force_brillig_false_inliner_0.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_empty/comptime_trait_constraint_method/execute__tests__force_brillig_false_inliner_0.snap
@@ -1,0 +1,26 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: artifact
+---
+{
+  "noir_version": "[noir_version]",
+  "hash": "[hash]",
+  "abi": {
+    "parameters": [],
+    "return_type": null,
+    "error_types": {}
+  },
+  "bytecode": [
+    "func 0",
+    "current witness index : _0",
+    "private parameters indices : []",
+    "public parameters indices : []",
+    "return value indices : []"
+  ],
+  "debug_symbols": "XY5BCsQwCEXv4rqLWfcqw1BsaosgJtikMITefWyYQOlK/3/6tcJCc9km1jXuML4rzMYivE0SA2aO6m49B+hyykbkFty4byU00gyjFpEBDpTShvaE2mpGc/oagHTx6oErC13d+XGBge158UBjnIX+ci0abjR/Uyf942Qx0FKMrqTGPPsH",
+  "file_map": {},
+  "names": [
+    "main"
+  ],
+  "brillig_names": []
+}

--- a/tooling/nargo_cli/tests/snapshots/compile_success_empty/derive_impl/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_empty/derive_impl/execute__tests__expanded.snap
@@ -12,10 +12,10 @@ comptime fn derive_default(typ: TypeDefinition) -> Quoted {
     let fields: [(Quoted, Type, Quoted)] = typ.fields_as_written();
     let fields: Quoted = join(make_field_exprs(fields));
     quote {
-        impl Default for type_name {
+        impl Default for $type_name {
             fn default() -> Self {
                 Self {
-                    fields
+                    $fields
                 }
             }
         }
@@ -49,7 +49,7 @@ comptime fn make_field_exprs(fields: [(Quoted, Type, Quoted)]) -> [Quoted] {
             let my_field: (Quoted, Type, Quoted) = ___i0[___i1];
             {
                 let name: Quoted = my_field.0;
-                result = result.push_back(quote { name: Default::default(),  });
+                result = result.push_back(quote { $name: Default::default(),  });
             }
         }
     };
@@ -63,7 +63,7 @@ comptime fn join(slice: [Quoted]) -> Quoted {
         for ___i1 in 0_u32..___i0.len() {
             let elem: Quoted = ___i0[___i1];
             {
-                result = quote { result elem };
+                result = quote { $result $elem };
             }
         }
     };

--- a/tooling/nargo_cli/tests/snapshots/compile_success_empty/inject_context_attribute/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_empty/inject_context_attribute/execute__tests__expanded.snap
@@ -57,7 +57,7 @@ comptime fn mapping_function(expr: Expr, f: FunctionDefinition) -> Option<Expr> 
                         arguments.push_front(quote { _context }.as_expr().unwrap());
                     let arguments: Quoted =
                         arguments.map(|arg: Expr| -> Quoted arg.quoted()).join(quote { ,  });
-                    Option::<Expr>::some(quote { name(arguments) }.as_expr().unwrap())
+                    Option::<Expr>::some(quote { $name($arguments) }.as_expr().unwrap())
                 } else {
                     Option::<Expr>::none()
                 }

--- a/tooling/nargo_cli/tests/snapshots/compile_success_empty/macros/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_empty/macros/execute__tests__expanded.snap
@@ -3,7 +3,7 @@ source: tooling/nargo_cli/tests/execute.rs
 expression: expanded_code
 ---
 comptime fn my_macro(x: Field, y: Field) -> Quoted {
-    quote { x + y + a + b }
+    quote { $x + $y + a + b }
 }
 
 fn main() {

--- a/tooling/nargo_cli/tests/snapshots/compile_success_empty/quoted_as_type/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_empty/quoted_as_type/execute__tests__expanded.snap
@@ -13,7 +13,7 @@ fn main() {
 comptime fn macro() -> Quoted {
     let typ: Type = quote { Foo < Field >  }.as_type();
     quote {
-        let foo: typ = Foo {
+        let foo: $typ = Foo {
             
         }
         ;

--- a/tooling/nargo_cli/tests/snapshots/compile_success_empty/regression_6077/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_empty/regression_6077/execute__tests__expanded.snap
@@ -16,7 +16,7 @@ pub fn my_fn() -> WeirdStruct<Field, [u8; 3]> {
 comptime fn mangle_fn(f: FunctionDefinition) {
     let return_type: Type = f.return_type();
     let generics: Quoted = f"Field,{return_type}".quoted_contents();
-    let new_return_type: Type = quote { WeirdStruct < generics >  }.as_type();
+    let new_return_type: Type = quote { WeirdStruct < $generics >  }.as_type();
     let new_body: Expr = quote {
         {
             WeirdStruct {

--- a/tooling/nargo_cli/tests/snapshots/compile_success_empty/resolved_type_in_constructor/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_empty/resolved_type_in_constructor/execute__tests__expanded.snap
@@ -9,7 +9,7 @@ fn main() {
 comptime fn my_macro() -> Quoted {
     let typ: Type = quote { Foo }.as_type();
     quote {
-        typ {
+        $typ {
             
         }
     }

--- a/tooling/nargo_cli/tests/snapshots/compile_success_empty/unquote_in_numeric_generic/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_empty/unquote_in_numeric_generic/execute__tests__expanded.snap
@@ -20,15 +20,15 @@ fn main() {
 comptime fn foo_impl(t: TypeDefinition) -> Quoted {
     let g: [(Type, Option<Type>)] = t.generics();
     let g_names: Quoted =
-        g.map(|(name, _): (Type, Option<Type>)| -> Quoted quote { name }).join(quote { ,  });
+        g.map(|(name, _): (Type, Option<Type>)| -> Quoted quote { $name }).join(quote { ,  });
     let g_intros: Quoted = g
         .map(|(name, typ): (Type, Option<Type>)| -> Quoted {
             let typ: Type = typ.unwrap();
-            quote { let name: typ }
+            quote { let $name: $typ }
         })
         .join(quote { ,  });
     quote {
-        impl < g_intros > Foo < g_names >  {
+        impl < $g_intros > Foo < $g_names >  {
             fn foo(self) {
                 let _ = self;
             }

--- a/tooling/nargo_cli/tests/snapshots/compile_success_empty/unquote_struct/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_empty/unquote_struct/execute__tests__expanded.snap
@@ -16,11 +16,11 @@ fn foo(x: Field, y: u32) -> u32 {
 comptime fn output_struct(f: FunctionDefinition) -> Quoted {
     let fields: Quoted = f
         .parameters()
-        .map(|(name, typ): (Quoted, Type)| -> Quoted quote { name: typ,  })
+        .map(|(name, typ): (Quoted, Type)| -> Quoted quote { $name: $typ,  })
         .join(quote {  });
     quote {
         struct Foo {
-            fields
+            $fields
         }
         impl Foo {
             fn assert_equal(self) {

--- a/tooling/nargo_cli/tests/snapshots/compile_success_empty/unquote_trait_constraint_in_trait_impl_position/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_empty/unquote_trait_constraint_in_trait_impl_position/execute__tests__expanded.snap
@@ -23,7 +23,7 @@ comptime fn foo(_: FunctionDefinition) -> Quoted {
     let tr: TraitConstraint = quote { Trait < Field >  }.as_trait_constraint();
     let st: Type = quote { Struct }.as_type();
     quote {
-        impl tr for st {
+        impl $tr for $st {
             fn method(self) -> Field {
                 1
             }

--- a/tooling/nargo_cli/tests/snapshots/compile_success_no_bug/noirc_frontend_tests_metaprogramming_unquoted_integer_as_integer_token/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_no_bug/noirc_frontend_tests_metaprogramming_unquoted_integer_as_integer_token/execute__tests__expanded.snap
@@ -15,7 +15,7 @@ pub fn foobar() {}
 comptime fn attr(_f: FunctionDefinition) -> Quoted {
     let serialized_len: Field = 1_Field;
     quote {
-        impl Serialize < serialized_len > for Field {
+        impl Serialize < $serialized_len > for Field {
             fn serialize() {
                 
             }

--- a/tooling/nargo_cli/tests/snapshots/execution_success/derive/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/derive/execute__tests__expanded.snap
@@ -21,9 +21,9 @@ impl DoNothing for MyStruct {
 comptime fn derive_do_nothing(s: TypeDefinition) -> Quoted {
     let typ: Type = s.as_type();
     let generics: Quoted =
-        s.generics().map(|g: (Type, Option<Type>)| -> Quoted quote { g }).join(quote { ,  });
+        s.generics().map(|g: (Type, Option<Type>)| -> Quoted quote { $g }).join(quote { ,  });
     quote {
-        impl < generics > DoNothing for typ {
+        impl < $generics > DoNothing for $typ {
             fn do_nothing(_self: Self) {
                 // Traits can't tell us what to do
                 println("something");

--- a/tooling/nargo_expand/src/printer.rs
+++ b/tooling/nargo_expand/src/printer.rs
@@ -752,7 +752,11 @@ impl<'context, 'string> ItemPrinter<'context, 'string> {
 
     fn show_trait_bound(&mut self, bound: &ResolvedTraitBound) {
         let trait_ = self.interner.get_trait(bound.trait_id);
-        self.push_str(&trait_.name.to_string());
+        self.show_reference_to_module_def_id(
+            ModuleDefId::TraitId(trait_.id),
+            trait_.visibility,
+            true,
+        );
         self.show_trait_generics(&bound.trait_generics);
     }
 

--- a/tooling/nargo_expand/src/printer.rs
+++ b/tooling/nargo_expand/src/printer.rs
@@ -1145,7 +1145,13 @@ impl<'context, 'string> ItemPrinter<'context, 'string> {
 
     fn show_quoted(&mut self, tokens: &[LocatedToken]) {
         self.push_str("quote {");
-        let string = tokens_to_string_with_indent(tokens, self.indent + 1, self.interner);
+        let preserve_unquote_markers = true;
+        let string = tokens_to_string_with_indent(
+            tokens,
+            self.indent + 1,
+            preserve_unquote_markers,
+            self.interner,
+        );
         if string.contains('\n') {
             self.push('\n');
             self.increase_indent();

--- a/tooling/nargo_expand/src/printer/hir.rs
+++ b/tooling/nargo_expand/src/printer/hir.rs
@@ -401,7 +401,20 @@ impl ItemPrinter<'_, '_> {
                     };
 
                 if !method_on_trait_self {
-                    self.show_type(&trait_method.constraint.typ);
+                    let trait_id = trait_method.constraint.trait_bound.trait_id;
+                    let module_data =
+                        &self.def_maps[&self.module_id.krate][self.module_id.local_id];
+                    if module_data.find_trait_in_scope(trait_id).is_none() {
+                        // It can happen that the trait is not in scope, for example if this call
+                        // was generated via macros using `get_trait_impl -> methods`.
+                        self.push('<');
+                        self.show_type(&trait_method.constraint.typ);
+                        self.push_str(" as ");
+                        self.show_trait_bound(&trait_method.constraint.trait_bound);
+                        self.push('>');
+                    } else {
+                        self.show_type(&trait_method.constraint.typ);
+                    }
                     self.push_str("::");
                     self.push_str(self.interner.function_name(&func_id));
                     if let Some(generics) = generics {


### PR DESCRIPTION
# Description

## Problem

For https://github.com/AztecProtocol/aztec-packages/issues/15971

## Summary

This mainly fixes an issue I knew about, but didn't consider it a priority to fix: calls generated by macros could refer to traits that are not in scope, if they are done using macro calls like `get_trait_impl`, then `methods`, etc. `nargo expand` will now check if the trait related to the call is in scope and, if not, use `<Type as Trait>::method` to call it.

While doing this I noticed that `nargo expand` would also not put unquote markers, so I fixed that too.

## Additional Context

I think we should put a disclaimer somewhere that `nargo expand` is mostly a debugging tool and that it will try its best to produce code that compiles, but it won't always be possible (even if we fix all bugs). For example if a macro inserts a struct value, `nargo expand` will show it as `Struct { field1: value1, field2: value2, ... }` even though those fields might be private.

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
