### PR TITLE
chore(mem2reg): removing seemingly unnecessary code

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/opt/mem2reg.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/mem2reg.rs
@@ -667,12 +667,6 @@ impl<'f> PerFunctionContext<'f> {
                 }
             }
             TerminatorInstruction::Return { return_values, .. } => {
-                // We need to appropriately mark each alias of a reference as being used as a return terminator argument.
-                // This prevents us potentially removing a last store from a preceding block or is altered within another function.
-                for return_value in return_values {
-                    self.instruction_input_references
-                        .extend(references.get_aliases_for_value(*return_value).iter());
-                }
                 // Removing all `last_stores` for each returned reference is more important here
                 // than setting them all to unknown since no other block should
                 // have a block with a Return terminator as a predecessor anyway.

--- a/compiler/noirc_evaluator/src/ssa/opt/mem2reg/block.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/mem2reg/block.rs
@@ -214,18 +214,6 @@ impl Block {
         }
     }
 
-    /// Collect all aliases used by the given value list
-    pub(super) fn collect_all_aliases(
-        &self,
-        values: impl IntoIterator<Item = ValueId>,
-    ) -> AliasSet {
-        let mut aliases = AliasSet::known_empty();
-        for value in values {
-            aliases.unify(&self.get_aliases_for_value(value));
-        }
-        aliases
-    }
-
     pub(super) fn get_aliases_for_value(&self, value: ValueId) -> Cow<AliasSet> {
         if let Some(expression) = self.expressions.get(&value) {
             if let Some(aliases) = self.aliases.get(expression) {


### PR DESCRIPTION
# Description

## Problem

Resolves #9394

## Summary

I don't fully intend this to get merged but it's interesting that there seems to be a lot of code that, when removed, has all tests still pass. Maybe there's some code that fails but isn't tested here? If CI passes I'll try to see if syncing this with Aztec-Packages causes no failures. If failures happen maybe we can craft some tests to prove why the code was needed.

## Additional Context

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
