### PR TITLE
fix: properly quote variables in install_bb.sh script

### DIFF
--- a/scripts/install_bb.sh
+++ b/scripts/install_bb.sh
@@ -4,8 +4,8 @@ VERSION="0.87.0"
 
 BBUP_PATH=~/.bb/bbup
 
-if ! [ -f $BBUP_PATH ]; then 
+if ! [ -f "$BBUP_PATH" ]; then 
     curl -L https://bbup.aztec.network | bash
 fi
 
-$BBUP_PATH -v $VERSION
+"$BBUP_PATH" -v "$VERSION"


### PR DESCRIPTION
# Description

## Problem

Unquoted shell variables in install_bb.sh script can cause failures when paths contain spaces or special characters.

## Summary

Add proper quoting around shell variables in the BB installation script to prevent potential failures and follow bash scripting best practices.

Changes:
- Quote $BBUP_PATH in file existence check  
- Quote $BBUP_PATH and $VERSION in command execution

## Additional Context

This follows standard bash security practices and prevents script failures in environments where paths might contain spaces.


## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
