### PR TITLE
chore(github): Refine pull request template wording

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,10 +1,10 @@
 # Description
 
-## Problem\*
+## Problem
 
 Resolves <!-- Link to GitHub Issue -->
 
-## Summary\*
+## Summary
 
 
 
@@ -12,14 +12,14 @@ Resolves <!-- Link to GitHub Issue -->
 
 
 
-## Documentation\*
+## User Documentation
 
 Check one:
-- [ ] No documentation needed.
-- [ ] Documentation included in this PR.
-- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.
+- [ ] No user documentation needed.
+- [ ] Changes in _docs/_ included in this PR.
+- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.
 
-# PR Checklist\*
+# PR Checklist
 
 - [ ] I have tested the changes locally.
 - [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.


### PR DESCRIPTION
# Description

## Summary

- Update wording in the documentation section to more accurately reflect it refers to our user documentations in _docs/_ (instead of inline development / auditing docs)
- Remove \* from sections

## Documentation\*

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
