### PR TITLE
fix(fuzzer): Set `in_dynamic` in `gen_match`

### DIFF
--- a/tooling/ast_fuzzer/src/program/func.rs
+++ b/tooling/ast_fuzzer/src/program/func.rs
@@ -1896,6 +1896,10 @@ impl<'a> FunctionContext<'a> {
             return Ok(None);
         }
 
+        // Similar to an `if` statement, if the source variable is dynamic, we can't do certain things in the body.
+        let in_dynamic = self.in_dynamic || src_dyn;
+        let was_in_dynamic = std::mem::replace(&mut self.in_dynamic, in_dynamic);
+
         let mut match_expr = Match {
             variable_to_match: (src_id, src_name),
             cases: vec![],
@@ -1904,6 +1908,8 @@ impl<'a> FunctionContext<'a> {
         };
 
         let num_cases = u.int_in_range(0..=self.ctx.config.max_match_cases)?;
+
+        // The dynamic nature of the final expression depends on the source and the rules.
         let mut is_dyn = src_dyn;
 
         // Generate a number of rows, depending on what we can do with the source type.
@@ -1973,6 +1979,7 @@ impl<'a> FunctionContext<'a> {
             match_expr.default_case = Some(Box::new(default_expr));
         }
 
+        self.in_dynamic = was_in_dynamic;
         let match_expr = Expression::Match(match_expr);
         let expr = Expression::Block(vec![src_expr, match_expr]);
 


### PR DESCRIPTION
# Description

## Problem

Resolves #10308 

## Summary

Fixes `gen_match` to set `FunctionContext::in_dynamic` based on whether the source variable we picked for the `match` statement is itself dynamic, and restore it in the end, same as how we do it in `gen_if`. Doing so prevents the fuzzer from trying to index an array with mutable references in it, if the matched variable is using dynamic input, which won't work in ACIR. 

## Additional Context

Tested with the following:
```shell
RUST_LOG=debug NOIR_AST_FUZZER_SEED=0xfd2ca35a00100000 cargo test -q -p noir_ast_fuzzer_fuzz pass_vs_prev
```

The generated code before the change:
```rust
    fn main(a: pub Field) -> return_data Field {
        let mut ctx_limit: u32 = 25_u32;
        let b = a;
        match b {
            226630802737065383642387626038886650849 => {
                let c: [(Field, &mut i64)] = &[(267519747042436056286341820759901913475, (&mut 307006126867071044_i64))];
                if (a == (a / a)) {
                    for idx_d in 46_u8 .. 39_u8 {
                        for idx_f in 119_i8 .. 124_i8 {
                            {
                                let g = a;
                                match g {
                                    -152875594709688994896322916824352868214 => (),
                                    _ => {
                                        let h = (5322686502621200259_u64 != 6495747675750672346_u64);
                                        if (false < {
                                            let i = h;
                                            match i {
                                                
                                                _ => true,
                                            }
                                        }) {
                                            ()
                                        };
                                    },
                                }
                            }
                        };
                        let j: (Field, str<0>, str<0>, i8) = (a, "", "", 49_i8);
                    };
                    ()
                };
                c[3265520634_u32].0
            },
            150827353031300122639667650524970171490 => a,
            -103933587173484451152076385605381625976 => 199032857318042892809271319541303173577,
            _ => a,
        }
    }
```

And after:
```rust
    fn main(a: pub Field) -> return_data Field {
        let mut ctx_limit: u32 = 25_u32;
        let b = a;
        match b {
            226630802737065383642387626038886650849 => {
                let c: [(Field, &mut i64)] = &[(267519747042436056286341820759901913475, (&mut 307006126867071044_i64))];
                if (a == 6055760048053943593826921740994926070) {
                    let mut i: &mut bool = {
                        for idx_d in -7514992686524347193_i64 .. -7514992686524347193_i64 {
                            let g: u128 = {
                                let mut f = (180901482207117996638448674696503279491_u128 != if false {
                                    116166712211093938879611889746841390886_u128
                                } else {
                                    let e = a;
                                    match e {
                                        -139248011646444690293166680800818854797 => (a as u128),
                                        273887774964362579278777547174575042546 => if false {
                                            (a as u128)
                                        } else {
                                            (a as u128)
                                        },
                                        64973696578819344788335335299775756413 => 250338802199149503130641295240148928915_u128,
                                        _ => 55874387991411920510417474015052858256_u128,
                                    }
                                });
                                188998793492372062418556405665699868859_u128
                            };
                            let mut h: u16 = 34324_u16;
                        };
                        (&mut true)
                    };
                    let j: u1 = 1_u1;
                } else {
                    ()
                };
                91314281410044743692954954248160301048
            },
            -78220819122445720757248201654250662655 => a,
            151124715665336195853055467096457850971 => a,
            _ => ((a / -258567428639833665899288087240050626269) / (a / a)),
        }
    }
    
```

It still creates the `c` array in the match containing mutable references, but `c[3265520634_u32].0` is replaced by `91314281410044743692954954248160301048`. 

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
