### PR TITLE
chore: remove npm token from CI

### DIFF
--- a/.github/workflows/publish-es-packages.yml
+++ b/.github/workflows/publish-es-packages.yml
@@ -156,9 +156,6 @@ jobs:
         run: |
           yarn nightly:version -- .${{ inputs.npm-tag }}
 
-      - name: Authenticate with npm
-        run: "echo npmAuthToken: ${{ secrets.NPM_TOKEN }} > ~/.yarnrc.yml"
-
       - name: Publish ES Packages
         run: yarn publish:all --provenance --access public --tag ${{ inputs.npm-tag }}
 


### PR DESCRIPTION
# Description

## Problem

Resolves <!-- Link to GitHub Issue -->

## Summary

I'm shifting us over to using OIDC credentials for publishing to NPM so this should be no longer necessary.

## Additional Context



## User Documentation

Check one:
- [ ] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
