### PR TITLE
chore(ssa): Validate that the `return_data` matches the `return` values

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/validation/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/validation/mod.rs
@@ -1761,6 +1761,21 @@ mod tests {
     }
 
     #[test]
+    fn return_data_matches_return_terminator() {
+        let src = "
+        acir(inline) pure fn main f0 {
+          return_data: v4
+          b0(v0: u32, v1: u64):
+            v2 = cast v0 as Field
+            v3 = cast v1 as Field
+            v4 = make_array [v2, v3] : [Field; 2]
+            return v4
+        }
+        ";
+        let _ = Ssa::from_str(src).unwrap();
+    }
+
+    #[test]
     #[should_panic(expected = "Databus return_data does not match return terminator")]
     fn return_data_does_not_match_return_terminator() {
         let src = "


### PR DESCRIPTION

# Description

## Problem

Resolves a question raised during the audit: 

> Can a value be returned in the databus and not be part of a return terminator?

## Summary

Adds a step to SSA validation to ascertain that if there is a non-empty `return_data` then it contains the same value as we see in the `return` terminator.

## Additional Context

In `convert_acir_main` we first construct the `return_witnesses` from the return terminator, and then pass them to `initialize_databus`, which expects that if there is a `return_data`, it corresponds 1:1 with the return witnesses.

The compiler would never construct an SSA that doesn't follow this expectation. The validation ensures that we don't accidentally create one by hand either.

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
