### PR TITLE
fix(ssa): Count params as loop header defined variables when folding

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/opt/constant_folding/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/constant_folding/mod.rs
@@ -3067,8 +3067,6 @@ mod tests {
       ";
         let ssa = Ssa::from_str(src).unwrap();
         let ssa = ssa.fold_constants_with_brillig(DEFAULT_MAX_ITER);
-        // ssa.normalize_ids();
-        // println!("{}", ssa.print_with(None));
         let elements = vec![Value::field((-2i128).into()), Value::field((-1i128).into())];
         let inputs = Value::array(elements, vec![Type::field()]);
         let results = ssa.interpret(vec![inputs]).unwrap();


### PR DESCRIPTION
# Description

## Problem

Resolves #11629

## Summary

Cleanup for https://github.com/noir-lang/noir/pull/11616

Block parameters of loop headers are now included in defined in the header preventing the hoisting logic from moving instructions that use those parameters past the loop header into the pre-header.

## Additional Context

## User Documentation

Check one:
- [X] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
