### PR TITLE
docs: correct folder name in the setup steps

### DIFF
--- a/docs/docs/tutorials/noirjs_app.md
+++ b/docs/docs/tutorials/noirjs_app.md
@@ -81,7 +81,7 @@ Finally we're up for something cool. But before we can execute a Noir program, w
 This can be done by cd-ing into our circuit directory and running the `nargo compile` command.
 
 ```bash
-cd circuits
+cd circuit
 
 nargo compile
 ```


### PR DESCRIPTION
# Description

Hey! the instructions say `cd circuits`, but the folder you actually make is `circuit`.

## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
