### PR TITLE
fix(brillig): Fix lookup for the back-edge

### DIFF
--- a/compiler/noirc_evaluator/src/brillig/brillig_check.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_check.rs
@@ -378,7 +378,7 @@ impl OpcodeAddressVisitor for AdvisoryCollector<'_> {
         self.reads.insert(*addr, location);
     }
 
-    /// Remember the opcode location where a memory address was last read.
+    /// Remember the opcode location where a memory address was last written.
     ///
     /// Insert an advisory if:
     /// * the address is not read after this opcode
@@ -415,6 +415,7 @@ impl OpcodeAddressVisitor for AdvisoryCollector<'_> {
                 self.add_advisory(location, OpcodeAdvisory::NeverRead { addr: *addr });
             }
         }
+
         self.writes.insert(*addr, location);
     }
 }


### PR DESCRIPTION
# Description

## Problem

Follow up for https://github.com/noir-lang/noir/pull/10746/files#r2590058977 

## Summary

Fixes the new Brillig opcode analysis doing a lookup of the reads in the descendants to allow the possibility that the successor hasn't been processed yet, which is the case for back-edges in loops.

## Additional Context



## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
