### PR TITLE
fix(ssa): Track instruction results when hoisting to loop header

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/opt/constant_folding/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/constant_folding/mod.rs
@@ -131,7 +131,7 @@ impl Function {
         let loops = Loops::find_all(self, LoopOrder::OutsideIn);
 
         // Identify loop headers, so we can try to avoid hoisting into them.
-        let loop_headers = loops
+        let mut loop_headers = loops
             .yet_to_unroll
             .into_iter()
             .map(|loop_| {
@@ -156,7 +156,7 @@ impl Function {
                 context.fold_constants_in_block(
                     &mut self.dfg,
                     &mut dom,
-                    &loop_headers,
+                    &mut loop_headers,
                     block,
                     interpreter,
                 );
@@ -268,7 +268,7 @@ impl Context {
         &mut self,
         dfg: &mut DataFlowGraph,
         dom: &mut DominatorTree,
-        loop_headers: &HashMap<BasicBlockId, HashSet<ValueId>>,
+        loop_headers: &mut HashMap<BasicBlockId, HashSet<ValueId>>,
         block_id: BasicBlockId,
         interpreter: &mut Option<Interpreter<Empty>>,
     ) {
@@ -322,7 +322,7 @@ impl Context {
         &mut self,
         dfg: &mut DataFlowGraph,
         dom: &mut DominatorTree,
-        loop_headers: &HashMap<BasicBlockId, HashSet<ValueId>>,
+        loop_headers: &mut HashMap<BasicBlockId, HashSet<ValueId>>,
         block: BasicBlockId,
         id: InstructionId,
         side_effects_enabled_var: &mut ValueId,
@@ -434,8 +434,21 @@ impl Context {
         // so it is deduplicated by the one in the target block.
         // In case it refers to an array that is mutated, we need to increment
         // its reference count.
-        if target_block != block && runtime_is_brillig {
-            Self::increase_rc(id, &new_results, block, dfg);
+        if target_block != block {
+            // If we hoisted into a loop header, update the set of values defined there
+            // so that subsequent hoist decisions don't incorrectly skip past it.
+            // Without this, the loop_headers set becomes stale after hoisting, and later
+            // instructions that use the hoisted result could be hoisted above the loop header
+            // to a block where the result isn't yet defined.
+            if let Some(values_defined_in_header) = loop_headers.get_mut(&target_block) {
+                for result in &new_results {
+                    values_defined_in_header.insert(*result);
+                }
+            }
+
+            if runtime_is_brillig {
+                Self::increase_rc(id, &new_results, block, dfg);
+            }
         }
 
         self.values_to_replace.batch_insert(&old_results, &new_results);
@@ -3102,6 +3115,68 @@ mod tests {
             jmp b4(v15, u1 0)
           b6():
             return v13
+        }
+        ");
+    }
+
+    #[test]
+    fn hoist_to_loop_header_tracks_new_values() {
+        // Regression test for hoisting through loop headers with stale value tracking.
+        //
+        // When b3 (loop body) and b4 (loop exit) both contain identical instructions
+        // (array_get v2 followed by mul), constant folding:
+        // 1. Processes b3 first and caches results
+        // 2. When processing b4, finds cache hits and hoists array_get to the common
+        //    dominator b1 (a loop header)
+        // 3. Without the appropriate tracking, the loop_headers set becomes stale after step 2 — it doesn't
+        //    include the newly hoisted array_get's result. So when b4's mul tries to
+        //    hoist, the code incorrectly escapes past the loop header to b0, creating invalid
+        //    SSA where the mul uses a value not yet defined.
+        let src = "
+        brillig(inline) fn main f0 {
+          b0(v0: [Field; 1]):
+            jmp b1(u8 0, v0)
+          b2():
+            return
+          b1(v1: u8, v2: [Field; 1]):
+            v3 = lt v1, u8 2
+            jmpif v3 then: b3, else: b4
+          b3():
+            v4 = array_get v2, index u32 0 -> Field
+            v5 = mul v4, v4
+            v6 = array_set v2, index u32 0, value v5
+            v7 = unchecked_add v1, u8 1
+            jmp b1(v7, v6)
+          b4():
+            v8 = array_get v2, index u32 0 -> Field
+            v9 = mul v8, v8
+            jmp b2()
+        }
+        ";
+        let ssa = Ssa::from_str(src).unwrap();
+        let ssa = ssa.fold_constants(DEFAULT_MAX_ITER);
+
+        let elements = vec![Value::field((2u32).into())];
+        let inputs = Value::array(elements, vec![Type::field()]);
+        let _ = ssa.interpret(vec![inputs]).unwrap();
+
+        assert_ssa_snapshot!(ssa, @r"
+        brillig(inline) fn main f0 {
+          b0(v0: [Field; 1]):
+            jmp b2(u8 0, v0)
+          b1():
+            return
+          b2(v1: u8, v2: [Field; 1]):
+            v5 = lt v1, u8 2
+            v7 = array_get v2, index u32 0 -> Field
+            v8 = mul v7, v7
+            jmpif v5 then: b3, else: b4
+          b3():
+            v9 = array_set v2, index u32 0, value v8
+            v11 = unchecked_add v1, u8 1
+            jmp b2(v11, v9)
+          b4():
+            jmp b1()
         }
         ");
     }


### PR DESCRIPTION
# Description

## Problem

Resolves #11633

## Summary

Follow-up post https://github.com/noir-lang/noir/pull/11616

When deduplicating identical instructions across sibling blocks (e.g. loop body vs loop exit), the pass hoists to their common dominator. If that dominator is a loop header, the pass tries to escape past it. The loop_headers map tracks which values are defined in each header to prevent escaping when the instruction depends on them. This map was never updated after hoisting new instructions into a header. A subsequent instruction using the hoisted result would see a stale map, escape the header, and land in a block where its operand isn't yet defined.

Changes:
- After hoisting into a loop header, record the new instruction's results in loop_headers so later hoist decisions stay correct.
- Regression unit test

## Additional Context

This blocks mem2reg_simple and being able to test it against the copy coalescing work https://github.com/noir-lang/noir/pull/11622.

## User Documentation

Check one:
- [X] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
