### PR TITLE
fix(parser): enforce left brace after match expression

### DIFF
--- a/compiler/noirc_frontend/src/ast/expression.rs
+++ b/compiler/noirc_frontend/src/ast/expression.rs
@@ -798,7 +798,7 @@ impl Display for MatchExpression {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         writeln!(f, "match {} {{", self.expression)?;
         for (pattern, branch) in &self.rules {
-            writeln!(f, "    {pattern} -> {branch},")?;
+            writeln!(f, "    {pattern} => {branch},")?;
         }
         write!(f, "}}")
     }

--- a/compiler/noirc_frontend/src/parser/parser/expression.rs
+++ b/compiler/noirc_frontend/src/parser/parser/expression.rs
@@ -596,7 +596,7 @@ impl Parser<'_> {
 
         let expression = self.parse_expression_except_constructor_or_error();
 
-        if !self.eat_left_bracket() {
+        if !self.eat_left_brace() {
             self.expected_token(Token::LeftBrace);
             return Some(ExpressionKind::Error);
         }


### PR DESCRIPTION
# Description

## Problem

Resolves #9911

## Summary

The code in the issue should have produced an error but didn't.

## Additional Context



## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
