### PR TITLE
chore(brillig): Document and test explicit memory limit

### DIFF
--- a/acvm-repo/brillig_vm/src/memory.rs
+++ b/acvm-repo/brillig_vm/src/memory.rs
@@ -452,7 +452,7 @@ impl<F: AcirField> Memory<F> {
     /// restrict us to fewer elements anyway. By using `i32::MAX`, we ensure the same behavior
     /// on both 32-bit and 64-bit systems.
     ///
-    /// See: https://github.com/rust-lang/rust/pull/95295 and https://doc.rust-lang.org/1.81.0/src/core/alloc/layout.rs.html
+    /// See: <https://github.com/rust-lang/rust/pull/95295> and <https://doc.rust-lang.org/1.81.0/src/core/alloc/layout.rs.html>
     const MAX_MEMORY_SIZE: usize = i32::MAX as usize;
 
     /// Increase the size of memory fit `size` elements, or the current length, whichever is bigger.


### PR DESCRIPTION
# Description

## Problem

Resolves #11200

Check out https://github.com/noir-lang/noir/issues/11200#issuecomment-3781188449 and the preceding discussion for more context. Rust has a fundamental per-allocation `isize::MAX` limit. 

## Summary

Changes:
- Clearer panic message instead of "capacity overflow" panic from Rust
- Test displaying this behavior 
- Deterministic behavior on 32-bit and 64-bit architectures

## Additional Context

To actually fix the auditor's concern in #11200 about being able to use the full u32 address space, we would most likely need chunked memory. In order to bypass Rust's fundamental allocation limit we would need many smaller Vec fields to cover the full address space. I made a follow-up here https://github.com/noir-lang/noir/issues/11291 for 1.0+, although I find this to be low priority either way as i32::MAX is a practical limit for the time being. 

## User Documentation

Check one:
- [X] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
