### PR TITLE
chore: error on match keyword when enums are not enabled

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/expressions.rs
+++ b/compiler/noirc_frontend/src/elaborator/expressions.rs
@@ -3,7 +3,7 @@
 use std::collections::HashMap;
 
 use iter_extended::vecmap;
-use noirc_errors::{Located, Location};
+use noirc_errors::{Located, Location, Span};
 use rustc_hash::FxHashSet as HashSet;
 
 use crate::{
@@ -1283,7 +1283,12 @@ impl Elaborator<'_> {
         match_expr: MatchExpression,
         location: Location,
     ) -> (HirExpression, Type) {
-        self.use_unstable_feature(UnstableFeature::Enums, location);
+        // Show error on the `match` keyword
+        let match_location = Location::new(
+            Span::from(location.span.start()..location.span.start() + 5),
+            location.file,
+        );
+        self.use_unstable_feature(UnstableFeature::Enums, match_location);
 
         let expr_location = match_expr.expression.location;
         let (expression, typ) = self.elaborate_expression(match_expr.expression);

--- a/compiler/noirc_frontend/src/tests/enums.rs
+++ b/compiler/noirc_frontend/src/tests/enums.rs
@@ -1,9 +1,6 @@
 use crate::elaborator::UnstableFeature;
-use crate::{hir::def_collector::dc_crate::CompilationError, parser::ParserErrorReason};
 
-use crate::tests::{
-    assert_no_errors, check_errors, check_errors_using_features, get_program_using_features,
-};
+use crate::tests::{assert_no_errors, check_errors, check_errors_using_features};
 
 #[test]
 fn error_with_duplicate_enum_variant() {
@@ -37,26 +34,17 @@ fn errors_on_unspecified_unstable_enum() {
 
 #[test]
 fn errors_on_unspecified_unstable_match() {
-    // TODO: update this test. Right now it's hard to test because the span happens in the entire
-    // `match` node but ideally it would be nice if it only happened in the `match` keyword.
-    // Enums are experimental - this will need to be updated when they are stabilized
     let src = r#"
     fn main() {
         match 3 {
+        ^^^^^ This requires the unstable feature 'enums' which is not enabled
+        ~~~~~ Pass -Zenums to nargo to enable this feature at your own risk.
             _ => (),
         }
     }
     "#;
-
     let no_features = &[];
-    let errors = get_program_using_features(src, no_features).2;
-    assert_eq!(errors.len(), 1);
-
-    let CompilationError::ParseError(error) = &errors[0] else {
-        panic!("Expected a ParseError experimental feature error");
-    };
-
-    assert!(matches!(error.reason(), Some(ParserErrorReason::ExperimentalFeature(_))));
+    check_errors_using_features(src, no_features);
 }
 
 #[test]


### PR DESCRIPTION
# Description

## Problem

Resolves #10546

## Summary



## Additional Context



## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
