### PR TITLE
chore(stdlib): Fix `__get_shuffle_indices` to use `break`

### DIFF
--- a/noir_stdlib/src/array/check_shuffle.nr
+++ b/noir_stdlib/src/array/check_shuffle.nr
@@ -10,15 +10,13 @@ where
     for i in 0..N {
         let mut found = false;
         for j in 0..N {
-            if ((shuffle_mask[j] == false) & (!found)) {
+            if (shuffle_mask[j] == false) {
                 if (lhs[i] == rhs[j]) {
                     found = true;
                     shuffle_indices[i] = j;
                     shuffle_mask[j] = true;
+                    break;
                 }
-            }
-            if (found) {
-                continue;
             }
         }
         assert(found == true, "check_shuffle, lhs and rhs arrays do not contain equivalent values");


### PR DESCRIPTION
# Description

## Problem

Just something I noticed while looking at how `check_shuffle` was implemented.

## Summary

Fixes `__get_shuffle_indices` to `break` out of the inner loop once the item is `found`, rather than `continue`. 

## Additional Context

It looks as if `__get_shuffle_indices` was originally written to be constrained.

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
