### PR TITLE
chore(frontend): Avoid silent fallback when returning turbofish generics for primitive types

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/primitive_types.rs
+++ b/compiler/noirc_frontend/src/elaborator/primitive_types.rs
@@ -260,11 +260,17 @@ impl Elaborator<'_> {
         primitive_type.to_type()
     }
 
+    /// Instantiates a primitive type with turbofish generics.
+    ///
+    /// # Returns
+    /// A tuple of:
+    /// - The instantiated [Type]
+    /// - A boolean indicating whether this primitive type has generics
     pub(crate) fn instantiate_primitive_type_with_turbofish(
         &mut self,
         primitive_type: PrimitiveType,
         turbofish: Option<Turbofish>,
-    ) -> Type {
+    ) -> (Type, bool) {
         match primitive_type {
             PrimitiveType::Bool
             | PrimitiveType::CtString
@@ -301,7 +307,7 @@ impl Elaborator<'_> {
                         },
                     ));
                 }
-                primitive_type.to_type()
+                (primitive_type.to_type(), false)
             }
             PrimitiveType::Str => {
                 let item = StrPrimitiveType;
@@ -323,7 +329,7 @@ impl Elaborator<'_> {
                 };
                 assert_eq!(args.len(), 1, "str generics should be: [length]");
                 let length = args.pop().unwrap();
-                Type::String(Box::new(length))
+                (Type::String(Box::new(length)), true)
             }
             PrimitiveType::Fmtstr => {
                 let item = FmtstrPrimitiveType;
@@ -346,7 +352,7 @@ impl Elaborator<'_> {
                 assert_eq!(args.len(), 2, "fmtstr generics should be: [length, element]");
                 let element = args.pop().unwrap();
                 let length = args.pop().unwrap();
-                Type::FmtString(Box::new(length), Box::new(element))
+                (Type::FmtString(Box::new(length), Box::new(element)), true)
             }
         }
     }

--- a/compiler/noirc_frontend/src/elaborator/types.rs
+++ b/compiler/noirc_frontend/src/elaborator/types.rs
@@ -926,7 +926,9 @@ impl Elaborator<'_> {
                 type_alias.get_type(&generics)
             }
             PathResolutionItem::PrimitiveType(primitive_type) => {
-                self.instantiate_primitive_type_with_turbofish(primitive_type, turbofish)
+                let (typ, _) =
+                    self.instantiate_primitive_type_with_turbofish(primitive_type, turbofish);
+                typ
             }
             PathResolutionItem::Module(..)
             | PathResolutionItem::Trait(..)

--- a/compiler/noirc_frontend/src/elaborator/variable.rs
+++ b/compiler/noirc_frontend/src/elaborator/variable.rs
@@ -260,15 +260,18 @@ impl Elaborator<'_> {
                 (Vec::new(), Some(self_type))
             }
             PathResolutionItem::PrimitiveFunction(primitive_type, turbofish, _func_id) => {
-                let typ = self.instantiate_primitive_type_with_turbofish(primitive_type, turbofish);
-                let generics = match typ {
-                    Type::String(length) => {
-                        vec![*length]
+                let (typ, has_generics) =
+                    self.instantiate_primitive_type_with_turbofish(primitive_type, turbofish);
+                let generics = if has_generics {
+                    match typ {
+                        Type::String(length) => vec![*length],
+                        Type::FmtString(length, element) => vec![*length, *element],
+                        _ => {
+                            unreachable!("ICE: Primitive type has been specified to have generics")
+                        }
                     }
-                    Type::FmtString(length, element) => {
-                        vec![*length, *element]
-                    }
-                    _ => Vec::new(),
+                } else {
+                    Vec::new()
                 };
                 (generics, None)
             }


### PR DESCRIPTION
# Description

## Problem\*

Working towards the audit of the elaborator group 7a

I noticed that in `resolve_item_turbofish_and_self_type` we deconstruct the resolved primitive type to fetch any possible generics as they are used later in the elaboration flow. The logic is currently correct but could be incorrect if we ever add another primitive type with generics and forget to return its generics after instantiating the type.

## Summary\*

When instantiating a primitive type with turbofish we now also return a bool as to whether that type should have generics. That bool then determines whether we return an empty list of generics, not the instantiated type. Now if we were to add another primitive type with generics and not return any generics, we would hit the new panic added in this PR. 

I thought about just adding a `has_generics` helper on `PrimitiveType` but this felt like we then still have two sources of truth when removing that is the goal of this refactor. We would have to remember to update this helper if we added a new primitive type.

## Additional Context



## Documentation\*

Check one:
- [ ] No documentation needed.
- [X] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
