### PR TITLE
chop: error on non constant inputs for Pedersen generators

### DIFF
--- a/compiler/noirc_evaluator/src/acir/mod.rs
+++ b/compiler/noirc_evaluator/src/acir/mod.rs
@@ -1751,9 +1751,9 @@ impl<'a> Context<'a> {
             Intrinsic::IsUnconstrained => {
                 unreachable!("Expected is_unconstrained to be removed by this point")
             }
-            Intrinsic::DerivePedersenGenerators => {
-                unreachable!("DerivePedersenGenerators can only be called with constants")
-            }
+            Intrinsic::DerivePedersenGenerators => Err(RuntimeError::AssertConstantFailed {
+                call_stack: self.acir_context.get_call_stack(),
+            }),
             Intrinsic::FieldLessThan => {
                 unreachable!("FieldLessThan can only be called in unconstrained")
             }


### PR DESCRIPTION
# Description

## Problem\*

Resolves #7064

## Summary\*
error when calling pedersen generators with non-constant inputs, instead of panic.


## Additional Context



## Documentation\*

Check one:
- [X] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
