### PR TITLE
fix: don't evaluate global without value

### DIFF
--- a/test_programs/compile_failure/global_without_value/Nargo.toml
+++ b/test_programs/compile_failure/global_without_value/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "global_without_value"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.33.0"
+
+[dependencies]

--- a/test_programs/compile_failure/global_without_value/src/main.nr
+++ b/test_programs/compile_failure/global_without_value/src/main.nr
@@ -1,0 +1,3 @@
+pub  global X: [Field];
+
+fn main() {}

--- a/tooling/nargo_cli/tests/snapshots/compile_failure/global_without_value/execute__tests__stderr.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_failure/global_without_value/execute__tests__stderr.snap
@@ -1,0 +1,12 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: stderr
+---
+error: Expected the global to have a value
+  ┌─ src/main.nr:1:13
+  │
+1 │ pub  global X: [Field];
+  │             -
+  │
+
+Aborting due to 1 previous error


### PR DESCRIPTION
# Description

## Problem

Resolves #10824

## Summary



## Additional Context



## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
