### PR TITLE
update GitHub actions in CI workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
         run: |
             cargo update --workspace
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 22.15.0
           cache: 'yarn'

--- a/.github/workflows/reports.yml
+++ b/.github/workflows/reports.yml
@@ -450,7 +450,7 @@ jobs:
         uses: ./scripts/.github/actions/download-nargo
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: ${{ matrix.repo }}
           path: test-repo


### PR DESCRIPTION
This PR updates GitHub Actions versions used in CI workflows:

In release.yml, upgraded actions/setup-node from v4 → v5
In reports.yml, upgraded actions/checkout from v4 → v5
