### PR TITLE
chore: we don't warn anymore when a single trait method is not in scope

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/path_resolution.rs
+++ b/compiler/noirc_frontend/src/elaborator/path_resolution.rs
@@ -124,8 +124,7 @@ enum MethodLookupResult {
     FoundMethod(PerNs),
     /// Found a trait method and it's currently in scope.
     FoundTraitMethod(PerNs, Ident),
-    /// There's only one trait method that matches, but it's not in scope
-    /// (we'll warn about this to avoid introducing a large breaking change)
+    /// There's only one trait method that matches, but it's not in scope.
     FoundOneTraitMethodButNotInScope(PerNs, TraitId),
     /// Multiple trait method matches were found and they are all in scope.
     FoundMultipleTraitMethods(Vec<(TraitId, Ident)>),


### PR DESCRIPTION
# Description

## Problem

No issue.

## Summary

When reviewing this code I thought we were still issuing a warning in this case, and I was about to report a bug/task but it turns out we changed this to an error some time ago.

## Additional Context



## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
