### PR TITLE
chore(acir): Do not copy element type sizes array when initializing

### DIFF
--- a/compiler/noirc_evaluator/src/acir/arrays.rs
+++ b/compiler/noirc_evaluator/src/acir/arrays.rs
@@ -836,19 +836,8 @@ impl Context<'_> {
                     unreachable!("ICE: element type size arrays are expected to be initialized");
                 }
 
-                let type_sizes_array_len = *self.internal_mem_block_lengths.get(inner_elem_type_sizes).ok_or_else(||
-                                            InternalError::General {
-                                                message: format!("Array {array_id}'s inner element type sizes array does not have a tracked length"),
-                                                call_stack: self.acir_context.get_call_stack(),
-                                            }
-                                        )?;
-                self.copy_dynamic_array(
-                    *inner_elem_type_sizes,
-                    element_type_sizes,
-                    type_sizes_array_len,
-                )?;
-                self.internal_mem_block_lengths.insert(element_type_sizes, type_sizes_array_len);
-                Ok(element_type_sizes)
+                self.internal_memory_blocks.insert(array_id, *inner_elem_type_sizes);
+                Ok(*inner_elem_type_sizes)
             }
             _ => Err(InternalError::Unexpected {
                 expected: "AcirValue::DynamicArray or AcirValue::Array".to_owned(),


### PR DESCRIPTION
# Description

## Problem\*

Working towards green-lighting of ACIR gen

## Summary\*

Still a draft as I want to see its effect on CI

## Additional Context



## Documentation\*

Check one:
- [X] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
