### PR TITLE
chore(ACIR): don't override output count in black box function

### DIFF
--- a/compiler/noirc_evaluator/src/acir/acir_context/black_box.rs
+++ b/compiler/noirc_evaluator/src/acir/acir_context/black_box.rs
@@ -13,7 +13,7 @@ impl<F: AcirField> AcirContext<F> {
         name: BlackBoxFunc,
         mut inputs: Vec<AcirValue>,
         num_bits: Option<u32>,
-        mut output_count: usize,
+        output_count: usize,
         predicate: Option<AcirVar>,
     ) -> Result<Vec<AcirVar>, RuntimeError> {
         // Separate out any arguments that should be constants
@@ -30,7 +30,13 @@ impl<F: AcirField> AcirContext<F> {
                         }));
                     }
                 }?;
-                output_count = input_size + (16 - input_size % 16);
+
+                assert_eq!(
+                    output_count,
+                    input_size + (16 - input_size % 16),
+                    "output count mismatch"
+                );
+
                 Vec::new()
             }
             BlackBoxFunc::RecursiveAggregation => {


### PR DESCRIPTION
# Description

## Problem

No issue, just a small thing.

## Summary

I noticed the output_count was overwritten here. I checked and the value set is always the value that is already passed as an argument to the function. Maybe the original intention of the code was asserting that the two are equal, so this is what's done here.

## Additional Context



## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
