### PR TITLE
fix(lsp): don't always process crate root doc comments

### DIFF
--- a/tooling/lsp/src/visitor_reference_finder.rs
+++ b/tooling/lsp/src/visitor_reference_finder.rs
@@ -30,6 +30,7 @@ use crate::{
 /// - attribute references (see `visit_meta_attribute`).
 pub(crate) struct VisitorReferenceFinder<'a> {
     source: &'a str,
+    file_id: FileId,
     byte_index: usize,
     /// The module ID in scope. This might change as we traverse the AST
     /// if we are analyzing something inside an inline module declaration.
@@ -47,7 +48,7 @@ pub(crate) struct VisitorReferenceFinder<'a> {
 impl<'a> VisitorReferenceFinder<'a> {
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
-        file: FileId,
+        file_id: FileId,
         source: &'a str,
         byte_index: usize,
         args: &'a ProcessRequestCallbackArgs<'a>,
@@ -56,7 +57,7 @@ impl<'a> VisitorReferenceFinder<'a> {
         let krate = args.crate_id;
         let def_map = &args.def_maps[&krate];
         let local_id = if let Some((module_index, _)) =
-            def_map.modules().iter().find(|(_, module_data)| module_data.location.file == file)
+            def_map.modules().iter().find(|(_, module_data)| module_data.location.file == file_id)
         {
             LocalModuleId::new(module_index)
         } else {
@@ -64,14 +65,14 @@ impl<'a> VisitorReferenceFinder<'a> {
         };
         let module_id = ModuleId { krate, local_id };
         let link_finder = LinkFinder::default();
-        Self { source, byte_index, module_id, args, link_finder, reference_id: None }
+        Self { source, file_id, byte_index, module_id, args, link_finder, reference_id: None }
     }
 
     pub(crate) fn find(
         &mut self,
         parsed_module: &ParsedModule,
     ) -> Option<(ReferenceId, Option<lsp_types::Location>)> {
-        // Find in the doc comments on the crate root
+        // Find in the doc comments on the crate root, if we are in the crate root
         self.find_in_reference_doc_comments(ReferenceId::Module(self.module_id));
 
         parsed_module.accept(self);
@@ -104,6 +105,12 @@ impl<'a> VisitorReferenceFinder<'a> {
         self.link_finder.reset();
         for located_comment in doc_comments {
             let location = located_comment.location();
+            if location.file != self.file_id {
+                // A module's comments might happen inline in the same file or in a different file.
+                // We should not process comments that are not in the current file.
+                continue;
+            }
+
             let Some(lsp_location) = to_lsp_location(self.args.files, location.file, location.span)
             else {
                 continue;


### PR DESCRIPTION
# Description

## Problem

Resolves a bug noticed by Nico that's important to fix.

## Summary

In https://github.com/noir-lang/noir/pull/11216 I fixed LSP not colorizing or showing links in the root crate module doc comments. However, when I did that I accidentally made it process these doc comments regardless of whether the current file was showing the root crate module. Then LSP would try to find the comment by indexing the current file's source with a location that wasn't for that file.

In this PR there are two fixes:
1. Instead of processing the root crate module doc comments we now process the current module doc comments
2. This could still lead to a comment being in a different file, if the module's comment happen on top of a module declaration (using `///` on top of `mod foo;`) as opposed to inline comments (`//!` in the foo.rs file), so now we skip comments that aren't in the current file.

I mention this is important to fix because if there are doc comments on the root module then LSP will start crashing and keep crashing.

## Additional Context

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
