### PR TITLE
chore: remove unused `compile_workspace`

### DIFF
--- a/tooling/nargo/src/ops/mod.rs
+++ b/tooling/nargo/src/ops/mod.rs
@@ -1,7 +1,7 @@
 pub use self::check::check_program;
 pub use self::compile::{
     check_crate_and_report_errors, collect_errors, compile_contract, compile_program,
-    compile_program_with_debug_instrumenter, compile_workspace, report_errors,
+    compile_program_with_debug_instrumenter, report_errors,
 };
 pub use self::optimize::{optimize_contract, optimize_program};
 pub use self::transform::{transform_contract, transform_program};


### PR DESCRIPTION
# Description

## Problem

No issue.

## Summary

I noticed that this function is unused. Can it be removed? I don't know if it was intended to be used as an API though.

## Additional Context

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
