### PR TITLE
fix(frontend): restore variable loop indices after while loops in ownership pass

### DIFF
--- a/compiler/noirc_frontend/src/ownership/last_uses.rs
+++ b/compiler/noirc_frontend/src/ownership/last_uses.rs
@@ -406,26 +406,33 @@ impl LastUseContext {
     }
 
     fn track_variables_in_for(&mut self, for_expr: &ast::For) {
+        // The start and end range are evaluated once before the loop begins,
+        // so they are tracked outside the loop scope.
         self.track_variables_in_expression(&for_expr.start_range);
         self.track_variables_in_expression(&for_expr.end_range);
-        self.track_variables_in_loop(&for_expr.block);
+        self.track_variables_in_loop_exprs(&[&for_expr.block]);
     }
 
     fn track_variables_in_while(&mut self, while_expr: &ast::While) {
-        self.push_loop_scope();
         // The condition is evaluated on every iteration of the loop and thus must be included in the loop scope.
-        self.track_variables_in_expression(&while_expr.condition);
-        self.track_variables_in_expression(&while_expr.body);
-        self.pop_loop_scope();
+        self.track_variables_in_loop_exprs(&[&while_expr.condition, &while_expr.body]);
     }
 
     fn track_variables_in_loop(&mut self, loop_body: &Expression) {
+        self.track_variables_in_loop_exprs(&[loop_body]);
+    }
+
+    /// Track variables in a loop body. Each expression in `loop_exprs` must be
+    /// an expression that is evaluated on each iteration of the loop.
+    fn track_variables_in_loop_exprs(&mut self, loop_exprs: &[&Expression]) {
         // Save the current loop index of the variables we are tracking.
         // They *might* be reassigned inside the loop, which would change their index, but we need to restore them after.
         let orig_indices = vecmap(&self.last_uses, |(id, (index, _))| (*id, *index));
 
         self.push_loop_scope();
-        self.track_variables_in_expression(loop_body);
+        for expr in loop_exprs {
+            self.track_variables_in_expression(expr);
+        }
         self.pop_loop_scope();
 
         for (id, orig_index) in orig_indices {

--- a/compiler/noirc_frontend/src/ownership/tests.rs
+++ b/compiler/noirc_frontend/src/ownership/tests.rs
@@ -652,6 +652,48 @@ fn overwrite_conditional() {
     ");
 }
 
+/// Regression: reassigning inside a while loop then using in a for loop.
+/// The while loop must restore the variable's loop_index so the for loop
+/// correctly sees the variable as defined outside and clones it.
+#[test]
+fn while_reassign_then_for_loop() {
+    let src = "
+    unconstrained fn main(cond: bool) {
+        let mut v = @[1, 2, 3];
+        while cond {
+            v = identity(v);
+            break;
+        }
+        for _ in 0..2 {
+            use_var(v);
+        }
+    }
+
+    fn use_var<T>(_x: T) {}
+    fn identity<T>(x: T) -> T { x }
+    ";
+
+    let program = get_monomorphized(src).unwrap();
+    // v must be cloned inside the for loop since it's used across iterations
+    insta::assert_snapshot!(program, @r"
+    unconstrained fn main$f0(cond$l0: bool) -> () {
+        let mut v$l1 = @[1, 2, 3];
+        while cond$l0 {
+            v$l1 = identity$f1(v$l1);
+            break
+        };
+        for _$l2 in 0 .. 2 {
+            use_var$f2(v$l1.clone());
+        }
+    }
+    unconstrained fn identity$f1(x$l3: [Field]) -> [Field] {
+        x$l3
+    }
+    unconstrained fn use_var$f2(_x$l4: [Field]) -> () {
+    }
+    ");
+}
+
 /// Regression test for https://github.com/noir-lang/noir/issues/11574
 /// When the reassignment is in the else branch, uses in the then branch
 /// should still get cloned if the variable is used after the if/else.
@@ -687,6 +729,208 @@ fn overwrite_conditional_swapped() {
     }
     unconstrained fn identity$f2(x$l3: [Field]) -> [Field] {
         x$l3
+    }
+    ");
+}
+
+#[test]
+fn match_with_reassignment_in_one_arm() {
+    let src = "
+    unconstrained fn main(x: u32) {
+        let mut v = @[1, 2, 3];
+        let result: () = match x {
+            0 => { v = identity(v); },
+            1 => { use_var(v); },
+            _ => { use_var(v); },
+        };
+        use_var(v);
+    }
+
+    fn use_var<T>(_x: T) {}
+    fn identity<T>(x: T) -> T { x }
+    ";
+
+    let program = get_monomorphized(src).unwrap();
+    insta::assert_snapshot!(program, @r"
+    unconstrained fn main$f0(x$l0: u32) -> () {
+        let mut v$l1 = @[1, 2, 3];
+        let result$l4 = {
+            let internal variable$l2 = x$l0;
+            match $2 {
+                0 => {
+                    v$l1 = identity$f1(v$l1)
+                },
+                1 => {
+                    use_var$f2(v$l1.clone());
+                },
+                _ => {
+                    let _$l3 = internal variable$l2;
+                    {
+                        use_var$f2(v$l1.clone());
+                    }
+                },
+            }
+        };
+        use_var$f2(v$l1);
+    }
+    unconstrained fn identity$f1(x$l5: [Field]) -> [Field] {
+        x$l5
+    }
+    unconstrained fn use_var$f2(_x$l6: [Field]) -> () {
+    }
+    ");
+}
+
+#[test]
+fn nested_if_reassignment() {
+    let src = "
+    unconstrained fn main(c1: bool, c2: bool) {
+        let mut v = @[1, 2, 3];
+        if c1 {
+            if c2 {
+                v = identity(v);
+            }
+            use_var(v);
+        } else {
+            use_var(v);
+        }
+        use_var(v);
+    }
+
+    fn use_var<T>(_x: T) {}
+    fn identity<T>(x: T) -> T { x }
+    ";
+
+    let program = get_monomorphized(src).unwrap();
+    insta::assert_snapshot!(program, @r"
+    unconstrained fn main$f0(c1$l0: bool, c2$l1: bool) -> () {
+        let mut v$l2 = @[1, 2, 3];
+        if c1$l0 {
+            if c2$l1 {
+                v$l2 = identity$f1(v$l2)
+            };
+            use_var$f2(v$l2.clone());
+        } else {
+            use_var$f2(v$l2.clone());
+        };
+        use_var$f2(v$l2);
+    }
+    unconstrained fn identity$f1(x$l3: [Field]) -> [Field] {
+        x$l3
+    }
+    unconstrained fn use_var$f2(_x$l4: [Field]) -> () {
+    }
+    ");
+}
+
+#[test]
+fn sequential_conditional_reassignments() {
+    let src = "
+    unconstrained fn main(c1: bool, c2: bool) {
+        let mut v = @[1, 2, 3];
+        if c1 {
+            v = identity(v);
+        }
+        if c2 {
+            v = identity(v);
+        }
+        use_var(v);
+    }
+
+    fn use_var<T>(_x: T) {}
+    fn identity<T>(x: T) -> T { x }
+    ";
+
+    let program = get_monomorphized(src).unwrap();
+    insta::assert_snapshot!(program, @r"
+    unconstrained fn main$f0(c1$l0: bool, c2$l1: bool) -> () {
+        let mut v$l2 = @[1, 2, 3];
+        if c1$l0 {
+            v$l2 = identity$f1(v$l2)
+        };
+        if c2$l1 {
+            v$l2 = identity$f1(v$l2)
+        };
+        use_var$f2(v$l2);
+    }
+    unconstrained fn identity$f1(x$l3: [Field]) -> [Field] {
+        x$l3
+    }
+    unconstrained fn use_var$f2(_x$l4: [Field]) -> () {
+    }
+    ");
+}
+
+#[test]
+fn both_branches_reassign() {
+    let src = "
+    unconstrained fn main(cond: bool) {
+        let mut v = @[1, 2, 3];
+        if cond {
+            v = identity(v);
+        } else {
+            v = identity(v);
+        }
+        use_var(v);
+    }
+
+    fn use_var<T>(_x: T) {}
+    fn identity<T>(x: T) -> T { x }
+    ";
+
+    let program = get_monomorphized(src).unwrap();
+    insta::assert_snapshot!(program, @r"
+    unconstrained fn main$f0(cond$l0: bool) -> () {
+        let mut v$l1 = @[1, 2, 3];
+        if cond$l0 {
+            v$l1 = identity$f1(v$l1)
+        } else {
+            v$l1 = identity$f1(v$l1)
+        };
+        use_var$f2(v$l1);
+    }
+    unconstrained fn identity$f1(x$l2: [Field]) -> [Field] {
+        x$l2
+    }
+    unconstrained fn use_var$f2(_x$l3: [Field]) -> () {
+    }
+    ");
+}
+
+#[test]
+fn loop_with_conditional_reassignment() {
+    let src = "
+    unconstrained fn main(cond: bool) {
+        let mut v = @[1, 2, 3];
+        for _ in 0..3 {
+            if cond {
+                v = identity(v);
+            }
+            use_var(v);
+        }
+        use_var(v);
+    }
+
+    fn use_var<T>(_x: T) {}
+    fn identity<T>(x: T) -> T { x }
+    ";
+
+    let program = get_monomorphized(src).unwrap();
+    insta::assert_snapshot!(program, @r"
+    unconstrained fn main$f0(cond$l0: bool) -> () {
+        let mut v$l1 = @[1, 2, 3];
+        for _$l2 in 0 .. 3 {
+            if cond$l0 {
+                v$l1 = identity$f1(v$l1)
+            };
+            use_var$f2(v$l1.clone());
+        };
+        use_var$f2(v$l1);
+    }
+    unconstrained fn identity$f1(x$l3: [Field]) -> [Field] {
+        x$l3
+    }
+    unconstrained fn use_var$f2(_x$l4: [Field]) -> () {
     }
     ");
 }


### PR DESCRIPTION
## Summary

- **Bug fix**: `track_variables_in_while` was missing the variable loop-index save/restore that `track_variables_in_loop` already had. When a variable was reassigned inside a `while` loop body, its `loop_index` was permanently changed. If the variable was then used inside a subsequent `for` or `loop` at the same nesting depth, the analysis incorrectly allowed moving instead of cloning — because the variable's loop_index matched the new loop's level.
- **Refactor**: Extracted shared loop logic into `track_variables_in_loop_exprs` so all three loop forms (`for`, `while`, `loop {}`) share the same save/restore behavior.
- **Tests**: Added 6 regression tests covering the while loop bug, match arm reassignment, nested if reassignment, sequential conditional reassignments, both-branch reassignment, and loop with conditional reassignment.

## Test plan

- [x] `cargo nextest run -p noirc_frontend --lib -E 'test(ownership)'` — 29/29 pass

---

I've done some refactoring which makes it harder to what the actual fix is. It's best seen by comparing the original code for while loops and loops and considering how `while true {}` should be equivalent to `loop {}` but it's not being treated equivalently atm.

https://github.com/noir-lang/noir/blob/f0e97ddfa4a502e2855386dad4e864482bec87b1/compiler/noirc_frontend/src/ownership/last_uses.rs#L414-L440