### PR TITLE
fix: utf-8 length for fmtstr

### DIFF
--- a/compiler/noirc_frontend/src/lexer/lexer.rs
+++ b/compiler/noirc_frontend/src/lexer/lexer.rs
@@ -603,7 +603,7 @@ impl<'a> Lexer<'a> {
                         // This might look a bit strange, but if there's `{{` or `}}` in the format string
                         // then it will be `{` and `}` in the string fragment respectively, but on the codegen
                         // phase it will be translated back to `{{` and `}}` to avoid executing an interpolation,
-                        // thus the actual length of the codegen'd string will be one more than what we get here.
+                        // thus the length of `{{` and `}}` need to be counted as 2.
                         //
                         // We could just make the fragment include the double curly braces, but then the interpreter
                         // would need to undo the curly braces, so it's simpler to add them during codegen.


### PR DESCRIPTION
# Description

## Problem

Resolves an inconsistency in the ftmstr length for UTF-8 content

## Summary

## Additional Context



## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
