### PR TITLE
fix: prevent `SignedField::from(i128::MIN)` from crashing

### DIFF
--- a/compiler/noirc_frontend/src/signed_field.rs
+++ b/compiler/noirc_frontend/src/signed_field.rs
@@ -219,7 +219,13 @@ impl From<u128> for SignedField {
 
 impl From<i128> for SignedField {
     fn from(value: i128) -> Self {
-        if value < 0 { Self::new((-value).into(), true) } else { Self::new(value.into(), false) }
+        if value == i128::MIN {
+            Self::new(FieldElement::from((i128::MAX as u128) + 1), true)
+        } else if value < 0 {
+            Self::new((-value).into(), true)
+        } else {
+            Self::new(value.into(), false)
+        }
     }
 }
 
@@ -422,5 +428,12 @@ mod tests {
             SignedField::negative(FieldElement::from((i128::MAX as u128) + 1)).to_i128(),
             i128::MIN
         );
+    }
+
+    #[test]
+    fn from_i128() {
+        assert_eq!(SignedField::from(i128::MAX).to_i128(), i128::MAX);
+        assert_eq!(SignedField::from(i128::MIN).to_i128(), i128::MIN);
+        assert_eq!(SignedField::from(i128::MIN + 1).to_i128(), i128::MIN + 1);
     }
 }


### PR DESCRIPTION
# Description

## Problem

Addresses https://github.com/noir-lang/noir/pull/9360#discussion_r2243723796

## Summary



## Additional Context



## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
