### PR TITLE
chore(docs): Add llms.txt plugin to docs 

### DIFF
--- a/docs/docs/getting_started/quick_start.md
+++ b/docs/docs/getting_started/quick_start.md
@@ -1,5 +1,6 @@
 ---
 title: Quick Start
+description: Install Nargo, set up a proving backend, and build your first Noir program end-to-end—create a project, compile and execute it, then generate and verify a proof with Barretenberg.
 tags: []
 sidebar_position: 0
 ---

--- a/docs/docs/getting_started/setting_up_shell_completions.md
+++ b/docs/docs/getting_started/setting_up_shell_completions.md
@@ -1,5 +1,6 @@
 ---
 title: Setting up shell completions
+description: Generate and install shell completion scripts for the nargo CLI in zsh, bash, fish, powershell, and elvish.
 tags: []
 sidebar_position: 3
 ---
@@ -29,7 +30,7 @@ Then copy the completion script to that directory:
 nargo generate-completion-script zsh > ~/.oh-my-zsh/completions/_nargo
 ```
 
-Without `oh-my-zsh`, you’ll need to add a path for completion scripts to your function path, and turn on completion script auto-loading. 
+Without `oh-my-zsh`, you’ll need to add a path for completion scripts to your function path, and turn on completion script auto-loading.
 First, add these lines to `~/.zshrc`:
 
 ```bash
@@ -58,7 +59,7 @@ If you have [bash-completion](https://github.com/scop/bash-completion) installed
 nargo generate-completion-script bash > /usr/local/etc/bash_completion.d/nargo
 ```
 
-Without `bash-completion`, you’ll need to source the completion script directly. 
+Without `bash-completion`, you’ll need to source the completion script directly.
 First create a directory such as `~/.bash_completions/`:
 
 ```bash
@@ -72,7 +73,6 @@ nargo generate-completion-script bash > ~/.bash_completions/nargo.bash
 ```
 
 Then add the following line to `~/.bash_profile` or `~/.bashrc`:
-
 
 ```bash
 source ~/.bash_completions/nargo.bash

--- a/docs/docs/noir/concepts/data_bus.mdx
+++ b/docs/docs/noir/concepts/data_bus.mdx
@@ -1,5 +1,6 @@
 ---
 title: Data Bus
+description: Use call_data and return_data to enable a backend optimization for more efficient recursion, with examples and constraints.
 sidebar_position: 13
 ---
 import Experimental from '@site/src/components/Notes/_experimental.mdx';

--- a/docs/docs/noir/concepts/data_types/function_types.md
+++ b/docs/docs/noir/concepts/data_types/function_types.md
@@ -1,5 +1,6 @@
 ---
 title: Function types
+description: Define and use function types for higher‑order functions in Noir, including syntax, examples, and notes on closures.
 sidebar_position: 10
 ---
 

--- a/docs/docs/noir/concepts/shadowing.md
+++ b/docs/docs/noir/concepts/shadowing.md
@@ -1,5 +1,6 @@
 ---
 title: Shadowing
+description: Rebind variables with the same name to derive new values, enabling ergonomic "temporary mutability" patterns in Noir.
 sidebar_position: 12
 ---
 

--- a/docs/docs/noir/modules_packages_crates/workspaces.md
+++ b/docs/docs/noir/modules_packages_crates/workspaces.md
@@ -1,5 +1,6 @@
 ---
 title: Workspaces
+description: Manage multiple related Noir packages in a single repository with a shared workspace, including members, default-member, and command scoping.
 sidebar_position: 3
 ---
 

--- a/docs/docs/noir/standard_library/bn254.md
+++ b/docs/docs/noir/standard_library/bn254.md
@@ -1,5 +1,6 @@
 ---
 title: Bn254 Field Library
+description: Optimized helpers for bn254 Fr—fast comparisons and decomposition tailored for Noir’s standard library.
 ---
 
 Noir provides a module in standard library with some optimized functions for bn254 Fr in `std::field::bn254`.

--- a/docs/docs/noir/standard_library/containers/boundedvec.md
+++ b/docs/docs/noir/standard_library/containers/boundedvec.md
@@ -1,5 +1,6 @@
 ---
 title: Bounded Vectors
+description: Growable vectors with a fixed maximum length; safer and more efficient than slices, with rich methods for access and mutation.
 keywords: [noir, vector, bounded vector, slice]
 sidebar_position: 1
 ---
@@ -238,7 +239,7 @@ Example:
 pub fn from_array<Len>(array: [T; Len]) -> Self
 ```
 
-Creates a new vector, populating it with values derived from an array input. 
+Creates a new vector, populating it with values derived from an array input.
 The maximum length of the vector is determined based on the type signature.
 
 Example:
@@ -288,7 +289,7 @@ Example:
 pub fn map<U, Env>(self, f: fn[Env](T) -> U) -> BoundedVec<U, MaxLen>
 ```
 
-Creates a new vector of equal size by calling a closure on each element in this vector.  
+Creates a new vector of equal size by calling a closure on each element in this vector.
 
 Example:
 

--- a/docs/docs/noir/standard_library/containers/hashmap.md
+++ b/docs/docs/noir/standard_library/containers/hashmap.md
@@ -1,5 +1,6 @@
 ---
 title: HashMap
+description: A bounded key–value map with fixed capacity and Poseidon-compatible hashing—APIs for insert, get, iteration, and more.
 keywords: [noir, map, hash, hashmap]
 sidebar_position: 1
 ---

--- a/docs/docs/noir/standard_library/fmtstr.md
+++ b/docs/docs/noir/standard_library/fmtstr.md
@@ -1,5 +1,6 @@
 ---
 title: fmtstr
+description: Format string literals at compile time—inspect raw contents or emit quoted strings for macro generation.
 ---
 
 `fmtstr<N, T>` is the type resulting from using format string (`f"..."`).
@@ -20,4 +21,4 @@ Returns the format string contents (with the leading and trailing double quotes)
 
 Example:
 
-#include_code as_quoted_str_test test_programs/compile_success_empty/comptime_fmt_strings/src/main.nr rust 
+#include_code as_quoted_str_test test_programs/compile_success_empty/comptime_fmt_strings/src/main.nr rust

--- a/docs/docs/noir/standard_library/meta/ctstring.md
+++ b/docs/docs/noir/standard_library/meta/ctstring.md
@@ -1,5 +1,6 @@
 ---
 title: CtString
+description: Compile-time, dynamically sized strings for `comptime`—build, append, and emit quoted string literals.
 ---
 
 `std::meta::ctstring` contains methods on the built-in `CtString` type which is

--- a/docs/docs/noir/standard_library/meta/expr.md
+++ b/docs/docs/noir/standard_library/meta/expr.md
@@ -1,5 +1,6 @@
 ---
 title: Expr
+description: Introspect and transform quoted expressions at compile time—inspect structure, resolve types, and modify sub-expressions.
 ---
 
 `std::meta::expr` contains methods on the built-in `Expr` type for quoted, syntactically valid expressions.
@@ -238,12 +239,12 @@ Returns this expression as a `Quoted` value. It's the same as `quote { $self }`.
 
 #include_code resolve noir_stdlib/src/meta/expr.nr rust
 
-Resolves and type-checks this expression and returns the result as a `TypedExpr`. 
+Resolves and type-checks this expression and returns the result as a `TypedExpr`.
 
 The `in_function` argument specifies where the expression is resolved:
 - If it's `none`, the expression is resolved in the function where `resolve` was called
 - If it's `some`, the expression is resolved in the given function
 
-If any names used by this expression are not in scope or if there are any type errors, 
-this will give compiler errors as if the expression was written directly into 
+If any names used by this expression are not in scope or if there are any type errors,
+this will give compiler errors as if the expression was written directly into
 the current `comptime` function.

--- a/docs/docs/noir/standard_library/meta/function_def.md
+++ b/docs/docs/noir/standard_library/meta/function_def.md
@@ -1,5 +1,6 @@
 ---
 title: FunctionDefinition
+description: Inspect and mutate function definitions in `comptime`—read signatures, body, attributes, and adjust parameters or return types.
 ---
 
 `std::meta::function_def` contains methods on the built-in `FunctionDefinition` type representing

--- a/docs/docs/noir/standard_library/meta/module.md
+++ b/docs/docs/noir/standard_library/meta/module.md
@@ -1,5 +1,6 @@
 ---
 title: Module
+description: Work with modules in `comptime`—query names, list functions/structs, detect contracts, and add new items.
 ---
 
 `std::meta::module` contains methods on the built-in `Module` type which represents a module in the source program.
@@ -12,8 +13,8 @@ declarations in the source program.
 
 #include_code add_item noir_stdlib/src/meta/module.nr rust
 
-Adds a top-level item (a function, a struct, a global, etc.) to the module. 
-Adding multiple items in one go is also valid if the `Quoted` value has multiple items in it.  
+Adds a top-level item (a function, a struct, a global, etc.) to the module.
+Adding multiple items in one go is also valid if the `Quoted` value has multiple items in it.
 Note that the items are type-checked as if they are inside the module they are being added to.
 
 ### functions

--- a/docs/docs/noir/standard_library/meta/op.md
+++ b/docs/docs/noir/standard_library/meta/op.md
@@ -1,5 +1,6 @@
 ---
 title: UnaryOp and BinaryOp
+description: Represent and inspect operators at compile time—check kinds, and emit quoted operator tokens.
 ---
 
 `std::meta::op` contains the `UnaryOp` and `BinaryOp` types as well as methods on them.

--- a/docs/docs/noir/standard_library/meta/quoted.md
+++ b/docs/docs/noir/standard_library/meta/quoted.md
@@ -1,5 +1,6 @@
 ---
 title: Quoted
+description: Token streams produced by `quote { ... }`—parse as expressions, modules, types, and inspect raw tokens.
 ---
 
 `std::meta::quoted` contains methods on the built-in `Quoted` type which represents

--- a/docs/docs/noir/standard_library/meta/struct_def.md
+++ b/docs/docs/noir/standard_library/meta/struct_def.md
@@ -1,5 +1,6 @@
 ---
 title: TypeDefinition
+description: Inspect and transform struct/enum type definitions—fields, generics, attributes, and module context.
 ---
 
 `std::meta::type_def` contains methods on the built-in `TypeDefinition` type.

--- a/docs/docs/noir/standard_library/meta/trait_constraint.md
+++ b/docs/docs/noir/standard_library/meta/trait_constraint.md
@@ -1,5 +1,6 @@
 ---
 title: TraitConstraint
+description: Represent trait constraints at compile time for searching and matching trait implementations.
 ---
 
 `std::meta::trait_constraint` contains methods on the built-in `TraitConstraint` type which represents

--- a/docs/docs/noir/standard_library/meta/trait_def.md
+++ b/docs/docs/noir/standard_library/meta/trait_def.md
@@ -1,5 +1,6 @@
 ---
 title: TraitDefinition
+description: Work with trait definitions at compile time—convert to trait constraints and inspect basic properties.
 ---
 
 `std::meta::trait_def` contains methods on the built-in `TraitDefinition` type. This type

--- a/docs/docs/noir/standard_library/meta/trait_impl.md
+++ b/docs/docs/noir/standard_library/meta/trait_impl.md
@@ -1,5 +1,6 @@
 ---
 title: TraitImpl
+description: Inspect concrete trait implementations—list methods and read trait generic arguments in `comptime`.
 ---
 
 `std::meta::trait_impl` contains methods on the built-in `TraitImpl` type which represents a trait

--- a/docs/docs/noir/standard_library/meta/typ.md
+++ b/docs/docs/noir/standard_library/meta/typ.md
@@ -1,5 +1,6 @@
 ---
 title: Type
+description: Represent and analyze types at compile time—query structure, check trait bounds, and resolve trait impls.
 ---
 
 `std::meta::typ` contains methods on the built-in `Type` type used for representing

--- a/docs/docs/noir/standard_library/meta/typed_expr.md
+++ b/docs/docs/noir/standard_library/meta/typed_expr.md
@@ -1,5 +1,6 @@
 ---
 title: TypedExpr
+description: Resolved, type-checked expressions—retrieve types, access referenced function definitions, and more.
 ---
 
 `std::meta::typed_expr` contains methods on the built-in `TypedExpr` type for resolved and type-checked expressions.

--- a/docs/docs/noir/standard_library/meta/unresolved_type.md
+++ b/docs/docs/noir/standard_library/meta/unresolved_type.md
@@ -1,5 +1,6 @@
 ---
 title: UnresolvedType
+description: Work with the syntactic form of types—inspect references, slices, and primitive kind checks before resolution.
 ---
 
 `std::meta::unresolved_type` contains methods on the built-in `UnresolvedType` type for the syntax of types.

--- a/docs/docs/noir/standard_library/options.md
+++ b/docs/docs/noir/standard_library/options.md
@@ -1,5 +1,6 @@
 ---
 title: Option<T> Type
+description: Express presence or absence safely with `Option<T>`—construct, inspect, and transform values without nulls.
 ---
 
 The `Option<T>` type is a way to express that a value might be present (`Some(T))` or absent (`None`). It's a safer way to handle potential absence of values, compared to using nulls in many other languages.

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -222,7 +222,7 @@ export default {
         title: 'Noir Language Documentation',
         excludeImports: true,
         ignoreFiles: [],
-        version: versions[0]
+        version: versions[0],
       },
     ],
   ],

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -214,17 +214,17 @@ export default {
       },
     ],
     [
-      "docusaurus-plugin-llms",
+      'docusaurus-plugin-llms',
       {
         generateLLMsTxt: true,
         generateLLMsFullTxt: true,
         docsDir: `versioned_docs/version-${versions[0]}/`,
-        title: "Aztec Protocol Documentation",
+        title: 'Noir Language Documentation',
         excludeImports: true,
-        ignoreFiles: [`versioned_docs/**/protocol-specs/*`],
+        ignoreFiles: [],
         version: versions[0],
         pathTransformation: {
-          ignorePaths: ["docs"],
+          ignorePaths: ['docs'],
         },
       },
     ],

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -222,10 +222,7 @@ export default {
         title: 'Noir Language Documentation',
         excludeImports: true,
         ignoreFiles: [],
-        version: versions[0],
-        pathTransformation: {
-          ignorePaths: ['docs'],
-        },
+        version: versions[0]
       },
     ],
   ],

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -1,5 +1,5 @@
 import type { Config } from '@docusaurus/types';
-
+const versions = require("./versions.json");
 const { themes } = require('prism-react-renderer');
 const lightTheme = themes.github;
 const darkTheme = themes.dracula;
@@ -211,6 +211,21 @@ export default {
         indexFormat: 'table',
         outputFileStrategy: 'members',
         membersWithOwnFile: ['Function', 'TypeAlias'],
+      },
+    ],
+    [
+      "docusaurus-plugin-llms",
+      {
+        generateLLMsTxt: true,
+        generateLLMsFullTxt: true,
+        docsDir: `versioned_docs/version-${versions[0]}/`,
+        title: "Aztec Protocol Documentation",
+        excludeImports: true,
+        ignoreFiles: [`versioned_docs/**/protocol-specs/*`],
+        version: versions[0],
+        pathTransformation: {
+          ignorePaths: ["docs"],
+        },
       },
     ],
   ],

--- a/docs/package.json
+++ b/docs/package.json
@@ -36,6 +36,7 @@
     "@docusaurus/tsconfig": "^3.7.0",
     "@docusaurus/types": "^3.7.0",
     "@types/prettier": "^3.0.0",
+    "docusaurus-plugin-llms": "^0.1.5",
     "docusaurus-plugin-typedoc": "1.2.3",
     "eslint-plugin-prettier": "^5.4.1",
     "prettier": "3.5.3",

--- a/docs/versioned_docs/version-v1.0.0-beta.10/getting_started/setting_up_shell_completions.md
+++ b/docs/versioned_docs/version-v1.0.0-beta.10/getting_started/setting_up_shell_completions.md
@@ -1,5 +1,6 @@
 ---
 title: Setting up shell completions
+description: Generate and install shell completion scripts for the nargo CLI in zsh, bash, fish, powershell, and elvish.
 tags: []
 sidebar_position: 3
 ---
@@ -29,7 +30,7 @@ Then copy the completion script to that directory:
 nargo generate-completion-script zsh > ~/.oh-my-zsh/completions/_nargo
 ```
 
-Without `oh-my-zsh`, you’ll need to add a path for completion scripts to your function path, and turn on completion script auto-loading. 
+Without `oh-my-zsh`, you’ll need to add a path for completion scripts to your function path, and turn on completion script auto-loading.
 First, add these lines to `~/.zshrc`:
 
 ```bash
@@ -58,7 +59,7 @@ If you have [bash-completion](https://github.com/scop/bash-completion) installed
 nargo generate-completion-script bash > /usr/local/etc/bash_completion.d/nargo
 ```
 
-Without `bash-completion`, you’ll need to source the completion script directly. 
+Without `bash-completion`, you’ll need to source the completion script directly.
 First create a directory such as `~/.bash_completions/`:
 
 ```bash

--- a/docs/versioned_docs/version-v1.0.0-beta.10/noir/concepts/data_bus.mdx
+++ b/docs/versioned_docs/version-v1.0.0-beta.10/noir/concepts/data_bus.mdx
@@ -1,5 +1,6 @@
 ---
 title: Data Bus
+description: Use call_data and return_data to enable a backend optimization for more efficient recursion, with examples and constraints.
 sidebar_position: 13
 ---
 import Experimental from '@site/src/components/Notes/_experimental.mdx';

--- a/docs/versioned_docs/version-v1.0.0-beta.10/noir/concepts/data_types/function_types.md
+++ b/docs/versioned_docs/version-v1.0.0-beta.10/noir/concepts/data_types/function_types.md
@@ -1,5 +1,6 @@
 ---
 title: Function types
+description: Define and use function types for higher‑order functions in Noir, including syntax, examples, and notes on closures.
 sidebar_position: 10
 ---
 

--- a/docs/versioned_docs/version-v1.0.0-beta.10/noir/concepts/shadowing.md
+++ b/docs/versioned_docs/version-v1.0.0-beta.10/noir/concepts/shadowing.md
@@ -1,5 +1,6 @@
 ---
 title: Shadowing
+description: Rebind variables with the same name to derive new values, enabling ergonomic "temporary mutability" patterns in Noir.
 sidebar_position: 12
 ---
 

--- a/docs/versioned_docs/version-v1.0.0-beta.10/noir/modules_packages_crates/workspaces.md
+++ b/docs/versioned_docs/version-v1.0.0-beta.10/noir/modules_packages_crates/workspaces.md
@@ -1,5 +1,6 @@
 ---
 title: Workspaces
+description: Manage multiple related Noir packages in a single repository with a shared workspace, including members, default-member, and command scoping.
 sidebar_position: 3
 ---
 

--- a/docs/versioned_docs/version-v1.0.0-beta.10/noir/standard_library/bn254.md
+++ b/docs/versioned_docs/version-v1.0.0-beta.10/noir/standard_library/bn254.md
@@ -1,5 +1,6 @@
 ---
 title: Bn254 Field Library
+description: Optimized helpers for bn254 Fr—fast comparisons and decomposition tailored for Noir’s standard library.
 ---
 
 Noir provides a module in standard library with some optimized functions for bn254 Fr in `std::field::bn254`.

--- a/docs/versioned_docs/version-v1.0.0-beta.10/noir/standard_library/containers/boundedvec.md
+++ b/docs/versioned_docs/version-v1.0.0-beta.10/noir/standard_library/containers/boundedvec.md
@@ -1,5 +1,6 @@
 ---
 title: Bounded Vectors
+description: Growable vectors with a fixed maximum length; safer and more efficient than slices, with rich methods for access and mutation.
 keywords: [noir, vector, bounded vector, slice]
 sidebar_position: 1
 ---
@@ -51,7 +52,7 @@ assert(empty_vector.len() == 0);
 Note that whenever calling `new` the maximum length of the vector should always be specified
 via a type signature:
 
-```rust title="new_example" showLineNumbers 
+```rust title="new_example" showLineNumbers
 fn good() -> BoundedVec<Field, 10> {
     // Ok! MaxLen is specified with a type annotation
     let v1: BoundedVec<Field, 3> = BoundedVec::new();
@@ -102,7 +103,7 @@ it is unsafe! Use at your own risk!
 
 Example:
 
-```rust title="get_unchecked_example" showLineNumbers 
+```rust title="get_unchecked_example" showLineNumbers
 fn sum_of_first_three<let N: u32>(v: BoundedVec<u32, N>) -> u32 {
     // Always ensure the length is larger than the largest
     // index passed to get_unchecked
@@ -150,7 +151,7 @@ Since this function does not perform a bounds check on length before accessing t
 
 Example:
 
-```rust title="set_unchecked_example" showLineNumbers 
+```rust title="set_unchecked_example" showLineNumbers
 fn set_unchecked_example() {
     let mut vec: BoundedVec<u32, 5> = BoundedVec::new();
     vec.extend_from_array([1, 2]);
@@ -192,7 +193,7 @@ Panics if the new length of the vector will be greater than the max length.
 
 Example:
 
-```rust title="bounded-vec-push-example" showLineNumbers 
+```rust title="bounded-vec-push-example" showLineNumbers
 let mut v: BoundedVec<Field, 2> = BoundedVec::new();
 
     v.push(1);
@@ -217,7 +218,7 @@ Panics if the vector is empty.
 
 Example:
 
-```rust title="bounded-vec-pop-example" showLineNumbers 
+```rust title="bounded-vec-pop-example" showLineNumbers
 let mut v: BoundedVec<Field, 2> = BoundedVec::new();
     v.push(1);
     v.push(2);
@@ -243,7 +244,7 @@ Returns the current length of this vector
 
 Example:
 
-```rust title="bounded-vec-len-example" showLineNumbers 
+```rust title="bounded-vec-len-example" showLineNumbers
 let mut v: BoundedVec<Field, 4> = BoundedVec::new();
     assert(v.len() == 0);
 
@@ -273,7 +274,7 @@ equal to the `MaxLen` parameter this vector was initialized with.
 
 Example:
 
-```rust title="bounded-vec-max-len-example" showLineNumbers 
+```rust title="bounded-vec-max-len-example" showLineNumbers
 let mut v: BoundedVec<Field, 5> = BoundedVec::new();
 
     assert(v.max_len() == 5);
@@ -297,7 +298,7 @@ Note that uninitialized elements may be zeroed out!
 
 Example:
 
-```rust title="bounded-vec-storage-example" showLineNumbers 
+```rust title="bounded-vec-storage-example" showLineNumbers
 let mut v: BoundedVec<Field, 5> = BoundedVec::new();
 
     assert(v.storage() == [0, 0, 0, 0, 0]);
@@ -321,7 +322,7 @@ to exceed the maximum length.
 
 Example:
 
-```rust title="bounded-vec-extend-from-array-example" showLineNumbers 
+```rust title="bounded-vec-extend-from-array-example" showLineNumbers
 let mut vec: BoundedVec<Field, 3> = BoundedVec::new();
     vec.extend_from_array([2, 4]);
 
@@ -346,7 +347,7 @@ to exceed the maximum length.
 
 Example:
 
-```rust title="bounded-vec-extend-from-bounded-vec-example" showLineNumbers 
+```rust title="bounded-vec-extend-from-bounded-vec-example" showLineNumbers
 let mut v1: BoundedVec<Field, 5> = BoundedVec::new();
     let mut v2: BoundedVec<Field, 7> = BoundedVec::new();
 
@@ -365,7 +366,7 @@ let mut v1: BoundedVec<Field, 5> = BoundedVec::new();
 pub fn from_array<Len>(array: [T; Len]) -> Self
 ```
 
-Creates a new vector, populating it with values derived from an array input. 
+Creates a new vector, populating it with values derived from an array input.
 The maximum length of the vector is determined based on the type signature.
 
 Example:
@@ -388,7 +389,7 @@ zeroed after that index, you can use `from_parts_unchecked` to remove the extra 
 
 Example:
 
-```rust title="from-parts" showLineNumbers 
+```rust title="from-parts" showLineNumbers
 let vec: BoundedVec<u32, 4> = BoundedVec::from_parts([1, 2, 3, 0], 3);
             assert_eq(vec.len(), 3);
 
@@ -418,7 +419,7 @@ to give incorrect results since it will check even elements past `len`.
 
 Example:
 
-```rust title="from-parts-unchecked" showLineNumbers 
+```rust title="from-parts-unchecked" showLineNumbers
 let vec: BoundedVec<u32, 4> = BoundedVec::from_parts_unchecked([1, 2, 3, 0], 3);
             assert_eq(vec.len(), 3);
 
@@ -439,11 +440,11 @@ let vec: BoundedVec<u32, 4> = BoundedVec::from_parts_unchecked([1, 2, 3, 0], 3);
 pub fn map<U, Env>(self, f: fn[Env](T) -> U) -> BoundedVec<U, MaxLen>
 ```
 
-Creates a new vector of equal size by calling a closure on each element in this vector.  
+Creates a new vector of equal size by calling a closure on each element in this vector.
 
 Example:
 
-```rust title="bounded-vec-map-example" showLineNumbers 
+```rust title="bounded-vec-map-example" showLineNumbers
 let vec: BoundedVec<u32, 4> = BoundedVec::from_array([1, 2, 3, 4]);
             let result = vec.map(|value| value * 2);
 ```
@@ -461,7 +462,7 @@ vector, along with its index in the vector.
 
 Example:
 
-```rust title="bounded-vec-mapi-example" showLineNumbers 
+```rust title="bounded-vec-mapi-example" showLineNumbers
 let vec: BoundedVec<u32, 4> = BoundedVec::from_array([1, 2, 3, 4]);
             let result = vec.mapi(|i, value| i + value * 2);
 ```
@@ -478,7 +479,7 @@ Calls a closure on each element in this vector.
 
 Example:
 
-```rust title="bounded-vec-for-each-example" showLineNumbers 
+```rust title="bounded-vec-for-each-example" showLineNumbers
 let vec: BoundedVec<u32, 3> = BoundedVec::from_array([1, 2, 3]);
             vec.for_each(|value| { *acc_ref += value; });
 ```
@@ -495,7 +496,7 @@ Calls a closure on each element in this vector, along with its index in the vect
 
 Example:
 
-```rust title="bounded-vec-for-eachi-example" showLineNumbers 
+```rust title="bounded-vec-for-eachi-example" showLineNumbers
 let vec: BoundedVec<u32, 3> = BoundedVec::from_array([1, 2, 3]);
             vec.for_eachi(|i, value| { *acc_ref += i * value; });
 ```
@@ -513,7 +514,7 @@ in this vector.
 
 Example:
 
-```rust title="bounded-vec-any-example" showLineNumbers 
+```rust title="bounded-vec-any-example" showLineNumbers
 let mut v: BoundedVec<u32, 3> = BoundedVec::new();
     v.extend_from_array([2, 4, 6]);
 

--- a/docs/versioned_docs/version-v1.0.0-beta.10/noir/standard_library/containers/hashmap.md
+++ b/docs/versioned_docs/version-v1.0.0-beta.10/noir/standard_library/containers/hashmap.md
@@ -1,5 +1,6 @@
 ---
 title: HashMap
+description: A bounded key–value map with fixed capacity and Poseidon-compatible hashing—APIs for insert, get, iteration, and more.
 keywords: [noir, map, hash, hashmap]
 sidebar_position: 1
 ---
@@ -29,7 +30,7 @@ let two = map.get(1).unwrap();
 
 ### default
 
-```rust title="default" showLineNumbers 
+```rust title="default" showLineNumbers
 impl<K, V, let N: u32, B> Default for HashMap<K, V, N, B>
 where
     B: BuildHasher + Default,
@@ -56,7 +57,7 @@ repeated here for convenience since it is the recommended way to create a hashma
 
 Example:
 
-```rust title="default_example" showLineNumbers 
+```rust title="default_example" showLineNumbers
 let hashmap: HashMap<u8, u32, 10, BuildHasherDefault<Poseidon2Hasher>> = HashMap::default();
     assert(hashmap.is_empty());
 ```
@@ -66,7 +67,7 @@ let hashmap: HashMap<u8, u32, 10, BuildHasherDefault<Poseidon2Hasher>> = HashMap
 Because `HashMap` has so many generic arguments that are likely to be the same throughout
 your program, it may be helpful to create a type alias:
 
-```rust title="type_alias" showLineNumbers 
+```rust title="type_alias" showLineNumbers
 type MyMap = HashMap<u8, u32, 10, BuildHasherDefault<Poseidon2Hasher>>;
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/execution_success/hashmap/src/main.nr#L202-L204" target="_blank" rel="noopener noreferrer">Source code: test_programs/execution_success/hashmap/src/main.nr#L202-L204</a></sub></sup>
@@ -74,7 +75,7 @@ type MyMap = HashMap<u8, u32, 10, BuildHasherDefault<Poseidon2Hasher>>;
 
 ### with_hasher
 
-```rust title="with_hasher" showLineNumbers 
+```rust title="with_hasher" showLineNumbers
 pub fn with_hasher(_build_hasher: B) -> Self
     where
         B: BuildHasher,
@@ -88,7 +89,7 @@ hashmaps are created with the same hasher instance.
 
 Example:
 
-```rust title="with_hasher_example" showLineNumbers 
+```rust title="with_hasher_example" showLineNumbers
 let my_hasher: BuildHasherDefault<Poseidon2Hasher> = Default::default();
     let hashmap: HashMap<u8, u32, 10, BuildHasherDefault<Poseidon2Hasher>> =
         HashMap::with_hasher(my_hasher);
@@ -99,7 +100,7 @@ let my_hasher: BuildHasherDefault<Poseidon2Hasher> = Default::default();
 
 ### get
 
-```rust title="get" showLineNumbers 
+```rust title="get" showLineNumbers
 pub fn get(self, key: K) -> Option<V>
     where
         K: Eq + Hash,
@@ -113,7 +114,7 @@ Retrieves a value from the hashmap, returning `Option::none()` if it was not fou
 
 Example:
 
-```rust title="get_example" showLineNumbers 
+```rust title="get_example" showLineNumbers
 fn get_example(map: HashMap<Field, Field, 5, BuildHasherDefault<Poseidon2Hasher>>) {
     let x = map.get(12);
 
@@ -127,7 +128,7 @@ fn get_example(map: HashMap<Field, Field, 5, BuildHasherDefault<Poseidon2Hasher>
 
 ### insert
 
-```rust title="insert" showLineNumbers 
+```rust title="insert" showLineNumbers
 pub fn insert(&mut self, key: K, value: V)
     where
         K: Eq + Hash,
@@ -142,7 +143,7 @@ previous value will be overridden with the newly provided one.
 
 Example:
 
-```rust title="insert_example" showLineNumbers 
+```rust title="insert_example" showLineNumbers
 let mut map: HashMap<Field, Field, 5, BuildHasherDefault<Poseidon2Hasher>> = HashMap::default();
     map.insert(12, 42);
     assert(map.len() == 1);
@@ -152,7 +153,7 @@ let mut map: HashMap<Field, Field, 5, BuildHasherDefault<Poseidon2Hasher>> = Has
 
 ### remove
 
-```rust title="remove" showLineNumbers 
+```rust title="remove" showLineNumbers
 pub fn remove(&mut self, key: K)
     where
         K: Eq + Hash,
@@ -167,7 +168,7 @@ in the map, this does nothing.
 
 Example:
 
-```rust title="remove_example" showLineNumbers 
+```rust title="remove_example" showLineNumbers
 map.remove(12);
     assert(map.is_empty());
 
@@ -180,7 +181,7 @@ map.remove(12);
 
 ### is_empty
 
-```rust title="is_empty" showLineNumbers 
+```rust title="is_empty" showLineNumbers
 pub fn is_empty(self) -> bool {
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/collections/map.nr#L166-L168" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/collections/map.nr#L166-L168</a></sub></sup>
@@ -190,7 +191,7 @@ True if the length of the hash map is empty.
 
 Example:
 
-```rust title="is_empty_example" showLineNumbers 
+```rust title="is_empty_example" showLineNumbers
 assert(map.is_empty());
 
     map.insert(1, 2);
@@ -204,7 +205,7 @@ assert(map.is_empty());
 
 ### len
 
-```rust title="len" showLineNumbers 
+```rust title="len" showLineNumbers
 pub fn len(self) -> u32 {
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/collections/map.nr#L428-L430" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/collections/map.nr#L428-L430</a></sub></sup>
@@ -214,7 +215,7 @@ Returns the current length of this hash map.
 
 Example:
 
-```rust title="len_example" showLineNumbers 
+```rust title="len_example" showLineNumbers
 // This is equivalent to checking map.is_empty()
     assert(map.len() == 0);
 
@@ -235,7 +236,7 @@ Example:
 
 ### capacity
 
-```rust title="capacity" showLineNumbers 
+```rust title="capacity" showLineNumbers
 pub fn capacity(_self: Self) -> u32 {
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/collections/map.nr#L450-L452" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/collections/map.nr#L450-L452</a></sub></sup>
@@ -252,7 +253,7 @@ element count will be lower than the full capacity.
 
 Example:
 
-```rust title="capacity_example" showLineNumbers 
+```rust title="capacity_example" showLineNumbers
 let empty_map: HashMap<Field, Field, 42, BuildHasherDefault<Poseidon2Hasher>> =
         HashMap::default();
     assert(empty_map.len() == 0);
@@ -263,7 +264,7 @@ let empty_map: HashMap<Field, Field, 42, BuildHasherDefault<Poseidon2Hasher>> =
 
 ### clear
 
-```rust title="clear" showLineNumbers 
+```rust title="clear" showLineNumbers
 pub fn clear(&mut self) {
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/collections/map.nr#L123-L125" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/collections/map.nr#L123-L125</a></sub></sup>
@@ -273,7 +274,7 @@ Clears the hashmap, removing all key-value pairs from it.
 
 Example:
 
-```rust title="clear_example" showLineNumbers 
+```rust title="clear_example" showLineNumbers
 assert(!map.is_empty());
     map.clear();
     assert(map.is_empty());
@@ -283,7 +284,7 @@ assert(!map.is_empty());
 
 ### contains_key
 
-```rust title="contains_key" showLineNumbers 
+```rust title="contains_key" showLineNumbers
 pub fn contains_key(self, key: K) -> bool
     where
         K: Hash + Eq,
@@ -298,7 +299,7 @@ the value associated with the key.
 
 Example:
 
-```rust title="contains_key_example" showLineNumbers 
+```rust title="contains_key_example" showLineNumbers
 if map.contains_key(7) {
         let value = map.get(7);
         assert(value.is_some());
@@ -311,7 +312,7 @@ if map.contains_key(7) {
 
 ### entries
 
-```rust title="entries" showLineNumbers 
+```rust title="entries" showLineNumbers
 pub fn entries(self) -> BoundedVec<(K, V), N> {
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/collections/map.nr#L190-L192" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/collections/map.nr#L190-L192</a></sub></sup>
@@ -323,7 +324,7 @@ The length of the returned vector is always equal to the length of the hashmap.
 
 Example:
 
-```rust title="entries_example" showLineNumbers 
+```rust title="entries_example" showLineNumbers
 let entries = map.entries();
 
     // The length of a hashmap may not be compile-time known, so we
@@ -340,7 +341,7 @@ let entries = map.entries();
 
 ### keys
 
-```rust title="keys" showLineNumbers 
+```rust title="keys" showLineNumbers
 pub fn keys(self) -> BoundedVec<K, N> {
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/collections/map.nr#L229-L231" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/collections/map.nr#L229-L231</a></sub></sup>
@@ -352,7 +353,7 @@ The length of the returned vector is always equal to the length of the hashmap.
 
 Example:
 
-```rust title="keys_example" showLineNumbers 
+```rust title="keys_example" showLineNumbers
 let keys = map.keys();
 
     for i in 0..keys.max_len() {
@@ -368,7 +369,7 @@ let keys = map.keys();
 
 ### values
 
-```rust title="values" showLineNumbers 
+```rust title="values" showLineNumbers
 pub fn values(self) -> BoundedVec<V, N> {
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/collections/map.nr#L266-L268" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/collections/map.nr#L266-L268</a></sub></sup>
@@ -380,7 +381,7 @@ The length of the returned vector is always equal to the length of the hashmap.
 
 Example:
 
-```rust title="values_example" showLineNumbers 
+```rust title="values_example" showLineNumbers
 let values = map.values();
 
     for i in 0..values.max_len() {
@@ -395,7 +396,7 @@ let values = map.values();
 
 ### iter_mut
 
-```rust title="iter_mut" showLineNumbers 
+```rust title="iter_mut" showLineNumbers
 pub fn iter_mut(&mut self, f: fn(K, V) -> (K, V))
     where
         K: Eq + Hash,
@@ -417,7 +418,7 @@ equal, which of the two values that will be present for the key in the resulting
 
 Example:
 
-```rust title="iter_mut_example" showLineNumbers 
+```rust title="iter_mut_example" showLineNumbers
 // Add 1 to each key in the map, and double the value associated with that key.
     map.iter_mut(|k, v| (k + 1, v * 2));
 ```
@@ -426,7 +427,7 @@ Example:
 
 ### iter_keys_mut
 
-```rust title="iter_keys_mut" showLineNumbers 
+```rust title="iter_keys_mut" showLineNumbers
 pub fn iter_keys_mut(&mut self, f: fn(K) -> K)
     where
         K: Eq + Hash,
@@ -448,7 +449,7 @@ equal, which of the two values that will be present for the key in the resulting
 
 Example:
 
-```rust title="iter_keys_mut_example" showLineNumbers 
+```rust title="iter_keys_mut_example" showLineNumbers
 // Double each key, leaving the value associated with that key untouched
     map.iter_keys_mut(|k| k * 2);
 ```
@@ -457,7 +458,7 @@ Example:
 
 ### iter_values_mut
 
-```rust title="iter_values_mut" showLineNumbers 
+```rust title="iter_values_mut" showLineNumbers
 pub fn iter_values_mut(&mut self, f: fn(V) -> V) {
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/collections/map.nr#L371-L373" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/collections/map.nr#L371-L373</a></sub></sup>
@@ -469,7 +470,7 @@ because the keys are untouched and the underlying hashmap thus does not need to 
 
 Example:
 
-```rust title="iter_values_mut_example" showLineNumbers 
+```rust title="iter_values_mut_example" showLineNumbers
 // Halve each value
     map.iter_values_mut(|v| v / 2);
 ```
@@ -478,7 +479,7 @@ Example:
 
 ### retain
 
-```rust title="retain" showLineNumbers 
+```rust title="retain" showLineNumbers
 pub fn retain(&mut self, f: fn(K, V) -> bool) {
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/collections/map.nr#L392-L394" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/collections/map.nr#L392-L394</a></sub></sup>
@@ -489,7 +490,7 @@ Any key-value pairs for which the function returns false will be removed from th
 
 Example:
 
-```rust title="retain_example" showLineNumbers 
+```rust title="retain_example" showLineNumbers
 map.retain(|k, v| (k != 0) & (v != 0));
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/execution_success/hashmap/src/main.nr#L280-L282" target="_blank" rel="noopener noreferrer">Source code: test_programs/execution_success/hashmap/src/main.nr#L280-L282</a></sub></sup>
@@ -499,7 +500,7 @@ map.retain(|k, v| (k != 0) & (v != 0));
 
 ### default
 
-```rust title="default" showLineNumbers 
+```rust title="default" showLineNumbers
 impl<K, V, let N: u32, B> Default for HashMap<K, V, N, B>
 where
     B: BuildHasher + Default,
@@ -521,7 +522,7 @@ Constructs an empty HashMap.
 
 Example:
 
-```rust title="default_example" showLineNumbers 
+```rust title="default_example" showLineNumbers
 let hashmap: HashMap<u8, u32, 10, BuildHasherDefault<Poseidon2Hasher>> = HashMap::default();
     assert(hashmap.is_empty());
 ```
@@ -530,7 +531,7 @@ let hashmap: HashMap<u8, u32, 10, BuildHasherDefault<Poseidon2Hasher>> = HashMap
 
 ### eq
 
-```rust title="eq" showLineNumbers 
+```rust title="eq" showLineNumbers
 impl<K, V, let N: u32, B> Eq for HashMap<K, V, N, B>
 where
     K: Eq + Hash,
@@ -562,7 +563,7 @@ Checks if two HashMaps are equal.
 
 Example:
 
-```rust title="eq_example" showLineNumbers 
+```rust title="eq_example" showLineNumbers
 let mut map1: HashMap<Field, u64, 4, BuildHasherDefault<Poseidon2Hasher>> = HashMap::default();
     let mut map2: HashMap<Field, u64, 4, BuildHasherDefault<Poseidon2Hasher>> = HashMap::default();
 

--- a/docs/versioned_docs/version-v1.0.0-beta.10/noir/standard_library/fmtstr.md
+++ b/docs/versioned_docs/version-v1.0.0-beta.10/noir/standard_library/fmtstr.md
@@ -1,5 +1,6 @@
 ---
 title: fmtstr
+description: Format string literals at compile time—inspect raw contents or emit quoted strings for macro generation.
 ---
 
 `fmtstr<N, T>` is the type resulting from using format string (`f"..."`).
@@ -8,7 +9,7 @@ title: fmtstr
 
 ### quoted_contents
 
-```rust title="quoted_contents" showLineNumbers 
+```rust title="quoted_contents" showLineNumbers
 pub comptime fn quoted_contents(self) -> Quoted {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/format_string.nr#L6-L8" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/format_string.nr#L6-L8</a></sub></sup>
@@ -18,7 +19,7 @@ Returns the format string contents (that is, without the leading and trailing do
 
 ### as_quoted_str
 
-```rust title="as_quoted_str" showLineNumbers 
+```rust title="as_quoted_str" showLineNumbers
 pub comptime fn as_quoted_str(self) -> Quoted {
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/format_string.nr#L11-L13" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/format_string.nr#L11-L13</a></sub></sup>
@@ -28,7 +29,7 @@ Returns the format string contents (with the leading and trailing double quotes)
 
 Example:
 
-```rust title="as_quoted_str_test" showLineNumbers 
+```rust title="as_quoted_str_test" showLineNumbers
 comptime {
         let x = 1;
         let f: str<_> = f"x = {x}".as_quoted_str!();

--- a/docs/versioned_docs/version-v1.0.0-beta.10/noir/standard_library/meta/ctstring.md
+++ b/docs/versioned_docs/version-v1.0.0-beta.10/noir/standard_library/meta/ctstring.md
@@ -1,5 +1,6 @@
 ---
 title: CtString
+description: Compile-time, dynamically sized strings for `comptime`—build, append, and emit quoted string literals.
 ---
 
 `std::meta::ctstring` contains methods on the built-in `CtString` type which is
@@ -16,7 +17,7 @@ afterward.
 
 ### AsCtString
 
-```rust title="as-ctstring" showLineNumbers 
+```rust title="as-ctstring" showLineNumbers
 pub trait AsCtString {
     comptime fn as_ctstring(self) -> CtString;
 }
@@ -37,7 +38,7 @@ impl<let N: u32, T> AsCtString for fmtstr<N, T> { ... }
 
 ### new
 
-```rust title="new" showLineNumbers 
+```rust title="new" showLineNumbers
 pub comptime fn new() -> Self {
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/ctstring.nr#L4-L6" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/ctstring.nr#L4-L6</a></sub></sup>
@@ -47,7 +48,7 @@ Creates an empty `CtString`.
 
 ### append_str
 
-```rust title="append_str" showLineNumbers 
+```rust title="append_str" showLineNumbers
 pub comptime fn append_str<let N: u32>(self, s: str<N>) -> Self {
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/ctstring.nr#L12-L14" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/ctstring.nr#L12-L14</a></sub></sup>
@@ -57,7 +58,7 @@ Returns a new CtString with the given str appended onto the end.
 
 ### append_fmtstr
 
-```rust title="append_fmtstr" showLineNumbers 
+```rust title="append_fmtstr" showLineNumbers
 pub comptime fn append_fmtstr<let N: u32, T>(self, s: fmtstr<N, T>) -> Self {
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/ctstring.nr#L18-L20" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/ctstring.nr#L18-L20</a></sub></sup>
@@ -67,7 +68,7 @@ Returns a new CtString with the given fmtstr appended onto the end.
 
 ### as_quoted_str
 
-```rust title="as_quoted_str" showLineNumbers 
+```rust title="as_quoted_str" showLineNumbers
 pub comptime fn as_quoted_str(self) -> Quoted {
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/ctstring.nr#L27-L29" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/ctstring.nr#L27-L29</a></sub></sup>
@@ -82,7 +83,7 @@ literal at this function's call site.
 
 Example:
 
-```rust title="as_quoted_str_example" showLineNumbers 
+```rust title="as_quoted_str_example" showLineNumbers
 let my_ctstring = "foo bar".as_ctstring();
             let my_str: str<7> = my_ctstring.as_quoted_str!();
 

--- a/docs/versioned_docs/version-v1.0.0-beta.10/noir/standard_library/meta/expr.md
+++ b/docs/versioned_docs/version-v1.0.0-beta.10/noir/standard_library/meta/expr.md
@@ -1,5 +1,6 @@
 ---
 title: Expr
+description: Introspect and transform quoted expressions at compile time—inspect structure, resolve types, and modify sub-expressions.
 ---
 
 `std::meta::expr` contains methods on the built-in `Expr` type for quoted, syntactically valid expressions.
@@ -8,7 +9,7 @@ title: Expr
 
 ### as_array
 
-```rust title="as_array" showLineNumbers 
+```rust title="as_array" showLineNumbers
 pub comptime fn as_array(self) -> Option<[Expr]> {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L10-L12" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L10-L12</a></sub></sup>
@@ -18,7 +19,7 @@ If this expression is an array, this returns a slice of each element in the arra
 
 ### as_assert
 
-```rust title="as_assert" showLineNumbers 
+```rust title="as_assert" showLineNumbers
 pub comptime fn as_assert(self) -> Option<(Expr, Option<Expr>)> {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L16-L18" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L16-L18</a></sub></sup>
@@ -28,7 +29,7 @@ If this expression is an assert, this returns the assert expression and the opti
 
 ### as_assert_eq
 
-```rust title="as_assert_eq" showLineNumbers 
+```rust title="as_assert_eq" showLineNumbers
 pub comptime fn as_assert_eq(self) -> Option<(Expr, Expr, Option<Expr>)> {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L23-L25" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L23-L25</a></sub></sup>
@@ -39,7 +40,7 @@ expressions, together with the optional message.
 
 ### as_assign
 
-```rust title="as_assign" showLineNumbers 
+```rust title="as_assign" showLineNumbers
 pub comptime fn as_assign(self) -> Option<(Expr, Expr)> {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L30-L32" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L30-L32</a></sub></sup>
@@ -50,7 +51,7 @@ and right hand side in order.
 
 ### as_binary_op
 
-```rust title="as_binary_op" showLineNumbers 
+```rust title="as_binary_op" showLineNumbers
 pub comptime fn as_binary_op(self) -> Option<(Expr, BinaryOp, Expr)> {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L37-L39" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L37-L39</a></sub></sup>
@@ -61,7 +62,7 @@ return the left-hand side, operator, and the right-hand side of the operation.
 
 ### as_block
 
-```rust title="as_block" showLineNumbers 
+```rust title="as_block" showLineNumbers
 pub comptime fn as_block(self) -> Option<[Expr]> {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L44-L46" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L44-L46</a></sub></sup>
@@ -72,7 +73,7 @@ a slice containing each statement.
 
 ### as_bool
 
-```rust title="as_bool" showLineNumbers 
+```rust title="as_bool" showLineNumbers
 pub comptime fn as_bool(self) -> Option<bool> {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L50-L52" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L50-L52</a></sub></sup>
@@ -82,7 +83,7 @@ If this expression is a boolean literal, return that literal.
 
 ### as_cast
 
-```rust title="as_cast" showLineNumbers 
+```rust title="as_cast" showLineNumbers
 #[builtin(expr_as_cast)]
     pub comptime fn as_cast(self) -> Option<(Expr, UnresolvedType)> {}
 ```
@@ -94,7 +95,7 @@ expression and the type to cast to.
 
 ### as_comptime
 
-```rust title="as_comptime" showLineNumbers 
+```rust title="as_comptime" showLineNumbers
 pub comptime fn as_comptime(self) -> Option<[Expr]> {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L64-L66" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L64-L66</a></sub></sup>
@@ -105,7 +106,7 @@ return each statement in the block.
 
 ### as_constructor
 
-```rust title="as_constructor" showLineNumbers 
+```rust title="as_constructor" showLineNumbers
 pub comptime fn as_constructor(self) -> Option<(UnresolvedType, [(Quoted, Expr)])> {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L71-L73" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L71-L73</a></sub></sup>
@@ -116,7 +117,7 @@ return the type and the fields.
 
 ### as_for
 
-```rust title="as_for" showLineNumbers 
+```rust title="as_for" showLineNumbers
 pub comptime fn as_for(self) -> Option<(Quoted, Expr, Expr)> {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L78-L80" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L78-L80</a></sub></sup>
@@ -127,7 +128,7 @@ the expression and the for loop body.
 
 ### as_for_range
 
-```rust title="as_for" showLineNumbers 
+```rust title="as_for" showLineNumbers
 pub comptime fn as_for(self) -> Option<(Quoted, Expr, Expr)> {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L78-L80" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L78-L80</a></sub></sup>
@@ -138,7 +139,7 @@ the range start, the range end and the for loop body.
 
 ### as_function_call
 
-```rust title="as_function_call" showLineNumbers 
+```rust title="as_function_call" showLineNumbers
 pub comptime fn as_function_call(self) -> Option<(Expr, [Expr])> {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L92-L94" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L92-L94</a></sub></sup>
@@ -149,7 +150,7 @@ the function and a slice of each argument.
 
 ### as_if
 
-```rust title="as_if" showLineNumbers 
+```rust title="as_if" showLineNumbers
 pub comptime fn as_if(self) -> Option<(Expr, Expr, Option<Expr>)> {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L100-L102" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L100-L102</a></sub></sup>
@@ -161,7 +162,7 @@ return the condition, then branch, and else branch. If there is no else branch,
 
 ### as_index
 
-```rust title="as_index" showLineNumbers 
+```rust title="as_index" showLineNumbers
 pub comptime fn as_index(self) -> Option<(Expr, Expr)> {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L107-L109" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L107-L109</a></sub></sup>
@@ -172,7 +173,7 @@ array and the index.
 
 ### as_integer
 
-```rust title="as_integer" showLineNumbers 
+```rust title="as_integer" showLineNumbers
 pub comptime fn as_integer(self) -> Option<(Field, bool)> {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L114-L116" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L114-L116</a></sub></sup>
@@ -183,7 +184,7 @@ as well as whether the integer is negative (true) or not (false).
 
 ### as_lambda
 
-```rust title="as_lambda" showLineNumbers 
+```rust title="as_lambda" showLineNumbers
 pub comptime fn as_lambda(
         self,
     ) -> Option<([(Expr, Option<UnresolvedType>)], Option<UnresolvedType>, Expr)> {}
@@ -195,7 +196,7 @@ If this expression is a lambda, returns the parameters, return type and body.
 
 ### as_let
 
-```rust title="as_let" showLineNumbers 
+```rust title="as_let" showLineNumbers
 pub comptime fn as_let(self) -> Option<(Expr, Option<UnresolvedType>, Expr)> {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L129-L131" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L129-L131</a></sub></sup>
@@ -206,7 +207,7 @@ the optional type annotation, and the assigned expression.
 
 ### as_member_access
 
-```rust title="as_member_access" showLineNumbers 
+```rust title="as_member_access" showLineNumbers
 pub comptime fn as_member_access(self) -> Option<(Expr, Quoted)> {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L136-L138" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L136-L138</a></sub></sup>
@@ -217,7 +218,7 @@ expression and the field. The field will be represented as a quoted value.
 
 ### as_method_call
 
-```rust title="as_method_call" showLineNumbers 
+```rust title="as_method_call" showLineNumbers
 pub comptime fn as_method_call(self) -> Option<(Expr, Quoted, [UnresolvedType], [Expr])> {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L143-L145" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L143-L145</a></sub></sup>
@@ -228,7 +229,7 @@ the receiver, method name, a slice of each generic argument, and a slice of each
 
 ### as_repeated_element_array
 
-```rust title="as_repeated_element_array" showLineNumbers 
+```rust title="as_repeated_element_array" showLineNumbers
 pub comptime fn as_repeated_element_array(self) -> Option<(Expr, Expr)> {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L150-L152" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L150-L152</a></sub></sup>
@@ -239,7 +240,7 @@ the repeated element and the length expressions.
 
 ### as_repeated_element_slice
 
-```rust title="as_repeated_element_slice" showLineNumbers 
+```rust title="as_repeated_element_slice" showLineNumbers
 pub comptime fn as_repeated_element_slice(self) -> Option<(Expr, Expr)> {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L157-L159" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L157-L159</a></sub></sup>
@@ -250,7 +251,7 @@ the repeated element and the length expressions.
 
 ### as_slice
 
-```rust title="as_slice" showLineNumbers 
+```rust title="as_slice" showLineNumbers
 pub comptime fn as_slice(self) -> Option<[Expr]> {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L164-L166" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L164-L166</a></sub></sup>
@@ -261,7 +262,7 @@ return each element of the slice.
 
 ### as_tuple
 
-```rust title="as_tuple" showLineNumbers 
+```rust title="as_tuple" showLineNumbers
 pub comptime fn as_tuple(self) -> Option<[Expr]> {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L171-L173" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L171-L173</a></sub></sup>
@@ -272,7 +273,7 @@ return each element of the tuple.
 
 ### as_unary_op
 
-```rust title="as_unary_op" showLineNumbers 
+```rust title="as_unary_op" showLineNumbers
 pub comptime fn as_unary_op(self) -> Option<(UnaryOp, Expr)> {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L178-L180" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L178-L180</a></sub></sup>
@@ -283,7 +284,7 @@ return the unary operator as well as the right-hand side expression.
 
 ### as_unsafe
 
-```rust title="as_unsafe" showLineNumbers 
+```rust title="as_unsafe" showLineNumbers
 pub comptime fn as_unsafe(self) -> Option<[Expr]> {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L185-L187" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L185-L187</a></sub></sup>
@@ -294,7 +295,7 @@ return each statement inside in a slice.
 
 ### has_semicolon
 
-```rust title="has_semicolon" showLineNumbers 
+```rust title="has_semicolon" showLineNumbers
 pub comptime fn has_semicolon(self) -> bool {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L206-L208" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L206-L208</a></sub></sup>
@@ -317,7 +318,7 @@ comptime {
 
 ### is_break
 
-```rust title="is_break" showLineNumbers 
+```rust title="is_break" showLineNumbers
 pub comptime fn is_break(self) -> bool {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L212-L214" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L212-L214</a></sub></sup>
@@ -327,7 +328,7 @@ pub comptime fn is_break(self) -> bool {}
 
 ### is_continue
 
-```rust title="is_continue" showLineNumbers 
+```rust title="is_continue" showLineNumbers
 pub comptime fn is_continue(self) -> bool {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L218-L220" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L218-L220</a></sub></sup>
@@ -337,7 +338,7 @@ pub comptime fn is_continue(self) -> bool {}
 
 ### modify
 
-```rust title="modify" showLineNumbers 
+```rust title="modify" showLineNumbers
 pub comptime fn modify<Env>(self, f: fn[Env](Expr) -> Option<Expr>) -> Expr {
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L229-L231" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L229-L231</a></sub></sup>
@@ -353,7 +354,7 @@ for expressions that are integers, doubling them, would return `(&[2], &[4, 6])`
 
 ### quoted
 
-```rust title="quoted" showLineNumbers 
+```rust title="quoted" showLineNumbers
 pub comptime fn quoted(self) -> Quoted {
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L266-L268" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L266-L268</a></sub></sup>
@@ -363,18 +364,18 @@ Returns this expression as a `Quoted` value. It's the same as `quote { $self }`.
 
 ### resolve
 
-```rust title="resolve" showLineNumbers 
+```rust title="resolve" showLineNumbers
 pub comptime fn resolve(self, in_function: Option<FunctionDefinition>) -> TypedExpr {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L282-L284" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L282-L284</a></sub></sup>
 
 
-Resolves and type-checks this expression and returns the result as a `TypedExpr`. 
+Resolves and type-checks this expression and returns the result as a `TypedExpr`.
 
 The `in_function` argument specifies where the expression is resolved:
 - If it's `none`, the expression is resolved in the function where `resolve` was called
 - If it's `some`, the expression is resolved in the given function
 
-If any names used by this expression are not in scope or if there are any type errors, 
-this will give compiler errors as if the expression was written directly into 
+If any names used by this expression are not in scope or if there are any type errors,
+this will give compiler errors as if the expression was written directly into
 the current `comptime` function.

--- a/docs/versioned_docs/version-v1.0.0-beta.10/noir/standard_library/meta/function_def.md
+++ b/docs/versioned_docs/version-v1.0.0-beta.10/noir/standard_library/meta/function_def.md
@@ -1,5 +1,6 @@
 ---
 title: FunctionDefinition
+description: Inspect and mutate function definitions in `comptime`—read signatures, body, attributes, and adjust parameters or return types.
 ---
 
 `std::meta::function_def` contains methods on the built-in `FunctionDefinition` type representing
@@ -9,7 +10,7 @@ a function definition in the source program.
 
 ### add_attribute
 
-```rust title="add_attribute" showLineNumbers 
+```rust title="add_attribute" showLineNumbers
 pub comptime fn add_attribute<let N: u32>(self, attribute: str<N>) {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/function_def.nr#L3-L5" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/function_def.nr#L3-L5</a></sub></sup>
@@ -21,7 +22,7 @@ This means any functions called at compile-time are invalid targets for this met
 
 ### as_typed_expr
 
-```rust title="as_typed_expr" showLineNumbers 
+```rust title="as_typed_expr" showLineNumbers
 pub comptime fn as_typed_expr(self) -> TypedExpr {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/function_def.nr#L8-L10" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/function_def.nr#L8-L10</a></sub></sup>
@@ -36,7 +37,7 @@ let _ = quote { $typed_expr(1, 2, 3); };
 
 ### body
 
-```rust title="body" showLineNumbers 
+```rust title="body" showLineNumbers
 pub comptime fn body(self) -> Expr {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/function_def.nr#L13-L15" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/function_def.nr#L13-L15</a></sub></sup>
@@ -48,7 +49,7 @@ This means any functions called at compile-time are invalid targets for this met
 
 ### has_named_attribute
 
-```rust title="has_named_attribute" showLineNumbers 
+```rust title="has_named_attribute" showLineNumbers
 pub comptime fn has_named_attribute<let N: u32>(self, name: str<N>) -> bool {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/function_def.nr#L18-L20" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/function_def.nr#L18-L20</a></sub></sup>
@@ -58,7 +59,7 @@ Returns true if this function has a custom attribute with the given name.
 
 ### is_unconstrained
 
-```rust title="is_unconstrained" showLineNumbers 
+```rust title="is_unconstrained" showLineNumbers
 pub comptime fn is_unconstrained(self) -> bool {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/function_def.nr#L23-L25" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/function_def.nr#L23-L25</a></sub></sup>
@@ -68,7 +69,7 @@ Returns true if this function is unconstrained.
 
 ### module
 
-```rust title="module" showLineNumbers 
+```rust title="module" showLineNumbers
 pub comptime fn module(self) -> Module {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/function_def.nr#L28-L30" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/function_def.nr#L28-L30</a></sub></sup>
@@ -78,7 +79,7 @@ Returns the module where the function is defined.
 
 ### name
 
-```rust title="name" showLineNumbers 
+```rust title="name" showLineNumbers
 pub comptime fn name(self) -> Quoted {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/function_def.nr#L33-L35" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/function_def.nr#L33-L35</a></sub></sup>
@@ -88,7 +89,7 @@ Returns the name of the function.
 
 ### parameters
 
-```rust title="parameters" showLineNumbers 
+```rust title="parameters" showLineNumbers
 pub comptime fn parameters(self) -> [(Quoted, Type)] {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/function_def.nr#L38-L40" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/function_def.nr#L38-L40</a></sub></sup>
@@ -98,7 +99,7 @@ Returns each parameter of the function as a tuple of (parameter pattern, paramet
 
 ### return_type
 
-```rust title="return_type" showLineNumbers 
+```rust title="return_type" showLineNumbers
 pub comptime fn return_type(self) -> Type {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/function_def.nr#L43-L45" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/function_def.nr#L43-L45</a></sub></sup>
@@ -108,7 +109,7 @@ The return type of the function.
 
 ### set_body
 
-```rust title="set_body" showLineNumbers 
+```rust title="set_body" showLineNumbers
 pub comptime fn set_body(self, body: Expr) {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/function_def.nr#L48-L50" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/function_def.nr#L48-L50</a></sub></sup>
@@ -120,7 +121,7 @@ This means any functions called at compile-time are invalid targets for this met
 
 ### set_parameters
 
-```rust title="set_parameters" showLineNumbers 
+```rust title="set_parameters" showLineNumbers
 pub comptime fn set_parameters(self, parameters: [(Quoted, Type)]) {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/function_def.nr#L53-L55" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/function_def.nr#L53-L55</a></sub></sup>
@@ -135,7 +136,7 @@ each parameter pattern to be a syntactically valid parameter.
 
 ### set_return_type
 
-```rust title="set_return_type" showLineNumbers 
+```rust title="set_return_type" showLineNumbers
 pub comptime fn set_return_type(self, return_type: Type) {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/function_def.nr#L58-L60" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/function_def.nr#L58-L60</a></sub></sup>
@@ -147,7 +148,7 @@ This means any functions called at compile-time are invalid targets for this met
 
 ### set_return_public
 
-```rust title="set_return_public" showLineNumbers 
+```rust title="set_return_public" showLineNumbers
 pub comptime fn set_return_public(self, public: bool) {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/function_def.nr#L63-L65" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/function_def.nr#L63-L65</a></sub></sup>
@@ -159,7 +160,7 @@ This means any functions called at compile-time are invalid targets for this met
 
 ### set_unconstrained
 
-```rust title="set_unconstrained" showLineNumbers 
+```rust title="set_unconstrained" showLineNumbers
 pub comptime fn set_unconstrained(self, value: bool) {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/function_def.nr#L71-L73" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/function_def.nr#L71-L73</a></sub></sup>
@@ -171,7 +172,7 @@ This means any functions called at compile-time are invalid targets for this met
 
 ### visibility
 
-```rust title="visibility" showLineNumbers 
+```rust title="visibility" showLineNumbers
 pub comptime fn visibility(self) -> Quoted {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/function_def.nr#L76-L78" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/function_def.nr#L76-L78</a></sub></sup>

--- a/docs/versioned_docs/version-v1.0.0-beta.10/noir/standard_library/meta/module.md
+++ b/docs/versioned_docs/version-v1.0.0-beta.10/noir/standard_library/meta/module.md
@@ -1,5 +1,6 @@
 ---
 title: Module
+description: Work with modules in `comptime`—query names, list functions/structs, detect contracts, and add new items.
 ---
 
 `std::meta::module` contains methods on the built-in `Module` type which represents a module in the source program.
@@ -10,19 +11,19 @@ declarations in the source program.
 
 ### add_item
 
-```rust title="add_item" showLineNumbers 
+```rust title="add_item" showLineNumbers
 pub comptime fn add_item(self, item: Quoted) {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/module.nr#L3-L5" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/module.nr#L3-L5</a></sub></sup>
 
 
-Adds a top-level item (a function, a struct, a global, etc.) to the module. 
-Adding multiple items in one go is also valid if the `Quoted` value has multiple items in it.  
+Adds a top-level item (a function, a struct, a global, etc.) to the module.
+Adding multiple items in one go is also valid if the `Quoted` value has multiple items in it.
 Note that the items are type-checked as if they are inside the module they are being added to.
 
 ### functions
 
-```rust title="functions" showLineNumbers 
+```rust title="functions" showLineNumbers
 pub comptime fn functions(self) -> [FunctionDefinition] {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/module.nr#L18-L20" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/module.nr#L18-L20</a></sub></sup>
@@ -32,7 +33,7 @@ Returns each function defined in the module.
 
 ### has_named_attribute
 
-```rust title="has_named_attribute" showLineNumbers 
+```rust title="has_named_attribute" showLineNumbers
 pub comptime fn has_named_attribute<let N: u32>(self, name: str<N>) -> bool {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/module.nr#L8-L10" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/module.nr#L8-L10</a></sub></sup>
@@ -42,7 +43,7 @@ Returns true if this module has a custom attribute with the given name.
 
 ### is_contract
 
-```rust title="is_contract" showLineNumbers 
+```rust title="is_contract" showLineNumbers
 pub comptime fn is_contract(self) -> bool {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/module.nr#L13-L15" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/module.nr#L13-L15</a></sub></sup>
@@ -52,7 +53,7 @@ pub comptime fn is_contract(self) -> bool {}
 
 ### name
 
-```rust title="name" showLineNumbers 
+```rust title="name" showLineNumbers
 pub comptime fn name(self) -> Quoted {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/module.nr#L28-L30" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/module.nr#L28-L30</a></sub></sup>
@@ -62,7 +63,7 @@ Returns the name of the module.
 
 ### structs
 
-```rust title="structs" showLineNumbers 
+```rust title="structs" showLineNumbers
 pub comptime fn structs(self) -> [TypeDefinition] {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/module.nr#L23-L25" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/module.nr#L23-L25</a></sub></sup>

--- a/docs/versioned_docs/version-v1.0.0-beta.10/noir/standard_library/meta/op.md
+++ b/docs/versioned_docs/version-v1.0.0-beta.10/noir/standard_library/meta/op.md
@@ -1,5 +1,6 @@
 ---
 title: UnaryOp and BinaryOp
+description: Represent and inspect operators at compile time—check kinds, and emit quoted operator tokens.
 ---
 
 `std::meta::op` contains the `UnaryOp` and `BinaryOp` types as well as methods on them.
@@ -15,7 +16,7 @@ Represents a unary operator. One of `-`, `!`, `&mut`, or `*`.
 
 #### is_minus
 
-```rust title="is_minus" showLineNumbers 
+```rust title="is_minus" showLineNumbers
 pub fn is_minus(self) -> bool {
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/op.nr#L26-L28" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L26-L28</a></sub></sup>
@@ -25,7 +26,7 @@ Returns `true` if this operator is `-`.
 
 #### is_not
 
-```rust title="is_not" showLineNumbers 
+```rust title="is_not" showLineNumbers
 pub fn is_not(self) -> bool {
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/op.nr#L32-L34" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L32-L34</a></sub></sup>
@@ -35,7 +36,7 @@ pub fn is_not(self) -> bool {
 
 #### is_mutable_reference
 
-```rust title="is_mutable_reference" showLineNumbers 
+```rust title="is_mutable_reference" showLineNumbers
 pub fn is_mutable_reference(self) -> bool {
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/op.nr#L38-L40" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L38-L40</a></sub></sup>
@@ -45,7 +46,7 @@ pub fn is_mutable_reference(self) -> bool {
 
 #### is_dereference
 
-```rust title="is_dereference" showLineNumbers 
+```rust title="is_dereference" showLineNumbers
 pub fn is_dereference(self) -> bool {
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/op.nr#L44-L46" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L44-L46</a></sub></sup>
@@ -55,7 +56,7 @@ pub fn is_dereference(self) -> bool {
 
 #### quoted
 
-```rust title="unary_quoted" showLineNumbers 
+```rust title="unary_quoted" showLineNumbers
 pub comptime fn quoted(self) -> Quoted {
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/op.nr#L50-L52" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L50-L52</a></sub></sup>
@@ -78,7 +79,7 @@ Represents a binary operator. One of `+`, `-`, `*`, `/`, `%`, `==`, `!=`, `<`, `
 
 #### is_add
 
-```rust title="is_add" showLineNumbers 
+```rust title="is_add" showLineNumbers
 pub fn is_add(self) -> bool {
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/op.nr#L88-L90" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L88-L90</a></sub></sup>
@@ -88,7 +89,7 @@ pub fn is_add(self) -> bool {
 
 #### is_subtract
 
-```rust title="is_subtract" showLineNumbers 
+```rust title="is_subtract" showLineNumbers
 pub fn is_subtract(self) -> bool {
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/op.nr#L94-L96" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L94-L96</a></sub></sup>
@@ -98,7 +99,7 @@ pub fn is_subtract(self) -> bool {
 
 #### is_multiply
 
-```rust title="is_multiply" showLineNumbers 
+```rust title="is_multiply" showLineNumbers
 pub fn is_multiply(self) -> bool {
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/op.nr#L100-L102" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L100-L102</a></sub></sup>
@@ -108,7 +109,7 @@ pub fn is_multiply(self) -> bool {
 
 #### is_divide
 
-```rust title="is_divide" showLineNumbers 
+```rust title="is_divide" showLineNumbers
 pub fn is_divide(self) -> bool {
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/op.nr#L106-L108" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L106-L108</a></sub></sup>
@@ -118,7 +119,7 @@ pub fn is_divide(self) -> bool {
 
 #### is_modulo
 
-```rust title="is_modulo" showLineNumbers 
+```rust title="is_modulo" showLineNumbers
 pub fn is_modulo(self) -> bool {
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/op.nr#L178-L180" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L178-L180</a></sub></sup>
@@ -128,7 +129,7 @@ pub fn is_modulo(self) -> bool {
 
 #### is_equal
 
-```rust title="is_equal" showLineNumbers 
+```rust title="is_equal" showLineNumbers
 pub fn is_equal(self) -> bool {
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/op.nr#L112-L114" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L112-L114</a></sub></sup>
@@ -138,7 +139,7 @@ pub fn is_equal(self) -> bool {
 
 #### is_not_equal
 
-```rust title="is_not_equal" showLineNumbers 
+```rust title="is_not_equal" showLineNumbers
 pub fn is_not_equal(self) -> bool {
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/op.nr#L118-L120" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L118-L120</a></sub></sup>
@@ -148,7 +149,7 @@ pub fn is_not_equal(self) -> bool {
 
 #### is_less_than
 
-```rust title="is_less_than" showLineNumbers 
+```rust title="is_less_than" showLineNumbers
 pub fn is_less_than(self) -> bool {
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/op.nr#L124-L126" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L124-L126</a></sub></sup>
@@ -158,7 +159,7 @@ pub fn is_less_than(self) -> bool {
 
 #### is_less_than_or_equal
 
-```rust title="is_less_than_or_equal" showLineNumbers 
+```rust title="is_less_than_or_equal" showLineNumbers
 pub fn is_less_than_or_equal(self) -> bool {
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/op.nr#L130-L132" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L130-L132</a></sub></sup>
@@ -168,7 +169,7 @@ pub fn is_less_than_or_equal(self) -> bool {
 
 #### is_greater_than
 
-```rust title="is_greater_than" showLineNumbers 
+```rust title="is_greater_than" showLineNumbers
 pub fn is_greater_than(self) -> bool {
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/op.nr#L136-L138" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L136-L138</a></sub></sup>
@@ -178,7 +179,7 @@ pub fn is_greater_than(self) -> bool {
 
 #### is_greater_than_or_equal
 
-```rust title="is_greater_than_or_equal" showLineNumbers 
+```rust title="is_greater_than_or_equal" showLineNumbers
 pub fn is_greater_than_or_equal(self) -> bool {
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/op.nr#L142-L144" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L142-L144</a></sub></sup>
@@ -188,7 +189,7 @@ pub fn is_greater_than_or_equal(self) -> bool {
 
 #### is_and
 
-```rust title="is_and" showLineNumbers 
+```rust title="is_and" showLineNumbers
 pub fn is_and(self) -> bool {
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/op.nr#L148-L150" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L148-L150</a></sub></sup>
@@ -198,7 +199,7 @@ pub fn is_and(self) -> bool {
 
 #### is_or
 
-```rust title="is_or" showLineNumbers 
+```rust title="is_or" showLineNumbers
 pub fn is_or(self) -> bool {
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/op.nr#L154-L156" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L154-L156</a></sub></sup>
@@ -208,7 +209,7 @@ pub fn is_or(self) -> bool {
 
 #### is_shift_right
 
-```rust title="is_shift_right" showLineNumbers 
+```rust title="is_shift_right" showLineNumbers
 pub fn is_shift_right(self) -> bool {
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/op.nr#L166-L168" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L166-L168</a></sub></sup>
@@ -218,7 +219,7 @@ pub fn is_shift_right(self) -> bool {
 
 #### is_shift_left
 
-```rust title="is_shift_left" showLineNumbers 
+```rust title="is_shift_left" showLineNumbers
 pub fn is_shift_left(self) -> bool {
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/op.nr#L172-L174" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L172-L174</a></sub></sup>
@@ -228,7 +229,7 @@ pub fn is_shift_left(self) -> bool {
 
 #### quoted
 
-```rust title="binary_quoted" showLineNumbers 
+```rust title="binary_quoted" showLineNumbers
 pub comptime fn quoted(self) -> Quoted {
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/op.nr#L184-L186" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L184-L186</a></sub></sup>

--- a/docs/versioned_docs/version-v1.0.0-beta.10/noir/standard_library/meta/quoted.md
+++ b/docs/versioned_docs/version-v1.0.0-beta.10/noir/standard_library/meta/quoted.md
@@ -1,5 +1,6 @@
 ---
 title: Quoted
+description: Token streams produced by `quote { ... }`—parse as expressions, modules, types, and inspect raw tokens.
 ---
 
 `std::meta::quoted` contains methods on the built-in `Quoted` type which represents
@@ -9,7 +10,7 @@ quoted token streams and is the result of the `quote { ... }` expression.
 
 ### as_expr
 
-```rust title="as_expr" showLineNumbers 
+```rust title="as_expr" showLineNumbers
 pub comptime fn as_expr(self) -> Option<Expr> {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/quoted.nr#L6-L8" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/quoted.nr#L6-L8</a></sub></sup>
@@ -20,7 +21,7 @@ the expression failed to parse.
 
 Example:
 
-```rust title="as_expr_example" showLineNumbers 
+```rust title="as_expr_example" showLineNumbers
 #[test]
     fn test_expr_as_function_call() {
         comptime {
@@ -36,7 +37,7 @@ Example:
 
 ### as_module
 
-```rust title="as_module" showLineNumbers 
+```rust title="as_module" showLineNumbers
 pub comptime fn as_module(self) -> Option<Module> {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/quoted.nr#L11-L13" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/quoted.nr#L11-L13</a></sub></sup>
@@ -47,7 +48,7 @@ Returns `Option::none()` if the module isn't found or this token stream cannot b
 
 Example:
 
-```rust title="as_module_example" showLineNumbers 
+```rust title="as_module_example" showLineNumbers
 mod baz {
     pub mod qux {}
 }
@@ -65,7 +66,7 @@ fn as_module_test() {
 
 ### as_trait_constraint
 
-```rust title="as_trait_constraint" showLineNumbers 
+```rust title="as_trait_constraint" showLineNumbers
 pub comptime fn as_trait_constraint(self) -> TraitConstraint {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/quoted.nr#L16-L18" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/quoted.nr#L16-L18</a></sub></sup>
@@ -77,7 +78,7 @@ stream does not parse and resolve to a valid trait constraint.
 
 Example:
 
-```rust title="implements_example" showLineNumbers 
+```rust title="implements_example" showLineNumbers
 pub fn function_with_where<T>(_x: T)
 where
     T: SomeTrait<i32>,
@@ -96,7 +97,7 @@ where
 
 ### as_type
 
-```rust title="as_type" showLineNumbers 
+```rust title="as_type" showLineNumbers
 pub comptime fn as_type(self) -> Type {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/quoted.nr#L21-L23" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/quoted.nr#L21-L23</a></sub></sup>
@@ -105,7 +106,7 @@ pub comptime fn as_type(self) -> Type {}
 Interprets this token stream as a resolved type. Panics if the token
 stream doesn't parse to a type or if the type isn't a valid type in scope.
 
-```rust title="implements_example" showLineNumbers 
+```rust title="implements_example" showLineNumbers
 pub fn function_with_where<T>(_x: T)
 where
     T: SomeTrait<i32>,
@@ -124,7 +125,7 @@ where
 
 ### tokens
 
-```rust title="tokens" showLineNumbers 
+```rust title="tokens" showLineNumbers
 pub comptime fn tokens(self) -> [Quoted] {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/quoted.nr#L26-L28" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/quoted.nr#L26-L28</a></sub></sup>

--- a/docs/versioned_docs/version-v1.0.0-beta.10/noir/standard_library/meta/struct_def.md
+++ b/docs/versioned_docs/version-v1.0.0-beta.10/noir/standard_library/meta/struct_def.md
@@ -1,5 +1,6 @@
 ---
 title: TypeDefinition
+description: Inspect and transform struct/enum type definitions—fields, generics, attributes, and module context.
 ---
 
 `std::meta::type_def` contains methods on the built-in `TypeDefinition` type.
@@ -9,7 +10,7 @@ This type corresponds to `struct Name { field1: Type1, ... }` and `enum Name { V
 
 ### add_attribute
 
-```rust title="add_attribute" showLineNumbers 
+```rust title="add_attribute" showLineNumbers
 pub comptime fn add_attribute<let N: u32>(self, attribute: str<N>) {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/type_def.nr#L5-L7" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/type_def.nr#L5-L7</a></sub></sup>
@@ -19,7 +20,7 @@ Adds an attribute to the data type.
 
 ### add_generic
 
-```rust title="add_generic" showLineNumbers 
+```rust title="add_generic" showLineNumbers
 pub comptime fn add_generic<let N: u32>(self, generic_name: str<N>) -> Type {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/type_def.nr#L10-L12" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/type_def.nr#L10-L12</a></sub></sup>
@@ -37,7 +38,7 @@ that are not used in function signatures.
 
 Example:
 
-```rust title="add-generic-example" showLineNumbers 
+```rust title="add-generic-example" showLineNumbers
 comptime fn add_generic(s: TypeDefinition) {
         assert_eq(s.generics().len(), 0);
         let new_generic = s.add_generic("T");
@@ -54,7 +55,7 @@ comptime fn add_generic(s: TypeDefinition) {
 
 ### as_type
 
-```rust title="as_type" showLineNumbers 
+```rust title="as_type" showLineNumbers
 pub comptime fn as_type(self) -> Type {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/type_def.nr#L17-L19" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/type_def.nr#L17-L19</a></sub></sup>
@@ -65,7 +66,7 @@ any generics, the generics are also included as-is.
 
 ### generics
 
-```rust title="generics" showLineNumbers 
+```rust title="generics" showLineNumbers
 pub comptime fn generics(self) -> [(Type, Option<Type>)] {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/type_def.nr#L29-L31" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/type_def.nr#L29-L31</a></sub></sup>
@@ -98,7 +99,7 @@ comptime fn example(foo: TypeDefinition) {
 
 ### fields
 
-```rust title="fields" showLineNumbers 
+```rust title="fields" showLineNumbers
 pub comptime fn fields(self, generic_args: [Type]) -> [(Quoted, Type, Quoted)] {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/type_def.nr#L37-L39" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/type_def.nr#L37-L39</a></sub></sup>
@@ -110,7 +111,7 @@ provided generic arguments.
 
 ### fields_as_written
 
-```rust title="fields_as_written" showLineNumbers 
+```rust title="fields_as_written" showLineNumbers
 pub comptime fn fields_as_written(self) -> [(Quoted, Type, Quoted)] {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/type_def.nr#L46-L48" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/type_def.nr#L46-L48</a></sub></sup>
@@ -123,7 +124,7 @@ function if possible.
 
 ### has_named_attribute
 
-```rust title="has_named_attribute" showLineNumbers 
+```rust title="has_named_attribute" showLineNumbers
 pub comptime fn has_named_attribute<let N: u32>(self, name: str<N>) -> bool {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/type_def.nr#L22-L24" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/type_def.nr#L22-L24</a></sub></sup>
@@ -133,7 +134,7 @@ Returns true if this type has a custom attribute with the given name.
 
 ### module
 
-```rust title="module" showLineNumbers 
+```rust title="module" showLineNumbers
 pub comptime fn module(self) -> Module {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/type_def.nr#L51-L53" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/type_def.nr#L51-L53</a></sub></sup>
@@ -143,7 +144,7 @@ Returns the module where the type is defined.
 
 ### name
 
-```rust title="name" showLineNumbers 
+```rust title="name" showLineNumbers
 pub comptime fn name(self) -> Quoted {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/type_def.nr#L56-L58" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/type_def.nr#L56-L58</a></sub></sup>
@@ -156,7 +157,7 @@ not be the full path to the type definition, nor will it include any generics.
 
 ### set_fields
 
-```rust title="set_fields" showLineNumbers 
+```rust title="set_fields" showLineNumbers
 pub comptime fn set_fields(self, new_fields: [(Quoted, Type, Quoted)]) {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/type_def.nr#L65-L67" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/type_def.nr#L65-L67</a></sub></sup>

--- a/docs/versioned_docs/version-v1.0.0-beta.10/noir/standard_library/meta/trait_constraint.md
+++ b/docs/versioned_docs/version-v1.0.0-beta.10/noir/standard_library/meta/trait_constraint.md
@@ -1,5 +1,6 @@
 ---
 title: TraitConstraint
+description: Represent trait constraints at compile time for searching and matching trait implementations.
 ---
 
 `std::meta::trait_constraint` contains methods on the built-in `TraitConstraint` type which represents

--- a/docs/versioned_docs/version-v1.0.0-beta.10/noir/standard_library/meta/trait_def.md
+++ b/docs/versioned_docs/version-v1.0.0-beta.10/noir/standard_library/meta/trait_def.md
@@ -1,5 +1,6 @@
 ---
 title: TraitDefinition
+description: Work with trait definitions at compile time—convert to trait constraints and inspect basic properties.
 ---
 
 `std::meta::trait_def` contains methods on the built-in `TraitDefinition` type. This type
@@ -9,7 +10,7 @@ represents trait definitions such as `trait Foo { .. }` at the top-level of a pr
 
 ### as_trait_constraint
 
-```rust title="as_trait_constraint" showLineNumbers 
+```rust title="as_trait_constraint" showLineNumbers
 pub comptime fn as_trait_constraint(_self: Self) -> TraitConstraint {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/trait_def.nr#L6-L8" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/trait_def.nr#L6-L8</a></sub></sup>

--- a/docs/versioned_docs/version-v1.0.0-beta.10/noir/standard_library/meta/trait_impl.md
+++ b/docs/versioned_docs/version-v1.0.0-beta.10/noir/standard_library/meta/trait_impl.md
@@ -1,5 +1,6 @@
 ---
 title: TraitImpl
+description: Inspect concrete trait implementations—list methods and read trait generic arguments in `comptime`.
 ---
 
 `std::meta::trait_impl` contains methods on the built-in `TraitImpl` type which represents a trait
@@ -9,7 +10,7 @@ implementation such as `impl Foo for Bar { ... }`.
 
 ### trait_generic_args
 
-```rust title="trait_generic_args" showLineNumbers 
+```rust title="trait_generic_args" showLineNumbers
 pub comptime fn trait_generic_args(self) -> [Type] {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/trait_impl.nr#L3-L5" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/trait_impl.nr#L3-L5</a></sub></sup>
@@ -38,7 +39,7 @@ comptime {
 
 ### methods
 
-```rust title="methods" showLineNumbers 
+```rust title="methods" showLineNumbers
 pub comptime fn methods(self) -> [FunctionDefinition] {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/trait_impl.nr#L8-L10" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/trait_impl.nr#L8-L10</a></sub></sup>

--- a/docs/versioned_docs/version-v1.0.0-beta.10/noir/standard_library/meta/typ.md
+++ b/docs/versioned_docs/version-v1.0.0-beta.10/noir/standard_library/meta/typ.md
@@ -1,5 +1,6 @@
 ---
 title: Type
+description: Represent and analyze types at compile time—query structure, check trait bounds, and resolve trait impls.
 ---
 
 `std::meta::typ` contains methods on the built-in `Type` type used for representing
@@ -7,7 +8,7 @@ a type in the source program.
 
 ## Functions
 
-```rust title="fresh_type_variable" showLineNumbers 
+```rust title="fresh_type_variable" showLineNumbers
 pub comptime fn fresh_type_variable() -> Type {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/typ.nr#L57-L59" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/typ.nr#L57-L59</a></sub></sup>
@@ -30,7 +31,7 @@ fail.
 
 Example:
 
-```rust title="serialize-setup" showLineNumbers 
+```rust title="serialize-setup" showLineNumbers
 trait Serialize<let N: u32> {}
 
 impl Serialize<1> for Field {}
@@ -48,7 +49,7 @@ where
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/compile_success_empty/comptime_type/src/main.nr#L14-L29" target="_blank" rel="noopener noreferrer">Source code: test_programs/compile_success_empty/comptime_type/src/main.nr#L14-L29</a></sub></sup>
 
-```rust title="fresh-type-variable-example" showLineNumbers 
+```rust title="fresh-type-variable-example" showLineNumbers
 let typevar1 = std::meta::typ::fresh_type_variable();
         let constraint = quote { Serialize<$typevar1> }.as_trait_constraint();
         let field_type = quote { Field }.as_type();
@@ -76,7 +77,7 @@ let typevar1 = std::meta::typ::fresh_type_variable();
 
 ### as_array
 
-```rust title="as_array" showLineNumbers 
+```rust title="as_array" showLineNumbers
 pub comptime fn as_array(self) -> Option<(Type, Type)> {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/typ.nr#L76-L78" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/typ.nr#L76-L78</a></sub></sup>
@@ -98,7 +99,7 @@ comptime {
 
 ### as_constant
 
-```rust title="as_constant" showLineNumbers 
+```rust title="as_constant" showLineNumbers
 pub comptime fn as_constant(self) -> Option<u32> {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/typ.nr#L83-L85" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/typ.nr#L83-L85</a></sub></sup>
@@ -109,7 +110,7 @@ return the numeric constant.
 
 ### as_integer
 
-```rust title="as_integer" showLineNumbers 
+```rust title="as_integer" showLineNumbers
 pub comptime fn as_integer(self) -> Option<(bool, u8)> {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/typ.nr#L90-L92" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/typ.nr#L90-L92</a></sub></sup>
@@ -120,7 +121,7 @@ if the type is signed, as well as the number of bits of this integer type.
 
 ### as_mutable_reference
 
-```rust title="as_mutable_reference" showLineNumbers 
+```rust title="as_mutable_reference" showLineNumbers
 pub comptime fn as_mutable_reference(self) -> Option<Type> {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/typ.nr#L96-L98" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/typ.nr#L96-L98</a></sub></sup>
@@ -130,7 +131,7 @@ If this is a mutable reference type `&mut T`, returns the mutable type `T`.
 
 ### as_slice
 
-```rust title="as_slice" showLineNumbers 
+```rust title="as_slice" showLineNumbers
 pub comptime fn as_slice(self) -> Option<Type> {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/typ.nr#L102-L104" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/typ.nr#L102-L104</a></sub></sup>
@@ -140,7 +141,7 @@ If this is a slice type, return the element type of the slice.
 
 ### as_str
 
-```rust title="as_str" showLineNumbers 
+```rust title="as_str" showLineNumbers
 pub comptime fn as_str(self) -> Option<Type> {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/typ.nr#L108-L110" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/typ.nr#L108-L110</a></sub></sup>
@@ -150,7 +151,7 @@ If this is a `str<N>` type, returns the length `N` as a type.
 
 ### as_data_type
 
-```rust title="as_data_type" showLineNumbers 
+```rust title="as_data_type" showLineNumbers
 pub comptime fn as_data_type(self) -> Option<(TypeDefinition, [Type])> {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/typ.nr#L119-L121" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/typ.nr#L119-L121</a></sub></sup>
@@ -161,7 +162,7 @@ any generic arguments on this type.
 
 ### as_tuple
 
-```rust title="as_tuple" showLineNumbers 
+```rust title="as_tuple" showLineNumbers
 pub comptime fn as_tuple(self) -> Option<[Type]> {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/typ.nr#L125-L127" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/typ.nr#L125-L127</a></sub></sup>
@@ -171,7 +172,7 @@ If this is a tuple type, returns each element type of the tuple.
 
 ### get_trait_impl
 
-```rust title="get_trait_impl" showLineNumbers 
+```rust title="get_trait_impl" showLineNumbers
 pub comptime fn get_trait_impl(self, constraint: TraitConstraint) -> Option<TraitImpl> {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/typ.nr#L148-L150" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/typ.nr#L148-L150</a></sub></sup>
@@ -198,7 +199,7 @@ comptime {
 
 ### implements
 
-```rust title="implements" showLineNumbers 
+```rust title="implements" showLineNumbers
 pub comptime fn implements(self, constraint: TraitConstraint) -> bool {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/typ.nr#L171-L173" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/typ.nr#L171-L173</a></sub></sup>
@@ -225,7 +226,7 @@ fn foo<T>() where T: Default {
 
 ### is_bool
 
-```rust title="is_bool" showLineNumbers 
+```rust title="is_bool" showLineNumbers
 pub comptime fn is_bool(self) -> bool {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/typ.nr#L177-L179" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/typ.nr#L177-L179</a></sub></sup>
@@ -235,7 +236,7 @@ pub comptime fn is_bool(self) -> bool {}
 
 ### is_field
 
-```rust title="is_field" showLineNumbers 
+```rust title="is_field" showLineNumbers
 pub comptime fn is_field(self) -> bool {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/typ.nr#L183-L185" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/typ.nr#L183-L185</a></sub></sup>
@@ -245,7 +246,7 @@ pub comptime fn is_field(self) -> bool {}
 
 ### is_unit
 
-```rust title="is_unit" showLineNumbers 
+```rust title="is_unit" showLineNumbers
 pub comptime fn is_unit(self) -> bool {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/typ.nr#L189-L191" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/typ.nr#L189-L191</a></sub></sup>

--- a/docs/versioned_docs/version-v1.0.0-beta.10/noir/standard_library/meta/typed_expr.md
+++ b/docs/versioned_docs/version-v1.0.0-beta.10/noir/standard_library/meta/typed_expr.md
@@ -1,5 +1,6 @@
 ---
 title: TypedExpr
+description: Resolved, type-checked expressions—retrieve types, access referenced function definitions, and more.
 ---
 
 `std::meta::typed_expr` contains methods on the built-in `TypedExpr` type for resolved and type-checked expressions.
@@ -8,7 +9,7 @@ title: TypedExpr
 
 ### get_type
 
-```rust title="as_function_definition" showLineNumbers 
+```rust title="as_function_definition" showLineNumbers
 pub comptime fn as_function_definition(self) -> Option<FunctionDefinition> {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/typed_expr.nr#L7-L9" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/typed_expr.nr#L7-L9</a></sub></sup>
@@ -18,7 +19,7 @@ If this expression refers to a function definitions, returns it. Otherwise retur
 
 ### get_type
 
-```rust title="get_type" showLineNumbers 
+```rust title="get_type" showLineNumbers
 pub comptime fn get_type(self) -> Option<Type> {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/typed_expr.nr#L13-L15" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/typed_expr.nr#L13-L15</a></sub></sup>

--- a/docs/versioned_docs/version-v1.0.0-beta.10/noir/standard_library/meta/unresolved_type.md
+++ b/docs/versioned_docs/version-v1.0.0-beta.10/noir/standard_library/meta/unresolved_type.md
@@ -1,5 +1,6 @@
 ---
 title: UnresolvedType
+description: Work with the syntactic form of types—inspect references, slices, and primitive kind checks before resolution.
 ---
 
 `std::meta::unresolved_type` contains methods on the built-in `UnresolvedType` type for the syntax of types.
@@ -8,7 +9,7 @@ title: UnresolvedType
 
 ### as_mutable_reference
 
-```rust title="as_mutable_reference" showLineNumbers 
+```rust title="as_mutable_reference" showLineNumbers
 pub comptime fn as_mutable_reference(self) -> Option<UnresolvedType> {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/unresolved_type.nr#L8-L10" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/unresolved_type.nr#L8-L10</a></sub></sup>
@@ -18,7 +19,7 @@ If this is a mutable reference type `&mut T`, returns the mutable type `T`.
 
 ### as_slice
 
-```rust title="as_slice" showLineNumbers 
+```rust title="as_slice" showLineNumbers
 pub comptime fn as_slice(self) -> Option<UnresolvedType> {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/unresolved_type.nr#L14-L16" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/unresolved_type.nr#L14-L16</a></sub></sup>
@@ -28,7 +29,7 @@ If this is a slice `&[T]`, returns the element type `T`.
 
 ### is_bool
 
-```rust title="is_bool" showLineNumbers 
+```rust title="is_bool" showLineNumbers
 pub comptime fn is_bool(self) -> bool {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/unresolved_type.nr#L20-L22" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/unresolved_type.nr#L20-L22</a></sub></sup>
@@ -38,7 +39,7 @@ Returns `true` if this type is `bool`.
 
 ### is_field
 
-```rust title="is_field" showLineNumbers 
+```rust title="is_field" showLineNumbers
 pub comptime fn is_field(self) -> bool {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/unresolved_type.nr#L26-L28" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/unresolved_type.nr#L26-L28</a></sub></sup>
@@ -48,7 +49,7 @@ Returns true if this type refers to the Field type.
 
 ### is_unit
 
-```rust title="is_unit" showLineNumbers 
+```rust title="is_unit" showLineNumbers
 pub comptime fn is_unit(self) -> bool {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/unresolved_type.nr#L32-L34" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/unresolved_type.nr#L32-L34</a></sub></sup>

--- a/docs/versioned_docs/version-v1.0.0-beta.10/noir/standard_library/options.md
+++ b/docs/versioned_docs/version-v1.0.0-beta.10/noir/standard_library/options.md
@@ -1,5 +1,6 @@
 ---
 title: Option<T> Type
+description: Express presence or absence safely with `Option<T>`—construct, inspect, and transform values without nulls.
 ---
 
 The `Option<T>` type is a way to express that a value might be present (`Some(T))` or absent (`None`). It's a safer way to handle potential absence of values, compared to using nulls in many other languages.

--- a/docs/versioned_docs/version-v1.0.0-beta.9/getting_started/setting_up_shell_completions.md
+++ b/docs/versioned_docs/version-v1.0.0-beta.9/getting_started/setting_up_shell_completions.md
@@ -1,5 +1,6 @@
 ---
 title: Setting up shell completions
+description: Generate and install shell completion scripts for the nargo CLI in zsh, bash, fish, powershell, and elvish.
 tags: []
 sidebar_position: 3
 ---
@@ -29,7 +30,7 @@ Then copy the completion script to that directory:
 nargo generate-completion-script zsh > ~/.oh-my-zsh/completions/_nargo
 ```
 
-Without `oh-my-zsh`, you’ll need to add a path for completion scripts to your function path, and turn on completion script auto-loading. 
+Without `oh-my-zsh`, you’ll need to add a path for completion scripts to your function path, and turn on completion script auto-loading.
 First, add these lines to `~/.zshrc`:
 
 ```bash
@@ -58,7 +59,7 @@ If you have [bash-completion](https://github.com/scop/bash-completion) installed
 nargo generate-completion-script bash > /usr/local/etc/bash_completion.d/nargo
 ```
 
-Without `bash-completion`, you’ll need to source the completion script directly. 
+Without `bash-completion`, you’ll need to source the completion script directly.
 First create a directory such as `~/.bash_completions/`:
 
 ```bash

--- a/docs/versioned_docs/version-v1.0.0-beta.9/noir/concepts/data_bus.mdx
+++ b/docs/versioned_docs/version-v1.0.0-beta.9/noir/concepts/data_bus.mdx
@@ -1,5 +1,6 @@
 ---
 title: Data Bus
+description: Use call_data and return_data to enable a backend optimization for more efficient recursion, with examples and constraints.
 sidebar_position: 13
 ---
 import Experimental from '@site/src/components/Notes/_experimental.mdx';

--- a/docs/versioned_docs/version-v1.0.0-beta.9/noir/concepts/data_types/function_types.md
+++ b/docs/versioned_docs/version-v1.0.0-beta.9/noir/concepts/data_types/function_types.md
@@ -1,5 +1,6 @@
 ---
 title: Function types
+description: Define and use function types for higher‑order functions in Noir, including syntax, examples, and notes on closures.
 sidebar_position: 10
 ---
 

--- a/docs/versioned_docs/version-v1.0.0-beta.9/noir/concepts/shadowing.md
+++ b/docs/versioned_docs/version-v1.0.0-beta.9/noir/concepts/shadowing.md
@@ -1,5 +1,6 @@
 ---
 title: Shadowing
+description: Rebind variables with the same name to derive new values, enabling ergonomic "temporary mutability" patterns in Noir.
 sidebar_position: 12
 ---
 

--- a/docs/versioned_docs/version-v1.0.0-beta.9/noir/modules_packages_crates/workspaces.md
+++ b/docs/versioned_docs/version-v1.0.0-beta.9/noir/modules_packages_crates/workspaces.md
@@ -1,5 +1,6 @@
 ---
 title: Workspaces
+description: Manage multiple related Noir packages in a single repository with a shared workspace, including members, default-member, and command scoping.
 sidebar_position: 3
 ---
 

--- a/docs/versioned_docs/version-v1.0.0-beta.9/noir/standard_library/bn254.md
+++ b/docs/versioned_docs/version-v1.0.0-beta.9/noir/standard_library/bn254.md
@@ -1,5 +1,6 @@
 ---
 title: Bn254 Field Library
+description: Optimized helpers for bn254 Fr—fast comparisons and decomposition tailored for Noir’s standard library.
 ---
 
 Noir provides a module in standard library with some optimized functions for bn254 Fr in `std::field::bn254`.

--- a/docs/versioned_docs/version-v1.0.0-beta.9/noir/standard_library/containers/boundedvec.md
+++ b/docs/versioned_docs/version-v1.0.0-beta.9/noir/standard_library/containers/boundedvec.md
@@ -1,5 +1,6 @@
 ---
 title: Bounded Vectors
+description: Growable vectors with a fixed maximum length; safer and more efficient than slices, with rich methods for access and mutation.
 keywords: [noir, vector, bounded vector, slice]
 sidebar_position: 1
 ---
@@ -51,7 +52,7 @@ assert(empty_vector.len() == 0);
 Note that whenever calling `new` the maximum length of the vector should always be specified
 via a type signature:
 
-```rust title="new_example" showLineNumbers 
+```rust title="new_example" showLineNumbers
 fn good() -> BoundedVec<Field, 10> {
     // Ok! MaxLen is specified with a type annotation
     let v1: BoundedVec<Field, 3> = BoundedVec::new();
@@ -102,7 +103,7 @@ it is unsafe! Use at your own risk!
 
 Example:
 
-```rust title="get_unchecked_example" showLineNumbers 
+```rust title="get_unchecked_example" showLineNumbers
 fn sum_of_first_three<let N: u32>(v: BoundedVec<u32, N>) -> u32 {
     // Always ensure the length is larger than the largest
     // index passed to get_unchecked
@@ -150,7 +151,7 @@ Since this function does not perform a bounds check on length before accessing t
 
 Example:
 
-```rust title="set_unchecked_example" showLineNumbers 
+```rust title="set_unchecked_example" showLineNumbers
 fn set_unchecked_example() {
     let mut vec: BoundedVec<u32, 5> = BoundedVec::new();
     vec.extend_from_array([1, 2]);
@@ -192,7 +193,7 @@ Panics if the new length of the vector will be greater than the max length.
 
 Example:
 
-```rust title="bounded-vec-push-example" showLineNumbers 
+```rust title="bounded-vec-push-example" showLineNumbers
 let mut v: BoundedVec<Field, 2> = BoundedVec::new();
 
     v.push(1);
@@ -217,7 +218,7 @@ Panics if the vector is empty.
 
 Example:
 
-```rust title="bounded-vec-pop-example" showLineNumbers 
+```rust title="bounded-vec-pop-example" showLineNumbers
 let mut v: BoundedVec<Field, 2> = BoundedVec::new();
     v.push(1);
     v.push(2);
@@ -243,7 +244,7 @@ Returns the current length of this vector
 
 Example:
 
-```rust title="bounded-vec-len-example" showLineNumbers 
+```rust title="bounded-vec-len-example" showLineNumbers
 let mut v: BoundedVec<Field, 4> = BoundedVec::new();
     assert(v.len() == 0);
 
@@ -273,7 +274,7 @@ equal to the `MaxLen` parameter this vector was initialized with.
 
 Example:
 
-```rust title="bounded-vec-max-len-example" showLineNumbers 
+```rust title="bounded-vec-max-len-example" showLineNumbers
 let mut v: BoundedVec<Field, 5> = BoundedVec::new();
 
     assert(v.max_len() == 5);
@@ -297,7 +298,7 @@ Note that uninitialized elements may be zeroed out!
 
 Example:
 
-```rust title="bounded-vec-storage-example" showLineNumbers 
+```rust title="bounded-vec-storage-example" showLineNumbers
 let mut v: BoundedVec<Field, 5> = BoundedVec::new();
 
     assert(v.storage() == [0, 0, 0, 0, 0]);
@@ -321,7 +322,7 @@ to exceed the maximum length.
 
 Example:
 
-```rust title="bounded-vec-extend-from-array-example" showLineNumbers 
+```rust title="bounded-vec-extend-from-array-example" showLineNumbers
 let mut vec: BoundedVec<Field, 3> = BoundedVec::new();
     vec.extend_from_array([2, 4]);
 
@@ -346,7 +347,7 @@ to exceed the maximum length.
 
 Example:
 
-```rust title="bounded-vec-extend-from-bounded-vec-example" showLineNumbers 
+```rust title="bounded-vec-extend-from-bounded-vec-example" showLineNumbers
 let mut v1: BoundedVec<Field, 5> = BoundedVec::new();
     let mut v2: BoundedVec<Field, 7> = BoundedVec::new();
 
@@ -365,7 +366,7 @@ let mut v1: BoundedVec<Field, 5> = BoundedVec::new();
 pub fn from_array<Len>(array: [T; Len]) -> Self
 ```
 
-Creates a new vector, populating it with values derived from an array input. 
+Creates a new vector, populating it with values derived from an array input.
 The maximum length of the vector is determined based on the type signature.
 
 Example:
@@ -388,7 +389,7 @@ zeroed after that index, you can use `from_parts_unchecked` to remove the extra 
 
 Example:
 
-```rust title="from-parts" showLineNumbers 
+```rust title="from-parts" showLineNumbers
 let vec: BoundedVec<u32, 4> = BoundedVec::from_parts([1, 2, 3, 0], 3);
             assert_eq(vec.len(), 3);
 
@@ -418,7 +419,7 @@ to give incorrect results since it will check even elements past `len`.
 
 Example:
 
-```rust title="from-parts-unchecked" showLineNumbers 
+```rust title="from-parts-unchecked" showLineNumbers
 let vec: BoundedVec<u32, 4> = BoundedVec::from_parts_unchecked([1, 2, 3, 0], 3);
             assert_eq(vec.len(), 3);
 
@@ -439,11 +440,11 @@ let vec: BoundedVec<u32, 4> = BoundedVec::from_parts_unchecked([1, 2, 3, 0], 3);
 pub fn map<U, Env>(self, f: fn[Env](T) -> U) -> BoundedVec<U, MaxLen>
 ```
 
-Creates a new vector of equal size by calling a closure on each element in this vector.  
+Creates a new vector of equal size by calling a closure on each element in this vector.
 
 Example:
 
-```rust title="bounded-vec-map-example" showLineNumbers 
+```rust title="bounded-vec-map-example" showLineNumbers
 let vec: BoundedVec<u32, 4> = BoundedVec::from_array([1, 2, 3, 4]);
             let result = vec.map(|value| value * 2);
 ```
@@ -461,7 +462,7 @@ vector, along with its index in the vector.
 
 Example:
 
-```rust title="bounded-vec-mapi-example" showLineNumbers 
+```rust title="bounded-vec-mapi-example" showLineNumbers
 let vec: BoundedVec<u32, 4> = BoundedVec::from_array([1, 2, 3, 4]);
             let result = vec.mapi(|i, value| i + value * 2);
 ```
@@ -478,7 +479,7 @@ Calls a closure on each element in this vector.
 
 Example:
 
-```rust title="bounded-vec-for-each-example" showLineNumbers 
+```rust title="bounded-vec-for-each-example" showLineNumbers
 let vec: BoundedVec<u32, 3> = BoundedVec::from_array([1, 2, 3]);
             vec.for_each(|value| { *acc_ref += value; });
 ```
@@ -495,7 +496,7 @@ Calls a closure on each element in this vector, along with its index in the vect
 
 Example:
 
-```rust title="bounded-vec-for-eachi-example" showLineNumbers 
+```rust title="bounded-vec-for-eachi-example" showLineNumbers
 let vec: BoundedVec<u32, 3> = BoundedVec::from_array([1, 2, 3]);
             vec.for_eachi(|i, value| { *acc_ref += i * value; });
 ```
@@ -513,7 +514,7 @@ in this vector.
 
 Example:
 
-```rust title="bounded-vec-any-example" showLineNumbers 
+```rust title="bounded-vec-any-example" showLineNumbers
 let mut v: BoundedVec<u32, 3> = BoundedVec::new();
     v.extend_from_array([2, 4, 6]);
 

--- a/docs/versioned_docs/version-v1.0.0-beta.9/noir/standard_library/containers/hashmap.md
+++ b/docs/versioned_docs/version-v1.0.0-beta.9/noir/standard_library/containers/hashmap.md
@@ -1,5 +1,6 @@
 ---
 title: HashMap
+description: A bounded key–value map with fixed capacity and Poseidon-compatible hashing—APIs for insert, get, iteration, and more.
 keywords: [noir, map, hash, hashmap]
 sidebar_position: 1
 ---
@@ -29,7 +30,7 @@ let two = map.get(1).unwrap();
 
 ### default
 
-```rust title="default" showLineNumbers 
+```rust title="default" showLineNumbers
 impl<K, V, let N: u32, B> Default for HashMap<K, V, N, B>
 where
     B: BuildHasher + Default,
@@ -56,7 +57,7 @@ repeated here for convenience since it is the recommended way to create a hashma
 
 Example:
 
-```rust title="default_example" showLineNumbers 
+```rust title="default_example" showLineNumbers
 let hashmap: HashMap<u8, u32, 10, BuildHasherDefault<Poseidon2Hasher>> = HashMap::default();
     assert(hashmap.is_empty());
 ```
@@ -66,7 +67,7 @@ let hashmap: HashMap<u8, u32, 10, BuildHasherDefault<Poseidon2Hasher>> = HashMap
 Because `HashMap` has so many generic arguments that are likely to be the same throughout
 your program, it may be helpful to create a type alias:
 
-```rust title="type_alias" showLineNumbers 
+```rust title="type_alias" showLineNumbers
 type MyMap = HashMap<u8, u32, 10, BuildHasherDefault<Poseidon2Hasher>>;
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/execution_success/hashmap/src/main.nr#L202-L204" target="_blank" rel="noopener noreferrer">Source code: test_programs/execution_success/hashmap/src/main.nr#L202-L204</a></sub></sup>
@@ -74,7 +75,7 @@ type MyMap = HashMap<u8, u32, 10, BuildHasherDefault<Poseidon2Hasher>>;
 
 ### with_hasher
 
-```rust title="with_hasher" showLineNumbers 
+```rust title="with_hasher" showLineNumbers
 pub fn with_hasher(_build_hasher: B) -> Self
     where
         B: BuildHasher,
@@ -88,7 +89,7 @@ hashmaps are created with the same hasher instance.
 
 Example:
 
-```rust title="with_hasher_example" showLineNumbers 
+```rust title="with_hasher_example" showLineNumbers
 let my_hasher: BuildHasherDefault<Poseidon2Hasher> = Default::default();
     let hashmap: HashMap<u8, u32, 10, BuildHasherDefault<Poseidon2Hasher>> =
         HashMap::with_hasher(my_hasher);
@@ -99,7 +100,7 @@ let my_hasher: BuildHasherDefault<Poseidon2Hasher> = Default::default();
 
 ### get
 
-```rust title="get" showLineNumbers 
+```rust title="get" showLineNumbers
 pub fn get(self, key: K) -> Option<V>
     where
         K: Eq + Hash,
@@ -113,7 +114,7 @@ Retrieves a value from the hashmap, returning `Option::none()` if it was not fou
 
 Example:
 
-```rust title="get_example" showLineNumbers 
+```rust title="get_example" showLineNumbers
 fn get_example(map: HashMap<Field, Field, 5, BuildHasherDefault<Poseidon2Hasher>>) {
     let x = map.get(12);
 
@@ -127,7 +128,7 @@ fn get_example(map: HashMap<Field, Field, 5, BuildHasherDefault<Poseidon2Hasher>
 
 ### insert
 
-```rust title="insert" showLineNumbers 
+```rust title="insert" showLineNumbers
 pub fn insert(&mut self, key: K, value: V)
     where
         K: Eq + Hash,
@@ -142,7 +143,7 @@ previous value will be overridden with the newly provided one.
 
 Example:
 
-```rust title="insert_example" showLineNumbers 
+```rust title="insert_example" showLineNumbers
 let mut map: HashMap<Field, Field, 5, BuildHasherDefault<Poseidon2Hasher>> = HashMap::default();
     map.insert(12, 42);
     assert(map.len() == 1);
@@ -152,7 +153,7 @@ let mut map: HashMap<Field, Field, 5, BuildHasherDefault<Poseidon2Hasher>> = Has
 
 ### remove
 
-```rust title="remove" showLineNumbers 
+```rust title="remove" showLineNumbers
 pub fn remove(&mut self, key: K)
     where
         K: Eq + Hash,
@@ -167,7 +168,7 @@ in the map, this does nothing.
 
 Example:
 
-```rust title="remove_example" showLineNumbers 
+```rust title="remove_example" showLineNumbers
 map.remove(12);
     assert(map.is_empty());
 
@@ -180,7 +181,7 @@ map.remove(12);
 
 ### is_empty
 
-```rust title="is_empty" showLineNumbers 
+```rust title="is_empty" showLineNumbers
 pub fn is_empty(self) -> bool {
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/collections/map.nr#L166-L168" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/collections/map.nr#L166-L168</a></sub></sup>
@@ -190,7 +191,7 @@ True if the length of the hash map is empty.
 
 Example:
 
-```rust title="is_empty_example" showLineNumbers 
+```rust title="is_empty_example" showLineNumbers
 assert(map.is_empty());
 
     map.insert(1, 2);
@@ -204,7 +205,7 @@ assert(map.is_empty());
 
 ### len
 
-```rust title="len" showLineNumbers 
+```rust title="len" showLineNumbers
 pub fn len(self) -> u32 {
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/collections/map.nr#L428-L430" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/collections/map.nr#L428-L430</a></sub></sup>
@@ -214,7 +215,7 @@ Returns the current length of this hash map.
 
 Example:
 
-```rust title="len_example" showLineNumbers 
+```rust title="len_example" showLineNumbers
 // This is equivalent to checking map.is_empty()
     assert(map.len() == 0);
 
@@ -235,7 +236,7 @@ Example:
 
 ### capacity
 
-```rust title="capacity" showLineNumbers 
+```rust title="capacity" showLineNumbers
 pub fn capacity(_self: Self) -> u32 {
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/collections/map.nr#L450-L452" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/collections/map.nr#L450-L452</a></sub></sup>
@@ -252,7 +253,7 @@ element count will be lower than the full capacity.
 
 Example:
 
-```rust title="capacity_example" showLineNumbers 
+```rust title="capacity_example" showLineNumbers
 let empty_map: HashMap<Field, Field, 42, BuildHasherDefault<Poseidon2Hasher>> =
         HashMap::default();
     assert(empty_map.len() == 0);
@@ -263,7 +264,7 @@ let empty_map: HashMap<Field, Field, 42, BuildHasherDefault<Poseidon2Hasher>> =
 
 ### clear
 
-```rust title="clear" showLineNumbers 
+```rust title="clear" showLineNumbers
 pub fn clear(&mut self) {
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/collections/map.nr#L123-L125" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/collections/map.nr#L123-L125</a></sub></sup>
@@ -273,7 +274,7 @@ Clears the hashmap, removing all key-value pairs from it.
 
 Example:
 
-```rust title="clear_example" showLineNumbers 
+```rust title="clear_example" showLineNumbers
 assert(!map.is_empty());
     map.clear();
     assert(map.is_empty());
@@ -283,7 +284,7 @@ assert(!map.is_empty());
 
 ### contains_key
 
-```rust title="contains_key" showLineNumbers 
+```rust title="contains_key" showLineNumbers
 pub fn contains_key(self, key: K) -> bool
     where
         K: Hash + Eq,
@@ -298,7 +299,7 @@ the value associated with the key.
 
 Example:
 
-```rust title="contains_key_example" showLineNumbers 
+```rust title="contains_key_example" showLineNumbers
 if map.contains_key(7) {
         let value = map.get(7);
         assert(value.is_some());
@@ -311,7 +312,7 @@ if map.contains_key(7) {
 
 ### entries
 
-```rust title="entries" showLineNumbers 
+```rust title="entries" showLineNumbers
 pub fn entries(self) -> BoundedVec<(K, V), N> {
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/collections/map.nr#L190-L192" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/collections/map.nr#L190-L192</a></sub></sup>
@@ -323,7 +324,7 @@ The length of the returned vector is always equal to the length of the hashmap.
 
 Example:
 
-```rust title="entries_example" showLineNumbers 
+```rust title="entries_example" showLineNumbers
 let entries = map.entries();
 
     // The length of a hashmap may not be compile-time known, so we
@@ -340,7 +341,7 @@ let entries = map.entries();
 
 ### keys
 
-```rust title="keys" showLineNumbers 
+```rust title="keys" showLineNumbers
 pub fn keys(self) -> BoundedVec<K, N> {
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/collections/map.nr#L229-L231" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/collections/map.nr#L229-L231</a></sub></sup>
@@ -352,7 +353,7 @@ The length of the returned vector is always equal to the length of the hashmap.
 
 Example:
 
-```rust title="keys_example" showLineNumbers 
+```rust title="keys_example" showLineNumbers
 let keys = map.keys();
 
     for i in 0..keys.max_len() {
@@ -368,7 +369,7 @@ let keys = map.keys();
 
 ### values
 
-```rust title="values" showLineNumbers 
+```rust title="values" showLineNumbers
 pub fn values(self) -> BoundedVec<V, N> {
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/collections/map.nr#L266-L268" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/collections/map.nr#L266-L268</a></sub></sup>
@@ -380,7 +381,7 @@ The length of the returned vector is always equal to the length of the hashmap.
 
 Example:
 
-```rust title="values_example" showLineNumbers 
+```rust title="values_example" showLineNumbers
 let values = map.values();
 
     for i in 0..values.max_len() {
@@ -395,7 +396,7 @@ let values = map.values();
 
 ### iter_mut
 
-```rust title="iter_mut" showLineNumbers 
+```rust title="iter_mut" showLineNumbers
 pub fn iter_mut(&mut self, f: fn(K, V) -> (K, V))
     where
         K: Eq + Hash,
@@ -417,7 +418,7 @@ equal, which of the two values that will be present for the key in the resulting
 
 Example:
 
-```rust title="iter_mut_example" showLineNumbers 
+```rust title="iter_mut_example" showLineNumbers
 // Add 1 to each key in the map, and double the value associated with that key.
     map.iter_mut(|k, v| (k + 1, v * 2));
 ```
@@ -426,7 +427,7 @@ Example:
 
 ### iter_keys_mut
 
-```rust title="iter_keys_mut" showLineNumbers 
+```rust title="iter_keys_mut" showLineNumbers
 pub fn iter_keys_mut(&mut self, f: fn(K) -> K)
     where
         K: Eq + Hash,
@@ -448,7 +449,7 @@ equal, which of the two values that will be present for the key in the resulting
 
 Example:
 
-```rust title="iter_keys_mut_example" showLineNumbers 
+```rust title="iter_keys_mut_example" showLineNumbers
 // Double each key, leaving the value associated with that key untouched
     map.iter_keys_mut(|k| k * 2);
 ```
@@ -457,7 +458,7 @@ Example:
 
 ### iter_values_mut
 
-```rust title="iter_values_mut" showLineNumbers 
+```rust title="iter_values_mut" showLineNumbers
 pub fn iter_values_mut(&mut self, f: fn(V) -> V) {
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/collections/map.nr#L371-L373" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/collections/map.nr#L371-L373</a></sub></sup>
@@ -469,7 +470,7 @@ because the keys are untouched and the underlying hashmap thus does not need to 
 
 Example:
 
-```rust title="iter_values_mut_example" showLineNumbers 
+```rust title="iter_values_mut_example" showLineNumbers
 // Halve each value
     map.iter_values_mut(|v| v / 2);
 ```
@@ -478,7 +479,7 @@ Example:
 
 ### retain
 
-```rust title="retain" showLineNumbers 
+```rust title="retain" showLineNumbers
 pub fn retain(&mut self, f: fn(K, V) -> bool) {
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/collections/map.nr#L392-L394" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/collections/map.nr#L392-L394</a></sub></sup>
@@ -489,7 +490,7 @@ Any key-value pairs for which the function returns false will be removed from th
 
 Example:
 
-```rust title="retain_example" showLineNumbers 
+```rust title="retain_example" showLineNumbers
 map.retain(|k, v| (k != 0) & (v != 0));
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/execution_success/hashmap/src/main.nr#L280-L282" target="_blank" rel="noopener noreferrer">Source code: test_programs/execution_success/hashmap/src/main.nr#L280-L282</a></sub></sup>
@@ -499,7 +500,7 @@ map.retain(|k, v| (k != 0) & (v != 0));
 
 ### default
 
-```rust title="default" showLineNumbers 
+```rust title="default" showLineNumbers
 impl<K, V, let N: u32, B> Default for HashMap<K, V, N, B>
 where
     B: BuildHasher + Default,
@@ -521,7 +522,7 @@ Constructs an empty HashMap.
 
 Example:
 
-```rust title="default_example" showLineNumbers 
+```rust title="default_example" showLineNumbers
 let hashmap: HashMap<u8, u32, 10, BuildHasherDefault<Poseidon2Hasher>> = HashMap::default();
     assert(hashmap.is_empty());
 ```
@@ -530,7 +531,7 @@ let hashmap: HashMap<u8, u32, 10, BuildHasherDefault<Poseidon2Hasher>> = HashMap
 
 ### eq
 
-```rust title="eq" showLineNumbers 
+```rust title="eq" showLineNumbers
 impl<K, V, let N: u32, B> Eq for HashMap<K, V, N, B>
 where
     K: Eq + Hash,
@@ -562,7 +563,7 @@ Checks if two HashMaps are equal.
 
 Example:
 
-```rust title="eq_example" showLineNumbers 
+```rust title="eq_example" showLineNumbers
 let mut map1: HashMap<Field, u64, 4, BuildHasherDefault<Poseidon2Hasher>> = HashMap::default();
     let mut map2: HashMap<Field, u64, 4, BuildHasherDefault<Poseidon2Hasher>> = HashMap::default();
 

--- a/docs/versioned_docs/version-v1.0.0-beta.9/noir/standard_library/fmtstr.md
+++ b/docs/versioned_docs/version-v1.0.0-beta.9/noir/standard_library/fmtstr.md
@@ -1,5 +1,6 @@
 ---
 title: fmtstr
+description: Format string literals at compile time—inspect raw contents or emit quoted strings for macro generation.
 ---
 
 `fmtstr<N, T>` is the type resulting from using format string (`f"..."`).
@@ -8,7 +9,7 @@ title: fmtstr
 
 ### quoted_contents
 
-```rust title="quoted_contents" showLineNumbers 
+```rust title="quoted_contents" showLineNumbers
 pub comptime fn quoted_contents(self) -> Quoted {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/format_string.nr#L6-L8" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/format_string.nr#L6-L8</a></sub></sup>
@@ -18,7 +19,7 @@ Returns the format string contents (that is, without the leading and trailing do
 
 ### as_quoted_str
 
-```rust title="as_quoted_str" showLineNumbers 
+```rust title="as_quoted_str" showLineNumbers
 pub comptime fn as_quoted_str(self) -> Quoted {
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/format_string.nr#L11-L13" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/format_string.nr#L11-L13</a></sub></sup>
@@ -28,7 +29,7 @@ Returns the format string contents (with the leading and trailing double quotes)
 
 Example:
 
-```rust title="as_quoted_str_test" showLineNumbers 
+```rust title="as_quoted_str_test" showLineNumbers
 comptime {
         let x = 1;
         let f: str<_> = f"x = {x}".as_quoted_str!();

--- a/docs/versioned_docs/version-v1.0.0-beta.9/noir/standard_library/meta/ctstring.md
+++ b/docs/versioned_docs/version-v1.0.0-beta.9/noir/standard_library/meta/ctstring.md
@@ -1,5 +1,6 @@
 ---
 title: CtString
+description: Compile-time, dynamically sized strings for `comptime`—build, append, and emit quoted string literals.
 ---
 
 `std::meta::ctstring` contains methods on the built-in `CtString` type which is
@@ -16,7 +17,7 @@ afterward.
 
 ### AsCtString
 
-```rust title="as-ctstring" showLineNumbers 
+```rust title="as-ctstring" showLineNumbers
 pub trait AsCtString {
     comptime fn as_ctstring(self) -> CtString;
 }
@@ -37,7 +38,7 @@ impl<let N: u32, T> AsCtString for fmtstr<N, T> { ... }
 
 ### new
 
-```rust title="new" showLineNumbers 
+```rust title="new" showLineNumbers
 pub comptime fn new() -> Self {
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/ctstring.nr#L4-L6" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/ctstring.nr#L4-L6</a></sub></sup>
@@ -47,7 +48,7 @@ Creates an empty `CtString`.
 
 ### append_str
 
-```rust title="append_str" showLineNumbers 
+```rust title="append_str" showLineNumbers
 pub comptime fn append_str<let N: u32>(self, s: str<N>) -> Self {
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/ctstring.nr#L12-L14" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/ctstring.nr#L12-L14</a></sub></sup>
@@ -57,7 +58,7 @@ Returns a new CtString with the given str appended onto the end.
 
 ### append_fmtstr
 
-```rust title="append_fmtstr" showLineNumbers 
+```rust title="append_fmtstr" showLineNumbers
 pub comptime fn append_fmtstr<let N: u32, T>(self, s: fmtstr<N, T>) -> Self {
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/ctstring.nr#L18-L20" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/ctstring.nr#L18-L20</a></sub></sup>
@@ -67,7 +68,7 @@ Returns a new CtString with the given fmtstr appended onto the end.
 
 ### as_quoted_str
 
-```rust title="as_quoted_str" showLineNumbers 
+```rust title="as_quoted_str" showLineNumbers
 pub comptime fn as_quoted_str(self) -> Quoted {
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/ctstring.nr#L27-L29" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/ctstring.nr#L27-L29</a></sub></sup>
@@ -82,7 +83,7 @@ literal at this function's call site.
 
 Example:
 
-```rust title="as_quoted_str_example" showLineNumbers 
+```rust title="as_quoted_str_example" showLineNumbers
 let my_ctstring = "foo bar".as_ctstring();
             let my_str: str<7> = my_ctstring.as_quoted_str!();
 

--- a/docs/versioned_docs/version-v1.0.0-beta.9/noir/standard_library/meta/expr.md
+++ b/docs/versioned_docs/version-v1.0.0-beta.9/noir/standard_library/meta/expr.md
@@ -1,5 +1,6 @@
 ---
 title: Expr
+description: Introspect and transform quoted expressions at compile time—inspect structure, resolve types, and modify sub-expressions.
 ---
 
 `std::meta::expr` contains methods on the built-in `Expr` type for quoted, syntactically valid expressions.
@@ -8,7 +9,7 @@ title: Expr
 
 ### as_array
 
-```rust title="as_array" showLineNumbers 
+```rust title="as_array" showLineNumbers
 pub comptime fn as_array(self) -> Option<[Expr]> {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L10-L12" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L10-L12</a></sub></sup>
@@ -18,7 +19,7 @@ If this expression is an array, this returns a slice of each element in the arra
 
 ### as_assert
 
-```rust title="as_assert" showLineNumbers 
+```rust title="as_assert" showLineNumbers
 pub comptime fn as_assert(self) -> Option<(Expr, Option<Expr>)> {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L16-L18" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L16-L18</a></sub></sup>
@@ -28,7 +29,7 @@ If this expression is an assert, this returns the assert expression and the opti
 
 ### as_assert_eq
 
-```rust title="as_assert_eq" showLineNumbers 
+```rust title="as_assert_eq" showLineNumbers
 pub comptime fn as_assert_eq(self) -> Option<(Expr, Expr, Option<Expr>)> {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L23-L25" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L23-L25</a></sub></sup>
@@ -39,7 +40,7 @@ expressions, together with the optional message.
 
 ### as_assign
 
-```rust title="as_assign" showLineNumbers 
+```rust title="as_assign" showLineNumbers
 pub comptime fn as_assign(self) -> Option<(Expr, Expr)> {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L30-L32" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L30-L32</a></sub></sup>
@@ -50,7 +51,7 @@ and right hand side in order.
 
 ### as_binary_op
 
-```rust title="as_binary_op" showLineNumbers 
+```rust title="as_binary_op" showLineNumbers
 pub comptime fn as_binary_op(self) -> Option<(Expr, BinaryOp, Expr)> {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L37-L39" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L37-L39</a></sub></sup>
@@ -61,7 +62,7 @@ return the left-hand side, operator, and the right-hand side of the operation.
 
 ### as_block
 
-```rust title="as_block" showLineNumbers 
+```rust title="as_block" showLineNumbers
 pub comptime fn as_block(self) -> Option<[Expr]> {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L44-L46" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L44-L46</a></sub></sup>
@@ -72,7 +73,7 @@ a slice containing each statement.
 
 ### as_bool
 
-```rust title="as_bool" showLineNumbers 
+```rust title="as_bool" showLineNumbers
 pub comptime fn as_bool(self) -> Option<bool> {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L50-L52" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L50-L52</a></sub></sup>
@@ -82,7 +83,7 @@ If this expression is a boolean literal, return that literal.
 
 ### as_cast
 
-```rust title="as_cast" showLineNumbers 
+```rust title="as_cast" showLineNumbers
 #[builtin(expr_as_cast)]
     pub comptime fn as_cast(self) -> Option<(Expr, UnresolvedType)> {}
 ```
@@ -94,7 +95,7 @@ expression and the type to cast to.
 
 ### as_comptime
 
-```rust title="as_comptime" showLineNumbers 
+```rust title="as_comptime" showLineNumbers
 pub comptime fn as_comptime(self) -> Option<[Expr]> {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L64-L66" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L64-L66</a></sub></sup>
@@ -105,7 +106,7 @@ return each statement in the block.
 
 ### as_constructor
 
-```rust title="as_constructor" showLineNumbers 
+```rust title="as_constructor" showLineNumbers
 pub comptime fn as_constructor(self) -> Option<(UnresolvedType, [(Quoted, Expr)])> {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L71-L73" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L71-L73</a></sub></sup>
@@ -116,7 +117,7 @@ return the type and the fields.
 
 ### as_for
 
-```rust title="as_for" showLineNumbers 
+```rust title="as_for" showLineNumbers
 pub comptime fn as_for(self) -> Option<(Quoted, Expr, Expr)> {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L78-L80" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L78-L80</a></sub></sup>
@@ -127,7 +128,7 @@ the expression and the for loop body.
 
 ### as_for_range
 
-```rust title="as_for" showLineNumbers 
+```rust title="as_for" showLineNumbers
 pub comptime fn as_for(self) -> Option<(Quoted, Expr, Expr)> {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L78-L80" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L78-L80</a></sub></sup>
@@ -138,7 +139,7 @@ the range start, the range end and the for loop body.
 
 ### as_function_call
 
-```rust title="as_function_call" showLineNumbers 
+```rust title="as_function_call" showLineNumbers
 pub comptime fn as_function_call(self) -> Option<(Expr, [Expr])> {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L92-L94" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L92-L94</a></sub></sup>
@@ -149,7 +150,7 @@ the function and a slice of each argument.
 
 ### as_if
 
-```rust title="as_if" showLineNumbers 
+```rust title="as_if" showLineNumbers
 pub comptime fn as_if(self) -> Option<(Expr, Expr, Option<Expr>)> {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L100-L102" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L100-L102</a></sub></sup>
@@ -161,7 +162,7 @@ return the condition, then branch, and else branch. If there is no else branch,
 
 ### as_index
 
-```rust title="as_index" showLineNumbers 
+```rust title="as_index" showLineNumbers
 pub comptime fn as_index(self) -> Option<(Expr, Expr)> {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L107-L109" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L107-L109</a></sub></sup>
@@ -172,7 +173,7 @@ array and the index.
 
 ### as_integer
 
-```rust title="as_integer" showLineNumbers 
+```rust title="as_integer" showLineNumbers
 pub comptime fn as_integer(self) -> Option<(Field, bool)> {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L114-L116" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L114-L116</a></sub></sup>
@@ -183,7 +184,7 @@ as well as whether the integer is negative (true) or not (false).
 
 ### as_lambda
 
-```rust title="as_lambda" showLineNumbers 
+```rust title="as_lambda" showLineNumbers
 pub comptime fn as_lambda(
         self,
     ) -> Option<([(Expr, Option<UnresolvedType>)], Option<UnresolvedType>, Expr)> {}
@@ -195,7 +196,7 @@ If this expression is a lambda, returns the parameters, return type and body.
 
 ### as_let
 
-```rust title="as_let" showLineNumbers 
+```rust title="as_let" showLineNumbers
 pub comptime fn as_let(self) -> Option<(Expr, Option<UnresolvedType>, Expr)> {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L129-L131" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L129-L131</a></sub></sup>
@@ -206,7 +207,7 @@ the optional type annotation, and the assigned expression.
 
 ### as_member_access
 
-```rust title="as_member_access" showLineNumbers 
+```rust title="as_member_access" showLineNumbers
 pub comptime fn as_member_access(self) -> Option<(Expr, Quoted)> {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L136-L138" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L136-L138</a></sub></sup>
@@ -217,7 +218,7 @@ expression and the field. The field will be represented as a quoted value.
 
 ### as_method_call
 
-```rust title="as_method_call" showLineNumbers 
+```rust title="as_method_call" showLineNumbers
 pub comptime fn as_method_call(self) -> Option<(Expr, Quoted, [UnresolvedType], [Expr])> {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L143-L145" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L143-L145</a></sub></sup>
@@ -228,7 +229,7 @@ the receiver, method name, a slice of each generic argument, and a slice of each
 
 ### as_repeated_element_array
 
-```rust title="as_repeated_element_array" showLineNumbers 
+```rust title="as_repeated_element_array" showLineNumbers
 pub comptime fn as_repeated_element_array(self) -> Option<(Expr, Expr)> {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L150-L152" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L150-L152</a></sub></sup>
@@ -239,7 +240,7 @@ the repeated element and the length expressions.
 
 ### as_repeated_element_slice
 
-```rust title="as_repeated_element_slice" showLineNumbers 
+```rust title="as_repeated_element_slice" showLineNumbers
 pub comptime fn as_repeated_element_slice(self) -> Option<(Expr, Expr)> {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L157-L159" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L157-L159</a></sub></sup>
@@ -250,7 +251,7 @@ the repeated element and the length expressions.
 
 ### as_slice
 
-```rust title="as_slice" showLineNumbers 
+```rust title="as_slice" showLineNumbers
 pub comptime fn as_slice(self) -> Option<[Expr]> {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L164-L166" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L164-L166</a></sub></sup>
@@ -261,7 +262,7 @@ return each element of the slice.
 
 ### as_tuple
 
-```rust title="as_tuple" showLineNumbers 
+```rust title="as_tuple" showLineNumbers
 pub comptime fn as_tuple(self) -> Option<[Expr]> {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L171-L173" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L171-L173</a></sub></sup>
@@ -272,7 +273,7 @@ return each element of the tuple.
 
 ### as_unary_op
 
-```rust title="as_unary_op" showLineNumbers 
+```rust title="as_unary_op" showLineNumbers
 pub comptime fn as_unary_op(self) -> Option<(UnaryOp, Expr)> {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L178-L180" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L178-L180</a></sub></sup>
@@ -283,7 +284,7 @@ return the unary operator as well as the right-hand side expression.
 
 ### as_unsafe
 
-```rust title="as_unsafe" showLineNumbers 
+```rust title="as_unsafe" showLineNumbers
 pub comptime fn as_unsafe(self) -> Option<[Expr]> {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L185-L187" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L185-L187</a></sub></sup>
@@ -294,7 +295,7 @@ return each statement inside in a slice.
 
 ### has_semicolon
 
-```rust title="has_semicolon" showLineNumbers 
+```rust title="has_semicolon" showLineNumbers
 pub comptime fn has_semicolon(self) -> bool {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L206-L208" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L206-L208</a></sub></sup>
@@ -317,7 +318,7 @@ comptime {
 
 ### is_break
 
-```rust title="is_break" showLineNumbers 
+```rust title="is_break" showLineNumbers
 pub comptime fn is_break(self) -> bool {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L212-L214" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L212-L214</a></sub></sup>
@@ -327,7 +328,7 @@ pub comptime fn is_break(self) -> bool {}
 
 ### is_continue
 
-```rust title="is_continue" showLineNumbers 
+```rust title="is_continue" showLineNumbers
 pub comptime fn is_continue(self) -> bool {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L218-L220" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L218-L220</a></sub></sup>
@@ -337,7 +338,7 @@ pub comptime fn is_continue(self) -> bool {}
 
 ### modify
 
-```rust title="modify" showLineNumbers 
+```rust title="modify" showLineNumbers
 pub comptime fn modify<Env>(self, f: fn[Env](Expr) -> Option<Expr>) -> Expr {
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L229-L231" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L229-L231</a></sub></sup>
@@ -353,7 +354,7 @@ for expressions that are integers, doubling them, would return `(&[2], &[4, 6])`
 
 ### quoted
 
-```rust title="quoted" showLineNumbers 
+```rust title="quoted" showLineNumbers
 pub comptime fn quoted(self) -> Quoted {
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L266-L268" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L266-L268</a></sub></sup>
@@ -363,18 +364,18 @@ Returns this expression as a `Quoted` value. It's the same as `quote { $self }`.
 
 ### resolve
 
-```rust title="resolve" showLineNumbers 
+```rust title="resolve" showLineNumbers
 pub comptime fn resolve(self, in_function: Option<FunctionDefinition>) -> TypedExpr {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L282-L284" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L282-L284</a></sub></sup>
 
 
-Resolves and type-checks this expression and returns the result as a `TypedExpr`. 
+Resolves and type-checks this expression and returns the result as a `TypedExpr`.
 
 The `in_function` argument specifies where the expression is resolved:
 - If it's `none`, the expression is resolved in the function where `resolve` was called
 - If it's `some`, the expression is resolved in the given function
 
-If any names used by this expression are not in scope or if there are any type errors, 
-this will give compiler errors as if the expression was written directly into 
+If any names used by this expression are not in scope or if there are any type errors,
+this will give compiler errors as if the expression was written directly into
 the current `comptime` function.

--- a/docs/versioned_docs/version-v1.0.0-beta.9/noir/standard_library/meta/function_def.md
+++ b/docs/versioned_docs/version-v1.0.0-beta.9/noir/standard_library/meta/function_def.md
@@ -1,5 +1,6 @@
 ---
 title: FunctionDefinition
+description: Inspect and mutate function definitions in `comptime`—read signatures, body, attributes, and adjust parameters or return types.
 ---
 
 `std::meta::function_def` contains methods on the built-in `FunctionDefinition` type representing
@@ -9,7 +10,7 @@ a function definition in the source program.
 
 ### add_attribute
 
-```rust title="add_attribute" showLineNumbers 
+```rust title="add_attribute" showLineNumbers
 pub comptime fn add_attribute<let N: u32>(self, attribute: str<N>) {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/function_def.nr#L3-L5" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/function_def.nr#L3-L5</a></sub></sup>
@@ -21,7 +22,7 @@ This means any functions called at compile-time are invalid targets for this met
 
 ### as_typed_expr
 
-```rust title="as_typed_expr" showLineNumbers 
+```rust title="as_typed_expr" showLineNumbers
 pub comptime fn as_typed_expr(self) -> TypedExpr {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/function_def.nr#L8-L10" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/function_def.nr#L8-L10</a></sub></sup>
@@ -36,7 +37,7 @@ let _ = quote { $typed_expr(1, 2, 3); };
 
 ### body
 
-```rust title="body" showLineNumbers 
+```rust title="body" showLineNumbers
 pub comptime fn body(self) -> Expr {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/function_def.nr#L13-L15" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/function_def.nr#L13-L15</a></sub></sup>
@@ -48,7 +49,7 @@ This means any functions called at compile-time are invalid targets for this met
 
 ### has_named_attribute
 
-```rust title="has_named_attribute" showLineNumbers 
+```rust title="has_named_attribute" showLineNumbers
 pub comptime fn has_named_attribute<let N: u32>(self, name: str<N>) -> bool {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/function_def.nr#L18-L20" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/function_def.nr#L18-L20</a></sub></sup>
@@ -58,7 +59,7 @@ Returns true if this function has a custom attribute with the given name.
 
 ### is_unconstrained
 
-```rust title="is_unconstrained" showLineNumbers 
+```rust title="is_unconstrained" showLineNumbers
 pub comptime fn is_unconstrained(self) -> bool {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/function_def.nr#L23-L25" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/function_def.nr#L23-L25</a></sub></sup>
@@ -68,7 +69,7 @@ Returns true if this function is unconstrained.
 
 ### module
 
-```rust title="module" showLineNumbers 
+```rust title="module" showLineNumbers
 pub comptime fn module(self) -> Module {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/function_def.nr#L28-L30" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/function_def.nr#L28-L30</a></sub></sup>
@@ -78,7 +79,7 @@ Returns the module where the function is defined.
 
 ### name
 
-```rust title="name" showLineNumbers 
+```rust title="name" showLineNumbers
 pub comptime fn name(self) -> Quoted {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/function_def.nr#L33-L35" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/function_def.nr#L33-L35</a></sub></sup>
@@ -88,7 +89,7 @@ Returns the name of the function.
 
 ### parameters
 
-```rust title="parameters" showLineNumbers 
+```rust title="parameters" showLineNumbers
 pub comptime fn parameters(self) -> [(Quoted, Type)] {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/function_def.nr#L38-L40" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/function_def.nr#L38-L40</a></sub></sup>
@@ -98,7 +99,7 @@ Returns each parameter of the function as a tuple of (parameter pattern, paramet
 
 ### return_type
 
-```rust title="return_type" showLineNumbers 
+```rust title="return_type" showLineNumbers
 pub comptime fn return_type(self) -> Type {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/function_def.nr#L43-L45" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/function_def.nr#L43-L45</a></sub></sup>
@@ -108,7 +109,7 @@ The return type of the function.
 
 ### set_body
 
-```rust title="set_body" showLineNumbers 
+```rust title="set_body" showLineNumbers
 pub comptime fn set_body(self, body: Expr) {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/function_def.nr#L48-L50" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/function_def.nr#L48-L50</a></sub></sup>
@@ -120,7 +121,7 @@ This means any functions called at compile-time are invalid targets for this met
 
 ### set_parameters
 
-```rust title="set_parameters" showLineNumbers 
+```rust title="set_parameters" showLineNumbers
 pub comptime fn set_parameters(self, parameters: [(Quoted, Type)]) {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/function_def.nr#L53-L55" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/function_def.nr#L53-L55</a></sub></sup>
@@ -135,7 +136,7 @@ each parameter pattern to be a syntactically valid parameter.
 
 ### set_return_type
 
-```rust title="set_return_type" showLineNumbers 
+```rust title="set_return_type" showLineNumbers
 pub comptime fn set_return_type(self, return_type: Type) {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/function_def.nr#L58-L60" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/function_def.nr#L58-L60</a></sub></sup>
@@ -147,7 +148,7 @@ This means any functions called at compile-time are invalid targets for this met
 
 ### set_return_public
 
-```rust title="set_return_public" showLineNumbers 
+```rust title="set_return_public" showLineNumbers
 pub comptime fn set_return_public(self, public: bool) {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/function_def.nr#L63-L65" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/function_def.nr#L63-L65</a></sub></sup>
@@ -159,7 +160,7 @@ This means any functions called at compile-time are invalid targets for this met
 
 ### set_unconstrained
 
-```rust title="set_unconstrained" showLineNumbers 
+```rust title="set_unconstrained" showLineNumbers
 pub comptime fn set_unconstrained(self, value: bool) {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/function_def.nr#L71-L73" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/function_def.nr#L71-L73</a></sub></sup>

--- a/docs/versioned_docs/version-v1.0.0-beta.9/noir/standard_library/meta/module.md
+++ b/docs/versioned_docs/version-v1.0.0-beta.9/noir/standard_library/meta/module.md
@@ -1,5 +1,6 @@
 ---
 title: Module
+description: Work with modules in `comptime`—query names, list functions/structs, detect contracts, and add new items.
 ---
 
 `std::meta::module` contains methods on the built-in `Module` type which represents a module in the source program.
@@ -10,19 +11,19 @@ declarations in the source program.
 
 ### add_item
 
-```rust title="add_item" showLineNumbers 
+```rust title="add_item" showLineNumbers
 pub comptime fn add_item(self, item: Quoted) {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/module.nr#L3-L5" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/module.nr#L3-L5</a></sub></sup>
 
 
-Adds a top-level item (a function, a struct, a global, etc.) to the module. 
-Adding multiple items in one go is also valid if the `Quoted` value has multiple items in it.  
+Adds a top-level item (a function, a struct, a global, etc.) to the module.
+Adding multiple items in one go is also valid if the `Quoted` value has multiple items in it.
 Note that the items are type-checked as if they are inside the module they are being added to.
 
 ### functions
 
-```rust title="functions" showLineNumbers 
+```rust title="functions" showLineNumbers
 pub comptime fn functions(self) -> [FunctionDefinition] {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/module.nr#L18-L20" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/module.nr#L18-L20</a></sub></sup>
@@ -32,7 +33,7 @@ Returns each function defined in the module.
 
 ### has_named_attribute
 
-```rust title="has_named_attribute" showLineNumbers 
+```rust title="has_named_attribute" showLineNumbers
 pub comptime fn has_named_attribute<let N: u32>(self, name: str<N>) -> bool {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/module.nr#L8-L10" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/module.nr#L8-L10</a></sub></sup>
@@ -42,7 +43,7 @@ Returns true if this module has a custom attribute with the given name.
 
 ### is_contract
 
-```rust title="is_contract" showLineNumbers 
+```rust title="is_contract" showLineNumbers
 pub comptime fn is_contract(self) -> bool {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/module.nr#L13-L15" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/module.nr#L13-L15</a></sub></sup>
@@ -52,7 +53,7 @@ pub comptime fn is_contract(self) -> bool {}
 
 ### name
 
-```rust title="name" showLineNumbers 
+```rust title="name" showLineNumbers
 pub comptime fn name(self) -> Quoted {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/module.nr#L28-L30" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/module.nr#L28-L30</a></sub></sup>
@@ -62,7 +63,7 @@ Returns the name of the module.
 
 ### structs
 
-```rust title="structs" showLineNumbers 
+```rust title="structs" showLineNumbers
 pub comptime fn structs(self) -> [TypeDefinition] {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/module.nr#L23-L25" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/module.nr#L23-L25</a></sub></sup>

--- a/docs/versioned_docs/version-v1.0.0-beta.9/noir/standard_library/meta/op.md
+++ b/docs/versioned_docs/version-v1.0.0-beta.9/noir/standard_library/meta/op.md
@@ -1,5 +1,6 @@
 ---
 title: UnaryOp and BinaryOp
+description: Represent and inspect operators at compile time—check kinds, and emit quoted operator tokens.
 ---
 
 `std::meta::op` contains the `UnaryOp` and `BinaryOp` types as well as methods on them.
@@ -15,7 +16,7 @@ Represents a unary operator. One of `-`, `!`, `&mut`, or `*`.
 
 #### is_minus
 
-```rust title="is_minus" showLineNumbers 
+```rust title="is_minus" showLineNumbers
 pub fn is_minus(self) -> bool {
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/op.nr#L26-L28" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L26-L28</a></sub></sup>
@@ -25,7 +26,7 @@ Returns `true` if this operator is `-`.
 
 #### is_not
 
-```rust title="is_not" showLineNumbers 
+```rust title="is_not" showLineNumbers
 pub fn is_not(self) -> bool {
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/op.nr#L32-L34" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L32-L34</a></sub></sup>
@@ -35,7 +36,7 @@ pub fn is_not(self) -> bool {
 
 #### is_mutable_reference
 
-```rust title="is_mutable_reference" showLineNumbers 
+```rust title="is_mutable_reference" showLineNumbers
 pub fn is_mutable_reference(self) -> bool {
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/op.nr#L38-L40" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L38-L40</a></sub></sup>
@@ -45,7 +46,7 @@ pub fn is_mutable_reference(self) -> bool {
 
 #### is_dereference
 
-```rust title="is_dereference" showLineNumbers 
+```rust title="is_dereference" showLineNumbers
 pub fn is_dereference(self) -> bool {
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/op.nr#L44-L46" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L44-L46</a></sub></sup>
@@ -55,7 +56,7 @@ pub fn is_dereference(self) -> bool {
 
 #### quoted
 
-```rust title="unary_quoted" showLineNumbers 
+```rust title="unary_quoted" showLineNumbers
 pub comptime fn quoted(self) -> Quoted {
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/op.nr#L50-L52" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L50-L52</a></sub></sup>
@@ -78,7 +79,7 @@ Represents a binary operator. One of `+`, `-`, `*`, `/`, `%`, `==`, `!=`, `<`, `
 
 #### is_add
 
-```rust title="is_add" showLineNumbers 
+```rust title="is_add" showLineNumbers
 pub fn is_add(self) -> bool {
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/op.nr#L88-L90" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L88-L90</a></sub></sup>
@@ -88,7 +89,7 @@ pub fn is_add(self) -> bool {
 
 #### is_subtract
 
-```rust title="is_subtract" showLineNumbers 
+```rust title="is_subtract" showLineNumbers
 pub fn is_subtract(self) -> bool {
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/op.nr#L94-L96" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L94-L96</a></sub></sup>
@@ -98,7 +99,7 @@ pub fn is_subtract(self) -> bool {
 
 #### is_multiply
 
-```rust title="is_multiply" showLineNumbers 
+```rust title="is_multiply" showLineNumbers
 pub fn is_multiply(self) -> bool {
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/op.nr#L100-L102" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L100-L102</a></sub></sup>
@@ -108,7 +109,7 @@ pub fn is_multiply(self) -> bool {
 
 #### is_divide
 
-```rust title="is_divide" showLineNumbers 
+```rust title="is_divide" showLineNumbers
 pub fn is_divide(self) -> bool {
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/op.nr#L106-L108" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L106-L108</a></sub></sup>
@@ -118,7 +119,7 @@ pub fn is_divide(self) -> bool {
 
 #### is_modulo
 
-```rust title="is_modulo" showLineNumbers 
+```rust title="is_modulo" showLineNumbers
 pub fn is_modulo(self) -> bool {
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/op.nr#L178-L180" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L178-L180</a></sub></sup>
@@ -128,7 +129,7 @@ pub fn is_modulo(self) -> bool {
 
 #### is_equal
 
-```rust title="is_equal" showLineNumbers 
+```rust title="is_equal" showLineNumbers
 pub fn is_equal(self) -> bool {
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/op.nr#L112-L114" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L112-L114</a></sub></sup>
@@ -138,7 +139,7 @@ pub fn is_equal(self) -> bool {
 
 #### is_not_equal
 
-```rust title="is_not_equal" showLineNumbers 
+```rust title="is_not_equal" showLineNumbers
 pub fn is_not_equal(self) -> bool {
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/op.nr#L118-L120" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L118-L120</a></sub></sup>
@@ -148,7 +149,7 @@ pub fn is_not_equal(self) -> bool {
 
 #### is_less_than
 
-```rust title="is_less_than" showLineNumbers 
+```rust title="is_less_than" showLineNumbers
 pub fn is_less_than(self) -> bool {
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/op.nr#L124-L126" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L124-L126</a></sub></sup>
@@ -158,7 +159,7 @@ pub fn is_less_than(self) -> bool {
 
 #### is_less_than_or_equal
 
-```rust title="is_less_than_or_equal" showLineNumbers 
+```rust title="is_less_than_or_equal" showLineNumbers
 pub fn is_less_than_or_equal(self) -> bool {
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/op.nr#L130-L132" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L130-L132</a></sub></sup>
@@ -168,7 +169,7 @@ pub fn is_less_than_or_equal(self) -> bool {
 
 #### is_greater_than
 
-```rust title="is_greater_than" showLineNumbers 
+```rust title="is_greater_than" showLineNumbers
 pub fn is_greater_than(self) -> bool {
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/op.nr#L136-L138" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L136-L138</a></sub></sup>
@@ -178,7 +179,7 @@ pub fn is_greater_than(self) -> bool {
 
 #### is_greater_than_or_equal
 
-```rust title="is_greater_than_or_equal" showLineNumbers 
+```rust title="is_greater_than_or_equal" showLineNumbers
 pub fn is_greater_than_or_equal(self) -> bool {
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/op.nr#L142-L144" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L142-L144</a></sub></sup>
@@ -188,7 +189,7 @@ pub fn is_greater_than_or_equal(self) -> bool {
 
 #### is_and
 
-```rust title="is_and" showLineNumbers 
+```rust title="is_and" showLineNumbers
 pub fn is_and(self) -> bool {
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/op.nr#L148-L150" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L148-L150</a></sub></sup>
@@ -198,7 +199,7 @@ pub fn is_and(self) -> bool {
 
 #### is_or
 
-```rust title="is_or" showLineNumbers 
+```rust title="is_or" showLineNumbers
 pub fn is_or(self) -> bool {
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/op.nr#L154-L156" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L154-L156</a></sub></sup>
@@ -208,7 +209,7 @@ pub fn is_or(self) -> bool {
 
 #### is_shift_right
 
-```rust title="is_shift_right" showLineNumbers 
+```rust title="is_shift_right" showLineNumbers
 pub fn is_shift_right(self) -> bool {
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/op.nr#L166-L168" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L166-L168</a></sub></sup>
@@ -218,7 +219,7 @@ pub fn is_shift_right(self) -> bool {
 
 #### is_shift_left
 
-```rust title="is_shift_left" showLineNumbers 
+```rust title="is_shift_left" showLineNumbers
 pub fn is_shift_left(self) -> bool {
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/op.nr#L172-L174" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L172-L174</a></sub></sup>
@@ -228,7 +229,7 @@ pub fn is_shift_left(self) -> bool {
 
 #### quoted
 
-```rust title="binary_quoted" showLineNumbers 
+```rust title="binary_quoted" showLineNumbers
 pub comptime fn quoted(self) -> Quoted {
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/op.nr#L184-L186" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L184-L186</a></sub></sup>

--- a/docs/versioned_docs/version-v1.0.0-beta.9/noir/standard_library/meta/quoted.md
+++ b/docs/versioned_docs/version-v1.0.0-beta.9/noir/standard_library/meta/quoted.md
@@ -1,5 +1,6 @@
 ---
 title: Quoted
+description: Token streams produced by `quote { ... }`—parse as expressions, modules, types, and inspect raw tokens.
 ---
 
 `std::meta::quoted` contains methods on the built-in `Quoted` type which represents
@@ -9,7 +10,7 @@ quoted token streams and is the result of the `quote { ... }` expression.
 
 ### as_expr
 
-```rust title="as_expr" showLineNumbers 
+```rust title="as_expr" showLineNumbers
 pub comptime fn as_expr(self) -> Option<Expr> {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/quoted.nr#L6-L8" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/quoted.nr#L6-L8</a></sub></sup>
@@ -20,7 +21,7 @@ the expression failed to parse.
 
 Example:
 
-```rust title="as_expr_example" showLineNumbers 
+```rust title="as_expr_example" showLineNumbers
 #[test]
     fn test_expr_as_function_call() {
         comptime {
@@ -36,7 +37,7 @@ Example:
 
 ### as_module
 
-```rust title="as_module" showLineNumbers 
+```rust title="as_module" showLineNumbers
 pub comptime fn as_module(self) -> Option<Module> {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/quoted.nr#L11-L13" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/quoted.nr#L11-L13</a></sub></sup>
@@ -47,7 +48,7 @@ Returns `Option::none()` if the module isn't found or this token stream cannot b
 
 Example:
 
-```rust title="as_module_example" showLineNumbers 
+```rust title="as_module_example" showLineNumbers
 mod baz {
     pub mod qux {}
 }
@@ -65,7 +66,7 @@ fn as_module_test() {
 
 ### as_trait_constraint
 
-```rust title="as_trait_constraint" showLineNumbers 
+```rust title="as_trait_constraint" showLineNumbers
 pub comptime fn as_trait_constraint(self) -> TraitConstraint {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/quoted.nr#L16-L18" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/quoted.nr#L16-L18</a></sub></sup>
@@ -77,7 +78,7 @@ stream does not parse and resolve to a valid trait constraint.
 
 Example:
 
-```rust title="implements_example" showLineNumbers 
+```rust title="implements_example" showLineNumbers
 pub fn function_with_where<T>(_x: T)
 where
     T: SomeTrait<i32>,
@@ -96,7 +97,7 @@ where
 
 ### as_type
 
-```rust title="as_type" showLineNumbers 
+```rust title="as_type" showLineNumbers
 pub comptime fn as_type(self) -> Type {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/quoted.nr#L21-L23" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/quoted.nr#L21-L23</a></sub></sup>
@@ -105,7 +106,7 @@ pub comptime fn as_type(self) -> Type {}
 Interprets this token stream as a resolved type. Panics if the token
 stream doesn't parse to a type or if the type isn't a valid type in scope.
 
-```rust title="implements_example" showLineNumbers 
+```rust title="implements_example" showLineNumbers
 pub fn function_with_where<T>(_x: T)
 where
     T: SomeTrait<i32>,
@@ -124,7 +125,7 @@ where
 
 ### tokens
 
-```rust title="tokens" showLineNumbers 
+```rust title="tokens" showLineNumbers
 pub comptime fn tokens(self) -> [Quoted] {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/quoted.nr#L26-L28" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/quoted.nr#L26-L28</a></sub></sup>

--- a/docs/versioned_docs/version-v1.0.0-beta.9/noir/standard_library/meta/struct_def.md
+++ b/docs/versioned_docs/version-v1.0.0-beta.9/noir/standard_library/meta/struct_def.md
@@ -1,5 +1,6 @@
 ---
 title: TypeDefinition
+description: Inspect and transform struct/enum type definitions—fields, generics, attributes, and module context.
 ---
 
 `std::meta::type_def` contains methods on the built-in `TypeDefinition` type.
@@ -9,7 +10,7 @@ This type corresponds to `struct Name { field1: Type1, ... }` and `enum Name { V
 
 ### add_attribute
 
-```rust title="add_attribute" showLineNumbers 
+```rust title="add_attribute" showLineNumbers
 pub comptime fn add_attribute<let N: u32>(self, attribute: str<N>) {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/type_def.nr#L5-L7" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/type_def.nr#L5-L7</a></sub></sup>
@@ -19,7 +20,7 @@ Adds an attribute to the data type.
 
 ### add_generic
 
-```rust title="add_generic" showLineNumbers 
+```rust title="add_generic" showLineNumbers
 pub comptime fn add_generic<let N: u32>(self, generic_name: str<N>) -> Type {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/type_def.nr#L10-L12" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/type_def.nr#L10-L12</a></sub></sup>
@@ -37,7 +38,7 @@ that are not used in function signatures.
 
 Example:
 
-```rust title="add-generic-example" showLineNumbers 
+```rust title="add-generic-example" showLineNumbers
 comptime fn add_generic(s: TypeDefinition) {
         assert_eq(s.generics().len(), 0);
         let new_generic = s.add_generic("T");
@@ -54,7 +55,7 @@ comptime fn add_generic(s: TypeDefinition) {
 
 ### as_type
 
-```rust title="as_type" showLineNumbers 
+```rust title="as_type" showLineNumbers
 pub comptime fn as_type(self) -> Type {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/type_def.nr#L17-L19" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/type_def.nr#L17-L19</a></sub></sup>
@@ -65,7 +66,7 @@ any generics, the generics are also included as-is.
 
 ### generics
 
-```rust title="generics" showLineNumbers 
+```rust title="generics" showLineNumbers
 pub comptime fn generics(self) -> [(Type, Option<Type>)] {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/type_def.nr#L29-L31" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/type_def.nr#L29-L31</a></sub></sup>
@@ -98,7 +99,7 @@ comptime fn example(foo: TypeDefinition) {
 
 ### fields
 
-```rust title="fields" showLineNumbers 
+```rust title="fields" showLineNumbers
 pub comptime fn fields(self, generic_args: [Type]) -> [(Quoted, Type, Quoted)] {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/type_def.nr#L37-L39" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/type_def.nr#L37-L39</a></sub></sup>
@@ -110,7 +111,7 @@ provided generic arguments.
 
 ### fields_as_written
 
-```rust title="fields_as_written" showLineNumbers 
+```rust title="fields_as_written" showLineNumbers
 pub comptime fn fields_as_written(self) -> [(Quoted, Type, Quoted)] {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/type_def.nr#L46-L48" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/type_def.nr#L46-L48</a></sub></sup>
@@ -123,7 +124,7 @@ function if possible.
 
 ### has_named_attribute
 
-```rust title="has_named_attribute" showLineNumbers 
+```rust title="has_named_attribute" showLineNumbers
 pub comptime fn has_named_attribute<let N: u32>(self, name: str<N>) -> bool {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/type_def.nr#L22-L24" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/type_def.nr#L22-L24</a></sub></sup>
@@ -133,7 +134,7 @@ Returns true if this type has a custom attribute with the given name.
 
 ### module
 
-```rust title="module" showLineNumbers 
+```rust title="module" showLineNumbers
 pub comptime fn module(self) -> Module {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/type_def.nr#L51-L53" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/type_def.nr#L51-L53</a></sub></sup>
@@ -143,7 +144,7 @@ Returns the module where the type is defined.
 
 ### name
 
-```rust title="name" showLineNumbers 
+```rust title="name" showLineNumbers
 pub comptime fn name(self) -> Quoted {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/type_def.nr#L56-L58" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/type_def.nr#L56-L58</a></sub></sup>
@@ -156,7 +157,7 @@ not be the full path to the type definition, nor will it include any generics.
 
 ### set_fields
 
-```rust title="set_fields" showLineNumbers 
+```rust title="set_fields" showLineNumbers
 pub comptime fn set_fields(self, new_fields: [(Quoted, Type, Quoted)]) {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/type_def.nr#L65-L67" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/type_def.nr#L65-L67</a></sub></sup>

--- a/docs/versioned_docs/version-v1.0.0-beta.9/noir/standard_library/meta/trait_constraint.md
+++ b/docs/versioned_docs/version-v1.0.0-beta.9/noir/standard_library/meta/trait_constraint.md
@@ -1,5 +1,6 @@
 ---
 title: TraitConstraint
+description: Represent trait constraints at compile time for searching and matching trait implementations.
 ---
 
 `std::meta::trait_constraint` contains methods on the built-in `TraitConstraint` type which represents

--- a/docs/versioned_docs/version-v1.0.0-beta.9/noir/standard_library/meta/trait_def.md
+++ b/docs/versioned_docs/version-v1.0.0-beta.9/noir/standard_library/meta/trait_def.md
@@ -1,5 +1,6 @@
 ---
 title: TraitDefinition
+description: Work with trait definitions at compile time—convert to trait constraints and inspect basic properties.
 ---
 
 `std::meta::trait_def` contains methods on the built-in `TraitDefinition` type. This type
@@ -9,7 +10,7 @@ represents trait definitions such as `trait Foo { .. }` at the top-level of a pr
 
 ### as_trait_constraint
 
-```rust title="as_trait_constraint" showLineNumbers 
+```rust title="as_trait_constraint" showLineNumbers
 pub comptime fn as_trait_constraint(_self: Self) -> TraitConstraint {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/trait_def.nr#L6-L8" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/trait_def.nr#L6-L8</a></sub></sup>

--- a/docs/versioned_docs/version-v1.0.0-beta.9/noir/standard_library/meta/trait_impl.md
+++ b/docs/versioned_docs/version-v1.0.0-beta.9/noir/standard_library/meta/trait_impl.md
@@ -1,5 +1,6 @@
 ---
 title: TraitImpl
+description: Inspect concrete trait implementations—list methods and read trait generic arguments in `comptime`.
 ---
 
 `std::meta::trait_impl` contains methods on the built-in `TraitImpl` type which represents a trait
@@ -9,7 +10,7 @@ implementation such as `impl Foo for Bar { ... }`.
 
 ### trait_generic_args
 
-```rust title="trait_generic_args" showLineNumbers 
+```rust title="trait_generic_args" showLineNumbers
 pub comptime fn trait_generic_args(self) -> [Type] {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/trait_impl.nr#L3-L5" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/trait_impl.nr#L3-L5</a></sub></sup>
@@ -38,7 +39,7 @@ comptime {
 
 ### methods
 
-```rust title="methods" showLineNumbers 
+```rust title="methods" showLineNumbers
 pub comptime fn methods(self) -> [FunctionDefinition] {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/trait_impl.nr#L8-L10" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/trait_impl.nr#L8-L10</a></sub></sup>

--- a/docs/versioned_docs/version-v1.0.0-beta.9/noir/standard_library/meta/typ.md
+++ b/docs/versioned_docs/version-v1.0.0-beta.9/noir/standard_library/meta/typ.md
@@ -1,5 +1,6 @@
 ---
 title: Type
+description: Represent and analyze types at compile time—query structure, check trait bounds, and resolve trait impls.
 ---
 
 `std::meta::typ` contains methods on the built-in `Type` type used for representing
@@ -7,7 +8,7 @@ a type in the source program.
 
 ## Functions
 
-```rust title="fresh_type_variable" showLineNumbers 
+```rust title="fresh_type_variable" showLineNumbers
 pub comptime fn fresh_type_variable() -> Type {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/typ.nr#L57-L59" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/typ.nr#L57-L59</a></sub></sup>
@@ -30,7 +31,7 @@ fail.
 
 Example:
 
-```rust title="serialize-setup" showLineNumbers 
+```rust title="serialize-setup" showLineNumbers
 trait Serialize<let N: u32> {}
 
 impl Serialize<1> for Field {}
@@ -48,7 +49,7 @@ where
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/compile_success_empty/comptime_type/src/main.nr#L14-L29" target="_blank" rel="noopener noreferrer">Source code: test_programs/compile_success_empty/comptime_type/src/main.nr#L14-L29</a></sub></sup>
 
-```rust title="fresh-type-variable-example" showLineNumbers 
+```rust title="fresh-type-variable-example" showLineNumbers
 let typevar1 = std::meta::typ::fresh_type_variable();
         let constraint = quote { Serialize<$typevar1> }.as_trait_constraint();
         let field_type = quote { Field }.as_type();
@@ -76,7 +77,7 @@ let typevar1 = std::meta::typ::fresh_type_variable();
 
 ### as_array
 
-```rust title="as_array" showLineNumbers 
+```rust title="as_array" showLineNumbers
 pub comptime fn as_array(self) -> Option<(Type, Type)> {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/typ.nr#L76-L78" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/typ.nr#L76-L78</a></sub></sup>
@@ -98,7 +99,7 @@ comptime {
 
 ### as_constant
 
-```rust title="as_constant" showLineNumbers 
+```rust title="as_constant" showLineNumbers
 pub comptime fn as_constant(self) -> Option<u32> {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/typ.nr#L83-L85" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/typ.nr#L83-L85</a></sub></sup>
@@ -109,7 +110,7 @@ return the numeric constant.
 
 ### as_integer
 
-```rust title="as_integer" showLineNumbers 
+```rust title="as_integer" showLineNumbers
 pub comptime fn as_integer(self) -> Option<(bool, u8)> {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/typ.nr#L90-L92" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/typ.nr#L90-L92</a></sub></sup>
@@ -120,7 +121,7 @@ if the type is signed, as well as the number of bits of this integer type.
 
 ### as_mutable_reference
 
-```rust title="as_mutable_reference" showLineNumbers 
+```rust title="as_mutable_reference" showLineNumbers
 pub comptime fn as_mutable_reference(self) -> Option<Type> {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/typ.nr#L96-L98" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/typ.nr#L96-L98</a></sub></sup>
@@ -130,7 +131,7 @@ If this is a mutable reference type `&mut T`, returns the mutable type `T`.
 
 ### as_slice
 
-```rust title="as_slice" showLineNumbers 
+```rust title="as_slice" showLineNumbers
 pub comptime fn as_slice(self) -> Option<Type> {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/typ.nr#L102-L104" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/typ.nr#L102-L104</a></sub></sup>
@@ -140,7 +141,7 @@ If this is a slice type, return the element type of the slice.
 
 ### as_str
 
-```rust title="as_str" showLineNumbers 
+```rust title="as_str" showLineNumbers
 pub comptime fn as_str(self) -> Option<Type> {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/typ.nr#L108-L110" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/typ.nr#L108-L110</a></sub></sup>
@@ -150,7 +151,7 @@ If this is a `str<N>` type, returns the length `N` as a type.
 
 ### as_data_type
 
-```rust title="as_data_type" showLineNumbers 
+```rust title="as_data_type" showLineNumbers
 pub comptime fn as_data_type(self) -> Option<(TypeDefinition, [Type])> {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/typ.nr#L119-L121" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/typ.nr#L119-L121</a></sub></sup>
@@ -161,7 +162,7 @@ any generic arguments on this type.
 
 ### as_tuple
 
-```rust title="as_tuple" showLineNumbers 
+```rust title="as_tuple" showLineNumbers
 pub comptime fn as_tuple(self) -> Option<[Type]> {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/typ.nr#L125-L127" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/typ.nr#L125-L127</a></sub></sup>
@@ -171,7 +172,7 @@ If this is a tuple type, returns each element type of the tuple.
 
 ### get_trait_impl
 
-```rust title="get_trait_impl" showLineNumbers 
+```rust title="get_trait_impl" showLineNumbers
 pub comptime fn get_trait_impl(self, constraint: TraitConstraint) -> Option<TraitImpl> {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/typ.nr#L148-L150" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/typ.nr#L148-L150</a></sub></sup>
@@ -198,7 +199,7 @@ comptime {
 
 ### implements
 
-```rust title="implements" showLineNumbers 
+```rust title="implements" showLineNumbers
 pub comptime fn implements(self, constraint: TraitConstraint) -> bool {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/typ.nr#L171-L173" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/typ.nr#L171-L173</a></sub></sup>
@@ -225,7 +226,7 @@ fn foo<T>() where T: Default {
 
 ### is_bool
 
-```rust title="is_bool" showLineNumbers 
+```rust title="is_bool" showLineNumbers
 pub comptime fn is_bool(self) -> bool {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/typ.nr#L177-L179" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/typ.nr#L177-L179</a></sub></sup>
@@ -235,7 +236,7 @@ pub comptime fn is_bool(self) -> bool {}
 
 ### is_field
 
-```rust title="is_field" showLineNumbers 
+```rust title="is_field" showLineNumbers
 pub comptime fn is_field(self) -> bool {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/typ.nr#L183-L185" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/typ.nr#L183-L185</a></sub></sup>
@@ -245,7 +246,7 @@ pub comptime fn is_field(self) -> bool {}
 
 ### is_unit
 
-```rust title="is_unit" showLineNumbers 
+```rust title="is_unit" showLineNumbers
 pub comptime fn is_unit(self) -> bool {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/typ.nr#L189-L191" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/typ.nr#L189-L191</a></sub></sup>

--- a/docs/versioned_docs/version-v1.0.0-beta.9/noir/standard_library/meta/typed_expr.md
+++ b/docs/versioned_docs/version-v1.0.0-beta.9/noir/standard_library/meta/typed_expr.md
@@ -1,5 +1,6 @@
 ---
 title: TypedExpr
+description: Resolved, type-checked expressions—retrieve types, access referenced function definitions, and more.
 ---
 
 `std::meta::typed_expr` contains methods on the built-in `TypedExpr` type for resolved and type-checked expressions.
@@ -8,7 +9,7 @@ title: TypedExpr
 
 ### get_type
 
-```rust title="as_function_definition" showLineNumbers 
+```rust title="as_function_definition" showLineNumbers
 pub comptime fn as_function_definition(self) -> Option<FunctionDefinition> {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/typed_expr.nr#L7-L9" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/typed_expr.nr#L7-L9</a></sub></sup>
@@ -18,7 +19,7 @@ If this expression refers to a function definitions, returns it. Otherwise retur
 
 ### get_type
 
-```rust title="get_type" showLineNumbers 
+```rust title="get_type" showLineNumbers
 pub comptime fn get_type(self) -> Option<Type> {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/typed_expr.nr#L13-L15" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/typed_expr.nr#L13-L15</a></sub></sup>

--- a/docs/versioned_docs/version-v1.0.0-beta.9/noir/standard_library/meta/unresolved_type.md
+++ b/docs/versioned_docs/version-v1.0.0-beta.9/noir/standard_library/meta/unresolved_type.md
@@ -1,5 +1,6 @@
 ---
 title: UnresolvedType
+description: Work with the syntactic form of types—inspect references, slices, and primitive kind checks before resolution.
 ---
 
 `std::meta::unresolved_type` contains methods on the built-in `UnresolvedType` type for the syntax of types.
@@ -8,7 +9,7 @@ title: UnresolvedType
 
 ### as_mutable_reference
 
-```rust title="as_mutable_reference" showLineNumbers 
+```rust title="as_mutable_reference" showLineNumbers
 pub comptime fn as_mutable_reference(self) -> Option<UnresolvedType> {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/unresolved_type.nr#L8-L10" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/unresolved_type.nr#L8-L10</a></sub></sup>
@@ -18,7 +19,7 @@ If this is a mutable reference type `&mut T`, returns the mutable type `T`.
 
 ### as_slice
 
-```rust title="as_slice" showLineNumbers 
+```rust title="as_slice" showLineNumbers
 pub comptime fn as_slice(self) -> Option<UnresolvedType> {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/unresolved_type.nr#L14-L16" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/unresolved_type.nr#L14-L16</a></sub></sup>
@@ -28,7 +29,7 @@ If this is a slice `&[T]`, returns the element type `T`.
 
 ### is_bool
 
-```rust title="is_bool" showLineNumbers 
+```rust title="is_bool" showLineNumbers
 pub comptime fn is_bool(self) -> bool {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/unresolved_type.nr#L20-L22" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/unresolved_type.nr#L20-L22</a></sub></sup>
@@ -38,7 +39,7 @@ Returns `true` if this type is `bool`.
 
 ### is_field
 
-```rust title="is_field" showLineNumbers 
+```rust title="is_field" showLineNumbers
 pub comptime fn is_field(self) -> bool {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/unresolved_type.nr#L26-L28" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/unresolved_type.nr#L26-L28</a></sub></sup>
@@ -48,7 +49,7 @@ Returns true if this type refers to the Field type.
 
 ### is_unit
 
-```rust title="is_unit" showLineNumbers 
+```rust title="is_unit" showLineNumbers
 pub comptime fn is_unit(self) -> bool {}
 ```
 > <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/unresolved_type.nr#L32-L34" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/unresolved_type.nr#L32-L34</a></sub></sup>

--- a/docs/versioned_docs/version-v1.0.0-beta.9/noir/standard_library/options.md
+++ b/docs/versioned_docs/version-v1.0.0-beta.9/noir/standard_library/options.md
@@ -1,5 +1,6 @@
 ---
 title: Option<T> Type
+description: Express presence or absence safely with `Option<T>`—construct, inspect, and transform values without nulls.
 ---
 
 The `Option<T>` type is a way to express that a value might be present (`Some(T))` or absent (`None`). It's a safer way to handle potential absence of values, compared to using nulls in many other languages.

--- a/yarn.lock
+++ b/yarn.lock
@@ -15535,6 +15535,7 @@ __metadata:
     "@types/prettier": "npm:^3.0.0"
     axios: "npm:^1.9.0"
     clsx: "npm:^1.2.1"
+    docusaurus-plugin-llms: "npm:^0.1.5"
     docusaurus-plugin-typedoc: "npm:1.2.3"
     eslint-plugin-prettier: "npm:^5.4.1"
     hast-util-is-element: "npm:^1.1.0"
@@ -15554,6 +15555,18 @@ __metadata:
     typescript: "npm:^5.8.3"
   languageName: unknown
   linkType: soft
+
+"docusaurus-plugin-llms@npm:^0.1.5":
+  version: 0.1.5
+  resolution: "docusaurus-plugin-llms@npm:0.1.5"
+  dependencies:
+    gray-matter: "npm:^4.0.3"
+    minimatch: "npm:^9.0.3"
+  peerDependencies:
+    "@docusaurus/core": ^3.0.0
+  checksum: 10/6d0c32efaa1acd12e4d320441d87bf26496f3e355b6419100a05d3098970eeabb1e45c1a22b06d8b14c65e8027dbd3b21bb2878bd4bf33f2766e477e6f856654
+  languageName: node
+  linkType: hard
 
 "docusaurus-plugin-typedoc@npm:1.2.3":
   version: 1.2.3
@@ -21755,7 +21768,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimatch@npm:^9.0.4, minimatch@npm:^9.0.5":
+"minimatch@npm:^9.0.3, minimatch@npm:^9.0.4, minimatch@npm:^9.0.5":
   version: 9.0.5
   resolution: "minimatch@npm:9.0.5"
   dependencies:


### PR DESCRIPTION
# Description

Adds a docusaurus plugin to generate a llms.txt file with the docs. Also adds descriptions to pages that were missing

## Problem\*


## Summary\*



## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [x] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
