### PR TITLE
fix(fuzz): Handle divisor of zero msg in error comparison

### DIFF
--- a/tooling/ast_fuzzer/src/compare/compiled.rs
+++ b/tooling/ast_fuzzer/src/compare/compiled.rs
@@ -206,11 +206,15 @@ impl Comparable for NargoErrorWithTypes {
             (
                 SolvingError(OpcodeResolutionError::UnsatisfiedConstrain { .. }, _),
                 AssertionFailed(_, _, _),
-            ) => msg2.as_ref().is_some_and(|msg| msg.contains("divide by zero")),
+            ) => msg2.as_ref().is_some_and(|msg| {
+                msg.contains("divide by zero") || msg.contains("divisor of zero")
+            }),
             (
                 AssertionFailed(_, _, _),
                 SolvingError(OpcodeResolutionError::UnsatisfiedConstrain { .. }, _),
-            ) => msg1.is_some_and(|msg| msg.contains("divide by zero")),
+            ) => msg1.is_some_and(|msg| {
+                msg.contains("divide by zero") || msg.contains("divisor of zero")
+            }),
             (
                 SolvingError(OpcodeResolutionError::IndexOutOfBounds { .. }, _),
                 AssertionFailed(_, _, _),


### PR DESCRIPTION
# Description

## Problem\*

Resolves on of the nightly errors in https://github.com/noir-lang/noir/actions/runs/17995847833/job/51195101153

## Summary\*

Consider the "attempt to calculate the remainder with a divisor of zero" message in the `Comparable` implementation for errors in the fuzzer.

## Additional Context

To reproduce:
```
NOIR_AST_FUZZER_SEED=0x96e5b5c900100000 cargo test -p noir_ast_fuzzer_fuzz acir_vs_brillig
```


## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
