### PR TITLE
chore: output "(last step)" for last SSA step

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/builder.rs
+++ b/compiler/noirc_evaluator/src/ssa/builder.rs
@@ -163,8 +163,9 @@ impl<'local> SsaBuilder<'local> {
 
     /// Run a list of SSA passes.
     pub fn run_passes(mut self, passes: &[SsaPass]) -> Result<Self, RuntimeError> {
-        for pass in passes {
-            self = self.try_run_pass(|ssa| pass.run(ssa), pass.msg)?;
+        for (index, pass) in passes.iter().enumerate() {
+            let last = index == passes.len() - 1;
+            self = self.try_run_pass(|ssa| pass.run(ssa), pass.msg, last)?;
         }
         Ok(self)
     }
@@ -180,14 +181,15 @@ impl<'local> SsaBuilder<'local> {
     }
 
     /// The same as `run_pass` but for passes that may fail
-    fn try_run_pass<F>(mut self, pass: F, msg: &str) -> Result<Self, RuntimeError>
+    fn try_run_pass<F>(mut self, pass: F, msg: &str, last: bool) -> Result<Self, RuntimeError>
     where
         F: FnOnce(Ssa) -> Result<Ssa, RuntimeError>,
     {
         // Count the number of times we have seen this message.
         let cnt = *self.passed.entry(msg.to_string()).and_modify(|cnt| *cnt += 1).or_insert(1);
         let step = self.passed.values().sum::<usize>();
-        let msg = format!("{msg} ({cnt}) (step {step})");
+        let last_step_msg = if last { " (last step)" } else { "" };
+        let msg = format!("{msg} ({cnt}) (step {step}){last_step_msg}");
 
         // See if we should skip this pass, including the count, so we can skip the n-th occurrence of a step.
         let skip = self.skip_passes.iter().any(|s| msg.contains(s));

--- a/tooling/nargo_cli/src/cli/interpret_cmd.rs
+++ b/tooling/nargo_cli/src/cli/interpret_cmd.rs
@@ -156,7 +156,9 @@ pub(crate) fn run(args: InterpretCommand, workspace: Workspace) -> Result<(), Cl
 
         // Run SSA passes in the pipeline and interpret the ones we are interested in.
         for (i, ssa_pass) in ssa_passes.iter().enumerate() {
-            let msg = format!("{} (step {})", ssa_pass.msg(), i + 1);
+            let last_step = i == ssa_passes.len() - 1;
+            let last_step_msg = if last_step { " (last step)" } else { "" };
+            let msg = format!("{} (step {}){last_step_msg}", ssa_pass.msg(), i + 1);
 
             if msg_matches(&args.compile_options.skip_ssa_pass, &msg) {
                 continue;

--- a/tooling/ssa_cli/src/cli/mod.rs
+++ b/tooling/ssa_cli/src/cli/mod.rs
@@ -135,11 +135,14 @@ fn parse_ssa(src: &str, validate: bool) -> eyre::Result<Ssa> {
 /// List of the SSA passes in the primary pipeline, enriched with their "step"
 /// count so we can use unambiguous naming in filtering.
 fn ssa_passes(options: &SsaEvaluatorOptions) -> Vec<(String, SsaPass<'_>)> {
-    primary_passes(options)
-        .into_iter()
+    let passes = primary_passes(options).into_iter();
+    let length = passes.len();
+    passes
         .enumerate()
         .map(|(i, pass)| {
-            let msg = format!("{} (step {})", pass.msg(), i + 1);
+            let last_step = i == length - 1;
+            let last_step_msg = if last_step { " (last step)" } else { "" };
+            let msg = format!("{} (step {}){last_step_msg}", pass.msg(), i + 1);
             (msg, pass)
         })
         .collect()


### PR DESCRIPTION
# Description

## Problem

No issue.

## Summary

Many times when I want to compare the final SSA of two versions of a compiler I use `--show-ssa` and manually find where the last SSA pass starts, copy that, etc. I could use "step N" if I knew what N is, but it keeps changing between compiler versions.

In this PR for the last step we also show "(last step)" so you can show only that by doing `--show-ssa-pass="last step"`.

## Additional Context



## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
