### PR TITLE
fix: allow overwrites at load factor threshold in HashMap::insert

### DIFF
--- a/noir_stdlib/src/collections/map.nr
+++ b/noir_stdlib/src/collections/map.nr
@@ -516,7 +516,6 @@ impl<K, V, let N: u32, B> HashMap<K, V, N, B> {
         B: BuildHasher,
     {
         // docs:end:insert
-        self.assert_load_factor();
 
         let hash = self.hash(key);
         let mut should_break = false;
@@ -529,6 +528,7 @@ impl<K, V, let N: u32, B> HashMap<K, V, N, B> {
 
                 // Either marked as deleted or has unset key-value.
                 if slot.is_available() {
+                    self.assert_load_factor();
                     insert = true;
                     self._len += 1;
                 } else {


### PR DESCRIPTION
Move the load factor assertion inside the branch that performs a true insertion (when the slot is available) and remove the unconditional check at the start of insert. This ensures that overwriting an existing key’s value is allowed even when the map is at or above the α_max threshold, since overwrites do not increase length or degrade the load factor. The change preserves the existing behavior of asserting on new unique inserts beyond the threshold, aligning with the load factor test and the intent to warn only when capacity-related performance would degrade.