### PR TITLE
fix: error if trait impl associated type is missing its body

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/comptime.rs
+++ b/compiler/noirc_frontend/src/elaborator/comptime.rs
@@ -585,6 +585,7 @@ impl<'context> Elaborator<'context> {
                         self.crate_id,
                         location.file,
                         local_module,
+                        &mut self.errors,
                     );
 
                 generated_items.trait_impls.push(UnresolvedTraitImpl {

--- a/compiler/noirc_frontend/src/hir/def_collector/dc_mod.rs
+++ b/compiler/noirc_frontend/src/hir/def_collector/dc_mod.rs
@@ -216,6 +216,7 @@ impl ModCollector<'_> {
                     krate,
                     self.file_id,
                     self.module_id,
+                    &mut errors,
                 );
 
             let module = ModuleId { krate, local_id: self.module_id };
@@ -1493,6 +1494,7 @@ pub(crate) fn collect_trait_impl_items(
     krate: CrateId,
     file_id: FileId,
     local_id: LocalModuleId,
+    errors: &mut Vec<CompilationError>,
 ) -> (UnresolvedFunctions, AssociatedTypes, AssociatedConstants) {
     let mut unresolved_functions =
         UnresolvedFunctions { file_id, functions: Vec::new(), trait_id: None, self_type: None };
@@ -1524,6 +1526,12 @@ pub(crate) fn collect_trait_impl_items(
                 associated_constants.push((name, typ, expr));
             }
             TraitImplItemKind::Type { name, alias } => {
+                if alias.is_none() {
+                    let ident = name.clone();
+                    let error = ResolverError::AssociatedTypeInImplWithoutBody { ident };
+                    errors.push(error.into());
+                }
+
                 associated_types.push((name, alias));
             }
         }

--- a/compiler/noirc_frontend/src/hir/resolution/errors.rs
+++ b/compiler/noirc_frontend/src/hir/resolution/errors.rs
@@ -202,6 +202,8 @@ pub enum ResolverError {
     PatternBoundMoreThanOnce { ident: Ident },
     #[error("{visibility} attribute is only allowed on entry point functions")]
     DataBusOnNonEntryPoint { visibility: String, ident: Ident },
+    #[error("Associated type in `impl` without body")]
+    AssociatedTypeInImplWithoutBody { ident: Ident },
 }
 
 impl ResolverError {
@@ -280,7 +282,8 @@ impl ResolverError {
             | ResolverError::NecessaryPub { ident }
             | ResolverError::UnconstrainedTypeParameter { ident }
             | ResolverError::DataBusOnNonEntryPoint { ident, .. }
-            | ResolverError::PatternBoundMoreThanOnce { ident } => ident.location(),
+            | ResolverError::PatternBoundMoreThanOnce { ident }
+            | ResolverError::AssociatedTypeInImplWithoutBody { ident } => ident.location(),
             ResolverError::PathResolutionError(path_resolution_error) => {
                 path_resolution_error.location()
             }
@@ -892,6 +895,13 @@ impl<'a> From<&'a ResolverError> for Diagnostic {
                 diag.add_note(
                     format!("The {visibility} attribute only has effects for the entry-point function of a program. Thus, adding it to other function can be deceiving and should be removed)"));
                 diag
+            },
+            ResolverError::AssociatedTypeInImplWithoutBody { ident } => {
+                Diagnostic::simple_error(
+                    "Associated type in impl without body".to_string(),
+                    "Provide a definition for the type: ` = <type>;`".to_string(),
+                    ident.location(),
+                )
             },
         }
     }

--- a/compiler/noirc_frontend/src/tests/traits/trait_impl_validation.rs
+++ b/compiler/noirc_frontend/src/tests/traits/trait_impl_validation.rs
@@ -257,3 +257,21 @@ fn check_trait_not_in_scope() {
     ";
     check_errors(src);
 }
+
+#[test]
+fn trait_impl_associated_type_without_body() {
+    let src = "
+    pub trait Trait {
+        type Assoc;
+    }
+
+    impl Trait for Field {
+        type Assoc;
+             ^^^^^ Associated type in impl without body
+             ~~~~~ Provide a definition for the type: ` = <type>;`
+    }
+
+    fn main() {}
+    ";
+    check_errors(src);
+}


### PR DESCRIPTION
# Description

## Problem

Resolves #11034

## Summary

I chose to make it a resolver error rather than a parser error so a code without a body can still be formatted well. At least it's the same as in Rust, it seems.

## Additional Context



## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
