### PR TITLE
fix: safe cast shift rhs to u32 in comptime interpreter

### DIFF
--- a/compiler/noirc_frontend/src/hir/comptime/interpreter/infix.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter/infix.rs
@@ -208,6 +208,7 @@ pub(super) fn evaluate_infix(
             (lhs_value as lhs ">>" rhs_value as rhs) {
                 int: {
                     #[allow(clippy::useless_conversion)]
+                    #[allow(clippy::unnecessary_fallible_conversions)]
                     let rhs: Result<u32, _> = rhs.try_into();
                     #[allow(irrefutable_let_patterns)]
                     let Ok(rhs) = rhs else {
@@ -223,6 +224,7 @@ pub(super) fn evaluate_infix(
             (lhs_value as lhs "<<" rhs_value as rhs) {
                 int: {
                     #[allow(clippy::useless_conversion)]
+                    #[allow(clippy::unnecessary_fallible_conversions)]
                     let rhs: Result<u32, _> = rhs.try_into();
                     #[allow(irrefutable_let_patterns)]
                     let Ok(rhs) = rhs else {


### PR DESCRIPTION
# Description

## Problem

Resolves https://github.com/noir-lang/noir/security/advisories/GHSA-g6r5-jjj6-7pj2

## Summary



## Additional Context



## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
