### PR TITLE
feat: allow double colon for specifying type generics

### DIFF
--- a/compiler/noirc_frontend/src/parser/parser/generics.rs
+++ b/compiler/noirc_frontend/src/parser/parser/generics.rs
@@ -126,7 +126,7 @@ impl Parser<'_> {
         Some(UnresolvedGeneric::Numeric { ident, typ })
     }
 
-    /// GenericTypeArgs = ( '<' GenericTypeArgsList? '>' )
+    /// GenericTypeArgs = ( '<' GenericTypeArgsList? '>' )?
     ///
     /// GenericTypeArgsList = GenericTypeArg ( ',' GenericTypeArg )* ','?
     ///
@@ -139,6 +139,13 @@ impl Parser<'_> {
     /// OrderedTypeArg = TypeOrTypeExpression
     pub(super) fn parse_generic_type_args(&mut self) -> GenericTypeArgs {
         let mut generic_type_args = GenericTypeArgs::default();
+
+        // Allow `Type::<Generic>` and `Type<Generic>` as it's common to confuse them.
+        // The formatter will remove the double colon.
+        if self.at(Token::DoubleColon) && self.next_is(Token::Less) {
+            self.bump();
+        }
+
         if !self.eat_less() {
             return generic_type_args;
         }

--- a/compiler/noirc_frontend/src/parser/parser/path.rs
+++ b/compiler/noirc_frontend/src/parser/parser/path.rs
@@ -52,6 +52,12 @@ impl Parser<'_> {
         )
     }
 
+    pub(super) fn parse_path_for_named_type(&mut self) -> Option<Path> {
+        let allow_turbofish = false;
+        let allow_trailing_double_colon = false;
+        self.parse_path_impl(allow_turbofish, allow_trailing_double_colon)
+    }
+
     pub(super) fn parse_path_impl(
         &mut self,
         allow_turbofish: bool,

--- a/compiler/noirc_frontend/src/parser/parser/type_expression.rs
+++ b/compiler/noirc_frontend/src/parser/parser/type_expression.rs
@@ -1,6 +1,9 @@
 use crate::{
     BinaryTypeOperator,
-    ast::{GenericTypeArgs, UnresolvedType, UnresolvedTypeData, UnresolvedTypeExpression},
+    ast::{
+        GenericTypeArgKind, GenericTypeArgs, UnresolvedType, UnresolvedTypeData,
+        UnresolvedTypeExpression,
+    },
     parser::{ParserError, labels::ParsingRuleLabel},
     signed_field::SignedField,
     token::Token,
@@ -207,11 +210,20 @@ impl Parser<'_> {
         // If we end up with a Variable type expression, make it a Named type (they are equivalent),
         // but for testing purposes and simplicity we default to types instead of type expressions.
         Some(
-            if let UnresolvedTypeData::Expression(UnresolvedTypeExpression::Variable(path)) =
+            if let UnresolvedTypeData::Expression(UnresolvedTypeExpression::Variable(mut path)) =
                 typ.typ
             {
+                let generics = std::mem::take(&mut path.segments.last_mut().unwrap().generics);
+                let mut generic_type_args = GenericTypeArgs::default();
+                if let Some(generics) = generics {
+                    generic_type_args.ordered_args = generics;
+                    for _ in 0..generic_type_args.ordered_args.len() {
+                        generic_type_args.kinds.push(GenericTypeArgKind::Ordered);
+                    }
+                }
+
                 UnresolvedType {
-                    typ: UnresolvedTypeData::Named(path, GenericTypeArgs::default(), false),
+                    typ: UnresolvedTypeData::Named(path, generic_type_args, false),
                     location: span,
                 }
             } else {
@@ -286,7 +298,7 @@ impl Parser<'_> {
     fn parse_atom_type_or_type_expression(&mut self) -> Option<UnresolvedType> {
         let start_location = self.current_token_location;
 
-        if let Some(path) = self.parse_path() {
+        if let Some(path) = self.parse_path_for_named_type() {
             let generics = self.parse_generic_type_args();
             let typ = UnresolvedTypeData::Named(path, generics, false);
             let location = self.location_since(start_location);
@@ -374,8 +386,12 @@ impl Parser<'_> {
 
 fn type_to_type_expr(typ: UnresolvedType) -> Option<UnresolvedTypeExpression> {
     match typ.typ {
-        UnresolvedTypeData::Named(var, generics, _) => {
-            if generics.is_empty() {
+        UnresolvedTypeData::Named(mut var, generics, _) => {
+            // A named type with no named generic arguments can be turned into a Variable type expression
+            if generics.named_args.is_empty() {
+                if !generics.ordered_args.is_empty() {
+                    var.segments.last_mut().unwrap().generics = Some(generics.ordered_args);
+                }
                 Some(UnresolvedTypeExpression::Variable(var))
             } else {
                 None
@@ -388,7 +404,7 @@ fn type_to_type_expr(typ: UnresolvedType) -> Option<UnresolvedTypeExpression> {
 
 fn type_is_type_expr(typ: &UnresolvedType) -> bool {
     match &typ.typ {
-        UnresolvedTypeData::Named(_, generics, _) => generics.is_empty(),
+        UnresolvedTypeData::Named(_, generics, _) => generics.named_args.is_empty(),
         UnresolvedTypeData::Expression(..) => true,
         _ => false,
     }

--- a/compiler/noirc_frontend/src/parser/parser/types.rs
+++ b/compiler/noirc_frontend/src/parser/parser/types.rs
@@ -93,7 +93,7 @@ impl Parser<'_> {
             return Some(typ);
         }
 
-        if let Some(path) = self.parse_path_no_turbofish() {
+        if let Some(path) = self.parse_path_for_named_type() {
             let generics = if allow_generics {
                 self.parse_generic_type_args()
             } else {
@@ -448,6 +448,30 @@ mod tests {
         };
         assert_eq!(path.to_string(), "foo::Bar");
         assert!(generics.is_empty());
+    }
+
+    #[test]
+    fn parses_named_type_with_generics_without_double_colon() {
+        let src = "foo::Bar<i32>";
+        let typ = parse_type_no_errors(src);
+        let UnresolvedTypeData::Named(path, generics, _) = typ.typ else {
+            panic!("Expected a named type")
+        };
+        assert_eq!(path.to_string(), "foo::Bar");
+        assert_eq!(generics.ordered_args.len(), 1);
+        assert_eq!(generics.ordered_args[0].typ.to_string(), "i32");
+    }
+
+    #[test]
+    fn parses_named_type_with_generics_with_double_colon() {
+        let src = "foo::Bar::<i32>";
+        let typ = parse_type_no_errors(src);
+        let UnresolvedTypeData::Named(path, generics, _) = typ.typ else {
+            panic!("Expected a named type")
+        };
+        assert_eq!(path.to_string(), "foo::Bar");
+        assert_eq!(generics.ordered_args.len(), 1);
+        assert_eq!(generics.ordered_args[0].typ.to_string(), "i32");
     }
 
     #[test]

--- a/tooling/nargo_fmt/src/formatter/expression.rs
+++ b/tooling/nargo_fmt/src/formatter/expression.rs
@@ -588,7 +588,7 @@ impl ChunkFormatter<'_, '_> {
     fn format_constructor(&mut self, constructor: ConstructorExpression) -> ChunkGroup {
         let mut group = ChunkGroup::new();
         group.text(self.chunk(|formatter| {
-            formatter.format_type(constructor.typ);
+            formatter.format_type_in_expression(constructor.typ);
             formatter.write_space();
             formatter.write_left_brace();
         }));

--- a/tooling/nargo_fmt/src/formatter/generics.rs
+++ b/tooling/nargo_fmt/src/formatter/generics.rs
@@ -59,6 +59,12 @@ impl Formatter<'_> {
 
     pub(super) fn format_generic_type_args(&mut self, mut generics: GenericTypeArgs) {
         self.skip_comments_and_whitespace();
+
+        // Outside of expressions, the double colon is optional so we prefer to omit it
+        if self.is_at(Token::DoubleColon) {
+            self.bump();
+        }
+
         if self.token != Token::Less {
             return;
         }

--- a/tooling/nargo_fmt/src/formatter/types.rs
+++ b/tooling/nargo_fmt/src/formatter/types.rs
@@ -7,6 +7,16 @@ use super::Formatter;
 
 impl Formatter<'_> {
     pub(super) fn format_type(&mut self, typ: UnresolvedType) {
+        let in_expression = false;
+        self.format_type_impl(typ, in_expression);
+    }
+
+    pub(super) fn format_type_in_expression(&mut self, typ: UnresolvedType) {
+        let in_expression = true;
+        self.format_type_impl(typ, in_expression);
+    }
+
+    fn format_type_impl(&mut self, typ: UnresolvedType, in_expression: bool) {
         self.skip_comments_and_whitespace();
 
         match typ.typ {
@@ -40,11 +50,15 @@ impl Formatter<'_> {
                 if !generic_type_args.is_empty() {
                     self.skip_comments_and_whitespace();
 
-                    // Apparently some Named types with generics have `::` before the generics
-                    // while others don't, so we have to account for both cases.
                     if self.is_at(Token::DoubleColon) {
-                        self.write_token(Token::DoubleColon);
+                        // Inside expressions, specifying a type's generics requires a double colon.
+                        if in_expression {
+                            self.write_token(Token::DoubleColon);
+                        } else {
+                            self.bump();
+                        }
                     }
+
                     self.format_generic_type_args(generic_type_args);
                 }
             }
@@ -215,8 +229,15 @@ mod tests {
     }
 
     #[test]
-    fn format_named_type_with_generics() {
+    fn format_named_type_with_generics_without_double_colon() {
         let src = " foo :: bar < A,  B  =  Field , C = i32 , D , >";
+        let expected = "foo::bar<A, B = Field, C = i32, D>";
+        assert_format_type(src, expected);
+    }
+
+    #[test]
+    fn format_named_type_with_generics_with_double_colon() {
+        let src = " foo :: bar :: < A,  B  =  Field , C = i32 , D , >";
         let expected = "foo::bar<A, B = Field, C = i32, D>";
         assert_format_type(src, expected);
     }


### PR DESCRIPTION
# Description

## Problem

Resolves #11455

## Summary



## Additional Context



## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
