### PR TITLE
chore(frontend): Monomorphization unit tests

### DIFF
--- a/compiler/noirc_frontend/src/monomorphization/tests.rs
+++ b/compiler/noirc_frontend/src/monomorphization/tests.rs
@@ -382,7 +382,7 @@ fn static_trait_method_call_with_multiple_generics() {
 
 #[test]
 fn generic_struct_implementing_generic_trait() {
-    // Make sure trait generics Input=X=Field and Output=Y=u32 bind correctly.
+    // Make sure trait generics Input=X=u8 and Output=Y=u32 bind correctly.
     let src = r#"
     trait MyTrait<Input, Output> {
         fn foo(input: Input) -> Output;


### PR DESCRIPTION
# Description

## Problem

Part of work for #10759

## Summary

These are some unit tests I added while working on the monomorphization audit. These tests are all but passing but I feel would be useful to include as regression tests either way. 

## Additional Context

## User Documentation

Check one:
- [X] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
