### PR TITLE
fix: don't assume default entry exists

### DIFF
--- a/tooling/nargo_cli/src/cli/mod.rs
+++ b/tooling/nargo_cli/src/cli/mod.rs
@@ -212,10 +212,12 @@ fn compile_with_maybe_dummy_workspace(
             CrateName::from_str(&package_name).expect("package_name to be a valid CrateName");
         let selection = PackageSelection::Selected(package_name);
 
+        let assume_default_entry = true;
         let workspace = resolve_workspace_from_fixed_toml(
             nargo_toml,
             selection,
             Some(NOIR_ARTIFACT_VERSION_STRING.to_owned()),
+            assume_default_entry,
         )?;
         compile_cmd::run(cmd, workspace)
     } else {

--- a/tooling/nargo_toml/src/lib.rs
+++ b/tooling/nargo_toml/src/lib.rs
@@ -548,7 +548,13 @@ pub fn resolve_workspace_from_toml(
     current_compiler_version: Option<String>,
 ) -> Result<Workspace, ManifestError> {
     let nargo_toml = read_toml(toml_path)?;
-    resolve_workspace_from_fixed_toml(nargo_toml, package_selection, current_compiler_version)
+    let assume_default_entry = false;
+    resolve_workspace_from_fixed_toml(
+        nargo_toml,
+        package_selection,
+        current_compiler_version,
+        assume_default_entry,
+    )
 }
 
 /// Resolves a Nargo.toml _ into a `Workspace` struct as defined by our `nargo` core.
@@ -558,8 +564,8 @@ pub fn resolve_workspace_from_fixed_toml(
     nargo_toml: NargoToml,
     package_selection: PackageSelection,
     current_compiler_version: Option<String>,
+    assume_default_entry: bool,
 ) -> Result<Workspace, ManifestError> {
-    let assume_default_entry = true;
     let workspace = toml_to_workspace(nargo_toml, package_selection, assume_default_entry)?;
     if let Some(current_compiler_version) = current_compiler_version {
         semver::semver_check_workspace(&workspace, current_compiler_version)?;


### PR DESCRIPTION
# Description

## Problem

Resolves #8749

## Summary

This got broken in #8253 because a helper function was introduced to compile from stdin and assume the entry file exists, but that helper function was also used for regular compilation.

## Additional Context

It would be nice to somehow test this but I'm not sure what's the best way to do it.

## Documentation

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
