### PR TITLE
chore: require ≥2 `FunctionId`'s in `create_apply_function`

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/opt/defunctionalize.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/defunctionalize.rs
@@ -539,7 +539,7 @@ fn function_id_to_field(function_id: FunctionId) -> FieldElement {
 /// The [FunctionId] of the new apply function
 ///
 /// # Panics
-/// If the `function_ids` argument has fewer than two elements.
+/// If the `function_ids` argument has fewer than two elements, implying that no apply function is necessary.
 fn create_apply_function(
     ssa: &mut Ssa,
     signature: Signature,


### PR DESCRIPTION
# Description

## Problem\*

Resolves https://github.com/noir-lang/noir/issues/10119

## Summary\*



## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [x] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
