### PR TITLE
chore: try printing byte arrays as strings in the SSA interpreter

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/interpreter/value.rs
+++ b/compiler/noirc_evaluator/src/ssa/interpreter/value.rs
@@ -442,19 +442,24 @@ impl std::fmt::Display for ArrayValue {
         {
             const FORM_FEED: u8 = 12; // This is the ASCII code for '\f', which isn't a valid escape sequence in strings
             let printable = self.elements.borrow().iter().all(|value| {
-                matches!(value, Value::Numeric(NumericValue::U8(byte)) 
-                  if *byte != FORM_FEED && 
-                    (byte.is_ascii_alphanumeric() 
-                      || byte.is_ascii_punctuation() 
+                matches!(value, Value::Numeric(NumericValue::U8(byte))
+                  if *byte != FORM_FEED &&
+                    (byte.is_ascii_alphanumeric()
+                      || byte.is_ascii_punctuation()
                       || byte.is_ascii_whitespace()))
             });
             if printable {
-                let bytes = self.elements.borrow().iter().map(|value| {
-                    let Value::Numeric(NumericValue::U8(byte)) = value else {
-                        panic!("Expected U8 value in array, found {value}");
-                    };
-                    *byte
-                }).collect::<Vec<_>>();
+                let bytes = self
+                    .elements
+                    .borrow()
+                    .iter()
+                    .map(|value| {
+                        let Value::Numeric(NumericValue::U8(byte)) = value else {
+                            panic!("Expected U8 value in array, found {value}");
+                        };
+                        *byte
+                    })
+                    .collect::<Vec<_>>();
                 let string = String::from_utf8(bytes).unwrap();
                 write!(f, "b{string:?}")?;
                 return Ok(());

--- a/compiler/noirc_evaluator/src/ssa/interpreter/value.rs
+++ b/compiler/noirc_evaluator/src/ssa/interpreter/value.rs
@@ -8,6 +8,7 @@ use crate::ssa::ir::{
     function::FunctionId,
     instruction::Intrinsic,
     integer::IntegerConstant,
+    is_printable_byte,
     types::{CompositeType, NumericType, Type},
     value::ValueId,
 };
@@ -440,13 +441,8 @@ impl std::fmt::Display for ArrayValue {
         if self.element_types.len() == 1
             && matches!(self.element_types[0], Type::Numeric(NumericType::Unsigned { bit_size: 8 }))
         {
-            const FORM_FEED: u8 = 12; // This is the ASCII code for '\f', which isn't a valid escape sequence in strings
             let printable = self.elements.borrow().iter().all(|value| {
-                matches!(value, Value::Numeric(NumericValue::U8(byte))
-                  if *byte != FORM_FEED &&
-                    (byte.is_ascii_alphanumeric()
-                      || byte.is_ascii_punctuation()
-                      || byte.is_ascii_whitespace()))
+                matches!(value, Value::Numeric(NumericValue::U8(byte)) if is_printable_byte(*byte))
             });
             if printable {
                 let bytes = self

--- a/compiler/noirc_evaluator/src/ssa/ir/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/mod.rs
@@ -12,3 +12,4 @@ pub(crate) mod post_order;
 pub(crate) mod printer;
 pub mod types;
 pub mod value;
+pub use printer::is_printable_byte;

--- a/compiler/noirc_evaluator/src/ssa/ir/printer.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/printer.rs
@@ -434,18 +434,21 @@ fn try_byte_array_to_string(elements: &Vector<ValueId>, dfg: &DataFlowGraph) -> 
             return None;
         }
         let byte: u8 = element as u8;
-        const FORM_FEED: u8 = 12; // This is the ASCII code for '\f', which isn't a valid escape sequence in strings
-        if byte != FORM_FEED
-            && (byte.is_ascii_alphanumeric()
-                || byte.is_ascii_punctuation()
-                || byte.is_ascii_whitespace())
-        {
+        if is_printable_byte(byte) {
             string.push(byte as char);
         } else {
             return None;
         }
     }
     Some(string)
+}
+
+pub fn is_printable_byte(byte: u8) -> bool {
+    const FORM_FEED: u8 = 12; // This is the ASCII code for '\f', which isn't a valid escape sequence in strings
+    byte != FORM_FEED
+        && (byte.is_ascii_alphanumeric()
+            || byte.is_ascii_punctuation()
+            || byte.is_ascii_whitespace())
 }
 
 fn result_types(dfg: &DataFlowGraph, results: &[ValueId]) -> String {


### PR DESCRIPTION
# Description

## Problem

No issue.

## Summary

While debugging https://github.com/noir-lang/noir/issues/9270 with `nargo interpret` it was hard to remember which values were correct or incorrect by looking at numbers. With this PR byte arrays that are likely strings will be shown as such, like we do everywhere else when it comes to SSA. For example:

```
--- Interpreter result after Initial SSA:
Ok(rc3 [rc1 [rc2 b"EN"], rc2 [rc2 b"EN"]])
```

## Additional Context



## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
