### PR TITLE
fix(browser): Disable web security in the `browser` test

### DIFF
--- a/examples/browser/browser.test.ts
+++ b/examples/browser/browser.test.ts
@@ -56,11 +56,19 @@ function createStaticServer(rootDir: string): http.Server {
   });
 }
 
+// Barretenberg fetches CRS data from https://crs.aztec.network/ which doesn't
+// serve CORS headers. Disable web security so these cross-origin fetches work.
+// It should return a `Access-Control-Allow-Origin: *` header to make it work.
+test.use({
+  launchOptions: {
+    args: ['--disable-web-security'],
+  },
+});
+
 test.describe('Noir Web App', () => {
   test.beforeAll(async () => {
     // Serve the pre-built files from the dist directory
     const distDir = resolve(__dirname, 'dist');
-
     // Start static file server for the already built files
     server = createStaticServer(distDir);
     await new Promise<void>((resolve) => {

--- a/examples/browser/index.js
+++ b/examples/browser/index.js
@@ -21,8 +21,11 @@ const show = (id, content) => {
 document.getElementById('submit').addEventListener('click', async () => {
   try {
     // docs:start:init
+    show('logs', 'Creating Noir...');
     const noir = new Noir(circuit);
+    show('logs', 'Creating Barretenberg...');
     const barretenbergAPI = await Barretenberg.new();
+    show('logs', 'Creating UltraHonkBackend...');
     const backend = new UltraHonkBackend(circuit.bytecode, barretenbergAPI);
     // docs:end:init
     // docs:start:execute


### PR DESCRIPTION
# Description

## Problem

`just run-example browser` fails in https://github.com/noir-lang/noir/pull/11417 and https://github.com/noir-lang/noir/pull/11509 as well. On the mainframe it fails on `master`. Not sure why it didn't fail on `master` in CI.

## Summary

Changes the `browser` example to disable web security, so that it can fetch the Common Reference String from `https://crs.aztec.network/g1.dat` and `g2.dat` when it creates the Barretenberg API. 

## Additional Context

The tests under compiler/integration-tests/test/browser also use `await Barretenberg.new()`, but it doesn't fail there, because the `web-test-runner.config.mjs` file sets up a middleware proxy which attaches the following headers:
```
ctx.set('Cross-Origin-Opener-Policy', 'same-origin');
ctx.set('Cross-Origin-Embedder-Policy', 'require-corp');
```

In the `browser` example, Playwright goes directly to `crc.aztec.network`, which doesn't serve the `Access-Control-Allow-Origin: *` header, and thus the Chromium browser started for the test fails. 

Adding this to the test helped see the error:
```
    page.on('console', msg => console.log(`BROWSER [${msg.type()}]: ${msg.text()}`));
    page.on('pageerror', err => console.log(`BROWSER ERROR: ${err.message}`));
```

This also happens if we start a Python server:
```
cd examples/browser/dist && python3 -m http.server 8080
```
When I opened the page in Safari I saw CORS failures with `g1.dat`, and I had to disable CORS in the developer options to make the page work.



## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
