### PR TITLE
chore: fix documentation around `current_witness_index`

### DIFF
--- a/acvm-repo/acir/src/circuit/mod.rs
+++ b/acvm-repo/acir/src/circuit/mod.rs
@@ -251,11 +251,6 @@ impl std::fmt::Display for BrilligOpcodeLocation {
 }
 
 impl<F: AcirField> Circuit<F> {
-    pub fn num_vars(&self) -> u32 {
-        // Increment by 1 to account for the zero witness
-        self.current_witness_index + 1
-    }
-
     /// Returns all witnesses which are required to execute the circuit successfully.
     pub fn circuit_arguments(&self) -> BTreeSet<Witness> {
         self.private_parameters.union(&self.public_parameters.0).cloned().collect()


### PR DESCRIPTION
# Description

## Problem

Resolves <!-- Link to GitHub Issue -->

## Summary

The doc comment on `current_witness_index` has an off-by-one error as we need to increment the value to get a unique witness index.

## Additional Context



## User Documentation

Check one:
- [ ] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
