### PR TITLE
chore(readme): Update local docs development prerequisites + Add version cutting instructions

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -18,9 +18,9 @@ Check out the contributing guide [here](../CONTRIBUTING.md).
 
 ### Prerequisites
 
-- Node.js (tested working with v25.8.0)
-- Yarn (tested working with v4.10.3)
-- Rust (tested working with v1.89.0)
+- Node.js ([pinned version](./package.json#L65))
+- Yarn ([pinned version](../package.json#L47))
+- Rust ([pinned version](../rust-toolchain.toml#L2))
 - GNU ld (tested working with v2.45.1-4.fc43)
 - jq (tested working with v1.8.1)
 


### PR DESCRIPTION
# Description

This PR:
1. Specifies the need for Rust, GNU ld, and jq as doc building prerequisites
3. Replaces doc building prerequisite versions with links to pinned versions in the codebase
4. Adds versioned docs cutting instructions for when carrying out manual docs cutting (e.g. https://github.com/noir-lang/noir/pull/11724, https://github.com/noir-lang/noir/pull/11750)
5. Minor rewording of Installation section for clarity

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
