### PR TITLE
fix(ssa): SSA interpreter to use the 2nd arg in `slice_refcount`

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/interpreter/intrinsics.rs
+++ b/compiler/noirc_evaluator/src/ssa/interpreter/intrinsics.rs
@@ -453,7 +453,9 @@ impl<W: Write> Interpreter<'_, W> {
                 Ok(vec![Value::bool(lhs < rhs)])
             }
             Intrinsic::ArrayRefCount | Intrinsic::SliceRefCount => {
-                let array = self.lookup_array_or_slice(args[0], "array/slice ref count")?;
+                // `slice_refcount` receives `[length, array]` as input. `array_refcount` gets just `[array]`
+                let idx = if matches!(intrinsic, Intrinsic::SliceRefCount) { 1 } else { 0 };
+                let array = self.lookup_array_or_slice(args[idx], "array/slice ref count")?;
                 let mut rc = *array.rc.borrow();
                 // ACIR always returns 0 for the refcounts, and we expect that IncRc and DecRc don't appear in constrained SSA.
                 // The interpreter starts with a default ref-count value of 1. If it did not change, treat it as zero to match ACIR.

--- a/compiler/noirc_evaluator/src/ssa/interpreter/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/interpreter/mod.rs
@@ -381,8 +381,7 @@ impl<'ssa, W: Write> Interpreter<'ssa, W> {
     }
 
     fn lookup_bytes(&self, value_id: ValueId, instruction: &'static str) -> IResult<Vec<u8>> {
-        let array =
-            self.lookup_helper(value_id, instruction, "array or slice", Value::as_array_or_slice)?;
+        let array = self.lookup_array_or_slice(value_id, instruction)?;
         let array = array.elements.borrow();
         array
             .iter()
@@ -400,8 +399,7 @@ impl<'ssa, W: Write> Interpreter<'ssa, W> {
     }
 
     fn lookup_vec_u32(&self, value_id: ValueId, instruction: &'static str) -> IResult<Vec<u32>> {
-        let array =
-            self.lookup_helper(value_id, instruction, "array or slice", Value::as_array_or_slice)?;
+        let array = self.lookup_array_or_slice(value_id, instruction)?;
         let array = array.elements.borrow();
         array
             .iter()
@@ -419,8 +417,7 @@ impl<'ssa, W: Write> Interpreter<'ssa, W> {
     }
 
     fn lookup_vec_u64(&self, value_id: ValueId, instruction: &'static str) -> IResult<Vec<u64>> {
-        let array =
-            self.lookup_helper(value_id, instruction, "array or slice", Value::as_array_or_slice)?;
+        let array = self.lookup_array_or_slice(value_id, instruction)?;
         let array = array.elements.borrow();
         array
             .iter()
@@ -442,8 +439,7 @@ impl<'ssa, W: Write> Interpreter<'ssa, W> {
         value_id: ValueId,
         instruction: &'static str,
     ) -> IResult<Vec<FieldElement>> {
-        let array =
-            self.lookup_helper(value_id, instruction, "array or slice", Value::as_array_or_slice)?;
+        let array = self.lookup_array_or_slice(value_id, instruction)?;
         let array = array.elements.borrow();
         array
             .iter()

--- a/compiler/noirc_evaluator/src/ssa/ir/instruction.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/instruction.rs
@@ -131,7 +131,7 @@ pub enum Intrinsic {
     /// in constrained context, it will be 0.
     ArrayRefCount,
     /// SliceRefCount - Gives the reference count of the slice
-    /// argument: slice (value id)
+    /// arguments: slice length, slice contents (value id)
     /// result: reference count of `slice`. In unconstrained context, the reference count is stored alongside the slice.
     /// in constrained context, it will be 0.
     SliceRefCount,


### PR DESCRIPTION
# Description

## Problem\*

Resolves #9925 

## Summary\*

Fixes the SSA interpreter handling of `Intrinsic::SliceRefCount` to use `arg[1]` instead of `arg[0]`, because ref-count gets both the slice length and the slice. 

## Additional Context

Even though `slice_refcount` doesn't _need_ the length to do its job, all other intrinsic `slice_*` operations take the length and the slice, which is why I suppose this was no exception. Having two arguments is part of the [SSA validation](https://github.com/noir-lang/noir/blob/39f193cf14d97b200611dd6f6c9dac42f52b0b63/compiler/noirc_evaluator/src/ssa/validation/mod.rs#L599-L603) as well, and this is how Brillig codegen expects it, so it's probably no accident.

## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
