### PR TITLE
chore: address TODO comments

### DIFF
--- a/compiler/noirc_evaluator/src/acir/mod.rs
+++ b/compiler/noirc_evaluator/src/acir/mod.rs
@@ -806,17 +806,13 @@ impl<'a> Context<'a> {
                         let outputs = self
                             .convert_ssa_intrinsic_call(*intrinsic, arguments, dfg, result_ids)?;
 
-                        // Issue #1438 causes this check to fail with intrinsics that return 0
-                        // results but the ssa form instead creates 1 unit result value.
-                        // assert_eq!(result_ids.len(), outputs.len());
+                        assert_eq!(result_ids.len(), outputs.len());
                         self.handle_ssa_call_outputs(result_ids, outputs, dfg)?;
                     }
-                    Value::ForeignFunction(_) => {
-                        // TODO: Remove this once elaborator is default frontend. This is now caught by a lint inside the frontend.
-                        return Err(RuntimeError::UnconstrainedOracleReturnToConstrained {
-                            call_stack: self.acir_context.get_call_stack(),
-                        });
-                    }
+                    Value::ForeignFunction(_) => unreachable!(
+                        "Frontend should remove any oracle calls from constrained functions"
+                    ),
+
                     _ => unreachable!("expected calling a function but got {function_value:?}"),
                 }
             }

--- a/compiler/noirc_evaluator/src/errors.rs
+++ b/compiler/noirc_evaluator/src/errors.rs
@@ -64,8 +64,6 @@ pub enum RuntimeError {
     BigIntModulus { call_stack: CallStack },
     #[error("Slices cannot be returned from an unconstrained runtime to a constrained runtime")]
     UnconstrainedSliceReturnToConstrained { call_stack: CallStack },
-    #[error("All `oracle` methods should be wrapped in an unconstrained fn")]
-    UnconstrainedOracleReturnToConstrained { call_stack: CallStack },
     #[error(
         "Could not resolve some references to the array. All references must be resolved at compile time"
     )]
@@ -78,7 +76,7 @@ pub enum RuntimeError {
         "Cannot return a function from an if or match expression, or assignment within these expressions"
     )]
     ReturnedFunctionFromDynamicIf { call_stack: CallStack },
-    /// This case is not an error. It's used during codegen to prevent inserting instructions after
+    /// This case is not an error. It's used during codegen to prevent inserting instructions after\
     /// code when a break or continue is generated.
     #[error("Break or continue")]
     BreakOrContinue { call_stack: CallStack },
@@ -200,7 +198,6 @@ impl RuntimeError {
             | RuntimeError::NestedSlice { call_stack, .. }
             | RuntimeError::BigIntModulus { call_stack, .. }
             | RuntimeError::UnconstrainedSliceReturnToConstrained { call_stack }
-            | RuntimeError::UnconstrainedOracleReturnToConstrained { call_stack }
             | RuntimeError::ReturnedReferenceFromDynamicIf { call_stack }
             | RuntimeError::ReturnedFunctionFromDynamicIf { call_stack }
             | RuntimeError::BreakOrContinue { call_stack }

--- a/compiler/noirc_evaluator/src/errors.rs
+++ b/compiler/noirc_evaluator/src/errors.rs
@@ -76,7 +76,7 @@ pub enum RuntimeError {
         "Cannot return a function from an if or match expression, or assignment within these expressions"
     )]
     ReturnedFunctionFromDynamicIf { call_stack: CallStack },
-    /// This case is not an error. It's used during codegen to prevent inserting instructions after\
+    /// This case is not an error. It's used during codegen to prevent inserting instructions after
     /// code when a break or continue is generated.
     #[error("Break or continue")]
     BreakOrContinue { call_stack: CallStack },


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This PR handles a couple of TODO comments now that elaborator is default + #1438 is resolved.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
