### PR TITLE
chore(ssa_fuzzer): refactor ssa_fuzzer part 2/4

### DIFF
--- a/tooling/ssa_fuzzer/fuzzer/src/fuzz_lib/fuzz_target_lib.rs
+++ b/tooling/ssa_fuzzer/fuzzer/src/fuzz_lib/fuzz_target_lib.rs
@@ -6,7 +6,7 @@ use super::{
 };
 use acvm::FieldElement;
 use acvm::acir::native_types::{Witness, WitnessMap};
-use noir_ssa_fuzzer::r#type::NumericType;
+use noir_ssa_fuzzer::r#type::{NumericType, Type};
 
 fn initialize_witness_map(
     initial_witness: &[WitnessValue;
@@ -56,7 +56,7 @@ pub(crate) fn fuzz_target(data: FuzzerData, options: FuzzerOptions) -> Option<Fu
     for func in data.functions {
         log::debug!("initial_witness: {witness_map:?}");
         log::debug!("commands: {:?}", func.commands);
-        fuzzer.process_function(func, types.clone());
+        fuzzer.process_function(func, types.iter().map(|t| Type::Numeric(*t)).collect());
     }
     fuzzer.finalize_and_run(witness_map)
 }

--- a/tooling/ssa_fuzzer/fuzzer/src/fuzz_lib/fuzzer.rs
+++ b/tooling/ssa_fuzzer/fuzzer/src/fuzz_lib/fuzzer.rs
@@ -22,17 +22,16 @@ use super::{
 };
 use acvm::FieldElement;
 use acvm::acir::native_types::{WitnessMap, WitnessStack};
-use libfuzzer_sys::{arbitrary, arbitrary::Arbitrary};
 use noir_ssa_executor::runner::execute_single;
 use noir_ssa_fuzzer::{
     runner::{CompareResults, run_and_compare},
-    r#type::NumericType,
+    r#type::Type,
 };
 use noirc_driver::CompiledProgram;
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 
-#[derive(Arbitrary, Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub(crate) struct FuzzerData {
     pub(crate) functions: Vec<FunctionData>,
     pub(crate) initial_witness:
@@ -62,9 +61,10 @@ pub(crate) struct FuzzerOutput {
 }
 
 impl FuzzerOutput {
-    pub(crate) fn get_return_value(&self) -> FieldElement {
-        let return_witness = self.program.program.functions[0].return_values.0.first().unwrap();
-        self.witness_stack.peek().unwrap().witness[return_witness]
+    pub(crate) fn get_return_values(&self) -> Vec<FieldElement> {
+        let return_witnesses = &self.program.program.functions[0].return_values.0;
+        let witness_vec = &self.witness_stack.peek().unwrap().witness;
+        return_witnesses.iter().map(|witness| witness_vec[witness]).collect()
     }
 }
 
@@ -86,11 +86,7 @@ impl Fuzzer {
         Self { contexts }
     }
 
-    pub(crate) fn process_function(
-        &mut self,
-        function_data: FunctionData,
-        types: Vec<NumericType>,
-    ) {
+    pub(crate) fn process_function(&mut self, function_data: FunctionData, types: Vec<Type>) {
         for context in &mut self.contexts {
             context.process_function(function_data.clone(), types.clone());
         }
@@ -111,7 +107,9 @@ impl Fuzzer {
         }
         let results_set = execution_results
             .values()
-            .map(|result| -> Option<FieldElement> { result.as_ref().map(|r| r.get_return_value()) })
+            .map(|result| -> Option<Vec<FieldElement>> {
+                result.as_ref().map(|r| r.get_return_values())
+            })
             .collect::<HashSet<_>>();
 
         if results_set.len() != 1 {
@@ -119,7 +117,7 @@ impl Fuzzer {
             for (mode, result) in execution_results {
                 if let Some(result) = result {
                     panic_string
-                        .push_str(&format!("Mode {mode:?}: {:?}\n", result.get_return_value()));
+                        .push_str(&format!("Mode {mode:?}: {:?}\n", result.get_return_values()));
                 } else {
                     panic_string.push_str(&format!("Mode {mode:?} failed\n"));
                 }
@@ -193,14 +191,12 @@ impl Fuzzer {
                 Some(FuzzerOutput { witness_stack: result, program: acir_program })
             }
             CompareResults::Disagree(acir_return_value, brillig_return_value) => {
-                let acir_return_witness =
-                    acir_program.program.functions[0].return_values.0.first().unwrap();
-                let brillig_return_witness =
-                    brillig_program.program.functions[0].return_values.0.first().unwrap();
-                let acir_return_value =
-                    acir_return_value.peek().unwrap().witness[acir_return_witness];
-                let brillig_return_value =
-                    brillig_return_value.peek().unwrap().witness[brillig_return_witness];
+                let acir_fuzzer_output =
+                    FuzzerOutput { witness_stack: acir_return_value, program: acir_program };
+                let brillig_fuzzer_output =
+                    FuzzerOutput { witness_stack: brillig_return_value, program: brillig_program };
+                let acir_return_value = acir_fuzzer_output.get_return_values();
+                let brillig_return_value = brillig_fuzzer_output.get_return_values();
                 panic!(
                     "ACIR and Brillig programs returned different results: \
                     ACIR returned {acir_return_value:?}, Brillig returned {brillig_return_value:?}"

--- a/tooling/ssa_fuzzer/fuzzer/src/fuzz_lib/instruction.rs
+++ b/tooling/ssa_fuzzer/fuzzer/src/fuzz_lib/instruction.rs
@@ -1,6 +1,6 @@
 use libfuzzer_sys::arbitrary;
 use libfuzzer_sys::arbitrary::Arbitrary;
-use noir_ssa_fuzzer::r#type::NumericType;
+use noir_ssa_fuzzer::r#type::{NumericType, Type};
 use serde::{Deserialize, Serialize};
 use strum_macros::EnumCount;
 #[derive(Arbitrary, Debug, Clone, Copy, Serialize, Deserialize)]
@@ -200,8 +200,8 @@ pub(crate) struct InstructionBlock {
 
 #[derive(Clone)]
 pub(crate) struct FunctionInfo {
-    pub(crate) input_types: Vec<NumericType>,
-    pub(crate) return_type: NumericType,
+    pub(crate) input_types: Vec<Type>,
+    pub(crate) return_type: Type,
     /// Max size of unrolled loops in the function
     pub(crate) max_unrolled_size: usize,
 }

--- a/tooling/ssa_fuzzer/fuzzer/src/fuzz_lib/program_context.rs
+++ b/tooling/ssa_fuzzer/fuzzer/src/fuzz_lib/program_context.rs
@@ -6,7 +6,7 @@ use super::{
 use acvm::FieldElement;
 use noir_ssa_fuzzer::{
     builder::{FuzzerBuilder, FuzzerBuilderError},
-    r#type::NumericType,
+    r#type::Type,
 };
 use noirc_driver::CompiledProgram;
 use noirc_evaluator::ssa::ir::{function::Function, map::Id};
@@ -15,7 +15,7 @@ use std::collections::BTreeMap;
 struct StoredFunction {
     id: Id<Function>,
     function: FunctionData,
-    types: Vec<NumericType>,
+    types: Vec<Type>,
 }
 
 /// FuzzerProgramContext is a context for storing and processing SSA functions
@@ -98,12 +98,12 @@ impl FuzzerProgramContext {
     }
 
     /// Stores function and its signature
-    pub(crate) fn process_function(&mut self, function: FunctionData, types: Vec<NumericType>) {
+    pub(crate) fn process_function(&mut self, function: FunctionData, types: Vec<Type>) {
         // leaving max_unrolled_size = 0 for now
         //
         let signature = FunctionInfo {
             input_types: types.clone(),
-            return_type: function.return_type,
+            return_type: function.return_type.clone(),
             max_unrolled_size: 0,
         };
         self.function_information.insert(self.current_function_id, signature);
@@ -235,11 +235,11 @@ impl FuzzerProgramContext {
                     self.values
                         .iter()
                         .zip(stored_function.types.iter())
-                        .map(|(value, type_)| (*value, *type_))
+                        .map(|(value, type_)| (*value, type_.unwrap_numeric()))
                         .collect(),
                     &self.instruction_blocks,
                     self.program_context_options.clone(),
-                    stored_function.function.return_type,
+                    stored_function.function.return_type.clone(),
                     defined_functions,
                     &mut self.acir_builder,
                     &mut self.brillig_builder,
@@ -249,7 +249,7 @@ impl FuzzerProgramContext {
                     stored_function.types.to_vec(),
                     &self.instruction_blocks,
                     self.program_context_options.clone(),
-                    stored_function.function.return_type,
+                    stored_function.function.return_type.clone(),
                     defined_functions,
                     &mut self.acir_builder,
                     &mut self.brillig_builder,

--- a/tooling/ssa_fuzzer/fuzzer/src/fuzz_lib/tests/arrays.rs
+++ b/tooling/ssa_fuzzer/fuzzer/src/fuzz_lib/tests/arrays.rs
@@ -9,7 +9,7 @@ use crate::instruction::{Argument, Instruction, InstructionBlock};
 use crate::options::FuzzerOptions;
 use crate::tests::common::default_witness;
 use acvm::FieldElement;
-use noir_ssa_fuzzer::r#type::NumericType;
+use noir_ssa_fuzzer::r#type::{NumericType, Type};
 
 /// Test array get and set
 /// fn main f0 {
@@ -58,8 +58,11 @@ fn array_get_and_set() {
         FuzzerFunctionCommand::InsertSimpleInstructionBlock { instruction_block_idx: 0 },
         FuzzerFunctionCommand::InsertSimpleInstructionBlock { instruction_block_idx: 1 },
     ];
-    let main_func =
-        FunctionData { commands, return_instruction_block_idx: 2, return_type: NumericType::Field };
+    let main_func = FunctionData {
+        commands,
+        return_instruction_block_idx: 2,
+        return_type: Type::Numeric(NumericType::Field),
+    };
     let fuzzer_data = FuzzerData {
         instruction_blocks: instructions_blocks,
         functions: vec![main_func],
@@ -67,7 +70,7 @@ fn array_get_and_set() {
     };
     let result = fuzz_target(fuzzer_data, FuzzerOptions::default());
     match result {
-        Some(result) => assert_eq!(result.get_return_value(), FieldElement::from(4_u32)),
+        Some(result) => assert_eq!(result.get_return_values()[0], FieldElement::from(4_u32)),
         None => panic!("Program failed to execute"),
     }
 }
@@ -145,8 +148,11 @@ fn test_reference_in_array() {
         FuzzerFunctionCommand::InsertSimpleInstructionBlock { instruction_block_idx: 4 },
         FuzzerFunctionCommand::InsertSimpleInstructionBlock { instruction_block_idx: 5 },
     ];
-    let main_func =
-        FunctionData { commands, return_instruction_block_idx: 6, return_type: NumericType::Field };
+    let main_func = FunctionData {
+        commands,
+        return_instruction_block_idx: 6,
+        return_type: Type::Numeric(NumericType::Field),
+    };
     let fuzzer_data = FuzzerData {
         instruction_blocks: instructions_blocks,
         functions: vec![main_func],
@@ -154,7 +160,7 @@ fn test_reference_in_array() {
     };
     let result = fuzz_target(fuzzer_data, FuzzerOptions::default());
     match result {
-        Some(result) => assert_eq!(result.get_return_value(), FieldElement::from(1_u32)),
+        Some(result) => assert_eq!(result.get_return_values()[0], FieldElement::from(1_u32)),
         None => panic!("Program failed to execute"),
     }
 }

--- a/tooling/ssa_fuzzer/fuzzer/src/fuzz_lib/tests/basic_unsigned_test.rs
+++ b/tooling/ssa_fuzzer/fuzzer/src/fuzz_lib/tests/basic_unsigned_test.rs
@@ -20,7 +20,7 @@ use crate::instruction::{Argument, Instruction, InstructionBlock};
 use crate::options::FuzzerOptions;
 use crate::{NUMBER_OF_PREDEFINED_VARIABLES, NUMBER_OF_VARIABLES_INITIAL};
 use acvm::FieldElement;
-use noir_ssa_fuzzer::r#type::NumericType;
+use noir_ssa_fuzzer::r#type::{NumericType, Type};
 
 /// Creates default witness values for testing
 /// Returns [U64(0), U64(1), U64(2), U64(3), U64(4)]
@@ -73,11 +73,11 @@ fn test_op_u64(op: UnsignedOp) -> FieldElement {
         functions: vec![FunctionData {
             commands: vec![],
             return_instruction_block_idx: 0,
-            return_type: NumericType::U64,
+            return_type: Type::Numeric(NumericType::U64),
         }],
         initial_witness: default_unsigned_witness(),
     };
-    fuzz_target(data, FuzzerOptions::default()).unwrap().get_return_value()
+    fuzz_target(data, FuzzerOptions::default()).unwrap().get_return_values()[0]
 }
 
 #[test]

--- a/tooling/ssa_fuzzer/fuzzer/src/fuzz_lib/tests/ecdsa.rs
+++ b/tooling/ssa_fuzzer/fuzzer/src/fuzz_lib/tests/ecdsa.rs
@@ -6,7 +6,7 @@ use crate::options::FuzzerOptions;
 use crate::tests::common::default_witness;
 use acvm::AcirField;
 use acvm::FieldElement;
-use noir_ssa_fuzzer::r#type::NumericType;
+use noir_ssa_fuzzer::r#type::{NumericType, Type};
 
 #[test]
 fn test_valid_ecdsa_signature_secp256r1() {
@@ -25,7 +25,7 @@ fn test_valid_ecdsa_signature_secp256r1() {
     let function = FunctionData {
         commands,
         return_instruction_block_idx: 0,
-        return_type: NumericType::Boolean,
+        return_type: Type::Numeric(NumericType::Boolean),
     };
     let data = FuzzerData {
         instruction_blocks: vec![block],
@@ -33,7 +33,7 @@ fn test_valid_ecdsa_signature_secp256r1() {
         initial_witness: default_witness(),
     };
     let result = fuzz_target(data, FuzzerOptions::default()).unwrap();
-    assert_eq!(result.get_return_value(), FieldElement::one());
+    assert_eq!(result.get_return_values()[0], FieldElement::one());
 }
 
 #[test]
@@ -53,7 +53,7 @@ fn test_valid_ecdsa_signature_secp256k1() {
     let function = FunctionData {
         commands,
         return_instruction_block_idx: 0,
-        return_type: NumericType::Boolean,
+        return_type: Type::Numeric(NumericType::Boolean),
     };
     let data = FuzzerData {
         instruction_blocks: vec![block],
@@ -61,7 +61,7 @@ fn test_valid_ecdsa_signature_secp256k1() {
         initial_witness: default_witness(),
     };
     let result = fuzz_target(data, FuzzerOptions::default()).unwrap();
-    assert_eq!(result.get_return_value(), FieldElement::one());
+    assert_eq!(result.get_return_values()[0], FieldElement::one());
 }
 
 #[test]
@@ -81,7 +81,7 @@ fn test_corrupted_ecdsa_signature_secp256r1() {
     let function = FunctionData {
         commands,
         return_instruction_block_idx: 0,
-        return_type: NumericType::Boolean,
+        return_type: Type::Numeric(NumericType::Boolean),
     };
     let data = FuzzerData {
         instruction_blocks: vec![block],
@@ -90,7 +90,7 @@ fn test_corrupted_ecdsa_signature_secp256r1() {
     };
     let result = fuzz_target(data, FuzzerOptions::default());
     match result {
-        Some(res) => panic!("Programs executed with the Result: {:?}", res.get_return_value()),
+        Some(res) => panic!("Programs executed with the Result: {:?}", res.get_return_values()),
         None => println!("Error. As expected"),
     }
 }
@@ -112,7 +112,7 @@ fn test_corrupted_ecdsa_signature_secp256k1() {
     let function = FunctionData {
         commands,
         return_instruction_block_idx: 0,
-        return_type: NumericType::Boolean,
+        return_type: Type::Numeric(NumericType::Boolean),
     };
     let data = FuzzerData {
         instruction_blocks: vec![block],
@@ -121,7 +121,7 @@ fn test_corrupted_ecdsa_signature_secp256k1() {
     };
     let result = fuzz_target(data, FuzzerOptions::default());
     match result {
-        Some(res) => panic!("Programs executed with the Result: {:?}", res.get_return_value()),
+        Some(res) => panic!("Programs executed with the Result: {:?}", res.get_return_values()),
         None => println!("Error. As expected"),
     }
 }

--- a/tooling/ssa_fuzzer/fuzzer/src/fuzz_lib/tests/embedded_curve_ops.rs
+++ b/tooling/ssa_fuzzer/fuzzer/src/fuzz_lib/tests/embedded_curve_ops.rs
@@ -5,7 +5,7 @@ use crate::instruction::{Instruction, InstructionBlock, Point, Scalar};
 use crate::options::FuzzerOptions;
 use crate::tests::common::default_witness;
 use acvm::FieldElement;
-use noir_ssa_fuzzer::r#type::NumericType;
+use noir_ssa_fuzzer::r#type::{NumericType, Type};
 
 /// fn main(lo: Field) -> pub Field {
 ///     let scalar_1 = std::embedded_curve_ops::EmbeddedCurveScalar::new(lo, 0);
@@ -34,8 +34,11 @@ fn smoke_test_embedded_curve_add() {
     };
     let block = InstructionBlock { instructions: vec![add_instruction] };
     let commands = vec![];
-    let function =
-        FunctionData { commands, return_instruction_block_idx: 0, return_type: NumericType::Field };
+    let function = FunctionData {
+        commands,
+        return_instruction_block_idx: 0,
+        return_type: Type::Numeric(NumericType::Field),
+    };
     let data = FuzzerData {
         instruction_blocks: vec![block],
         functions: vec![function],
@@ -43,7 +46,7 @@ fn smoke_test_embedded_curve_add() {
     };
     let result = fuzz_target(data, FuzzerOptions::default()).unwrap();
     assert_eq!(
-        result.get_return_value(),
+        result.get_return_values()[0],
         FieldElement::try_from_str(
             "8902249110305491597038405103722863701255802573786510474664632793109847672620"
         )
@@ -75,8 +78,11 @@ fn smoke_test_embedded_multi_scalar_mul() {
     };
     let block = InstructionBlock { instructions: vec![instruction] };
     let commands = vec![];
-    let function =
-        FunctionData { commands, return_instruction_block_idx: 0, return_type: NumericType::Field };
+    let function = FunctionData {
+        commands,
+        return_instruction_block_idx: 0,
+        return_type: Type::Numeric(NumericType::Field),
+    };
     let data = FuzzerData {
         instruction_blocks: vec![block],
         functions: vec![function],
@@ -84,7 +90,7 @@ fn smoke_test_embedded_multi_scalar_mul() {
     };
     let result = fuzz_target(data, FuzzerOptions::default()).unwrap();
     assert_eq!(
-        result.get_return_value(),
+        result.get_return_values()[0],
         FieldElement::try_from_str(
             "-3851299760922698091325321774664553326049887197487063802849283717866939395465"
         )

--- a/tooling/ssa_fuzzer/fuzzer/src/fuzz_lib/tests/hash_tests.rs
+++ b/tooling/ssa_fuzzer/fuzzer/src/fuzz_lib/tests/hash_tests.rs
@@ -12,6 +12,7 @@ use crate::options::FuzzerOptions;
 use crate::tests::common::default_witness;
 use acvm::FieldElement;
 use noir_ssa_fuzzer::r#type::NumericType;
+use noir_ssa_fuzzer::r#type::Type;
 
 /// blake2s(to_le_radix(0, 256, 32)) == blake2s computed with noir
 ///
@@ -29,8 +30,11 @@ fn smoke_test_blake2s_hash() {
     };
     let instructions_blocks = vec![blake2s_hash_block];
     let commands = vec![];
-    let main_func =
-        FunctionData { commands, return_instruction_block_idx: 0, return_type: NumericType::Field };
+    let main_func = FunctionData {
+        commands,
+        return_instruction_block_idx: 0,
+        return_type: Type::Numeric(NumericType::Field),
+    };
     let fuzzer_data = FuzzerData {
         instruction_blocks: instructions_blocks,
         functions: vec![main_func],
@@ -39,7 +43,7 @@ fn smoke_test_blake2s_hash() {
     let result = fuzz_target(fuzzer_data, FuzzerOptions::default());
     match result {
         Some(result) => assert_eq!(
-            result.get_return_value(),
+            result.get_return_values()[0],
             FieldElement::try_from_str(
                 "-9211429028062209127175291049466917975585300944217240748738694765619842249938"
             )
@@ -65,8 +69,11 @@ fn smoke_test_blake3_hash() {
     };
     let instructions_blocks = vec![blake3_hash_block];
     let commands = vec![];
-    let main_func =
-        FunctionData { commands, return_instruction_block_idx: 0, return_type: NumericType::Field };
+    let main_func = FunctionData {
+        commands,
+        return_instruction_block_idx: 0,
+        return_type: Type::Numeric(NumericType::Field),
+    };
     let fuzzer_data = FuzzerData {
         instruction_blocks: instructions_blocks,
         functions: vec![main_func],
@@ -75,7 +82,7 @@ fn smoke_test_blake3_hash() {
     let result = fuzz_target(fuzzer_data, FuzzerOptions::default());
     match result {
         Some(result) => assert_eq!(
-            result.get_return_value(),
+            result.get_return_values()[0],
             FieldElement::try_from_str(
                 "11496696481601359239189947342432058980836600577383371976100559912527609453094"
             )
@@ -106,8 +113,11 @@ fn smoke_test_aes128_encrypt() {
     };
     let instructions_blocks = vec![aes128_encrypt_block];
     let commands = vec![];
-    let main_func =
-        FunctionData { commands, return_instruction_block_idx: 0, return_type: NumericType::Field };
+    let main_func = FunctionData {
+        commands,
+        return_instruction_block_idx: 0,
+        return_type: Type::Numeric(NumericType::Field),
+    };
     let fuzzer_data = FuzzerData {
         instruction_blocks: instructions_blocks,
         functions: vec![main_func],
@@ -116,7 +126,7 @@ fn smoke_test_aes128_encrypt() {
     let result = fuzz_target(fuzzer_data, FuzzerOptions::default());
     match result {
         Some(result) => assert_eq!(
-            result.get_return_value(),
+            result.get_return_values()[0],
             FieldElement::try_from_str(
                 "7228449286344697221705732525592563926191809635549234005020486075743434697058"
             )
@@ -152,8 +162,11 @@ fn smoke_test_keccakf1600() {
     let commands =
         vec![FuzzerFunctionCommand::InsertSimpleInstructionBlock { instruction_block_idx: 0 }];
     // this function will take the last defined u64, which is equal to the last element of the keccakf1600 permuted array
-    let main_func =
-        FunctionData { commands, return_instruction_block_idx: 1, return_type: NumericType::U64 };
+    let main_func = FunctionData {
+        commands,
+        return_instruction_block_idx: 1,
+        return_type: Type::Numeric(NumericType::U64),
+    };
     let fuzzer_data = FuzzerData {
         instruction_blocks: instructions_blocks,
         functions: vec![main_func],
@@ -162,7 +175,7 @@ fn smoke_test_keccakf1600() {
     let result = fuzz_target(fuzzer_data, FuzzerOptions::default());
     match result {
         Some(result) => {
-            assert_eq!(result.get_return_value(), FieldElement::from(16929593379567477321_u64));
+            assert_eq!(result.get_return_values()[0], FieldElement::from(16929593379567477321_u64));
         }
         None => panic!("Program failed to execute"),
     }
@@ -192,8 +205,11 @@ fn smoke_test_sha256_compression() {
     let instructions_blocks = vec![cast_block, sha256_compression_block];
     let commands =
         vec![FuzzerFunctionCommand::InsertSimpleInstructionBlock { instruction_block_idx: 0 }];
-    let main_func =
-        FunctionData { commands, return_instruction_block_idx: 1, return_type: NumericType::U32 };
+    let main_func = FunctionData {
+        commands,
+        return_instruction_block_idx: 1,
+        return_type: Type::Numeric(NumericType::U32),
+    };
     let fuzzer_data = FuzzerData {
         instruction_blocks: instructions_blocks,
         functions: vec![main_func],
@@ -202,7 +218,7 @@ fn smoke_test_sha256_compression() {
     let result = fuzz_target(fuzzer_data, FuzzerOptions::default());
     match result {
         Some(result) => {
-            assert_eq!(result.get_return_value(), FieldElement::from(3205228454_u32));
+            assert_eq!(result.get_return_values()[0], FieldElement::from(3205228454_u32));
         }
         None => panic!("Program failed to execute"),
     }

--- a/tooling/ssa_fuzzer/fuzzer/src/fuzz_lib/tests/loops.rs
+++ b/tooling/ssa_fuzzer/fuzzer/src/fuzz_lib/tests/loops.rs
@@ -10,7 +10,7 @@ use crate::instruction::{Argument, Instruction, InstructionBlock};
 use crate::options::FuzzerOptions;
 use crate::tests::common::default_witness;
 use acvm::FieldElement;
-use noir_ssa_fuzzer::r#type::NumericType;
+use noir_ssa_fuzzer::r#type::{NumericType, Type};
 
 /// fn main(x: Field) -> pub Field {
 ///   let mut y = x;
@@ -51,13 +51,13 @@ fn test_simple_loop() {
         functions: vec![FunctionData {
             commands,
             return_instruction_block_idx: 1, // v12 = load v8 -> Field; return v12
-            return_type: NumericType::Field,
+            return_type: Type::Numeric(NumericType::Field),
         }],
         initial_witness: default_witness(),
     };
     let result = fuzz_target(data, FuzzerOptions::default());
     match result {
-        Some(result) => assert_eq!(result.get_return_value(), FieldElement::from(1024_u32)),
+        Some(result) => assert_eq!(result.get_return_values()[0], FieldElement::from(1024_u32)),
         None => panic!("Program failed to execute"),
     }
 }
@@ -119,13 +119,13 @@ fn test_nested_loop() {
         functions: vec![FunctionData {
             commands,
             return_instruction_block_idx: 1, // v13 = load v9 -> Field; return v13
-            return_type: NumericType::Field,
+            return_type: Type::Numeric(NumericType::Field),
         }],
         initial_witness: default_witness(),
     };
     let result = fuzz_target(data, FuzzerOptions::default());
     match result {
-        Some(result) => assert_eq!(result.get_return_value(), FieldElement::from(131072_u32)),
+        Some(result) => assert_eq!(result.get_return_values()[0], FieldElement::from(131072_u32)),
         None => panic!("Program failed to execute"),
     }
 }
@@ -189,13 +189,13 @@ fn test_loop_broken_with_jmp() {
         functions: vec![FunctionData {
             commands,
             return_instruction_block_idx: 1,
-            return_type: NumericType::Field,
+            return_type: Type::Numeric(NumericType::Field),
         }],
         initial_witness: default_witness(),
     };
     let result = fuzz_target(data, FuzzerOptions::default());
     match result {
-        Some(result) => assert_eq!(result.get_return_value(), FieldElement::from(4096_u32)),
+        Some(result) => assert_eq!(result.get_return_values()[0], FieldElement::from(4096_u32)),
         None => panic!("Program failed to execute"),
     }
 }
@@ -259,13 +259,13 @@ fn test_jmp_if_in_cycle() {
         functions: vec![FunctionData {
             commands: commands.clone(),
             return_instruction_block_idx: 1,
-            return_type: NumericType::Field,
+            return_type: Type::Numeric(NumericType::Field),
         }],
         initial_witness: default_witness(),
     };
     let result = fuzz_target(data, FuzzerOptions::default());
     match result {
-        Some(result) => assert_eq!(result.get_return_value(), FieldElement::from(22_u32)),
+        Some(result) => assert_eq!(result.get_return_values()[0], FieldElement::from(22_u32)),
         None => panic!("Program failed to execute"),
     }
 
@@ -294,13 +294,13 @@ fn test_jmp_if_in_cycle() {
         functions: vec![FunctionData {
             commands,
             return_instruction_block_idx: 1,
-            return_type: NumericType::Field,
+            return_type: Type::Numeric(NumericType::Field),
         }],
         initial_witness: default_witness(),
     };
     let result = fuzz_target(data, FuzzerOptions::default());
     match result {
-        Some(result) => assert_eq!(result.get_return_value(), FieldElement::from(2048_u32)),
+        Some(result) => assert_eq!(result.get_return_values()[0], FieldElement::from(2048_u32)),
         None => panic!("Program failed to execute"),
     }
 }

--- a/tooling/ssa_fuzzer/fuzzer/src/mutations/basic_types/mod.rs
+++ b/tooling/ssa_fuzzer/fuzzer/src/mutations/basic_types/mod.rs
@@ -2,5 +2,6 @@ pub(crate) mod bool;
 pub(crate) mod numeric_type;
 pub(crate) mod point;
 pub(crate) mod scalar;
+pub(crate) mod ssa_fuzzer_type;
 pub(crate) mod usize;
 pub(crate) mod vec;

--- a/tooling/ssa_fuzzer/fuzzer/src/mutations/basic_types/ssa_fuzzer_type.rs
+++ b/tooling/ssa_fuzzer/fuzzer/src/mutations/basic_types/ssa_fuzzer_type.rs
@@ -1,0 +1,52 @@
+use crate::mutations::{
+    basic_types::numeric_type::generate_random_numeric_type,
+    configuration::{
+        BASIC_GENERATE_NUMERIC_TYPE_CONFIGURATION, BASIC_GENERATE_TYPE_CONFIGURATION, GenerateType,
+        GenerateTypeConfig,
+    },
+};
+use noir_ssa_fuzzer::r#type::Type;
+use rand::{Rng, rngs::StdRng};
+use std::sync::Arc;
+
+// god save me
+// can be Reference(Array(Reference(Slice(Reference(Numeric)))))
+// hope can handle it
+fn generate_random_reference_type(rng: &mut StdRng, config: GenerateTypeConfig) -> Type {
+    Type::Reference(Arc::new(generate_random_ssa_fuzzer_type(rng, config)))
+}
+
+fn generate_random_array_type(rng: &mut StdRng, config: GenerateTypeConfig) -> Type {
+    Type::Array(
+        Arc::new(vec![generate_random_ssa_fuzzer_type(rng, config)]),
+        rng.gen_range(u8::MIN..u8::MAX).into(),
+    )
+}
+
+fn generate_random_slice_type(rng: &mut StdRng, config: GenerateTypeConfig) -> Type {
+    Type::Slice(Arc::new(vec![generate_random_ssa_fuzzer_type(rng, config)]))
+}
+
+pub(crate) fn generate_random_ssa_fuzzer_type(
+    rng: &mut StdRng,
+    config: GenerateTypeConfig,
+) -> Type {
+    match config.select(rng) {
+        GenerateType::Numeric => Type::Numeric(generate_random_numeric_type(
+            rng,
+            BASIC_GENERATE_NUMERIC_TYPE_CONFIGURATION,
+        )),
+        GenerateType::Reference => generate_random_reference_type(rng, config),
+        GenerateType::Array => generate_random_array_type(rng, config),
+        GenerateType::Slice => generate_random_slice_type(rng, config),
+    }
+}
+
+// TODO
+pub(crate) fn mutate_ssa_fuzzer_type(
+    type_: &mut Type,
+    rng: &mut StdRng,
+    _config: GenerateTypeConfig,
+) {
+    *type_ = generate_random_ssa_fuzzer_type(rng, BASIC_GENERATE_TYPE_CONFIGURATION);
+}

--- a/tooling/ssa_fuzzer/fuzzer/src/mutations/basic_types/vec.rs
+++ b/tooling/ssa_fuzzer/fuzzer/src/mutations/basic_types/vec.rs
@@ -7,24 +7,8 @@
 //! 5. Mutate a random element at a random index
 //! 6. Push a default element to the end of the vector
 
-use crate::mutations::configuration::{
-    SIZE_OF_LARGE_ARBITRARY_BUFFER, VecMutationConfig, VecMutationOptions,
-};
-use libfuzzer_sys::arbitrary::{Arbitrary, Unstructured};
+use crate::mutations::configuration::{VecMutationConfig, VecMutationOptions};
 use rand::{Rng, rngs::StdRng};
-
-/// Mutate the entire vector, replacing it with a random vector
-struct RandomMutation;
-impl RandomMutation {
-    fn mutate<T>(rng: &mut StdRng, vec: &mut Vec<T>)
-    where
-        T: for<'a> Arbitrary<'a>,
-    {
-        let mut bytes = [0u8; SIZE_OF_LARGE_ARBITRARY_BUFFER];
-        rng.fill(&mut bytes);
-        *vec = Unstructured::new(&bytes).arbitrary().unwrap();
-    }
-}
 
 /// Insert a random element at a random index
 struct RandomInsertion;
@@ -33,9 +17,7 @@ impl RandomInsertion {
         rng: &mut StdRng,
         vec: &mut Vec<T>,
         generate_random_element_function: impl Fn(&mut StdRng) -> T,
-    ) where
-        T: for<'a> Arbitrary<'a>,
-    {
+    ) {
         let element = generate_random_element_function(rng);
         if !vec.is_empty() {
             let index = rng.gen_range(0..vec.len());
@@ -102,10 +84,9 @@ pub(crate) fn mutate_vec<T>(
     generate_random_element_function: impl Fn(&mut StdRng) -> T,
     config: VecMutationConfig,
 ) where
-    T: for<'a> Arbitrary<'a> + Default,
+    T: Default,
 {
     match config.select(rng) {
-        VecMutationOptions::Random => RandomMutation::mutate(rng, vec),
         VecMutationOptions::Insertion => {
             RandomInsertion::mutate(rng, vec, generate_random_element_function);
         }

--- a/tooling/ssa_fuzzer/fuzzer/src/mutations/configuration.rs
+++ b/tooling/ssa_fuzzer/fuzzer/src/mutations/configuration.rs
@@ -131,17 +131,15 @@ pub(crate) const BASIC_ARGUMENT_MUTATION_CONFIGURATION: ArgumentMutationConfig =
 
 #[derive(Copy, Clone, Debug)]
 pub(crate) enum VecMutationOptions {
-    Random,
     Insertion,
     Deletion,
     Swap,
     ElementMutation,
     PushDefault,
 }
-pub(crate) type VecMutationConfig = WeightedSelectionConfig<VecMutationOptions, 6>;
+pub(crate) type VecMutationConfig = WeightedSelectionConfig<VecMutationOptions, 5>;
 
 pub(crate) const BASIC_VEC_MUTATION_CONFIGURATION: VecMutationConfig = VecMutationConfig::new([
-    (VecMutationOptions::Random, 1),
     (VecMutationOptions::Insertion, 7),
     (VecMutationOptions::Deletion, 22),
     (VecMutationOptions::Swap, 20),
@@ -416,6 +414,31 @@ const _: () = {
     assert!(
         BASIC_GENERATE_NUMERIC_TYPE_CONFIGURATION.options_with_weights.len() == NumericType::COUNT,
         "BASIC_GENERATE_NUMERIC_TYPE_CONFIGURATION must have an entry for every GenerateNumericType variant"
+    );
+};
+
+#[derive(Copy, Clone, Debug)]
+pub(crate) enum GenerateType {
+    Numeric,
+    Reference,
+    Array,
+    Slice,
+}
+
+pub(crate) type GenerateTypeConfig = WeightedSelectionConfig<GenerateType, 4>;
+pub(crate) const BASIC_GENERATE_TYPE_CONFIGURATION: GenerateTypeConfig = GenerateTypeConfig::new([
+    (GenerateType::Numeric, 20),
+    (GenerateType::Reference, 4),
+    (GenerateType::Array, 1),
+    (GenerateType::Slice, 1),
+]);
+
+const _: () = {
+    use noir_ssa_fuzzer::r#type::Type;
+    use strum::EnumCount;
+    assert!(
+        BASIC_GENERATE_TYPE_CONFIGURATION.options_with_weights.len() == Type::COUNT,
+        "BASIC_GENERATE_TYPE_CONFIGURATION must have an entry for every Type variant"
     );
 };
 

--- a/tooling/ssa_fuzzer/fuzzer/src/mutations/functions/commands_mutator.rs
+++ b/tooling/ssa_fuzzer/fuzzer/src/mutations/functions/commands_mutator.rs
@@ -10,7 +10,7 @@ use crate::mutations::{
 };
 use rand::rngs::StdRng;
 
-fn generate_random_fuzzer_function_command(rng: &mut StdRng) -> FuzzerFunctionCommand {
+pub(crate) fn generate_random_fuzzer_function_command(rng: &mut StdRng) -> FuzzerFunctionCommand {
     match BASIC_GENERATE_COMMAND_CONFIGURATION.select(rng) {
         GenerateCommand::InsertJmpIfBlock => {
             FuzzerFunctionCommand::InsertJmpIfBlock { block_then_idx: 0, block_else_idx: 0 }

--- a/tooling/ssa_fuzzer/fuzzer/src/mutations/functions/function.rs
+++ b/tooling/ssa_fuzzer/fuzzer/src/mutations/functions/function.rs
@@ -1,7 +1,7 @@
 use crate::mutations::{
-    basic_types::{numeric_type::mutate_numeric_type, usize::mutate_usize},
+    basic_types::{ssa_fuzzer_type::mutate_ssa_fuzzer_type, usize::mutate_usize},
     configuration::{
-        BASIC_FUNCTION_MUTATION_CONFIGURATION, BASIC_NUMERIC_TYPE_MUTATION_CONFIGURATION,
+        BASIC_FUNCTION_MUTATION_CONFIGURATION, BASIC_GENERATE_TYPE_CONFIGURATION,
         BASIC_USIZE_MUTATION_CONFIGURATION, FunctionMutationOptions,
     },
     functions::{FunctionData, commands_mutator},
@@ -21,11 +21,7 @@ pub(crate) fn mutate_function(data: &mut FunctionData, rng: &mut StdRng) {
             commands_mutator::mutate_vec_fuzzer_command(&mut data.commands, rng);
         }
         FunctionMutationOptions::ReturnType => {
-            mutate_numeric_type(
-                &mut data.return_type,
-                rng,
-                BASIC_NUMERIC_TYPE_MUTATION_CONFIGURATION,
-            );
+            mutate_ssa_fuzzer_type(&mut data.return_type, rng, BASIC_GENERATE_TYPE_CONFIGURATION);
         }
     }
 }

--- a/tooling/ssa_fuzzer/fuzzer/src/mutations/functions/mod.rs
+++ b/tooling/ssa_fuzzer/fuzzer/src/mutations/functions/mod.rs
@@ -4,18 +4,19 @@ mod function;
 
 use crate::fuzz_lib::function_context::FunctionData;
 use crate::mutations::{
-    basic_types::vec::mutate_vec,
-    configuration::{BASIC_VEC_MUTATION_CONFIGURATION, SIZE_OF_LARGE_ARBITRARY_BUFFER},
+    basic_types::{ssa_fuzzer_type::generate_random_ssa_fuzzer_type, vec::mutate_vec},
+    configuration::{BASIC_GENERATE_TYPE_CONFIGURATION, BASIC_VEC_MUTATION_CONFIGURATION},
+    functions::commands_mutator::generate_random_fuzzer_function_command,
     functions::function::mutate_function,
 };
-use libfuzzer_sys::arbitrary::Unstructured;
 use rand::{Rng, rngs::StdRng};
 
 fn generate_random_function_data(rng: &mut StdRng) -> FunctionData {
-    let mut buf = [0u8; SIZE_OF_LARGE_ARBITRARY_BUFFER];
-    rng.fill(&mut buf);
-    let mut unstructured = Unstructured::new(&buf);
-    unstructured.arbitrary().unwrap()
+    FunctionData {
+        commands: vec![generate_random_fuzzer_function_command(rng)],
+        return_instruction_block_idx: rng.gen_range(u8::MIN..u8::MAX).into(),
+        return_type: generate_random_ssa_fuzzer_type(rng, BASIC_GENERATE_TYPE_CONFIGURATION),
+    }
 }
 
 pub(crate) fn mutate(vec_function_data: &mut Vec<FunctionData>, rng: &mut StdRng) {

--- a/tooling/ssa_fuzzer/src/builder.rs
+++ b/tooling/ssa_fuzzer/src/builder.rs
@@ -172,7 +172,7 @@ impl FuzzerBuilder {
     /// Inserts a cast instruction
     pub fn insert_cast(&mut self, value: TypedValue, cast_type: Type) -> TypedValue {
         assert!(value.is_numeric(), "must be numeric");
-        assert!(cast_type.is_numeric(), "must be numeric");
+        assert!(cast_type.is_numeric(), "must be numeric, got {cast_type:?}");
 
         let init_bit_length = value.bit_length();
 
@@ -376,6 +376,20 @@ impl FuzzerBuilder {
             "All elements must have the same type"
         );
         let array_elements_type = Type::Array(Arc::new(vec![element_type]), array_length);
+        let res = self.builder.insert_make_array(
+            elements.into_iter().map(|e| e.value_id).collect(),
+            array_elements_type.clone().into(),
+        );
+        TypedValue::new(res, array_elements_type)
+    }
+
+    pub fn insert_slice(&mut self, elements: Vec<TypedValue>) -> TypedValue {
+        let element_type = elements[0].type_of_variable.clone();
+        assert!(
+            elements.iter().all(|e| e.type_of_variable == element_type),
+            "All elements must have the same type"
+        );
+        let array_elements_type = Type::Slice(Arc::new(vec![element_type]));
         let res = self.builder.insert_make_array(
             elements.into_iter().map(|e| e.value_id).collect(),
             array_elements_type.clone().into(),

--- a/tooling/ssa_fuzzer/src/type.rs
+++ b/tooling/ssa_fuzzer/src/type.rs
@@ -58,7 +58,7 @@ impl From<NumericType> for SsaNumericType {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, EnumCount)]
 pub enum Type {
     Numeric(NumericType),
     Reference(Arc<Type>),


### PR DESCRIPTION
# Description
Functions now can return references, arrays and slices

### `function_context.rs`
+ Now function returns `Type` instead of `NumericType`
### `fuzzer.rs`
+ `get_return_value` -> `get_return_values`, returns all return witnesses, not just one
### `instruction.rs`
+ input_types for functions are now Types, not numeric types. But fuzzer still fills all functions with numeric types (TODO in followups)
### `basic_tests.rs`
+ Added test checking that function can return array
### Mutations
+ Added mutations and generators for `Type`
+ Removed random mutation from vector (from arbitrary bytes), because `Type` cannot implement `Arbitrary`. 
### `runner.rs`
+ Now comparing all return witnesses, not just one
### `builder.rs`
+ Added `insert_slice`



## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*



## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
