### PR TITLE
fix: disallow `_` in where clauses, and disallow unused trait impl generics

### DIFF
--- a/.github/benchmark_projects.yml
+++ b/.github/benchmark_projects.yml
@@ -1,4 +1,4 @@
-define: &AZ_COMMIT 9adfd777a799c38e8053ce89d2c80542d71fb063
+define: &AZ_COMMIT 95215869f4912edf381752443e5accb2468bc069
 projects:
   private-kernel-inner:
     repo: AztecProtocol/aztec-packages

--- a/EXTERNAL_NOIR_LIBRARIES.yml
+++ b/EXTERNAL_NOIR_LIBRARIES.yml
@@ -1,4 +1,4 @@
-define: &AZ_COMMIT 9adfd777a799c38e8053ce89d2c80542d71fb063
+define: &AZ_COMMIT 95215869f4912edf381752443e5accb2468bc069
 libraries:
   noir_check_shuffle:
     repo: noir-lang/noir_check_shuffle

--- a/compiler/noirc_frontend/src/elaborator/mod.rs
+++ b/compiler/noirc_frontend/src/elaborator/mod.rs
@@ -864,7 +864,7 @@ impl<'context> Elaborator<'context> {
         &mut self,
         constraint: &UnresolvedTraitConstraint,
     ) -> Option<TraitConstraint> {
-        let wildcard_allowed = true;
+        let wildcard_allowed = false;
         let typ = self.resolve_type(constraint.typ.clone(), wildcard_allowed);
         let trait_bound = self.resolve_trait_bound(&constraint.trait_bound)?;
         let location = constraint.trait_bound.trait_path.location;
@@ -891,7 +891,7 @@ impl<'context> Elaborator<'context> {
         let the_trait = self.lookup_trait_or_error(trait_path)?;
         let trait_id = the_trait.id;
         let location = bound.trait_path.location;
-        let wildcard_allowed = true;
+        let wildcard_allowed = false;
 
         let (ordered, named) = self.resolve_type_args_inner(
             bound.trait_generics.clone(),

--- a/compiler/noirc_frontend/src/tests.rs
+++ b/compiler/noirc_frontend/src/tests.rs
@@ -4292,10 +4292,21 @@ fn unconstrained_type_parameter_in_trait_impl() {
         impl<T, U> Trait<T> for Foo<T> {}
                 ^ The type parameter `U` is not constrained by the impl trait, self type, or predicates
                 ~ Hint: remove the `U` type parameter
-
-        fn main() {}
         "#;
     check_errors!(src);
+}
+
+#[test]
+fn does_not_error_if_type_parameter_is_used_in_trait_bound_named_generic() {
+    let src = r#"
+    pub trait SomeTrait {}
+    pub trait AnotherTrait {
+        type AssocType;
+    }
+
+    impl<T, U> SomeTrait for T where T: AnotherTrait<AssocType=U> {}
+    "#;
+    assert_no_errors!(src);
 }
 
 #[test]

--- a/compiler/noirc_frontend/src/tests.rs
+++ b/compiler/noirc_frontend/src/tests.rs
@@ -4284,6 +4284,21 @@ fn unconstrained_numeric_generic_in_impl() {
 }
 
 #[test]
+fn unconstrained_type_parameter_in_trait_impl() {
+    let src = r#"
+        pub trait Trait<T> {}
+        pub struct Foo<T> {}
+
+        impl<T, U> Trait<T> for Foo<T> {}
+                ^ The type parameter `U` is not constrained by the impl trait, self type, or predicates
+                ~ Hint: remove the `U` type parameter
+
+        fn main() {}
+        "#;
+    check_errors!(src);
+}
+
+#[test]
 fn resolves_generic_type_argument_via_self() {
     let src = "
     pub struct Foo<T> {}

--- a/test_programs/compile_failure/wildcards_in_wrong_places/src/main.nr
+++ b/test_programs/compile_failure/wildcards_in_wrong_places/src/main.nr
@@ -16,4 +16,17 @@ pub trait Trait {
     fn trait_method(_: [_; _]) -> [_; _];
 }
 
+pub struct Gen<T> {}
+pub trait Trait2<T> {}
+
+pub fn bar<T>()
+where
+    Gen<_>: Trait2<T>,
+{}
+
+impl<T> Trait2<T> for Gen<T>
+where
+    Gen<_>: Trait2<_>,
+{}
+
 fn main() {}

--- a/tooling/nargo_cli/tests/snapshots/compile_failure/broken_impl/execute__tests__stderr.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_failure/broken_impl/execute__tests__stderr.snap
@@ -9,6 +9,13 @@ error: Expected a trait, found error
   │          -
   │
 
+error: The type parameter `Foo` is not constrained by the impl trait, self type, or predicates
+  ┌─ src/main.nr:2:7
+  │
+2 │ impl< Foo for
+  │       --- Hint: remove the `Foo` type parameter
+  │
+
 error: Expected a generic parameter but found 'for'
   ┌─ src/main.nr:2:11
   │
@@ -41,4 +48,4 @@ error: Expected a '{' but found end of input
   │ ╰'
   │  
 
-Aborting due to 5 previous errors
+Aborting due to 6 previous errors

--- a/tooling/nargo_cli/tests/snapshots/compile_failure/wildcards_in_wrong_places/execute__tests__stderr.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_failure/wildcards_in_wrong_places/execute__tests__stderr.snap
@@ -45,6 +45,13 @@ error: The placeholder `_` is not allowed within types on item signatures for fu
   │
 
 error: The placeholder `_` is not allowed within types on item signatures for functions
+   ┌─ src/main.nr:24:9
+   │
+24 │     Gen<_>: Trait2<T>,
+   │         -
+   │
+
+error: The placeholder `_` is not allowed within types on item signatures for functions
    ┌─ src/main.nr:10:16
    │
 10 │     fn foo(_: [_; _]) -> [_; _] {
@@ -70,6 +77,20 @@ error: The placeholder `_` is not allowed within types on item signatures for fu
    │
 10 │     fn foo(_: [_; _]) -> [_; _] {
    │                              -
+   │
+
+error: The placeholder `_` is not allowed within types on item signatures for functions
+   ┌─ src/main.nr:29:9
+   │
+29 │     Gen<_>: Trait2<_>,
+   │         -
+   │
+
+error: The placeholder `_` is not allowed within types on item signatures for functions
+   ┌─ src/main.nr:29:20
+   │
+29 │     Gen<_>: Trait2<_>,
+   │                    -
    │
 
 error: The placeholder `_` is not allowed within types on item signatures for functions
@@ -100,4 +121,18 @@ error: The placeholder `_` is not allowed within types on item signatures for fu
    │                                       -
    │
 
-Aborting due to 14 previous errors
+error: The placeholder `_` is not allowed within types on item signatures for functions
+   ┌─ src/main.nr:29:9
+   │
+29 │     Gen<_>: Trait2<_>,
+   │         -
+   │
+
+error: The placeholder `_` is not allowed within types on item signatures for functions
+   ┌─ src/main.nr:29:20
+   │
+29 │     Gen<_>: Trait2<_>,
+   │                    -
+   │
+
+Aborting due to 19 previous errors


### PR DESCRIPTION
# Description

## Problem

Resolves #9870

## Summary



## Additional Context



## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
