### PR TITLE
fix: Check NamedGenerics by id, not name

### DIFF
--- a/compiler/noirc_frontend/src/hir_def/types/unification.rs
+++ b/compiler/noirc_frontend/src/hir_def/types/unification.rs
@@ -99,13 +99,6 @@ impl Type {
     ) -> Result<(), UnificationError> {
         use Type::*;
 
-        // If the two types are exactly the same then they trivially unify.
-        // This check avoids potentially unifying very complex types (usually infix
-        // expressions) when they are the same.
-        if self == other {
-            return Ok(());
-        }
-
         let lhs = self.follow_bindings_shallow();
         let rhs = other.follow_bindings_shallow();
 

--- a/compiler/noirc_frontend/src/tests/traits/trait_associated_items.rs
+++ b/compiler/noirc_frontend/src/tests/traits/trait_associated_items.rs
@@ -538,3 +538,31 @@ fn associated_and_type_mismatch_across_traits() {
     "#;
     check_errors(src);
 }
+
+#[test]
+fn associated_mismatch_with_identical_names() {
+    // Error message is confusing here but it is an improvement over no error
+    let src = r#"
+        pub mod one {
+            pub trait Eggs {
+                type Item;
+                fn give() -> Self::Item;
+            }
+        }
+
+        pub mod two {
+            pub trait Eggs {
+                type Item;
+                fn take(eggs: Self::Item);
+            }
+        }
+
+        pub fn mix<T: one::Eggs + two::Eggs>() {
+            T::take(T::give());
+                    ^^^^^^^^^ Expected type <T as Eggs>::Item, found type <T as Eggs>::Item
+        }
+
+        fn main() {}
+    "#;
+    check_errors(src);
+}


### PR DESCRIPTION
# Description

## Problem

Inspired by https://github.com/noir-lang/noir/pull/11346#issuecomment-3806310923 (but still requires the fixes from that PR)
Resolves https://github.com/noir-lang/noir/issues/11358

## Summary

Changes type checking to stop relying on the names for NamedGenerics, which may be the same (at least, pre-Akosh's PRs) in some cases with different traits which each define associated types of the same name. Comparing integers should be faster than comparing strings anyway.

## Additional Context

~~Waiting to merge this until after @aakoshh's PRs to use the tests added there~~

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
