### PR TITLE
fix: Update workspace documentation for libraries

### DIFF
--- a/docs/versioned_docs/version-v1.0.0-beta.18/noir/modules_packages_crates/workspaces.md
+++ b/docs/versioned_docs/version-v1.0.0-beta.18/noir/modules_packages_crates/workspaces.md
@@ -40,7 +40,7 @@ current directory where `nargo` was invoked.
 
 `default-member` indicates which package various commands process by default.
 
-Libraries can be defined in a workspace. Inside a workspace, these are consumed as `{ path = "../to_lib" }` dependencies in Nargo.toml.
+Libraries can be defined in a workspace.
 
 Inside a workspace, these are consumed as `{ path = "../to_lib" }` dependencies in Nargo.toml.
 


### PR DESCRIPTION
# Description

removed duplicate sentence in `docs/noir/modules_packages_crates/workspaces`

## Problem

## Summary

## Additional Context

## User Documentation

Check one:
- [ ] No user documentation needed.
- [x] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
