### PR TITLE
chore(docs): Add missing `;` in integer wrapping code example

### DIFF
--- a/docs/docs/noir/concepts/data_types/integers.md
+++ b/docs/docs/noir/concepts/data_types/integers.md
@@ -125,7 +125,7 @@ fn wrapping_mul(self, y: Self) -> Self;
 Example of how it is used:
 
 ```rust
-use std::ops::WrappingAdd
+use std::ops::WrappingAdd;
 fn main(x: u8, y: u8) -> pub u8 {
     x.wrapping_add(y)
 }

--- a/docs/versioned_docs/version-v1.0.0-beta.18/noir/concepts/data_types/integers.md
+++ b/docs/versioned_docs/version-v1.0.0-beta.18/noir/concepts/data_types/integers.md
@@ -125,7 +125,7 @@ fn wrapping_mul(self, y: Self) -> Self;
 Example of how it is used:
 
 ```rust
-use std::ops::WrappingAdd
+use std::ops::WrappingAdd;
 fn main(x: u8, y: u8) -> pub u8 {
     x.wrapping_add(y)
 }


### PR DESCRIPTION
# Description

The current example in the wrapping methods section under integers doesn't compile due to a missing `;`.
This PR adds the `;`.

## User Documentation

Check one:
- [ ] No user documentation needed.
- [x] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
