### PR TITLE
fix: perform abi check on struct on declaration, not usage

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/globals.rs
+++ b/compiler/noirc_frontend/src/elaborator/globals.rs
@@ -76,7 +76,6 @@ impl Elaborator<'_> {
                 if matches!(attr.kind, SecondaryAttributeKind::Abi(_)) {
                     self.push_err(ResolverError::AbiAttributeOutsideContract {
                         location: attr.location,
-                        usage_location: None,
                     });
                 }
             }

--- a/compiler/noirc_frontend/src/elaborator/types.rs
+++ b/compiler/noirc_frontend/src/elaborator/types.rs
@@ -37,7 +37,6 @@ use crate::{
         DependencyId, ExprId, FuncId, GlobalValue, TraitId, TraitImplKind, TraitItemId,
     },
     shared::Signedness,
-    token::SecondaryAttributeKind,
 };
 
 use super::{
@@ -419,19 +418,6 @@ impl Elaborator<'_> {
                     });
 
                     return Type::Error;
-                }
-
-                if !self.in_contract()
-                    && self
-                        .interner
-                        .type_attributes(&data_type.borrow().id)
-                        .iter()
-                        .any(|attr| matches!(attr.kind, SecondaryAttributeKind::Abi(_)))
-                {
-                    self.push_err(ResolverError::AbiAttributeOutsideContract {
-                        location: data_type.borrow().name.location(),
-                        usage_location: Some(path.location),
-                    });
                 }
 
                 let (args, _) = self.resolve_type_args_inner(

--- a/compiler/noirc_frontend/src/hir/def_collector/dc_mod.rs
+++ b/compiler/noirc_frontend/src/hir/def_collector/dc_mod.rs
@@ -1262,6 +1262,17 @@ pub fn collect_struct(
 
     let parent_module_id = ModuleId { krate, local_id: module_id };
 
+    // ABI attributes are only meaningful within contracts, so error if used elsewhere.
+    if !def_map[module_id].is_contract {
+        for attr in &unresolved.struct_def.attributes {
+            if matches!(attr.kind, SecondaryAttributeKind::Abi(_)) {
+                definition_errors.push(
+                    ResolverError::AbiAttributeOutsideContract { location: attr.location }.into(),
+                );
+            }
+        }
+    }
+
     let has_allow_dead_code =
         unresolved.struct_def.attributes.iter().any(|attr| attr.kind.is_allow("dead_code"));
 

--- a/compiler/noirc_frontend/src/hir/resolution/errors.rs
+++ b/compiler/noirc_frontend/src/hir/resolution/errors.rs
@@ -65,7 +65,7 @@ pub enum ResolverError {
     #[error("Nested vectors, i.e. vectors within an array or vector, are not supported")]
     NestedVectors { location: Location },
     #[error("#[abi(tag)] attribute is only allowed in contracts")]
-    AbiAttributeOutsideContract { location: Location, usage_location: Option<Location> },
+    AbiAttributeOutsideContract { location: Location },
     #[error(
         "Usage of the `#[foreign]` or `#[builtin]` function attributes are not allowed outside of the Noir standard library"
     )]
@@ -491,19 +491,12 @@ impl<'a> From<&'a ResolverError> for Diagnostic {
                 "Try to use a constant sized array or BoundedVec instead".into(),
                 *location,
             ),
-            ResolverError::AbiAttributeOutsideContract { location, usage_location } => {
-                let mut diagnostic = Diagnostic::simple_error(
+            ResolverError::AbiAttributeOutsideContract { location } => {
+                Diagnostic::simple_error(
                     "#[abi(tag)] attributes can only be used in contracts".to_string(),
                     "misplaced #[abi(tag)] attribute".to_string(),
                     *location,
-                );
-                if let Some(usage_location) = usage_location {
-                    diagnostic.add_secondary(
-                        "the type is used outside of a contract".to_string(),
-                        *usage_location,
-                    );
-                }
-                diagnostic
+                )
             }
             ResolverError::LowLevelFunctionOutsideOfStdlib { location } => Diagnostic::simple_error(
                 "Definition of low-level function outside of standard library".into(),

--- a/compiler/noirc_frontend/src/tests/runtime.rs
+++ b/compiler/noirc_frontend/src/tests/runtime.rs
@@ -318,15 +318,25 @@ fn deny_no_predicates_attribute_on_entry_point() {
 }
 
 #[test]
-fn deny_abi_attribute_outside_of_contract() {
+fn deny_abi_attribute_on_global_outside_contract() {
     let src = r#"
-
         #[abi(foo)]
         ^^^^^^^^^^^ #[abi(tag)] attributes can only be used in contracts
         ~~~~~~~~~~~ misplaced #[abi(tag)] attribute
         global foo: Field = 1;
     "#;
     check_errors(src);
+}
+
+#[test]
+fn allow_abi_attribute_on_global_inside_contract() {
+    let src = r#"
+    contract moo {
+        #[abi(foo)]
+        global foo: Field = 1;
+    }
+    "#;
+    assert_no_errors(src);
 }
 
 #[test]

--- a/compiler/noirc_frontend/src/tests/structs.rs
+++ b/compiler/noirc_frontend/src/tests/structs.rs
@@ -329,21 +329,35 @@ fn constructor_private_field() {
 }
 
 #[test]
-fn abi_attribute_outside_contract() {
+fn deny_abi_attribute_on_struct_outside_contract() {
     let src = r#"
-        pub contract moo {
+        pub mod moo {
             #[abi(hello)]
+            ^^^^^^^^^^^^^ #[abi(tag)] attributes can only be used in contracts
+            ~~~~~~~~~~~~~ misplaced #[abi(tag)] attribute
             pub struct Foo {}
-                       ^^^ #[abi(tag)] attributes can only be used in contracts
-                       ~~~ misplaced #[abi(tag)] attribute
         }
 
         pub fn foo(_: moo::Foo) {}
-                      ~~~~~~~~ the type is used outside of a contract
 
         fn main() {}
     "#;
     check_errors(src);
+}
+
+#[test]
+fn allow_abi_attribute_on_struct_inside_contract() {
+    let src = r#"
+        pub contract moo {
+            #[abi(hello)]
+            pub struct Foo {}
+        }
+
+        pub fn foo(_: moo::Foo) {}
+
+        fn main() {}
+    "#;
+    assert_no_errors(src);
 }
 
 #[test]

--- a/compiler/noirc_frontend/src/tests/unused_items.rs
+++ b/compiler/noirc_frontend/src/tests/unused_items.rs
@@ -163,8 +163,10 @@ fn does_not_warn_on_unused_global_if_it_has_an_abi_attribute() {
 #[test]
 fn does_not_warn_on_unused_struct_if_it_has_an_abi_attribute() {
     let src = r#"
-    #[abi(dummy)]
-    struct Foo { bar: u8 }
+    contract moo {
+        #[abi(dummy)]
+        struct Foo { bar: u8 }
+    }
     "#;
     assert_no_errors(src);
 }
@@ -200,9 +202,11 @@ fn no_warning_on_inner_struct_when_parent_is_used() {
 #[test]
 fn no_warning_on_struct_if_it_has_an_abi_attribute() {
     let src = r#"
-    #[abi(functions)]
-    struct Foo {
-        a: Field,
+    contract moo {
+        #[abi(functions)]
+        struct Foo {
+            a: Field,
+        }
     }
     "#;
     assert_no_errors(src);
@@ -211,13 +215,15 @@ fn no_warning_on_struct_if_it_has_an_abi_attribute() {
 #[test]
 fn no_warning_on_indirect_struct_if_it_has_an_abi_attribute() {
     let src = r#"
-    struct Bar {
-        field: Field,
-    }
-
-    #[abi(functions)]
-    struct Foo {
-        bar: Bar,
+    contract moo {
+        struct Bar {
+            field: Field,
+        }
+    
+        #[abi(functions)]
+        struct Foo {
+            bar: Bar,
+        }
     }
     "#;
     assert_no_errors(src);

--- a/test_programs/compile_success_empty/attributes_struct/src/main.nr
+++ b/test_programs/compile_success_empty/attributes_struct/src/main.nr
@@ -9,9 +9,11 @@ fn main() {}
 
 // Check that add_attribute and has_named_attribute work well
 
-#[abi(something)]
-#[add_attribute]
-pub struct Foo {}
+contract moo {
+    #[abi(something)]
+    #[super::add_attribute]
+    pub struct Foo {}
+}
 
 comptime fn add_attribute(s: TypeDefinition) {
     assert(!s.has_named_attribute("foo"));

--- a/tooling/nargo_cli/tests/snapshots/compile_success_empty/attributes_struct/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_empty/attributes_struct/execute__tests__expanded.snap
@@ -11,8 +11,10 @@ pub struct SomeStruct {
 
 fn main() {}
 
-#[abi(something)]
-pub struct Foo {}
+contract moo {
+    #[abi(something)]
+    pub struct Foo {}
+}
 
 comptime fn add_attribute(s: TypeDefinition) {
     assert(!s.has_named_attribute("foo"));


### PR DESCRIPTION
# Description

## Problem

Resolves an issue mentioned over Slack.

## Summary

Before this PR, a **usage** of a struct marked with `abi` that happened outside of a contract (that is, the usage happened outside of a contract) produced a compilation error. However, the error should happen if an abi struct is **declared** outside of a contract, regardless of where it's used (for example, it could be used in helper functions outside of the contract).

## Additional Context



## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
