### PR TITLE
chore(fuzzing): fix default artifact for brillig target 

### DIFF
--- a/tooling/ssa_fuzzer/fuzzer/src/brillig.rs
+++ b/tooling/ssa_fuzzer/fuzzer/src/brillig.rs
@@ -47,7 +47,7 @@ static ARTIFACTS_SUFFIX: OnceLock<String> = OnceLock::new();
 fn create_base_contract_artifact() -> Value {
     json!({
         "noir_version": "1.0.0-beta.15+9eee29a37dc509be15e24777188d87ca38b522f7-aztec",
-        "name": "Amogus",
+        "name": "AvmTest",
         "functions": [
             {
                 "name": "main2",


### PR DESCRIPTION
# Description
Something changed in the transpiler and it broke `brillig` target
I do not know why, but changing artifact helped 
## Problem

Resolves <!-- Link to GitHub Issue -->

## Summary



## Additional Context



## User Documentation

Check one:
- [ ] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
