### PR TITLE
fix(fuzzer): Mark DivisionByZero with different types as equivalent

### DIFF
--- a/tooling/ast_fuzzer/src/compare/interpreted.rs
+++ b/tooling/ast_fuzzer/src/compare/interpreted.rs
@@ -210,6 +210,10 @@ impl Comparable for ssa::interpreter::errors::InterpreterError {
                     msg == "attempt to divide by zero" || msg.contains("divisor of zero")
                 })
             }
+            (DivisionByZero { .. }, DivisionByZero { .. }) => {
+                // Signed math in ACIR is expanded to unsigned math. We may have two different `DivisionByZero` errors due to differing types.
+                true
+            }
             (PoppedFromEmptySlice { .. }, ConstrainEqFailed { msg, .. }) => {
                 // The removal of unreachable instructions can replace popping from an empty slice with an always-fail constraint.
                 msg.as_ref().is_some_and(|msg| msg == "Index out of bounds")


### PR DESCRIPTION
# Description

## Problem\*

Resolves #10065

## Summary\*

Signed math in ACIR is expanded to unsigned math. We may have two different `DivisionByZero` errors due to differing types.

## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [X] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
