### PR TITLE
fix(comptime): Implement `Hash` and `PartialEq` for `TraitConstraint`

### DIFF
--- a/compiler/noirc_frontend/src/hir/type_check/generics.rs
+++ b/compiler/noirc_frontend/src/hir/type_check/generics.rs
@@ -177,7 +177,7 @@ impl Generic for FmtstrPrimitiveType {
 
 /// TraitGenerics are different from regular generics in that they can
 /// also contain associated type arguments.
-#[derive(Default, PartialEq, Eq, Clone, Hash, Ord, PartialOrd)]
+#[derive(Default, Clone, Ord, PartialOrd, Eq)]
 pub struct TraitGenerics {
     pub ordered: Vec<Type>,
     pub named: Vec<NamedType>,
@@ -194,6 +194,13 @@ impl TraitGenerics {
     pub fn is_empty(&self) -> bool {
         self.ordered.is_empty() && self.named.is_empty()
     }
+
+    /// Return references to the named types sorted by name.
+    fn named_sorted(&self) -> Vec<&NamedType> {
+        let mut named = self.named.iter().collect::<Vec<_>>();
+        named.sort_by_key(|x| &x.name);
+        named
+    }
 }
 
 impl std::fmt::Display for TraitGenerics {
@@ -205,6 +212,19 @@ impl std::fmt::Display for TraitGenerics {
 impl std::fmt::Debug for TraitGenerics {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         fmt_trait_generics(self, f, true)
+    }
+}
+
+impl PartialEq for TraitGenerics {
+    fn eq(&self, other: &Self) -> bool {
+        self.ordered == other.ordered && self.named_sorted() == other.named_sorted()
+    }
+}
+
+impl std::hash::Hash for TraitGenerics {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.ordered.hash(state);
+        self.named_sorted().hash(state);
     }
 }
 

--- a/test_programs/execution_success/comptime_trait_constraint_hash_and_eq/Nargo.toml
+++ b/test_programs/execution_success/comptime_trait_constraint_hash_and_eq/Nargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "comptime_trait_constraint_hash_and_eq"
+type = "bin"
+authors = [""]
+
+[dependencies]

--- a/test_programs/execution_success/comptime_trait_constraint_hash_and_eq/src/main.nr
+++ b/test_programs/execution_success/comptime_trait_constraint_hash_and_eq/src/main.nr
@@ -1,0 +1,80 @@
+use std::hash::{Hash, Hasher};
+
+trait TwoOrdered<A, B> {}
+
+trait TwoNamed {
+    type A;
+    type B;
+}
+
+impl TwoOrdered<Field, u8> for Field {}
+impl TwoOrdered<u8, Field> for Field {}
+
+impl TwoNamed for Field {
+    type A = Field;
+    type B = u8;
+}
+
+struct TestHasher {
+    result: Field,
+}
+
+impl Hasher for TestHasher {
+    fn finish(self) -> Field {
+        self.result
+    }
+    fn write(&mut self, input: Field) {
+        self.result += input;
+    }
+}
+
+comptime fn hash_constraint(t: TraitConstraint) -> Field {
+    let mut h = TestHasher { result: 0 };
+    t.hash(&mut h);
+    h.finish()
+}
+
+fn main() {
+    comptime {
+        let t = quote { Field }.as_type();
+
+        // The constraints below are semantically equivalent,
+        // so they should be considered equal and have the same hash.
+        {
+            let c1 = quote { TwoNamed<A = Field, B = u8> }.as_trait_constraint();
+            let c2 = quote { TwoNamed<B = u8, A = Field> }.as_trait_constraint();
+
+            // They should be printed in the original order.
+            println(c1);
+            println(c2);
+
+            assert(t.implements(c1));
+            assert(t.implements(c2));
+
+            assert(c1 == c2);
+
+            let hash_c1 = hash_constraint(c1);
+            let hash_c2 = hash_constraint(c2);
+            assert(hash_c1 == hash_c2);
+        }
+
+        // The constraints below are not equivalents.
+        {
+            let c1 = quote { TwoOrdered<Field, u8> }.as_trait_constraint();
+            let c2 = quote { TwoOrdered<u8, Field> }.as_trait_constraint();
+
+            // They should be printed in the original order.
+            println(c1);
+            println(c2);
+
+            assert(t.implements(c1));
+            assert(t.implements(c2));
+
+            assert(c1 != c2);
+
+            let hash_c1 = hash_constraint(c1);
+            let hash_c2 = hash_constraint(c2);
+            assert(hash_c1 != hash_c2);
+        }
+    }
+}

--- a/tooling/nargo_cli/tests/snapshots/execution_success/comptime_trait_constraint_hash_and_eq/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/comptime_trait_constraint_hash_and_eq/execute__tests__expanded.snap
@@ -1,0 +1,47 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: expanded_code
+---
+use std::hash::{Hash, Hasher};
+
+trait TwoOrdered<A, B> {}
+
+impl TwoOrdered<Field, u8> for Field {}
+
+impl TwoOrdered<u8, Field> for Field {}
+
+trait TwoNamed {
+    type A;
+
+    type B;
+}
+
+impl TwoNamed for Field {
+    type A = Self;
+
+    type B = u8;
+}
+
+struct TestHasher {
+    result: Field,
+}
+
+impl Hasher for TestHasher {
+    fn finish(self) -> Field {
+        self.result
+    }
+
+    fn write(&mut self, input: Field) {
+        self.result = self.result + input;
+    }
+}
+
+comptime fn hash_constraint(t: TraitConstraint) -> Field {
+    let mut h: TestHasher = TestHasher { result: 0_Field };
+    t.hash(&mut h);
+    h.finish()
+}
+
+fn main() {
+    ()
+}

--- a/tooling/nargo_cli/tests/snapshots/execution_success/comptime_trait_constraint_hash_and_eq/execute__tests__stdout.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/comptime_trait_constraint_hash_and_eq/execute__tests__stdout.snap
@@ -1,0 +1,8 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: stdout
+---
+TwoNamed<A = Field, B = u8>
+TwoNamed<B = u8, A = Field>
+TwoOrdered<Field, u8>
+TwoOrdered<u8, Field>


### PR DESCRIPTION
# Description

## Problem

Resolves https://app.audithub.dev/app/organizations/161/projects/600/project-viewer?version=1408&issueId=871

## Summary

Implement `Hash` and `PartialEq` for `TraitConstraint` so that the equality/hash of a quoted trait constraint such as `quote { TwoNamed<A = Field, B = u8> }.as_trait_constraint()` does not depend on the ordering of the named generics (the associated types in the constraint).

## Additional Context



## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
