### PR TITLE
fix(mem2reg): Consider aliases of a loaded address to be loaded from as well

### DIFF
--- a/test_programs/execution_success/regression_9538/Nargo.toml
+++ b/test_programs/execution_success/regression_9538/Nargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "regression_9538"
+type = "bin"
+authors = [""]
+
+[dependencies]

--- a/test_programs/execution_success/regression_9538/Prover.toml
+++ b/test_programs/execution_success/regression_9538/Prover.toml
@@ -1,0 +1,3 @@
+a = true
+b = ["one", "two"]
+return = "two"

--- a/test_programs/execution_success/regression_9538/src/main.nr
+++ b/test_programs/execution_success/regression_9538/src/main.nr
@@ -1,0 +1,10 @@
+unconstrained fn main(a: bool, mut b: (str<3>, str<3>)) -> pub str<3> {
+    if a {
+        func_2((if a { (&mut b.1) } else { (&mut b.0) }))
+    } else {
+        func_2((if a { (&mut b.1) } else { (&mut b.0) }))
+    }
+}
+unconstrained fn func_2(a: &mut str<3>) -> str<3> {
+    *a
+}

--- a/tooling/debugger/ignored-tests.txt
+++ b/tooling/debugger/ignored-tests.txt
@@ -10,6 +10,7 @@ reference_counts_slices_inliner_0
 references
 regression_4709
 regression_7323
+regression_9538
 reference_only_used_as_alias
 brillig_rc_regression_6123
 array_rc_regression_7842

--- a/tooling/nargo_cli/tests/snapshots/execution_success/regression_9538/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/regression_9538/execute__tests__expanded.snap
@@ -1,0 +1,15 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: expanded_code
+---
+unconstrained fn main(a: bool, mut b: (str<3>, str<3>)) -> pub str<3> {
+    if a {
+        func_2(if a { &mut b.1 } else { &mut b.0 })
+    } else {
+        func_2(if a { &mut b.1 } else { &mut b.0 })
+    }
+}
+
+unconstrained fn func_2(a: &mut str<3>) -> str<3> {
+    *a
+}

--- a/tooling/nargo_cli/tests/snapshots/execution_success/regression_9538/execute__tests__force_brillig_false_inliner_-9223372036854775808.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/regression_9538/execute__tests__force_brillig_false_inliner_-9223372036854775808.snap
@@ -1,0 +1,76 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: artifact
+---
+{
+  "noir_version": "[noir_version]",
+  "hash": "[hash]",
+  "abi": {
+    "parameters": [
+      {
+        "name": "a",
+        "type": {
+          "kind": "boolean"
+        },
+        "visibility": "private"
+      },
+      {
+        "name": "b",
+        "type": {
+          "kind": "tuple",
+          "fields": [
+            {
+              "kind": "string",
+              "length": 3
+            },
+            {
+              "kind": "string",
+              "length": 3
+            }
+          ]
+        },
+        "visibility": "private"
+      }
+    ],
+    "return_type": {
+      "abi_type": {
+        "kind": "string",
+        "length": 3
+      },
+      "visibility": "public"
+    },
+    "error_types": {
+      "12049594436772143978": {
+        "error_kind": "string",
+        "string": "array ref-count underflow detected"
+      },
+      "17843811134343075018": {
+        "error_kind": "string",
+        "string": "Stack too deep"
+      }
+    }
+  },
+  "bytecode": [
+    "func 0",
+    "current witness index : _9",
+    "private parameters indices : [_0, _1, _2, _3, _4, _5, _6]",
+    "public parameters indices : []",
+    "return value indices : [_7, _8, _9]",
+    "BRILLIG CALL func 0: inputs: [EXPR [ (1, _0) 0 ], [EXPR [ (1, _1) 0 ], EXPR [ (1, _2) 0 ], EXPR [ (1, _3) 0 ]], [EXPR [ (1, _4) 0 ], EXPR [ (1, _5) 0 ], EXPR [ (1, _6) 0 ]]], outputs: [[_7, _8, _9]]",
+    "unconstrained func 0",
+    "[Const { destination: Direct(2), bit_size: Integer(U32), value: 1 }, Const { destination: Direct(1), bit_size: Integer(U32), value: 32846 }, Const { destination: Direct(0), bit_size: Integer(U32), value: 3 }, Const { destination: Relative(4), bit_size: Integer(U32), value: 7 }, Const { destination: Relative(5), bit_size: Integer(U32), value: 0 }, CalldataCopy { destination_address: Direct(32836), size_address: Relative(4), offset_address: Relative(5) }, Cast { destination: Direct(32836), source: Direct(32836), bit_size: Integer(U1) }, Cast { destination: Direct(32837), source: Direct(32837), bit_size: Integer(U8) }, Cast { destination: Direct(32838), source: Direct(32838), bit_size: Integer(U8) }, Cast { destination: Direct(32839), source: Direct(32839), bit_size: Integer(U8) }, Cast { destination: Direct(32840), source: Direct(32840), bit_size: Integer(U8) }, Cast { destination: Direct(32841), source: Direct(32841), bit_size: Integer(U8) }, Cast { destination: Direct(32842), source: Direct(32842), bit_size: Integer(U8) }, Mov { destination: Relative(1), source: Direct(32836) }, Const { destination: Relative(2), bit_size: Integer(U32), value: 32837 }, Const { destination: Relative(5), bit_size: Integer(U32), value: 3 }, Mov { destination: Relative(4), source: Direct(1) }, Const { destination: Relative(6), bit_size: Integer(U32), value: 4 }, BinaryIntOp { destination: Direct(1), op: Add, bit_size: U32, lhs: Direct(1), rhs: Relative(6) }, IndirectConst { destination_pointer: Relative(4), bit_size: Integer(U32), value: 1 }, BinaryIntOp { destination: Relative(6), op: Add, bit_size: U32, lhs: Relative(4), rhs: Direct(2) }, Mov { destination: Direct(32771), source: Relative(2) }, Mov { destination: Direct(32772), source: Relative(6) }, Mov { destination: Direct(32773), source: Relative(5) }, Call { location: 50 }, Mov { destination: Relative(2), source: Relative(4) }, Const { destination: Relative(3), bit_size: Integer(U32), value: 32840 }, Const { destination: Relative(5), bit_size: Integer(U32), value: 3 }, Mov { destination: Relative(4), source: Direct(1) }, Const { destination: Relative(6), bit_size: Integer(U32), value: 4 }, BinaryIntOp { destination: Direct(1), op: Add, bit_size: U32, lhs: Direct(1), rhs: Relative(6) }, IndirectConst { destination_pointer: Relative(4), bit_size: Integer(U32), value: 1 }, BinaryIntOp { destination: Relative(6), op: Add, bit_size: U32, lhs: Relative(4), rhs: Direct(2) }, Mov { destination: Direct(32771), source: Relative(3) }, Mov { destination: Direct(32772), source: Relative(6) }, Mov { destination: Direct(32773), source: Relative(5) }, Call { location: 50 }, Mov { destination: Relative(3), source: Relative(4) }, Call { location: 61 }, Call { location: 62 }, BinaryIntOp { destination: Relative(2), op: Add, bit_size: U32, lhs: Relative(1), rhs: Direct(2) }, Const { destination: Relative(3), bit_size: Integer(U32), value: 32843 }, Const { destination: Relative(4), bit_size: Integer(U32), value: 3 }, Mov { destination: Direct(32771), source: Relative(2) }, Mov { destination: Direct(32772), source: Relative(3) }, Mov { destination: Direct(32773), source: Relative(4) }, Call { location: 50 }, Const { destination: Relative(2), bit_size: Integer(U32), value: 32843 }, Const { destination: Relative(3), bit_size: Integer(U32), value: 3 }, Stop { return_data: HeapVector { pointer: Relative(2), size: Relative(3) } }, BinaryIntOp { destination: Direct(32775), op: Add, bit_size: U32, lhs: Direct(32771), rhs: Direct(32773) }, Mov { destination: Direct(32776), source: Direct(32771) }, Mov { destination: Direct(32777), source: Direct(32772) }, BinaryIntOp { destination: Direct(32778), op: Equals, bit_size: U32, lhs: Direct(32776), rhs: Direct(32775) }, JumpIf { condition: Direct(32778), location: 60 }, Load { destination: Direct(32774), source_pointer: Direct(32776) }, Store { destination_pointer: Direct(32777), source: Direct(32774) }, BinaryIntOp { destination: Direct(32776), op: Add, bit_size: U32, lhs: Direct(32776), rhs: Direct(2) }, BinaryIntOp { destination: Direct(32777), op: Add, bit_size: U32, lhs: Direct(32777), rhs: Direct(2) }, Jump { location: 53 }, Return, Return, Call { location: 99 }, Mov { destination: Relative(5), source: Direct(1) }, BinaryIntOp { destination: Direct(1), op: Add, bit_size: U32, lhs: Direct(1), rhs: Direct(2) }, Store { destination_pointer: Relative(5), source: Relative(2) }, Mov { destination: Relative(2), source: Direct(1) }, BinaryIntOp { destination: Direct(1), op: Add, bit_size: U32, lhs: Direct(1), rhs: Direct(2) }, Store { destination_pointer: Relative(2), source: Relative(3) }, Not { destination: Relative(3), source: Relative(1), bit_size: U1 }, JumpIf { condition: Relative(1), location: 84 }, Jump { location: 72 }, ConditionalMov { destination: Relative(6), source_a: Relative(2), source_b: Relative(5), condition: Relative(1) }, Load { destination: Relative(1), source_pointer: Relative(6) }, Load { destination: Relative(2), source_pointer: Relative(1) }, Const { destination: Relative(3), bit_size: Integer(U32), value: 0 }, BinaryIntOp { destination: Relative(5), op: Equals, bit_size: U32, lhs: Relative(3), rhs: Relative(2) }, Not { destination: Relative(5), source: Relative(5), bit_size: U1 }, JumpIf { condition: Relative(5), location: 80 }, Call { location: 105 }, BinaryIntOp { destination: Relative(2), op: Add, bit_size: U32, lhs: Relative(2), rhs: Direct(2) }, Store { destination_pointer: Relative(1), source: Relative(2) }, Mov { destination: Relative(4), source: Relative(1) }, Jump { location: 97 }, Not { destination: Relative(3), source: Relative(1), bit_size: U1 }, ConditionalMov { destination: Relative(6), source_a: Relative(2), source_b: Relative(5), condition: Relative(1) }, Load { destination: Relative(1), source_pointer: Relative(6) }, Load { destination: Relative(2), source_pointer: Relative(1) }, Const { destination: Relative(3), bit_size: Integer(U32), value: 0 }, BinaryIntOp { destination: Relative(5), op: Equals, bit_size: U32, lhs: Relative(3), rhs: Relative(2) }, Not { destination: Relative(5), source: Relative(5), bit_size: U1 }, JumpIf { condition: Relative(5), location: 93 }, Call { location: 105 }, BinaryIntOp { destination: Relative(2), op: Add, bit_size: U32, lhs: Relative(2), rhs: Direct(2) }, Store { destination_pointer: Relative(1), source: Relative(2) }, Mov { destination: Relative(4), source: Relative(1) }, Jump { location: 97 }, Mov { destination: Relative(1), source: Relative(4) }, Return, Const { destination: Direct(32772), bit_size: Integer(U32), value: 30720 }, BinaryIntOp { destination: Direct(32771), op: LessThan, bit_size: U32, lhs: Direct(0), rhs: Direct(32772) }, JumpIf { condition: Direct(32771), location: 104 }, IndirectConst { destination_pointer: Direct(1), bit_size: Integer(U64), value: 17843811134343075018 }, Trap { revert_data: HeapVector { pointer: Direct(1), size: Direct(2) } }, Return, IndirectConst { destination_pointer: Direct(1), bit_size: Integer(U64), value: 12049594436772143978 }, Trap { revert_data: HeapVector { pointer: Direct(1), size: Direct(2) } }, Return]"
+  ],
+  "debug_symbols": "pZLdioQwDIXfJde9aPzXVxGRqnUolCodXVjEd9/UKM5eDCw7N/2aJic9kGww6G59tMaN0xOqeoPOG2vNo7VTrxYzOXrdQIYjj6BCAXkMVUxIGCkjY+SMglEeKCQDGVSZEHJGwSgPlJKBjIgRM+i/ZN8FXMbaxWsdfL04Jf+z8totULnVWgFfyq5H0XNW7uCiPGWlAO0GIjUcjdXhtotbLd9LSzy1mNzq9M9yzKJTHyG+00cf6vE/+oYi1Rv/a/R76OSN6qw+w3F1/Ut2+Z6vzLU6s596Paxeh073/tAc61SKTDYCkF7qshQokxDRwGuUKYV5swcnPw==",
+  "file_map": {
+    "50": {
+      "source": "unconstrained fn main(a: bool, mut b: (str<3>, str<3>)) -> pub str<3> {\n    if a {\n        func_2((if a { (&mut b.1) } else { (&mut b.0) }))\n    } else {\n        func_2((if a { (&mut b.1) } else { (&mut b.0) }))\n    }\n}\nunconstrained fn func_2(a: &mut str<3>) -> str<3> {\n    *a\n}\n",
+      "path": ""
+    }
+  },
+  "names": [
+    "main"
+  ],
+  "brillig_names": [
+    "main"
+  ]
+}

--- a/tooling/nargo_cli/tests/snapshots/execution_success/regression_9538/execute__tests__force_brillig_false_inliner_0.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/regression_9538/execute__tests__force_brillig_false_inliner_0.snap
@@ -1,0 +1,76 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: artifact
+---
+{
+  "noir_version": "[noir_version]",
+  "hash": "[hash]",
+  "abi": {
+    "parameters": [
+      {
+        "name": "a",
+        "type": {
+          "kind": "boolean"
+        },
+        "visibility": "private"
+      },
+      {
+        "name": "b",
+        "type": {
+          "kind": "tuple",
+          "fields": [
+            {
+              "kind": "string",
+              "length": 3
+            },
+            {
+              "kind": "string",
+              "length": 3
+            }
+          ]
+        },
+        "visibility": "private"
+      }
+    ],
+    "return_type": {
+      "abi_type": {
+        "kind": "string",
+        "length": 3
+      },
+      "visibility": "public"
+    },
+    "error_types": {
+      "12049594436772143978": {
+        "error_kind": "string",
+        "string": "array ref-count underflow detected"
+      },
+      "17843811134343075018": {
+        "error_kind": "string",
+        "string": "Stack too deep"
+      }
+    }
+  },
+  "bytecode": [
+    "func 0",
+    "current witness index : _9",
+    "private parameters indices : [_0, _1, _2, _3, _4, _5, _6]",
+    "public parameters indices : []",
+    "return value indices : [_7, _8, _9]",
+    "BRILLIG CALL func 0: inputs: [EXPR [ (1, _0) 0 ], [EXPR [ (1, _1) 0 ], EXPR [ (1, _2) 0 ], EXPR [ (1, _3) 0 ]], [EXPR [ (1, _4) 0 ], EXPR [ (1, _5) 0 ], EXPR [ (1, _6) 0 ]]], outputs: [[_7, _8, _9]]",
+    "unconstrained func 0",
+    "[Const { destination: Direct(2), bit_size: Integer(U32), value: 1 }, Const { destination: Direct(1), bit_size: Integer(U32), value: 32846 }, Const { destination: Direct(0), bit_size: Integer(U32), value: 3 }, Const { destination: Relative(4), bit_size: Integer(U32), value: 7 }, Const { destination: Relative(5), bit_size: Integer(U32), value: 0 }, CalldataCopy { destination_address: Direct(32836), size_address: Relative(4), offset_address: Relative(5) }, Cast { destination: Direct(32836), source: Direct(32836), bit_size: Integer(U1) }, Cast { destination: Direct(32837), source: Direct(32837), bit_size: Integer(U8) }, Cast { destination: Direct(32838), source: Direct(32838), bit_size: Integer(U8) }, Cast { destination: Direct(32839), source: Direct(32839), bit_size: Integer(U8) }, Cast { destination: Direct(32840), source: Direct(32840), bit_size: Integer(U8) }, Cast { destination: Direct(32841), source: Direct(32841), bit_size: Integer(U8) }, Cast { destination: Direct(32842), source: Direct(32842), bit_size: Integer(U8) }, Mov { destination: Relative(1), source: Direct(32836) }, Const { destination: Relative(2), bit_size: Integer(U32), value: 32837 }, Const { destination: Relative(5), bit_size: Integer(U32), value: 3 }, Mov { destination: Relative(4), source: Direct(1) }, Const { destination: Relative(6), bit_size: Integer(U32), value: 4 }, BinaryIntOp { destination: Direct(1), op: Add, bit_size: U32, lhs: Direct(1), rhs: Relative(6) }, IndirectConst { destination_pointer: Relative(4), bit_size: Integer(U32), value: 1 }, BinaryIntOp { destination: Relative(6), op: Add, bit_size: U32, lhs: Relative(4), rhs: Direct(2) }, Mov { destination: Direct(32771), source: Relative(2) }, Mov { destination: Direct(32772), source: Relative(6) }, Mov { destination: Direct(32773), source: Relative(5) }, Call { location: 50 }, Mov { destination: Relative(2), source: Relative(4) }, Const { destination: Relative(3), bit_size: Integer(U32), value: 32840 }, Const { destination: Relative(5), bit_size: Integer(U32), value: 3 }, Mov { destination: Relative(4), source: Direct(1) }, Const { destination: Relative(6), bit_size: Integer(U32), value: 4 }, BinaryIntOp { destination: Direct(1), op: Add, bit_size: U32, lhs: Direct(1), rhs: Relative(6) }, IndirectConst { destination_pointer: Relative(4), bit_size: Integer(U32), value: 1 }, BinaryIntOp { destination: Relative(6), op: Add, bit_size: U32, lhs: Relative(4), rhs: Direct(2) }, Mov { destination: Direct(32771), source: Relative(3) }, Mov { destination: Direct(32772), source: Relative(6) }, Mov { destination: Direct(32773), source: Relative(5) }, Call { location: 50 }, Mov { destination: Relative(3), source: Relative(4) }, Call { location: 61 }, Call { location: 62 }, BinaryIntOp { destination: Relative(2), op: Add, bit_size: U32, lhs: Relative(1), rhs: Direct(2) }, Const { destination: Relative(3), bit_size: Integer(U32), value: 32843 }, Const { destination: Relative(4), bit_size: Integer(U32), value: 3 }, Mov { destination: Direct(32771), source: Relative(2) }, Mov { destination: Direct(32772), source: Relative(3) }, Mov { destination: Direct(32773), source: Relative(4) }, Call { location: 50 }, Const { destination: Relative(2), bit_size: Integer(U32), value: 32843 }, Const { destination: Relative(3), bit_size: Integer(U32), value: 3 }, Stop { return_data: HeapVector { pointer: Relative(2), size: Relative(3) } }, BinaryIntOp { destination: Direct(32775), op: Add, bit_size: U32, lhs: Direct(32771), rhs: Direct(32773) }, Mov { destination: Direct(32776), source: Direct(32771) }, Mov { destination: Direct(32777), source: Direct(32772) }, BinaryIntOp { destination: Direct(32778), op: Equals, bit_size: U32, lhs: Direct(32776), rhs: Direct(32775) }, JumpIf { condition: Direct(32778), location: 60 }, Load { destination: Direct(32774), source_pointer: Direct(32776) }, Store { destination_pointer: Direct(32777), source: Direct(32774) }, BinaryIntOp { destination: Direct(32776), op: Add, bit_size: U32, lhs: Direct(32776), rhs: Direct(2) }, BinaryIntOp { destination: Direct(32777), op: Add, bit_size: U32, lhs: Direct(32777), rhs: Direct(2) }, Jump { location: 53 }, Return, Return, Call { location: 99 }, Mov { destination: Relative(5), source: Direct(1) }, BinaryIntOp { destination: Direct(1), op: Add, bit_size: U32, lhs: Direct(1), rhs: Direct(2) }, Store { destination_pointer: Relative(5), source: Relative(2) }, Mov { destination: Relative(2), source: Direct(1) }, BinaryIntOp { destination: Direct(1), op: Add, bit_size: U32, lhs: Direct(1), rhs: Direct(2) }, Store { destination_pointer: Relative(2), source: Relative(3) }, Not { destination: Relative(3), source: Relative(1), bit_size: U1 }, JumpIf { condition: Relative(1), location: 84 }, Jump { location: 72 }, ConditionalMov { destination: Relative(6), source_a: Relative(2), source_b: Relative(5), condition: Relative(1) }, Load { destination: Relative(1), source_pointer: Relative(6) }, Load { destination: Relative(2), source_pointer: Relative(1) }, Const { destination: Relative(3), bit_size: Integer(U32), value: 0 }, BinaryIntOp { destination: Relative(5), op: Equals, bit_size: U32, lhs: Relative(3), rhs: Relative(2) }, Not { destination: Relative(5), source: Relative(5), bit_size: U1 }, JumpIf { condition: Relative(5), location: 80 }, Call { location: 105 }, BinaryIntOp { destination: Relative(2), op: Add, bit_size: U32, lhs: Relative(2), rhs: Direct(2) }, Store { destination_pointer: Relative(1), source: Relative(2) }, Mov { destination: Relative(4), source: Relative(1) }, Jump { location: 97 }, Not { destination: Relative(3), source: Relative(1), bit_size: U1 }, ConditionalMov { destination: Relative(6), source_a: Relative(2), source_b: Relative(5), condition: Relative(1) }, Load { destination: Relative(1), source_pointer: Relative(6) }, Load { destination: Relative(2), source_pointer: Relative(1) }, Const { destination: Relative(3), bit_size: Integer(U32), value: 0 }, BinaryIntOp { destination: Relative(5), op: Equals, bit_size: U32, lhs: Relative(3), rhs: Relative(2) }, Not { destination: Relative(5), source: Relative(5), bit_size: U1 }, JumpIf { condition: Relative(5), location: 93 }, Call { location: 105 }, BinaryIntOp { destination: Relative(2), op: Add, bit_size: U32, lhs: Relative(2), rhs: Direct(2) }, Store { destination_pointer: Relative(1), source: Relative(2) }, Mov { destination: Relative(4), source: Relative(1) }, Jump { location: 97 }, Mov { destination: Relative(1), source: Relative(4) }, Return, Const { destination: Direct(32772), bit_size: Integer(U32), value: 30720 }, BinaryIntOp { destination: Direct(32771), op: LessThan, bit_size: U32, lhs: Direct(0), rhs: Direct(32772) }, JumpIf { condition: Direct(32771), location: 104 }, IndirectConst { destination_pointer: Direct(1), bit_size: Integer(U64), value: 17843811134343075018 }, Trap { revert_data: HeapVector { pointer: Direct(1), size: Direct(2) } }, Return, IndirectConst { destination_pointer: Direct(1), bit_size: Integer(U64), value: 12049594436772143978 }, Trap { revert_data: HeapVector { pointer: Direct(1), size: Direct(2) } }, Return]"
+  ],
+  "debug_symbols": "pZLdioQwDIXfJde9aPzXVxGRqnUolCodXVjEd9/UKM5eDCw7N/2aJic9kGww6G59tMaN0xOqeoPOG2vNo7VTrxYzOXrdQIYjj6BCAXkMVUxIGCkjY+SMglEeKCQDGVSZEHJGwSgPlJKBjIgRM+i/ZN8FXMbaxWsdfL04Jf+z8totULnVWgFfyq5H0XNW7uCiPGWlAO0GIjUcjdXhtotbLd9LSzy1mNzq9M9yzKJTHyG+00cf6vE/+oYi1Rv/a/R76OSN6qw+w3F1/Ut2+Z6vzLU6s596Paxeh073/tAc61SKTDYCkF7qshQokxDRwGuUKYV5swcnPw==",
+  "file_map": {
+    "50": {
+      "source": "unconstrained fn main(a: bool, mut b: (str<3>, str<3>)) -> pub str<3> {\n    if a {\n        func_2((if a { (&mut b.1) } else { (&mut b.0) }))\n    } else {\n        func_2((if a { (&mut b.1) } else { (&mut b.0) }))\n    }\n}\nunconstrained fn func_2(a: &mut str<3>) -> str<3> {\n    *a\n}\n",
+      "path": ""
+    }
+  },
+  "names": [
+    "main"
+  ],
+  "brillig_names": [
+    "main"
+  ]
+}

--- a/tooling/nargo_cli/tests/snapshots/execution_success/regression_9538/execute__tests__force_brillig_false_inliner_9223372036854775807.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/regression_9538/execute__tests__force_brillig_false_inliner_9223372036854775807.snap
@@ -1,0 +1,76 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: artifact
+---
+{
+  "noir_version": "[noir_version]",
+  "hash": "[hash]",
+  "abi": {
+    "parameters": [
+      {
+        "name": "a",
+        "type": {
+          "kind": "boolean"
+        },
+        "visibility": "private"
+      },
+      {
+        "name": "b",
+        "type": {
+          "kind": "tuple",
+          "fields": [
+            {
+              "kind": "string",
+              "length": 3
+            },
+            {
+              "kind": "string",
+              "length": 3
+            }
+          ]
+        },
+        "visibility": "private"
+      }
+    ],
+    "return_type": {
+      "abi_type": {
+        "kind": "string",
+        "length": 3
+      },
+      "visibility": "public"
+    },
+    "error_types": {
+      "12049594436772143978": {
+        "error_kind": "string",
+        "string": "array ref-count underflow detected"
+      },
+      "17843811134343075018": {
+        "error_kind": "string",
+        "string": "Stack too deep"
+      }
+    }
+  },
+  "bytecode": [
+    "func 0",
+    "current witness index : _9",
+    "private parameters indices : [_0, _1, _2, _3, _4, _5, _6]",
+    "public parameters indices : []",
+    "return value indices : [_7, _8, _9]",
+    "BRILLIG CALL func 0: inputs: [EXPR [ (1, _0) 0 ], [EXPR [ (1, _1) 0 ], EXPR [ (1, _2) 0 ], EXPR [ (1, _3) 0 ]], [EXPR [ (1, _4) 0 ], EXPR [ (1, _5) 0 ], EXPR [ (1, _6) 0 ]]], outputs: [[_7, _8, _9]]",
+    "unconstrained func 0",
+    "[Const { destination: Direct(2), bit_size: Integer(U32), value: 1 }, Const { destination: Direct(1), bit_size: Integer(U32), value: 32846 }, Const { destination: Direct(0), bit_size: Integer(U32), value: 3 }, Const { destination: Relative(4), bit_size: Integer(U32), value: 7 }, Const { destination: Relative(5), bit_size: Integer(U32), value: 0 }, CalldataCopy { destination_address: Direct(32836), size_address: Relative(4), offset_address: Relative(5) }, Cast { destination: Direct(32836), source: Direct(32836), bit_size: Integer(U1) }, Cast { destination: Direct(32837), source: Direct(32837), bit_size: Integer(U8) }, Cast { destination: Direct(32838), source: Direct(32838), bit_size: Integer(U8) }, Cast { destination: Direct(32839), source: Direct(32839), bit_size: Integer(U8) }, Cast { destination: Direct(32840), source: Direct(32840), bit_size: Integer(U8) }, Cast { destination: Direct(32841), source: Direct(32841), bit_size: Integer(U8) }, Cast { destination: Direct(32842), source: Direct(32842), bit_size: Integer(U8) }, Mov { destination: Relative(1), source: Direct(32836) }, Const { destination: Relative(2), bit_size: Integer(U32), value: 32837 }, Const { destination: Relative(5), bit_size: Integer(U32), value: 3 }, Mov { destination: Relative(4), source: Direct(1) }, Const { destination: Relative(6), bit_size: Integer(U32), value: 4 }, BinaryIntOp { destination: Direct(1), op: Add, bit_size: U32, lhs: Direct(1), rhs: Relative(6) }, IndirectConst { destination_pointer: Relative(4), bit_size: Integer(U32), value: 1 }, BinaryIntOp { destination: Relative(6), op: Add, bit_size: U32, lhs: Relative(4), rhs: Direct(2) }, Mov { destination: Direct(32771), source: Relative(2) }, Mov { destination: Direct(32772), source: Relative(6) }, Mov { destination: Direct(32773), source: Relative(5) }, Call { location: 50 }, Mov { destination: Relative(2), source: Relative(4) }, Const { destination: Relative(3), bit_size: Integer(U32), value: 32840 }, Const { destination: Relative(5), bit_size: Integer(U32), value: 3 }, Mov { destination: Relative(4), source: Direct(1) }, Const { destination: Relative(6), bit_size: Integer(U32), value: 4 }, BinaryIntOp { destination: Direct(1), op: Add, bit_size: U32, lhs: Direct(1), rhs: Relative(6) }, IndirectConst { destination_pointer: Relative(4), bit_size: Integer(U32), value: 1 }, BinaryIntOp { destination: Relative(6), op: Add, bit_size: U32, lhs: Relative(4), rhs: Direct(2) }, Mov { destination: Direct(32771), source: Relative(3) }, Mov { destination: Direct(32772), source: Relative(6) }, Mov { destination: Direct(32773), source: Relative(5) }, Call { location: 50 }, Mov { destination: Relative(3), source: Relative(4) }, Call { location: 61 }, Call { location: 62 }, BinaryIntOp { destination: Relative(2), op: Add, bit_size: U32, lhs: Relative(1), rhs: Direct(2) }, Const { destination: Relative(3), bit_size: Integer(U32), value: 32843 }, Const { destination: Relative(4), bit_size: Integer(U32), value: 3 }, Mov { destination: Direct(32771), source: Relative(2) }, Mov { destination: Direct(32772), source: Relative(3) }, Mov { destination: Direct(32773), source: Relative(4) }, Call { location: 50 }, Const { destination: Relative(2), bit_size: Integer(U32), value: 32843 }, Const { destination: Relative(3), bit_size: Integer(U32), value: 3 }, Stop { return_data: HeapVector { pointer: Relative(2), size: Relative(3) } }, BinaryIntOp { destination: Direct(32775), op: Add, bit_size: U32, lhs: Direct(32771), rhs: Direct(32773) }, Mov { destination: Direct(32776), source: Direct(32771) }, Mov { destination: Direct(32777), source: Direct(32772) }, BinaryIntOp { destination: Direct(32778), op: Equals, bit_size: U32, lhs: Direct(32776), rhs: Direct(32775) }, JumpIf { condition: Direct(32778), location: 60 }, Load { destination: Direct(32774), source_pointer: Direct(32776) }, Store { destination_pointer: Direct(32777), source: Direct(32774) }, BinaryIntOp { destination: Direct(32776), op: Add, bit_size: U32, lhs: Direct(32776), rhs: Direct(2) }, BinaryIntOp { destination: Direct(32777), op: Add, bit_size: U32, lhs: Direct(32777), rhs: Direct(2) }, Jump { location: 53 }, Return, Return, Call { location: 99 }, Mov { destination: Relative(5), source: Direct(1) }, BinaryIntOp { destination: Direct(1), op: Add, bit_size: U32, lhs: Direct(1), rhs: Direct(2) }, Store { destination_pointer: Relative(5), source: Relative(2) }, Mov { destination: Relative(2), source: Direct(1) }, BinaryIntOp { destination: Direct(1), op: Add, bit_size: U32, lhs: Direct(1), rhs: Direct(2) }, Store { destination_pointer: Relative(2), source: Relative(3) }, Not { destination: Relative(3), source: Relative(1), bit_size: U1 }, JumpIf { condition: Relative(1), location: 84 }, Jump { location: 72 }, ConditionalMov { destination: Relative(6), source_a: Relative(2), source_b: Relative(5), condition: Relative(1) }, Load { destination: Relative(1), source_pointer: Relative(6) }, Load { destination: Relative(2), source_pointer: Relative(1) }, Const { destination: Relative(3), bit_size: Integer(U32), value: 0 }, BinaryIntOp { destination: Relative(5), op: Equals, bit_size: U32, lhs: Relative(3), rhs: Relative(2) }, Not { destination: Relative(5), source: Relative(5), bit_size: U1 }, JumpIf { condition: Relative(5), location: 80 }, Call { location: 105 }, BinaryIntOp { destination: Relative(2), op: Add, bit_size: U32, lhs: Relative(2), rhs: Direct(2) }, Store { destination_pointer: Relative(1), source: Relative(2) }, Mov { destination: Relative(4), source: Relative(1) }, Jump { location: 97 }, Not { destination: Relative(3), source: Relative(1), bit_size: U1 }, ConditionalMov { destination: Relative(6), source_a: Relative(2), source_b: Relative(5), condition: Relative(1) }, Load { destination: Relative(1), source_pointer: Relative(6) }, Load { destination: Relative(2), source_pointer: Relative(1) }, Const { destination: Relative(3), bit_size: Integer(U32), value: 0 }, BinaryIntOp { destination: Relative(5), op: Equals, bit_size: U32, lhs: Relative(3), rhs: Relative(2) }, Not { destination: Relative(5), source: Relative(5), bit_size: U1 }, JumpIf { condition: Relative(5), location: 93 }, Call { location: 105 }, BinaryIntOp { destination: Relative(2), op: Add, bit_size: U32, lhs: Relative(2), rhs: Direct(2) }, Store { destination_pointer: Relative(1), source: Relative(2) }, Mov { destination: Relative(4), source: Relative(1) }, Jump { location: 97 }, Mov { destination: Relative(1), source: Relative(4) }, Return, Const { destination: Direct(32772), bit_size: Integer(U32), value: 30720 }, BinaryIntOp { destination: Direct(32771), op: LessThan, bit_size: U32, lhs: Direct(0), rhs: Direct(32772) }, JumpIf { condition: Direct(32771), location: 104 }, IndirectConst { destination_pointer: Direct(1), bit_size: Integer(U64), value: 17843811134343075018 }, Trap { revert_data: HeapVector { pointer: Direct(1), size: Direct(2) } }, Return, IndirectConst { destination_pointer: Direct(1), bit_size: Integer(U64), value: 12049594436772143978 }, Trap { revert_data: HeapVector { pointer: Direct(1), size: Direct(2) } }, Return]"
+  ],
+  "debug_symbols": "pZLdioQwDIXfJde9aPzXVxGRqnUolCodXVjEd9/UKM5eDCw7N/2aJic9kGww6G59tMaN0xOqeoPOG2vNo7VTrxYzOXrdQIYjj6BCAXkMVUxIGCkjY+SMglEeKCQDGVSZEHJGwSgPlJKBjIgRM+i/ZN8FXMbaxWsdfL04Jf+z8totULnVWgFfyq5H0XNW7uCiPGWlAO0GIjUcjdXhtotbLd9LSzy1mNzq9M9yzKJTHyG+00cf6vE/+oYi1Rv/a/R76OSN6qw+w3F1/Ut2+Z6vzLU6s596Paxeh073/tAc61SKTDYCkF7qshQokxDRwGuUKYV5swcnPw==",
+  "file_map": {
+    "50": {
+      "source": "unconstrained fn main(a: bool, mut b: (str<3>, str<3>)) -> pub str<3> {\n    if a {\n        func_2((if a { (&mut b.1) } else { (&mut b.0) }))\n    } else {\n        func_2((if a { (&mut b.1) } else { (&mut b.0) }))\n    }\n}\nunconstrained fn func_2(a: &mut str<3>) -> str<3> {\n    *a\n}\n",
+      "path": ""
+    }
+  },
+  "names": [
+    "main"
+  ],
+  "brillig_names": [
+    "main"
+  ]
+}

--- a/tooling/nargo_cli/tests/snapshots/execution_success/regression_9538/execute__tests__force_brillig_true_inliner_-9223372036854775808.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/regression_9538/execute__tests__force_brillig_true_inliner_-9223372036854775808.snap
@@ -1,0 +1,76 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: artifact
+---
+{
+  "noir_version": "[noir_version]",
+  "hash": "[hash]",
+  "abi": {
+    "parameters": [
+      {
+        "name": "a",
+        "type": {
+          "kind": "boolean"
+        },
+        "visibility": "private"
+      },
+      {
+        "name": "b",
+        "type": {
+          "kind": "tuple",
+          "fields": [
+            {
+              "kind": "string",
+              "length": 3
+            },
+            {
+              "kind": "string",
+              "length": 3
+            }
+          ]
+        },
+        "visibility": "private"
+      }
+    ],
+    "return_type": {
+      "abi_type": {
+        "kind": "string",
+        "length": 3
+      },
+      "visibility": "public"
+    },
+    "error_types": {
+      "12049594436772143978": {
+        "error_kind": "string",
+        "string": "array ref-count underflow detected"
+      },
+      "17843811134343075018": {
+        "error_kind": "string",
+        "string": "Stack too deep"
+      }
+    }
+  },
+  "bytecode": [
+    "func 0",
+    "current witness index : _9",
+    "private parameters indices : [_0, _1, _2, _3, _4, _5, _6]",
+    "public parameters indices : []",
+    "return value indices : [_7, _8, _9]",
+    "BRILLIG CALL func 0: inputs: [EXPR [ (1, _0) 0 ], [EXPR [ (1, _1) 0 ], EXPR [ (1, _2) 0 ], EXPR [ (1, _3) 0 ]], [EXPR [ (1, _4) 0 ], EXPR [ (1, _5) 0 ], EXPR [ (1, _6) 0 ]]], outputs: [[_7, _8, _9]]",
+    "unconstrained func 0",
+    "[Const { destination: Direct(2), bit_size: Integer(U32), value: 1 }, Const { destination: Direct(1), bit_size: Integer(U32), value: 32846 }, Const { destination: Direct(0), bit_size: Integer(U32), value: 3 }, Const { destination: Relative(4), bit_size: Integer(U32), value: 7 }, Const { destination: Relative(5), bit_size: Integer(U32), value: 0 }, CalldataCopy { destination_address: Direct(32836), size_address: Relative(4), offset_address: Relative(5) }, Cast { destination: Direct(32836), source: Direct(32836), bit_size: Integer(U1) }, Cast { destination: Direct(32837), source: Direct(32837), bit_size: Integer(U8) }, Cast { destination: Direct(32838), source: Direct(32838), bit_size: Integer(U8) }, Cast { destination: Direct(32839), source: Direct(32839), bit_size: Integer(U8) }, Cast { destination: Direct(32840), source: Direct(32840), bit_size: Integer(U8) }, Cast { destination: Direct(32841), source: Direct(32841), bit_size: Integer(U8) }, Cast { destination: Direct(32842), source: Direct(32842), bit_size: Integer(U8) }, Mov { destination: Relative(1), source: Direct(32836) }, Const { destination: Relative(2), bit_size: Integer(U32), value: 32837 }, Const { destination: Relative(5), bit_size: Integer(U32), value: 3 }, Mov { destination: Relative(4), source: Direct(1) }, Const { destination: Relative(6), bit_size: Integer(U32), value: 4 }, BinaryIntOp { destination: Direct(1), op: Add, bit_size: U32, lhs: Direct(1), rhs: Relative(6) }, IndirectConst { destination_pointer: Relative(4), bit_size: Integer(U32), value: 1 }, BinaryIntOp { destination: Relative(6), op: Add, bit_size: U32, lhs: Relative(4), rhs: Direct(2) }, Mov { destination: Direct(32771), source: Relative(2) }, Mov { destination: Direct(32772), source: Relative(6) }, Mov { destination: Direct(32773), source: Relative(5) }, Call { location: 50 }, Mov { destination: Relative(2), source: Relative(4) }, Const { destination: Relative(3), bit_size: Integer(U32), value: 32840 }, Const { destination: Relative(5), bit_size: Integer(U32), value: 3 }, Mov { destination: Relative(4), source: Direct(1) }, Const { destination: Relative(6), bit_size: Integer(U32), value: 4 }, BinaryIntOp { destination: Direct(1), op: Add, bit_size: U32, lhs: Direct(1), rhs: Relative(6) }, IndirectConst { destination_pointer: Relative(4), bit_size: Integer(U32), value: 1 }, BinaryIntOp { destination: Relative(6), op: Add, bit_size: U32, lhs: Relative(4), rhs: Direct(2) }, Mov { destination: Direct(32771), source: Relative(3) }, Mov { destination: Direct(32772), source: Relative(6) }, Mov { destination: Direct(32773), source: Relative(5) }, Call { location: 50 }, Mov { destination: Relative(3), source: Relative(4) }, Call { location: 61 }, Call { location: 62 }, BinaryIntOp { destination: Relative(2), op: Add, bit_size: U32, lhs: Relative(1), rhs: Direct(2) }, Const { destination: Relative(3), bit_size: Integer(U32), value: 32843 }, Const { destination: Relative(4), bit_size: Integer(U32), value: 3 }, Mov { destination: Direct(32771), source: Relative(2) }, Mov { destination: Direct(32772), source: Relative(3) }, Mov { destination: Direct(32773), source: Relative(4) }, Call { location: 50 }, Const { destination: Relative(2), bit_size: Integer(U32), value: 32843 }, Const { destination: Relative(3), bit_size: Integer(U32), value: 3 }, Stop { return_data: HeapVector { pointer: Relative(2), size: Relative(3) } }, BinaryIntOp { destination: Direct(32775), op: Add, bit_size: U32, lhs: Direct(32771), rhs: Direct(32773) }, Mov { destination: Direct(32776), source: Direct(32771) }, Mov { destination: Direct(32777), source: Direct(32772) }, BinaryIntOp { destination: Direct(32778), op: Equals, bit_size: U32, lhs: Direct(32776), rhs: Direct(32775) }, JumpIf { condition: Direct(32778), location: 60 }, Load { destination: Direct(32774), source_pointer: Direct(32776) }, Store { destination_pointer: Direct(32777), source: Direct(32774) }, BinaryIntOp { destination: Direct(32776), op: Add, bit_size: U32, lhs: Direct(32776), rhs: Direct(2) }, BinaryIntOp { destination: Direct(32777), op: Add, bit_size: U32, lhs: Direct(32777), rhs: Direct(2) }, Jump { location: 53 }, Return, Return, Call { location: 99 }, Mov { destination: Relative(5), source: Direct(1) }, BinaryIntOp { destination: Direct(1), op: Add, bit_size: U32, lhs: Direct(1), rhs: Direct(2) }, Store { destination_pointer: Relative(5), source: Relative(2) }, Mov { destination: Relative(2), source: Direct(1) }, BinaryIntOp { destination: Direct(1), op: Add, bit_size: U32, lhs: Direct(1), rhs: Direct(2) }, Store { destination_pointer: Relative(2), source: Relative(3) }, Not { destination: Relative(3), source: Relative(1), bit_size: U1 }, JumpIf { condition: Relative(1), location: 84 }, Jump { location: 72 }, ConditionalMov { destination: Relative(6), source_a: Relative(2), source_b: Relative(5), condition: Relative(1) }, Load { destination: Relative(1), source_pointer: Relative(6) }, Load { destination: Relative(2), source_pointer: Relative(1) }, Const { destination: Relative(3), bit_size: Integer(U32), value: 0 }, BinaryIntOp { destination: Relative(5), op: Equals, bit_size: U32, lhs: Relative(3), rhs: Relative(2) }, Not { destination: Relative(5), source: Relative(5), bit_size: U1 }, JumpIf { condition: Relative(5), location: 80 }, Call { location: 105 }, BinaryIntOp { destination: Relative(2), op: Add, bit_size: U32, lhs: Relative(2), rhs: Direct(2) }, Store { destination_pointer: Relative(1), source: Relative(2) }, Mov { destination: Relative(4), source: Relative(1) }, Jump { location: 97 }, Not { destination: Relative(3), source: Relative(1), bit_size: U1 }, ConditionalMov { destination: Relative(6), source_a: Relative(2), source_b: Relative(5), condition: Relative(1) }, Load { destination: Relative(1), source_pointer: Relative(6) }, Load { destination: Relative(2), source_pointer: Relative(1) }, Const { destination: Relative(3), bit_size: Integer(U32), value: 0 }, BinaryIntOp { destination: Relative(5), op: Equals, bit_size: U32, lhs: Relative(3), rhs: Relative(2) }, Not { destination: Relative(5), source: Relative(5), bit_size: U1 }, JumpIf { condition: Relative(5), location: 93 }, Call { location: 105 }, BinaryIntOp { destination: Relative(2), op: Add, bit_size: U32, lhs: Relative(2), rhs: Direct(2) }, Store { destination_pointer: Relative(1), source: Relative(2) }, Mov { destination: Relative(4), source: Relative(1) }, Jump { location: 97 }, Mov { destination: Relative(1), source: Relative(4) }, Return, Const { destination: Direct(32772), bit_size: Integer(U32), value: 30720 }, BinaryIntOp { destination: Direct(32771), op: LessThan, bit_size: U32, lhs: Direct(0), rhs: Direct(32772) }, JumpIf { condition: Direct(32771), location: 104 }, IndirectConst { destination_pointer: Direct(1), bit_size: Integer(U64), value: 17843811134343075018 }, Trap { revert_data: HeapVector { pointer: Direct(1), size: Direct(2) } }, Return, IndirectConst { destination_pointer: Direct(1), bit_size: Integer(U64), value: 12049594436772143978 }, Trap { revert_data: HeapVector { pointer: Direct(1), size: Direct(2) } }, Return]"
+  ],
+  "debug_symbols": "pZLdioQwDIXfJde9aPzXVxGRqnUolCodXVjEd9/UKM5eDCw7N/2aJic9kGww6G59tMaN0xOqeoPOG2vNo7VTrxYzOXrdQIYjj6BCAXkMVUxIGCkjY+SMglEeKCQDGVSZEHJGwSgPlJKBjIgRM+i/ZN8FXMbaxWsdfL04Jf+z8totULnVWgFfyq5H0XNW7uCiPGWlAO0GIjUcjdXhtotbLd9LSzy1mNzq9M9yzKJTHyG+00cf6vE/+oYi1Rv/a/R76OSN6qw+w3F1/Ut2+Z6vzLU6s596Paxeh073/tAc61SKTDYCkF7qshQokxDRwGuUKYV5swcnPw==",
+  "file_map": {
+    "50": {
+      "source": "unconstrained fn main(a: bool, mut b: (str<3>, str<3>)) -> pub str<3> {\n    if a {\n        func_2((if a { (&mut b.1) } else { (&mut b.0) }))\n    } else {\n        func_2((if a { (&mut b.1) } else { (&mut b.0) }))\n    }\n}\nunconstrained fn func_2(a: &mut str<3>) -> str<3> {\n    *a\n}\n",
+      "path": ""
+    }
+  },
+  "names": [
+    "main"
+  ],
+  "brillig_names": [
+    "main"
+  ]
+}

--- a/tooling/nargo_cli/tests/snapshots/execution_success/regression_9538/execute__tests__force_brillig_true_inliner_0.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/regression_9538/execute__tests__force_brillig_true_inliner_0.snap
@@ -1,0 +1,76 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: artifact
+---
+{
+  "noir_version": "[noir_version]",
+  "hash": "[hash]",
+  "abi": {
+    "parameters": [
+      {
+        "name": "a",
+        "type": {
+          "kind": "boolean"
+        },
+        "visibility": "private"
+      },
+      {
+        "name": "b",
+        "type": {
+          "kind": "tuple",
+          "fields": [
+            {
+              "kind": "string",
+              "length": 3
+            },
+            {
+              "kind": "string",
+              "length": 3
+            }
+          ]
+        },
+        "visibility": "private"
+      }
+    ],
+    "return_type": {
+      "abi_type": {
+        "kind": "string",
+        "length": 3
+      },
+      "visibility": "public"
+    },
+    "error_types": {
+      "12049594436772143978": {
+        "error_kind": "string",
+        "string": "array ref-count underflow detected"
+      },
+      "17843811134343075018": {
+        "error_kind": "string",
+        "string": "Stack too deep"
+      }
+    }
+  },
+  "bytecode": [
+    "func 0",
+    "current witness index : _9",
+    "private parameters indices : [_0, _1, _2, _3, _4, _5, _6]",
+    "public parameters indices : []",
+    "return value indices : [_7, _8, _9]",
+    "BRILLIG CALL func 0: inputs: [EXPR [ (1, _0) 0 ], [EXPR [ (1, _1) 0 ], EXPR [ (1, _2) 0 ], EXPR [ (1, _3) 0 ]], [EXPR [ (1, _4) 0 ], EXPR [ (1, _5) 0 ], EXPR [ (1, _6) 0 ]]], outputs: [[_7, _8, _9]]",
+    "unconstrained func 0",
+    "[Const { destination: Direct(2), bit_size: Integer(U32), value: 1 }, Const { destination: Direct(1), bit_size: Integer(U32), value: 32846 }, Const { destination: Direct(0), bit_size: Integer(U32), value: 3 }, Const { destination: Relative(4), bit_size: Integer(U32), value: 7 }, Const { destination: Relative(5), bit_size: Integer(U32), value: 0 }, CalldataCopy { destination_address: Direct(32836), size_address: Relative(4), offset_address: Relative(5) }, Cast { destination: Direct(32836), source: Direct(32836), bit_size: Integer(U1) }, Cast { destination: Direct(32837), source: Direct(32837), bit_size: Integer(U8) }, Cast { destination: Direct(32838), source: Direct(32838), bit_size: Integer(U8) }, Cast { destination: Direct(32839), source: Direct(32839), bit_size: Integer(U8) }, Cast { destination: Direct(32840), source: Direct(32840), bit_size: Integer(U8) }, Cast { destination: Direct(32841), source: Direct(32841), bit_size: Integer(U8) }, Cast { destination: Direct(32842), source: Direct(32842), bit_size: Integer(U8) }, Mov { destination: Relative(1), source: Direct(32836) }, Const { destination: Relative(2), bit_size: Integer(U32), value: 32837 }, Const { destination: Relative(5), bit_size: Integer(U32), value: 3 }, Mov { destination: Relative(4), source: Direct(1) }, Const { destination: Relative(6), bit_size: Integer(U32), value: 4 }, BinaryIntOp { destination: Direct(1), op: Add, bit_size: U32, lhs: Direct(1), rhs: Relative(6) }, IndirectConst { destination_pointer: Relative(4), bit_size: Integer(U32), value: 1 }, BinaryIntOp { destination: Relative(6), op: Add, bit_size: U32, lhs: Relative(4), rhs: Direct(2) }, Mov { destination: Direct(32771), source: Relative(2) }, Mov { destination: Direct(32772), source: Relative(6) }, Mov { destination: Direct(32773), source: Relative(5) }, Call { location: 50 }, Mov { destination: Relative(2), source: Relative(4) }, Const { destination: Relative(3), bit_size: Integer(U32), value: 32840 }, Const { destination: Relative(5), bit_size: Integer(U32), value: 3 }, Mov { destination: Relative(4), source: Direct(1) }, Const { destination: Relative(6), bit_size: Integer(U32), value: 4 }, BinaryIntOp { destination: Direct(1), op: Add, bit_size: U32, lhs: Direct(1), rhs: Relative(6) }, IndirectConst { destination_pointer: Relative(4), bit_size: Integer(U32), value: 1 }, BinaryIntOp { destination: Relative(6), op: Add, bit_size: U32, lhs: Relative(4), rhs: Direct(2) }, Mov { destination: Direct(32771), source: Relative(3) }, Mov { destination: Direct(32772), source: Relative(6) }, Mov { destination: Direct(32773), source: Relative(5) }, Call { location: 50 }, Mov { destination: Relative(3), source: Relative(4) }, Call { location: 61 }, Call { location: 62 }, BinaryIntOp { destination: Relative(2), op: Add, bit_size: U32, lhs: Relative(1), rhs: Direct(2) }, Const { destination: Relative(3), bit_size: Integer(U32), value: 32843 }, Const { destination: Relative(4), bit_size: Integer(U32), value: 3 }, Mov { destination: Direct(32771), source: Relative(2) }, Mov { destination: Direct(32772), source: Relative(3) }, Mov { destination: Direct(32773), source: Relative(4) }, Call { location: 50 }, Const { destination: Relative(2), bit_size: Integer(U32), value: 32843 }, Const { destination: Relative(3), bit_size: Integer(U32), value: 3 }, Stop { return_data: HeapVector { pointer: Relative(2), size: Relative(3) } }, BinaryIntOp { destination: Direct(32775), op: Add, bit_size: U32, lhs: Direct(32771), rhs: Direct(32773) }, Mov { destination: Direct(32776), source: Direct(32771) }, Mov { destination: Direct(32777), source: Direct(32772) }, BinaryIntOp { destination: Direct(32778), op: Equals, bit_size: U32, lhs: Direct(32776), rhs: Direct(32775) }, JumpIf { condition: Direct(32778), location: 60 }, Load { destination: Direct(32774), source_pointer: Direct(32776) }, Store { destination_pointer: Direct(32777), source: Direct(32774) }, BinaryIntOp { destination: Direct(32776), op: Add, bit_size: U32, lhs: Direct(32776), rhs: Direct(2) }, BinaryIntOp { destination: Direct(32777), op: Add, bit_size: U32, lhs: Direct(32777), rhs: Direct(2) }, Jump { location: 53 }, Return, Return, Call { location: 99 }, Mov { destination: Relative(5), source: Direct(1) }, BinaryIntOp { destination: Direct(1), op: Add, bit_size: U32, lhs: Direct(1), rhs: Direct(2) }, Store { destination_pointer: Relative(5), source: Relative(2) }, Mov { destination: Relative(2), source: Direct(1) }, BinaryIntOp { destination: Direct(1), op: Add, bit_size: U32, lhs: Direct(1), rhs: Direct(2) }, Store { destination_pointer: Relative(2), source: Relative(3) }, Not { destination: Relative(3), source: Relative(1), bit_size: U1 }, JumpIf { condition: Relative(1), location: 84 }, Jump { location: 72 }, ConditionalMov { destination: Relative(6), source_a: Relative(2), source_b: Relative(5), condition: Relative(1) }, Load { destination: Relative(1), source_pointer: Relative(6) }, Load { destination: Relative(2), source_pointer: Relative(1) }, Const { destination: Relative(3), bit_size: Integer(U32), value: 0 }, BinaryIntOp { destination: Relative(5), op: Equals, bit_size: U32, lhs: Relative(3), rhs: Relative(2) }, Not { destination: Relative(5), source: Relative(5), bit_size: U1 }, JumpIf { condition: Relative(5), location: 80 }, Call { location: 105 }, BinaryIntOp { destination: Relative(2), op: Add, bit_size: U32, lhs: Relative(2), rhs: Direct(2) }, Store { destination_pointer: Relative(1), source: Relative(2) }, Mov { destination: Relative(4), source: Relative(1) }, Jump { location: 97 }, Not { destination: Relative(3), source: Relative(1), bit_size: U1 }, ConditionalMov { destination: Relative(6), source_a: Relative(2), source_b: Relative(5), condition: Relative(1) }, Load { destination: Relative(1), source_pointer: Relative(6) }, Load { destination: Relative(2), source_pointer: Relative(1) }, Const { destination: Relative(3), bit_size: Integer(U32), value: 0 }, BinaryIntOp { destination: Relative(5), op: Equals, bit_size: U32, lhs: Relative(3), rhs: Relative(2) }, Not { destination: Relative(5), source: Relative(5), bit_size: U1 }, JumpIf { condition: Relative(5), location: 93 }, Call { location: 105 }, BinaryIntOp { destination: Relative(2), op: Add, bit_size: U32, lhs: Relative(2), rhs: Direct(2) }, Store { destination_pointer: Relative(1), source: Relative(2) }, Mov { destination: Relative(4), source: Relative(1) }, Jump { location: 97 }, Mov { destination: Relative(1), source: Relative(4) }, Return, Const { destination: Direct(32772), bit_size: Integer(U32), value: 30720 }, BinaryIntOp { destination: Direct(32771), op: LessThan, bit_size: U32, lhs: Direct(0), rhs: Direct(32772) }, JumpIf { condition: Direct(32771), location: 104 }, IndirectConst { destination_pointer: Direct(1), bit_size: Integer(U64), value: 17843811134343075018 }, Trap { revert_data: HeapVector { pointer: Direct(1), size: Direct(2) } }, Return, IndirectConst { destination_pointer: Direct(1), bit_size: Integer(U64), value: 12049594436772143978 }, Trap { revert_data: HeapVector { pointer: Direct(1), size: Direct(2) } }, Return]"
+  ],
+  "debug_symbols": "pZLdioQwDIXfJde9aPzXVxGRqnUolCodXVjEd9/UKM5eDCw7N/2aJic9kGww6G59tMaN0xOqeoPOG2vNo7VTrxYzOXrdQIYjj6BCAXkMVUxIGCkjY+SMglEeKCQDGVSZEHJGwSgPlJKBjIgRM+i/ZN8FXMbaxWsdfL04Jf+z8totULnVWgFfyq5H0XNW7uCiPGWlAO0GIjUcjdXhtotbLd9LSzy1mNzq9M9yzKJTHyG+00cf6vE/+oYi1Rv/a/R76OSN6qw+w3F1/Ut2+Z6vzLU6s596Paxeh073/tAc61SKTDYCkF7qshQokxDRwGuUKYV5swcnPw==",
+  "file_map": {
+    "50": {
+      "source": "unconstrained fn main(a: bool, mut b: (str<3>, str<3>)) -> pub str<3> {\n    if a {\n        func_2((if a { (&mut b.1) } else { (&mut b.0) }))\n    } else {\n        func_2((if a { (&mut b.1) } else { (&mut b.0) }))\n    }\n}\nunconstrained fn func_2(a: &mut str<3>) -> str<3> {\n    *a\n}\n",
+      "path": ""
+    }
+  },
+  "names": [
+    "main"
+  ],
+  "brillig_names": [
+    "main"
+  ]
+}

--- a/tooling/nargo_cli/tests/snapshots/execution_success/regression_9538/execute__tests__force_brillig_true_inliner_9223372036854775807.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/regression_9538/execute__tests__force_brillig_true_inliner_9223372036854775807.snap
@@ -1,0 +1,76 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: artifact
+---
+{
+  "noir_version": "[noir_version]",
+  "hash": "[hash]",
+  "abi": {
+    "parameters": [
+      {
+        "name": "a",
+        "type": {
+          "kind": "boolean"
+        },
+        "visibility": "private"
+      },
+      {
+        "name": "b",
+        "type": {
+          "kind": "tuple",
+          "fields": [
+            {
+              "kind": "string",
+              "length": 3
+            },
+            {
+              "kind": "string",
+              "length": 3
+            }
+          ]
+        },
+        "visibility": "private"
+      }
+    ],
+    "return_type": {
+      "abi_type": {
+        "kind": "string",
+        "length": 3
+      },
+      "visibility": "public"
+    },
+    "error_types": {
+      "12049594436772143978": {
+        "error_kind": "string",
+        "string": "array ref-count underflow detected"
+      },
+      "17843811134343075018": {
+        "error_kind": "string",
+        "string": "Stack too deep"
+      }
+    }
+  },
+  "bytecode": [
+    "func 0",
+    "current witness index : _9",
+    "private parameters indices : [_0, _1, _2, _3, _4, _5, _6]",
+    "public parameters indices : []",
+    "return value indices : [_7, _8, _9]",
+    "BRILLIG CALL func 0: inputs: [EXPR [ (1, _0) 0 ], [EXPR [ (1, _1) 0 ], EXPR [ (1, _2) 0 ], EXPR [ (1, _3) 0 ]], [EXPR [ (1, _4) 0 ], EXPR [ (1, _5) 0 ], EXPR [ (1, _6) 0 ]]], outputs: [[_7, _8, _9]]",
+    "unconstrained func 0",
+    "[Const { destination: Direct(2), bit_size: Integer(U32), value: 1 }, Const { destination: Direct(1), bit_size: Integer(U32), value: 32846 }, Const { destination: Direct(0), bit_size: Integer(U32), value: 3 }, Const { destination: Relative(4), bit_size: Integer(U32), value: 7 }, Const { destination: Relative(5), bit_size: Integer(U32), value: 0 }, CalldataCopy { destination_address: Direct(32836), size_address: Relative(4), offset_address: Relative(5) }, Cast { destination: Direct(32836), source: Direct(32836), bit_size: Integer(U1) }, Cast { destination: Direct(32837), source: Direct(32837), bit_size: Integer(U8) }, Cast { destination: Direct(32838), source: Direct(32838), bit_size: Integer(U8) }, Cast { destination: Direct(32839), source: Direct(32839), bit_size: Integer(U8) }, Cast { destination: Direct(32840), source: Direct(32840), bit_size: Integer(U8) }, Cast { destination: Direct(32841), source: Direct(32841), bit_size: Integer(U8) }, Cast { destination: Direct(32842), source: Direct(32842), bit_size: Integer(U8) }, Mov { destination: Relative(1), source: Direct(32836) }, Const { destination: Relative(2), bit_size: Integer(U32), value: 32837 }, Const { destination: Relative(5), bit_size: Integer(U32), value: 3 }, Mov { destination: Relative(4), source: Direct(1) }, Const { destination: Relative(6), bit_size: Integer(U32), value: 4 }, BinaryIntOp { destination: Direct(1), op: Add, bit_size: U32, lhs: Direct(1), rhs: Relative(6) }, IndirectConst { destination_pointer: Relative(4), bit_size: Integer(U32), value: 1 }, BinaryIntOp { destination: Relative(6), op: Add, bit_size: U32, lhs: Relative(4), rhs: Direct(2) }, Mov { destination: Direct(32771), source: Relative(2) }, Mov { destination: Direct(32772), source: Relative(6) }, Mov { destination: Direct(32773), source: Relative(5) }, Call { location: 50 }, Mov { destination: Relative(2), source: Relative(4) }, Const { destination: Relative(3), bit_size: Integer(U32), value: 32840 }, Const { destination: Relative(5), bit_size: Integer(U32), value: 3 }, Mov { destination: Relative(4), source: Direct(1) }, Const { destination: Relative(6), bit_size: Integer(U32), value: 4 }, BinaryIntOp { destination: Direct(1), op: Add, bit_size: U32, lhs: Direct(1), rhs: Relative(6) }, IndirectConst { destination_pointer: Relative(4), bit_size: Integer(U32), value: 1 }, BinaryIntOp { destination: Relative(6), op: Add, bit_size: U32, lhs: Relative(4), rhs: Direct(2) }, Mov { destination: Direct(32771), source: Relative(3) }, Mov { destination: Direct(32772), source: Relative(6) }, Mov { destination: Direct(32773), source: Relative(5) }, Call { location: 50 }, Mov { destination: Relative(3), source: Relative(4) }, Call { location: 61 }, Call { location: 62 }, BinaryIntOp { destination: Relative(2), op: Add, bit_size: U32, lhs: Relative(1), rhs: Direct(2) }, Const { destination: Relative(3), bit_size: Integer(U32), value: 32843 }, Const { destination: Relative(4), bit_size: Integer(U32), value: 3 }, Mov { destination: Direct(32771), source: Relative(2) }, Mov { destination: Direct(32772), source: Relative(3) }, Mov { destination: Direct(32773), source: Relative(4) }, Call { location: 50 }, Const { destination: Relative(2), bit_size: Integer(U32), value: 32843 }, Const { destination: Relative(3), bit_size: Integer(U32), value: 3 }, Stop { return_data: HeapVector { pointer: Relative(2), size: Relative(3) } }, BinaryIntOp { destination: Direct(32775), op: Add, bit_size: U32, lhs: Direct(32771), rhs: Direct(32773) }, Mov { destination: Direct(32776), source: Direct(32771) }, Mov { destination: Direct(32777), source: Direct(32772) }, BinaryIntOp { destination: Direct(32778), op: Equals, bit_size: U32, lhs: Direct(32776), rhs: Direct(32775) }, JumpIf { condition: Direct(32778), location: 60 }, Load { destination: Direct(32774), source_pointer: Direct(32776) }, Store { destination_pointer: Direct(32777), source: Direct(32774) }, BinaryIntOp { destination: Direct(32776), op: Add, bit_size: U32, lhs: Direct(32776), rhs: Direct(2) }, BinaryIntOp { destination: Direct(32777), op: Add, bit_size: U32, lhs: Direct(32777), rhs: Direct(2) }, Jump { location: 53 }, Return, Return, Call { location: 99 }, Mov { destination: Relative(5), source: Direct(1) }, BinaryIntOp { destination: Direct(1), op: Add, bit_size: U32, lhs: Direct(1), rhs: Direct(2) }, Store { destination_pointer: Relative(5), source: Relative(2) }, Mov { destination: Relative(2), source: Direct(1) }, BinaryIntOp { destination: Direct(1), op: Add, bit_size: U32, lhs: Direct(1), rhs: Direct(2) }, Store { destination_pointer: Relative(2), source: Relative(3) }, Not { destination: Relative(3), source: Relative(1), bit_size: U1 }, JumpIf { condition: Relative(1), location: 84 }, Jump { location: 72 }, ConditionalMov { destination: Relative(6), source_a: Relative(2), source_b: Relative(5), condition: Relative(1) }, Load { destination: Relative(1), source_pointer: Relative(6) }, Load { destination: Relative(2), source_pointer: Relative(1) }, Const { destination: Relative(3), bit_size: Integer(U32), value: 0 }, BinaryIntOp { destination: Relative(5), op: Equals, bit_size: U32, lhs: Relative(3), rhs: Relative(2) }, Not { destination: Relative(5), source: Relative(5), bit_size: U1 }, JumpIf { condition: Relative(5), location: 80 }, Call { location: 105 }, BinaryIntOp { destination: Relative(2), op: Add, bit_size: U32, lhs: Relative(2), rhs: Direct(2) }, Store { destination_pointer: Relative(1), source: Relative(2) }, Mov { destination: Relative(4), source: Relative(1) }, Jump { location: 97 }, Not { destination: Relative(3), source: Relative(1), bit_size: U1 }, ConditionalMov { destination: Relative(6), source_a: Relative(2), source_b: Relative(5), condition: Relative(1) }, Load { destination: Relative(1), source_pointer: Relative(6) }, Load { destination: Relative(2), source_pointer: Relative(1) }, Const { destination: Relative(3), bit_size: Integer(U32), value: 0 }, BinaryIntOp { destination: Relative(5), op: Equals, bit_size: U32, lhs: Relative(3), rhs: Relative(2) }, Not { destination: Relative(5), source: Relative(5), bit_size: U1 }, JumpIf { condition: Relative(5), location: 93 }, Call { location: 105 }, BinaryIntOp { destination: Relative(2), op: Add, bit_size: U32, lhs: Relative(2), rhs: Direct(2) }, Store { destination_pointer: Relative(1), source: Relative(2) }, Mov { destination: Relative(4), source: Relative(1) }, Jump { location: 97 }, Mov { destination: Relative(1), source: Relative(4) }, Return, Const { destination: Direct(32772), bit_size: Integer(U32), value: 30720 }, BinaryIntOp { destination: Direct(32771), op: LessThan, bit_size: U32, lhs: Direct(0), rhs: Direct(32772) }, JumpIf { condition: Direct(32771), location: 104 }, IndirectConst { destination_pointer: Direct(1), bit_size: Integer(U64), value: 17843811134343075018 }, Trap { revert_data: HeapVector { pointer: Direct(1), size: Direct(2) } }, Return, IndirectConst { destination_pointer: Direct(1), bit_size: Integer(U64), value: 12049594436772143978 }, Trap { revert_data: HeapVector { pointer: Direct(1), size: Direct(2) } }, Return]"
+  ],
+  "debug_symbols": "pZLdioQwDIXfJde9aPzXVxGRqnUolCodXVjEd9/UKM5eDCw7N/2aJic9kGww6G59tMaN0xOqeoPOG2vNo7VTrxYzOXrdQIYjj6BCAXkMVUxIGCkjY+SMglEeKCQDGVSZEHJGwSgPlJKBjIgRM+i/ZN8FXMbaxWsdfL04Jf+z8totULnVWgFfyq5H0XNW7uCiPGWlAO0GIjUcjdXhtotbLd9LSzy1mNzq9M9yzKJTHyG+00cf6vE/+oYi1Rv/a/R76OSN6qw+w3F1/Ut2+Z6vzLU6s596Paxeh073/tAc61SKTDYCkF7qshQokxDRwGuUKYV5swcnPw==",
+  "file_map": {
+    "50": {
+      "source": "unconstrained fn main(a: bool, mut b: (str<3>, str<3>)) -> pub str<3> {\n    if a {\n        func_2((if a { (&mut b.1) } else { (&mut b.0) }))\n    } else {\n        func_2((if a { (&mut b.1) } else { (&mut b.0) }))\n    }\n}\nunconstrained fn func_2(a: &mut str<3>) -> str<3> {\n    *a\n}\n",
+      "path": ""
+    }
+  },
+  "names": [
+    "main"
+  ],
+  "brillig_names": [
+    "main"
+  ]
+}

--- a/tooling/nargo_cli/tests/snapshots/execution_success/regression_9538/execute__tests__stdout.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/regression_9538/execute__tests__stdout.snap
@@ -1,0 +1,5 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: stdout
+---
+[regression_9538] Circuit output: "two"


### PR DESCRIPTION
# Description

## Problem\*

Resolves #9538 

## Summary\*

Fixes `mem2reg` to add the aliases of the `address` in a `Load` instruction to the `last_loads` of the `PerFunctionContext`. 

## Additional Context

In https://github.com/noir-lang/noir/pull/9305 I added handling of `IfElse` instructions to `mem2reg` where if the result of the `IfElse` was a reference, then the `then_value` and the `else_value` were considered to be aliases of that result address. For example consider this SSA in the new integration test:

```rust
After Simplifying (4) (step 31):
brillig(inline) predicate_pure fn main f0 {
  b0(v0: u1, v1: [u8; 3], v2: [u8; 3]):
    v4 = allocate -> &mut [u8; 3]
    store v1 at v4
    v5 = allocate -> &mut [u8; 3]
    store v2 at v5
    v6 = not v0
    jmpif v0 then: b1, else: b2
  b1():
    v9 = not v0
    v10 = if v0 then v5 else (if v9) v4
    v11 = load v10 -> [u8; 3]                     	// src/main.nr:5:9
    inc_rc v11                                    	// src/main.nr:5:9
    jmp b3(v11)
  b2():
    v7 = if v0 then v5 else (if v6) v4            	// src/main.nr:3:9
    v8 = load v7 -> [u8; 3]                       	// src/main.nr:5:9
    inc_rc v8                                     	// src/main.nr:5:9
    jmp b3(v8)
  b3(v3: [u8; 3]):
    return v3
}
```

In `v10 = if v0 then v5 else (if v9) v4`, `v5` and `v4` are registered as aliases of `v10`. 

In #9305 this had the effect in the handling of `Call`: for example if `v10` was passed to a call, then all of its aliases would be added to `instruction_references`. In this bug, however, that was not enough. 

The problem was we removed the stores to `v5` and `v4`. The final decision whether to keep them looks like this:
```rust
                if !self.last_loads.contains_key(store_address)
                    && !store_alias_used
                    && !is_dereference
                {
                    self.instructions_to_remove.insert(*store_instruction);
                }
```
I focused a lot on `store_alias_used`, but that doesn't apply here: when we consider whether to remove the store to `v4`, it doesn't have an alias that is used, instead, `v4` is an alias of `v10`. I'm not sure why this relationship isn't bidirectional, but it looked to me like `last_loads` is the key here: normally we would be loading `v4` or `v5`, but instead we are loading them indirectly due to the `IfElse`. I thought it makes sense that if what we load has aliases, we might consider them being loaded as well, which directly prevents stores to them from being removed.

Conveniently `last_loads` acts across blocks, while `Block::last_store` does not, so even though `Load` marks the address as used, which marks all of its aliases as used, which removes the `last_store` from being considered for removal, it doesn't affect the previous `Block`, where it will remain a candidate and be removed anyway.

## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
