### PR TITLE
fix: don't remove signed min int division overflow in DIE

### DIFF
--- a/test_programs/compile_success_with_bug/regression_10498/Nargo.toml
+++ b/test_programs/compile_success_with_bug/regression_10498/Nargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "regression_10498"
+type = "bin"
+authors = [""]
+
+[dependencies]

--- a/test_programs/compile_success_with_bug/regression_10498/src/main.nr
+++ b/test_programs/compile_success_with_bug/regression_10498/src/main.nr
@@ -1,0 +1,7 @@
+fn main() -> pub bool {
+    foo().0
+}
+
+fn foo() -> (bool, i8) {
+    (true, (-128_i8 / -1_i8))
+}

--- a/tooling/nargo_cli/tests/snapshots/compile_success_with_bug/regression_10498/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_with_bug/regression_10498/execute__tests__expanded.snap
@@ -1,0 +1,11 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: expanded_code
+---
+fn main() -> pub bool {
+    foo().0
+}
+
+fn foo() -> (bool, i8) {
+    (true, -128_i8 / -1_i8)
+}

--- a/tooling/nargo_cli/tests/snapshots/compile_success_with_bug/regression_10498/execute__tests__stderr.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_with_bug/regression_10498/execute__tests__stderr.snap
@@ -1,0 +1,13 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: stderr
+---
+bug: Assertion is always false: Attempt to divide with overflow
+  ┌─ src/main.nr:6:13
+  │
+6 │     (true, (-128_i8 / -1_i8))
+  │             --------------- As a result, the compiled circuit is ensured to fail. Other assertions may also fail during execution
+  │
+  = Call stack:
+    1. src/main.nr:2:5
+    2. src/main.nr:6:13


### PR DESCRIPTION
# Description

## Problem

Resolves #10498

## Summary



## Additional Context



## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
