### PR TITLE
fix: avoid producing duplicate private error messages

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/scope.rs
+++ b/compiler/noirc_frontend/src/elaborator/scope.rs
@@ -1,6 +1,7 @@
 //! Lexical scoping, variable lookup, and closure capture tracking.
 
 use crate::ast::{ERROR_IDENT, Ident};
+use crate::elaborator::path_resolution::PathResolution;
 use crate::hir::def_map::{LocalModuleId, ModuleId};
 
 use crate::hir::scope::{Scope as GenericScope, ScopeTree as GenericScopeTree};
@@ -226,8 +227,9 @@ impl Elaborator<'_> {
         path: TypedPath,
         mode: PathResolutionMode,
     ) -> Option<Shared<TypeAlias>> {
-        match self.resolve_path_or_error_inner(path, PathResolutionTarget::Type, mode) {
-            Ok(PathResolutionItem::TypeAlias(type_alias_id)) => {
+        match self.resolve_path_inner(path, PathResolutionTarget::Type, mode) {
+            Ok(PathResolution { item: PathResolutionItem::TypeAlias(type_alias_id), errors }) => {
+                self.push_errors(errors);
                 Some(self.interner.get_type_alias(type_alias_id))
             }
             _ => None,

--- a/tooling/nargo_cli/tests/snapshots/compile_failure/orphaned_trait_impl/execute__tests__stderr.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_failure/orphaned_trait_impl/execute__tests__stderr.snap
@@ -16,20 +16,6 @@ error: MyStruct is private and not visible from the current module
   │                                  -------- MyStruct is private
   │
 
-error: MyStruct is private and not visible from the current module
-  ┌─ src/main.nr:1:34
-  │
-1 │ impl crate1::MyTrait for crate2::MyStruct {
-  │                                  -------- MyStruct is private
-  │
-
-error: MyStruct is private and not visible from the current module
-  ┌─ src/main.nr:1:34
-  │
-1 │ impl crate1::MyTrait for crate2::MyStruct {
-  │                                  -------- MyStruct is private
-  │
-
 error: Orphaned trait implementation
   ┌─ src/main.nr:1:26
   │
@@ -37,4 +23,4 @@ error: Orphaned trait implementation
   │                          ---------------- Either the type or the trait must be from the same crate as the trait implementation
   │
 
-Aborting due to 5 previous errors
+Aborting due to 3 previous errors


### PR DESCRIPTION
# Description

## Problem

Resolves #10366

## Summary

Does what is suggested in the related issue.

## Additional Context



## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
