### PR TITLE
chore: remove empty main from frontend tests

### DIFF
--- a/compiler/noirc_frontend/src/tests.rs
+++ b/compiler/noirc_frontend/src/tests.rs
@@ -531,9 +531,6 @@ fn check_trait_missing_implementation() {
             Self { bar: x, array: [x,y] }
         }
     }
-
-    fn main() {
-    }
     ";
     check_errors!(src);
 }
@@ -551,9 +548,6 @@ fn check_trait_not_in_scope() {
         fn default(x: Field, y: Field) -> Self {
             Self { bar: x, array: [x,y] }
         }
-    }
-
-    fn main() {
     }
     ";
     check_errors!(src);
@@ -600,9 +594,6 @@ fn check_trait_wrong_parameter() {
             Foo {bar: x}
         }
     }
-
-    fn main() {
-    }
     ";
     check_errors!(src);
 }
@@ -624,9 +615,6 @@ fn check_trait_wrong_parameter2() {
                                 ^^^ Parameter #2 of method `default` must be of type Field, not Foo
             Self { bar: x, array: [x, y.bar] }
         }
-    }
-
-    fn main() {
     }
     ";
     check_errors!(src);
@@ -664,9 +652,6 @@ fn check_trait_wrong_parameters_count() {
            ^^^^^^^ `Default2::default` expects 2 parameters, but this method has 1
             Self { bar: x, array: [x, x] }
         }
-    }
-
-    fn main() {
     }
     ";
     check_errors!(src);
@@ -742,9 +727,6 @@ fn check_trait_duplicate_declaration() {
           ~~~~~~~~ Second trait definition found here
         fn default(x: Field) -> Self;
     }
-
-    fn main() {
-    }
     ";
     check_errors!(src);
 }
@@ -815,8 +797,6 @@ fn test_impl_self_within_default_def() {
             self
         }
     }
-
-    fn main() { }
     ";
     assert_no_errors!(src);
 }
@@ -1192,8 +1172,6 @@ fn deny_cyclic_globals() {
         global B: u32 = A;
                         ^ Variable not in scope
                         ~ Could not find variable
-
-        fn main() {}
     "#;
     check_errors!(src);
 }
@@ -1205,7 +1183,6 @@ fn deny_cyclic_type_aliases() {
         type B = A;
         ^^^^^^^^^^ Dependency cycle found
         ~~~~~~~~~~ 'B' recursively depends on itself: B -> A -> B
-        fn main() {}
     "#;
     check_errors!(src);
 }
@@ -1592,8 +1569,6 @@ fn wrong_type_in_for_range() {
 fn numeric_generic_in_function_signature() {
     let src = r#"
     pub fn foo<let N: u32>(arr: [Field; N]) -> [Field; N] { arr }
-
-    fn main() { }
     "#;
     assert_no_errors!(src);
 }
@@ -1685,8 +1660,6 @@ fn numeric_generic_as_return_type() {
         ^^^^^^^^ Type annotation needed
         ~~~~~~~~ Could not determine the type of the generic argument `T` declared on the function `zeroed`
     }
-
-    fn main() {}
     "#;
     check_errors!(src);
 }
@@ -1735,8 +1708,6 @@ fn numeric_generic_used_in_nested_type_pass() {
     pub struct InnerNumeric<let N: u32> {
         inner: [u64; N],
     }
-
-    fn main() { }
     "#;
     assert_no_errors!(src);
 }
@@ -1763,8 +1734,6 @@ fn numeric_generic_used_in_trait() {
     trait Deserialize<let N: u32, T> {
         fn deserialize(fields: [Field; N], other: T) -> Self;
     }
-
-    fn main() { }
     "#;
     assert_no_errors!(src);
 }
@@ -1796,8 +1765,6 @@ fn numeric_generic_in_trait_impl_with_extra_impl_generics() {
     trait Deserialize<let N: u32> {
         fn deserialize(fields: [Field; N]) -> Self;
     }
-
-    fn main() { }
     "#;
     assert_no_errors!(src);
 }
@@ -1816,8 +1783,6 @@ fn numeric_generic_used_in_where_clause() {
         }
         T::deserialize(fields)
     }
-
-    fn main() { }
     "#;
     assert_no_errors!(src);
 }
@@ -1835,8 +1800,6 @@ fn numeric_generic_used_in_turbofish() {
         assert(double::<9>() == 18);
         assert(double::<7 + 8>() == 30);
     }
-
-    fn main() { }
     "#;
     assert_no_errors!(src);
 }
@@ -2479,8 +2442,6 @@ fn trait_impl_generics_count_mismatch() {
 
     impl Foo<()> for Field {}
          ^^^ Foo expects 0 generics but 1 was given
-
-    fn main() {}
     "#;
     check_errors!(src);
 }
@@ -2505,8 +2466,6 @@ fn duplicate_struct_field() {
         ^ Duplicate definitions of struct field with name x found
         ~ Second struct field found here
     }
-
-    fn main() {}
     "#;
     check_errors!(src);
 }
@@ -2514,30 +2473,28 @@ fn duplicate_struct_field() {
 #[test]
 fn trait_constraint_on_tuple_type() {
     let src = r#"
-        trait Foo<A> {
-            fn foo(self, x: A) -> bool;
-        }
+    trait Foo<A> {
+        fn foo(self, x: A) -> bool;
+    }
 
-        pub fn bar<T, U, V>(x: (T, U), y: V) -> bool where (T, U): Foo<V> {
-            x.foo(y)
-        }
-
-        fn main() {}"#;
+    pub fn bar<T, U, V>(x: (T, U), y: V) -> bool where (T, U): Foo<V> {
+        x.foo(y)
+    }
+    "#;
     assert_no_errors!(src);
 }
 
 #[test]
 fn trait_constraint_on_tuple_type_pub_crate() {
     let src = r#"
-        pub(crate) trait Foo<A> {
-            fn foo(self, x: A) -> bool;
-        }
+    pub(crate) trait Foo<A> {
+        fn foo(self, x: A) -> bool;
+    }
 
-        pub fn bar<T, U, V>(x: (T, U), y: V) -> bool where (T, U): Foo<V> {
-            x.foo(y)
-        }
-
-        fn main() {}"#;
+    pub fn bar<T, U, V>(x: (T, U), y: V) -> bool where (T, U): Foo<V> {
+        x.foo(y)
+    }
+    "#;
     assert_no_errors!(src);
 }
 
@@ -2700,8 +2657,6 @@ fn trait_impl_for_a_type_that_implements_another_trait() {
     pub fn use_it<T>(t: T) -> i32 where T: Two {
         Two::two(t)
     }
-
-    fn main() {}
     "#;
     assert_no_errors!(src);
 }
@@ -2740,8 +2695,6 @@ fn trait_impl_for_a_type_that_implements_another_trait_with_another_impl_used() 
     pub fn use_it(t: u32) -> i32 {
         Two::two(t)
     }
-
-    fn main() {}
     "#;
     assert_no_errors!(src);
 }
@@ -2860,8 +2813,6 @@ fn do_not_infer_partial_global_types() {
                    ^^^^^^^^^^^^^^^^^^^ Globals must have a specified type
             (&["hi"], [[]; 3]);
             ~~~~~~~~~~~~~~~~~~ Inferred type is `([str<2>], [[Field; 0]; 3])`
-
-        fn main() { }
     "#;
     check_errors!(src);
 }
@@ -3202,8 +3153,6 @@ fn uses_self_in_import() {
     pub fn baz() -> i32 {
         bar::foo()
     }
-
-    fn main() {}
     "#;
     assert_no_errors!(src);
 }
@@ -3337,8 +3286,6 @@ fn errors_with_better_message_when_trying_to_invoke_struct_field_that_is_a_funct
                 ~~~~~~~~~~~~~~~ to call the function stored in 'wrapped', surround the field access with parentheses: '(', ')'
             }
         }
-
-        fn main() {}
     "#;
     check_errors!(src);
 }
@@ -3355,8 +3302,6 @@ fn disallows_test_attribute_on_impl_method() {
             fn foo() { }
                ^^^ The `#[test]` attribute is disallowed on `impl` methods
         }
-
-        fn main() { }
     ";
     check_errors!(src);
 }
@@ -3375,8 +3320,6 @@ fn disallows_test_attribute_on_trait_impl_method() {
             fn foo() { }
                ^^^ The `#[test]` attribute is disallowed on `impl` methods
         }
-
-        fn main() { }
     ";
     check_errors!(src);
 }
@@ -3392,8 +3335,6 @@ fn disallows_export_attribute_on_impl_method() {
             fn foo() { }
                ^^^ The `#[export]` attribute is disallowed on `impl` methods
         }
-
-        fn main() { }
     ";
     check_errors!(src);
 }
@@ -3413,8 +3354,6 @@ fn disallows_export_attribute_on_trait_impl_method() {
             fn foo() { }
                ^^^ The `#[export]` attribute is disallowed on `impl` methods
         }
-
-        fn main() { }
     ";
     check_errors!(src);
 }
@@ -3423,8 +3362,6 @@ fn disallows_export_attribute_on_trait_impl_method() {
 fn allows_multiple_underscore_parameters() {
     let src = r#"
         pub fn foo(_: i32, _: i64) {}
-
-        fn main() {}
     "#;
     assert_no_errors!(src);
 }
@@ -3452,8 +3389,6 @@ fn errors_on_cyclic_globals() {
     pub comptime global B: u32 = A;
                                  ^ Variable not in scope
                                  ~ Could not find variable
-
-    fn main() { }
     "#;
     check_errors!(src);
 }
@@ -3633,9 +3568,6 @@ fn infers_lambda_argument_from_function_return_type() {
     pub fn func() -> fn(Foo) -> Field {
         |foo| foo.value
     }
-
-    fn main() {
-    }
     "#;
     assert_no_errors!(src);
 }
@@ -3650,9 +3582,6 @@ fn infers_lambda_argument_from_function_return_type_multiple_statements() {
     pub fn func() -> fn(Foo) -> Field {
         let _ = 1;
         |foo| foo.value
-    }
-
-    fn main() {
     }
     "#;
     assert_no_errors!(src);
@@ -3671,9 +3600,6 @@ fn infers_lambda_argument_from_function_return_type_when_inside_if() {
         } else {
             |foo| foo.value
         }
-    }
-
-    fn main() {
     }
     "#;
     assert_no_errors!(src);
@@ -3940,8 +3866,6 @@ fn check_impl_duplicate_method_without_self() {
            ^^^ duplicate definitions of foo found
            ~~~ second definition found here
     }
-
-    fn main() {}
     ";
     check_errors!(src);
 }
@@ -4204,8 +4128,6 @@ fn object_type_must_be_known_in_method_call() {
                 ~~~ Type must be known by this point to know which method to call
         bar
     }
-
-    fn main() {}
     "#;
     check_errors!(src);
 }

--- a/compiler/noirc_frontend/src/tests/aliases.rs
+++ b/compiler/noirc_frontend/src/tests/aliases.rs
@@ -94,8 +94,6 @@ fn double_generic_alias_in_path() {
 fn identity_numeric_type_alias_works() {
     let src = r#"
     pub type Identity<let N: u32>: u32 = N;
-
-    fn main() {}
     "#;
     assert_no_errors!(src);
 }

--- a/compiler/noirc_frontend/src/tests/enums.rs
+++ b/compiler/noirc_frontend/src/tests/enums.rs
@@ -16,8 +16,6 @@ fn error_with_duplicate_enum_variant() {
         ^^^ Duplicate definitions of enum variant with name Bar found
         ~~~ Second enum variant found here
     }
-
-    fn main() {}
     "#;
     check_errors!(src);
 }
@@ -364,7 +362,6 @@ fn match_on_empty_enum() {
             match v {}
         }
         pub enum Void {}
-        fn main() {}
         ",
         &features
     );

--- a/compiler/noirc_frontend/src/tests/metaprogramming.rs
+++ b/compiler/noirc_frontend/src/tests/metaprogramming.rs
@@ -83,8 +83,6 @@ fn unquoted_integer_as_integer_token() {
             }
         }
     }
-
-    fn main() {}
     "#;
 
     assert_no_errors!(src);
@@ -168,8 +166,6 @@ fn uses_correct_type_for_attribute_arguments() {
         let y: u32 = 1;
         let _ = y == i[0];
     }
-
-    fn main() {}
     "#;
     assert_no_errors!(src);
 }

--- a/compiler/noirc_frontend/src/tests/traits.rs
+++ b/compiler/noirc_frontend/src/tests/traits.rs
@@ -21,8 +21,6 @@ fn trait_inheritance() {
         pub fn foo<T>(baz: T) -> (Field, Field, Field) where T: Baz {
             (baz.foo(), baz.bar(), baz.baz())
         }
-
-        fn main() {}
     "#;
     assert_no_errors!(src);
 }
@@ -41,8 +39,6 @@ fn trait_inheritance_with_generics() {
         pub fn foo<T>(x: T) -> i32 where T: Bar<i32> {
             x.foo()
         }
-
-        fn main() {}
     "#;
     assert_no_errors!(src);
 }
@@ -61,8 +57,6 @@ fn trait_inheritance_with_generics_2() {
         pub fn foo<T>(x: T) -> i32 where T: Bar<i32, i32> {
             x.foo()
         }
-
-        fn main() {}
     "#;
     assert_no_errors!(src);
 }
@@ -77,8 +71,6 @@ fn trait_inheritance_with_generics_3() {
         impl Foo<i32> for () {}
 
         impl Bar<i32> for () {}
-
-        fn main() {}
     "#;
     assert_no_errors!(src);
 }
@@ -93,8 +85,6 @@ fn trait_inheritance_with_generics_4() {
         impl Foo for () { type A = i32; }
 
         impl Bar<i32> for () {}
-
-        fn main() {}
     "#;
     assert_no_errors!(src);
 }
@@ -106,7 +96,6 @@ fn trait_inheritance_dependency_cycle() {
               ^^^ Dependency cycle found
               ~~~ 'Foo' recursively depends on itself: Foo -> Bar -> Foo
         trait Bar: Foo {}
-        fn main() {}
     "#;
     check_errors!(src);
 }
@@ -170,8 +159,6 @@ fn does_not_error_if_impl_trait_constraint_is_satisfied_for_concrete_type() {
         pub struct Bar;
 
         impl Foo<SomeGreeter> for Bar {}
-
-        fn main() {}
     "#;
     assert_no_errors!(src);
 }
@@ -227,8 +214,6 @@ fn errors_if_impl_trait_constraint_is_not_satisfied() {
         impl Foo<SomeGreeter> for Bar {}
                                   ^^^ The trait bound `SomeGreeter: Greeter` is not satisfied
                                   ~~~ The trait `Greeter` is not implemented for `SomeGreeter`
-
-        fn main() {}
     "#;
     check_errors!(src);
 }
@@ -413,8 +398,6 @@ fn trait_alias_with_where_clause_has_equivalent_errors() {
             x.baz()
             ^^^^^^^ No method named 'baz' found for type 'T'
         }
-
-        fn main() {}
     "#;
     check_errors!(src);
 }
@@ -439,8 +422,6 @@ fn trait_alias_with_where_clause_has_equivalent_errors_2() {
             x.baz()
             ^^^^^^^ No method named 'baz' found for type 'T'
         }
-
-        fn main() {}
     "#;
     check_errors!(alias_src);
 }
@@ -460,8 +441,6 @@ fn removes_assumed_parent_traits_after_function_ends() {
     where
         T: Foo,
     {}
-
-    fn main() {}
     "#;
     assert_no_errors!(src);
 }
@@ -523,8 +502,6 @@ fn does_not_crash_on_as_trait_path_with_empty_path() {
         struct Foo {
             x: <N>,
         }
-
-        fn main() {}
     "#;
 
     let allow_parser_errors = true;
@@ -634,8 +611,6 @@ fn calls_trait_function_if_it_is_only_candidate_in_scope_in_nested_module_using_
             let _ = super::Bar::foo();
         }
     }
-
-    fn main() {}
 
     pub struct Bar {}
 
@@ -913,8 +888,6 @@ fn type_checks_trait_default_method_and_errors() {
                 ~~~~ bool returned here
             }
         }
-
-        fn main() {}
     "#;
     check_errors!(src);
 }
@@ -928,8 +901,6 @@ fn type_checks_trait_default_method_and_does_not_error() {
                 1
             }
         }
-
-        fn main() {}
     "#;
     assert_no_errors!(src);
 }
@@ -947,8 +918,6 @@ fn type_checks_trait_default_method_and_does_not_error_using_self() {
                 1
             }
         }
-
-        fn main() {}
     "#;
     assert_no_errors!(src);
 }
@@ -1041,8 +1010,6 @@ fn error_on_duplicate_impl_with_associated_type() {
                      ~~~ Overlapping impl
             type Bar = u8;
         }
-
-        fn main() {}
     "#;
     check_errors!(src);
 }
@@ -1064,8 +1031,6 @@ fn error_on_duplicate_impl_with_associated_constant() {
                      ~~~ Overlapping impl
             let Bar: u32 = 6;
         }
-
-        fn main() {}
     "#;
     check_errors!(src);
 }
@@ -1299,8 +1264,6 @@ fn returns_self_in_trait_method_1() {
             Self {}
         }
     }
-
-    fn main() {}
     ";
     assert_no_errors!(src);
 }
@@ -1330,8 +1293,6 @@ fn returns_self_in_trait_method_2() {
             Self {}
         }
     }
-
-    fn main() {}
     ";
     assert_no_errors!(src);
 }
@@ -1357,8 +1318,6 @@ fn returns_self_in_trait_method_3() {
             0
         }
     }
-
-    fn main() {}
     ";
     assert_no_errors!(src);
 }
@@ -1381,8 +1340,6 @@ fn trait_impl_with_where_clause_with_trait_with_associated_numeric() {
     impl Foo for Field{
         fn foo<B>(_: B) where B: Bar {} 
     }
-
-    fn main() {}
     ";
     assert_no_errors!(src);
 }
@@ -1405,8 +1362,6 @@ fn trait_impl_with_where_clause_with_trait_with_associated_type() {
     impl Foo for Field{
         fn foo<B>(_: B) where B: Bar {} 
     }
-
-    fn main() {}
     ";
     assert_no_errors!(src);
 }
@@ -1569,8 +1524,6 @@ fn trait_impl_with_child_constraint() {
 
     impl<T: Parent> Parent for Struct<T> {}
     impl<T: Child> Child for Struct<T> {}
-
-    fn main() {}
     "#;
     assert_no_errors!(src);
 }
@@ -1895,8 +1848,6 @@ fn associated_constant_sum_of_other_constants_2() {
         let f = <[Field; X] as Deserialize>::deserialize;
         let _ = f([0; X + 1]);
     }
-
-    fn main() {}
     "#;
     assert_no_errors!(src);
 }
@@ -1929,8 +1880,6 @@ fn associated_constant_sum_of_other_constants_3() {
         let f = <[Field; X] as Deserialize>::deserialize;
         let _ = f([0; X]);
     }
-
-    fn main() {}
     "#;
     assert_no_errors!(src);
 }
@@ -1963,8 +1912,6 @@ fn associated_constant_mul_of_other_constants() {
         let f = <[Field; X] as Deserialize>::deserialize;
         let _ = f([0; X]);
     }
-
-    fn main() {}
     "#;
     assert_no_errors!(src);
 }
@@ -1986,8 +1933,6 @@ fn trait_bound_with_associated_constant() {
     }
 
     impl Trait<Field> for i32 {}
-
-    fn main() {}
     "#;
     assert_no_errors!(src);
 }
@@ -2007,8 +1952,6 @@ fn trait_method_call_when_it_has_bounds_on_generic() {
     pub fn foo<B: BigNum, Curve: BigCurve<B>>() {
         let _: Curve = BigCurve::new();
     }
-
-    fn main() {}
     "#;
     assert_no_errors!(src);
 }
@@ -2028,8 +1971,6 @@ fn trait_bound_constraining_two_generics() {
 
     pub struct HasBaz1 {}
     impl Baz<HasFoo1, ()> for HasBaz1 {}
-
-    fn main() {}
     "#;
     assert_no_errors!(src);
 }
@@ -2059,8 +2000,6 @@ fn trait_where_clause_associated_type_constraint_expected_order() {
 
     pub struct HasBaz1 {}
     impl Baz<HasFoo1> for HasBaz1 {}
-
-    fn main() {}
     "#;
     assert_no_errors!(src);
 }
@@ -2090,8 +2029,6 @@ fn trait_where_clause_associated_type_constraint_unexpected_order() {
 
     pub struct HasBaz1 {}
     impl Baz<HasFoo1> for HasBaz1 {}
-
-    fn main() {}
     "#;
     assert_no_errors!(src);
 }

--- a/compiler/noirc_frontend/src/tests/unused_items.rs
+++ b/compiler/noirc_frontend/src/tests/unused_items.rs
@@ -130,7 +130,6 @@ fn errors_on_unused_type_alias() {
          ~~~ unused type alias
     type Bar = Field;
     pub fn bar(_: Bar) {}
-    fn main() {}
     "#;
     check_errors!(src);
 }
@@ -157,8 +156,6 @@ fn does_not_warn_on_unused_global_if_it_has_an_abi_attribute() {
         #[abi(notes)]
         global bar: u64 = 1;
     }
-
-    fn main() {}
     "#;
     assert_no_errors!(src);
 }
@@ -168,8 +165,6 @@ fn does_not_warn_on_unused_struct_if_it_has_an_abi_attribute() {
     let src = r#"
     #[abi(dummy)]
     struct Foo { bar: u8 }
-
-    fn main() {}
     "#;
     assert_no_errors!(src);
 }
@@ -179,8 +174,6 @@ fn does_not_warn_on_unused_function_if_it_has_an_export_attribute() {
     let src = r#"
     #[export]
     fn foo() {}
-
-    fn main() {}
     "#;
     assert_no_errors!(src);
 }
@@ -211,8 +204,6 @@ fn no_warning_on_struct_if_it_has_an_abi_attribute() {
     struct Foo {
         a: Field,
     }
-
-    fn main() {}
     "#;
     assert_no_errors!(src);
 }
@@ -228,8 +219,6 @@ fn no_warning_on_indirect_struct_if_it_has_an_abi_attribute() {
     struct Foo {
         bar: Bar,
     }
-
-    fn main() {}
     "#;
     assert_no_errors!(src);
 }
@@ -268,8 +257,6 @@ fn resolves_trait_where_clause_in_the_correct_module() {
     where
         T: Foo,
     {}
-
-    fn main() {}
     "#;
     assert_no_errors!(src);
 }

--- a/compiler/noirc_frontend/src/tests/visibility.rs
+++ b/compiler/noirc_frontend/src/tests/visibility.rs
@@ -26,7 +26,6 @@ fn errors_if_type_alias_aliases_more_private_type() {
     pub fn no_unused_warnings() {
         let _: Bar = Foo {};
     }
-    fn main() {}
     "#;
     check_errors!(src);
 }
@@ -42,7 +41,6 @@ fn errors_if_type_alias_aliases_more_private_type_in_generic() {
         let _ = Foo {};
         let _: Bar = Generic { value: Foo {} };
     }
-    fn main() {}
     "#;
     check_errors!(src);
 }
@@ -60,7 +58,6 @@ fn errors_if_pub_type_alias_leaks_private_type_in_generic() {
             let _: FooBar = Foo { value: Bar {} };
         }
     }
-    fn main() {}
     "#;
     check_errors!(src);
 }
@@ -78,7 +75,6 @@ fn errors_if_pub_struct_field_leaks_private_type_in_generic() {
             let _ = FooBar { value: Foo { value: Bar {} } };
         }
     }
-    fn main() {}
     "#;
     check_errors!(src);
 }
@@ -94,7 +90,6 @@ fn errors_if_pub_function_leaks_private_type_in_return() {
             Bar {}
         }
     }
-    fn main() {}
     "#;
     check_errors!(src);
 }
@@ -111,7 +106,6 @@ fn errors_if_pub_function_leaks_private_type_in_arg() {
             let _ = Bar {};
         }
     }
-    fn main() {}
     "#;
     check_errors!(src);
 }
@@ -132,7 +126,6 @@ fn does_not_error_if_pub_function_is_on_private_struct() {
             let _ = Bar {};
         }
     }
-    fn main() {}
     "#;
     assert_no_errors!(src);
 }
@@ -155,7 +148,6 @@ fn errors_if_pub_function_on_pub_struct_returns_private() {
             let _ = Foo {};            
         }
     }
-    fn main() {}
     "#;
     check_errors!(src);
 }
@@ -180,7 +172,6 @@ fn does_not_error_if_pub_trait_is_defined_on_private_struct() {
             let _ = Bar {};
         }
     }
-    fn main() {}
     "#;
     assert_no_errors!(src);
 }
@@ -200,7 +191,6 @@ fn errors_if_pub_trait_returns_private_struct() {
             let _ = Bar {};
         }
     }
-    fn main() {}
     "#;
     check_errors!(src);
 }
@@ -263,8 +253,6 @@ fn errors_if_calling_private_struct_method() {
             ^^^ bar is private and not visible from the current module
             ~~~ bar is private
     }
-
-    fn main() {}
     "#;
     check_errors!(src);
 }
@@ -285,8 +273,6 @@ fn does_not_warn_if_calling_pub_crate_struct_method_from_same_crate() {
     pub fn method(foo: moo::Foo) {
         foo.bar()
     }
-
-    fn main() {}
     "#;
     assert_no_errors!(src);
 }
@@ -346,8 +332,6 @@ fn error_when_accessing_private_struct_field() {
             ^ x is private and not visible from the current module
             ~ x is private
     }
-
-    fn main() {}
     "#;
     check_errors!(src);
 }
@@ -576,8 +560,6 @@ fn private_impl_method_on_another_module_1() {
             self.foo();
         }
     }
-
-    fn main() {}
     "#;
     assert_no_errors!(src);
 }
@@ -602,8 +584,6 @@ fn private_impl_method_on_another_module_2() {
             foo.foo();
         }
     }
-
-    fn main() {}
     "#;
     assert_no_errors!(src);
 }

--- a/justfile
+++ b/justfile
@@ -1,6 +1,6 @@
-ci := if env("CI") == "true" {
+ci := if env("CI", "") == "true" {
   "1"
-} else if env("CI") == "1" {
+} else if env("CI", "") == "1" {
   "1"
 } else {
   "0"


### PR DESCRIPTION
# Description

## Problem

No issue.

## Summary

Now that frontend tests don't generate a test program they don't need to have a main function.

## Additional Context

This PR also fixes a small issue in the justfile.

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
