### PR TITLE
chore(frontend): add regression test for associated constant in return type with generic impl forwarding

### DIFF
--- a/compiler/noirc_frontend/src/tests/traits/trait_associated_items.rs
+++ b/compiler/noirc_frontend/src/tests/traits/trait_associated_items.rs
@@ -1821,3 +1821,27 @@ fn associated_constant_can_reference_generic_from_trait_bound() {
     "#;
     assert_no_errors(src);
 }
+
+/// Regression test for https://github.com/noir-lang/noir/issues/11538
+#[test]
+fn associated_constant_in_return_type_with_generic_impl_forwarding() {
+    let src = r#"
+    pub struct A<F> { pub f: F }
+
+    pub trait E {
+        let x: u32;
+        fn g() -> str<Self::x>;
+    }
+
+    impl<F: E> E for A<F> {
+        let x: u32 = F::x;
+
+        fn g() -> str<Self::x> {
+            F::g()
+        }
+    }
+
+    fn main() {}
+    "#;
+    assert_no_errors(src);
+}


### PR DESCRIPTION

# Description

## Problem

Resolves https://github.com/noir-lang/noir/issues/11572

## Summary

Adds a test for a program that previously caused a stack overflow: a trait with an associated constant used in a method return type (`str<Self::x>`), where a generic impl forwards both the constant and method through its type parameter.

This has already been fixed since dff422f31893e23b418f7854ce383d8a0cf540c0 but as the issue presents differently than the existing test it's worth adding a regression test.

## Additional Context



## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
