### PR TITLE
fix: remove `impl From<usize> for MemoryValue`

### DIFF
--- a/acvm-repo/brillig_vm/src/foreign_call.rs
+++ b/acvm-repo/brillig_vm/src/foreign_call.rs
@@ -363,7 +363,7 @@ impl<F: AcirField, B: BlackBoxFunctionSolver<F>> VM<'_, F, B> {
                         // Set the size in the size address.
                         // Note that unlike `pointer`, we don't treat `size` as a pointer here, even though it is;
                         // instead we expect the post-call codegen will copy it to the heap.
-                        self.memory.write(*size_addr, values.len().into());
+                        self.memory.write(*size_addr, assert_u32(values.len()).into());
                         self.write_values_to_memory(*pointer, values, value_types)?;
                     } else {
                         unimplemented!("deflattening heap vectors from foreign calls");

--- a/acvm-repo/brillig_vm/src/memory.rs
+++ b/acvm-repo/brillig_vm/src/memory.rs
@@ -297,12 +297,6 @@ impl<F: AcirField> From<u8> for MemoryValue<F> {
     }
 }
 
-impl<F: AcirField> From<usize> for MemoryValue<F> {
-    fn from(value: usize) -> Self {
-        MemoryValue::U32(value as u32)
-    }
-}
-
 impl<F: AcirField> From<u32> for MemoryValue<F> {
     fn from(value: u32) -> Self {
         MemoryValue::U32(value)

--- a/acvm-repo/brillig_vm/tests/foreign_calls.rs
+++ b/acvm-repo/brillig_vm/tests/foreign_calls.rs
@@ -526,12 +526,12 @@ fn foreign_call_opcode_nested_arrays_input() {
     let mut memory = vec![MemoryValue::from(1_u32)];
 
     // Declare a4: [RC, ...items]
-    let a4_ptr = memory.len();
+    let a4_ptr = memory.len() as u32;
     memory.extend(vec![MemoryValue::from(1_u32)]);
     memory.extend(a4.clone());
 
     // Declare a9: [RC, ...items]
-    let a9_ptr = memory.len();
+    let a9_ptr = memory.len() as u32;
     memory.extend(vec![MemoryValue::from(1_u32)]);
     memory.extend(a9.clone());
 


### PR DESCRIPTION
# Description

## Problem

Resolves #11193

## Summary

It seems after the recent changes to go from `usize` to `u32`, only one place used this code. It's been replaced by an assertion.

## Additional Context



## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
