### PR TITLE
chore: bump timeout

### DIFF
--- a/EXTERNAL_NOIR_LIBRARIES.yml
+++ b/EXTERNAL_NOIR_LIBRARIES.yml
@@ -71,7 +71,7 @@ libraries:
     repo: AztecProtocol/aztec-packages
     ref: *AZ_COMMIT
     path: noir-projects/aztec-nr
-    timeout: 230
+    timeout: 250
     critical: false
   noir_contracts:
     repo: AztecProtocol/aztec-packages


### PR DESCRIPTION
# Description

## Problem

Resolves CI almost always failing because of a timeout

## Summary

It usually takes 225 seconds instead of 220. This bumps it to 230.

## Additional Context



## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
