### PR TITLE
fix(doc): code block overflow

### DIFF
--- a/noir_stdlib/docs/styles.css
+++ b/noir_stdlib/docs/styles.css
@@ -139,6 +139,10 @@ ul.item-list, ul.sidebar-list {
     font-family: "Source Serif 4", NanumBarunGothic, serif;
 }
 
+.comments pre {
+    overflow: auto;
+}
+
 .comments code, .item-description code {
     background-color: var(--code-color);
     border-radius: 6px;

--- a/tooling/nargo_doc/src/styles.css
+++ b/tooling/nargo_doc/src/styles.css
@@ -139,6 +139,10 @@ ul.item-list, ul.sidebar-list {
     font-family: "Source Serif 4", NanumBarunGothic, serif;
 }
 
+.comments pre {
+    overflow: auto;
+}
+
 .comments code, .item-description code {
     background-color: var(--code-color);
     border-radius: 6px;


### PR DESCRIPTION
# Description

## Problem

Another thing noticed by Nico.

## Summary

Before:

<img width="1528" height="129" alt="image" src="https://github.com/user-attachments/assets/86015253-085c-4734-9837-f2a807522c3e" />

After:

![comment-overflow](https://github.com/user-attachments/assets/134245e1-16bf-4cc4-9f2c-4d9a50757b8c)

## Additional Context



## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
