### PR TITLE
fix: error on `Module::add_item` if a module is from an external crate

### DIFF
--- a/compiler/noirc_frontend/src/hir/comptime/errors.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/errors.rs
@@ -307,6 +307,10 @@ pub enum InterpreterError {
     TraitImplResolutionRecursionLimitReached {
         location: Location,
     },
+    CannotAddItemToExternalCrateModule {
+        module: String,
+        location: Location,
+    },
 
     // These cases are not errors, they are just used to prevent us from running more code
     // until the loop can be resumed properly. These cases will never be displayed to users.
@@ -407,7 +411,8 @@ impl InterpreterError {
             | InterpreterError::CheckedTransmuteFailed { location, .. }
             | InterpreterError::UnexpectedEscapedTokenInQuote { location, .. }
             | InterpreterError::TraitImplResolutionRecursionLimitReached { location }
-            | InterpreterError::AttributeRecursionLimitExceeded { location } => *location,
+            | InterpreterError::AttributeRecursionLimitExceeded { location }
+            | InterpreterError::CannotAddItemToExternalCrateModule { location, .. } => *location,
             InterpreterError::FailedToParseMacro { error, .. } => error.location(),
             InterpreterError::NoMatchingImplFound { error } => error.location,
             InterpreterError::DuplicateStructFieldInSetFields { name, .. } => name.location(),
@@ -866,6 +871,11 @@ impl<'a> From<&'a InterpreterError> for CustomDiagnostic {
             }
             InterpreterError::TraitImplResolutionRecursionLimitReached { location } => {
                 let primary = "Trait impl resolution recursion limit reached".to_string();
+                let secondary = String::new();
+                CustomDiagnostic::simple_warning(primary, secondary, *location)
+            }
+            InterpreterError::CannotAddItemToExternalCrateModule { module, location } => {
+                let primary = format!("Cannot add items to external crate module `{module}`");
                 let secondary = String::new();
                 CustomDiagnostic::simple_warning(primary, secondary, *location)
             }

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
@@ -40,7 +40,7 @@ use crate::{
             value::{ExprValue, FormatStringFragment, TypedExpr},
         },
         def_collector::dc_crate::CollectedItems,
-        def_map::{ModuleDefId, ModuleId},
+        def_map::{ModuleDefId, ModuleId, fully_qualified_module_path},
     },
     hir_def::{
         expr::{HirExpression, HirIdent, HirLiteral, ImplKind, TraitItem},
@@ -2924,6 +2924,17 @@ fn module_add_item(
 ) -> IResult<Value> {
     let (self_argument, item) = check_two_arguments(arguments, location)?;
     let module_id = get_module(self_argument)?;
+
+    let current_crate = interpreter.elaborator.module_id().krate;
+    if current_crate != module_id.krate {
+        let module = fully_qualified_module_path(
+            interpreter.elaborator.def_maps,
+            interpreter.elaborator.crate_graph,
+            &current_crate,
+            module_id,
+        );
+        return Err(InterpreterError::CannotAddItemToExternalCrateModule { module, location });
+    }
 
     let parser = Parser::parse_top_level_items;
     let top_level_statements = parse(interpreter.elaborator, item, parser, "a top-level item")?;

--- a/test_programs/compile_failure/regression_11579/Nargo.toml
+++ b/test_programs/compile_failure/regression_11579/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "regression_11579"
+type = "bin"
+authors = [""]
+
+[dependencies]
+dependency = { path = "dependency" }

--- a/test_programs/compile_failure/regression_11579/dependency/Nargo.toml
+++ b/test_programs/compile_failure/regression_11579/dependency/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "dependency"
+type = "lib"
+authors = [""]
+compiler_unstable_features = ["enums"]
+
+[dependencies]

--- a/test_programs/compile_failure/regression_11579/dependency/src/lib.nr
+++ b/test_programs/compile_failure/regression_11579/dependency/src/lib.nr
@@ -1,0 +1,8 @@
+pub comptime mut global modules: [Module] = @[];
+
+#[attr]
+pub mod foo {}
+
+comptime fn attr(m: Module) {
+    modules = modules.push_back(m);
+}

--- a/test_programs/compile_failure/regression_11579/src/main.nr
+++ b/test_programs/compile_failure/regression_11579/src/main.nr
@@ -1,0 +1,9 @@
+#[foo]
+comptime fn foo(_: FunctionDefinition) {
+    let m = dependency::modules[0];
+    m.add_item(quote { pub fn bar() {} });
+}
+
+fn main() {
+    dependency::foo::bar()
+}

--- a/tooling/nargo_cli/tests/snapshots/compile_failure/regression_11579/execute__tests__stderr.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_failure/regression_11579/execute__tests__stderr.snap
@@ -1,0 +1,19 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: stderr
+---
+warning: Cannot add items to external crate module `dependency::foo`
+  ┌─ src/main.nr:4:5
+  │
+4 │     m.add_item(quote { pub fn bar() {} });
+  │     -------------------------------------
+  │
+
+error: Could not resolve 'bar' in path
+  ┌─ src/main.nr:8:22
+  │
+8 │     dependency::foo::bar()
+  │                      ---
+  │
+
+Aborting due to 1 previous error


### PR DESCRIPTION
# Description

## Problem

Resolves #11579

## Summary



## Additional Context



## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
