### PR TITLE
chore: replacing usage of `assert_always_fail` in `noirc_evaluator`

### DIFF
--- a/compiler/noirc_evaluator/src/acir/acir_context/mod.rs
+++ b/compiler/noirc_evaluator/src/acir/acir_context/mod.rs
@@ -557,12 +557,6 @@ impl<F: AcirField> AcirContext<F> {
         self.assert_eq_var(var, zero, Some(msg))
     }
 
-    /// Add an always-fail assertion with a message.
-    pub(crate) fn assert_always_fail(&mut self, msg: String) -> Result<(), RuntimeError> {
-        let one = self.add_constant(F::one());
-        self.assert_zero_var(one, msg)
-    }
-
     pub(crate) fn values_to_expressions_or_memory(
         &self,
         values: &[AcirValue],
@@ -833,7 +827,7 @@ impl<F: AcirField> AcirContext<F> {
                 let msg = format!(
                     "attempted to divide by constant larger than operand type: {rhs_bits} > {bit_size}"
                 );
-                self.assert_always_fail(msg)?;
+                self.assert_zero_var(predicate, msg)?;
                 return Ok((zero, zero));
             }
 

--- a/compiler/noirc_evaluator/src/acir/tests/instructions/binary.rs
+++ b/compiler/noirc_evaluator/src/acir/tests/instructions/binary.rs
@@ -676,3 +676,71 @@ fn xor_u8() {
     ASSERT w2 = w3
     ");
 }
+
+#[test]
+fn div_divisor_overflow_with_side_effects_enabled() {
+    let src = "
+    acir(inline) fn main f0 {
+      b0(v0: u8):
+        enable_side_effects u1 1
+        v1 = div v0, u8 256
+        return v0
+    }
+    ";
+    let program = ssa_to_acir_program(src);
+
+    assert_circuit_snapshot!(program, @r"
+    func 0
+    private parameters: [w0]
+    public parameters: []
+    return values: [w1]
+    BLACKBOX::RANGE input: w0, bits: 8
+    ASSERT 0 = 1
+    ASSERT w1 = w0
+    ");
+}
+
+#[test]
+fn div_divisor_overflow_without_side_effects_enabled() {
+    let src = "
+    acir(inline) fn main f0 {
+      b0(v0: u8):
+        enable_side_effects u1 0
+        v1 = div v0, u8 256
+        return v0
+    }
+    ";
+    let program = ssa_to_acir_program(src);
+
+    assert_circuit_snapshot!(program, @r"
+    func 0
+    private parameters: [w0]
+    public parameters: []
+    return values: [w1]
+    BLACKBOX::RANGE input: w0, bits: 8
+    ASSERT w1 = w0
+    ");
+}
+
+#[test]
+fn div_divisor_overflow_with_dynamic_side_effects_enabled() {
+    let src = "
+    acir(inline) fn main f0 {
+      b0(v0: u8, v1: u1):
+        enable_side_effects v1
+        v2 = div v0, u8 256
+        return v0
+    }
+    ";
+    let program = ssa_to_acir_program(src);
+
+    assert_circuit_snapshot!(program, @r"
+    func 0
+    private parameters: [w0, w1]
+    public parameters: []
+    return values: [w2]
+    BLACKBOX::RANGE input: w0, bits: 8
+    ASSERT w1 = 0
+    ASSERT w2 = w0
+    ");
+}


### PR DESCRIPTION

# Description

## Problem

Resolves https://github.com/noir-lang/noir/security/advisories/GHSA-wq62-cp93-4556

## Summary

Replacing usage of `assert_always_fail` with ensuring that the predicate passed to `euclidean_division_var` is zero and adding tests involving `enable_side_effects` in `noirc_evaluator`

## Additional Context



## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
