### PR TITLE
chore(ACIR): use u32::MAX for PLACEHOLDER_BRILLIG_INDEX

### DIFF
--- a/compiler/noirc_evaluator/src/acir/acir_context/generated_acir/brillig_directive.rs
+++ b/compiler/noirc_evaluator/src/acir/acir_context/generated_acir/brillig_directive.rs
@@ -13,7 +13,7 @@ use crate::brillig::brillig_ir::artifact::GeneratedBrillig;
 /// This index should be used when adding a Brillig call during code generation.
 /// Code generation should then keep track of that unresolved call opcode which will be resolved with the
 /// correct function index after code generation.
-pub(crate) const PLACEHOLDER_BRILLIG_INDEX: BrilligFunctionId = BrilligFunctionId(std::u32::MAX);
+pub(crate) const PLACEHOLDER_BRILLIG_INDEX: BrilligFunctionId = BrilligFunctionId(u32::MAX);
 
 #[derive(Debug, Clone)]
 pub(crate) struct BrilligStdLib<F> {

--- a/compiler/noirc_evaluator/src/acir/acir_context/generated_acir/mod.rs
+++ b/compiler/noirc_evaluator/src/acir/acir_context/generated_acir/mod.rs
@@ -643,7 +643,7 @@ impl<F: AcirField> GeneratedAcir<F> {
         match &mut self.opcodes[acir_index] {
             AcirOpcode::BrilligCall { id, .. } => {
                 assert!(*id == PLACEHOLDER_BRILLIG_INDEX, "expected placeholder brillig index");
-                *id = brillig_function_index
+                *id = brillig_function_index;
             }
             _ => panic!("expected brillig call opcode"),
         }


### PR DESCRIPTION
# Description

## Problem

Resolves #10256

## Summary

It's not possible to use `Option` because the ACIR calls must have a valid function ID, a `u32`. However, we can use `u32::MAX` instead of zero. Then it's very unlikely that this `u32::MAX` corresponds to an actual function, and if we ever try to call a function with a value `u32::MAX` it'll definitely be because we forgot to replace an stdlib call.

## Additional Context



## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
