### PR TITLE
chore: get trait as non-mut

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/scope.rs
+++ b/compiler/noirc_frontend/src/elaborator/scope.rs
@@ -41,8 +41,8 @@ impl Elaborator<'_> {
         self.interner.get_type(type_id)
     }
 
-    pub(super) fn get_trait_mut(&mut self, trait_id: TraitId) -> &mut Trait {
-        self.interner.get_trait_mut(trait_id)
+    pub(super) fn get_trait(&mut self, trait_id: TraitId) -> &Trait {
+        self.interner.get_trait(trait_id)
     }
 
     /// For each [crate::elaborator::LambdaContext] on the lambda stack with a scope index higher than that
@@ -159,12 +159,12 @@ impl Elaborator<'_> {
     }
 
     /// Lookup a given trait by name/path.
-    pub(crate) fn lookup_trait_or_error(&mut self, path: TypedPath) -> Option<&mut Trait> {
+    pub(crate) fn lookup_trait_or_error(&mut self, path: TypedPath) -> Option<&Trait> {
         let location = path.location;
         match self.resolve_path_or_error(path, PathResolutionTarget::Type) {
             Ok(item) => {
                 if let PathResolutionItem::Trait(trait_id) = item {
-                    Some(self.get_trait_mut(trait_id))
+                    Some(self.get_trait(trait_id))
                 } else {
                     self.push_err(ResolverError::Expected {
                         expected: "trait",

--- a/compiler/noirc_frontend/src/elaborator/traits.rs
+++ b/compiler/noirc_frontend/src/elaborator/traits.rs
@@ -351,7 +351,7 @@ impl Elaborator<'_> {
             return Vec::new();
         };
 
-        let the_trait = self.get_trait_mut(trait_id);
+        let the_trait = self.get_trait(trait_id);
 
         if the_trait.associated_types.len() > bound.trait_generics.named_args.len() {
             let trait_name = the_trait.name.to_string();


### PR DESCRIPTION
# Description

## Problem

No issue.

## Summary

I noticed that there's a `get_trait_mut` method but the returned trait was never mutated. This PR changes it to be non-mut for clarity.

## Additional Context



## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
