### PR TITLE
chore(die): IncrementRc/DecrementRc comments

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/opt/die.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/die.rs
@@ -10,8 +10,7 @@
 //!   and its results are all unused the instruction will be marked for removal.
 //!   Traversing in reverse enables removing entire unused chains of computation.
 //! - The pass also tracks unused [IncrementRc][Instruction::IncrementRc] and [DecrementRc][Instruction::DecrementRc] instructions.
-//!   This pass defines an IncrementRc/DecrementRc as unused if the increment/decrement occurs on an array type that is never mutated
-//!   in the current block.   
+//!   As these instructions contain side effects we only remove them after analyzing an entire function to see if their values are unused.
 //! - Block parameters are also tracked. Unused parameters are pruned in a follow-up [prune_dead_parameters] pass
 //!   to maintain separation of concerns and SSA consistency.
 //! - The main DIE pass and dead parameter pruning are called in a fixed point feedback loop that stops


### PR DESCRIPTION
# Description

## Problem\*

Resolves #9517 

## Summary\*

This is a minor last comment cleanup that I missed after #9809. The old comment is inaccurate and the logic it outlines does not exist anywhere in DIE anymore.

With this DIE should be ready for internal audit.

## Additional Context

## Documentation\*

Check one:
- [ ] No documentation needed.
- [X] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
