### PR TITLE
fix(ssa_fuzzer): fix limits + forbid mutable set

### DIFF
--- a/tooling/ssa_fuzzer/fuzzer/src/fuzz_lib/block_context.rs
+++ b/tooling/ssa_fuzzer/fuzzer/src/fuzz_lib/block_context.rs
@@ -1,4 +1,4 @@
-use super::instruction::{Argument, FunctionSignature, Instruction};
+use super::instruction::{Argument, FunctionInfo, Instruction};
 use super::options::SsaBlockOptions;
 use noir_ssa_fuzzer::{
     builder::{FuzzerBuilder, InstructionWithOneArg, InstructionWithTwoArgs},
@@ -559,7 +559,7 @@ impl BlockContext {
                     value.clone(),
                 );
             }
-            Instruction::ArraySet { array_index, index, value_index, mutable, safe_index } => {
+            Instruction::ArraySet { array_index, index, value_index, safe_index } => {
                 if !self.options.instruction_options.array_set_enabled {
                     return;
                 }
@@ -613,13 +613,12 @@ impl BlockContext {
                     array_id.clone(),
                     index_casted.clone(),
                     value.clone(),
-                    mutable,
                     safe_index,
                 );
                 assert_eq!(
                     new_array.value_id,
                     brillig_builder
-                        .insert_array_set(array_id, index_casted, value, mutable, safe_index)
+                        .insert_array_set(array_id, index_casted, value, safe_index)
                         .value_id
                 );
 
@@ -687,7 +686,6 @@ impl BlockContext {
                 array_index,
                 index,
                 value_index,
-                mutable,
                 safe_index,
             } => {
                 if !self.options.instruction_options.array_set_enabled
@@ -735,7 +733,6 @@ impl BlockContext {
                     stored_array.array_id.clone(),
                     index_id.clone(),
                     value.clone(),
-                    mutable,
                     safe_index,
                 );
                 assert_eq!(
@@ -745,7 +742,6 @@ impl BlockContext {
                             stored_array.array_id.clone(),
                             index_id,
                             value,
-                            mutable,
                             safe_index,
                         )
                         .value_id
@@ -839,7 +835,7 @@ impl BlockContext {
         acir_builder: &mut FuzzerBuilder,
         brillig_builder: &mut FuzzerBuilder,
         function_id: Id<Function>,
-        function_signature: FunctionSignature,
+        function_signature: FunctionInfo,
         args: &[usize],
     ) {
         // On SSA level you cannot just call a function by its id, you need to import it first

--- a/tooling/ssa_fuzzer/fuzzer/src/fuzz_lib/block_context.rs
+++ b/tooling/ssa_fuzzer/fuzzer/src/fuzz_lib/block_context.rs
@@ -502,6 +502,9 @@ impl BlockContext {
                 {
                     return;
                 }
+                if !safe_index && !self.options.instruction_options.insecure_get_set_enabled {
+                    return;
+                }
                 if self.stored_arrays.is_empty() {
                     return;
                 }
@@ -558,6 +561,9 @@ impl BlockContext {
             }
             Instruction::ArraySet { array_index, index, value_index, mutable, safe_index } => {
                 if !self.options.instruction_options.array_set_enabled {
+                    return;
+                }
+                if !safe_index && !self.options.instruction_options.insecure_get_set_enabled {
                     return;
                 }
                 if self.stored_arrays.is_empty() {
@@ -629,6 +635,9 @@ impl BlockContext {
                 {
                     return;
                 }
+                if !safe_index && !self.options.instruction_options.insecure_get_set_enabled {
+                    return;
+                }
                 if self.stored_arrays.is_empty() {
                     return;
                 }
@@ -684,6 +693,9 @@ impl BlockContext {
                 if !self.options.instruction_options.array_set_enabled
                     || !self.options.instruction_options.create_array_enabled
                 {
+                    return;
+                }
+                if !safe_index && !self.options.instruction_options.insecure_get_set_enabled {
                     return;
                 }
                 if self.stored_arrays.is_empty() {

--- a/tooling/ssa_fuzzer/fuzzer/src/fuzz_lib/function_context.rs
+++ b/tooling/ssa_fuzzer/fuzzer/src/fuzz_lib/function_context.rs
@@ -1,6 +1,6 @@
 use super::NUMBER_OF_VARIABLES_INITIAL;
 use super::block_context::BlockContext;
-use super::instruction::FunctionSignature;
+use super::instruction::FunctionInfo;
 use super::instruction::InstructionBlock;
 use super::options::{FunctionContextOptions, SsaBlockOptions};
 use acvm::FieldElement;
@@ -153,7 +153,7 @@ pub(crate) struct FuzzerFunctionContext<'a> {
     parent_iterations_count: usize,
 
     return_type: ValueType,
-    defined_functions: BTreeMap<Id<Function>, FunctionSignature>,
+    defined_functions: BTreeMap<Id<Function>, FunctionInfo>,
 }
 
 impl<'a> FuzzerFunctionContext<'a> {
@@ -164,7 +164,7 @@ impl<'a> FuzzerFunctionContext<'a> {
         instruction_blocks: &'a Vec<InstructionBlock>,
         context_options: FunctionContextOptions,
         return_type: ValueType,
-        defined_functions: BTreeMap<Id<Function>, FunctionSignature>,
+        defined_functions: BTreeMap<Id<Function>, FunctionInfo>,
         acir_builder: &'a mut FuzzerBuilder,
         brillig_builder: &'a mut FuzzerBuilder,
     ) -> Self {
@@ -213,7 +213,7 @@ impl<'a> FuzzerFunctionContext<'a> {
         instruction_blocks: &'a Vec<InstructionBlock>,
         context_options: FunctionContextOptions,
         return_type: ValueType,
-        defined_functions: BTreeMap<Id<Function>, FunctionSignature>,
+        defined_functions: BTreeMap<Id<Function>, FunctionInfo>,
         acir_builder: &'a mut FuzzerBuilder,
         brillig_builder: &'a mut FuzzerBuilder,
     ) -> Self {
@@ -312,8 +312,9 @@ impl<'a> FuzzerFunctionContext<'a> {
 
         self.store_variables();
 
-        if block_then_instruction_block.instructions.len()
-            + block_else_instruction_block.instructions.len()
+        if (block_then_instruction_block.instructions.len()
+            + block_else_instruction_block.instructions.len())
+            * self.parent_iterations_count
             + self.inserted_instructions_count
             > self.function_context_options.max_instructions_num
         {
@@ -420,7 +421,8 @@ impl<'a> FuzzerFunctionContext<'a> {
 
         // find instruction block to be inserted
         let block = self.instruction_blocks[block_idx % self.instruction_blocks.len()].clone();
-        if block.instructions.len() + self.inserted_instructions_count
+        if (block.instructions.len() + self.inserted_instructions_count)
+            * self.parent_iterations_count
             > self.function_context_options.max_instructions_num
         {
             return;
@@ -634,7 +636,8 @@ impl<'a> FuzzerFunctionContext<'a> {
             FuzzerFunctionCommand::InsertSimpleInstructionBlock { instruction_block_idx } => {
                 let instruction_block =
                     &self.instruction_blocks[instruction_block_idx % self.instruction_blocks.len()];
-                if self.inserted_instructions_count + instruction_block.instructions.len()
+                if (self.inserted_instructions_count + instruction_block.instructions.len())
+                    * self.parent_iterations_count
                     > self.function_context_options.max_instructions_num
                 {
                     return;
@@ -690,13 +693,23 @@ impl<'a> FuzzerFunctionContext<'a> {
                     .keys()
                     .nth(function_idx % num_of_defined_functions)
                     .unwrap();
-                let function_signature = self.defined_functions[&function_id].clone();
+                let function_info = self.defined_functions[&function_id].clone();
+                if function_info.max_unrolled_size == 0 {
+                    unreachable!("Encountered a function with no unrolled size");
+                }
+                let unrolled_size = function_info.max_unrolled_size * self.parent_iterations_count;
+                if self.inserted_instructions_count + unrolled_size
+                    > self.function_context_options.max_instructions_num
+                {
+                    return;
+                }
+                self.inserted_instructions_count += unrolled_size;
 
                 self.current_block.context.process_function_call(
                     self.acir_builder,
                     self.brillig_builder,
                     function_id,
-                    function_signature,
+                    function_info,
                     args,
                 );
             }

--- a/tooling/ssa_fuzzer/fuzzer/src/fuzz_lib/fuzz_target_lib.rs
+++ b/tooling/ssa_fuzzer/fuzzer/src/fuzz_lib/fuzz_target_lib.rs
@@ -48,6 +48,7 @@ pub(crate) fn fuzz_target(data: FuzzerData, options: FuzzerOptions) -> Option<Fu
     if data.instruction_blocks.is_empty() {
         return None;
     }
+    log::debug!("instruction_blocks: {:?}", data.instruction_blocks);
     let (witness_map, values, types) = initialize_witness_map(&data.initial_witness);
 
     let mut fuzzer = Fuzzer::new(data.instruction_blocks, values, options);

--- a/tooling/ssa_fuzzer/fuzzer/src/fuzz_lib/fuzz_target_lib.rs
+++ b/tooling/ssa_fuzzer/fuzzer/src/fuzz_lib/fuzz_target_lib.rs
@@ -65,6 +65,7 @@ mod tests {
     use super::*;
     use crate::function_context::{FieldRepresentation, FunctionData, FuzzerFunctionCommand};
     use crate::instruction::{Argument, Instruction, InstructionBlock};
+    use acvm::AcirField;
     use libfuzzer_sys::{arbitrary, arbitrary::Arbitrary};
 
     fn default_witness() -> [WitnessValue; (NUMBER_OF_VARIABLES_INITIAL - 2) as usize] {
@@ -797,7 +798,6 @@ mod tests {
                 array_index: 0,
                 index: arg_0_field,
                 value_index: 4, // set v4
-                mutable: false,
                 safe_index: true,
             }],
         };
@@ -869,7 +869,6 @@ mod tests {
                 array_index: 0,
                 index: 1,
                 value_index: 0,
-                mutable: false,
                 safe_index: true,
             }],
         };
@@ -921,6 +920,107 @@ mod tests {
         let result = fuzz_target(fuzzer_data, FuzzerOptions::default());
         match result {
             Some(result) => assert_eq!(result.get_return_value(), FieldElement::from(1_u32)),
+            None => panic!("Program failed to execute"),
+        }
+    }
+
+    /// Test that the fuzzer doesn't insert too many instructions with function calls
+    ///
+    /// The most cursed test
+    /// Creates main and 2 functions
+    /// First function has cycle for 200 iterations for i in 1..200 {i *= i}
+    /// Second function has cycle for 10 iterations for i in 1..10  {i *= i}
+    /// Main function tries to insert second and first functions
+    /// If the second function is too big for the chosen configuration,
+    /// the fuzzer should insert only the second function and the result should be the output of the second function
+    /// Otherwise, the result should be the output of the first function
+    #[test]
+    fn test_does_not_insert_too_many_instructions_with_function_calls() {
+        let dummy_arg = Argument { index: 0, value_type: ValueType::I64 };
+        let dummy_block = InstructionBlock {
+            instructions: vec![Instruction::AddChecked { lhs: dummy_arg, rhs: dummy_arg }],
+        };
+        let arg_2_field = Argument { index: 2, value_type: ValueType::Field };
+        let arg_5_field = Argument { index: 5, value_type: ValueType::Field };
+        let arg_6_field = Argument { index: 6, value_type: ValueType::Field };
+
+        // v8 = allocate -> &mut Field (memory address)
+        // store v2 at v8
+        let add_to_memory_block =
+            InstructionBlock { instructions: vec![Instruction::AddToMemory { lhs: arg_2_field }] };
+        let typed_memory_0 = Argument { index: 0, value_type: ValueType::Field };
+        // load v8 -> Field (loads from first defined memory address, which is v8)
+        let load_block = InstructionBlock {
+            instructions: vec![Instruction::LoadFromMemory { memory_addr: typed_memory_0 }],
+        };
+        let load_mul_set_block = InstructionBlock {
+            instructions: vec![
+                Instruction::LoadFromMemory { memory_addr: typed_memory_0 }, // v13 = load v8 -> Field (loaded value is 5th defined field)
+                Instruction::MulChecked { lhs: arg_5_field, rhs: arg_2_field }, // v14 = mul v13, v2 (v14 -- 6th defined field)
+                Instruction::SetToMemory { memory_addr_index: 0, value: arg_6_field }, // store v14 at v8
+            ],
+        };
+        let commands_for_main = vec![
+            FuzzerFunctionCommand::InsertFunctionCall {
+                function_idx: 1, // second function has cycle for 10 iterations
+                args: [0, 1, 2, 3, 4, 0, 1],
+            }, // call function, should be skipped
+            FuzzerFunctionCommand::InsertFunctionCall {
+                function_idx: 0, // first function has cycle for 200 iterations
+                args: [0, 1, 2, 3, 4, 0, 1],
+            }, // call function, should be skipped
+        ];
+        let commands_for_function1 = vec![
+            FuzzerFunctionCommand::InsertSimpleInstructionBlock { instruction_block_idx: 0 }, // add v2 to memory
+            FuzzerFunctionCommand::InsertCycle { block_body_idx: 2, start_iter: 1, end_iter: 200 }, // for i in 1..200 do load_mul_set_block
+        ];
+        let commands_for_function2 = vec![
+            FuzzerFunctionCommand::InsertSimpleInstructionBlock { instruction_block_idx: 0 }, // add v2 to memory
+            FuzzerFunctionCommand::InsertCycle { block_body_idx: 2, start_iter: 1, end_iter: 10 }, // for i in 1..10 do load_mul_set_block
+        ];
+        let main_func = FunctionData {
+            commands: commands_for_main,
+            return_instruction_block_idx: 3, // dummy block
+            return_type: ValueType::Field,
+        };
+        let function_func = FunctionData {
+            commands: commands_for_function1,
+            return_instruction_block_idx: 1, // v12 = load v8 -> Field; return v12
+            return_type: ValueType::Field,
+        };
+        let function_func2 = FunctionData {
+            commands: commands_for_function2,
+            return_instruction_block_idx: 1, // v12 = load v8 -> Field; return v12
+            return_type: ValueType::Field,
+        };
+        let data = FuzzerData {
+            instruction_blocks: vec![
+                add_to_memory_block,
+                load_block,
+                load_mul_set_block,
+                dummy_block,
+            ],
+            functions: vec![main_func, function_func, function_func2],
+            initial_witness: default_witness(),
+        };
+        // with max 100 instructions only second function should be executed
+        let options = FuzzerOptions { max_instructions_num: 100, ..FuzzerOptions::default() };
+        let result = fuzz_target(data.clone(), options);
+        match result {
+            Some(result) => assert_eq!(result.get_return_value(), FieldElement::from(1024_u32)),
+            None => panic!("Program failed to execute"),
+        }
+        // with max 1000 instructions both functions should be executed
+        // and the result should be the output of the first function
+        let options = FuzzerOptions { max_instructions_num: 1000, ..FuzzerOptions::default() };
+        let result = fuzz_target(data.clone(), options);
+        match result {
+            Some(result) => {
+                assert_eq!(
+                    result.get_return_value(),
+                    FieldElement::from(2_u32).pow(&FieldElement::from(200_u32)) // 2^200
+                )
+            }
             None => panic!("Program failed to execute"),
         }
     }

--- a/tooling/ssa_fuzzer/fuzzer/src/fuzz_lib/instruction.rs
+++ b/tooling/ssa_fuzzer/fuzzer/src/fuzz_lib/instruction.rs
@@ -84,13 +84,7 @@ pub(crate) enum Instruction {
     /// Set element in array, index will be casted to u32, only for arrays without references
     /// Value will be cast to the type of the array
     /// If safe_index is true, index will be taken modulo the size of the array
-    ArraySet {
-        array_index: usize,
-        index: Argument,
-        value_index: usize,
-        mutable: bool,
-        safe_index: bool,
-    },
+    ArraySet { array_index: usize, index: Argument, value_index: usize, safe_index: bool },
     /// Get element from array, index is constant
     /// If safe_index is true, index will be taken modulo the size of the array
     ArrayGetWithConstantIndex { array_index: usize, index: usize, safe_index: bool },
@@ -101,7 +95,6 @@ pub(crate) enum Instruction {
         array_index: usize,
         index: usize,
         value_index: usize,
-        mutable: bool,
         safe_index: bool,
     },
 }
@@ -126,7 +119,9 @@ pub(crate) struct InstructionBlock {
 }
 
 #[derive(Clone)]
-pub(crate) struct FunctionSignature {
+pub(crate) struct FunctionInfo {
     pub(crate) input_types: Vec<ValueType>,
     pub(crate) return_type: ValueType,
+    /// Max size of unrolled loops in the function
+    pub(crate) max_unrolled_size: usize,
 }

--- a/tooling/ssa_fuzzer/fuzzer/src/fuzz_lib/options.rs
+++ b/tooling/ssa_fuzzer/fuzzer/src/fuzz_lib/options.rs
@@ -23,6 +23,7 @@ pub(crate) struct InstructionOptions {
     pub(crate) create_array_enabled: bool,
     pub(crate) array_get_enabled: bool,
     pub(crate) array_set_enabled: bool,
+    pub(crate) insecure_get_set_enabled: bool,
 }
 
 impl Default for InstructionOptions {
@@ -48,6 +49,7 @@ impl Default for InstructionOptions {
             create_array_enabled: true,
             array_get_enabled: true,
             array_set_enabled: true,
+            insecure_get_set_enabled: false,
         }
     }
 }

--- a/tooling/ssa_fuzzer/fuzzer/src/fuzz_lib/program_context.rs
+++ b/tooling/ssa_fuzzer/fuzzer/src/fuzz_lib/program_context.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 
-use super::function_context::{FunctionData, FuzzerFunctionContext};
-use super::instruction::{FunctionSignature, InstructionBlock};
+use super::function_context::{FunctionData, FuzzerFunctionCommand, FuzzerFunctionContext};
+use super::instruction::{FunctionInfo, InstructionBlock};
 use super::options::{FunctionContextOptions, FuzzerMode, FuzzerOptions};
 use acvm::FieldElement;
 use noir_ssa_fuzzer::{
@@ -27,8 +27,8 @@ pub(crate) struct FuzzerProgramContext {
     program_context_options: FunctionContextOptions, // TODO
     /// Whether the program is executed in constants
     is_constant: bool,
-    /// Function signatures
-    function_signatures: BTreeMap<Id<Function>, FunctionSignature>,
+    /// Function information
+    function_information: BTreeMap<Id<Function>, FunctionInfo>,
     /// Stored functions
     stored_functions: Vec<StoredFunction>,
     /// Current function id
@@ -61,7 +61,7 @@ impl FuzzerProgramContext {
             brillig_builder,
             program_context_options,
             is_constant: false,
-            function_signatures: BTreeMap::new(),
+            function_information: BTreeMap::new(),
             stored_functions: Vec::new(),
             current_function_id: Id::new(0),
             instruction_blocks,
@@ -86,7 +86,7 @@ impl FuzzerProgramContext {
             brillig_builder,
             program_context_options,
             is_constant: true,
-            function_signatures: BTreeMap::new(),
+            function_information: BTreeMap::new(),
             stored_functions: Vec::new(),
             current_function_id: Id::new(0),
             instruction_blocks,
@@ -98,21 +98,131 @@ impl FuzzerProgramContext {
 
     /// Stores function and its signature
     pub(crate) fn process_function(&mut self, function: FunctionData, types: Vec<ValueType>) {
-        let signature =
-            FunctionSignature { input_types: types.clone(), return_type: function.return_type };
-        self.function_signatures.insert(self.current_function_id, signature);
+        // leaving max_unrolled_size = 0 for now
+        //
+        let signature = FunctionInfo {
+            input_types: types.clone(),
+            return_type: function.return_type,
+            max_unrolled_size: 0,
+        };
+        self.function_information.insert(self.current_function_id, signature);
         let stored_function = StoredFunction { id: self.current_function_id, function, types };
         self.stored_functions.push(stored_function);
         self.current_function_id = Id::new(self.current_function_id.to_u32() + 1);
     }
 
+    /// Initializes unrolled sizes for all functions in the program
+    ///
+    /// Unrolled size is the number of instructions that will be executed in a loop
+    ///
+    /// It is calculated by multiplying the size of the instruction block by the number of iterations
+    /// in the loop
+    ///
+    /// It is used to limit the number of instructions in the program
+    fn initialize_unrolled_sizes(&mut self) {
+        // design of the fuzzer allows to call functions only defined after the current one
+        // go from the last function to the first one
+        for function in self.stored_functions.iter_mut().rev() {
+            let mut max_unrolled_size = 1;
+            let mut cycle_sizes = Vec::new();
+            let mut iterations_before = 1;
+            for command in &function.function.commands {
+                match command {
+                    FuzzerFunctionCommand::InsertCycle { block_body_idx, start_iter, end_iter } => {
+                        let instruction_block_size = self.instruction_blocks
+                            [*block_body_idx % self.instruction_blocks.len()]
+                        .instructions
+                        .len();
+                        let cycle_iterations_count =
+                            if end_iter > start_iter { end_iter - start_iter + 1 } else { 1 }
+                                as usize;
+                        cycle_sizes.push(cycle_iterations_count);
+                        iterations_before *= cycle_iterations_count;
+                        max_unrolled_size += instruction_block_size * iterations_before;
+                    }
+                    FuzzerFunctionCommand::InsertSimpleInstructionBlock {
+                        instruction_block_idx,
+                    } => {
+                        let instruction_block_size = self.instruction_blocks
+                            [*instruction_block_idx % self.instruction_blocks.len()]
+                        .instructions
+                        .len();
+                        max_unrolled_size += instruction_block_size * iterations_before;
+                    }
+                    FuzzerFunctionCommand::InsertJmpIfBlock { block_then_idx, block_else_idx } => {
+                        let instruction_block_size_then = self.instruction_blocks
+                            [*block_then_idx % self.instruction_blocks.len()]
+                        .instructions
+                        .len();
+                        let instruction_block_size_else = self.instruction_blocks
+                            [*block_else_idx % self.instruction_blocks.len()]
+                        .instructions
+                        .len();
+                        max_unrolled_size += instruction_block_size_then * iterations_before
+                            + instruction_block_size_else * iterations_before;
+                    }
+                    FuzzerFunctionCommand::InsertJmpBlock { block_idx } => {
+                        let instruction_block_size = self.instruction_blocks
+                            [*block_idx % self.instruction_blocks.len()]
+                        .instructions
+                        .len();
+                        // InsertJmpBlock breaks the loop, so we need to divide by the size of the previous cycle
+                        let previous_cycle_size = cycle_sizes.pop().unwrap_or(1);
+                        iterations_before /= previous_cycle_size;
+                        max_unrolled_size += instruction_block_size * iterations_before;
+                    }
+                    FuzzerFunctionCommand::SwitchToNextBlock => {
+                        // SwitchToNextBlock breaks the loop
+                        iterations_before /= cycle_sizes.pop().unwrap_or(1);
+                    }
+                    FuzzerFunctionCommand::InsertFunctionCall { function_idx, .. } => {
+                        let defined_functions = self
+                            .function_information
+                            .clone()
+                            .into_iter()
+                            .filter(|(id, _)| id.to_u32() > function.id.to_u32())
+                            .collect::<Vec<_>>();
+                        if defined_functions.is_empty() {
+                            continue;
+                        }
+                        let function_to_call = defined_functions
+                            .get(*function_idx % defined_functions.len())
+                            .unwrap()
+                            .0;
+                        let function_to_call_signature =
+                            self.function_information.get(&function_to_call).unwrap();
+                        let function_to_call_max_unrolled_size =
+                            function_to_call_signature.max_unrolled_size;
+                        if function_to_call_max_unrolled_size == 0 {
+                            unreachable!("Encountered a function with no unrolled size");
+                        }
+                        max_unrolled_size += function_to_call_max_unrolled_size * iterations_before;
+                    }
+                }
+            }
+            let final_block_size = self.instruction_blocks
+                [function.function.return_instruction_block_idx % self.instruction_blocks.len()]
+            .instructions
+            .len();
+            max_unrolled_size += final_block_size;
+            self.function_information.get_mut(&function.id).unwrap().max_unrolled_size =
+                max_unrolled_size;
+        }
+    }
+
+    /// Initializes information of all functions in the program
+    fn initialize_function_info(&mut self) {
+        self.initialize_unrolled_sizes();
+    }
+
     /// Creates new ACIR and Brillig functions for each of stored functions and finalizes them
     pub(crate) fn finalize_program(&mut self) {
+        self.initialize_function_info();
         for i in 0..self.stored_functions.len() {
             let stored_function = &self.stored_functions[i];
             // use only functions defined after this one to avoid recursion
-            let defined_functions: BTreeMap<Id<Function>, FunctionSignature> = self
-                .function_signatures
+            let defined_functions: BTreeMap<Id<Function>, FunctionInfo> = self
+                .function_information
                 .clone()
                 .into_iter()
                 .filter(|func_id| func_id.0.to_u32() > stored_function.id.to_u32())

--- a/tooling/ssa_fuzzer/fuzzer/src/fuzz_target.rs
+++ b/tooling/ssa_fuzzer/fuzzer/src/fuzz_target.rs
@@ -45,9 +45,10 @@ libfuzzer_sys::fuzz_target!(|data: &[u8]| -> Corpus {
         shl_enabled: false,
         shr_enabled: false,
         alloc_enabled: false,
+        array_get_enabled: false,
         ..InstructionOptions::default()
     };
-    let modes = vec![FuzzerMode::NonConstant, FuzzerMode::NonConstantWithoutSimplifying];
+    let modes = vec![FuzzerMode::NonConstant];
     let fuzzer_command_options =
         FuzzerCommandOptions { loops_enabled: false, ..FuzzerCommandOptions::default() };
     let options = FuzzerOptions {

--- a/tooling/ssa_fuzzer/fuzzer/src/fuzz_target.rs
+++ b/tooling/ssa_fuzzer/fuzzer/src/fuzz_target.rs
@@ -50,7 +50,7 @@ libfuzzer_sys::fuzz_target!(|data: &[u8]| -> Corpus {
     };
     let modes = vec![FuzzerMode::NonConstant];
     let fuzzer_command_options =
-        FuzzerCommandOptions { loops_enabled: false, ..FuzzerCommandOptions::default() };
+        FuzzerCommandOptions { loops_enabled: true, ..FuzzerCommandOptions::default() };
     let options = FuzzerOptions {
         compile_options,
         instruction_options,

--- a/tooling/ssa_fuzzer/fuzzer/src/mutations/configuration.rs
+++ b/tooling/ssa_fuzzer/fuzzer/src/mutations/configuration.rs
@@ -228,16 +228,14 @@ pub(crate) enum ArraySetMutationOptions {
     ArrayIndex,
     Index,
     ValueIndex,
-    Mutable,
     SafeIndex,
 }
-pub(crate) type ArraySetMutationConfig = WeightedSelectionConfig<ArraySetMutationOptions, 5>;
+pub(crate) type ArraySetMutationConfig = WeightedSelectionConfig<ArraySetMutationOptions, 4>;
 pub(crate) const BASIC_ARRAY_SET_MUTATION_CONFIGURATION: ArraySetMutationConfig =
     ArraySetMutationConfig::new([
         (ArraySetMutationOptions::ArrayIndex, 5),
         (ArraySetMutationOptions::Index, 5),
         (ArraySetMutationOptions::ValueIndex, 5),
-        (ArraySetMutationOptions::Mutable, 1),
         (ArraySetMutationOptions::SafeIndex, 1),
     ]);
 

--- a/tooling/ssa_fuzzer/fuzzer/src/mutations/instructions/instruction_mutator.rs
+++ b/tooling/ssa_fuzzer/fuzzer/src/mutations/instructions/instruction_mutator.rs
@@ -117,7 +117,7 @@ impl InstructionMutator for InstructionArgumentsMutation {
                     }
                 }
             }
-            Instruction::ArraySet { array_index, index, value_index, mutable, safe_index } => {
+            Instruction::ArraySet { array_index, index, value_index, safe_index } => {
                 match BASIC_ARRAY_SET_MUTATION_CONFIGURATION.select(rng) {
                     ArraySetMutationOptions::ArrayIndex => {
                         mutate_usize(array_index, rng, BASIC_USIZE_MUTATION_CONFIGURATION);
@@ -127,9 +127,6 @@ impl InstructionMutator for InstructionArgumentsMutation {
                     }
                     ArraySetMutationOptions::ValueIndex => {
                         mutate_usize(value_index, rng, BASIC_USIZE_MUTATION_CONFIGURATION);
-                    }
-                    ArraySetMutationOptions::Mutable => {
-                        mutate_bool(mutable, rng, BASIC_BOOL_MUTATION_CONFIGURATION);
                     }
                     ArraySetMutationOptions::SafeIndex => {
                         mutate_bool(safe_index, rng, BASIC_SAFE_INDEX_MUTATION_CONFIGURATION);
@@ -177,7 +174,6 @@ impl InstructionMutator for InstructionArgumentsMutation {
                 array_index,
                 index,
                 value_index,
-                mutable,
                 safe_index,
             } => match BASIC_ARRAY_SET_MUTATION_CONFIGURATION.select(rng) {
                 ArraySetMutationOptions::ArrayIndex => {
@@ -188,9 +184,6 @@ impl InstructionMutator for InstructionArgumentsMutation {
                 }
                 ArraySetMutationOptions::ValueIndex => {
                     mutate_usize(value_index, rng, BASIC_USIZE_MUTATION_CONFIGURATION);
-                }
-                ArraySetMutationOptions::Mutable => {
-                    mutate_bool(mutable, rng, BASIC_BOOL_MUTATION_CONFIGURATION);
                 }
                 ArraySetMutationOptions::SafeIndex => {
                     mutate_bool(safe_index, rng, BASIC_SAFE_INDEX_MUTATION_CONFIGURATION);

--- a/tooling/ssa_fuzzer/src/builder.rs
+++ b/tooling/ssa_fuzzer/src/builder.rs
@@ -463,7 +463,7 @@ impl FuzzerBuilder {
             array.value_id,
             index.value_id,
             value.value_id,
-            mutable,
+            false,
             ArrayOffset::None,
         );
         TypedValue::new(res, array.type_of_variable.clone())

--- a/tooling/ssa_fuzzer/src/builder.rs
+++ b/tooling/ssa_fuzzer/src/builder.rs
@@ -449,7 +449,6 @@ impl FuzzerBuilder {
         array: TypedValue,
         index: TypedValue,
         value: TypedValue,
-        mutable: bool,
         safe_index: bool,
     ) -> TypedValue {
         assert!(matches!(array.type_of_variable, Type::Array(_, _)));


### PR DESCRIPTION
# Description
SSA fuzzer could not predict the size of the function before call, so the program generated with loops were unlimited by size.
## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*



## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
