### PR TITLE
chore(docs): fix aes docs

### DIFF
--- a/docs/docs/noir/standard_library/cryptographic_primitives/ciphers.mdx
+++ b/docs/docs/noir/standard_library/cryptographic_primitives/ciphers.mdx
@@ -17,10 +17,10 @@ Given a plaintext as an array of bytes, returns the corresponding aes128 ciphert
 
 ```rust
 fn main() {
-    let input: [u8; 4] = [0, 12, 3, 15] // Random bytes, will be padded to 16 bytes.
-    let iv: [u8; 16] = [0; 16]; // Initialisation vector
-    let key: [u8; 16] = [0; 16] // AES key
-    let ciphertext = std::aes128::aes128_encrypt(inputs.as_bytes(), iv.as_bytes(), key.as_bytes()); // In this case, the output length will be 16 bytes.
+    let input: [u8; 4] = [0, 12, 3, 15]; // Random bytes, will be padded to 16 bytes.
+    let iv: [u8; 16] = [0; 16]; // Initialization vector
+    let key: [u8; 16] = [0; 16]; // AES key
+    let ciphertext = std::aes128::aes128_encrypt(input, iv, key); // In this case, the output length will be 16 bytes.
 }
 ```
 


### PR DESCRIPTION
# Description
The current code in docs cannot compile and contains typo
## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*



## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
