### PR TITLE
chore: minor constant_folding refactors

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/opt/constant_folding/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/constant_folding/mod.rs
@@ -135,7 +135,7 @@ fn constant_folding_post_check(context: &Context, dfg: &DataFlowGraph) {
 }
 
 struct Context {
-    /// Keeps track of visted blocks and blocks to visit.
+    /// Keeps track of visited blocks and blocks to visit.
     block_queue: VisitOnceDeque,
 
     /// Whether to use [constraints][Instruction::Constrain] to inform simplifications later on in the program.

--- a/compiler/noirc_evaluator/src/ssa/opt/constant_folding/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/constant_folding/mod.rs
@@ -275,7 +275,7 @@ impl Context {
                         }
                     }
 
-                    self.values_to_replace.batch_insert(&old_results, &cached);
+                    self.values_to_replace.batch_insert(&old_results, cached);
                     return;
                 }
                 CacheResult::NeedToHoistToCommonBlock(dominator) => {

--- a/compiler/noirc_evaluator/src/ssa/opt/constant_folding/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/constant_folding/mod.rs
@@ -135,7 +135,7 @@ fn constant_folding_post_check(context: &Context, dfg: &DataFlowGraph) {
 }
 
 struct Context {
-    /// Maps pre-folded ValueIds to the new ValueIds obtained by re-inserting the instruction.
+    /// Keeps track of visted blocks and blocks to visit.
     block_queue: VisitOnceDeque,
 
     /// Whether to use [constraints][Instruction::Constrain] to inform simplifications later on in the program.

--- a/compiler/noirc_evaluator/src/ssa/opt/constant_folding/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/constant_folding/mod.rs
@@ -23,7 +23,7 @@ use crate::ssa::{
     interpreter::{Interpreter, InterpreterOptions},
     ir::{
         basic_block::BasicBlockId,
-        dfg::{DataFlowGraph, InsertInstructionResult},
+        dfg::DataFlowGraph,
         dom::DominatorTree,
         function::{Function, FunctionId},
         instruction::{ArrayOffset, Instruction, InstructionId},
@@ -350,18 +350,14 @@ impl Context {
             .then(|| vecmap(old_results, |result| dfg.type_of_value(*result)));
 
         let call_stack = dfg.get_instruction_call_stack_id(id);
-        let new_results = match dfg.insert_instruction_and_results_if_simplified(
+        let results = dfg.insert_instruction_and_results_if_simplified(
             instruction,
             block,
             ctrl_typevars,
             call_stack,
             Some(id),
-        ) {
-            InsertInstructionResult::SimplifiedTo(new_result) => vec![new_result],
-            InsertInstructionResult::SimplifiedToMultiple(new_results) => new_results,
-            InsertInstructionResult::Results(_, new_results) => new_results.to_vec(),
-            InsertInstructionResult::InstructionRemoved => vec![],
-        };
+        );
+        let new_results = results.results().to_vec();
         // Optimizations while inserting the instruction should not change the number of results.
         assert_eq!(old_results.len(), new_results.len());
 

--- a/compiler/noirc_evaluator/src/ssa/opt/constant_folding/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/constant_folding/mod.rs
@@ -275,7 +275,6 @@ impl Context {
                         }
                     }
 
-                    let cached = cached.to_vec();
                     self.values_to_replace.batch_insert(&old_results, &cached);
                     return;
                 }

--- a/compiler/noirc_evaluator/src/ssa/opt/constant_folding/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/constant_folding/mod.rs
@@ -1208,6 +1208,9 @@ mod test {
 
     #[test]
     fn does_not_use_cached_constrain_in_block_that_is_not_dominated() {
+        // Here v1 in b2 was incorrectly determined to be equal to `Field 1` in the past
+        // because of the constrain in b1. However, b2 is not dominated by b1 so this
+        // assumption is not valid.
         let src = "
             brillig(inline) fn main f0 {
               b0(v0: Field, v1: Field):

--- a/compiler/noirc_evaluator/src/ssa/opt/constant_folding/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/constant_folding/mod.rs
@@ -25,7 +25,7 @@ use crate::ssa::{
         basic_block::BasicBlockId,
         dfg::{DataFlowGraph, InsertInstructionResult},
         dom::DominatorTree,
-        function::{Function, FunctionId, RuntimeType},
+        function::{Function, FunctionId},
         instruction::{ArrayOffset, Instruction, InstructionId},
         types::NumericType,
         value::{Value, ValueId, ValueMapping},
@@ -79,7 +79,7 @@ impl Ssa {
         // Collect all brillig functions so that later we can find them when processing a call instruction
         let mut brillig_functions: BTreeMap<FunctionId, Function> = BTreeMap::new();
         for (func_id, func) in &self.functions {
-            if let RuntimeType::Brillig(..) = func.runtime() {
+            if func.runtime().is_brillig() {
                 let cloned_function = Function::clone_with_id(*func_id, func);
                 brillig_functions.insert(*func_id, cloned_function);
             };


### PR DESCRIPTION
# Description

## Problem

No issue, just part of the audit.

## Summary

Just some things I noticed, doesn't change the pass's functionality. Each commit is self-contained.

## Additional Context



## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
