### PR TITLE
chore: mark ACIR C++ generated code as generated

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,4 @@
 tooling/nargo_cli/tests/snapshots/**/* linguist-generated=true
 noir_stdlib/docs/**/* linguist-generated=true
+acvm-repo/acir/codegen/acir.cpp linguist-generated=true
+acvm-repo/acir/codegen/witness.cpp linguist-generated=true


### PR DESCRIPTION
# Description

## Problem

Something I noticed while reviewing https://github.com/noir-lang/noir/pull/10151

## Summary

This just makes it easier to quickly see that these files are auto-generated, so we don't have to meticulously review them in PRs.

## Additional Context



## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
