### PR TITLE
chore: add tests to ensure that JSON serialization of foreign call values is unambiguous

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -845,9 +845,11 @@ name = "brillig"
 version = "1.0.0-beta.10"
 dependencies = [
  "acir_field",
+ "num-bigint",
  "proptest",
  "proptest-derive",
  "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/acvm-repo/acir_field/src/generic_ark.rs
+++ b/acvm-repo/acir_field/src/generic_ark.rs
@@ -144,7 +144,7 @@ macro_rules! field_wrapper {
                 $field::max_num_bytes()
             }
 
-            fn modulus() -> num_bigint::BigUint {
+            fn modulus() -> ::num_bigint::BigUint {
                 $field::modulus()
             }
 

--- a/acvm-repo/brillig/Cargo.toml
+++ b/acvm-repo/brillig/Cargo.toml
@@ -21,6 +21,12 @@ serde.workspace = true
 proptest = { workspace = true, optional = true }
 proptest-derive = { workspace = true, optional = true }
 
+[dev-dependencies]
+serde_json.workspace = true
+proptest.workspace = true
+proptest-derive.workspace = true
+num-bigint.workspace = true
+
 [features]
 default = []
 bn254 = ["acir_field/bn254"]

--- a/acvm-repo/brillig/src/foreign_call.rs
+++ b/acvm-repo/brillig/src/foreign_call.rs
@@ -3,6 +3,7 @@ use serde::{Deserialize, Serialize};
 
 /// Single input or output of a [foreign call][crate::Opcode::ForeignCall].
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Clone)]
+#[cfg_attr(test, derive(proptest_derive::Arbitrary))]
 #[serde(untagged)]
 pub enum ForeignCallParam<F> {
     Single(F),
@@ -40,6 +41,7 @@ impl<F: AcirField> ForeignCallParam<F> {
 
 /// Represents the full output of a [foreign call][crate::Opcode::ForeignCall].
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Clone, Default)]
+#[cfg_attr(test, derive(proptest_derive::Arbitrary))]
 pub struct ForeignCallResult<F> {
     /// Resolved output values of the foreign call.
     pub values: Vec<ForeignCallParam<F>>,
@@ -60,5 +62,45 @@ impl<F> From<Vec<F>> for ForeignCallResult<F> {
 impl<F> From<Vec<ForeignCallParam<F>>> for ForeignCallResult<F> {
     fn from(values: Vec<ForeignCallParam<F>>) -> Self {
         ForeignCallResult { values }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use acir_field::FieldElement;
+    use proptest::prelude::*;
+
+    use super::{ForeignCallParam, ForeignCallResult};
+
+    // Define a wrapper around field so we can implement `Arbitrary`.
+    // NB there are other methods like `arbitrary_field_elements` around the codebase,
+    // but for `proptest_derive::Arbitrary` we need `F: AcirField + Arbitrary`.
+    acir_field::field_wrapper!(TestField, FieldElement);
+
+    impl Arbitrary for TestField {
+        type Parameters = ();
+        type Strategy = BoxedStrategy<Self>;
+
+        fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
+            any::<u128>().prop_map(|v| Self(FieldElement::from(v))).boxed()
+        }
+    }
+
+    proptest! {
+        #[test]
+        fn foreign_call_arg_serialization_roundtrip(param: ForeignCallParam<TestField>) {
+            let serialized = serde_json::to_string(&param).unwrap();
+            let deserialized: ForeignCallParam<TestField> = serde_json::from_str(&serialized).unwrap();
+
+            prop_assert_eq!(param, deserialized);
+        }
+
+        #[test]
+        fn foreign_call_return_serialization_roundtrip(param: ForeignCallResult<TestField>) {
+            let serialized = serde_json::to_string(&param).unwrap();
+            let deserialized: ForeignCallResult<TestField> = serde_json::from_str(&serialized).unwrap();
+
+            prop_assert_eq!(param, deserialized);
+        }
     }
 }

--- a/tooling/nargo/src/foreign_calls/rpc.rs
+++ b/tooling/nargo/src/foreign_calls/rpc.rs
@@ -146,7 +146,33 @@ where
 }
 
 #[cfg(test)]
-mod tests {
+mod serialization_tests {
+    use acvm::{
+        AcirField, FieldElement, acir::brillig::ForeignCallParam,
+        brillig_vm::brillig::ForeignCallResult,
+    };
+
+    #[test]
+    fn deserializes_json_as_expected() {
+        let raw_responses: [(&str, Vec<ForeignCallParam<FieldElement>>); 3] = [
+            ("[]", Vec::new()),
+            (
+                "[\"0x0000000000000000000000000000000000000000000000000000000000000001\"]",
+                vec![ForeignCallParam::Single(FieldElement::one())],
+            ),
+            ("[[]]", vec![ForeignCallParam::Array(Vec::new())]),
+        ];
+
+        for (raw_response, expected) in raw_responses {
+            let decoded_response: ForeignCallResult<FieldElement> =
+                serde_json::from_str(&format!("{{ \"values\": {raw_response} }}")).unwrap();
+            assert_eq!(decoded_response, ForeignCallResult { values: expected });
+        }
+    }
+}
+
+#[cfg(test)]
+mod server_tests {
     use acvm::{
         FieldElement, acir::brillig::ForeignCallParam, brillig_vm::brillig::ForeignCallResult,
         pwg::ForeignCallWaitInfo,


### PR DESCRIPTION
…

# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

The issue with serialization I'm getting in https://github.com/AztecProtocol/aztec-packages/pull/14311 is due to an ambiguous serialisation of foreign call args/return values to JSON under the new serialization format. This PR adds some tests to catch issues like this in future.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
