### PR TITLE
chore: restrict visibility of `pop_rc_for` and `RcInstruction`

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/opt/rc.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/rc.rs
@@ -38,10 +38,10 @@ struct Context {
     inc_rcs: HashMap<Type, Vec<RcInstruction>>,
 }
 
-pub(crate) struct RcInstruction {
-    pub(crate) id: InstructionId,
-    pub(crate) array: ValueId,
-    pub(crate) possibly_mutated: bool,
+struct RcInstruction {
+    id: InstructionId,
+    array: ValueId,
+    possibly_mutated: bool,
 }
 
 impl Function {
@@ -133,7 +133,7 @@ impl Context {
 }
 
 /// Finds and pops the IncRc for the given array value if possible.
-pub(crate) fn pop_rc_for(
+fn pop_rc_for(
     value: ValueId,
     function: &Function,
     inc_rcs: &mut HashMap<Type, Vec<RcInstruction>>,


### PR DESCRIPTION
# Description

## Problem

Resolves <!-- Link to GitHub Issue -->

## Summary

Resolves  https://cantina.xyz/code/8902524c-abe0-401a-92af-cf2ef468213d/findings?finding=9

## Additional Context



## User Documentation

Check one:
- [ ] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
