### PR TITLE
chore: validate that all jmpif conditions are boolean

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/opt/constant_folding/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/constant_folding/mod.rs
@@ -1212,13 +1212,14 @@ mod test {
         let src = "
             brillig(inline) fn main f0 {
               b0(v0: Field, v1: Field):
-                v3 = eq v0, Field 0
-                jmpif v3 then: b1, else: b2
+                v2 = eq v0, Field 0
+                jmpif v2 then: b1, else: b2
               b1():
                 constrain v1 == Field 1
                 jmp b2()
               b2():
-                jmpif v0 then: b3, else: b4
+                v3 = eq v0, Field 1
+                jmpif v3 then: b3, else: b4
               b3():
                 constrain v1 == Field 1 // This was incorrectly hoisted to b0 but this condition is not valid when going b0 -> b2 -> b4
                 jmp b4()
@@ -1237,7 +1238,8 @@ mod test {
                 v2 = eq v0, u32 0
                 jmpif v2 then: b4, else: b1
               b1():
-                jmpif v0 then: b3, else: b2
+                v3 = eq v0, u32 1
+                jmpif v3 then: b3, else: b2
               b2():
                 jmp b5()
               b3():

--- a/compiler/noirc_evaluator/src/ssa/opt/loop_invariant.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/loop_invariant.rs
@@ -3540,7 +3540,7 @@ mod control_dependence {
               v4 = lt v3, u32 2
               jmpif v4 then: b2, else: b3
             b2():
-              jmpif v2 then: b4, else: b5
+              jmpif v1 then: b4, else: b5
             b3():
               return
             b4():

--- a/compiler/noirc_evaluator/src/ssa/opt/preprocess_fns.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/preprocess_fns.rs
@@ -97,14 +97,15 @@ mod tests {
         }
         acir(inline) fn foo f0 {
           b0(v0: u32, v1: Field):
-            jmpif v0 then: b1, else: b2
+            v2 = eq v0, u32 1
+            jmpif v2 then: b1, else: b2
           b1():
             v6 = add v0, u32 1
             jmp b3(v6, v1)
           b2():
             v5 = sub v0, u32 1
             jmp b3(v5, v1)
-          b3(v2: u32, v3: Field):
+          b3(v3: u32, v4: Field):
             return
         }
         "#;
@@ -112,7 +113,7 @@ mod tests {
         let ssa = Ssa::from_str(src).unwrap();
         let ssa = ssa.preprocess_functions(i64::MAX, MAX_INSTRUCTIONS).unwrap();
 
-        assert_ssa_snapshot!(ssa, @r#"
+        assert_ssa_snapshot!(ssa, @r"
         acir(inline) fn main f0 {
           b0():
             call f1()
@@ -120,16 +121,17 @@ mod tests {
         }
         acir(inline) fn foo f1 {
           b0(v0: u32, v1: Field):
-            jmpif v0 then: b1, else: b2
+            v3 = eq v0, u32 1
+            jmpif v3 then: b1, else: b2
           b1():
-            v4 = add v0, u32 1
+            v5 = add v0, u32 1
             jmp b3()
           b2():
-            v3 = sub v0, u32 1
+            v4 = sub v0, u32 1
             jmp b3()
           b3():
             return
         }
-        "#);
+        ");
     }
 }

--- a/compiler/noirc_evaluator/src/ssa/parser/tests.rs
+++ b/compiler/noirc_evaluator/src/ssa/parser/tests.rs
@@ -178,20 +178,8 @@ fn test_multiple_blocks_and_jmp() {
 fn test_jmpif() {
     let src = "
         acir(inline) fn main f0 {
-          b0(v0: Field):
+          b0(v0: u1):
             jmpif v0 then: b1, else: b2
-          b1():
-            jmp b2()
-          b2():
-            return
-        }
-        ";
-    assert_ssa_roundtrip(src);
-
-    let src = "
-        acir(inline) fn main f0 {
-          b0(v0: Field):
-            jmpif v0 then: b2, else: b1
           b1():
             jmp b2()
           b2():
@@ -205,7 +193,7 @@ fn test_jmpif() {
 fn test_multiple_jmpif() {
     let src = "
         acir(inline) fn main f0 {
-          b0(v0: Field, v1: Field):
+          b0(v0: u1, v1: u1):
             jmpif v0 then: b1, else: b2
           b1():
             jmp b4()

--- a/compiler/noirc_evaluator/src/ssa/validation/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/validation/mod.rs
@@ -21,7 +21,7 @@ use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 pub(crate) mod dynamic_array_indices;
 
 use crate::ssa::{
-    ir::{dfg::DataFlowGraph, instruction::TerminatorInstruction},
+    ir::{basic_block::BasicBlockId, dfg::DataFlowGraph, instruction::TerminatorInstruction},
     ssa_gen::Ssa,
 };
 
@@ -679,6 +679,26 @@ impl<'f> Validator<'f> {
         }
     }
 
+    fn validate_block_terminator(&self, block: BasicBlockId) {
+        let terminator = self.function.dfg[block]
+            .terminator()
+            .expect("Block is expected to have a terminator instruction");
+
+        match terminator {
+            TerminatorInstruction::JmpIf { condition, .. } => {
+                let condition_type = self.function.dfg.type_of_value(*condition);
+                assert_eq!(
+                    condition_type,
+                    Type::bool(),
+                    "JmpIf conditions should have boolean type"
+                );
+            }
+            TerminatorInstruction::Jmp { .. }
+            | TerminatorInstruction::Return { .. }
+            | TerminatorInstruction::Unreachable { .. } => (),
+        }
+    }
+
     fn run(&mut self) {
         self.type_check_globals();
         self.validate_single_return_block();
@@ -689,6 +709,7 @@ impl<'f> Validator<'f> {
                 self.type_check_instruction(*instruction);
                 self.check_calls_in_unconstrained(*instruction);
             }
+            self.validate_block_terminator(block);
         }
     }
 }
@@ -1296,6 +1317,24 @@ mod tests {
             v5 = array_get v4, index v0 -> Field
             return
         }
+        ";
+        let _ = Ssa::from_str(src).unwrap();
+    }
+
+    #[test]
+    #[should_panic(expected = "JmpIf conditions should have boolean type")]
+    fn disallows_non_boolean_jmpif_condition() {
+        let src = "
+        acir(inline) fn main f0 {
+          b0(v0: u32):
+            jmpif v0 then: b1, else: b2
+          b1():
+            jmp b2()
+          b2():
+            return
+
+        }
+        
         ";
         let _ = Ssa::from_str(src).unwrap();
     }


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

We're currently allowing SSA which has non-boolean types for the jmpif conditions. This PR adds a validation to ensure that this cannot happen in our test code.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
