### PR TITLE
fix: preserve stores to references escaping via returned arrays in mem2reg

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/opt/mem2reg.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/mem2reg.rs
@@ -3093,41 +3093,170 @@ mod tests {
         assert_ssa_does_not_change(src, Ssa::mem2reg);
     }
 
-    // Regression test: Mem2Reg should not remove stores to references that escape
-    // via a returned array. Based on fuzzer-found bug where stores in b0 were removed
-    // even though the references were placed in an array and returned in b3.
-    #[test]
-    fn keep_store_to_reference_in_returned_array_across_branches() {
-        // Minimal reproduction of the failing pattern:
-        // - v7 and v9 are allocated and stored to in b0
-        // - Control flow branches (jmpif) to b1 or b2
-        // - Array containing v7, v9 is created and returned in b3
-        // - Mem2Reg must NOT remove the stores to v7 and v9
-        let src = r#"
-        brillig(inline) fn func_1 f0 {
-          b0(v2: [&mut u1; 3]):
-            v7 = allocate -> &mut u1
-            store u1 0 at v7
-            v9 = allocate -> &mut u1
-            store u1 0 at v9
-            v11 = array_get v2, index u32 2 -> &mut u1
-            v12 = load v11 -> u1
-            jmpif v12 then: b1, else: b2
-          b1():
-            v16 = array_get v2, index u32 1 -> &mut u1
-            jmp b3(v16)
-          b2():
-            v14 = array_get v2, index u32 0 -> &mut u1
-            jmp b3(v14)
-          b3(v6: &mut u1):
-            v17 = allocate -> &mut u1
-            store u1 1 at v17
-            v19 = make_array [v7, v9, v6, v17] : [&mut u1; 4]
-            return v19
-        }
-        "#;
+    /// Tests for `collect_terminator_value_aliases` which recursively collects
+    /// aliases for values used in block terminators (return, jmp, etc.).
+    mod terminator_value_aliases {
+        use super::*;
 
-        // The stores to v7 and v9 must be preserved since they escape via the returned array
-        assert_ssa_does_not_change(src, Ssa::mem2reg);
+        // Regression test: Mem2Reg should not remove stores to references that escape
+        // via a returned array. Based on fuzzer-found bug where stores in b0 were removed
+        // even though the references were placed in an array and returned in b3.
+        #[test]
+        fn keep_store_to_reference_in_returned_array_across_branches() {
+            // Minimal reproduction of the failing pattern:
+            // - v7 and v9 are allocated and stored to in b0
+            // - Control flow branches (jmpif) to b1 or b2
+            // - Array containing v7, v9 is created and returned in b3
+            // - Mem2Reg must NOT remove the stores to v7 and v9
+            let src = r#"
+            brillig(inline) fn func_1 f0 {
+              b0(v2: [&mut u1; 3]):
+                v7 = allocate -> &mut u1
+                store u1 0 at v7
+                v9 = allocate -> &mut u1
+                store u1 0 at v9
+                v11 = array_get v2, index u32 2 -> &mut u1
+                v12 = load v11 -> u1
+                jmpif v12 then: b1, else: b2
+              b1():
+                v16 = array_get v2, index u32 1 -> &mut u1
+                jmp b3(v16)
+              b2():
+                v14 = array_get v2, index u32 0 -> &mut u1
+                jmp b3(v14)
+              b3(v6: &mut u1):
+                v17 = allocate -> &mut u1
+                store u1 1 at v17
+                v19 = make_array [v7, v9, v6, v17] : [&mut u1; 4]
+                return v19
+            }
+            "#;
+
+            // The stores to v7 and v9 must be preserved since they escape via the returned array
+            assert_ssa_does_not_change(src, Ssa::mem2reg);
+        }
+
+        // Test that the recursive alias collection works for nested arrays.
+        // This extends keep_store_to_reference_in_returned_array_across_branches to verify
+        // that references nested within inner arrays are also properly tracked.
+        #[test]
+        fn keep_store_to_reference_in_returned_nested_array_across_branches() {
+            // Similar pattern to the non-nested test, but the references are placed in inner
+            // arrays which are then placed in an outer array that is returned.
+            // - v7 and v9 are allocated and stored to in b0
+            // - Control flow branches (jmpif) to b1 or b2
+            // - Inner arrays containing [v7] and [v9] are created
+            // - Outer array containing the inner arrays is created and returned in b3
+            // - Mem2Reg must NOT remove the stores to v7 and v9
+            let src = r#"
+            brillig(inline) fn func_1 f0 {
+              b0(v2: [&mut u1; 3]):
+                v7 = allocate -> &mut u1
+                store u1 0 at v7
+                v9 = allocate -> &mut u1
+                store u1 0 at v9
+                v11 = array_get v2, index u32 2 -> &mut u1
+                v12 = load v11 -> u1
+                jmpif v12 then: b1, else: b2
+              b1():
+                v16 = array_get v2, index u32 1 -> &mut u1
+                jmp b3(v16)
+              b2():
+                v14 = array_get v2, index u32 0 -> &mut u1
+                jmp b3(v14)
+              b3(v6: &mut u1):
+                v17 = allocate -> &mut u1
+                store u1 1 at v17
+                v20 = make_array [v7, v9] : [&mut u1; 2]
+                v21 = make_array [v6, v17] : [&mut u1; 2]
+                v22 = make_array [v20, v21] : [[&mut u1; 2]; 2]
+                return v22
+            }
+            "#;
+
+            // The stores to v7 and v9 must be preserved since they escape via the nested returned array
+            assert_ssa_does_not_change(src, Ssa::mem2reg);
+        }
+
+        // Test that the recursive alias collection works for non-homogeneous arrays
+        // containing a mix of references and primitive values.
+        #[test]
+        fn keep_store_to_reference_in_returned_non_homogeneous_array_across_branches() {
+            // Similar pattern to the other tests, but the returned array contains a mix
+            // of references and primitive values (tuples with both).
+            // - v7 and v9 are allocated and stored to in b0
+            // - Control flow branches (jmpif) to b1 or b2
+            // - Array containing tuples of (u32, &mut u1) is created and returned in b3
+            // - Mem2Reg must NOT remove the stores to v7 and v9
+            let src = r#"
+            brillig(inline) fn func_1 f0 {
+              b0(v2: [&mut u1; 3]):
+                v7 = allocate -> &mut u1
+                store u1 0 at v7
+                v9 = allocate -> &mut u1
+                store u1 0 at v9
+                v11 = array_get v2, index u32 2 -> &mut u1
+                v12 = load v11 -> u1
+                jmpif v12 then: b1, else: b2
+              b1():
+                v16 = array_get v2, index u32 1 -> &mut u1
+                jmp b3(v16)
+              b2():
+                v14 = array_get v2, index u32 0 -> &mut u1
+                jmp b3(v14)
+              b3(v6: &mut u1):
+                v17 = allocate -> &mut u1
+                store u1 1 at v17
+                v20 = make_array [u32 1, v7, u32 2, v9, u32 3, v6, u32 4, v17] : [(u32, &mut u1); 4]
+                return v20
+            }
+            "#;
+
+            // The stores to v7 and v9 must be preserved since they escape via the returned array
+            assert_ssa_does_not_change(src, Ssa::mem2reg);
+        }
+
+        // Test that the recursive alias collection works for arrays containing
+        // references to arrays (i.e., `[&mut [T; N]; M]`).
+        #[test]
+        fn keep_store_to_array_reference_in_returned_array_across_branches() {
+            // Similar pattern to the other tests, but the returned array contains
+            // references that point to arrays. Stores to those array references
+            // must be preserved.
+            // - v7 and v9 are allocated as references to arrays and stored to in b0
+            // - Control flow branches (jmpif) to b1 or b2
+            // - Array containing references [v7, v9, ...] is created and returned in b3
+            // - Mem2Reg must NOT remove the stores to v7 and v9
+            let src = r#"
+            brillig(inline) fn func_1 f0 {
+              b0(v2: [&mut [u1; 2]; 3]):
+                v7 = allocate -> &mut [u1; 2]
+                v8 = make_array [u1 0, u1 1] : [u1; 2]
+                store v8 at v7
+                v9 = allocate -> &mut [u1; 2]
+                v10 = make_array [u1 1, u1 0] : [u1; 2]
+                store v10 at v9
+                v11 = array_get v2, index u32 2 -> &mut [u1; 2]
+                v12 = load v11 -> [u1; 2]
+                v13 = array_get v12, index u32 0 -> u1
+                jmpif v13 then: b1, else: b2
+              b1():
+                v16 = array_get v2, index u32 1 -> &mut [u1; 2]
+                jmp b3(v16)
+              b2():
+                v14 = array_get v2, index u32 0 -> &mut [u1; 2]
+                jmp b3(v14)
+              b3(v6: &mut [u1; 2]):
+                v17 = allocate -> &mut [u1; 2]
+                v18 = make_array [u1 0, u1 0] : [u1; 2]
+                store v18 at v17
+                v19 = make_array [v7, v9, v6, v17] : [&mut [u1; 2]; 4]
+                return v19
+            }
+            "#;
+
+            // The stores to v7 and v9 must be preserved since they escape via the returned array
+            assert_ssa_does_not_change(src, Ssa::mem2reg);
+        }
     }
 }


### PR DESCRIPTION
# Description

## Problem

This PR fixes both of the fuzzing failures from https://github.com/noir-lang/noir/actions/runs/21657646702/job/62435681192

## Summary

When a `make_array` contains references from mixed sources (locally allocated and unknown/parameter references), alias analysis marks the array as having unknown aliases. This caused mem2reg to skip tracking stores to the locally allocated references, incorrectly removing them.

The fix recursively processes array constant elements when overall aliases are unknown, ensuring stores to elements with known aliases are preserved.

## Additional Context



## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
