### PR TITLE
chore: add another mem2reg regression for #9613

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/opt/mem2reg.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/mem2reg.rs
@@ -1633,7 +1633,7 @@ mod tests {
     }
 
     #[test]
-    fn does_not_replaces_load_with_value_when_one_of_its_predecessors_changes_it() {
+    fn does_not_replace_load_with_value_when_one_of_its_predecessors_changes_it() {
         // This is another regression test for https://github.com/noir-lang/noir/pull/9613
         // There, in `v5 = load v0 -> Field` it was incorrectly assumed that v5 could
         // be replaced with `Field 0`, but another predecessor, through an alias


### PR DESCRIPTION
# Description

## Problem

Something else that breaks with #9613 but there was no such test.

## Summary

I still didn't investigate why #9613 breaks this but I'll do that next, then I'll try to revive #9613 once more (third time's a charm?)

## Additional Context



## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
