### PR TITLE
fix(ssa): Validate Brillig array accesses have OOB checks 

### DIFF
--- a/test_programs/execution_failure/unused_array_get_unknown_index_out_of_bounds/src/main.nr
+++ b/test_programs/execution_failure/unused_array_get_unknown_index_out_of_bounds/src/main.nr
@@ -1,4 +1,4 @@
-fn main(x: Field) {
+fn main(x: u32) {
     let array = [1, 2, 3];
     let _ = array[x]; // Index out of bounds
 }

--- a/test_programs/execution_failure/unused_array_set_unknown_index_out_of_bounds/src/main.nr
+++ b/test_programs/execution_failure/unused_array_set_unknown_index_out_of_bounds/src/main.nr
@@ -1,4 +1,4 @@
-fn main(x: Field) {
+fn main(x: u32) {
     let mut array = [1, 2, 3];
     array[x] = 1; // Index out of bounds
 }

--- a/test_programs/execution_failure/unused_slice_get_unknown_index_out_of_bounds/src/main.nr
+++ b/test_programs/execution_failure/unused_slice_get_unknown_index_out_of_bounds/src/main.nr
@@ -1,4 +1,4 @@
-fn main(x: Field) {
+fn main(x: u32) {
     let slice = &[1, 2, 3];
     let _ = slice[x]; // Index out of bounds
 }


### PR DESCRIPTION
# Description

## Problem\*

Resolves #9159
Resolves #9437

Both SSAs in the issues above will fail during validation as they are not well formed SSA. 

## Summary\*

I added a new validation check into SSA that:
1. Tracks the state of constrains where we have a possible array OOB check. We differentiate between an always failing constrain (e.g., `constrain u1 0 == u1 1`) from an OOB constant index and a constrain from a dynamic index.
2. In the case of a dynamic index we look into the instruction of the LHS of the constrain. If it is a LT instruction we store that lhs and rhs of that LT operation. We are essentially collecting a set of all possible array accesses. 
4. Once we reach an array get/set we check whether the index from that operations exists in a our potential array OOB check candidates. If the index exists and the array lengths match, we have a safe array access.
5. I cleared the possible array OOB checks per block as I did not want to deal with dominance checks and that would be a larger refactor of the validator. 

## Additional Context



## Documentation\*

Check one:
- [X] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
