### PR TITLE
chore: remove redundant clones

### DIFF
--- a/tooling/acvm_cli/src/fs/witness.rs
+++ b/tooling/acvm_cli/src/fs/witness.rs
@@ -39,7 +39,7 @@ pub(crate) fn read_witness_from_file(
         let index =
             Witness(key.trim().parse().map_err(|_| CliError::WitnessIndexError(key.clone()))?);
         if !value.is_str() {
-            return Err(CliError::WitnessValueError(key.clone()));
+            return Err(CliError::WitnessValueError(key));
         }
         let field = FieldElement::from_hex(value.as_str().unwrap()).unwrap();
         witnesses.insert(index, field);

--- a/tooling/noirc_abi/src/input_parser/mod.rs
+++ b/tooling/noirc_abi/src/input_parser/mod.rs
@@ -149,7 +149,7 @@ impl InputValue {
                     return Err(InputTypecheckingError::UnexpectedField {
                         path,
                         typ: abi_param.clone(),
-                        extra_field: extra_field.to_string(),
+                        extra_field,
                     });
                 }
 


### PR DESCRIPTION
# Description

- `acvm_cli/src/fs/witness.rs`: remove clone on error path
- `noirc_abi/src/input_parser/mod.rs`: remove redundant to_string on already-owned String
