### PR TITLE
chore: remove variable flag from poseidon2 hash

### DIFF
--- a/acvm-repo/bn254_blackbox_solver/src/poseidon2.rs
+++ b/acvm-repo/bn254_blackbox_solver/src/poseidon2.rs
@@ -543,23 +543,13 @@ impl Poseidon2<'_> {
     }
 }
 
-/// Performs a poseidon hash with a sponge construction equivalent to the one in poseidon2.nr
-///
-/// The `is_variable_length` parameter is there to so we can produce an equivalent hash with
-/// the Barretenberg implementation which distinguishes between variable and fixed length inputs.
-/// Set it to true if the input length matches the static size expected by the Noir function.
-pub fn poseidon_hash(
-    inputs: &[FieldElement],
-    is_variable_length: bool,
-) -> Result<FieldElement, BlackBoxResolutionError> {
+/// Performs a poseidon hash with a sponge construction equivalent to the one in the Barretenberg proving system
+pub fn poseidon_hash(inputs: &[FieldElement]) -> Result<FieldElement, BlackBoxResolutionError> {
     let two_pow_64 = 18446744073709551616_u128.into();
     let iv = FieldElement::from(inputs.len()) * two_pow_64;
     let mut sponge = Poseidon2Sponge::new(iv, 3);
     for input in inputs.iter() {
         sponge.absorb(*input)?;
-    }
-    if is_variable_length {
-        sponge.absorb(FieldElement::from(1u32))?;
     }
     sponge.squeeze()
 }
@@ -650,7 +640,7 @@ mod test {
             FieldElement::from(3u128),
             FieldElement::from(4u128),
         ];
-        let result = super::poseidon_hash(&fields, false).expect("should hash successfully");
+        let result = super::poseidon_hash(&fields).expect("should hash successfully");
         assert_eq!(
             result,
             field_from_hex("130bf204a32cac1f0ace56c78b731aa3809f06df2731ebcf6b3464a15788b1b9"),


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This PR brings back the rust changes from #7284.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
