### PR TITLE
feat(LSP): show errors on stdlib files

### DIFF
--- a/tooling/lsp/src/notifications/mod.rs
+++ b/tooling/lsp/src/notifications/mod.rs
@@ -356,6 +356,7 @@ fn custom_diagnostic_to_diagnostic(
     let call_stack = diagnostic
         .call_stack
         .into_iter()
+        .rev()
         .filter_map(|frame| call_stack_frame_to_related_information(frame, files, fm));
     let related_information: Vec<_> = secondaries.chain(notes).chain(call_stack).collect();
 


### PR DESCRIPTION
# Description

## Problem

Resolves https://github.com/AztecProtocol/aztec-packages/pull/17827#discussion_r2455013169

## Summary

Two things here:
1. Some time ago we enabled navigating to stdlib files. What was missing here was allowing errors (diangnostics) to also refer to the stdlib (now that they can be navigated too)
    - When doing this I realized this stdlib handling was missing in a few places, mainly when showing secondary locations and an error's backtrace
2. The callstack order is reversed, so when you click on successive entries you go up in the callstack, as can be seen in the next video


![lsp-errors](https://github.com/user-attachments/assets/751ea7f6-ae35-43f6-af0c-0b4d67bb260b)



## Additional Context



## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
