### PR TITLE
fix: dedicated block_id for return_data

### DIFF
--- a/compiler/noirc_evaluator/src/acir/mod.rs
+++ b/compiler/noirc_evaluator/src/acir/mod.rs
@@ -83,6 +83,11 @@ struct Context<'a> {
     /// Each acir memory block corresponds to a different SSA array.
     memory_blocks: HashMap<Id<Value>, BlockId>,
 
+    /// The BlockId dedicated to return_data
+    /// It is not managed by memory_blocks to ensure getting always a fresh block for return_data, even if
+    /// the SSA array has already been initialized to a block.
+    return_data_block_id: Option<BlockId>,
+
     /// Maps SSA values to BlockId's used internally for computing the accurate flattened
     /// index of non-homogenous arrays.
     /// See [arrays] for more information about the purpose of the type sizes array.
@@ -127,6 +132,7 @@ impl<'a> Context<'a> {
             acir_context,
             initialized_arrays: HashSet::default(),
             memory_blocks: HashMap::default(),
+            return_data_block_id: None,
             element_type_sizes_blocks: HashMap::default(),
             type_sizes_to_blocks: HashMap::default(),
             max_block_id: 0,

--- a/compiler/noirc_evaluator/src/acir/tests/mod.rs
+++ b/compiler/noirc_evaluator/src/acir/tests/mod.rs
@@ -397,6 +397,32 @@ fn databus() {
 }
 
 #[test]
+fn databus_deduplicate_call_and_return_data() {
+    // call_data and return_data are the same
+    let src = "
+    acir(inline) pure fn main f0 {
+    call_data(0): array: v1, indices: []
+    return_data: v1
+    b0(v0: Field):
+        v1 = make_array [v0] : [Field; 1]
+        return v1
+    }
+    ";
+    let program = ssa_to_acir_program(src);
+
+    // Check that RETURNDATA and CALLDATA are distinct blocks
+    assert_circuit_snapshot!(program, @r"
+    func 0
+    private parameters: [w0]
+    public parameters: []
+    return values: []
+    ASSERT w1 = w0
+    INIT RETURNDATA b0 = [w1]
+    INIT CALLDATA 0 b1 = [w0]
+    ");
+}
+
+#[test]
 fn blake3_slice_regression() {
     // Sanity check for blake3 black box call brillig codegen.
     let src = "


### PR DESCRIPTION
# Description

## Problem

Resolves #11319 

## Summary
Use a dedicated BlockId for return_data


## Additional Context



## User Documentation

Check one:
- [X] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
