### PR TITLE
chore: More BTreeSet avoidance

### DIFF
--- a/acvm-repo/acvm/src/compiler/optimizers/merge_expressions.rs
+++ b/acvm-repo/acvm/src/compiler/optimizers/merge_expressions.rs
@@ -126,8 +126,9 @@ impl<F: AcirField> MergeExpressionsOptimizer<F> {
                                     self.modified_gates.insert(target, Opcode::AssertZero(expr));
                                     self.deleted_gates.insert(source);
                                     // Update the 'used_witness' map to account for the merge.
-                                    let mut witness_list = CircuitSimulator::expr_wit(&expr_use);
-                                    witness_list.extend(CircuitSimulator::expr_wit(&expr_define));
+                                    let witness_list = CircuitSimulator::expr_wit(&expr_use);
+                                    let witness_list = witness_list.chain(CircuitSimulator::expr_wit(&expr_define));
+
                                     for w2 in witness_list {
                                         if !circuit_io.contains(&w2) {
                                             used_witness.entry(w2).and_modify(|v| {
@@ -165,42 +166,43 @@ impl<F: AcirField> MergeExpressionsOptimizer<F> {
         (new_circuit, new_acir_opcode_positions)
     }
 
-    fn brillig_input_wit(&self, input: &BrilligInputs<F>) -> BTreeSet<Witness> {
-        let mut result = BTreeSet::new();
+    fn for_each_brillig_input_wit(&self, input: &BrilligInputs<F>, mut f: impl FnMut(Witness)) {
         match input {
             BrilligInputs::Single(expr) => {
-                result.extend(CircuitSimulator::expr_wit(expr));
+                for witness in CircuitSimulator::expr_wit(expr) {
+                    f(witness);
+                }
             }
             BrilligInputs::Array(exprs) => {
                 for expr in exprs {
-                    result.extend(CircuitSimulator::expr_wit(expr));
+                    for witness in CircuitSimulator::expr_wit(expr) {
+                        f(witness);
+                    }
                 }
             }
             BrilligInputs::MemoryArray(block_id) => {
-                let witnesses = self.resolved_blocks.get(block_id).expect("Unknown block id");
-                result.extend(witnesses);
+                for witness in self.resolved_blocks.get(block_id).expect("Unknown block id") {
+                    f(*witness);
+                }
             }
         }
-        result
     }
 
-    fn brillig_output_wit(&self, output: &BrilligOutputs) -> BTreeSet<Witness> {
-        let mut result = BTreeSet::new();
+    fn for_each_brillig_output_wit(&self, output: &BrilligOutputs, mut f: impl FnMut(Witness)) {
         match output {
-            BrilligOutputs::Simple(witness) => {
-                result.insert(*witness);
-            }
+            BrilligOutputs::Simple(witness) => f(*witness),
             BrilligOutputs::Array(witnesses) => {
-                result.extend(witnesses);
+                for witness in witnesses {
+                    f(*witness);
+                }
             }
         }
-        result
     }
 
     // Returns the input witnesses used by the opcode
     fn witness_inputs(&self, opcode: &Opcode<F>) -> BTreeSet<Witness> {
         match opcode {
-            Opcode::AssertZero(expr) => CircuitSimulator::expr_wit(expr),
+            Opcode::AssertZero(expr) => CircuitSimulator::expr_wit(expr).collect(),
             Opcode::BlackBoxFuncCall(bb_func) => {
                 let mut witnesses = bb_func.get_input_witnesses();
                 witnesses.extend(bb_func.get_outputs_vec());
@@ -209,9 +211,8 @@ impl<F: AcirField> MergeExpressionsOptimizer<F> {
             }
             Opcode::MemoryOp { block_id: _, op } => {
                 //index and value
-                let mut witnesses = CircuitSimulator::expr_wit(&op.index);
-                witnesses.extend(CircuitSimulator::expr_wit(&op.value));
-                witnesses
+                let witnesses = CircuitSimulator::expr_wit(&op.index);
+                witnesses.chain(CircuitSimulator::expr_wit(&op.value)).collect()
             }
 
             Opcode::MemoryInit { block_id: _, init, block_type: _ } => {
@@ -220,15 +221,15 @@ impl<F: AcirField> MergeExpressionsOptimizer<F> {
             Opcode::BrilligCall { inputs, outputs, .. } => {
                 let mut witnesses = BTreeSet::new();
                 for i in inputs {
-                    witnesses.extend(self.brillig_input_wit(i));
+                    self.for_each_brillig_input_wit(i, |witness| { witnesses.insert(witness); });
                 }
                 for i in outputs {
-                    witnesses.extend(self.brillig_output_wit(i));
+                    self.for_each_brillig_output_wit(i, |witness| { witnesses.insert(witness); });
                 }
                 witnesses
             }
             Opcode::Call { id: _, inputs, outputs, predicate } => {
-                let mut witnesses: BTreeSet<Witness> = BTreeSet::from_iter(inputs.iter().copied());
+                let mut witnesses: BTreeSet<Witness> = inputs.iter().copied().collect();
                 witnesses.extend(outputs);
 
                 if let Some(p) = predicate {

--- a/acvm-repo/acvm/src/compiler/simulator.rs
+++ b/acvm-repo/acvm/src/compiler/simulator.rs
@@ -7,7 +7,7 @@ use acir::{
     },
     native_types::{Expression, Witness},
 };
-use std::collections::{BTreeSet, HashSet};
+use std::collections::HashSet;
 
 /// Simulate a symbolic solve for a circuit
 /// Instead of evaluating witness values from the inputs, like the PWG module is doing,
@@ -183,11 +183,9 @@ impl CircuitSimulator {
         }
     }
 
-    pub(crate) fn expr_wit<F>(expr: &Expression<F>) -> BTreeSet<Witness> {
-        let mut result = BTreeSet::new();
-        result.extend(expr.mul_terms.iter().flat_map(|i| vec![i.1, i.2]));
-        result.extend(expr.linear_combinations.iter().map(|i| i.1));
-        result
+    pub(crate) fn expr_wit<F>(expr: &Expression<F>) -> impl Iterator<Item = Witness> {
+        expr.mul_terms.iter().flat_map(|i| [i.1, i.2])
+            .chain(expr.linear_combinations.iter().map(|i| i.1))
     }
 }
 


### PR DESCRIPTION
# Description

## Problem\*

Resolves #10106 

## Summary\*

Avoids collecting into a BTreeSet altogether in a few intermediate steps. Instead we either return an iterator to extend into a larger BTreeSet in `witness_inputs` or use a for_each pattern when we'd otherwise need to return multiple different iterator types (to avoid boxing iterators or pulling in `itertools::either`).

## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
