### PR TITLE
fix(fuzz): Consider `PoppedFromEmptySlice` and `ConstrainEqFailed` as comparable

### DIFF
--- a/tooling/ast_fuzzer/src/compare/interpreted.rs
+++ b/tooling/ast_fuzzer/src/compare/interpreted.rs
@@ -223,6 +223,10 @@ impl Comparable for ssa::interpreter::errors::InterpreterError {
             (DivisionByZero { .. }, ConstrainEqFailed { msg, .. }) => {
                 msg.as_ref().is_some_and(|msg| msg == "attempt to divide by zero")
             }
+            (PoppedFromEmptySlice { .. }, ConstrainEqFailed { msg, .. }) => {
+                // The removal of unreachable instructions can replace popping from an empty slice with an always-fail constraint.
+                msg.as_ref().is_some_and(|msg| msg == "Index out of bounds")
+            }
             (e1, e2) => {
                 // The format strings contain SSA instructions,
                 // where the only difference might be the value ID.


### PR DESCRIPTION
# Description

## Problem\*

Resolves a nightly issue in https://github.com/noir-lang/noir/actions/runs/17116141854/job/48547513915

## Summary\*

Consider `PoppedFromEmptySlice` equivalent to `ConstrainEqFailed` with "Index out of bounds" in the fuzzer, as it is replaced by `remove_unreachalbe_instructions`. 

## Additional Context

To replicate before this change:
```shell
RUST_LOG=debug NOIR_AST_FUZZER_SEED=0x2ab41c7300100000 cargo test -p noir_ast_fuzzer_fuzz pass_vs_prev
```

## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
