### PR TITLE
chore: bump external pinned commits

### DIFF
--- a/.github/benchmark_projects.yml
+++ b/.github/benchmark_projects.yml
@@ -1,4 +1,4 @@
-define: &AZ_COMMIT 42a2a79dada020a4e18dab4edbec0031ee2920a5
+define: &AZ_COMMIT 85c44ed86f7fa13e4737e0f9d39d6a82f05858c2
 projects:
   private-kernel-inner:
     repo: AztecProtocol/aztec-packages

--- a/EXTERNAL_NOIR_LIBRARIES.yml
+++ b/EXTERNAL_NOIR_LIBRARIES.yml
@@ -1,4 +1,4 @@
-define: &AZ_COMMIT 42a2a79dada020a4e18dab4edbec0031ee2920a5
+define: &AZ_COMMIT 85c44ed86f7fa13e4737e0f9d39d6a82f05858c2
 libraries:
   noir_check_shuffle:
     repo: noir-lang/noir_check_shuffle


### PR DESCRIPTION

Automated update of the pinned commit of [aztec-packages](https://github.com/AztecProtocol/aztec-packages) repository against which we run benchmarks.
