### PR TITLE
fix(ssa): Use reverse post order when traversing blocks in simple_optimization

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/opt/as_slice_length.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/as_slice_length.rs
@@ -28,7 +28,7 @@ impl Ssa {
 
 impl Function {
     pub(crate) fn as_slice_optimization(&mut self) {
-        self.simple_reachable_blocks_optimization(|context| {
+        self.simple_optimization(|context| {
             let instruction_id = context.instruction_id;
             let instruction = context.instruction();
 

--- a/compiler/noirc_evaluator/src/ssa/opt/brillig_array_get_and_set.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/brillig_array_get_and_set.rs
@@ -40,7 +40,7 @@ impl Ssa {
 
 impl Function {
     pub(super) fn brillig_array_get_and_set(&mut self) {
-        self.simple_reachable_blocks_optimization(|context| {
+        self.simple_optimization(|context| {
             let instruction = context.instruction();
             match instruction {
                 Instruction::ArrayGet { array, index, offset } => {

--- a/compiler/noirc_evaluator/src/ssa/opt/check_u128_mul_overflow.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/check_u128_mul_overflow.rs
@@ -35,7 +35,7 @@ impl Function {
             return;
         }
 
-        self.simple_reachable_blocks_optimization(|context| {
+        self.simple_optimization(|context| {
             context.insert_current_instruction();
 
             let block_id = context.block_id;

--- a/compiler/noirc_evaluator/src/ssa/opt/checked_to_unchecked.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/checked_to_unchecked.rs
@@ -28,7 +28,7 @@ impl Function {
     fn checked_to_unchecked(&mut self) {
         let mut value_max_num_bits = HashMap::<ValueId, u32>::default();
 
-        self.simple_reachable_blocks_optimization(|context| {
+        self.simple_optimization(|context| {
             let instruction = context.instruction();
             let Instruction::Binary(binary) = instruction else {
                 return;

--- a/compiler/noirc_evaluator/src/ssa/opt/expand_signed_checks.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/expand_signed_checks.rs
@@ -32,7 +32,7 @@ impl Function {
     pub(crate) fn expand_signed_checks(&mut self) {
         // TODO: consider whether we can implement this more efficiently in brillig.
 
-        self.simple_reachable_blocks_optimization(|context| {
+        self.simple_optimization(|context| {
             let instruction_id = context.instruction_id;
             let instruction = context.instruction();
 

--- a/compiler/noirc_evaluator/src/ssa/opt/make_constrain_not_equal.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/make_constrain_not_equal.rs
@@ -30,7 +30,7 @@ impl Function {
             return;
         }
 
-        self.simple_reachable_blocks_optimization(|context| {
+        self.simple_optimization(|context| {
             let instruction = context.instruction();
 
             let Instruction::Constrain(lhs, rhs, msg) = instruction else {

--- a/compiler/noirc_evaluator/src/ssa/opt/remove_bit_shifts.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/remove_bit_shifts.rs
@@ -35,7 +35,7 @@ impl Function {
             return;
         }
 
-        self.simple_reachable_blocks_optimization(|context| {
+        self.simple_optimization(|context| {
             let instruction_id = context.instruction_id;
             let instruction = context.instruction();
 

--- a/compiler/noirc_evaluator/src/ssa/opt/remove_enable_side_effects.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/remove_enable_side_effects.rs
@@ -49,7 +49,7 @@ impl Function {
 
         let mut previous_block = None;
 
-        self.simple_reachable_blocks_optimization(|context| {
+        self.simple_optimization(|context| {
             if Some(context.block_id) != previous_block {
                 active_condition = one;
                 last_side_effects_enabled_instruction = None;

--- a/compiler/noirc_evaluator/src/ssa/opt/remove_if_else.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/remove_if_else.rs
@@ -67,7 +67,7 @@ impl Context {
         // Make sure this optimization runs when there's only one block
         assert_eq!(function.dfg[block].successors().count(), 0);
 
-        function.simple_reachable_blocks_optimization_result(|context| {
+        function.simple_optimization_result(|context| {
             let instruction_id = context.instruction_id;
             let instruction = context.instruction();
 

--- a/compiler/noirc_evaluator/src/ssa/opt/remove_truncate_after_range_check.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/remove_truncate_after_range_check.rs
@@ -23,7 +23,7 @@ impl Function {
         // Keeps the minimum bit size a value was range-checked against
         let mut range_checks: HashMap<ValueId, u32> = HashMap::default();
 
-        self.simple_reachable_blocks_optimization(|context| {
+        self.simple_optimization(|context| {
             let instruction_id = context.instruction_id;
             let instruction = context.instruction();
 

--- a/compiler/noirc_evaluator/src/ssa/opt/remove_unreachable_instructions.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/remove_unreachable_instructions.rs
@@ -60,7 +60,7 @@ impl Function {
         let one = self.dfg.make_constant(1_u32.into(), NumericType::bool());
         let mut side_effects_condition = one;
 
-        self.simple_reachable_blocks_optimization(|context| {
+        self.simple_optimization(|context| {
             let block_id = context.block_id;
 
             if current_block_id != Some(block_id) {

--- a/compiler/noirc_evaluator/src/ssa/opt/simple_optimization.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/simple_optimization.rs
@@ -29,11 +29,11 @@ impl Function {
     ///
     /// `replace_value` can be used to replace a value with another one. This substitution will be
     /// performed in all subsequent instructions.
-    pub(crate) fn simple_reachable_blocks_optimization<F>(&mut self, mut f: F)
+    pub(crate) fn simple_optimization<F>(&mut self, mut f: F)
     where
         F: FnMut(&mut SimpleOptimizationContext<'_, '_>),
     {
-        self.simple_reachable_blocks_optimization_result(move |context| {
+        self.simple_optimization_result(move |context| {
             f(context);
             Ok(())
         })
@@ -54,10 +54,7 @@ impl Function {
     ///
     /// `replace_value` can be used to replace a value with another one. This substitution will be
     /// performed in all subsequent instructions.
-    pub(crate) fn simple_reachable_blocks_optimization_result<F>(
-        &mut self,
-        mut f: F,
-    ) -> RtResult<()>
+    pub(crate) fn simple_optimization_result<F>(&mut self, mut f: F) -> RtResult<()>
     where
         F: FnMut(&mut SimpleOptimizationContext<'_, '_>) -> RtResult<()>,
     {


### PR DESCRIPTION
# Description

## Problem\*

Resolves panics in https://github.com/noir-lang/noir/pull/9373 where we have unknown values when we reach inlining

## Summary\*

I switched to using the reverse post order (RPO) during the `simple_optimization` abstraction. This was necessary as during `remove_bit_shifts` we were replace old results with the new results but these were not being seen by the canonical block ordering. This concern was raised on the initial PR https://github.com/noir-lang/noir/pull/8102#discussion_r2047325251. It looks like we finally found a situation which breaks the usage of `reachable_blocks` over the actual canonical block ordering. 

I decided it would be best to just be safe and use the RPO during `simple_optimization`. If we are replacing values, we want to make sure that the replacement values are propagated to all the original values. 

`reachable_blocks` returns a `BTreeSet`. This means we have an ordered set of our blocks. In the test added in this PR (which is the failure from the parent), b3 would be traversed before b12, but v9 in b12 was replaced. That means v9 in b3 is never replaced and we end up with a non-existent value.

## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [X] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
