### PR TITLE
chore(fuzz): Refactor logging in the AST fuzzer

### DIFF
--- a/tooling/ast_fuzzer/README.md
+++ b/tooling/ast_fuzzer/README.md
@@ -38,7 +38,7 @@ cargo +nightly fuzz run acir_vs_brillig fuzz/artifacts/acir_vs_brillig/crash-927
 
 Note that `cargo fuzz` requires `nightly` build, which can be either turned on with the `cargo +nightly` flag, or by running `rustup default nightly`. Also note that `cargo fuzz run` automatically creates a `--release` build, there is no need for an explicit flag to be passed.
 
-The `NOIR_AST_FUZZER_SHOW_AST` env var can be used to print the AST before compilation, in case the compiler crashes on the generated program. Otherwise if the execution fails, the output will include the AST, the inputs, and the ACIR/Brillig opcodes.
+If the execution fails, the output will include the AST, the inputs, and the ACIR/Brillig opcodes.
 
 ## `arbtest`
 
@@ -48,7 +48,11 @@ To get quick feedback about whether there are any easy-to-discover bugs, we can 
 cargo test -p noir_ast_fuzzer_fuzz arbtest
 ```
 
-Unlike `cargo fuzz`, these don't "ramp up" the complexity of the code, but go full tilt from the beginning, and only run for a limited amount of time (e.g. 10 seconds). Upon failure they print a hexadecimal `seed`, which can be used with the `NOIR_AST_FUZZER_SEED` env var to replicate the error.
+Unlike `cargo fuzz`, these don't "ramp up" the complexity of the code, but go full tilt from the beginning, and only run for a limited amount of time (e.g. 10 seconds).
+
+Upon failure they print a hexadecimal `seed`, which can be used with the `NOIR_AST_FUZZER_SEED` env var to replicate the error.
+
+If the compiler crashes during the generation of the SSA artifacts, the problematic program will be printed during attempts to reproduce the issue using a seed. The printing of all inputs can be turned on by setting `RUST_LOG=debug`.
 
 ## Minimizing Noir
 

--- a/tooling/ast_fuzzer/fuzz/src/lib.rs
+++ b/tooling/ast_fuzzer/fuzz/src/lib.rs
@@ -43,8 +43,6 @@ pub fn default_ssa_options() -> SsaEvaluatorOptions {
 }
 
 /// Compile a [Program] into SSA or panic.
-///
-/// Prints the AST if `NOIR_AST_FUZZER_SHOW_AST` is set.
 pub fn create_ssa_or_die(
     program: Program,
     options: &SsaEvaluatorOptions,

--- a/tooling/ast_fuzzer/fuzz/src/lib.rs
+++ b/tooling/ast_fuzzer/fuzz/src/lib.rs
@@ -118,11 +118,28 @@ where
                 .serialize(&inputs.input_map, &inputs.abi)
                 .unwrap_or_else(|e| format!("failed to serialize inputs: {e}"))
         );
+
+        // Display a Program without the Brillig opcodes, which are unreadable.
+        fn display_program(artifact: &SsaProgramArtifact) {
+            for (func_index, function) in artifact.program.functions.iter().enumerate() {
+                eprintln!("func {func_index}");
+                eprintln!("{function}");
+            }
+            for (func_index, function) in
+                artifact.program.unconstrained_functions.iter().enumerate()
+            {
+                eprintln!("unconstrained func {func_index}");
+                eprintln!("opcode count: {}", function.bytecode.len());
+            }
+        }
+
         eprintln!("---\nOptions 1:\n{:?}", inputs.ssa1.options);
-        eprintln!("---\nProgram 1:\n{}", inputs.ssa1.artifact.program);
+        eprintln!("---\nProgram 1:");
+        display_program(&inputs.ssa1.artifact);
 
         eprintln!("---\nOptions 2:\n{:?}", inputs.ssa2.options);
-        eprintln!("---\nProgram 2:\n{}", inputs.ssa2.artifact.program);
+        eprintln!("---\nProgram 2:");
+        display_program(&inputs.ssa1.artifact);
 
         // Returning it as-is, so we can see the error message at the bottom as well.
         Err(report)

--- a/tooling/ast_fuzzer/fuzz/src/lib.rs
+++ b/tooling/ast_fuzzer/fuzz/src/lib.rs
@@ -42,17 +42,19 @@ pub fn default_ssa_options() -> SsaEvaluatorOptions {
     }
 }
 
-/// Compile a [Program] into SSA or panic.
-pub fn create_ssa_or_die(
+/// Compile a monomorphized [Program] into circuit or panic.
+pub fn compile_into_circuit_or_die(
     program: Program,
     options: &SsaEvaluatorOptions,
     msg: Option<&str>,
 ) -> SsaProgramArtifact {
-    create_ssa_with_passes_or_die(program, options, &primary_passes(options), msg)
+    compile_into_circuit_with_ssa_passes_or_die(program, options, &primary_passes(options), msg)
 }
 
-/// Compile a [Program] into SSA using the given SSA passes, or panic if it cannot be compiled.
-pub fn create_ssa_with_passes_or_die(
+/// Compile a monomorphized [Program] into circuit using the given SSA passes or panic.
+///
+/// If there is a seed in the environment, then it prints the AST when an error is encountered.
+pub fn compile_into_circuit_with_ssa_passes_or_die(
     program: Program,
     options: &SsaEvaluatorOptions,
     primary: &[SsaPass],

--- a/tooling/ast_fuzzer/fuzz/src/targets/acir_vs_brillig.rs
+++ b/tooling/ast_fuzzer/fuzz/src/targets/acir_vs_brillig.rs
@@ -41,7 +41,6 @@ mod tests {
 
     /// ```ignore
     /// NOIR_AST_FUZZER_SEED=0x6819c61400001000 \
-    /// NOIR_AST_FUZZER_SHOW_AST=1 \
     /// cargo test -p noir_ast_fuzzer_fuzz acir_vs_brillig
     /// ```
     #[test]

--- a/tooling/ast_fuzzer/fuzz/src/targets/acir_vs_brillig.rs
+++ b/tooling/ast_fuzzer/fuzz/src/targets/acir_vs_brillig.rs
@@ -1,7 +1,7 @@
 //! Compare the execution of random ASTs between the normal execution
 //! vs when everything is forced to be Brillig.
 use crate::targets::default_config;
-use crate::{compare_results_compiled, create_ssa_or_die, default_ssa_options};
+use crate::{compare_results_compiled, compile_into_circuit_or_die, default_ssa_options};
 use arbitrary::Arbitrary;
 use arbitrary::Unstructured;
 use color_eyre::eyre;
@@ -16,13 +16,16 @@ pub fn fuzz(u: &mut Unstructured) -> eyre::Result<()> {
         config,
         |u, program| {
             let options = CompareOptions::arbitrary(u)?;
-            let ssa =
-                create_ssa_or_die(program, &options.onto(default_ssa_options()), Some("acir"));
+            let ssa = compile_into_circuit_or_die(
+                program,
+                &options.onto(default_ssa_options()),
+                Some("acir"),
+            );
             Ok((ssa, options))
         },
         |u, program| {
             let options = CompareOptions::arbitrary(u)?;
-            let ssa = create_ssa_or_die(
+            let ssa = compile_into_circuit_or_die(
                 change_all_functions_into_unconstrained(program),
                 &options.onto(default_ssa_options()),
                 Some("brillig"),

--- a/tooling/ast_fuzzer/fuzz/src/targets/comptime_vs_brillig_direct.rs
+++ b/tooling/ast_fuzzer/fuzz/src/targets/comptime_vs_brillig_direct.rs
@@ -62,7 +62,6 @@ mod tests {
 
     /// ```ignore
     /// NOIR_AST_FUZZER_SEED=0x6819c61400001000 \
-    /// NOIR_AST_FUZZER_SHOW_AST=1 \
     /// cargo test -p noir_ast_fuzzer_fuzz comptime_vs_brillig_direct
     /// ```
     #[test]

--- a/tooling/ast_fuzzer/fuzz/src/targets/comptime_vs_brillig_direct.rs
+++ b/tooling/ast_fuzzer/fuzz/src/targets/comptime_vs_brillig_direct.rs
@@ -7,7 +7,7 @@
 //! through nargo, which speeds up execution but also currently
 //! has some issues (inability to use prints among others).
 use crate::targets::default_config;
-use crate::{compare_results_comptime, create_ssa_or_die, default_ssa_options};
+use crate::{compare_results_comptime, compile_into_circuit_or_die, default_ssa_options};
 use arbitrary::Unstructured;
 use color_eyre::eyre;
 use noir_ast_fuzzer::Config;
@@ -36,7 +36,7 @@ pub fn fuzz(u: &mut Unstructured) -> eyre::Result<()> {
 
     let inputs = CompareComptime::arb(u, config, |program| {
         let options = CompareOptions::default();
-        let ssa = create_ssa_or_die(
+        let ssa = compile_into_circuit_or_die(
             change_all_functions_into_unconstrained(program),
             &options.onto(default_ssa_options()),
             Some("brillig"),
@@ -46,7 +46,7 @@ pub fn fuzz(u: &mut Unstructured) -> eyre::Result<()> {
 
     let result = inputs.exec_direct(|program| {
         let options = CompareOptions::default();
-        let ssa = create_ssa_or_die(
+        let ssa = compile_into_circuit_or_die(
             program,
             &options.onto(default_ssa_options()),
             Some("comptime_result_wrapper"),

--- a/tooling/ast_fuzzer/fuzz/src/targets/comptime_vs_brillig_nargo.rs
+++ b/tooling/ast_fuzzer/fuzz/src/targets/comptime_vs_brillig_nargo.rs
@@ -51,7 +51,6 @@ mod tests {
 
     /// ```ignore
     /// NOIR_AST_FUZZER_SEED=0x6819c61400001000 \
-    /// NOIR_AST_FUZZER_SHOW_AST=1 \
     /// cargo test -p noir_ast_fuzzer_fuzz comptime_vs_brillig_nargo
     /// ```
     #[test]

--- a/tooling/ast_fuzzer/fuzz/src/targets/comptime_vs_brillig_nargo.rs
+++ b/tooling/ast_fuzzer/fuzz/src/targets/comptime_vs_brillig_nargo.rs
@@ -7,7 +7,7 @@
 //! but at the moment is more feature complete than using the interpreter
 //! directly.
 use crate::targets::default_config;
-use crate::{compare_results_comptime, create_ssa_or_die, default_ssa_options};
+use crate::{compare_results_comptime, compile_into_circuit_or_die, default_ssa_options};
 use arbitrary::Unstructured;
 use color_eyre::eyre;
 use noir_ast_fuzzer::Config;
@@ -33,7 +33,7 @@ pub fn fuzz(u: &mut Unstructured) -> eyre::Result<()> {
 
     let inputs = CompareComptime::arb(u, config, |program| {
         let options = CompareOptions::default();
-        let ssa = create_ssa_or_die(
+        let ssa = compile_into_circuit_or_die(
             change_all_functions_into_unconstrained(program),
             &options.onto(default_ssa_options()),
             Some("brillig"),

--- a/tooling/ast_fuzzer/fuzz/src/targets/min_vs_full.rs
+++ b/tooling/ast_fuzzer/fuzz/src/targets/min_vs_full.rs
@@ -3,7 +3,8 @@
 //! and the fully optimized version.
 use crate::targets::default_config;
 use crate::{
-    compare_results_compiled, create_ssa_or_die, create_ssa_with_passes_or_die, default_ssa_options,
+    compare_results_compiled, compile_into_circuit_or_die,
+    compile_into_circuit_with_ssa_passes_or_die, default_ssa_options,
 };
 use arbitrary::{Arbitrary, Unstructured};
 use color_eyre::eyre;
@@ -22,7 +23,7 @@ pub fn fuzz(u: &mut Unstructured) -> eyre::Result<()> {
             // We want to do the minimum possible amount of SSA passes. Brillig can get away with fewer than ACIR,
             // because ACIR needs unrolling of loops for example, so we treat everything as Brillig.
             let options = CompareOptions::default();
-            let ssa = create_ssa_with_passes_or_die(
+            let ssa = compile_into_circuit_with_ssa_passes_or_die(
                 change_all_functions_into_unconstrained(program),
                 &options.onto(default_ssa_options()),
                 &passes,
@@ -32,8 +33,11 @@ pub fn fuzz(u: &mut Unstructured) -> eyre::Result<()> {
         },
         |u, program| {
             let options = CompareOptions::arbitrary(u)?;
-            let ssa =
-                create_ssa_or_die(program, &options.onto(default_ssa_options()), Some("final"));
+            let ssa = compile_into_circuit_or_die(
+                program,
+                &options.onto(default_ssa_options()),
+                Some("final"),
+            );
             Ok((ssa, options))
         },
     )?;

--- a/tooling/ast_fuzzer/fuzz/src/targets/min_vs_full.rs
+++ b/tooling/ast_fuzzer/fuzz/src/targets/min_vs_full.rs
@@ -51,7 +51,6 @@ pub fn fuzz(u: &mut Unstructured) -> eyre::Result<()> {
 mod tests {
     /// ```ignore
     /// NOIR_AST_FUZZER_SEED=0x6819c61400001000 \
-    /// NOIR_AST_FUZZER_SHOW_AST=1 \
     /// cargo test -p noir_ast_fuzzer_fuzz min_vs_full
     /// ```
     #[test]

--- a/tooling/ast_fuzzer/fuzz/src/targets/mod.rs
+++ b/tooling/ast_fuzzer/fuzz/src/targets/mod.rs
@@ -69,7 +69,6 @@ mod tests {
     /// Run it with for example:
     /// ```ignore
     /// NOIR_AST_FUZZER_SEED=0x6819c61400001000 \
-    /// NOIR_AST_FUZZER_SHOW_AST=1 \
     /// cargo test -p noir_ast_fuzzer_fuzz acir_vs_brillig
     /// ```
     ///

--- a/tooling/ast_fuzzer/fuzz/src/targets/orig_vs_morph.rs
+++ b/tooling/ast_fuzzer/fuzz/src/targets/orig_vs_morph.rs
@@ -820,7 +820,6 @@ mod helpers {
 mod tests {
     /// ```ignore
     /// NOIR_AST_FUZZER_SEED=0xb2fb5f0b00100000 \
-    /// NOIR_AST_FUZZER_SHOW_AST=1 \
     /// cargo test -p noir_ast_fuzzer_fuzz orig_vs_morph
     /// ```
     #[test]

--- a/tooling/ast_fuzzer/fuzz/src/targets/orig_vs_morph.rs
+++ b/tooling/ast_fuzzer/fuzz/src/targets/orig_vs_morph.rs
@@ -4,7 +4,7 @@
 use std::cell::{Cell, RefCell};
 
 use crate::targets::default_config;
-use crate::{compare_results_compiled, create_ssa_or_die, default_ssa_options};
+use crate::{compare_results_compiled, compile_into_circuit_or_die, default_ssa_options};
 use arbitrary::{Arbitrary, Unstructured};
 use color_eyre::eyre;
 use noir_ast_fuzzer::compare::{CompareMorph, CompareOptions};
@@ -28,7 +28,9 @@ pub fn fuzz(u: &mut Unstructured) -> eyre::Result<()> {
             rewrite_program(u, &mut program, &rules, max_rewrites);
             Ok((program, options))
         },
-        |program, options| create_ssa_or_die(program, &options.onto(default_ssa_options()), None),
+        |program, options| {
+            compile_into_circuit_or_die(program, &options.onto(default_ssa_options()), None)
+        },
     )?;
 
     let result = inputs.exec()?;

--- a/tooling/ast_fuzzer/src/compare/compiled.rs
+++ b/tooling/ast_fuzzer/src/compare/compiled.rs
@@ -11,7 +11,7 @@ use noirc_abi::{Abi, InputMap, input_parser::InputValue};
 use noirc_evaluator::{ErrorType, ssa::SsaProgramArtifact};
 use noirc_frontend::monomorphization::ast::Program;
 
-use crate::{Config, arb_inputs, arb_program, program_abi};
+use crate::{Config, arb_inputs, arb_program, compare::logging, program_abi};
 
 use super::{Comparable, CompareOptions, CompareResult, FailedOutput, HasPrograms, PassedOutput};
 
@@ -240,13 +240,6 @@ impl<P> CompareCompiled<P> {
         let blackbox_solver = Bn254BlackBoxSolver(false);
         let initial_witness = self.abi.encode(&self.input_map, None).wrap_err("abi::encode")?;
 
-        log::debug!(
-            "ABI input:\n{}",
-            noirc_abi::input_parser::Format::Toml
-                .serialize(&self.input_map, &self.abi)
-                .unwrap_or_else(|e| format!("failed to serialize inputs: {e}"))
-        );
-
         let do_exec = |program| {
             let mut print = Vec::new();
 
@@ -298,12 +291,17 @@ impl CompareCompiled<Program> {
     ) -> arbitrary::Result<Self> {
         let program = arb_program(u, c)?;
         let abi = program_abi(&program);
+        logging::log_program(&program, "");
 
         let ssa1 = CompareArtifact::from(f(u, program.clone())?);
         let ssa2 = CompareArtifact::from(g(u, program.clone())?);
 
+        logging::log_options(&ssa1.options, "1st");
+        logging::log_options(&ssa2.options, "2nd");
+
         let input_program = &ssa1.artifact.program;
         let input_map = arb_inputs(u, input_program, &abi)?;
+        logging::log_abi_inputs(&abi, &input_map);
 
         Ok(Self { program, abi, input_map, ssa1, ssa2 })
     }
@@ -327,7 +325,12 @@ impl CompareMorph {
         g: impl Fn(Program, &CompareOptions) -> SsaProgramArtifact,
     ) -> arbitrary::Result<Self> {
         let program1 = arb_program(u, c)?;
+        logging::log_program(&program1, "orig");
+
         let (program2, options) = f(u, program1.clone())?;
+        logging::log_program(&program2, "morph");
+        logging::log_options(&options, "");
+
         let abi = program_abi(&program1);
 
         let ssa1 = g(program1.clone(), &options);
@@ -335,6 +338,7 @@ impl CompareMorph {
 
         let input_program = &ssa1.program;
         let input_map = arb_inputs(u, input_program, &abi)?;
+        logging::log_abi_inputs(&abi, &input_map);
 
         Ok(Self {
             program: (program1, program2),

--- a/tooling/ast_fuzzer/src/compare/interpreted.rs
+++ b/tooling/ast_fuzzer/src/compare/interpreted.rs
@@ -16,7 +16,7 @@ use noirc_evaluator::ssa::{
 use noirc_frontend::{Shared, monomorphization::ast::Program};
 use regex::Regex;
 
-use crate::{Config, arb_program, input::arb_inputs_from_ssa, program_abi};
+use crate::{Config, arb_program, compare::logging, input::arb_inputs_from_ssa, program_abi};
 
 use super::{Comparable, CompareOptions, CompareResult, FailedOutput, PassedOutput};
 
@@ -70,43 +70,24 @@ impl CompareInterpreted {
     ) -> arbitrary::Result<Self> {
         let program = arb_program(u, c)?;
         let abi = program_abi(&program);
+        logging::log_program(&program, "");
+
         let (options, ssa1, ssa2) = f(u, program.clone())?;
 
+        logging::log_options(&options, "");
+        logging::log_ssa(&ssa1.ssa, &format!("after step {} - {}", ssa1.step, ssa1.msg));
+        logging::log_ssa(&ssa2.ssa, &format!("after step {} - {}", ssa2.step, ssa2.msg));
+
         let input_map = arb_inputs_from_ssa(u, &ssa1.ssa, &abi)?;
+        logging::log_abi_inputs(&abi, &input_map);
+
         let ssa_args = input_values_to_ssa(&abi, &input_map);
+        logging::log_ssa_inputs(&ssa_args);
 
         Ok(Self { program, abi, input_map, ssa_args, options, ssa1, ssa2 })
     }
 
     pub fn exec(&self) -> eyre::Result<CompareInterpretedResult> {
-        // Debug prints up front in case the interpreter panics. Turn them on with `RUST_LOG=debug cargo test ...`
-        log::debug!("Program: \n{}\n", crate::DisplayAstAsNoir(&self.program));
-        log::debug!(
-            "ABI inputs: \n{}\n",
-            noirc_abi::input_parser::Format::Toml.serialize(&self.input_map, &self.abi).unwrap()
-        );
-        log::debug!(
-            "SSA inputs:\n{}\n",
-            self.ssa_args
-                .iter()
-                .enumerate()
-                .map(|(i, v)| format!("{i}: {v}"))
-                .collect::<Vec<_>>()
-                .join("\n")
-        );
-        log::debug!(
-            "SSA after step {} ({}):\n{}\n",
-            self.ssa1.step,
-            self.ssa1.msg,
-            self.ssa1.ssa.print_without_locations()
-        );
-        log::debug!(
-            "SSA after step {} ({}):\n{}\n",
-            self.ssa2.step,
-            self.ssa2.msg,
-            self.ssa2.ssa.print_without_locations()
-        );
-
         // Interpret an SSA with a fresh copy of the input values.
         let interpret = |ssa: &Ssa| {
             let mut output = Vec::new();

--- a/tooling/ast_fuzzer/src/compare/mod.rs
+++ b/tooling/ast_fuzzer/src/compare/mod.rs
@@ -183,7 +183,7 @@ mod logging {
     }
 
     pub(super) fn log_program(program: &Program, msg: &str) {
-        log::debug!("AST{}:\n{}\n", format_msg(msg), DisplayAstAsNoir(&program));
+        log::debug!("AST{}:\n{}\n", format_msg(msg), DisplayAstAsNoir(program));
     }
 
     pub(super) fn log_ssa(ssa: &Ssa, msg: &str) {
@@ -202,7 +202,7 @@ mod logging {
         log::debug!(
             "ABI inputs:\n{}\n",
             noirc_abi::input_parser::Format::Toml
-                .serialize(&input_map, &abi)
+                .serialize(input_map, abi)
                 .unwrap_or_else(|e| format!("failed to serialize inputs: {e}"))
         );
     }

--- a/tooling/ast_fuzzer/src/compare/mod.rs
+++ b/tooling/ast_fuzzer/src/compare/mod.rs
@@ -166,3 +166,56 @@ where
         }
     }
 }
+
+/// We can turn on the logging of artifacts by setting the `RUST_LOG=debug` env var.
+///
+/// This can help reproducing failures. The functions in this module can help cut back some repetition.
+/// Log things as soon as they are available in case the next step fails.
+mod logging {
+    use noirc_abi::{Abi, InputMap};
+    use noirc_evaluator::ssa::{interpreter::value::Value, ssa_gen::Ssa};
+    use noirc_frontend::monomorphization::ast::Program;
+
+    use crate::{DisplayAstAsNoir, compare::CompareOptions};
+
+    fn format_msg(msg: &str) -> String {
+        if msg.is_empty() { String::new() } else { format!(" ({msg})") }
+    }
+
+    pub(super) fn log_program(program: &Program, msg: &str) {
+        log::debug!("AST{}:\n{}\n", format_msg(msg), DisplayAstAsNoir(&program));
+    }
+
+    pub(super) fn log_ssa(ssa: &Ssa, msg: &str) {
+        log::debug!("SSA{}:\n{}\n", format_msg(msg), ssa.print_without_locations());
+    }
+
+    pub(super) fn log_comptime(src: &str, msg: &str) {
+        log::debug!("comptime source{}:\n{}\n", format_msg(msg), src);
+    }
+
+    pub(super) fn log_options(options: &CompareOptions, msg: &str) {
+        log::debug!("Options{}:\n{:?}\n", format_msg(msg), options);
+    }
+
+    pub(super) fn log_abi_inputs(abi: &Abi, input_map: &InputMap) {
+        log::debug!(
+            "ABI inputs:\n{}\n",
+            noirc_abi::input_parser::Format::Toml
+                .serialize(&input_map, &abi)
+                .unwrap_or_else(|e| format!("failed to serialize inputs: {e}"))
+        );
+    }
+
+    pub(super) fn log_ssa_inputs(ssa_args: &[Value]) {
+        log::debug!(
+            "SSA inputs:\n{}\n",
+            ssa_args
+                .iter()
+                .enumerate()
+                .map(|(i, v)| format!("{i}: {v}"))
+                .collect::<Vec<_>>()
+                .join("\n")
+        );
+    }
+}


### PR DESCRIPTION
# Description

## Problem\*

Follow up for the issue @vezenovm encountered in https://github.com/noir-lang/noir/pull/9882#issuecomment-3300370867

## Summary\*

* Changes the way we can tell the AST fuzzer to log the generated artifacts to be triggered by the `RUST_LOG=debug` env var, which now causes everything to be printed as logs from the `arb` methods. 
* Removes the `NOIR_AST_FUZZER_SHOW_AST` options, which was used to print the AST before trying to convert it into SSA, but if `NOIR_AST_FUZZER_SEED` is present, it will automatically print the AST _iff_ there is an error during compilation. 
* Renames `create_ssa_or_die` to `compile_into_circuit_or_die`, because some passes actually create `Ssa`, while the `SsaProgramArtifact` doesn't actually have the `Ssa` in it, which is a bit confusing.
* Omits the Brillig bytecode from the output when there is an error, as this was always just an unreadable wall of text.

## Additional Context

An example of the new output:

```
❯ RUST_LOG=debug NOIR_AST_FUZZER_SEED=0xe6851ab700100000 cargo test -q -p noir_ast_fuzzer_fuzz pass_vs_prev
running 1 test
[2025-09-17T09:42:14Z DEBUG noir_ast_fuzzer::compare::logging] AST:
    global G_A: [[str<1>; 4]; 4] = [["P", "T", "C", "Q"], ["Q", "N", "O", "Q"], ["A", "B", "T", "H"], ["V", "X", "C", "U"]];
    global G_B: [str<1>; 4] = ["L", "K", "G", "J"];
    global G_C: [[str<1>; 4]; 4] = [["G", "Y", "A", "V"], ["Z", "E", "Z", "I"], ["X", "B", "H", "A"], ["S", "G", "S", "Y"]];
    unconstrained fn main() -> pub [(bool, str<1>, str<1>, str<1>); 1] {
        let mut ctx_limit: u32 = 25_u32;
        let mut a = G_C[(if true {
            3859550138_u32
        } else {
            if false {
                2150811138_u32
            } else {
                if true {
                    if false {
                        1330515451_u32
                    } else {
                        2516186332_u32
                    }
                } else {
                    2760297220_u32
                }
            }
        } % 4_u32)];
        for idx_b in 1908093938_i32 .. 1908093946_i32 {
            break;
        };
        [(false, a[(3324712353_u32 % 4_u32)], a[2_u32], a[2_u32])]
    }
    
    
targets::pass_vs_prev::tests::fuzz_with_arbtest --- FAILED

failures:

---- targets::pass_vs_prev::tests::fuzz_with_arbtest stdout ----

thread 'targets::pass_vs_prev::tests::fuzz_with_arbtest' panicked at compiler/noirc_evaluator/src/ssa/opt/mem2reg.rs:454:46:
index out of bounds: the len is 23 but the index is 37
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

arbtest failed!
    Seed: 0xe6851ab700100000




failures:
    targets::pass_vs_prev::tests::fuzz_with_arbtest

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 5 filtered out; finished in 0.03s

error: test failed, to rerun pass `-p noir_ast_fuzzer_fuzz --lib`
```

## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
