### PR TITLE
chore: use `NOIR_REPO_TOKEN` for triggering binary builds for release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -153,7 +153,7 @@ jobs:
           workflow: publish-nargo.yml
           repo: noir-lang/noir
           ref: master
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.NOIR_REPO_TOKEN }}
           inputs: '{ "tag": "${{ needs.release-please.outputs.tag-name }}", "publish": true }'
 
   publish-es-packages:


### PR DESCRIPTION
# Description

## Problem

Resolves <!-- Link to GitHub Issue -->

## Summary

Cutting a release currently fails to trigger builds of these due to newly restricted permissions on the `GITHUB_TOKEN`. This PR switches over to using `NOIR_REPO_TOKEN` to get around these.

## Additional Context



## User Documentation

Check one:
- [ ] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
