### PR TITLE
fix(expand): better handling of dereferences (again)

### DIFF
--- a/test_programs/compile_success_empty/nested_dereferences/src/main.nr
+++ b/test_programs/compile_success_empty/nested_dereferences/src/main.nr
@@ -2,7 +2,16 @@ struct Foo {
     inner: Field,
 }
 
+struct Bar {
+    inner: Foo,
+}
+
 fn main() {
+    nested_dereferences();
+    nested_struct_aliases_in_array();
+}
+
+fn nested_dereferences() {
     let mut var = Foo { inner: 0 };
     let ref = &mut &mut var;
 
@@ -16,4 +25,22 @@ fn main() {
     assert((**ref).inner == 2);
     assert((**array[0]).inner == 2);
     assert((**array[1]).inner == 2);
+}
+
+fn nested_struct_aliases_in_array() {
+    let mut var = Bar { inner: Foo { inner: 0 } };
+
+    let ref = &mut &mut &mut var;
+
+    let mut array = [ref, ref];
+
+    (**array[0]).inner.inner += 5;
+    (**array[1]).inner.inner += 2;
+
+    assert(var.inner.inner == 7);
+    assert((***ref).inner.inner == 7);
+    assert((**array[0]).inner.inner == 7);
+    assert((**array[1]).inner.inner == 7);
+
+    assert(var.inner.inner == 7);
 }

--- a/tooling/nargo_cli/tests/snapshots/compile_success_empty/comptime_closures/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_empty/comptime_closures/execute__tests__expanded.snap
@@ -8,9 +8,9 @@ fn main() {
 
 fn closure_test(mut x: Field) {
     let one: Field = 1_Field;
-    let add1: fn[(Field,)](&mut Field) = |z: &mut Field| (|| { *(z) = *z + one; })();
+    let add1: fn[(Field,)](&mut Field) = |z: &mut Field| (|| { *z = *z + one; })();
     let two: Field = 2_Field;
-    let add2: fn[(Field,)](&mut Field) = |z: &mut Field| { *(z) = *z + two; };
+    let add2: fn[(Field,)](&mut Field) = |z: &mut Field| { *z = *z + two; };
     add1(&mut x);
     assert(x == 1_Field);
     add2(&mut x);
@@ -20,7 +20,7 @@ fn closure_test(mut x: Field) {
 
 fn issue_2120() {
     let x1: &mut Field = &mut 42_Field;
-    let set_x1: fn[(&mut Field,)](Field) = |y: Field| { *(x1) = y; };
+    let set_x1: fn[(&mut Field,)](Field) = |y: Field| { *x1 = y; };
     assert(*x1 == 42_Field);
     set_x1(44_Field);
     assert(*x1 == 44_Field);

--- a/tooling/nargo_cli/tests/snapshots/compile_success_empty/generators/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_empty/generators/execute__tests__expanded.snap
@@ -5,7 +5,7 @@ expression: expanded_code
 fn make_counter() -> fn[(&mut Field,)]() -> Field {
     let mut x: &mut Field = &mut 0_Field;
     || -> Field {
-        *(x) = *x + 1_Field;
+        *x = *x + 1_Field;
         *x
     }
 }
@@ -16,8 +16,8 @@ fn fibonacci_generator() -> fn[(&mut Field, &mut Field)]() -> Field {
     || -> Field {
         let old_x: Field = *x;
         let old_y: Field = *y;
-        *(y) = *x + *y;
-        *(x) = old_y;
+        *y = *x + *y;
+        *x = old_y;
         old_x
     }
 }

--- a/tooling/nargo_cli/tests/snapshots/compile_success_empty/higher_order_fn_selector/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_empty/higher_order_fn_selector/execute__tests__expanded.snap
@@ -3,16 +3,16 @@ source: tooling/nargo_cli/tests/execute.rs
 expression: expanded_code
 ---
 fn g(x: &mut Field) {
-    *(x) = *x * 2_Field;
+    *x = *x * 2_Field;
 }
 
 fn h(x: &mut Field) {
-    *(x) = *x * 3_Field;
+    *x = *x * 3_Field;
 }
 
 fn selector(flag: &mut bool) -> fn(&mut Field) {
     let my_func: fn(&mut Field) = if *flag { g } else { h };
-    *(flag) = !*flag;
+    *flag = !*flag;
     my_func
 }
 

--- a/tooling/nargo_cli/tests/snapshots/compile_success_empty/nested_dereferences/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_empty/nested_dereferences/execute__tests__expanded.snap
@@ -6,15 +6,37 @@ struct Foo {
     inner: Field,
 }
 
+struct Bar {
+    inner: Foo,
+}
+
 fn main() {
+    nested_dereferences();
+    nested_struct_aliases_in_array();
+}
+
+fn nested_dereferences() {
     let mut var: Foo = Foo { inner: 0_Field };
     let ref: &mut &mut Foo = &mut &mut var;
     let mut array: [&mut &mut Foo; 2] = [ref, ref];
     assert((**array[0_u32]).inner == 0_Field);
-    (*(*(array[0_u32]))).inner = 1_Field;
-    (*(*(array[1_u32]))).inner = 2_Field;
+    (**array[0_u32]).inner = 1_Field;
+    (**array[1_u32]).inner = 2_Field;
     assert(var.inner == 2_Field);
     assert((**ref).inner == 2_Field);
     assert((**array[0_u32]).inner == 2_Field);
     assert((**array[1_u32]).inner == 2_Field);
+}
+
+fn nested_struct_aliases_in_array() {
+    let mut var: Bar = Bar { inner: Foo { inner: 0_Field } };
+    let ref: &mut &mut &mut Bar = &mut &mut &mut var;
+    let mut array: [&mut &mut &mut Bar; 2] = [ref, ref];
+    (**array[0_u32]).inner.inner = (**array[0_u32]).inner.inner + 5_Field;
+    (**array[1_u32]).inner.inner = (**array[1_u32]).inner.inner + 2_Field;
+    assert(var.inner.inner == 7_Field);
+    assert((***ref).inner.inner == 7_Field);
+    assert((**array[0_u32]).inner.inner == 7_Field);
+    assert((**array[1_u32]).inner.inner == 7_Field);
+    assert(var.inner.inner == 7_Field);
 }

--- a/tooling/nargo_cli/tests/snapshots/compile_success_empty/nested_ref_param_regression_9500/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_empty/nested_ref_param_regression_9500/execute__tests__expanded.snap
@@ -10,7 +10,7 @@ fn main() {
 }
 
 fn foo(ref1: &mut Field, ref2: &mut Field, _ref3: &mut &mut Field) {
-    *(ref1) = 1_Field;
-    *(ref2) = 2_Field;
+    *ref1 = 1_Field;
+    *ref2 = 2_Field;
     for _ in 0_u32..10_u32 {}
 }

--- a/tooling/nargo_cli/tests/snapshots/compile_success_empty/references_aliasing/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_empty/references_aliasing/execute__tests__expanded.snap
@@ -13,15 +13,15 @@ fn main() {
 }
 
 fn increment(mut r: &mut Field) {
-    *(r) = *r + 1_Field;
+    *r = *r + 1_Field;
 }
 
 fn regression_2445() {
     let mut var: Field = 0_Field;
     let ref: &mut &mut Field = &mut &mut var;
     let mut array: [&mut &mut Field; 2] = [ref, ref];
-    *(*(array[0_u32])) = 1_Field;
-    *(*(array[1_u32])) = 2_Field;
+    **array[0_u32] = 1_Field;
+    **array[1_u32] = 2_Field;
     assert(var == 2_Field);
     assert(**ref == 2_Field);
     assert(**array[0_u32] == 2_Field);
@@ -32,7 +32,7 @@ fn single_alias_inside_loop() {
     let mut var: Field = 0_Field;
     let ref: &mut &mut Field = &mut &mut var;
     for _ in 0_u32..1_u32 {
-        *(*(ref)) = 2_Field;
+        **ref = 2_Field;
     }
     assert(var == 2_Field);
     assert(**ref == 2_Field);

--- a/tooling/nargo_cli/tests/snapshots/compile_success_empty/regression_9398/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_empty/regression_9398/execute__tests__expanded.snap
@@ -12,6 +12,6 @@ fn main() {
 
 fn foo(param: [&mut str<4>; 1]) {
     let s: &mut str<4> = param[0_u32];
-    *(s) = "GOOD";
+    *s = "GOOD";
     for _ in 0_u32..1_u32 {}
 }

--- a/tooling/nargo_cli/tests/snapshots/compile_success_no_bug/noirc_frontend_tests_mutate_with_reference_in_lambda/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_no_bug/noirc_frontend_tests_mutate_with_reference_in_lambda/execute__tests__expanded.snap
@@ -4,7 +4,7 @@ expression: expanded_code
 ---
 fn main() {
     let x: &mut Field = &mut 3_Field;
-    let f: fn[(&mut Field,)]() = || { *(x) = *x + 2_Field; };
+    let f: fn[(&mut Field,)]() = || { *x = *x + 2_Field; };
     f();
     assert(*x == 5_Field);
 }

--- a/tooling/nargo_cli/tests/snapshots/compile_success_no_bug/noirc_frontend_tests_mutate_with_reference_marked_mutable_in_lambda/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_no_bug/noirc_frontend_tests_mutate_with_reference_marked_mutable_in_lambda/execute__tests__expanded.snap
@@ -4,7 +4,7 @@ expression: expanded_code
 ---
 fn main() {
     let mut x: &mut Field = &mut 3_Field;
-    let f: fn[(&mut Field,)]() = || { *(x) = *x + 2_Field; };
+    let f: fn[(&mut Field,)]() = || { *x = *x + 2_Field; };
     f();
     assert(*x == 5_Field);
 }

--- a/tooling/nargo_cli/tests/snapshots/execution_success/closures_mut_ref/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/closures_mut_ref/execute__tests__expanded.snap
@@ -4,9 +4,9 @@ expression: expanded_code
 ---
 fn main(mut x: Field) {
     let one: Field = 1_Field;
-    let add1: fn[(Field,)](&mut Field) = |z: &mut Field| { *(z) = *z + one; };
+    let add1: fn[(Field,)](&mut Field) = |z: &mut Field| { *z = *z + one; };
     let two: Field = 2_Field;
-    let add2: fn[(Field,)](&mut Field) = |z: &mut Field| { *(z) = *z + two; };
+    let add2: fn[(Field,)](&mut Field) = |z: &mut Field| { *z = *z + two; };
     add1(&mut x);
     assert(x == 1_Field);
     add2(&mut x);
@@ -16,7 +16,7 @@ fn main(mut x: Field) {
 
 fn issue_2120() {
     let x1: &mut Field = &mut 42_Field;
-    let set_x1: fn[(&mut Field,)](Field) = |y: Field| { *(x1) = y; };
+    let set_x1: fn[(&mut Field,)](Field) = |y: Field| { *x1 = y; };
     assert(*x1 == 42_Field);
     set_x1(44_Field);
     assert(*x1 == 44_Field);

--- a/tooling/nargo_cli/tests/snapshots/execution_success/hint_black_box/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/hint_black_box/execute__tests__expanded.snap
@@ -73,5 +73,5 @@ unconstrained fn brillig_slice_sum(xs: [u32]) -> u32 {
 }
 
 fn set_ref(c: &mut u32, b: &mut u32) {
-    *(c) = *b;
+    *c = *b;
 }

--- a/tooling/nargo_cli/tests/snapshots/execution_success/missing_closure_env/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/missing_closure_env/execute__tests__expanded.snap
@@ -4,7 +4,7 @@ expression: expanded_code
 ---
 fn main(x: Field) {
     let x1: &mut Field = &mut 42_Field;
-    let set_x1: fn[(&mut Field,)](Field) = |y: Field| { *(x1) = y; };
+    let set_x1: fn[(&mut Field,)](Field) = |y: Field| { *x1 = y; };
     assert(*x1 == 42_Field);
     set_x1(44_Field);
     assert(*x1 == 44_Field);

--- a/tooling/nargo_cli/tests/snapshots/execution_success/reference_cancelling/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/reference_cancelling/execute__tests__expanded.snap
@@ -12,7 +12,7 @@ fn main() {
 fn store_through_outer_pointer() -> bool {
     let a: &mut ((bool,),) = &mut ((false,),);
     let b: &mut bool = &mut a.0.0;
-    *(a) = ((true,),);
+    *a = ((true,),);
     println(*b);
     *b
 }

--- a/tooling/nargo_cli/tests/snapshots/execution_success/reference_only_used_as_alias/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/reference_only_used_as_alias/execute__tests__expanded.snap
@@ -76,7 +76,7 @@ unconstrained fn func(input: u32) {
     let mut var: u32 = input;
     let ref: &mut &mut u32 = &mut &mut var;
     for _ in 0_u32..1_u32 {
-        *(*(ref)) = 2_u32;
+        **ref = 2_u32;
     }
     assert(var == 2_u32);
     assert(**ref == 2_u32);

--- a/tooling/nargo_cli/tests/snapshots/execution_success/references/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/references/execute__tests__expanded.snap
@@ -18,7 +18,7 @@ fn main(mut x: Field) {
     add1(*nested_allocations.y);
     assert(**nested_allocations.y == 1_Field);
     let mut c: C = C { foo: 0_Field, bar: &mut C2 { array: &mut [1_Field, 2_Field] } };
-    *(c.bar.array) = [3_Field, 4_Field];
+    *c.bar.array = [3_Field, 4_Field];
     assert(*c.bar.array == [3_Field, 4_Field]);
     regression_1887();
     regression_2054();
@@ -34,7 +34,7 @@ fn main(mut x: Field) {
 }
 
 fn add1(x: &mut Field) {
-    *(x) = *x + 1_Field;
+    *x = *x + 1_Field;
 }
 
 struct S {
@@ -99,7 +99,7 @@ fn regression_2030() {
     let ref: &mut Field = &mut 0_Field;
     let mut array: [&mut Field; 2] = [ref, ref];
     let _: Field = *array[0_u32];
-    *(array[0_u32]) = 1_Field;
+    *array[0_u32] = 1_Field;
 }
 
 fn regression_2255() {
@@ -109,7 +109,7 @@ fn regression_2255() {
 }
 
 fn regression_2255_helper(mut x: &mut Field) {
-    *(x) = 1_Field;
+    *x = 1_Field;
 }
 
 fn regression_6443() {
@@ -119,7 +119,7 @@ fn regression_6443() {
 }
 
 fn regression_6443_helper(x: &mut Field) {
-    *(x) = 1_Field;
+    *x = 1_Field;
 }
 
 fn regression_2218(x: Field, y: Field) -> Field {
@@ -127,17 +127,17 @@ fn regression_2218(x: Field, y: Field) -> Field {
     let q1: &mut Field = *q;
     let q2: &mut Field = *q;
     if x != y {
-        *(q1) = 1_Field;
+        *q1 = 1_Field;
         if x != 20_Field {
-            *(q1) = 10_Field;
-            *(q2) = 2_Field;
+            *q1 = 10_Field;
+            *q2 = 2_Field;
             assert(*q1 == 2_Field);
         } else {
-            *(q2) = 15_Field;
+            *q2 = 15_Field;
             assert(*q1 == 15_Field);
         }
     } else {
-        *(q2) = 20_Field;
+        *q2 = 20_Field;
         assert(*q1 == 20_Field);
     };
     let value: Field = *q1;
@@ -165,11 +165,11 @@ fn regression_2218_loop(x: Field, y: Field) {
     let q2: &mut Field = *q;
     for _ in 0_u32..1_u32 {
         if x != y {
-            *(q1) = 10_Field;
-            *(q2) = 2_Field;
+            *q1 = 10_Field;
+            *q2 = 2_Field;
             assert(*q1 == 2_Field);
         } else {
-            *(q2) = 20_Field;
+            *q2 = 20_Field;
             assert(*q1 == 20_Field);
         }
     }
@@ -177,28 +177,28 @@ fn regression_2218_loop(x: Field, y: Field) {
     for _ in 0_u32..1_u32 {
         for _ in 0_u32..5_u32 {
             if x != y {
-                *(q1) = 1_Field;
+                *q1 = 1_Field;
                 if x != 20_Field {
-                    *(q1) = 10_Field;
-                    *(q2) = 2_Field;
+                    *q1 = 10_Field;
+                    *q2 = 2_Field;
                     assert(*q1 == 2_Field);
                 }
             } else {
-                *(q2) = 20_Field;
+                *q2 = 20_Field;
                 assert(*q1 == 20_Field);
             }
         }
         if x != y {
-            *(q1) = 1_Field;
+            *q1 = 1_Field;
             for _ in 0_u32..5_u32 {
                 if x != 20_Field {
-                    *(q1) = 10_Field;
-                    *(q2) = 2_Field;
+                    *q1 = 10_Field;
+                    *q2 = 2_Field;
                     assert(*q1 == 2_Field);
                 }
             }
         } else {
-            *(q2) = 20_Field;
+            *q2 = 20_Field;
             assert(*q1 == 20_Field);
         }
     }
@@ -206,16 +206,16 @@ fn regression_2218_loop(x: Field, y: Field) {
     if x != y {
         for _ in 0_u32..5_u32 {
             if x != y {
-                *(q1) = 1_Field;
+                *q1 = 1_Field;
                 if x != 20_Field {
-                    *(q1) = 10_Field;
-                    *(q2) = 2_Field;
+                    *q1 = 10_Field;
+                    *q2 = 2_Field;
                     assert(*q1 == 2_Field);
                 }
             }
         }
     } else {
-        *(q2) = 20_Field;
+        *q2 = 20_Field;
         assert(*q1 == 20_Field);
     };
     assert(*q1 == 2_Field);

--- a/tooling/nargo_cli/tests/snapshots/execution_success/regression_9037/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/regression_9037/execute__tests__expanded.snap
@@ -12,7 +12,7 @@ unconstrained fn main() -> pub [[bool; 1]; 1] {
 
 unconstrained fn func_3(a: ([bool; 1],), mut c: [[bool; 1]; 1], ctx_limit: &mut u32) -> bool {
     if *ctx_limit > 0_u32 {
-        *(ctx_limit) = *ctx_limit - 1_u32;
+        *ctx_limit = *ctx_limit - 1_u32;
         if func_3(G_B, [a.0], ctx_limit) {
             c[0_u32] = {
                 {

--- a/tooling/nargo_cli/tests/snapshots/execution_success/regression_9303/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/regression_9303/execute__tests__expanded.snap
@@ -17,7 +17,7 @@ unconstrained fn func_5(
     if *ctx_limit == 0_u32 {
         (a.0[0_u32], *a.1)
     } else {
-        *(ctx_limit) = *ctx_limit - 1_u32;
+        *ctx_limit = *ctx_limit - 1_u32;
         func_5(if *a.1 { a } else { (a.0, &mut c.1) }, c, ctx_limit)
     }
 }

--- a/tooling/nargo_cli/tests/snapshots/execution_success/regression_9415/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/regression_9415/execute__tests__expanded.snap
@@ -7,6 +7,6 @@ unconstrained fn main(index: u32) {
     let v1: &mut Field = &mut 2_Field;
     let mut v3: [&mut Field; 1] = [v0];
     v3[index] = v1;
-    *(v3[index]) = 3_Field;
+    *v3[index] = 3_Field;
     assert(*v3[index] == 3_Field);
 }

--- a/tooling/nargo_cli/tests/snapshots/execution_success/regression_9439/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/regression_9439/execute__tests__expanded.snap
@@ -8,7 +8,7 @@ unconstrained fn main(n: u32) {
     for _ in 0_u32..n {
         slice = slice.push_back(num1);
     }
-    *(slice[0_u32]) = 9_Field;
+    *slice[0_u32] = 9_Field;
     assert(*slice[0_u32] == 9_Field);
     assert(*num1 == 9_Field);
 }

--- a/tooling/nargo_cli/tests/snapshots/execution_success/regression_9455/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/regression_9455/execute__tests__expanded.snap
@@ -5,6 +5,6 @@ expression: expanded_code
 unconstrained fn main(predicate: bool) {
     let num1: &mut Field = &mut 0_Field;
     let array: [&mut Field; 1] = if predicate { [num1] } else { [num1] };
-    *(array[0_u32]) = 9_Field;
+    *array[0_u32] = 9_Field;
     assert(*array[0_u32] == 9_Field);
 }

--- a/tooling/nargo_cli/tests/snapshots/execution_success/struct_assignment_with_shared_ref_to_field/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/struct_assignment_with_shared_ref_to_field/execute__tests__expanded.snap
@@ -21,6 +21,6 @@ fn plain_store() -> bool {
 fn store_through_pointer() -> bool {
     let a: &mut (bool,) = &mut (false,);
     let b: &mut bool = &mut a.0;
-    *(a) = (true,);
+    *a = (true,);
     *b
 }


### PR DESCRIPTION
# Description

## Problem

Resolves #9581

## Summary

The logic for printing dereferences in l-values was still wrong. In some cases it missed a parentheses, in many cases it added parentheses for no reasons. I ended up with a code that prints dereferences with the minimum number of parentheses, if you look at the snapshots diff. So this is a fix but also an enhancement.

## Additional Context



## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
