### PR TITLE
fix: clean up after foreign call resolver fails

### DIFF
--- a/tooling/nargo/src/ops/execute.rs
+++ b/tooling/nargo/src/ops/execute.rs
@@ -440,7 +440,7 @@ mod test {
                 NargoError::ForeignCallError(
                     ForeignCallError::ExternalResolverError(jsonrpsee::core::client::Error::Custom(error_message))
                 )
-                 if error_message == "ORACLE_CALL_BROKE".to_string()
+                 if error_message == *"ORACLE_CALL_BROKE"
             ),
             "Execution did not fail with expected message"
         );


### PR DESCRIPTION
# Description

## Problem

Resolves <!-- Link to GitHub Issue -->

## Summary

This PR resolves an issue where the executor does not correctly set its error state when a foreign call resolver returns an error. This resulted in the fuzzer being unable to access the failing witness map.

## Additional Context



## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
