### PR TITLE
fix: replace bound type variables found in `bindings` during canonica…

### DIFF
--- a/compiler/noirc_frontend/src/hir_def/types/arithmetic.rs
+++ b/compiler/noirc_frontend/src/hir_def/types/arithmetic.rs
@@ -164,6 +164,15 @@ impl Type {
 
                 Type::CheckedCast { from: Box::new(from), to: Box::new(to) }
             }
+            Type::TypeVariable(type_var) if type_var.borrow().is_unbound() => {
+                // Even if a type variable is unbound, its value could be in `bindings`.
+                // Use the underlying type in that case.
+                if let Some((_, _, typ)) = bindings.get(&type_var.id()) {
+                    typ.clone()
+                } else {
+                    self.clone()
+                }
+            }
             other => other.clone(),
         }
     }


### PR DESCRIPTION
…lization

# Description

## Problem

Resolves #9326

## Summary

This was another issue related to type variables, their ordering, and `sort_commutative`.

The idea of `sort_commutative` is to transform an expression like `(1 + a) + 2` into `(a + 1) + 2`, that is, always place constants on the right-hand side (that way when we need to simplify the addition above we can rely on the constants always being in those places).

For types that aren't constants, they are rearranged according to the order given by `impl Ord for Type`, which, for type variables, depends on their ID.

The problem was that we ended up with an expression like `(a + b) - 1` where, depending on the entire code to compile, the same expression could end up having `a: '1, b: '2` or `a: '2, a: '1`, that is, both are type variables but they got different IDs.

(Why they get different IDs? I didn't check, but the code should work fine regardless of this, so...)

Now imagine `b` is bound to a constant in `bindings`. `sort_commutative` will either leave it like `(a + b) - 1` or `(b + a) - 1`. That means that, when eventually we try to simplify the above we'll end up with `(a + 1) - 1` or `(1 + a) -1`): we'll be able to simplify it in the first scenario but not in the second one.

What this PR does is to eagerly replace `b` with `1` way before we reach `sort_commutative`. We do this when we canonicalize types. That guarantees that we always end up with `(a + 1) - 1` and are able to simplify it.

(and in general it's always okay to eagerly replace an unbound type variable with its value found in `bindings`).

## Additional Context

Jake proposed calling `substitute` with the bindings right at the beginning of `canonicalize`, which is a good idea. I'm going to try that in a separate PR and see if it makes a difference in performance (it could be better because it would replace bindings everywhere, not just in infix expressions).

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
