### PR TITLE
fix(fuzz): Install `just` in nightly fuzz workflow

### DIFF
--- a/.github/workflows/nightly-fuzz-test.yml
+++ b/.github/workflows/nightly-fuzz-test.yml
@@ -28,6 +28,8 @@ jobs:
         with:
           targets: x86_64-unknown-linux-gnu
 
+      - uses: taiki-e/install-action@just
+
       - name: Run fuzzer
         run: just fuzz-nightly
         env:


### PR DESCRIPTION
# Description

## Problem\*

The nightly fuzzing started failing because `just` is not installed https://github.com/noir-lang/noir/actions/runs/17421911917

## Summary\*

Install `just` as part of the workflow.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
