### PR TITLE
chore: push noir stdlib docs to gh pages

### DIFF
--- a/.github/workflows/publish-stdlib-docs.yml
+++ b/.github/workflows/publish-stdlib-docs.yml
@@ -1,7 +1,6 @@
 name: stdlib docs
 
 on:
-  pull_request:
   push:
     branches:
       - master
@@ -39,7 +38,7 @@ jobs:
           retention-days: 3
 
   build-stdlib-docs:
-    name: Integration Tests (Node)
+    name: Build stdlib docs
     runs-on: ubuntu-24.04
     needs: [build-nargo]
     timeout-minutes: 30
@@ -65,7 +64,7 @@ jobs:
           retention-days: 3
 
   publish-stdlib-docs:
-    name: Publish Stdlib Docs
+    name: Publish stdlib Docs
     runs-on: ubuntu-24.04
     needs: [build-stdlib-docs]
     timeout-minutes: 30


### PR DESCRIPTION
# Description

## Problem

Resolves <!-- Link to GitHub Issue -->

## Summary

This PR adds publishing for stdlib docs at noir-lang.github.io/noir/stdlib/.

## Additional Context



## User Documentation

Check one:
- [ ] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
