### PR TITLE
fix(ssa): Simplify always-fail range constraint

### DIFF
--- a/test_programs/compile_success_with_bug/regression_9872/Nargo.toml
+++ b/test_programs/compile_success_with_bug/regression_9872/Nargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "regression_9872"
+type = "bin"
+authors = [""]
+
+[dependencies]

--- a/test_programs/compile_success_with_bug/regression_9872/src/main.nr
+++ b/test_programs/compile_success_with_bug/regression_9872/src/main.nr
@@ -1,0 +1,4 @@
+fn main() -> pub bool {
+    let b: [&mut bool] = &[(&mut true), (&mut false)];
+    *b[2]
+}

--- a/tooling/nargo_cli/tests/snapshots/compile_success_with_bug/regression_9872/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_with_bug/regression_9872/execute__tests__expanded.snap
@@ -1,0 +1,8 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: expanded_code
+---
+fn main() -> pub bool {
+    let b: [&mut bool] = &[&mut true, &mut false];
+    *b[2_u32]
+}

--- a/tooling/nargo_cli/tests/snapshots/compile_success_with_bug/regression_9872/execute__tests__stderr.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_with_bug/regression_9872/execute__tests__stderr.snap
@@ -1,0 +1,12 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: stderr
+---
+bug: Assertion is always false: Index out of bounds
+  ┌─ src/main.nr:3:8
+  │
+3 │     *b[2]
+  │        - As a result, the compiled circuit is ensured to fail. Other assertions may also fail during execution
+  │
+  = Call stack:
+    1. src/main.nr:3:8


### PR DESCRIPTION
# Description

## Problem\*

Resolves https://github.com/noir-lang/noir/issues/9872

## Summary\*

Changes `simplify` handling of `RangeCheck` to check not only if a constant definitely fits into the maximum bit size, but whether it definitely does _not_ fit, and insert an always fail constraint instead. 

This allows `remove_unreachable_instructions` to terminate the block with `unreachable` later.

## Additional Context

See https://github.com/noir-lang/noir/issues/9872#issuecomment-3302243107 for details.


## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
