### PR TITLE
fix: revert "feat(ACIR): reuse element_type_sizes blocks with the same str…

### DIFF
--- a/compiler/noirc_evaluator/src/acir/arrays.rs
+++ b/compiler/noirc_evaluator/src/acir/arrays.rs
@@ -881,14 +881,8 @@ impl Context<'_> {
             AcirValue::Array(values) => {
                 let flat_elem_type_sizes = calculate_element_type_sizes_array(values);
 
-                // If there's already a block with these same sizes, reuse it. It's fine do to so
-                // because the element type sizes array is never mutated.
-                if let Some(block_id) = self.type_sizes_to_blocks.get(&flat_elem_type_sizes) {
-                    return Ok(*block_id);
-                }
-
                 // The final array should will the flattened index at each outer array index
-                let init_values = vecmap(flat_elem_type_sizes.clone(), |type_size| {
+                let init_values = vecmap(flat_elem_type_sizes, |type_size| {
                     let var = self.acir_context.add_constant(type_size);
                     AcirValue::Var(var, NumericType::NativeField)
                 });
@@ -898,8 +892,6 @@ impl Context<'_> {
                     element_type_sizes_len,
                     Some(AcirValue::Array(init_values.into())),
                 )?;
-
-                self.type_sizes_to_blocks.insert(flat_elem_type_sizes, element_type_sizes);
 
                 Ok(element_type_sizes)
             }

--- a/compiler/noirc_evaluator/src/acir/mod.rs
+++ b/compiler/noirc_evaluator/src/acir/mod.rs
@@ -91,10 +91,6 @@ struct Context<'a> {
     /// which utilizes this internal memory for ACIR generation.
     element_type_sizes_blocks: HashMap<Id<Value>, BlockId>,
 
-    /// Maps type sizes to BlockId. This is used to reuse the same BlockId if different
-    /// non-homogenous arrays end up having the same type sizes layout.
-    type_sizes_to_blocks: HashMap<Vec<usize>, BlockId>,
-
     /// Number of the next BlockId, it is used to construct
     /// a new BlockId
     max_block_id: u32,
@@ -129,7 +125,6 @@ impl<'a> Context<'a> {
             initialized_arrays: HashSet::default(),
             memory_blocks: HashMap::default(),
             element_type_sizes_blocks: HashMap::default(),
-            type_sizes_to_blocks: HashMap::default(),
             max_block_id: 0,
             data_bus: DataBus::default(),
             shared_context,


### PR DESCRIPTION
…ucture (#10231)"

This reverts commit 7fb2f1a26b9c04860e24f018eb528a9a84e0f055.

# Description

## Problem

#10231 seems to cause a stackoverflow when running tests.

## Summary

It's unclear why this change would cause a stackoverflow. However, this is a minimal optimization so we can revert it now and try to bring it back later on.

## Additional Context



## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
