### PR TITLE
chore(remove_paired_rc: Add various unit tests

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/opt/rc.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/rc.rs
@@ -154,9 +154,13 @@ fn remove_instructions(to_remove: HashSet<InstructionId>, function: &mut Functio
 #[cfg(test)]
 mod test {
 
-    use crate::ssa::{
-        ir::{basic_block::BasicBlockId, dfg::DataFlowGraph, instruction::Instruction},
-        ssa_gen::Ssa,
+    use crate::{
+        assert_ssa_snapshot,
+        ssa::{
+            ir::{basic_block::BasicBlockId, dfg::DataFlowGraph, instruction::Instruction},
+            opt::assert_normalized_ssa_equals,
+            ssa_gen::Ssa,
+        },
     };
 
     fn count_inc_rcs(block: BasicBlockId, dfg: &DataFlowGraph) -> usize {
@@ -264,5 +268,179 @@ mod test {
         // No changes, the array is possibly mutated
         assert_eq!(count_inc_rcs(entry, &main.dfg), 1);
         assert_eq!(count_dec_rcs(entry, &main.dfg), 1);
+    }
+
+    #[test]
+    fn lone_inc_rc() {
+        let src = "
+        brillig(inline) fn foo f0 {
+          b0(v0: [Field; 2]):
+            inc_rc v0
+            return v0
+        }
+        ";
+        let ssa = Ssa::from_str(src).unwrap();
+        let ssa = ssa.remove_paired_rc();
+        assert_normalized_ssa_equals(ssa, src);
+    }
+
+    #[test]
+    fn lone_dec_rc() {
+        let src = "
+        brillig(inline) fn foo f0 {
+          b0(v0: [Field; 2]):
+            dec_rc v0
+            return v0
+        }
+        ";
+        let ssa = Ssa::from_str(src).unwrap();
+        let ssa = ssa.remove_paired_rc();
+        assert_normalized_ssa_equals(ssa, src);
+    }
+
+    #[test]
+    fn multiple_rc_pairs_mutation_on_different_types() {
+        let src = "
+        brillig(inline) fn mutator f0 {
+          b0(v0: [Field; 3], v1: [Field; 5]):
+            inc_rc v0
+            inc_rc v1
+            v2 = allocate -> &mut [Field; 3]
+            store v0 at v2
+            v3 = load v2 -> [Field; 3]
+            v6 = array_set v3, index u32 0, value Field 5
+            store v6 at v2
+            v8 = array_get v1, index u32 1 -> Field
+            dec_rc v0
+            dec_rc v1
+            return
+        }
+        ";
+
+        let ssa = Ssa::from_str(src).unwrap();
+        let ssa = ssa.remove_paired_rc();
+        // We expect the paired RC on v0 to remain, but we expect the paired RC on v1 to be removed
+        // as they operate over different types ([Field; 2] and [Field; 5]) respectively.
+        assert_ssa_snapshot!(ssa, @r"
+        brillig(inline) fn mutator f0 {
+          b0(v0: [Field; 3], v1: [Field; 5]):
+            inc_rc v0
+            v2 = allocate -> &mut [Field; 3]
+            store v0 at v2
+            v3 = load v2 -> [Field; 3]
+            v6 = array_set v3, index u32 0, value Field 5
+            store v6 at v2
+            v8 = array_get v1, index u32 1 -> Field
+            dec_rc v0
+            return
+        }
+        ");
+    }
+
+    #[test]
+    fn multiple_rc_pairs_mutation_on_matching_types() {
+        let src = "
+        brillig(inline) fn mutator f0 {
+          b0(v0: [Field; 5], v1: [Field; 5]):
+            inc_rc v0
+            inc_rc v1
+            v2 = allocate -> &mut [Field; 5]
+            store v0 at v2
+            v3 = load v2 -> [Field; 5]
+            v6 = array_set v3, index u32 0, value Field 5
+            store v6 at v2
+            v8 = array_get v1, index u32 1 -> Field
+            dec_rc v0
+            dec_rc v1
+            return
+        }
+        ";
+
+        let ssa = Ssa::from_str(src).unwrap();
+        let ssa = ssa.remove_paired_rc();
+        // We expect the paired RC on v0 to remain, but we expect the paired RC on v1 to be removed
+        // as they operate over different types ([Field; 2] and [Field; 5]) respectively.
+        assert_ssa_snapshot!(ssa, @r"
+        brillig(inline) fn mutator f0 {
+          b0(v0: [Field; 5], v1: [Field; 5]):
+            inc_rc v0
+            inc_rc v1
+            v2 = allocate -> &mut [Field; 5]
+            store v0 at v2
+            v3 = load v2 -> [Field; 5]
+            v6 = array_set v3, index u32 0, value Field 5
+            store v6 at v2
+            v8 = array_get v1, index u32 1 -> Field
+            dec_rc v0
+            dec_rc v1
+            return
+        }
+        ");
+    }
+
+    #[test]
+    fn rc_pair_with_same_type_but_different_values() {
+        let src = "
+        brillig(inline) fn foo f0 {
+          b0(v0: [Field; 2], v1: [Field; 2]):
+            inc_rc v0
+            dec_rc v1
+            v2 = make_array [v0] : [[Field; 2]; 1]
+            return v2
+        }
+        ";
+        let ssa = Ssa::from_str(src).unwrap();
+        let ssa = ssa.remove_paired_rc();
+        assert_normalized_ssa_equals(ssa, src);
+    }
+
+    #[test]
+    fn do_not_remove_pairs_across_blocks() {
+        let src = "
+        brillig(inline) fn foo f0 {
+          b0(v0: [Field; 2]):
+            inc_rc v0
+            jmp b1()
+          b1():
+            dec_rc v0
+            jmp b2()
+          b2():
+            v1 = make_array [v0] : [[Field; 2]; 1]
+            return v1  
+        }
+        ";
+        let ssa = Ssa::from_str(src).unwrap();
+        let ssa = ssa.remove_paired_rc();
+        assert_normalized_ssa_equals(ssa, src);
+    }
+
+    #[test]
+    fn remove_pair_across_blocks() {
+        let src = "
+        brillig(inline) fn foo f0 {
+          b0(v0: [Field; 2]):
+            inc_rc v0
+            jmp b1()
+          b1():
+            jmp b2()
+          b2():
+            dec_rc v0
+            v1 = make_array [v0] : [[Field; 2]; 1]
+            return v1  
+        }
+        ";
+        let ssa = Ssa::from_str(src).unwrap();
+        let ssa = ssa.remove_paired_rc();
+        assert_ssa_snapshot!(ssa, @r"
+        brillig(inline) fn foo f0 {
+          b0(v0: [Field; 2]):
+            jmp b1()
+          b1():
+            jmp b2()
+          b2():
+            v1 = make_array [v0] : [[Field; 2]; 1]
+            return v1
+        }
+        ");
     }
 }


### PR DESCRIPTION
# Description

## Problem\*

Part of the internal audit

## Summary\*

We did not have many tests in `remove_paired_rc` confirming its intended functionality. I have added several here.

## Additional Context



## Documentation\*

Check one:
- [X] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
