### PR TITLE
fix: handle u128 indices in comptime interpreter

### DIFF
--- a/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
@@ -1684,6 +1684,7 @@ fn bounds_check(array: Value, index: Value, location: Location) -> IResult<(Vect
         Value::U16(value) => value as usize,
         Value::U32(value) => value as usize,
         Value::U64(value) => value as usize,
+        Value::U128(value) => value as usize,
         value => {
             let typ = value.get_type().into_owned();
             return Err(InterpreterError::NonIntegerUsedAsIndex { typ, location });


### PR DESCRIPTION
# Description

## Problem

Resolves #10859 

## Summary

Quick fix for #10859 to handle u128s in the same way as other integer types.

## Additional Context



## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
