### PR TITLE
fix: type mismatch assigning fmtstr without interpolation to a variable

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/ssa_gen/context.rs
+++ b/compiler/noirc_evaluator/src/ssa/ssa_gen/context.rs
@@ -207,7 +207,8 @@ impl<'a> FunctionContext<'a> {
             ast::Type::Tuple(fields) => {
                 Tree::Branch(vecmap(fields, |field| Self::map_type_helper(field, f)))
             }
-            ast::Type::Unit => Tree::empty(),
+            // TODO: WIP
+            // ast::Type::Unit => Tree::empty(),
             // A mutable reference wraps each element into a reference.
             // This can be multiple values if the element type is a tuple.
             ast::Type::Reference(element, _) => {
@@ -259,7 +260,8 @@ impl<'a> FunctionContext<'a> {
             ast::Type::FmtString(_, _) => {
                 panic!("convert_non_tuple_type called on a fmt string: {typ}")
             }
-            ast::Type::Unit => panic!("convert_non_tuple_type called on a unit type"),
+            // TODO: WIP
+            // ast::Type::Unit => panic!("convert_non_tuple_type called on a unit type"),
             ast::Type::Tuple(_) => panic!("convert_non_tuple_type called on a tuple: {typ}"),
             ast::Type::Function(_, _, _, _) => Type::Function,
             ast::Type::Slice(_) => panic!("convert_non_tuple_type called on a slice: {typ}"),

--- a/compiler/noirc_evaluator/src/ssa/ssa_gen/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/ssa_gen/mod.rs
@@ -283,7 +283,8 @@ impl FunctionContext<'_> {
 
                 Ok(Tree::Branch(vec![string, field_count.into(), fields]))
             }
-            ast::Literal::Unit => Ok(Self::unit_value()),
+            // TODO: WIP
+            // ast::Literal::Unit => Ok(Self::unit_value()),
         }
     }
 
@@ -410,8 +411,13 @@ impl FunctionContext<'_> {
         match expr {
             Expression::Ident(ident) => Ok(self.codegen_ident_reference(ident)),
             Expression::ExtractTupleField(tuple, index) => {
+                // TODO: WIP
                 let tuple = self.codegen_reference(tuple)?;
-                Ok(Self::get_field(tuple, *index))
+                if tuple.is_leaf() {
+                    Ok(tuple)
+                } else {
+                    Ok(Self::get_field(tuple, *index))
+                }
             }
             other => self.codegen_expression(other),
         }
@@ -1035,8 +1041,14 @@ impl FunctionContext<'_> {
         tuple: &Expression,
         field_index: usize,
     ) -> Result<Values, RuntimeError> {
-        let tuple = self.codegen_expression(tuple)?;
-        Ok(Self::get_field(tuple, field_index))
+        // TODO: WIP
+        let tuple = self.codegen_reference(tuple)?;
+        if tuple.is_leaf() {
+            Ok(tuple)
+        } else {
+            // TODO: NOTE: there's another Self::get_field case in codegen_reference
+            Ok(Self::get_field(tuple, field_index))
+        }
     }
 
     /// Generate SSA for a function call. Note that calls to built-in functions

--- a/compiler/noirc_evaluator/src/ssa/ssa_gen/value.rs
+++ b/compiler/noirc_evaluator/src/ssa/ssa_gen/value.rs
@@ -149,6 +149,14 @@ impl<T> Tree<T> {
             Tree::Leaf(value) => value,
         }
     }
+
+    // TODO: WIP
+    pub(super) fn is_leaf(&self) -> bool {
+        match self {
+            Tree::Leaf(_) => true,
+            _ => false,
+        }
+    }
 }
 
 impl From<IrValueId> for Values {

--- a/compiler/noirc_evaluator/src/ssa/validation/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/validation/mod.rs
@@ -274,6 +274,13 @@ impl<'f> Validator<'f> {
                 let called_function = &self.ssa.functions[func_id];
 
                 let parameter_types = called_function.view().parameter_types();
+
+                // TODO: WIP
+                let argument_types = arguments.iter().map(|arg| {
+                    dfg.type_of_value(*arg)
+                }).collect::<Vec<_>>();
+                dbg!(&called_function, &arguments, &parameter_types, argument_types);
+
                 assert_eq!(
                     arguments.len(),
                     parameter_types.len(),

--- a/compiler/noirc_frontend/src/elaborator/patterns.rs
+++ b/compiler/noirc_frontend/src/elaborator/patterns.rs
@@ -128,6 +128,7 @@ impl Elaborator<'_> {
             Pattern::Tuple(fields, location) => {
                 let field_types = match expected_type.follow_bindings() {
                     Type::Tuple(fields) => fields,
+                    Type::Unit => vec![],
                     Type::Error => Vec::new(),
                     expected_type => {
                         let tuple =

--- a/compiler/noirc_frontend/src/hir_def/types/unification.rs
+++ b/compiler/noirc_frontend/src/hir_def/types/unification.rs
@@ -183,6 +183,15 @@ impl Type {
                 }
             }
 
+            // TODO: WIP
+            (Tuple(elements), Unit) | (Unit, Tuple(elements)) => {
+                if elements.len() == 0 {
+                    Ok(())
+                } else {
+                    Err(UnificationError)
+                }
+            }
+
             // No recursive try_unify call for struct fields. Don't want
             // to mutate shared type variables within struct definitions.
             // This isn't possible currently but will be once noir gets generic types

--- a/compiler/noirc_frontend/src/monomorphization/ast.rs
+++ b/compiler/noirc_frontend/src/monomorphization/ast.rs
@@ -74,7 +74,8 @@ impl Expression {
                 Literal::Array(literal) | Literal::Slice(literal) => borrowed(&literal.typ),
                 Literal::Integer(_, typ, _) => borrowed(typ),
                 Literal::Bool(_) => borrowed(&Type::Bool),
-                Literal::Unit => borrowed(&Type::Unit),
+                // TODO: WIP
+                // Literal::Unit => borrowed(&Type::Unit),
                 Literal::Str(s) => owned(Type::String(s.len() as u32)),
                 Literal::FmtStr(_, size, expr) => expr.return_type().and_then(|typ| {
                     owned(Type::FmtString(*size as u32, Box::new(typ.into_owned())))
@@ -196,6 +197,14 @@ impl Expression {
             | Expression::Continue => false,
         }
     }
+
+    // TODO: WIP
+    pub fn is_unit(&self) -> bool {
+        match self {
+            Expression::Tuple(fields) => fields.len() == 0,
+            _ => false,
+        }
+    }
 }
 
 /// A definition is either a local (variable), function, or is a built-in
@@ -272,7 +281,8 @@ pub enum Literal {
     Slice(ArrayLiteral),
     Integer(SignedField, Type, Location),
     Bool(bool),
-    Unit,
+    // TODO: WIP
+    // Unit,
     Str(String),
     FmtStr(Vec<FmtStrFragment>, u64, Box<Expression>),
 }
@@ -503,7 +513,8 @@ pub enum Type {
     Bool,
     String(/*len:*/ u32), // String(4) = str[4]
     FmtString(/*len:*/ u32, Box<Type>),
-    Unit,
+    // TODO: WIP
+    // Unit,
     Tuple(Vec<Type>),
     Slice(Box<Type>),
     Reference(Box<Type>, /*mutable:*/ bool),
@@ -650,7 +661,8 @@ impl Display for Type {
             Type::FmtString(len, elements) => {
                 write!(f, "fmtstr<{len}, {elements}>")
             }
-            Type::Unit => write!(f, "()"),
+            // TODO: WIP
+            // Type::Unit => write!(f, "()"),
             Type::Tuple(elements) => {
                 let elements = vecmap(elements, ToString::to_string);
                 if elements.len() == 1 {
@@ -665,8 +677,16 @@ impl Display for Type {
                 }
 
                 let args = vecmap(args, ToString::to_string);
-                let closure_env_text = match **env {
-                    Type::Unit => "".to_string(),
+                let closure_env_text = match *(env.clone()) {
+                    // TODO: WIP
+                    // Type::Unit => "".to_string(),
+                    Type::Tuple(elements) => {
+                        if elements.len() == 0 {
+                            "".to_string()
+                        } else {
+                            format!(" with closure environment {env}")
+                        }
+                    }
                     _ => format!(" with closure environment {env}"),
                 };
                 write!(f, "fn({}) -> {}{}", args.join(", "), ret, closure_env_text)

--- a/compiler/noirc_frontend/src/monomorphization/mod.rs
+++ b/compiler/noirc_frontend/src/monomorphization/mod.rs
@@ -521,7 +521,9 @@ impl<'interner> Monomorphizer<'interner> {
                     self.repeated_array(expr, repeated_element, length, true)?
                 }
             },
-            HirExpression::Literal(HirLiteral::Unit) => ast::Expression::Block(vec![]),
+            // TODO: WIP
+            // ast::Expression::Block(vec![]),
+            HirExpression::Literal(HirLiteral::Unit) => ast::Expression::Tuple(vec![]),
             HirExpression::Block(block) => self.block(block.statements)?,
             HirExpression::Unsafe(block) => self.block(block.statements)?,
 
@@ -1327,7 +1329,9 @@ impl<'interner> Monomorphizer<'interner> {
                     Box::new(Self::convert_type_helper(fields.as_ref(), location, seen_types)?);
                 ast::Type::FmtString(size, fields)
             }
-            HirType::Unit => ast::Type::Unit,
+            // TODO: WIP
+            // ast::Type::Unit,
+            HirType::Unit => ast::Type::Tuple(vec![]),
             HirType::Array(length, element) => {
                 let element =
                     Box::new(Self::convert_type_helper(element.as_ref(), location, seen_types)?);
@@ -1463,7 +1467,8 @@ impl<'interner> Monomorphizer<'interner> {
                 let make_function = |is_unconstrained, args, ret, env| {
                     use ast::Type::*;
                     match &env {
-                        Unit => Function(args, ret, Box::new(env), is_unconstrained),
+                        // TODO: WIP
+                        // Unit => Function(args, ret, Box::new(env), is_unconstrained),
                         Tuple(_) => Tuple(vec![
                             env.clone(),
                             Function(args, ret, Box::new(env), is_unconstrained),
@@ -2096,7 +2101,7 @@ impl<'interner> Monomorphizer<'interner> {
         let typ = ast::Type::Function(
             parameter_types,
             Box::new(ret_type),
-            Box::new(ast::Type::Unit),
+            Box::new(ast::Type::Tuple(vec![])),
             false,
         );
 
@@ -2336,7 +2341,8 @@ impl<'interner> Monomorphizer<'interner> {
                 ast::Expression::Literal(ast::Literal::Integer(zero, typ, location))
             }
             ast::Type::Bool => ast::Expression::Literal(ast::Literal::Bool(false)),
-            ast::Type::Unit => ast::Expression::Literal(ast::Literal::Unit),
+            // TODO: WIP
+            // ast::Type::Unit => ast::Expression::Literal(ast::Expression::Tuple(vec![])),
             ast::Type::Array(length, element_type) => {
                 let element = self.zeroed_value_of_type(element_type.as_ref(), location);
                 ast::Expression::Literal(ast::Literal::Array(ast::ArrayLiteral {
@@ -2559,10 +2565,12 @@ impl<'interner> Monomorphizer<'interner> {
     }
 }
 
+// TODO: WIP
 fn unwrap_tuple_type(typ: &HirType) -> Vec<HirType> {
     match typ.follow_bindings() {
         HirType::Tuple(fields) => fields.clone(),
-        other => unreachable!("unwrap_tuple_type: expected tuple, found {:?}", other),
+        HirType::Unit => vec![],
+        other => unreachable!("unwrap_tuple_type: expected tuple or unit, found {:?}", other),
     }
 }
 

--- a/compiler/noirc_frontend/src/monomorphization/printer.rs
+++ b/compiler/noirc_frontend/src/monomorphization/printer.rs
@@ -284,9 +284,10 @@ impl AstPrinter {
                 }
                 write!(f, "\"")
             }
-            Literal::Unit => {
-                write!(f, "()")
-            }
+            // TODO: WIP
+            // Literal::Unit => {
+            //     write!(f, "()")
+            // }
         }
     }
 

--- a/compiler/noirc_frontend/src/ownership/last_uses.rs
+++ b/compiler/noirc_frontend/src/ownership/last_uses.rs
@@ -315,7 +315,9 @@ impl LastUseContext {
 
     fn track_variables_in_literal(&mut self, literal: &Literal) {
         match literal {
-            Literal::Integer(..) | Literal::Bool(_) | Literal::Unit | Literal::Str(_) => (),
+            // TODO: WIP
+            // Literal::Integer(..) | Literal::Bool(_) | Literal::Unit | Literal::Str(_) => (),
+            Literal::Integer(..) | Literal::Bool(_) | Literal::Str(_) => (),
 
             Literal::FmtStr(_, _, captures) => self.track_variables_in_expression(captures),
 

--- a/compiler/noirc_frontend/src/ownership/mod.rs
+++ b/compiler/noirc_frontend/src/ownership/mod.rs
@@ -241,7 +241,9 @@ impl Context {
 
     fn handle_literal(&mut self, literal: &mut Literal) {
         match literal {
-            Literal::Integer(..) | Literal::Bool(_) | Literal::Unit | Literal::Str(_) => (),
+            // TODO: WIP
+            // Literal::Integer(..) | Literal::Bool(_) | Literal::Unit | Literal::Str(_) => (),
+            Literal::Integer(..) | Literal::Bool(_) | Literal::Str(_) => (),
 
             Literal::FmtStr(_, _, captures) => self.handle_expression(captures),
 
@@ -347,7 +349,9 @@ impl Context {
                 if name == "array_len" {
                     if let Some(Expression::Clone(array)) = call.arguments.get_mut(0) {
                         let array =
-                            std::mem::replace(array.as_mut(), Expression::Literal(Literal::Unit));
+                            // TODO: WIP
+                            // std::mem::replace(array.as_mut(), Expression::Literal(Literal::Unit));
+                            std::mem::replace(array.as_mut(), Expression::Tuple(vec![]));
                         call.arguments[0] = array;
                     }
                 }
@@ -417,7 +421,9 @@ fn contains_index(lvalue: &LValue) -> bool {
 /// Note that this method should be careful not to actually duplicate the given expression
 /// so that we do not duplicate any side-effects.
 fn clone_expr(expr: &mut Expression) {
-    let unit = Expression::Literal(Literal::Unit);
+    // TODO: WIP
+    // let unit = Expression::Literal(Literal::Unit);
+    let unit = Expression::Tuple(vec![]);
     let old_expr = std::mem::replace(expr, unit);
     *expr = Expression::Clone(Box::new(old_expr));
 }
@@ -427,7 +433,8 @@ fn contains_array_or_str_type(typ: &Type) -> bool {
         Type::Field
         | Type::Integer(..)
         | Type::Bool
-        | Type::Unit
+        // TODO: WIP
+        // | Type::Unit
         | Type::Function(..)
         | Type::Reference(..) => false,
 

--- a/compiler/noirc_frontend/src/tests.rs
+++ b/compiler/noirc_frontend/src/tests.rs
@@ -4535,3 +4535,27 @@ fn disallows_references_in_globals() {
     "#;
     check_errors!(src);
 }
+
+#[test]
+fn TODO_rename_unit_match() {
+    let src = r#"
+    fn foo(x: ()) {
+        let (): () = x;
+    }
+
+    fn main() {
+        foo(())
+    }
+    "#;
+    assert_no_errors!(src);
+}
+
+#[test]
+fn regression_9729() {
+    let src = r#"
+    fn main() {
+        let _: fmtstr<5, ()> = f"Hello";
+    }
+    "#;
+    assert_no_errors!(src);
+}

--- a/test_programs/compile_success_no_bug/regression_9729/Nargo.toml
+++ b/test_programs/compile_success_no_bug/regression_9729/Nargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "regression_9729"
+type = "bin"
+authors = [""]
+
+[dependencies]

--- a/test_programs/compile_success_no_bug/regression_9729/src/main.nr
+++ b/test_programs/compile_success_no_bug/regression_9729/src/main.nr
@@ -1,0 +1,13 @@
+fn foo(x: ()) {
+    let (): () = x;
+}
+
+unconstrained fn bar(x: ()) {
+    let (): () = x;
+}
+
+fn main() {
+    foo(());
+    unsafe { bar(()) };
+    let _: fmtstr<5, ()> = f"Hello";
+}

--- a/tooling/ast_fuzzer/src/abi.rs
+++ b/tooling/ast_fuzzer/src/abi.rs
@@ -21,7 +21,8 @@ pub fn program_abi(program: &Program) -> Abi {
         .collect();
 
     let return_type = match &main.return_type {
-        Type::Unit => None,
+        // TODO: WIP
+        // Type::Unit => None,
         typ => Some(AbiReturnType {
             abi_type: to_abi_type(typ),
             visibility: to_abi_visibility(&program.return_visibility()),
@@ -34,8 +35,10 @@ pub fn program_abi(program: &Program) -> Abi {
 /// Check if a type is valid as an ABI parameter for the `main` function.
 fn is_valid_in_abi(typ: &Type) -> bool {
     match typ {
-        Type::Unit
-        | Type::FmtString(_, _)
+        // TODO: WIP
+        // Type::Unit
+        // | Type::FmtString(_, _)
+        Type::FmtString(_, _)
         | Type::Slice(_)
         | Type::Reference(_, _)
         | Type::Function(_, _, _, _) => false,

--- a/tooling/ast_fuzzer/src/program/expr.rs
+++ b/tooling/ast_fuzzer/src/program/expr.rs
@@ -32,7 +32,8 @@ pub fn gen_literal(
     use IntegerBitSize::*;
 
     let expr = match typ {
-        Type::Unit => Expression::Literal(Literal::Unit),
+        // TODO: WIP
+        // Type::Unit => Expression::Literal(Literal::Unit),
         Type::Bool => lit_bool(bool::arbitrary(u)?),
         Type::Field => {
             let field = SignedField::new(Field::from(u128::arbitrary(u)?), bool::arbitrary(u)?);

--- a/tooling/ast_fuzzer/src/program/func.rs
+++ b/tooling/ast_fuzzer/src/program/func.rs
@@ -1197,11 +1197,15 @@ impl<'a> FunctionContext<'a> {
 
         // Require a positive budget, so that we have some for the block itself and its contents.
         if freq.enabled_when("if", self.budget > 1) {
-            return self.gen_if(u, &Type::Unit, self.max_depth(), Flags::TOP).map(|(e, _)| e);
+            // TODO: WIP
+            // return self.gen_if(u, &Type::Unit, self.max_depth(), Flags::TOP).map(|(e, _)| e);
+            return self.gen_if(u, &Type::Tuple(vec![]), self.max_depth(), Flags::TOP).map(|(e, _)| e);
         }
 
         if freq.enabled_when("match", self.budget > 1 && !self.ctx.config.avoid_match) {
-            if let Some((e, _)) = self.gen_match(u, &Type::Unit, self.max_depth())? {
+            // TODO: WIP
+            // if let Some((e, _)) = self.gen_match(u, &Type::Unit, self.max_depth())? {
+            if let Some((e, _)) = self.gen_match(u, &Type::Tuple(vec![]), self.max_depth())? {
                 return Ok(e);
             }
         }
@@ -1211,7 +1215,9 @@ impl<'a> FunctionContext<'a> {
         }
 
         if freq.enabled_when("call", self.budget > 0) {
-            if let Some((e, _)) = self.gen_call(u, &Type::Unit, self.max_depth())? {
+            // TODO: WIP
+            // if let Some((e, _)) = self.gen_call(u, &Type::Unit, self.max_depth())? {
+            if let Some((e, _)) = self.gen_call(u, &Type::Tuple(vec![]), self.max_depth())? {
                 return Ok(e);
             }
         }
@@ -1481,14 +1487,18 @@ impl<'a> FunctionContext<'a> {
             definition: Definition::Oracle("print".to_string()),
             mutable: false,
             name: "print_oracle".to_string(),
-            typ: Type::Function(param_types, Box::new(Type::Unit), Box::new(Type::Unit), true),
+            // TODO: WIP
+            // typ: Type::Function(param_types, Box::new(Type::Unit), Box::new(Type::Unit), true),
+            typ: Type::Function(param_types, Box::new(Type::Tuple(vec![])), Box::new(Type::Tuple(vec![])), true),
             id: self.next_ident_id(),
         };
 
         let call = Expression::Call(Call {
             func: Box::new(Expression::Ident(print_oracle_ident)),
             arguments: args,
-            return_type: Type::Unit,
+            // TODO: WIP
+            // return_type: Type::Unit,
+            return_type: Type::Tuple(vec![]),
             location: Location::dummy(),
         });
 
@@ -1617,7 +1627,9 @@ impl<'a> FunctionContext<'a> {
         self.decrease_budget(1);
 
         let was_in_loop = std::mem::replace(&mut self.in_loop, true);
-        let (block, _) = self.gen_block(u, &Type::Unit)?;
+        // TODO: WIP
+        // let (block, _) = self.gen_block(u, &Type::Unit)?;
+        let (block, _) = self.gen_block(u, &Type::Tuple(vec![]))?;
         self.in_loop = was_in_loop;
 
         let expr = Expression::For(For {
@@ -1741,7 +1753,9 @@ impl<'a> FunctionContext<'a> {
 
         // Get the randomized loop body
         let was_in_loop = std::mem::replace(&mut self.in_loop, true);
-        let (mut loop_body, _) = self.gen_block(u, &Type::Unit)?;
+        // TODO: WIP
+        // let (mut loop_body, _) = self.gen_block(u, &Type::Unit)?;
+        let (mut loop_body, _) = self.gen_block(u, &Type::Tuple(vec![]))?;
         self.in_loop = was_in_loop;
 
         // Increment the index in the beginning of the body.
@@ -1759,7 +1773,9 @@ impl<'a> FunctionContext<'a> {
             expr::binary(idx_expr, BinaryOp::Equal, expr::u32_literal(max_loop_size as u32)),
             Expression::Break,
             loop_body,
-            Type::Unit,
+            // TODO: WIP
+            // Type::Unit,
+            Type::Tuple(vec![]),
         );
 
         Ok(Expression::Block(vec![let_idx, Expression::Loop(Box::new(loop_body))]))
@@ -1786,7 +1802,9 @@ impl<'a> FunctionContext<'a> {
 
         // Get the randomized loop body
         let was_in_loop = std::mem::replace(&mut self.in_loop, true);
-        let (mut loop_body, _) = self.gen_block(u, &Type::Unit)?;
+        // TODO: WIP
+        // let (mut loop_body, _) = self.gen_block(u, &Type::Unit)?;
+        let (mut loop_body, _) = self.gen_block(u, &Type::Tuple(vec![]))?;
         self.in_loop = was_in_loop;
 
         // Increment the index in the beginning of the body.
@@ -1804,7 +1822,9 @@ impl<'a> FunctionContext<'a> {
             expr::binary(idx_expr, BinaryOp::Equal, expr::u32_literal(max_loop_size as u32)),
             Expression::Break,
             loop_body,
-            Type::Unit,
+            // TODO: WIP
+            // Type::Unit,
+            Type::Tuple(vec![]),
         )]);
 
         // Generate the `while` condition with depth 1
@@ -2092,7 +2112,9 @@ impl<'a> FunctionContext<'a> {
             typ: Type::Function(
                 param_types,
                 Box::new(callee.return_type.clone()),
-                Box::new(Type::Unit),
+                // TODO: WIP
+                // Box::new(Type::Unit),
+                Box::new(Type::Tuple(vec![])),
                 callee.unconstrained,
             ),
             id: self.next_ident_id(),
@@ -2205,7 +2227,9 @@ impl<'a> FunctionContext<'a> {
             definition: Definition::Builtin("array_len".to_string()),
             mutable: false,
             name: "len".to_string(),
-            typ: Type::Function(vec![typ], Box::new(types::U32), Box::new(Type::Unit), false),
+            // TODO: WIP
+            // typ: Type::Function(vec![typ], Box::new(types::U32), Box::new(Type::Unit), false),
+            typ: Type::Function(vec![typ], Box::new(types::U32), Box::new(Type::Tuple(vec![])), false),
             id: self.next_ident_id(),
         };
         Expression::Call(Call {
@@ -2232,7 +2256,9 @@ impl<'a> FunctionContext<'a> {
             typ: Type::Function(
                 arg_types,
                 Box::new(return_type.clone()),
-                Box::new(Type::Unit),
+                // TODO: WIP
+                // Box::new(Type::Unit),
+                Box::new(Type::Tuple(vec![])),
                 false,
             ),
             id: self.next_ident_id(),

--- a/tooling/ast_fuzzer/src/program/mod.rs
+++ b/tooling/ast_fuzzer/src/program/mod.rs
@@ -278,7 +278,9 @@ impl Context {
                 let typ = Type::Function(
                     param_types,
                     Box::new(callee.return_type.clone()),
-                    Box::new(Type::Unit),
+                    // TODO: WIP
+                    // Box::new(Type::Unit),
+                    Box::new(Type::Tuple(vec![])),
                     callee.unconstrained,
                 );
                 if u.ratio(2, 5)? { types::ref_mut(typ) } else { typ }

--- a/tooling/ast_fuzzer/src/program/rewrite/limit.rs
+++ b/tooling/ast_fuzzer/src/program/rewrite/limit.rs
@@ -266,7 +266,9 @@ impl<'a, 'b> LimitContext<'a, 'b> {
                 typ: Type::Function(
                     self.func.parameters.iter().map(|p| p.3.clone()).collect(),
                     Box::new(self.func.return_type.clone()),
-                    Box::new(Type::Unit),
+                    // TODO: WIP
+                    // Box::new(Type::Unit),
+                    Box::new(Type::Tuple(vec![])),
                     self.func.unconstrained,
                 ),
                 id: self.next_ident_id(),

--- a/tooling/ast_fuzzer/src/program/types.rs
+++ b/tooling/ast_fuzzer/src/program/types.rs
@@ -18,7 +18,9 @@ pub const U32: Type = Type::Integer(Signedness::Unsigned, IntegerBitSize::Thirty
 /// Leaf types have a depth of 0.
 pub fn type_depth(typ: &Type) -> usize {
     match typ {
-        Type::Field | Type::Bool | Type::String(_) | Type::Unit | Type::Integer(_, _) => 0,
+        // TODO: WIP
+        // Type::Field | Type::Bool | Type::String(_) | Type::Unit | Type::Integer(_, _) => 0,
+        Type::Field | Type::Bool | Type::String(_) | Type::Integer(_, _) => 0,
         Type::Array(_, typ) | Type::Slice(typ) => 1 + type_depth(typ),
         Type::Tuple(types) => 1 + types.iter().map(type_depth).max().unwrap_or_default(),
         Type::Reference(typ, _) => 1 + type_depth(typ.as_ref()),
@@ -54,7 +56,9 @@ pub fn can_be_main(typ: &Type) -> bool {
 
 /// Check if a variable with a given type can be used in a match.
 pub fn can_be_matched(typ: &Type) -> bool {
-    matches!(typ, Type::Unit | Type::Bool | Type::Field | Type::Integer(_, _) | Type::Tuple(_))
+    // TODO: WIP
+    // matches!(typ, Type::Unit | Type::Bool | Type::Field | Type::Integer(_, _) | Type::Tuple(_))
+    matches!(typ, Type::Bool | Type::Field | Type::Integer(_, _) | Type::Tuple(_))
 }
 
 /// Collect all the sub-types produced by a type.
@@ -132,7 +136,9 @@ pub fn types_produced(typ: &Type) -> HashSet<Type> {
             Type::Function(_, ret, _, _) => {
                 visit(acc, ret);
             }
-            Type::Unit | Type::FmtString(_, _) => {}
+            // TODO: WIP
+            // Type::Unit | Type::FmtString(_, _) => {}
+            Type::FmtString(_, _) => {}
         }
     }
 
@@ -156,7 +162,8 @@ pub fn to_hir_type(typ: &Type) -> hir_def::types::Type {
     };
 
     match typ {
-        Type::Unit => HirType::Unit,
+        // TODO: WIP
+        // Type::Unit => HirType::Unit,
         Type::Bool => HirType::Bool,
         Type::Field => HirType::FieldElement,
         Type::Integer(signedness, integer_bit_size) => {
@@ -186,7 +193,12 @@ pub fn is_numeric(typ: &Type) -> bool {
 
 /// Check if a type is `Unit`.
 pub fn is_unit(typ: &Type) -> bool {
-    matches!(typ, Type::Unit)
+    // TODO: WIP
+    // matches!(typ, Type::Unit)
+    match typ {
+        Type::Tuple(items) => items.len() == 0,
+        _ => false,
+    }
 }
 
 /// Check if the type works with `UnaryOp::Not`
@@ -227,7 +239,8 @@ pub fn contains_reference(typ: &Type) -> bool {
         | Type::Integer(_, _)
         | Type::Bool
         | Type::String(_)
-        | Type::Unit
+        // TODO: WIP
+        // | Type::Unit
         | Type::FmtString(_, _)
         | Type::Function(_, _, _, _) => false,
         Type::Array(_, typ) | Type::Slice(typ) => contains_reference(typ),
@@ -243,7 +256,8 @@ pub fn contains_slice(typ: &Type) -> bool {
         | Type::Integer(_, _)
         | Type::Bool
         | Type::String(_)
-        | Type::Unit
+        // TODO: WIP
+        // | Type::Unit
         | Type::FmtString(_, _)
         | Type::Function(_, _, _, _) => false,
         Type::Array(_, typ) | Type::Reference(typ, _) => contains_slice(typ),
@@ -255,7 +269,9 @@ pub fn contains_slice(typ: &Type) -> bool {
 pub fn is_printable(typ: &Type) -> bool {
     match typ {
         Type::Reference(_, _) => false,
-        Type::Field | Type::Integer(_, _) | Type::String(_) | Type::Bool | Type::Unit => true,
+        // TODO: WIP
+        // Type::Field | Type::Integer(_, _) | Type::String(_) | Type::Bool | Type::Unit => true,
+        Type::Field | Type::Integer(_, _) | Type::String(_) | Type::Bool => true,
         Type::Slice(typ) | Type::Array(_, typ) | Type::FmtString(_, typ) => is_printable(typ),
         Type::Tuple(types) => types.iter().all(is_printable),
         // Function signatures are printable, although they might differ when we force things to be Brillig.

--- a/tooling/ast_fuzzer/src/program/visitor.rs
+++ b/tooling/ast_fuzzer/src/program/visitor.rs
@@ -57,7 +57,9 @@ where
                     visit_expr_be_mut(expr, b, e, i);
                 }
             }
-            Literal::Integer(_, _, _) | Literal::Bool(_) | Literal::Unit | Literal::Str(_) => {}
+            // TODO: WIP
+            // Literal::Integer(_, _, _) | Literal::Bool(_) | Literal::Unit | Literal::Str(_) => {}
+            Literal::Integer(_, _, _) | Literal::Bool(_) | Literal::Str(_) => {}
             Literal::FmtStr(_, _, expr) => {
                 visit_expr_be_mut(expr, b, e, i);
             }
@@ -222,7 +224,9 @@ where
                     visit_expr_be(expr, b, e, i);
                 }
             }
-            Literal::Integer(_, _, _) | Literal::Bool(_) | Literal::Unit | Literal::Str(_) => {}
+            // TODO: WIP
+            // Literal::Integer(_, _, _) | Literal::Bool(_) | Literal::Unit | Literal::Str(_) => {}
+            Literal::Integer(_, _, _) | Literal::Bool(_) | Literal::Str(_) => {}
             Literal::FmtStr(_, _, expr) => {
                 visit_expr_be(expr, b, e, i);
             }


### PR DESCRIPTION
# Description

## Problem\*

Resolves https://github.com/noir-lang/noir/issues/9729

## Summary\*



## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
