### PR TITLE
chore: Remove unnecessary allocation in `expr_with`

### DIFF
--- a/acvm-repo/acvm/src/compiler/simulator.rs
+++ b/acvm-repo/acvm/src/compiler/simulator.rs
@@ -185,7 +185,7 @@ impl CircuitSimulator {
 
     pub(crate) fn expr_wit<F>(expr: &Expression<F>) -> BTreeSet<Witness> {
         let mut result = BTreeSet::new();
-        result.extend(expr.mul_terms.iter().flat_map(|i| vec![i.1, i.2]));
+        result.extend(expr.mul_terms.iter().flat_map(|i| [i.1, i.2]));
         result.extend(expr.linear_combinations.iter().map(|i| i.1));
         result
     }


### PR DESCRIPTION
# Description

## Problem\*

Resolves #10102 

## Summary\*

Removes an unnecessary allocation in `expr_wit`

## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
