### PR TITLE
chore(ci): fix external checks

### DIFF
--- a/.github/benchmark_projects.yml
+++ b/.github/benchmark_projects.yml
@@ -72,7 +72,7 @@ projects:
     ref: *AZ_COMMIT
     path: noir-projects/noir-protocol-circuits/crates/rollup-checkpoint-root-single-block
     num_runs: 5
-    timeout: 15
+    timeout: 60
     compilation-timeout: 20
     execution-timeout: 0.75
     compilation-memory-limit: 10000
@@ -82,7 +82,7 @@ projects:
     ref: *AZ_COMMIT
     path: noir-projects/noir-protocol-circuits/crates/rollup-checkpoint-root
     num_runs: 5
-    timeout: 15
+    timeout: 60
     compilation-timeout: 20
     execution-timeout: 1
     compilation-memory-limit: 10000

--- a/.github/benchmark_projects.yml
+++ b/.github/benchmark_projects.yml
@@ -73,7 +73,7 @@ projects:
     path: noir-projects/noir-protocol-circuits/crates/rollup-checkpoint-root-single-block
     num_runs: 5
     timeout: 60
-    compilation-timeout: 20
+    compilation-timeout: 250
     execution-timeout: 0.75
     compilation-memory-limit: 10000
     execution-memory-limit: 2000
@@ -83,7 +83,7 @@ projects:
     path: noir-projects/noir-protocol-circuits/crates/rollup-checkpoint-root
     num_runs: 5
     timeout: 60
-    compilation-timeout: 20
+    compilation-timeout: 250
     execution-timeout: 1
     compilation-memory-limit: 10000
     execution-memory-limit: 2000

--- a/.github/benchmark_projects.yml
+++ b/.github/benchmark_projects.yml
@@ -65,7 +65,7 @@ projects:
     repo: AztecProtocol/aztec-packages
     ref: *AZ_COMMIT
     path: noir-projects/noir-protocol-circuits/crates/rollup-checkpoint-root-single-block
-    num_runs: 5
+    num_runs: 1
     compilation-timeout: 250
     execution-timeout: 0.75
     compilation-memory-limit: 10000
@@ -74,7 +74,7 @@ projects:
     repo: AztecProtocol/aztec-packages
     ref: *AZ_COMMIT
     path: noir-projects/noir-protocol-circuits/crates/rollup-checkpoint-root
-    num_runs: 5
+    num_runs: 1
     compilation-timeout: 250
     execution-timeout: 1
     compilation-memory-limit: 10000

--- a/.github/benchmark_projects.yml
+++ b/.github/benchmark_projects.yml
@@ -14,7 +14,6 @@ projects:
     ref: *AZ_COMMIT
     path: noir-projects/noir-protocol-circuits/crates/private-kernel-tail
     num_runs: 5
-    timeout: 4
     compilation-timeout: 3
     execution-timeout: 0.04
     compilation-memory-limit: 300
@@ -24,7 +23,6 @@ projects:
     ref: *AZ_COMMIT
     path: noir-projects/noir-protocol-circuits/crates/private-kernel-reset
     num_runs: 5
-    timeout: 250
     compilation-timeout: 10
     execution-timeout: 0.35
     compilation-memory-limit: 750
@@ -35,7 +33,6 @@ projects:
     path: noir-projects/noir-protocol-circuits/crates/rollup-block-root-first-empty-tx
     cannot_execute: true
     num_runs: 5
-    timeout: 60
     compilation-timeout: 30
     compilation-memory-limit: 1500
   rollup-block-root-single-tx:
@@ -44,7 +41,6 @@ projects:
     path: noir-projects/noir-protocol-circuits/crates/rollup-block-root-single-tx
     cannot_execute: true
     num_runs: 1
-    timeout: 60
     compilation-timeout: 250
     compilation-memory-limit: 10000
   rollup-block-root:
@@ -52,7 +48,6 @@ projects:
     ref: *AZ_COMMIT
     path: noir-projects/noir-protocol-circuits/crates/rollup-block-root
     num_runs: 1
-    timeout: 60
     compilation-timeout: 250
     execution-timeout: 40
     compilation-memory-limit: 10000
@@ -62,7 +57,6 @@ projects:
     ref: *AZ_COMMIT
     path: noir-projects/noir-protocol-circuits/crates/rollup-checkpoint-merge
     num_runs: 5
-    timeout: 15
     compilation-timeout: 20
     execution-timeout: 0.75
     compilation-memory-limit: 1700
@@ -72,7 +66,6 @@ projects:
     ref: *AZ_COMMIT
     path: noir-projects/noir-protocol-circuits/crates/rollup-checkpoint-root-single-block
     num_runs: 5
-    timeout: 60
     compilation-timeout: 250
     execution-timeout: 0.75
     compilation-memory-limit: 10000
@@ -82,7 +75,6 @@ projects:
     ref: *AZ_COMMIT
     path: noir-projects/noir-protocol-circuits/crates/rollup-checkpoint-root
     num_runs: 5
-    timeout: 60
     compilation-timeout: 250
     execution-timeout: 1
     compilation-memory-limit: 10000
@@ -92,7 +84,6 @@ projects:
     ref: *AZ_COMMIT
     path: noir-projects/noir-protocol-circuits/crates/rollup-tx-merge
     num_runs: 5
-    timeout: 300
     compilation-timeout: 4
     execution-timeout: 0.01
     compilation-memory-limit: 450
@@ -102,7 +93,6 @@ projects:
     ref: *AZ_COMMIT
     path: noir-projects/noir-protocol-circuits/crates/rollup-root
     num_runs: 5
-    timeout: 300
     compilation-timeout: 2
     execution-timeout: 0.6
     compilation-memory-limit: 500
@@ -112,7 +102,6 @@ projects:
     ref: *AZ_COMMIT
     path: noir-projects/noir-protocol-circuits/crates/rollup-tx-base-private
     num_runs: 5
-    timeout: 15
     compilation-timeout: 30
     execution-timeout: 0.75
     compilation-memory-limit: 1700
@@ -122,7 +111,6 @@ projects:
     ref: *AZ_COMMIT
     path: noir-projects/noir-protocol-circuits/crates/rollup-tx-base-public
     num_runs: 5
-    timeout: 15
     compilation-timeout: 100
     execution-timeout: 0.75
     compilation-memory-limit: 8000
@@ -131,7 +119,6 @@ projects:
     repo: noir-lang/noir
     path: test_programs/benchmarks/semaphore_depth_10
     num_runs: 20
-    timeout: 300
     compilation-timeout: 2
     execution-timeout: 0.6
     compilation-memory-limit: 450
@@ -140,7 +127,6 @@ projects:
     repo: noir-lang/noir
     path: test_programs/benchmarks/sha512_100_bytes
     num_runs: 10
-    timeout: 300
     compilation-timeout: 10
     execution-timeout: 5
     compilation-memory-limit: 450

--- a/.github/workflows/reports.yml
+++ b/.github/workflows/reports.yml
@@ -335,7 +335,7 @@ jobs:
   external_repo_reports:
     needs: [build-nargo, build-noir-inspector, benchmark-projects-list]
     runs-on: ubuntu-22.04
-    timeout-minutes: 15
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
@@ -364,7 +364,6 @@ jobs:
 
       - name: Download noir-inspector binary
         uses: ./.github/actions/download-noir-inspector
-
 
       - name: Generate compilation report
         id: compilation_report
@@ -838,13 +837,13 @@ jobs:
       - upload_execution_memory_report
 
     steps:
-        - name: Report overall success
-          run: |
-            if [[ $FAIL == true ]]; then
-                exit 1
-            else
-                exit 0
-            fi
-          env:
-            # We treat any skipped or failing jobs as a failure for the workflow as a whole.
-            FAIL: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped') }}
+      - name: Report overall success
+        run: |
+          if [[ $FAIL == true ]]; then
+              exit 1
+          else
+              exit 0
+          fi
+        env:
+          # We treat any skipped or failing jobs as a failure for the workflow as a whole.
+          FAIL: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped') }}

--- a/EXTERNAL_NOIR_LIBRARIES.yml
+++ b/EXTERNAL_NOIR_LIBRARIES.yml
@@ -115,6 +115,8 @@ libraries:
     path: noir-projects/noir-protocol-circuits/crates/rollup-lib
     timeout: 900
     critical: false
+    # Use 4 test threads for rollup-lib because each test requires a lot of memory, and multiple ones in parallel exceed the maximum memory limit.
+    nargo_args: "--test-threads 4"
   zk_regex:
     repo: Mach-34/noir-zk-regex
     ref: 20de93bd8b30bb51271690c7d13fad86399527e1

--- a/EXTERNAL_NOIR_LIBRARIES.yml
+++ b/EXTERNAL_NOIR_LIBRARIES.yml
@@ -115,8 +115,8 @@ libraries:
     path: noir-projects/noir-protocol-circuits/crates/rollup-lib
     timeout: 900
     critical: false
-    # Use 4 test threads for rollup-lib because each test requires a lot of memory, and multiple ones in parallel exceed the maximum memory limit.
-    nargo_args: "--test-threads 4"
+    # Use 2 test threads for rollup-lib because each test requires a lot of memory, and multiple ones in parallel exceed the maximum memory limit.
+    nargo_args: "--test-threads 2"
   zk_regex:
     repo: Mach-34/noir-zk-regex
     ref: 20de93bd8b30bb51271690c7d13fad86399527e1

--- a/EXTERNAL_NOIR_LIBRARIES.yml
+++ b/EXTERNAL_NOIR_LIBRARIES.yml
@@ -109,14 +109,14 @@ libraries:
     path: noir-projects/noir-protocol-circuits/crates/types
     timeout: 150
     critical: false
-  protocol_circuits_rollup_lib:
-    repo: AztecProtocol/aztec-packages
-    ref: *AZ_COMMIT
-    path: noir-projects/noir-protocol-circuits/crates/rollup-lib
-    timeout: 900
-    critical: false
-    # Use 2 test threads for rollup-lib because each test requires a lot of memory, and multiple ones in parallel exceed the maximum memory limit.
-    nargo_args: "--test-threads 2"
+  # protocol_circuits_rollup_lib:
+  #   repo: AztecProtocol/aztec-packages
+  #   ref: *AZ_COMMIT
+  #   path: noir-projects/noir-protocol-circuits/crates/rollup-lib
+  #   timeout: 900
+  #   critical: false
+  #   # Use 1 test threads for rollup-lib because each test requires a lot of memory, and multiple ones in parallel exceed the maximum memory limit.
+  #   nargo_args: "--test-threads 1"
   zk_regex:
     repo: Mach-34/noir-zk-regex
     ref: 20de93bd8b30bb51271690c7d13fad86399527e1

--- a/EXTERNAL_NOIR_LIBRARIES.yml
+++ b/EXTERNAL_NOIR_LIBRARIES.yml
@@ -115,8 +115,6 @@ libraries:
     path: noir-projects/noir-protocol-circuits/crates/rollup-lib
     timeout: 900
     critical: false
-    # Use 1 test threads for rollup-lib because each test requires a lot of memory, and multiple ones in parallel exceed the maximum memory limit.
-    nargo_args: "--test-threads 1"
   zk_regex:
     repo: Mach-34/noir-zk-regex
     ref: 20de93bd8b30bb51271690c7d13fad86399527e1


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This PR updates the timeouts appropriately for some of the heavier benchmark projects.

I've also had to disable the rolluplib tests.


## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
