### PR TITLE
chore(brillig_vm): Memory unit tests

### DIFF
--- a/acvm-repo/brillig_vm/src/memory.rs
+++ b/acvm-repo/brillig_vm/src/memory.rs
@@ -423,7 +423,7 @@ mod tests {
     fn write_and_read_slice() {
         let mut memory = Memory::<FieldElement>::default();
         // [1, 2, 3, 4, 5]
-        let values: Vec<_> = (1..=5).map(|x| MemoryValue::U32(x)).collect();
+        let values: Vec<_> = (1..=5).map(MemoryValue::U32).collect();
 
         // Write at an address > 0 to show resizing
         memory.write_slice(MemoryAddress::direct(2), &values);


### PR DESCRIPTION
# Description

## Problem\*

Working towards green-lighting Brillig #9800

Our VM `Memory` was only implicitly tested through integration tests.

## Summary\*

Adds unit tests for the `Memory` struct and its impl methods

## Additional Context



## Documentation\*

Check one:
- [X] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
