### PR TITLE
chore: use `u64` over `Field` in template program

### DIFF
--- a/docs/docs/noir/concepts/comptime.md
+++ b/docs/docs/noir/concepts/comptime.md
@@ -225,7 +225,7 @@ So the library author can instead quote `$crate::foo::my_function()` and have it
 ```rust
 /// We want to access this function within the quoted code below
 /// and we want it to work in external crates.
-pub fn double(x: Field) -> Field { x * 2 }
+pub fn double(x: u64) -> u64 { x * 2 }
 
 comptime fn double_twice(code: Quoted) -> Quoted {
     quote {

--- a/docs/docs/noir/concepts/data_types/arrays.md
+++ b/docs/docs/noir/concepts/data_types/arrays.md
@@ -17,9 +17,9 @@ An array is one way of grouping together values into one compound type. Array ty
 or explicitly specified via the syntax `[<Type>; <Size>]`:
 
 ```rust
-fn main(x : Field, y : Field) {
+fn main(x : u64, y : u64) {
     let my_arr = [x, y];
-    let your_arr: [Field; 2] = [x, y];
+    let your_arr: [u64; 2] = [x, y];
 }
 ```
 

--- a/docs/docs/noir/concepts/data_types/fields.md
+++ b/docs/docs/noir/concepts/data_types/fields.md
@@ -15,11 +15,9 @@ sidebar_position: 0
 
 The field type corresponds to the native field type of the proving backend.
 
-The size of a Noir field depends on the elliptic curve's finite field for the proving backend
-adopted. For example, a field would be a 254-bit integer when paired with the default backend that
-spans the Grumpkin curve.
+The size of a Noir field depends on the elliptic curve's finite field for the proving backend  adopted. For example, a field would be a 254-bit integer when paired with the default backend that spans the Grumpkin curve.
 
-Fields support integer arithmetic and are often used as the default numeric type in Noir:
+Fields support integer arithmetic:
 
 ```rust
 fn main(x : Field, y : Field)  {
@@ -27,11 +25,9 @@ fn main(x : Field, y : Field)  {
 }
 ```
 
-`x`, `y` and `z` are all private fields in this example. Using the `let` keyword we defined a new
-private value `z` constrained to be equal to `x + y`.
+`x`, `y` and `z` are all private fields in this example. Using the `let` keyword we defined a new private value `z` constrained to be equal to `x + y`.
 
-If proving efficiency is of priority, fields should be used as a default for solving problems.
-Smaller integer types (e.g. `u64`) incur extra range constraints.
+If proving efficiency is of priority, fields should be used as a default for solving problems. Smaller integer types (e.g. `u64`) incur extra range constraints.
 
 ## Methods
 

--- a/docs/docs/noir/concepts/data_types/index.md
+++ b/docs/docs/noir/concepts/data_types/index.md
@@ -54,7 +54,7 @@ All data types in Noir are private by default. Types are explicitly declared as 
 `pub` modifier:
 
 ```rust
-fn main(x : Field, y : pub Field) -> pub Field {
+fn main(x: u32, y: pub u32) -> pub u32 {
     x + y
 }
 ```

--- a/docs/docs/noir/concepts/data_types/slices.mdx
+++ b/docs/docs/noir/concepts/data_types/slices.mdx
@@ -124,7 +124,7 @@ let append = &[1, 2].append(&[3, 4, 5]);
 Inserts an element at a specified index and shifts all following elements by 1.
 
 ```rust
-fn insert(_self: Self, _index: Field, _elem: T) -> Self
+fn insert(_self: Self, _index: u32, _elem: T) -> Self
 ```
 
 Example:
@@ -141,7 +141,7 @@ View the corresponding test file [here][test-file].
 Remove an element at a specified index, shifting all elements after it to the left, returning the altered slice and the removed element.
 
 ```rust
-fn remove(_self: Self, _index: Field) -> (Self, T)
+fn remove(_self: Self, _index: u32) -> (Self, T)
 ```
 
 Example:

--- a/docs/docs/noir/concepts/ops.md
+++ b/docs/docs/noir/concepts/ops.md
@@ -52,7 +52,7 @@ This differs from the operations such as `+` where the operands are used in _com
 ### Bitwise Operations Example
 
 ```rust
-fn main(x : Field) {
+fn main(x: Field) {
     let y = x as u32;
     let z = y & y;
 }

--- a/docs/docs/noir/concepts/traits.md
+++ b/docs/docs/noir/concepts/traits.md
@@ -415,7 +415,7 @@ case, type inference determines the impl that is selected.
 ```rust
 let my_struct = MyStruct::default();
 
-let x: Field = Default::default();
+let x: u64 = Default::default();
 let result = x + Default::default();
 ```
 

--- a/docs/docs/noir/modules_packages_crates/dependencies.md
+++ b/docs/docs/noir/modules_packages_crates/dependencies.md
@@ -105,7 +105,7 @@ For example, the [phy_vector](https://github.com/resurgencelabs/phy_vector) libr
 ```rust
 use phy_vector;
 
-fn main(x : Field, y : pub Field) {
+fn main(x : u32, y : pub u32) {
   //...
   let f = phy_vector::fraction::toFraction(true, 2, 1);
   //...

--- a/docs/docs/noir/standard_library/containers/vec.mdx
+++ b/docs/docs/noir/standard_library/containers/vec.mdx
@@ -74,7 +74,7 @@ assert(empty_vector.len() == 0);
 Retrieves an element from the vector at a given index. Panics if the index points beyond the vector's end.
 
 ```rust
-pub fn get(self, index: Field) -> T
+pub fn get(self, index: u32) -> T
 ```
 
 Example:
@@ -87,7 +87,7 @@ assert(vector.get(1) == 20);
 ### set
 
 ```rust
-pub fn set(&mut self: Self, index: u64, value: T) {
+pub fn set(&mut self: Self, index: u32, value: T)
 ```
 
 Writes an element to the vector at the given index, starting from zero.
@@ -141,7 +141,7 @@ assert(vector.len() == 1);
 Inserts an element at a specified index, shifting subsequent elements to the right.
 
 ```rust
-pub fn insert(&mut self, index: Field, elem: T)
+pub fn insert(&mut self, index: u32, elem: T)
 ```
 
 Example:

--- a/docs/docs/noir/standard_library/logging.md
+++ b/docs/docs/noir/standard_library/logging.md
@@ -28,11 +28,11 @@ Both `print` and `println` are generic functions which can work on integers, fie
 
 ```rust
 struct Person {
-    age: Field,
-    height: Field,
+    age: u32,
+    height: u32,
 }
 
-fn main(age: Field, height: Field) {
+fn main(age: u32, height: u32) {
     let person = Person {
         age: age,
         height: height,

--- a/docs/docs/tooling/fuzzer.md
+++ b/docs/docs/tooling/fuzzer.md
@@ -24,7 +24,7 @@ A simple example of a fuzzing harness is the following:
 ```rust
 #[fuzz]
 fn fuzz_add(a: Field, b: Field) {
-    assert(a!=(b+3));
+    assert(a != (b+3));
 }
 ```
 

--- a/docs/docs/tooling/tests.md
+++ b/docs/docs/tooling/tests.md
@@ -45,7 +45,7 @@ fn test_add() {
 You can be more specific and make it fail with a specific reason by using `should_fail_with = "<the reason for failure>"`:
 
 ```rust
-fn main(african_swallow_avg_speed : Field) {
+fn main(african_swallow_avg_speed: u64) {
     assert(african_swallow_avg_speed == 65, "What is the airspeed velocity of an unladen swallow");
 }
 
@@ -63,7 +63,7 @@ fn test_bridgekeeper() {
 The string given to `should_fail_with` doesn't need to exactly match the failure reason, it just needs to be a substring of it:
 
 ```rust
-fn main(african_swallow_avg_speed : Field) {
+fn main(african_swallow_avg_speed: u64) {
     assert(african_swallow_avg_speed == 65, "What is the airspeed velocity of an unladen swallow");
 }
 

--- a/tooling/nargo_cli/src/cli/noir_template_files/binary.nr
+++ b/tooling/nargo_cli/src/cli/noir_template_files/binary.nr
@@ -1,4 +1,4 @@
-fn main(x: Field, y: pub Field) {
+fn main(x: u64, y: pub u64) {
     assert(x != y);
 }
 


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

We want to discourage people defaulting to the `Field` type so this is a nudge to use integer types instead.

## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
