### PR TITLE
chore: re-use original type

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/opt/remove_bit_shifts.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/remove_bit_shifts.rs
@@ -270,8 +270,7 @@ impl Context<'_, '_, '_> {
                 let add = BinaryOp::Add { unchecked: true };
                 let div_complement = self.insert_binary(lhs_sign_as_field, add, lhs_as_field);
                 let div_complement = self.insert_truncate(div_complement, bit_size, bit_size + 1);
-                let div_complement =
-                    self.insert_cast(div_complement, NumericType::signed(bit_size));
+                let div_complement = self.insert_cast(div_complement, lhs_typ);
                 // Performs the division on the adjusted complement (or the operand if positive)
                 let shifted_complement = self.insert_binary(div_complement, BinaryOp::Div, pow);
                 // For negative numbers, convert back to 2-complement by subtracting 1.


### PR DESCRIPTION
# Description

## Problem

Resolves #10984 

## Summary



## Additional Context



## User Documentation

Check one:
- [X] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
