### PR TITLE
chore(docs): Copy latest getting started guide into versioned docs

### DIFF
--- a/docs/versioned_docs/version-v1.0.0-beta.11/getting_started/quick_start.md
+++ b/docs/versioned_docs/version-v1.0.0-beta.11/getting_started/quick_start.md
@@ -17,8 +17,6 @@ curl -L https://raw.githubusercontent.com/noir-lang/noirup/refs/heads/main/insta
 noirup
 ```
 
-Once installed, you can [set up shell completions for the `nargo` command](../tooling/shell_completions.md).
-
 ## Nargo
 
 Nargo provides the ability to initiate and execute Noir projects. Let's initialize the traditional `hello_world`:

--- a/docs/versioned_docs/version-v1.0.0-beta.12/getting_started/quick_start.md
+++ b/docs/versioned_docs/version-v1.0.0-beta.12/getting_started/quick_start.md
@@ -17,8 +17,6 @@ curl -L https://raw.githubusercontent.com/noir-lang/noirup/refs/heads/main/insta
 noirup
 ```
 
-Once installed, you can [set up shell completions for the `nargo` command](../tooling/shell_completions.md).
-
 ## Nargo
 
 Nargo provides the ability to initiate and execute Noir projects. Let's initialize the traditional `hello_world`:


### PR DESCRIPTION
# Description

## Problem\*

The proving backend section of the getting started guide in v1.0.0-beta.11's and beta.12's versioned docs is incompatible with the latest bb, as there was a minor update to the path of writing / pulling verification keys.

## Summary\*

Copy in the latest docs that refers readers to Barretenberg's new getting started guide into v1.0.0-beta.11's and beta.12's versioned docs.

## Additional Context

Thank you @satyambnsal for reporting the problem on Discord.

## Documentation\*

Check one:
- [ ] No documentation needed.
- [x] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
