### PR TITLE
chore(brillig): Document assumption about Brillig VM input validation

### DIFF
--- a/acvm-repo/brillig_vm/src/lib.rs
+++ b/acvm-repo/brillig_vm/src/lib.rs
@@ -16,7 +16,7 @@
 //!
 //! When using the VM with Noir programs, the ABI layer handles input validation
 //! automatically. Direct consumers of the VM API must implement their own input validation.
-//! 
+//!
 //! [acir]: https://crates.io/crates/acir
 //! [acvm]: https://crates.io/crates/acvm
 


### PR DESCRIPTION
# Description

## Problem

Resolves #11192 

## Summary

As mentioned in https://github.com/noir-lang/noir/pull/11243#pullrequestreview-3672341386 the VM does not perform input validation and it is expected that the consumer of the VM API performs input validation. This documents that assumption.

## Additional Context



## User Documentation

Check one:
- [X] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
