### PR TITLE
chore(ci): do not fail CI if there are no changes to stdlib docs

### DIFF
--- a/.github/workflows/publish-stdlib-docs.yml
+++ b/.github/workflows/publish-stdlib-docs.yml
@@ -96,5 +96,9 @@ jobs:
           # This could _potentially_ clash with pushing benchmarks to this branch at the same time.
           # In practice, this will complete much sooner than the benchmarks are generated.
           git add ./stdlib/*
-          git commit -m "update noirdoc"
-          git push
+          if git diff --cached --quiet; then
+            echo "No changes to commit"
+          else
+            git commit -m "update noirdoc"
+            git push
+          fi


### PR DESCRIPTION
# Description

## Problem

Resolves <!-- Link to GitHub Issue -->

## Summary

This is currently always failing in master due to the empty commit being generated. We can just succeed while not pushing in this case.

## Additional Context



## User Documentation

Check one:
- [ ] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
