### PR TITLE
fix(ACIR): correctly display the zero expression

### DIFF
--- a/acvm-repo/acir/src/circuit/opcodes.rs
+++ b/acvm-repo/acir/src/circuit/opcodes.rs
@@ -220,7 +220,7 @@ mod tests {
 
     use crate::{
         circuit::opcodes::{BlackBoxFuncCall, BlockId, BlockType, FunctionInput},
-        native_types::Witness,
+        native_types::{Expression, Witness},
     };
 
     use super::Opcode;
@@ -265,5 +265,11 @@ mod tests {
             range.to_string(),
             @"BLACKBOX::RANGE input: w0, bits: 32"
         );
+    }
+
+    #[test]
+    fn display_zero() {
+        let zero = Opcode::AssertZero(Expression::<FieldElement>::default());
+        assert_eq!(zero.to_string(), "ASSERT 0 = 0");
     }
 }

--- a/acvm-repo/acir/src/native_types/expression/mod.rs
+++ b/acvm-repo/acir/src/native_types/expression/mod.rs
@@ -429,7 +429,7 @@ pub(crate) fn display_expression<F: AcirField>(
     }
 
     if expr.q_c.is_zero() {
-        if as_equal_to_zero && !printed_term {
+        if !printed_term {
             write!(f, "0")?;
         }
     } else {
@@ -531,5 +531,11 @@ mod tests {
                 q_c: FieldElement::from(10u128)
             }
         );
+    }
+
+    #[test]
+    fn display_zero() {
+        let zero = Expression::<FieldElement>::default();
+        assert_eq!(zero.to_string(), "0");
     }
 }


### PR DESCRIPTION
# Description

## Problem

No issue, just a tiny thing I noticed.

## Summary

The expression "zero" was displayed as an empty string instead of as a zero.

## Additional Context



## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
