### PR TITLE
fix: Disable early mem2reg

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/mod.rs
@@ -129,7 +129,8 @@ pub fn primary_passes(options: &SsaEvaluatorOptions) -> Vec<SsaPass<'_>> {
         SsaPass::new(Ssa::defunctionalize, "Defunctionalization"),
         SsaPass::new_try(Ssa::inline_simple_functions, "Inlining simple functions")
             .and_then(Ssa::remove_unreachable_functions),
-        SsaPass::new(Ssa::mem2reg, "Mem2Reg"),
+        // BUG: Enabling this mem2reg causes test failures in aztec-nr; specifically `state_vars::private_mutable::test::initialize_and_get_pending`
+        // SsaPass::new(Ssa::mem2reg, "Mem2Reg"),
         SsaPass::new(Ssa::remove_paired_rc, "Removing Paired rc_inc & rc_decs"),
         SsaPass::new(Ssa::purity_analysis, "Purity Analysis"),
         SsaPass::new_try(


### PR DESCRIPTION
# Description

## Problem\*

Resolves failures in https://github.com/AztecProtocol/aztec-packages/pull/17203

## Summary\*

I was able to get the `state_vars::private_mutable::test::initialize_and_get_pending` test passing by disabling this run.

We will need to create a reproduction separately but this provides a quick fix to get Noir synced in aztec-packages. 

Here is a picture of the commit history:
<img width="1261" height="127" alt="Screenshot 2025-09-24 at 7 10 00 PM" src="https://github.com/user-attachments/assets/c0d37bc8-d682-4849-94d0-253434d1cfcc" />

Run `noirup -C b2452725d8a6778bd9e9617c7e80d1c502ec397a` (the commit at which PR #9744 was merged). The aztec-nr tests in https://github.com/AztecProtocol/aztec-packages/pull/17203 will pass at that commit.

Building Noir on master will cause the test to fail. However, once we comment out that mem2reg test we will start to pass again. So it looks like some other changes in mem2reg since that PR have now have started causing breakages.  

## Additional Context

## Documentation\*

Check one:
- [X] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
