### PR TITLE
chore(brillig): Regression test for foreign call vector input truncation

### DIFF
--- a/acvm-repo/brillig_vm/tests/foreign_calls.rs
+++ b/acvm-repo/brillig_vm/tests/foreign_calls.rs
@@ -760,11 +760,10 @@ fn foreign_call_opcode_vector_input_nested_composite_array() {
     ])
     .collect();
 
-    // Convert memory to calldata (as FieldElements)
     let calldata: Vec<FieldElement> = memory.iter().map(|v| v.to_field()).collect();
 
-    // The expected inputs to the oracle should be ONLY the 12 valid fields (flattened).
-    // If truncation was buggy (kept 24 instead of 12), we'd see garbage (999) values.
+    // The expected inputs to the oracle should be only the 12 valid flattened fields.
+    // If truncation was buggy (kept > 12 values), we'd see garbage (999) values.
     let expected_oracle_input: Vec<FieldElement> = vec![
         1u128.into(),
         2u128.into(),


### PR DESCRIPTION
# Description

## Problem

Additional test in support of #11125

## Summary

I added a test `foreign_call_opcode_vector_input_nested_composite_array` which fails when adapted to the pre-#11125 commit [e576ac2](https://github.com/noir-lang/noir/commit/e576ac2c10e718d40b4fe32f1215fc150c190c46). In the broken version the only way the test passes is when the array type in the vector element used its semi-flattened length (however using the semi flattened length and not the semantic length is in itself a bug). 

## Additional Context

## User Documentation

Check one:
- [X] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
