### PR TITLE
fix(brillig_gen): Switch to iterative variable liveness

### DIFF
--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/variable_liveness.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/variable_liveness.rs
@@ -303,8 +303,6 @@ impl VariableLiveness {
                     for successor_id in unprocessed_successors {
                         stack.push((successor_id, false));
                     }
-                    // All successors ready, push this block with processed = true
-                    stack.push((block_id, true));
                 }
             }
         }


### PR DESCRIPTION
# Description

## Problem

Looking to resolve stack overflow flake in blob lib

## Summary

I asked Claude to switch our recursive algo to an iterative one. The algorithm looks to be correct upon review, our existing tests are passing, and the stack overflow no longer occurs.

## Additional Context



## User Documentation

Check one:
- [X] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
