### PR TITLE
fix: prevent double register deallocation in coalescing hub pattern

### DIFF
--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_block.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_block.rs
@@ -446,9 +446,10 @@ impl<'block, Registers: RegisterAllocator> BrilligBlock<'block, Registers> {
                 let is_hoisted_global = self.get_hoisted_global(dfg, *dead_variable).is_some();
                 let not_global = !is_global && !is_hoisted_global;
                 if not_global {
-                    if let Some(partner) =
-                        self.function_context.coalescing.get_partner(dead_variable)
-                        && self.variables.is_allocated(&partner)
+                    if self
+                        .function_context
+                        .coalescing
+                        .has_live_partner(dead_variable, |v| self.variables.is_allocated(v))
                     {
                         // This value shares a register with a coalescing partner that is
                         // still alive. We must not deallocate the register yet; it will

--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/coalescing.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/coalescing.rs
@@ -40,8 +40,9 @@ fn can_coalesce_param_side(
 pub(crate) struct CoalescingMap {
     coalesced: HashMap<ValueId, ValueId>,
     /// Reverse mapping: values that are targets of coalescing.
-    /// Maps a coalescing target back to its source.
-    coalesced_reverse: HashMap<ValueId, ValueId>,
+    /// Maps a coalescing target back to all its sources (multiple values
+    /// can map to the same hub value).
+    coalesced_reverse: HashMap<ValueId, Vec<ValueId>>,
 }
 
 impl CoalescingMap {
@@ -153,7 +154,10 @@ impl CoalescingMap {
             }
         }
 
-        let coalesced_reverse = coalesced.iter().map(|(k, v)| (*v, *k)).collect::<HashMap<_, _>>();
+        let mut coalesced_reverse: HashMap<ValueId, Vec<ValueId>> = HashMap::default();
+        for (k, v) in &coalesced {
+            coalesced_reverse.entry(*v).or_default().push(*k);
+        }
         Self { coalesced, coalesced_reverse }
     }
 
@@ -170,12 +174,41 @@ impl CoalescingMap {
         self.coalesced.contains_key(value_id)
     }
 
-    /// Bidirectional lookup: returns the coalescing partner of `value_id`,
-    /// regardless of whether it is the arg or the param in the pair. Used when
-    /// a value dies to check whether its partner is still alive and sharing
-    /// the same register.
-    pub(crate) fn get_partner(&self, value_id: &ValueId) -> Option<ValueId> {
-        self.coalesced.get(value_id).or_else(|| self.coalesced_reverse.get(value_id)).copied()
+    /// Check whether any value sharing a register with `value_id` through
+    /// coalescing is still alive (i.e., satisfies the `is_alive` predicate).
+    ///
+    /// Multiple values can share a register through a "hub" pattern:
+    /// e.g., `v1 → v_hub ← v3` means v1, v_hub, and v3 all share one register.
+    /// When `v1` dies we must check whether `v_hub` or any sibling (like `v3`)
+    /// is still alive before deallocating the register.
+    pub(crate) fn has_live_partner(
+        &self,
+        value_id: &ValueId,
+        is_alive: impl Fn(&ValueId) -> bool,
+    ) -> bool {
+        // Forward: check the hub this value maps to
+        if let Some(hub) = self.coalesced.get(value_id) {
+            if is_alive(hub) {
+                return true;
+            }
+            // Also check siblings: other values that map to the same hub
+            if let Some(siblings) = self.coalesced_reverse.get(hub) {
+                for sibling in siblings {
+                    if sibling != value_id && is_alive(sibling) {
+                        return true;
+                    }
+                }
+            }
+        }
+        // Reverse: this value is a hub — check all values that map to it
+        if let Some(sources) = self.coalesced_reverse.get(value_id) {
+            for source in sources {
+                if is_alive(source) {
+                    return true;
+                }
+            }
+        }
+        false
     }
 
     #[cfg(test)]

--- a/compiler/noirc_evaluator/src/brillig/mod.rs
+++ b/compiler/noirc_evaluator/src/brillig/mod.rs
@@ -372,4 +372,27 @@ mod memory_layout {
 
         let _ = ssa.to_brillig(&BrilligOptions::default());
     }
+
+    /// Regression test: two coalesced values sharing a register through a target
+    /// (v1->v2 arg-side, v3->v2 param-side) both die at the same instruction in b2.
+    /// The partner (v2) is not alive in b2, so both try to deallocate the same
+    /// register — the second attempt must not panic.
+    #[test]
+    fn coalescing_target_double_dealloc() {
+        let src = "
+        brillig(inline) fn main f0 {
+          b0(v0: Field):
+            v1 = add v0, Field 1
+            jmp b1(v1)
+          b1(v2: Field):
+            jmp b2(v2)
+          b2(v3: Field):
+            v4 = eq v3, v1
+            return v4
+        }
+        ";
+
+        let ssa = Ssa::from_str(src).unwrap();
+        let _ = ssa.to_brillig(&BrilligOptions::default());
+    }
 }


### PR DESCRIPTION
## Summary

Fixed was pulled out from [af10059](https://github.com/noir-lang/noir/pull/11556/commits/af10059e49100df947ffc5d5c1c0eebe2c35867f) in #11556

- Fixes a "register already deallocated" panic in Brillig codegen when multiple coalesced values share a register through a common hub value
- The root cause was a lossy reverse mapping (`HashMap<ValueId, ValueId>`) that could only track one source per target. When multiple values coalesced to the same hub (e.g., `v1 → v2 ← v3`), the reverse map would silently drop earlier entries, causing `get_partner` to miss live siblings and attempt to deallocate the same register twice
- Changes `coalesced_reverse` to a multimap (`HashMap<ValueId, Vec<ValueId>>`) and replaces `get_partner` with `has_live_partner` that checks the hub, all siblings, and all reverse sources before deciding whether a register can be freed

## Test plan

- [x] Added regression test `coalescing_target_double_dealloc` that reproduces the exact pattern (two values sharing a register through a hub, both dying at the same instruction)
- [x] All 17 coalescing unit tests pass
- [x] All 205 Brillig tests pass  
- [x] Fuzzer smoke test passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)