### PR TITLE
fix: skip empty AssertZero opcodes in ACVM optimizer

### DIFF
--- a/acvm-repo/acvm/src/compiler/optimizers/mod.rs
+++ b/acvm-repo/acvm/src/compiler/optimizers/mod.rs
@@ -63,18 +63,23 @@ pub(super) fn optimize_internal<F: AcirField>(
 
     info!("Number of opcodes before: {}", acir.opcodes.len());
 
-    // General optimizer pass
-    let opcodes: Vec<Opcode<F>> = acir
+    // General optimizer pass: simplify expressions and remove trivially-satisfied constraints.
+    let (opcodes, acir_opcode_positions): (Vec<_>, Vec<_>) = acir
         .opcodes
         .into_iter()
-        .map(|opcode| {
+        .zip(acir_opcode_positions)
+        .filter_map(|(opcode, position)| {
             if let Opcode::AssertZero(arith_expr) = opcode {
-                Opcode::AssertZero(GeneralOptimizer::optimize(arith_expr))
+                let optimized = GeneralOptimizer::optimize(arith_expr);
+                if optimized.is_zero() {
+                    return None;
+                }
+                Some((Opcode::AssertZero(optimized), position))
             } else {
-                opcode
+                Some((opcode, position))
             }
         })
-        .collect();
+        .unzip();
     let acir = Circuit { opcodes, ..acir };
 
     // Unused memory optimization pass
@@ -99,4 +104,30 @@ pub(super) fn optimize_internal<F: AcirField>(
     info!("Number of opcodes after: {}", acir.opcodes.len());
 
     (acir, acir_opcode_positions)
+}
+
+#[cfg(test)]
+mod tests {
+    use acir::{FieldElement, circuit::Circuit};
+    use std::collections::BTreeMap;
+
+    use crate::{assert_circuit_snapshot, compiler::optimizers::optimize_internal};
+
+    #[test]
+    fn removes_empty_assert_zero_opcodes() {
+        let src = "
+        private parameters: [w0, w1]
+        public parameters: []
+        return values: []
+        ASSERT w0*w1 - w1*w0 = 0
+        ";
+        let circuit = Circuit::<FieldElement>::from_str(src).unwrap();
+        let acir_opcode_positions = (0..circuit.opcodes.len()).collect();
+        let (optimized, _) = optimize_internal(circuit, acir_opcode_positions, &BTreeMap::new());
+        assert_circuit_snapshot!(optimized, @r"
+        private parameters: [w0, w1]
+        public parameters: []
+        return values: []
+        ");
+    }
 }

--- a/compiler/noirc_evaluator/src/acir/mod.rs
+++ b/compiler/noirc_evaluator/src/acir/mod.rs
@@ -922,24 +922,33 @@ impl<'a> Context<'a> {
     }
 }
 
-/// Check post ACIR generation properties
+/// Check post ACIR generation properties:
+/// * No empty `AssertZero` opcodes (asserting `0 == 0`) should be emitted.
 /// * No memory opcodes should be laid down that write to the internal type sizes array.
 ///   See [arrays] for more information on the type sizes array.
 #[cfg(debug_assertions)]
 fn acir_post_check(context: &Context<'_>, acir: &GeneratedAcir<FieldElement>) {
     use acvm::acir::circuit::Opcode;
     for opcode in acir.opcodes() {
-        let Opcode::MemoryOp { block_id, op } = opcode else {
-            continue;
-        };
-        if op.operation.is_one() {
-            // Check that we have no writes to the type size arrays
-            let is_type_sizes_array =
-                context.element_type_sizes_blocks.values().any(|id| id == block_id);
-            assert!(
-                !is_type_sizes_array,
-                "ICE: Writes to the internal type sizes array are forbidden"
-            );
+        match opcode {
+            Opcode::AssertZero(expr) => {
+                assert!(
+                    !expr.is_zero(),
+                    "ICE: Empty AssertZero opcodes (0 == 0) should not be emitted"
+                );
+            }
+            Opcode::MemoryOp { block_id, op } => {
+                if op.operation.is_one() {
+                    // Check that we have no writes to the type size arrays
+                    let is_type_sizes_array =
+                        context.element_type_sizes_blocks.values().any(|id| id == block_id);
+                    assert!(
+                        !is_type_sizes_array,
+                        "ICE: Writes to the internal type sizes array are forbidden"
+                    );
+                }
+            }
+            _ => {}
         }
     }
 }


### PR DESCRIPTION
## Summary

- The ACVM general optimizer can simplify `AssertZero` expressions to zero (e.g., `w0*w1 - w1*w0`) producing trivially-satisfied `ASSERT 0 = 0` opcodes. These are now filtered out during the optimizer pass.
- Added a `debug_assertions` post-check in ACIR generation to catch any empty `AssertZero` opcodes being emitted.

## Test plan

- Added unit test in the ACVM optimizer (`removes_empty_assert_zero_opcodes`) verifying that `w0*w1 - w1*w0` is simplified and removed.