### PR TITLE
chore: redo typo PR by spuradage

### DIFF
--- a/acvm-repo/acvm/src/compiler/optimizers/redundant_range.rs
+++ b/acvm-repo/acvm/src/compiler/optimizers/redundant_range.rs
@@ -183,7 +183,7 @@ impl<'a, F: AcirField> RangeOptimizer<'a, F> {
     /// a minimal number of times that still allows us to avoid executing
     /// any new side effects due to their removal.
     ///
-    /// The idea is to keep only the RANGE opcodes that have stricly smaller bit-size requirements
+    /// The idea is to keep only the RANGE opcodes that have strictly smaller bit-size requirements
     /// than before, i.e the ones that are at a 'switch point'.
     /// Furthermore, we only keep the switch points that are last before
     /// a 'side-effect' opcode (i.e a Brillig call).

--- a/compiler/noirc_evaluator/src/ssa/ssa_gen/context.rs
+++ b/compiler/noirc_evaluator/src/ssa/ssa_gen/context.rs
@@ -413,7 +413,7 @@ impl<'a> FunctionContext<'a> {
                 NumericType::Unsigned { bit_size: 1 },
             ) => self.builder.insert_truncate(value, 1, *incoming_type_size),
 
-            // For mixed singed to unsigned:
+            // For mixed signed to unsigned:
             (
                 Type::Numeric(NumericType::Signed { bit_size: incoming_type_size }),
                 NumericType::Unsigned { bit_size: target_type_size },

--- a/docs/versioned_docs/version-v1.0.0-beta.2/noir/standard_library/is_unconstrained.md
+++ b/docs/versioned_docs/version-v1.0.0-beta.2/noir/standard_library/is_unconstrained.md
@@ -1,7 +1,7 @@
 ---
 title: Is Unconstrained Function
 description:
-  The is_unconstrained function returns wether the context at that point of the program is unconstrained or not.
+  The is_unconstrained function returns whether the context at that point of the program is unconstrained or not.
 keywords:
   [
     unconstrained
@@ -12,7 +12,7 @@ It's very common for functions in circuits to take unconstrained hints of an exp
 
 When a function is marked as unconstrained, any subsequent functions that it calls will also be run in an unconstrained context. However, if we are implementing a library function, other users might call it within an unconstrained context or a constrained one. Generally, in an unconstrained context we prefer just computing the result instead of taking a hint of it and verifying it, since that'd mean doing the same computation twice:
 
-```rust 
+```rust
 
 fn my_expensive_computation(){
   ...
@@ -33,7 +33,7 @@ pub fn external_interface(){
 In order to improve the performance in an unconstrained context you can use the function at `std::runtime::is_unconstrained() -> bool`:
 
 
-```rust 
+```rust
 use dep::std::runtime::is_unconstrained;
 
 fn my_expensive_computation(){

--- a/tooling/noir_js/src/witness_generation.ts
+++ b/tooling/noir_js/src/witness_generation.ts
@@ -76,7 +76,7 @@ export async function generateWitness(
     const solvedWitness = await executeProgram(base64Decode(compiledProgram.bytecode), witnessMap, foreignCallHandler);
     return solvedWitness;
   } catch (err) {
-    // Typescript types catched errors as unknown or any, so we need to narrow its type to check if it has raw assertion payload.
+    // Typescript types caught errors as unknown or any, so we need to narrow its type to check if it has raw assertion payload.
     if (typeof err === 'object' && err !== null && 'rawAssertionPayload' in err) {
       throw enrichExecutionError(compiledProgram, err as ExecutionError);
     }


### PR DESCRIPTION
Thanks spuradage for https://github.com/noir-lang/noir/pull/10223. Our policy is to redo typo changes to dissuade metric farming. This is an automated script.