### PR TITLE
chore: greenlight check_u128_mul_overflow

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/opt/check_u128_mul_overflow.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/check_u128_mul_overflow.rs
@@ -291,7 +291,7 @@ mod tests {
         acir(inline) fn main f0 {
           b0(v0: u128, v1: u1):
             enable_side_effects v1
-            v2 = mul v0, u128 18446744073709551617
+            v2 = mul v0, u128 85070591730234615865843651857942052864
             return v2
         }
         ";
@@ -302,7 +302,7 @@ mod tests {
         acir(inline) fn main f0 {
           b0(v0: u128, v1: u1):
             enable_side_effects v1
-            v3 = mul v0, u128 18446744073709551617
+            v3 = mul v0, u128 85070591730234615865843651857942052864
             v5 = div v0, u128 18446744073709551616
             v6 = cast v1 as u128
             v7 = unchecked_mul v5, v6


### PR DESCRIPTION
# Description

## Problem

Resolves #9521

## Summary



## Additional Context

I'm thinking that if either lhs or rhs are known constants then checking if they are less than 2^64 is fine, but we could also do better and check if they are less than 2^125. The reason is that if either of them is less than 2^125 then the maximum value when multiplying that with a u128 is 2^(125 + 128) = 2^253 which I think still fits in a Field element. Because ACIR will check for overflow (but not if the value exceeds Field element) there's no need to do a separate overflow check here.

However, I wasn't sure if it was okay to do that so I'll just capture a separate issue for that: https://github.com/noir-lang/noir/issues/9760

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
