### PR TITLE
fix(SSA): validate that enable_side_effects takes a u1

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/opt/remove_enable_side_effects.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/remove_enable_side_effects.rs
@@ -208,13 +208,13 @@ mod test {
     fn keeps_enable_side_effects_for_instructions_that_have_side_effects() {
         let src = "
         acir(inline) fn main f0 {
-          b0(v0: [u16; 3], v1: u32, v2: u32):
-            enable_side_effects v1
-            v3 = array_get v0, index v1 -> u16
-            enable_side_effects v1
+          b0(v0: [u16; 3], v1: u32, v2: u1, v3: u1):
+            enable_side_effects v2
             v4 = array_get v0, index v1 -> u16
             enable_side_effects v2
             v5 = array_get v0, index v1 -> u16
+            enable_side_effects v3
+            v6 = array_get v0, index v1 -> u16
             enable_side_effects u1 1
             v7 = array_get v0, index v1 -> u16
             return
@@ -224,16 +224,17 @@ mod test {
         let ssa = ssa.remove_enable_side_effects();
         assert_ssa_snapshot!(ssa, @r"
         acir(inline) fn main f0 {
-          b0(v0: [u16; 3], v1: u32, v2: u32):
-            enable_side_effects v1
-            v3 = array_get v0, index v1 -> u16
-            v4 = array_get v0, index v1 -> u16
+          b0(v0: [u16; 3], v1: u32, v2: u1, v3: u1):
             enable_side_effects v2
+            v4 = array_get v0, index v1 -> u16
             v5 = array_get v0, index v1 -> u16
+            enable_side_effects v3
+            v6 = array_get v0, index v1 -> u16
             enable_side_effects u1 1
-            v7 = array_get v0, index v1 -> u16
+            v8 = array_get v0, index v1 -> u16
             return
-        }");
+        }
+        ");
     }
 
     #[test]

--- a/compiler/noirc_evaluator/src/ssa/parser/tests.rs
+++ b/compiler/noirc_evaluator/src/ssa/parser/tests.rs
@@ -371,7 +371,7 @@ fn test_constrain_not_equal() {
 fn test_enable_side_effects() {
     let src = "
         acir(inline) fn main f0 {
-          b0(v0: Field):
+          b0(v0: u1):
             enable_side_effects v0
             return
         }

--- a/compiler/noirc_evaluator/src/ssa/validation/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/validation/mod.rs
@@ -267,6 +267,10 @@ impl<'f> Validator<'f> {
                     );
                 }
             }
+            Instruction::EnableSideEffectsIf { condition } => {
+                let condition_type = dfg.type_of_value(*condition);
+                assert_u1(&condition_type, "enable_side_effects condition");
+            }
             _ => (),
         }
     }
@@ -1981,5 +1985,18 @@ mod tests {
         let ssa = builder.finish();
 
         Validator::new(&ssa.functions[&main_id], &ssa).run();
+    }
+
+    #[test]
+    #[should_panic(expected = "enable_side_effects condition must be u1, not u32")]
+    fn enable_side_effects_with_non_bool() {
+        let src = "
+        acir(inline) pure fn main f0 {
+          b0(v0: u32):
+            enable_side_effects v0
+            return
+        }
+        ";
+        let _ = Ssa::from_str(src).unwrap();
     }
 }


### PR DESCRIPTION
# Description

## Problem

Resolves #11000

## Summary



## Additional Context



## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
