### PR TITLE
fix: subtraction operator for witness

### DIFF
--- a/acvm-repo/acir/src/native_types/expression/operators.rs
+++ b/acvm-repo/acir/src/native_types/expression/operators.rs
@@ -108,7 +108,7 @@ impl<F: AcirField> Sub<&Expression<F>> for Witness {
     type Output = Expression<F>;
     #[inline]
     fn sub(self, rhs: &Expression<F>) -> Self::Output {
-        rhs - self
+        &Expression::from(self) - rhs
     }
 }
 


### PR DESCRIPTION
# Description

## Problem

Witness subtraction was done in reverse.

## Summary



## Additional Context



## User Documentation

Check one:
- [X] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
