### PR TITLE
fix(elaborator): Elaborate pending `impl Trait` functions on-the-fly

### DIFF
--- a/compiler/noirc_frontend/src/tests/traits/mod.rs
+++ b/compiler/noirc_frontend/src/tests/traits/mod.rs
@@ -5,6 +5,7 @@
 //! trait inheritance, method resolution, impl validation, associated items, and qualified path syntax.
 
 mod trait_aliases;
+mod trait_as_type;
 mod trait_associated_items;
 mod trait_bounds;
 mod trait_default_methods;

--- a/compiler/noirc_frontend/src/tests/traits/trait_as_type.rs
+++ b/compiler/noirc_frontend/src/tests/traits/trait_as_type.rs
@@ -1,0 +1,68 @@
+//! Functions returning `impl Trait`.
+use crate::{elaborator::UnstableFeature, tests::check_errors_using_features};
+
+/// Show that `impl Trait` functions mutually calling each other do not compile currently.
+/// The example below does compile in Rust, but we need to refactor how types are substituted
+/// to make it work in the elaborator.
+#[test]
+fn mutually_recursive_impl_trait_functions() {
+    let src = r#"
+    trait Foo {}
+
+    struct Bar {}
+    struct Baz {}
+    impl Foo for Bar {}
+    impl Foo for Baz {}
+
+    fn main() {
+        let _bar = bar(true);
+        let _baz = baz(true);
+    }
+
+    fn bar(recur: bool) -> impl Foo {
+        if recur {
+            let _baz = baz(false);
+        }
+        Bar {}
+    }
+
+    fn baz(recur: bool) -> impl Foo {
+        if recur {
+            let _bar = bar(false);
+                       ^^^ Dependency cycle found
+                       ~~~ 'bar' recursively depends on itself: 'impl Trait' could not be resolved to the type of the function body
+        }
+        Baz {}
+    }
+    "#;
+    check_errors_using_features(src, &[UnstableFeature::TraitAsType]);
+}
+
+/// Show that the elaborator handle acyclic `impl Trait` functions that appear
+/// out of dependency order, by elaborating the callee on the fly.
+#[test]
+fn out_of_order_impl_trait_functions() {
+    let src = r#"
+    trait Foo {}
+
+    struct Bar {}
+    struct Baz {}
+    impl Foo for Bar {}
+    impl Foo for Baz {}
+
+    fn main() {
+        let _bar = bar();
+    }
+
+    fn bar() -> impl Foo {
+        let _baz = baz();
+        Bar {}
+    }
+
+    fn baz() -> impl Foo {
+        Baz {}
+    }
+    "#;
+    // Not using `assert_no_errors` because it does not enable the feature.
+    check_errors_using_features(src, &[UnstableFeature::TraitAsType]);
+}


### PR DESCRIPTION
# Description

## Problem

Resolves #11141

## Summary

* Changes `NodeInterner::id_type_substitute_trait_as_type` to return a `Result<Type, FuncId>` to signal to the `Elaborator` that a function returning an `impl Trait` needs to be elaborated before we can tell the type of its body.
* Changes `Elaborator::type_check_variable_with_bindings` to be ready to try and elaborate the callee function once, and then try again to see if we managed to handle the a call chain and can now determine the type of the function body. If the second attempt fails, it returns an `ResolverError::DependencyCycle`, highlighting the location of the recursive function call which depended on something in the call chain.

## Additional Context

Rust handles the examples in the ticket, even the mutually recursive one, but at least with the change in this PR we 1) avoid a panic and 2) handle the simpler acyclic case without relying on the order of function definitions.

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
