### PR TITLE
chore: Fix typo in defunctionalize docs

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/opt/defunctionalize.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/defunctionalize.rs
@@ -21,7 +21,7 @@
 //! fn apply(function_id: Field, arg1: Field, arg2: Field) -> Field {
 //!     match function_id {
 //!         0 -> function0(arg1, arg2),
-//!         1 -> function0(arg1, arg2),
+//!         1 -> function1(arg1, arg2),
 //!         ...
 //!         N -> functionN(arg1, arg2),
 //!     }


### PR DESCRIPTION
# Description

## Problem\*

Resolves https://cantina.xyz/code/5387827b-5629-4d61-beda-76d82161d335/findings/9

## Summary\*



## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
