### PR TITLE
fix: error on boolean shift overflow in interpreter

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/interpreter/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/interpreter/mod.rs
@@ -1583,14 +1583,14 @@ fn interpret_u1_binary_op(
         BinaryOp::Xor => lhs ^ rhs,
         BinaryOp::Shl => {
             if rhs {
-                false
+                return Err(overflow());
             } else {
                 lhs
             }
         }
         BinaryOp::Shr => {
             if rhs {
-                false
+                return Err(overflow());
             } else {
                 lhs
             }

--- a/compiler/noirc_evaluator/src/ssa/opt/constant_folding.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/constant_folding.rs
@@ -1859,6 +1859,25 @@ mod test {
     }
 
     #[test]
+    fn do_not_inline_brillig_overflow() {
+        // Regression test for https://github.com/noir-lang/noir/issues/9694
+        // The call can be constant
+        let src = "
+            acir(inline) predicate_pure fn main f0 {
+            b0():
+                v2 = call f1(u1 0) -> u1
+                return v2
+            }
+            brillig(inline) predicate_pure fn func_5 f1 {
+            b0(v0: u1):
+                v2 = shl v0, u1 1
+                return v2
+            }
+        ";
+        assert_ssa_does_not_change(src, Ssa::fold_constants_with_brillig);
+    }
+
+    #[test]
     fn does_not_deduplicate_calls_to_functions_which_differ_in_return_value_types() {
         // We have a few intrinsics which have a generic return value (generally for array lengths), we want
         // to avoid deduplicating these.


### PR DESCRIPTION
# Description

## Problem\*

Resolves #9694

## Summary\*
return errors on boolean shift in the interpreter


## Additional Context



## Documentation\*

Check one:
- [X] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
