### PR TITLE
chore: add test for when pending snapshots are committed

### DIFF
--- a/.github/workflows/test-rust-workspace.yml
+++ b/.github/workflows/test-rust-workspace.yml
@@ -85,6 +85,21 @@ jobs:
         env:
           NEXTEST_PROFILE: ${{ (github.event_name == 'merge_group' && 'merge-queue') || (github.ref == 'refs/heads/master' && 'ci-master') || 'ci' }}
 
+  check-pending-snapshots:
+    name: Check for pending snapshots
+    runs-on: ubuntu-22.04
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Install just
+        uses: taiki-e/install-action@just
+
+      - name: Check for pending snapshots
+        run: just check-pending-snapshots
+
   # This is a job which depends on all test jobs and reports the overall status.
   # This allows us to add/remove test jobs without having to update the required workflows.
   tests-end:
@@ -94,6 +109,7 @@ jobs:
     if: ${{ always() }}
     needs:
       - run-tests
+      - check-pending-snapshots
 
     steps:
       - name: Report overall success

--- a/justfile
+++ b/justfile
@@ -110,6 +110,16 @@ fuzz-nightly: install-rust-tools
   # In the nightly tests we want to explore uncharted territory.
   NOIR_AST_FUZZER_FORCE_NON_DETERMINISTIC=1 cargo nextest run -p noir_ast_fuzzer_fuzz --no-fail-fast
 
+# Checks if there are any pending insta.rs snapshots and errors if any exist.
+check-pending-snapshots:
+  #!/usr/bin/env bash
+  snapshots=$(find . -name *.snap.new) 
+  if [[ -n "$snapshots" ]]; then \
+    echo "Found pending snapshots:"
+    echo ""
+    echo $snapshots
+    exit 1
+  fi
 
 export RUSTDOCFLAGS := "-Dwarnings -Drustdoc::unescaped_backticks"
 # Generate doc.rs site for Rust code.


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This PR adds a test to check that no pending snapshots have been committed.


## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
