### PR TITLE
fix(ssa): Tracking nested array aliases 

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/opt/mem2reg.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/mem2reg.rs
@@ -786,7 +786,7 @@ impl<'f> PerFunctionContext<'f> {
         }
     }
 
-    /// In order to handle nested arrays we need to recursively search for whether there 
+    /// In order to handle nested arrays we need to recursively search for whether there
     /// are any aliases contained within an array's elements.
     fn collect_array_aliases(
         &self,


### PR DESCRIPTION
# Description

## Problem

Resolves https://github.com/noir-lang/noir/security/advisories/GHSA-fch6-63xj-6qgm

## Summary

- Refactors `add_array_aliases` to `collect_array_aliases` where we return an `AliasSet` rather than mutating one. This was necessary as we now have to borrow `references: &Block`
- Properly handles non-constant arrays (e.g., `array_set` results) looking up tracked aliases using the aliases map rather than directly checking for SSA reference values
- Added a test from the PoC

## Additional Context



## User Documentation

Check one:
- [X] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
