### PR TITLE
chore: add missing cases of snapshot tests in `remove_bit_shifts`

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/opt/remove_bit_shifts.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/remove_bit_shifts.rs
@@ -399,12 +399,12 @@ mod tests {
         #[test]
         fn removes_shl_with_constant_rhs() {
             let src = "
-        acir(inline) fn main f0 {
-          b0(v0: u32):
-            v2 = shl v0, u32 2
-            return v2
-        }
-        ";
+            acir(inline) fn main f0 {
+              b0(v0: u32):
+                v2 = shl v0, u32 2
+                return v2
+            }
+            ";
             let ssa = Ssa::from_str(src).unwrap();
             let ssa = ssa.remove_bit_shifts();
             assert_ssa_snapshot!(ssa, @r"
@@ -422,12 +422,12 @@ mod tests {
         #[test]
         fn removes_shl_with_non_constant_rhs() {
             let src = "
-        acir(inline) fn main f0 {
-          b0(v0: u32, v1: u32):
-            v2 = shl v0, v1
-            return v2
-        }
-        ";
+            acir(inline) fn main f0 {
+              b0(v0: u32, v1: u32):
+                v2 = shl v0, v1
+                return v2
+            }
+            ";
             let ssa = Ssa::from_str(src).unwrap();
             let ssa = ssa.remove_bit_shifts();
 


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This PR adds the missing bitshift cases in the snapshot tests for right shifts and signed types

## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
