### PR TITLE
chore: only run remove_paired_rc in brillig functions

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/opt/rc.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/rc.rs
@@ -53,6 +53,11 @@ impl Function {
     /// This restriction lets this function largely ignore merging intermediate results from other
     /// blocks and handling loops.
     pub(crate) fn remove_paired_rc(&mut self) {
+        if !self.runtime().is_brillig() {
+            // dec_rc and inc_rc only have an effect in Brillig
+            return;
+        }
+
         // `dec_rc` is only issued for parameters currently so we can speed things
         // up a bit by skipping any functions without them.
         if !contains_array_parameter(self) {


### PR DESCRIPTION
# Description

## Problem

Resolves #9424

## Summary



## Additional Context



## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
