### PR TITLE
fix: mark operations on zero-capacity slices as unreachable

### DIFF
--- a/test_programs/execution_success/regression_9969/Nargo.toml
+++ b/test_programs/execution_success/regression_9969/Nargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "regression_9969"
+type = "bin"
+authors = [""]
+
+[dependencies]

--- a/test_programs/execution_success/regression_9969/Prover.toml
+++ b/test_programs/execution_success/regression_9969/Prover.toml
@@ -1,0 +1,2 @@
+b = false
+return = 0

--- a/test_programs/execution_success/regression_9969/src/main.nr
+++ b/test_programs/execution_success/regression_9969/src/main.nr
@@ -1,0 +1,8 @@
+fn main(b: bool) -> pub Field {
+    let a: [&mut Field] = &[];
+    if b {
+        *a[0]
+    } else {
+        0
+    }
+}

--- a/tooling/nargo_cli/tests/snapshots/execution_success/regression_9969/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/regression_9969/execute__tests__expanded.snap
@@ -1,0 +1,12 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: expanded_code
+---
+fn main(b: bool) -> pub Field {
+    let a: [&mut Field] = &[];
+    if b {
+        *a[0_u32]
+    } else {
+        0_Field
+    }
+}

--- a/tooling/nargo_cli/tests/snapshots/execution_success/regression_9969/execute__tests__stdout.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/regression_9969/execute__tests__stdout.snap
@@ -1,0 +1,5 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: stdout
+---
+[regression_9969] Circuit output: 0x00


### PR DESCRIPTION
# Description

## Problem\*

Resolves #9969

## Summary\*

This PR adds a tentative fix for the linked issue where we're not removing reads from zero-length slices. I'm thinking that this is sufficient to cover the nasty cases but it needs some extra investigation.

## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
