### PR TITLE
feat: prevent `make_array` from creating slices

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/ir/dfg/simplify/call.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/dfg/simplify/call.rs
@@ -106,26 +106,7 @@ pub(super) fn simplify_call(
         // Strings are already arrays of bytes in SSA
         Intrinsic::ArrayAsStrUnchecked => SimplifyResult::SimplifiedTo(arguments[0]),
         Intrinsic::AsSlice => {
-            let array = dfg.get_array_constant(arguments[0]);
-            if let Some((array, array_type)) = array {
-                // Compute the resulting slice length by dividing the flattened
-                // array length by the size of each array element
-                let elements_size = array_type.element_size();
-                let inner_element_types = array_type.element_types();
-                assert_eq!(
-                    0,
-                    array.len() % elements_size,
-                    "expected array length to be multiple of its elements size"
-                );
-                let slice_length_value = array.len() / elements_size;
-                let slice_length =
-                    dfg.make_constant(slice_length_value.into(), NumericType::length_type());
-                let new_slice =
-                    make_array(dfg, array, Type::Slice(inner_element_types), block, call_stack);
-                SimplifyResult::SimplifiedToMultiple(vec![slice_length, new_slice])
-            } else {
-                SimplifyResult::None
-            }
+            SimplifyResult::None
         }
         Intrinsic::SlicePushBack => {
             let slice = dfg.get_array_constant(arguments[1]);

--- a/compiler/noirc_evaluator/src/ssa/ir/dfg/simplify/call.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/dfg/simplify/call.rs
@@ -105,9 +105,7 @@ pub(super) fn simplify_call(
         }
         // Strings are already arrays of bytes in SSA
         Intrinsic::ArrayAsStrUnchecked => SimplifyResult::SimplifiedTo(arguments[0]),
-        Intrinsic::AsSlice => {
-            SimplifyResult::None
-        }
+        Intrinsic::AsSlice => SimplifyResult::None,
         Intrinsic::SlicePushBack => {
             let slice = dfg.get_array_constant(arguments[1]);
             if let Some((mut slice, element_type)) = slice {

--- a/compiler/noirc_evaluator/src/ssa/validation/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/validation/mod.rs
@@ -1207,9 +1207,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(
-        expected = "MakeArray slice has 3 elements but composite type has 2 types which don't divide the number of elements"
-    )]
+    #[should_panic(expected = "MakeArray must return an array type, not [(u8, u8)]")]
     fn make_array_slice_returns_incorrect_length() {
         let src = "
         acir(inline) fn main f0 {


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*



## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
