### PR TITLE
chore: schedule algolia crawls and alert on failure

### DIFF
--- a/.github/workflows/recrawler.yml
+++ b/.github/workflows/recrawler.yml
@@ -2,6 +2,9 @@ name: Algolia Recrawl
 on:
   push:
     branches: [ master ]
+  schedule:
+    # Run on weekdays at 0900
+    - cron: "0 9 * * 1-5"
   workflow_dispatch:
 
 jobs:
@@ -22,3 +25,17 @@ jobs:
           site-url: 'https://noir-lang.org/'
           crawler-name: noir-lang
           override-config: false
+
+      - name: Get current date
+        id: date
+        run: echo "DAY=date::$(date +'%u')" >> $GITHUB_OUTPUT
+
+      - name: Send an alert in slack
+        # Send notifications on scheduled runs if there's a failure.
+        if: ${{ failure() && github.event_name == 'schedule' }}
+        uses: slackapi/slack-github-action@v2.1.1
+        with:
+          webhook: ${{ secrets.ALGOLIA_FAILURE_ALERT_URL }}
+          webhook-type: webhook-trigger
+          payload: |
+            workflow-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}


### PR DESCRIPTION


# Description

## Problem

Resolves <!-- Link to GitHub Issue -->

## Summary

Added a scheduled trigger for weekday recrawls and included steps to  send alerts on failure.

## Additional Context



## User Documentation

Check one:
- [ ] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
