### PR TITLE
chore: remove stale RUSTSEC-2026-0002 advisory

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -8,7 +8,6 @@ yanked = "warn"
 ignore = [
     "RUSTSEC-2024-0388", # derivative unmaintained
     "RUSTSEC-2024-0436", # paste unmaintained
-    "RUSTSEC-2026-0002", # Blocked on https://github.com/cmpute/num-prime/pull/26
 ]
 
 # This section is considered when running `cargo deny check bans`.


### PR DESCRIPTION
# Description

## Problem

Resolves this ci build error: https://github.com/noir-lang/noir/actions/runs/21042663657/job/60508449152?pr=11218

## Summary



## Additional Context



## User Documentation

Check one:
- [ ] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
