### PR TITLE
feat(cli): allow 'nargo init' to accept project name as positional argument

### DIFF
--- a/Nargo.toml
+++ b/Nargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "myproject"
+type = "bin"
+authors = [""]
+
+[dependencies]

--- a/src/main.nr
+++ b/src/main.nr
@@ -1,0 +1,11 @@
+fn main(x: Field, y: pub Field) {
+    assert(x != y);
+}
+
+#[test]
+fn test_main() {
+    main(1, 2);
+
+    // Uncomment to make test fail
+    // main(1, 1);
+}

--- a/tooling/nargo_cli/src/cli/init_cmd.rs
+++ b/tooling/nargo_cli/src/cli/init_cmd.rs
@@ -12,8 +12,11 @@ use std::path::PathBuf;
 #[derive(Debug, Clone, Args)]
 pub(crate) struct InitCommand {
     /// Name of the package [default: current directory name]
-    #[clap(long)]
-    name: Option<CrateName>,
+    /// Can be given as a positional argument or via --name.
+    #[clap(value_name = "name", value_parser, required = false)]
+    #[clap(long, allow_hyphen_values = true)]
+    #[clap(index = 1)]
+    pub(crate) name: Option<CrateName>,
 
     /// Use a library template
     #[arg(long, conflicts_with = "bin", conflicts_with = "contract")]


### PR DESCRIPTION
# Description

Resolves #3007  
Discussed in https://github.com/orgs/noir-lang/discussions/3003 and converted to https://github.com/noir-lang/noir/issues/3007

## Problem

Previously, initializing a new Noir project with a custom name required using a flag (`nargo init --name myproject`). This was less intuitive and inconsistent with the CLI experience in other tools like Cargo and NPM.

## Summary

- Adds support for `nargo init [name]`, allowing the project name to be provided as a positional argument.
- Retains compatibility with `nargo init --name [name]`.
- Names with hyphens are now also supported as positional arguments.
- This makes the UX more intuitive and user-friendly.

## Usage Examples

**Before:**
```sh
nargo init --name myproject
```

**After:**
```sh
nargo init myproject
nargo init --name myproject
```

## Additional Context

This change improves ergonomics and brings `nargo` in line with other package managers, making it easier for new users to get started.

## Documentation

Check one:
- [ ] No documentation needed.
- [x] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.