### PR TITLE
chore: no need to get all fields to fetch one

### DIFF
--- a/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
@@ -1036,10 +1036,7 @@ impl<'local, 'interner> Interpreter<'local, 'interner> {
                 let index = name.parse::<usize>().ok();
                 match index.and_then(|index| types.get(index)) {
                     Some(value) => return Ok(value.clone()),
-                    None => {
-                        let tuple_types = vecmap(types, |typ| typ.borrow().get_type().into_owned());
-                        Type::Tuple(tuple_types)
-                    }
+                    None => Type::Tuple(vecmap(types, |typ| typ.borrow().get_type().into_owned())),
                 }
             }
             Value::Pointer(element, ..) => {


### PR DESCRIPTION
# Description

## Problem

No issue, just something I noticed while auditing.

## Summary

In the comptime interpreter, when we need to resolve something like `foo.bar` or `tuple.0` we used to fetch all of the struct's or tuple's fields, then looked up the one with a matching name. However, we can directly lookup the name without building intermediate hashmaps or creating strings for "0", "1", etc. in the tuple case. This is slightly more efficient (probably not noticeable, though comptime code is usually the slowest part in the compiler) but it's also maybe simpler code.

## Additional Context



## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
