### PR TITLE
fix(elaborator): Pass the `unresolved_globals` to the `Elaborator` created for the comptime `Interpreter`

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/comptime.rs
+++ b/compiler/noirc_frontend/src/elaborator/comptime.rs
@@ -125,6 +125,7 @@ impl<'context> Elaborator<'context> {
             self.crate_graph,
             self.interpreter_output,
             self.required_unstable_features,
+            self.unresolved_globals,
             self.crate_id,
             self.interpreter_call_stack.clone(),
             self.options,

--- a/compiler/noirc_frontend/src/hir/mod.rs
+++ b/compiler/noirc_frontend/src/hir/mod.rs
@@ -10,9 +10,10 @@ use crate::ast::UnresolvedGenerics;
 use crate::debug::DebugInstrumenter;
 use crate::elaborator::UnstableFeature;
 use crate::graph::{CrateGraph, CrateId};
+use crate::hir::def_collector::dc_crate::UnresolvedGlobal;
 use crate::hir::def_map::DefMaps;
 use crate::hir_def::function::FuncMeta;
-use crate::node_interner::{FuncId, NodeInterner, TypeId};
+use crate::node_interner::{FuncId, GlobalId, NodeInterner, TypeId};
 use crate::parser::ParserError;
 use crate::usage_tracker::UsageTracker;
 use crate::{Kind, ParsedModule, ResolvedGeneric, ResolvedGenerics, TypeVariable};
@@ -62,6 +63,9 @@ pub struct Context<'file_manager, 'parsed_files> {
 
     /// Any unstable features required by the current package or its dependencies.
     pub required_unstable_features: BTreeMap<CrateId, Vec<UnstableFeature>>,
+
+    /// Unresolved globals that need to be elaborated.
+    pub unresolved_globals: BTreeMap<GlobalId, UnresolvedGlobal>,
 }
 
 #[derive(Debug)]
@@ -85,6 +89,7 @@ impl Context<'_, '_> {
             package_build_path: PathBuf::default(),
             interpreter_output: Some(Rc::new(RefCell::new(std::io::stdout()))),
             required_unstable_features: BTreeMap::new(),
+            unresolved_globals: BTreeMap::new(),
         }
     }
 
@@ -104,6 +109,7 @@ impl Context<'_, '_> {
             package_build_path: PathBuf::default(),
             interpreter_output: Some(Rc::new(RefCell::new(std::io::stdout()))),
             required_unstable_features: BTreeMap::new(),
+            unresolved_globals: BTreeMap::new(),
         }
     }
 

--- a/compiler/noirc_frontend/src/monomorphization/tests.rs
+++ b/compiler/noirc_frontend/src/monomorphization/tests.rs
@@ -1353,7 +1353,7 @@ fn out_of_order_globals() {
     global BAR: fn(u32) -> u32 = bar;
 
     fn main(x: u32) -> pub u32 {
-        BAR(x) + BAZ
+        BAR(x) + BAZ + FOO
     }
 
     fn bar(x: u32) -> u32 { x + FOO }
@@ -1365,7 +1365,7 @@ fn out_of_order_globals() {
     global BAZ$g0: u32 = 3;
     global FOO$g1: u32 = 1;
     fn main$f0(x$l0: u32) -> pub u32 {
-        (bar$f1(x$l0) + BAZ$g0)
+        ((bar$f1(x$l0) + BAZ$g0) + FOO$g1)
     }
     fn bar$f1(x$l1: u32) -> u32 {
         (x$l1 + FOO$g1)

--- a/compiler/noirc_frontend/src/node_interner/mod.rs
+++ b/compiler/noirc_frontend/src/node_interner/mod.rs
@@ -851,13 +851,19 @@ impl NodeInterner {
         self.try_id_type(index).cloned().unwrap_or(Type::Error)
     }
 
+    /// Returns the type of an item, or `None` if it was not found.
     pub fn try_id_type(&self, index: impl Into<Index>) -> Option<&Type> {
         self.id_to_type.get(&index.into())
     }
 
     /// Returns the type of the definition, or [Type::Error] if it was not found.
     pub fn definition_type(&self, id: DefinitionId) -> Type {
-        self.definition_to_type.get(&id).cloned().unwrap_or(Type::Error)
+        self.try_definition_type(id).cloned().unwrap_or(Type::Error)
+    }
+
+    /// Returns the type of the definition, or `None` if it was not found.
+    pub fn try_definition_type(&self, id: DefinitionId) -> Option<&Type> {
+        self.definition_to_type.get(&id)
     }
 
     /// Returns the type of the definition, unless it's a function returning an `impl Trait`,


### PR DESCRIPTION
# Description

## Problem

Resolves #11182 

## Summary

Out of order globals weren't handled because the `Elaborator` instance created for the comptime interpreter did not know about unresolved globals.

## Additional Context



## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
