### PR TITLE
fix: check --program-directory exists and is a directory

### DIFF
--- a/tooling/nargo_cli/src/cli/mod.rs
+++ b/tooling/nargo_cli/src/cli/mod.rs
@@ -235,6 +235,13 @@ where
     C: WorkspaceCommand,
     R: FnOnce(C, Workspace) -> Result<(), CliError>,
 {
+    if !config.program_dir.exists() {
+        return Err(CliError::ProgramDirDoesNotExist(config.program_dir));
+    }
+    if !config.program_dir.is_dir() {
+        return Err(CliError::ProgramDirIsNotADirectory(config.program_dir));
+    }
+
     // All commands need to run on the workspace level, because that's where the `target` directory is.
     let workspace_dir = nargo_toml::find_root(&config.program_dir, true)?;
     let package_dir = nargo_toml::find_root(&config.program_dir, false)?;

--- a/tooling/nargo_cli/src/errors.rs
+++ b/tooling/nargo_cli/src/errors.rs
@@ -14,6 +14,12 @@ pub enum CliError {
     #[error("Error: destination {} already exists\n\nUse `new init` to initialize the directory", .0.display())]
     DestinationAlreadyExists(PathBuf),
 
+    #[error("Error: --program-directory '{}' does not exist", .0.display())]
+    ProgramDirDoesNotExist(PathBuf),
+
+    #[error("Error: --program-directory '{}' is not a directory", .0.display())]
+    ProgramDirIsNotADirectory(PathBuf),
+
     #[error(
         "Error: `nargo init` cannot be run on existing packages.\nNote: `Nargo.toml` already exists."
     )]


### PR DESCRIPTION
# Description

## Problem

Resolves #10133

## Summary



## Additional Context



## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
