### PR TITLE
fix: disable comptime printing when requesting json output

### DIFF
--- a/tooling/nargo_cli/src/cli/info_cmd.rs
+++ b/tooling/nargo_cli/src/cli/info_cmd.rs
@@ -62,7 +62,7 @@ impl WorkspaceCommand for InfoCommand {
 
 pub(crate) fn run(mut args: InfoCommand, workspace: Workspace) -> Result<(), CliError> {
     if args.json {
-        // In order to have a machine readable output, we cannot allow the program print arbitrary data to stdout.
+        // In order to have a machine readable output, we cannot allow the program to print arbitrary data to stdout.
         args.compile_options.disable_comptime_printing = true;
     }
 

--- a/tooling/nargo_cli/src/cli/info_cmd.rs
+++ b/tooling/nargo_cli/src/cli/info_cmd.rs
@@ -61,6 +61,11 @@ impl WorkspaceCommand for InfoCommand {
 }
 
 pub(crate) fn run(mut args: InfoCommand, workspace: Workspace) -> Result<(), CliError> {
+    if args.json {
+        // In order to have a machine readable output, we cannot allow the program print arbitrary data to stdout.
+        args.compile_options.disable_comptime_printing = true;
+    }
+
     if args.profile_execution {
         // Execution profiling is only relevant with the Brillig VM
         // as a constrained circuit should have totally flattened control flow (e.g. loops and if statements).


### PR DESCRIPTION
# Description

## Problem\*

Resolves #9380 

## Summary\*

We now specify that we expect zero comptime printing when requesting a machine readable output.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
