### PR TITLE
chore(acir): improve error message for static regex compilation

### DIFF
--- a/acvm-repo/acir/src/lib.rs
+++ b/acvm-repo/acir/src/lib.rs
@@ -288,7 +288,7 @@ mod reflection {
         fn replace_array_with_shared_ptr(source: &mut String) {
             // Capture `std::array<$TYPE, $LEN>`
             let re = Regex::new(r#"std::array<\s*([^,<>]+?)\s*,\s*([0-9]+)\s*>"#)
-                .expect("failed to create regex");
+                .expect("Static regex for std::array pattern should always compile");
 
             let fixed =
                 re.replace_all(source, "std::shared_ptr<std::array<${1}, ${2}>>").into_owned();


### PR DESCRIPTION
# Description

Replace generic "failed to create regex" with more descriptive error message that clarifies this is a static regex pattern that should always compile successfully. This provides better context for developers if compilation unexpectedly fails.
## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
