### PR TITLE
chore: simplify signed shift right

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/ir/instruction.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/instruction.rs
@@ -309,7 +309,12 @@ pub enum Instruction {
     /// Computes a bit wise not
     Not(ValueId),
 
-    /// Truncates `value` to `bit_size`
+    /// Truncates `value` to `bit_size`.
+    /// Note that given a value of bit size N, truncating it to N bits is valid and sometimes
+    /// necessary, particularly in ACIR.
+    /// For example `i8` is represented as the values in the range `Field 0`..=`Field 255`.
+    /// It's valid to perform an unchecked add on `i8 -1` (`Field 255`), which results in
+    /// `Field 256`, to later truncate that value (still typed as `i8`) to 8 bits to get `i8 0`.
     Truncate { value: ValueId, bit_size: u32, max_bit_size: u32 },
 
     /// Constrains two values to be equal to one another.


### PR DESCRIPTION
# Description

## Problem

No issue, just something I didn't fully understand while greenlighting remove_bit_shifts.

## Summary

When simplifying a signed shift right the SSA we produced was:
- cast lhs to Field
- add one to it, if it's negative
- truncate it to the original type
- cast it back to the original type
- perform the division
- subtract one to it, if it's negative
- truncate it

I noticed two things:
1. I didn't understand why going to Field to perform the first operation was necessary
2. I didn't understand why the final truncation was needed, if it's truncating to N bits a value that has a maximum value of N bits

I finally understood why the final truncation is needed (and also the intermediate one). I documented this in the `Truncate` instruction. I'm still not sure it's intuitive (I feel there's a leaky abstraction here) but at least now it's documented.

Then, going to Field isn't necessary because truncating already takes care of doing it the right way. This doesn't result in any ACIR improvement but at least it's less Rust code and less SSA instructions.

## Additional Context

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
