### PR TITLE
chore: replace `debug_assert` with `assert`

### DIFF
--- a/acvm-repo/brillig_vm/src/foreign_call.rs
+++ b/acvm-repo/brillig_vm/src/foreign_call.rs
@@ -261,7 +261,7 @@ impl<F: AcirField, B: BlackBoxFunctionSolver<F>> VM<'_, F, B> {
             ));
         }
 
-        debug_assert_eq!(
+        assert_eq!(
             destinations.len(),
             destination_value_types.len(),
             "Number of destinations must match number of value types",
@@ -335,7 +335,7 @@ impl<F: AcirField, B: BlackBoxFunctionSolver<F>> VM<'_, F, B> {
                             &mut flatten_values_idx,
                             value_type,
                         )?;
-                        debug_assert_eq!(
+                        assert_eq!(
                             flatten_values_idx,
                             output_fields.len(),
                             "Not all values were written to memory"

--- a/compiler/noirc_evaluator/src/acir/acir_context/generated_acir/mod.rs
+++ b/compiler/noirc_evaluator/src/acir/acir_context/generated_acir/mod.rs
@@ -116,7 +116,7 @@ impl<F: AcirField> GeneratedAcir<F> {
     ) {
         // TODO: enable this check for all block_types
         if block_type == BlockType::ReturnData {
-            debug_assert!(!init.is_empty(), "Cannot initialize memory with empty init");
+            assert!(!init.is_empty(), "Cannot initialize memory with empty init");
         }
         self.push_opcode(AcirOpcode::MemoryInit { block_id, init, block_type });
     }

--- a/compiler/noirc_evaluator/src/acir/acir_context/mod.rs
+++ b/compiler/noirc_evaluator/src/acir/acir_context/mod.rs
@@ -218,7 +218,7 @@ impl<F: AcirField> AcirContext<F> {
         if expression.to_const().is_none() {
             self.mark_variables_equivalent(var, witness_var)?;
         }
-        debug_assert!(self.var_to_expression(witness_var)?.to_witness().is_some());
+        assert!(self.var_to_expression(witness_var)?.to_witness().is_some());
 
         Ok(witness_var)
     }

--- a/compiler/noirc_evaluator/src/acir/arrays.rs
+++ b/compiler/noirc_evaluator/src/acir/arrays.rs
@@ -171,7 +171,7 @@ impl Context<'_> {
     ) -> Result<(), RuntimeError> {
         // Initialize return_data using provided witnesses
         if let Some(return_data) = self.data_bus.return_data {
-            debug_assert!(!witnesses.is_empty(), "return data cannot be empty");
+            assert!(!witnesses.is_empty(), "return data cannot be empty");
 
             let block_id = self.block_id(return_data);
             let already_initialized = self.initialized_arrays.contains(&block_id);

--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_call/mod.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_call/mod.rs
@@ -207,7 +207,7 @@ impl<Registers: RegisterAllocator> BrilligBlock<'_, Registers> {
         source_len: SingleAddrVariable,
         binary_op: BrilligBinaryOp,
     ) {
-        debug_assert!(matches!(binary_op, BrilligBinaryOp::Add | BrilligBinaryOp::Sub));
+        assert!(matches!(binary_op, BrilligBinaryOp::Add | BrilligBinaryOp::Sub));
         self.brillig_context.codegen_usize_op(source_len.address, target_len.address, binary_op, 1);
     }
 

--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_instructions/brillig_memory.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_instructions/brillig_memory.rs
@@ -440,7 +440,7 @@ impl<Registers: RegisterAllocator> BrilligBlock<'_, Registers> {
         // Initialize the variable, which allocates memory on the heap to hold the metadata and the items.
         match new_variable {
             BrilligVariable::BrilligArray(brillig_array) => {
-                debug_assert_eq!(SemiFlattenedLength(assert_u32(array.len())), brillig_array.size);
+                assert_eq!(SemiFlattenedLength(assert_u32(array.len())), brillig_array.size);
                 self.brillig_context.codegen_initialize_array(brillig_array);
             }
             BrilligVariable::BrilligVector(vector) => {

--- a/compiler/noirc_evaluator/src/brillig/brillig_ir/codegen_control_flow.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_ir/codegen_control_flow.rs
@@ -296,7 +296,7 @@ impl<F: AcirField + DebugToString, Registers: RegisterAllocator> BrilligContext<
         condition: SingleAddrVariable,
         assert_message: Option<String>,
     ) {
-        debug_assert!(condition.bit_size == 1);
+        assert!(condition.bit_size == 1);
 
         // Compute error selector if we have a message
         let error_selector = assert_message.map(|message| {

--- a/compiler/noirc_evaluator/src/brillig/brillig_ir/instructions.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_ir/instructions.rs
@@ -262,7 +262,7 @@ impl<F: AcirField + DebugToString, Registers: RegisterAllocator> BrilligContext<
     ///
     /// Entering a context resets the current section to 0 and the next section to 1.
     pub(crate) fn enter_context(&mut self, label: Label) {
-        debug_assert!(label.section.is_none(), "new context should have no section");
+        assert!(label.section.is_none(), "new context should have no section");
         self.debug_show.enter_context(label.to_string());
         self.context_label = label.clone();
         // Add a context label to the next opcode

--- a/compiler/noirc_evaluator/src/ssa/ir/dfg/simplify/cast.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/dfg/simplify/cast.rs
@@ -17,7 +17,7 @@ pub(super) fn simplify_cast(
     dfg: &mut DataFlowGraph,
 ) -> SimplifyResult {
     use SimplifyResult::*;
-    debug_assert!(
+    assert!(
         dfg.type_of_value(value).is_numeric(),
         "Can only cast numeric types, got {:?}",
         dfg.type_of_value(value)

--- a/compiler/noirc_evaluator/src/ssa/ir/dom.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/dom.rs
@@ -278,7 +278,7 @@ impl DominatorTree {
             }
         }
 
-        debug_assert_eq!(block_a_id, block_b_id, "Unreachable block passed to common_dominator?");
+        assert_eq!(block_a_id, block_b_id, "Unreachable block passed to common_dominator?");
         block_a_id
     }
 

--- a/compiler/noirc_evaluator/src/ssa/ir/value.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/value.rs
@@ -93,11 +93,7 @@ impl ValueMapping {
     }
 
     pub(crate) fn batch_insert(&mut self, from: &[ValueId], to: &[ValueId]) {
-        debug_assert_eq!(
-            from.len(),
-            to.len(),
-            "Lengths of arrays of values being mapped must match"
-        );
+        assert_eq!(from.len(), to.len(), "Lengths of arrays of values being mapped must match");
         for (from_value, to_value) in from.iter().zip(to) {
             self.insert(*from_value, *to_value);
         }

--- a/compiler/noirc_evaluator/src/ssa/opt/defunctionalize.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/defunctionalize.rs
@@ -557,7 +557,7 @@ fn create_apply_function(
     caller_runtime: RuntimeType,
     function_ids: Vec<(FunctionId, RuntimeType)>,
 ) -> FunctionId {
-    debug_assert!(
+    assert!(
         function_ids.len() > 1,
         "create_apply_function is expected to be called with two or more FunctionIds"
     );

--- a/compiler/noirc_evaluator/src/ssa/opt/pure.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/pure.rs
@@ -240,7 +240,7 @@ fn analyze_call_graph(
             // Therefore inserting into func_to_scc here is safe, and there will
             // be no overwrites.
             let inserted = func_to_scc.insert(func, i);
-            debug_assert!(inserted.is_none(), "Function appears in multiple SCCs");
+            assert!(inserted.is_none(), "Function appears in multiple SCCs");
         }
     }
 

--- a/compiler/noirc_evaluator/src/ssa/opt/unrolling.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/unrolling.rs
@@ -905,7 +905,7 @@ impl BoilerplateStats {
         // NB we have not checked that these are actual pairs.
         let load_and_store = self.loads.min(self.stores) * 2;
         let total_boilerplate = self.increments + load_and_store + boilerplate;
-        debug_assert!(
+        assert!(
             total_boilerplate <= self.all_instructions,
             "Boilerplate instructions exceed total instructions in loop"
         );

--- a/compiler/noirc_evaluator/src/ssa/ssa_gen/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/ssa_gen/mod.rs
@@ -577,7 +577,7 @@ impl FunctionContext<'_> {
             // to assert that the index fits in the relevant number of bits.
             let array_len_constant = array_len_constant.expect("array checked to be constant");
             let array_len_bits = array_len_constant.ilog2();
-            debug_assert_eq!(2u32.pow(array_len_bits), array_len_constant);
+            assert_eq!(2u32.pow(array_len_bits), array_len_constant);
             // TODO(https://github.com/noir-lang/noir/issues/9191): this cast results in better circuit generation.
             // There's an optimization here that we should find automatically.
             let index_as_field = self.builder.insert_cast(index, NumericType::NativeField);

--- a/compiler/noirc_frontend/src/elaborator/patterns.rs
+++ b/compiler/noirc_frontend/src/elaborator/patterns.rs
@@ -599,7 +599,7 @@ impl Elaborator<'_> {
         resolved_turbofish: Option<Vec<Located<Type>>>,
         location: Location,
     ) -> Vec<Type> {
-        debug_assert_eq!(
+        assert_eq!(
             generics.len(),
             item_generic_kinds.len(),
             "ICE: generics count should match the expected kinds"

--- a/compiler/noirc_frontend/src/elaborator/statements.rs
+++ b/compiler/noirc_frontend/src/elaborator/statements.rs
@@ -145,11 +145,11 @@ impl Elaborator<'_> {
 
         let definition = match global_id {
             None => {
-                debug_assert!(!let_stmt.is_global_let);
+                assert!(!let_stmt.is_global_let);
                 DefinitionKind::Local(Some(expression))
             }
             Some(id) => {
-                debug_assert!(let_stmt.is_global_let);
+                assert!(let_stmt.is_global_let);
                 DefinitionKind::Global(id)
             }
         };

--- a/compiler/noirc_printable_type/src/lib.rs
+++ b/compiler/noirc_printable_type/src/lib.rs
@@ -156,10 +156,7 @@ fn to_string<F: AcirField>(value: &PrintableValue<F>, typ: &PrintableType) -> Op
                 return None;
             };
             // Retain the lower 'width' bits
-            debug_assert!(
-                *width <= 128,
-                "We don't currently support unsigned integers larger than u128"
-            );
+            assert!(*width <= 128, "We don't currently support unsigned integers larger than u128");
             let mut uint_cast = f.to_u128();
             if *width != 128 {
                 uint_cast &= (1 << width) - 1;


### PR DESCRIPTION
# Description

## Problem

Resolves #11196

## Summary

I replaced all occurrences as in most if not all of them the checks should be performed very quickly, and also most appear during code generation and not at runtime.

## Additional Context



## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
