### PR TITLE
chore(ACIR): simpler AsSlice implementation

### DIFF
--- a/compiler/noirc_evaluator/src/acir/call/intrinsics/mod.rs
+++ b/compiler/noirc_evaluator/src/acir/call/intrinsics/mod.rs
@@ -101,7 +101,11 @@ impl Context<'_> {
                 };
                 let slice_length = self.acir_context.add_constant(slice_length);
                 let acir_value = self.convert_value(array_contents, dfg);
-                Ok(vec![AcirValue::Var(slice_length, AcirType::unsigned(32)), acir_value])
+                let result = self.read_array(acir_value)?;
+                Ok(vec![
+                    AcirValue::Var(slice_length, AcirType::unsigned(32)),
+                    AcirValue::Array(result),
+                ])
             }
 
             Intrinsic::SlicePushBack => self.convert_slice_push_back(arguments, dfg),


### PR DESCRIPTION
# Description

## Problem

No issue, just one more thing I noticed.

## Summary

`AsSlice` was already changed in https://github.com/noir-lang/noir/pull/10168 to use the non-flattened size.

However, I just realized that the `AsSlice` always operates on arrays so:
- we can get the length from the Array type
- ~there's no need to read an array from the value because the value is already an array~ -> it seems this makes things worse

This has no impact on the final ACIR nor fixes any bugs, but it does make `AsSlice` simpler and simpler to reason about.

## Additional Context



## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
