### PR TITLE
chore(frontend): Various comptime blocks unit tests

### DIFF
--- a/compiler/noirc_frontend/src/tests/metaprogramming.rs
+++ b/compiler/noirc_frontend/src/tests/metaprogramming.rs
@@ -752,8 +752,9 @@ fn multiple_comptime_blocks_share_scope() {
     assert_no_errors(src);
 }
 
+// Reactivate once https://github.com/noir-lang/noir/issues/10397 is resolved
 #[test]
-#[should_panic = "Reactivate once https://github.com/noir-lang/noir/issues/10397 is resolved"]
+#[should_panic]
 fn nested_comptime_accesses_outer_comptime_variable() {
     let src = r#"
         fn main() {
@@ -769,8 +770,9 @@ fn nested_comptime_accesses_outer_comptime_variable() {
     assert_no_errors(src);
 }
 
+// Reactivate once https://github.com/noir-lang/noir/issues/10397 is resolved
 #[test]
-#[should_panic = "Reactivate once https://github.com/noir-lang/noir/issues/10397 is resolved"]
+#[should_panic]
 fn nested_comptime_accesses_outer_comptime_func_variable() {
     let src = r#"
     comptime fn main() {
@@ -784,8 +786,9 @@ fn nested_comptime_accesses_outer_comptime_func_variable() {
     assert_no_errors(src);
 }
 
+// Reactivate once https://github.com/noir-lang/noir/issues/10397 is resolved
 #[test]
-#[should_panic = "Reactivate once https://github.com/noir-lang/noir/issues/10397 is resolved"]
+#[should_panic]
 fn nested_comptime_with_mut_variable() {
     let src = r#"
         fn main() {
@@ -801,8 +804,9 @@ fn nested_comptime_with_mut_variable() {
     assert_no_errors(src);
 }
 
+// Reactivate once https://github.com/noir-lang/noir/issues/10397 is resolved
 #[test]
-#[should_panic = "Reactivate once https://github.com/noir-lang/noir/issues/10397 is resolved"]
+#[should_panic]
 fn nested_comptime_mut_outer_comptime_func_variable() {
     let src = r#"
     comptime fn main() {
@@ -816,8 +820,9 @@ fn nested_comptime_mut_outer_comptime_func_variable() {
     assert_no_errors(src);
 }
 
+// Reactivate once https://github.com/noir-lang/noir/issues/10397 is resolved
 #[test]
-#[should_panic = "Reactivate once https://github.com/noir-lang/noir/issues/10397 is resolved"]
+#[should_panic]
 fn comptime_function_with_comptime_block_called_from_comptime() {
     let src = r#"
         comptime fn helper(x: Field) -> Field {
@@ -837,8 +842,9 @@ fn comptime_function_with_comptime_block_called_from_comptime() {
     assert_no_errors(src);
 }
 
+// Reactivate once https://github.com/noir-lang/noir/issues/10397 is resolved
 #[test]
-#[should_panic = "Reactivate once https://github.com/noir-lang/noir/issues/10397 is resolved"]
+#[should_panic]
 fn runtime_function_with_comptime_block_called_from_comptime() {
     let src = r#"
         fn helper(x: Field) -> Field {


### PR DESCRIPTION
# Description

## Problem\*

Working towards the green-light of the elaborator group 7a

## Summary\*

I noticed our tests for comptime blocks was severely lacking. You can see the various comptime tests that have been added in the diff.

Multiple tests are ignored as a result of https://github.com/noir-lang/noir/issues/10397

## Additional Context



## Documentation\*

Check one:
- [X] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
