### PR TITLE
fix: check value of `ArraySet` during `array_set_optimization`

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/opt/array_set.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/array_set.rs
@@ -414,6 +414,8 @@ mod tests {
         let _ssa = ssa.array_set_optimization();
     }
 
+    // Previously, the first array_set instruction, which modifies v2 in the below
+    // code snippet, was marked as mut despite v2 being used in the next array_set instruction.
     #[test]
     fn regression_10245() {
         let src = "
@@ -424,15 +426,6 @@ mod tests {
                 return v6, v5
             }
             ";
-        let ssa = Ssa::from_str(src).unwrap();
-        let ssa = ssa.array_set_optimization();
-        assert_ssa_snapshot!(ssa, @r"
-            acir(inline) predicate_pure fn main f0 {
-              b0(v0: Field, v1: [[Field; 1]; 2], v2: [Field; 1]):
-                v5 = array_set v2, index u32 0, value Field 4
-                v6 = array_set v1, index u32 0, value v2
-                return v6, v5
-            }
-        ");
+        assert_ssa_does_not_change(src, Ssa::array_set_optimization);
     }
 }


### PR DESCRIPTION
# Description

## Problem\*

Resolves https://github.com/noir-lang/noir/issues/10245

## Summary\*

Checking for nested array case during `array_set_optimization`

## Additional Context



## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
