### PR TITLE
fix(elaborator): Create new type variable for each generic kind of `FmtStr`

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/primitive_types.rs
+++ b/compiler/noirc_frontend/src/elaborator/primitive_types.rs
@@ -326,14 +326,15 @@ impl Elaborator<'_> {
                 Type::String(Box::new(length))
             }
             PrimitiveType::Fmtstr => {
-                let item_generic_kinds = FmtstrPrimitiveType.generic_kinds(self.interner);
+                let item = FmtstrPrimitiveType;
+                let item_generic_kinds = item.generic_kinds(self.interner);
                 let generics = vecmap(&item_generic_kinds, |kind| {
                     self.interner.next_type_variable_with_kind(kind.clone())
                 });
                 let mut args = if let Some(turbofish) = turbofish {
                     self.resolve_item_turbofish_generics(
-                        "primitive type",
-                        "fmtstr",
+                        FmtstrPrimitiveType.item_kind(),
+                        &item.item_name(self.interner),
                         item_generic_kinds,
                         generics,
                         Some(turbofish.generics),


### PR DESCRIPTION
# Description

## Problem\*

Resolves something I noticed while auditing `primitive_types`: `instantiate_primitive_type_with_turbofish` only puts the first `kind` into `generics`; if `turbofish` is `None` this `generics` will become `args`, which in the next step is asserted to have a length of 2. `resolve_item_turbofish_generics` also asserts that `turbofish.generics` has the same length as `generics`: one of these assertions will fail: `turbofish.generics` has to have a length of 2 to pass the eventual assertion, but then it fails because it's not 1 long like `generics`.

## Summary\*

Makes sure all generic kind of `str` and `fmtstr` have a type variable in `generics`.

## Additional Context

Not sure yet if there is a good place to put tests for this. I guess a turbo fish with a format string isn't something that anyone explicitly calls.

## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
