### PR TITLE
fix: lookup method in trait constraints for structs

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/types.rs
+++ b/compiler/noirc_frontend/src/elaborator/types.rs
@@ -2239,41 +2239,10 @@ impl Elaborator<'_> {
             return self.return_trait_method_in_scope(&generic_methods, method_name, location);
         }
 
-        if let Type::DataType(datatype, _) = object_type {
-            let datatype = datatype.borrow();
-            let mut has_field_with_function_type = false;
-
-            if let Some(fields) = datatype.fields_raw() {
-                has_field_with_function_type = fields
-                    .iter()
-                    .any(|field| field.name.as_str() == method_name && field.typ.is_function());
-            }
-
-            if has_field_with_function_type {
-                self.push_err(TypeCheckError::CannotInvokeStructFieldFunctionType {
-                    method_name: method_name.to_string(),
-                    object_type: object_type.clone(),
-                    location,
-                });
-            } else {
-                self.push_err(TypeCheckError::UnresolvedMethodCall {
-                    method_name: method_name.to_string(),
-                    object_type: object_type.clone(),
-                    location,
-                });
-            }
-            None
-        } else {
-            // It could be that this type is a composite type that is bound to a trait,
-            // for example `x: (T, U) ... where (T, U): SomeTrait`
-            // (so this case is a generalization of the NamedGeneric case)
-            self.lookup_method_in_trait_constraints(
-                object_type,
-                method_name,
-                location,
-                object_location,
-            )
-        }
+        // It could be that this type is a composite type that is bound to a trait,
+        // for example `x: (T, U) ... where (T, U): SomeTrait`
+        // (so this case is a generalization of the NamedGeneric case)
+        self.lookup_method_in_trait_constraints(object_type, method_name, location, object_location)
     }
 
     /// Given a list of functions and the trait they belong to, returns the one function
@@ -2503,13 +2472,33 @@ impl Elaborator<'_> {
             self.push_err(TypeCheckError::TypeAnnotationsNeededForMethodCall {
                 location: object_location,
             });
-        } else {
-            self.push_err(TypeCheckError::UnresolvedMethodCall {
-                method_name: method_name.to_string(),
-                object_type: object_type.clone(),
-                location,
-            });
+            return None;
         }
+
+        // Check if it's `foo.bar()` where `bar` is a member of the struct `foo`.
+        // In that case we tell the user that they need to write it like `(foo.bar)()`.
+        if let Type::DataType(datatype, _) = object_type {
+            let datatype = datatype.borrow();
+            let has_field_with_function_type = datatype.fields_raw().is_some_and(|fields| {
+                fields
+                    .iter()
+                    .any(|field| field.name.as_str() == method_name && field.typ.is_function())
+            });
+            if has_field_with_function_type {
+                self.push_err(TypeCheckError::CannotInvokeStructFieldFunctionType {
+                    method_name: method_name.to_string(),
+                    object_type: object_type.clone(),
+                    location,
+                });
+                return None;
+            }
+        }
+
+        self.push_err(TypeCheckError::UnresolvedMethodCall {
+            method_name: method_name.to_string(),
+            object_type: object_type.clone(),
+            location,
+        });
 
         None
     }

--- a/compiler/noirc_frontend/src/tests/traits/trait_bounds.rs
+++ b/compiler/noirc_frontend/src/tests/traits/trait_bounds.rs
@@ -602,56 +602,48 @@ fn errors_on_mutually_recursive_impls() {
     check_errors(src);
 }
 
-// Regression test for https://github.com/noir-lang/noir/issues/11514
 #[test]
-#[should_panic(expected = "Expected no errors")]
 fn where_clause_on_generic_struct_parameter() {
     let src = r#"
     pub trait E {
-        fn e(self) -> u32;
+        fn e(self);
     }
 
-    struct A<F> {
+    pub struct A<F> {
         f: F,
     }
 
-    struct F<G> {
+    pub struct F<G> {
         g: G,
     }
 
-    fn f<X>(w: A<F<X>>)
+    pub fn f<X>(w: A<F<X>>)
     where
         F<X>: E,
     {
         w.f.e();
     }
-
-    fn main() {}
     "#;
     assert_no_errors(src);
 }
 
-// Regression test for https://github.com/noir-lang/noir/issues/11514 (simplified)
 #[test]
-#[should_panic(expected = "Expected no errors")]
 fn where_clause_on_self_type_with_generic() {
     let src = r#"
     pub trait E {
-        fn e(self) -> u32;
+        fn e(self);
     }
 
-    struct A<F> {
+    pub struct A<F> {
         f: F,
     }
 
-    fn f<X>(a: A<X>)
+    pub fn f<X>(a: A<X>)
     where
         A<X>: E,
     {
         a.e();
     }
-
-    fn main() {}
     "#;
     assert_no_errors(src);
 }


### PR DESCRIPTION
# Description

## Problem

Resolves #11514

## Summary

The bug was that when we failed to find a method on a type, if that type was a struct we'd check if we were trying to call a method by using one of its field names... but regardless of whether this happened or not we stopped looking and never searched in the function's trait constraints.

The fix here is to move that "are we calling a method that has the name of a field" to after we tried searching in the trait constraints in scope.

## Additional Context



## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
