### PR TITLE
fix: update noirjs_app.md 

### DIFF
--- a/docs/docs/tutorials/noirjs_app.md
+++ b/docs/docs/tutorials/noirjs_app.md
@@ -23,7 +23,7 @@ Let's go barebones. Doing the bare minimum is not only simple, but also allows y
 Barebones means we can immediately start with the dependencies even on an empty folder 😈:
 
 ```bash
-yarn add @noir-lang/noir_js@1.0.0-beta.6 @aztec/bb.js@0.84.0
+yarn add @noir-lang/noir_js@1.0.0-beta.8 @aztec/bb.js@0.84.0
 ```
 
 Wait, what are these dependencies?


### PR DESCRIPTION
# Description
The current Docs under noirjs_app.md as per the beta-8 release, uses the older version of noir_js that is `@noir-lang/noir_js@1.0.0-beta.6 ` instead of the newer compatible version `@noir-lang/noir_js@1.0.0-beta.8 

## Problem\*
https://github.com/noir-lang/noir/issues/9333

Resolves <!-- Link to GitHub Issue -->

## Summary\*
I have updated the Docs to use the newer version of noirjs as beta.8 so as to work efficiently.



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
