### PR TITLE
chore(die): small nit to remove a check which is not useful

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/opt/die/prune_dead_parameters.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/die/prune_dead_parameters.rs
@@ -217,7 +217,7 @@ impl Function {
             // Update the predecessor argument list to match the new parameter list
             self.update_predecessor_terminators(cfg.predecessors(block), block, &keep_list);
 
-            if block == self.entry_block() && can_prune_entry_block {
+            if block == self.entry_block() {
                 entry_block_keep_list = Some(keep_list);
             }
         }


### PR DESCRIPTION
# Description

## Problem\*

Noticed a redundant check during DIE audit

## Summary\*

The second check using `can_prune_entry_block` is not needed due to the first one.

## Additional Context



## Documentation\*

Check one:
- [X] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
