### PR TITLE
chore(ssa): Skip emitting databus instructions for Brillig functions

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/function_builder/data_bus.rs
+++ b/compiler/noirc_evaluator/src/ssa/function_builder/data_bus.rs
@@ -211,15 +211,15 @@ impl FunctionBuilder {
         // Only decompose values into flat array_gets and build the data bus array
         // for ACIR functions. In Brillig, the data bus array is never created and
         // the flat array_get instructions would be dead code.
-        let is_acir = matches!(self.current_function.runtime(), RuntimeType::Acir(_));
-        if is_acir {
-            for value in values {
-                self.add_to_data_bus(*value, &mut databus);
-            }
+        if !matches!(self.current_function.runtime(), RuntimeType::Acir(_)) {
+            return DataBusBuilder { call_data_id, ..DataBusBuilder::new() };
+        }
+
+        for value in values {
+            self.add_to_data_bus(*value, &mut databus);
         }
         let len = databus.values.len() as u32;
-
-        let array = (len > 0 && is_acir).then(|| {
+        let array = (len > 0).then(|| {
             let array_type = Type::Array(Arc::new(vec![Type::field()]), SemanticLength(len));
             self.insert_make_array(databus.values, array_type)
         });

--- a/compiler/noirc_evaluator/src/ssa/ssa_gen/tests.rs
+++ b/compiler/noirc_evaluator/src/ssa/ssa_gen/tests.rs
@@ -603,3 +603,39 @@ fn for_loop_inclusive_max_value_to_max_value() {
     }
     ");
 }
+
+#[test]
+fn brillig_function_with_databus_array_input() {
+    let src = "
+    unconstrained fn main(x: call_data(0) [Field; 3]) {}
+    ";
+    let ssa = get_initial_ssa(src).unwrap();
+
+    // No databus instructions emitted for Brillig functions
+    assert_ssa_snapshot!(ssa, @r"
+    brillig(inline) fn main f0 {
+      b0(v0: [Field; 3]):
+        return
+    }
+    ");
+}
+
+#[test]
+fn acir_function_with_databus_array_input() {
+    let src = "
+    fn main(x: call_data(0) [Field; 3]) {}
+    ";
+    let ssa = get_initial_ssa(src).unwrap();
+
+    assert_ssa_snapshot!(ssa, @r"
+    acir(inline) fn main f0 {
+      call_data(0): array: v7, indices: [v0: 0]
+      b0(v0: [Field; 3]):
+        v2 = array_get v0, index u32 0 -> Field
+        v4 = array_get v0, index u32 1 -> Field
+        v6 = array_get v0, index u32 2 -> Field
+        v7 = make_array [v2, v4, v6] : [Field; 3]
+        return
+    }
+    ");
+}


### PR DESCRIPTION
# Description

## Problem

No issue but resolved a bug I was running into in https://github.com/noir-lang/noir/pull/7852

## Summary

In `initialize_data_bus`, the `add_to_data_bus` loop emits `array_get` and `cast` instructions that are dead code in Brillig functions, since the data bus array is used created for them: https://github.com/noir-lang/noir/blob/e0de7d63085f569207f5a421ab85e226d8bb64d6/compiler/noirc_evaluator/src/ssa/function_builder/data_bus.rs#L145 

Guard the loop with an ACIR runtime check so these unnecessary instructions are never emitted.

## Additional Context



## User Documentation

Check one:
- [X] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
