### PR TITLE
fix(elaborator): Filter skipped interpreter error when calling macro arguments  

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/expressions.rs
+++ b/compiler/noirc_frontend/src/elaborator/expressions.rs
@@ -1634,7 +1634,7 @@ impl Elaborator<'_> {
 
         let mut interpreter = self.setup_interpreter();
         let mut comptime_args = Vec::new();
-        let mut errors = Vec::new();
+        let mut errors: Vec<CompilationError> = Vec::new();
 
         for argument in arguments {
             match interpreter.evaluate(argument) {
@@ -1650,7 +1650,7 @@ impl Elaborator<'_> {
         let result = interpreter.call_function(function, comptime_args, bindings, location);
 
         if !errors.is_empty() {
-            self.errors.append(&mut errors);
+            self.push_errors(errors);
             return None;
         }
 

--- a/compiler/noirc_frontend/src/tests/metaprogramming.rs
+++ b/compiler/noirc_frontend/src/tests/metaprogramming.rs
@@ -1114,3 +1114,22 @@ fn comptime_uhashmap_of_vectors_attribute() {
     "#;
     assert_no_errors(src);
 }
+
+#[test]
+fn regression_11016() {
+    let src = "
+    fn main() {
+        let _s1 = comptime {
+            foo
+            ^^^ cannot find `foo` in this scope
+            ~~~ not found in this scope
+        };
+        call!(quote {});
+    }
+
+    comptime fn call(x: Quoted) -> Quoted {
+        quote { $x() }
+    }
+    ";
+    check_errors(src);
+}


### PR DESCRIPTION
# Description

## Problem

Resolves #11016

## Summary

When interpreting a macro's arguments we were appending errors directly to the elaborator rather than going through `Elaborator::push_err`. Thus, when we had a previous error from a comptime block the interpreter would return `SkippedDueToTypeErrors` immediately. 

## Additional Context



## User Documentation

Check one:
- [X] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
