### PR TITLE
chore: Add `PostOrder::into_vec_reverse`

### DIFF
--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_fn.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_fn.rs
@@ -45,10 +45,7 @@ impl FunctionContext {
     pub(crate) fn new(function: &Function, is_entry_point: bool) -> Self {
         let id = function.id();
 
-        let mut reverse_post_order = Vec::new();
-        reverse_post_order.extend_from_slice(PostOrder::with_function(function).as_slice());
-        reverse_post_order.reverse();
-
+        let reverse_post_order = PostOrder::with_function(function).into_vec_reverse();
         let constants = ConstantAllocation::from_function(function);
         let liveness = VariableLiveness::from_function(function, &constants);
 

--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/variable_liveness.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/variable_liveness.rs
@@ -179,9 +179,7 @@ impl VariableLiveness {
 
     fn compute_block_param_definitions(&mut self, func: &Function) {
         // Going in reverse post order to process the entry block first
-        let mut reverse_post_order = Vec::new();
-        reverse_post_order.extend_from_slice(self.post_order.as_slice());
-        reverse_post_order.reverse();
+        let reverse_post_order = self.post_order.clone().into_vec_reverse();
         for block in reverse_post_order {
             let params = func.dfg[block].parameters();
             // If it has no dominator, it's the entry block

--- a/compiler/noirc_evaluator/src/ssa/ir/post_order.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/post_order.rs
@@ -15,7 +15,7 @@ enum Visit {
     Last,
 }
 
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub(crate) struct PostOrder(Vec<BasicBlockId>);
 
 impl PostOrder {
@@ -36,8 +36,16 @@ impl PostOrder {
         PostOrder(Self::compute_post_order(cfg))
     }
 
+    /// Return blocks in post-order.
     pub(crate) fn into_vec(self) -> Vec<BasicBlockId> {
         self.0
+    }
+
+    /// Return blocks in reverse-post-order a.k.a. forward-order.
+    pub(crate) fn into_vec_reverse(self) -> Vec<BasicBlockId> {
+        let mut blocks = self.into_vec();
+        blocks.reverse();
+        blocks
     }
 
     // Computes the post-order of the CFG by doing a depth-first traversal of the

--- a/compiler/noirc_evaluator/src/ssa/opt/normalize_value_ids.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/normalize_value_ids.rs
@@ -95,8 +95,7 @@ impl Context {
         let reachable_blocks = old_function.reachable_blocks();
         self.new_ids.populate_blocks(reachable_blocks, old_function, new_function);
 
-        let mut reverse_post_order = PostOrder::with_function(old_function).into_vec();
-        reverse_post_order.reverse();
+        let reverse_post_order = PostOrder::with_function(old_function).into_vec_reverse();
 
         // Map each parameter, instruction, and terminator
         for old_block_id in reverse_post_order {

--- a/compiler/noirc_evaluator/src/ssa/opt/simple_optimization.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/simple_optimization.rs
@@ -61,8 +61,7 @@ impl Function {
         let mut values_to_replace = ValueMapping::default();
         let mut enable_side_effects =
             self.dfg.make_constant(FieldElement::from(1_u128), NumericType::bool());
-        let mut reverse_post_order = PostOrder::with_function(self).into_vec();
-        reverse_post_order.reverse();
+        let reverse_post_order = PostOrder::with_function(self).into_vec_reverse();
         for block_id in reverse_post_order {
             let instruction_ids = self.dfg[block_id].take_instructions();
             self.dfg[block_id].instructions_mut().reserve(instruction_ids.len());


### PR DESCRIPTION
# Description

## Problem\*

Maxim said we should move away from `reachable_blocks` towards using reverse-post-order, which is used in multiple places already, but always in an ad-hoc fashion.

## Summary\*

Adds a `PostOrder::into_vec_reverse` method to encapsulate reversing the post-order vector to get the forward order. Makes it easier to discover this option and reduces the need for copy pasting.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
