### PR TITLE
chore: enforce pre/post-conditions on `flatten_cfg`

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/opt/flatten_cfg.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/flatten_cfg.rs
@@ -172,13 +172,11 @@ impl Ssa {
         }
 
         for function in self.functions.values_mut() {
-            // Disabled due to failures
             #[cfg(debug_assertions)]
             flatten_cfg_pre_check(function);
 
             flatten_function_cfg(function, &no_predicates);
 
-            // Disabled as we're getting failures, I would expect this to pass however.
             #[cfg(debug_assertions)]
             flatten_cfg_post_check(function);
         }

--- a/compiler/noirc_evaluator/src/ssa/opt/flatten_cfg.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/flatten_cfg.rs
@@ -173,14 +173,14 @@ impl Ssa {
 
         for function in self.functions.values_mut() {
             // Disabled due to failures
-            // #[cfg(debug_assertions)]
-            // flatten_cfg_pre_check(function);
+            #[cfg(debug_assertions)]
+            flatten_cfg_pre_check(function);
 
             flatten_function_cfg(function, &no_predicates);
 
             // Disabled as we're getting failures, I would expect this to pass however.
-            // #[cfg(debug_assertions)]
-            // flatten_cfg_post_check(function);
+            #[cfg(debug_assertions)]
+            flatten_cfg_post_check(function);
         }
         self
     }


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This PR enforces some expected conditions which were disabled.

## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
