### PR TITLE
chore(brillig): Include function name with `--count-array-copies` debug information

### DIFF
--- a/compiler/noirc_evaluator/src/brillig/brillig_gen.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen.rs
@@ -60,9 +60,9 @@ pub(crate) fn gen_brillig_for(
         func.id(),
         true,
         globals_memory_size,
+        func.name(),
         &options,
     );
-    entry_point.name = func.name().to_string();
 
     // Link the entry point with all dependencies
     while let Some(unresolved_fn_label) = entry_point.first_unresolved_function_call() {

--- a/compiler/noirc_evaluator/src/brillig/brillig_ir.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_ir.rs
@@ -140,9 +140,11 @@ impl<F, R> BrilligContext<F, R> {
 
 /// Regular brillig context to codegen user defined functions
 impl<F: AcirField + DebugToString> BrilligContext<F, Stack> {
-    pub(crate) fn new(options: &BrilligOptions) -> BrilligContext<F, Stack> {
+    pub(crate) fn new(function_name: &str, options: &BrilligOptions) -> BrilligContext<F, Stack> {
+        let mut obj = BrilligArtifact::default();
+        obj.name = function_name.to_owned();
         BrilligContext {
-            obj: BrilligArtifact::default(),
+            obj,
             registers: Stack::new(),
             context_label: Label::entrypoint(),
             current_section: 0,
@@ -299,6 +301,10 @@ impl<F: AcirField + DebugToString, Registers: RegisterAllocator> BrilligContext<
         self.obj
     }
 
+    pub(crate) fn name(&self) -> &str {
+        &self.obj.name
+    }
+
     /// Sets a current call stack that the next pushed opcodes will be associated with.
     pub(crate) fn set_call_stack(&mut self, call_stack: CallStackId) {
         self.obj.set_call_stack(call_stack);
@@ -369,7 +375,7 @@ pub(crate) mod tests {
             enable_debug_assertions: true,
             enable_array_copy_counter: false,
         };
-        let mut context = BrilligContext::new(&options);
+        let mut context = BrilligContext::new("test", &options);
         context.enter_context(Label::function(id));
         context
     }
@@ -391,6 +397,7 @@ pub(crate) mod tests {
             FunctionId::test_new(0),
             false,
             0,
+            "entry_point",
             &options,
         );
         entry_point_artifact.link_with(&artifact);
@@ -438,7 +445,7 @@ pub(crate) mod tests {
             enable_debug_assertions: true,
             enable_array_copy_counter: false,
         };
-        let mut context = BrilligContext::new(&options);
+        let mut context = BrilligContext::new("test", &options);
         let r_stack = ReservedRegisters::free_memory_pointer();
         // Start stack pointer at 0
         context.usize_const_instruction(r_stack, FieldElement::from(ReservedRegisters::len() + 3));

--- a/compiler/noirc_evaluator/src/brillig/brillig_ir/codegen_stack.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_ir/codegen_stack.rs
@@ -212,7 +212,7 @@ mod tests {
             enable_debug_assertions: true,
             enable_array_copy_counter: false,
         };
-        let mut context = BrilligContext::new(&options);
+        let mut context = BrilligContext::new("test", &options);
         context.enter_context(Label::function(FunctionId::test_new(0)));
         context
     }

--- a/compiler/noirc_evaluator/src/brillig/brillig_ir/entry_point.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_ir/entry_point.rs
@@ -24,9 +24,10 @@ impl<F: AcirField + DebugToString> BrilligContext<F, Stack> {
         target_function: FunctionId,
         globals_init: bool,
         globals_memory_size: usize,
+        name: &str,
         options: &BrilligOptions,
     ) -> BrilligArtifact<F> {
-        let mut context = BrilligContext::new(options);
+        let mut context = BrilligContext::new(name, options);
 
         context.set_globals_memory_size(Some(globals_memory_size));
 

--- a/compiler/noirc_evaluator/src/brillig/brillig_ir/procedures/array_copy.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_ir/procedures/array_copy.rs
@@ -88,7 +88,7 @@ pub(super) fn compile_array_copy_procedure<F: AcirField + DebugToString>(
 }
 
 /// The message to print when copying an array.
-const ARRAY_COPY_COUNTER_MESSAGE: &str = "Total arrays copied: {}";
+const ARRAY_COPY_COUNTER_MESSAGE: &str = "Total arrays copied in";
 
 /// The metadata string needed to tell `print` to print out a u32
 const PRINT_U32_TYPE_STRING: &str = "{\"kind\":\"unsignedinteger\",\"width\":32}";
@@ -153,7 +153,9 @@ impl<F: AcirField + DebugToString, Registers: RegisterAllocator> BrilligContext<
         });
 
         let newline = ValueOrArray::MemoryAddress(ReservedRegisters::usize_one());
-        let message = literal_string_to_value(ARRAY_COPY_COUNTER_MESSAGE, self);
+        let message_with_func_name =
+            format!("{ARRAY_COPY_COUNTER_MESSAGE} {}: {{}}", &self.name(),);
+        let message = literal_string_to_value(&message_with_func_name, self);
         let item_count = ValueOrArray::MemoryAddress(ReservedRegisters::usize_one());
         let value_to_print = ValueOrArray::MemoryAddress(array_copy_counter.extract_register());
         let type_string_metadata = literal_string_to_value(PRINT_U32_TYPE_STRING, self);
@@ -173,7 +175,7 @@ impl<F: AcirField + DebugToString, Registers: RegisterAllocator> BrilligContext<
         let u32_type = HeapValueType::Simple(BitSize::Integer(IntegerBitSize::U32));
 
         let newline_type = u1_type.clone();
-        let size = ARRAY_COPY_COUNTER_MESSAGE.len();
+        let size = message_with_func_name.len();
         let msg_type = HeapValueType::Array { value_types: vec![u8_type.clone()], size };
         let item_count_type = HeapValueType::field();
         let value_to_print_type = u32_type;

--- a/compiler/noirc_evaluator/src/brillig/mod.rs
+++ b/compiler/noirc_evaluator/src/brillig/mod.rs
@@ -102,7 +102,7 @@ impl Brillig {
         hoisted_global_constants: &HashMap<(FieldElement, NumericType), BrilligVariable>,
         is_entry_point: bool,
     ) -> BrilligArtifact<FieldElement> {
-        let mut brillig_context = BrilligContext::new(options);
+        let mut brillig_context = BrilligContext::new(func.name(), options);
 
         let mut function_context = FunctionContext::new(func, is_entry_point);
 
@@ -122,9 +122,7 @@ impl Brillig {
             );
         }
 
-        let mut artifact = brillig_context.artifact();
-        artifact.name = func.name().to_string();
-        artifact
+        brillig_context.artifact()
     }
 }
 


### PR DESCRIPTION
# Description

## Problem\*

Resolves #9612 

## Summary\*

This PR simply updates the `emit_println_of_array_copy_counter` procedure to include the artifact name in the array copies debug message. This did require changing the order of when names are included in a Brillig artifact. Currently, artifact names are only included after code gen as they were only needed by downstream tools such as `nargo`. Now that we need the name as part of code gen I switched us to include the function name at the start of codegen.

The `execution_success/brilig_arrays` output with `nargo execute --force --count-array-copies` looks like such:
```
Total arrays copied in read_array: 0
Total arrays copied in read_write_array: 1
```

## Additional Context



## Documentation\*

Check one:
- [X] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
