### PR TITLE
chore: Test reference_expression cases

### DIFF
--- a/compiler/noirc_frontend/src/monomorphization/proxies.rs
+++ b/compiler/noirc_frontend/src/monomorphization/proxies.rs
@@ -288,7 +288,7 @@ fn make_proxy(id: FuncId, ident: Ident, unconstrained: bool) -> Function {
 mod tests {
     use crate::{
         hir::{def_collector::dc_crate::CompilationError, resolution::errors::ResolverError},
-        test_utils::{get_monomorphized_no_emit_test, get_monomorphized_with_error_filter},
+        test_utils::{get_monomorphized, get_monomorphized_with_error_filter},
     };
 
     #[test]
@@ -306,7 +306,7 @@ mod tests {
         }
         ";
 
-        let program = get_monomorphized_no_emit_test(src).unwrap();
+        let program = get_monomorphized(src).unwrap();
         insta::assert_snapshot!(program, @r"
         fn main$f0() -> () {
             {
@@ -336,7 +336,7 @@ mod tests {
         }
         ";
 
-        let program = get_monomorphized_no_emit_test(src).unwrap();
+        let program = get_monomorphized(src).unwrap();
         insta::assert_snapshot!(program, @r"
         unconstrained fn main$f0() -> () {
             foo$f1((bar$f2, bar$f2));

--- a/compiler/noirc_frontend/src/test_utils.rs
+++ b/compiler/noirc_frontend/src/test_utils.rs
@@ -26,10 +26,6 @@ use fm::FileManager;
 
 use crate::monomorphization::{ast::Program, errors::MonomorphizationError, monomorphize};
 
-pub fn get_monomorphized_no_emit_test(src: &str) -> Result<Program, MonomorphizationError> {
-    get_monomorphized(src)
-}
-
 pub fn get_monomorphized(src: &str) -> Result<Program, MonomorphizationError> {
     get_monomorphized_with_error_filter(src, |_| false)
 }


### PR DESCRIPTION
# Description

## Problem

## Summary

Adds a test to test each case in the ownership pass' `reference_expression` method, testing cases where we shouldn't insert a clone even on a non-last use.

## Additional Context

Also removes an extra function which is a duplicate of `get_monomorphized`

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
