### PR TITLE
fix(docs): improve trailing newline handling in code preprocessor

### DIFF
--- a/docs/scripts/preprocess/include_code.js
+++ b/docs/scripts/preprocess/include_code.js
@@ -56,7 +56,8 @@ function processHighlighting(codeSnippet, identifier) {
     result += line === '' && mutated ? '' : line + '\n';
   }
 
-  return result.trim();
+  // Remove trailing newline
+  return result.replace(/\n$/, '');
 }
 
 let lastReleasedVersion;


### PR DESCRIPTION
# Description

Replace `trim()` with precise regex replacement to only remove the final trailing newline in processHighlighting function. This prevents unintended removal of leading/trailing whitespace in code snippets while still maintaining clean output formatting.

## Problem\*

Unexpected deletion of the leading space on the first line can cause misalignment between lines.

<img width="846" height="593" alt="image" src="https://github.com/user-attachments/assets/afe872e9-5d92-4550-9a50-b0f4f328b3dc" />

## Summary\*

- Changed from `trim()` to `replace(/\n$/, '')` to only remove the final newline
- Preserves intentional leading/trailing whitespace in code snippets

## Additional Context

Output after testing with `node docs/scripts/preprocess/index.js`:

noirjs_app.md

```js title="init" showLineNumbers 
    const noir = new Noir(circuit);
    const backend = new UltraHonkBackend(circuit.bytecode);
```

## Documentation\*

Check one:
- [ ✅ ] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ✅ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
