### PR TITLE
fix: remove warning from `std::verify_proof_with_type`

### DIFF
--- a/compiler/noirc_evaluator/src/acir/mod.rs
+++ b/compiler/noirc_evaluator/src/acir/mod.rs
@@ -12,7 +12,6 @@ use std::collections::{BTreeMap, HashSet};
 use types::{AcirDynamicArray, AcirValue};
 
 use acvm::acir::{
-    BlackBoxFunc,
     circuit::{
         AssertionPayload, ExpressionWidth, OpcodeLocation, brillig::BrilligFunctionId,
         opcodes::AcirFunctionId,
@@ -675,7 +674,7 @@ impl<'a> Context<'a> {
         ssa: &Ssa,
         result_ids: &[ValueId],
     ) -> Result<Vec<SsaReport>, RuntimeError> {
-        let mut warnings = Vec::new();
+        let warnings = Vec::new();
 
         match instruction {
             Instruction::Call { func, arguments } => {
@@ -795,14 +794,6 @@ impl<'a> Context<'a> {
                         }
                     }
                     Value::Intrinsic(intrinsic) => {
-                        if matches!(
-                            intrinsic,
-                            Intrinsic::BlackBox(BlackBoxFunc::RecursiveAggregation)
-                        ) {
-                            warnings.push(SsaReport::Warning(InternalWarning::VerifyProof {
-                                call_stack: self.acir_context.get_call_stack(),
-                            }));
-                        }
                         let outputs = self
                             .convert_ssa_intrinsic_call(*intrinsic, arguments, dfg, result_ids)?;
 

--- a/compiler/noirc_evaluator/src/errors.rs
+++ b/compiler/noirc_evaluator/src/errors.rs
@@ -102,9 +102,6 @@ impl From<SsaReport> for CustomDiagnostic {
                     InternalWarning::ReturnConstant { call_stack } => {
                         ("This variable contains a value which is constrained to be a constant. Consider removing this value as additional return values increase proving/verification time".to_string(), call_stack)
                     },
-                    InternalWarning::VerifyProof { call_stack } => {
-                        ("The validity of the proof passed to verify_proof(...) can only be checked by the proving backend, so witness execution will defer checking of these proofs to the proving backend. Passing an invalid proof is expected to cause the proving backend to either fail to generate a proof or generate a proof which fails verification".to_string(), call_stack)
-                    },
                 };
                 let call_stack = vecmap(call_stack, |location| location);
                 let location = call_stack.last().expect("Expected RuntimeError to have a location");
@@ -142,8 +139,6 @@ impl From<SsaReport> for CustomDiagnostic {
 pub enum InternalWarning {
     #[error("Return variable contains a constant value")]
     ReturnConstant { call_stack: CallStack },
-    #[error("Calling std::verify_proof(...) does not check that the provided proof is valid")]
-    VerifyProof { call_stack: CallStack },
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Error, Serialize, Deserialize, Hash)]

--- a/docs/docs/noir/standard_library/recursion.mdx
+++ b/docs/docs/noir/standard_library/recursion.mdx
@@ -8,60 +8,12 @@ import BlackBoxInfo from '@site/src/components/Notes/_blackbox';
 
 Noir supports recursively verifying proofs, meaning you verify the proof of a Noir program in another Noir program. This enables creating proofs of arbitrary size by doing step-wise verification of smaller components of a large proof.
 
-Read [the explainer on recursion](../../explainers/explainer-recursion.md) to know more about this function and the [guide on how to use it.](../../how_to/how-to-recursion.md)
+Noir cannot check internally whether a recursive proof is valid or not as this can only be checked by the proving backend. This means that witness execution can still succeed in the case where an invalid proof is used, however an invalid proof is expected to cause the proving backend to fail to generate a valid proof. 
 
-## Verifying Recursive Proofs
-
-```rust
-#[foreign(recursive_aggregation)]
-pub fn verify_proof(verification_key: [Field], proof: [Field], public_inputs: [Field], key_hash: Field) {}
-```
+In order to verify recursive proofs from Barretenberg, it's recommended to use the [bb_proof_verification](https://github.com/AztecProtocol/aztec-packages/tree/next/barretenberg/noir/bb_proof_verification) library which is published by the Barretenberg team.
 
 <BlackBoxInfo to="black_box_fns"/>
 
-## Example usage
-
-```rust
-
-fn main(
-    verification_key : [Field; 114],
-    proof : [Field; 93],
-    public_inputs : [Field; 1],
-    key_hash : Field,
-    proof_b : [Field; 93],
-) {
-    std::verify_proof(
-        verification_key,
-        proof,
-        public_inputs,
-        key_hash
-    );
-
-    std::verify_proof(
-        verification_key,
-        proof_b,
-        public_inputs,
-        key_hash
-    );
-}
-```
+Read [the explainer on recursion](../../explainers/explainer-recursion.md) to know more about this function and the [guide on how to use it.](../../how_to/how-to-recursion.md)
 
 You can see a full example of recursive proofs in [this example recursion demo repo](https://github.com/noir-lang/noir-examples/tree/master/recursion).
-
-## Parameters
-
-### `verification_key`
-
-The verification key for the zk program that is being verified.
-
-### `proof`
-
-The proof for the zk program that is being verified.
-
-### `public_inputs`
-
-These represent the public inputs of the proof we are verifying.
-
-### `key_hash`
-
-A key hash is used to check the validity of the verification key. The circuit implementing this opcode can use this hash to ensure that the key provided to the circuit matches the key produced by the circuit creator.


### PR DESCRIPTION
# Description

## Problem\*

Resolves #9359

## Summary\*

This PR removes the warning around using `std::verify_proof_with_type`

## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [x] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
