### PR TITLE
chore(ACIR): don't do index out of bounds in some cases

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/ssa_gen/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/ssa_gen/mod.rs
@@ -534,8 +534,16 @@ impl FunctionContext<'_> {
             .get_numeric_constant(array_len)
             .and_then(|value| value.try_to_u32());
 
-        // This optimization seems to cause regressions in brillig so we restrict it to ACIR.
         let runtime = self.builder.current_function.runtime();
+
+        if runtime.is_acir()
+            && array_len_constant.is_some()
+            && !self.builder.current_function.dfg.is_constant(index)
+        {
+            return;
+        }
+
+        // This optimization seems to cause regressions in brillig so we restrict it to ACIR.
         if runtime.is_acir() && array_len_constant.is_some_and(u32::is_power_of_two) {
             // If the array length is a power of two then we can make use of the range check opcode
             // to assert that the index fits in the relevant number of bits.


### PR DESCRIPTION
# Description

## Problem

No issue, just trying something.

## Summary

I noticed that in some cases we can omit the out-of-bounds check in ACIR. However, I think this leads to a worse performance so I'm opening this PR to verify that but also to try to understand why...

## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
