### PR TITLE
chore(licm): Break things up further in LICM

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/opt/loop_invariant.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/loop_invariant.rs
@@ -612,7 +612,7 @@ impl<'f> LoopInvariantContext<'f> {
 
         // When hoisting a control dependent instruction, if a side effectual instruction comes in the predecessor block
         // of that instruction we can no longer hoist the control dependent instruction.
-        // This is important for maintaining ordering semantic correctness of the code.
+        // This is important for maintaining the execution order and semantic correctness of the code.
         // If the predecessors are all pure, the block might turn impure as an when we encounter
         // a side-effectful instruction in it later.
         let is_impure = all_predecessors.iter().any(|block| {

--- a/compiler/noirc_evaluator/src/ssa/opt/loop_invariant.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/loop_invariant.rs
@@ -421,7 +421,7 @@ impl<'f> LoopInvariantContext<'f> {
                     }
                 } else {
                     let dfg = &self.inserter.function.dfg;
-                    // If the block has already been labelled as impure, we do need to check the current
+                    // If the block has already been labelled as impure, we don't need to check the current
                     // instruction's side effects.
                     if !block_context.is_impure {
                         block_context.is_impure = dfg[instruction_id].has_side_effects(dfg);

--- a/compiler/noirc_evaluator/src/ssa/opt/loop_invariant.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/loop_invariant.rs
@@ -236,7 +236,7 @@ struct BlockContext {
     /// Tracks whether the current block has a side-effectual instruction.
     /// This is maintained per instruction for hoisting control dependent instructions
     is_impure: bool,
-    /// Stores whether the current loop has known fix upper and lower bounds that
+    /// Stores whether the current loop has known fixed upper and lower bounds that
     /// indicate that it is guaranteed to execute at least once.
     does_execute: bool,
 }


### PR DESCRIPTION
# Description

## Problem\*

`LoopContext` had a bunch of `current_block_*` fields which had to be reset for each block we iterated over in `hoist_loop_invariants`, and assigned new values in various methods that also mutated other fields on `LoopContext`. Some were unrelated, like `is_control_dependent_post_pre_header` also set the block purity, seemingly just because `all_predecessors` was available there. This made it hard to find where various flags on `LoopContext` came from.

## Summary\*

* Breaks out the `current_block_*` fields from `LoopContext` into a `BlockContext` and introduces an `LoopInvariantContext::init_block_context` method to create it, so we cannot forget to set the values, and there is no risk of reusing something from the previous iteration. 
* Changes all query methods for the `BlockContext` initialisation to avoid mutating the `LoopContext`, so it's a bit more obvious where things are set, all clear in the `init_block_context` method.
* Renames `get_values_defined_in_loop` to `init_loop_context` as it did more than what it said on the tin.
* Makes `LoopContext::pre_header` non-optional.
* Copied some extra explanation for control dependence from the paper to have an intuitive definition.
* Avoid checking repeatedly whether the bounds in the `LoopContext` guarantee execution by storing the result in a field.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
