### PR TITLE
chore: add a regression test for #9613

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/opt/mem2reg.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/mem2reg.rs
@@ -1588,6 +1588,9 @@ mod tests {
         // This is a regression test for https://github.com/noir-lang/noir/pull/9613
         // In that PR all tests passed but the sync to Aztec-Packages failed.
         // That PR had `store v3 at v1` incorrectly removed.
+        // Even though v3 is what was in v1 and it might seem that there's no
+        // need to put v3 back in v1, v0 and v1 might be aliases so `store v2 at v0`
+        // might change the value at v1, so the next store to v1 must be preserved.
         let src = r#"
         acir(inline) fn create_note f0 {
           b0(v0: &mut [Field; 1], v1: &mut [Field; 1]):

--- a/compiler/noirc_evaluator/src/ssa/opt/mem2reg.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/mem2reg.rs
@@ -1582,4 +1582,25 @@ mod tests {
         }
         ");
     }
+
+    #[test]
+    fn does_not_remove_store_to_potentially_aliased_address() {
+        // This is a regression test for https://github.com/noir-lang/noir/pull/9613
+        // In that PR all tests passed but the sync to Aztec-Packages failed.
+        // That PR had `store v3 at v1` incorrectly removed.
+        let src = r#"
+        acir(inline) fn create_note f0 {
+          b0(v0: &mut [Field; 1], v1: &mut [Field; 1]):
+            v2 = load v0 -> [Field; 1]
+            v3 = load v1 -> [Field; 1]
+            store v2 at v0
+            store v3 at v1
+            v4 = load v1 -> [Field; 1]
+            v6 = make_array [Field 0] : [Field; 1]
+            store v6 at v1
+            return v1
+        }
+        "#;
+        assert_ssa_does_not_change(src, Ssa::mem2reg);
+    }
 }


### PR DESCRIPTION
# Description

## Problem

Something pending from https://github.com/noir-lang/noir/pull/9628

## Summary

I found an SSA code that breaks with the incorrect PR.

I still didn't have time to investigate why that regression happens in that PR. Tomorrow I'll try to bring back #9613 while trying to fix the bug as I think the logic there is mostly fine (and if I manage to do so I'll check that it doesn't break Aztec-Packages).

## Additional Context



## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
