### PR TITLE
chore: greenlight remove enable side effects

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/opt/remove_enable_side_effects.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/remove_enable_side_effects.rs
@@ -65,7 +65,6 @@ impl Function {
             }
             previous_block = Some(context.block_id);
 
-            let instruction_id = context.instruction_id;
             let instruction = context.instruction();
 
             // If we run into another `Instruction::EnableSideEffectsIf` before encountering any
@@ -89,8 +88,8 @@ impl Function {
                 if condition_is_one {
                     last_side_effects_enabled_instruction = None;
                 } else {
+                    last_side_effects_enabled_instruction = Some(context.instruction_id);
                     context.remove_current_instruction();
-                    last_side_effects_enabled_instruction = Some(instruction_id);
                 }
                 return;
             }


### PR DESCRIPTION
# Description

## Problem

Resolves #9527

## Summary

I added doc comments and tests.

One of the tests checks that if we have `enable_side_effects u1 1` then it's inserted right away as opposed to before an instruction affected by the side-effects vars... but I don't know why this is done. Wouldn't it be better to always insert these right before the instructions they affect?

## Additional Context



## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
