### PR TITLE
chore: use SignedField::from_signed in enums.rs

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/enums.rs
+++ b/compiler/noirc_frontend/src/elaborator/enums.rs
@@ -836,26 +836,13 @@ impl Elaborator<'_> {
             expr_location: location,
         });
 
-        // Convert a signed integer type like i32 to SignedField
-        macro_rules! signed_to_signed_field {
-            ($value:expr) => {{
-                let negative = $value < 0;
-                // Widen the value so that SignedType::MIN does not wrap to 0 when negated below
-                let mut widened = i128::from($value);
-                if negative {
-                    widened = -widened;
-                }
-                SignedField::new(widened.into(), negative)
-            }};
-        }
-
         let value = match constant {
             Value::Bool(value) => SignedField::positive(value),
             Value::Field(value) => value,
-            Value::I8(value) => signed_to_signed_field!(value),
-            Value::I16(value) => signed_to_signed_field!(value),
-            Value::I32(value) => signed_to_signed_field!(value),
-            Value::I64(value) => signed_to_signed_field!(value),
+            Value::I8(value) => SignedField::from_signed(value),
+            Value::I16(value) => SignedField::from_signed(value),
+            Value::I32(value) => SignedField::from_signed(value),
+            Value::I64(value) => SignedField::from_signed(value),
             Value::U1(value) => SignedField::positive(value),
             Value::U8(value) => SignedField::positive(u128::from(value)),
             Value::U16(value) => SignedField::positive(u128::from(value)),


### PR DESCRIPTION
# Description

## Problem

No issue.

## Summary

While auditing enums.rs I noticed this piece of code and looked at it carefully to see if it might have bugs. Then I found out that there's a `SignedField::from_signed` function already so reused that. If there are bugs in this conversion, at least now they are all in the same place now (the function seems correct, though :-))

## Additional Context



## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
