### PR TITLE
chore(ssa): Validate array operands

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/opt/remove_enable_side_effects.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/remove_enable_side_effects.rs
@@ -292,10 +292,10 @@ mod test {
     fn remove_enable_side_effects_for_slice_push_front() {
         let src = "
         acir(inline) predicate_pure fn main f0 {
-          b0(v0: [u32; 3], v1: u32):
+          b0(v0: [u32; 3], v1: u1, v2: u32):
             v3 = array_get v0, index u32 0 -> u32
             v7 = make_array [Field 1, Field 2, Field 3] : [Field]
-            v9 = array_set v7, index v0, value Field 4
+            v9 = array_set v7, index v2, value Field 4
 
             // this instruction should be removed
             enable_side_effects v1
@@ -308,11 +308,11 @@ mod test {
         let ssa = ssa.remove_enable_side_effects();
         assert_ssa_snapshot!(ssa, @r"
         acir(inline) predicate_pure fn main f0 {
-          b0(v0: u32, v1: u1):
-            v3 = array_get v0, index u32 0 -> u32
-            v7 = make_array [Field 1, Field 2, Field 3] : [Field]
-            v9 = array_set v7, index v0, value Field 4
-            v13, v14 = call slice_push_front(u32 3, v9, Field 5) -> (u32, [Field])
+          b0(v0: [u32; 3], v1: u1, v2: u32):
+            v4 = array_get v0, index u32 0 -> u32
+            v8 = make_array [Field 1, Field 2, Field 3] : [Field]
+            v10 = array_set v8, index v2, value Field 4
+            v14, v15 = call slice_push_front(u32 3, v10, Field 5) -> (u32, [Field])
             return
         }
         ");
@@ -354,10 +354,10 @@ mod test {
     fn keep_enable_side_effects_for_slice_insert() {
         let src = "
         acir(inline) predicate_pure fn main f0 {
-          b0(v0: [u32; 3], v1: u1):
+          b0(v0: [u32; 3], v1: u1, v2: u32):
             v3 = array_get v0, index u32 0 -> u32
             v7 = make_array [Field 1, Field 2, Field 3] : [Field]
-            v9 = array_set v7, index v0, value Field 4
+            v9 = array_set v7, index v2, value Field 4
             enable_side_effects v1
             v13, v14 = call slice_insert(u32 3, v9, u32 1, Field 5) -> (u32, [Field])
             return
@@ -370,10 +370,10 @@ mod test {
     fn keep_enable_side_effects_for_slice_remove() {
         let src = "
         acir(inline) predicate_pure fn main f0 {
-          b0(v0: [u32; 3], v1: u32):
+          b0(v0: [u32; 3], v1: u1, v2: u32):
             v3 = array_get v0, index u32 0 -> u32
             v7 = make_array [Field 1, Field 2, Field 3] : [Field]
-            v9 = array_set v7, index v0, value Field 4
+            v9 = array_set v7, index v2, value Field 4
             enable_side_effects v1
             v13, v14, v15 = call slice_remove(u32 3, v9, u32 1) -> (u32, [Field], Field)
             return

--- a/compiler/noirc_evaluator/src/ssa/opt/remove_enable_side_effects.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/remove_enable_side_effects.rs
@@ -262,10 +262,10 @@ mod test {
     fn remove_enable_side_effects_for_slice_push_back() {
         let src = "
         acir(inline) predicate_pure fn main f0 {
-          b0(v0: u32, v1: u1):
+          b0(v0: [u32; 3], v1: u1, v2: u32):
             v3 = array_get v0, index u32 0 -> u32
             v7 = make_array [Field 1, Field 2, Field 3] : [Field]
-            v9 = array_set v7, index v0, value Field 4
+            v9 = array_set v7, index v2, value Field 4
 
             // this instruction should be removed
             enable_side_effects v1
@@ -278,11 +278,11 @@ mod test {
         let ssa = ssa.remove_enable_side_effects();
         assert_ssa_snapshot!(ssa, @r"
         acir(inline) predicate_pure fn main f0 {
-          b0(v0: u32, v1: u1):
-            v3 = array_get v0, index u32 0 -> u32
-            v7 = make_array [Field 1, Field 2, Field 3] : [Field]
-            v9 = array_set v7, index v0, value Field 4
-            v13, v14 = call slice_push_back(u32 3, v9, Field 5) -> (u32, [Field])
+          b0(v0: [u32; 3], v1: u1, v2: u32):
+            v4 = array_get v0, index u32 0 -> u32
+            v8 = make_array [Field 1, Field 2, Field 3] : [Field]
+            v10 = array_set v8, index v2, value Field 4
+            v14, v15 = call slice_push_back(u32 3, v10, Field 5) -> (u32, [Field])
             return
         }
         ");
@@ -292,7 +292,7 @@ mod test {
     fn remove_enable_side_effects_for_slice_push_front() {
         let src = "
         acir(inline) predicate_pure fn main f0 {
-          b0(v0: u32, v1: u1):
+          b0(v0: [u32; 3], v1: u32):
             v3 = array_get v0, index u32 0 -> u32
             v7 = make_array [Field 1, Field 2, Field 3] : [Field]
             v9 = array_set v7, index v0, value Field 4
@@ -322,10 +322,10 @@ mod test {
     fn keep_enable_side_effects_for_slice_pop_back() {
         let src = "
         acir(inline) predicate_pure fn main f0 {
-          b0(v0: u32, v1: u1):
+          b0(v0: [u32; 3], v1: u1, v2: u32):
             v3 = array_get v0, index u32 0 -> u32
             v7 = make_array [Field 1, Field 2, Field 3] : [Field]
-            v9 = array_set v7, index v0, value Field 4
+            v9 = array_set v7, index v2, value Field 4
             enable_side_effects v1
             v13, v14, v15 = call slice_pop_back(u32 3, v9) -> (u32, [Field], Field)
             return
@@ -338,10 +338,10 @@ mod test {
     fn keep_enable_side_effects_for_slice_pop_front() {
         let src = "
         acir(inline) predicate_pure fn main f0 {
-          b0(v0: u32, v1: u1):
+          b0(v0: [u32; 3], v1: u1, v2: u32):
             v3 = array_get v0, index u32 0 -> u32
             v7 = make_array [Field 1, Field 2, Field 3] : [Field]
-            v9 = array_set v7, index v0, value Field 4
+            v9 = array_set v7, index v2, value Field 4
             enable_side_effects v1
             v13, v14, v15 = call slice_pop_front(u32 3, v9) -> (Field, u32, [Field])
             return
@@ -354,7 +354,7 @@ mod test {
     fn keep_enable_side_effects_for_slice_insert() {
         let src = "
         acir(inline) predicate_pure fn main f0 {
-          b0(v0: u32, v1: u1):
+          b0(v0: [u32; 3], v1: u1):
             v3 = array_get v0, index u32 0 -> u32
             v7 = make_array [Field 1, Field 2, Field 3] : [Field]
             v9 = array_set v7, index v0, value Field 4
@@ -370,7 +370,7 @@ mod test {
     fn keep_enable_side_effects_for_slice_remove() {
         let src = "
         acir(inline) predicate_pure fn main f0 {
-          b0(v0: u32, v1: u1):
+          b0(v0: [u32; 3], v1: u32):
             v3 = array_get v0, index u32 0 -> u32
             v7 = make_array [Field 1, Field 2, Field 3] : [Field]
             v9 = array_set v7, index v0, value Field 4

--- a/compiler/noirc_evaluator/src/ssa/validation/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/validation/mod.rs
@@ -1667,30 +1667,24 @@ mod tests {
     #[test]
     #[should_panic(expected = "ArrayGet/ArraySet index must be u32")]
     fn array_get_wrong_index_type() {
-        let src = format!(
-            r#"
-        acir(inline) predicate_pure fn main f0 {{
+        let src = "
+        acir(inline) predicate_pure fn main f0 {
           b0(v0: [u8; 3], v1: u64):
             v2 = array_get v0, index v1 -> u32
             return v2
-        }}
-        "#
-        );
-        let _ = Ssa::from_str(&src).unwrap();
+        }";
+        let _ = Ssa::from_str(src).unwrap();
     }
 
     #[test]
     #[should_panic(expected = "ArrayGet/ArraySet must operate on an array")]
     fn array_get_wrong_array_type() {
-        let src = format!(
-            r#"
-        acir(inline) predicate_pure fn main f0 {{
+        let src = "
+        acir(inline) predicate_pure fn main f0 {
           b0(v0: u32, v1: u32):
             v2 = array_get v0, index v1 -> u32
             return v2
-        }}
-        "#
-        );
-        let _ = Ssa::from_str(&src).unwrap();
+        }";
+        let _ = Ssa::from_str(src).unwrap();
     }
 }

--- a/compiler/noirc_evaluator/src/ssa/validation/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/validation/mod.rs
@@ -172,10 +172,15 @@ impl<'f> Validator<'f> {
                     panic!("Cannot use `{operator}` with field elements");
                 };
             }
-            Instruction::ArrayGet { index, .. } | Instruction::ArraySet { index, .. } => {
+            Instruction::ArrayGet { array, index, .. }
+            | Instruction::ArraySet { array, index, .. } => {
                 let index_type = dfg.type_of_value(*index);
                 if !matches!(index_type, Type::Numeric(NumericType::Unsigned { bit_size: 32 })) {
                     panic!("ArrayGet/ArraySet index must be u32");
+                }
+                let array_type = dfg.type_of_value(*array);
+                if !array_type.contains_an_array() {
+                    panic!("ArrayGet/ArraySet must operate on an array; got {array_type}");
                 }
             }
             Instruction::Call { func, arguments } => {
@@ -1606,7 +1611,7 @@ mod tests {
             return
 
         }
-        
+
         ";
         let _ = Ssa::from_str(src).unwrap();
     }
@@ -1617,7 +1622,7 @@ mod tests {
         let src = "
         acir(inline) fn main f0 {
             b0():
-              v3 = make_array [Field 1, Field 2, Field 3] : [Field] 
+              v3 = make_array [Field 1, Field 2, Field 3] : [Field]
               v4 = call f1(v3) -> u32
               return v4
         }
@@ -1657,5 +1662,35 @@ mod tests {
         }
         ";
         let _ = Ssa::from_str(src).unwrap();
+    }
+
+    #[test]
+    #[should_panic(expected = "ArrayGet/ArraySet index must be u32")]
+    fn array_get_wrong_index_type() {
+        let src = format!(
+            r#"
+        acir(inline) predicate_pure fn main f0 {{
+          b0(v0: [u8; 3], v1: u64):
+            v2 = array_get v0, index v1 -> u32
+            return v2
+        }}
+        "#
+        );
+        let _ = Ssa::from_str(&src).unwrap();
+    }
+
+    #[test]
+    #[should_panic(expected = "ArrayGet/ArraySet must operate on an array")]
+    fn array_get_wrong_array_type() {
+        let src = format!(
+            r#"
+        acir(inline) predicate_pure fn main f0 {{
+          b0(v0: u32, v1: u32):
+            v2 = array_get v0, index v1 -> u32
+            return v2
+        }}
+        "#
+        );
+        let _ = Ssa::from_str(&src).unwrap();
     }
 }


### PR DESCRIPTION
# Description

## Problem\*

Resolves #9931 

## Summary\*

Add SSA validation for the `array` type in `ArrayGet` and `ArraySet`.
Fix the SSA in unit tests in `remove_enable_side_effects`.


## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
