### PR TITLE
fix(mem2reg): Assume all function reference parameters have an unknown alias set with nested references

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/opt/mem2reg.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/mem2reg.rs
@@ -350,8 +350,8 @@ impl<'f> PerFunctionContext<'f> {
                 // If the type indirectly contains a reference we have to assume all references
                 // are unknown since we don't have any ValueIds to use.
                 Type::Reference(element) if element.contains_reference() => {
-                  self.mark_all_unknown(params, references);
-                  return;
+                    self.mark_all_unknown(params, references);
+                    return;
                 }
                 Type::Reference(element) => {
                     let empty_aliases = AliasSet::known_empty();
@@ -360,8 +360,8 @@ impl<'f> PerFunctionContext<'f> {
                     alias_set.insert(*param);
                 }
                 typ if typ.contains_reference() => {
-                  self.mark_all_unknown(params, references);
-                  return;
+                    self.mark_all_unknown(params, references);
+                    return;
                 }
                 _ => continue,
             }

--- a/test_programs/compile_success_empty/nested_ref_param_regression_9500/Nargo.toml
+++ b/test_programs/compile_success_empty/nested_ref_param_regression_9500/Nargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "nested_ref_param_regression_9500"
+type = "bin"
+authors = [""]
+
+[dependencies]

--- a/test_programs/compile_success_empty/nested_ref_param_regression_9500/src/main.nr
+++ b/test_programs/compile_success_empty/nested_ref_param_regression_9500/src/main.nr
@@ -1,0 +1,12 @@
+fn main() {
+    let ref = &mut 0;
+    let ref3 = &mut &mut 0;
+    foo(ref, ref, ref3);
+    assert_eq(*ref, 2);
+}
+
+fn foo(ref1: &mut Field, ref2: &mut Field, _ref3: &mut &mut Field) {
+    *ref1 = 1;
+    *ref2 = 2;
+    for _ in 0..10 {}
+}

--- a/tooling/nargo_cli/tests/snapshots/compile_success_empty/nested_ref_param_regression_9500/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_empty/nested_ref_param_regression_9500/execute__tests__expanded.snap
@@ -1,0 +1,16 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: expanded_code
+---
+fn main() {
+    let ref: &mut Field = &mut 0_Field;
+    let ref3: &mut &mut Field = &mut &mut 0_Field;
+    foo(ref, ref, ref3);
+    assert(*ref == 2_Field);
+}
+
+fn foo(ref1: &mut Field, ref2: &mut Field, _ref3: &mut &mut Field) {
+    *(ref1) = 1_Field;
+    *(ref2) = 2_Field;
+    for _ in 0_u32..10_u32 {}
+}

--- a/tooling/nargo_cli/tests/snapshots/compile_success_empty/nested_ref_param_regression_9500/execute__tests__force_brillig_false_inliner_0.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_empty/nested_ref_param_regression_9500/execute__tests__force_brillig_false_inliner_0.snap
@@ -1,0 +1,26 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: artifact
+---
+{
+  "noir_version": "[noir_version]",
+  "hash": "[hash]",
+  "abi": {
+    "parameters": [],
+    "return_type": null,
+    "error_types": {}
+  },
+  "bytecode": [
+    "func 0",
+    "current witness index : _0",
+    "private parameters indices : []",
+    "public parameters indices : []",
+    "return value indices : []"
+  ],
+  "debug_symbols": "XY5BCsQwCEXv4rqLWfcqw1BsaosgJtikMITefWyYQOlK/3/6tcJCc9km1jXuML4rzMYivE0SA2aO6m49B+hyykbkFty4byU00gyjFpEBDpTShvaE2mpGc/oagHTx6oErC13d+XGBge158UBjnIX+ci0abjR/Uyf942Qx0FKMrqTGPPsH",
+  "file_map": {},
+  "names": [
+    "main"
+  ],
+  "brillig_names": []
+}


### PR DESCRIPTION
# Description

## Problem\*

Resolves #9500 

## Summary\*

As per the comment on `add_aliases_for_reference_parameters` the method attempts to do the following:
```
    /// Go through each parameter and register that all reference parameters of the same type are
    /// possibly aliased to each other. If there are parameters with nested references (arrays of
    /// references or references containing other references) we give up and assume all parameter
    /// references are `AliasSet::unknown()`.
```
However, we never actually do what the comment says in the method. This PR fixes that and appropriately mark all parameters as unknown in the case of a nested reference.

## Additional Context



## Documentation\*

Check one:
- [X] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
