### PR TITLE
feat: improved error message when if is missing its condition

### DIFF
--- a/compiler/noirc_frontend/src/parser/errors.rs
+++ b/compiler/noirc_frontend/src/parser/errors.rs
@@ -115,6 +115,8 @@ pub enum ParserErrorReason {
     AssociatedTraitConstantDefaultValuesAreNotSupported,
     #[error("`mut` on a binding cannot be repeated")]
     MutOnABindingCannotBeRepeated,
+    #[error("missing condition for `if` expression")]
+    MissingIfCondition,
 }
 
 /// Represents a parsing error, or a parsing error in the making.


### PR DESCRIPTION
# Description

## Problem

Resolves #10962

## Summary

Technically the previous error was also fine: if we have `if { ... }` then that block can actually be the condition. This works in Rust too. However, Rust guesses that the block was meant to be the consequence block if another `{` doesn't come after the block and produces a better error message. This is what this PR does too.

<img width="545" height="386" alt="image" src="https://github.com/user-attachments/assets/3b2984dd-741a-4bf1-8b05-369a52215b87" />


## Additional Context

## User Documentation

Check one:
- [ ] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
