### PR TITLE
chore: create directory when writing witness artefact

### DIFF
--- a/tooling/artifact_cli/src/fs/witness.rs
+++ b/tooling/artifact_cli/src/fs/witness.rs
@@ -3,7 +3,10 @@ use std::path::{Path, PathBuf};
 use acir::FieldElement;
 use acvm::acir::native_types::WitnessStack;
 
-use crate::errors::{CliError, FilesystemError};
+use crate::{
+    errors::{CliError, FilesystemError},
+    fs::artifact::write_to_file,
+};
 
 /// Write `witness.gz` to the output directory.
 pub fn save_witness_to_dir(
@@ -19,7 +22,7 @@ pub fn save_witness_to_dir(
         FilesystemError::OutputWitnessCreationFailed(witness_path.clone(), format!("{e:?}"))
     })?;
 
-    std::fs::write(&witness_path, buf.as_slice()).map_err(|e| {
+    write_to_file(buf.as_slice(), &witness_path).map_err(|e| {
         FilesystemError::OutputWitnessCreationFailed(witness_path.clone(), e.to_string())
     })?;
 


### PR DESCRIPTION
# Description

## Problem\*

Resolves #8137

## Summary\*
small change to create the parent directory if it does not exist when writing the witness file.


## Additional Context



## Documentation\*

Check one:
- [X] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
