### PR TITLE
chore: greenlight `brillig_array_get_and_set` for audits

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/opt/brillig_array_get_and_set.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/brillig_array_get_and_set.rs
@@ -119,7 +119,7 @@ impl Function {
     }
 }
 
-/// Given an array or slice value and a constant index, returns an offseted index
+/// Given an array or slice value and a constant index, returns an offset (shifted) index
 /// together with which type of [`ArrayOffset`] was used to shift it.
 fn compute_index_and_offset(
     context: &mut SimpleOptimizationContext,


### PR DESCRIPTION
# Description

## Problem

Resolves #9523

## Summary

I couldn't find much to do here though I did introduce a few tiny refactors, mainly for consistency with other passes and to avoid an `expect`. I hope it's fine to do such refactors at this point.

## Additional Context



## Documentation

Check one:
- [ ] No documentation needed.
- [x] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
