### PR TITLE
chore: typos and some refactors, fixes, tests in `acvm/src/compiler`

### DIFF
--- a/acvm-repo/acvm/src/compiler/optimizers/merge_expressions.rs
+++ b/acvm-repo/acvm/src/compiler/optimizers/merge_expressions.rs
@@ -126,8 +126,10 @@ impl<F: AcirField> MergeExpressionsOptimizer<F> {
                                     self.modified_gates.insert(target, Opcode::AssertZero(expr));
                                     self.deleted_gates.insert(source);
                                     // Update the 'used_witness' map to account for the merge.
-                                    let mut witness_list = CircuitSimulator::expr_wit(&expr_use);
-                                    witness_list.extend(CircuitSimulator::expr_wit(&expr_define));
+                                    let mut witness_list =
+                                        CircuitSimulator::expr_witness(&expr_use);
+                                    witness_list
+                                        .extend(CircuitSimulator::expr_witness(&expr_define));
                                     for w2 in witness_list {
                                         if !circuit_io.contains(&w2) {
                                             used_witness.entry(w2).and_modify(|v| {
@@ -169,11 +171,11 @@ impl<F: AcirField> MergeExpressionsOptimizer<F> {
         let mut result = BTreeSet::new();
         match input {
             BrilligInputs::Single(expr) => {
-                result.extend(CircuitSimulator::expr_wit(expr));
+                result.extend(CircuitSimulator::expr_witness(expr));
             }
             BrilligInputs::Array(exprs) => {
                 for expr in exprs {
-                    result.extend(CircuitSimulator::expr_wit(expr));
+                    result.extend(CircuitSimulator::expr_witness(expr));
                 }
             }
             BrilligInputs::MemoryArray(block_id) => {
@@ -200,7 +202,7 @@ impl<F: AcirField> MergeExpressionsOptimizer<F> {
     // Returns the input witnesses used by the opcode
     fn witness_inputs(&self, opcode: &Opcode<F>) -> BTreeSet<Witness> {
         match opcode {
-            Opcode::AssertZero(expr) => CircuitSimulator::expr_wit(expr),
+            Opcode::AssertZero(expr) => CircuitSimulator::expr_witness(expr),
             Opcode::BlackBoxFuncCall(bb_func) => {
                 let mut witnesses = bb_func.get_input_witnesses();
                 witnesses.extend(bb_func.get_outputs_vec());
@@ -209,8 +211,8 @@ impl<F: AcirField> MergeExpressionsOptimizer<F> {
             }
             Opcode::MemoryOp { block_id: _, op } => {
                 //index and value
-                let mut witnesses = CircuitSimulator::expr_wit(&op.index);
-                witnesses.extend(CircuitSimulator::expr_wit(&op.value));
+                let mut witnesses = CircuitSimulator::expr_witness(&op.index);
+                witnesses.extend(CircuitSimulator::expr_witness(&op.value));
                 witnesses
             }
 
@@ -232,7 +234,7 @@ impl<F: AcirField> MergeExpressionsOptimizer<F> {
                 witnesses.extend(outputs);
 
                 if let Some(p) = predicate {
-                    witnesses.extend(CircuitSimulator::expr_wit(p));
+                    witnesses.extend(CircuitSimulator::expr_witness(p));
                 }
                 witnesses
             }

--- a/acvm-repo/acvm/src/compiler/optimizers/mod.rs
+++ b/acvm-repo/acvm/src/compiler/optimizers/mod.rs
@@ -17,33 +17,6 @@ use tracing::info;
 
 use self::unused_memory::UnusedMemoryOptimizer;
 
-use super::{AcirTransformationMap, transform_assert_messages};
-
-/// Applies backend independent optimizations to a [`Circuit`].
-pub fn optimize<F: AcirField>(
-    acir: Circuit<F>,
-    brillig_side_effects: &BTreeMap<BrilligFunctionId, bool>,
-) -> (Circuit<F>, AcirTransformationMap) {
-    // Track original acir opcode positions throughout the transformation passes of the compilation
-    // by applying the modifications done to the circuit opcodes and also to the opcode_positions (delete and insert)
-    // For instance, here before any transformation, the old acir opcode positions have not changed.
-    // So acir_opcode_positions = 0, 1,...,n-1, representing the index of the opcode in Circuit.opcodes vector.
-    let acir_opcode_positions = (0..acir.opcodes.len()).collect();
-
-    // `optimize_internal()` may change the circuit, and it returns a new one, as well the new_opcode_positions
-    // In the new circuit, the opcode at index `i` corresponds to the opcode at index `new_opcode_positions[i]` in the original circuit.
-    // For instance let's say it removed the opcode at index 3, and replaced the one at index 5 by two new opcodes
-    // The new_opcode_positions is now: 0,1,2,4,5,5,6,....n-1
-    let (mut acir, new_opcode_positions) =
-        optimize_internal(acir, acir_opcode_positions, brillig_side_effects);
-
-    let transformation_map = AcirTransformationMap::new(&new_opcode_positions);
-
-    acir.assert_messages = transform_assert_messages(acir.assert_messages, &transformation_map);
-
-    (acir, transformation_map)
-}
-
 /// Applies backend independent optimizations to a [`Circuit`].
 ///
 /// Accepts an injected `acir_opcode_positions` to allow optimizations to be applied in a loop.
@@ -83,16 +56,10 @@ pub(super) fn optimize_internal<F: AcirField>(
     let (acir, acir_opcode_positions) =
         memory_optimizer.remove_unused_memory_initializations(acir_opcode_positions);
 
-    // let (acir, acir_opcode_positions) =
-    // ConstantBackpropagationOptimizer::backpropagate_constants(acir, acir_opcode_positions);
-
     // Range optimization pass
     let range_optimizer = RangeOptimizer::new(acir, brillig_side_effects);
     let (acir, acir_opcode_positions) =
         range_optimizer.replace_redundant_ranges(acir_opcode_positions);
-
-    // let (acir, acir_opcode_positions) =
-    // ConstantBackpropagationOptimizer::backpropagate_constants(acir, acir_opcode_positions);
 
     info!("Number of opcodes after: {}", acir.opcodes.len());
 

--- a/acvm-repo/acvm/src/compiler/simulator.rs
+++ b/acvm-repo/acvm/src/compiler/simulator.rs
@@ -9,29 +9,29 @@ use acir::{
 };
 use std::collections::{BTreeSet, HashSet};
 
-/// Simulate a symbolic solve for a circuit
+/// Simulate solving a circuit symbolically
 /// Instead of evaluating witness values from the inputs, like the PWG module is doing,
-/// this pass simply mark the witness that can be evaluated, from the known inputs,
+/// this pass simply marks the witness that can be evaluated, from the known inputs,
 /// and incrementally from the previously marked witnesses.
-/// This avoid any computation on a big field which makes the process efficient.
+/// This avoids any computation on a big field which makes the process efficient.
 /// When all the witness of an opcode are marked as solvable, it means that the
 /// opcode is solvable.
 #[derive(Default)]
 pub struct CircuitSimulator {
     /// Track the witnesses that can be solved
-    solvable_witness: HashSet<Witness>,
+    solvable_witnesses: HashSet<Witness>,
 
     /// Track whether a [`BlockId`] has been initialized
     initialized_blocks: HashSet<BlockId>,
 }
 
 impl CircuitSimulator {
-    /// Simulate a symbolic solve for a circuit by keeping track of the witnesses that can be solved.
-    /// Returns the index of the opcode that cannot be solved, if any.
+    /// Simulate solving a circuit symbolically by keeping track of the witnesses that can be solved.
+    /// Returns the index of an opcode that cannot be solved, if any.
     #[tracing::instrument(level = "trace", skip_all)]
     pub fn check_circuit<F: AcirField>(&mut self, circuit: &Circuit<F>) -> Option<usize> {
         let circuit_inputs = circuit.circuit_arguments();
-        self.solvable_witness.extend(circuit_inputs.iter());
+        self.solvable_witnesses.extend(circuit_inputs.iter());
         for (i, op) in circuit.opcodes.iter().enumerate() {
             if !self.try_solve(op) {
                 return Some(i);
@@ -46,18 +46,18 @@ impl CircuitSimulator {
         match opcode {
             Opcode::AssertZero(expr) => {
                 for (_, w1, w2) in &expr.mul_terms {
-                    if !self.solvable_witness.contains(w1) {
-                        if !self.solvable_witness.contains(w2) {
+                    if !self.solvable_witnesses.contains(w1) {
+                        if !self.solvable_witnesses.contains(w2) {
                             return false;
                         }
                         unresolved.insert(*w1);
                     }
-                    if !self.solvable_witness.contains(w2) && w1 != w2 {
+                    if !self.solvable_witnesses.contains(w2) && w1 != w2 {
                         unresolved.insert(*w2);
                     }
                 }
                 for (_, w) in &expr.linear_combinations {
-                    if !self.solvable_witness.contains(w) {
+                    if !self.solvable_witnesses.contains(w) {
                         unresolved.insert(*w);
                     }
                 }
@@ -100,7 +100,7 @@ impl CircuitSimulator {
             }
             Opcode::MemoryInit { block_id, init, .. } => {
                 for w in init {
-                    if !self.solvable_witness.contains(w) {
+                    if !self.solvable_witnesses.contains(w) {
                         return false;
                     }
                 }
@@ -131,7 +131,7 @@ impl CircuitSimulator {
             }
             Opcode::Call { id: _, inputs, outputs, predicate } => {
                 for w in inputs {
-                    if !self.solvable_witness.contains(w) {
+                    if !self.solvable_witnesses.contains(w) {
                         return false;
                     }
                 }
@@ -150,23 +150,25 @@ impl CircuitSimulator {
 
     /// Adds the witness to set of solvable witness
     pub(crate) fn mark_solvable(&mut self, witness: Witness) {
-        self.solvable_witness.insert(witness);
+        self.solvable_witnesses.insert(witness);
     }
 
     pub fn can_solve_function_input<F: AcirField>(&self, input: &FunctionInput<F>) -> bool {
         if let FunctionInput::Witness(w) = input {
-            return self.solvable_witness.contains(w);
+            return self.solvable_witnesses.contains(w);
         }
         true
     }
+
     fn can_solve_expression<F>(&self, expr: &Expression<F>) -> bool {
-        for w in Self::expr_wit(expr) {
-            if !self.solvable_witness.contains(&w) {
+        for w in Self::expr_witness(expr) {
+            if !self.solvable_witnesses.contains(&w) {
                 return false;
             }
         }
         true
     }
+
     fn can_solve_brillig_input<F>(&mut self, input: &BrilligInputs<F>) -> bool {
         match input {
             BrilligInputs::Single(expr) => self.can_solve_expression(expr),
@@ -183,7 +185,7 @@ impl CircuitSimulator {
         }
     }
 
-    pub(crate) fn expr_wit<F>(expr: &Expression<F>) -> BTreeSet<Witness> {
+    pub(crate) fn expr_witness<F>(expr: &Expression<F>) -> BTreeSet<Witness> {
         let mut result = BTreeSet::new();
         result.extend(expr.mul_terms.iter().flat_map(|i| vec![i.1, i.2]));
         result.extend(expr.linear_combinations.iter().map(|i| i.1));
@@ -191,6 +193,8 @@ impl CircuitSimulator {
     }
 }
 
+// TODO: add test(s) for BlackBoxFuncCall
+// TODO: how to test parity with "full" circuit solver?
 #[cfg(test)]
 mod tests {
     use std::collections::BTreeSet;


### PR DESCRIPTION
# Description

## Problem\*


## Summary\*

- Typos and updating some comments
- https://github.com/noir-lang/noir/issues/10109
- Combining `compile` and `optimize`
- Adding tests
- Increasing the default `MAX_TRANSFORMER_PASSES`

## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
