### PR TITLE
fix(ssa): correct SSA syntax in documentation comment

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/opt/remove_unreachable_instructions.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/remove_unreachable_instructions.rs
@@ -90,7 +90,7 @@
 //! constrain v0 == u1 0, "Index out of bounds"
 //! v2 = allocate -> &mut Field
 //! store Field 0 at v2
-//! v3 <- load v2 -> Field
+//! v3 = load v2 -> Field
 //! v4 = add v3, Field 2
 //! ```
 //!


### PR DESCRIPTION
The SSA example used `<-` instead of `=` for assignment, which is inconsistent with the actual SSA syntax used throughout the codebase.

Changed `v3 <- load v2 -> Field` to `v3 = load v2 -> Field` to match the standard SSA representation format.