### PR TITLE
feat(ssa): `constant_folding` with revisits

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/ir/dfg/simplify.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/dfg/simplify.rs
@@ -27,6 +27,7 @@ pub(crate) use call::constant_to_radix;
 
 /// Contains the result to Instruction::simplify, specifying how the instruction
 /// should be simplified.
+#[derive(Debug)]
 pub(crate) enum SimplifyResult {
     /// Replace this function's result with the given value
     SimplifiedTo(ValueId),

--- a/compiler/noirc_evaluator/src/ssa/ir/value.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/value.rs
@@ -93,8 +93,6 @@ impl ValueMapping {
     }
 
     pub(crate) fn batch_insert(&mut self, from: &[ValueId], to: &[ValueId]) {
-        println!("    batch_insert(from = {from:?}, to = {to:?})");
-
         debug_assert_eq!(
             from.len(),
             to.len(),

--- a/compiler/noirc_evaluator/src/ssa/ir/value.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/value.rs
@@ -93,6 +93,8 @@ impl ValueMapping {
     }
 
     pub(crate) fn batch_insert(&mut self, from: &[ValueId], to: &[ValueId]) {
+        println!("    batch_insert(from = {from:?}, to = {to:?})");
+
         debug_assert_eq!(
             from.len(),
             to.len(),

--- a/compiler/noirc_evaluator/src/ssa/opt/constant_folding/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/constant_folding/mod.rs
@@ -119,6 +119,7 @@ impl Function {
 
         while let Some(block) = context.block_queue.pop_front() {
             context.fold_constants_in_block(&mut self.dfg, &mut dom, block, interpreter);
+            context.block_queue.extend(self.dfg[block].successors());
         }
 
         #[cfg(debug_assertions)]
@@ -226,8 +227,6 @@ impl Context {
         terminator.map_values_mut(&mut resolve_cache);
         dfg[block_id].set_terminator(terminator);
         dfg.data_bus.map_values_mut(resolve_cache);
-
-        self.block_queue.extend(dfg[block_id].successors());
     }
 
     fn fold_constants_into_instruction(

--- a/compiler/noirc_evaluator/src/ssa/opt/constant_folding/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/constant_folding/mod.rs
@@ -277,11 +277,12 @@ impl Context {
                     self.values_to_replace.batch_insert(&old_results, cached);
                     return;
                 }
-                CacheResult::NeedToHoistToCommonBlock(dominator) => {
+                CacheResult::NeedToHoistToCommonBlock { dominator, origin } => {
                     // Just change the block to insert in the common dominator instead.
                     // This will only move the current instance of the instruction right now.
                     // When constant folding is run a second time later on, it'll catch
                     // that the previous instance can be deduplicated to this instance.
+
                     block = dominator;
                 }
             }

--- a/compiler/noirc_evaluator/src/ssa/opt/constant_folding/result_cache.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/constant_folding/result_cache.rs
@@ -187,6 +187,10 @@ impl ResultCache {
         has_side_effects: bool,
     ) -> Option<CacheResult> {
         self.result.as_ref().and_then(|(origin, results)| {
+            if *origin == block {
+                // A revisit of the same block.
+                return None;
+            }
             if dom.dominates(*origin, block) {
                 Some(CacheResult::Cached(results))
             } else if !has_side_effects {

--- a/compiler/noirc_evaluator/src/ssa/visit_once_deque.rs
+++ b/compiler/noirc_evaluator/src/ssa/visit_once_deque.rs
@@ -1,52 +1,58 @@
-use std::collections::{HashSet, VecDeque};
+use std::{
+    collections::{HashSet, VecDeque},
+    hash::Hash,
+};
 
 use crate::ssa::ir::basic_block::BasicBlockId;
 
-/// A wrapper around `VecDeque` to ensure that we never process the same [`BasicBlockId`] more than once.
-#[derive(Debug, Default)]
-pub(crate) struct VisitOnceDeque {
-    visited_blocks: HashSet<BasicBlockId>,
-    block_queue: VecDeque<BasicBlockId>,
+/// A wrapper around `VecDeque` to ensure that we never process the same item more than once.
+#[derive(Debug)]
+pub(crate) struct VisitOnceDeque<T = BasicBlockId> {
+    visited_blocks: HashSet<T>,
+    block_queue: VecDeque<T>,
 }
 
-impl VisitOnceDeque {
-    pub(crate) fn push_back(&mut self, item: BasicBlockId) {
+impl<T: Hash + Eq + Copy> VisitOnceDeque<T> {
+    pub(crate) fn new() -> Self {
+        Self { visited_blocks: HashSet::new(), block_queue: VecDeque::new() }
+    }
+    pub(crate) fn push_back(&mut self, item: T) {
         self.block_queue.push_back(item);
     }
 
-    pub(crate) fn extend<T: IntoIterator<Item = BasicBlockId>>(&mut self, items: T) {
+    pub(crate) fn extend(&mut self, items: impl IntoIterator<Item = T>) {
         self.block_queue.extend(items);
     }
 
-    pub(crate) fn pop_front(&mut self) -> Option<BasicBlockId> {
+    pub(crate) fn pop_front(&mut self) -> Option<T> {
         let item = self.block_queue.pop_front()?;
         if self.visited_blocks.insert(item) { Some(item) } else { self.pop_front() }
     }
 
-    pub(crate) fn pop_back(&mut self) -> Option<BasicBlockId> {
+    pub(crate) fn pop_back(&mut self) -> Option<T> {
         let item = self.block_queue.pop_back()?;
         if self.visited_blocks.insert(item) { Some(item) } else { self.pop_back() }
     }
 }
 
+impl<T: Hash + Eq + Copy> Default for VisitOnceDeque<T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use crate::ssa::{ir::basic_block::BasicBlockId, visit_once_deque::VisitOnceDeque};
+    use crate::ssa::visit_once_deque::VisitOnceDeque;
 
     #[test]
     fn does_not_return_duplicates() {
         let mut deque = VisitOnceDeque::default();
-        deque.extend([
-            BasicBlockId::test_new(0),
-            BasicBlockId::test_new(1),
-            BasicBlockId::test_new(2),
-            BasicBlockId::test_new(0),
-            BasicBlockId::test_new(1),
-        ]);
+        deque.extend([0, 1, 2, 0, 1]);
 
-        assert_eq!(deque.pop_front(), Some(BasicBlockId::test_new(0)));
-        assert_eq!(deque.pop_back(), Some(BasicBlockId::test_new(1)));
-        assert_eq!(deque.pop_front(), Some(BasicBlockId::test_new(2)));
+        assert_eq!(deque.pop_front(), Some(0));
+        assert_eq!(deque.pop_back(), Some(1));
+        assert_eq!(deque.pop_front(), Some(2));
         assert_eq!(deque.pop_front(), None);
         assert_eq!(deque.pop_back(), None);
     }

--- a/compiler/noirc_evaluator/src/ssa/visit_once_deque.rs
+++ b/compiler/noirc_evaluator/src/ssa/visit_once_deque.rs
@@ -16,8 +16,13 @@ impl<T: Hash + Eq + Copy> VisitOnceDeque<T> {
     pub(crate) fn new() -> Self {
         Self { visited_blocks: HashSet::new(), block_queue: VecDeque::new() }
     }
+
     pub(crate) fn push_back(&mut self, item: T) {
         self.block_queue.push_back(item);
+    }
+
+    pub(crate) fn push_front(&mut self, item: T) {
+        self.block_queue.push_front(item);
     }
 
     pub(crate) fn extend(&mut self, items: impl IntoIterator<Item = T>) {
@@ -32,6 +37,11 @@ impl<T: Hash + Eq + Copy> VisitOnceDeque<T> {
     pub(crate) fn pop_back(&mut self) -> Option<T> {
         let item = self.block_queue.pop_back()?;
         if self.visited_blocks.insert(item) { Some(item) } else { self.pop_back() }
+    }
+
+    /// Forget whether we visited a specific item.
+    pub(crate) fn clear_visited(&mut self, item: &T) {
+        self.visited_blocks.remove(item);
     }
 }
 
@@ -55,5 +65,20 @@ mod tests {
         assert_eq!(deque.pop_front(), Some(2));
         assert_eq!(deque.pop_front(), None);
         assert_eq!(deque.pop_back(), None);
+    }
+
+    #[test]
+    fn can_clear_visited() {
+        let mut deque = VisitOnceDeque::default();
+        deque.extend([0, 1, 2]);
+
+        assert_eq!(deque.pop_front(), Some(0));
+        deque.push_front(0);
+        assert_eq!(deque.pop_front(), Some(1));
+        deque.clear_visited(&1);
+        deque.push_front(1);
+        assert_eq!(deque.pop_front(), Some(1));
+        assert_eq!(deque.pop_front(), Some(2));
+        assert_eq!(deque.pop_front(), None);
     }
 }


### PR DESCRIPTION
# Description

## Problem\*

Resolves #9963 

## Summary\*

Changes `constant_folding` to schedule revisits of blocks under the following circumstances:
* Say we have CFG like `b0 -> [b1, b2]`. When in `b2` we find a duplicate instruction from `b1` and hoist the instruction from `b2` to the common denominator `b0`, schedule a revisit of `b1` and then `b2`, so that we can deduplicate the instruction in `b1` with that of `b0` and then we can look for any instruction that we can now again hoist from `b2` or `b1` into `b0`. 
* Say we have a CFG like `b0 -> [b1 -> b2, b3]`, and we replaced an instruction in `b2` with the results of its duplicate in `b1`, then we found another duplicate of the one `b1` in `b3`. We hoisted the instruction from `b3` into `b0`, and revisited `b1`, where we replaced it with the instruction now in `b0`. Then, revisit `b2` again as a dependant of `b1`, so that we can deduplicate that too. 

Fixes `simplify` to not insert a new result if the instruction simplified to itself (can happen with `Binary`: instead of `None` it returns `SimplifiedToInstruction(maybe-self)`).

TODO: 
- Add a test that checks whether indirect dependants need to be revisited.
- Investigate the long compilation time involving Poseidon hashes in `regression_5252` and `fold_2_to_17`
- Think of some limit to how many times we can trigger revisits.

## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
