### PR TITLE
fix: mark array_set value as last used

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/opt/array_set.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/array_set.rs
@@ -431,6 +431,11 @@ mod tests {
 
     #[test]
     fn array_set_array_value_should_mark_as_last_used() {
+        // If we don't mark the value of `array_set` as last used then v7 ends up being
+        //
+        //     v7 = array_set mut v1, index u32 0, value Field 1
+        //
+        // which is incorrect.
         let src = r#"
         acir(inline) fn main f0 {
           b0():


### PR DESCRIPTION
# Description

## Problem

Resolves a bug that could happen if we don't mark an array_set value as last used.

## Summary

I couldn't reproduce this in a Noir program, though.

## Additional Context



## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
