### PR TITLE
fix: fmtstr length measurement

### DIFF
--- a/compiler/noirc_frontend/src/lexer/lexer.rs
+++ b/compiler/noirc_frontend/src/lexer/lexer.rs
@@ -597,7 +597,7 @@ impl<'a> Lexer<'a> {
                     };
 
                     string.push(char);
-                    length += 1;
+                    length += char.len_utf8() as u32;
 
                     if char == '{' || char == '}' {
                         // This might look a bit strange, but if there's `{{` or `}}` in the format string

--- a/test_programs/compile_success_empty/fmtstr_utf8_length/Nargo.toml
+++ b/test_programs/compile_success_empty/fmtstr_utf8_length/Nargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "fmtstr_utf8_length"
+type = "bin"
+authors = [""]
+
+[dependencies]

--- a/test_programs/compile_success_empty/fmtstr_utf8_length/src/main.nr
+++ b/test_programs/compile_success_empty/fmtstr_utf8_length/src/main.nr
@@ -1,0 +1,12 @@
+// Checks that fmtstr and string compute lengths consistently, by
+// measuring the byte length of the UTF-8 encoding.
+fn main() {
+    let _s: str<1> = "a";
+    let _f: fmtstr<1, _> = f"a";
+
+    let _s2: str<2> = "é";
+    let _f2: fmtstr<2, _> = f"é";
+
+    let _s3: str<3> = "中";
+    let _f3: fmtstr<3, _> = f"中";
+}


### PR DESCRIPTION
# Description

## Problem

Fmtstr and str length encoding was inconsistent – fmtstr counted utf-8 codepoints, str counts utf-8 bytes.

## Summary

This makes fmtstr count bytes

## Additional Context

Saying "no documentation needed" because it seems like the current behavior is undocumented anyway

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
