### PR TITLE
chore: ensure that `useful_instructions` cannot overflow

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/opt/unrolling.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/unrolling.rs
@@ -891,7 +891,7 @@ impl BoilerplateStats {
         let load_and_store = self.loads.min(self.stores) * 2;
         let total_boilerplate = self.increments + load_and_store + boilerplate;
         debug_assert!(
-            total_boilerplate < self.all_instructions,
+            total_boilerplate <= self.all_instructions,
             "Boilerplate instructions exceed total instructions in loop"
         );
         self.all_instructions.saturating_sub(total_boilerplate)


### PR DESCRIPTION
# Description

## Problem\*

Resolves #10163

## Summary\*

This PR applies the recommendation from #10163

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
