### PR TITLE
feat(LSP): semantic tokens for doc comment code blocks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3628,6 +3628,7 @@ dependencies = [
  "convert_case",
  "fm",
  "fuzzy-matcher",
+ "insta",
  "iter-extended",
  "nargo",
  "nargo_doc",

--- a/tooling/lsp/Cargo.toml
+++ b/tooling/lsp/Cargo.toml
@@ -42,3 +42,4 @@ wasm-bindgen.workspace = true
 
 [dev-dependencies]
 tokio = { version = "1.0", features = ["macros", "rt"] }
+insta.workspace = true

--- a/tooling/lsp/src/requests/mod.rs
+++ b/tooling/lsp/src/requests/mod.rs
@@ -394,7 +394,7 @@ pub(crate) fn on_initialize(
     }
 }
 
-pub(crate) fn semantic_token_types() -> [SemanticTokenType; 8] {
+pub(crate) fn semantic_token_types() -> [SemanticTokenType; 12] {
     [
         SemanticTokenType::NAMESPACE,
         SemanticTokenType::STRUCT,
@@ -404,6 +404,10 @@ pub(crate) fn semantic_token_types() -> [SemanticTokenType; 8] {
         SemanticTokenType::METHOD,
         SemanticTokenType::VARIABLE,
         SemanticTokenType::PROPERTY,
+        SemanticTokenType::NUMBER,
+        SemanticTokenType::KEYWORD,
+        SemanticTokenType::STRING,
+        SemanticTokenType::OPERATOR,
     ]
 }
 


### PR DESCRIPTION
# Description

## Problem

No issue.

## Summary

One more feature related to doc comments (but unrelated to `nargo doc`) is highlighting code blocks in doc comments in the editor, like Rust Analyzer does.

Here's an example in the standard library:

<img width="602" height="263" alt="image" src="https://github.com/user-attachments/assets/231bec92-a6d4-4c1b-aa56-04e1b68892e6" />

Here's an example in Aztec-Packages:

<img width="771" height="376" alt="image" src="https://github.com/user-attachments/assets/d995ffd7-874f-423b-88a9-b921001a5194" />

Another example:

<img width="1092" height="497" alt="image" src="https://github.com/user-attachments/assets/84da4d9c-d777-4e49-b5d4-48474f8f684d" />


## Additional Context



## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
