### PR TITLE
feat: better check_u128_mul_overflow logic when an operand is constant

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/opt/check_u128_mul_overflow.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/check_u128_mul_overflow.rs
@@ -72,7 +72,7 @@ fn check_u128_mul_overflow(
     let lhs_value = dfg.get_numeric_constant(lhs);
     let rhs_value = dfg.get_numeric_constant(rhs);
 
-    // If we multiply a constant value 2^n by an uknown u128 value we get at most `2^(n+128) - 2`.
+    // If we multiply a constant value 2^n by an unknown u128 value we get at most `2^(n+128) - 2`.
     // If `n+128` does not overflow the maximum Field element value, there's no need to check for overflow.
     let max_const_value_that_does_not_overflow = 1_u128 << (FieldElement::max_num_bits() - 128);
     if lhs_value.is_some_and(|value| value.to_u128() < max_const_value_that_does_not_overflow)


### PR DESCRIPTION
# Description

## Problem

Resolves #9760

## Summary

See the linked issue explanation and also the comments in this PR.

## Additional Context

I thought we could also do better in more cases. For example if the LHS is a constant that, when multiplied, could overflow, then we'd only need to check that the bits of RHS are less than `bits(Field) - bits(LHS)` instead of checking that it's less than `2^64`. However, the only thing that would change here is the constant we divide by: the check will still be there so the performance will be the same.

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
