### PR TITLE
fix(fuzzer): Add the "in" keyword to `make_name`

### DIFF
--- a/tooling/ast_fuzzer/src/program/mod.rs
+++ b/tooling/ast_fuzzer/src/program/mod.rs
@@ -546,7 +546,7 @@ fn make_name(mut id: usize, is_global: bool) -> String {
     }
     name.reverse();
     let mut name = name.into_iter().collect::<String>();
-    if matches!(name.as_str(), "as" | "if" | "fn" | "for" | "loop") {
+    if matches!(name.as_str(), "as" | "if" | "in" | "fn" | "for" | "loop") {
         name = format!("{name}_");
     }
     if is_global { format!("G_{name}") } else { name }


### PR DESCRIPTION
# Description

## Problem

At least once the fuzzer generated a random program that had `in` as a variable name.

## Summary

Prevents `make_name` from using `in` as variable name.

## Additional Context



## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
