### PR TITLE
chore: Use 8 partitions for rust tests

### DIFF
--- a/.github/workflows/test-rust-workspace-arm64.yml
+++ b/.github/workflows/test-rust-workspace-arm64.yml
@@ -63,7 +63,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        partition: [1, 2, 3, 4]
+        partition: [1, 2, 3, 4, 5, 6, 7, 8]
     steps:
       - uses: actions/checkout@v5
 
@@ -85,7 +85,7 @@ jobs:
         run: |
           RUST_MIN_STACK=8388608 \
           cargo nextest run --archive-file nextest-archive-arm64.tar.zst \
-            --partition count:${{ matrix.partition }}/4 \
+            --partition count:${{ matrix.partition }}/8 \
             --profile ci-master
 
   # This is a job which depends on all test jobs and reports the overall status.

--- a/.github/workflows/test-rust-workspace-msrv.yml
+++ b/.github/workflows/test-rust-workspace-msrv.yml
@@ -77,7 +77,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        partition: [1, 2, 3, 4]
+        partition: [1, 2, 3, 4, 5, 6, 7, 8]
     steps:
       - uses: actions/checkout@v5
 
@@ -99,7 +99,7 @@ jobs:
         run: |
           RUST_MIN_STACK=8388608 \
           cargo nextest run --archive-file nextest-archive.tar.zst \
-            --partition count:${{ matrix.partition }}/4 \
+            --partition count:${{ matrix.partition }}/8 \
             --profile ci-master
 
   # This is a job which depends on all test jobs and reports the overall status.

--- a/.github/workflows/test-rust-workspace.yml
+++ b/.github/workflows/test-rust-workspace.yml
@@ -64,7 +64,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        partition: [1, 2, 3, 4]
+        partition: [1, 2, 3, 4, 5, 6, 7, 8]
     steps:
       - uses: actions/checkout@v5
 
@@ -87,7 +87,7 @@ jobs:
           echo "Running with profile: $NEXTEST_PROFILE"
           RUST_MIN_STACK=8388608 \
           cargo nextest run --archive-file nextest-archive.tar.zst \
-            --partition count:${{ matrix.partition }}/4 \
+            --partition count:${{ matrix.partition }}/8 \
             --profile $NEXTEST_PROFILE
         env:
           NEXTEST_PROFILE: ${{ (github.event_name == 'merge_group' && 'merge-queue') || (github.ref == 'refs/heads/master' && 'ci-master') || 'ci' }}


### PR DESCRIPTION
# Description

## Problem\*

Several PRs were timing out, e.g: https://github.com/noir-lang/noir/pull/9967 so I'm dividing rust tests into 8 partitions instead of increasing the time out limit.

## Summary\*



## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
