### PR TITLE
chore: use `assert_ssa_does_not_change` throughout all SSA tests

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/opt/brillig_array_get_and_set.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/brillig_array_get_and_set.rs
@@ -140,7 +140,7 @@ fn compute_index_and_offset(
 
 #[cfg(test)]
 mod tests {
-    use crate::{assert_ssa_snapshot, ssa::opt::assert_normalized_ssa_equals};
+    use crate::{assert_ssa_snapshot, ssa::opt::assert_ssa_does_not_change};
 
     use super::Ssa;
 
@@ -197,10 +197,7 @@ mod tests {
             return v2
         }
         ";
-
-        let ssa = Ssa::from_str(src).unwrap();
-        let ssa = ssa.brillig_array_get_and_set();
-        assert_normalized_ssa_equals(ssa, src);
+        assert_ssa_does_not_change(src, Ssa::brillig_array_get_and_set);
     }
 
     #[test]
@@ -212,10 +209,7 @@ mod tests {
             return v2
         }
         ";
-
-        let ssa = Ssa::from_str(src).unwrap();
-        let ssa = ssa.brillig_array_get_and_set();
-        assert_normalized_ssa_equals(ssa, src);
+        assert_ssa_does_not_change(src, Ssa::brillig_array_get_and_set);
     }
 
     #[test]
@@ -271,10 +265,7 @@ mod tests {
             return v2
         }
         ";
-
-        let ssa = Ssa::from_str(src).unwrap();
-        let ssa = ssa.brillig_array_get_and_set();
-        assert_normalized_ssa_equals(ssa, src);
+        assert_ssa_does_not_change(src, Ssa::brillig_array_get_and_set);
     }
 
     #[test]
@@ -286,9 +277,6 @@ mod tests {
             return v2
         }
         ";
-
-        let ssa = Ssa::from_str(src).unwrap();
-        let ssa = ssa.brillig_array_get_and_set();
-        assert_normalized_ssa_equals(ssa, src);
+        assert_ssa_does_not_change(src, Ssa::brillig_array_get_and_set);
     }
 }

--- a/compiler/noirc_evaluator/src/ssa/opt/check_u128_mul_overflow.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/check_u128_mul_overflow.rs
@@ -142,7 +142,7 @@ fn check_u128_mul_overflow(
 mod tests {
     use crate::{
         assert_ssa_snapshot,
-        ssa::{opt::assert_normalized_ssa_equals, ssa_gen::Ssa},
+        ssa::{opt::assert_ssa_does_not_change, ssa_gen::Ssa},
     };
 
     #[test]
@@ -154,10 +154,7 @@ mod tests {
             return
         }
         ";
-        let ssa = Ssa::from_str(src).unwrap();
-
-        let ssa = ssa.check_u128_mul_overflow();
-        assert_normalized_ssa_equals(ssa, src);
+        assert_ssa_does_not_change(src, Ssa::check_u128_mul_overflow);
     }
 
     #[test]
@@ -169,10 +166,7 @@ mod tests {
             return
         }
         ";
-        let ssa = Ssa::from_str(src).unwrap();
-
-        let ssa = ssa.check_u128_mul_overflow();
-        assert_normalized_ssa_equals(ssa, src);
+        assert_ssa_does_not_change(src, Ssa::check_u128_mul_overflow);
     }
 
     #[test]
@@ -278,10 +272,7 @@ mod tests {
             return
         }
         ";
-        let ssa = Ssa::from_str(src).unwrap();
-
-        let ssa = ssa.check_u128_mul_overflow();
-        assert_normalized_ssa_equals(ssa, src);
+        assert_ssa_does_not_change(src, Ssa::check_u128_mul_overflow);
     }
     #[test]
     fn predicate_overflow() {

--- a/compiler/noirc_evaluator/src/ssa/opt/checked_to_unchecked.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/checked_to_unchecked.rs
@@ -162,7 +162,7 @@ fn get_max_num_bits(
 mod tests {
     use crate::{
         assert_ssa_snapshot,
-        ssa::{opt::assert_normalized_ssa_equals, ssa_gen::Ssa},
+        ssa::{opt::assert_ssa_does_not_change, ssa_gen::Ssa},
     };
 
     #[test]
@@ -309,9 +309,7 @@ mod tests {
             return v5
         }
         ";
-        let ssa = Ssa::from_str(src).unwrap();
-        let ssa = ssa.checked_to_unchecked();
-        assert_normalized_ssa_equals(ssa, src);
+        assert_ssa_does_not_change(src, Ssa::checked_to_unchecked);
     }
 
     #[test]
@@ -325,9 +323,7 @@ mod tests {
             return v3
         }
         ";
-        let ssa = Ssa::from_str(src).unwrap();
-        let ssa = ssa.checked_to_unchecked();
-        assert_normalized_ssa_equals(ssa, src);
+        assert_ssa_does_not_change(src, Ssa::checked_to_unchecked);
     }
 
     #[test]
@@ -342,9 +338,7 @@ mod tests {
             return v2
         }
         ";
-        let ssa = Ssa::from_str(src).unwrap();
-        let ssa = ssa.checked_to_unchecked();
-        assert_normalized_ssa_equals(ssa, src);
+        assert_ssa_does_not_change(src, Ssa::checked_to_unchecked);
     }
 
     #[test]

--- a/compiler/noirc_evaluator/src/ssa/opt/constant_folding.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/constant_folding.rs
@@ -1013,7 +1013,7 @@ mod test {
                 types::{NumericType, Type},
                 value::ValueMapping,
             },
-            opt::assert_normalized_ssa_equals,
+            opt::{assert_normalized_ssa_equals, assert_ssa_does_not_change},
         },
     };
 
@@ -1148,9 +1148,7 @@ mod test {
                 return v3
             }
             ";
-        let ssa = Ssa::from_str(src).unwrap();
-        let ssa = ssa.fold_constants();
-        assert_normalized_ssa_equals(ssa, src);
+        assert_ssa_does_not_change(src, Ssa::fold_constants);
     }
 
     #[test]
@@ -1235,11 +1233,7 @@ mod test {
             return
         }
         ";
-        let ssa = Ssa::from_str(src).unwrap();
-
-        // Expected output is unchanged
-        let ssa = ssa.fold_constants();
-        assert_normalized_ssa_equals(ssa, src);
+        assert_ssa_does_not_change(src, Ssa::fold_constants);
     }
 
     #[test]
@@ -1692,9 +1686,7 @@ mod test {
                 return
             }
             ";
-        let ssa = Ssa::from_str(src).unwrap();
-        let ssa = ssa.fold_constants_using_constraints();
-        assert_normalized_ssa_equals(ssa, src);
+        assert_ssa_does_not_change(src, Ssa::fold_constants_using_constraints);
     }
 
     #[test]
@@ -1716,9 +1708,7 @@ mod test {
                 return
             }
             ";
-        let ssa = Ssa::from_str(src).unwrap();
-        let ssa = ssa.fold_constants_using_constraints();
-        assert_normalized_ssa_equals(ssa, src);
+        assert_ssa_does_not_change(src, Ssa::fold_constants_using_constraints);
     }
 
     #[test]
@@ -1742,9 +1732,7 @@ mod test {
                 return
             }
             ";
-        let ssa = Ssa::from_str(src).unwrap();
-        let ssa = ssa.fold_constants_using_constraints();
-        assert_normalized_ssa_equals(ssa, src);
+        assert_ssa_does_not_change(src, Ssa::fold_constants_using_constraints);
     }
 
     #[test]
@@ -1795,12 +1783,7 @@ mod test {
             return v6
         }
         ";
-
-        let ssa = Ssa::from_str(src).unwrap();
-
-        let ssa = ssa.fold_constants_using_constraints();
-        // We expect the code to be unchanged
-        assert_normalized_ssa_equals(ssa, src);
+        assert_ssa_does_not_change(src, Ssa::fold_constants_using_constraints);
     }
 
     #[test]
@@ -1875,10 +1858,7 @@ mod test {
             return
         }
         ";
-
-        let ssa = Ssa::from_str(src).unwrap();
-        let ssa = ssa.fold_constants();
-        assert_normalized_ssa_equals(ssa, src);
+        assert_ssa_does_not_change(src, Ssa::fold_constants);
     }
 
     #[test]
@@ -1895,10 +1875,7 @@ mod test {
             return
         }
         ";
-
-        let ssa = Ssa::from_str(src).unwrap();
-        let ssa = ssa.fold_constants();
-        assert_normalized_ssa_equals(ssa, src);
+        assert_ssa_does_not_change(src, Ssa::fold_constants);
     }
 
     #[test]
@@ -1915,10 +1892,7 @@ mod test {
             return
         }
         ";
-
-        let ssa = Ssa::from_str(src).unwrap();
-        let ssa = ssa.fold_constants();
-        assert_normalized_ssa_equals(ssa, src);
+        assert_ssa_does_not_change(src, Ssa::fold_constants);
     }
 
     #[test]
@@ -1935,10 +1909,7 @@ mod test {
             return
         }
         ";
-
-        let ssa = Ssa::from_str(src).unwrap();
-        let ssa = ssa.fold_constants();
-        assert_normalized_ssa_equals(ssa, src);
+        assert_ssa_does_not_change(src, Ssa::fold_constants);
     }
 
     #[test]
@@ -1955,21 +1926,7 @@ mod test {
             return
         }
         ";
-
-        let ssa = Ssa::from_str(src).unwrap();
-        let ssa = ssa.fold_constants();
-
-        assert_ssa_snapshot!(ssa, @r"
-        acir(inline) fn main f0 {
-          b0(v0: u32, v1: u32, v2: u1):
-            enable_side_effects v2
-            v4 = div v1, u32 2
-            v5 = not v2
-            enable_side_effects v5
-            v6 = div v1, u32 2
-            return
-        }
-        ");
+        assert_ssa_does_not_change(src, Ssa::fold_constants);
     }
 
     #[test]

--- a/compiler/noirc_evaluator/src/ssa/opt/die.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/die.rs
@@ -1004,7 +1004,7 @@ mod test {
                 map::Id,
                 types::{NumericType, Type},
             },
-            opt::assert_normalized_ssa_equals,
+            opt::assert_ssa_does_not_change,
         },
     };
 
@@ -1106,11 +1106,7 @@ mod test {
                 return v2
             }
             ";
-        let ssa = Ssa::from_str(src).unwrap();
-
-        // We expect the output to be unchanged
-        let ssa = ssa.dead_instruction_elimination();
-        assert_normalized_ssa_equals(ssa, src);
+        assert_ssa_does_not_change(src, Ssa::dead_instruction_elimination);
     }
 
     #[test]
@@ -1214,9 +1210,7 @@ mod test {
                 return
             }
             ";
-        let ssa = Ssa::from_str(src).unwrap();
-        let ssa = ssa.dead_instruction_elimination();
-        assert_normalized_ssa_equals(ssa, src);
+        assert_ssa_does_not_change(src, Ssa::dead_instruction_elimination);
     }
 
     #[test]
@@ -1306,10 +1300,7 @@ mod test {
             return Field 1
         }
         ";
-
-        let ssa = Ssa::from_str(src).unwrap();
-        let ssa = ssa.dead_instruction_elimination();
-        assert_normalized_ssa_equals(ssa, src);
+        assert_ssa_does_not_change(src, Ssa::dead_instruction_elimination);
     }
 
     #[test]
@@ -1507,10 +1498,7 @@ mod test {
             return v2
         }
         "#;
-
-        let ssa = Ssa::from_str(src).unwrap();
-        let ssa = ssa.dead_instruction_elimination();
-        assert_normalized_ssa_equals(ssa, src);
+        assert_ssa_does_not_change(src, Ssa::dead_instruction_elimination);
     }
 
     #[test]
@@ -1525,10 +1513,7 @@ mod test {
             return v0
         }
         "#;
-
-        let ssa = Ssa::from_str(src).unwrap();
-        let ssa = ssa.dead_instruction_elimination();
-        assert_normalized_ssa_equals(ssa, src);
+        assert_ssa_does_not_change(src, Ssa::dead_instruction_elimination);
     }
 
     #[test]
@@ -1584,9 +1569,7 @@ mod test {
             return v3
         }
         ";
-        let ssa = Ssa::from_str(src).unwrap();
-        let ssa = ssa.dead_instruction_elimination_pre_flattening();
-        assert_normalized_ssa_equals(ssa, src);
+        assert_ssa_does_not_change(src, Ssa::dead_instruction_elimination_pre_flattening);
     }
 
     #[test]
@@ -1712,11 +1695,8 @@ mod test {
             jmp b1()
         }
         ";
-        let ssa = Ssa::from_str(src).unwrap();
-        let ssa = ssa.dead_instruction_elimination();
-
         // If `inc_rc v3` were removed, we risk it later being mutated in `v19 = array_set v18, index u32 0, value Field 1`.
         // Thus, when we later go to do `v22 = array_set v21, index u32 0, value v3` once more, we will be writing [1] rather than [2].
-        assert_normalized_ssa_equals(ssa, src);
+        assert_ssa_does_not_change(src, Ssa::dead_instruction_elimination);
     }
 }

--- a/compiler/noirc_evaluator/src/ssa/opt/expand_signed_checks.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/expand_signed_checks.rs
@@ -470,7 +470,7 @@ fn expand_signed_checks_post_check(func: &Function) {
 mod tests {
     use crate::{
         assert_ssa_snapshot,
-        ssa::{opt::assert_normalized_ssa_equals, ssa_gen::Ssa},
+        ssa::{opt::assert_ssa_does_not_change, ssa_gen::Ssa},
     };
 
     #[test]
@@ -600,9 +600,7 @@ mod tests {
             return v2
         }
         ";
-        let ssa = Ssa::from_str(src).unwrap();
-        let ssa = ssa.expand_signed_checks();
-        assert_normalized_ssa_equals(ssa, src);
+        assert_ssa_does_not_change(src, Ssa::expand_signed_checks);
     }
 
     #[test]
@@ -614,9 +612,7 @@ mod tests {
             return v2
         }
         ";
-        let ssa = Ssa::from_str(src).unwrap();
-        let ssa = ssa.expand_signed_checks();
-        assert_normalized_ssa_equals(ssa, src);
+        assert_ssa_does_not_change(src, Ssa::expand_signed_checks);
     }
 
     #[test]
@@ -628,8 +624,6 @@ mod tests {
             return v2
         }
         ";
-        let ssa = Ssa::from_str(src).unwrap();
-        let ssa = ssa.expand_signed_checks();
-        assert_normalized_ssa_equals(ssa, src);
+        assert_ssa_does_not_change(src, Ssa::expand_signed_checks);
     }
 }

--- a/compiler/noirc_evaluator/src/ssa/opt/inline_simple_functions.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/inline_simple_functions.rs
@@ -84,13 +84,11 @@ impl Ssa {
 mod test {
     use crate::{
         assert_ssa_snapshot,
-        ssa::{Ssa, opt::assert_normalized_ssa_equals},
+        ssa::{Ssa, opt::assert_ssa_does_not_change},
     };
 
     fn assert_does_not_inline(src: &str) {
-        let ssa = Ssa::from_str(src).unwrap();
-        let ssa = ssa.inline_simple_functions();
-        assert_normalized_ssa_equals(ssa, src);
+        assert_ssa_does_not_change(src, Ssa::inline_simple_functions);
     }
 
     #[test]

--- a/compiler/noirc_evaluator/src/ssa/opt/mem2reg.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/mem2reg.rs
@@ -717,7 +717,7 @@ impl<'f> PerFunctionContext<'f> {
 mod tests {
     use crate::{
         assert_ssa_snapshot,
-        ssa::{Ssa, opt::assert_normalized_ssa_equals},
+        ssa::{Ssa, opt::assert_ssa_does_not_change},
     };
 
     #[test]
@@ -857,7 +857,8 @@ mod tests {
         // to remove it.
         // The final store in b1 is removed as no loads are done within any blocks
         // to the stored values.
-        let expected = "
+        let ssa = ssa.mem2reg();
+        assert_ssa_snapshot!(ssa, @r"
         acir(inline) fn main f0 {
           b0():
             v0 = allocate -> &mut Field
@@ -868,10 +869,7 @@ mod tests {
             store Field 1 at v0
             return
         }
-        ";
-
-        let ssa = ssa.mem2reg();
-        assert_normalized_ssa_equals(ssa, expected);
+        ");
     }
 
     #[test]
@@ -906,9 +904,7 @@ mod tests {
             return
         }
         ";
-        let ssa = Ssa::from_str(src).unwrap();
-        let ssa = ssa.mem2reg();
-        assert_normalized_ssa_equals(ssa, src);
+        assert_ssa_does_not_change(src, Ssa::mem2reg);
     }
 
     #[test]
@@ -926,9 +922,7 @@ mod tests {
             return
         }
         ";
-        let ssa = Ssa::from_str(src).unwrap();
-        let ssa = ssa.mem2reg();
-        assert_normalized_ssa_equals(ssa, src);
+        assert_ssa_does_not_change(src, Ssa::mem2reg);
     }
 
     #[test]
@@ -1039,12 +1033,7 @@ mod tests {
             return
         }
         ";
-
-        let ssa = Ssa::from_str(src).unwrap();
-
-        let ssa = ssa.mem2reg();
-        // We expect the program to be unchanged
-        assert_normalized_ssa_equals(ssa, src);
+        assert_ssa_does_not_change(src, Ssa::mem2reg);
     }
 
     #[test]
@@ -1078,12 +1067,7 @@ mod tests {
             return
         }
         ";
-
-        let ssa = Ssa::from_str(src).unwrap();
-
-        let ssa = ssa.mem2reg();
-        // We expect the program to be unchanged
-        assert_normalized_ssa_equals(ssa, src);
+        assert_ssa_does_not_change(src, Ssa::mem2reg);
     }
 
     #[test]
@@ -1108,10 +1092,7 @@ mod tests {
             return v3
         }
         ";
-
-        let ssa = Ssa::from_str(src).unwrap();
-        let ssa = ssa.mem2reg();
-        assert_normalized_ssa_equals(ssa, src);
+        assert_ssa_does_not_change(src, Ssa::mem2reg);
     }
 
     #[test]
@@ -1144,11 +1125,7 @@ mod tests {
             return v1
         }
         ";
-
-        let ssa = Ssa::from_str(src).unwrap();
-        let ssa = ssa.mem2reg();
-
-        assert_normalized_ssa_equals(ssa, src);
+        assert_ssa_does_not_change(src, Ssa::mem2reg);
     }
 
     #[test]
@@ -1169,10 +1146,7 @@ mod tests {
             return v4
         }
         ";
-
-        let ssa = Ssa::from_str(src).unwrap();
-        let ssa = ssa.mem2reg();
-        assert_normalized_ssa_equals(ssa, src);
+        assert_ssa_does_not_change(src, Ssa::mem2reg);
     }
 
     #[test]
@@ -1195,10 +1169,7 @@ mod tests {
             return v7
         }
         ";
-
-        let ssa = Ssa::from_str(src).unwrap();
-        let ssa = ssa.mem2reg();
-        assert_normalized_ssa_equals(ssa, src);
+        assert_ssa_does_not_change(src, Ssa::mem2reg);
     }
 
     #[test]
@@ -1221,10 +1192,7 @@ mod tests {
             return v7
         }
         ";
-
-        let ssa = Ssa::from_str(src).unwrap();
-        let ssa = ssa.mem2reg();
-        assert_normalized_ssa_equals(ssa, src);
+        assert_ssa_does_not_change(src, Ssa::mem2reg);
     }
 
     #[test]
@@ -1345,9 +1313,7 @@ mod tests {
             return v0
         }
         ";
-        let ssa = Ssa::from_str(src).unwrap();
-        let ssa = ssa.mem2reg();
-        assert_normalized_ssa_equals(ssa, src);
+        assert_ssa_does_not_change(src, Ssa::mem2reg);
     }
 
     #[test]
@@ -1382,9 +1348,7 @@ mod tests {
             return v1
         }
         ";
-        let ssa = Ssa::from_str(src).unwrap();
-        let ssa = ssa.mem2reg();
-        assert_normalized_ssa_equals(ssa, src);
+        assert_ssa_does_not_change(src, Ssa::mem2reg);
     }
 
     #[test]
@@ -1416,9 +1380,7 @@ mod tests {
                 return v7
             }
         ";
-        let ssa = Ssa::from_str(src).unwrap();
-        let ssa = ssa.mem2reg();
-        assert_normalized_ssa_equals(ssa, src);
+        assert_ssa_does_not_change(src, Ssa::mem2reg);
     }
 
     #[test]
@@ -1445,9 +1407,7 @@ mod tests {
             return
         }
         ";
-        let ssa = Ssa::from_str(src).unwrap();
-        let ssa = ssa.mem2reg();
-        assert_normalized_ssa_equals(ssa, src);
+        assert_ssa_does_not_change(src, Ssa::mem2reg);
     }
 
     #[test]
@@ -1462,12 +1422,7 @@ mod tests {
             return
         }
         ";
-
-        let ssa = Ssa::from_str(src).unwrap();
-
-        let ssa = ssa.mem2reg();
-        // We expect the program to be unchanged
-        assert_normalized_ssa_equals(ssa, src);
+        assert_ssa_does_not_change(src, Ssa::mem2reg);
     }
 
     #[test]
@@ -1483,12 +1438,7 @@ mod tests {
             return v0
         }
         ";
-
-        let ssa = Ssa::from_str(src).unwrap();
-
-        let ssa = ssa.mem2reg();
-        // We expect the program to be unchanged
-        assert_normalized_ssa_equals(ssa, src);
+        assert_ssa_does_not_change(src, Ssa::mem2reg);
     }
 
     #[test]
@@ -1506,12 +1456,7 @@ mod tests {
             return
         }
         ";
-
-        let ssa = Ssa::from_str(src).unwrap();
-
-        let ssa = ssa.mem2reg();
-        // We expect the program to be unchanged
-        assert_normalized_ssa_equals(ssa, src);
+        assert_ssa_does_not_change(src, Ssa::mem2reg);
     }
 
     #[test]
@@ -1571,10 +1516,7 @@ mod tests {
                 return
             }
         ";
-
-        let ssa = Ssa::from_str(src).unwrap();
-        let ssa = ssa.mem2reg();
-        assert_normalized_ssa_equals(ssa, src);
+        assert_ssa_does_not_change(src, Ssa::mem2reg);
     }
 
     #[test]

--- a/compiler/noirc_evaluator/src/ssa/opt/rc.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/rc.rs
@@ -163,7 +163,7 @@ mod test {
         assert_ssa_snapshot,
         ssa::{
             ir::{basic_block::BasicBlockId, dfg::DataFlowGraph, instruction::Instruction},
-            opt::assert_normalized_ssa_equals,
+            opt::assert_ssa_does_not_change,
             ssa_gen::Ssa,
         },
     };
@@ -284,9 +284,7 @@ mod test {
             return v0
         }
         ";
-        let ssa = Ssa::from_str(src).unwrap();
-        let ssa = ssa.remove_paired_rc();
-        assert_normalized_ssa_equals(ssa, src);
+        assert_ssa_does_not_change(src, Ssa::remove_paired_rc);
     }
 
     #[test]
@@ -298,9 +296,7 @@ mod test {
             return v0
         }
         ";
-        let ssa = Ssa::from_str(src).unwrap();
-        let ssa = ssa.remove_paired_rc();
-        assert_normalized_ssa_equals(ssa, src);
+        assert_ssa_does_not_change(src, Ssa::remove_paired_rc);
     }
 
     #[test]
@@ -393,9 +389,7 @@ mod test {
             return v2
         }
         ";
-        let ssa = Ssa::from_str(src).unwrap();
-        let ssa = ssa.remove_paired_rc();
-        assert_normalized_ssa_equals(ssa, src);
+        assert_ssa_does_not_change(src, Ssa::remove_paired_rc);
     }
 
     #[test]
@@ -413,11 +407,9 @@ mod test {
             return v1  
         }
         ";
-        let ssa = Ssa::from_str(src).unwrap();
-        let ssa = ssa.remove_paired_rc();
         // This pass is very conservative and only looks for inc_rc's in the entry block and dec_rc's in the exit block
         // The dec_rc is not in the return block so we do not expect the rc pair to be removed.
-        assert_normalized_ssa_equals(ssa, src);
+        assert_ssa_does_not_change(src, Ssa::remove_paired_rc);
     }
 
     #[test]

--- a/compiler/noirc_evaluator/src/ssa/opt/remove_truncate_after_range_check.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/remove_truncate_after_range_check.rs
@@ -66,7 +66,7 @@ impl Function {
 mod tests {
     use crate::{
         assert_ssa_snapshot,
-        ssa::{opt::assert_normalized_ssa_equals, ssa_gen::Ssa},
+        ssa::{opt::assert_ssa_does_not_change, ssa_gen::Ssa},
     };
 
     #[test]
@@ -129,9 +129,6 @@ mod tests {
             return v1
         }
         ";
-
-        let ssa = Ssa::from_str(src).unwrap();
-        let ssa = ssa.remove_truncate_after_range_check();
-        assert_normalized_ssa_equals(ssa, src);
+        assert_ssa_does_not_change(src, Ssa::remove_truncate_after_range_check);
     }
 }

--- a/compiler/noirc_evaluator/src/ssa/opt/remove_unreachable_functions.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/remove_unreachable_functions.rs
@@ -140,7 +140,7 @@ fn used_functions(func: &Function) -> BTreeSet<FunctionId> {
 
 #[cfg(test)]
 mod tests {
-    use crate::{assert_ssa_snapshot, ssa::opt::assert_normalized_ssa_equals};
+    use crate::{assert_ssa_snapshot, ssa::opt::assert_ssa_does_not_change};
 
     use super::Ssa;
 
@@ -215,12 +215,7 @@ mod tests {
               return v3
           }
         "#;
-
-        let ssa = Ssa::from_str(src).unwrap();
-        let ssa = ssa.remove_unreachable_functions();
-
-        // It should not remove anything.
-        assert_normalized_ssa_equals(ssa, src);
+        assert_ssa_does_not_change(src, Ssa::remove_unreachable_functions);
     }
 
     #[test]
@@ -245,11 +240,7 @@ mod tests {
             return
         }
         "#;
-
-        let ssa = Ssa::from_str(src).unwrap();
-        let ssa = ssa.remove_unreachable_functions();
-
-        assert_normalized_ssa_equals(ssa, src);
+        assert_ssa_does_not_change(src, Ssa::remove_unreachable_functions);
     }
 
     #[test]
@@ -266,23 +257,20 @@ mod tests {
             v4 = array_get v3, index u32 0 -> function
             v5 = call v4(v0) -> Field
             return
-          }
-          
-          acir(inline) fn my_fun f1 {
-            b0(v0: Field):
-              v2 = add v0, Field 1
-              return v2
-          }
-          
-          acir(inline) fn my_fun2 f2 {
-            b0(v0: Field):
-              v2 = add v0, Field 2
-              return v2
-          }"#;
-
-        let ssa = Ssa::from_str(src).unwrap();
-        let ssa = ssa.remove_unreachable_functions();
-
-        assert_normalized_ssa_equals(ssa, src);
+        }
+        
+        acir(inline) fn my_fun f1 {
+          b0(v0: Field):
+            v2 = add v0, Field 1
+            return v2
+        }
+        
+        acir(inline) fn my_fun2 f2 {
+          b0(v0: Field):
+            v2 = add v0, Field 2
+            return v2
+        }
+        "#;
+        assert_ssa_does_not_change(src, Ssa::remove_unreachable_functions);
     }
 }

--- a/compiler/noirc_evaluator/src/ssa/opt/remove_unreachable_instructions.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/remove_unreachable_instructions.rs
@@ -406,7 +406,7 @@ fn insert_constraint(
 mod test {
     use crate::{
         assert_ssa_snapshot,
-        ssa::{opt::assert_normalized_ssa_equals, ssa_gen::Ssa},
+        ssa::{opt::assert_ssa_does_not_change, ssa_gen::Ssa},
     };
 
     #[test]
@@ -515,9 +515,7 @@ mod test {
             return v1
         }
         "#;
-        let ssa = Ssa::from_str(src).unwrap();
-        let ssa = ssa.remove_unreachable_instructions();
-        assert_normalized_ssa_equals(ssa, src);
+        assert_ssa_does_not_change(src, Ssa::remove_unreachable_instructions);
     }
 
     #[test]
@@ -1004,10 +1002,7 @@ mod test {
             return v4
         }
         ";
-
-        let ssa = Ssa::from_str(src).unwrap();
-        let ssa = ssa.remove_unreachable_instructions();
-        assert_normalized_ssa_equals(ssa, src);
+        assert_ssa_does_not_change(src, Ssa::remove_unreachable_instructions);
     }
 
     #[test]

--- a/compiler/noirc_evaluator/src/ssa/opt/simplify_cfg.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/simplify_cfg.rs
@@ -418,7 +418,7 @@ fn try_inline_into_predecessor(
 mod test {
     use crate::{
         assert_ssa_snapshot,
-        ssa::{Ssa, opt::assert_normalized_ssa_equals},
+        ssa::{Ssa, opt::assert_ssa_does_not_change},
     };
 
     #[test]
@@ -518,8 +518,7 @@ mod test {
           b2():
             return
         }";
-        let ssa = Ssa::from_str(src).unwrap();
-        assert_normalized_ssa_equals(ssa.simplify_cfg(), src);
+        assert_ssa_does_not_change(src, Ssa::simplify_cfg);
     }
 
     #[test]
@@ -771,9 +770,7 @@ mod test {
             return
         }
         ";
-        let ssa = Ssa::from_str(src).unwrap();
-        let ssa = ssa.simplify_cfg();
-        assert_normalized_ssa_equals(ssa, src);
+        assert_ssa_does_not_change(src, Ssa::simplify_cfg);
     }
 
     #[test]


### PR DESCRIPTION
# Description

## Problem

No issue, just something that was left pending.

## Summary

## Additional Context



## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
