### PR TITLE
chore: remove ignored test for long ECDSA hashes

### DIFF
--- a/acvm-repo/blackbox_solver/src/ecdsa/secp256r1.rs
+++ b/acvm-repo/blackbox_solver/src/ecdsa/secp256r1.rs
@@ -38,7 +38,7 @@ use crate::BlackBoxResolutionError;
 /// According to ECDSA specification, the message hash leftmost bits should be truncated
 /// up to the curve order length, and then reduced modulo the curve order.
 pub(super) fn verify_signature(
-    hashed_msg: &[u8],
+    hashed_msg: &[u8; 32],
     public_key_x_bytes: &[u8; 32],
     public_key_y_bytes: &[u8; 32],
     signature: &[u8; 64],


### PR DESCRIPTION
# Description

## Problem

Resolves <!-- Link to GitHub Issue -->

## Summary

This PR resolves the first bulletpoint in https://github.com/noir-lang/noir/issues/11058.

The ECDSA spec allows for hashes to be used which are longer than 32 bytes, this is done by appropriately truncating the hash to 32 bytes. There is no need to handle this inside of the ECDSA verification opcodes themselves however, as this can be done directly in noir.

We then do not support hashes larger than 32 bytes in the opcode solvers.

## Additional Context



## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
