### PR TITLE
feat(ssa): `constant_folding` with loop

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/builder.rs
+++ b/compiler/noirc_evaluator/src/ssa/builder.rs
@@ -185,12 +185,12 @@ impl<'local> SsaBuilder<'local> {
     }
 
     fn print(mut self, msg: &str) -> Self {
+        let print_ssa_pass = self.ssa_logging.matches(msg);
+
         // Always normalize if we are going to print at least one of the passes
         if !matches!(self.ssa_logging, SsaLogging::None) {
             self.ssa.normalize_ids();
         }
-
-        let print_ssa_pass = self.ssa_logging.matches(msg);
 
         if print_ssa_pass {
             println_to_stdout!("After {msg}:\n{}", self.ssa.print_with(self.files));

--- a/compiler/noirc_evaluator/src/ssa/visit_once_deque.rs
+++ b/compiler/noirc_evaluator/src/ssa/visit_once_deque.rs
@@ -21,10 +21,6 @@ impl<T: Hash + Eq + Copy> VisitOnceDeque<T> {
         self.block_queue.push_back(item);
     }
 
-    pub(crate) fn push_front(&mut self, item: T) {
-        self.block_queue.push_front(item);
-    }
-
     pub(crate) fn extend(&mut self, items: impl IntoIterator<Item = T>) {
         self.block_queue.extend(items);
     }
@@ -37,16 +33,6 @@ impl<T: Hash + Eq + Copy> VisitOnceDeque<T> {
     pub(crate) fn pop_back(&mut self) -> Option<T> {
         let item = self.block_queue.pop_back()?;
         if self.visited_blocks.insert(item) { Some(item) } else { self.pop_back() }
-    }
-
-    /// Forget whether we visited a specific item.
-    pub(crate) fn clear_visited(&mut self, item: &T) {
-        self.visited_blocks.remove(item);
-    }
-
-    /// Forget all visits.
-    pub(crate) fn clear_all_visited(&mut self) {
-        self.visited_blocks.clear();
     }
 }
 
@@ -70,20 +56,5 @@ mod tests {
         assert_eq!(deque.pop_front(), Some(2));
         assert_eq!(deque.pop_front(), None);
         assert_eq!(deque.pop_back(), None);
-    }
-
-    #[test]
-    fn can_clear_visited() {
-        let mut deque = VisitOnceDeque::default();
-        deque.extend([0, 1, 2]);
-
-        assert_eq!(deque.pop_front(), Some(0));
-        deque.push_front(0);
-        assert_eq!(deque.pop_front(), Some(1));
-        deque.clear_visited(&1);
-        deque.push_front(1);
-        assert_eq!(deque.pop_front(), Some(1));
-        assert_eq!(deque.pop_front(), Some(2));
-        assert_eq!(deque.pop_front(), None);
     }
 }


### PR DESCRIPTION
# Description

## Problem\*

Resolves #9963 

## Summary\*

Alternative to https://github.com/noir-lang/noir/pull/10013 that works more in line with the "restart from" idea in https://github.com/noir-lang/noir/issues/9963#issuecomment-3325625432

During constant folding when we encounter a block `b2` that repeats an instruction from `b1`, and hoists it into the common dominator `b0`, then we remember that after the current folding iteration is over, we should revisit `b1` to deduplicate whatever that instruction was with the one now in `b0`, but before that visit `b0` as well, because we need to rebuild the cache in order for the deduplication to happen in `b1`.

Once the current iteration is finished, we find the common dominator of all the blocks that got anything hoisted, and start another iteration from there.

## Additional Context

The revisit mechanism in #10013 was difficult to reason about, and although tests were green, some aztec-protocol contracts still hit ICE with unmapped instructions. I reckon the reason was that the cache was visible in revisits, so in a CFG like `b0 -> b1 -> [b2, b3] -> b4` if we revisited b1 we saw instructions cached by b4, and started hoisting them into b0, or earlier versions of themselves. 

In this version the cache is cleared and rebuilt from scratch in each iteration, so blocks should only see the ones that preceded them, but not themselves, for example.

It is also easier to reason about how to limit how many times we go over the graph.

## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
