### PR TITLE
fix: restore side effects in interpreter between calls

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/interpreter/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/interpreter/mod.rs
@@ -135,13 +135,12 @@ impl<'ssa, W: Write> Interpreter<'ssa, W> {
         self.functions
     }
 
-    /// Resets interpreter state for reuse between top-level calls.
+    /// Resets the step counter to 0.
     ///
-    /// This resets the step counter and side_effects_enabled state,
-    /// preparing the interpreter to interpret a new entry point.
-    pub(crate) fn reset_state(&mut self) {
+    /// This resets the step counter, to reset the budget before
+    /// interpreting the next entry point.
+    pub(crate) fn reset_step_counter(&mut self) {
         self.step_counter = 0;
-        self.call_context_mut().side_effects_enabled = true;
     }
 
     /// Increment the step counter, or return [InterpreterError::OutOfBudget].

--- a/compiler/noirc_evaluator/src/ssa/opt/constant_folding/interpret.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/constant_folding/interpret.rs
@@ -76,7 +76,7 @@ fn evaluate_const_argument_call(
     let interpreter_args =
         arguments.iter().map(|arg| const_ir_value_to_interpreter_value(*arg, dfg)).collect();
 
-    interpreter.reset_state();
+    interpreter.reset_step_counter();
 
     let Ok(result_values) = interpreter.call_function(*func_id, interpreter_args) else {
         return EvaluationResult::CannotEvaluate;


### PR DESCRIPTION
# Description

## Problem

Resolves #10842

## Summary
Side effect is a property of the Interpreter which need to be restored between function calls


## Additional Context



## User Documentation

Check one:
- [X] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
