### PR TITLE
chore(comptime): Additional cast test cases

### DIFF
--- a/compiler/noirc_frontend/src/hir/comptime/interpreter/cast.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter/cast.rs
@@ -155,11 +155,8 @@ pub(super) fn evaluate_cast_one_step(
                 Err(InterpreterError::TypeUnsupported { typ, location })
             }
         },
-        Type::Bool => {
-            panic!(
-                "ICE: It is expected that casting to a bool has been blocked by the type checker"
-            )
-        }
+        // Checking `lhs_is_negative` is necessary to account for negative values that get truncated to zero
+        Type::Bool => Ok(Value::Bool(!lhs.is_zero() || lhs_is_negative)),
         typ => Err(InterpreterError::CastToNonNumericType { typ, location }),
     }
 }
@@ -281,12 +278,27 @@ mod tests {
     }
 
     #[test]
-    #[should_panic]
     fn bool_casts() {
         let location = Location::dummy();
 
-        let lhs = Value::Field(SignedField::positive(0u32));
-        let typ = Type::Bool;
-        let _ = evaluate_cast_one_step(&typ, location, lhs.clone());
+        let tests = [
+            (Value::Field(SignedField::positive(0u32)), Type::Bool, Value::Bool(false)),
+            (Value::Field(SignedField::positive(1u32)), Type::Bool, Value::Bool(true)),
+            (Value::Field(SignedField::positive(255u32)), Type::Bool, Value::Bool(true)),
+            (Value::Field(SignedField::negative(1u32)), Type::Bool, Value::Bool(true)),
+            (Value::Field(SignedField::negative(0u32)), Type::Bool, Value::Bool(false)),
+            (Value::U8(0), Type::Bool, Value::Bool(false)),
+            (Value::I8(0), Type::Bool, Value::Bool(false)),
+            (Value::I8(-1), Type::Bool, Value::Bool(true)),
+        ];
+
+        for (lhs, typ, expected) in tests {
+            let actual = evaluate_cast_one_step(&typ, location, lhs.clone());
+            assert_eq!(
+                actual,
+                Ok(expected.clone()),
+                "{lhs:?} as {typ}, expected {expected:?}, got {actual:?}"
+            );
+        }
     }
 }

--- a/compiler/noirc_frontend/src/tests/cast.rs
+++ b/compiler/noirc_frontend/src/tests/cast.rs
@@ -76,3 +76,31 @@ fn error_on_cast_over_type_variable() {
     "#;
     check_errors(src);
 }
+
+#[test]
+fn cast_numeric_to_bool() {
+    let src = "
+    fn main() {
+        let x: u64 = 1;
+        let _ = x as bool;
+                ^^^^^^^^^ Cannot cast `u64` as `bool`
+                ~~~~~~~~~ compare with zero instead: ` != 0`
+    }
+    ";
+    check_errors(src);
+}
+
+#[test]
+fn cast_numeric_to_bool_comptime() {
+    let src = "
+    fn main() {
+        comptime {
+            let x: u64 = 1;
+            let _ = x as bool;
+                    ^^^^^^^^^ Cannot cast `u64` as `bool`
+                    ~~~~~~~~~ compare with zero instead: ` != 0`
+        }
+    }
+    ";
+    check_errors(src);
+}


### PR DESCRIPTION
# Description

## Problem

Auditing `interpreter/cast.rs`

We emit `TypeCheckError::CannotCastNumericToBool` in the elaborator when attempting to cast to bool. However, we still support casting to bool in the comptime interpreter.

## Summary

I debated between panicking here or keeping the current implementation (which is correct).

I decided to ultimately just succeed gracefully here. If we ever change this functionality we will not have to update the bool casting code as well. To make sure the casting logic is correct I just added some tests that were missing for casting to a bool.

It also looks like we still execute the comptime interpreter even when we have type check errors. Adding a panic would cause this code to panic rather than return an error:
```noir
    fn main() {
        comptime {
            let x: u64 = 1;
            let _ = x as bool;
        }
    }
```

I have added this as a test to our frontend unit tests.

## Additional Context



## User Documentation

Check one:
- [X] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
