### PR TITLE
chore: add noir-frontend-tests skill for writing frontend unit tests

### DIFF
--- a/.claude/skills/noir-frontend-tests/SKILL.md
+++ b/.claude/skills/noir-frontend-tests/SKILL.md
@@ -124,6 +124,7 @@ fn descriptive_name() {
   - Fix: mark items `pub` to suppress "unused" warnings.
   - `pub struct`, `pub fn` for items not called from `main()`.
   - If a struct is pub but never constructed, that's still a warning — add `pub` to fields too, or construct it.
+  - Use the `_` placeholder to suppress unused variable warnings (e.g., an unused `x: u32` param becomes `_x: u32`)
 - **Always include `fn main() {}`**: Programs without `main` will fail differently.
 - **No stdlib by default**: `get_program` doesn't include the stdlib. Use `check_errors_with_stdlib` or `root_and_stdlib: true` if you need stdlib types/traits.
 - **Run command**: `cargo nextest run -p noirc_frontend -E 'test(test_name)'`


### PR DESCRIPTION
# Description

## Problem

Resolves <!-- Link to GitHub Issue -->

## Summary

This PR adds a skill to claude to give some best practices on writing tests for the frontend.

## Additional Context



## User Documentation

Check one:
- [ ] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
