### PR TITLE
fix(cli): Remove 'Expression Width' from the info table

### DIFF
--- a/tooling/noirc_artifacts_info/src/lib.rs
+++ b/tooling/noirc_artifacts_info/src/lib.rs
@@ -92,7 +92,8 @@ pub fn show_info_report(info_report: InfoReport, json: bool) {
         // Otherwise print human-readable table.
         if !info_report.programs.is_empty() {
             let mut program_table = Table::new();
-            let titles = row![Fm->"Package", Fm->"Function", Fm->"Expression Width", Fm->"ACIR Opcodes", Fm->"Brillig Opcodes"];
+            let titles =
+                row![Fm->"Package", Fm->"Function", Fm->"ACIR Opcodes", Fm->"Brillig Opcodes"];
             let num_titles = titles.len();
             program_table.set_titles(titles);
 


### PR DESCRIPTION
# Description

## Problem

I noticed looking at circuit sizes in https://github.com/noir-lang/noir/pull/11253 that the `info` output is was weird:
```console
❯ cargo run -q -p nargo_cli -- info --force-brillig
+-----------------+----------+------------------+--------------+-----------------+
| Package         | Function | Expression Width | ACIR Opcodes | Brillig Opcodes |
+-----------------+----------+------------------+--------------+-----------------+
| regression_9439 | main     | 1                | 159          |                 |
+-----------------+----------+------------------+--------------+-----------------+
| regression_9439 | main     | N/A              | 159          |                 |
+-----------------+----------+------------------+--------------+-----------------+
```
Why does it say 159 ACIR opcodes and no Brillig when I'm using `--force-brillig`?

## Summary

* Fixes the `info` command to no longer include `Expression Width` as a column
* Adds assertion that rows match the expected number of columns
* Formats the first row as titles

## Additional Context

Now it looks like this:
```console
❯ cargo run -q -p nargo_cli -- info --force-brillig --inliner-aggressiveness 0

+-----------------+----------+--------------+-----------------+
| Package         | Function | ACIR Opcodes | Brillig Opcodes |
+=================+==========+==============+=================+
| regression_9439 | main     | 1            | 159             |
+-----------------+----------+--------------+-----------------+
| regression_9439 | main     | N/A          | 159             |
+-----------------+----------+--------------+-----------------+

```

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
