### PR TITLE
fix(formatter): don't revert indentation increase after popping it

### DIFF
--- a/tooling/nargo_fmt/src/chunks.rs
+++ b/tooling/nargo_fmt/src/chunks.rs
@@ -1033,6 +1033,10 @@ impl<'a> Formatter<'a> {
                 }
                 Chunk::PopIndentation => {
                     self.pop_indentation();
+
+                    // Any increased indentation that we were planning to undo must not be undone
+                    // if we change the current indentation to something completely different.
+                    increased_indentation = 0;
                 }
                 Chunk::TrailingComma => {
                     unreachable!(

--- a/tooling/nargo_fmt/src/formatter/expression.rs
+++ b/tooling/nargo_fmt/src/formatter/expression.rs
@@ -2628,4 +2628,16 @@ global y = 1;
 "#;
         assert_format_with_max_width(src, src, 40);
     }
+
+    #[test]
+    fn regression_9556() {
+        let src = r#"fn foo() {
+    let x = a()
+        .bcde(fghijk
+            );
+    x
+}
+"#;
+        assert_format_with_max_width(src, src, 20)
+    }
 }

--- a/tooling/nargo_fmt/src/formatter/expression.rs
+++ b/tooling/nargo_fmt/src/formatter/expression.rs
@@ -2638,6 +2638,6 @@ global y = 1;
     x
 }
 "#;
-        assert_format_with_max_width(src, src, 20)
+        assert_format_with_max_width(src, src, 20);
     }
 }


### PR DESCRIPTION
# Description

## Problem

Resolves #9556

## Summary

A quick fix for the issue. Ideally the formatting could be better but at least we don't end up with a wrong indentation later on...

(but this fix is good on its own, regardless of it not leading to an ideal code formatting)

## Additional Context



## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
