### PR TITLE
fix: substitute bindings in type before canonicalization

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/types.rs
+++ b/compiler/noirc_frontend/src/elaborator/types.rs
@@ -760,7 +760,7 @@ impl Elaborator<'_> {
                     (lhs, rhs) => {
                         let infix = Type::infix_expr(Box::new(lhs), op, Box::new(rhs));
                         Type::CheckedCast { from: Box::new(infix.clone()), to: Box::new(infix) }
-                            .canonicalize(&TypeBindings::default())
+                            .canonicalize()
                     }
                 }
             }

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
@@ -645,11 +645,10 @@ impl<'local, 'interner> Interpreter<'local, 'interner> {
                     unreachable!("Expected associated type to be numeric");
                 };
                 let location = self.elaborator.interner.expr_location(&id);
-                match associated_type.typ.evaluate_to_field_element(
-                    &associated_type.typ.kind(),
-                    &TypeBindings::default(),
-                    location,
-                ) {
+                match associated_type
+                    .typ
+                    .evaluate_to_field_element(&associated_type.typ.kind(), location)
+                {
                     Ok(value) => self.evaluate_integer(value.into(), id),
                     Err(err) => Err(InterpreterError::NonIntegerArrayLength {
                         typ: associated_type.typ.clone(),
@@ -666,11 +665,7 @@ impl<'local, 'interner> Interpreter<'local, 'interner> {
     fn evaluate_numeric_generic(&self, value: Type, expected: &Type, id: ExprId) -> IResult<Value> {
         let location = self.elaborator.interner.id_location(id);
         let value = value
-            .evaluate_to_field_element(
-                &Kind::Numeric(Box::new(expected.clone())),
-                &TypeBindings::default(),
-                location,
-            )
+            .evaluate_to_field_element(&Kind::Numeric(Box::new(expected.clone())), location)
             .map_err(|err| {
                 let typ = value;
                 let err = Some(Box::new(err));

--- a/compiler/noirc_frontend/src/hir_def/types.rs
+++ b/compiler/noirc_frontend/src/hir_def/types.rs
@@ -1099,7 +1099,7 @@ impl std::fmt::Display for Type {
             }
             Type::Quoted(quoted) => write!(f, "{quoted}"),
             Type::InfixExpr(lhs, op, rhs, _) => {
-                let this = self.canonicalize_checked(&TypeBindings::default());
+                let this = self.canonicalize_checked();
 
                 // Prevent infinite recursion
                 if this != *self { write!(f, "{this}") } else { write!(f, "({lhs} {op} {rhs})") }
@@ -1854,13 +1854,11 @@ impl Type {
     /// If this type is a Type::Constant (used in array lengths), or is bound
     /// to a Type::Constant, return the constant as a u32.
     pub fn evaluate_to_u32(&self, location: Location) -> Result<u32, TypeCheckError> {
-        self.evaluate_to_field_element(&Kind::u32(), &TypeBindings::default(), location).map(
-            |field_element| {
-                field_element.try_to_u32().expect(
-                    "ICE: size should have already been checked by evaluate_to_field_element",
-                )
-            },
-        )
+        self.evaluate_to_field_element(&Kind::u32(), location).map(|field_element| {
+            field_element
+                .try_to_u32()
+                .expect("ICE: size should have already been checked by evaluate_to_field_element")
+        })
     }
 
     // TODO(https://github.com/noir-lang/noir/issues/6260): remove
@@ -1868,11 +1866,10 @@ impl Type {
     pub(crate) fn evaluate_to_field_element(
         &self,
         kind: &Kind,
-        bindings: &TypeBindings,
         location: Location,
     ) -> Result<acvm::FieldElement, TypeCheckError> {
         let run_simplifications = true;
-        self.evaluate_to_field_element_helper(kind, location, bindings, run_simplifications)
+        self.evaluate_to_field_element_helper(kind, location, run_simplifications)
     }
 
     /// evaluate_to_field_element with optional generic arithmetic simplifications
@@ -1880,7 +1877,6 @@ impl Type {
         &self,
         kind: &Kind,
         location: Location,
-        bindings: &TypeBindings,
         run_simplifications: bool,
     ) -> Result<acvm::FieldElement, TypeCheckError> {
         if let Some((binding, binding_kind)) = self.get_inner_type_variable() {
@@ -1890,27 +1886,15 @@ impl Type {
                         return binding.evaluate_to_field_element_helper(
                             &binding_kind,
                             location,
-                            bindings,
                             run_simplifications,
                         );
                     }
                 }
-                TypeBinding::Unbound(type_variable_id, kind) => {
-                    if kind.unifies(&binding_kind) {
-                        if let Some((_, _, typ)) = bindings.get(type_variable_id) {
-                            return typ.evaluate_to_field_element_helper(
-                                &binding_kind,
-                                location,
-                                bindings,
-                                run_simplifications,
-                            );
-                        }
-                    }
-                }
+                TypeBinding::Unbound(..) => (),
             }
         }
 
-        match self.canonicalize_with_simplifications(bindings, run_simplifications) {
+        match self.canonicalize_with_simplifications(run_simplifications) {
             Type::Constant(x, constant_kind) => {
                 if kind.unifies(&constant_kind) {
                     kind.ensure_value_fits(x, location)
@@ -1928,13 +1912,11 @@ impl Type {
                     let lhs_value = lhs.evaluate_to_field_element_helper(
                         &infix_kind,
                         location,
-                        bindings,
                         run_simplifications,
                     )?;
                     let rhs_value = rhs.evaluate_to_field_element_helper(
                         &infix_kind,
                         location,
-                        bindings,
                         run_simplifications,
                     )?;
                     op.function(lhs_value, rhs_value, &infix_kind, location)
@@ -1947,17 +1929,14 @@ impl Type {
                 }
             }
             Type::CheckedCast { from, to } => {
-                let to_value = to.evaluate_to_field_element(kind, bindings, location)?;
+                let to_value = to.evaluate_to_field_element(kind, location)?;
 
                 // if both 'to' and 'from' evaluate to a constant,
                 // return None unless they match
                 let skip_simplifications = false;
-                if let Ok(from_value) = from.evaluate_to_field_element_helper(
-                    kind,
-                    location,
-                    bindings,
-                    skip_simplifications,
-                ) {
+                if let Ok(from_value) =
+                    from.evaluate_to_field_element_helper(kind, location, skip_simplifications)
+                {
                     if to_value == from_value {
                         Ok(to_value)
                     } else {

--- a/compiler/noirc_frontend/src/hir_def/types/arithmetic.rs
+++ b/compiler/noirc_frontend/src/hir_def/types/arithmetic.rs
@@ -73,9 +73,10 @@ impl Type {
         found_checked_cast: bool,
         run_simplifications: bool,
     ) -> Type {
-        match self {
+        let typ = self.substitute(bindings);
+        match typ {
             Type::InfixExpr(lhs, op, rhs, inversion) => {
-                let kind = lhs.infix_kind(rhs);
+                let kind = lhs.infix_kind(&rhs);
                 let dummy_location = Location::dummy();
 
                 let evaluate = |typ: &Type| {
@@ -89,8 +90,8 @@ impl Type {
 
                 // evaluate_to_field_element also calls canonicalize so if we just called
                 // `self.evaluate_to_field_element(..)` we'd get infinite recursion.
-                if let Ok(lhs_value) = evaluate(lhs) {
-                    if let Ok(rhs_value) = evaluate(rhs) {
+                if let Ok(lhs_value) = evaluate(&lhs) {
+                    if let Ok(rhs_value) = evaluate(&rhs) {
                         if let Ok(result) = op.function(lhs_value, rhs_value, &kind, dummy_location)
                         {
                             return Type::Constant(result, kind);
@@ -122,34 +123,33 @@ impl Type {
                 }
 
                 if !run_simplifications {
-                    return Type::InfixExpr(Box::new(lhs), *op, Box::new(rhs), *inversion);
+                    return Type::InfixExpr(Box::new(lhs), op, Box::new(rhs), inversion);
                 }
 
                 if let Some(result) =
-                    Self::try_simplify_non_constants_in_lhs(&lhs, *op, &rhs, bindings)
+                    Self::try_simplify_non_constants_in_lhs(&lhs, op, &rhs, bindings)
                 {
                     return result.canonicalize_unchecked(bindings);
                 }
 
                 if let Some(result) =
-                    Self::try_simplify_non_constants_in_rhs(&lhs, *op, &rhs, bindings)
+                    Self::try_simplify_non_constants_in_rhs(&lhs, op, &rhs, bindings)
                 {
                     return result.canonicalize_unchecked(bindings);
                 }
 
                 // Try to simplify partially constant expressions in the form `(N op1 C1) op2 C2`
                 // where C1 and C2 are constants that can be combined (e.g. N + 5 - 3 = N + 2)
-                if let Some(result) =
-                    Self::try_simplify_partial_constants(&lhs, *op, &rhs, bindings)
+                if let Some(result) = Self::try_simplify_partial_constants(&lhs, op, &rhs, bindings)
                 {
                     return result.canonicalize_unchecked(bindings);
                 }
 
                 if op.is_commutative() {
-                    return Self::sort_commutative(&lhs, *op, &rhs, bindings);
+                    return Self::sort_commutative(lhs, op, rhs, bindings);
                 }
 
-                Type::InfixExpr(Box::new(lhs), *op, Box::new(rhs), *inversion)
+                Type::InfixExpr(Box::new(lhs), op, Box::new(rhs), inversion)
             }
             Type::CheckedCast { from, to } => {
                 let inner_found_checked_cast = true;
@@ -164,17 +164,18 @@ impl Type {
 
                 Type::CheckedCast { from: Box::new(from), to: Box::new(to) }
             }
-            other => other.clone(),
+            other => other,
         }
     }
 
     fn sort_commutative(
-        lhs: &Type,
+        lhs: Type,
         op: BinaryTypeOperator,
-        rhs: &Type,
+        rhs: Type,
         bindings: &TypeBindings,
     ) -> Type {
-        let mut queue = vec![lhs.clone(), rhs.clone()];
+        let kind = lhs.infix_kind(&rhs);
+        let mut queue = vec![lhs, rhs];
 
         // Maps each term to the number of times that term was used.
         let mut sorted = BTreeMap::new();
@@ -225,14 +226,14 @@ impl Type {
             }
 
             if constant != zero_value {
-                let constant = Type::Constant(constant, lhs.infix_kind(rhs));
+                let constant = Type::Constant(constant, kind);
                 typ = Type::infix_expr(Box::new(typ), op, Box::new(constant));
             }
 
             typ
         } else {
             // Every type must have been a constant
-            Type::Constant(constant, lhs.infix_kind(rhs))
+            Type::Constant(constant, kind)
         }
     }
 

--- a/compiler/noirc_frontend/src/hir_def/types/unification.rs
+++ b/compiler/noirc_frontend/src/hir_def/types/unification.rs
@@ -272,6 +272,7 @@ impl Type {
 
             (Constant(value, kind), other) | (other, Constant(value, kind)) => {
                 let dummy_location = Location::dummy();
+                let other = other.substitute(&bindings);
                 if let Ok(other_value) = other.evaluate_to_field_element(kind, dummy_location) {
                     if *value == other_value && kind.unifies(&other.kind()) {
                         Ok(())
@@ -287,7 +288,7 @@ impl Type {
                             rhs.clone(),
                         );
 
-                        new_type.try_unify(lhs, bindings)?;
+                        new_type.try_unify(&lhs, bindings)?;
                         Ok(())
                     } else {
                         Err(UnificationError)
@@ -472,6 +473,7 @@ impl Type {
             if let Some(lhs_op_inverse) = lhs_op.approx_inverse() {
                 let kind = lhs_lhs.infix_kind(lhs_rhs);
                 let dummy_location = Location::dummy();
+                let lhs_rhs = lhs_rhs.substitute(bindings);
                 if let Ok(value) = lhs_rhs.evaluate_to_field_element(&kind, dummy_location) {
                     let lhs_rhs = Box::new(Type::Constant(value, kind));
                     let new_rhs =

--- a/compiler/noirc_frontend/src/hir_def/types/unification.rs
+++ b/compiler/noirc_frontend/src/hir_def/types/unification.rs
@@ -110,12 +110,12 @@ impl Type {
         let rhs = other.follow_bindings_shallow();
 
         let lhs = match lhs.as_ref() {
-            Type::InfixExpr(..) => Cow::Owned(self.canonicalize(bindings)),
+            Type::InfixExpr(..) => Cow::Owned(self.substitute(bindings).canonicalize()),
             other => Cow::Borrowed(other),
         };
 
         let rhs = match rhs.as_ref() {
-            Type::InfixExpr(..) => Cow::Owned(other.canonicalize(bindings)),
+            Type::InfixExpr(..) => Cow::Owned(other.substitute(bindings).canonicalize()),
             other => Cow::Borrowed(other),
         };
 
@@ -272,9 +272,7 @@ impl Type {
 
             (Constant(value, kind), other) | (other, Constant(value, kind)) => {
                 let dummy_location = Location::dummy();
-                if let Ok(other_value) =
-                    other.evaluate_to_field_element(kind, bindings, dummy_location)
-                {
+                if let Ok(other_value) = other.evaluate_to_field_element(kind, dummy_location) {
                     if *value == other_value && kind.unifies(&other.kind()) {
                         Ok(())
                     } else {
@@ -474,9 +472,7 @@ impl Type {
             if let Some(lhs_op_inverse) = lhs_op.approx_inverse() {
                 let kind = lhs_lhs.infix_kind(lhs_rhs);
                 let dummy_location = Location::dummy();
-                if let Ok(value) =
-                    lhs_rhs.evaluate_to_field_element(&kind, bindings, dummy_location)
-                {
+                if let Ok(value) = lhs_rhs.evaluate_to_field_element(&kind, dummy_location) {
                     let lhs_rhs = Box::new(Type::Constant(value, kind));
                     let new_rhs =
                         Type::inverted_infix_expr(Box::new(other.clone()), lhs_op_inverse, lhs_rhs);

--- a/compiler/noirc_frontend/src/hir_def/types/unification.rs
+++ b/compiler/noirc_frontend/src/hir_def/types/unification.rs
@@ -272,7 +272,7 @@ impl Type {
 
             (Constant(value, kind), other) | (other, Constant(value, kind)) => {
                 let dummy_location = Location::dummy();
-                let other = other.substitute(&bindings);
+                let other = other.substitute(bindings);
                 if let Ok(other_value) = other.evaluate_to_field_element(kind, dummy_location) {
                     if *value == other_value && kind.unifies(&other.kind()) {
                         Ok(())

--- a/compiler/noirc_frontend/src/monomorphization/mod.rs
+++ b/compiler/noirc_frontend/src/monomorphization/mod.rs
@@ -1128,11 +1128,10 @@ impl<'interner> Monomorphizer<'interner> {
                 let Kind::Numeric(numeric_type) = associated_type.typ.kind() else {
                     unreachable!("Expected associated type to be numeric");
                 };
-                match associated_type.typ.evaluate_to_field_element(
-                    &associated_type.typ.kind(),
-                    &TypeBindings::default(),
-                    location,
-                ) {
+                match associated_type
+                    .typ
+                    .evaluate_to_field_element(&associated_type.typ.kind(), location)
+                {
                     Ok(value) => {
                         let typ = Self::convert_type(&numeric_type, location)?;
                         let value = SignedField::positive(value);
@@ -1158,13 +1157,13 @@ impl<'interner> Monomorphizer<'interner> {
         location: Location,
     ) -> Result<ast::Expression, MonomorphizationError> {
         let expected_kind = Kind::Numeric(Box::new(expected_type.clone()));
-        let value = value
-            .evaluate_to_field_element(&expected_kind, &TypeBindings::default(), location)
-            .map_err(|err| MonomorphizationError::UnknownArrayLength {
+        let value = value.evaluate_to_field_element(&expected_kind, location).map_err(|err| {
+            MonomorphizationError::UnknownArrayLength {
                 length: value.follow_bindings(),
                 err,
                 location,
-            })?;
+            }
+        })?;
 
         let expr_kind = Kind::Numeric(Box::new(expr_type.clone()));
         if !expected_kind.unifies(&expr_kind) {
@@ -1571,15 +1570,11 @@ impl<'interner> Monomorphizer<'interner> {
                 location,
             });
         }
-        let to_value = to.evaluate_to_field_element(&to.kind(), &TypeBindings::default(), location);
+        let to_value = to.evaluate_to_field_element(&to.kind(), location);
         if to_value.is_ok() {
             let skip_simplifications = false;
-            let from_value = from.evaluate_to_field_element_helper(
-                &to.kind(),
-                location,
-                &TypeBindings::default(),
-                skip_simplifications,
-            );
+            let from_value =
+                from.evaluate_to_field_element_helper(&to.kind(), location, skip_simplifications);
             if from_value.is_err() || from_value.unwrap() != to_value.clone().unwrap() {
                 return Err(MonomorphizationError::CheckedCastFailed {
                     actual: HirType::Constant(to_value.unwrap(), to.kind()),


### PR DESCRIPTION
# Description

## Problem

Resolves https://github.com/noir-lang/noir/issues/9326

Alternative to #9327

## Summary

This was another issue related to type variables, their ordering, and `sort_commutative`.

The idea of `sort_commutative` is to transform an expression like `(1 + a) + 2` into `(a + 1) + 2`, that is, always place constants on the right-hand side (that way when we need to simplify the addition above we can rely on the constants always being in those places).

For types that aren't constants, they are rearranged according to the order given by `impl Ord for Type`, which, for type variables, depends on their ID.

The problem was that we ended up with an expression like `(a + b) - 1` where, depending on the entire code to compile, the same expression could end up having `a: '1, b: '2` or `a: '2, a: '1`, that is, both are type variables but they got different IDs.

(Why they get different IDs? I didn't check, but the code should work fine regardless of this, so...)

Now imagine `b` is bound to a constant in `bindings`. `sort_commutative` will either leave it like `(a + b) - 1` or `(b + a) - 1`. That means that, when eventually we try to simplify the above we'll end up with `(a + 1) - 1` or `(1 + a) -1`): we'll be able to simplify it in the first scenario but not in the second one.

What this PR does is to eagerly replace `b` with `1` way before we reach `sort_commutative`. We do this before type canonicalization.

This partially reverts what #9265 did, greatly simplifying the code (no need to pass `bindings` all around).

## Additional Context



## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
