### PR TITLE
chore!: drop support for legacy bincode format

### DIFF
--- a/acvm-repo/acir/src/serialization.rs
+++ b/acvm-repo/acir/src/serialization.rs
@@ -160,17 +160,18 @@ where
     R: prost::Message,
     ProtoSchema<F>: ProtoCodec<T, R>,
 {
-    match Format::from_env() {
+    let format = match Format::from_env() {
         Ok(Some(format)) => {
             // This will need a new `bb` even if it's the bincode format, because of the format byte.
-            serialize_with_format(value, format)
+            format
         }
         Ok(None) => {
             // This is how the currently released `bb` expects the data.
-            bincode_serialize(value)
+            Format::Bincode
         }
-        Err(e) => Err(std::io::Error::other(e)),
-    }
+        Err(e) => return Err(std::io::Error::other(e)),
+    };
+    serialize_with_format(value, format)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
# Description

## Problem

Resolves <!-- Link to GitHub Issue -->

## Summary

This PR drops support for the `BincodeLegacy` serialization format.

## Additional Context



## User Documentation

Check one:
- [ ] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
