### PR TITLE
fix: evaluate repeated array expr once

### DIFF
--- a/test_programs/execution_success/regression_10452/Nargo.toml
+++ b/test_programs/execution_success/regression_10452/Nargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "regression_10452"
+type = "bin"
+authors = [""]
+
+[dependencies]

--- a/test_programs/execution_success/regression_10452/src/main.nr
+++ b/test_programs/execution_success/regression_10452/src/main.nr
@@ -1,0 +1,21 @@
+fn main() {
+    test();
+
+    comptime {
+        test();
+    }
+}
+
+fn test() {
+    let x = &mut 0;
+    let inc = || {
+        *x += 1;
+        *x
+    };
+
+    let _ = [inc(); 0];
+    assert_eq(*x, 1);
+
+    let _ = [inc(); 100];
+    assert_eq(*x, 2);
+}

--- a/tooling/nargo_cli/tests/snapshots/execution_success/regression_10452/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/regression_10452/execute__tests__expanded.snap
@@ -1,0 +1,20 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: expanded_code
+---
+fn main() {
+    test();
+    ()
+}
+
+fn test() {
+    let x: &mut Field = &mut 0_Field;
+    let inc: fn[(&mut Field,)]() -> Field = || -> Field {
+        *x = *x + 1_Field;
+        *x
+    };
+    let _: [Field; 0] = [inc(); 0];
+    assert(*x == 1_Field);
+    let _: [Field; 100] = [inc(); 100];
+    assert(*x == 2_Field);
+}

--- a/tooling/nargo_cli/tests/snapshots/execution_success/regression_10452/execute__tests__stdout.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/regression_10452/execute__tests__stdout.snap
@@ -1,0 +1,5 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: stdout
+---
+


### PR DESCRIPTION
# Description

## Problem

Resolves #10452

## Summary



## Additional Context



## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
