### PR TITLE
chore: Refactor `compute_dominance_frontiers`

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/ir/dom.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/dom.rs
@@ -279,6 +279,22 @@ impl DominatorTree {
 
     /// Computes the dominance frontier for all blocks in the dominator tree.
     ///
+    /// The Dominance Frontier of a basic block X is the set of all blocks that are immediate
+    /// successors to blocks dominated by X, but which aren’t themselves strictly dominated by X.
+    /// It is the set of blocks that are not dominated X, and which are “first reached” on paths from X.
+    ///
+    /// For example in the following CFG, the DF of `B` is `{E}`, because while `B` dominates `C`,
+    /// there is another path to `E` through `D`.
+    /// ```text
+    ///    A
+    ///   / \
+    ///  B   D
+    ///  |   |
+    ///  C   |
+    ///   \ /
+    ///    E
+    /// ```
+    ///
     /// This method uses the algorithm specified in Cooper, Keith D. et al. “A Simple, Fast Dominance Algorithm.” (1999).
     /// As referenced in the paper a dominance frontier is the set of all CFG nodes, y, such that
     /// b dominates a predecessor of y but does not strictly dominate y.
@@ -295,26 +311,38 @@ impl DominatorTree {
             HashMap::default();
 
         let nodes = self.nodes.keys().copied().collect::<Vec<_>>();
+        // Find out about each block which dominance frontiers they belong to, if any.
         for block_id in nodes {
             let predecessors = cfg.predecessors(block_id);
-            // Dominance frontier nodes must have more than one predecessor
-            if predecessors.len() > 1 {
-                // Iterate over the predecessors of the current block
-                for pred_id in predecessors {
-                    let mut runner = pred_id;
-                    // We start by checking if the current block dominates the predecessor
-                    while let Some(immediate_dominator) = self.immediate_dominator(block_id) {
-                        if immediate_dominator != runner && !self.dominates(block_id, runner) {
-                            dominance_frontiers.entry(runner).or_default().insert(block_id);
-                            let Some(runner_immediate_dom) = self.immediate_dominator(runner)
-                            else {
-                                break;
-                            };
-                            runner = runner_immediate_dom;
-                        } else {
-                            break;
-                        }
+            // Dominance frontier nodes must have more than one predecessor. They are join points in the CFG.
+            if predecessors.len() <= 1 {
+                continue;
+            }
+            let Some(immediate_dominator) = self.immediate_dominator(block_id) else {
+                continue;
+            };
+            // Iterate over the predecessors of the current block and walk backwards from them in the dominator tree.
+            for pred_id in predecessors {
+                let mut runner = pred_id;
+                loop {
+                    // Once we reach the immediate dominator of the current block, we know the current block
+                    // won't be in the frontier of any further blocks (frontier blocks are *not* dominated by them).
+                    if immediate_dominator == runner {
+                        break;
                     }
+                    // Checking if the current block dominates the predecessor;
+                    // for example a loop header has the loop body as one of its predecessors, which it dominates,
+                    // but we don't consider following back-edges as alternative paths on which we reach the header first.
+                    if self.dominates(block_id, runner) {
+                        break;
+                    }
+                    dominance_frontiers.entry(runner).or_default().insert(block_id);
+                    // Continue walking backwards to the dominators of the runner, which also have the
+                    // current block in their frontier, unless they dominate it.
+                    let Some(runner_immediate_dom) = self.immediate_dominator(runner) else {
+                        break;
+                    };
+                    runner = runner_immediate_dom;
                 }
             }
         }
@@ -615,6 +643,17 @@ mod tests {
         assert!(dom_frontiers.is_empty());
     }
 
+    /// ```text
+    ///       b0
+    ///       |
+    /// +---> b1
+    /// |    /  \
+    /// |   b2  b3
+    /// |  / |
+    /// | b4 |
+    /// |  \ |
+    /// +---b5
+    /// ```
     fn loop_with_cond() -> Ssa {
         let src = "
         brillig(inline) fn main f0 {

--- a/compiler/noirc_evaluator/src/ssa/ir/dom.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/dom.rs
@@ -283,8 +283,8 @@ impl DominatorTree {
     /// successors to blocks dominated by X, but which aren’t themselves strictly dominated by X.
     /// It is the set of blocks that are not dominated X, and which are “first reached” on paths from X.
     ///
-    /// For example in the following CFG, the DF of `B` is `{E}`, because while `B` dominates `C`,
-    /// there is another path to `E` through `D`.
+    /// For example in the following CFG the DF of B is {E}, because B dominates {C},
+    /// but it's just one edge away from dominating E, as there is another path to E through D.
     /// ```text
     ///    A
     ///   / \

--- a/compiler/noirc_evaluator/src/ssa/opt/loop_invariant.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/loop_invariant.rs
@@ -51,7 +51,9 @@
 //! b dominates a predecessor of y but does not strictly dominate y.
 //! ```
 //! Reversing this for post-dominance we can see that the conditions for control dependence
-//! are the same as those for post-dominance frontiers.
+//! are the same as those for post-dominance frontiers: the post-dominance frontier of a block Y
+//! is the set of blocks closest to Y where a choice was made of whether to reach Y or not.
+//!
 //! Thus, we rewrite our control dependence condition as Y is control dependent on X iff X is in PDF(Y).
 //!
 //! We then can store the PDFs for every block as part of the context of this pass, and use it for checking control dependence.
@@ -326,7 +328,7 @@ impl PostDominanceFrontiers {
     /// regarding post-dominance frontiers and control dependence.
     fn is_control_dependent(&self, parent_block: BasicBlockId, block: BasicBlockId) -> bool {
         match self.post_dom_frontiers.get(&block) {
-            Some(dependent_blocks) => dependent_blocks.contains(&parent_block),
+            Some(frontier) => frontier.contains(&parent_block),
             None => false,
         }
     }


### PR DESCRIPTION
# Description

## Problem\*

`compute_dominance_frontiers` contained a confusing `while` condition.

## Summary\*

Changes `compute_dominance_frontiers` to compute `immediate_dominator` once and use `loop`, instead of computing it repeatedly with the same arguments in a `while` condition. Added some extra comments and examples as well.

## Additional Context

On an earlier bug fix I found this `while` suspicious: I wasn't sure if we should have been calling it with the `runner` instead of the `block_id`, since the latter doesn't change during the iteration.

For the record, this is the pseudo code from the paper; it might be where the `while` was coming from.

<img width="401" height="186" alt="Screenshot 2025-09-01 at 16 40 39" src="https://github.com/user-attachments/assets/9a83deba-a608-4d76-912b-0b9829beb78b" />

## Documentation\*
Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
