### PR TITLE
chore: do lazy cloning of `Instruction`s

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/opt/brillig_entry_points.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/brillig_entry_points.rs
@@ -167,17 +167,19 @@ fn resolve_cloned_function_call_sites(
     for block_id in function.reachable_blocks() {
         #[allow(clippy::unnecessary_to_owned)] // clippy is wrong here
         for instruction_id in function.dfg[block_id].instructions().to_vec() {
-            let instruction = function.dfg[instruction_id].clone();
+            let instruction = &function.dfg[instruction_id];
             let Instruction::Call { func: func_value_id, arguments } = instruction else {
                 continue;
             };
-            let func_value = &function.dfg[func_value_id];
+            let func_value = &function.dfg[*func_value_id];
             let Value::Function(func_id) = func_value else { continue };
 
-            let Some(new_func_id) = new_functions_map.get(func_id) else {
+            let Some(new_func_id) = new_functions_map.get(func_id).copied() else {
                 continue;
             };
-            let new_function_value_id = function.dfg.import_function(*new_func_id);
+
+            let arguments = arguments.to_vec();
+            let new_function_value_id = function.dfg.import_function(new_func_id);
             function.dfg[instruction_id] =
                 Instruction::Call { func: new_function_value_id, arguments };
         }
@@ -296,12 +298,12 @@ fn collect_callsites_to_rewrite(
     for block_id in function.reachable_blocks() {
         #[allow(clippy::unnecessary_to_owned)] // clippy is wrong here
         for instruction_id in function.dfg[block_id].instructions().to_vec() {
-            let instruction = function.dfg[instruction_id].clone();
+            let instruction = &function.dfg[instruction_id];
             let Instruction::Call { func: func_value_id, arguments } = instruction else {
                 continue;
             };
 
-            let func_value = &function.dfg[func_value_id];
+            let func_value = &function.dfg[*func_value_id];
             let Value::Function(func_id) = func_value else { continue };
             let Some(new_id) = calls_to_update.get(&(entry_point, *func_id)) else {
                 continue;
@@ -313,7 +315,7 @@ fn collect_callsites_to_rewrite(
                 function_to_update: function.id(),
                 instruction: instruction_id,
                 new_func_to_call: *new_id,
-                call_args: arguments,
+                call_args: arguments.to_vec(),
             };
             new_calls_to_update.insert(new_call);
         }


### PR DESCRIPTION
# Description

## Problem

Resolves #10663 

## Summary

I've modified the mentioned functions so that we avoid immediately cloning the instruction. There doesn't seem to be any other instances (from a quick grep of the codebase)

## Additional Context



## User Documentation

Check one:
- [ ] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
