### PR TITLE
chore: remove trailing spaces from bash scripts

### DIFF
--- a/examples/solidity_verifier/test.sh
+++ b/examples/solidity_verifier/test.sh
@@ -9,7 +9,7 @@ rm -f ./src/contract.sol
 
 ./solidity_verifier.sh
 
-if ! [ -f ./src/contract.sol ]; then 
+if ! [ -f ./src/contract.sol ]; then
     printf '%s\n' "Contract not written to file" >&2
     exit 1
 fi

--- a/scripts/check-critical-libraries.sh
+++ b/scripts/check-critical-libraries.sh
@@ -42,17 +42,17 @@ checkYarnInstalled() {
 # Run tests for a library directory
 runLibraryTests() {
     LIB_DIR=$1
-    
+
     (
         cd $LIB_DIR
-        
+
         # Check if library has package.json (needs yarn setup)
         if [ -f "package.json" ]; then
             echo "Detected package.json, setting up yarn dependencies..."
             checkYarnInstalled
             yarn install --frozen-lockfile 2>&1 || yarn install 2>&1
         fi
-        
+
         # Check for custom test script
         if [ -f "scripts/run.sh" ]; then
             echo "Running custom test script: scripts/run.sh"
@@ -72,10 +72,10 @@ runLibraryTests() {
 for REPO in ${REPOS_TO_CHECK[@]}; do
     echo "Checking $REPO"
     TMP_DIR=$(mktemp -d)
-    
+
     TAG=$(getLatestReleaseTagForRepo $REPO)
     git clone $REPO -c advice.detachedHead=false --depth 1 --branch $TAG $TMP_DIR
-    
+
     runLibraryTests $TMP_DIR
 
     rm -rf $TMP_DIR

--- a/scripts/count_loc.sh
+++ b/scripts/count_loc.sh
@@ -7,7 +7,7 @@ cd $(dirname "$0")/../
 if ! command -v "tokei" >/dev/null 2>&1; then
     echo "Error: tokei is required but not installed." >&2
     echo "Error: Run \`cargo install --git https://github.com/TomAFrench/tokei --branch tf/add-noir-support tokei\`" >&2
-    
+
     exit 1
 fi
 

--- a/scripts/gather_benchmark_data.sh
+++ b/scripts/gather_benchmark_data.sh
@@ -15,7 +15,7 @@ setup_repo() {
     local temp_dir=$3
 
     local repo_url="https://github.com/$repo_slug"
-    
+
     # Sadly we cannot use depth=1 clones here as we need to be able to checkout
     # commit hashes as well as branches/releases
     git clone $repo_url $temp_dir
@@ -48,7 +48,7 @@ save_artifact() {
 if [ -z "${REPO_DIR:-}" ]; then
     TMP_DIR=$(mktemp -d)
     trap "rm -rf $TMP_DIR" EXIT
-    
+
     setup_repo $REPO_SLUG $PROJECT_TAG $TMP_DIR
 fi
 

--- a/scripts/install_bb.sh
+++ b/scripts/install_bb.sh
@@ -4,7 +4,7 @@ VERSION="3.0.0-nightly.20260102"
 
 BBUP_PATH=~/.bb/bbup
 
-if ! [ -f $BBUP_PATH ]; then 
+if ! [ -f $BBUP_PATH ]; then
     curl -L https://raw.githubusercontent.com/AztecProtocol/aztec-packages/refs/heads/next/barretenberg/bbup/install | bash
 fi
 

--- a/scripts/process_benchmark_data.sh
+++ b/scripts/process_benchmark_data.sh
@@ -22,9 +22,9 @@ average_times() {
           current_time = substr($1, 0, seconds)
           return current_time;
         }
-        
+
         printf "Could not parse time: %" $1 > "/dev/stderr"
-        
+
         printf "ERROR"
         exit 1
     }
@@ -34,7 +34,7 @@ average_times() {
       sum += seconds;
       n++;
     }
-    END {   
+    END {
       if (n > 0)
         printf "%.3f\n", sum / n
       else

--- a/test_programs/gates_report.sh
+++ b/test_programs/gates_report.sh
@@ -33,11 +33,11 @@ test_dirs=$(ls $artifacts_path)
 
 echo "{\"programs\": [" > gates_report.json
 
-# Bound for checking where to place last parentheses 
+# Bound for checking where to place last parentheses
 NUM_ARTIFACTS=$(ls -1q "$artifacts_path" | wc -l)
 
 ITER="1"
-for pathname in $test_dirs; do    
+for pathname in $test_dirs; do
     ARTIFACT_NAME=$(basename "$pathname")
     if [[ " ${excluded_dirs[@]} " =~ "$ARTIFACT_NAME" ]]; then
         ITER=$(( $ITER + 1 ))
@@ -51,13 +51,13 @@ for pathname in $test_dirs; do
 
     if (($ITER == $NUM_ARTIFACTS)); then
         echo "" >> gates_report.json
-    else 
+    else
         echo "," >> gates_report.json
     fi
 
     ITER=$(( $ITER + 1 ))
 done
 
-echo "]}" >> gates_report.json 
+echo "]}" >> gates_report.json
 
 

--- a/test_programs/gates_report_brillig.sh
+++ b/test_programs/gates_report_brillig.sh
@@ -3,11 +3,11 @@ set -eo pipefail
 
 # These tests are incompatible with artifact size reporting
 excluded_dirs=(
-  "workspace" 
-  "workspace_default_member" 
-  "double_verify_nested_proof" 
-  "overlapping_dep_and_mod" 
-  "comptime_println" 
+  "workspace"
+  "workspace_default_member"
+  "double_verify_nested_proof"
+  "overlapping_dep_and_mod"
+  "comptime_println"
   # This test utilizes enums which are experimental
   "regression_7323"
 )

--- a/test_programs/memory_report.sh
+++ b/test_programs/memory_report.sh
@@ -24,7 +24,7 @@ FIRST="1"
 FLAGS=${FLAGS:- ""}
 echo "[" > memory_report.json
 
-for test_path in ${tests_to_profile[@]}; do    
+for test_path in ${tests_to_profile[@]}; do
         cd $base_path/$test_path
 
         if [ $FIRST = "1" ]
@@ -50,12 +50,12 @@ for test_path in ${tests_to_profile[@]}; do
             COMMAND="execute --silence-warnings"
         fi
 
-        heaptrack --output $current_dir/$test_name"_heap" $NARGO $COMMAND 
-        if test -f $current_dir/$test_name"_heap.gz"; 
-        then 
+        heaptrack --output $current_dir/$test_name"_heap" $NARGO $COMMAND
+        if test -f $current_dir/$test_name"_heap.gz";
+        then
             heaptrack --analyze $current_dir/$test_name"_heap.gz" > $current_dir/$test_name"_heap_analysis.txt"
             rm $current_dir/$test_name"_heap.gz"
-        else 
+        else
             heaptrack --analyze $current_dir/$test_name"_heap.zst" > $current_dir/$test_name"_heap_analysis.txt"
             rm $current_dir/$test_name"_heap.zst"
         fi

--- a/test_programs/parse_memory.sh
+++ b/test_programs/parse_memory.sh
@@ -15,7 +15,7 @@ elif [[ $1 =~ $MEGABYTES_REGEX ]]; then
   echo ${BASH_REMATCH[1]} | awk '{printf "%.3f\n", $1}'
 elif [[ $1 =~ $GIGABYTES_REGEX ]]; then
   echo ${BASH_REMATCH[1]} 1000 | awk '{printf "%.3f\n", $1*$2}'
-else 
+else
   echo "Could not parse memory: unrecognized format" 1>&2
   exit 1
 fi

--- a/test_programs/parse_time.sh
+++ b/test_programs/parse_time.sh
@@ -15,7 +15,7 @@ elif [[ $1 =~ $MILLISECONDS_REGEX ]]; then
   echo ${BASH_REMATCH[1]} 1000 | awk '{printf "%.3f\n", $1/$2}'
 elif [[ $1 =~ $SECONDS_REGEX ]]; then
   echo ${BASH_REMATCH[1]} | awk '{printf "%.3f\n", $1}'
-else 
+else
   echo "Could not parse time: unrecognized format" 1>&2
   exit 1
 fi


### PR DESCRIPTION
# Description

## Problem

Resolves <!-- Link to GitHub Issue -->

## Summary

We've got a bunch of trailing spaces in bash scripts which is not great so this PR removes them.

## Additional Context



## User Documentation

Check one:
- [ ] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
