### PR TITLE
chore: set permissions in msrv workflow

### DIFF
--- a/.github/workflows/test-rust-workspace-msrv.yml
+++ b/.github/workflows/test-rust-workspace-msrv.yml
@@ -113,6 +113,7 @@ jobs:
       - run-tests
     permissions:
       contents: read
+      issues: write
 
     steps:
       - name: Report overall success


### PR DESCRIPTION
# Description

## Problem

Resolves <!-- Link to GitHub Issue -->

## Summary

We're not getting issues being opened by https://github.com/noir-lang/noir/actions/workflows/test-rust-workspace-msrv.yml

## Additional Context



## User Documentation

Check one:
- [ ] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
