### PR TITLE
chore: clippy::needless_pass_by_ref_mut

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,6 +85,7 @@ cast_lossless = "warn"
 semicolon_if_nothing_returned = "warn"
 result_large_err = "allow"
 uninlined_format_args = "warn"
+needless_pass_by_ref_mut = "warn"
 
 [workspace.dependencies]
 

--- a/acvm-repo/acir/src/lib.rs
+++ b/acvm-repo/acir/src/lib.rs
@@ -548,7 +548,7 @@ mod reflection {
         }
 
         /// Tuples serialize as a vector of underlying data.
-        fn generate_tuple(&mut self, _name: &str, _formats: &[Format]) {
+        fn generate_tuple(&self, _name: &str, _formats: &[Format]) {
             unimplemented!("Until we have a tuple enum in our schema we don't need this.");
         }
 

--- a/acvm-repo/acir/src/parser/mod.rs
+++ b/acvm-repo/acir/src/parser/mod.rs
@@ -941,7 +941,7 @@ impl<'a> Parser<'a> {
         if self.eat(token.clone())? { Ok(()) } else { self.expected_token(token) }
     }
 
-    fn at(&mut self, token: Token) -> bool {
+    fn at(&self, token: Token) -> bool {
         self.token.token() == &token
     }
 
@@ -970,42 +970,42 @@ impl<'a> Parser<'a> {
         })
     }
 
-    fn expected_identifier<T>(&mut self) -> ParseResult<T> {
+    fn expected_identifier<T>(&self) -> ParseResult<T> {
         Err(ParserError::ExpectedIdentifier {
             found: self.token.token().clone(),
             span: self.token.span(),
         })
     }
 
-    fn expected_field_element<T>(&mut self) -> ParseResult<T> {
+    fn expected_field_element<T>(&self) -> ParseResult<T> {
         Err(ParserError::ExpectedFieldElement {
             found: self.token.token().clone(),
             span: self.token.span(),
         })
     }
 
-    fn expected_witness<T>(&mut self) -> ParseResult<T> {
+    fn expected_witness<T>(&self) -> ParseResult<T> {
         Err(ParserError::ExpectedWitness {
             found: self.token.token().clone(),
             span: self.token.span(),
         })
     }
 
-    fn expected_block_id<T>(&mut self) -> ParseResult<T> {
+    fn expected_block_id<T>(&self) -> ParseResult<T> {
         Err(ParserError::ExpectedBlockId {
             found: self.token.token().clone(),
             span: self.token.span(),
         })
     }
 
-    fn expected_term<T>(&mut self) -> ParseResult<T> {
+    fn expected_term<T>(&self) -> ParseResult<T> {
         Err(ParserError::ExpectedTerm {
             found: self.token.token().clone(),
             span: self.token.span(),
         })
     }
 
-    fn expected_token<T>(&mut self, token: Token) -> ParseResult<T> {
+    fn expected_token<T>(&self, token: Token) -> ParseResult<T> {
         Err(ParserError::ExpectedToken {
             token,
             found: self.token.token().clone(),
@@ -1013,7 +1013,7 @@ impl<'a> Parser<'a> {
         })
     }
 
-    fn expected_one_of_tokens<T>(&mut self, tokens: &[Token]) -> ParseResult<T> {
+    fn expected_one_of_tokens<T>(&self, tokens: &[Token]) -> ParseResult<T> {
         Err(ParserError::ExpectedOneOfTokens {
             tokens: tokens.to_vec(),
             found: self.token.token().clone(),

--- a/acvm-repo/acvm/src/compiler/simulator.rs
+++ b/acvm-repo/acvm/src/compiler/simulator.rs
@@ -175,7 +175,7 @@ impl CircuitSimulator {
         true
     }
 
-    fn can_solve_brillig_input<F>(&mut self, input: &BrilligInputs<F>) -> bool {
+    fn can_solve_brillig_input<F>(&self, input: &BrilligInputs<F>) -> bool {
         match input {
             BrilligInputs::Single(expr) => self.can_solve_expression(expr),
             BrilligInputs::Array(exprs) => {

--- a/acvm-repo/acvm_js/src/js_execution_error.rs
+++ b/acvm-repo/acvm_js/src/js_execution_error.rs
@@ -45,7 +45,7 @@ impl JsExecutionError {
         acir_function_id: Option<AcirFunctionId>,
         brillig_function_id: Option<BrilligFunctionId>,
     ) -> Self {
-        let mut error = JsExecutionError::constructor(JsString::from(message));
+        let error = JsExecutionError::constructor(JsString::from(message));
         let js_call_stack = match call_stack {
             Some(call_stack) => {
                 let js_array = Array::new();
@@ -89,7 +89,7 @@ impl JsExecutionError {
         error
     }
 
-    fn set_property(&mut self, property: &str, value: JsValue) {
+    fn set_property(&self, property: &str, value: JsValue) {
         assert!(
             Reflect::set(self, &JsValue::from(property), &value).expect("Errors should be objects"),
             "Errors should be writable"

--- a/compiler/noirc_evaluator/src/acir/arrays.rs
+++ b/compiler/noirc_evaluator/src/acir/arrays.rs
@@ -373,7 +373,7 @@ impl Context<'_> {
     /// cf. <https://github.com/noir-lang/noir/pull/4971>
     /// For simplicity we compute the offset only for simple arrays
     fn compute_offset(
-        &mut self,
+        &self,
         instruction: InstructionId,
         dfg: &DataFlowGraph,
         array_typ: &Type,

--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_block_variables.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_block_variables.rs
@@ -86,7 +86,7 @@ impl BlockVariables {
     pub(crate) fn define_variable<Registers: RegisterAllocator>(
         &mut self,
         function_context: &mut FunctionContext,
-        brillig_context: &mut BrilligContext<FieldElement, Registers>,
+        brillig_context: &BrilligContext<FieldElement, Registers>,
         value_id: ValueId,
         dfg: &DataFlowGraph,
     ) -> BrilligVariable {
@@ -111,7 +111,7 @@ impl BlockVariables {
     pub(crate) fn define_single_addr_variable<Registers: RegisterAllocator>(
         &mut self,
         function_context: &mut FunctionContext,
-        brillig_context: &mut BrilligContext<FieldElement, Registers>,
+        brillig_context: &BrilligContext<FieldElement, Registers>,
         value: ValueId,
         dfg: &DataFlowGraph,
     ) -> SingleAddrVariable {
@@ -123,8 +123,8 @@ impl BlockVariables {
     pub(crate) fn remove_variable<Registers: RegisterAllocator>(
         &mut self,
         value_id: &ValueId,
-        function_context: &mut FunctionContext,
-        brillig_context: &mut BrilligContext<FieldElement, Registers>,
+        function_context: &FunctionContext,
+        brillig_context: &BrilligContext<FieldElement, Registers>,
     ) {
         assert!(self.available_variables.remove(value_id), "ICE: Variable is not available");
 
@@ -151,7 +151,7 @@ impl BlockVariables {
     /// * the variable is not in [Self::available_variables], which means it is no longer live
     /// * the variable is not in [FunctionContext::ssa_value_allocations], which means it was never defined
     pub(crate) fn get_allocation(
-        &mut self,
+        &self,
         function_context: &FunctionContext,
         value_id: ValueId,
     ) -> BrilligVariable {
@@ -180,7 +180,7 @@ pub(crate) fn compute_array_length(
 /// For a given [ValueId], allocates the necessary registers to hold it.
 pub(crate) fn allocate_value<F, Registers: RegisterAllocator>(
     value_id: ValueId,
-    brillig_context: &mut BrilligContext<F, Registers>,
+    brillig_context: &BrilligContext<F, Registers>,
     dfg: &DataFlowGraph,
 ) -> Allocated<BrilligVariable, Registers> {
     let typ = dfg.type_of_value(value_id);
@@ -190,7 +190,7 @@ pub(crate) fn allocate_value<F, Registers: RegisterAllocator>(
 
 /// For a given [Type], allocates the necessary registers to hold it.
 pub(crate) fn allocate_value_with_type<F, Registers: RegisterAllocator>(
-    brillig_context: &mut BrilligContext<F, Registers>,
+    brillig_context: &BrilligContext<F, Registers>,
     typ: Type,
 ) -> Allocated<BrilligVariable, Registers> {
     match typ {

--- a/compiler/noirc_evaluator/src/brillig/brillig_ir/codegen_memory.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_ir/codegen_memory.rs
@@ -535,7 +535,7 @@ impl<F: AcirField + DebugToString, Registers: RegisterAllocator> BrilligContext<
     /// The inputs are:
     /// * the `pointer` to the array/vector
     /// * the `rc` address of the vector where we have the current RC loaded already
-    pub(crate) fn codegen_decrement_rc(&mut self, _pointer: MemoryAddress, _rc: MemoryAddress) {
+    pub(crate) fn codegen_decrement_rc(&self, _pointer: MemoryAddress, _rc: MemoryAddress) {
         // In benchmarks having this on didn't have a noticeable performance benefit,
         // but it does have a small increase in byte code size and the number of executed opcodes.
         // When we disabled `dec_rc` in SSA, the performance improved, so for now we disabled this,

--- a/compiler/noirc_evaluator/src/brillig/brillig_ir/entry_point.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_ir/entry_point.rs
@@ -160,7 +160,7 @@ impl<F: AcirField + DebugToString> BrilligContext<F, Stack> {
     }
 
     fn allocate_function_arguments(
-        &mut self,
+        &self,
         arguments: &[BrilligParameter],
     ) -> Vec<Allocated<BrilligVariable, Stack>> {
         arguments

--- a/compiler/noirc_evaluator/src/brillig/brillig_ir/registers.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_ir/registers.rs
@@ -509,12 +509,12 @@ impl<F, Registers: RegisterAllocator> BrilligContext<F, Registers> {
     /// Manually deallocates a register which is no longer in use.
     ///
     /// This could be one of the pre-allocated ones which doesn't have automation.
-    pub(crate) fn deallocate_register(&mut self, register: MemoryAddress) {
+    pub(crate) fn deallocate_register(&self, register: MemoryAddress) {
         self.registers_mut().deallocate_register(register);
     }
 
     /// Allocates an unused register.
-    pub(crate) fn allocate_register(&mut self) -> Allocated<MemoryAddress, Registers> {
+    pub(crate) fn allocate_register(&self) -> Allocated<MemoryAddress, Registers> {
         let addr = self.registers_mut().allocate_register();
         Allocated::new_addr(addr, self.registers.clone())
     }
@@ -529,27 +529,25 @@ impl<F, Registers: RegisterAllocator> BrilligContext<F, Registers> {
 
     /// Allocate a [SingleAddrVariable].
     pub(crate) fn allocate_single_addr(
-        &mut self,
+        &self,
         bit_size: u32,
     ) -> Allocated<SingleAddrVariable, Registers> {
         self.allocate_register().map(|a| SingleAddrVariable::new(a, bit_size))
     }
 
     /// Allocate a [SingleAddrVariable] with the size of a Brillig memory address.
-    pub(crate) fn allocate_single_addr_usize(
-        &mut self,
-    ) -> Allocated<SingleAddrVariable, Registers> {
+    pub(crate) fn allocate_single_addr_usize(&self) -> Allocated<SingleAddrVariable, Registers> {
         self.allocate_register().map(SingleAddrVariable::new_usize)
     }
 
     /// Allocate a [SingleAddrVariable] with a size of 1 bit.
-    pub(crate) fn allocate_single_addr_bool(&mut self) -> Allocated<SingleAddrVariable, Registers> {
+    pub(crate) fn allocate_single_addr_bool(&self) -> Allocated<SingleAddrVariable, Registers> {
         self.allocate_single_addr(1)
     }
 
     /// Allocate a [SingleAddrVariable] with a size of `BRILLIG_MEMORY_ADDRESSING_BIT_SIZE` bit.
     #[allow(unused)]
-    pub(crate) fn allocate_single_addr_mem(&mut self) -> Allocated<SingleAddrVariable, Registers> {
+    pub(crate) fn allocate_single_addr_mem(&self) -> Allocated<SingleAddrVariable, Registers> {
         self.allocate_single_addr(BRILLIG_MEMORY_ADDRESSING_BIT_SIZE)
     }
 
@@ -557,7 +555,7 @@ impl<F, Registers: RegisterAllocator> BrilligContext<F, Registers> {
     ///
     /// This does not include allocating memory for the data on the heap or shaping the meta-data.
     /// That is done by [BrilligContext::codegen_initialize_vector].
-    pub(crate) fn allocate_brillig_vector(&mut self) -> Allocated<BrilligVector, Registers> {
+    pub(crate) fn allocate_brillig_vector(&self) -> Allocated<BrilligVector, Registers> {
         self.allocate_register().map(|a| BrilligVector { pointer: a })
     }
 
@@ -566,14 +564,14 @@ impl<F, Registers: RegisterAllocator> BrilligContext<F, Registers> {
     /// This does not include allocating memory for the data on the heap or shaping the meta-data.
     /// That is done by [BrilligContext::codegen_initialize_array].
     pub(crate) fn allocate_brillig_array(
-        &mut self,
+        &self,
         size: SemiFlattenedLength,
     ) -> Allocated<BrilligArray, Registers> {
         self.allocate_register().map(|a| BrilligArray { pointer: a, size })
     }
 
     /// Allocate a [HeapVector].
-    pub(crate) fn allocate_heap_vector(&mut self) -> Allocated<HeapVector, Registers> {
+    pub(crate) fn allocate_heap_vector(&self) -> Allocated<HeapVector, Registers> {
         let pointer = self.allocate_register();
         let size = self.allocate_register();
         pointer.map2(size, |pointer, size| HeapVector { pointer, size })
@@ -581,7 +579,7 @@ impl<F, Registers: RegisterAllocator> BrilligContext<F, Registers> {
 
     /// Allocate a [HeapArray].
     pub(crate) fn allocate_heap_array(
-        &mut self,
+        &self,
         size: SemiFlattenedLength,
     ) -> Allocated<HeapArray, Registers> {
         self.allocate_register().map(|pointer| HeapArray { pointer, size })

--- a/compiler/noirc_evaluator/src/ssa/checks/check_for_underconstrained_values.rs
+++ b/compiler/noirc_evaluator/src/ssa/checks/check_for_underconstrained_values.rs
@@ -20,6 +20,7 @@ impl Ssa {
     /// If this is the case, then part of the final circuit can be completely replaced by any other passing circuit, since there are no constraints ensuring connections.
     /// Go through each top-level non-Brillig function and detect if it has independent subgraphs
     #[tracing::instrument(level = "trace", skip(self))]
+    #[allow(clippy::needless_pass_by_ref_mut)]
     pub(crate) fn check_for_underconstrained_values(&mut self) -> Vec<SsaReport> {
         self.functions
             .values()
@@ -40,6 +41,7 @@ impl Ssa {
 
     /// Detect Brillig calls left unconstrained with manual asserts
     /// and return a vector of bug reports if any have been found
+    #[allow(clippy::needless_pass_by_ref_mut)]
     pub(crate) fn check_for_missing_brillig_constraints(
         &mut self,
         enable_lookback: bool,
@@ -569,7 +571,7 @@ impl DependencyContext {
 
     /// Every Brillig call not properly constrained should remain in the tainted set
     /// at this point. For each, emit a corresponding warning.
-    fn collect_warnings(&mut self, function: &Function) -> Vec<SsaReport> {
+    fn collect_warnings(&self, function: &Function) -> Vec<SsaReport> {
         let warnings: Vec<SsaReport> = self
             .tainted
             .keys()
@@ -690,7 +692,7 @@ impl Context {
     ///
     /// Goes through each set of connected ValueIds and see if function arguments or return values are in the set
     fn find_sets_connected_to_function_inputs_or_outputs(
-        &mut self,
+        &self,
         function: &Function,
     ) -> BTreeSet<usize> {
         let returns = function.returns().unwrap_or_default();

--- a/compiler/noirc_evaluator/src/ssa/function_builder/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/function_builder/mod.rs
@@ -242,7 +242,7 @@ impl FunctionBuilder {
     }
 
     /// Returns the block currently being inserted into
-    pub(crate) fn current_block(&mut self) -> BasicBlockId {
+    pub(crate) fn current_block(&self) -> BasicBlockId {
         self.current_block
     }
 

--- a/compiler/noirc_evaluator/src/ssa/interpreter/intrinsics.rs
+++ b/compiler/noirc_evaluator/src/ssa/interpreter/intrinsics.rs
@@ -17,7 +17,7 @@ use super::{ArrayValue, IResult, IResults, InternalError, Interpreter, Interpret
 
 impl<W: Write> Interpreter<'_, W> {
     pub(super) fn call_intrinsic(
-        &mut self,
+        &self,
         intrinsic: Intrinsic,
         args: &[ValueId],
         results: &[ValueId],

--- a/compiler/noirc_evaluator/src/ssa/interpreter/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/interpreter/mod.rs
@@ -839,7 +839,7 @@ impl<'ssa, W: Write> Interpreter<'ssa, W> {
     }
 
     fn interpret_range_check(
-        &mut self,
+        &self,
         value_id: ValueId,
         max_bit_size: u32,
         error_message: Option<&String>,
@@ -1039,7 +1039,7 @@ impl<'ssa, W: Write> Interpreter<'ssa, W> {
         Ok(())
     }
 
-    fn interpret_store(&mut self, address: ValueId, value: ValueId) -> IResult<()> {
+    fn interpret_store(&self, address: ValueId, value: ValueId) -> IResult<()> {
         let reference_address = self.lookup_reference(address, "store")?;
 
         let value = self.lookup(value)?;

--- a/compiler/noirc_evaluator/src/ssa/ir/function_inserter.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/function_inserter.rs
@@ -68,7 +68,7 @@ impl<'f> FunctionInserter<'f> {
     }
 
     /// Get an instruction and make sure all the values in it are freshly resolved.
-    pub(crate) fn map_instruction(&mut self, id: InstructionId) -> (Instruction, CallStackId) {
+    pub(crate) fn map_instruction(&self, id: InstructionId) -> (Instruction, CallStackId) {
         let mut instruction = self.function.dfg[id].clone();
         instruction.map_values_mut(|id| self.resolve(id));
         (instruction, self.function.dfg.get_instruction_call_stack_id(id))

--- a/compiler/noirc_evaluator/src/ssa/opt/basic_conditional.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/basic_conditional.rs
@@ -50,7 +50,7 @@ impl Ssa {
             no_predicates.insert(function.id(), function.is_no_predicates());
         }
         for function in self.functions.values_mut() {
-            flatten_function(function, &mut no_predicates);
+            flatten_function(function, &no_predicates);
         }
         self
     }
@@ -242,7 +242,7 @@ fn block_cost(block: BasicBlockId, dfg: &DataFlowGraph) -> u32 {
 }
 
 /// Identifies all simple conditionals in the function and flattens them
-fn flatten_function(function: &mut Function, no_predicates: &mut HashMap<FunctionId, bool>) {
+fn flatten_function(function: &mut Function, no_predicates: &HashMap<FunctionId, bool>) {
     // This pass is dedicated to brillig functions
     if !function.runtime().is_brillig() {
         return;
@@ -296,7 +296,7 @@ fn flatten_function(function: &mut Function, no_predicates: &mut HashMap<Functio
 fn flatten_multiple(
     conditionals: &Vec<BasicConditional>,
     function: &mut Function,
-    no_predicates: &mut HashMap<FunctionId, bool>,
+    no_predicates: &HashMap<FunctionId, bool>,
 ) {
     // 1. process each basic conditional, using a new context per conditional
     let post_order = PostOrder::with_function(function);
@@ -342,7 +342,7 @@ impl Context<'_> {
     fn flatten_single_conditional(
         &mut self,
         conditional: &BasicConditional,
-        no_predicates: &mut HashMap<FunctionId, bool>,
+        no_predicates: &HashMap<FunctionId, bool>,
     ) {
         // Manually inline 'then', 'else' and 'exit' into the entry block
         //0. initialize the context for flattening a 'single conditional'

--- a/compiler/noirc_evaluator/src/ssa/opt/constant_folding/interpret.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/constant_folding/interpret.rs
@@ -53,7 +53,7 @@ enum EvaluationResult {
 fn evaluate_const_argument_call(
     instruction: &Instruction,
     interpreter: &mut Interpreter<Empty>,
-    dfg: &mut DataFlowGraph,
+    dfg: &DataFlowGraph,
 ) -> EvaluationResult {
     let Instruction::Call { func: func_id, arguments } = instruction else {
         return EvaluationResult::NotABrilligCall;

--- a/compiler/noirc_evaluator/src/ssa/opt/constant_folding/simplification_cache.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/constant_folding/simplification_cache.rs
@@ -70,10 +70,7 @@ impl ConstraintSimplificationCache {
 
     /// Get the simplification mapping from complex to simpler instructions,
     /// which all depend on the same side effect condition variable.
-    pub(super) fn get(
-        &mut self,
-        predicate: ValueId,
-    ) -> Option<&HashMap<ValueId, SimplificationCache>> {
+    pub(super) fn get(&self, predicate: ValueId) -> Option<&HashMap<ValueId, SimplificationCache>> {
         self.0.get(&predicate)
     }
 }

--- a/compiler/noirc_evaluator/src/ssa/opt/defunctionalize.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/defunctionalize.rs
@@ -125,7 +125,7 @@ impl Ssa {
 
 impl DefunctionalizationContext {
     /// Defunctionalize all functions in the SSA
-    fn defunctionalize_all(mut self, ssa: &mut Ssa) {
+    fn defunctionalize_all(self, ssa: &mut Ssa) {
         for function in ssa.functions.values_mut() {
             // We mutate value types in `defunctionalize`, so to prevent that from affecting which
             // apply functions are chosen we replace all first-class function calls with calls to
@@ -141,7 +141,7 @@ impl DefunctionalizationContext {
     /// Replaces any function calls using first-class function values with calls to the
     /// appropriate `apply` function. Note that this must be done before types are mutated
     /// in `defunctionalize` since this uses the pre-mutated types to query apply functions.
-    fn replace_first_class_calls_with_apply_function(&mut self, func: &mut Function) {
+    fn replace_first_class_calls_with_apply_function(&self, func: &mut Function) {
         for block_id in func.reachable_blocks() {
             let block = &mut func.dfg[block_id];
 
@@ -191,7 +191,7 @@ impl DefunctionalizationContext {
     }
 
     /// Defunctionalize a single function
-    fn defunctionalize(&mut self, func: &mut Function) {
+    fn defunctionalize(&self, func: &mut Function) {
         for block_id in func.reachable_blocks() {
             let block = &mut func.dfg[block_id];
 

--- a/compiler/noirc_evaluator/src/ssa/opt/die/array_oob_checks.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/die/array_oob_checks.rs
@@ -18,7 +18,7 @@ impl Context {
     /// some of the instructions in a group are used but not all of them, no check
     /// is inserted, so this method might return `false`.
     pub(super) fn replace_array_instructions_with_out_of_bounds_checks(
-        &mut self,
+        &self,
         function: &mut Function,
         block_id: BasicBlockId,
         possible_index_out_of_bounds_indexes: &mut Vec<usize>,

--- a/compiler/noirc_evaluator/src/ssa/opt/evaluate_static_assert_and_assert_constant.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/evaluate_static_assert_and_assert_constant.rs
@@ -116,7 +116,7 @@ fn get_blocks_within_empty_loop(function: &Function) -> HashSet<BasicBlockId> {
 /// This returns Ok(true) if the given instruction should be kept in the block and
 /// Ok(false) if it should be removed.
 fn check_instruction(
-    function: &mut Function,
+    function: &Function,
     instruction: InstructionId,
     assert_constant_id: Option<ValueId>,
     static_assert_id: Option<ValueId>,

--- a/compiler/noirc_evaluator/src/ssa/opt/loop_invariant.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/loop_invariant.rs
@@ -662,7 +662,7 @@ impl<'f> LoopInvariantContext<'f> {
     /// 1. Whether the instruction can be hoisted
     /// 2. If it can be hoisted, does it require an `IncrementRc` instruction.
     fn can_hoist_invariant(
-        &mut self,
+        &self,
         loop_context: &LoopContext,
         block_context: &BlockContext,
         instruction_id: InstructionId,

--- a/compiler/noirc_evaluator/src/ssa/opt/loop_invariant/simplify.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/loop_invariant/simplify.rs
@@ -242,7 +242,7 @@ impl LoopInvariantContext<'_> {
     ///
     /// `header` indicates if we are in the loop header where loop bounds do not apply yet
     fn simplify_induction_variable_in_binary(
-        &mut self,
+        &self,
         loop_context: &LoopContext,
         binary: &Binary,
         is_header: bool,

--- a/compiler/noirc_evaluator/src/ssa/opt/normalize_value_ids.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/normalize_value_ids.rs
@@ -179,7 +179,7 @@ impl IdMaps {
     }
 
     fn map_value(
-        &mut self,
+        &self,
         new_function: &mut Function,
         old_function: &Function,
         old_value: ValueId,

--- a/compiler/noirc_evaluator/src/ssa/opt/rc.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/rc.rs
@@ -73,7 +73,7 @@ impl Function {
     }
 }
 
-fn contains_array_parameter(function: &mut Function) -> bool {
+fn contains_array_parameter(function: &Function) -> bool {
     let mut parameters = function.parameters().iter();
     parameters.any(|parameter| function.dfg.type_of_value(*parameter).contains_an_array())
 }

--- a/compiler/noirc_evaluator/src/ssa/parser/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/parser/mod.rs
@@ -1177,71 +1177,71 @@ impl<'a> Parser<'a> {
         self.lexer.next_token().map_err(ParserError::LexerError)
     }
 
-    fn expected_instruction_or_terminator<T>(&mut self) -> ParseResult<T> {
+    fn expected_instruction_or_terminator<T>(&self) -> ParseResult<T> {
         Err(ParserError::ExpectedInstructionOrTerminator {
             found: self.token.token().clone(),
             span: self.token.span(),
         })
     }
 
-    fn expected_string<T>(&mut self) -> ParseResult<T> {
+    fn expected_string<T>(&self) -> ParseResult<T> {
         Err(ParserError::ExpectedString {
             found: self.token.token().clone(),
             span: self.token.span(),
         })
     }
 
-    fn expected_string_or_data<T>(&mut self) -> ParseResult<T> {
+    fn expected_string_or_data<T>(&self) -> ParseResult<T> {
         Err(ParserError::ExpectedStringOrData {
             found: self.token.token().clone(),
             span: self.token.span(),
         })
     }
 
-    fn expected_byte_string<T>(&mut self) -> ParseResult<T> {
+    fn expected_byte_string<T>(&self) -> ParseResult<T> {
         Err(ParserError::ExpectedByteString {
             found: self.token.token().clone(),
             span: self.token.span(),
         })
     }
 
-    fn expected_identifier<T>(&mut self) -> ParseResult<T> {
+    fn expected_identifier<T>(&self) -> ParseResult<T> {
         Err(ParserError::ExpectedIdentifier {
             found: self.token.token().clone(),
             span: self.token.span(),
         })
     }
 
-    fn expected_int<T>(&mut self) -> ParseResult<T> {
+    fn expected_int<T>(&self) -> ParseResult<T> {
         Err(ParserError::ExpectedInt { found: self.token.token().clone(), span: self.token.span() })
     }
 
-    fn unexpected_offset<T>(&mut self, found: Token, span: Span) -> ParseResult<T> {
+    fn unexpected_offset<T>(&self, found: Token, span: Span) -> ParseResult<T> {
         Err(ParserError::UnexpectedOffset { found, span })
     }
 
-    fn expected_type<T>(&mut self) -> ParseResult<T> {
+    fn expected_type<T>(&self) -> ParseResult<T> {
         Err(ParserError::ExpectedType {
             found: self.token.token().clone(),
             span: self.token.span(),
         })
     }
 
-    fn expected_value<T>(&mut self) -> ParseResult<T> {
+    fn expected_value<T>(&self) -> ParseResult<T> {
         Err(ParserError::ExpectedValue {
             found: self.token.token().clone(),
             span: self.token.span(),
         })
     }
 
-    fn expected_global_value<T>(&mut self) -> ParseResult<T> {
+    fn expected_global_value<T>(&self) -> ParseResult<T> {
         Err(ParserError::ExpectedGlobalValue {
             found: self.token.token().clone(),
             span: self.token.span(),
         })
     }
 
-    fn expected_token<T>(&mut self, token: Token) -> ParseResult<T> {
+    fn expected_token<T>(&self, token: Token) -> ParseResult<T> {
         Err(ParserError::ExpectedToken {
             token,
             found: self.token.token().clone(),
@@ -1249,7 +1249,7 @@ impl<'a> Parser<'a> {
         })
     }
 
-    fn expected_one_of_tokens<T>(&mut self, tokens: &[Token]) -> ParseResult<T> {
+    fn expected_one_of_tokens<T>(&self, tokens: &[Token]) -> ParseResult<T> {
         Err(ParserError::ExpectedOneOfTokens {
             tokens: tokens.to_vec(),
             found: self.token.token().clone(),

--- a/compiler/noirc_frontend/src/elaborator/enums.rs
+++ b/compiler/noirc_frontend/src/elaborator/enums.rs
@@ -1248,7 +1248,7 @@ impl<'elab, 'ctx> MatchCompiler<'elab, 'ctx> {
 
     /// Return the variable that was referred to the most in `rows`, or panic if there are zero
     /// `rows`
-    fn branch_variable(&mut self, rows: &[Row]) -> DefinitionId {
+    fn branch_variable(&self, rows: &[Row]) -> DefinitionId {
         assert!(!rows.is_empty(), "ICE branch_variable: expected at least one row");
         let mut counts = HashMap::default();
 

--- a/compiler/noirc_frontend/src/elaborator/expressions.rs
+++ b/compiler/noirc_frontend/src/elaborator/expressions.rs
@@ -1611,7 +1611,7 @@ impl Elaborator<'_> {
     }
 
     fn try_get_comptime_function(
-        &mut self,
+        &self,
         func: ExprId,
         location: Location,
     ) -> Result<Option<FuncId>, ResolverError> {

--- a/compiler/noirc_frontend/src/elaborator/function.rs
+++ b/compiler/noirc_frontend/src/elaborator/function.rs
@@ -386,7 +386,7 @@ impl Elaborator<'_> {
     /// function. If the given type is not sized (e.g. contains a vector or NamedGeneric type), an
     /// error is issued.
     fn check_if_type_is_valid_for_program(
-        &mut self,
+        &self,
         typ: &Type,
         is_entry_point: bool,
         has_inline_attribute: bool,
@@ -409,7 +409,7 @@ impl Elaborator<'_> {
     }
 
     fn check_if_type_is_valid_for_program_input(
-        &mut self,
+        &self,
         typ: &Type,
         is_entry_point: bool,
         has_inline_attribute: bool,
@@ -425,7 +425,7 @@ impl Elaborator<'_> {
     }
 
     fn check_if_type_is_valid_for_program_output(
-        &mut self,
+        &self,
         typ: &Type,
         is_entry_point: bool,
         has_inline_attribute: bool,

--- a/compiler/noirc_frontend/src/elaborator/impls.rs
+++ b/compiler/noirc_frontend/src/elaborator/impls.rs
@@ -145,7 +145,7 @@ impl Elaborator<'_> {
     pub(super) fn declare_methods_on_data_type(
         &mut self,
         trait_id: Option<TraitId>,
-        functions: &mut UnresolvedFunctions,
+        functions: &UnresolvedFunctions,
         location: Location,
     ) {
         let self_type = functions.self_type.as_ref();

--- a/compiler/noirc_frontend/src/elaborator/scope.rs
+++ b/compiler/noirc_frontend/src/elaborator/scope.rs
@@ -39,7 +39,7 @@ impl Elaborator<'_> {
         self.interner.get_type(type_id)
     }
 
-    pub(super) fn get_trait(&mut self, trait_id: TraitId) -> &Trait {
+    pub(super) fn get_trait(&self, trait_id: TraitId) -> &Trait {
         self.interner.get_trait(trait_id)
     }
 

--- a/compiler/noirc_frontend/src/elaborator/trait_impls.rs
+++ b/compiler/noirc_frontend/src/elaborator/trait_impls.rs
@@ -174,7 +174,7 @@ impl Elaborator<'_> {
             self.collect_trait_impl_methods(trait_id, trait_impl, &where_clause);
 
             let location = trait_impl.object_type.location;
-            self.declare_methods_on_data_type(Some(trait_id), &mut trait_impl.methods, location);
+            self.declare_methods_on_data_type(Some(trait_id), &trait_impl.methods, location);
 
             let trait_visibility = self.interner.get_trait(trait_id).visibility;
 
@@ -669,7 +669,7 @@ impl Elaborator<'_> {
 
     // Replace implicitly added unbound named generics with fresh type variables
     fn bind_to_fresh_variable(
-        &mut self,
+        &self,
         named_generics: &mut [NamedType],
         bindings: &mut TypeBindings,
     ) {

--- a/compiler/noirc_frontend/src/elaborator/traits.rs
+++ b/compiler/noirc_frontend/src/elaborator/traits.rs
@@ -779,7 +779,7 @@ impl Elaborator<'_> {
 ///
 /// This does not type check the body of the impl function.
 pub(crate) fn check_trait_impl_method_matches_declaration(
-    interner: &mut NodeInterner,
+    interner: &NodeInterner,
     function: FuncId,
     noir_function: &NoirFunction,
 ) -> Vec<TypeCheckError> {

--- a/compiler/noirc_frontend/src/elaborator/types.rs
+++ b/compiler/noirc_frontend/src/elaborator/types.rs
@@ -900,10 +900,7 @@ impl Elaborator<'_> {
     ///
     /// Returns the trait method, trait constraint, and whether the impl is assumed to exist by a where clause or not
     /// E.g. `t.method()` with `where T: Foo<Bar>` in scope will return `(Foo::method, T, vec![Bar])`
-    fn resolve_trait_static_method_by_self(
-        &mut self,
-        path: &TypedPath,
-    ) -> Option<TraitPathResolution> {
+    fn resolve_trait_static_method_by_self(&self, path: &TypedPath) -> Option<TraitPathResolution> {
         // If we are inside a trait impl, `Self` is known to be a concrete type so we don't have
         // to solve the path via trait method lookup.
         if self.current_trait_impl.is_some() {

--- a/compiler/noirc_frontend/src/hir/comptime/display.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/display.rs
@@ -358,7 +358,7 @@ impl<'interner> TokenPrettyPrinter<'interner> {
         Ok(())
     }
 
-    fn write_indent(&mut self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn write_indent(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", " ".repeat(self.indent * 4))
     }
 }

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
@@ -1234,7 +1234,7 @@ impl<'local, 'interner> Interpreter<'local, 'interner> {
         Ok(Value::Tuple(fields))
     }
 
-    fn evaluate_lambda(&mut self, lambda: HirLambda, id: ExprId) -> IResult<Value> {
+    fn evaluate_lambda(&self, lambda: HirLambda, id: ExprId) -> IResult<Value> {
         let location = self.elaborator.interner.expr_location(&id);
         let env = try_vecmap(&lambda.captures, |capture| {
             let value = self.lookup_id(capture.ident.id, location)?;
@@ -1658,7 +1658,7 @@ impl<'local, 'interner> Interpreter<'local, 'interner> {
         }
     }
 
-    fn evaluate_break(&mut self, id: StmtId) -> IResult<Value> {
+    fn evaluate_break(&self, id: StmtId) -> IResult<Value> {
         if self.in_loop {
             Err(InterpreterError::Break)
         } else {
@@ -1667,7 +1667,7 @@ impl<'local, 'interner> Interpreter<'local, 'interner> {
         }
     }
 
-    fn evaluate_continue(&mut self, id: StmtId) -> IResult<Value> {
+    fn evaluate_continue(&self, id: StmtId) -> IResult<Value> {
         if self.in_loop {
             Err(InterpreterError::Continue)
         } else {
@@ -1680,10 +1680,7 @@ impl<'local, 'interner> Interpreter<'local, 'interner> {
         self.evaluate_statement(statement)
     }
 
-    fn print_oracle(
-        &mut self,
-        arguments: Vec<(Value, Location)>,
-    ) -> Result<Value, InterpreterError> {
+    fn print_oracle(&self, arguments: Vec<(Value, Location)>) -> Result<Value, InterpreterError> {
         assert_eq!(arguments.len(), 2);
 
         let Some(output) = self.elaborator.interpreter_output else {

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
@@ -605,7 +605,7 @@ fn type_def_has_named_attribute(
 /// Returns (name, type, visibility) tuples of each field of this TypeDefinition.
 /// Applies the given generic arguments to each field.
 fn type_def_fields(
-    interner: &mut NodeInterner,
+    interner: &NodeInterner,
     arguments: Vec<(Value, Location)>,
     location: Location,
     call_stack: &Vector<Location>,
@@ -658,7 +658,7 @@ fn type_def_fields(
 ///
 /// Note that any generic arguments won't be applied: if you need them to be, use `fields`.
 fn type_def_fields_as_written(
-    interner: &mut NodeInterner,
+    interner: &NodeInterner,
     arguments: Vec<(Value, Location)>,
     location: Location,
 ) -> IResult<Value> {
@@ -1363,7 +1363,7 @@ fn trait_def_eq(arguments: Vec<(Value, Location)>, location: Location) -> IResul
 
 // fn methods(self) -> [FunctionDefinition]
 fn trait_impl_methods(
-    interner: &mut NodeInterner,
+    interner: &NodeInterner,
     arguments: Vec<(Value, Location)>,
     location: Location,
 ) -> IResult<Value> {
@@ -1381,7 +1381,7 @@ fn trait_impl_methods(
 
 // fn trait_generic_args(self) -> [Type]
 fn trait_impl_trait_generic_args(
-    interner: &mut NodeInterner,
+    interner: &NodeInterner,
     arguments: Vec<(Value, Location)>,
     location: Location,
 ) -> IResult<Value> {
@@ -3157,7 +3157,7 @@ fn quoted_hash(arguments: Vec<(Value, Location)>, location: Location) -> IResult
 }
 
 fn trait_def_as_trait_constraint(
-    interner: &mut NodeInterner,
+    interner: &NodeInterner,
     arguments: Vec<(Value, Location)>,
     location: Location,
 ) -> IResult<Value> {

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter/foreign.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter/foreign.rs
@@ -26,7 +26,7 @@ use super::{
 
 impl Interpreter<'_, '_> {
     pub(super) fn call_foreign(
-        &mut self,
+        &self,
         name: &str,
         arguments: Vec<(Value, Location)>,
         return_type: Type,

--- a/compiler/noirc_frontend/src/hir/printer/items.rs
+++ b/compiler/noirc_frontend/src/hir/printer/items.rs
@@ -196,7 +196,7 @@ impl<'context> ItemBuilder<'context> {
         })
     }
 
-    fn build_data_type(&mut self, type_id: TypeId) -> Item {
+    fn build_data_type(&self, type_id: TypeId) -> Item {
         let data_type = self.interner.get_type(type_id);
 
         let impls = if let Some(methods) =
@@ -213,7 +213,7 @@ impl<'context> ItemBuilder<'context> {
         Item::DataType(DataType { id: type_id, impls, trait_impls })
     }
 
-    fn build_impls<'a, 'b>(&'a mut self, methods: impl Iterator<Item = &'b Methods>) -> Vec<Impl> {
+    fn build_impls<'a, 'b>(&'a self, methods: impl Iterator<Item = &'b Methods>) -> Vec<Impl> {
         // Gather all impl methods
         // First split methods by impl methods and trait impl methods
         let mut impl_methods = Vec::new();
@@ -243,7 +243,7 @@ impl<'context> ItemBuilder<'context> {
             .collect()
     }
 
-    fn build_impl(&mut self, typ: Type, methods: Vec<ImplMethod>) -> Impl {
+    fn build_impl(&self, typ: Type, methods: Vec<ImplMethod>) -> Impl {
         let mut generics = BTreeSet::new();
         gather_named_type_vars(&typ, &mut generics);
 
@@ -266,7 +266,7 @@ impl<'context> ItemBuilder<'context> {
         Impl { generics, typ, methods }
     }
 
-    fn build_data_type_trait_impls(&mut self, data_type: &crate::DataType) -> Vec<TraitImpl> {
+    fn build_data_type_trait_impls(&self, data_type: &crate::DataType) -> Vec<TraitImpl> {
         let mut trait_impls = self
             .trait_impls
             .iter()
@@ -286,7 +286,7 @@ impl<'context> ItemBuilder<'context> {
         trait_impls.into_iter().map(|(trait_impl, _)| self.build_trait_impl(trait_impl)).collect()
     }
 
-    fn build_trait_impls_for_trait(&mut self, trait_id: TraitId) -> Vec<TraitImpl> {
+    fn build_trait_impls_for_trait(&self, trait_id: TraitId) -> Vec<TraitImpl> {
         let mut trait_impls = Vec::new();
 
         for trait_impl_id in &self.trait_impls {
@@ -304,7 +304,7 @@ impl<'context> ItemBuilder<'context> {
         trait_impls.into_iter().map(|(trait_impl, _)| self.build_trait_impl(trait_impl)).collect()
     }
 
-    fn sort_trait_impls(&mut self, trait_impls: &mut [(TraitImplId, Location)]) {
+    fn sort_trait_impls(&self, trait_impls: &mut [(TraitImplId, Location)]) {
         trait_impls.sort_by_key(|(trait_impl_id, location)| {
             let trait_impl = self.interner.get_trait_implementation(*trait_impl_id);
             let trait_impl = trait_impl.borrow();
@@ -313,7 +313,7 @@ impl<'context> ItemBuilder<'context> {
         });
     }
 
-    fn build_trait_impl(&mut self, trait_impl_id: TraitImplId) -> TraitImpl {
+    fn build_trait_impl(&self, trait_impl_id: TraitImplId) -> TraitImpl {
         let trait_impl = self.interner.get_trait_implementation(trait_impl_id);
         let trait_impl = trait_impl.borrow();
         let external_types = self.type_only_mention_types_outside_current_crate(&trait_impl.typ);
@@ -332,7 +332,7 @@ impl<'context> ItemBuilder<'context> {
         }
     }
 
-    fn build_trait(&mut self, trait_id: TraitId) -> Item {
+    fn build_trait(&self, trait_id: TraitId) -> Item {
         let trait_ = self.interner.get_trait(trait_id);
 
         let mut func_ids = trait_
@@ -415,7 +415,7 @@ impl<'context> ItemBuilder<'context> {
         }
     }
 
-    pub(super) fn add_primitive_types(&mut self, items: &mut Vec<(ItemVisibility, Item)>) {
+    pub(super) fn add_primitive_types(&self, items: &mut Vec<(ItemVisibility, Item)>) {
         self.add_primitive_type(Type::Bool, items);
         self.add_primitive_type(Type::Integer(Signedness::Unsigned, IntegerBitSize::One), items);
         self.add_primitive_type(Type::Integer(Signedness::Unsigned, IntegerBitSize::Eight), items);
@@ -458,7 +458,7 @@ impl<'context> ItemBuilder<'context> {
         }
     }
 
-    fn add_primitive_type(&mut self, typ: Type, items: &mut Vec<(ItemVisibility, Item)>) {
+    fn add_primitive_type(&self, typ: Type, items: &mut Vec<(ItemVisibility, Item)>) {
         let mut impls = if let Some(methods) = self.interner.get_type_methods(&typ) {
             self.build_impls(methods.values())
         } else {
@@ -474,7 +474,7 @@ impl<'context> ItemBuilder<'context> {
         items.push((ItemVisibility::Public, Item::PrimitiveType(primitive_type)));
     }
 
-    fn build_primitive_type_trait_impls(&mut self, primitive_type: &Type) -> Vec<TraitImpl> {
+    fn build_primitive_type_trait_impls(&self, primitive_type: &Type) -> Vec<TraitImpl> {
         let mut trait_impls = self
             .trait_impls
             .iter()

--- a/compiler/noirc_frontend/src/hir/resolution/import.rs
+++ b/compiler/noirc_frontend/src/hir/resolution/import.rs
@@ -251,7 +251,7 @@ impl PathResolutionTargetResolver<'_, '_> {
     ///
     /// Returns a path with its kind unchanged, paired up with the importing or defining module itself as the target.
     fn resolve_crate_path(
-        &mut self,
+        &self,
         path: TypedPath,
         krate: CrateId,
     ) -> Result<(TypedPath, ModuleId), PathResolutionError> {
@@ -317,7 +317,7 @@ impl PathResolutionTargetResolver<'_, '_> {
     /// * get the parent of the current importing module
     /// * return the path still with [PathKind::Super], paired up with the parent module
     fn resolve_super_path(
-        &mut self,
+        &self,
         path: TypedPath,
     ) -> Result<(TypedPath, ModuleId), PathResolutionError> {
         let Some(parent_module_id) = get_module(self.def_maps, self.importing_module).parent else {

--- a/compiler/noirc_frontend/src/lexer/lexer.rs
+++ b/compiler/noirc_frontend/src/lexer/lexer.rs
@@ -85,24 +85,24 @@ impl<'a> Lexer<'a> {
     }
 
     /// Peeks at the next char. Does not iterate the cursor
-    fn peek_char(&mut self) -> Option<char> {
+    fn peek_char(&self) -> Option<char> {
         self.chars.clone().next().map(|(_, ch)| ch)
     }
 
     /// Peeks at the character two positions ahead. Does not iterate the cursor
-    fn peek2_char(&mut self) -> Option<char> {
+    fn peek2_char(&self) -> Option<char> {
         let mut chars = self.chars.clone();
         chars.next();
         chars.next().map(|(_, ch)| ch)
     }
 
     /// Peeks at the next char and returns true if it is equal to the char argument
-    fn peek_char_is(&mut self, ch: char) -> bool {
+    fn peek_char_is(&self, ch: char) -> bool {
         self.peek_char() == Some(ch)
     }
 
     /// Peeks at the character two positions ahead and returns true if it is equal to the char argument
-    fn peek2_char_is(&mut self, ch: char) -> bool {
+    fn peek2_char_is(&self, ch: char) -> bool {
         self.peek2_char() == Some(ch)
     }
 

--- a/compiler/noirc_frontend/src/monomorphization/builtin.rs
+++ b/compiler/noirc_frontend/src/monomorphization/builtin.rs
@@ -106,7 +106,7 @@ impl Monomorphizer<'_> {
 
     /// Check the given type conversion that the types are equal, or issue an error if not.
     fn check_transmute(
-        &mut self,
+        &self,
         actual: &Type,
         expected: &Type,
         location: Location,

--- a/compiler/noirc_frontend/src/monomorphization/mod.rs
+++ b/compiler/noirc_frontend/src/monomorphization/mod.rs
@@ -366,7 +366,7 @@ impl<'interner> Monomorphizer<'interner> {
         IdentId(id)
     }
 
-    fn lookup_local(&mut self, id: node_interner::DefinitionId) -> Option<Definition> {
+    fn lookup_local(&self, id: node_interner::DefinitionId) -> Option<Definition> {
         self.locals.get(&id).copied().map(Definition::Local)
     }
 
@@ -1223,7 +1223,7 @@ impl<'interner> Monomorphizer<'interner> {
     }
 
     /// Find a captured variable in the innermost closure, and construct an expression
-    fn lookup_captured_expr(&mut self, id: node_interner::DefinitionId) -> Option<ast::Expression> {
+    fn lookup_captured_expr(&self, id: node_interner::DefinitionId) -> Option<ast::Expression> {
         let ctx = self.lambda_envs_stack.last()?;
         ctx.captures.iter().position(|capture| capture.ident.id == id).map(|index| {
             ast::Expression::ExtractTupleField(
@@ -1234,7 +1234,7 @@ impl<'interner> Monomorphizer<'interner> {
     }
 
     /// Find a captured variable in the innermost closure construct a LValue
-    fn lookup_captured_lvalue(&mut self, id: node_interner::DefinitionId) -> Option<ast::LValue> {
+    fn lookup_captured_lvalue(&self, id: node_interner::DefinitionId) -> Option<ast::LValue> {
         let ctx = self.lambda_envs_stack.last()?;
         ctx.captures.iter().position(|capture| capture.ident.id == id).map(|index| {
             ast::LValue::MemberAccess {
@@ -2140,7 +2140,7 @@ impl<'interner> Monomorphizer<'interner> {
     }
 
     fn check_arguments_crossing_runtime_boundaries(
-        &mut self,
+        &self,
         call: &HirCallExpression,
     ) -> Result<(), MonomorphizationError> {
         for argument in &call.arguments {
@@ -2159,7 +2159,7 @@ impl<'interner> Monomorphizer<'interner> {
     }
 
     fn check_return_type_crossing_runtime_boundaries(
-        &mut self,
+        &self,
         return_type: &Type,
         location: Location,
     ) -> Result<(), MonomorphizationError> {
@@ -2183,7 +2183,7 @@ impl<'interner> Monomorphizer<'interner> {
     }
 
     fn check_return_type_returned_from_oracle(
-        &mut self,
+        &self,
         return_type: &Type,
         location: Location,
     ) -> Result<(), MonomorphizationError> {
@@ -2214,7 +2214,7 @@ impl<'interner> Monomorphizer<'interner> {
     /// The caller that is running a Noir program should then deserialize the `PrintableType`,
     /// and accurately decode the list of field elements passed to the foreign call.
     fn append_printable_type_info(
-        &mut self,
+        &self,
         hir_argument: &HirExpression,
         arguments: &mut Vec<ast::Expression>,
     ) {
@@ -2978,7 +2978,7 @@ fn resolve_trait_item_impl(
 /// However, we can bind `M` to `N`, so it eventually resolves to `2`,
 /// which is what this method does.
 fn bind_trait_impl_func_generics_to_trait_func_generics(
-    interner: &mut NodeInterner,
+    interner: &NodeInterner,
     method_id: TraitItemId,
     impl_id: node_interner::TraitImplId,
     bindings: &mut TypeBindings,

--- a/compiler/noirc_frontend/src/monomorphization/printer.rs
+++ b/compiler/noirc_frontend/src/monomorphization/printer.rs
@@ -238,7 +238,7 @@ impl AstPrinter {
         }
     }
 
-    fn next_line(&mut self, f: &mut Formatter) -> std::fmt::Result {
+    fn next_line(&self, f: &mut Formatter) -> std::fmt::Result {
         writeln!(f)?;
         for _ in 0..self.indent_level {
             write!(f, "    ")?;

--- a/compiler/noirc_frontend/src/parser/parser/function.rs
+++ b/compiler/noirc_frontend/src/parser/parser/function.rs
@@ -244,7 +244,7 @@ impl Parser<'_> {
         Param { visibility, pattern, typ, location: self.location_since(start_location) }
     }
 
-    fn self_pattern_param(&mut self, self_pattern: SelfPattern) -> Param {
+    fn self_pattern_param(&self, self_pattern: SelfPattern) -> Param {
         let ident_location = self.previous_token_location;
         let ident = Ident::new("self".to_string(), ident_location);
         let path = Path::from_single("Self".to_owned(), ident_location);

--- a/compiler/noirc_frontend/src/parser/parser/statement.rs
+++ b/compiler/noirc_frontend/src/parser/parser/statement.rs
@@ -364,7 +364,7 @@ impl Parser<'_> {
         }
     }
 
-    fn empty_for_loop(&mut self, identifier: Ident, start_location: Location) -> ForLoopStatement {
+    fn empty_for_loop(&self, identifier: Ident, start_location: Location) -> ForLoopStatement {
         let location = self.location_at_previous_token_end();
         ForLoopStatement {
             identifier,

--- a/compiler/noirc_frontend/src/parser/parser/type_expression.rs
+++ b/compiler/noirc_frontend/src/parser/parser/type_expression.rs
@@ -363,9 +363,7 @@ impl Parser<'_> {
         })
     }
 
-    fn expected_type_expression_after_this(
-        &mut self,
-    ) -> Result<UnresolvedTypeExpression, ParserError> {
+    fn expected_type_expression_after_this(&self) -> Result<UnresolvedTypeExpression, ParserError> {
         Err(ParserError::expected_label(
             ParsingRuleLabel::TypeExpression,
             self.token.token().clone(),

--- a/compiler/noirc_frontend/src/parser/parser/types.rs
+++ b/compiler/noirc_frontend/src/parser/parser/types.rs
@@ -307,7 +307,7 @@ impl Parser<'_> {
         if self.eat_colon() { Some(self.parse_type_or_error()) } else { None }
     }
 
-    fn error_type_at_previous_token_end(&mut self) -> UnresolvedType {
+    fn error_type_at_previous_token_end(&self) -> UnresolvedType {
         UnresolvedTypeData::Error.with_location(self.location_at_previous_token_end())
     }
 }

--- a/tooling/ast_fuzzer/src/program/func.rs
+++ b/tooling/ast_fuzzer/src/program/func.rs
@@ -1949,11 +1949,7 @@ impl<'a> FunctionContext<'a> {
     }
 
     /// Generate a random field that can be used in the match constructor of a numeric type.
-    fn gen_num_field(
-        &mut self,
-        u: &mut Unstructured,
-        typ: &Type,
-    ) -> arbitrary::Result<SignedField> {
+    fn gen_num_field(&self, u: &mut Unstructured, typ: &Type) -> arbitrary::Result<SignedField> {
         let literal = self.gen_literal(u, typ)?;
         let Expression::Literal(Literal::Integer(field, _, _)) = literal else {
             unreachable!("expected Literal::Integer; got {literal:?}");
@@ -1963,7 +1959,7 @@ impl<'a> FunctionContext<'a> {
 
     /// Generate a match constructor for a numeric type.
     fn gen_num_match_constructor(
-        &mut self,
+        &self,
         u: &mut Unstructured,
         typ: &Type,
     ) -> arbitrary::Result<Constructor> {

--- a/tooling/debugger/src/repl.rs
+++ b/tooling/debugger/src/repl.rs
@@ -101,7 +101,7 @@ impl<'a> AsyncReplDebugger<'a> {
         }
     }
 
-    fn send_status(&mut self, status: DebuggerStatus) {
+    fn send_status(&self, status: DebuggerStatus) {
         self.status_sender.send(status).expect("Downstream channel closed");
     }
 
@@ -170,25 +170,25 @@ impl<'a> AsyncReplDebugger<'a> {
                         Self::add_breakpoint_at_line(&mut context, line_number);
                     }
                     DebugCommandAPI::ShowVariables => {
-                        Self::show_variables(&mut context);
+                        Self::show_variables(&context);
                     }
                     DebugCommandAPI::ShowWitnessMap => {
-                        Self::show_witness_map(&mut context);
+                        Self::show_witness_map(&context);
                     }
                     DebugCommandAPI::ShowWitness(index) => {
-                        Self::show_witness(&mut context, index);
+                        Self::show_witness(&context, index);
                     }
                     DebugCommandAPI::ShowBrilligMemory => {
-                        Self::show_brillig_memory(&mut context);
+                        Self::show_brillig_memory(&context);
                     }
                     DebugCommandAPI::ShowCurrentCallStack => {
-                        self.show_current_call_stack(&mut context);
+                        self.show_current_call_stack(&context);
                     }
                     DebugCommandAPI::ShowOpcodes => {
-                        self.show_opcodes(&mut context);
+                        self.show_opcodes(&context);
                     }
                     DebugCommandAPI::ShowCurrentVmStatus => {
-                        self.show_current_vm_status(&mut context);
+                        self.show_current_vm_status(&context);
                     }
                     DebugCommandAPI::Terminate => {
                         self.terminate(context);
@@ -203,7 +203,7 @@ impl<'a> AsyncReplDebugger<'a> {
         }
     }
 
-    fn show_current_vm_status(&self, context: &mut Context<'_>) {
+    fn show_current_vm_status(&self, context: &Context<'_>) {
         let location = context.get_current_debug_location();
 
         match location {
@@ -242,7 +242,7 @@ impl<'a> AsyncReplDebugger<'a> {
 
     fn show_stack_frame(
         &self,
-        context: &mut Context<'_>,
+        context: &Context<'_>,
         index: usize,
         debug_location: &DebugLocation,
     ) {
@@ -271,7 +271,7 @@ impl<'a> AsyncReplDebugger<'a> {
         print_source_code_location(self.debug_artifact, &locations, self.raw_source_printing);
     }
 
-    fn show_current_call_stack(&mut self, context: &mut Context<'_>) {
+    fn show_current_call_stack(&self, context: &Context<'_>) {
         let call_stack = context.get_call_stack();
 
         if call_stack.is_empty() {
@@ -284,13 +284,13 @@ impl<'a> AsyncReplDebugger<'a> {
         }
     }
 
-    fn show_opcodes(&mut self, context: &mut Context<'_>) {
+    fn show_opcodes(&self, context: &Context<'_>) {
         for i in 0..self.circuits.len() {
             self.show_opcodes_of_circuit(context, i as u32);
         }
     }
 
-    fn show_opcodes_of_circuit(&mut self, context: &mut Context<'_>, circuit_id: u32) {
+    fn show_opcodes_of_circuit(&self, context: &Context<'_>, circuit_id: u32) {
         let current_opcode_location =
             context.get_current_debug_location().and_then(|debug_location| {
                 if debug_location.circuit_id == circuit_id {
@@ -441,7 +441,7 @@ impl<'a> AsyncReplDebugger<'a> {
         self.show_current_vm_status(context);
     }
 
-    fn show_witness_map(context: &mut Context<'_>) {
+    fn show_witness_map(context: &Context<'_>) {
         let witness_map = context.get_witness_map();
         // NOTE: we need to clone() here to get the iterator
         for (witness, value) in witness_map.clone().into_iter() {
@@ -449,7 +449,7 @@ impl<'a> AsyncReplDebugger<'a> {
         }
     }
 
-    fn show_witness(context: &mut Context<'_>, index: u32) {
+    fn show_witness(context: &Context<'_>, index: u32) {
         if let Some(value) = context.get_witness_map().get_index(index) {
             println!("_{index} = {value}");
         }
@@ -466,7 +466,7 @@ impl<'a> AsyncReplDebugger<'a> {
         println!("_{index} = {value}");
     }
 
-    fn show_brillig_memory(context: &mut Context<'_>) {
+    fn show_brillig_memory(context: &Context<'_>) {
         if !context.is_executing_brillig() {
             println!("Not executing a Brillig block");
             return;
@@ -508,7 +508,7 @@ impl<'a> AsyncReplDebugger<'a> {
         context.write_brillig_memory(index, field_value, bit_size);
     }
 
-    fn show_variables(context: &mut Context<'_>) {
+    fn show_variables(context: &Context<'_>) {
         let variables: Vec<DebugStackFrame<FieldElement>> =
             context.get_variables().iter().map(DebugStackFrame::from).collect();
         for frame in variables {

--- a/tooling/greybox_fuzzer/src/mutation/int.rs
+++ b/tooling/greybox_fuzzer/src/mutation/int.rs
@@ -407,7 +407,7 @@ impl<'a> IntMutator<'a> {
     }
 
     /// Negate a signed value
-    fn negate_signed_int(&mut self, input: &i128, width: u32) -> InputValue {
+    fn negate_signed_int(&self, input: &i128, width: u32) -> InputValue {
         InputValue::Field(match width {
             8 => neg_as_to_field::<i8>(input),
             16 => neg_as_to_field::<i16>(input),
@@ -542,7 +542,7 @@ impl<'a> IntMutator<'a> {
     }
 
     /// Negate an unsigned value
-    fn negate_unsigned_int(&mut self, input: &u128, width: u32) -> InputValue {
+    fn negate_unsigned_int(&self, input: &u128, width: u32) -> InputValue {
         InputValue::Field(match width {
             8 => wrapping_neg_as_to_field::<u8>(input),
             16 => wrapping_neg_as_to_field::<u16>(input),

--- a/tooling/nargo/src/foreign_calls/rpc.rs
+++ b/tooling/nargo/src/foreign_calls/rpc.rs
@@ -161,7 +161,7 @@ impl RPCForeignCallExecutor {
     }
 
     fn send_foreign_call<F>(
-        &mut self,
+        &self,
         foreign_call: &ForeignCallWaitInfo<F>,
     ) -> Result<ForeignCallResult<F>, jsonrpsee::core::ClientError>
     where

--- a/tooling/nargo_doc/src/links.rs
+++ b/tooling/nargo_doc/src/links.rs
@@ -108,7 +108,7 @@ impl LinkFinder {
 
     #[allow(clippy::too_many_arguments)]
     fn find_links_in_line(
-        &mut self,
+        &self,
         line: &str,
         line_number: usize,
         current_module_id: ModuleId,

--- a/tooling/ssa_fuzzer/fuzzer/src/fuzz_lib/block_context.rs
+++ b/tooling/ssa_fuzzer/fuzzer/src/fuzz_lib/block_context.rs
@@ -673,7 +673,7 @@ impl BlockContext {
     }
 
     /// Takes scalar from [`super::instruction::Scalar`] and converts it to [`noir_ssa_fuzzer::typed_value::Scalar`]
-    fn ssa_scalar_from_instruction_scalar(&mut self, scalar: InstructionScalar) -> Option<Scalar> {
+    fn ssa_scalar_from_instruction_scalar(&self, scalar: InstructionScalar) -> Option<Scalar> {
         let lo = self.get_stored_variable(&Type::Numeric(NumericType::Field), scalar.field_lo_idx);
         let hi = self.get_stored_variable(&Type::Numeric(NumericType::Field), scalar.field_hi_idx);
         match (lo, hi) {
@@ -684,7 +684,7 @@ impl BlockContext {
 
     /// Takes point from [`super::instruction::Point`] and converts it to [`noir_ssa_fuzzer::typed_value::Point`]
     fn ssa_point_from_instruction_point(
-        &mut self,
+        &self,
         builder: &mut FuzzerBuilder,
         point: InstructionPoint,
     ) -> Option<Point> {
@@ -702,7 +702,7 @@ impl BlockContext {
     }
 
     fn insert_array(
-        &mut self,
+        &self,
         builder: &mut FuzzerBuilder,
         elements_indices: Vec<usize>,
         element_type: Type,
@@ -739,7 +739,7 @@ impl BlockContext {
     /// * TypedValue
     /// * None if the instruction is not enabled or the array is not stored
     fn insert_array_get(
-        &mut self,
+        &self,
         builder: &mut FuzzerBuilder,
         array_index: usize,
         index: TypedValue,
@@ -791,7 +791,7 @@ impl BlockContext {
     /// * TypedValue referencing the new array
     /// * None if the instruction is not enabled or the array is not stored
     fn insert_array_set(
-        &mut self,
+        &self,
         builder: &mut FuzzerBuilder,
         array_index: usize,
         index: TypedValue,

--- a/tooling/ssa_fuzzer/fuzzer/src/fuzz_lib/function_context.rs
+++ b/tooling/ssa_fuzzer/fuzzer/src/fuzz_lib/function_context.rs
@@ -688,7 +688,7 @@ impl<'a> FuzzerFunctionContext<'a> {
     ///
     /// SSA block can use variables from predecessor that is not in branch. e.g. b7 can use variables from b4.
     /// This function is used to determine which block's variables can be inherited by merged block.
-    fn find_closest_parent(&mut self, lhs: &StoredBlock, rhs: &StoredBlock) -> BasicBlockId {
+    fn find_closest_parent(&self, lhs: &StoredBlock, rhs: &StoredBlock) -> BasicBlockId {
         for block in &lhs.context.parent_blocks_history {
             if rhs.context.parent_blocks_history.contains(block) {
                 return *block;


### PR DESCRIPTION
# Description

## Problem

Resolves https://cantina.xyz/code/8902524c-abe0-401a-92af-cf2ef468213d/findings?finding=13

## Summary

Instead of solving just this instance I wondered if there's a clippy rule for this... and there is one! So now it's enabled for all our code. I hope that's fine.

## Additional Context

In a few cases clippy is wrong, I think it's because `par_iter` is used. But just two cases need to be allowed.

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
