### PR TITLE
chore(test): Filter `ram_blowup_regression` by default on local testing

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,19 +1,20 @@
+# Default profile for local testing. Other profiles are layered on top.
+[profile.default]
+# We do not run `ram_blowup_regression` by default as it's very slow
+default-filter = "not test(ram_blowup_regression)"
+
 [profile.ci]
 # Do not cancel the test run on the first failure.
 fail-fast = false
 
-# We do not run `ram_blowup_regression` by default as it's very slow
-default-filter = "not test(ram_blowup_regression)"
-
 [profile.ci-master]
 # Do not cancel the test run on the first failure.
 fail-fast = false
-
+# Run all tests.
 default-filter = "all()"
 
 [profile.merge-queue]
 # fail fast to kick from merge queue faster.
 fail-fast = true
-
 # Disable fuzzing to avoid flakiness
 default-filter = "not test(ram_blowup_regression) or not (package(noir_ast_fuzzer_fuzz) or test(arb_program_freqs_in_expected_range))"


### PR DESCRIPTION
# Description

## Problem\*

Followup for https://github.com/noir-lang/noir/pull/9717#issuecomment-3249172898

## Summary\*

Changes the default `nextest` profile to exclude the `ram_blowup_test`. 

## Additional Context

It will be tested on [ci-master](https://github.com/noir-lang/noir/blob/910cd9349e0b9382c1512935bc3e1d791891bd21/.github/workflows/test-rust-workspace.yml#L86)

## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
