### PR TITLE
chore: improve documentation around use of casting to truncate

### DIFF
--- a/compiler/noirc_evaluator/src/brillig/brillig_ir/codegen_intrinsic.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_ir/codegen_intrinsic.rs
@@ -43,7 +43,6 @@ impl<F: AcirField + DebugToString, Registers: RegisterAllocator> BrilligContext<
 
             // We then cast back to the original type to satisfy typed memory.
             self.cast_instruction(destination_of_truncated_value, *intermediate_register);
-            self.deallocate_single_addr(intermediate_register);
 
             return;
         }


### PR DESCRIPTION
# Description

## Problem

Resolves <!-- Link to GitHub Issue -->

## Summary

Auditors had a couple questions about what we're doing here so I've written a little more docs to explain it. At the same time I noticed that we're not de-allocating the temporary register.

## Additional Context



## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
