### PR TITLE
chore: avoid unrolling loop headers twice in unrolling passes

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/opt/unrolling.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/unrolling.rs
@@ -976,7 +976,7 @@ struct LoopIteration<'f> {
     original_blocks: HashMap<BasicBlockId, BasicBlockId>,
     visited_blocks: HashSet<BasicBlockId>,
 
-    /// Has `unroll_loop_iteration` reached the `loop_header_id`
+    /// Has `unroll_loop_iteration` reached the `loop_header_id`?
     encountered_loop_header: bool,
 
     insert_block: BasicBlockId,


### PR DESCRIPTION
# Description

## Problem\*

Resolves https://github.com/noir-lang/noir/issues/10161

## Summary\*

Adds `loop_header_id` to `visited_blocks` in `unroll_header`

## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [x] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
