### PR TITLE
fix(fmt): format the old vector syntax into the new one

### DIFF
--- a/tooling/nargo_fmt/src/formatter/expression.rs
+++ b/tooling/nargo_fmt/src/formatter/expression.rs
@@ -154,7 +154,13 @@ impl ChunkFormatter<'_, '_> {
 
         group.text(self.chunk(|formatter| {
             if is_vector {
-                formatter.write_token(Token::At);
+                if formatter.is_at(Token::DeprecatedVectorStart) {
+                    // Support the old vector syntax `&[1, 2, 3]`
+                    formatter.bump();
+                    formatter.write("@");
+                } else {
+                    formatter.write_token(Token::At);
+                }
             }
             formatter.write_left_bracket();
         }));
@@ -1436,6 +1442,13 @@ mod tests {
     #[test]
     fn format_standard_vector() {
         let src = "global x = @ [ 1 , 2 , 3 , ] ;";
+        let expected = "global x = @[1, 2, 3];\n";
+        assert_format(src, expected);
+    }
+
+    #[test]
+    fn format_old_vector_syntax() {
+        let src = "global x = &[ 1 , 2 , 3 , ] ;";
         let expected = "global x = @[1, 2, 3];\n";
         assert_format(src, expected);
     }


### PR DESCRIPTION
# Description

## Problem

Resolves #11127

## Summary

I saw the formatter got updated in the previous PR to produce `@[...]` for vectors, but I didn't realize it choked on the old syntax.

## Additional Context



## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
