### PR TITLE
chore: automatically bump `bb_proof_verification` dependencies

### DIFF
--- a/compiler/integration-tests/circuits/recursion/Nargo.toml
+++ b/compiler/integration-tests/circuits/recursion/Nargo.toml
@@ -4,4 +4,4 @@ type = "bin"
 authors = [""]
 
 [dependencies]
-bb_proof_verification = {  git = "https://github.com/AztecProtocol/aztec-packages", tag ="v3.0.0-nightly.20251104", directory = "./barretenberg/noir/bb_proof_verification" }
+bb_proof_verification = {  git = "https://github.com/AztecProtocol/aztec-packages", tag = "v3.0.0-nightly.20251104", directory = "./barretenberg/noir/bb_proof_verification" }

--- a/scripts/bump-bb.sh
+++ b/scripts/bump-bb.sh
@@ -7,7 +7,7 @@ sed -i.bak "s/^VERSION=.*/VERSION=\"$BB_VERSION\"/" ./scripts/install_bb.sh  && 
 
 # Update bb_proof_verification tag in Nargo.toml files (these require a leading 'v')
 grep -rl 'bb_proof_verification' --include='Nargo.toml' . | while read -r file; do
-    sed -i.bak '/bb_proof_verification/s/tag = "v[^"]*"/tag = "v'"$BB_VERSION"'"/' "$file" && rm "$file.bak"
+    sed -i.bak '/bb_proof_verification/s/tag *= *"v[^"]*"/tag = "v'"$BB_VERSION"'"/' "$file" && rm "$file.bak"
 done
 
 tmp=$(mktemp)


### PR DESCRIPTION
# Description

## Problem

Resolves <!-- Link to GitHub Issue -->

## Summary

We now search and replace any `bb_proof_verification` dependencies in the repository to avoid mystery errors from incompatibilities.

## Additional Context



## User Documentation

Check one:
- [ ] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
