### PR TITLE
fix(acir): Unify empty vector handling in pop

### DIFF
--- a/compiler/noirc_evaluator/src/acir/call/intrinsics/vector_ops.rs
+++ b/compiler/noirc_evaluator/src/acir/call/intrinsics/vector_ops.rs
@@ -336,7 +336,16 @@ impl Context<'_> {
         }
 
         let one = self.acir_context.add_constant(FieldElement::one());
-        let new_vector_length_var = self.acir_context.sub_var(vector_length_var, one)?;
+        let mut new_vector_length_var = self.acir_context.sub_var(vector_length_var, one)?;
+
+        // For unknown length under a side effect variable, we want to multiply with the side effect variable
+        // to ensure we don't end up trying to look up an item at index -1, when the semantic length is 0,
+        // which can fail a circuit even when the side effects are disabled.
+        if is_unknown_length {
+            new_vector_length_var = self
+                .acir_context
+                .mul_var(new_vector_length_var, self.current_side_effects_enabled_var)?;
+        }
 
         Ok(new_vector_length_var)
     }

--- a/compiler/noirc_evaluator/src/acir/tests/intrinsics.rs
+++ b/compiler/noirc_evaluator/src/acir/tests/intrinsics.rs
@@ -272,8 +272,22 @@ fn vector_pop_back_unknown_length() {
     BLACKBOX::RANGE input: w1, bits: 1
     ASSERT w2 = 1
     INIT b0 = [w2]
-    ASSERT w3 = w1*w1 - w1
-    READ w4 = b0[w3]
+    BRILLIG CALL func: 0, predicate: w1, inputs: [w1], outputs: [w3]
+    ASSERT w4 = w1*w3
+    ASSERT w1 = w1*w4
+    ASSERT w5 = w1*w1 - w1
+    READ w6 = b0[w5]
+
+    unconstrained func 0: directive_invert
+    0: @21 = const u32 1
+    1: @20 = const u32 0
+    2: @0 = calldata copy [@20; @21]
+    3: @2 = const field 0
+    4: @3 = field eq @0, @2
+    5: jump if @3 to 8
+    6: @1 = const field 1
+    7: @0 = field field_div @1, @0
+    8: stop @[@20; @21]
     ");
 }
 


### PR DESCRIPTION
# Description

## Problem

Resolves https://cantina.xyz/code/50033e8c-8b46-41bc-b019-62098708057b/findings?finding=18

## Summary

Unifies the handling of empty-vector checks in `vector_pop_front` and `vector_pop_back`. 

## Additional Context

* https://github.com/noir-lang/noir/pull/10455 added some prevention but it only worked for the disabled case.
* https://github.com/noir-lang/noir/pull/11107 added handling in `vector_pop_front` and an integration test for `vector_pop_back`, but the latter failed with the `Failed to solve program: 'Index out of bounds, array has size 2, but index was -1'` instead of `Assertion failed: Attempt to pop_back from an empty vector`. 

I was a bit preplexed why we need both of the above fixes, but we do, otherwise integration tests fail. If we have a non-constant length, we add an assertion that the length is not zero, which only kicks in if the side effects are enabled, but if they are disabled, we return 0 for the new length, so we end up reading item 0 in both pop versions, rather than item -1. 

But how can we read item 0 from an empty vector? The reason this is needed is because we are reading item 0 from a vector which is merged across multiple branches, and isn't actually physically empty, just its semantic length is 0. So we _can_ read item 0 without a problem on the disabled branch. This is illustrated in the first PR linked above.

If we didn't have a case of merging vectors of different lengths, at least one of which is non-zero, then the compiler would know that the length is constant 0, and it would return early from the `convert_vector_pop_*` methods.

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
