### PR TITLE
chore: bump external pinned commits

### DIFF
--- a/.github/benchmark_projects.yml
+++ b/.github/benchmark_projects.yml
@@ -1,4 +1,4 @@
-define: &AZ_COMMIT 3bc986da25df117f91b133c4a370b214d3d88e96
+define: &AZ_COMMIT e4a6c70dc9e896f76fd4274d3d01e6ebd8f708c6
 projects:
   private-kernel-inner:
     repo: AztecProtocol/aztec-packages

--- a/EXTERNAL_NOIR_LIBRARIES.yml
+++ b/EXTERNAL_NOIR_LIBRARIES.yml
@@ -1,4 +1,4 @@
-define: &AZ_COMMIT 3bc986da25df117f91b133c4a370b214d3d88e96
+define: &AZ_COMMIT e4a6c70dc9e896f76fd4274d3d01e6ebd8f708c6
 libraries:
   noir_check_shuffle:
     repo: noir-lang/noir_check_shuffle


### PR DESCRIPTION

Automated update of the pinned commit of [aztec-packages](https://github.com/AztecProtocol/aztec-packages) repository against which we run benchmarks.
