### PR TITLE
fix: prevent crash when resolving method in trait impl with unknown t…

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/variable.rs
+++ b/compiler/noirc_frontend/src/elaborator/variable.rs
@@ -248,15 +248,16 @@ impl Elaborator<'_> {
         // Check if the constant exists in the trait definition (even if impl is missing it).
         // This prevents spurious "Could not resolve" errors inside trait methods when the impl is missing the constant,
         // since the "missing associated constant" error is reported elsewhere.
-        let trait_impl = self.interner.get_trait_implementation(*trait_impl_id);
-        let trait_id = trait_impl.borrow().trait_id;
-        let trait_ = self.interner.get_trait(trait_id);
-        if let Some(definition_id) = trait_.associated_constant_ids.get(name).copied() {
-            let numeric_type = self.interner.definition_type(definition_id);
-            let hir_ident = HirIdent::non_trait_method(definition_id, location);
-            let hir_expr = HirExpression::Ident(hir_ident, None);
-            let id = self.interner.push_expr_full(hir_expr, location, numeric_type.clone());
-            return Some((id, numeric_type));
+        if let Some(trait_impl) = self.interner.try_get_trait_implementation(*trait_impl_id) {
+            let trait_id = trait_impl.borrow().trait_id;
+            let trait_ = self.interner.get_trait(trait_id);
+            if let Some(definition_id) = trait_.associated_constant_ids.get(name).copied() {
+                let numeric_type = self.interner.definition_type(definition_id);
+                let hir_ident = HirIdent::non_trait_method(definition_id, location);
+                let hir_expr = HirExpression::Ident(hir_ident, None);
+                let id = self.interner.push_expr_full(hir_expr, location, numeric_type.clone());
+                return Some((id, numeric_type));
+            }
         }
 
         // Check the `Self::method_name` case when `Self` is a primitive type (2 segments)

--- a/compiler/noirc_frontend/src/tests/traits/trait_associated_items.rs
+++ b/compiler/noirc_frontend/src/tests/traits/trait_associated_items.rs
@@ -1845,3 +1845,18 @@ fn associated_constant_in_return_type_with_generic_impl_forwarding() {
     "#;
     assert_no_errors(src);
 }
+
+// Regression test for https://github.com/noir-lang/noir/issues/11655
+#[test]
+fn self_method_call_on_trait_impl_for_unknown_trait() {
+    let src = r#"
+    impl Unknown for Field {
+         ^^^^^^^ Trait Unknown not found
+        fn unknown() {
+            Self::method()
+                  ^^^^^^ No method named 'method' found for type 'Field'
+        }
+    }
+    "#;
+    check_errors(src);
+}


### PR DESCRIPTION
…rait

# Description

## Problem

Resolves #11655

## Summary



## Additional Context

I was trying to generate docs in https://github.com/AztecProtocol/aztec-packages/pull/20747 and hit this crash.

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
