### PR TITLE
fix: forbid modifying functions using builtin macros in another crate

### DIFF
--- a/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
@@ -140,6 +140,10 @@ impl<'local, 'interner> Interpreter<'local, 'interner> {
         }
     }
 
+    pub(crate) fn current_function(&self) -> Option<FuncId> {
+        self.current_function
+    }
+
     /// Call the given function with the given arguments and return the result.
     ///
     /// This will handle internal details like binding generics and error handling.

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
@@ -53,7 +53,7 @@ use crate::{
         function::FunctionBody,
         traits::{ResolvedTraitBound, TraitConstraint},
     },
-    node_interner::{DefinitionKind, NodeInterner, TraitImplKind},
+    node_interner::{DefinitionKind, FuncId, NodeInterner, TraitImplKind},
     parser::{Parser, StatementOrExpressionOrLValue},
     shared::{Signedness, Visibility},
     signed_field::SignedField,
@@ -2554,8 +2554,12 @@ fn function_def_add_attribute(
         });
     };
 
+    let self_arg = self_argument.0.clone();
     let func_id = get_function_def(self_argument)?;
     check_function_not_yet_resolved(interpreter, func_id, location)?;
+
+    let func_module = func_module(interpreter, &func_id);
+    check_item_crate_matches_current_crate(interpreter, &self_arg, func_module, location)?;
 
     let function_modifiers = interpreter.elaborator.interner.function_modifiers_mut(&func_id);
 
@@ -2753,10 +2757,14 @@ fn function_def_set_body(
     location: Location,
 ) -> IResult<Value> {
     let (self_argument, body_argument) = check_two_arguments(arguments, location)?;
+    let self_arg = self_argument.0.clone();
     let body_location = body_argument.1;
 
     let func_id = get_function_def(self_argument)?;
     check_function_not_yet_resolved(interpreter, func_id, location)?;
+
+    let func_module = func_module(interpreter, &func_id);
+    check_item_crate_matches_current_crate(interpreter, &self_arg, func_module, location)?;
 
     let body_argument = get_expr(interpreter.elaborator.interner, body_argument)?;
     let statement_kind = match body_argument {
@@ -2794,10 +2802,14 @@ fn function_def_set_parameters(
     location: Location,
 ) -> IResult<Value> {
     let (self_argument, parameters_argument) = check_two_arguments(arguments, location)?;
+    let self_arg = self_argument.0.clone();
     let parameters_argument_location = parameters_argument.1;
 
     let func_id = get_function_def(self_argument)?;
     check_function_not_yet_resolved(interpreter, func_id, location)?;
+
+    let func_module = func_module(interpreter, &func_id);
+    check_item_crate_matches_current_crate(interpreter, &self_arg, func_module, location)?;
 
     let (input_parameters, _type) = get_vector(parameters_argument)?;
 
@@ -2853,10 +2865,14 @@ fn function_def_set_return_type(
     location: Location,
 ) -> IResult<Value> {
     let (self_argument, return_type_argument) = check_two_arguments(arguments, location)?;
+    let self_arg = self_argument.0.clone();
     let return_type = get_type(return_type_argument)?;
 
     let func_id = get_function_def(self_argument)?;
     check_function_not_yet_resolved(interpreter, func_id, location)?;
+
+    let func_module = func_module(interpreter, &func_id);
+    check_item_crate_matches_current_crate(interpreter, &self_arg, func_module, location)?;
 
     let quoted_type_id = interpreter.elaborator.interner.push_quoted_type(return_type.clone());
 
@@ -2878,9 +2894,13 @@ fn function_def_set_return_public(
     location: Location,
 ) -> IResult<Value> {
     let (self_argument, public) = check_two_arguments(arguments, location)?;
+    let self_arg = self_argument.0.clone();
 
     let func_id = get_function_def(self_argument)?;
     check_function_not_yet_resolved(interpreter, func_id, location)?;
+
+    let func_module = func_module(interpreter, &func_id);
+    check_item_crate_matches_current_crate(interpreter, &self_arg, func_module, location)?;
 
     let public = get_bool(public)?;
 
@@ -2898,9 +2918,15 @@ fn function_def_set_return_data(
     location: Location,
 ) -> IResult<Value> {
     let self_argument = check_one_argument(arguments, location)?;
+    let self_arg = self_argument.0.clone();
 
     let func_id = get_function_def(self_argument)?;
     check_function_not_yet_resolved(interpreter, func_id, location)?;
+
+    let func_meta_read = interpreter.elaborator.interner.function_meta(&func_id);
+    let func_module =
+        ModuleId { krate: func_meta_read.source_crate, local_id: func_meta_read.source_module };
+    check_item_crate_matches_current_crate(interpreter, &self_arg, func_module, location)?;
 
     let func_meta = interpreter.elaborator.interner.function_meta_mut(&func_id);
     func_meta.return_visibility = Visibility::ReturnData;
@@ -2916,9 +2942,13 @@ fn function_def_set_unconstrained(
     location: Location,
 ) -> IResult<Value> {
     let (self_argument, unconstrained) = check_two_arguments(arguments, location)?;
+    let self_arg = self_argument.0.clone();
 
     let func_id = get_function_def(self_argument)?;
     check_function_not_yet_resolved(interpreter, func_id, location)?;
+
+    let func_module = func_module(interpreter, &func_id);
+    check_item_crate_matches_current_crate(interpreter, &self_arg, func_module, location)?;
 
     let unconstrained = get_bool(unconstrained)?;
 
@@ -2997,6 +3027,11 @@ fn module_hash(arguments: Vec<(Value, Location)>, location: Location) -> IResult
 
 fn module_eq(arguments: Vec<(Value, Location)>, location: Location) -> IResult<Value> {
     eq_item(arguments, location, get_module)
+}
+
+fn func_module(interpreter: &Interpreter, func_id: &FuncId) -> ModuleId {
+    let func_meta_read = interpreter.elaborator.interner.function_meta(func_id);
+    ModuleId { krate: func_meta_read.source_crate, local_id: func_meta_read.source_module }
 }
 
 // fn functions(self) -> [FunctionDefinition]

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin/builtin_helpers.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin/builtin_helpers.rs
@@ -497,12 +497,19 @@ pub(super) fn check_item_crate_matches_current_crate(
     item_module: ModuleId,
     location: Location,
 ) -> IResult<()> {
-    let current_crate = interpreter.elaborator.module_id().krate;
+    let elaborator_crate = interpreter.elaborator.module_id().krate;
+    // current_crate is the crate where current_function() is defined, or the one
+    // of the elaborator's current module if there is no current function
+    let current_crate = if let Some(func_id) = interpreter.current_function() {
+        interpreter.elaborator.interner.function_meta(&func_id).source_crate
+    } else {
+        elaborator_crate
+    };
     if current_crate != item_module.krate {
         let module = fully_qualified_module_path(
             interpreter.elaborator.def_maps,
             interpreter.elaborator.crate_graph,
-            &current_crate,
+            &elaborator_crate,
             item_module,
         );
         let item = item.display(interpreter.elaborator.interner).to_string();

--- a/test_programs/compile_failure/comptime_lib_cannot_mutate_caller/Nargo.toml
+++ b/test_programs/compile_failure/comptime_lib_cannot_mutate_caller/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "comptime_lib_cannot_mutate_caller"
+type = "bin"
+authors = [""]
+
+[dependencies]
+dependency = { path = "dependency" }

--- a/test_programs/compile_failure/comptime_lib_cannot_mutate_caller/dependency/Nargo.toml
+++ b/test_programs/compile_failure/comptime_lib_cannot_mutate_caller/dependency/Nargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "dependency"
+type = "lib"
+authors = [""]
+
+[dependencies]

--- a/test_programs/compile_failure/comptime_lib_cannot_mutate_caller/dependency/src/lib.nr
+++ b/test_programs/compile_failure/comptime_lib_cannot_mutate_caller/dependency/src/lib.nr
@@ -1,0 +1,5 @@
+// This attribute function tries to modify a function from the caller's crate.
+// This should be rejected: a library cannot mutate items in the calling crate.
+pub comptime fn make_unconstrained(f: FunctionDefinition) {
+    f.set_unconstrained(true);
+}

--- a/test_programs/compile_failure/comptime_lib_cannot_mutate_caller/src/main.nr
+++ b/test_programs/compile_failure/comptime_lib_cannot_mutate_caller/src/main.nr
@@ -1,0 +1,8 @@
+use dependency::make_unconstrained;
+
+// Applying a library attribute that tries to set_unconstrained on a local function
+// should fail because the library cannot modify items in the caller's crate.
+#[make_unconstrained]
+fn foo() {}
+
+fn main() {}


### PR DESCRIPTION
# Description

## Problem

Resolves Veridise audit report group9 issue 848: Comptime code can manipulate caller crate
https://app.audithub.dev/app/organizations/161/projects/600/project-viewer?version=1408&issueId=848

## Summary
Check the crate where the macro is defined in the macro builtins for modifying functions.


## Additional Context



## User Documentation

Check one:
- [X] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
