### PR TITLE
fix(LSP): show fn env and omit unit return type in inlay hints

### DIFF
--- a/tooling/lsp/src/requests/inlay_hint.rs
+++ b/tooling/lsp/src/requests/inlay_hint.rs
@@ -499,20 +499,32 @@ fn push_type_parts(typ: &Type, parts: &mut Vec<InlayHintLabelPart>, files: &File
                 parts.push(string_part(">"));
             }
         }
-        Type::Function(args, return_type, _env, unconstrained) => {
+        Type::Function(args, return_type, env, unconstrained) => {
             if *unconstrained {
                 parts.push(string_part("unconstrained "));
             }
 
-            parts.push(string_part("fn("));
+            if matches!(**env, Type::Unit) {
+                parts.push(string_part("fn("));
+            } else {
+                parts.push(string_part("fn["));
+                push_type_parts(env, parts, files);
+                parts.push(string_part("]("));
+            }
+
             for (index, arg) in args.iter().enumerate() {
                 push_type_parts(arg, parts, files);
                 if index != args.len() - 1 {
                     parts.push(string_part(", "));
                 }
             }
-            parts.push(string_part(") -> "));
-            push_type_parts(return_type, parts, files);
+
+            if matches!(**return_type, Type::Unit) {
+                parts.push(string_part(")"));
+            } else {
+                parts.push(string_part(") -> "));
+                push_type_parts(return_type, parts, files);
+            }
         }
         Type::Reference(typ, false) => {
             parts.push(string_part("&"));
@@ -853,6 +865,42 @@ mod inlay_hints_tests {
                 new_text: ": i32".to_string(),
             }])
         );
+    }
+
+    #[test]
+    async fn test_fn_no_env_no_return_type_hint() {
+        let inlay_hints = get_inlay_hints(131, 133, type_hints()).await;
+        assert_eq!(inlay_hints.len(), 1);
+
+        let position = Position { line: 132, character: 9 };
+
+        let inlay_hint = &inlay_hints[0];
+        assert_eq!(inlay_hint.position, position);
+
+        if let InlayHintLabel::LabelParts(labels) = &inlay_hint.label {
+            let label = labels.iter().map(|label| label.value.clone()).collect::<String>();
+            assert_eq!(label, ": fn()");
+        } else {
+            panic!("Expected InlayHintLabel::LabelParts, got {:?}", inlay_hint.label);
+        }
+    }
+
+    #[test]
+    async fn test_fn_env_return_type_hint() {
+        let inlay_hints = get_inlay_hints(136, 138, type_hints()).await;
+        assert_eq!(inlay_hints.len(), 1);
+
+        let position = Position { line: 137, character: 9 };
+
+        let inlay_hint = &inlay_hints[0];
+        assert_eq!(inlay_hint.position, position);
+
+        if let InlayHintLabel::LabelParts(labels) = &inlay_hint.label {
+            let label = labels.iter().map(|label| label.value.clone()).collect::<String>();
+            assert_eq!(label, ": fn[(i32,)]() -> i32");
+        } else {
+            panic!("Expected InlayHintLabel::LabelParts, got {:?}", inlay_hint.label);
+        }
     }
 
     #[test]

--- a/tooling/lsp/test_programs/inlay_hints/src/main.nr
+++ b/tooling/lsp/test_programs/inlay_hints/src/main.nr
@@ -128,3 +128,12 @@ pub fn chain() {
         .any(|x| x > 5)
         .not();
 }
+
+fn fn_no_env_no_return() {
+    let _ = || {};
+}
+
+fn fn_env_and_return() {
+    let x: i32 = 1;
+    let _ = || { x };
+}


### PR DESCRIPTION
# Description

## Problem

No issue.

## Summary

I noticed that inlay hints for `fn` types wasn't including the env. This PR fixes that.

Before:

<img width="551" height="137" alt="Screenshot 2025-11-21 at 16 13 48" src="https://github.com/user-attachments/assets/1c212028-e4ce-4869-ad1d-3c06cd032cf6" />

After:

<img width="580" height="133" alt="Screenshot 2025-11-21 at 16 14 02" src="https://github.com/user-attachments/assets/bead1d59-1e9f-41bb-bcf4-9bdc9b171778" />

(in this case the env shouldn't be there but this is a bug, and with this LSP fix it's easier to tell)

## Additional Context



## User Documentation

Check one:
- [ ] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
