### PR TITLE
chore: Check an inline always weight threshold during inline info computation

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/mod.rs
@@ -110,8 +110,8 @@ pub fn primary_passes(options: &SsaEvaluatorOptions) -> Vec<SsaPass> {
         SsaPass::new(Ssa::expand_signed_checks, "expand signed checks"),
         SsaPass::new(Ssa::remove_unreachable_functions, "Removing Unreachable Functions"),
         SsaPass::new(Ssa::defunctionalize, "Defunctionalization"),
-        SsaPass::new(Ssa::inline_simple_functions, "Inlining simple functions")
-            .and_then(Ssa::remove_unreachable_functions),
+        // SsaPass::new(Ssa::inline_simple_functions, "Inlining simple functions")
+        // .and_then(Ssa::remove_unreachable_functions),
         // BUG: Enabling this mem2reg causes an integration test failure in aztec-package; see:
         // https://github.com/AztecProtocol/aztec-packages/pull/11294#issuecomment-2622809518
         //SsaPass::new(Ssa::mem2reg, "Mem2Reg (1st)"),

--- a/compiler/noirc_evaluator/src/ssa/opt/inline_simple_functions.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/inline_simple_functions.rs
@@ -27,6 +27,7 @@ use crate::ssa::{
 const MAX_INSTRUCTIONS: usize = 10;
 
 impl Ssa {
+    #[allow(dead_code)]
     /// See the [`inline_simple_functions`][self] module for more information.
     pub(crate) fn inline_simple_functions(mut self: Ssa) -> Ssa {
         let call_graph = CallGraph::from_ssa(&self);

--- a/compiler/noirc_evaluator/src/ssa/opt/pure.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/pure.rs
@@ -274,7 +274,12 @@ fn analyze_call_graph(
 mod test {
     use crate::{
         assert_ssa_snapshot,
-        ssa::{interpreter::value::Value, ir::{function::FunctionId, types::NumericType}, opt::pure::Purity, ssa_gen::Ssa},
+        ssa::{
+            interpreter::value::Value,
+            ir::{function::FunctionId, types::NumericType},
+            opt::pure::Purity,
+            ssa_gen::Ssa,
+        },
     };
 
     #[test]
@@ -613,7 +618,7 @@ mod test {
         }
         "#);
     }
-            
+
     ///TODO(https://github.com/noir-lang/noir/issues/9451): Remove the `should_panic` once the bug is fixed
     #[test]
     #[should_panic]
@@ -646,13 +651,19 @@ mod test {
 
         let ssa = Ssa::from_str(src).unwrap();
         // Can uncomment to see that we do not fail when running constant folding before purity analysis
-        let ssa = ssa.fold_constants_using_constraints();        
-        let _ = ssa.interpret(vec![Value::from_constant(1_u32.into(), NumericType::unsigned(32)).unwrap()]).unwrap();
-        
-        let ssa = ssa.purity_analysis();
-        let _ = ssa.interpret(vec![Value::from_constant(1_u32.into(), NumericType::unsigned(32)).unwrap()]).unwrap();
+        let ssa = ssa.fold_constants_using_constraints();
+        let _ = ssa
+            .interpret(vec![Value::from_constant(1_u32.into(), NumericType::unsigned(32)).unwrap()])
+            .unwrap();
 
-        let ssa = ssa.fold_constants_using_constraints();        
-        let _ = ssa.interpret(vec![Value::from_constant(1_u32.into(), NumericType::unsigned(32)).unwrap()]).unwrap();
+        let ssa = ssa.purity_analysis();
+        let _ = ssa
+            .interpret(vec![Value::from_constant(1_u32.into(), NumericType::unsigned(32)).unwrap()])
+            .unwrap();
+
+        let ssa = ssa.fold_constants_using_constraints();
+        let _ = ssa
+            .interpret(vec![Value::from_constant(1_u32.into(), NumericType::unsigned(32)).unwrap()])
+            .unwrap();
     }
 }


### PR DESCRIPTION
# Description

## Problem\*

Resolves #9486 

## Summary\*

I was just looking to show how we could improve our inline infos computation to remove the `inline_simple_functions` pass entirely.

## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
