### PR TITLE
fix(visibility): First segment always visible via `super`

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/path_resolution.rs
+++ b/compiler/noirc_frontend/src/elaborator/path_resolution.rs
@@ -503,9 +503,9 @@ impl Elaborator<'_> {
         }
 
         let first_segment_is_always_visible = match path.kind {
-            PathKind::Crate => true,
+            PathKind::Crate | PathKind::Super => true,
             PathKind::Plain => importing_module == starting_module,
-            PathKind::Super | PathKind::Resolved(_) => false,
+            PathKind::Resolved(_) => false,
             PathKind::Dep => {
                 unreachable!("ICE: Dependency path kinds should have been turned into Plain.")
             }

--- a/compiler/noirc_frontend/src/tests/visibility.rs
+++ b/compiler/noirc_frontend/src/tests/visibility.rs
@@ -335,9 +335,8 @@ fn does_not_error_if_calling_private_struct_function_from_extension() {
     assert_no_errors(src);
 }
 
-// FIXME (#10730): Going through super should work, as it does in Rust.
 #[test]
-fn error_when_accessing_private_module_through_super() {
+fn does_not_error_when_accessing_private_module_through_super() {
     let src = r#"
     mod foo {
         pub struct Foo {}
@@ -346,8 +345,6 @@ fn error_when_accessing_private_module_through_super() {
     mod bar {
         pub fn bar() {
             let _f = super::foo::Foo {};
-                            ^^^ foo is private and not visible from the current module
-                            ~~~ foo is private
         }
     }
 
@@ -355,7 +352,7 @@ fn error_when_accessing_private_module_through_super() {
         bar::bar();
     }
     "#;
-    check_errors(src);
+    assert_no_errors(src);
 }
 
 #[test]


### PR DESCRIPTION
# Description

## Problem

Resolves #10730

## Summary

Changes `resolve_name_in_module` to treat `super::foo` similar to `crate::foo` in that `foo` will be considered visible to the module we are trying to use it from via `super::foo`, even if `foo` is private to modules higher up the hierarchy. This makes sense as a child module should at least be able to _see_ what exists in its parent module, even if it cannot access the items _inside_ its sibling modules.


## Additional Context



## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
