### PR TITLE
fix: don't capture comptime vars in closures

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/scope.rs
+++ b/compiler/noirc_frontend/src/elaborator/scope.rs
@@ -59,10 +59,17 @@ impl Elaborator<'_> {
                     .position(|capture| capture.ident.id == hir_ident.id);
 
                 if position.is_none() {
-                    self.lambda_stack[lambda_index].captures.push(HirCapturedVar {
-                        ident: hir_ident.clone(),
-                        transitive_capture_index,
-                    });
+                    // In a comptime context we capture comptime and non-comptime variables
+                    // (the latter will be an error).
+                    // In a non-comptime context we don't capture comptime variables.
+                    if self.in_comptime_context()
+                        || !self.interner.definition(hir_ident.id).is_comptime_local()
+                    {
+                        self.lambda_stack[lambda_index].captures.push(HirCapturedVar {
+                            ident: hir_ident.clone(),
+                            transitive_capture_index,
+                        });
+                    }
                 }
 
                 if lambda_index + 1 < self.lambda_stack.len() {

--- a/test_programs/execution_success/do_not_capture_comptime_locals/Nargo.toml
+++ b/test_programs/execution_success/do_not_capture_comptime_locals/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "do_not_capture_comptime_locals"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.31.0"
+
+[dependencies]

--- a/test_programs/execution_success/do_not_capture_comptime_locals/src/main.nr
+++ b/test_programs/execution_success/do_not_capture_comptime_locals/src/main.nr
@@ -1,0 +1,5 @@
+fn main() {
+    comptime let x = 1;
+    let f = || { println(x); };
+    f();
+}

--- a/tooling/nargo_cli/tests/snapshots/execution_success/do_not_capture_comptime_locals/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/do_not_capture_comptime_locals/execute__tests__expanded.snap
@@ -1,0 +1,9 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: expanded_code
+---
+fn main() {
+    ();
+    let f: fn() = || { println(1_Field); };
+    f();
+}

--- a/tooling/nargo_cli/tests/snapshots/execution_success/do_not_capture_comptime_locals/execute__tests__stdout.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/do_not_capture_comptime_locals/execute__tests__stdout.snap
@@ -1,0 +1,5 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: stdout
+---
+0x01


### PR DESCRIPTION
# Description

## Problem

Resolves #10564

## Summary



## Additional Context



## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
