### PR TITLE
chore: validate Poseidon2 opcode output length

### DIFF
--- a/acvm-repo/acvm/src/compiler/validator.rs
+++ b/acvm-repo/acvm/src/compiler/validator.rs
@@ -309,7 +309,7 @@ pub fn validate_witness<F: AcirField>(
                         assert_eq!(
                             outputs.len(),
                             state.len(),
-                            "Poseidon2 opcode violation: expected {} but found {} results",
+                            "Poseidon2Permutation opcode violation: expected {} but found {} results",
                             state.len(),
                             outputs.len()
                         );


### PR DESCRIPTION
# Description

## Problem

Resolves https://cantina.xyz/code/50033e8c-8b46-41bc-b019-62098708057b/findings?finding=12
Issue 12 from Cantina group 5 report: Poseidon2Permutation validation can silently pass on output/state length mismatch

## Summary



## Additional Context



## User Documentation

Check one:
- [X] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
