### PR TITLE
fix(LSP): don't crash on broken function definition

### DIFF
--- a/compiler/noirc_frontend/src/parser/parser.rs
+++ b/compiler/noirc_frontend/src/parser/parser.rs
@@ -220,7 +220,12 @@ impl<'a> Parser<'a> {
                     }
                 },
                 Some(Err(lexer_error)) => self.errors.push(lexer_error.into()),
-                None => return (eof_located_token(), last_comments),
+                None => {
+                    let end_span = Span::single_char(self.current_token_location.span.end());
+                    let end_location = Location::new(end_span, self.current_token_location.file);
+                    let end_token = LocatedToken::new(Token::EOF, end_location);
+                    return (end_token, last_comments);
+                }
             }
         }
     }

--- a/tooling/lsp/src/requests/document_symbol.rs
+++ b/tooling/lsp/src/requests/document_symbol.rs
@@ -509,13 +509,48 @@ impl Visitor for DocumentSymbolCollector<'_> {
 
 #[cfg(test)]
 mod document_symbol_tests {
-    use crate::test_utils;
+    use crate::{notifications::on_did_open_text_document, test_utils};
 
     use super::*;
     use async_lsp::lsp_types::{
-        PartialResultParams, Range, SymbolKind, TextDocumentIdentifier, WorkDoneProgressParams,
+        DidOpenTextDocumentParams, PartialResultParams, Range, SymbolKind, TextDocumentIdentifier,
+        TextDocumentItem, WorkDoneProgressParams,
     };
     use tokio::test;
+
+    async fn get_document_symbols(src: &str) -> Vec<DocumentSymbol> {
+        let (mut state, noir_text_document) = test_utils::init_lsp_server("document_symbol").await;
+
+        let _ = on_did_open_text_document(
+            &mut state,
+            DidOpenTextDocumentParams {
+                text_document: TextDocumentItem {
+                    uri: noir_text_document.clone(),
+                    language_id: "noir".to_string(),
+                    version: 0,
+                    text: src.to_string(),
+                },
+            },
+        );
+
+        let response = on_document_symbol_request(
+            &mut state,
+            DocumentSymbolParams {
+                text_document: TextDocumentIdentifier { uri: noir_text_document },
+                work_done_progress_params: WorkDoneProgressParams { work_done_token: None },
+                partial_result_params: PartialResultParams { partial_result_token: None },
+            },
+        )
+        .await
+        .expect("Could not execute on_document_symbol_request")
+        .unwrap();
+
+        let DocumentSymbolResponse::Nested(symbols) = response else {
+            panic!("Expected response to be nested");
+        };
+
+        symbols
+    }
 
     #[test]
     async fn test_document_symbol() {
@@ -750,6 +785,28 @@ mod document_symbol_tests {
                     children: Some(Vec::new())
                 }
             ]
+        );
+    }
+
+    #[test]
+    async fn test_function_with_just_open_parentheses() {
+        let src = "fn main(\n";
+        let mut symbols = get_document_symbols(src).await;
+        assert_eq!(symbols.len(), 1);
+        let symbol = symbols.remove(0);
+        assert_eq!(
+            symbol.range,
+            Range {
+                start: Position { line: 0, character: 0 },
+                end: Position { line: 1, character: 0 },
+            }
+        );
+        assert_eq!(
+            symbol.selection_range,
+            Range {
+                start: Position { line: 0, character: 3 },
+                end: Position { line: 0, character: 7 },
+            }
         );
     }
 }


### PR DESCRIPTION
# Description

## Problem

No issue, just something I noticed while writing some Noir code.

## Summary

LSP crashed on the documentSymbol request on code like "fn foo(", that is, a function with an unclosed parentheses.

The issue was that the function body ended up having the location since "(" until the end, but the end token always had a dummy location of zero. This PR changes that location to be the actual end of the file. This might solve many LSP issues with broken code where a node's location end up having part of its location computed from the end token location.

## Additional Context

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
