### PR TITLE
fix: Stop mem2reg from removing stores to references which are aliased in the future

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/opt/mem2reg.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/mem2reg.rs
@@ -3326,7 +3326,7 @@ mod tests {
         assert_ssa_does_not_change(src, Ssa::mem2reg);
     }
 
-    // Variant of [ref_block_param_in_loop] using a nested reference instead
+    /// Variant of [ref_block_param_in_loop] using a nested reference instead
     #[test]
     fn nested_reference_in_loop() {
         let src = r#"


### PR DESCRIPTION
# Description

## Problem

Resolves https://github.com/noir-lang/noir/issues/11479

## Summary

See issue for more explanation - we were erroneously removing stores to references which only become aliased on loop iterations after the first one. E.g. if you `store` your reference to a nested one at the _end_ of a block it may become aliased, but we may have already removed a store in the current block. If the current block is part of a loop, this is an issue.

To fix this, I've delayed the alias check for removing store instructions until the end of mem2reg.

## Additional Context

The new mem2reg_simple pass is generating code like this which our current mem2reg is changing the results of.

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
