### PR TITLE
chore: add regression to ensure array_get optimization is valid

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/ir/dfg/simplify.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/dfg/simplify.rs
@@ -374,9 +374,7 @@ fn optimize_length_one_array_read(
 /// We want to optimize `v4` to `11`. To do this we need to follow the array value
 /// through several array sets. For each array set:
 /// - If the index is non-constant we fail the optimization since any index may be changed
-/// - If the index is constant and is our target index, we conservatively fail the optimization
-///   in case the array_set is disabled from a previous `enable_side_effects_if` and the array get
-///   was not.
+///
 /// - Otherwise, we check the array value of the array set.
 ///   - If the array value is constant, we use that array.
 ///   - If the array value is from a previous array-set, we recur.
@@ -385,6 +383,10 @@ fn optimize_length_one_array_read(
 /// That is, we have multiple `array_set` instructions setting various constant indexes
 /// of the same array, returning a modified version. We want to go backwards until we
 /// find the last `array_set` for the index we are interested in, and return the value set.
+///
+/// This optimization should be disabled in case of array-set is under an `enable_side_effects_if`
+/// In that case, array-get are Loads before flattening and IfElse after, so the optimization will
+/// not apply.
 fn try_optimize_array_get_from_previous_set(
     dfg: &mut DataFlowGraph,
     mut array_id: ValueId,

--- a/test_programs/execution_success/array_get_conditional_set/Nargo.toml
+++ b/test_programs/execution_success/array_get_conditional_set/Nargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "array_get_conditional_set"
+type = "bin"
+authors = [""]
+
+[dependencies]

--- a/test_programs/execution_success/array_get_conditional_set/Prover.toml
+++ b/test_programs/execution_success/array_get_conditional_set/Prover.toml
@@ -1,0 +1,1 @@
+condition = false

--- a/test_programs/execution_success/array_get_conditional_set/src/main.nr
+++ b/test_programs/execution_success/array_get_conditional_set/src/main.nr
@@ -1,0 +1,17 @@
+// Test that try_optimize_array_get_from_previous_set does not 
+// optimizes away an array_get when the preceding array_set
+// might be disabled by enable_side_effects_if
+
+fn main(condition: bool) {
+    let mut arr = [1, 2, 3];
+
+    // This array_set should be disabled when condition is false.
+    if condition {
+        arr[0] = 10;
+    }
+
+    // And then prevent to optimize the array-get with 10.
+    let val = arr[0];
+    assert(val == 1); 
+
+}


### PR DESCRIPTION

# Description

## Problem

Resolves https://ai.cantina.xyz/share/M8ptl1OQrTupbd8JiV0HrY-_yeqbrn-xa4Doh99LGB0/view?scanId=d3ca5ea4-1e0e-4943-8a82-11523cacab30&findingId=70fed138-29b7-41b5-89c2-5926714b4508

## Summary
The reported issue mentions that `try_optimize_array_get_from_previous_set()` should not optimise array_get with a conditional array_set.
This is correct, and it is what happens currently.
So I did not change the implementation but rather added a test that check that it works explicitly.


## Additional Context
The reason the issue was reported is because `try_optimize_array_get_from_previous_set()` does not check for `enable_side_effect` at all. Instead it relies on the fact that accessing arrays from a conditional branch will never lead to an array-set, but rather:
- a Load instruction, or
- an IfElse instruction, or
- an arithmetic operation (when IfElse are removed).

Since there is no explicit check, this statement may become incorrect in the future (due to changes in the code), so I added an integration test to validate explicitely that reading an array after a conditional array_set works.


## User Documentation

Check one:
- [X] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
