### PR TITLE
chore(ast_fuzzer): Allow passing compilation options to cvise tool

### DIFF
--- a/tooling/ast_fuzzer/minimizer/README.md
+++ b/tooling/ast_fuzzer/minimizer/README.md
@@ -29,11 +29,18 @@ and we need a single line of the error message we are looking to preserve from i
 With that, we need to invoke the `minimize.sh` script as follows:
 
 ```shell
-tooling/ast_fuzzer/minimizer/scripts/minimize.sh "<error-message>" execute path/to/main.nr
+tooling/ast_fuzzer/minimizer/scripts/minimize.sh "<error-message>" execute [compile options...] path/to/main.nr
 ```
 
 The command can be `compile` or `execute`. The latter needs a `Prover.toml` file, which can be given following
 the path to `main.nr`, or it is assumed to be in the parent directory of `main.nr`, like a regular Noir project.
+
+You can also supply `nargo` compilation options. This is useful for cases where we want to minimize a program
+that only fails under certain compilation conditions (e.g., experimental features, different compilation pipeline). Example usage:
+
+```shell
+tooling/ast_fuzzer/minimizer/scripts/minimize.sh "<error-message>" execute -Zenums --minimal-ssa path/to/main.nr
+```
 
 The script makes a `main.nr.bkp` backup file, because the tool will minimize the Noir code in-place.
 

--- a/tooling/ast_fuzzer/minimizer/scripts/docker-entry.sh
+++ b/tooling/ast_fuzzer/minimizer/scripts/docker-entry.sh
@@ -10,12 +10,13 @@ set -e
 # If it's not present, it means the latest reduction step was not interesting.
 # We could have the script read env vars on the fly instead of splicing them in verbatim,
 # but this is perhaps closer to how `cvise` wants an parameterless script.
+
 cat > check.sh <<EOF
 nargo new test_project
 cp main.nr test_project/src
 cp /noir/Prover.toml test_project
 cd test_project
-nargo $CMD 2>&1 | grep "$MSG"
+nargo $CMD $OPTIONS 2>&1 | grep "$MSG"
 EOF
 
 chmod +x check.sh

--- a/tooling/ast_fuzzer/minimizer/scripts/minimize.sh
+++ b/tooling/ast_fuzzer/minimizer/scripts/minimize.sh
@@ -2,7 +2,7 @@
 
 function usage {
     echo $1
-    echo "usage: ./minimize.sh 'error message' (compile|execute) path/to/main.nr [path/to/Prover.toml]"
+    echo "usage: ./minimize.sh 'error message' (compile|execute) [compile options...] path/to/main.nr [path/to/Prover.toml]"
     exit 1
 }
 
@@ -16,7 +16,25 @@ if [ -z "$CMD" ]; then
     usage "missing command"
 fi
 
-MAIN_PATH=$1; shift
+# Grab everything until we hit a .nr file. These are our compile options.
+OPTIONS=()
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        *.nr)
+            MAIN_PATH=$1
+            shift
+            break
+            ;;
+        *)
+            OPTIONS+=("$1")
+            shift
+            ;;
+    esac
+done
+
+# Build a string from the array of options
+OPTIONS="${OPTIONS[*]}"
+
 if [ -z "$MAIN_PATH" ]; then
     usage "missing path to main.nr"
 fi
@@ -47,4 +65,5 @@ exec docker run --init -it --rm \
     -v "$PROVER_PATH":/noir/Prover.toml \
     -e MSG="$MSG" \
     -e CMD="$CMD" \
+    -e OPTIONS="$OPTIONS" \
     noir-minimizer


### PR DESCRIPTION
# Description

## Problem\*

No issue but something I needed to minimize the program from this min_vs_full fuzzer failure https://github.com/noir-lang/noir/actions/runs/17981940230/job/51151135676?pr=9985. 

## Summary\*

When minimizing programs with `cvise` you can now pass compilation flags to nargo. This is most useful if the fuzz program uses experimental features (which need `-Zenums`) or only fails when run with `--minimal-ssa`. 

## Additional Context


## Documentation\*

Check one:
- [ ] No documentation needed.
- [X] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
