### PR TITLE
chore: have dependabot ignore bb.js

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,6 +24,8 @@ updates:
       # Keep compatible with our minimum supported Node version (22.x)
       - dependency-name: "@types/node"
         versions: [">=23.0.0"]
+      # Ignore updates for @aztec/bb.js as it's managed separately
+      - dependency-name: "@aztec/bb.js"
     groups:
       # group updates for linter
       linter:


### PR DESCRIPTION
# Description

## Problem

Resolves <!-- Link to GitHub Issue -->

## Summary

dependabot is trying to bump the bb.js version but we need to update a number of other references in parallel so we don't want dependabot to handle this.

## Additional Context



## User Documentation

Check one:
- [ ] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
