### PR TITLE
chore: bump external pinned commits

### DIFF
--- a/.github/benchmark_projects.yml
+++ b/.github/benchmark_projects.yml
@@ -1,4 +1,4 @@
-define: &AZ_COMMIT 940351a2d7cb027bc9ce6844dfc1158fbc684333
+define: &AZ_COMMIT 755cc08ead3ee6e6bc741a4f2a254554dca6fe16
 projects:
   private-kernel-inner:
     repo: AztecProtocol/aztec-packages

--- a/EXTERNAL_NOIR_LIBRARIES.yml
+++ b/EXTERNAL_NOIR_LIBRARIES.yml
@@ -1,4 +1,4 @@
-define: &AZ_COMMIT 940351a2d7cb027bc9ce6844dfc1158fbc684333
+define: &AZ_COMMIT 755cc08ead3ee6e6bc741a4f2a254554dca6fe16
 libraries:
   noir_check_shuffle:
     repo: noir-lang/noir_check_shuffle


### PR DESCRIPTION

Automated update of the pinned commit of [aztec-packages](https://github.com/AztecProtocol/aztec-packages) repository against which we run benchmarks.
