### PR TITLE
fix: issues with nargo, JSON, anvil, and cast

### DIFF
--- a/examples/solidity_verifier/solidity_verifier.sh
+++ b/examples/solidity_verifier/solidity_verifier.sh
@@ -10,7 +10,7 @@ $BACKEND write_vk -b ./target/hello_world.json -o ./target --oracle_hash keccak
 $BACKEND write_solidity_verifier -k ./target/vk -o ./src/contract.sol
 
 # We now generate a proof and check whether the verifier contract will verify it.
-nargo execute --pedantic-solving witness
+nargo execute --pedantic-solving hello_world
 
 # Generate proof in bytes and fields format
 $BACKEND prove -b ./target/hello_world.json -w ./target/witness.gz --oracle_hash keccak --output_format bytes_and_fields -o ./target
@@ -21,14 +21,15 @@ $BACKEND verify -k ./target/vk -p ./target/proof -i ./target/public_inputs --ora
 # Read proof and convert to hex string
 PROOF_HEX=$(cat ./target/proof | od -An -v -t x1 | tr -d $' \n')
 # public_inputs_fields already contain each public input in hex format, but we need to remove quotes for using in `cast`
-PUBLIC_INPUTS_HEX=$(cat ./target/public_inputs_fields.json | tr -d '"')
+PUBLIC_INPUTS_HEX=$(jq -r '.[]' ./target/public_inputs_fields.json | tr '\n' ' ')
 
 # Spin up an anvil node to deploy the contract to
 #
 # Code size limit is set to 10x normal to avoid being broken in case contracts
 # are too large. Recommended to remove in your code.
 anvil --code-size-limit=400000 &
-trap 'kill %-' EXIT
+ANVIL_PID=$!
+trap 'kill $ANVIL_PID' EXIT
 
 DEPLOY_INFO=$(forge create HonkVerifier \
   --rpc-url "127.0.0.1:8545" \
@@ -38,4 +39,4 @@ DEPLOY_INFO=$(forge create HonkVerifier \
 VERIFIER_ADDRESS=$(echo $DEPLOY_INFO | jq -r '.deployedTo')
 
 # Call the verifier contract with our proof.
-cast call "$VERIFIER_ADDRESS" "verify(bytes, bytes32[])(bool)" "$PROOF_HEX" "$PUBLIC_INPUTS_HEX"
+cast call "$VERIFIER_ADDRESS" "verify(bytes, bytes32[])(bool)" "0x$PROOF_HEX" $PUBLIC_INPUTS_HEX


### PR DESCRIPTION
# Description

## Problem\*

scripts were failing due to incorrect package name, JSON parsing issues, anvil not being cleaned up, and missing `0x` in hex arguments.

## Summary\*

* fixed `nargo execute` to use the correct package (`hello_world`).
* converted JSON array properly for `cast` using `jq`.
* ensured `anvil` process is cleaned up on exit.
* added `0x` prefix to `$PROOF_HEX` for `cast call`.

## Additional Context

these changes make the scripts run reliably without errors and handle cleanup properly.

## Documentation\*

Check one:

* [x] No documentation needed.
* [ ] Documentation included in this PR.
* [ ] **\[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

* [x] I have tested the changes locally.
* [x] I have formatted the changes with [[Prettier](https://prettier.io/)](https://prettier.io/) and/or `cargo fmt` on default settings.