### PR TITLE
chore(ssa): Simplify shl/shr identity operations

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/ir/dfg/simplify/binary.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/dfg/simplify/binary.rs
@@ -293,8 +293,92 @@ pub(super) fn simplify_binary(binary: &Binary, dfg: &mut DataFlowGraph) -> Simpl
             }
         }
         BinaryOp::Shl | BinaryOp::Shr => {
+            if lhs_is_zero {
+                let zero = dfg.make_constant(FieldElement::zero(), lhs_type);
+                return SimplifyResult::SimplifiedTo(zero);
+            }
+            if rhs_is_zero {
+                return SimplifyResult::SimplifiedTo(lhs);
+            }
             return SimplifyResult::SimplifiedToInstruction(simplified);
         }
     };
     SimplifyResult::SimplifiedToInstruction(simplified)
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{assert_ssa_snapshot, ssa::ssa_gen::Ssa};
+
+    #[test]
+    fn replaces_shl_identity_with_lhs() {
+        let src = "
+        acir(inline) predicate_pure fn main f0 {
+          b0(v0: u8):
+            v1 = shl v0, u8 0
+            return v1
+        }
+        ";
+        let ssa = Ssa::from_str_simplifying(src).unwrap();
+        assert_ssa_snapshot!(ssa, @r"
+        acir(inline) predicate_pure fn main f0 {
+          b0(v0: u8):
+            return v0
+        }
+        ");
+    }
+
+    #[test]
+    fn replaces_shr_identity_with_lhs() {
+        let src = "
+        acir(inline) predicate_pure fn main f0 {
+          b0(v0: u8):
+            v1 = shr v0, u8 0
+            return v1
+        }
+        ";
+        let ssa = Ssa::from_str_simplifying(src).unwrap();
+        assert_ssa_snapshot!(ssa, @r"
+        acir(inline) predicate_pure fn main f0 {
+          b0(v0: u8):
+            return v0
+        }
+        ");
+    }
+
+    #[test]
+    fn replaces_shl_on_zero_lhs_with_zero() {
+        let src = "
+        acir(inline) predicate_pure fn main f0 {
+          b0(v0: u8):
+            v1 = shl u8 0, v0
+            return v1
+        }
+        ";
+        let ssa = Ssa::from_str_simplifying(src).unwrap();
+        assert_ssa_snapshot!(ssa, @r"
+        acir(inline) predicate_pure fn main f0 {
+          b0(v0: u8):
+            return u8 0
+        }
+        ");
+    }
+
+    #[test]
+    fn replaces_shr_on_zero_lhs_with_zero() {
+        let src = "
+        acir(inline) predicate_pure fn main f0 {
+          b0(v0: u8):
+            v1 = shr u8 0, v0
+            return v1
+        }
+        ";
+        let ssa = Ssa::from_str_simplifying(src).unwrap();
+        assert_ssa_snapshot!(ssa, @r"
+        acir(inline) predicate_pure fn main f0 {
+          b0(v0: u8):
+            return u8 0
+        }
+        ");
+    }
 }


### PR DESCRIPTION
# Description

## Problem\*

Resolves something I noticed while reviewing https://github.com/noir-lang/noir/pull/9585

## Summary\*

Shifting by an lhs by zero will always result in the provided lhs.
The same is true for when the lhs is zero. Shifting zeroes will simply produce another number of zeroes. 

## Additional Context



## Documentation\*

Check one:
- [X] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
