### PR TITLE
fix(ssa): use `for_each_value_alias` in mem2reg `Call` handler for `instruction_input_references`

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/opt/mem2reg.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/mem2reg.rs
@@ -3530,7 +3530,7 @@ mod tests {
 
         // This test checks the Call instruction path: to ensure that when a call argument
         // is an array with unknown combined aliases, stores to those elements are
-        // not incorrectly removed. 
+        // not incorrectly removed.
         //
         // This test directly checks the `instruction_input_references` set because the bug
         // is currently masked at the store-removal stage by `mark_all_unknown` → `clear_aliases`


### PR DESCRIPTION
# Description

## Problem

Resolves <!-- Link to GitHub Issue -->

## Summary

This is continuing the work in #11494 in another instance of the same issue.

When a Call argument is an array with unknown combined aliases (e.g. mixing a block-parameter reference with a locally allocated reference), `get_aliases_for_value().iter()` yields nothing because `AliasSet::iter()` returns an empty iterator for the unknown state. This means element aliases are not added to `instruction_input_references`, which could cause incorrect store removal if other conservative mechanisms change.

This PR replaces the `.iter()` call with `for_each_value_alias`, which recurses into array constant elements when the combined alias set is unknown, matching the fix already applied to the Store and IfElse handlers.

## Additional Context

I've needed to have the test inspect the internal state of the mem2reg pass directly as this error is caught by the `mark_all_unknown` call.

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
