### PR TITLE
chore: a few more tests for field to i128

### DIFF
--- a/acvm-repo/acir_field/src/field_element.rs
+++ b/acvm-repo/acir_field/src/field_element.rs
@@ -481,6 +481,7 @@ impl Write for BitCounter {
 mod tests {
     use super::{AcirField, FieldElement};
     use proptest::prelude::*;
+    use std::ops::Neg;
 
     #[test]
     fn requires_zero_bit_to_hold_zero() {
@@ -657,17 +658,27 @@ mod tests {
         assert_eq!(F::zero().try_into_i128(), Some(0));
         assert_eq!(F::from(42_i128).try_into_i128(), Some(42));
         assert_eq!(F::from(i128::MAX).try_into_i128(), Some(i128::MAX));
+        assert_eq!(F::from(-i128::MAX).try_into_i128(), Some(-i128::MAX));
 
         // Valid negative conversions
         assert_eq!(F::from(-1_i128).try_into_i128(), Some(-1));
         assert_eq!(F::from(-42_i128).try_into_i128(), Some(-42));
         assert_eq!(F::from(i128::MIN + 1).try_into_i128(), Some(i128::MIN + 1));
-
+        assert_eq!(F::from(i128::MAX - 1).try_into_i128(), Some(i128::MAX - 1));
+        assert_eq!(F::from(1_i128 << 126).try_into_i128(), Some(1_i128 << 126));
+        assert_eq!(F::from(-((1_i128 << 126) - 1)).try_into_i128(), Some(-((1_i128 << 126) - 1)));
         // Invalid conversions
         assert_eq!(F::from(1_u128 << 127).try_into_i128(), None);
         assert_eq!(F::from(u128::MAX).try_into_i128(), None);
         // i128::MIN doesn't fit due to implementation
         assert_eq!(F::from(i128::MIN).try_into_i128(), None);
+        // A few other invalid values
+        assert_eq!(F::from((1_u128 << 127) + 1).try_into_i128(), None);
+        assert_eq!(F::from((1_u128 << 127) + 1000).try_into_i128(), None);
+        assert_eq!(F::from(1_u128 << 127).neg().try_into_i128(), None);
+        assert_eq!(F::from((1_u128 << 127) + 1).neg().try_into_i128(), None);
+        assert_eq!(F::from((1_u128 << 127) + 100).try_into_i128(), None);
+        assert_eq!(F::from((1_u128 << 127) + 100).neg().try_into_i128(), None);
     }
 
     #[test]


### PR DESCRIPTION
# Description

## Problem

Resolves #11050 

## Summary
The issue is already solved by #10360, but while checking it was working properly, I tested a few more cases that I add here.


## Additional Context



## User Documentation

Check one:
- [X] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
