### PR TITLE
chore(ci): force cargo-binstall to install tools in CI

### DIFF
--- a/.github/workflows/test-js-packages.yml
+++ b/.github/workflows/test-js-packages.yml
@@ -7,9 +7,6 @@ on:
     branches:
       - master
 
-env:
-  CI: 1
-
 # This will cancel previous runs when a branch or PR is updated
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref || github.run_id }}

--- a/justfile
+++ b/justfile
@@ -1,4 +1,10 @@
-ci := env("CI", "")
+ci := if env("CI") == "true" {
+  "1"
+} else if env("CI") == "1" {
+  "1"
+} else {
+  "0"
+} 
 use-cross := env("JUST_USE_CROSS", "")
 
 # target information


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This PR addresses the CI issues that have cropped up from using `cargo-binstall` in CI by forcing an install.

## Additional Context

See https://github.com/cargo-bins/cargo-binstall/issues/2215

## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
