### PR TITLE
chore: bring back comments that relate tests to issues

### DIFF
--- a/compiler/noirc_frontend/src/tests/traits/trait_bounds.rs
+++ b/compiler/noirc_frontend/src/tests/traits/trait_bounds.rs
@@ -602,6 +602,7 @@ fn errors_on_mutually_recursive_impls() {
     check_errors(src);
 }
 
+// Regression test for https://github.com/noir-lang/noir/issues/11514
 #[test]
 fn where_clause_on_generic_struct_parameter() {
     let src = r#"
@@ -627,6 +628,7 @@ fn where_clause_on_generic_struct_parameter() {
     assert_no_errors(src);
 }
 
+// Regression test for https://github.com/noir-lang/noir/issues/11514 (simplified)
 #[test]
 fn where_clause_on_self_type_with_generic() {
     let src = r#"


### PR DESCRIPTION
# Description

## Problem

No issue.

## Summary

In #11533 I deleted a couple of `should_panic` on tests, because now they pass, but I also deleted their link to some GitHub issues. I don't know why I did that, but I think it's better to keep that relationship.

## Additional Context



## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
