### PR TITLE
fix(parser): error on unexpected type expression in type alias

### DIFF
--- a/compiler/noirc_frontend/src/parser/errors.rs
+++ b/compiler/noirc_frontend/src/parser/errors.rs
@@ -121,6 +121,10 @@ pub enum ParserErrorReason {
     MissingIfCondition,
     #[error("expected an identifier, found reserved identifier `_`")]
     ExpectedIdentifierGotUnderscore,
+    #[error(
+        "type expression is not allowed for type aliases (Is this a numeric type alias? If so, the numeric type must be specified with `: <type>`"
+    )]
+    UnexpectedTypeExpressionInTypeAlias,
 }
 
 /// Represents a parsing error, or a parsing error in the making.


### PR DESCRIPTION
# Description

## Problem

Resolves #10754

## Summary

The issue was that when numeric type aliases were introduced we started parsing the type alias value as a type **or type expression**, even for regular type aliases. However, for regular type aliases type expressions should not be allowed.

Instead of parsing one or another depending on whether a numeric type was specified, we always parse the value as a type or type expression, but give an error if it's a type expression for a type alias (the error message and location is a bit better this way).

## Additional Context



## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
