### PR TITLE
fix: add missing js_sys import in foreign_call outputs module

### DIFF
--- a/acvm-repo/acvm_js/src/foreign_call/outputs.rs
+++ b/acvm-repo/acvm_js/src/foreign_call/outputs.rs
@@ -2,6 +2,7 @@ use acvm::{
     FieldElement,
     brillig_vm::brillig::{ForeignCallParam, ForeignCallResult},
 };
+use js_sys;
 use wasm_bindgen::JsValue;
 
 use crate::js_witness_map::js_value_to_field_element;


### PR DESCRIPTION
Add missing js_sys import to fix compilation errors in foreign_call outputs module.
The module was using js_sys::Array without importing the js_sys crate.