### PR TITLE
fix(fmt): handle negative literals in turbofish

### DIFF
--- a/tooling/nargo_fmt/src/formatter/expression.rs
+++ b/tooling/nargo_fmt/src/formatter/expression.rs
@@ -2649,4 +2649,13 @@ global y = 1;
 "#;
         assert_format_with_max_width(src, src, 20);
     }
+
+    #[test]
+    fn turbofish_with_negative_literal() {
+        let src = r#"fn main() {
+    foo::<-128>();
+}
+"#;
+        assert_format(src, src);
+    }
 }

--- a/tooling/nargo_fmt/src/formatter/type_expression.rs
+++ b/tooling/nargo_fmt/src/formatter/type_expression.rs
@@ -17,11 +17,17 @@ impl Formatter<'_> {
                 self.write_current_token_and_bump();
             }
             UnresolvedTypeExpression::BinaryOperation(lhs, _operator, rhs, _span) => {
-                self.format_type_expression(*lhs);
-                self.write_space();
-                self.write_current_token_and_bump();
-                self.write_space();
-                self.format_type_expression(*rhs);
+                // Special case: `-expr` is parsed as `0 - expr`
+                if self.is_at(Token::Minus) {
+                    self.write_current_token_and_bump();
+                    self.format_type_expression(*rhs);
+                } else {
+                    self.format_type_expression(*lhs);
+                    self.write_space();
+                    self.write_current_token_and_bump();
+                    self.write_space();
+                    self.format_type_expression(*rhs);
+                }
             }
             UnresolvedTypeExpression::AsTraitPath(as_trait_path) => {
                 self.format_as_trait_path(*as_trait_path);


### PR DESCRIPTION
# Description

## Problem

Resolves #10451

## Summary



## Additional Context



## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
