### PR TITLE
chore: harden brillig outputs

### DIFF
--- a/acvm-repo/acvm/src/pwg/brillig.rs
+++ b/acvm-repo/acvm/src/pwg/brillig.rs
@@ -283,21 +283,32 @@ impl<'b, B: BlackBoxFunctionSolver<F>, F: AcirField> BrilligSolver<'b, F, B> {
         for output in outputs.iter() {
             match output {
                 BrilligOutputs::Simple(witness) => {
-                    insert_value(witness, memory[current_ret_data_idx].to_field(), witness_map)?;
-                    current_ret_data_idx += 1;
+                    let value = memory
+                        .get(current_ret_data_idx)
+                        .expect("Return data index exceeds memory bounds");
+                    insert_value(witness, value.to_field(), witness_map)?;
+                    current_ret_data_idx =
+                        current_ret_data_idx.checked_add(1).expect("Return data index overflow");
                 }
                 BrilligOutputs::Array(witness_arr) => {
                     for witness in witness_arr.iter() {
-                        let value = &memory[current_ret_data_idx];
+                        let value = memory
+                            .get(current_ret_data_idx)
+                            .expect("Return data index exceeds memory bounds");
                         insert_value(witness, value.to_field(), witness_map)?;
-                        current_ret_data_idx += 1;
+                        current_ret_data_idx = current_ret_data_idx
+                            .checked_add(1)
+                            .expect("Return data index overflow");
                     }
                 }
             }
         }
 
+        let expected_end = return_data_offset
+            .checked_add(return_data_size)
+            .expect("Return data offset and size overflow");
         assert!(
-            current_ret_data_idx == return_data_offset + return_data_size,
+            current_ret_data_idx == expected_end,
             "Brillig VM did not write the expected number of return values"
         );
         Ok(())
@@ -323,8 +334,13 @@ fn extract_failure_payload_from_memory<F: AcirField>(
     if revert_data_size == 0 {
         None
     } else {
-        let mut revert_values_iter =
-            memory[revert_data_offset..(revert_data_offset + revert_data_size)].iter();
+        let end = revert_data_offset
+            .checked_add(revert_data_size)
+            .expect("Revert data offset and size overflow");
+        let mut revert_values_iter = memory
+            .get(revert_data_offset..end)
+            .expect("Revert data offset and size exceed memory bounds")
+            .iter();
         let error_selector = ErrorSelector::new(
             revert_values_iter
                 .next()


### PR DESCRIPTION
# Description

## Problem

Resolves: Malformed Brillig trap revert metadata can panic in payload extraction

Cantina group 5 issue https://cantina.xyz/code/50033e8c-8b46-41bc-b019-62098708057b/findings/14

## Summary



## Additional Context



## User Documentation

Check one:
- [X] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
