### PR TITLE
fix: remember dereference in mem2reg ArrayGet

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/opt/mem2reg.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/mem2reg.rs
@@ -1466,4 +1466,25 @@ mod tests {
         // We expect the program to be unchanged
         assert_normalized_ssa_equals(ssa, src);
     }
+
+    #[test]
+    fn does_not_remove_store_to_return_value() {
+        // The last store can't be removed as it stores a value in a function parameter
+        let src = "
+        acir(inline) fn main f0 {
+          b0():
+            v0 = allocate -> &mut Field
+            store Field 4 at v0
+            jmp b1()
+          b1():
+            return v0
+        }
+        ";
+
+        let ssa = Ssa::from_str(src).unwrap();
+
+        let ssa = ssa.mem2reg();
+        // We expect the program to be unchanged
+        assert_normalized_ssa_equals(ssa, src);
+    }
 }

--- a/compiler/noirc_evaluator/src/ssa/opt/mem2reg.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/mem2reg.rs
@@ -1076,7 +1076,7 @@ mod tests {
 
     #[test]
     fn keep_repeat_loads_with_alias_store() {
-        // v7, v8, and v9 alias one another. We want to make sure that a repeat load to v7 with a store
+        // v1, v2, and v3 alias one another. We want to make sure that a repeat load to v1 with a store
         // to its aliases in between the repeat loads does not remove those loads.
         let src = "
         acir(inline) fn main f0 {

--- a/compiler/noirc_evaluator/src/ssa/opt/mem2reg.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/mem2reg.rs
@@ -1446,4 +1446,24 @@ mod tests {
         let ssa = ssa.mem2reg();
         assert_normalized_ssa_equals(ssa, src);
     }
+
+    #[test]
+    fn does_not_remove_store_to_function_parameter() {
+        // The last store can't be removed as it stores a value in a function parameter
+        let src = "
+        acir(inline) fn main f0 {
+          b0(v0: &mut Field):
+            jmp b1()
+          b1():
+            store Field 4 at v0
+            return
+        }
+        ";
+
+        let ssa = Ssa::from_str(src).unwrap();
+
+        let ssa = ssa.mem2reg();
+        // We expect the program to be unchanged
+        assert_normalized_ssa_equals(ssa, src);
+    }
 }

--- a/test_programs/compile_success_empty/regression_9398/Nargo.toml
+++ b/test_programs/compile_success_empty/regression_9398/Nargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "regression_9398"
+type = "bin"
+authors = [""]
+
+[dependencies]

--- a/test_programs/compile_success_empty/regression_9398/src/main.nr
+++ b/test_programs/compile_success_empty/regression_9398/src/main.nr
@@ -1,0 +1,13 @@
+fn main() {
+    let string = &mut "OOPS";
+    let param = [string];
+    assert_eq(*param[0], "OOPS");
+    foo(param);
+    assert_eq(*param[0], "GOOD");
+}
+
+fn foo(param: [&mut str<4>; 1]) {
+    let s = param[0];
+    *s = "GOOD";
+    for _ in 0..1 {}
+}

--- a/tooling/nargo_cli/tests/snapshots/compile_success_empty/regression_9398/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_empty/regression_9398/execute__tests__expanded.snap
@@ -1,0 +1,17 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: expanded_code
+---
+fn main() {
+    let string: &mut str<4> = &mut "OOPS";
+    let param: [&mut str<4>; 1] = [string];
+    assert(*param[0_u32] == "OOPS");
+    foo(param);
+    assert(*param[0_u32] == "GOOD");
+}
+
+fn foo(param: [&mut str<4>; 1]) {
+    let s: &mut str<4> = param[0_u32];
+    *(s) = "GOOD";
+    for _ in 0_u32..1_u32 {}
+}

--- a/tooling/nargo_cli/tests/snapshots/compile_success_empty/regression_9398/execute__tests__force_brillig_false_inliner_0.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_empty/regression_9398/execute__tests__force_brillig_false_inliner_0.snap
@@ -1,0 +1,26 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: artifact
+---
+{
+  "noir_version": "[noir_version]",
+  "hash": "[hash]",
+  "abi": {
+    "parameters": [],
+    "return_type": null,
+    "error_types": {}
+  },
+  "bytecode": [
+    "func 0",
+    "current witness index : _0",
+    "private parameters indices : []",
+    "public parameters indices : []",
+    "return value indices : []"
+  ],
+  "debug_symbols": "XY5BCsQwCEXv4rqLWfcqw1BsaosgJtikMITefWyYQOlK/3/6tcJCc9km1jXuML4rzMYivE0SA2aO6m49B+hyykbkFty4byU00gyjFpEBDpTShvaE2mpGc/oagHTx6oErC13d+XGBge158UBjnIX+ci0abjR/Uyf942Qx0FKMrqTGPPsH",
+  "file_map": {},
+  "names": [
+    "main"
+  ],
+  "brillig_names": []
+}


### PR DESCRIPTION
# Description

## Problem

Resolves #9398

## Summary

Also adds a couple of tests for code that wasn't hit in these unit tests.

I'm not entirely sure the fix is correct though, but: it seems to fix the issue, and `array_get` that returns a reference does seem very similar to loading a reference value from an address (if we consider the array value to be an address).

## Additional Context


## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
