### PR TITLE
chore: add a mem2reg test for when all references need to be invalidated

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/opt/mem2reg.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/mem2reg.rs
@@ -1423,7 +1423,7 @@ mod tests {
         // This is just a test to ensure the case where `aliases.is_unknown()` is tested.
         // Here, `v8 = load v0 -> Field` cannot be removed and replaced with `Field 10`
         // because `v6` is passed to another function and we don't know what that reference
-        // points it, and it could potentially change the value of `v0`.
+        // points to, and it could potentially change the value of `v0`.
         let src = "
         brillig(inline) fn foo f0 {
           b0(v0: &mut Field):

--- a/compiler/noirc_evaluator/src/ssa/opt/mem2reg/block.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/mem2reg/block.rs
@@ -93,9 +93,8 @@ impl Block {
         let aliases = self.aliases.entry(expression.clone()).or_default();
 
         if aliases.is_unknown() {
-            // uh-oh, we don't know at all what this reference refers to, could be anything.
-            // Now we have to invalidate every reference we know of
-            self.invalidate_all_references();
+            assert!(self.references.is_empty());
+            assert!(self.last_stores.is_empty());
         } else if let Some(alias) = aliases.single_alias() {
             self.references.insert(alias, value);
         } else {
@@ -107,11 +106,6 @@ impl Block {
                 }
             });
         }
-    }
-
-    fn invalidate_all_references(&mut self) {
-        self.references.clear();
-        self.last_stores.clear();
     }
 
     pub(super) fn unify(mut self, other: &Self) -> Self {

--- a/compiler/noirc_evaluator/src/ssa/opt/mem2reg/block.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/mem2reg/block.rs
@@ -93,8 +93,9 @@ impl Block {
         let aliases = self.aliases.entry(expression.clone()).or_default();
 
         if aliases.is_unknown() {
-            assert!(self.references.is_empty());
-            assert!(self.last_stores.is_empty());
+            // uh-oh, we don't know at all what this reference refers to, could be anything.
+            // Now we have to invalidate every reference we know of
+            self.invalidate_all_references();
         } else if let Some(alias) = aliases.single_alias() {
             self.references.insert(alias, value);
         } else {
@@ -106,6 +107,11 @@ impl Block {
                 }
             });
         }
+    }
+
+    fn invalidate_all_references(&mut self) {
+        self.references.clear();
+        self.last_stores.clear();
     }
 
     pub(super) fn unify(mut self, other: &Self) -> Self {


### PR DESCRIPTION
# Description

## Problem

No issue, just part of the mem2reg audit.

## Summary

While browsing the code I noticed this case where aliases is empty, in which case we have to invalidate all references. I wondered what piece of code could produce a reference for which we don't have at least one alias (itself) so I added a debug print in that case. The debug print was hit, but then I checked if, when it's hit, there were references and last stores to invalidate at all. At least when running all tests I couldn't find such case so this PR turns that into an assertion.

Well, when creating this PR it turns out the fuzzer found some code that triggered that case. I reduced that code, got an SSA for it and added a test for that scenario, trying to explain the reasoning behind it.

## Additional Context


## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
