### PR TITLE
fix(elaborator): Replace generics with fresh type variables in `add_prepared_trait_implementation`

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/trait_impls.rs
+++ b/compiler/noirc_frontend/src/elaborator/trait_impls.rs
@@ -244,13 +244,13 @@ impl Elaborator<'_> {
                 methods,
             });
 
-            let generics = vecmap(&self.generics, |generic| generic.type_var.clone());
+            let impl_generics = vecmap(&self.generics, |generic| generic.type_var.clone());
 
             match self.interner.add_trait_implementation(
                 self_type.clone(),
                 trait_id,
                 trait_impl.impl_id.expect("ICE: impl_id should be set in define_function_metas"),
-                generics,
+                impl_generics,
                 resolved_trait_impl,
                 location,
             ) {
@@ -833,7 +833,13 @@ impl Elaborator<'_> {
         if let Some(trait_id) = trait_id {
             // The ordered generics and associated types are already stored by `resolve_trait_impl_associated_types`.
             // Now that we have resolved the self-type, register the prepared trait impl for it.
-            self.interner.add_prepared_trait_implementation(self_type.clone(), trait_id, impl_id);
+            let impl_generics = vecmap(&self.generics, |generic| generic.type_var.clone());
+            self.interner.add_prepared_trait_implementation(
+                self_type.clone(),
+                trait_id,
+                impl_id,
+                impl_generics,
+            );
         }
 
         trait_impl.methods.self_type = Some(self_type.clone());

--- a/compiler/noirc_frontend/src/node_interner/trait_impl.rs
+++ b/compiler/noirc_frontend/src/node_interner/trait_impl.rs
@@ -101,6 +101,35 @@ impl NodeInterner {
         }
     }
 
+    /// Replace each generic with a fresh type variable.
+    ///
+    /// For example if the object type if `Foo<T'3>` then it becomes `Foo<'5>`.
+    /// The difference is that `Foo<T'3>` would not unify with `Foo<T'4>`,
+    /// but as `Foo<'5>` it will, allowing us to match existing implementations.
+    fn replace_generics_with_fresh_type_variable(
+        &self,
+        object_type: &Type,
+        impl_generics: GenericTypeVars,
+    ) -> (Type, TypeBindings) {
+        let substitutions = impl_generics
+            .into_iter()
+            .map(|typevar| {
+                let typevar_kind = typevar.kind();
+                let typevar_id = typevar.id();
+                let substitution = (
+                    typevar,
+                    typevar_kind.clone(),
+                    self.next_type_variable_with_kind(typevar_kind),
+                );
+                (typevar_id, substitution)
+            })
+            .collect();
+
+        let instantiated_object_type = object_type.substitute(&substitutions);
+
+        (instantiated_object_type, substitutions)
+    }
+
     /// Adds a prepared trait implementation.
     ///
     /// This is called before the normal implementation is ready, so we can look up the
@@ -110,12 +139,18 @@ impl NodeInterner {
         object_type: Type,
         trait_id: TraitId,
         impl_id: TraitImplId,
+        impl_generics: GenericTypeVars,
     ) {
         if matches!(object_type, Type::Error) {
             // If we stored a prepared impl for Error, it would later unify with anything,
             // leading to potentially unexpected duplications with the real prepared impl.
             return;
         }
+
+        // When looking for an existing type, we first have to make the unifying more relaxed by replacing
+        // named generics with fresh type variables, otherwise we can end up with duplicates.
+        let (instantiated_object_type, _) =
+            self.replace_generics_with_fresh_type_variable(&object_type, impl_generics);
 
         // Check that we haven't already some overlapping implementation.
         // Get the generics, which are inserted by `resolve_trait_impl_associated_types`
@@ -128,7 +163,7 @@ impl NodeInterner {
         });
 
         let existing = self.try_lookup_trait_implementation(
-            &object_type,
+            &instantiated_object_type,
             trait_id,
             &trait_generics.ordered,
             &associated_types,
@@ -137,6 +172,7 @@ impl NodeInterner {
         if existing.is_ok() {
             return;
         }
+
         let entries = self.trait_implementation_map.entry(trait_id).or_default();
         entries.push((object_type, TraitImplKind::Prepared(impl_id)));
     }
@@ -164,22 +200,8 @@ impl NodeInterner {
             .into());
         }
 
-        // Replace each generic with a fresh type variable
-        let substitutions = impl_generics
-            .into_iter()
-            .map(|typevar| {
-                let typevar_kind = typevar.kind();
-                let typevar_id = typevar.id();
-                let substitution = (
-                    typevar,
-                    typevar_kind.clone(),
-                    self.next_type_variable_with_kind(typevar_kind),
-                );
-                (typevar_id, substitution)
-            })
-            .collect();
-
-        let instantiated_object_type = object_type.substitute(&substitutions);
+        let (instantiated_object_type, substitutions) =
+            self.replace_generics_with_fresh_type_variable(&object_type, impl_generics);
 
         let trait_generics = self.get_trait_generics_for_impl(impl_id);
 

--- a/compiler/noirc_frontend/src/tests.rs
+++ b/compiler/noirc_frontend/src/tests.rs
@@ -275,7 +275,7 @@ fn check_errors_with_options(src: &str, monomorphize: bool, options: GetProgramO
             } else {
                 report_all(context.file_manager.as_file_map(), &errors, false, false);
                 panic!(
-                    "Couldn't find primary error at {span:?} with message {primary_message:?}.\nAll errors: {errors:?}"
+                    "Couldn't find primary error at {span:?} with message {primary_message:?}.\nAll errors: {errors:?}\nExpected primaries: {primary_spans_with_errors:?}\nExpected secondaries: {secondary_spans_with_errors:?}"
                 );
             }
         };

--- a/compiler/noirc_frontend/src/tests/traits/trait_impl_validation.rs
+++ b/compiler/noirc_frontend/src/tests/traits/trait_impl_validation.rs
@@ -489,3 +489,17 @@ fn generic_struct_implementing_generic_trait() {
     "#;
     assert_no_errors(src);
 }
+
+#[test]
+fn overlapping_generic_impls() {
+    let src = r#"
+    pub struct Foo<T> {}
+    pub trait Bar {}
+    impl<T> Bar for Foo<T> {}
+            ~~~ Previous impl defined here
+    impl<T> Bar for Foo<T> {}
+                    ^^^^^^ Impl for type `Foo<T>` overlaps with existing impl
+                    ~~~~~~ Overlapping impl
+    "#;
+    check_errors(src);
+}


### PR DESCRIPTION
# Description

## Problem

Resolves #11570 

## Summary

Fixes `add_prepared_trait_implementation` to replace generics with fresh type variables when looking for an existing prepared trait implementation, which is how it happens in `add_trait_implementation`. 

## Additional Context

In the code of the ticket we ended up with 2 prepared trait implementations, with the difference in their `object_type` being that one was for `Foo<T'3>` and the other for `Foo<T'4>`. `add_prepared_trait_implementation` did not detect them as duplicates because `T'3` did not unify with `T'4`, because they were both `NamedGeneric` types. 

The reason it later found both in `add_trait_implementation` was because that method prepared a `substitutions` map that replaced every generic with a fresh type variable, for example `'3` was replaced with `'5`, and used this with `object_type.instantiate(substitutions)` to create an `instantiated_object_type`, e.g. `Foo<'5>`, and search implementations for that. `'5` happily unifies with `T'3` and `T'4` as well. 

We are now doing the same in `add_prepared_trait_implementation` when looking for an existing one. 

Another thing that `add_trait_implementation` did was to _generalize_ the `object_type` (turn it into a `Type::Forall`) before inserting it into the list of implementations. However when I tried this with the prepared type, I got multiple test failures. I also got test failures when I tried to store the `instantiated_object_type` in the mapping.


## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
