### PR TITLE
chore(licm): More unit tests and a fix

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/opt/loop_invariant.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/loop_invariant.rs
@@ -2121,11 +2121,10 @@ mod test {
             unreachable!("body should end in jmpif");
         };
 
-        let is_var = || ssa.main().dfg.get_numeric_constant(*condition).is_none();
-        let is_one =
-            || ssa.main().dfg.get_numeric_constant(*condition).map_or(false, |c| c.is_one());
-        let is_zero =
-            || ssa.main().dfg.get_numeric_constant(*condition).map_or(false, |c| c.is_zero());
+        let dfg = &ssa.main().dfg;
+        let is_var = || dfg.get_numeric_constant(*condition).is_none();
+        let is_one = || dfg.get_numeric_constant(*condition).is_some_and(|c| c.is_one());
+        let is_zero = || dfg.get_numeric_constant(*condition).is_some_and(|c| c.is_zero());
 
         match simplify_to {
             None => {

--- a/compiler/noirc_evaluator/src/ssa/opt/loop_invariant/simplify.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/loop_invariant/simplify.rs
@@ -26,10 +26,6 @@ impl LoopInvariantContext<'_> {
         binary: &Binary,
     ) -> bool {
         match binary.operator {
-            // An unchecked operation cannot overflow, so it can be safely evaluated
-            BinaryOp::Add { unchecked: true }
-            | BinaryOp::Mul { unchecked: true }
-            | BinaryOp::Sub { unchecked: true } => true,
             BinaryOp::Div | BinaryOp::Mod => {
                 // Division can be evaluated if we ensure that the divisor cannot be zero
                 let Some((left, value, lower, upper)) =
@@ -58,9 +54,11 @@ impl LoopInvariantContext<'_> {
 
                 false
             }
+            // An unchecked operation cannot overflow, so it can be safely evaluated.
             // Some checked operations can be safely evaluated, depending on the loop bounds, but in that case,
-            // they would have been already converted to unchecked operation in `simplify_induction_variable_in_binary()`
-            _ => false,
+            // they would have been already converted to unchecked operation in `simplify_induction_variable_in_binary()`.
+            // These are all handled by `requires_acir_gen_predicate`, and are redundant with `can_be_hoisted`.
+            _ => !binary.requires_acir_gen_predicate(&self.inserter.function.dfg),
         }
     }
 

--- a/compiler/noirc_evaluator/src/ssa/opt/loop_invariant/simplify.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/loop_invariant/simplify.rs
@@ -73,7 +73,7 @@ impl LoopInvariantContext<'_> {
     /// with a known upper bound, we know whether that binary operation will ever overflow.
     /// If we determine that an overflow is not possible we can convert the checked operation to unchecked.
     ///
-    /// The function returns false if the instruction must be added to the block
+    /// The function returns `false` if the instruction must be added to the block, which involves further simplification.
     pub(super) fn simplify_from_loop_bounds(
         &mut self,
         loop_context: &LoopContext,
@@ -93,7 +93,6 @@ impl LoopInvariantContext<'_> {
                 self.inserter.function.dfg[instruction_id] = instruction;
                 false
             }
-            SimplifyResult::Remove => true,
             SimplifyResult::None => false,
             _ => unreachable!(
                 "ICE - loop bounds simplification should only simplify to a value or an instruction"

--- a/compiler/noirc_evaluator/src/ssa/opt/loop_invariant/simplify.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/loop_invariant/simplify.rs
@@ -103,7 +103,7 @@ impl LoopInvariantContext<'_> {
 
     /// Simplify 'assert(lhs < rhs)' into 'assert(max(lhs) < rhs)' if lhs is an induction variable and rhs a loop invariant
     /// For this simplification to be valid, we need to ensure that the induction variable takes all the values from min(induction) up to max(induction)
-    /// This means that the assert must be executed  at each loop iteration, and that the loop processes all the iteration space
+    /// This means that the assert must be executed at each loop iteration, and that the loop processes all the iteration space
     /// This is ensured via control dependence and the check for break patterns, before calling this function.
     fn simplify_induction_in_constrain(
         &mut self,
@@ -187,7 +187,8 @@ impl LoopInvariantContext<'_> {
         ))
     }
 
-    /// Returns the binary instruction only if the input value refers to a binary instruction with invariant and induction variables as operands
+    /// Returns the binary instruction only if the input value refers to a binary instruction
+    /// with invariant and induction variables as operands.
     /// The return values are:
     /// - a boolean indicating if the induction variable is on the lhs
     /// - the minimum and maximum values of the induction variable, coming from the loop bounds
@@ -253,7 +254,8 @@ impl LoopInvariantContext<'_> {
                 block_context.is_header,
             ),
             Instruction::Constrain(x, y, err) => {
-                // Ensure the loop is fully executed
+                // Ensure the loop is fully executed, so we know that if the constraint would fail for *some* value,
+                // then it *will* definitely take up that value, and not break out early.
                 if loop_context.no_break
                     && block_context.can_simplify_control_dependent_instruction()
                 {


### PR DESCRIPTION
# Description

## Problem\*

Increase test coverage.

## Summary\*

Implement unit tests for code identified in https://github.com/noir-lang/noir/pull/9718 

Fixes the logic for `ConstrainNotEqual` which had min/max swapped.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
