### PR TITLE
fix: don't track struct members with error for LSP

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/expressions.rs
+++ b/compiler/noirc_frontend/src/elaborator/expressions.rs
@@ -1072,6 +1072,7 @@ impl Elaborator<'_> {
                     field: field_name.clone(),
                     struct_definition: struct_type.borrow().name.clone(),
                 });
+                continue;
             }
 
             if let Some((index, visibility)) = expected_index_and_visibility {

--- a/compiler/noirc_frontend/src/elaborator/patterns.rs
+++ b/compiler/noirc_frontend/src/elaborator/patterns.rs
@@ -395,6 +395,7 @@ impl Elaborator<'_> {
                     field: field.clone(),
                     struct_definition: struct_type.borrow().name.clone(),
                 });
+                continue;
             }
 
             ret.push((field, resolved));


### PR DESCRIPTION
# Description

## Problem

No issue, just trying to prevent LSP from ever crashing.

## Summary

This code would crash LSP:

```noir
struct Foo {}

fn main() {
    let Foo { x } = Foo { x: 1 };
}
```

for two reasons:
1. Inlay hints for the `x` in the struct pattern would crash
2. Hovering over that `x` would crash

The reason is that the struct field was registered for LSP when it didn't exist. Now we don't do that anymore.

## Additional Context

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
