### PR TITLE
fix(ssa): apply pending value replacements to terminators within simplify_cfg loop

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/opt/simplify_cfg.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/simplify_cfg.rs
@@ -111,13 +111,6 @@ fn simplify_current_block(
             | check_for_constant_jmpif(function, block, cfg)
             | check_for_converging_jmpif(function, block, cfg)
             | try_inline_successor(function, cfg, block, values_to_replace);
-
-        // Inlining a successor can introduce a terminator that references values with
-        // pending replacements (e.g. block parameters mapped to constants). Apply them
-        // to the terminator so the next iteration can detect newly-constant jmpif conditions.
-        if simplified && !values_to_replace.is_empty() {
-            function.dfg.replace_values_in_block_terminator(block, values_to_replace);
-        }
     }
 }
 
@@ -411,7 +404,16 @@ fn try_inline_successor(
             // If successful, `block` will be empty and unreachable after this call, so any
             // optimizations performed after this point on the same block should check if
             // the inlining here was successful before continuing.
-            try_inline_into_predecessor(function, cfg, destination, block)
+            let simplified = try_inline_into_predecessor(function, cfg, destination, block);
+
+            // Inlining a successor can introduce a terminator that references values with
+            // pending replacements (e.g. block parameters mapped to constants). Apply them
+            // to the terminator so the next iteration can detect newly-constant jmpif conditions.
+            if simplified && !values_to_replace.is_empty() {
+                function.dfg.replace_values_in_block_terminator(block, values_to_replace);
+            }
+
+            simplified
         } else {
             false
         }


### PR DESCRIPTION
Pulling out this change from #11602 as it's nice and self-contained. We need this as otherwise constant jmpifs can survive simplify_cfg

---

## Summary

- `simplify_cfg` failed its own post-condition (no constant-condition `jmpif` remaining) when inlining a successor block whose parameters mapped to constants
- The root cause: `values_to_replace` wasn't applied within `simplify_current_block`'s loop, so newly-constant `jmpif` conditions created by parameter substitution went unfolded
- Apply `values_to_replace` after each successful simplification iteration so the next pass detects and folds any newly-constant conditions

## Test plan

- Parametrized existing `handles_cascading_simplifications` test with `#[test_case]` for both `acir` and `brillig` runtimes (the `acir` case previously panicked)
- All 17 `simplify_cfg` tests pass
- Full evaluator test suite (1132 tests) passes