### PR TITLE
chore: bump external pinned commits

### DIFF
--- a/.github/benchmark_projects.yml
+++ b/.github/benchmark_projects.yml
@@ -1,4 +1,4 @@
-define: &AZ_COMMIT 0cb3cbd0bccbb83fa4e4dcf060c21230696b7df1
+define: &AZ_COMMIT 940351a2d7cb027bc9ce6844dfc1158fbc684333
 projects:
   private-kernel-inner:
     repo: AztecProtocol/aztec-packages

--- a/EXTERNAL_NOIR_LIBRARIES.yml
+++ b/EXTERNAL_NOIR_LIBRARIES.yml
@@ -1,4 +1,4 @@
-define: &AZ_COMMIT 0cb3cbd0bccbb83fa4e4dcf060c21230696b7df1
+define: &AZ_COMMIT 940351a2d7cb027bc9ce6844dfc1158fbc684333
 libraries:
   noir_check_shuffle:
     repo: noir-lang/noir_check_shuffle


### PR DESCRIPTION

Automated update of the pinned commit of [aztec-packages](https://github.com/AztecProtocol/aztec-packages) repository against which we run benchmarks.
