### PR TITLE
feat(lsp): suggest function parameters

### DIFF
--- a/tooling/lsp/src/requests/completion/params.rs
+++ b/tooling/lsp/src/requests/completion/params.rs
@@ -1,0 +1,168 @@
+//! If the cursor is at the end of a function parameter name, suggest parameter names (and their types)
+//! that exists in the same module, impl or trait.
+use std::collections::HashSet;
+
+use noirc_frontend::{
+    ParsedModule,
+    ast::{NoirFunction, NoirTrait, Pattern, TraitItem, TypeImpl, UnresolvedTypeData},
+    parser::ItemKind,
+};
+
+use crate::requests::completion::{NodeFinder, name_matches, variable_completion_item};
+
+impl NodeFinder<'_> {
+    pub(super) fn try_complete_function_param_in_parsed_module(
+        &mut self,
+        parsed_module: &ParsedModule,
+    ) -> bool {
+        let functions = parsed_module.items.iter().filter_map(|item| {
+            if let ItemKind::Function(function) = &item.kind { Some(function) } else { None }
+        });
+
+        let function_and_name =
+            find_function_and_parameter_name_at_byte_index(functions.clone(), self.byte_index);
+        let Some((function, name)) = function_and_name else {
+            return false;
+        };
+
+        let names_to_exclude = names_to_exclude(function, name);
+
+        self.suggest_function_parameters(functions, name, names_to_exclude);
+
+        true
+    }
+
+    pub(super) fn try_complete_function_param_in_type_impl(
+        &mut self,
+        type_impl: &TypeImpl,
+    ) -> bool {
+        let functions =
+            type_impl.methods.iter().map(|(documented_method, _)| &documented_method.item);
+
+        let function_and_name =
+            find_function_and_parameter_name_at_byte_index(functions.clone(), self.byte_index);
+        let Some((function, name)) = function_and_name else {
+            return false;
+        };
+
+        let names_to_exclude = names_to_exclude(function, name);
+
+        self.suggest_function_parameters(functions, name, names_to_exclude);
+
+        true
+    }
+
+    pub(super) fn try_complete_function_param_in_trait(&mut self, trait_: &NoirTrait) -> bool {
+        // Since NoirTrait doesn't hold `NoirFunction`s we have to repeat a bit the code here.
+        let parameters_and_name = trait_.items.iter().find_map(|documented_item| {
+            if let TraitItem::Function { parameters, .. } = &documented_item.item {
+                for (name, _typ) in parameters {
+                    if self.byte_index == name.span().end() as usize {
+                        return Some((parameters, name.as_str()));
+                    }
+                }
+            }
+            None
+        });
+        let Some((parameters, name)) = parameters_and_name else {
+            return false;
+        };
+
+        let mut names_to_exclude = HashSet::new();
+        for (ident, _) in parameters {
+            if ident.as_str() != name {
+                names_to_exclude.insert(ident.to_string());
+            }
+        }
+
+        let mut suggested = HashSet::new();
+        for documented_item in &trait_.items {
+            if let TraitItem::Function { parameters, .. } = &documented_item.item {
+                for (ident, typ) in parameters {
+                    if matches!(typ.typ, UnresolvedTypeData::Error) {
+                        continue;
+                    };
+                    let param_name = ident.as_str();
+                    if names_to_exclude.contains(param_name) {
+                        continue;
+                    }
+
+                    if name_matches(param_name, name) {
+                        let label = format!("{param_name}: {typ}");
+                        if suggested.insert(label.clone()) {
+                            let item = variable_completion_item(label, None);
+                            self.completion_items.push(item);
+                        }
+                    }
+                }
+            }
+        }
+
+        true
+    }
+
+    fn suggest_function_parameters<'a>(
+        &mut self,
+        functions: impl Iterator<Item = &'a NoirFunction>,
+        name: &str,
+        names_to_exclude: HashSet<String>,
+    ) {
+        let mut suggested = HashSet::new();
+        for function in functions {
+            for parameter in function.parameters() {
+                let Pattern::Identifier(ident) = &parameter.pattern else {
+                    continue;
+                };
+                if matches!(parameter.typ.typ, UnresolvedTypeData::Error) {
+                    continue;
+                };
+                let param_name = ident.as_str();
+                if names_to_exclude.contains(param_name) {
+                    continue;
+                }
+
+                if name_matches(param_name, name) {
+                    let label = format!("{param_name}: {}", parameter.typ);
+                    if suggested.insert(label.clone()) {
+                        let item = variable_completion_item(label, None);
+                        self.completion_items.push(item);
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Tries to find a function parameter inside `functions` that is being autocompleted.
+/// Returns that function together with the parameter name, if found.
+fn find_function_and_parameter_name_at_byte_index<'a>(
+    mut functions: impl Iterator<Item = &'a NoirFunction>,
+    byte_index: usize,
+) -> Option<(&'a NoirFunction, &'a str)> {
+    functions.find_map(|function| {
+        for parameter in function.parameters() {
+            let Pattern::Identifier(ident) = &parameter.pattern else {
+                return None;
+            };
+            if byte_index == ident.span().end() as usize {
+                return Some((function, ident.as_str()));
+            }
+        }
+        None
+    })
+}
+
+// Don't suggest names of parameters that already exist in the given function,
+// unless it's the name currently being completed.
+fn names_to_exclude(function: &NoirFunction, name: &str) -> HashSet<String> {
+    let mut names_to_exclude = HashSet::new();
+    for parameter in function.parameters() {
+        let Pattern::Identifier(ident) = &parameter.pattern else {
+            continue;
+        };
+        if ident.as_str() != name {
+            names_to_exclude.insert(ident.to_string());
+        }
+    }
+    names_to_exclude
+}

--- a/tooling/lsp/src/requests/completion/tests.rs
+++ b/tooling/lsp/src/requests/completion/tests.rs
@@ -3521,4 +3521,79 @@ fn main() {
         // This used to suggest `use std::meta::ctstring::Append`, which is wrong
         assert_eq!(addition_text_edit.new_text, "use std::append::Append;\n");
     }
+
+    #[test]
+    async fn autocompletes_function_parameter_in_top_level_module() {
+        let src = r#"
+        fn one(he>|<)
+
+        fn two(hello: HelloWorld) {}
+        fn three(hello: HelloWorld) {}
+
+        mod moo {
+            fn four(help: Help) {}
+        }
+        "#;
+
+        assert_completion(src, vec![variable_completion_item("hello: HelloWorld", None)]).await;
+    }
+
+    #[test]
+    async fn does_not_suggest_parameter_that_exists_in_current_function() {
+        let src = r#"
+        fn one(hello: HelloWorld, he>|<)
+        "#;
+
+        assert_completion(src, vec![]).await;
+    }
+
+    #[test]
+    async fn autocompletes_function_parameter_in_submodule() {
+        let src = r#"
+        mod moo {
+            fn one(he>|<)
+
+            fn two(hello: HelloWorld) {}
+            fn three(hello: HelloWorld) {}
+        }
+
+        fn four(help: Help) {}
+        "#;
+
+        assert_completion(src, vec![variable_completion_item("hello: HelloWorld", None)]).await;
+    }
+
+    #[test]
+    async fn autocompletes_function_parameter_in_impl() {
+        let src = r#"
+        struct Foo {}
+
+        impl Foo {
+            fn one(he>|<)
+
+            fn two(hello: HelloWorld) {}
+            fn three(hello: HelloWorld) {}
+        }
+
+        fn four(help: Help) {}
+        "#;
+
+        assert_completion(src, vec![variable_completion_item("hello: HelloWorld", None)]).await;
+    }
+
+    #[test]
+    async fn autocompletes_function_parameter_in_trait() {
+        let src = r#"
+        trait Foo {
+            fn one(he>|<)
+
+            fn two(hello: HelloWorld) {}
+            fn three(hello: HelloWorld) {}
+        }
+
+        fn four(help: Help) {}
+        "#;
+
+        assert_completion(src, vec![variable_completion_item("hello: HelloWorld", None)]).await;
+    }
 }


### PR DESCRIPTION
# Description

## Problem

No issue, just something I like and enjoy while coding in Rust.

## Summary

I noticed that Rust will suggest parameter names, and their types, as you are typing a parameter name. I'm not sure what the logic is, but it seems to suggest parameters in the same "context" as you are now: the same module, the same trait, the same impl.

This is what this PR does.

Here it is in action in the card_game_contract:

![lsp-suggest-parameters](https://github.com/user-attachments/assets/9754ee95-2d08-4a6b-a67f-21adf71d2561)


## Additional Context


## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
