### PR TITLE
chore: have `--with-ssa-locations` instead of `--no-ssa-locations`

### DIFF
--- a/compiler/noirc_driver/src/lib.rs
+++ b/compiler/noirc_driver/src/lib.rs
@@ -80,10 +80,10 @@ pub struct CompileOptions {
     #[arg(long, hide = true)]
     pub show_ssa_pass: Vec<String>,
 
-    /// Do not emit source file locations when emitting debug information for the SSA IR to stdout.
-    /// By default, source file locations will be shown.
+    /// Emit source file locations when emitting debug information for the SSA IR to stdout.
+    /// By default, source file locations won't be shown.
     #[arg(long, hide = true)]
-    pub no_ssa_locations: bool,
+    pub with_ssa_locations: bool,
 
     /// Only show the SSA and ACIR for the contract function with a given name.
     #[arg(long, hide = true)]
@@ -821,7 +821,7 @@ pub fn compile_no_check(
             create_program(
                 program,
                 &ssa_evaluator_options,
-                if options.no_ssa_locations { None } else { Some(&context.file_manager) },
+                if options.with_ssa_locations { Some(&context.file_manager) } else { None },
             )?
         };
 

--- a/tooling/nargo_cli/src/cli/interpret_cmd.rs
+++ b/tooling/nargo_cli/src/cli/interpret_cmd.rs
@@ -130,7 +130,7 @@ pub(crate) fn run(args: InterpretCommand, workspace: Workspace) -> Result<(), Cl
 
         let interpreter_options = InterpreterOptions { trace: args.trace, ..Default::default() };
         let file_manager =
-            if args.compile_options.no_ssa_locations { None } else { Some(&file_manager) };
+            if args.compile_options.with_ssa_locations { Some(&file_manager) } else { None };
 
         print_and_interpret_ssa(
             ssa_options,


### PR DESCRIPTION
# Description

## Problem

No issue, just something I noticed and other might agree with.

## Summary

By default locations in SSA are printed but it's more often that we don't want them than we do.

## Additional Context



## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
