### PR TITLE
chore(ACIR): prefer displaying `ASSERT return_value = ...`

### DIFF
--- a/acvm-repo/acir/src/circuit/mod.rs
+++ b/acvm-repo/acir/src/circuit/mod.rs
@@ -5,6 +5,7 @@ pub mod brillig;
 pub mod opcodes;
 
 use crate::{
+    circuit::opcodes::display_opcode,
     native_types::{Expression, Witness},
     serialization::{deserialize_any_format, serialize_with_format_from_env},
 };
@@ -355,7 +356,8 @@ impl<F: AcirField> std::fmt::Display for Circuit<F> {
         write_witness_indices(f, &self.return_values.indices())?;
 
         for opcode in &self.opcodes {
-            writeln!(f, "{opcode}")?;
+            display_opcode(opcode, Some(&self.return_values), f)?;
+            writeln!(f)?;
         }
         Ok(())
     }

--- a/compiler/noirc_evaluator/src/acir/tests/arrays.rs
+++ b/compiler/noirc_evaluator/src/acir/tests/arrays.rs
@@ -30,9 +30,9 @@ fn array_set_not_mutable() {
     READ w12 = b1[w11]
     ASSERT w13 = 2
     READ w14 = b1[w13]
-    ASSERT w10 = w5
-    ASSERT w12 = w6
-    ASSERT w14 = w7
+    ASSERT w5 = w10
+    ASSERT w6 = w12
+    ASSERT w7 = w14
     ");
 }
 
@@ -63,9 +63,9 @@ fn array_set_mutable() {
     READ w12 = b0[w11]
     ASSERT w13 = 2
     READ w14 = b0[w13]
-    ASSERT w10 = w5
-    ASSERT w12 = w6
-    ASSERT w14 = w7
+    ASSERT w5 = w10
+    ASSERT w6 = w12
+    ASSERT w7 = w14
     ");
 }
 
@@ -192,9 +192,9 @@ fn generates_memory_op_for_dynamic_write() {
     READ w11 = b1[w10]
     ASSERT w12 = 2
     READ w13 = b1[w12]
-    ASSERT w9 = w4
-    ASSERT w11 = w5
-    ASSERT w13 = w6
+    ASSERT w4 = w9
+    ASSERT w5 = w11
+    ASSERT w6 = w13
     ");
 }
 
@@ -272,9 +272,9 @@ fn generates_predicated_index_and_dummy_value_for_dynamic_write() {
     READ w14 = b1[w13]
     ASSERT w15 = 2
     READ w16 = b1[w15]
-    ASSERT w12 = w5
-    ASSERT w14 = w6
-    ASSERT w16 = w7
+    ASSERT w5 = w12
+    ASSERT w6 = w14
+    ASSERT w7 = w16
     ");
 }
 

--- a/compiler/noirc_evaluator/src/acir/tests/call.rs
+++ b/compiler/noirc_evaluator/src/acir/tests/call.rs
@@ -151,7 +151,7 @@ fn basic_nested_call(inline_type: InlineType) {
     return values: [w2]
     ASSERT w3 = w0 + 2
     CALL func: 2, predicate: 1, inputs: [w3, w1], outputs: [w4]
-    ASSERT w4 = w2
+    ASSERT w2 = w4
 
     func 2
     private parameters: [w0, w1]
@@ -187,7 +187,7 @@ fn call_with_predicate() {
     return values: [w2]
     BLACKBOX::RANGE input: w1, bits: 1
     CALL func: 1, predicate: w1, inputs: [w0], outputs: [w3]
-    ASSERT w3 = w2
+    ASSERT w2 = w3
 
     func 1
     private parameters: [w0]

--- a/compiler/noirc_evaluator/src/acir/tests/instructions.rs
+++ b/compiler/noirc_evaluator/src/acir/tests/instructions.rs
@@ -124,7 +124,7 @@ fn truncate_u16_to_6_bits() {
     BLACKBOX::RANGE input: w2, bits: 10
     BLACKBOX::RANGE input: w3, bits: 6
     ASSERT w3 = w0 - 64*w2
-    ASSERT w3 = w1
+    ASSERT w1 = w3
 
     unconstrained func 0: directive_integer_quotient
     0: @10 = const u32 2
@@ -179,7 +179,7 @@ fn truncate_field_to_6_bits() {
     ASSERT 0 = -w2*w6 + 342003794872488675347600089769644923258568193756500536620284440415247007744*w6
     ASSERT w7 = w3*w6
     ASSERT w7 = 0
-    ASSERT w3 = w1
+    ASSERT w1 = w3
 
     unconstrained func 0: directive_integer_quotient
     0: @10 = const u32 2

--- a/compiler/noirc_evaluator/src/acir/tests/instructions/binary.rs
+++ b/compiler/noirc_evaluator/src/acir/tests/instructions/binary.rs
@@ -119,7 +119,7 @@ fn eq_field() {
     BRILLIG CALL func: 0, inputs: [w3], outputs: [w4]
     ASSERT w5 = -w3*w4 + 1
     ASSERT 0 = w3*w5
-    ASSERT w5 = w2
+    ASSERT w2 = w5
 
     unconstrained func 0: directive_invert
     0: @21 = const u32 1
@@ -174,7 +174,7 @@ fn checked_add_u8_no_predicate() {
     BLACKBOX::RANGE input: w1, bits: 8
     ASSERT w3 = w0 + w1
     BLACKBOX::RANGE input: w3, bits: 8
-    ASSERT w3 = w2
+    ASSERT w2 = w3
     ");
 }
 
@@ -201,7 +201,7 @@ fn checked_add_u8_with_predicate() {
     BLACKBOX::RANGE input: w2, bits: 1
     ASSERT w4 = w0*w2 + w1*w2
     BLACKBOX::RANGE input: w4, bits: 8
-    ASSERT w4 = w3
+    ASSERT w3 = w4
     ");
 }
 
@@ -229,7 +229,7 @@ fn checked_mul_u8_with_predicate() {
     ASSERT w4 = w0*w1
     ASSERT w5 = w2*w4
     BLACKBOX::RANGE input: w5, bits: 8
-    ASSERT w5 = w3
+    ASSERT w3 = w5
     ");
 }
 
@@ -267,7 +267,7 @@ fn div_u8_no_predicate_by_witness() {
     ASSERT w6 = w1 - w5 - 1
     BLACKBOX::RANGE input: w6, bits: 8
     ASSERT w5 = -w1*w4 + w0
-    ASSERT w4 = w2
+    ASSERT w2 = w4
 
     unconstrained func 0: directive_invert
     0: @21 = const u32 1
@@ -318,7 +318,7 @@ fn div_u8_no_predicate_by_constant() {
     ASSERT w4 = w3 + 1
     BLACKBOX::RANGE input: w4, bits: 3
     ASSERT w3 = w0 - 7*w2
-    ASSERT w2 = w1
+    ASSERT w1 = w2
 
     unconstrained func 0: directive_integer_quotient
     0: @10 = const u32 2
@@ -372,7 +372,7 @@ fn div_u8_with_predicate() {
     BLACKBOX::RANGE input: w8, bits: 8
     ASSERT w9 = w1*w6 + w7
     ASSERT 0 = w0*w2 - w2*w9
-    ASSERT w6 = w3
+    ASSERT w3 = w6
 
     unconstrained func 0: directive_invert
     0: @21 = const u32 1
@@ -424,7 +424,7 @@ fn mod_u8_no_predicate() {
     ASSERT w6 = w1 - w5 - 1
     BLACKBOX::RANGE input: w6, bits: 8
     ASSERT w5 = -w1*w4 + w0
-    ASSERT w5 = w2
+    ASSERT w2 = w5
 
     unconstrained func 0: directive_invert
     0: @21 = const u32 1
@@ -471,7 +471,7 @@ fn eq_u8() {
     BRILLIG CALL func: 0, inputs: [w3], outputs: [w4]
     ASSERT w5 = -w3*w4 + 1
     ASSERT 0 = w3*w5
-    ASSERT w5 = w2
+    ASSERT w2 = w5
 
     unconstrained func 0: directive_invert
     0: @21 = const u32 1
@@ -519,7 +519,7 @@ fn lt_u8() {
     BLACKBOX::RANGE input: w3, bits: 1
     BLACKBOX::RANGE input: w4, bits: 8
     ASSERT w4 = w0 - w1 - 256*w3 + 256
-    ASSERT w3 = -w2 + 1
+    ASSERT w2 = -w3 + 1
 
     unconstrained func 0: directive_integer_quotient
     0: @10 = const u32 2
@@ -574,7 +574,7 @@ fn and_u8() {
     BLACKBOX::RANGE input: w0, bits: 8
     BLACKBOX::RANGE input: w1, bits: 8
     BLACKBOX::AND inputs: [w0, w1], bits: 8, output: w3
-    ASSERT w3 = w2
+    ASSERT w2 = w3
     ");
 }
 
@@ -625,7 +625,7 @@ fn or_u8() {
     ASSERT w3 = -w0 + 255
     ASSERT w4 = -w1 + 255
     BLACKBOX::AND inputs: [w3, w4], bits: 8, output: w5
-    ASSERT w5 = -w2 + 255
+    ASSERT w2 = -w5 + 255
     ");
 }
 
@@ -673,6 +673,6 @@ fn xor_u8() {
     BLACKBOX::RANGE input: w0, bits: 8
     BLACKBOX::RANGE input: w1, bits: 8
     BLACKBOX::XOR inputs: [w0, w1], bits: 8, output: w3
-    ASSERT w3 = w2
+    ASSERT w2 = w3
     ");
 }

--- a/compiler/noirc_evaluator/src/acir/tests/mod.rs
+++ b/compiler/noirc_evaluator/src/acir/tests/mod.rs
@@ -128,7 +128,7 @@ fn no_zero_bits_range_check() {
     ASSERT 0 = -w2*w6 + 85500948718122168836900022442411230814642048439125134155071110103811751936*w6
     ASSERT w7 = w3*w6
     ASSERT w7 = 0
-    ASSERT w3 = w1
+    ASSERT w1 = w3
 
     unconstrained func 0: directive_integer_quotient
     0: @10 = const u32 2


### PR DESCRIPTION
# Description

## Problem

No issue.

## Summary

This is a really a minor thing but it makes it slightly easier to read ACIR and understand what the return values are constrained against.

## Additional Context



## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
