### PR TITLE
chore(ci): Fail circuit sizes job on noir-gates-diff error

### DIFF
--- a/.github/workflows/reports.yml
+++ b/.github/workflows/reports.yml
@@ -172,7 +172,6 @@ jobs:
 
       - name: Compare gates reports
         id: gates_diff
-        continue-on-error: true  # Allow workflow to succeed even if no baseline exists yet
         uses: noir-lang/noir-gates-diff@dbe920a8dcc3370af4be4f702ca9cef29317bec1
         with:
           report: gates_report.json


### PR DESCRIPTION
# Description

## Problem

Follow-up to https://github.com/noir-lang/noir/pull/11011 for resolving https://github.com/noir-lang/noir/pull/11011#issuecomment-3687326827. 

## Summary

This should only be merged once https://github.com/noir-lang/noir/pull/11011 is merged. 

Once we #11011 gives us a valid artifact on master again we set errors from noir-gates-diff to cause the CI to fail. In fact, I expect this job to fail until the parent #11011 is merged into master as the parent branch will not have an artifact. 

## Additional Context



## User Documentation

Check one:
- [X] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
