### PR TITLE
propagate BlackBoxFunc into get_hash_input for accurate error context

### DIFF
--- a/acvm-repo/acvm/src/pwg/blackbox/mod.rs
+++ b/acvm-repo/acvm/src/pwg/blackbox/mod.rs
@@ -91,11 +91,25 @@ pub(crate) fn solve<F: AcirField>(
         }
         BlackBoxFuncCall::Blake2s { outputs, .. } => {
             let inputs = bb_func.get_inputs_vec();
-            solve_generic_256_hash_opcode(initial_witness, &inputs, None, outputs, blake2s)
+            solve_generic_256_hash_opcode(
+                initial_witness,
+                &inputs,
+                None,
+                outputs,
+                acir::BlackBoxFunc::Blake2s,
+                blake2s,
+            )
         }
         BlackBoxFuncCall::Blake3 { outputs, .. } => {
             let inputs = bb_func.get_inputs_vec();
-            solve_generic_256_hash_opcode(initial_witness, &inputs, None, outputs, blake3)
+            solve_generic_256_hash_opcode(
+                initial_witness,
+                &inputs,
+                None,
+                outputs,
+                acir::BlackBoxFunc::Blake3,
+                blake3,
+            )
         }
         BlackBoxFuncCall::Keccakf1600 { inputs, outputs } => {
             let mut state = [0; 25];


### PR DESCRIPTION
# Description

## Problem

get_hash_input() always reported errors with BlackBoxFunc::Blake2s, even when invoked for other hash functions via the generic resolver solve_generic_256_hash_opcode(). This produced incorrect error context for Blake3.

## Summary

Propagated the actual blackbox function enum (acir::BlackBoxFunc) from the dispatch site in blackbox/mod.rs into solve_generic_256_hash_opcode() and then into get_hash_input(). Now, any failure (e.g., invalid message_size) is reported with the correct black box function variant, matching the opcode being executed.


# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
