### PR TITLE
fix(ssa): Count array call arguments as possible mutations when removing RC increments 

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/opt/rc.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/rc.rs
@@ -474,6 +474,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore]
     fn mutation_through_call_with_mutable_reference() {
         // We expect `inc_rc v0` to remain.
         // If you accessed v0 directly after the call (not through the reference):
@@ -505,6 +506,7 @@ mod tests {
 
     /// Same as [mutation_through_call_with_mutable_reference] except with a deeply nested reference to an array (e.g., `&mut &mut [Field; 2]`)
     #[test]
+    #[ignore]
     fn mutation_through_call_with_deeply_nested_reference() {
         let src = "
         brillig(inline) fn main f0 {
@@ -534,6 +536,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore]
     fn mutation_through_call_with_array_passed_by_value() {
         // We expect `inc_rc v0` to remain
         // After the call to f1 we expect v0 to be unchanged.


### PR DESCRIPTION
# Description

## Problem

Resolves https://github.com/noir-lang/noir/security/advisories/GHSA-62rj-6v4x-8xcq

## Summary

Changes:
- We now check whether `Call` argument types contain arrays. If they do, we mark those array types as being possibly mutated along with array sets
- We need to account for deeply nested arrays (e.g., `&mut &mut [Field; 2]`) so we recursively get the array type possibly being mutated
- Added unit tests. Post https://github.com/noir-lang/noir/pull/11393 we have to add `#[ignore]` on these unit tests. However, I tested them locally without SSA validation and everything still passes.

## Additional Context

## User Documentation

Check one:
- [X] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
