### PR TITLE
chore: add explicit GITHUB_TOKEN permissions to all workflows

### DIFF
--- a/.github/workflows/bump-aztec-packages-commit.yml
+++ b/.github/workflows/bump-aztec-packages-commit.yml
@@ -6,6 +6,7 @@ on:
     # Trigger at 8am on Mondays
     - cron: '0 8 * * 1'
 
+permissions: {}
 
 jobs:
   bump-commit:

--- a/.github/workflows/cache-cleanup.yml
+++ b/.github/workflows/cache-cleanup.yml
@@ -10,11 +10,13 @@ on:
     types:
       - closed
 
+permissions: {}
+
 jobs:
   cleanup:
     runs-on: ubuntu-22.04
     permissions:
-      contents: write
+      actions: write
     steps:
       - name: Cleanup
         run: |

--- a/.github/workflows/deny.yml
+++ b/.github/workflows/deny.yml
@@ -9,6 +9,8 @@ on:
     paths: [Cargo.lock, .github/workflows/deny.yml]
   merge_group:
 
+permissions: {}
+
 env:
   RUSTFLAGS: -D warnings
   CARGO_TERM_COLOR: always

--- a/.github/workflows/docs-dead-links.yml
+++ b/.github/workflows/docs-dead-links.yml
@@ -5,6 +5,8 @@ on:
     # Run a check at 9 AM UTC
     - cron: "0 9 * * *"
 
+permissions: {}
+
 # This will cancel previous runs when a branch or PR is updated
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref || github.run_id }}

--- a/.github/workflows/docs-pr.yml
+++ b/.github/workflows/docs-pr.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
   merge_group:
 
+permissions: {}
+
 jobs:
   add_label:
     runs-on: ubuntu-22.04
@@ -54,6 +56,8 @@ jobs:
 
   build_preview:
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v6

--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -7,6 +7,8 @@ on:
     branches:
       - master
 
+permissions: {}
+
 # This will cancel previous runs when a branch or PR is updated
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref || github.run_id }}

--- a/.github/workflows/publish-acvm.yml
+++ b/.github/workflows/publish-acvm.yml
@@ -7,12 +7,15 @@ on:
         description: The acvm reference to checkout
         required: true
 
+permissions: {}
+
 jobs:
   publish:
     name: Publish in order
     runs-on: ubuntu-22.04
     permissions:
       contents: read
+      issues: write
     steps:
       - name: Checkout sources
         uses: actions/checkout@v6

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -7,6 +7,8 @@ on:
     paths: [docs/**]
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   publish-docs:
     name: Publish docs

--- a/.github/workflows/publish-es-packages.yml
+++ b/.github/workflows/publish-es-packages.yml
@@ -14,9 +14,13 @@ on:
 
 run-name: Publish ES Packages from ${{ inputs.noir-ref }} under @${{ inputs.npm-tag }} tag.
 
+permissions: {}
+
 jobs:
   build-noirc_abi_wasm:
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
     steps:
       - name: Checkout Noir repo
         uses: actions/checkout@v6
@@ -50,6 +54,8 @@ jobs:
 
   build-noir_wasm:
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
     steps:
       - name: Checkout sources
         uses: actions/checkout@v6
@@ -86,6 +92,8 @@ jobs:
 
   build-acvm_js:
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
     steps:
       - name: Checkout sources
         uses: actions/checkout@v6

--- a/.github/workflows/publish-nargo.yml
+++ b/.github/workflows/publish-nargo.yml
@@ -17,6 +17,7 @@ on:
   merge_group:
   pull_request:
 
+permissions: {}
 
 jobs:
   build-apple-darwin:

--- a/.github/workflows/publish-nightly.yml
+++ b/.github/workflows/publish-nightly.yml
@@ -5,9 +5,13 @@ on:
     # Run a nightly release at 2 AM UTC
     - cron: "0 2 * * *"
 
+permissions: {}
+
 jobs:
   dispatch-publish-es:
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
     steps:
       - name: Dispatch to publish-nargo
         uses: benc-uk/workflow-dispatch@v1

--- a/.github/workflows/publish-stdlib-docs.yml
+++ b/.github/workflows/publish-stdlib-docs.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - master
 
+permissions: {}
+
 jobs:
   build-nargo:
     runs-on: ubuntu-22.04

--- a/.github/workflows/recrawler.yml
+++ b/.github/workflows/recrawler.yml
@@ -7,6 +7,8 @@ on:
     - cron: "0 9 * * 1-5"
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   algolia_recrawl:
     name: Algolia Recrawl

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - master
 
+permissions: {}
+
 jobs:
   release-please:
     name: Create Release
@@ -12,6 +14,8 @@ jobs:
       release-pr: ${{ steps.release.outputs.pr }}
       tag-name: ${{ steps.release.outputs.tag_name }}
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
     steps:
       - name: Run release-please
         id: release
@@ -24,6 +28,8 @@ jobs:
     needs: [release-please]
     if: ${{ needs.release-please.outputs.release-pr }}
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
     steps:
       - name: Checkout release branch
         uses: actions/checkout@v6
@@ -67,6 +73,8 @@ jobs:
     needs: [release-please, update-acvm-workspace-package-versions]
     if: ${{ needs.release-please.outputs.release-pr }}
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout release branch
@@ -150,6 +158,8 @@ jobs:
     needs: [release-please]
     if: ${{ needs.release-please.outputs.tag-name }}
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
     steps:
       - name: Dispatch to publish workflow
         uses: benc-uk/workflow-dispatch@v1
@@ -165,6 +175,8 @@ jobs:
     needs: [release-please]
     if: ${{ needs.release-please.outputs.tag-name }}
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
     steps:
       - name: Dispatch to publish-es-packages
         uses: benc-uk/workflow-dispatch@v1
@@ -179,6 +191,8 @@ jobs:
     needs: [release-please]
     if: ${{ needs.release-please.outputs.tag-name }}
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
 
     steps:
       - name: Dispatch to publish-acvm

--- a/.github/workflows/reports.yml
+++ b/.github/workflows/reports.yml
@@ -6,6 +6,8 @@ on:
       - master
   pull_request:
 
+permissions: {}
+
 jobs:
   rust_benchmarks:
     name: Rust Benchmarks
@@ -59,6 +61,8 @@ jobs:
     name: Load benchmark projects list
     runs-on: ubuntu-22.04
     timeout-minutes: 5
+    permissions:
+      contents: read
     outputs:
       projects: ${{ steps.get_bench_projects.outputs.projects }}
 
@@ -76,6 +80,8 @@ jobs:
   build-nargo:
     runs-on: ubuntu-22.04
     timeout-minutes: 15
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout Noir repo
@@ -110,6 +116,8 @@ jobs:
   build-noir-inspector:
     runs-on: ubuntu-22.04
     timeout-minutes: 15
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout Noir repo
@@ -344,6 +352,8 @@ jobs:
     needs: [build-nargo, build-noir-inspector, benchmark-projects-list]
     runs-on: ubuntu-22.04
     timeout-minutes: 20
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -466,6 +476,8 @@ jobs:
     needs: [build-nargo, benchmark-projects-list]
     runs-on: ubuntu-22.04
     timeout-minutes: 30
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -1049,6 +1061,8 @@ jobs:
     name: End
     runs-on: ubuntu-22.04
     timeout-minutes: 5
+    permissions:
+      contents: read
     # We want this job to always run (even if the dependant jobs fail) as we want this job to fail rather than skipping.
     if: ${{ always() }}
     needs:

--- a/.github/workflows/rustdoc.yml
+++ b/.github/workflows/rustdoc.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - master
 
+permissions: {}
+
 # This will cancel previous runs when a branch or PR is updated
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref || github.run_id }}

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -2,6 +2,8 @@ name: Spellcheck
 
 on: [pull_request]
 
+permissions: {}
+
 # This will cancel previous runs when a branch or PR is updated
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref || github.run_id }}

--- a/.github/workflows/test-js-packages.yml
+++ b/.github/workflows/test-js-packages.yml
@@ -7,6 +7,8 @@ on:
     branches:
       - master
 
+permissions: {}
+
 # This will cancel previous runs when a branch or PR is updated
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref || github.run_id }}

--- a/.github/workflows/test-rust-workspace-arm64.yml
+++ b/.github/workflows/test-rust-workspace-arm64.yml
@@ -11,6 +11,8 @@ on:
     # Run a check at 9 AM UTC
     - cron: "0 9 * * *"
 
+permissions: {}
+
 jobs:
   build-test-artifacts:
     name: Build test artifacts
@@ -99,6 +101,7 @@ jobs:
       - run-tests
     permissions:
       contents: read
+      issues: write
 
     steps:
       - name: Report overall success

--- a/.github/workflows/test-rust-workspace-msrv.yml
+++ b/.github/workflows/test-rust-workspace-msrv.yml
@@ -13,6 +13,8 @@ on:
     branches:
       - master
 
+permissions: {}
+
 # This will cancel previous runs when a branch or PR is updated
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref || github.run_id }}

--- a/.github/workflows/test-rust-workspace.yml
+++ b/.github/workflows/test-rust-workspace.yml
@@ -7,6 +7,8 @@ on:
     branches:
       - master
 
+permissions: {}
+
 # This will cancel previous runs when a branch or PR is updated
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref || github.run_id }}


### PR DESCRIPTION
## Summary

Fixes GitHub code scanning alerts for missing explicit workflow permissions. Without top-level `permissions:` declarations, workflows inherit the repository/organization default token permissions, which is typically read-write — violating the principle of least privilege.

- Adds `permissions: {}` (default-deny) at the top level of all 21 workflows that were missing it
- Adds explicit job-level `permissions` to 17 jobs across 5 workflows that were missing them (`reports.yml`, `release.yml`, `publish-nightly.yml`, `publish-es-packages.yml`, `docs-pr.yml`)
- Fixes incorrect permissions on 3 jobs:
  - `cache-cleanup.yml`: `contents: write` → `actions: write` (`gh actions-cache delete` needs `actions: write`, not `contents: write`)
  - `publish-acvm.yml`: adds missing `issues: write` (needed by `JasonEtco/create-an-issue`)
  - `test-rust-workspace-arm64.yml`: adds missing `issues: write` to `tests-end` (needed by `JasonEtco/create-an-issue`)

## Test plan

- [x] Verify YAML syntax is valid (validated locally with Python yaml parser)
- [x] Confirm all 23 workflows have a top-level `permissions:` key
- [x] Confirm every job in every workflow has a `permissions:` key
- [x] Spot-check that CI workflows still pass (job-level permissions override top-level, so existing correct jobs are unaffected)