### PR TITLE
feat(ACIR): reuse element_type_sizes blocks with the same structure

### DIFF
--- a/compiler/noirc_evaluator/src/acir/mod.rs
+++ b/compiler/noirc_evaluator/src/acir/mod.rs
@@ -91,6 +91,10 @@ struct Context<'a> {
     /// which utilizes this internal memory for ACIR generation.
     element_type_sizes_blocks: HashMap<Id<Value>, BlockId>,
 
+    /// Maps type sizes to BlockId. This is used to reuse the same BlockId if different
+    /// non-homogenous arrays end up having the same type sizes layout.
+    type_sizes_to_blocks: HashMap<Vec<usize>, BlockId>,
+
     /// Number of the next BlockId, it is used to construct
     /// a new BlockId
     max_block_id: u32,
@@ -125,6 +129,7 @@ impl<'a> Context<'a> {
             initialized_arrays: HashSet::default(),
             memory_blocks: HashMap::default(),
             element_type_sizes_blocks: HashMap::default(),
+            type_sizes_to_blocks: HashMap::default(),
             max_block_id: 0,
             data_bus: DataBus::default(),
             shared_context,


### PR DESCRIPTION
# Description

## Problem

Resolves #10230

## Summary



## Additional Context

It's unclear if in practice this will happen, but it's a very simple optimization so it might be worth it.

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
