### PR TITLE
chore: remove unnecessary truncation when removing shift-right

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/opt/remove_bit_shifts.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/remove_bit_shifts.rs
@@ -158,12 +158,11 @@ impl Context<'_, '_, '_> {
                 // - ones_complement(lhs) / (2^rhs) == 0
                 // As the upper bit is set for the ones complement of negative numbers we'd need 2^rhs
                 // to be larger than the lhs bitsize for this to overflow.
-                let shifted = self.insert_binary(
+                self.insert_binary(
                     shifted_complement,
                     BinaryOp::Sub { unchecked: true },
                     lhs_sign_as_int,
-                );
-                self.insert_truncate(shifted, bit_size, bit_size + 1)
+                )
             }
 
             NumericType::NativeField => unreachable!("Bit shifts are disallowed on `Field` type"),
@@ -721,8 +720,7 @@ mod tests {
                 v9 = div v7, i32 4
                 v10 = cast v2 as i32
                 v11 = unchecked_sub v9, v10
-                v12 = truncate v11 to 32 bits, max_bit_size: 33
-                return v12
+                return v11
             }
             ");
         }
@@ -799,8 +797,7 @@ mod tests {
                 v65 = div v64, v57
                 v66 = cast v59 as i32
                 v67 = unchecked_sub v65, v66
-                v68 = truncate v67 to 32 bits, max_bit_size: 33
-                return v68
+                return v67
             }
             "#);
         }


### PR DESCRIPTION
# Description

## Problem

No issue, just something I noticed while writing docs for remove_shift_right.

## Summary

At the end of replacing shift-right we truncate, for example, an i8 to 8 bits. That should always be a no-op so in this PR that's removed.

## Additional Context



## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
