### PR TITLE
chore: Regression test for calling a mutable closure inside a mutable closure

### DIFF
--- a/test_programs/compile_success_empty/call_mut_closure_inside_mut_closure/Nargo.toml
+++ b/test_programs/compile_success_empty/call_mut_closure_inside_mut_closure/Nargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "call_mut_closure_inside_mut_closure"
+type = "bin"
+authors = [""]
+
+[dependencies]

--- a/test_programs/compile_success_empty/call_mut_closure_inside_mut_closure/src/main.nr
+++ b/test_programs/compile_success_empty/call_mut_closure_inside_mut_closure/src/main.nr
@@ -1,0 +1,9 @@
+// Regression for issue #5545 ()https://github.com/noir-lang/noir/issues/5545
+fn main() {
+    let mut c = || {
+        let mut d = || {};
+        d();
+    };
+
+    c();
+}

--- a/tooling/nargo_cli/tests/snapshots/compile_success_empty/call_mut_closure_inside_mut_closure/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_empty/call_mut_closure_inside_mut_closure/execute__tests__expanded.snap
@@ -1,0 +1,11 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: expanded_code
+---
+fn main() {
+    let mut c: fn() = || {
+        let mut d: fn() = || {};
+        d();
+    };
+    c();
+}

--- a/tooling/nargo_cli/tests/snapshots/compile_success_empty/call_mut_closure_inside_mut_closure/execute__tests__force_brillig_false_inliner_0.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_empty/call_mut_closure_inside_mut_closure/execute__tests__force_brillig_false_inliner_0.snap
@@ -1,0 +1,26 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: artifact
+---
+{
+  "noir_version": "[noir_version]",
+  "hash": "[hash]",
+  "abi": {
+    "parameters": [],
+    "return_type": null,
+    "error_types": {}
+  },
+  "bytecode": [
+    "func 0",
+    "current witness index : _0",
+    "private parameters indices : []",
+    "public parameters indices : []",
+    "return value indices : []"
+  ],
+  "debug_symbols": "XY5BCsQwCEXv4rqLWfcqw1BsaosgJtikMITefWyYQOlK/3/6tcJCc9km1jXuML4rzMYivE0SA2aO6m49B+hyykbkFty4byU00gyjFpEBDpTShvaE2mpGc/oagHTx6oErC13d+XGBge158UBjnIX+ci0abjR/Uyf942Qx0FKMrqTGPPsH",
+  "file_map": {},
+  "names": [
+    "main"
+  ],
+  "brillig_names": []
+}


### PR DESCRIPTION
# Description

## Problem\*

Resolves #5545 

## Summary\*

Going through existing inlining bugs and found this one that looks to be passing now. 

We now appropriately compile to an empty program for the snippet in #5545. This PR simply adds the test as a regression. Hitting the recursion limit error (previously a panic as per the issue) is unexpected and it looks like the compiler now correctly handles this case (there have been updates to both defunctionalization and inlining since this issue was created). 

## Additional Context



## Documentation\*

Check one:
- [X] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
