### PR TITLE
fix(frontend): only confirm moves from current branch on conditional reassignment

### DIFF
--- a/compiler/noirc_frontend/src/ownership/last_uses.rs
+++ b/compiler/noirc_frontend/src/ownership/last_uses.rs
@@ -300,6 +300,27 @@ impl LastUseContext {
         }
     }
 
+    /// Navigate the `Branches` tree along the given path and extract only
+    /// the sub-tree at the leaf, replacing it with `Branches::None`.
+    /// Sibling branches are left untouched.
+    fn extract_branch_at_path(
+        branches: &mut Branches,
+        path: &[(IfOrMatchId, BranchId)],
+    ) -> Branches {
+        match path {
+            [] => std::mem::replace(branches, Branches::None),
+            [(if_id, branch_id), rest @ ..] => {
+                if let Branches::IfOrMatch(id, map) = branches
+                    && *id == *if_id
+                    && let Some(branch) = map.get_mut(branch_id)
+                {
+                    return Self::extract_branch_at_path(branch, rest);
+                }
+                Branches::None
+            }
+        }
+    }
+
     /// Collect the last use(s) of every local variable.
     fn get_variables_to_move(self) -> HashMap<LocalId, Vec<IdentId>> {
         let mut moves = self.confirmed_moves;
@@ -515,8 +536,12 @@ impl LastUseContext {
             // Confirm any last uses we have on the variable at this point (which may be in `assign.expression`),
             // From here on it acts as a newly declared variable with no history.
             if let Some((_, branches)) = self.last_uses.get_mut(&local_id) {
-                let branches = std::mem::replace(branches, Branches::None);
-                self.confirmed_moves.entry(local_id).or_default().extend(branches.flatten_uses());
+                let path = self
+                    .current_loop_and_branch
+                    .last()
+                    .expect("We should always have at least 1 path");
+                let extracted = Self::extract_branch_at_path(branches, path);
+                self.confirmed_moves.entry(local_id).or_default().extend(extracted.flatten_uses());
                 return;
             }
         }

--- a/compiler/noirc_frontend/src/ownership/tests.rs
+++ b/compiler/noirc_frontend/src/ownership/tests.rs
@@ -651,3 +651,42 @@ fn overwrite_conditional() {
     }
     ");
 }
+
+/// Regression test for https://github.com/noir-lang/noir/issues/11574
+/// When the reassignment is in the else branch, uses in the then branch
+/// should still get cloned if the variable is used after the if/else.
+#[test]
+fn overwrite_conditional_swapped() {
+    let src = "
+    unconstrained fn main(cond: bool) {
+        let mut v = @[1, 2, 3];
+        if cond {
+            use_var(v);
+        } else {
+            v = identity(v);
+        }
+        use_var(v);
+    }
+
+    fn use_var<T>(_x: T) {}
+    fn identity<T>(x: T) -> T { x }
+    ";
+
+    let program = get_monomorphized(src).unwrap();
+    insta::assert_snapshot!(program, @r"
+    unconstrained fn main$f0(cond$l0: bool) -> () {
+        let mut v$l1 = @[1, 2, 3];
+        if cond$l0 {
+            use_var$f1(v$l1.clone());
+        } else {
+            v$l1 = identity$f2(v$l1)
+        };
+        use_var$f1(v$l1);
+    }
+    unconstrained fn use_var$f1(_x$l2: [Field]) -> () {
+    }
+    unconstrained fn identity$f2(x$l3: [Field]) -> [Field] {
+        x$l3
+    }
+    ");
+}


### PR DESCRIPTION
## Summary

- Fixes a bug where a variable reassignment inside one branch of an `if`/`else` (e.g., `v = identity(v)` in the `else` branch) incorrectly confirmed moves from **all** branches, causing a missing `.clone()` in sibling branches.
- Adds `extract_branch_at_path` helper to navigate the `Branches` tree to the current branch and only extract that sub-tree, leaving sibling branches untouched.
- Adds regression test `overwrite_conditional_swapped` for the exact scenario from the issue.

Closes #11574

## Test plan

- [x] New regression test `overwrite_conditional_swapped` passes
- [x] All 23 ownership tests pass
- [x] Full `noirc_frontend` test suite (1439 tests) passes