### PR TITLE
chore: check in memop operation for witnesses

### DIFF
--- a/acvm-repo/acvm/src/compiler/optimizers/common_subexpression/merge_expressions.rs
+++ b/acvm-repo/acvm/src/compiler/optimizers/common_subexpression/merge_expressions.rs
@@ -205,11 +205,10 @@ impl<F: AcirField> MergeExpressionsOptimizer<F> {
                 }
                 witnesses
             }
-            Opcode::MemoryOp { block_id: _, op } => {
-                //index and value
-                let witnesses = CircuitSimulator::expr_witness(&op.index);
-                witnesses.chain(CircuitSimulator::expr_witness(&op.value)).collect()
-            }
+            Opcode::MemoryOp { block_id: _, op } => CircuitSimulator::expr_witness(&op.operation)
+                .chain(CircuitSimulator::expr_witness(&op.index))
+                .chain(CircuitSimulator::expr_witness(&op.value))
+                .collect(),
 
             Opcode::MemoryInit { block_id: _, init, block_type: _ } => {
                 init.iter().cloned().collect()


### PR DESCRIPTION
# Description

## Problem

Resolves <!-- Link to GitHub Issue -->

## Summary

This changes isn't technically necessary as we only emit constant values for `operation` and are planning to enforce this on a type level soon but this PR fully satisfies https://audithub.veridise.com/app/organizations/161/projects/462/project-viewer?version=1133&issue=745 in the meantime. 

## Additional Context



## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
