### PR TITLE
chore: improve error message when assigning to numeric type alias

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/statements.rs
+++ b/compiler/noirc_frontend/src/elaborator/statements.rs
@@ -457,8 +457,15 @@ impl Elaborator<'_> {
                         let ident = HirIdent::non_trait_method(id, location);
                         self.elaborate_lvalue_ident(ident, location)
                     }
-                    Ok(IdentFromPath::TypeAlias(_)) => {
-                        (HirLValue::Error { location }, Type::Error, false, Vec::new())
+                    Ok(IdentFromPath::TypeAlias(type_alias_id)) => {
+                        let type_alias = self.interner.get_type_alias(type_alias_id);
+                        self.push_err(ResolverError::Expected {
+                            location,
+                            expected: "value",
+                            found: format!("type alias `{}`", type_alias.borrow().name),
+                        });
+                        let mutable = true;
+                        (HirLValue::Error { location }, Type::Error, mutable, Vec::new())
                     }
                     Err(error) => {
                         // We couldn't find a variable or global. Let's see if the identifier refers to something

--- a/compiler/noirc_frontend/src/tests/aliases.rs
+++ b/compiler/noirc_frontend/src/tests/aliases.rs
@@ -910,3 +910,16 @@ fn regression_10764_underscore_impl() {
     "#;
     check_errors(src);
 }
+
+#[test]
+fn cannot_assign_to_numeric_type_alias() {
+    let src = r#"
+    type N: u32 = 1;
+
+    fn main() {
+        N = 2;
+        ^ expected value, found type alias `N`
+    }
+    "#;
+    check_errors(src);
+}


### PR DESCRIPTION
# Description

## Problem

Resolves https://app.audithub.dev/app/organizations/161/projects/599/project-viewer?version=1406&issueId=857

## Summary

In reality the issue got solved when we removed `DefinitionId::dummy_id` but the error for this code:

```noir
type N: u32 = 1;

fn main() {
    N = 2;
}
```

was:

```
Variable `(undeclared variable)` must be mutable to be assigned to
```

Now the error is a bit better.


## Additional Context



## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
