### PR TITLE
fix: prevent invalid types in test/fuzz functions

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/mod.rs
+++ b/compiler/noirc_frontend/src/elaborator/mod.rs
@@ -929,6 +929,8 @@ impl<'context> Elaborator<'context> {
         let name_ident = HirIdent::non_trait_method(id, location);
 
         let is_entry_point = self.is_entry_point_function(func, in_contract);
+        let is_test_or_fuzz =
+            func.attributes().is_test_function() || func.attributes().is_fuzzing_harness();
 
         // Both the #[fold] and #[no_predicates] alter a function's inline type and code generation in similar ways.
         // In certain cases such as type checking (for which the following flag will be used) both attributes
@@ -993,12 +995,12 @@ impl<'context> Elaborator<'context> {
 
             self.check_if_type_is_valid_for_program_input(
                 &typ,
-                is_entry_point,
+                is_entry_point || is_test_or_fuzz,
                 has_inline_attribute,
                 type_location,
             );
 
-            if is_entry_point {
+            if is_entry_point || is_test_or_fuzz {
                 self.mark_type_as_used(&typ);
             }
 

--- a/compiler/noirc_frontend/src/hir/type_check/errors.rs
+++ b/compiler/noirc_frontend/src/hir/type_check/errors.rs
@@ -618,7 +618,7 @@ impl<'a> From<&'a TypeCheckError> for Diagnostic {
             }
             TypeCheckError::InvalidTypeForEntryPoint { location } => Diagnostic::simple_error(
                 "Only sized types may be used in the entry point to a program".to_string(),
-                "Slices, references, or any type containing them may not be used in main, contract functions, or foldable functions".to_string(), *location),
+                "Slices, references, or any type containing them may not be used in main, contract functions, test functions, fuzz functions or foldable functions".to_string(), *location),
             TypeCheckError::MismatchTraitImplNumParameters {
                 expected_num_parameters,
                 actual_num_parameters,

--- a/test_programs/compile_failure/test_invalid_argument_type/Nargo.toml
+++ b/test_programs/compile_failure/test_invalid_argument_type/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "test_invalid_argument_type"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.33.0"
+
+[dependencies]

--- a/test_programs/compile_failure/test_invalid_argument_type/src/main.nr
+++ b/test_programs/compile_failure/test_invalid_argument_type/src/main.nr
@@ -1,0 +1,4 @@
+fn main() {}
+
+#[test]
+fn test(_arg: &mut i32) {}

--- a/tooling/nargo_cli/tests/snapshots/compile_failure/array_oob_regression_7952/execute__tests__stderr.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_failure/array_oob_regression_7952/execute__tests__stderr.snap
@@ -6,7 +6,7 @@ error: Only sized types may be used in the entry point to a program
   ┌─ src/main.nr:1:12
   │
 1 │ fn main(a: [[u32; 0]; 1], b: bool) -> pub [u32; 0] {
-  │            ------------- Slices, references, or any type containing them may not be used in main, contract functions, or foldable functions
+  │            ------------- Slices, references, or any type containing them may not be used in main, contract functions, test functions, fuzz functions or foldable functions
   │
 
 Aborting due to 1 previous error

--- a/tooling/nargo_cli/tests/snapshots/compile_failure/databus_dead_param/execute__tests__stderr.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_failure/databus_dead_param/execute__tests__stderr.snap
@@ -6,7 +6,7 @@ error: Only sized types may be used in the entry point to a program
   ┌─ src/main.nr:4:22
   │
 4 │     _b: call_data(0) [(i8, i8, bool, bool, str<0>); 2],
-  │                      --------------------------------- Slices, references, or any type containing them may not be used in main, contract functions, or foldable functions
+  │                      --------------------------------- Slices, references, or any type containing them may not be used in main, contract functions, test functions, fuzz functions or foldable functions
   │
 
 Aborting due to 1 previous error

--- a/tooling/nargo_cli/tests/snapshots/compile_failure/databus_in_fn_with_empty_arr/execute__tests__stderr.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_failure/databus_in_fn_with_empty_arr/execute__tests__stderr.snap
@@ -6,7 +6,7 @@ error: Only sized types may be used in the entry point to a program
   ┌─ src/main.nr:1:17
   │
 1 │ fn main(_empty: [u32; 0], value_1: u32, value_2: call_data(0) u32) {
-  │                 -------- Slices, references, or any type containing them may not be used in main, contract functions, or foldable functions
+  │                 -------- Slices, references, or any type containing them may not be used in main, contract functions, test functions, fuzz functions or foldable functions
   │
 
 Aborting due to 1 previous error

--- a/tooling/nargo_cli/tests/snapshots/compile_failure/main_with_generics/execute__tests__stderr.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_failure/main_with_generics/execute__tests__stderr.snap
@@ -13,7 +13,7 @@ error: Only sized types may be used in the entry point to a program
   ┌─ src/main.nr:1:24
   │
 1 │ fn main<let F: u32>(x: [Field; F]) {
-  │                        ---------- Slices, references, or any type containing them may not be used in main, contract functions, or foldable functions
+  │                        ---------- Slices, references, or any type containing them may not be used in main, contract functions, test functions, fuzz functions or foldable functions
   │
 
 Aborting due to 2 previous errors

--- a/tooling/nargo_cli/tests/snapshots/compile_failure/test_invalid_argument_type/execute__tests__stderr.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_failure/test_invalid_argument_type/execute__tests__stderr.snap
@@ -1,0 +1,12 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: stderr
+---
+error: Only sized types may be used in the entry point to a program
+  ┌─ src/main.nr:4:15
+  │
+4 │ fn test(_arg: &mut i32) {}
+  │               -------- Slices, references, or any type containing them may not be used in main, contract functions, test functions, fuzz functions or foldable functions
+  │
+
+Aborting due to 1 previous error

--- a/tooling/nargo_cli/tests/snapshots/compile_failure/unit_in_main/execute__tests__stderr.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_failure/unit_in_main/execute__tests__stderr.snap
@@ -6,7 +6,7 @@ error: Only sized types may be used in the entry point to a program
   ┌─ src/main.nr:1:12
   │
 1 │ fn main(_: ()) {}
-  │            -- Slices, references, or any type containing them may not be used in main, contract functions, or foldable functions
+  │            -- Slices, references, or any type containing them may not be used in main, contract functions, test functions, fuzz functions or foldable functions
   │
 
 Aborting due to 1 previous error


### PR DESCRIPTION
# Description

## Problem

Resolves #9322

## Summary



## Additional Context



## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
