### PR TITLE
feat(github): Add Security Policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -22,4 +22,6 @@ Bugs are all unexpected behaviors in the system, while vulnerabilities are a sub
 
 Report all vulnerabilities using ["Report a vulnerability"](https://github.com/noir-lang/noir/security/advisories/new), which will create a private GitHub security advisory, notify, and be accessible to a small security team who will scope out and execute next steps in addressing the vulnerability. The security team may reach out to you on GitHub for additional details and guidance.
 
-Please **do NOT** report vulnerabilities using public GitHub Issues. That would expose Noir projects to undesirable risks of being exploited.
+You may find GitHub's documentation on [best practices for writing repository security advisories](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/best-practices-for-writing-repository-security-advisories) useful for filling out the reporting form.
+
+Please **DO NOT** report vulnerabilities using public GitHub Issues. That would expose Noir projects to undesirable risks of being exploited.


### PR DESCRIPTION
# Description

## Summary\*

Add a simple security policy guiding people to privately report and inform us of vulnerabilities they come across using https://github.com/noir-lang/noir/security/advisories/new.

The SECURITY.md file will be rendered and displayed at the top of the page when people click into the ["Security" tab](https://github.com/noir-lang/noir/security) in this repository.

## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
