### PR TITLE
fix: increment depth counter in follow_bindings to prevent stack overflow

### DIFF
--- a/compiler/noirc_frontend/src/hir_def/types.rs
+++ b/compiler/noirc_frontend/src/hir_def/types.rs
@@ -2630,10 +2630,11 @@ impl Type {
     ///
     /// Expected to be called on an instantiated type (with no Type::Foralls)
     pub fn follow_bindings(&self) -> Type {
-        fn helper(this: &Type, i: u32) -> Type {
+        fn helper(this: &Type, mut i: u32) -> Type {
             if i >= TYPE_RECURSION_LIMIT {
                 panic!("Type recursion limit reached - types are too large")
             }
+            i += 1;
             let recur = |typ| helper(typ, i);
 
             use Type::*;
@@ -3475,5 +3476,62 @@ impl PartialEq for Type {
             ) => lhs_var.id() == rhs_var.id(),
             _ => false,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Creates a tuple type nested to the specified depth.
+    /// For example, depth 3 creates: (((Field,),),)
+    fn create_nested_tuple(depth: usize) -> Type {
+        let mut typ = Type::FieldElement;
+        for _ in 0..depth {
+            typ = Type::Tuple(vec![typ]);
+        }
+        typ
+    }
+
+    #[test]
+    fn follow_bindings_on_shallow_tuple() {
+        // Depth 99 is within the limit
+        let typ = create_nested_tuple((TYPE_RECURSION_LIMIT - 1) as usize);
+        let result = typ.follow_bindings();
+        assert!(matches!(result, Type::Tuple(_)));
+    }
+
+    #[test]
+    #[should_panic(expected = "Type recursion limit reached - types are too large")]
+    fn follow_bindings_on_deeply_nested_tuple() {
+        // Depth 100 hits the limit
+        let typ = create_nested_tuple(TYPE_RECURSION_LIMIT as usize);
+        let _ = typ.follow_bindings();
+    }
+
+    /// Creates an array type nested to the specified depth.
+    /// For example, depth 3 creates: [[[Field; 1]; 1]; 1]
+    fn create_nested_array(depth: usize) -> Type {
+        let mut typ = Type::FieldElement;
+        for _ in 0..depth {
+            typ = Type::Array(Box::new(Type::Constant(1.into(), Kind::u32())), Box::new(typ));
+        }
+        typ
+    }
+
+    #[test]
+    fn follow_bindings_on_shallow_array() {
+        // Depth 99 is within the limit (siblings share depth)
+        let typ = create_nested_array((TYPE_RECURSION_LIMIT - 1) as usize);
+        let result = typ.follow_bindings();
+        assert!(matches!(result, Type::Array(_, _)));
+    }
+
+    #[test]
+    #[should_panic(expected = "Type recursion limit reached - types are too large")]
+    fn follow_bindings_on_deeply_nested_array() {
+        // Depth 100 hits the limit
+        let typ = create_nested_array(TYPE_RECURSION_LIMIT as usize);
+        let _ = typ.follow_bindings();
     }
 }

--- a/compiler/noirc_frontend/src/monomorphization/tests.rs
+++ b/compiler/noirc_frontend/src/monomorphization/tests.rs
@@ -460,6 +460,7 @@ fn multiple_trait_impls_with_different_instantiations() {
 #[should_panic(expected = "Type recursion limit reached - types are too large")]
 fn extreme_type_alias_chain_stack_overflow() {
     // Generate a chain of 2,000 type aliases programmatically
+    // This exercises follow_bindings_shallow which handles alias chains.
     // ```
     // type Alias2000 = u8;
     // type Alias1999 = Alias2000;
@@ -487,6 +488,31 @@ fn extreme_type_alias_chain_stack_overflow() {
             x
         }}
     "#
+    );
+
+    let _ = get_monomorphized(&src);
+}
+
+#[test]
+#[should_panic(expected = "Type recursion limit reached - types are too large")]
+fn deeply_nested_tuple_type_stack_overflow() {
+    // Generate deeply nested tuple types by wrapping values repeatedly.
+    // This exercises follow_bindings which handles nested type structures.
+    // Each wrap adds one level: Field -> (Field,) -> ((Field,),) -> ...
+    use crate::TYPE_RECURSION_LIMIT;
+    const DEPTH: usize = TYPE_RECURSION_LIMIT as usize + 10;
+
+    let mut body = String::from("let v0: Field = 1;\n");
+    for i in 1..=DEPTH {
+        body.push_str(&format!("    let v{i} = (v{},);\n", i - 1));
+    }
+
+    let src = format!(
+        r#"
+fn main() {{
+    {body}
+}}
+"#
     );
 
     let _ = get_monomorphized(&src);


### PR DESCRIPTION
# Description

## Problem

This PR fixes the issue raised in the call with veridise.

## Summary

The follow_bindings helper function had a bug where the depth counter `i` was checked but never incremented before being passed to the recursive closure. This meant deeply nested types could cause stack overflow instead of hitting the TYPE_RECURSION_LIMIT.

Added unit tests for follow_bindings with nested tuples and arrays, plus a Noir-based test that creates deeply nested tuple types.


For simplicity we only increment `i` as a measure of depth as opposed to as a measure of type complexity (array types which contain 2 types only increment `i` once)
## Additional Context



## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
