### PR TITLE
chore: use new ACIR syntax in docs, and some tests

### DIFF
--- a/acvm-repo/acvm/src/compiler/optimizers/general.rs
+++ b/acvm-repo/acvm/src/compiler/optimizers/general.rs
@@ -19,11 +19,11 @@ impl GeneralOptimizer {
     }
 }
 
-/// Simplifies all mul terms of the form `(scale, w_l, w_r)` with the same bi-variate variables
+/// Simplifies all mul terms of the form `scale*w1*w2` with the same bi-variate variables
 /// while also removing terms that end up with a zero coefficient.
 ///
-/// For instance, mul terms `(0,1,1), (2,2,1) (-1,2,1) (-1,1,2)` will return an
-/// empty vector, because: (2,1) and (1,2) are the same bi-variate variable
+/// For instance, mul terms `0*w1*w1 + 2*w2*w1 - w2*w1 - w1*w2` will return an
+/// empty vector, because: w1*w2 and w2*w1 are the same bi-variate variable
 /// and the resulting scale is `2-1-1 = 0`
 fn simplify_mul_terms<F: AcirField>(mut gate: Expression<F>) -> Expression<F> {
     let mut hash_map: IndexMap<(Witness, Witness), F> = IndexMap::new();

--- a/acvm-repo/acvm/src/compiler/optimizers/merge_expressions.rs
+++ b/acvm-repo/acvm/src/compiler/optimizers/merge_expressions.rs
@@ -38,11 +38,15 @@ impl<F: AcirField> MergeExpressionsOptimizer<F> {
     /// The second pass looks for AssertZero opcodes having a witness which is only used by another arithmetic opcode.
     /// In that case, the opcode with the smallest index is merged into the other one via Gaussian elimination.
     /// For instance, if we have 'w1' used only by these two opcodes,
-    /// where `(5,w2,w3)` refers the expression `5*w2*w3` and `(2, w1)` refers to the expression `2*w1`:
-    /// [(1, w2,w3), (2, w2), (2, w1), (1, w3)] // This opcode 'defines' the variable w1
-    /// [(2, w3, w4), (2,w1), (1, w4)]          // which is only used here
-    /// We will remove the first one and modify the second one like this:
-    /// [(2, w3, w4), (1, w4), (-1, w2), (-1/2, w3), (-1/2, w2, w3)]
+    /// `5*w2*w3` and `w1`:
+    /// w2*w3 + 2*w2 + w1 + w3 = 0   // This opcode 'defines' the variable w1
+    /// 2*w3*w4 + w1 + w4 = 0        // which is only used here
+    ///
+    /// For w1 we can say:
+    /// w1 = -1/2*w2*w3 - w2 - 1/2*w3
+    ///
+    /// Then we will remove the first one and modify the second one like this:
+    /// 2*w3*w4 + w4 - w2 - 1/2*w3 - 1/2*w2*w3 = 0
     ///
     /// This transformation is relevant for Plonk-ish backends although they have a limited width because
     /// they can potentially handle expressions with large linear combinations using 'big-add' gates.

--- a/acvm-repo/acvm/src/compiler/optimizers/unused_memory.rs
+++ b/acvm-repo/acvm/src/compiler/optimizers/unused_memory.rs
@@ -76,12 +76,9 @@ impl<F: AcirField> UnusedMemoryOptimizer<F> {
 
 #[cfg(test)]
 mod tests {
+    use crate::assert_circuit_snapshot;
+
     use super::*;
-    use acir::{
-        FieldElement,
-        circuit::opcodes::BlockType,
-        native_types::{Expression, Witness},
-    };
 
     #[test]
     fn unused_memory_is_removed() {
@@ -89,30 +86,19 @@ mod tests {
         private parameters: [w0, w1]
         public parameters: []
         return values: [w2]
+        INIT b0 = [w0, w1]
+        ASSERT w0 - w1 - w2 = 0
         ";
-        let mut circuit = Circuit::from_str(src).unwrap();
-        // MEMORYINIT [w0, w1]
-        // EXPR [ (1, w0) (-1, w1) (-1, w2) 0 ]
-        circuit.opcodes = vec![
-            Opcode::MemoryInit {
-                block_id: BlockId(0),
-                init: vec![Witness(0), Witness(1)],
-                block_type: BlockType::Memory,
-            },
-            Opcode::AssertZero(Expression {
-                mul_terms: Vec::new(),
-                linear_combinations: vec![
-                    (FieldElement::from(1_u128), Witness(0)),
-                    (FieldElement::from(-1_i128), Witness(1)),
-                    (FieldElement::from(-1_i128), Witness(2)),
-                ],
-                q_c: FieldElement::from(0u128),
-            }),
-        ];
+        let circuit = Circuit::from_str(src).unwrap();
         let unused_memory = UnusedMemoryOptimizer::new(circuit);
         assert_eq!(unused_memory.unused_memory_initializations.len(), 1);
         let (circuit, _) = unused_memory.remove_unused_memory_initializations(vec![0, 1]);
-        assert_eq!(circuit.opcodes.len(), 1);
+        assert_circuit_snapshot!(circuit, @r"
+        private parameters: [w0, w1]
+        public parameters: []
+        return values: [w2]
+        ASSERT w2 = w0 - w1
+        ");
     }
 
     #[test]
@@ -121,29 +107,13 @@ mod tests {
         private parameters: [w0, w1]
         public parameters: []
         return values: [w2]
+        INIT RETURNDATA b0 = [w0, w1]
+        ASSERT w2 = w0 - w1
         ";
-        let mut circuit = Circuit::from_str(src).unwrap();
-        // MEMORYINIT [w0, w1]
-        // EXPR [ (1, w0) (-1, w1) (-1, w2) 0 ]
-        circuit.opcodes = vec![
-            Opcode::MemoryInit {
-                block_id: BlockId(0),
-                init: vec![Witness(0), Witness(1)],
-                block_type: BlockType::ReturnData,
-            },
-            Opcode::AssertZero(Expression {
-                mul_terms: Vec::new(),
-                linear_combinations: vec![
-                    (FieldElement::from(1_u128), Witness(0)),
-                    (FieldElement::from(-1_i128), Witness(1)),
-                    (FieldElement::from(-1_i128), Witness(2)),
-                ],
-                q_c: FieldElement::from(0u128),
-            }),
-        ];
-        let unused_memory = UnusedMemoryOptimizer::new(circuit);
+        let circuit = Circuit::from_str(src).unwrap();
+        let unused_memory = UnusedMemoryOptimizer::new(circuit.clone());
         assert_eq!(unused_memory.unused_memory_initializations.len(), 1);
-        let (circuit, _) = unused_memory.remove_unused_memory_initializations(vec![0, 1]);
-        assert_eq!(circuit.opcodes.len(), 2);
+        let (optimized_circuit, _) = unused_memory.remove_unused_memory_initializations(vec![0, 1]);
+        assert_eq!(optimized_circuit, circuit);
     }
 }

--- a/acvm-repo/acvm/src/pwg/mod.rs
+++ b/acvm-repo/acvm/src/pwg/mod.rs
@@ -52,21 +52,20 @@
 //! Example:
 // Compiled ACIR for main (non-transformed):
 // func 0
-// current witness: w9
 // private parameters: [w0, w1, w2, w3, w4]
 // public parameters: []
 // return values: [w9]
-// BLACKBOX::RANGE [w0]:32 bits []
-// BLACKBOX::RANGE [w1]:32 bits []
-// BLACKBOX::RANGE [w2]:32 bits []
-// BLACKBOX::RANGE [w3]:32 bits []
-// BLACKBOX::RANGE [w4]:32 bits []
-// EXPR [ (1, w0) (-1, w1) (-1, w6) 0 ]
-// BRILLIG CALL func 0: inputs: [EXPR [ (1, w6) 0 ]], outputs: [w7]
-// EXPR [ (1, w6, w7) (1, w8) -1 ]
-// EXPR [ (1, w6, w8) 0 ]
-// EXPR [ (1, w1, w8) 0 ]
-// EXPR [ (1, w0) (-1, w2) (-1, w9) 0 ]
+// BLACKBOX::RANGE input: w0, bits: 32
+// BLACKBOX::RANGE input: w1, bits: 32
+// BLACKBOX::RANGE input: w2, bits: 32
+// BLACKBOX::RANGE input: w3, bits: 32
+// BLACKBOX::RANGE input: w4, bits: 32
+// ASSERT w0 - w1 - w6 = 0
+// BRILLIG CALL func: 0, inputs: [w6], outputs: [w7]
+// ASSERT w6*w7 + w8 - 1 = 0
+// ASSERT w6*w8 = 0
+// ASSERT w1*w8 = 0
+// ASSERT w0 - w2 - w9 = 0
 //!
 //! This ACIR program defines the 'main' function and indicates it is 'non-transformed'.
 //! Indeed, some ACIR pass can transform the ACIR program in order to apply optimisations,
@@ -81,7 +80,7 @@
 //! The first ACIR opcodes are RANGE opcodes which ensure the inputs have the expected range (as specified in the Noir source code).
 //! Solving this black-box simply means to validate that the values (from `initial_witness`) are indeed 32 bits for w0, w1, w2, w3, w4
 //! If `initial_witness` does not have values for w0, w1, w2, w3, w4, or if the values are over 32 bits, the execution will fail.
-//! The next opcode is an AssertZero opcode: EXPR [ (1, w0) (-1, w1) (-1, w6) 0 ], which indicates that `w0 - w1 - w6` should be equal to 0.
+//! The next opcode is an AssertZero opcode: ASSERT w0 - w1 - w6 = 0, which indicates that `w0 - w1 - w6` should be equal to 0.
 //! Since we know the values of `w0, w1` from `initial_witness`, we can compute `w6 = w0 + w1` so that the AssertZero is satified.
 //! Solving AssertZero means computing the unknown witness and adding the result to `initial_witness`, which now contains the value for `w6`.
 //! The next opcode is a Brillig Call where input is `w6` and output is `w7`. From the function id of the opcode, the solver will retrieve the


### PR DESCRIPTION
# Description

## Problem

No issue, just part of auditing.

## Summary

Note: I don't want to run `GeneralOptimizer` on `merge_expressions`. However, for the test I wrote it fails because it ends up generating:

```
ASSERT w2 = -4*w1 + 2*w0 + 4*w1 + 14
```

and that can't be solved (though I think it should?)

That said, I don't know how merge expressions is working right now if in this example it ends up adding and subtracting the same expression, which ends up not being solvable.

## Additional Context



## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
