### PR TITLE
fix(mem2reg): consider call return aliases

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/opt/mem2reg.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/mem2reg.rs
@@ -2443,10 +2443,6 @@ mod tests {
             return v0
         }
         ";
-        let ssa = Ssa::from_str(src).unwrap();
-        let ssa = ssa.mem2reg();
-        println!("{}", ssa);
-
         assert_ssa_does_not_change(src, Ssa::mem2reg);
     }
 
@@ -2472,7 +2468,6 @@ mod tests {
             return v0
         }
         ";
-
         assert_ssa_does_not_change(src, Ssa::mem2reg);
     }
 
@@ -2497,7 +2492,6 @@ mod tests {
             return v0
         }
         ";
-
         assert_ssa_does_not_change(src, Ssa::mem2reg);
     }
 }


### PR DESCRIPTION
# Description

## Problem

Resolves #10001

## Summary

I started with a very naive solution to this. I originally tried to alias return values to arguments but noticed that it didn't work with arrays... so I went with the more pessimistic solution.

Here I want to see if the benchmarks degrade. I'll try later to do something a bit more optimal in case there are no nested references.

Edit: no benchmark changes so I think this PR is good as it is. I can capture an issue to improve the performance for the case I mentioned, if needed. Let me know!

## Additional Context



## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
