### PR TITLE
fix: avoid adding default entry

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/opt/brillig_entry_points.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/brillig_entry_points.rs
@@ -98,7 +98,7 @@ impl Ssa {
         let brillig_entry_points =
             get_brillig_entry_points_with_reachability(&self.functions, self.main_id, &call_graph);
         let functions_to_clone_map = build_functions_to_clone(&brillig_entry_points);
-        let (calls_to_update, mut new_functions_map) =
+        let (calls_to_update, new_functions_map) =
             build_calls_to_update(&mut self, functions_to_clone_map, &brillig_entry_points);
 
         // Now we want to actually rewrite the appropriate call sites


### PR DESCRIPTION
# Description

## Problem

Resolves #10662 

## Summary



## Additional Context



## User Documentation

Check one:
- [X] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
