### PR TITLE
chore(evaluator): fix BigIntToLeBytes to always output 32 bytes

### DIFF
--- a/compiler/noirc_evaluator/src/acir/acir_context/black_box.rs
+++ b/compiler/noirc_evaluator/src/acir/acir_context/black_box.rs
@@ -95,11 +95,7 @@ impl<F: AcirField, B: BlackBoxFunctionSolver<F>> AcirContext<F, B> {
                 for i in const_inputs {
                     field_inputs.push(i?);
                 }
-                let bigint = self.big_int_ctx.get(field_inputs[0]);
-                let modulus = self.big_int_ctx.modulus(bigint.modulus_id::<F>());
-                let bytes_len = ((modulus - BigUint::from(1_u32)).bits() - 1) / 8 + 1;
-                output_count = bytes_len as usize;
-                assert!(bytes_len == 32);
+                output_count = 32;
                 (field_inputs, vec![])
             }
             BlackBoxFunc::BigIntFromLeBytes => {


### PR DESCRIPTION
# Description

Replace modulus-derived output length with a fixed output_count = 32 and remove the assert. This change is necessary because the BigIntToLeBytes contract across the stack (frontend interpreter docs/logic, ACVM pedantic checks, and Brillig VM implementation) mandates a 32-byte little-endian output with zero-padding. The previous behavior could panic or desynchronize sizes for non-standard moduli and conflicted with the global expectation of a fixed 32-byte output.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
