### PR TITLE
fix(ssa): Clear aliases when marking references unknown

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/opt/mem2reg.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/mem2reg.rs
@@ -914,11 +914,13 @@ impl<'f> PerFunctionContext<'f> {
                 }
 
                 references.set_unknown(value);
-                self.clear_aliases(references, value);
                 references.mark_value_used(value, self.inserter.function);
 
                 // If a reference is an argument to a call, the last load to that address and its aliases needs to remain.
                 references.keep_last_load_for(value);
+
+                // Clear aliases AFTER keep_last_load_for so it can still find the aliases to preserve
+                self.clear_aliases(references, value);
             }
         }
     }
@@ -3418,5 +3420,56 @@ mod tests {
         assert_eq!(result_after, expected_result, "result after mem2reg should still be 200");
 
         assert_ssa_does_not_change(src, Ssa::mem2reg);
+    }
+
+    /// When a reference is stored inside an array that is passed to a call,
+    /// the load after the call must be preserved (the callee can modify through the nested reference).
+    #[test]
+    fn call_with_nested_reference_parameter() {
+        // Simplified version of the original test case - a reference v2 is put inside an array v3
+        // which is passed to call f1. The load from v2 after the call must be preserved.
+        let src = r#"
+        acir(inline) fn main f0 {
+          b0():
+            v1 = allocate -> &mut Field
+            store Field 100 at v1
+            v2 = allocate -> &mut Field
+            store Field 200 at v2
+            v3 = make_array [v2] : [&mut Field; 1]
+            call f1(v3)
+            v5 = load v2 -> Field
+            return v5
+        }
+        acir(inline) fn foo f1 {
+          b0(v0: [&mut Field; 1]):
+            v2 = array_get v0, index u32 0 -> &mut Field
+            store Field 999 at v2
+            return
+        }
+        "#;
+
+        // The critical check: after mem2reg, the load after `call f1(v3)` must still exist.
+        // v2 is aliased through the array v3, so the call could modify it.
+        let ssa = Ssa::from_str(src).unwrap();
+        let ssa = ssa.mem2reg();
+        // v5 = load v1 must be preserved after `call f1(v3)` since f1 can modify through the nested reference
+        assert_ssa_snapshot!(ssa, @r"
+        acir(inline) fn main f0 {
+          b0():
+            v0 = allocate -> &mut Field
+            v1 = allocate -> &mut Field
+            store Field 200 at v1
+            v3 = make_array [v1] : [&mut Field; 1]
+            call f1(v3)
+            v5 = load v1 -> Field
+            return v5
+        }
+        acir(inline) fn foo f1 {
+          b0(v0: [&mut Field; 1]):
+            v2 = array_get v0, index u32 0 -> &mut Field
+            store Field 999 at v2
+            return
+        }
+        ");
     }
 }


### PR DESCRIPTION
# Description

## Problem

No issue, as the bug was found when debugging another issue. The bug is contained in the unit test added in this PR.

## Summary

- Fixes a bug where mem2reg incorrectly removed stores to references that were passed to function calls in loops
- When `mark_all_unknown` sets a reference's value to unknown, it now also clears the alias set
- Without this fix, the deferred store removal logic saw a "single alias" and incorrectly removed the store

#### Root Cause

When a reference is passed to a call, `mark_all_unknown` is invoked to invalidate the known value. However, it did not clear the alias set. This caused the deferred removal check (`single_alias().is_some()`) to return `true`, leading to incorrect store removal when the called function could have established additional aliases.

## Additional Context

This needed https://github.com/noir-lang/noir/pull/11480 as well to work.  

## User Documentation

Check one:
- [X] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
