### PR TITLE
fix: error if `Quoted::as_module` finds private module

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/mod.rs
+++ b/compiler/noirc_frontend/src/elaborator/mod.rs
@@ -460,9 +460,8 @@ impl<'context> Elaborator<'context> {
 
     pub(crate) fn resolve_module_by_path(&mut self, path: TypedPath) -> Option<ModuleId> {
         match self.resolve_path_as_type(path) {
-            Ok(PathResolution { item: PathResolutionItem::Module(module_id), errors })
-                if errors.is_empty() =>
-            {
+            Ok(PathResolution { item: PathResolutionItem::Module(module_id), errors }) => {
+                self.push_errors(errors);
                 Some(module_id)
             }
             _ => None,

--- a/test_programs/compile_failure/regression_10411/Nargo.toml
+++ b/test_programs/compile_failure/regression_10411/Nargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "regression_10411"
+type = "bin"
+authors = [""]
+
+[dependencies]

--- a/test_programs/compile_failure/regression_10411/src/main.nr
+++ b/test_programs/compile_failure/regression_10411/src/main.nr
@@ -1,0 +1,10 @@
+mod foo {
+    mod bar {}
+}
+
+fn main() {
+    comptime {
+        let m = quote { foo::bar }.as_module();
+        let _ = m.unwrap();
+    }
+}

--- a/tooling/nargo_cli/tests/snapshots/compile_failure/regression_10411/execute__tests__stderr.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_failure/regression_10411/execute__tests__stderr.snap
@@ -1,0 +1,15 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: stderr
+---
+error: bar is private and not visible from the current module
+  ┌─ src/main.nr:7:17
+  │
+7 │         let m = quote { foo::bar }.as_module();
+  │                 ------------------------------
+  │                 │            │
+  │                 │            bar is private
+  │                 While evaluating `Quoted::as_module`
+  │
+
+Aborting due to 1 previous error


### PR DESCRIPTION
# Description

## Problem

Resolves #10411

## Summary



## Additional Context



## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
