### PR TITLE
chore: add regression tests for trait resolution issues

### DIFF
--- a/compiler/noirc_frontend/src/tests/traits/trait_associated_items.rs
+++ b/compiler/noirc_frontend/src/tests/traits/trait_associated_items.rs
@@ -1103,3 +1103,24 @@ fn fully_qualified_nested_associated_type() {
     ";
     check_errors(src);
 }
+
+/// Regression test for https://github.com/noir-lang/noir/issues/11538
+#[test]
+fn associated_constant_can_reference_generic_from_trait_bound() {
+    let src = r#"
+    pub trait E {
+        let x: u32;
+    }
+
+    pub struct A<F> {
+        pub f: F,
+    }
+
+    impl<X: E> E for A<X> {
+        let x: u32 = X::x;
+    }
+
+    fn main() {}
+    "#;
+    assert_no_errors(src);
+}

--- a/compiler/noirc_frontend/src/tests/traits/trait_method_resolution.rs
+++ b/compiler/noirc_frontend/src/tests/traits/trait_method_resolution.rs
@@ -770,3 +770,33 @@ fn regression_10766() {
     "#;
     check_errors(src);
 }
+
+/// Regression test for https://github.com/noir-lang/noir/issues/11540
+#[test]
+#[should_panic(expected = "Expected no errors")]
+fn trait_method_resolved_with_multiple_impls_different_type_params() {
+    let src = r#"
+    pub struct Foo<let Y: u32, A> {}
+
+    pub trait Bar {
+        comptime fn bar();
+    }
+
+    impl<let X: u32> Bar for Foo<X, u8> {
+        comptime fn bar() {}
+    }
+
+    impl<let X: u32> Bar for Foo<X, u16> {
+        comptime fn bar() {}
+    }
+
+    fn g<let Z: u32>() {
+        Foo::<Z, u8>::bar();
+    }
+
+    fn main() {
+        g::<1>();
+    }
+    "#;
+    assert_no_errors(src);
+}

--- a/compiler/noirc_frontend/src/tests/traits/trait_qualified_paths.rs
+++ b/compiler/noirc_frontend/src/tests/traits/trait_qualified_paths.rs
@@ -533,3 +533,26 @@ fn self_resolves_correctly_when_multiple_trait_impls_exist() {
     "#;
     assert_no_errors(src);
 }
+
+/// Regression test for https://github.com/noir-lang/noir/issues/11539
+#[test]
+fn generic_substitution_with_turbofish_trait_method() {
+    let src = r#"
+    pub struct Foo<let Y: u32> {}
+
+    pub trait Bar {
+        comptime fn bar();
+    }
+
+    impl<let X: u32> Bar for Foo<X> {
+        comptime fn bar() {}
+    }
+
+    pub fn f<let X: u32>() {
+        Foo::<X>::bar();
+    }
+
+    fn main() {}
+    "#;
+    assert_no_errors(src);
+}


### PR DESCRIPTION

# Description

## Problem

Resolves #11538
Resolves #11539

## Summary

This PR adds some regression tests for the issues #11538, #11539, #11540.

The first two of these issues are already addressed in master, the last still exists so is set up as `should_panic`

## Additional Context



## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
