### PR TITLE
fix(ssa): Keep reference count increments for array set values

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/opt/preprocess_fns.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/preprocess_fns.rs
@@ -56,8 +56,11 @@ impl Ssa {
             let mut function = function.inlined(&self, &should_inline_call)?;
             // Help unrolling determine bounds.
             function.as_slice_optimization();
+            println!("Pre LICM:\n{}", function);
+
             // Prepare for unrolling
             function.loop_invariant_code_motion();
+            println!("Post LICM:\n{}", function);
             // We might not be able to unroll all loops without fully inlining them, so ignore errors.
             let _ = function.unroll_loops_iteratively();
             // Reduce the number of redundant stores/loads after unrolling
@@ -73,6 +76,7 @@ impl Ssa {
         // Remove any functions that have been inlined into others already.
         let ssa = self.remove_unreachable_functions();
         // Remove leftover instructions.
+        // Ok(ssa)
         Ok(ssa.dead_instruction_elimination_pre_flattening())
     }
 }


### PR DESCRIPTION
# Description

## Problem\*

Resolves #9155 

## Summary\*

Take the SSA posted from the issue:
<details><summary>Details</summary>
<p>

```
brillig(inline) predicate_pure fn func_1 f1 {
  b0(v0: [[Field; 1]; 1]):
    v2 = allocate -> &mut [[Field; 1]; 1]
    store v0 at v2
    v4 = make_array [Field 2] : [Field; 1]
    jmp b1(u32 0)
  b1(v1: u32):
    v7 = lt v1, u32 2
    jmpif v7 then: b2, else: b3
  b2():
    v11 = allocate -> &mut Field
    store Field 0 at v11
    jmp b4()
  b3():
    v8 = load v2 -> [[Field; 1]; 1]
    v9 = array_get v8, index u32 0 -> [Field; 1]
    inc_rc v9
    v10 = array_get v9, index u32 0 -> Field
    return v10
  b4():
    v13 = load v11 -> Field
    v15 = eq v13, Field 1
    jmpif v15 then: b5, else: b6
  b5():
    inc_rc v4                                                               // <- this inc_rc gets removed
    v22 = load v2 -> [[Field; 1]; 1]
    v23 = array_set v22, index u32 0, value v4
    store v23 at v2
    v25 = unchecked_add v1, u32 1
    jmp b1(v25)
  b6():
    v16 = load v11 -> Field
    v17 = add v16, Field 1
    store v17 at v11
    v18 = load v2 -> [[Field; 1]; 1]
    v19 = array_get v18, index u32 0 -> [Field; 1]
    v20 = array_set v19, index u32 0, value Field 1
    v21 = array_set v18, index u32 0, value v20
    store v21 at v2
    jmp b4()
}
```

</p>
</details> 

When `inc_rc v4` gets removed, we risk it later being mutated in `v20 = array_set v19, index u32 0, value Field 1`. Thus, when we later go to do `v23 = array_set v22, index u32 0, value v4` once more, we will be writing [1] rather than [2].

The `inc_rc` in b5 is inserted by LICM (correctly). And if we hoist [2] manually and check the monomorphized program we can see that we are expected to clone [2]:
```
unconstrained fn func_1$f1(mut a$l0: [[Field; 1]; 1]) -> Field {
    let two$l1 = [2];
    {
        let mut i$l2 = 0;
        loop {
            if (i$l2 == 2) {
                break
            } else {
                i$l2 = (i$l2 + 1);
                let mut j$l3 = 0;
                loop {
                    if (j$l3 == 1) {
                        break
                    } else {
                        j$l3 = (j$l3 + 1);
                        a$l0[0][0] = 1
                    }
                };
                a$l0[0] = two$l1.clone()
            }
        }
    };;
    a$l0[0].clone()[0]
}
```

## Additional Context

Thanks to @asterite for debugging this issue. 

## Documentation\*

Check one:
- [X] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
