### PR TITLE
chore: add assertion that RHS type of a bit shift is a power of 2

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/opt/remove_bit_shifts.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/remove_bit_shifts.rs
@@ -329,7 +329,10 @@ impl Context<'_, '_, '_> {
             1
         } else {
             let exponent_bit_size = self.context.dfg.type_of_value(exponent).bit_size();
-            assert!(exponent_bit_size.is_power_of_two(), "ICE: exponent type bit size is expected to be a power of two");
+            assert!(
+                exponent_bit_size.is_power_of_two(),
+                "ICE: exponent type bit size is expected to be a power of two"
+            );
             exponent_bit_size.ilog2()
         };
         let result_types = vec![Type::Array(Arc::new(vec![Type::bool()]), max_exponent_bits)];


### PR DESCRIPTION
# Description

## Problem

Resolves #10986 

## Summary

We now assert on the expected behaviour.

## Additional Context



## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
