### PR TITLE
fix: copy lambda env in comptime evaluation

### DIFF
--- a/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
@@ -1247,11 +1247,12 @@ impl<'local, 'interner> Interpreter<'local, 'interner> {
         let location = self.elaborator.interner.expr_location(&id);
         let env = try_vecmap(&lambda.captures, |capture| {
             let value = self.lookup_id(capture.ident.id, location)?;
-            match value {
+            let value = match value {
                 // Dereference mutable variables to capture by value
                 Value::Pointer(elem, true, _) => Ok(elem.unwrap_or_clone()),
                 other => Ok(other),
-            }
+            }?;
+            Ok(value.move_struct())
         })?;
 
         let typ = self.elaborator.interner.id_type(id).follow_bindings();

--- a/test_programs/execution_success/lambda_env_is_copied/Nargo.toml
+++ b/test_programs/execution_success/lambda_env_is_copied/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "lambda_env_is_copied"
+version = "0.1.0"
+type = "bin"
+authors = [""]
+
+[dependencies]

--- a/test_programs/execution_success/lambda_env_is_copied/src/main.nr
+++ b/test_programs/execution_success/lambda_env_is_copied/src/main.nr
@@ -1,0 +1,12 @@
+struct Pair {
+    x: i32,
+    y: i32,
+}
+
+fn main() {
+    let mut p = Pair { x: 1, y: 2 };
+    let get_x = || p.x;
+    p.x = 99;
+    let captured_x = get_x();
+    assert_eq(captured_x, 1);
+}

--- a/tooling/nargo_cli/tests/snapshots/execution_success/lambda_env_is_copied/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/lambda_env_is_copied/execute__tests__expanded.snap
@@ -1,0 +1,16 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: expanded_code
+---
+struct Pair {
+    x: i32,
+    y: i32,
+}
+
+fn main() {
+    let mut p: Pair = Pair { x: 1_i32, y: 2_i32 };
+    let get_x: fn[(Pair,)]() -> i32 = || -> i32 p.x;
+    p.x = 99_i32;
+    let captured_x: i32 = get_x();
+    assert(captured_x == 1_i32);
+}

--- a/tooling/nargo_cli/tests/snapshots/execution_success/lambda_env_is_copied/execute__tests__stdout.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/lambda_env_is_copied/execute__tests__stdout.snap
@@ -1,0 +1,5 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: stdout
+---
+


### PR DESCRIPTION
# Description

## Problem

Resolves https://app.audithub.dev/app/organizations/161/projects/600/project-viewer?version=1408&issueId=823

## Summary



## Additional Context

The regression test fails with `--force-comptime` on `master`.

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
