### PR TITLE
chore(ACIR): no need to return types in `flatten`

### DIFF
--- a/compiler/noirc_evaluator/src/acir/call/intrinsics/slice_ops.rs
+++ b/compiler/noirc_evaluator/src/acir/call/intrinsics/slice_ops.rs
@@ -292,7 +292,6 @@ impl Context<'_> {
         // We need to a fully flat list of AcirVar's as a dynamic array is represented with flat memory.
         let mut inner_elem_size_usize = 0;
         let mut flattened_elements = Vec::new();
-        let mut new_value_types = Vec::new();
         for elem in elements_to_insert {
             let element = self.convert_value(*elem, dfg);
             // Flatten into (AcirVar, NumericType) pairs
@@ -300,9 +299,8 @@ impl Context<'_> {
             let elem_size = flat_element.len();
             inner_elem_size_usize += elem_size;
             slice_size += elem_size;
-            for (var, typ) in flat_element {
+            for var in flat_element {
                 flattened_elements.push(var);
-                new_value_types.push(typ);
             }
         }
         let inner_elem_size = self.acir_context.add_constant(inner_elem_size_usize);
@@ -518,7 +516,7 @@ impl Context<'_> {
         // In practice `popped_elements_size` should never exceed the `slice_size` but we do a saturating sub to be safe.
         let result_size = slice_size.saturating_sub(popped_elements_size);
         self.initialize_array(result_block_id, result_size, None)?;
-        for (i, (current_value, _)) in flat_slice.iter().enumerate().take(result_size) {
+        for (i, current_value) in flat_slice.iter().enumerate().take(result_size) {
             let current_index = self.acir_context.add_constant(i);
 
             let shifted_index = self.acir_context.add_constant(i + popped_elements_size);

--- a/compiler/noirc_evaluator/src/acir/mod.rs
+++ b/compiler/noirc_evaluator/src/acir/mod.rs
@@ -848,14 +848,14 @@ impl<'a> Context<'a> {
         self.acir_context.truncate_var(var, bit_size, max_bit_size)
     }
 
-    /// Fetch a flat list of ([AcirVar], [AcirType]).
+    /// Fetch a flat list of [AcirVar].
     ///
-    /// Flattens an [AcirValue] into a vector of `(AcirVar, AcirType)`.
+    /// Flattens an [AcirValue] into a vector of `AcirVar`.
     ///
     /// This is an extension of [AcirValue::flatten] that also supports [AcirValue::DynamicArray].
-    fn flatten(&mut self, value: &AcirValue) -> Result<Vec<(AcirVar, NumericType)>, RuntimeError> {
+    fn flatten(&mut self, value: &AcirValue) -> Result<Vec<AcirVar>, RuntimeError> {
         Ok(match value {
-            AcirValue::Var(var, typ) => vec![(*var, typ.to_numeric_type())],
+            AcirValue::Var(var, _) => vec![*var],
             AcirValue::Array(array) => {
                 let mut result = Vec::new();
                 for elem in array {
@@ -869,7 +869,7 @@ impl<'a> Context<'a> {
 
                 for value in elements {
                     match value {
-                        AcirValue::Var(var, typ) => result.push((var, typ.to_numeric_type())),
+                        AcirValue::Var(var, _) => result.push(var),
                         _ => unreachable!("ICE: Dynamic memory should already be flat"),
                     }
                 }


### PR DESCRIPTION
# Description

## Problem

No issue, just something I noticed.

## Summary

I think these stopped being needed after https://github.com/noir-lang/noir/pull/10128 as we no longer need to append these types to a AcirDynamicArray's `value_types`.

## Additional Context



## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
