### PR TITLE
chore: bump external pinned commits

### DIFF
--- a/.github/benchmark_projects.yml
+++ b/.github/benchmark_projects.yml
@@ -1,4 +1,4 @@
-define: &AZ_COMMIT 8fd3ab3ebb75d53958ba0bd1f487b64b7548c444
+define: &AZ_COMMIT 8bd8f2033c441d7bb02feaa19528a71e93189db6
 projects:
   private-kernel-inner:
     repo: AztecProtocol/aztec-packages

--- a/EXTERNAL_NOIR_LIBRARIES.yml
+++ b/EXTERNAL_NOIR_LIBRARIES.yml
@@ -1,4 +1,4 @@
-define: &AZ_COMMIT 8fd3ab3ebb75d53958ba0bd1f487b64b7548c444
+define: &AZ_COMMIT 8bd8f2033c441d7bb02feaa19528a71e93189db6
 libraries:
   noir_check_shuffle:
     repo: noir-lang/noir_check_shuffle


### PR DESCRIPTION

Automated update of the pinned commit of [aztec-packages](https://github.com/AztecProtocol/aztec-packages) repository against which we run benchmarks.
