### PR TITLE
fix: transform into constrain_not_equal outside enable_side_effects

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/opt/make_constrain_not_equal.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/make_constrain_not_equal.rs
@@ -157,6 +157,7 @@ mod tests {
     /// semantics with respect to `enable_side_effects`:
     /// - `Constrain` ignores `enable_side_effects` (always executes)
     /// - `ConstrainNotEqual` respects `enable_side_effects` (only executes when enabled)
+    ///
     /// Because `Constrain` ignores side effects, during the `remove_enable_side_effects`
     /// pass it might end up under a different side effect than it started with after flattening,
     /// which makes it unsafe to transform it into `ConstrainNotEqual`. Since we don't validate


### PR DESCRIPTION
# Description

## Problem

Resolves #10929 

## Summary
Do not substitute constrain with constrain_not_equal when there are side_effects.


## Additional Context



## User Documentation

Check one:
- [X] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
