### PR TITLE
fix(mem2reg): Update array set value alias set and propagate array get result as alias 

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/opt/mem2reg.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/mem2reg.rs
@@ -575,8 +575,7 @@ impl<'f> PerFunctionContext<'f> {
                         aliases.insert(result);
                     }
 
-                    // Any aliases of the array need to be updated to also include the result of the array access.
-                    // We update the alias set of those values by pointing them to the new array expression.
+                    // Any aliases of the array need to be updated to also include the result of the array get in their alias sets.
                     for alias in (*references.get_aliases_for_value(array)).clone().iter() {
                         // An expression for the alias might already exist, so try to fetch it first
                         let expression = references.expressions.get(&alias).copied();

--- a/compiler/noirc_evaluator/src/ssa/opt/mem2reg/block.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/mem2reg/block.rs
@@ -237,16 +237,6 @@ impl Block {
         Cow::Owned(AliasSet::unknown())
     }
 
-    pub(super) fn set_alias_for_value(&mut self, value: ValueId, alias: ValueId) {
-        // An expression for the value might already exist, so try to fetch it first
-        let expression = self.expressions.get(&value).copied();
-        let expression = expression.unwrap_or(Expression::Other(value));
-
-        if let Some(aliases) = self.aliases.get_mut(&expression) {
-            aliases.insert(alias);
-        }
-    }
-
     pub(super) fn set_last_load(&mut self, address: ValueId, instruction: InstructionId) {
         let aliases = self.get_aliases_for_value(address);
         if !aliases.is_unknown() {


### PR DESCRIPTION
# Description

## Problem\*

Alternative to #10175
Resolves #10070 
Resolves #10020

Fix to timed out tests https://github.com/noir-lang/noir/pull/10175#pullrequestreview-3331581074

## Summary\*

We were appropriately setting the initial alias sets for the results of make_array, array_get, and array_set with arrays of references. We just were not also setting the alias sets of the array elements themselves to also include the result of `array_get` and `array_set` in their alias sets. 

For example in this code:
```
        brillig(inline) fn main f0 {
          b0(v0: [&mut Field; 1], v1: u1):
            v3 = allocate -> &mut Field
            v4 = allocate -> &mut Field
            jmpif v1 then: b1, else: b2
          b1():
            v7 = array_set v0, index u32 0, value v3
            jmp b3(v7)
          b2():
            v6 = array_set v0, index u32 0, value v4
            jmp b3(v6)
          b3(v2: [&mut Field; 1]):
            v8 = array_get v2, index u32 0 -> &mut Field
            store Field 1 at v8
            store Field 2 at v3
            store Field 3 at v4
            v12 = load v8 -> Field
            return v12
        }
```
`v6` and `v7` have the appropriate alias sets. However, v3 and v4 were not being updated to include v6 and v7 in their own alias sets. This PR makes that change and #10070 passes.

Same thing for this case:
```
        acir(inline) predicate_pure fn main f0 {
          b0():
            v1 = allocate -> &mut Field
            store Field 0 at v1
            v3 = allocate -> &mut Field
            store Field 0 at v3
            v4 = make_array [v1, v3] : [&mut Field; 2]
            v5 = allocate -> &mut Field
            store Field 0 at v5
            jmp b1(u32 0)
          b1(v0: u32):
            v7 = eq v0, u32 0
            jmpif v7 then: b2, else: b3
          b2():
            v9 = array_get v4, index v0 -> &mut Field
            store Field 1 at v9
            store Field 2 at v1
            v12 = load v5 -> Field
            v13 = load v9 -> Field
            v14 = add v12, v13
            store v14 at v5
            v16 = unchecked_add v0, u32 1
            jmp b1(v16)
          b3():
            v8 = load v5 -> Field
            return v8
        }
```
`v4` and `v9` had the appropriate alias sets post the array_get in b2. However, the aliases of `v4` (which are `v1` and `v3`) were not being updated to include `v9` in their alias sets. Once making this update #10020 passes.

## Additional Context

We can see in https://github.com/noir-lang/noir/pull/10242#pullrequestreview-3356982197 that the `rollup-checkpoint-root-*` tests are back. 

## Documentation\*

Check one:
- [X] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
