### PR TITLE
fix: use try_bind() to check for self-referencing types

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/trait_impls.rs
+++ b/compiler/noirc_frontend/src/elaborator/trait_impls.rs
@@ -87,12 +87,19 @@ impl Elaborator<'_> {
                     };
                     let wildcard_allowed =
                         WildcardAllowed::No(WildcardDisallowedContext::AssociatedType);
+                    let location = unresolved_type.location;
                     let resolved_type = self.resolve_type_with_kind(
                         unresolved_type,
                         &associated_type.typ.kind(),
                         wildcard_allowed,
                     );
-                    named_generic.type_var.bind(resolved_type);
+                    if let Err(error) = named_generic.type_var.try_bind(
+                        resolved_type,
+                        &named_generic.type_var.kind(),
+                        location,
+                    ) {
+                        self.push_err(error);
+                    }
                 }
             }
 

--- a/test_programs/compile_failure/cyclic_associated_type/Nargo.toml
+++ b/test_programs/compile_failure/cyclic_associated_type/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "cyclic_associated_type"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.33.0"
+
+[dependencies]

--- a/test_programs/compile_failure/cyclic_associated_type/src/main.nr
+++ b/test_programs/compile_failure/cyclic_associated_type/src/main.nr
@@ -1,0 +1,10 @@
+trait Foo {
+    type Bar;
+}
+
+impl Foo for () {
+    // Self::Bar refers to itself, creating a cyclic type
+    type Bar = Self::Bar;
+}
+
+fn main() { }

--- a/tooling/nargo_cli/tests/snapshots/compile_failure/cyclic_associated_type/execute__tests__stderr.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_failure/cyclic_associated_type/execute__tests__stderr.snap
@@ -1,0 +1,12 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: stderr
+---
+error: Binding `Bar` here to the `_` inside would create a cyclic type
+  ┌─ src/main.nr:7:16
+  │
+7 │     type Bar = Self::Bar;
+  │                --------- Cyclic types have unlimited size and are prohibited in Noir
+  │
+
+Aborting due to 1 previous error


### PR DESCRIPTION
# Description

## Problem

Resolves #10765

## Summary



## Additional Context



## User Documentation

Check one:
- [X] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
