### PR TITLE
chore: better naming in out_of_bounds checks

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/opt/die/array_oob_checks.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/die/array_oob_checks.rs
@@ -114,15 +114,15 @@ impl Context {
                 let array_length =
                     function.dfg.make_constant(u128::from(array_length).into(), length_type);
 
-                let is_index_out_of_bounds = function.dfg.insert_instruction_and_results(
+                let is_index_in_bounds = function.dfg.insert_instruction_and_results(
                     Instruction::binary(BinaryOp::Lt, index, array_length),
                     block_id,
                     None,
                     call_stack,
                 );
-                let is_index_out_of_bounds = is_index_out_of_bounds.first();
+                let is_index_in_bounds = is_index_in_bounds.first();
                 let true_const = function.dfg.make_constant(true.into(), NumericType::bool());
-                (is_index_out_of_bounds, true_const)
+                (is_index_in_bounds, true_const)
             };
 
             let (lhs, rhs) = apply_side_effects(


### PR DESCRIPTION
# Description

## Problem

Resolves #10695

## Summary



## Additional Context



## User Documentation

Check one:
- [X] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
