### PR TITLE
chore: document indexing array with Field elements

### DIFF
--- a/docs/docs/noir/concepts/data_types/arrays.md
+++ b/docs/docs/noir/concepts/data_types/arrays.md
@@ -113,6 +113,24 @@ fn main(x: u32) {
 }
 ```
 
+## Indexing with Field Elements
+Working with the native Field type can help producing more optimized programs (if you know what you are doing!), by avoiding overflow checks in general and in particular for array index, u32 arithmetic.
+However Noir type system will require your array index to be `u32`, so if you computed an array index using the Field type, you will have to convert it into a `u32`. This operation is usually costly because the 'unbounded' Field element needs to be reduced modulo `2^32`. However we can benefit from the array out-of-bound checks in order to avoid this costly operation.
+One way to do it is the following:
+1. use `assert_max_bit_size::<32>();` and `as u32` in order to convert a Field into a u32 using only one range-check, if you know that the Field is indeed 32 bits (or less).
+2. Index the array with the resulting u32: `array[x as u32]`. This will remove the range-check from the previous step.
+
+```rust
+fn foo(x: Field, array: [Field; 10]) -> Field {
+    // x is used to index `array`, so it must fit into 32 bits
+    x.assert_max_bit_size::<32>();
+    // assert_max_bit_size::<32>() makes the u32 conversion: `x as u32`, free.
+    // Accessing the array also implies an out-of-bound check, so it makes the range-check `x.assert_max_bit_size::<32>();`
+    // redundant. It will be removed in a later stage.
+    array[x as u32]
+}
+```
+
 ## Types
 
 You can create arrays of primitive types or structs. There is not yet support for nested arrays


### PR DESCRIPTION
# Description

## Problem

The documentation does not mention how to efficiently use a Field for indexing arrays. This is a common pattern and it is easy to get it wrong.

## Summary



## Additional Context



## User Documentation

Check one:
- [ ] No user documentation needed.
- [X] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
