### PR TITLE
fix: mark bb predicates as used in merge_expression

### DIFF
--- a/acvm-repo/acvm/src/compiler/optimizers/common_subexpression/merge_expressions.rs
+++ b/acvm-repo/acvm/src/compiler/optimizers/common_subexpression/merge_expressions.rs
@@ -200,7 +200,9 @@ impl<F: AcirField> MergeExpressionsOptimizer<F> {
             Opcode::BlackBoxFuncCall(bb_func) => {
                 let mut witnesses = bb_func.get_input_witnesses();
                 witnesses.extend(bb_func.get_outputs_vec());
-
+                if let Some(w) = bb_func.get_predicate() {
+                    witnesses.insert(w);
+                }
                 witnesses
             }
             Opcode::MemoryOp { block_id: _, op } => {


### PR DESCRIPTION
# Description

## Problem

Similar to #10922, black box predicate was not taken into account for the opcode's used witnesses.

## Summary



## Additional Context



## User Documentation

Check one:
- [X] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
