### PR TITLE
fix: safer handling of `req.url`

### DIFF
--- a/examples/docs_tutorials/browser/browser.test.ts
+++ b/examples/docs_tutorials/browser/browser.test.ts
@@ -15,7 +15,7 @@ const SERVER_PORT = 8080;
 function createStaticServer(rootDir: string): http.Server {
   return http.createServer((req, res) => {
     // Normalize and resolve the requested path to prevent directory traversal
-    const requestedPath = req.url === '/' ? 'index.html' : req.url!.slice(1); // Remove leading slash
+    const requestedPath = !req.url || req.url === '/' ? 'index.html' : req.url.slice(1);
     const candidatePath = path.resolve(rootDir, requestedPath);
 
     let filePath: string;


### PR DESCRIPTION
# Description

## Problem*
`req.url` can actually be `undefined`, which could cause a runtime error when calling `.slice(1)`.

## Summary*
changed the line to safely handle the case when `req.url` is missing:
```ts
- const requestedPath = req.url === '/' ? 'index.html' : req.url!.slice(1);
+ const requestedPath = !req.url || req.url === '/' ? 'index.html' : req.url.slice(1);
````

everything else was left as is since it already worked fine.

## Additional Context

playwright assertions and `__dirname` logic didn’t need any changes.

## Documentation\*

Check one:

* [x] No documentation needed.
* [ ] Documentation included in this PR.
* [ ] **\[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

* [x] I have tested the changes locally.
* [x] I have formatted the changes with [[Prettier](https://prettier.io/)](https://prettier.io/) and/or `cargo fmt` on default settings.