### PR TITLE
fix: disallow references in globals

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/statements.rs
+++ b/compiler/noirc_frontend/src/elaborator/statements.rs
@@ -82,7 +82,8 @@ impl Elaborator<'_> {
     }
 
     pub(super) fn elaborate_local_let(&mut self, let_stmt: LetStatement) -> (HirStatement, Type) {
-        self.elaborate_let(let_stmt, None)
+        let (let_statement, typ) = self.elaborate_let(let_stmt, None);
+        (HirStatement::Let(let_statement), typ)
     }
 
     /// Elaborate a local or global let statement.
@@ -93,7 +94,7 @@ impl Elaborator<'_> {
         &mut self,
         let_stmt: LetStatement,
         global_id: Option<GlobalId>,
-    ) -> (HirStatement, Type) {
+    ) -> (HirLetStatement, Type) {
         let type_contains_unspecified = let_stmt.r#type.contains_unspecified();
         let annotated_type = self.resolve_inferred_type(let_stmt.r#type);
 
@@ -145,7 +146,7 @@ impl Elaborator<'_> {
         let is_global_let = let_stmt.is_global_let;
         let let_ =
             HirLetStatement::new(pattern, r#type, expression, attributes, comptime, is_global_let);
-        (HirStatement::Let(let_), Type::Unit)
+        (let_, Type::Unit)
     }
 
     pub(super) fn elaborate_assign(&mut self, assign: AssignStatement) -> (HirStatement, Type) {

--- a/compiler/noirc_frontend/src/hir/resolution/errors.rs
+++ b/compiler/noirc_frontend/src/hir/resolution/errors.rs
@@ -188,6 +188,8 @@ pub enum ResolverError {
     AmbiguousAssociatedType { trait_name: String, associated_type_name: String, location: Location },
     #[error("The placeholder `_` is not allowed within types on item signatures for functions")]
     WildcardTypeDisallowed { location: Location },
+    #[error("References are not allowed in globals")]
+    ReferencesNotAllowedInGlobals { location: Location },
 }
 
 impl ResolverError {
@@ -252,7 +254,8 @@ impl ResolverError {
             | ResolverError::UnreachableStatement { location, .. }
             | ResolverError::AssociatedItemConstraintsNotAllowedInGenerics { location }
             | ResolverError::AmbiguousAssociatedType { location, .. }
-            | ResolverError::WildcardTypeDisallowed { location } => *location,
+            | ResolverError::WildcardTypeDisallowed { location }
+            | ResolverError::ReferencesNotAllowedInGlobals { location } => *location,
             ResolverError::UnusedVariable { ident }
             | ResolverError::UnusedItem { ident, .. }
             | ResolverError::DuplicateField { field: ident }
@@ -794,6 +797,13 @@ impl<'a> From<&'a ResolverError> for Diagnostic {
             ResolverError::WildcardTypeDisallowed { location } => {
                 Diagnostic::simple_error(
                     "The placeholder `_` is not allowed within types on item signatures for functions".to_string(),
+                    String::new(),
+                    *location,
+                )
+            }
+            ResolverError::ReferencesNotAllowedInGlobals { location } => {
+                Diagnostic::simple_error(
+                    "References are not allowed in globals".to_string(),
                     String::new(),
                     *location,
                 )

--- a/compiler/noirc_frontend/src/tests.rs
+++ b/compiler/noirc_frontend/src/tests.rs
@@ -4565,3 +4565,12 @@ fn cannot_assign_to_nested_struct() {
     "#;
     check_errors!(src);
 }
+
+#[test]
+fn disallows_references_in_globals() {
+    let src = r#"
+    pub global mutable: &mut Field = &mut 0;
+               ^^^^^^^ References are not allowed in globals
+    "#;
+    check_errors!(src);
+}


### PR DESCRIPTION
# Description

## Problem

Resolves #9422

## Summary

The error always points to the global name and doesn't ultimately mention the reference type that triggers the issue, but this could be improved later on if needed.

## Additional Context



## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
