### PR TITLE
fix: do u128 operations with u128, not i128

### DIFF
--- a/compiler/noirc_frontend/src/hir/type_check/errors.rs
+++ b/compiler/noirc_frontend/src/hir/type_check/errors.rs
@@ -54,7 +54,7 @@ pub enum TypeCheckError {
         location: Location,
     },
     #[error("Evaluating `{op}` on `{lhs}`, `{rhs}` failed")]
-    FailingBinaryOp { op: BinaryTypeOperator, lhs: i128, rhs: i128, location: Location },
+    FailingBinaryOp { op: BinaryTypeOperator, lhs: String, rhs: String, location: Location },
     #[error("Type {typ:?} cannot be used in a {place:?}")]
     TypeCannotBeUsed { typ: Type, place: &'static str, location: Location },
     #[error("Expected type {expected_typ:?} is not the same as {expr_typ:?}")]

--- a/compiler/noirc_frontend/src/tests/arithmetic_generics.rs
+++ b/compiler/noirc_frontend/src/tests/arithmetic_generics.rs
@@ -1,5 +1,7 @@
 #![cfg(test)]
 
+use core::panic;
+
 use acvm::{AcirField, FieldElement};
 
 use crate::assert_no_errors;
@@ -93,10 +95,12 @@ fn arithmetic_generics_checked_cast_zeros() {
             }
             _ => panic!("unexpected length: {length:?}"),
         }
-        assert!(matches!(
-            err,
-            TypeCheckError::FailingBinaryOp { op: BinaryTypeOperator::Modulo, lhs: 0, rhs: 0, .. }
-        ));
+        let TypeCheckError::FailingBinaryOp { op, lhs, rhs, .. } = err else {
+            panic!("Expected FailingBinaryOp, but found: {err:?}");
+        };
+        assert_eq!(op, &BinaryTypeOperator::Modulo);
+        assert_eq!(lhs, "0");
+        assert_eq!(rhs, "0");
     } else {
         panic!("unexpected error: {monomorphization_error:?}");
     }

--- a/test_programs/compile_success_empty/comptime_u128_ops/Nargo.toml
+++ b/test_programs/compile_success_empty/comptime_u128_ops/Nargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "comptime_u128_ops"
+type = "bin"
+authors = [""]
+
+[dependencies]

--- a/test_programs/compile_success_empty/comptime_u128_ops/src/main.nr
+++ b/test_programs/compile_success_empty/comptime_u128_ops/src/main.nr
@@ -1,0 +1,19 @@
+fn main() {
+    comptime {
+        let y = foo::<340282366920938463463374607431768211455, 1>();
+        assert_eq(y.n(), 340282366920938463463374607431768211454);
+    }
+}
+
+struct T<let N: u128> {}
+
+impl<let N: u128> T<N> {
+    fn n(self) -> u128 {
+        let _ = self;
+        N
+    }
+}
+
+fn foo<let x: u128, let y: u128>() -> T<x - y> {
+    T {}
+}

--- a/tooling/nargo_cli/tests/snapshots/compile_success_empty/comptime_u128_ops/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_empty/comptime_u128_ops/execute__tests__expanded.snap
@@ -1,0 +1,20 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: expanded_code
+---
+fn main() {
+    ()
+}
+
+struct T<let N: u128> {}
+
+impl<let N: u128> T<N> {
+    fn n(self) -> u128 {
+        let _: Self = self;
+        N
+    }
+}
+
+fn foo<let x: u128, let y: u128>() -> T<x - y> {
+    T::<x - y> {}
+}

--- a/tooling/nargo_cli/tests/snapshots/compile_success_empty/comptime_u128_ops/execute__tests__force_brillig_false_inliner_0.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_empty/comptime_u128_ops/execute__tests__force_brillig_false_inliner_0.snap
@@ -1,0 +1,26 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: artifact
+---
+{
+  "noir_version": "[noir_version]",
+  "hash": "[hash]",
+  "abi": {
+    "parameters": [],
+    "return_type": null,
+    "error_types": {}
+  },
+  "bytecode": [
+    "func 0",
+    "current witness index : _0",
+    "private parameters indices : []",
+    "public parameters indices : []",
+    "return value indices : []"
+  ],
+  "debug_symbols": "XY5BCsQwCEXv4rqLWfcqw1BsaosgJtikMITefWyYQOlK/3/6tcJCc9km1jXuML4rzMYivE0SA2aO6m49B+hyykbkFty4byU00gyjFpEBDpTShvaE2mpGc/oagHTx6oErC13d+XGBge158UBjnIX+ci0abjR/Uyf942Qx0FKMrqTGPPsH",
+  "file_map": {},
+  "names": [
+    "main"
+  ],
+  "brillig_names": []
+}


### PR DESCRIPTION
# Description

## Problem

Resolves #9192

## Summary



## Additional Context



## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
