### PR TITLE
chore(ci): fix permissions about publishing rustdoc

### DIFF
--- a/.github/workflows/rustdoc.yml
+++ b/.github/workflows/rustdoc.yml
@@ -57,7 +57,7 @@ jobs:
     runs-on: ubuntu-22.04
     needs: build
     permissions:
-      contents: read
+      contents: write
     steps:
       - uses: actions/checkout@v5
         with:


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*



## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
