### PR TITLE
chore: replace some unused `RegisterAllocator` methods with panics

### DIFF
--- a/compiler/noirc_evaluator/src/brillig/brillig_ir/registers.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_ir/registers.rs
@@ -359,7 +359,7 @@ impl RegisterAllocator for GlobalSpace {
         _preallocated_registers: Vec<MemoryAddress>,
         _layout: LayoutConfig,
     ) -> Self {
-        unimplemented!("blah")
+        unimplemented!("`GlobalSpace` does not implement `from_preallocated_registers")
     }
 
     fn empty_registers_start(&self) -> MemoryAddress {


### PR DESCRIPTION
# Description

## Problem

Resolves <!-- Link to GitHub Issue -->

## Summary



## Additional Context



## User Documentation

Check one:
- [ ] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
