### PR TITLE
chore: typos and some refactors in `acvm/src/pwg/mod.rs`

### DIFF
--- a/acvm-repo/acvm/tests/solver.rs
+++ b/acvm-repo/acvm/tests/solver.rs
@@ -50,7 +50,7 @@ fn bls12_381_circuit() {
     let mut acvm = ACVM::new(&solver, &opcodes, witness_assignments, &[], &[]);
     // use the partial witness generation solver with our acir program
     let solver_status = acvm.solve();
-    assert_eq!(solver_status, ACVMStatus::Solved, "should be fully solved");
+    assert_eq!(solver_status, &ACVMStatus::Solved, "should be fully solved");
 
     // ACVM should be able to be finalized in `Solved` state.
     let witness_stack = acvm.finalize();
@@ -192,7 +192,7 @@ fn inversion_brillig_oracle_equivalence() {
 
     // After filling data request, continue solving
     let solver_status = acvm.solve();
-    assert_eq!(solver_status, ACVMStatus::Solved, "should be fully solved");
+    assert_eq!(solver_status, &ACVMStatus::Solved, "should be fully solved");
 
     // ACVM should be able to be finalized in `Solved` state.
     acvm.finalize();
@@ -372,7 +372,7 @@ fn double_inversion_brillig_oracle() {
 
     // After filling data request, continue solving
     let solver_status = acvm.solve();
-    assert_eq!(solver_status, ACVMStatus::Solved, "should be fully solved");
+    assert_eq!(solver_status, &ACVMStatus::Solved, "should be fully solved");
 
     // ACVM should be able to be finalized in `Solved` state.
     acvm.finalize();
@@ -524,7 +524,7 @@ fn oracle_dependent_execution() {
 
     // After filling data request, continue solving
     let solver_status = acvm.solve();
-    assert_eq!(solver_status, ACVMStatus::Solved, "should be fully solved");
+    assert_eq!(solver_status, &ACVMStatus::Solved, "should be fully solved");
 
     // ACVM should be able to be finalized in `Solved` state.
     acvm.finalize();
@@ -606,7 +606,7 @@ fn brillig_oracle_predicate() {
     let unconstrained_functions = vec![brillig_bytecode];
     let mut acvm = ACVM::new(&solver, &opcodes, witness_assignments, &unconstrained_functions, &[]);
     let solver_status = acvm.solve();
-    assert_eq!(solver_status, ACVMStatus::Solved, "should be fully solved");
+    assert_eq!(solver_status, &ACVMStatus::Solved, "should be fully solved");
 
     // ACVM should be able to be finalized in `Solved` state.
     acvm.finalize();
@@ -644,7 +644,7 @@ fn unsatisfied_opcode_resolved() {
     let solver_status = acvm.solve();
     assert_eq!(
         solver_status,
-        ACVMStatus::Failure(OpcodeResolutionError::UnsatisfiedConstrain {
+        &ACVMStatus::Failure(OpcodeResolutionError::UnsatisfiedConstrain {
             opcode_location: ErrorLocation::Resolved(OpcodeLocation::Acir(0)),
             payload: None
         }),
@@ -769,7 +769,7 @@ fn unsatisfied_opcode_resolved_brillig() {
     let solver_status = acvm.solve();
     assert_eq!(
         solver_status,
-        ACVMStatus::Failure(OpcodeResolutionError::BrilligFunctionFailed {
+        &ACVMStatus::Failure(OpcodeResolutionError::BrilligFunctionFailed {
             function_id: BrilligFunctionId(0),
             payload: None,
             call_stack: vec![OpcodeLocation::Brillig { acir_index: 0, brillig_index: 6 }]
@@ -815,7 +815,7 @@ fn memory_operations() {
     let unconstrained_functions = vec![];
     let mut acvm = ACVM::new(&solver, &opcodes, initial_witness, &unconstrained_functions, &[]);
     let solver_status = acvm.solve();
-    assert_eq!(solver_status, ACVMStatus::Solved);
+    assert_eq!(solver_status, &ACVMStatus::Solved);
     let witness_map = acvm.finalize();
 
     assert_eq!(witness_map[&Witness(8)], FieldElement::from(6u128));
@@ -894,7 +894,7 @@ where
     let unconstrained_functions = vec![];
     let mut acvm = ACVM::new(&solver, &opcodes, initial_witness, &unconstrained_functions, &[]);
     let solver_status = acvm.solve();
-    assert_eq!(solver_status, ACVMStatus::Solved);
+    assert_eq!(solver_status, &ACVMStatus::Solved);
     let witness_map = acvm.finalize();
 
     Ok(outputs
@@ -940,7 +940,7 @@ fn solve_blackbox_func_call(
     let unconstrained_functions = vec![];
     let mut acvm = ACVM::new(&solver, &opcodes, initial_witness, &unconstrained_functions, &[]);
     let solver_status = acvm.solve();
-    assert_eq!(solver_status, ACVMStatus::Solved);
+    assert_eq!(solver_status, &ACVMStatus::Solved);
     let witness_map = acvm.finalize();
 
     Ok(witness_map[&Witness(3)])

--- a/acvm-repo/acvm_js/src/execute.rs
+++ b/acvm-repo/acvm_js/src/execute.rs
@@ -241,7 +241,7 @@ impl<'a, B: BlackBoxFunctionSolver<FieldElement>> ProgramExecutor<'a, B> {
             );
 
             loop {
-                let solver_status = acvm.solve();
+                let solver_status = acvm.solve().clone();
 
                 match solver_status {
                     ACVMStatus::Solved => break,
@@ -314,12 +314,12 @@ impl<'a, B: BlackBoxFunctionSolver<FieldElement>> ProgramExecutor<'a, B> {
                     }
                     ACVMStatus::RequiresAcirCall(call_info) => {
                         let acir_to_call = &self.functions[call_info.id.as_usize()];
-                        let initial_witness = call_info.initial_witness;
+                        let initial_witness = &call_info.initial_witness;
                         let call_solved_witness = self
                             .execute_circuit(
                                 acir_to_call,
                                 call_info.id,
-                                initial_witness,
+                                initial_witness.clone(),
                                 witness_stack,
                             )
                             .await?;

--- a/compiler/noirc_evaluator/src/acir/tests/mod.rs
+++ b/compiler/noirc_evaluator/src/acir/tests/mod.rs
@@ -291,7 +291,7 @@ fn execute_ssa(
         &brillig_functions,
         &[],
     );
-    let status = acvm.solve();
+    let status = acvm.solve().clone();
     if status == ACVMStatus::Solved {
         (status, output.map(|o| acvm.witness_map()[o]))
     } else {

--- a/tooling/nargo/src/ops/execute.rs
+++ b/tooling/nargo/src/ops/execute.rs
@@ -116,7 +116,7 @@ impl<'a, F: AcirField, B: BlackBoxFunctionSolver<F>, E: ForeignCallExecutor<F>>
         acvm.with_brillig_fuzzing(self.brillig_branch_to_feature_map);
 
         loop {
-            let solver_status = acvm.solve();
+            let solver_status = acvm.solve().clone();
 
             match solver_status {
                 ACVMStatus::Solved => break,
@@ -159,7 +159,7 @@ impl<'a, F: AcirField, B: BlackBoxFunctionSolver<F>, E: ForeignCallExecutor<F>>
                     };
 
                     return Err(NargoError::ExecutionError(execution_error_from(
-                        error,
+                        error.clone(),
                         &self.call_stack,
                     )));
                 }


### PR DESCRIPTION
# Description

## Problem\*


## Summary\*

- Typos and updating some comments
- https://github.com/noir-lang/noir/issues/10053
- Deduplicating documentation for `Opcode` [here](https://github.com/noir-lang/noir/blob/cf7dbf1659809f13a556ab42bb57e9fbe3b2f1e0/acvm-repo/acvm/src/pwg/mod.rs#L32) and  [here](https://github.com/noir-lang/noir/blob/cf7dbf1659809f13a556ab42bb57e9fbe3b2f1e0/acvm-repo/acir/src/circuit/opcodes.rs#L49)
- https://github.com/noir-lang/noir/issues/10052
- Removing `.clone()` from `ACVM::solve` https://github.com/noir-lang/noir/blob/4a54015da396e2df656f64fc5b3b587639ad85c8/acvm-repo/acvm/src/pwg/mod.rs#L501 
- `self.current_opcode()` util function
- Refactoring `solve_brillig_call_opcode` and `solve_call_opcode` to accept the opcode that’s already been indexed to avoid having an `unreachable` case https://github.com/noir-lang/noir/blob/4a54015da396e2df656f64fc5b3b587639ad85c8/acvm-repo/acvm/src/pwg/mod.rs#L530 

## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [x] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
