### PR TITLE
fix(ssa): Print all blocks including unreachable ones

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/ir/printer.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/printer.rs
@@ -15,7 +15,7 @@ use crate::ssa::{
 };
 
 use super::{
-    basic_block::BasicBlockId,
+    basic_block::{BasicBlock, BasicBlockId},
     dfg::DataFlowGraph,
     function::Function,
     instruction::{ConstrainError, Instruction, InstructionId, TerminatorInstruction},
@@ -93,8 +93,8 @@ fn display_function(
         writeln!(f, "{} fn {} {} {{", function.runtime(), function.name(), function.id())?;
     }
 
-    for (block_id, _) in function.dfg.basic_blocks_iter() {
-        display_block(&function.dfg, block_id, files, f)?;
+    for (block_id, block) in function.dfg.basic_blocks_iter() {
+        display_block(&function.dfg, block_id, block, files, f)?;
     }
     write!(f, "}}")
 }
@@ -103,11 +103,10 @@ fn display_function(
 fn display_block(
     dfg: &DataFlowGraph,
     block_id: BasicBlockId,
+    block: &BasicBlock,
     fm: Option<&fm::FileManager>,
     f: &mut Formatter,
 ) -> Result {
-    let block = &dfg[block_id];
-
     writeln!(f, "  {}({}):", block_id, value_list_with_types(dfg, block.parameters()))?;
 
     for instruction in block.instructions() {


### PR DESCRIPTION
# Description

## Problem\*

Part of resolving issues with testing unreachable blocks (https://github.com/noir-lang/noir/issues/9432)

## Summary\*

I switched to `basic_blocks_iter` when displaying a function instead of `reachable_blocks`.

## Additional Context

## Documentation\*

Check one:
- [X] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
