### PR TITLE
fix(LSP): visit crate root module doc comments

### DIFF
--- a/tooling/lsp/src/doc_comments.rs
+++ b/tooling/lsp/src/doc_comments.rs
@@ -14,8 +14,13 @@ pub(crate) fn current_module_and_type(
     match id {
         ReferenceId::Module(module_id) => {
             let parent_module =
-                get_parent_module(ModuleDefId::ModuleId(module_id), args.interner, args.def_maps)?;
-            Some((parent_module, None))
+                get_parent_module(ModuleDefId::ModuleId(module_id), args.interner, args.def_maps);
+            if let Some(parent_module) = parent_module {
+                Some((parent_module, None))
+            } else {
+                // If there's no parent module, it means we are in the crate root module
+                Some((module_id, None))
+            }
         }
         ReferenceId::Type(type_id)
         | ReferenceId::StructMember(type_id, _)

--- a/tooling/lsp/src/requests/semantic_tokens.rs
+++ b/tooling/lsp/src/requests/semantic_tokens.rs
@@ -22,7 +22,7 @@ use noirc_frontend::{
         Visitor,
     },
     elaborator::PrimitiveType,
-    hir::def_map::ModuleDefId,
+    hir::def_map::{ModuleDefId, ModuleId},
     lexer::Lexer,
     node_interner::ReferenceId,
     parser::ParsedSubModule,
@@ -93,6 +93,11 @@ impl<'args> SemanticTokenCollector<'args> {
     }
 
     fn collect(&mut self, parsed_module: &noirc_frontend::ParsedModule) -> Vec<SemanticToken> {
+        // Also process doc comments for the crate root module
+        let local_module_id = self.args.def_maps[&self.args.crate_id].root();
+        let module_id = ModuleId { krate: self.args.crate_id, local_id: local_module_id };
+        self.process_reference_id(ReferenceId::Module(module_id));
+
         parsed_module.accept(self);
         std::mem::take(&mut self.tokens)
     }

--- a/tooling/lsp/src/visitor_reference_finder.rs
+++ b/tooling/lsp/src/visitor_reference_finder.rs
@@ -71,6 +71,9 @@ impl<'a> VisitorReferenceFinder<'a> {
         &mut self,
         parsed_module: &ParsedModule,
     ) -> Option<(ReferenceId, Option<lsp_types::Location>)> {
+        // Find in the doc comments on the crate root
+        self.find_in_reference_doc_comments(ReferenceId::Module(self.module_id));
+
         parsed_module.accept(self);
 
         std::mem::take(&mut self.reference_id)


### PR DESCRIPTION
# Description

## Problem

Yet another issue noticed by Nico.

## Summary

LSP features for doc comments didn't work for doc comments on the crate root module. And it made sense because those comments weren't "visted" by LSP.

Note how the link in the first doc comment isn't colored:

<img width="821" height="264" alt="image" src="https://github.com/user-attachments/assets/427532c8-a540-44c4-8bbb-446c1d49fdd9" />

This is now fixed.


## Additional Context



## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
