### PR TITLE
chore: remove unused predicate from mem-op solver

### DIFF
--- a/acvm-repo/acvm/src/pwg/memory_op.rs
+++ b/acvm-repo/acvm/src/pwg/memory_op.rs
@@ -84,7 +84,7 @@ impl<F: AcirField> MemoryOpSolver<F> {
     /// Update the 'block_values' by processing the provided Memory opcode
     /// The opcode 'op' contains the index and value of the operation and the type
     /// of the operation.
-    /// They are all stored as an [Expression]
+    /// They are all stored as an [acir::native_types::Expression]
     /// The type of 'operation' is '0' for a read and '1' for a write. It must be a constant
     /// expression.
     /// Index is not required to be constant but it must reduce to a known value

--- a/acvm-repo/acvm/src/pwg/mod.rs
+++ b/acvm-repo/acvm/src/pwg/mod.rs
@@ -524,12 +524,7 @@ impl<'a, F: AcirField, B: BlackBoxFunctionSolver<F>> ACVM<'a, F, B> {
                     .block_solvers
                     .get_mut(block_id)
                     .expect("Memory block should have been initialized before use");
-                solver.solve_memory_op(
-                    op,
-                    &mut self.witness_map,
-                    &None,
-                    self.backend.pedantic_solving(),
-                )
+                solver.solve_memory_op(op, &mut self.witness_map)
             }
             Opcode::BrilligCall { .. } => match self.solve_brillig_call_opcode() {
                 Ok(Some(foreign_call)) => return self.wait_for_foreign_call(foreign_call),


### PR DESCRIPTION
# Description

## Problem\*

Resolves #10078

## Summary\*

Memory operations don't have predicates applied to them so we can remove this code entirely.

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
