### PR TITLE
fix(ssa): Clear the SSA interpreter `call_stack` between top level calls

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/interpreter/tests/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/interpreter/tests/mod.rs
@@ -1791,12 +1791,12 @@ fn call_stack_is_cleared_between_entry_calls() {
     assert_eq!(interpreter.call_stack.len(), 1, "starts with the global context");
 
     let main_id = FunctionId::new(0);
-    interpreter.call_function(main_id, vec![Value::u32(0)]).expect("0 should succeed");
+    interpreter.interpret_function(main_id, vec![Value::u32(0)]).expect("0 should succeed");
     assert_eq!(interpreter.call_stack.len(), 1, "reset after successful call");
 
-    interpreter.call_function(main_id, vec![Value::u32(1)]).expect_err("1 should fail");
+    interpreter.interpret_function(main_id, vec![Value::u32(1)]).expect_err("1 should fail");
     assert_eq!(interpreter.call_stack.len(), 2, "contains the last entry after failure");
 
-    interpreter.call_function(main_id, vec![Value::u32(0)]).expect("0 should succeed");
+    interpreter.interpret_function(main_id, vec![Value::u32(0)]).expect("0 should succeed");
     assert_eq!(interpreter.call_stack.len(), 1, "should clear the previous leftover");
 }

--- a/compiler/noirc_evaluator/src/ssa/opt/constant_folding/interpret.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/constant_folding/interpret.rs
@@ -76,9 +76,7 @@ fn evaluate_const_argument_call(
     let interpreter_args =
         arguments.iter().map(|arg| const_ir_value_to_interpreter_value(*arg, dfg)).collect();
 
-    interpreter.reset_step_counter();
-
-    let Ok(result_values) = interpreter.call_function(*func_id, interpreter_args) else {
+    let Ok(result_values) = interpreter.interpret_function(*func_id, interpreter_args) else {
         return EvaluationResult::CannotEvaluate;
     };
 


### PR DESCRIPTION
# Description

## Problem

Resolves #10891 

## Summary

* Adds an `Interpreter::interpret_function` (similar to `Interpreter::interpret_globals` and `Ssa::interpret_function`) as an entry point for a top level function call. This function calls `Interpreter::call_function`, but before that it sets the `step_counter` to 0 and truncates the `call_stack` to 1, to make sure we don't carry over state from any previous calls. 
* Makes `Interpreter::call_function` private, so we always interact with the `interpret_*` methods.
* Removes `Interpreter::reset_step_counter`, as it is now included in the `interpret_function` method.

## Additional Context



## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
