### PR TITLE
chore: fix clippy warnings from stable Rust toolchain

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,6 +89,7 @@ uninlined_format_args = "warn"
 needless_pass_by_ref_mut = "warn"
 non_std_lazy_statics = "warn"
 return_and_then = "warn"
+unnecessary_unwrap = "warn"
 unnecessary_debug_formatting = "warn"
 
 [workspace.dependencies]

--- a/acvm-repo/acir_field/src/field_element.rs
+++ b/acvm-repo/acir_field/src/field_element.rs
@@ -312,7 +312,7 @@ impl<F: PrimeField> AcirField for FieldElement<F> {
         write!(&mut result, "{:x}", trimmed[0]).unwrap();
 
         // Ensure even length by padding if necessary
-        if result.len() % 2 != 0 {
+        if !result.len().is_multiple_of(2) {
             // Insert '0' after "0x" to make it even
             result.insert(2, '0');
         }
@@ -329,7 +329,7 @@ impl<F: PrimeField> AcirField for FieldElement<F> {
         let value = hex_str.strip_prefix("0x").unwrap_or(hex_str);
 
         // Decode directly, handling even length efficiently
-        let hex_as_bytes = if value.len() % 2 == 0 {
+        let hex_as_bytes = if value.len().is_multiple_of(2) {
             hex::decode(value).ok()?
         } else {
             // For odd length, prepend '0' to the string view only for decoding

--- a/acvm-repo/acvm/src/pwg/blackbox/embedded_curve_ops.rs
+++ b/acvm-repo/acvm/src/pwg/blackbox/embedded_curve_ops.rs
@@ -32,8 +32,8 @@ pub(crate) fn execute_multi_scalar_mul<F: AcirField>(
     scalars: &[FunctionInput<F>],
     predicate: FunctionInput<F>,
 ) -> Result<(F, F, F), OpcodeResolutionError<F>> {
-    assert!(scalars.len() % 2 == 0, "Number of scalars must be even");
-    assert!(points.len() % 3 == 0, "Number of points must be a multiple of 3");
+    assert!(scalars.len().is_multiple_of(2), "Number of scalars must be even");
+    assert!(points.len().is_multiple_of(3), "Number of points must be a multiple of 3");
     assert_eq!(
         scalars.len() / 2,
         points.len() / 3,

--- a/acvm-repo/blackbox_solver/src/aes128.rs
+++ b/acvm-repo/blackbox_solver/src/aes128.rs
@@ -8,7 +8,7 @@ pub fn aes128_encrypt(
     iv: [u8; 16],
     key: [u8; 16],
 ) -> Result<Vec<u8>, BlackBoxResolutionError> {
-    if inputs.len() % 16 != 0 {
+    if !inputs.len().is_multiple_of(16) {
         return Err(BlackBoxResolutionError::Failed(
             acir::BlackBoxFunc::AES128Encrypt,
             "input length must be a multiple of 16".to_string(),

--- a/acvm-repo/brillig/src/lengths.rs
+++ b/acvm-repo/brillig/src/lengths.rs
@@ -123,7 +123,7 @@ impl Div<ElementTypesLength> for SemiFlattenedLength {
     type Output = SemanticLength;
 
     fn div(self, rhs: ElementTypesLength) -> Self::Output {
-        if self.0 % rhs.0 != 0 {
+        if !self.0.is_multiple_of(rhs.0) {
             panic!(
                 "Division of SemiFlattenedLength {} by ElementTypesLength {} has remainder",
                 self.0, rhs.0
@@ -211,7 +211,7 @@ impl Div<ElementsFlattenedLength> for FlattenedLength {
     type Output = SemanticLength;
 
     fn div(self, rhs: ElementsFlattenedLength) -> Self::Output {
-        if self.0 % rhs.0 != 0 {
+        if !self.0.is_multiple_of(rhs.0) {
             panic!(
                 "Division of FlattenedLength {} by ElementsFlattenedLength {} has remainder",
                 self.0, rhs.0

--- a/acvm-repo/brillig_vm/src/foreign_call.rs
+++ b/acvm-repo/brillig_vm/src/foreign_call.rs
@@ -193,7 +193,7 @@ impl<F: AcirField, B: BlackBoxFunctionSolver<F>> VM<'_, F, B> {
             // Check that the sequence of value types fit an integer number of
             // times inside the given size.
             assert!(
-                0 == size % assert_u32(value_types.len()),
+                size.is_multiple_of(assert_u32(value_types.len())),
                 "array/vector does not contain a whole number of elements"
             );
 

--- a/compiler/noirc_evaluator/src/acir/acir_context/black_box.rs
+++ b/compiler/noirc_evaluator/src/acir/acir_context/black_box.rs
@@ -39,7 +39,7 @@ impl<F: AcirField> AcirContext<F> {
                     }
                 }?;
 
-                assert!(input_size % 16 == 0, "input length must be a multiple of 16");
+                assert!(input_size.is_multiple_of(16), "input length must be a multiple of 16");
                 assert_eq!(output_count, input_size, "output count mismatch");
 
                 Vec::new()

--- a/compiler/noirc_evaluator/src/ssa/ir/dfg/simplify/call.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/dfg/simplify/call.rs
@@ -778,7 +778,7 @@ fn simplify_derive_generators(
             }
             let len = results.len() as u32;
             assert!(
-                len % 3 == 0,
+                len.is_multiple_of(3),
                 "The number of results from derive_generators must be a multiple of 3"
             );
             let typ = Type::Array(

--- a/compiler/noirc_evaluator/src/ssa/ir/instruction/binary.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/instruction/binary.rs
@@ -384,8 +384,8 @@ impl BinaryOp {
             BinaryOp::Xor => |x, y| Some(x ^ y),
             BinaryOp::Eq => |x, y| Some(u128::from(x == y)),
             BinaryOp::Lt => |x, y| Some(u128::from(x < y)),
-            BinaryOp::Shl => |x, y| y.to_u32().and_then(|y| x.checked_shl(y)),
-            BinaryOp::Shr => |x, y| y.to_u32().and_then(|y| x.checked_shr(y)),
+            BinaryOp::Shl => |x, y| x.checked_shl(y.to_u32()?),
+            BinaryOp::Shr => |x, y| x.checked_shr(y.to_u32()?),
         }
     }
 
@@ -401,8 +401,8 @@ impl BinaryOp {
             BinaryOp::Xor => |x, y| Some(x ^ y),
             BinaryOp::Eq => |x, y| Some(i128::from(x == y)),
             BinaryOp::Lt => |x, y| Some(i128::from(x < y)),
-            BinaryOp::Shl => |x, y| y.to_u32().and_then(|y| x.checked_shl(y)),
-            BinaryOp::Shr => |x, y| y.to_u32().and_then(|y| x.checked_shr(y)),
+            BinaryOp::Shl => |x, y| x.checked_shl(y.to_u32()?),
+            BinaryOp::Shr => |x, y| x.checked_shr(y.to_u32()?),
         }
     }
 

--- a/compiler/noirc_evaluator/src/ssa/validation/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/validation/mod.rs
@@ -668,7 +668,7 @@ impl<'f> Validator<'f> {
 
                 let input_length = assert_u8_array(&input_type, "aes128_encrypt input");
                 assert!(
-                    input_length % 16 == 0,
+                    input_length.is_multiple_of(16),
                     "aes128_encrypt input length must be a multiple of 16"
                 );
 

--- a/compiler/noirc_frontend/src/monomorphization/ast.rs
+++ b/compiler/noirc_frontend/src/monomorphization/ast.rs
@@ -75,11 +75,15 @@ impl Expression {
                 Literal::Bool(_) => borrowed(&Type::Bool),
                 Literal::Unit => borrowed(&Type::Unit),
                 Literal::Str(s) => owned(Type::String(s.len() as u32)),
-                Literal::FmtStr(_, size, expr) => expr.return_type().and_then(|typ| {
+                Literal::FmtStr(_, size, expr) => {
+                    let typ = expr.return_type()?;
                     owned(Type::FmtString(*size as u32, Box::new(typ.into_owned())))
-                }),
+                }
             },
-            Expression::Block(xs) => xs.last().and_then(|x| x.return_type()),
+            Expression::Block(xs) => {
+                let x = xs.last()?;
+                x.return_type()
+            }
             Expression::Unary(unary) => borrowed(&unary.result_type),
             Expression::Binary(binary) => {
                 if binary.operator.is_comparator() {

--- a/tooling/acvm_cli/src/cli/execute_cmd.rs
+++ b/tooling/acvm_cli/src/cli/execute_cmd.rs
@@ -51,12 +51,8 @@ fn run_command(args: ExecuteCommand) -> Result<String, CliError> {
     let output_witness_string = create_output_witness_string(
         &output_witness.peek().expect("Should have a witness stack item").witness,
     )?;
-    if args.output_witness.is_some() {
-        save_witness_to_dir(
-            &output_witness,
-            &args.output_witness.unwrap(),
-            &args.working_directory,
-        )?;
+    if let Some(output_witness_path) = args.output_witness {
+        save_witness_to_dir(&output_witness, &output_witness_path, &args.working_directory)?;
     }
     Ok(output_witness_string)
 }

--- a/tooling/greybox_fuzzer/src/mutation/mod.rs
+++ b/tooling/greybox_fuzzer/src/mutation/mod.rs
@@ -51,8 +51,7 @@ impl NodeWeight {
         self.start += start_offset;
         self.end += start_offset;
         let mut current_update = start_offset;
-        if self.subnodes.is_some() {
-            let subnode_weights = self.subnodes.as_mut().unwrap();
+        if let Some(subnode_weights) = &mut self.subnodes {
             for subnode_weight in subnode_weights.iter_mut() {
                 let weight_update = subnode_weight.get_weight();
                 subnode_weight.calculate_offsets(current_update);

--- a/tooling/nargo_cli/src/cli/test_cmd/formatters.rs
+++ b/tooling/nargo_cli/src/cli/test_cmd/formatters.rs
@@ -283,7 +283,9 @@ impl Formatter for TerseFormatter {
         // but we also want the output to be readable in case the terminal isn't maximized.
         const MAX_TESTS_PER_LINE: usize = 88;
 
-        if current_test_count % MAX_TESTS_PER_LINE == 0 && current_test_count < total_test_count {
+        if current_test_count.is_multiple_of(MAX_TESTS_PER_LINE)
+            && current_test_count < total_test_count
+        {
             writeln!(writer, " {current_test_count}/{total_test_count}")?;
         }
 

--- a/tooling/noirc_abi/src/input_parser/json.rs
+++ b/tooling/noirc_abi/src/input_parser/json.rs
@@ -139,7 +139,7 @@ impl JsonTypes {
             return "0x00".to_owned();
         }
         let mut trimmed_field = field.to_hex().trim_start_matches('0').to_owned();
-        if trimmed_field.len() % 2 != 0 {
+        if !trimmed_field.len().is_multiple_of(2) {
             trimmed_field = "0".to_owned() + &trimmed_field;
         }
         "0x".to_owned() + &trimmed_field

--- a/tooling/ssa_cli/src/cli/mod.rs
+++ b/tooling/ssa_cli/src/cli/mod.rs
@@ -58,7 +58,10 @@ enum SsaCommand {
 pub(crate) fn start_cli() -> eyre::Result<()> {
     let SsaCli { command, args } = SsaCli::parse();
 
-    let ssa = || read_source(args.source_path).and_then(|src| parse_ssa(&src, !args.no_validate));
+    let ssa = || {
+        let src = read_source(args.source_path)?;
+        parse_ssa(&src, !args.no_validate)
+    };
 
     match command {
         SsaCommand::List => {


### PR DESCRIPTION
I've started getting a number of warnings popping up in vscode so I've applied the fixes here.

## Summary
- Fix all clippy warnings produced by stable Rust (1.93.0) across 16 files
- Addresses three lint categories: `return_and_then` (use `?` instead of `.and_then()`), `unnecessary_unwrap` (use `if let Some` instead of `.is_some()` + `.unwrap()`), and `manual_is_multiple_of` (use `.is_multiple_of()` instead of `% n == 0`)
- Enable `clippy::unnecessary_unwrap` as a workspace-level lint in `Cargo.toml`

## Test plan
- [x] `cargo clippy --workspace --release --all-targets` clean on MSRV (1.89.0)
- [x] `rustup run stable cargo clippy --workspace --release --all-targets` clean on stable (1.93.0)