### PR TITLE
fix: remove saturation from loop bound increments

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/ir/integer.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/integer.rs
@@ -65,34 +65,38 @@ impl IntegerConstant {
     }
 
     /// Increment the value by 1
-    /// 
+    ///
     /// # Panics
-    /// 
+    ///
     /// Panics if the increment causes an overflow.
     pub(crate) fn inc(self) -> Self {
         match self {
-            Self::Signed { value, bit_size } => {
-                Self::Signed { value: value.checked_add(1).expect("ICE: overflow while incrementing constant"), bit_size }
-            }
-            Self::Unsigned { value, bit_size } => {
-                Self::Unsigned { value: value.checked_add(1).expect("ICE: overflow while incrementing constant"), bit_size }
-            }
+            Self::Signed { value, bit_size } => Self::Signed {
+                value: value.checked_add(1).expect("ICE: overflow while incrementing constant"),
+                bit_size,
+            },
+            Self::Unsigned { value, bit_size } => Self::Unsigned {
+                value: value.checked_add(1).expect("ICE: overflow while incrementing constant"),
+                bit_size,
+            },
         }
     }
 
     /// Decrement the value by 1, saturating at the minimum value.
-    /// 
+    ///
     /// # panics
-    /// 
+    ///
     /// Panics if the decrement causes an overflow.
     pub(crate) fn dec(self) -> Self {
         match self {
-            Self::Signed { value, bit_size } => {
-                Self::Signed { value: value.checked_sub(1).expect("ICE: overflow while decrementing constant"), bit_size }
-            }
-            Self::Unsigned { value, bit_size } => {
-                Self::Unsigned { value: value.checked_sub(1).expect("ICE: overflow while decrementing constant"), bit_size }
-            }
+            Self::Signed { value, bit_size } => Self::Signed {
+                value: value.checked_sub(1).expect("ICE: overflow while decrementing constant"),
+                bit_size,
+            },
+            Self::Unsigned { value, bit_size } => Self::Unsigned {
+                value: value.checked_sub(1).expect("ICE: overflow while decrementing constant"),
+                bit_size,
+            },
         }
     }
 

--- a/compiler/noirc_evaluator/src/ssa/opt/unrolling.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/unrolling.rs
@@ -1833,7 +1833,8 @@ mod tests {
     #[test]
     #[should_panic(expected = "ICE: overflow while incrementing constant")]
     fn unroll_loop_upper_bound_saturated() {
-        let ssa = format!(r#"
+        let ssa = format!(
+            r#"
         acir(inline) fn main f0 {{
           b0():
             jmp b1(u128 {0})
@@ -1847,14 +1848,16 @@ mod tests {
             jmp b1(v6)
           b3():
             return
-    }}"#, u128::MAX);
+    }}"#,
+            u128::MAX
+        );
 
         let ssa = Ssa::from_str(&ssa).unwrap();
         let function = ssa.main();
-        
+
         let loops = Loops::find_all(function);
         assert_eq!(loops.yet_to_unroll.len(), 1);
-        
+
         let loop_ = &loops.yet_to_unroll[0];
         let pre_header =
             loop_.get_pre_header(function, &loops.cfg).expect("Should have a pre_header");


### PR DESCRIPTION
# Description

## Problem

Resolves <!-- Link to GitHub Issue -->

## Summary

This PR modifies how we increment/decrement loop `IntegerConstant`s so that we throw an ICE rather than saturating in the case of overflow. This should not have any significant impact as the only case where this can occur is when the upper bound is `i128::MAX` or `u128::MAX`.

Previously the saturation behaviour would result in the lower and upper bounds being equal but we will now reject any loops where the upper bound is one of these two values with an ICE.

## Additional Context



## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
