### PR TITLE
chore(licm): Add `CanBeHoistedResult::WithRefCount`

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/opt/loop_invariant.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/loop_invariant.rs
@@ -91,6 +91,7 @@ use crate::ssa::{
     ir::{
         basic_block::BasicBlockId,
         cfg::ControlFlowGraph,
+        dfg::DataFlowGraph,
         dom::DominatorTree,
         function::Function,
         function_inserter::FunctionInserter,
@@ -665,7 +666,6 @@ impl<'f> LoopInvariantContext<'f> {
         instruction_id: InstructionId,
     ) -> bool {
         use CanBeHoistedResult::*;
-        use Instruction::*;
 
         let mut is_loop_invariant = true;
         // The list of blocks for a nested loop contain any inner loops as well.
@@ -686,22 +686,19 @@ impl<'f> LoopInvariantContext<'f> {
             return false;
         }
 
-        // MakeArray is only safe to hoist in ACIR, but we know that in Brillig we will insert an `IncRc`
-        // in `LoopInvariantContext::hoist_loop_invariants` to keep it safe, so it's okay to hoist them.
-        if matches!(instruction, MakeArray { .. }) {
-            return true;
-        }
-
         // Check if the operation depends only on the outer loop variable, in which case it can be hoisted
         // into the pre-header of a nested loop even if the nested loop does not execute.
         if self.can_be_hoisted_from_loop_bounds(loop_context, &instruction) {
             return true;
         }
 
-        match can_be_hoisted(&instruction, self.inserter.function) {
+        match can_be_hoisted(&instruction, &self.inserter.function.dfg) {
             Yes => true,
             No => false,
             WithPredicate => block_context.can_hoist_control_dependent_instruction(),
+            // MakeArray is only safe to hoist in ACIR, but we know that in Brillig we will insert an `IncRc`
+            // in `LoopInvariantContext::hoist_loop_invariants` to keep it safe, so it's okay to hoist them.
+            WithRefCount => true,
         }
     }
 
@@ -797,6 +794,7 @@ enum CanBeHoistedResult {
     Yes,
     No,
     WithPredicate,
+    WithRefCount,
 }
 
 impl From<bool> for CanBeHoistedResult {
@@ -825,7 +823,7 @@ impl From<bool> for CanBeHoistedResult {
 /// This differs from `can_be_deduplicated` as that method assumes there is a matching instruction
 /// with the same inputs. Hoisting is for lone instructions, meaning a mislabeled hoist could cause
 /// unexpected failures if the instruction was never meant to be executed.
-fn can_be_hoisted(instruction: &Instruction, function: &Function) -> CanBeHoistedResult {
+fn can_be_hoisted(instruction: &Instruction, dfg: &DataFlowGraph) -> CanBeHoistedResult {
     use CanBeHoistedResult::*;
     use Instruction::*;
 
@@ -839,9 +837,9 @@ fn can_be_hoisted(instruction: &Instruction, function: &Function) -> CanBeHoiste
         | DecrementRc { .. } => No,
 
         Call { func, .. } => {
-            let purity = match function.dfg[*func] {
+            let purity = match dfg[*func] {
                 Value::Intrinsic(intrinsic) => Some(intrinsic.purity()),
-                Value::Function(id) => function.dfg.purity_of(id),
+                Value::Function(id) => dfg.purity_of(id),
                 _ => None,
             };
             match purity {
@@ -855,7 +853,7 @@ fn can_be_hoisted(instruction: &Instruction, function: &Function) -> CanBeHoiste
         Cast(source, target_type) => {
             // A cast may have dependence on a range-check, which may not be hoisted, so we cannot always hoist a cast.
             // We can safely hoist a cast from a smaller to a larger type as no range check is necessary in this case.
-            let source_type = function.dfg.type_of_value(*source).unwrap_numeric();
+            let source_type = dfg.type_of_value(*source).unwrap_numeric();
             (source_type.bit_size() <= target_type.bit_size()).into()
         }
 
@@ -873,15 +871,17 @@ fn can_be_hoisted(instruction: &Instruction, function: &Function) -> CanBeHoiste
         // hoisted. We know that in this module we will insert a corresponding `IncRc` to
         // allow safe hoisting in unconstrained code, but just in case we would expose this
         // function to other modules, we return a more restrictive result here.
-        MakeArray { .. } => function.runtime().is_acir().into(),
+        MakeArray { .. } => {
+            if dfg.runtime().is_acir() {
+                Yes
+            } else {
+                WithRefCount
+            }
+        }
 
         // These can have different behavior depending on the predicate.
         Binary(_) | ArraySet { .. } | ArrayGet { .. } => {
-            if !instruction.requires_acir_gen_predicate(&function.dfg) {
-                Yes
-            } else {
-                WithPredicate
-            }
+            if !instruction.requires_acir_gen_predicate(dfg) { Yes } else { WithPredicate }
         }
     }
 }
@@ -2331,7 +2331,7 @@ mod test {
     }
 
     /// Test that in itself `MakeArray` is only safe to be hoisted in ACIR.
-    #[test_case(RuntimeType::Brillig(InlineType::default()), CanBeHoistedResult::No)]
+    #[test_case(RuntimeType::Brillig(InlineType::default()), CanBeHoistedResult::WithRefCount)]
     #[test_case(RuntimeType::Acir(InlineType::default()), CanBeHoistedResult::Yes)]
     fn make_array_can_be_hoisted(runtime: RuntimeType, result: CanBeHoistedResult) {
         // This is just a stub to create a function with the expected runtime.
@@ -2351,7 +2351,7 @@ mod test {
             typ: Type::Array(Arc::new(vec![]), 0),
         };
 
-        assert_eq!(can_be_hoisted(&instruction, function), result);
+        assert_eq!(can_be_hoisted(&instruction, &function.dfg), result);
     }
 }
 


### PR DESCRIPTION
# Description

## Problem\*

Resolves https://github.com/noir-lang/noir/pull/9807#discussion_r2342125956

## Summary\*

Adds `CanBeHoistedResult::WithRefCount` from https://github.com/noir-lang/noir/pull/9807 regardless of whether we adopt anything else from that PR.

Changes `LoopInvariantContext::can_hoist_invariant` to return an extra `bool` to signal whether `IncrementRc` needs to be inserted, so we don't need to keep in sync the decision when `WithRefCount` is returned and the actual insertion of the RC, with a comment that we will do so. I went back and forth between returning `CanBeHoistedResult` from `can_hoist_invariant` and matching it in `hoist_loop_invariants`, but in the past I found it useful to debug the various decision points in `can_hoist_invariant`, and thought it was better to keep these close together, rather than spread it out where "from bounds" and "with control" are in different places.

## Additional Context


## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
