### PR TITLE
fix(ssa): Mark known nested references as unknown when marking their outer references unknown

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/opt/mem2reg.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/mem2reg.rs
@@ -831,12 +831,13 @@ impl<'f> PerFunctionContext<'f> {
     fn mark_all_unknown(&self, values: &[ValueId], references: &mut Block) {
         for value in values {
             let typ = self.inserter.function.dfg.type_of_value(*value);
+            // We must recursively check composite types for a reference (e.g., array of references),
+            // as we still need to mark those internal references as unknown.
             if typ.contains_reference() {
                 let value = *value;
 
-                // If we have a nested reference (e.g. &mut &mut Field), recurse to invalidate
-                // what it points to. This is necessary because a callee could load this
-                // reference and mutate through the inner reference.
+                // If we have a nested reference (e.g., &mut &mut Field), recurse to invalidate what it points to.
+                // This is necessary because for example, a callee could load this reference and mutate through the inner reference.
                 if let Type::Reference(element) = &typ {
                     if element.contains_reference() {
                         if let Some(inner_ref) = references.get_known_value(value) {


### PR DESCRIPTION
# Description

## Problem

Resolves https://github.com/noir-lang/noir/security/advisories/GHSA-rh9h-x248-64rw

## Summary

When a nested reference is passed to a call, `mark_all_unknown` only invalidated the argument itself, not the memory reachable by dereferencing it. This caused mem2reg to retain stale known values for inner references that the callee could mutate. You can look at the advisory or tests in this PR to see the bug in SSA for.

Changes:
- In `mark_all_unknown`, when a nested reference is passed, get the known inner reference before calling set_unknown                                        
- Recursively call mark_all_unknown on the inner reference. This should let us handle arbitrary nesting depth. 
- Added the test from the advisory and another with deeper nesting

## Additional Context



## User Documentation

Check one:
- [X] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
