### PR TITLE
added pub to to_le_radix and to_be_radix

### DIFF
--- a/noir_stdlib/src/field/mod.nr
+++ b/noir_stdlib/src/field/mod.nr
@@ -155,7 +155,7 @@ impl Field {
         bytes
     }
 
-    fn to_le_radix<let N: u32>(self: Self, radix: u32) -> [u8; N] {
+    pub fn to_le_radix<let N: u32>(self: Self, radix: u32) -> [u8; N] {
         // Brillig does not need an immediate radix
         if !crate::runtime::is_unconstrained() {
             static_assert(1 < radix, "radix must be greater than 1");
@@ -165,7 +165,7 @@ impl Field {
         __to_le_radix(self, radix)
     }
 
-    fn to_be_radix<let N: u32>(self: Self, radix: u32) -> [u8; N] {
+    pub fn to_be_radix<let N: u32>(self: Self, radix: u32) -> [u8; N] {
         // Brillig does not need an immediate radix
         if !crate::runtime::is_unconstrained() {
             static_assert(1 < radix, "radix must be greater than 1");


### PR DESCRIPTION
# Description

Proposing to add `pub` to `to_le_radix()` and `to_be_radix()` in Field impl

## Problem\*

These methods are useful but inaccessible from outside due to compile error `to_be_radix is private`. Let me know if this change doesn't make sense. 

details: https://github.com/AztecProtocol/aztec-packages/issues/17153

## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
