### PR TITLE
chore: remove redundant cast in flatten_cfg

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/opt/flatten_cfg.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/flatten_cfg.rs
@@ -850,12 +850,8 @@ impl<'f> Context<'f> {
         match instruction {
             Instruction::Constrain(lhs, rhs, message) => {
                 // Replace constraint `lhs == rhs` with `condition * lhs == condition * rhs`.
-
-                // Condition needs to be cast to argument type in order to multiply them together.
-                let casted_condition =
-                    self.cast_condition_to_value_type(condition, lhs, call_stack);
-                let lhs = self.mul_by_condition(lhs, casted_condition, call_stack);
-                let rhs = self.mul_by_condition(rhs, casted_condition, call_stack);
+                let lhs = self.mul_by_condition(lhs, condition, call_stack);
+                let rhs = self.mul_by_condition(rhs, condition, call_stack);
                 Instruction::Constrain(lhs, rhs, message)
             }
             Instruction::ConstrainNotEqual(_, _, _) => {


### PR DESCRIPTION
# Description

## Problem

Resolves #10786

## Summary



## Additional Context



## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
