### PR TITLE
chore(acir): avoid duplication when invoking brillig stdlib call

### DIFF
--- a/compiler/noirc_evaluator/src/acir/acir_context/brillig_call.rs
+++ b/compiler/noirc_evaluator/src/acir/acir_context/brillig_call.rs
@@ -17,10 +17,10 @@ impl<F: AcirField> AcirContext<F> {
         &mut self,
         predicate: AcirVar,
         brillig_stdlib_func: BrilligStdlibFunc,
-        stdlib_func_bytecode: &GeneratedBrillig<F>,
         inputs: Vec<AcirValue>,
         outputs: Vec<AcirType>,
     ) -> Result<Vec<AcirValue>, RuntimeError> {
+        let stdlib_func_bytecode = &self.brillig_stdlib.get_code(brillig_stdlib_func).clone();
         self.brillig_call(
             predicate,
             stdlib_func_bytecode,

--- a/compiler/noirc_evaluator/src/acir/acir_context/mod.rs
+++ b/compiler/noirc_evaluator/src/acir/acir_context/mod.rs
@@ -288,7 +288,6 @@ impl<F: AcirField> AcirContext<F> {
         let results = self.stdlib_brillig_call(
             predicate,
             BrilligStdlibFunc::Inverse,
-            &self.brillig_stdlib.get_code(BrilligStdlibFunc::Inverse).clone(),
             vec![AcirValue::Var(var, AcirType::field())],
             vec![AcirType::field()],
         )?;
@@ -882,7 +881,6 @@ impl<F: AcirField> AcirContext<F> {
             .stdlib_brillig_call(
                 predicate,
                 BrilligStdlibFunc::Quotient,
-                &self.brillig_stdlib.get_code(BrilligStdlibFunc::Quotient).clone(),
                 vec![
                     AcirValue::Var(lhs, AcirType::unsigned(bit_size)),
                     AcirValue::Var(rhs, AcirType::unsigned(bit_size)),


### PR DESCRIPTION
# Description

## Problem

No issue, just a tiny thing I noticed while auditing ACIR.

## Summary



## Additional Context



## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
