### PR TITLE
fix: don't allow unknown witnesses in CircuitSimulator write op

### DIFF
--- a/acvm-repo/acvm/src/compiler/simulator.rs
+++ b/acvm-repo/acvm/src/compiler/simulator.rs
@@ -105,7 +105,7 @@ impl CircuitSimulator {
                     self.mark_solvable(w);
                     true
                 } else {
-                    self.try_solve(&Opcode::AssertZero(op.value.clone()))
+                    self.can_solve_expression(&op.value)
                 }
             }
             Opcode::MemoryInit { block_id, init, .. } => {
@@ -363,5 +363,31 @@ mod tests {
         ";
         let circuit = Circuit::from_str(src).unwrap();
         assert_eq!(CircuitSimulator::check_circuit(&circuit), Some(0));
+    }
+
+    #[test]
+    fn reports_some_when_write_has_a_single_unknown_witness_in_its_value() {
+        let src = "
+        private parameters: [w0, w1]
+        public parameters: []
+        return values: []
+        INIT b0 = [w0]
+        WRITE b0[w0] = w1 + w2
+        ";
+        let circuit = Circuit::from_str(src).unwrap();
+        assert_eq!(CircuitSimulator::check_circuit(&circuit), Some(1));
+    }
+
+    #[test]
+    fn reports_none_when_write_has_known_witnesses_in_its_value() {
+        let src = "
+        private parameters: [w0, w1, w2]
+        public parameters: []
+        return values: []
+        INIT b0 = [w0]
+        WRITE b0[w0] = w1 + w2
+        ";
+        let circuit = Circuit::from_str(src).unwrap();
+        assert_eq!(CircuitSimulator::check_circuit(&circuit), None);
     }
 }


### PR DESCRIPTION
# Description

## Problem

Resolves #11054

## Summary



## Additional Context



## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
