### PR TITLE
chore: some mem2reg refactors regarding expressions and aliases

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/opt/mem2reg.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/mem2reg.rs
@@ -192,10 +192,8 @@ impl<'f> PerFunctionContext<'f> {
                 // then that reference gets to keep its last store.
                 let typ = self.inserter.function.dfg.type_of_value(value);
                 if Self::contains_references(&typ) {
-                    if let Some(expression) = references.expressions.get(&value) {
-                        if let Some(aliases) = references.aliases.get(expression) {
-                            all_terminator_values.extend(aliases.iter());
-                        }
+                    if let Some(aliases) = references.aliases_of(value) {
+                        all_terminator_values.extend(aliases.iter());
                     }
                 }
             });
@@ -240,47 +238,45 @@ impl<'f> PerFunctionContext<'f> {
         let reference_parameters = self.reference_parameters();
 
         // Check whether the store address has an alias that crosses an entry point boundary (e.g. a Call or Return)
-        if let Some(expression) = block.expressions.get(store_address) {
-            if let Some(aliases) = block.aliases.get(expression) {
-                let allocation_aliases_parameter =
-                    aliases.any(|alias| reference_parameters.contains(&alias));
-                if allocation_aliases_parameter == Some(true) {
-                    return true;
-                }
+        if let Some(aliases) = block.aliases_of(*store_address) {
+            let allocation_aliases_parameter =
+                aliases.any(|alias| reference_parameters.contains(&alias));
+            if allocation_aliases_parameter == Some(true) {
+                return true;
+            }
 
-                let allocation_aliases_parameter =
-                    aliases.any(|alias| per_func_block_params.contains(&alias));
-                if allocation_aliases_parameter == Some(true) {
-                    return true;
-                }
+            let allocation_aliases_parameter =
+                aliases.any(|alias| per_func_block_params.contains(&alias));
+            if allocation_aliases_parameter == Some(true) {
+                return true;
+            }
 
-                // Is any alias of this address an input to some function call, or a return value?
-                let allocation_aliases_instr_input =
-                    aliases.any(|alias| self.instruction_input_references.contains(&alias));
-                if allocation_aliases_instr_input == Some(true) {
-                    return true;
-                }
+            // Is any alias of this address an input to some function call, or a return value?
+            let allocation_aliases_instr_input =
+                aliases.any(|alias| self.instruction_input_references.contains(&alias));
+            if allocation_aliases_instr_input == Some(true) {
+                return true;
+            }
 
-                // Is any alias of this address used in a block terminator?
-                let allocation_aliases_terminator_args =
-                    aliases.any(|alias| all_terminator_values.contains(&alias));
-                if allocation_aliases_terminator_args == Some(true) {
-                    return true;
-                }
+            // Is any alias of this address used in a block terminator?
+            let allocation_aliases_terminator_args =
+                aliases.any(|alias| all_terminator_values.contains(&alias));
+            if allocation_aliases_terminator_args == Some(true) {
+                return true;
+            }
 
-                // Check whether there are any aliases whose instructions are not all marked for removal.
-                // If there is any alias marked to survive, we should not remove its last store.
-                let has_alias_not_marked_for_removal = aliases.any(|alias| {
-                    if let Some(alias_instructions) = self.aliased_references.get(&alias) {
-                        !alias_instructions.is_subset(&self.instructions_to_remove)
-                    } else {
-                        false
-                    }
-                });
-
-                if has_alias_not_marked_for_removal == Some(true) {
-                    return true;
+            // Check whether there are any aliases whose instructions are not all marked for removal.
+            // If there is any alias marked to survive, we should not remove its last store.
+            let has_alias_not_marked_for_removal = aliases.any(|alias| {
+                if let Some(alias_instructions) = self.aliased_references.get(&alias) {
+                    !alias_instructions.is_subset(&self.instructions_to_remove)
+                } else {
+                    false
                 }
+            });
+
+            if has_alias_not_marked_for_removal == Some(true) {
+                return true;
             }
         }
 
@@ -400,14 +396,12 @@ impl<'f> PerFunctionContext<'f> {
         let reference_parameters = self.reference_parameters();
 
         for (allocation, instruction) in &references.last_stores {
-            if let Some(expression) = references.expressions.get(allocation) {
-                if let Some(aliases) = references.aliases.get(expression) {
-                    let allocation_aliases_parameter =
-                        aliases.any(|alias| reference_parameters.contains(&alias));
-                    // If `allocation_aliases_parameter` is known to be false
-                    if allocation_aliases_parameter == Some(false) {
-                        self.instructions_to_remove.insert(*instruction);
-                    }
+            if let Some(aliases) = references.aliases_of(*allocation) {
+                let allocation_aliases_parameter =
+                    aliases.any(|alias| reference_parameters.contains(&alias));
+                // If `allocation_aliases_parameter` is known to be false
+                if allocation_aliases_parameter == Some(false) {
+                    self.instructions_to_remove.insert(*instruction);
                 }
             }
         }

--- a/compiler/noirc_evaluator/src/ssa/opt/mem2reg.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/mem2reg.rs
@@ -467,7 +467,7 @@ impl<'f> PerFunctionContext<'f> {
                     // Remember that this address has been loaded, so stores to it should not be removed.
                     self.last_loads.insert(address);
                     // Stores to any of its aliases should also be considered loaded.
-                    references.for_each_alias_of(address, |_, alias| {
+                    references.for_each_alias_of(address, |alias| {
                         self.last_loads.insert(alias);
                     });
                 }
@@ -508,7 +508,7 @@ impl<'f> PerFunctionContext<'f> {
 
                 // Remember that we used the value in this instruction. If this instruction
                 // isn't removed at the end, we need to keep the stores to the value as well.
-                references.for_each_alias_of(value, |_, alias| {
+                references.for_each_alias_of(value, |alias| {
                     self.aliased_references.entry(alias).or_default().insert(instruction);
                 });
 
@@ -529,7 +529,7 @@ impl<'f> PerFunctionContext<'f> {
                 let array = *array;
                 let array_typ = self.inserter.function.dfg.type_of_value(array);
                 if Self::contains_references(&array_typ) {
-                    references.for_each_alias_of(array, |_, alias| {
+                    references.for_each_alias_of(array, |alias| {
                         self.instruction_input_references.insert(alias);
                     });
                     references.mark_value_used(array, self.inserter.function);
@@ -572,7 +572,7 @@ impl<'f> PerFunctionContext<'f> {
                     // Similar to how we remember that we used a value in a `Store` instruction,
                     // take note that it was used in the `ArraySet`. If this instruction is not
                     // going to be removed at the end, we shall keep the stores to this value as well.
-                    references.for_each_alias_of(*value, |_, alias| {
+                    references.for_each_alias_of(*value, |alias| {
                         self.aliased_references.entry(alias).or_default().insert(instruction);
                     });
                 }
@@ -581,7 +581,7 @@ impl<'f> PerFunctionContext<'f> {
                 // We need to appropriately mark each alias of a reference as being used as a call argument.
                 // This prevents us potentially removing a last store from a preceding block or is altered within another function.
                 for arg in arguments {
-                    references.for_each_alias_of(*arg, |_, alias| {
+                    references.for_each_alias_of(*arg, |alias| {
                         self.instruction_input_references.insert(alias);
                     });
                 }
@@ -730,7 +730,7 @@ impl<'f> PerFunctionContext<'f> {
                 // We need to appropriately mark each alias of a reference as being used as a return terminator argument.
                 // This prevents us potentially removing a last store from a preceding block or is altered within another function.
                 for return_value in return_values {
-                    references.for_each_alias_of(*return_value, |_, alias| {
+                    references.for_each_alias_of(*return_value, |alias| {
                         self.instruction_input_references.insert(alias);
                     });
                 }

--- a/compiler/noirc_evaluator/src/ssa/opt/mem2reg.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/mem2reg.rs
@@ -236,45 +236,32 @@ impl<'f> PerFunctionContext<'f> {
         let reference_parameters = self.reference_parameters();
 
         // Check whether the store address has an alias that crosses an entry point boundary (e.g. a Call or Return)
-        let aliases = block.get_aliases_for_value(*store_address);
-        let allocation_aliases_parameter =
-            aliases.any(|alias| reference_parameters.contains(&alias));
-        if allocation_aliases_parameter == Some(true) {
-            return true;
-        }
-
-        let allocation_aliases_parameter =
-            aliases.any(|alias| per_func_block_params.contains(&alias));
-        if allocation_aliases_parameter == Some(true) {
-            return true;
-        }
-
-        // Is any alias of this address an input to some function call, or a return value?
-        let allocation_aliases_instr_input =
-            aliases.any(|alias| self.instruction_input_references.contains(&alias));
-        if allocation_aliases_instr_input == Some(true) {
-            return true;
-        }
-
-        // Is any alias of this address used in a block terminator?
-        let allocation_aliases_terminator_args =
-            aliases.any(|alias| all_terminator_values.contains(&alias));
-        if allocation_aliases_terminator_args == Some(true) {
-            return true;
-        }
-
-        // Check whether there are any aliases whose instructions are not all marked for removal.
-        // If there is any alias marked to survive, we should not remove its last store.
-        let has_alias_not_marked_for_removal = aliases.any(|alias| {
-            if let Some(alias_instructions) = self.aliased_references.get(&alias) {
-                !alias_instructions.is_subset(&self.instructions_to_remove)
-            } else {
-                false
+        for alias in block.get_aliases_for_value(*store_address).iter() {
+            if reference_parameters.contains(&alias) {
+                return true;
             }
-        });
 
-        if has_alias_not_marked_for_removal == Some(true) {
-            return true;
+            if per_func_block_params.contains(&alias) {
+                return true;
+            }
+
+            // Is any alias of this address an input to some function call, or a return value?
+            if self.instruction_input_references.contains(&alias) {
+                return true;
+            }
+
+            // Is any alias of this address used in a block terminator?
+            if all_terminator_values.contains(&alias) {
+                return true;
+            }
+
+            // Check whether there are any aliases whose instructions are not all marked for removal.
+            // If there is any alias marked to survive, we should not remove its last store.
+            if let Some(alias_instructions) = self.aliased_references.get(&alias) {
+                if !alias_instructions.is_subset(&self.instructions_to_remove) {
+                    return true;
+                }
+            }
         }
 
         false

--- a/compiler/noirc_evaluator/src/ssa/opt/mem2reg.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/mem2reg.rs
@@ -194,9 +194,7 @@ impl<'f> PerFunctionContext<'f> {
                 if Self::contains_references(&typ) {
                     if let Some(expression) = references.expressions.get(&value) {
                         if let Some(aliases) = references.aliases.get(expression) {
-                            aliases.for_each(|alias| {
-                                all_terminator_values.insert(alias);
-                            });
+                            all_terminator_values.extend(aliases.iter());
                         }
                     }
                 }
@@ -389,10 +387,10 @@ impl<'f> PerFunctionContext<'f> {
             let previous = references.aliases.insert(expression, aliases.clone());
             assert!(previous.is_none());
 
-            aliases.for_each(|alias| {
+            for alias in aliases.iter() {
                 let previous = references.expressions.insert(alias, expression);
                 assert!(previous.is_none());
-            });
+            }
         }
     }
 

--- a/compiler/noirc_evaluator/src/ssa/opt/mem2reg/alias_set.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/mem2reg/alias_set.rs
@@ -82,18 +82,15 @@ impl AliasSet {
         self.aliases.as_ref().map(|aliases| aliases.iter().copied().any(f))
     }
 
-    pub(super) fn for_each(&self, mut f: impl FnMut(ValueId)) {
-        if let Some(aliases) = &self.aliases {
-            for alias in aliases {
-                f(*alias);
-            }
-        }
+    /// Returns an iterator over the values in this alias set.
+    pub(super) fn iter(&self) -> impl Iterator<Item = ValueId> {
+        self.aliases.iter().flat_map(|aliases| aliases.iter().copied())
     }
 
     /// Return the first ValueId in the alias set as long as there is at least one.
     /// The ordering is arbitrary (by lowest ValueId) so this method should only be
     /// used when you need an arbitrary ValueId from the alias set.
     pub(super) fn first(&self) -> Option<ValueId> {
-        self.aliases.as_ref().and_then(|aliases| aliases.iter().next().copied())
+        self.iter().next()
     }
 }

--- a/compiler/noirc_evaluator/src/ssa/opt/mem2reg/block.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/mem2reg/block.rs
@@ -175,12 +175,9 @@ impl Block {
     fn keep_last_stores_for(&mut self, address: ValueId, function: &Function) {
         self.keep_last_store(address, function);
 
-        if let Some(expr) = self.expressions.get(&address) {
-            if let Some(aliases) = self.aliases.get(expr).cloned() {
-                for alias in aliases.iter() {
-                    self.keep_last_store(alias, function);
-                }
-            }
+        let aliases = (*self.get_aliases_for_value(address)).clone();
+        for alias in aliases.iter() {
+            self.keep_last_store(alias, function);
         }
     }
 

--- a/compiler/noirc_evaluator/src/ssa/opt/mem2reg/block.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/mem2reg/block.rs
@@ -101,11 +101,11 @@ impl Block {
         } else {
             // More than one alias. We're not sure which it refers to so we have to
             // conservatively invalidate all references it may refer to.
-            aliases.for_each(|alias| {
+            for alias in aliases.iter() {
                 if let Some(reference_value) = self.references.get_mut(&alias) {
                     *reference_value = ReferenceValue::Unknown;
                 }
-            });
+            }
         }
     }
 
@@ -173,9 +173,9 @@ impl Block {
     pub(super) fn for_each_alias_of<T>(&self, address: ValueId, mut f: impl FnMut(ValueId) -> T) {
         if let Some(expr) = self.expressions.get(&address) {
             if let Some(aliases) = self.aliases.get(expr) {
-                aliases.for_each(|alias| {
+                for alias in aliases.iter() {
                     f(alias);
-                });
+                }
             }
         }
     }
@@ -192,9 +192,9 @@ impl Block {
 
         if let Some(expr) = self.expressions.get(&address) {
             if let Some(aliases) = self.aliases.get(expr).cloned() {
-                aliases.for_each(|alias| {
+                for alias in aliases.iter() {
                     self.keep_last_store(alias, function);
-                });
+                }
             }
         }
     }
@@ -262,9 +262,9 @@ impl Block {
 
         if let Some(expr) = self.expressions.get(&address) {
             if let Some(aliases) = self.aliases.get(expr).cloned() {
-                aliases.for_each(|alias| {
+                for alias in aliases.iter() {
                     self.last_loads.remove(&alias);
-                });
+                }
             }
         }
     }

--- a/compiler/noirc_evaluator/src/ssa/opt/mem2reg/block.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/mem2reg/block.rs
@@ -65,13 +65,10 @@ impl ReferenceValue {
 impl Block {
     /// If the given reference id points to a known value, return the value
     pub(super) fn get_known_value(&self, address: ValueId) -> Option<ValueId> {
-        if let Some(aliases) = self.aliases_of(address) {
-            // We could allow multiple aliases if we check that the reference
-            // value in each is equal.
-            if let Some(alias) = aliases.single_alias() {
-                if let Some(ReferenceValue::Known(value)) = self.references.get(&alias) {
-                    return Some(*value);
-                }
+        // We could allow multiple aliases if we check that the reference value in each is equal.
+        if let Some(alias) = self.get_aliases_for_value(address).single_alias() {
+            if let Some(ReferenceValue::Known(value)) = self.references.get(&alias) {
+                return Some(*value);
             }
         }
 
@@ -168,23 +165,6 @@ impl Block {
         }
     }
 
-    pub(super) fn aliases_of(&self, address: ValueId) -> Option<&AliasSet> {
-        if let Some(expression) = self.expressions.get(&address) {
-            self.aliases.get(expression)
-        } else {
-            None
-        }
-    }
-
-    /// Iterate through each known alias of the given address and apply the function `f` to each.
-    pub(super) fn for_each_alias_of<T>(&self, address: ValueId, mut f: impl FnMut(ValueId) -> T) {
-        if let Some(aliases) = self.aliases_of(address) {
-            for alias in aliases.iter() {
-                f(alias);
-            }
-        }
-    }
-
     /// Forget the last store to an address and all of its aliases, to eliminate them
     /// from the candidates for removal at the end.
     ///
@@ -195,9 +175,11 @@ impl Block {
     fn keep_last_stores_for(&mut self, address: ValueId, function: &Function) {
         self.keep_last_store(address, function);
 
-        if let Some(aliases) = self.aliases_of(address).cloned() {
-            for alias in aliases.iter() {
-                self.keep_last_store(alias, function);
+        if let Some(expr) = self.expressions.get(&address) {
+            if let Some(aliases) = self.aliases.get(expr).cloned() {
+                for alias in aliases.iter() {
+                    self.keep_last_store(alias, function);
+                }
             }
         }
     }
@@ -247,11 +229,13 @@ impl Block {
     }
 
     pub(super) fn get_aliases_for_value(&self, value: ValueId) -> Cow<AliasSet> {
-        if let Some(aliases) = self.aliases_of(value) {
-            Cow::Borrowed(aliases)
-        } else {
-            Cow::Owned(AliasSet::unknown())
+        if let Some(expression) = self.expressions.get(&value) {
+            if let Some(aliases) = self.aliases.get(expression) {
+                return Cow::Borrowed(aliases);
+            }
         }
+
+        Cow::Owned(AliasSet::unknown())
     }
 
     pub(super) fn set_last_load(&mut self, address: ValueId, instruction: InstructionId) {

--- a/compiler/noirc_evaluator/src/ssa/opt/mem2reg/block.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/mem2reg/block.rs
@@ -175,8 +175,7 @@ impl Block {
     fn keep_last_stores_for(&mut self, address: ValueId, function: &Function) {
         self.keep_last_store(address, function);
 
-        let aliases = (*self.get_aliases_for_value(address)).clone();
-        for alias in aliases.iter() {
+        for alias in (*self.get_aliases_for_value(address)).clone().iter() {
             self.keep_last_store(alias, function);
         }
     }

--- a/compiler/noirc_evaluator/src/ssa/opt/mem2reg/block.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/mem2reg/block.rs
@@ -243,7 +243,7 @@ impl Block {
         self.last_loads.remove(&address);
 
         if let Some(expr) = self.expressions.get(&address) {
-            if let Some(aliases) = self.aliases.get(expr).cloned() {
+            if let Some(aliases) = self.aliases.get(expr) {
                 for alias in aliases.iter() {
                     self.last_loads.remove(&alias);
                 }


### PR DESCRIPTION
# Description

## Problem

Part of #9393

## Summary

This PR tries to make the code more meaningful by removing some duplicated code and trying to avoid leaking some implementation details (although mem2reg is not very bug and it mostly knowns how everything is actually implemented). But the goal is to make the code easier to read, with less `if`s.

Then I also found out that `is_store_alias_used` could be slightly refactored as well. Now it doesn't call the `any` method on `AliasSet`, which had checks like `value == Some(true)`, and I also think it might be slightly faster as we need to traverse the alias set just once.

## Additional Context

Now `AliasSet` has an `iter()` method. I wanted to have `impl IntoIterator for &AliasSet` so it can be iterated without having to call `.iter()` but I couldn't find a way to do it without having `IntoIterator` use `Box<dyn Iterator...>`, resulting in a heap allocation.

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
