### PR TITLE
chore(frontend): Primitive types generic count unit tests

### DIFF
--- a/compiler/noirc_frontend/src/tests/turbofish.rs
+++ b/compiler/noirc_frontend/src/tests/turbofish.rs
@@ -634,7 +634,6 @@ fn incorrect_turbofish_count_on_primitive_str() {
 
 #[test]
 fn incorrect_turbofish_count_on_primitive_fmtstr() {
-    // Test fmtstr with wrong number of generics (should take 2, given 1)
     let src = r#"
         trait MyTrait {
             fn foo();
@@ -647,6 +646,24 @@ fn incorrect_turbofish_count_on_primitive_fmtstr() {
         fn main() {
             let _ = fmtstr::<5>::foo();
                           ^^^^^ primitive type fmtstr expects 2 generics but 1 was given
+        }
+    "#;
+    check_errors(src);
+}
+
+#[test]
+fn turbofish_on_primitive_fmtstr() {
+    let src = r#"
+        trait MyTrait {
+            fn foo();
+        }
+
+        impl<let N: u32, T> MyTrait for fmtstr<N, T> {
+            fn foo() { }
+        }
+
+        fn main() {
+            let _ = fmtstr::<5, Field>::foo();
         }
     "#;
     check_errors(src);


### PR DESCRIPTION
# Description

## Problem\*

As part of the elaborator audit, I was looking at the primitive_types module. We had a previous fix https://github.com/noir-lang/noir/pull/10349 where we actually resolved all generics on a fmtstr turbofish. I wanted to try and hit this code path to see if I could trigger the args length assertion. 

## Summary\*

I have added a unit test which would panic before #10349. While I was at it I decided to add a few more turbofish incorrect generic count tests for other primitive types to make sure we have full test coverage.

## Additional Context



## Documentation\*

Check one:
- [X] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
