### PR TITLE
chore: disallow databus outside of main()

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/function.rs
+++ b/compiler/noirc_frontend/src/elaborator/function.rs
@@ -335,7 +335,9 @@ impl Elaborator<'_> {
             self.run_lint(|_| {
                 lints::unnecessary_pub_argument(func, visibility, is_pub_allowed).map(Into::into)
             });
-
+            self.run_lint(|_| {
+                lints::databus_on_non_entry_point(func, visibility, is_entry_point).map(Into::into)
+            });
             let type_location = typ.location;
             let typ = match typ.typ {
                 UnresolvedTypeData::TraitAsType(path, args) => {

--- a/compiler/noirc_frontend/src/elaborator/lints.rs
+++ b/compiler/noirc_frontend/src/elaborator/lints.rs
@@ -273,6 +273,27 @@ pub(super) fn unnecessary_pub_argument(
     }
 }
 
+/// call_data and return_data visibility modifiers are only allowed on entry point functions.
+pub(super) fn databus_on_non_entry_point(
+    func: &NoirFunction,
+    visibility: Visibility,
+    is_entry_point: bool,
+) -> Option<ResolverError> {
+    if !is_entry_point {
+        match visibility {
+            Visibility::CallData(_) | Visibility::ReturnData => {
+                Some(ResolverError::DataBusOnNonEntryPoint {
+                    ident: func.name_ident().clone(),
+                    visibility: visibility.to_string(),
+                })
+            }
+            _ => None,
+        }
+    } else {
+        None
+    }
+}
+
 /// Checks if an ExprId, which has to be an integer literal, fits in its type.
 pub(crate) fn check_integer_literal_fits_its_type(
     interner: &NodeInterner,

--- a/compiler/noirc_frontend/src/tests/visibility.rs
+++ b/compiler/noirc_frontend/src/tests/visibility.rs
@@ -648,3 +648,21 @@ fn only_one_private_error_when_name_in_types_and_values_namespace_collides() {
     ";
     check_errors(src);
 }
+
+#[test]
+fn databus_only_allowed_in_main() {
+    let src = "
+fn main(a: u32) -> pub u32 {
+    let a = inner(a);
+    let c = a << 2;
+    c
+}
+
+fn inner(a: call_data(0) u32) -> return_data u32 {
+   ~~~~~ unnecessary call_data(0)
+   ^^^^^ unnecessary call_data(0) attribute for function inner
+    a
+}
+    ";
+    check_errors(src);
+}


### PR DESCRIPTION
# Description

## Problem

Resolves #10653 

## Summary



## Additional Context



## User Documentation

Check one:
- [X] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
