### PR TITLE
chore(frontend): Clearer error for missing unsafe block

### DIFF
--- a/compiler/noirc_frontend/src/hir/type_check/errors.rs
+++ b/compiler/noirc_frontend/src/hir/type_check/errors.rs
@@ -205,7 +205,7 @@ pub enum TypeCheckError {
     #[error("Functions cannot be returned from an unconstrained runtime to a constrained runtime")]
     UnconstrainedFunctionReturnToConstrained { location: Location },
     #[error(
-        "Call to unconstrained function is unsafe and must be in an unconstrained function or unsafe block"
+        "Call to unconstrained function from constrained function is unsafe and must be in an unconstrained function or unsafe block"
     )]
     Unsafe { location: Location },
     #[error("Converting an unconstrained fn to a non-unconstrained fn is unsafe")]

--- a/tooling/nargo_cli/tests/snapshots/compile_failure/brillig_vec_to_acir/execute__tests__stderr.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_failure/brillig_vec_to_acir/execute__tests__stderr.snap
@@ -23,7 +23,7 @@ warning: use of deprecated function push
    │         ------ std::collections::vec::Vec is deprecated, use the built-in vector type instead
    │
 
-error: Call to unconstrained function is unsafe and must be in an unconstrained function or unsafe block
+error: Call to unconstrained function from constrained function is unsafe and must be in an unconstrained function or unsafe block
   ┌─ src/main.nr:5:13
   │
 5 │     new_x = clear(x, y);

--- a/tooling/nargo_cli/tests/snapshots/compile_failure/brillig_vector_to_acir/execute__tests__stderr.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_failure/brillig_vector_to_acir/execute__tests__stderr.snap
@@ -16,7 +16,7 @@ warning: unused variable x
   │                        - unused variable
   │
 
-error: Call to unconstrained function is unsafe and must be in an unconstrained function or unsafe block
+error: Call to unconstrained function from constrained function is unsafe and must be in an unconstrained function or unsafe block
   ┌─ src/main.nr:5:13
   │
 5 │     new_x = clear(x, y);


### PR DESCRIPTION
# Description

## Problem

Resolves #10385 

## Summary

It makes sense that in `comptime` code we would not require `unsafe` and globals are evaluated in a comptime context. 

We should be explicit that an unsafe block is for when we cross from the constrained -> unconstrained boundary. I also added the test from #10385 as a passing regression test.

Another option would be to require `unsafe` from `comptime` as well. Although this feels like overkill. 

## Additional Context

## User Documentation

Check one:
- [X] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
