### PR TITLE
chore: lock Cargo.lock in cargo-binstall

### DIFF
--- a/justfile
+++ b/justfile
@@ -22,7 +22,7 @@ install-binstall:
     curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
   fi
 
-cargo-binstall-args := if ci == "1" { "--force" } else { "" }
+cargo-binstall-args := if ci == "1" { "--force --locked" } else { "--locked" }
 
 # Installs tools necessary for working with Rust code
 install-rust-tools: install-binstall


### PR DESCRIPTION
# Description

## Problem

Resolves <!-- Link to GitHub Issue -->

## Summary

This PR locks the lockfile when we fallback to compiling from source with cargo-binstall to avoid msrv issues.

## Additional Context



## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
