### PR TITLE
chore: only simplify ArrayGet from ArraySet in ValueMerger

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/ir/dfg.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/dfg.rs
@@ -322,9 +322,35 @@ impl DataFlowGraph {
             return InsertInstructionResult::InstructionRemoved;
         }
 
-        let simplify_result =
-            simplify(&instruction, self, block, ctrl_typevars.clone(), call_stack);
+        let skip_array_set_when_simplifying_array_get = true;
+        let simplify_result = simplify(
+            &instruction,
+            self,
+            block,
+            ctrl_typevars.clone(),
+            call_stack,
+            skip_array_set_when_simplifying_array_get,
+        );
 
+        self.handle_simplify_result(
+            simplify_result,
+            instruction,
+            block,
+            ctrl_typevars,
+            call_stack,
+            existing_id,
+        )
+    }
+
+    fn handle_simplify_result(
+        &mut self,
+        simplify_result: SimplifyResult,
+        instruction: Instruction,
+        block: BasicBlockId,
+        ctrl_typevars: Option<Vec<Type>>,
+        call_stack: CallStackId,
+        existing_id: Option<InstructionId>,
+    ) -> InsertInstructionResult<'_> {
         match simplify_result {
             SimplifyResult::SimplifiedTo(simplification) => {
                 InsertInstructionResult::SimplifiedTo(simplification)
@@ -393,6 +419,36 @@ impl DataFlowGraph {
                 )
             }
         }
+    }
+
+    pub(crate) fn insert_array_get_with_simplify(
+        &mut self,
+        array: ValueId,
+        index: ValueId,
+        block: BasicBlockId,
+        ctrl_typevars: Option<Vec<Type>>,
+        call_stack: CallStackId,
+    ) -> InsertInstructionResult<'_> {
+        let instruction = Instruction::ArrayGet { array, index };
+
+        let skip_array_set_when_simplifying_array_get = false;
+        let simplify_result = simplify(
+            &instruction,
+            self,
+            block,
+            ctrl_typevars.clone(),
+            call_stack,
+            skip_array_set_when_simplifying_array_get,
+        );
+
+        self.handle_simplify_result(
+            simplify_result,
+            instruction,
+            block,
+            ctrl_typevars,
+            call_stack,
+            None,
+        )
     }
 
     /// Replace an existing instruction with a new one.

--- a/compiler/noirc_evaluator/src/ssa/ir/dfg/simplify.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/dfg/simplify.rs
@@ -75,6 +75,7 @@ pub(crate) fn simplify(
     block: BasicBlockId,
     ctrl_typevars: Option<Vec<Type>>,
     call_stack: CallStackId,
+    skip_array_set_when_simplifying_array_get: bool,
 ) -> SimplifyResult {
     use SimplifyResult::*;
 
@@ -115,7 +116,12 @@ pub(crate) fn simplify(
         Instruction::ConstrainNotEqual(..) => None,
         Instruction::ArrayGet { array, index } => {
             if let Some(index) = dfg.get_numeric_constant(*index) {
-                return try_optimize_array_get_from_previous_set(dfg, *array, index);
+                return try_optimize_array_get_from_previous_instructions(
+                    dfg,
+                    *array,
+                    index,
+                    skip_array_set_when_simplifying_array_get,
+                );
             }
 
             let array_or_vector_type = dfg.type_of_value(*array);
@@ -357,7 +363,13 @@ fn optimize_length_one_array_read(
     );
     dfg.insert_instruction_and_results(index_constraint, block, None, call_stack);
 
-    let result = try_optimize_array_get_from_previous_set(dfg, array, FieldElement::zero());
+    let recurse = true;
+    let result = try_optimize_array_get_from_previous_instructions(
+        dfg,
+        array,
+        FieldElement::zero(),
+        recurse,
+    );
     if let SimplifyResult::None = result {
         SimplifyResult::SimplifiedToInstruction(Instruction::ArrayGet { array, index: zero })
     } else {
@@ -385,10 +397,11 @@ fn optimize_length_one_array_read(
 /// That is, we have multiple `array_set` instructions setting various constant indexes
 /// of the same array, returning a modified version. We want to go backwards until we
 /// find the last `array_set` for the index we are interested in, and return the value set.
-fn try_optimize_array_get_from_previous_set(
+fn try_optimize_array_get_from_previous_instructions(
     dfg: &mut DataFlowGraph,
     mut array_id: ValueId,
     target_index: FieldElement,
+    skip_array_set: bool,
 ) -> SimplifyResult {
     // The target index must be less than the maximum array length
     let Some(target_index_u32) = target_index.try_to_u32() else {
@@ -401,7 +414,7 @@ fn try_optimize_array_get_from_previous_set(
         if let Some(instruction) = dfg.get_local_or_global_instruction(array_id) {
             match instruction {
                 Instruction::ArraySet { array, index, value, .. } => {
-                    if let Some(constant) = dfg.get_numeric_constant(*index) {
+                    if !skip_array_set && let Some(constant) = dfg.get_numeric_constant(*index) {
                         if constant == target_index {
                             return SimplifyResult::SimplifiedTo(*value);
                         }

--- a/compiler/noirc_evaluator/src/ssa/ir/dfg/simplify/value_merger.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/dfg/simplify/value_merger.rs
@@ -172,9 +172,14 @@ impl<'a> ValueMerger<'a> {
                 let typevars = Some(vec![element_type.clone()]);
 
                 let mut get_element = |array, typevars| {
-                    let get = Instruction::ArrayGet { array, index };
                     self.dfg
-                        .insert_instruction_and_results(get, self.block, typevars, self.call_stack)
+                        .insert_array_get_with_simplify(
+                            array,
+                            index,
+                            self.block,
+                            typevars,
+                            self.call_stack,
+                        )
                         .first()
                 };
 
@@ -235,14 +240,15 @@ impl<'a> ValueMerger<'a> {
 
                 let mut get_element = |array, typevars, len: SemiFlattenedLength| {
                     assert!(index_u32 < len.0, "get_element invoked with an out of bounds index");
-                    let get = Instruction::ArrayGet { array, index };
-                    let results = self.dfg.insert_instruction_and_results(
-                        get,
-                        self.block,
-                        typevars,
-                        self.call_stack,
-                    );
-                    results.first()
+                    self.dfg
+                        .insert_array_get_with_simplify(
+                            array,
+                            index,
+                            self.block,
+                            typevars,
+                            self.call_stack,
+                        )
+                        .first()
                 };
 
                 // If it's out of bounds for the "then" vector, a value in the "else" *must* exist.


### PR DESCRIPTION
# Description

## Problem

Resolves a potential issue when ArrayGet is simplified.

## Summary

An ArrayGet might be simplified to reuse the value of a previous ArraySet. However, that ArraySet might have a different predicate applied to it, so it's not always correct to do this. However, it seems this doesn't implies a bug in Noir because mutable arrays are always put behind an `allocate`, so arrays never seem to be reused this way.

However, `ValueMerger` does rely on this optimization, and it even does it when the predicates are different. However, it then multiplies the fetched value by the correct predicate so this is always safe.

So, this PR is an attempt to only do this optimization in `ValueMerger`.

The code here isn't final, but I'm opening this PR to see what are the regressions.

## Additional Context



## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
