### PR TITLE
chore(ssa): Assert that array offset are not set

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/ir/dfg/simplify.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/dfg/simplify.rs
@@ -119,9 +119,10 @@ pub(crate) fn simplify(
             if matches!(array_or_slice_type, Type::Array(_, 1))
                 && array_or_slice_type.flattened_size() == 1
             {
+                assert_eq!(*offset, ArrayOffset::None);
                 // If the array is of length 1 then we know the only value which can be potentially read out of it.
                 // We can then simply assert that the index is equal to zero and return the array's contained value.
-                optimize_length_one_array_read(dfg, block, call_stack, *array, *index, *offset)
+                optimize_length_one_array_read(dfg, block, call_stack, *array, *index)
             } else {
                 None
             }
@@ -342,7 +343,6 @@ fn optimize_length_one_array_read(
     call_stack: CallStackId,
     array: ValueId,
     index: ValueId,
-    offset: ArrayOffset,
 ) -> SimplifyResult {
     let zero = dfg.make_constant(FieldElement::zero(), NumericType::length_type());
     let index_constraint = Instruction::Constrain(
@@ -357,7 +357,7 @@ fn optimize_length_one_array_read(
         SimplifyResult::SimplifiedToInstruction(Instruction::ArrayGet {
             array,
             index: zero,
-            offset,
+            offset: ArrayOffset::None,
         })
     } else {
         result

--- a/compiler/noirc_evaluator/src/ssa/opt/constant_folding/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/constant_folding/mod.rs
@@ -1157,9 +1157,6 @@ mod test {
             }
             ";
         let ssa = Ssa::from_str(src).unwrap();
-        // Need to run SSA pass that sets up Brillig array gets
-        let ssa = ssa.brillig_array_get_and_set();
-
         let ssa = ssa.fold_constants_with_brillig();
         let ssa = ssa.remove_unreachable_functions();
         assert_ssa_snapshot!(ssa, @r"


### PR DESCRIPTION
# Description

## Problem\*

Part of auditing `brillig_array_get_and_set`. 

## Summary\*

Add assertions that `ArrayGet::offset` and `ArraySet::offset` are `None` in some operations where they weren't handled.

For example `Instruction::has_side_effects` uses `DataFlowGraph::is_safe_index` to test that a constant index is less than the length of the array, however it did not take into account that the `offset` could have made the index equal to the logical size. 

We could fix this by accounting for the offset and subtracting its value. This PR instead just panics, as this pass should not be followed up by anything that accesses these functions at the moment.

Removes `offset` handling from `remove_unreachable_instructions`: since it appeared under `runtime.is_acir()`, it should never be set anyway. 

## Additional Context

I am not exactly sure why this pass exists if I'm honest. I understand what it's doing, thanks to @asterite having added docs during the green lighting, however during Brillig codegen we [check if the instruction has offset](https://github.com/noir-lang/noir/blob/74b44a7a683ee8447cf00d39b864f1ad9c8a05f8/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_block.rs#L840-L846) and if the index is dynamic then we [have to generate offsets](https://github.com/noir-lang/noir/blob/74b44a7a683ee8447cf00d39b864f1ad9c8a05f8/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_block.rs#L1166-L1169) anyway, so why don't we insert the necessary constants into the DFG during codegen, and then avoid having to have the `offset: _` pattern throughout the codebase, and having to reason about whether using `index` without considering `offset` is correct or not? 


## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
