### PR TITLE
fix: do not crash when R is zero

### DIFF
--- a/acvm-repo/blackbox_solver/src/ecdsa/secp256k1.rs
+++ b/acvm-repo/blackbox_solver/src/ecdsa/secp256k1.rs
@@ -98,6 +98,7 @@ pub(super) fn verify_signature(
 
     match R.to_encoded_point(false).coordinates() {
         Coordinates::Uncompressed { x, y: _ } => Ok(Scalar::from_repr(*x).unwrap().eq(&r)),
+        Coordinates::Identity => Ok(false),
         _ => unreachable!("Point is uncompressed"),
     }
 }

--- a/acvm-repo/blackbox_solver/src/ecdsa/secp256r1.rs
+++ b/acvm-repo/blackbox_solver/src/ecdsa/secp256r1.rs
@@ -99,6 +99,7 @@ pub(super) fn verify_signature(
 
     match R.to_encoded_point(false).coordinates() {
         Coordinates::Uncompressed { x, y: _ } => Ok(Scalar::from_repr(*x).unwrap().eq(&r)),
+        Coordinates::Identity => Ok(false),
         _ => unreachable!("Point is uncompressed"),
     }
 }


### PR DESCRIPTION
# Description

## Problem

Resolves https://github.com/noir-lang/noir/security/advisories/GHSA-6j45-727g-vcr2

## Summary
Verify to false instead of panic when R is zero.


## Additional Context



## User Documentation

Check one:
- [X] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
