### PR TITLE
fix(interpreter): Return fresh nested array on array get in ACIR

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/interpreter/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/interpreter/mod.rs
@@ -930,10 +930,8 @@ impl<'ssa, W: Write> Interpreter<'ssa, W> {
             })?;
 
             // Either return a fresh nested array (in constrained context) or just clone the element.
-            element
-                .as_array_or_slice()
-                .filter(|_| !self.in_unconstrained_context())
-                .map(|array| {
+            if !self.in_unconstrained_context() {
+                if let Some(array) = element.as_array_or_slice() {
                     // In the ACIR runtime we expect fresh arrays when accessing a nested array.
                     // If we do not clone the elements here a mutable array set afterwards could mutate
                     // not just this returned array but the array we are fetching from in this array get.
@@ -943,8 +941,12 @@ impl<'ssa, W: Write> Interpreter<'ssa, W> {
                         element_types: array.element_types,
                         is_slice: array.is_slice,
                     })
-                })
-                .unwrap_or_else(|| element.clone())
+                } else {
+                    element.clone()
+                }
+            } else {
+                element.clone()
+            }
         };
         self.define(result, element)?;
         Ok(())


### PR DESCRIPTION
# Description

## Problem\*

Resolves #9830

This will unblock adding the tests in #9789.

## Summary\*

When fetching arrays in ACIR we treat them as entirely fresh objects. However, in the interpreter we implement arrays use shared mutable references. Thus, when we returned a nested array and then marked it mutable in the array set optimization we were in fact mutating the parent array we fetched from as well. This breaks the semantics of arrays in ACIR.

Looking at the SSA after the array set optimization:
```
acir(inline) predicate_pure fn main f0 {
  b0(v0: u1, v1: u32):
    v4 = make_array [u1 1, u1 0, u1 1] : [u1; 3]
    v5 = make_array [v4] : [[u1; 3]; 1]
    v7 = add v1, u32 1
    v8 = array_get v5, index v1 -> [u1; 3]
    v9 = array_set mut v8, index u32 1, value u1 1
    v10 = array_get v9, index v7 -> u1
    enable_side_effects v0
    v11 = add v1, u32 1
    v12 = array_get v5, index v1 -> [u1; 3]
    v13 = array_get v12, index v11 -> u1
    v14 = not v0
    enable_side_effects u1 1
    v15 = unchecked_mul v0, v13
    v16 = unchecked_mul v14, v10
    v17 = unchecked_add v15, v16
    return v17
}
```
We expect `v8` to be its own fresh array. I changed the interpreter to check if we are returned an array from an array get and if we are to clone its elements and construct a new shared mutable reference to its elements. 

## Additional Context

## Documentation\*

Check one:
- [ ] No documentation needed.
- [X] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
