### PR TITLE
fix(frontend): use integer division for ambiguous type-level constants

### DIFF
--- a/compiler/noirc_frontend/src/hir_def/types.rs
+++ b/compiler/noirc_frontend/src/hir_def/types.rs
@@ -277,6 +277,13 @@ impl Kind {
         }
     }
 
+    fn is_definitely_field_element(&self) -> bool {
+        match self.follow_bindings() {
+            Self::Numeric(typ) => matches!(*typ, Type::FieldElement),
+            _ => false,
+        }
+    }
+
     fn integral_minimum_size(&self) -> Option<SignedField> {
         match self.follow_bindings() {
             Kind::Any | Kind::IntegerOrField | Kind::Integer | Kind::Normal => None,
@@ -3300,9 +3307,25 @@ impl BinaryTypeOperator {
                 BinaryTypeOperator::Addition => Ok(a + b),
                 BinaryTypeOperator::Subtraction => Ok(a - b),
                 BinaryTypeOperator::Multiplication => Ok(a * b),
-                BinaryTypeOperator::Division => (!b.is_zero())
-                    .then(|| a / b)
-                    .ok_or(TypeCheckError::DivisionByZero { lhs: a, rhs: b, location }),
+                BinaryTypeOperator::Division => {
+                    if b.is_zero() {
+                        return Err(TypeCheckError::DivisionByZero { lhs: a, rhs: b, location });
+                    }
+                    if kind.is_definitely_field_element() {
+                        Ok(a / b)
+                    } else {
+                        let a_i128 = a.to_i128();
+                        let b_i128 = b.to_i128();
+                        let err = TypeCheckError::FailingBinaryOp {
+                            op: self,
+                            lhs: a_i128.to_string(),
+                            rhs: b_i128.to_string(),
+                            location,
+                        };
+                        let result = a_i128.checked_div(b_i128).ok_or(err)?;
+                        Ok(result.into())
+                    }
+                }
                 BinaryTypeOperator::Modulo => {
                     Err(TypeCheckError::ModuloOnFields { lhs: a, rhs: b, location })
                 }

--- a/compiler/noirc_frontend/src/tests/arithmetic_generics.rs
+++ b/compiler/noirc_frontend/src/tests/arithmetic_generics.rs
@@ -287,3 +287,16 @@ fn numeric_generic_arithmetic_in_return_type_concat() {
     "#;
     assert_no_errors(src);
 }
+
+#[test]
+fn arithmetic_generics_division_on_type_constants() {
+    let src = r#"
+        fn foo<let N: u32>(_x: [Field; N]) {}
+
+        fn main() {
+            // 11 / 2 = 5
+            foo::<11 / 2>([0; 5]);
+        }
+    "#;
+    assert_no_errors(src);
+}


### PR DESCRIPTION
## Summary
- Unsuffixed integer literals in turbofish positions (e.g. `foo::<11 / 2>()`) were evaluated using field element division (modular inverse) instead of integer division
- Root cause: their `Kind` was an unbound `IntegerOrField` type variable, and `integral_maximum_size()` returns `None` for both `Field` and `IntegerOrField`, routing both to the field division path
- Added `Kind::is_definitely_field_element()` to distinguish known `Field` from ambiguous kinds, using integer division for the latter
- Added regression test

## Test plan
- [x] New test `arithmetic_generics_division_on_type_constants` verifies `11
 / 2 = 5`
- [x] All ~1494 frontend tests pass
- [x] Proptests pass (no regression in `compare_to_comptime`)

Closes #11722