### PR TITLE
fix(ssa): Pass to expand array accesses in Brillig with explicit OOB checks 

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/mod.rs
@@ -107,6 +107,7 @@ pub struct ArtifactsAndWarnings(pub Artifacts, pub Vec<SsaReport>);
 /// something we take can advantage of in the [secondary_passes].
 pub fn primary_passes(options: &SsaEvaluatorOptions) -> Vec<SsaPass> {
     vec![
+        SsaPass::new(Ssa::expand_array_oob_checks, "expand array OOB checks"),
         SsaPass::new(Ssa::expand_signed_checks, "expand signed checks"),
         SsaPass::new(Ssa::remove_unreachable_functions, "Removing Unreachable Functions"),
         SsaPass::new(Ssa::defunctionalize, "Defunctionalization"),
@@ -228,6 +229,8 @@ pub fn secondary_passes(brillig: &Brillig) -> Vec<SsaPass> {
 /// In the future, we can potentially execute the actual initial version using the SSA interpreter.
 pub fn minimal_passes() -> Vec<SsaPass<'static>> {
     vec![
+        // Array access operations need to be expanded to account for explicit out of bounds checks.
+        SsaPass::new(Ssa::expand_array_oob_checks, "expand array OOB checks"),
         // Signed integer operations need to be expanded in order to have the appropriate overflow checks applied.
         SsaPass::new(Ssa::expand_signed_checks, "expand signed checks"),
         // We need to get rid of function pointer parameters, otherwise they cause panic in Brillig generation.

--- a/compiler/noirc_evaluator/src/ssa/opt/expand_array_oob_checks.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/expand_array_oob_checks.rs
@@ -1,0 +1,226 @@
+/// Expands array accesses in Brillig to include explicit out of bounds (OOB) checks.
+///
+/// In the Brillig runtime, array accesses are treated as pointer accesses and thus are unprotected
+/// in isolation. For example, if we have an array access that is out of bounds, but there is memory
+/// declared for other purposes after the array pointer, the bytecode will look in that unrelated memory.
+/// Thus, in order to keep array accesses safe we have separate OOB checks.
+///
+/// In order to maintain a simple initial SSA generation, we simply inject these checks
+/// as part of our SSA compilation flow.
+use crate::ssa::{
+    ir::{
+        function::Function,
+        instruction::{Binary, BinaryOp, ConstrainError, Instruction},
+        types::NumericType,
+    },
+    ssa_gen::Ssa,
+};
+
+impl Ssa {
+    pub(crate) fn expand_array_oob_checks(mut self) -> Ssa {
+        for function in self.functions.values_mut() {
+            function.expand_array_oob_checks();
+        }
+        self
+    }
+}
+
+impl Function {
+    pub(crate) fn expand_array_oob_checks(&mut self) {
+        // This check should only be run over Brillig runtimes
+        if self.runtime().is_acir() {
+            return;
+        }
+
+        self.simple_optimization(|context| {
+            let instruction = context.instruction();
+            let block_id = context.block_id;
+
+            let (Instruction::ArrayGet { array, index, .. }
+            | Instruction::ArraySet { array, index, .. }) = instruction
+            else {
+                return;
+            };
+
+            let Some(length) = context.dfg.try_get_array_length(*array) else {
+                // If we do not have an array length it means we have a slice, for which we should
+                // always have separate access checks against the dynamic length in the initial SSA
+                return;
+            };
+
+            let index = *index;
+            let length = context.dfg.make_constant(length.into(), NumericType::length_type());
+
+            let is_offset_out_of_bounds =
+                Instruction::Binary(Binary { lhs: index, operator: BinaryOp::Lt, rhs: length });
+            let is_offset_out_of_bounds = context
+                .dfg
+                .insert_instruction_and_results(
+                    is_offset_out_of_bounds,
+                    block_id,
+                    None,
+                    context.call_stack_id,
+                )
+                .first();
+
+            let true_const = context.dfg.make_constant(true.into(), NumericType::bool());
+
+            let assert_message = Some(ConstrainError::from("Index out of bounds".to_owned()));
+            let constrain =
+                Instruction::Constrain(is_offset_out_of_bounds, true_const, assert_message);
+            context.dfg.insert_instruction_and_results(
+                constrain,
+                block_id,
+                None,
+                context.call_stack_id,
+            );
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        assert_ssa_snapshot,
+        ssa::{opt::assert_normalized_ssa_equals, ssa_gen::Ssa},
+    };
+
+    fn check_acir_unchanged(src: &str) {
+        let acir_src = &src.replace("brillig", "acir");
+        let acir_ssa = Ssa::from_str(acir_src).unwrap();
+        let ssa = acir_ssa.expand_array_oob_checks();
+        assert_normalized_ssa_equals(ssa, acir_src);
+    }
+
+    #[test]
+    fn array_get_oob_constant_index_brillig() {
+        let src = r"
+        brillig(inline) fn main f0 {
+          b0():
+            v3 = make_array [Field 1, Field 2, Field 3] : [Field; 3]
+            v5 = array_get v3, index u32 10 -> Field
+            return
+        }
+        ";
+        check_acir_unchanged(src);
+
+        let ssa = Ssa::from_str(src).unwrap();
+        let ssa = ssa.expand_array_oob_checks();
+
+        assert_ssa_snapshot!(ssa, @r#"
+        brillig(inline) fn main f0 {
+          b0():
+            v3 = make_array [Field 1, Field 2, Field 3] : [Field; 3]
+            constrain u1 0 == u1 1, "Index out of bounds"
+            v7 = array_get v3, index u32 10 -> Field
+            return
+        }
+        "#);
+    }
+
+    #[test]
+    fn array_get_in_bounds_constant_index_brillig() {
+        let src = r"
+        brillig(inline) fn main f0 {
+          b0():
+            v3 = make_array [Field 1, Field 2, Field 3] : [Field; 3]
+            v5 = array_get v3, index u32 2 -> Field
+            return
+        }
+        ";
+        check_acir_unchanged(src);
+
+        let ssa = Ssa::from_str(src).unwrap();
+        let ssa = ssa.expand_array_oob_checks();
+
+        // The always true constrain is expected to be simplified out
+        assert_ssa_snapshot!(ssa, @r#"
+        brillig(inline) fn main f0 {
+          b0():
+            v3 = make_array [Field 1, Field 2, Field 3] : [Field; 3]
+            v5 = array_get v3, index u32 2 -> Field
+            return
+        }
+        "#);
+    }
+
+    #[test]
+    fn array_set_oob_constant_index_brillig() {
+        let src = r"
+        brillig(inline) fn main f0 {
+          b0():
+            v3 = make_array [Field 1, Field 2, Field 3] : [Field; 3]
+            v6 = array_set v3, index u32 10, value Field 5
+            return
+        }
+        ";
+        check_acir_unchanged(src);
+
+        let ssa = Ssa::from_str(src).unwrap();
+        let ssa = ssa.expand_array_oob_checks();
+
+        assert_ssa_snapshot!(ssa, @r#"
+        brillig(inline) fn main f0 {
+          b0():
+            v3 = make_array [Field 1, Field 2, Field 3] : [Field; 3]
+            constrain u1 0 == u1 1, "Index out of bounds"
+            v8 = array_set v3, index u32 10, value Field 5
+            return
+        }
+        "#);
+    }
+
+    #[test]
+    fn array_get_oob_dynamic_index_brillig() {
+        let src = "
+        brillig(inline) fn main f0 {
+          b0(v0: u32):
+            v4 = make_array [Field 1, Field 2, Field 3] : [Field; 3]
+            v5 = array_get v4, index v0 -> Field
+            return
+        }
+        ";
+        check_acir_unchanged(src);
+
+        let ssa = Ssa::from_str(src).unwrap();
+        let ssa = ssa.expand_array_oob_checks();
+
+        assert_ssa_snapshot!(ssa, @r#"
+        brillig(inline) fn main f0 {
+          b0(v0: u32):
+            v4 = make_array [Field 1, Field 2, Field 3] : [Field; 3]
+            v6 = lt v0, u32 3
+            constrain v6 == u1 1, "Index out of bounds"
+            v8 = array_get v4, index v0 -> Field
+            return
+        }
+        "#);
+    }
+
+    #[test]
+    fn array_set_oob_dynamic_index_brillig() {
+        let src = "
+        brillig(inline) fn main f0 {
+          b0(v0: u32):
+            v4 = make_array [Field 1, Field 2, Field 3] : [Field; 3]
+            v6 = array_set v4, index v0, value Field 5
+            return
+        }
+        ";
+        check_acir_unchanged(src);
+
+        let ssa = Ssa::from_str(src).unwrap();
+        let ssa = ssa.expand_array_oob_checks();
+
+        assert_ssa_snapshot!(ssa, @r#"
+        brillig(inline) fn main f0 {
+          b0(v0: u32):
+            v4 = make_array [Field 1, Field 2, Field 3] : [Field; 3]
+            v6 = lt v0, u32 3
+            constrain v6 == u1 1, "Index out of bounds"
+            v9 = array_set v4, index v0, value Field 5
+            return
+        }
+        "#);
+    }
+}

--- a/compiler/noirc_evaluator/src/ssa/opt/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/mod.rs
@@ -15,6 +15,7 @@ mod constant_folding;
 mod defunctionalize;
 mod die;
 mod evaluate_static_assert_and_assert_constant;
+mod expand_array_oob_checks;
 mod expand_signed_checks;
 pub(crate) mod flatten_cfg;
 mod hint;


### PR DESCRIPTION
# Description

## Problem\*

Resolves #9159
Resolves #9437 

## Summary\*

We now insert array OOB checks in a separate `expand_array_oob_checks` pass (similar to `expand_signed_checks`). This simplifies the validation required for a well-formed SSA and both ACIR/Brillig can generate initial "unsafe" array accesses.

The new pass goes over all array accesses in Brillig and inserts OOB checks. If we have a safe array access we expect the inserted instructions to be immediately simplified out.  

## Additional Context

## Documentation\*

Check one:
- [ ] No documentation needed.
- [X] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
