### PR TITLE
fix: proper field comparison in comptime

### DIFF
--- a/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
@@ -3322,11 +3322,11 @@ mod tests {
     }
 
     fn pos(v: u128) -> Value {
-        Value::Field(SignedField::positive(v))
+        Value::field(SignedField::positive(v))
     }
 
     fn neg(v: u128) -> Value {
-        Value::Field(SignedField::negative(v))
+        Value::field(SignedField::negative(v))
     }
 
     #[test]


### PR DESCRIPTION
# Description

## Problem

Resolves Issue 870 from Group 9 Veridise audit: Comptime field comparison uses signed semantics diverging from runtime.
https://app.audithub.dev/app/organizations/161/projects/600/project-viewer?version=1408&issueId=870


## Summary



## Additional Context



## User Documentation

Check one:
- [X] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
