### PR TITLE
fix: simplify before simulate

### DIFF
--- a/acvm-repo/acvm/src/compiler/simulator.rs
+++ b/acvm-repo/acvm/src/compiler/simulator.rs
@@ -9,6 +9,8 @@ use acir::{
 };
 use std::collections::HashSet;
 
+use crate::pwg::arithmetic::ExpressionSolver;
+
 /// Simulate solving a circuit symbolically
 /// Instead of evaluating witness values from the inputs, like the PWG module is doing,
 /// this pass simply marks the witness that can be evaluated, from the known inputs,
@@ -55,7 +57,10 @@ impl CircuitSimulator {
         match opcode {
             Opcode::AssertZero(expr) => {
                 let mut unresolved = HashSet::new();
-                for (_, w1, w2) in &expr.mul_terms {
+                let combined_mul_terms = ExpressionSolver::combine_mul_terms(&expr.mul_terms);
+                let combined_linear_terms =
+                    ExpressionSolver::combine_linear_terms(&expr.linear_combinations);
+                for (_, w1, w2) in &combined_mul_terms {
                     if !self.solvable_witnesses.contains(w1) {
                         if !self.solvable_witnesses.contains(w2) {
                             return false;
@@ -66,7 +71,7 @@ impl CircuitSimulator {
                         unresolved.insert(*w2);
                     }
                 }
-                for (_, w) in &expr.linear_combinations {
+                for (_, w) in &combined_linear_terms {
                     if !self.solvable_witnesses.contains(w) {
                         unresolved.insert(*w);
                     }
@@ -385,5 +390,18 @@ mod tests {
         ";
         let circuit = Circuit::from_str(src).unwrap();
         assert_eq!(CircuitSimulator::check_circuit(&circuit), None);
+    }
+
+    #[test]
+    fn reports_some_when_expression_can_simplify() {
+        let src = "
+        private parameters: []
+        public parameters: []
+        return values: []
+        ASSERT w1 = w1
+        ASSERT w2 = w1
+        ";
+        let empty_circuit = Circuit::from_str(src).unwrap();
+        assert_eq!(CircuitSimulator::check_circuit(&empty_circuit), Some(1));
     }
 }

--- a/acvm-repo/acvm/src/pwg/arithmetic.rs
+++ b/acvm-repo/acvm/src/pwg/arithmetic.rs
@@ -295,7 +295,7 @@ impl ExpressionSolver {
 
     /// Combines linear terms with the same witness by summing their coefficients.
     /// For example `w1 + 2*w1` becomes `3*w1`.
-    fn combine_linear_terms<F: AcirField>(
+    pub(crate) fn combine_linear_terms<F: AcirField>(
         linear_combinations: &[(F, Witness)],
     ) -> Vec<(F, Witness)> {
         let mut combined_linear_combinations = std::collections::HashMap::new();
@@ -318,7 +318,7 @@ impl ExpressionSolver {
     /// Combines multiplication terms with the same witnesses by summing their coefficients.
     /// For example `w1*w2 + 2*w2*w1` becomes `3*w1*w2`. If a coefficient ends up being zero,
     /// the term is removed.
-    fn combine_mul_terms<F: AcirField>(
+    pub(crate) fn combine_mul_terms<F: AcirField>(
         mul_terms: &[(F, Witness, Witness)],
     ) -> Vec<(F, Witness, Witness)> {
         // This is similar to GeneralOptimizer::simplify_mul_terms but it's duplicated because


### PR DESCRIPTION
# Description

## Problem

Resolves AssertZero solvability check treats tautological self-equalities as solvable assignments
Issue #10 in group 5: https://cantina.xyz/code/50033e8c-8b46-41bc-b019-62098708057b

## Summary
Simplify the expression before doing the simulation.


## Additional Context
Although the expression should have already been simplified, it is better to not have to assume it.


## User Documentation

Check one:
- [X] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
