### PR TITLE
fix: disallow keywords in attributes

### DIFF
--- a/compiler/noirc_frontend/src/parser/parser/attributes.rs
+++ b/compiler/noirc_frontend/src/parser/parser/attributes.rs
@@ -143,15 +143,7 @@ impl Parser<'_> {
     }
 
     fn parse_non_tag_attribute(&mut self, start_location: Location) -> Attribute {
-        if matches!(&self.token.token(), Token::Keyword(..))
-            && (self.next_is(Token::LeftParen) || self.next_is(Token::RightBracket))
-        {
-            // This is a Meta attribute with the syntax `keyword(arg1, arg2, .., argN)`
-            let path = Path::from_single(self.token.to_string(), self.current_token_location);
-            let name = MetaAttributeName::Path(path);
-            self.bump();
-            self.parse_meta_attribute(name, start_location)
-        } else if let Some(path) = self.parse_path_no_turbofish() {
+        if let Some(path) = self.parse_path_no_turbofish() {
             if let Some(ident) = path.as_ident() {
                 if ident.as_str() == "test" {
                     // The test attribute is the only secondary attribute that has `a = b` in its syntax
@@ -761,22 +753,6 @@ mod tests {
             panic!("Expected meta attribute");
         };
         assert_eq!(meta.name.to_string(), "foo");
-        assert!(meta.arguments.is_empty());
-    }
-
-    #[test]
-    fn parses_meta_attribute_single_identifier_as_keyword() {
-        let src = "#[dep]";
-        let mut parser = Parser::for_str_with_dummy_file(src);
-        let (attribute, _span) = parser.parse_attribute().unwrap();
-        expect_no_errors(&parser.errors);
-        let Attribute::Secondary(attribute) = attribute else {
-            panic!("Expected secondary attribute");
-        };
-        let SecondaryAttributeKind::Meta(meta) = attribute.kind else {
-            panic!("Expected meta attribute");
-        };
-        assert_eq!(meta.name.to_string(), "dep");
         assert!(meta.arguments.is_empty());
     }
 


### PR DESCRIPTION
# Description

## Problem

Resolves #10426

## Summary



## Additional Context



## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
