### PR TITLE
fix: keep track of comptime closure callstack

### DIFF
--- a/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
@@ -318,7 +318,11 @@ impl<'local, 'interner> Interpreter<'local, 'interner> {
         let old_module = self.elaborator.replace_module(module_scope);
         let old_function = std::mem::replace(&mut self.current_function, function_scope);
 
+        self.elaborator.interpreter_call_stack.push_back(call_location);
+
         let result = self.call_closure_inner(lambda, environment, arguments, call_location);
+
+        self.elaborator.interpreter_call_stack.pop_back();
 
         self.current_function = old_function;
         if let Some(old_module) = old_module {

--- a/test_programs/compile_failure/comptime_closure_callstack/Nargo.toml
+++ b/test_programs/compile_failure/comptime_closure_callstack/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "comptime_closure_callstack"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.26.0"
+
+[dependencies]

--- a/test_programs/compile_failure/comptime_closure_callstack/src/main.nr
+++ b/test_programs/compile_failure/comptime_closure_callstack/src/main.nr
@@ -1,0 +1,8 @@
+fn main() {
+    comptime {
+        let z = || assert(false);
+        let y = || z();
+        let x = || y();
+        x()
+    }
+}

--- a/tooling/nargo_cli/tests/snapshots/compile_failure/comptime_closure_callstack/execute__tests__stderr.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_failure/comptime_closure_callstack/execute__tests__stderr.snap
@@ -1,0 +1,16 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: stderr
+---
+error: Assertion failed
+  ┌─ src/main.nr:3:27
+  │
+3 │         let z = || assert(false);
+  │                           -----
+  │
+  = Call stack:
+    1. src/main.nr:6:9
+    2. src/main.nr:5:20
+    3. src/main.nr:4:20
+
+Aborting due to 1 previous error


### PR DESCRIPTION
# Description

## Problem

Resolves #10734

## Summary



## Additional Context



## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
