### PR TITLE
chore: Early return in remove_if_else for functions without IfElse instructions

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/opt/remove_if_else.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/remove_if_else.rs
@@ -180,10 +180,10 @@ impl Context {
         let block = function.entry_block();
 
         // Early return if there is no IfElse instruction.
-        if function.dfg[block]
+        if !function.dfg[block]
             .instructions()
             .iter()
-            .all(|inst| !matches!(function.dfg[*inst], Instruction::IfElse { .. }))
+            .any(|inst| matches!(function.dfg[*inst], Instruction::IfElse { .. }))
         {
             return Ok(());
         }


### PR DESCRIPTION
# Description

## Problem

Resolves #10976

## Summary



## Additional Context



## User Documentation

Check one:
- [X] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
