### PR TITLE
chore(ACVM): use Vec instead of Hash for memory blocks

### DIFF
--- a/acvm-repo/acvm/src/pwg/brillig.rs
+++ b/acvm-repo/acvm/src/pwg/brillig.rs
@@ -133,11 +133,7 @@ impl<'b, B: BlackBoxFunctionSolver<F>, F: AcirField> BrilligSolver<'b, F, B> {
                     let memory_block = memory
                         .get(block_id)
                         .ok_or(OpcodeNotSolvable::MissingMemoryBlock(block_id.0))?;
-                    for memory_index in 0..memory_block.block_len {
-                        let memory_value = memory_block
-                            .block_value
-                            .get(&memory_index)
-                            .expect("All memory is initialized on creation");
+                    for memory_value in memory_block.block_value.iter() {
                         calldata.push(*memory_value);
                     }
                 }

--- a/acvm-repo/acvm/src/pwg/mod.rs
+++ b/acvm-repo/acvm/src/pwg/mod.rs
@@ -604,12 +604,7 @@ impl<'a, F: AcirField, B: BlackBoxFunctionSolver<F>> ACVM<'a, F, B> {
                 }
                 ExpressionOrMemory::Memory(block_id) => {
                     let memory_block = self.block_solvers.get(block_id)?;
-                    fields.extend((0..memory_block.block_len).map(|memory_index| {
-                        *memory_block
-                            .block_value
-                            .get(&memory_index)
-                            .expect("All memory is initialized on creation")
-                    }));
+                    fields.extend(&memory_block.block_value);
                 }
             }
         }


### PR DESCRIPTION
# Description

## Problem

No issue, just something I noticed while auditing the ACVM.

## Summary

Given that memory blocks must always be initialized before being accessed, and that they never grow, we can use a `Vec` instead of a `HashMap`. I believe this should use less memory and be more efficient. That said, I don't know if this will be noticeable.

## Additional Context



## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
