### PR TITLE
fix: unwrap expr in comptime is_break/is_continue/has_semicolon

### DIFF
--- a/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
@@ -2370,6 +2370,7 @@ fn expr_has_semicolon(
 ) -> IResult<Value> {
     let self_argument = check_one_argument(arguments, location)?;
     let expr_value = get_expr(interner, self_argument)?;
+    let expr_value = unwrap_expr_value_except_semi(interner, expr_value);
     Ok(Value::Bool(matches!(expr_value, ExprValue::Statement(StatementKind::Semi(..)))))
 }
 
@@ -2381,6 +2382,7 @@ fn expr_is_break(
 ) -> IResult<Value> {
     let self_argument = check_one_argument(arguments, location)?;
     let expr_value = get_expr(interner, self_argument)?;
+    let expr_value = unwrap_expr_value(interner, expr_value);
     Ok(Value::Bool(matches!(expr_value, ExprValue::Statement(StatementKind::Break))))
 }
 
@@ -2392,6 +2394,7 @@ fn expr_is_continue(
 ) -> IResult<Value> {
     let self_argument = check_one_argument(arguments, location)?;
     let expr_value = get_expr(interner, self_argument)?;
+    let expr_value = unwrap_expr_value(interner, expr_value);
     Ok(Value::Bool(matches!(expr_value, ExprValue::Statement(StatementKind::Continue))))
 }
 
@@ -2476,15 +2479,36 @@ fn expr_resolve(
     })
 }
 
-fn unwrap_expr_value(interner: &NodeInterner, mut expr_value: ExprValue) -> ExprValue {
+fn unwrap_expr_value(interner: &NodeInterner, expr_value: ExprValue) -> ExprValue {
+    let unwrap_semi = true;
+    unwrap_expr_value_helper(interner, expr_value, unwrap_semi)
+}
+
+fn unwrap_expr_value_except_semi(interner: &NodeInterner, expr_value: ExprValue) -> ExprValue {
+    let unwrap_semi = false;
+    unwrap_expr_value_helper(interner, expr_value, unwrap_semi)
+}
+
+fn unwrap_expr_value_helper(
+    interner: &NodeInterner,
+    mut expr_value: ExprValue,
+    unwrap_semi: bool,
+) -> ExprValue {
     loop {
         match expr_value {
             ExprValue::Expression(ExpressionKind::Parenthesized(expression)) => {
                 expr_value = ExprValue::Expression(expression.kind);
             }
-            ExprValue::Statement(StatementKind::Expression(expression))
-            | ExprValue::Statement(StatementKind::Semi(expression)) => {
+            ExprValue::Statement(StatementKind::Expression(expression)) => {
                 expr_value = ExprValue::Expression(expression.kind);
+            }
+            ExprValue::Statement(StatementKind::Semi(expression)) => {
+                if unwrap_semi {
+                    expr_value = ExprValue::Expression(expression.kind);
+                } else {
+                    expr_value = ExprValue::Statement(StatementKind::Semi(expression));
+                    break;
+                }
             }
             ExprValue::Expression(ExpressionKind::Interned(id)) => {
                 expr_value = ExprValue::Expression(interner.get_expression_kind(id).clone());

--- a/test_programs/compile_success_empty/expr_has_semicolon_is_break_is_continue_consistency/Nargo.toml
+++ b/test_programs/compile_success_empty/expr_has_semicolon_is_break_is_continue_consistency/Nargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "expr_has_semicolon_is_break_is_continue_consistency"
+type = "bin"
+authors = [""]
+
+[dependencies]

--- a/test_programs/compile_success_empty/expr_has_semicolon_is_break_is_continue_consistency/src/main.nr
+++ b/test_programs/compile_success_empty/expr_has_semicolon_is_break_is_continue_consistency/src/main.nr
@@ -1,0 +1,44 @@
+// This program checks that `is_break`, `is_continue` and `has_semicolon` work the same
+// way for a quoted expression and recursive quoted values that eventually lead to the same expression.
+fn main() {
+    comptime {
+        let a = quote { break }.as_expr().unwrap();
+        let b = quote { $a }.as_expr().unwrap();
+        let c = quote { $b }.as_expr().unwrap();
+
+        assert(a.is_break());
+        assert(b.is_break());
+        assert(c.is_break());
+
+        // c is still semantically identical to `break`.
+        assert(a.quoted() == quote { break });
+        assert(b.quoted() == quote { break });
+        assert(c.quoted() == quote { break });
+
+        let a = quote { continue }.as_expr().unwrap();
+        let b = quote { $a }.as_expr().unwrap();
+        let c = quote { $b }.as_expr().unwrap();
+
+        assert(a.is_continue());
+        assert(b.is_continue());
+        assert(c.is_continue());
+
+        // c is still semantically identical to `continue`.
+        assert(a.quoted() == quote { continue });
+        assert(b.quoted() == quote { continue });
+        assert(c.quoted() == quote { continue });
+
+        let block = quote { { 1; } }.as_expr().unwrap();
+        let a = block.as_block().unwrap()[0];
+        let b = quote { $a }.as_expr().unwrap();
+        let c = quote { $b }.as_expr().unwrap();
+
+        assert(a.has_semicolon());
+        assert(b.has_semicolon());
+        assert(c.has_semicolon()); // WRONG
+
+        // c is still semantically identical to `1;`.
+        assert(a.quoted() == c.quoted());
+        assert(c.quoted() == quote { 1; });
+    }
+}

--- a/tooling/nargo_cli/tests/snapshots/compile_success_empty/expr_has_semicolon_is_break_is_continue_consistency/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_empty/expr_has_semicolon_is_break_is_continue_consistency/execute__tests__expanded.snap
@@ -1,0 +1,7 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: expanded_code
+---
+fn main() {
+    ()
+}


### PR DESCRIPTION
# Description

## Problem

Resolves https://app.audithub.dev/app/organizations/161/projects/600/project-viewer?version=1408&issueId=874

## Summary



## Additional Context



## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
