### PR TITLE
refactor: monomorphizer public fields

### DIFF
--- a/compiler/noirc_frontend/src/monomorphization/mod.rs
+++ b/compiler/noirc_frontend/src/monomorphization/mod.rs
@@ -60,7 +60,7 @@ struct LambdaContext {
 ///
 /// This struct holds the FIFO queue of functions to monomorphize, which is added to
 /// whenever a new (function, type) combination is encountered.
-pub(super) struct Monomorphizer<'interner> {
+pub struct Monomorphizer<'interner> {
     /// Functions are keyed by their unique ID, whether they're unconstrained, their expected type,
     /// and any generics they have so that we can monomorphize a new version of the function for each type.
     ///
@@ -72,16 +72,16 @@ pub(super) struct Monomorphizer<'interner> {
     /// duplicated during monomorphization. Doing so would allow them to be used polymorphically
     /// but would also cause them to be re-evaluated which is a performance trap that would
     /// confuse users.
-    locals: HashMap<node_interner::DefinitionId, LocalId>,
+    pub locals: HashMap<node_interner::DefinitionId, LocalId>,
 
     /// Globals are keyed by their unique ID because they are never duplicated during monomorphization.
     globals: HashMap<node_interner::GlobalId, GlobalId>,
 
-    finished_globals: HashMap<GlobalId, (String, ast::Type, ast::Expression)>,
+    pub finished_globals: HashMap<GlobalId, (String, ast::Type, ast::Expression)>,
 
     /// Queue of functions to monomorphize next each item in the queue is a tuple of:
     /// (old_id, new_monomorphized_id, any type bindings to apply, the trait method if old_id is from a trait impl, is_unconstrained, location)
-    queue: VecDeque<(
+    pub queue: VecDeque<(
         node_interner::FuncId,
         FuncId,
         TypeBindings,
@@ -92,10 +92,10 @@ pub(super) struct Monomorphizer<'interner> {
 
     /// When a function finishes being monomorphized, the monomorphized ast::Function is
     /// stored here along with its FuncId.
-    finished_functions: BTreeMap<FuncId, Function>,
+    pub finished_functions: BTreeMap<FuncId, Function>,
 
     /// Used to reference existing definitions in the HIR
-    interner: &'interner mut NodeInterner,
+    pub interner: &'interner mut NodeInterner,
 
     lambda_envs_stack: Vec<LambdaContext>,
 
@@ -106,11 +106,11 @@ pub(super) struct Monomorphizer<'interner> {
 
     is_range_loop: bool,
 
-    return_location: Option<Location>,
+    pub return_location: Option<Location>,
 
-    debug_type_tracker: DebugTypeTracker,
+    pub debug_type_tracker: DebugTypeTracker,
 
-    in_unconstrained_function: bool,
+    pub in_unconstrained_function: bool,
 
     /// Set to true to force every function to be unconstrained.
     /// Note that this also changes the first-class function representation
@@ -208,7 +208,7 @@ pub fn monomorphize_debug(
 }
 
 impl<'interner> Monomorphizer<'interner> {
-    pub(crate) fn new(
+    pub fn new(
         interner: &'interner mut NodeInterner,
         debug_type_tracker: DebugTypeTracker,
         force_unconstrained: bool,
@@ -338,7 +338,7 @@ impl<'interner> Monomorphizer<'interner> {
             .insert(turbofish_generics, new_id);
     }
 
-    fn compile_main(
+    pub fn compile_main(
         &mut self,
         main_id: node_interner::FuncId,
     ) -> Result<FunctionSignature, MonomorphizationError> {
@@ -360,7 +360,7 @@ impl<'interner> Monomorphizer<'interner> {
         Ok(main_meta.function_signature())
     }
 
-    fn function(
+    pub fn function(
         &mut self,
         f: node_interner::FuncId,
         id: FuncId,

--- a/compiler/noirc_frontend/src/monomorphization/mod.rs
+++ b/compiler/noirc_frontend/src/monomorphization/mod.rs
@@ -1959,7 +1959,7 @@ impl<'interner> Monomorphizer<'interner> {
         Expression::Literal(Literal::Slice(arr_literal))
     }
 
-    fn queue_function(
+    pub fn queue_function(
         &mut self,
         id: node_interner::FuncId,
         expr_id: ExprId,


### PR DESCRIPTION
# Description

## Problem*

Resolves #9978 

This PR addresses the need to make Noir more extensible and library-friendly for external tools. Currently, it's not possible to interact with the monomorphization process from an external tool, which forces developers to maintain forks of Noir.

## Summary*

This PR makes the `Monomorphizer` struct and its relevant methods and fields public. This change will allow external tools, such as our formal verification tool, to integrate with the monomorphization process and use Noir as a library.

## Additional Context

This is one of the two PRs that will allow us to move our formal verification tool off of a Noir fork.

## Documentation*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
