### PR TITLE
feat: mark slice variants of ecdsa verification as deprecated

### DIFF
--- a/docs/docs/noir/standard_library/cryptographic_primitives/ecdsa_sig_verification.mdx
+++ b/docs/docs/noir/standard_library/cryptographic_primitives/ecdsa_sig_verification.mdx
@@ -29,6 +29,12 @@ fn main(hashed_message : [u8;32], pub_key_x : [u8;32], pub_key_y : [u8;32], sign
 
 ## ecdsa_secp256k1::verify_signature_slice
 
+:::info
+
+This method is deprecated and will be removed in 1.0.0-beta.12
+
+:::
+
 Verifier for ECDSA Secp256k1 signatures where the message is a slice.
 
 #include_code ecdsa_secp256k1_slice noir_stdlib/src/ecdsa_secp256k1.nr rust
@@ -54,6 +60,12 @@ fn main(hashed_message : [u8;32], pub_key_x : [u8;32], pub_key_y : [u8;32], sign
 <BlackBoxInfo to="../black_box_fns"/>
 
 ## ecdsa_secp256r1::verify_signature
+
+:::info
+
+This method is deprecated and will be removed in 1.0.0-beta.12
+
+:::
 
 Verifier for ECDSA Secp256r1 signatures where the message is a slice.
 

--- a/docs/versioned_docs/version-v1.0.0-beta.10/noir/standard_library/cryptographic_primitives/ecdsa_sig_verification.mdx
+++ b/docs/versioned_docs/version-v1.0.0-beta.10/noir/standard_library/cryptographic_primitives/ecdsa_sig_verification.mdx
@@ -53,6 +53,12 @@ fn main(hashed_message : [u8;32], pub_key_x : [u8;32], pub_key_y : [u8;32], sign
 
 ## ecdsa_secp256k1::verify_signature_slice
 
+:::info
+
+This method is deprecated and will be removed in 1.0.0-beta.12
+
+:::
+
 Verifier for ECDSA Secp256k1 signatures where the message is a slice.
 
 ```rust title="ecdsa_secp256k1_slice" showLineNumbers 
@@ -96,6 +102,12 @@ fn main(hashed_message : [u8;32], pub_key_x : [u8;32], pub_key_y : [u8;32], sign
 <BlackBoxInfo to="../black_box_fns"/>
 
 ## ecdsa_secp256r1::verify_signature
+
+:::info
+
+This method is deprecated and will be removed in 1.0.0-beta.12
+
+:::
 
 Verifier for ECDSA Secp256r1 signatures where the message is a slice.
 

--- a/noir_stdlib/src/ecdsa_secp256k1.nr
+++ b/noir_stdlib/src/ecdsa_secp256k1.nr
@@ -24,6 +24,7 @@ pub fn verify_signature<let N: u32>(
 // docs:end:ecdsa_secp256k1
 {}
 
+#[deprecated("This method is deprecated and will be removed in 1.0.0-beta.12")]
 #[foreign(ecdsa_secp256k1)]
 // docs:start:ecdsa_secp256k1_slice
 pub fn verify_signature_slice(

--- a/noir_stdlib/src/ecdsa_secp256r1.nr
+++ b/noir_stdlib/src/ecdsa_secp256r1.nr
@@ -9,6 +9,7 @@ pub fn verify_signature<let N: u32>(
 // docs:end:ecdsa_secp256r1
 {}
 
+#[deprecated("This method is deprecated and will be removed in 1.0.0-beta.12")]
 #[foreign(ecdsa_secp256r1)]
 // docs:start:ecdsa_secp256r1_slice
 pub fn verify_signature_slice(


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This is just fundamentally broken as it cannot handle dynamic length slices properly so we should remove these.

## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
