### PR TITLE
fix: mark ECDSA verification as `PureWithPredicate`

### DIFF
--- a/acvm-repo/acir/src/circuit/black_box_functions.rs
+++ b/acvm-repo/acir/src/circuit/black_box_functions.rs
@@ -92,15 +92,16 @@ impl BlackBoxFunc {
         match self {
             BlackBoxFunc::RecursiveAggregation
             | BlackBoxFunc::MultiScalarMul
-            | BlackBoxFunc::EmbeddedCurveAdd => true,
+            | BlackBoxFunc::EmbeddedCurveAdd
+            | BlackBoxFunc::EcdsaSecp256k1
+            | BlackBoxFunc::EcdsaSecp256r1
+            | BlackBoxFunc::RANGE => true,
+
             BlackBoxFunc::AES128Encrypt
             | BlackBoxFunc::AND
             | BlackBoxFunc::XOR
-            | BlackBoxFunc::RANGE
             | BlackBoxFunc::Blake2s
             | BlackBoxFunc::Blake3
-            | BlackBoxFunc::EcdsaSecp256k1
-            | BlackBoxFunc::EcdsaSecp256r1
             | BlackBoxFunc::Keccakf1600
             | BlackBoxFunc::Poseidon2Permutation
             | BlackBoxFunc::Sha256Compression => false,

--- a/compiler/noirc_evaluator/src/ssa/opt/die.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/die.rs
@@ -569,6 +569,7 @@ mod test {
             opt::assert_ssa_does_not_change,
         },
     };
+    use test_case::test_case;
 
     #[test]
     fn dead_instruction_elimination() {
@@ -1209,5 +1210,20 @@ mod test {
         }
         "#;
         assert_ssa_does_not_change(src, Ssa::dead_instruction_elimination);
+    }
+
+    #[test_case("ecdsa_secp256k1")]
+    #[test_case("ecdsa_secp256r1")]
+    fn does_not_remove_unused_ecdsa_verification(ecdsa_func: &str) {
+        let src = format!(
+            r#"
+        acir(inline) fn main f0 {{
+            b0(v0: [u8; 32], v1: [u8; 32], v2: [u8; 64], v3: [u8; 32]):
+            v4 = call {ecdsa_func}(v0, v1, v2, v3, u1 1) -> u1
+            return
+        }}
+        "#
+        );
+        assert_ssa_does_not_change(&src, Ssa::dead_instruction_elimination);
     }
 }

--- a/compiler/noirc_evaluator/src/ssa/opt/pure.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/pure.rs
@@ -301,6 +301,8 @@ mod test {
         ssa::{ir::function::FunctionId, opt::pure::Purity, ssa_gen::Ssa},
     };
 
+    use test_case::test_case;
+
     #[test]
     fn classify_functions() {
         let src = "
@@ -874,5 +876,24 @@ mod test {
         assert_eq!(purities[&FunctionId::test_new(0)], Purity::Impure);
         assert_eq!(purities[&FunctionId::test_new(1)], Purity::Pure);
         assert_eq!(purities[&FunctionId::test_new(1)], Purity::Pure);
+    }
+
+    #[test_case("ecdsa_secp256k1")]
+    #[test_case("ecdsa_secp256r1")]
+    fn marks_ecdsa_verification_as_pure_with_predicate(ecdsa_func: &str) {
+        let src = format!(
+            r#"
+        acir(inline) fn main f0 {{
+            b0(v0: [u8; 32], v1: [u8; 32], v2: [u8; 64], v3: [u8; 32]):
+            v4 = call {ecdsa_func}(v0, v1, v2, v3, u1 1) -> u1
+            return
+        }}
+        "#
+        );
+        let ssa = Ssa::from_str(&src).unwrap();
+        let ssa = ssa.purity_analysis();
+
+        let purities = &ssa.main().dfg.function_purities;
+        assert_eq!(purities[&FunctionId::test_new(0)], Purity::PureWithPredicate);
     }
 }


### PR DESCRIPTION
# Description

## Problem

Resolves <!-- Link to GitHub Issue -->

## Summary

This PR marks ECDSA verification (as well as the range opcode) as having side effects due to the potential for invalid curve points/signatures from violating constraints in the backend.

## Additional Context

I've opened https://github.com/noir-lang/noir/issues/10422 as a result of this issue.


## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
