### PR TITLE
fix: skip release-end job when release PR isn't updated

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,7 +112,7 @@ jobs:
     name: Release End
     runs-on: ubuntu-22.04
     # We want this job to always run (even if the dependant jobs fail) as we need apply changes to the sticky comment.
-    if: ${{ always() }}
+    if: ${{ always() && needs.release-please.outputs.release-pr }}
 
     needs:
       - release-please
@@ -137,8 +137,6 @@ jobs:
         run: |
           if [[ $FAIL == true ]]; then
               exit 1
-          else
-              exit 0
           fi
 
   build-binaries:


### PR DESCRIPTION
# Description

## Problem

Resolves <!-- Link to GitHub Issue -->

## Summary

Condition the release-end job on release-pr output to avoid JSON parsing errors when release-please doesn't create/update a PR.

This fixes the error shown in https://github.com/noir-lang/noir/actions/runs/20661406199/job/59324593439 where we're attempting to parse a value which doesn't exist as json.

## Additional Context



## User Documentation

Check one:
- [ ] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
