### PR TITLE
fix: Update Rust toolchain to 1.88.0 for wasm-pack compatibility

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.85.0"
+channel = "1.88.0"
 components = [ "rust-src" ]
 targets = [ "wasm32-unknown-unknown", "wasm32-wasip1", "aarch64-apple-darwin" ]
 profile = "default"


### PR DESCRIPTION
# Description

## Problem\*

When running `cargo install wasm-pack`, the installation fails with the following error:

```
rustc 1.85.0 is not supported by the following package:
    home@0.5.12 requires rustc 1.88
  Try re-running cargo install with --locked
```

## Summary\*

This occurs because the `home` crate v0.5.12 (a dependency of wasm-pack v0.13.1) requires Rust 1.88 or later, but the project's `rust-toolchain.toml` specifies version 1.85.0.

## Additional Context

### Solution: 
Update the Rust toolchain version from `1.85.0` to `1.88.0` in `rust-toolchain.toml`.

### Testing
- ✅ Successfully installed wasm-pack with `cargo install wasm-pack`
- ✅ Verified build completes without errors

## Documentation\*

Check one:
- [ ✅ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ✅ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
