### PR TITLE
feat!: add `enable-contracts` flag

### DIFF
--- a/compiler/noirc_driver/src/lib.rs
+++ b/compiler/noirc_driver/src/lib.rs
@@ -230,6 +230,16 @@ pub struct CompileOptions {
     /// Used internally to avoid comptime println from producing output
     #[arg(long, hide = true)]
     pub disable_comptime_printing: bool,
+
+    /// Enable compilation of contract crates.
+    ///
+    /// Noir contracts are expected to be compiled within a larger smart contract development environment.
+    /// It's likely that if you're compiling a contract crate using Nargo directly, you may run into issues
+    /// due to missing this environment, e.g. tests may depend on foreign call handlers that are not available.
+    ///
+    /// If you are sure you want to compile contract crates directly, you can enable this flag.
+    #[arg(long)]
+    pub enable_contracts: bool,
 }
 
 impl Default for CompileOptions {
@@ -269,6 +279,7 @@ impl Default for CompileOptions {
             unstable_features: Vec::new(),
             no_unstable_features: false,
             disable_comptime_printing: false,
+            enable_contracts: false,
         }
     }
 }
@@ -561,6 +572,14 @@ pub fn compile_contract(
     crate_id: CrateId,
     options: &CompileOptions,
 ) -> CompilationResult<CompiledContract> {
+    if !options.enable_contracts {
+        let err = CustomDiagnostic::from_message(
+            "compiling contract crates is disabled by default. To enable, pass the `--enable-contracts` flag to Nargo.",
+            FileId::default(),
+        );
+        return Err(vec![err]);
+    }
+
     let (_, warnings) = check_crate(context, crate_id, options)?;
 
     let def_map = context.def_map(&crate_id).expect("The local crate should be analyzed already");

--- a/compiler/noirc_driver/tests/contracts.rs
+++ b/compiler/noirc_driver/tests/contracts.rs
@@ -6,11 +6,8 @@ use noirc_errors::CustomDiagnostic;
 use noirc_frontend::hir::{Context, def_map::parse_file};
 
 #[test]
-fn reject_crates_containing_multiple_contracts() -> Result<(), ErrorsAndWarnings> {
-    let source = "
-contract Foo {}
-
-contract Bar {}";
+fn reject_crates_without_enable_contracts_flag() -> Result<(), ErrorsAndWarnings> {
+    let source = "contract Foo {}";
 
     let root = Path::new("");
     let file_name = Path::new("main.nr");
@@ -34,10 +31,47 @@ contract Bar {}";
     assert_eq!(
         errors,
         vec![CustomDiagnostic::from_message(
+            "compiling contract crates is disabled by default. To enable, pass the `--enable-contracts` flag to Nargo.",
+            FileId::default()
+        )],
+        "compiler should reject contract crates when the enable_contracts flag is not set"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn reject_crates_containing_multiple_contracts() -> Result<(), ErrorsAndWarnings> {
+    let source = "
+contract Foo {}
+
+contract Bar {}";
+
+    let root = Path::new("");
+    let file_name = Path::new("main.nr");
+    let mut file_manager = file_manager_with_stdlib(root);
+    file_manager.add_file_with_source(file_name, source.to_owned()).expect(
+        "Adding source buffer to file manager should never fail when file manager is empty",
+    );
+    let parsed_files = file_manager
+        .as_file_map()
+        .all_file_ids()
+        .map(|&file_id| (file_id, parse_file(&file_manager, file_id)))
+        .collect();
+
+    let mut context = Context::new(file_manager, parsed_files);
+    let root_crate_id = prepare_crate(&mut context, file_name);
+
+    let options = CompileOptions { enable_contracts: true, ..CompileOptions::default() };
+    let errors = noirc_driver::compile_contract(&mut context, root_crate_id, &options).unwrap_err();
+
+    assert_eq!(
+        errors,
+        vec![CustomDiagnostic::from_message(
             "Packages are limited to a single contract",
             FileId::default()
         )],
-        "stdlib is producing warnings"
+        "compiler should reject crates containing multiple contracts"
     );
 
     Ok(())


### PR DESCRIPTION
# Description

## Problem

Resolves #10104 

## Summary

This PR adds the `enable-contracts` flag which @nventuro hallucinated in roadmap standup.

This PR is draft, pending update to copy to link to the correct pages in docs.

## Additional Context



## User Documentation

Check one:
- [ ] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
