### PR TITLE
fix(docs): resolve #include_code macros in v1.0.0-beta.19 versioned docs

### DIFF
--- a/docs/versioned_docs/version-v1.0.0-beta.19/noir/concepts/comptime.md
+++ b/docs/versioned_docs/version-v1.0.0-beta.19/noir/concepts/comptime.md
@@ -119,7 +119,29 @@ program at that point, and parse it as an expression. To do this, we have to add
 If the value was created locally and there is no function returning it, `std::meta::unquote!(_)` can be used instead.
 Calling such a function at compile-time without `!` will just return the `Quoted` value to be further manipulated. For example:
 
-#include_code quote-example noir_stdlib/src/meta/mod.nr rust
+```rust title="quote-example" showLineNumbers 
+comptime fn quote_one() -> Quoted {
+        quote { 1 }
+    }
+
+    #[test]
+    fn returning_versus_macro_insertion() {
+        comptime {
+            // let _a: Quoted = quote { 1 };
+            let _a: Quoted = quote_one();
+
+            // let _b: Field = 1;
+            let _b: Field = quote_one!();
+
+            // Since integers default to fields, if we
+            // want a different type we have to explicitly cast
+            // let _c: i32 = 1 as i32;
+            let _c: i32 = quote_one!() as i32;
+        }
+    }
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/mod.nr#L131-L151" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/mod.nr#L131-L151</a></sub></sup>
+
 
 For those familiar with quoting from other languages (primarily lisps), Noir's `quote` is actually a _quasiquote_.
 This means we can escape the quoting by using the unquote operator to splice values in the middle of quoted code.
@@ -196,7 +218,42 @@ Note that formatting a quoted value with multiple tokens will always insert a sp
 undesired, you'll need to only operate on quoted values containing a single token. To do this, you can iterate
 over each token of a larger quoted value with `.tokens()`:
 
-#include_code concatenate-example noir_stdlib/src/meta/mod.nr rust
+```rust title="concatenate-example" showLineNumbers 
+comptime fn concatenate(q1: Quoted, q2: Quoted) -> Quoted {
+        assert(q1.tokens().len() <= 1);
+        assert(q2.tokens().len() <= 1);
+
+        f"{q1}{q2}".quoted_contents()
+    }
+
+    // The CtString type is also useful for a compile-time string of unbounded size
+    // so that you can append to it in a loop.
+    comptime fn double_spaced(q: Quoted) -> CtString {
+        let mut result = "".as_ctstring();
+
+        for token in q.tokens() {
+            if result != "".as_ctstring() {
+                result = result.append_str("  ");
+            }
+            result = result.append_fmtstr(f"{token}");
+        }
+
+        result
+    }
+
+    #[test]
+    fn concatenate_test() {
+        comptime {
+            let result = concatenate(quote {foo}, quote {bar});
+            assert_eq(result, quote {foobar});
+
+            let result = double_spaced(quote {foo bar 3}).as_quoted_str!();
+            assert_eq(result, "foo  bar  3");
+        }
+    }
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/mod.nr#L266-L299" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/mod.nr#L266-L299</a></sub></sup>
+
 
 ### $crate
 
@@ -250,18 +307,67 @@ Note that expressions are not valid at top-level so you'll get an error trying t
 You can insert other top-level items such as trait impls, structs, or functions this way though.
 For example, this is the mechanism used to insert additional trait implementations into the program when deriving a trait impl from a struct:
 
-#include_code derive-field-count-example noir_stdlib/src/meta/mod.nr rust
+```rust title="derive-field-count-example" showLineNumbers 
+trait FieldCount {
+        fn field_count() -> u32;
+    }
+
+    #[derive_field_count]
+    struct Bar {
+        x: Field,
+        y: [Field; 2],
+    }
+
+    comptime fn derive_field_count(s: TypeDefinition) -> Quoted {
+        let typ = s.as_type();
+        let field_count = s.fields_as_written().len();
+        quote {
+            impl FieldCount for $typ {
+                fn field_count() -> u32 {
+                    $field_count
+                }
+            }
+        }
+    }
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/mod.nr#L153-L175" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/mod.nr#L153-L175</a></sub></sup>
+
 
 ### Calling annotations with additional arguments
 
 Arguments may optionally be given to attributes.
 When this is done, these additional arguments are passed to the attribute function after the item argument.
 
-#include_code annotation-arguments-example noir_stdlib/src/meta/mod.nr rust
+```rust title="annotation-arguments-example" showLineNumbers 
+#[assert_field_is_type(quote { i32 }.as_type())]
+    struct MyStruct {
+        my_field: i32,
+    }
+
+    comptime fn assert_field_is_type(s: TypeDefinition, typ: Type) {
+        // Assert the first field in `s` has type `typ`
+        let fields = s.fields([]);
+        assert_eq(fields[0].1, typ);
+    }
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/mod.nr#L177-L188" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/mod.nr#L177-L188</a></sub></sup>
+
 
 We can also take any number of arguments by adding the `varargs` attribute:
 
-#include_code annotation-varargs-example noir_stdlib/src/meta/mod.nr rust
+```rust title="annotation-varargs-example" showLineNumbers 
+#[assert_three_args(1, 2, 3)]
+    struct MyOtherStruct {
+        my_other_field: u32,
+    }
+
+    #[varargs]
+    comptime fn assert_three_args(_s: TypeDefinition, args: [Field]) {
+        assert_eq(args.len(), 3);
+    }
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/mod.nr#L190-L200" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/mod.nr#L190-L200</a></sub></sup>
+
 
 ### Attribute Evaluation Order
 
@@ -361,10 +467,110 @@ struct MyStruct { my_field: u32 }
 To implement `derive` we'll have to create a `comptime` function that accepts
 a variable amount of traits.
 
-#include_code derive_example noir_stdlib/src/meta/mod.nr rust
+```rust title="derive_example" showLineNumbers 
+// These are needed for the unconstrained hashmap we're using to store derive functions
+use crate::collections::umap::UHashMap;
+use crate::hash::BuildHasherDefault;
+use crate::hash::poseidon2::Poseidon2Hasher;
+
+// A derive function is one that given a type definition can
+// create us a quoted trait impl from it.
+pub type DeriveFunction = fn(TypeDefinition) -> Quoted;
+
+// We'll keep a global HANDLERS map to keep track of the derive handler for each trait
+comptime mut global HANDLERS: UHashMap<TraitDefinition, DeriveFunction, BuildHasherDefault<Poseidon2Hasher>> =
+    UHashMap::default();
+
+// Given a type definition and a vector of traits to derive, create trait impls for each.
+// This function is as simple as iterating over the vector, checking if we have a trait
+// handler registered for the given trait, calling it, and appending the result.
+#[varargs]
+pub comptime fn derive(s: TypeDefinition, traits: [TraitDefinition]) -> Quoted {
+    let mut result = quote {};
+
+    for trait_to_derive in traits {
+        let handler = HANDLERS.get(trait_to_derive);
+        assert(handler.is_some(), f"No derive function registered for `{trait_to_derive}`");
+
+        let trait_impl = handler.unwrap()(s);
+        result = quote { $result $trait_impl };
+    }
+
+    result
+}
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/mod.nr#L33-L66" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/mod.nr#L33-L66</a></sub></sup>
+
 
 Registering a derive function could be done as follows:
 
-#include_code derive_via noir_stdlib/src/meta/mod.nr rust
+```rust title="derive_via" showLineNumbers 
+// To register a handler for a trait, just add it to our handlers map
+pub comptime fn derive_via(t: TraitDefinition, f: DeriveFunction) {
+    HANDLERS.insert(t, f);
+}
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/mod.nr#L68-L75" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/mod.nr#L68-L75</a></sub></sup>
 
-#include_code big-derive-usage-example noir_stdlib/src/meta/mod.nr rust
+
+```rust title="big-derive-usage-example" showLineNumbers 
+// Finally, to register a handler we call the above function as an annotation
+    // with our handler function.
+    #[derive_via(derive_do_nothing)]
+    trait DoNothing {
+        fn do_nothing(self);
+    }
+
+    comptime fn derive_do_nothing(s: TypeDefinition) -> Quoted {
+        // This is simplified since we don't handle generics or where clauses!
+        // In a real example we'd likely also need to introduce each of
+        // `s.generics()` as well as a trait constraint for each generic
+        // to ensure they also implement the trait.
+        let typ = s.as_type();
+        quote {
+            impl DoNothing for $typ {
+                fn do_nothing(self) {
+                    // Traits can't tell us what to do
+                    println("something");
+                }
+            }
+        }
+    }
+
+    // Since `DoNothing` is a simple trait which:
+    // 1. Only has one method
+    // 2. Does not have any generics on the trait itself
+    // We can use `std::meta::make_trait_impl` to help us out.
+    // This helper function will generate our impl for us along with any
+    // necessary where clauses and still provides a flexible interface
+    // for us to work on each field on the struct.
+    comptime fn derive_do_nothing_alt(s: TypeDefinition) -> Quoted {
+        let trait_name = quote { DoNothing };
+        let method_signature = quote { fn do_nothing(self) };
+
+        // Call `do_nothing` recursively on each field in the struct
+        let for_each_field = |field_name| quote { self.$field_name.do_nothing(); };
+
+        // Some traits like Eq want to join each field expression with something like `&`.
+        // We don't need that here
+        let join_fields_with = quote {};
+
+        // The body function is a spot to insert any extra setup/teardown needed.
+        // We'll insert our println here. Since we recur on each field, we should see
+        // one println for the struct itself, followed by a println for every field (recursively).
+        let body = |body| quote {
+            println("something");
+            $body
+        };
+        crate::meta::make_trait_impl(
+            s,
+            trait_name,
+            method_signature,
+            for_each_field,
+            join_fields_with,
+            body,
+        )
+    }
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/mod.nr#L202-L260" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/mod.nr#L202-L260</a></sub></sup>
+

--- a/docs/versioned_docs/version-v1.0.0-beta.19/noir/concepts/data_types/fields.md
+++ b/docs/versioned_docs/version-v1.0.0-beta.19/noir/concepts/data_types/fields.md
@@ -37,43 +37,93 @@ After declaring a Field, you can use these common methods on it:
 
 Transforms the field into an array of bits, Little Endian.
 
-#include_code to_le_bits noir_stdlib/src/field/mod.nr rust
+```rust title="to_le_bits" showLineNumbers 
+pub fn to_le_bits<let N: u32>(self: Self) -> [u1; N] {
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/field/mod.nr#L29-L31" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/field/mod.nr#L29-L31</a></sub></sup>
+
 
 example:
 
-#include_code to_le_bits_example noir_stdlib/src/field/mod.nr rust
+```rust title="to_le_bits_example" showLineNumbers 
+fn test_to_le_bits() {
+        let field = 2;
+        let bits: [u1; 8] = field.to_le_bits();
+        assert_eq(bits, [0, 1, 0, 0, 0, 0, 0, 0]);
+    }
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/field/mod.nr#L356-L362" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/field/mod.nr#L356-L362</a></sub></sup>
+
 
 
 ### to_be_bits
 
 Transforms the field into an array of bits, Big Endian.
 
-#include_code to_be_bits noir_stdlib/src/field/mod.nr rust
+```rust title="to_be_bits" showLineNumbers 
+pub fn to_be_bits<let N: u32>(self: Self) -> [u1; N] {
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/field/mod.nr#L61-L63" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/field/mod.nr#L61-L63</a></sub></sup>
+
 
 example:
 
-#include_code to_be_bits_example noir_stdlib/src/field/mod.nr rust
+```rust title="to_be_bits_example" showLineNumbers 
+fn test_to_be_bits() {
+        let field = 2;
+        let bits: [u1; 8] = field.to_be_bits();
+        assert_eq(bits, [0, 0, 0, 0, 0, 0, 1, 0]);
+    }
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/field/mod.nr#L347-L353" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/field/mod.nr#L347-L353</a></sub></sup>
+
 
 
 ### to_le_bytes
 
 Transforms into an array of bytes, Little Endian
 
-#include_code to_le_bytes noir_stdlib/src/field/mod.nr rust
+```rust title="to_le_bytes" showLineNumbers 
+pub fn to_le_bytes<let N: u32>(self: Self) -> [u8; N] {
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/field/mod.nr#L93-L95" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/field/mod.nr#L93-L95</a></sub></sup>
+
 
 example:
 
-#include_code to_le_bytes_example noir_stdlib/src/field/mod.nr rust
+```rust title="to_le_bytes_example" showLineNumbers 
+fn test_to_le_bytes() {
+        let field = 2;
+        let bytes: [u8; 8] = field.to_le_bytes();
+        assert_eq(bytes, [2, 0, 0, 0, 0, 0, 0, 0]);
+        assert_eq(Field::from_le_bytes::<8>(bytes), field);
+    }
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/field/mod.nr#L375-L382" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/field/mod.nr#L375-L382</a></sub></sup>
+
 
 ### to_be_bytes
 
 Transforms into an array of bytes, Big Endian
 
-#include_code to_be_bytes noir_stdlib/src/field/mod.nr rust
+```rust title="to_be_bytes" showLineNumbers 
+pub fn to_be_bytes<let N: u32>(self: Self) -> [u8; N] {
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/field/mod.nr#L130-L132" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/field/mod.nr#L130-L132</a></sub></sup>
+
 
 example:
 
-#include_code to_be_bytes_example noir_stdlib/src/field/mod.nr rust
+```rust title="to_be_bytes_example" showLineNumbers 
+fn test_to_be_bytes() {
+        let field = 2;
+        let bytes: [u8; 8] = field.to_be_bytes();
+        assert_eq(bytes, [0, 0, 0, 0, 0, 0, 0, 2]);
+        assert_eq(Field::from_be_bytes::<8>(bytes), field);
+    }
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/field/mod.nr#L365-L372" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/field/mod.nr#L365-L372</a></sub></sup>
+
 
 ### pow_32
 
@@ -97,7 +147,11 @@ fn main() {
 
 Adds a constraint to specify that the field can be represented with `bit_size` number of bits
 
-#include_code assert_max_bit_size noir_stdlib/src/field/mod.nr rust
+```rust title="assert_max_bit_size" showLineNumbers 
+pub fn assert_max_bit_size<let BIT_SIZE: u32>(self) {
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/field/mod.nr#L10-L12" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/field/mod.nr#L10-L12</a></sub></sup>
+
 
 example:
 

--- a/docs/versioned_docs/version-v1.0.0-beta.19/noir/concepts/data_types/integers.md
+++ b/docs/versioned_docs/version-v1.0.0-beta.19/noir/concepts/data_types/integers.md
@@ -125,7 +125,7 @@ fn wrapping_mul(self, y: Self) -> Self;
 Example of how it is used:
 
 ```rust
-use std::ops::WrappingAdd;
+use std::ops::WrappingAdd
 fn main(x: u8, y: u8) -> pub u8 {
     x.wrapping_add(y)
 }

--- a/docs/versioned_docs/version-v1.0.0-beta.19/noir/concepts/generics.md
+++ b/docs/versioned_docs/version-v1.0.0-beta.19/noir/concepts/generics.md
@@ -207,8 +207,56 @@ fn main() {
 
 Note that if there is any over or underflow the types will fail to unify:
 
-#include_code underflow-example test_programs/compile_failure/arithmetic_generics_underflow/src/main.nr rust
+```rust title="underflow-example" showLineNumbers 
+fn pop<let N: u32>(array: [Field; N]) -> [Field; N - 1] {
+    let mut result: [Field; N - 1] = std::mem::zeroed();
+    for i in 0..N - 1 {
+        result[i] = array[i];
+    }
+    result
+}
+
+fn main() {
+    // error: Could not determine array length `(0 - 1)`
+    pop([]);
+}
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/compile_failure/arithmetic_generics_underflow/src/main.nr#L1-L14" target="_blank" rel="noopener noreferrer">Source code: test_programs/compile_failure/arithmetic_generics_underflow/src/main.nr#L1-L14</a></sub></sup>
+
 
 This also applies if there is underflow in an intermediate calculation:
 
-#include_code intermediate-underflow-example test_programs/compile_failure/arithmetic_generics_intermediate_underflow/src/main.nr rust
+```rust title="intermediate-underflow-example" showLineNumbers 
+fn main() {
+    // From main it looks like there's nothing sketchy going on
+    seems_fine([]);
+}
+
+// Since `seems_fine` says it can receive and return any length N
+fn seems_fine<let N: u32>(array: [Field; N]) -> [Field; N] {
+    // But inside `seems_fine` we pop from the array which
+    // requires the length to be greater than zero.
+
+    // error: Could not determine array length `(0 - 1)`
+    push_zero(pop(array))
+}
+
+fn pop<let N: u32>(array: [Field; N]) -> [Field; N - 1] {
+    let mut result: [Field; N - 1] = std::mem::zeroed();
+    for i in 0..N - 1 {
+        result[i] = array[i];
+    }
+    result
+}
+
+fn push_zero<let N: u32>(array: [Field; N]) -> [Field; N + 1] {
+    let mut result: [Field; N + 1] = std::mem::zeroed();
+    for i in 0..N {
+        result[i] = array[i];
+    }
+    // index N is already zeroed
+    result
+}
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/compile_failure/arithmetic_generics_intermediate_underflow/src/main.nr#L1-L32" target="_blank" rel="noopener noreferrer">Source code: test_programs/compile_failure/arithmetic_generics_intermediate_underflow/src/main.nr#L1-L32</a></sub></sup>
+

--- a/docs/versioned_docs/version-v1.0.0-beta.19/noir/standard_library/containers/boundedvec.md
+++ b/docs/versioned_docs/version-v1.0.0-beta.19/noir/standard_library/containers/boundedvec.md
@@ -52,7 +52,18 @@ assert(empty_vector.len() == 0);
 Note that whenever calling `new` the maximum length of the vector should always be specified
 via a type signature:
 
-#include_code new_example test_programs/noir_test_success/bounded_vec/src/main.nr rust
+```rust title="new_example" showLineNumbers 
+fn good() -> BoundedVec<Field, 10> {
+    // Ok! MaxLen is specified with a type annotation
+    let v1: BoundedVec<Field, 3> = BoundedVec::new();
+    let v2 = BoundedVec::new();
+
+    // Ok! MaxLen is known from the type of `good`'s return value
+    v2
+}
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/noir_test_success/bounded_vec/src/main.nr#L6-L15" target="_blank" rel="noopener noreferrer">Source code: test_programs/noir_test_success/bounded_vec/src/main.nr#L6-L15</a></sub></sup>
+
 
 This defaulting of `MaxLen` (and numeric generics in general) to zero may change in future noir versions
 but for now make sure to use type annotations when using bounded vectors. Otherwise, you will receive a constraint failure at runtime when the vec is pushed to.
@@ -92,7 +103,19 @@ it is unsafe! Use at your own risk!
 
 Example:
 
-#include_code get_unchecked_example test_programs/noir_test_success/bounded_vec/src/main.nr rust
+```rust title="get_unchecked_example" showLineNumbers 
+fn sum_of_first_three<let N: u32>(v: BoundedVec<u32, N>) -> u32 {
+    // Always ensure the length is larger than the largest
+    // index passed to get_unchecked
+    assert(v.len() > 2);
+    let first = v.get_unchecked(0);
+    let second = v.get_unchecked(1);
+    let third = v.get_unchecked(2);
+    first + second + third
+}
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/noir_test_success/bounded_vec/src/main.nr#L42-L52" target="_blank" rel="noopener noreferrer">Source code: test_programs/noir_test_success/bounded_vec/src/main.nr#L42-L52</a></sub></sup>
+
 
 ### set
 
@@ -128,7 +151,33 @@ Since this function does not perform a bounds check on length before accessing t
 
 Example:
 
-#include_code set_unchecked_example test_programs/noir_test_success/bounded_vec/src/main.nr rust
+```rust title="set_unchecked_example" showLineNumbers 
+fn set_unchecked_example() {
+    let mut vec: BoundedVec<u32, 5> = BoundedVec::new();
+    vec.extend_from_array([1, 2]);
+
+    // Here we're safely writing within the valid range of `vec`
+    // `vec` now has the value [42, 2]
+    vec.set_unchecked(0, 42);
+
+    // We can then safely read this value back out of `vec`.
+    // Notice that we use the checked version of `get` which would prevent reading unsafe values.
+    assert_eq(vec.get(0), 42);
+
+    // We've now written past the end of `vec`.
+    // As this index is still within the maximum potential length of `v`,
+    // it won't cause a constraint failure.
+    vec.set_unchecked(2, 42);
+    println(vec);
+
+    // This will write past the end of the maximum potential length of `vec`,
+    // it will then trigger a constraint failure.
+    vec.set_unchecked(5, 42);
+    println(vec);
+}
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/noir_test_success/bounded_vec/src/main.nr#L55-L79" target="_blank" rel="noopener noreferrer">Source code: test_programs/noir_test_success/bounded_vec/src/main.nr#L55-L79</a></sub></sup>
+
 
 
 ### push
@@ -144,7 +193,17 @@ Panics if the new length of the vector will be greater than the max length.
 
 Example:
 
-#include_code bounded-vec-push-example test_programs/noir_test_success/bounded_vec/src/main.nr rust
+```rust title="bounded-vec-push-example" showLineNumbers 
+let mut v: BoundedVec<Field, 2> = BoundedVec::new();
+
+    v.push(1);
+    v.push(2);
+
+    // Panics with failed assertion "push out of bounds"
+    v.push(3);
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/noir_test_success/bounded_vec/src/main.nr#L83-L91" target="_blank" rel="noopener noreferrer">Source code: test_programs/noir_test_success/bounded_vec/src/main.nr#L83-L91</a></sub></sup>
+
 
 ### pop
 
@@ -159,7 +218,21 @@ Panics if the vector is empty.
 
 Example:
 
-#include_code bounded-vec-pop-example test_programs/noir_test_success/bounded_vec/src/main.nr rust
+```rust title="bounded-vec-pop-example" showLineNumbers 
+let mut v: BoundedVec<Field, 2> = BoundedVec::new();
+    v.push(1);
+    v.push(2);
+
+    let two = v.pop();
+    let one = v.pop();
+
+    assert(two == 2);
+    assert(one == 1);
+    // error: cannot pop from an empty vector
+    // let _ = v.pop();
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/noir_test_success/bounded_vec/src/main.nr#L96-L108" target="_blank" rel="noopener noreferrer">Source code: test_programs/noir_test_success/bounded_vec/src/main.nr#L96-L108</a></sub></sup>
+
 
 ### len
 
@@ -171,7 +244,24 @@ Returns the current length of this vector
 
 Example:
 
-#include_code bounded-vec-len-example test_programs/noir_test_success/bounded_vec/src/main.nr rust
+```rust title="bounded-vec-len-example" showLineNumbers 
+let mut v: BoundedVec<Field, 4> = BoundedVec::new();
+    assert(v.len() == 0);
+
+    v.push(100);
+    assert(v.len() == 1);
+
+    v.push(200);
+    v.push(300);
+    v.push(400);
+    assert(v.len() == 4);
+
+    let _ = v.pop();
+    let _ = v.pop();
+    assert(v.len() == 2);
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/noir_test_success/bounded_vec/src/main.nr#L113-L128" target="_blank" rel="noopener noreferrer">Source code: test_programs/noir_test_success/bounded_vec/src/main.nr#L113-L128</a></sub></sup>
+
 
 ### max_len
 
@@ -184,7 +274,15 @@ equal to the `MaxLen` parameter this vector was initialized with.
 
 Example:
 
-#include_code bounded-vec-max-len-example test_programs/noir_test_success/bounded_vec/src/main.nr rust
+```rust title="bounded-vec-max-len-example" showLineNumbers 
+let mut v: BoundedVec<Field, 5> = BoundedVec::new();
+
+    assert(v.max_len() == 5);
+    v.push(10);
+    assert(v.max_len() == 5);
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/noir_test_success/bounded_vec/src/main.nr#L133-L139" target="_blank" rel="noopener noreferrer">Source code: test_programs/noir_test_success/bounded_vec/src/main.nr#L133-L139</a></sub></sup>
+
 
 ### storage
 
@@ -200,7 +298,16 @@ Note that uninitialized elements may be zeroed out!
 
 Example:
 
-#include_code bounded-vec-storage-example test_programs/noir_test_success/bounded_vec/src/main.nr rust
+```rust title="bounded-vec-storage-example" showLineNumbers 
+let mut v: BoundedVec<Field, 5> = BoundedVec::new();
+
+    assert(v.storage() == [0, 0, 0, 0, 0]);
+
+    v.push(57);
+    assert(v.storage() == [57, 0, 0, 0, 0]);
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/noir_test_success/bounded_vec/src/main.nr#L144-L151" target="_blank" rel="noopener noreferrer">Source code: test_programs/noir_test_success/bounded_vec/src/main.nr#L144-L151</a></sub></sup>
+
 
 ### extend_from_array
 
@@ -215,7 +322,16 @@ to exceed the maximum length.
 
 Example:
 
-#include_code bounded-vec-extend-from-array-example test_programs/noir_test_success/bounded_vec/src/main.nr rust
+```rust title="bounded-vec-extend-from-array-example" showLineNumbers 
+let mut vec: BoundedVec<Field, 3> = BoundedVec::new();
+    vec.extend_from_array([2, 4]);
+
+    assert(vec.len() == 2);
+    assert(vec.get(0) == 2);
+    assert(vec.get(1) == 4);
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/noir_test_success/bounded_vec/src/main.nr#L156-L163" target="_blank" rel="noopener noreferrer">Source code: test_programs/noir_test_success/bounded_vec/src/main.nr#L156-L163</a></sub></sup>
+
 
 ### extend_from_bounded_vec
 
@@ -231,7 +347,18 @@ to exceed the maximum length.
 
 Example:
 
-#include_code bounded-vec-extend-from-bounded-vec-example test_programs/noir_test_success/bounded_vec/src/main.nr rust
+```rust title="bounded-vec-extend-from-bounded-vec-example" showLineNumbers 
+let mut v1: BoundedVec<Field, 5> = BoundedVec::new();
+    let mut v2: BoundedVec<Field, 7> = BoundedVec::new();
+
+    v2.extend_from_array([1, 2, 3]);
+    v1.extend_from_bounded_vec(v2);
+
+    assert(v1.storage() == [1, 2, 3, 0, 0]);
+    assert(v2.storage() == [1, 2, 3, 0, 0, 0, 0]);
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/noir_test_success/bounded_vec/src/main.nr#L168-L177" target="_blank" rel="noopener noreferrer">Source code: test_programs/noir_test_success/bounded_vec/src/main.nr#L168-L177</a></sub></sup>
+
 
 ### from_array
 
@@ -262,7 +389,18 @@ zeroed after that index, you can use `from_parts_unchecked` to remove the extra 
 
 Example:
 
-#include_code from-parts noir_stdlib/src/collections/bounded_vec.nr rust
+```rust title="from-parts" showLineNumbers 
+let vec: BoundedVec<u32, 4> = BoundedVec::from_parts([1, 2, 3, 0], 3);
+            assert_eq(vec.len(), 3);
+
+            // Any elements past the given length are zeroed out, so these
+            // two BoundedVecs will be completely equal
+            let vec1: BoundedVec<u32, 4> = BoundedVec::from_parts([1, 2, 3, 1], 3);
+            let vec2: BoundedVec<u32, 4> = BoundedVec::from_parts([1, 2, 3, 2], 3);
+            assert_eq(vec1, vec2);
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/collections/bounded_vec.nr#L1120-L1129" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/collections/bounded_vec.nr#L1120-L1129</a></sub></sup>
+
 
 ### from_parts_unchecked
 
@@ -281,7 +419,20 @@ to give incorrect results since it will check even elements past `len`.
 
 Example:
 
-#include_code from-parts-unchecked noir_stdlib/src/collections/bounded_vec.nr rust
+```rust title="from-parts-unchecked" showLineNumbers 
+let vec: BoundedVec<u32, 4> = BoundedVec::from_parts_unchecked([1, 2, 3, 0], 3);
+            assert_eq(vec.len(), 3);
+
+            // invalid use!
+            let vec1: BoundedVec<u32, 4> = BoundedVec::from_parts_unchecked([1, 2, 3, 1], 3);
+            let vec2: BoundedVec<u32, 4> = BoundedVec::from_parts_unchecked([1, 2, 3, 2], 3);
+
+            // both vecs have length 3 so we'd expect them to be equal, but this
+            // fails because elements past the length are still checked in eq
+            assert(vec1 != vec2);
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/collections/bounded_vec.nr#L1134-L1145" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/collections/bounded_vec.nr#L1134-L1145</a></sub></sup>
+
 
 ### map
 
@@ -293,7 +444,12 @@ Creates a new vector of equal size by calling a closure on each element in this 
 
 Example:
 
-#include_code bounded-vec-map-example noir_stdlib/src/collections/bounded_vec.nr rust
+```rust title="bounded-vec-map-example" showLineNumbers 
+let vec: BoundedVec<u32, 4> = BoundedVec::from_array([1, 2, 3, 4]);
+            let result = vec.map(|value| value * 2);
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/collections/bounded_vec.nr#L770-L773" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/collections/bounded_vec.nr#L770-L773</a></sub></sup>
+
 
 ### mapi
 
@@ -306,7 +462,12 @@ vector, along with its index in the vector.
 
 Example:
 
-#include_code bounded-vec-mapi-example noir_stdlib/src/collections/bounded_vec.nr rust
+```rust title="bounded-vec-mapi-example" showLineNumbers 
+let vec: BoundedVec<u32, 4> = BoundedVec::from_array([1, 2, 3, 4]);
+            let result = vec.mapi(|i, value| i + value * 2);
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/collections/bounded_vec.nr#L831-L834" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/collections/bounded_vec.nr#L831-L834</a></sub></sup>
+
 
 ### for_each
 
@@ -318,7 +479,12 @@ Calls a closure on each element in this vector.
 
 Example:
 
-#include_code bounded-vec-for-each-example noir_stdlib/src/collections/bounded_vec.nr rust
+```rust title="bounded-vec-for-each-example" showLineNumbers 
+let vec: BoundedVec<u32, 3> = BoundedVec::from_array([1, 2, 3]);
+            vec.for_each(|value| { *acc_ref += value; });
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/collections/bounded_vec.nr#L887-L890" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/collections/bounded_vec.nr#L887-L890</a></sub></sup>
+
 
 ### for_eachi
 
@@ -330,7 +496,12 @@ Calls a closure on each element in this vector, along with its index in the vect
 
 Example:
 
-#include_code bounded-vec-for-eachi-example noir_stdlib/src/collections/bounded_vec.nr rust
+```rust title="bounded-vec-for-eachi-example" showLineNumbers 
+let vec: BoundedVec<u32, 3> = BoundedVec::from_array([1, 2, 3]);
+            vec.for_eachi(|i, value| { *acc_ref += i * value; });
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/collections/bounded_vec.nr#L959-L962" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/collections/bounded_vec.nr#L959-L962</a></sub></sup>
+
 
 ### any
 
@@ -343,4 +514,12 @@ in this vector.
 
 Example:
 
-#include_code bounded-vec-any-example test_programs/noir_test_success/bounded_vec/src/main.nr rust
+```rust title="bounded-vec-any-example" showLineNumbers 
+let mut v: BoundedVec<u32, 3> = BoundedVec::new();
+    v.extend_from_array([2, 4, 6]);
+
+    let all_even = !v.any(|elem: u32| elem % 2 != 0);
+    assert(all_even);
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/noir_test_success/bounded_vec/src/main.nr#L244-L250" target="_blank" rel="noopener noreferrer">Source code: test_programs/noir_test_success/bounded_vec/src/main.nr#L244-L250</a></sub></sup>
+

--- a/docs/versioned_docs/version-v1.0.0-beta.19/noir/standard_library/containers/hashmap.md
+++ b/docs/versioned_docs/version-v1.0.0-beta.19/noir/standard_library/containers/hashmap.md
@@ -30,7 +30,23 @@ let two = map.get(1).unwrap();
 
 ### default
 
-#include_code default noir_stdlib/src/collections/map.nr rust
+```rust title="default" showLineNumbers 
+impl<K, V, let N: u32, B> Default for HashMap<K, V, N, B>
+where
+    B: BuildHasher + Default,
+{
+    /// Constructs an empty HashMap.
+    ///
+    /// Example:
+    ///
+    /// ```noir
+    /// let hashmap: HashMap<u8, u32, 10, BuildHasherDefault<Poseidon2Hasher>> = HashMap::default();
+    /// assert(hashmap.is_empty());
+    /// ```
+    fn default() -> Self {
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/collections/map.nr#L677-L691" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/collections/map.nr#L677-L691</a></sub></sup>
+
 
 Creates a fresh, empty HashMap.
 
@@ -41,79 +57,190 @@ repeated here for convenience since it is the recommended way to create a hashma
 
 Example:
 
-#include_code default_example test_programs/execution_success/hashmap/src/main.nr rust
+```rust title="default_example" showLineNumbers 
+let hashmap: HashMap<u8, u32, 10, BuildHasherDefault<Poseidon2Hasher>> = HashMap::default();
+    assert(hashmap.is_empty());
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/execution_success/hashmap/src/main.nr#L232-L235" target="_blank" rel="noopener noreferrer">Source code: test_programs/execution_success/hashmap/src/main.nr#L232-L235</a></sub></sup>
+
 
 Because `HashMap` has so many generic arguments that are likely to be the same throughout
 your program, it may be helpful to create a type alias:
 
-#include_code type_alias test_programs/execution_success/hashmap/src/main.nr rust
+```rust title="type_alias" showLineNumbers 
+type MyMap = HashMap<u8, u32, 10, BuildHasherDefault<Poseidon2Hasher>>;
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/execution_success/hashmap/src/main.nr#L226-L228" target="_blank" rel="noopener noreferrer">Source code: test_programs/execution_success/hashmap/src/main.nr#L226-L228</a></sub></sup>
+
 
 ### with_hasher
 
-#include_code with_hasher noir_stdlib/src/collections/map.nr rust
+```rust title="with_hasher" showLineNumbers 
+pub fn with_hasher(_build_hasher: B) -> Self
+    where
+        B: BuildHasher,
+    {
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/collections/map.nr#L104-L109" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/collections/map.nr#L104-L109</a></sub></sup>
+
 
 Creates a hashmap with an existing `BuildHasher`. This can be used to ensure multiple
 hashmaps are created with the same hasher instance.
 
 Example:
 
-#include_code with_hasher_example test_programs/execution_success/hashmap/src/main.nr rust
+```rust title="with_hasher_example" showLineNumbers 
+let my_hasher: BuildHasherDefault<Poseidon2Hasher> = Default::default();
+    let hashmap: HashMap<u8, u32, 10, BuildHasherDefault<Poseidon2Hasher>> =
+        HashMap::with_hasher(my_hasher);
+    assert(hashmap.is_empty());
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/execution_success/hashmap/src/main.nr#L236-L241" target="_blank" rel="noopener noreferrer">Source code: test_programs/execution_success/hashmap/src/main.nr#L236-L241</a></sub></sup>
+
 
 ### get
 
-#include_code get noir_stdlib/src/collections/map.nr rust
+```rust title="get" showLineNumbers 
+pub fn get(self, key: K) -> Option<V>
+    where
+        K: Eq + Hash,
+        B: BuildHasher,
+    {
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/collections/map.nr#L467-L473" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/collections/map.nr#L467-L473</a></sub></sup>
+
 
 Retrieves a value from the hashmap, returning `Option::none()` if it was not found.
 
 Example:
 
-#include_code get_example test_programs/execution_success/hashmap/src/main.nr rust
+```rust title="get_example" showLineNumbers 
+fn get_example(map: HashMap<Field, Field, 5, BuildHasherDefault<Poseidon2Hasher>>) {
+    let x = map.get(12);
+
+    if x.is_some() {
+        assert(x.unwrap() == 42);
+    }
+}
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/execution_success/hashmap/src/main.nr#L321-L329" target="_blank" rel="noopener noreferrer">Source code: test_programs/execution_success/hashmap/src/main.nr#L321-L329</a></sub></sup>
+
 
 ### insert
 
-#include_code insert noir_stdlib/src/collections/map.nr rust
+```rust title="insert" showLineNumbers 
+pub fn insert(&mut self, key: K, value: V)
+    where
+        K: Eq + Hash,
+        B: BuildHasher,
+    {
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/collections/map.nr#L507-L513" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/collections/map.nr#L507-L513</a></sub></sup>
+
 
 Inserts a new key-value pair into the map. If the key was already in the map, its
 previous value will be overridden with the newly provided one.
 
 Example:
 
-#include_code insert_example test_programs/execution_success/hashmap/src/main.nr rust
+```rust title="insert_example" showLineNumbers 
+let mut map: HashMap<Field, Field, 5, BuildHasherDefault<Poseidon2Hasher>> = HashMap::default();
+    map.insert(12, 42);
+    assert(map.len() == 1);
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/execution_success/hashmap/src/main.nr#L242-L246" target="_blank" rel="noopener noreferrer">Source code: test_programs/execution_success/hashmap/src/main.nr#L242-L246</a></sub></sup>
+
 
 ### remove
 
-#include_code remove noir_stdlib/src/collections/map.nr rust
+```rust title="remove" showLineNumbers 
+pub fn remove(&mut self, key: K)
+    where
+        K: Eq + Hash,
+        B: BuildHasher,
+    {
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/collections/map.nr#L561-L567" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/collections/map.nr#L561-L567</a></sub></sup>
+
 
 Removes the given key-value pair from the map. If the key was not already present
 in the map, this does nothing.
 
 Example:
 
-#include_code remove_example test_programs/execution_success/hashmap/src/main.nr rust
+```rust title="remove_example" showLineNumbers 
+map.remove(12);
+    assert(map.is_empty());
+
+    // If a key was not present in the map, remove does nothing
+    map.remove(12);
+    assert(map.is_empty());
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/execution_success/hashmap/src/main.nr#L249-L256" target="_blank" rel="noopener noreferrer">Source code: test_programs/execution_success/hashmap/src/main.nr#L249-L256</a></sub></sup>
+
 
 ### is_empty
 
-#include_code is_empty noir_stdlib/src/collections/map.nr rust
+```rust title="is_empty" showLineNumbers 
+pub fn is_empty(self) -> bool {
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/collections/map.nr#L167-L169" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/collections/map.nr#L167-L169</a></sub></sup>
+
 
 True if the length of the hash map is empty.
 
 Example:
 
-#include_code is_empty_example test_programs/execution_success/hashmap/src/main.nr rust
+```rust title="is_empty_example" showLineNumbers 
+assert(map.is_empty());
+
+    map.insert(1, 2);
+    assert(!map.is_empty());
+
+    map.remove(1);
+    assert(map.is_empty());
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/execution_success/hashmap/src/main.nr#L257-L265" target="_blank" rel="noopener noreferrer">Source code: test_programs/execution_success/hashmap/src/main.nr#L257-L265</a></sub></sup>
+
 
 ### len
 
-#include_code len noir_stdlib/src/collections/map.nr rust
+```rust title="len" showLineNumbers 
+pub fn len(self) -> u32 {
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/collections/map.nr#L426-L428" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/collections/map.nr#L426-L428</a></sub></sup>
+
 
 Returns the current length of this hash map.
 
 Example:
 
-#include_code len_example test_programs/execution_success/hashmap/src/main.nr rust
+```rust title="len_example" showLineNumbers 
+// This is equivalent to checking map.is_empty()
+    assert(map.len() == 0);
+
+    map.insert(1, 2);
+    map.insert(3, 4);
+    map.insert(5, 6);
+    assert(map.len() == 3);
+
+    // 3 was already present as a key in the hash map, so the length is unchanged
+    map.insert(3, 7);
+    assert(map.len() == 3);
+
+    map.remove(1);
+    assert(map.len() == 2);
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/execution_success/hashmap/src/main.nr#L266-L281" target="_blank" rel="noopener noreferrer">Source code: test_programs/execution_success/hashmap/src/main.nr#L266-L281</a></sub></sup>
+
 
 ### capacity
 
-#include_code capacity noir_stdlib/src/collections/map.nr rust
+```rust title="capacity" showLineNumbers 
+pub fn capacity(_self: Self) -> u32 {
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/collections/map.nr#L448-L450" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/collections/map.nr#L448-L450</a></sub></sup>
+
 
 Returns the maximum capacity of this hashmap. This is always equal to the capacity
 specified in the hashmap's type.
@@ -126,32 +253,70 @@ element count will be lower than the full capacity.
 
 Example:
 
-#include_code capacity_example test_programs/execution_success/hashmap/src/main.nr rust
+```rust title="capacity_example" showLineNumbers 
+let empty_map: HashMap<Field, Field, 42, BuildHasherDefault<Poseidon2Hasher>> =
+        HashMap::default();
+    assert(empty_map.len() == 0);
+    assert(empty_map.capacity() == 42);
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/execution_success/hashmap/src/main.nr#L282-L287" target="_blank" rel="noopener noreferrer">Source code: test_programs/execution_success/hashmap/src/main.nr#L282-L287</a></sub></sup>
+
 
 ### clear
 
-#include_code clear noir_stdlib/src/collections/map.nr rust
+```rust title="clear" showLineNumbers 
+pub fn clear(&mut self) {
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/collections/map.nr#L124-L126" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/collections/map.nr#L124-L126</a></sub></sup>
+
 
 Clears the hashmap, removing all key-value pairs from it.
 
 Example:
 
-#include_code clear_example test_programs/execution_success/hashmap/src/main.nr rust
+```rust title="clear_example" showLineNumbers 
+assert(!map.is_empty());
+    map.clear();
+    assert(map.is_empty());
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/execution_success/hashmap/src/main.nr#L288-L292" target="_blank" rel="noopener noreferrer">Source code: test_programs/execution_success/hashmap/src/main.nr#L288-L292</a></sub></sup>
+
 
 ### contains_key
 
-#include_code contains_key noir_stdlib/src/collections/map.nr rust
+```rust title="contains_key" showLineNumbers 
+pub fn contains_key(self, key: K) -> bool
+    where
+        K: Hash + Eq,
+        B: BuildHasher,
+    {
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/collections/map.nr#L144-L150" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/collections/map.nr#L144-L150</a></sub></sup>
+
 
 True if the hashmap contains the given key. Unlike `get`, this will not also return
 the value associated with the key.
 
 Example:
 
-#include_code contains_key_example test_programs/execution_success/hashmap/src/main.nr rust
+```rust title="contains_key_example" showLineNumbers 
+if map.contains_key(7) {
+        let value = map.get(7);
+        assert(value.is_some());
+    } else {
+        println("No value for key 7!");
+    }
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/execution_success/hashmap/src/main.nr#L293-L300" target="_blank" rel="noopener noreferrer">Source code: test_programs/execution_success/hashmap/src/main.nr#L293-L300</a></sub></sup>
+
 
 ### entries
 
-#include_code entries noir_stdlib/src/collections/map.nr rust
+```rust title="entries" showLineNumbers 
+pub fn entries(self) -> BoundedVec<(K, V), N> {
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/collections/map.nr#L191-L193" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/collections/map.nr#L191-L193</a></sub></sup>
+
 
 Returns a vector of each key-value pair present in the hashmap.
 
@@ -159,11 +324,28 @@ The length of the returned vector is always equal to the length of the hashmap.
 
 Example:
 
-#include_code entries_example test_programs/execution_success/hashmap/src/main.nr rust
+```rust title="entries_example" showLineNumbers 
+let entries = map.entries();
+
+    // The length of a hashmap may not be compile-time known, so we
+    // need to loop over its capacity instead
+    for i in 0..map.capacity() {
+        if i < entries.len() {
+            let (key, value) = entries.get(i);
+            println(f"{key} -> {value}");
+        }
+    }
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/execution_success/hashmap/src/main.nr#L332-L343" target="_blank" rel="noopener noreferrer">Source code: test_programs/execution_success/hashmap/src/main.nr#L332-L343</a></sub></sup>
+
 
 ### keys
 
-#include_code keys noir_stdlib/src/collections/map.nr rust
+```rust title="keys" showLineNumbers 
+pub fn keys(self) -> BoundedVec<K, N> {
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/collections/map.nr#L229-L231" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/collections/map.nr#L229-L231</a></sub></sup>
+
 
 Returns a vector of each key present in the hashmap.
 
@@ -171,11 +353,27 @@ The length of the returned vector is always equal to the length of the hashmap.
 
 Example:
 
-#include_code keys_example test_programs/execution_success/hashmap/src/main.nr rust
+```rust title="keys_example" showLineNumbers 
+let keys = map.keys();
+
+    for i in 0..keys.max_len() {
+        if i < keys.len() {
+            let key = keys.get_unchecked(i);
+            let value = map.get(key).unwrap_unchecked();
+            println(f"{key} -> {value}");
+        }
+    }
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/execution_success/hashmap/src/main.nr#L344-L354" target="_blank" rel="noopener noreferrer">Source code: test_programs/execution_success/hashmap/src/main.nr#L344-L354</a></sub></sup>
+
 
 ### values
 
-#include_code values noir_stdlib/src/collections/map.nr rust
+```rust title="values" showLineNumbers 
+pub fn values(self) -> BoundedVec<V, N> {
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/collections/map.nr#L265-L267" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/collections/map.nr#L265-L267</a></sub></sup>
+
 
 Returns a vector of each value present in the hashmap.
 
@@ -183,11 +381,30 @@ The length of the returned vector is always equal to the length of the hashmap.
 
 Example:
 
-#include_code values_example test_programs/execution_success/hashmap/src/main.nr rust
+```rust title="values_example" showLineNumbers 
+let values = map.values();
+
+    for i in 0..values.max_len() {
+        if i < values.len() {
+            let value = values.get_unchecked(i);
+            println(f"Found value {value}");
+        }
+    }
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/execution_success/hashmap/src/main.nr#L355-L364" target="_blank" rel="noopener noreferrer">Source code: test_programs/execution_success/hashmap/src/main.nr#L355-L364</a></sub></sup>
+
 
 ### iter_mut
 
-#include_code iter_mut noir_stdlib/src/collections/map.nr rust
+```rust title="iter_mut" showLineNumbers 
+pub fn iter_mut(&mut self, f: fn(K, V) -> (K, V))
+    where
+        K: Eq + Hash,
+        B: BuildHasher,
+    {
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/collections/map.nr#L301-L307" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/collections/map.nr#L301-L307</a></sub></sup>
+
 
 Iterates through each key-value pair of the HashMap, setting each key-value pair to the
 result returned from the given function.
@@ -201,11 +418,24 @@ equal, which of the two values that will be present for the key in the resulting
 
 Example:
 
-#include_code iter_mut_example test_programs/execution_success/hashmap/src/main.nr rust
+```rust title="iter_mut_example" showLineNumbers 
+// Add 1 to each key in the map, and double the value associated with that key.
+    map.iter_mut(|k, v| (k + 1, v * 2));
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/execution_success/hashmap/src/main.nr#L368-L371" target="_blank" rel="noopener noreferrer">Source code: test_programs/execution_success/hashmap/src/main.nr#L368-L371</a></sub></sup>
+
 
 ### iter_keys_mut
 
-#include_code iter_keys_mut noir_stdlib/src/collections/map.nr rust
+```rust title="iter_keys_mut" showLineNumbers 
+pub fn iter_keys_mut(&mut self, f: fn(K) -> K)
+    where
+        K: Eq + Hash,
+        B: BuildHasher,
+    {
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/collections/map.nr#L339-L345" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/collections/map.nr#L339-L345</a></sub></sup>
+
 
 Iterates through the HashMap, mutating each key to the result returned from
 the given function.
@@ -219,11 +449,20 @@ equal, which of the two values that will be present for the key in the resulting
 
 Example:
 
-#include_code iter_keys_mut_example test_programs/execution_success/hashmap/src/main.nr rust
+```rust title="iter_keys_mut_example" showLineNumbers 
+// Double each key, leaving the value associated with that key untouched
+    map.iter_keys_mut(|k| k * 2);
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/execution_success/hashmap/src/main.nr#L372-L375" target="_blank" rel="noopener noreferrer">Source code: test_programs/execution_success/hashmap/src/main.nr#L372-L375</a></sub></sup>
+
 
 ### iter_values_mut
 
-#include_code iter_values_mut noir_stdlib/src/collections/map.nr rust
+```rust title="iter_values_mut" showLineNumbers 
+pub fn iter_values_mut(&mut self, f: fn(V) -> V) {
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/collections/map.nr#L371-L373" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/collections/map.nr#L371-L373</a></sub></sup>
+
 
 Iterates through the HashMap, applying the given function to each value and mutating the
 value to equal the result. This function is more efficient than `iter_mut` and `iter_keys_mut`
@@ -231,37 +470,110 @@ because the keys are untouched and the underlying hashmap thus does not need to 
 
 Example:
 
-#include_code iter_values_mut_example test_programs/execution_success/hashmap/src/main.nr rust
+```rust title="iter_values_mut_example" showLineNumbers 
+// Halve each value
+    map.iter_values_mut(|v| v / 2);
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/execution_success/hashmap/src/main.nr#L376-L379" target="_blank" rel="noopener noreferrer">Source code: test_programs/execution_success/hashmap/src/main.nr#L376-L379</a></sub></sup>
+
 
 ### retain
 
-#include_code retain noir_stdlib/src/collections/map.nr rust
+```rust title="retain" showLineNumbers 
+pub fn retain(&mut self, f: fn(K, V) -> bool) {
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/collections/map.nr#L391-L393" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/collections/map.nr#L391-L393</a></sub></sup>
+
 
 Retains only the key-value pairs for which the given function returns true.
 Any key-value pairs for which the function returns false will be removed from the map.
 
 Example:
 
-#include_code retain_example test_programs/execution_success/hashmap/src/main.nr rust
+```rust title="retain_example" showLineNumbers 
+map.retain(|k, v| (k != 0) & (v != 0));
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/execution_success/hashmap/src/main.nr#L304-L306" target="_blank" rel="noopener noreferrer">Source code: test_programs/execution_success/hashmap/src/main.nr#L304-L306</a></sub></sup>
+
 
 ## Trait Implementations
 
 ### default
 
-#include_code default noir_stdlib/src/collections/map.nr rust
+```rust title="default" showLineNumbers 
+impl<K, V, let N: u32, B> Default for HashMap<K, V, N, B>
+where
+    B: BuildHasher + Default,
+{
+    /// Constructs an empty HashMap.
+    ///
+    /// Example:
+    ///
+    /// ```noir
+    /// let hashmap: HashMap<u8, u32, 10, BuildHasherDefault<Poseidon2Hasher>> = HashMap::default();
+    /// assert(hashmap.is_empty());
+    /// ```
+    fn default() -> Self {
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/collections/map.nr#L677-L691" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/collections/map.nr#L677-L691</a></sub></sup>
+
 
 Constructs an empty HashMap.
 
 Example:
 
-#include_code default_example test_programs/execution_success/hashmap/src/main.nr rust
+```rust title="default_example" showLineNumbers 
+let hashmap: HashMap<u8, u32, 10, BuildHasherDefault<Poseidon2Hasher>> = HashMap::default();
+    assert(hashmap.is_empty());
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/execution_success/hashmap/src/main.nr#L232-L235" target="_blank" rel="noopener noreferrer">Source code: test_programs/execution_success/hashmap/src/main.nr#L232-L235</a></sub></sup>
+
 
 ### eq
 
-#include_code eq noir_stdlib/src/collections/map.nr rust
+```rust title="eq" showLineNumbers 
+impl<K, V, let N: u32, B> Eq for HashMap<K, V, N, B>
+where
+    K: Eq + Hash,
+    V: Eq,
+    B: BuildHasher,
+{
+    /// Checks if two HashMaps are equal.
+    ///
+    /// Example:
+    ///
+    /// ```noir
+    /// let mut map1: HashMap<Field, u64, 4, BuildHasherDefault<Poseidon2Hasher>> = HashMap::default();
+    /// let mut map2: HashMap<Field, u64, 4, BuildHasherDefault<Poseidon2Hasher>> = HashMap::default();
+    ///
+    /// map1.insert(1, 2);
+    /// map1.insert(3, 4);
+    ///
+    /// map2.insert(3, 4);
+    /// map2.insert(1, 2);
+    ///
+    /// assert(map1 == map2);
+    /// ```
+    fn eq(self, other: HashMap<K, V, N, B>) -> bool {
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/collections/map.nr#L627-L651" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/collections/map.nr#L627-L651</a></sub></sup>
+
 
 Checks if two HashMaps are equal.
 
 Example:
 
-#include_code eq_example test_programs/execution_success/hashmap/src/main.nr rust
+```rust title="eq_example" showLineNumbers 
+let mut map1: HashMap<Field, u64, 4, BuildHasherDefault<Poseidon2Hasher>> = HashMap::default();
+    let mut map2: HashMap<Field, u64, 4, BuildHasherDefault<Poseidon2Hasher>> = HashMap::default();
+
+    map1.insert(1, 2);
+    map1.insert(3, 4);
+
+    map2.insert(3, 4);
+    map2.insert(1, 2);
+
+    assert(map1 == map2);
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/execution_success/hashmap/src/main.nr#L307-L318" target="_blank" rel="noopener noreferrer">Source code: test_programs/execution_success/hashmap/src/main.nr#L307-L318</a></sub></sup>
+

--- a/docs/versioned_docs/version-v1.0.0-beta.19/noir/standard_library/cryptographic_primitives/ciphers.mdx
+++ b/docs/versioned_docs/version-v1.0.0-beta.19/noir/standard_library/cryptographic_primitives/ciphers.mdx
@@ -13,7 +13,30 @@ import BlackBoxInfo from '@site/src/components/Notes/_blackbox';
 
 Given a plaintext as an array of bytes, returns the corresponding aes128 ciphertext (CBC mode). Input padding is automatically performed using PKCS#7, so that the output length is `input.len() + (16 - input.len() % 16)`.
 
-#include_code aes128 noir_stdlib/src/aes128.nr rust
+```rust title="aes128" showLineNumbers 
+// Given a plaintext as an array of bytes, returns the corresponding aes128 ciphertext (CBC mode). Input padding is performed using PKCS#7, so that the output length is `input.len() + (16 - input.len() % 16)`.
+pub fn aes128_encrypt<let N: u32>(
+    input: [u8; N],
+    iv: [u8; 16],
+    key: [u8; 16],
+) -> [u8; N + 16 - N % 16] {
+    let padding_length = (16 - N % 16) as u8;
+    let mut padded_input: [u8; N + 16 - N % 16] = [0; N + 16 - N % 16];
+    for i in 0..N {
+        padded_input[i] = input[i];
+    }
+    for i in N..N + 16 - N % 16 {
+        padded_input[i] = padding_length;
+    }
+    let output = aes128_encrypt_padded_input(padded_input, iv, key);
+    output
+}
+
+#[foreign(aes128_encrypt)]
+fn aes128_encrypt_padded_input<let N: u32>(input: [u8; N], iv: [u8; 16], key: [u8; 16]) -> [u8; N] {}
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/aes128.nr#L1-L23" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/aes128.nr#L1-L23</a></sub></sup>
+
 
 ```rust
 fn main() {

--- a/docs/versioned_docs/version-v1.0.0-beta.19/noir/standard_library/cryptographic_primitives/ecdsa_sig_verification.mdx
+++ b/docs/versioned_docs/version-v1.0.0-beta.19/noir/standard_library/cryptographic_primitives/ecdsa_sig_verification.mdx
@@ -13,7 +13,31 @@ Noir supports ECDSA signatures verification over the secp256k1 and secp256r1 cur
 
 Verifier for ECDSA Secp256k1 signatures.
 
-#include_code ecdsa_secp256k1 noir_stdlib/src/ecdsa_secp256k1.nr rust
+```rust title="ecdsa_secp256k1" showLineNumbers 
+/// Verifies a ECDSA signature over the secp256k1 curve.
+/// - inputs:
+///     - x coordinate of public key as 32 bytes
+///     - y coordinate of public key as 32 bytes
+///     - the signature, as a 64 bytes array
+///       The signature internally will be represented as `(r, s)`,
+///       where `r` and `s` are fixed-sized big endian scalar values.
+///       As the `secp256k1` has a 256-bit modulus, we have a 64 byte signature
+///       while `r` and `s` will both be 32 bytes.
+///       We expect `s` to be normalized. This means given the curve's order,
+///       `s` should be less than or equal to `order / 2`.
+///       This is done to prevent malleability.
+///       For more context regarding malleability you can reference BIP 0062.
+///     - the hash of the message, as a vector of bytes
+/// - output: false for failure and true for success
+pub fn verify_signature(
+    public_key_x: [u8; 32],
+    public_key_y: [u8; 32],
+    signature: [u8; 64],
+    message_hash: [u8; 32],
+) -> bool
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/ecdsa_secp256k1.nr#L1-L23" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/ecdsa_secp256k1.nr#L1-L23</a></sub></sup>
+
 
 example:
 
@@ -31,7 +55,16 @@ fn main(hashed_message : [u8;32], pub_key_x : [u8;32], pub_key_y : [u8;32], sign
 Verifier for ECDSA Secp256r1 signatures.
 See ecdsa_secp256r1::verify_signature_vector for a version that accepts vectors directly.
 
-#include_code ecdsa_secp256r1 noir_stdlib/src/ecdsa_secp256r1.nr rust
+```rust title="ecdsa_secp256r1" showLineNumbers 
+pub fn verify_signature(
+    public_key_x: [u8; 32],
+    public_key_y: [u8; 32],
+    signature: [u8; 64],
+    message_hash: [u8; 32],
+) -> bool
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/ecdsa_secp256r1.nr#L1-L8" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/ecdsa_secp256r1.nr#L1-L8</a></sub></sup>
+
 
 example:
 

--- a/docs/versioned_docs/version-v1.0.0-beta.19/noir/standard_library/cryptographic_primitives/embedded_curve_ops.mdx
+++ b/docs/versioned_docs/version-v1.0.0-beta.19/noir/standard_library/cryptographic_primitives/embedded_curve_ops.mdx
@@ -22,7 +22,14 @@ the curve and returns a sum of the resulting points.
 
 Points represented as x and y coordinates [x1, y1, x2, y2, ...], scalars as low and high limbs [low1, high1, low2, high2, ...].
 
-#include_code multi_scalar_mul noir_stdlib/src/embedded_curve_ops.nr rust
+```rust title="multi_scalar_mul" showLineNumbers 
+pub fn multi_scalar_mul<let N: u32>(
+    points: [EmbeddedCurvePoint; N],
+    scalars: [EmbeddedCurveScalar; N],
+) -> EmbeddedCurvePoint
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/embedded_curve_ops.nr#L142-L147" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/embedded_curve_ops.nr#L142-L147</a></sub></sup>
+
 
 example
 
@@ -38,7 +45,11 @@ fn main(point_x: Field, point_y: Field, scalar_low: Field, scalar_high: Field) {
 Performs fixed base scalar multiplication over the embedded curve (multiplies input scalar with a generator point).
 The function accepts a single scalar on the input represented as 2 fields.
 
-#include_code fixed_base_scalar_mul noir_stdlib/src/embedded_curve_ops.nr rust
+```rust title="fixed_base_scalar_mul" showLineNumbers 
+pub fn fixed_base_scalar_mul(scalar: EmbeddedCurveScalar) -> EmbeddedCurvePoint
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/embedded_curve_ops.nr#L159-L161" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/embedded_curve_ops.nr#L159-L161</a></sub></sup>
+
 
 example
 
@@ -61,7 +72,14 @@ This function takes two `EmbeddedCurvePoint` structures as parameters, represent
 ### Returns:
 - `EmbeddedCurvePoint`: The resulting point after the addition of `point1` and `point2`.
 
-#include_code embedded_curve_add noir_stdlib/src/embedded_curve_ops.nr rust
+```rust title="embedded_curve_add" showLineNumbers 
+pub fn embedded_curve_add(
+    point1: EmbeddedCurvePoint,
+    point2: EmbeddedCurvePoint,
+) -> EmbeddedCurvePoint {
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/embedded_curve_ops.nr#L172-L177" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/embedded_curve_ops.nr#L172-L177</a></sub></sup>
+
 
 example
 

--- a/docs/versioned_docs/version-v1.0.0-beta.19/noir/standard_library/cryptographic_primitives/hashes.mdx
+++ b/docs/versioned_docs/version-v1.0.0-beta.19/noir/standard_library/cryptographic_primitives/hashes.mdx
@@ -31,7 +31,11 @@ This is a different function than sha256. See [this library](https://github.com/
 
 ::: 
 
-#include_code sha256_compression noir_stdlib/src/hash/mod.nr rust
+```rust title="sha256_compression" showLineNumbers 
+pub fn sha256_compression(input: [u32; 16], state: [u32; 8]) -> [u32; 8] {}
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/hash/mod.nr#L11-L13" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/hash/mod.nr#L11-L13</a></sub></sup>
+
 
 <BlackBoxInfo to="../black_box_fns"/>
 
@@ -39,7 +43,11 @@ This is a different function than sha256. See [this library](https://github.com/
 
 Given an array of bytes, returns an array with the Blake2 hash
 
-#include_code blake2s noir_stdlib/src/hash/mod.nr rust
+```rust title="blake2s" showLineNumbers 
+pub fn blake2s<let N: u32>(input: [u8; N]) -> [u8; 32]
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/hash/mod.nr#L28-L30" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/hash/mod.nr#L28-L30</a></sub></sup>
+
 
 example:
 
@@ -56,7 +64,11 @@ fn main() {
 
 Given an array of bytes, returns an array with the Blake3 hash
 
-#include_code blake3 noir_stdlib/src/hash/mod.nr rust
+```rust title="blake3" showLineNumbers 
+pub fn blake3<let N: u32>(input: [u8; N]) -> [u8; 32]
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/hash/mod.nr#L33-L35" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/hash/mod.nr#L33-L35</a></sub></sup>
+
 
 example:
 
@@ -73,11 +85,22 @@ fn main() {
 
 Given an array of Fields, returns the Pedersen hash.
 
-#include_code pedersen_hash noir_stdlib/src/hash/mod.nr rust
+```rust title="pedersen_hash" showLineNumbers 
+pub fn pedersen_hash<let N: u32>(input: [Field; N]) -> Field
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/hash/mod.nr#L71-L73" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/hash/mod.nr#L71-L73</a></sub></sup>
+
 
 example:
 
-#include_code pedersen-hash test_programs/execution_success/pedersen_hash/src/main.nr rust
+```rust title="pedersen-hash" showLineNumbers 
+fn main(x: Field, y: Field, expected_hash: Field) {
+    let hash = std::hash::pedersen_hash([x, y]);
+    assert_eq(hash, expected_hash);
+}
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/execution_success/pedersen_hash/src/main.nr#L1-L6" target="_blank" rel="noopener noreferrer">Source code: test_programs/execution_success/pedersen_hash/src/main.nr#L1-L6</a></sub></sup>
+
 
 <BlackBoxInfo to="../black_box_fns" />
 
@@ -85,11 +108,23 @@ example:
 
 Given an array of Fields, returns the Pedersen commitment.
 
-#include_code pedersen_commitment noir_stdlib/src/hash/mod.nr rust
+```rust title="pedersen_commitment" showLineNumbers 
+pub fn pedersen_commitment<let N: u32>(input: [Field; N]) -> EmbeddedCurvePoint {
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/hash/mod.nr#L51-L53" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/hash/mod.nr#L51-L53</a></sub></sup>
+
 
 example:
 
-#include_code pedersen-commitment test_programs/execution_success/pedersen_commitment/src/main.nr rust
+```rust title="pedersen-commitment" showLineNumbers 
+fn main(x: Field, y: Field, expected_commitment: std::embedded_curve_ops::EmbeddedCurvePoint) {
+    let commitment = std::hash::pedersen_commitment([x, y]);
+    assert_eq(commitment.x, expected_commitment.x);
+    assert_eq(commitment.y, expected_commitment.y);
+}
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/execution_success/pedersen_commitment/src/main.nr#L1-L7" target="_blank" rel="noopener noreferrer">Source code: test_programs/execution_success/pedersen_commitment/src/main.nr#L1-L7</a></sub></sup>
+
 
 <BlackBoxInfo to="../black_box_fns"/>
 
@@ -97,6 +132,10 @@ example:
 
 Given an initial `[u64; 25]` state, returns the state resulting from applying a keccakf1600 permutation (`[u64; 25]`).
 
-#include_code keccakf1600 noir_stdlib/src/hash/mod.nr rust
+```rust title="keccakf1600" showLineNumbers 
+pub fn keccakf1600(input: [u64; 25]) -> [u64; 25] {}
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/hash/mod.nr#L16-L18" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/hash/mod.nr#L16-L18</a></sub></sup>
+
 
 <BlackBoxInfo to="../black_box_fns"/>

--- a/docs/versioned_docs/version-v1.0.0-beta.19/noir/standard_library/fmtstr.md
+++ b/docs/versioned_docs/version-v1.0.0-beta.19/noir/standard_library/fmtstr.md
@@ -9,16 +9,32 @@ description: Format string literals at compile time—inspect raw contents or em
 
 ### quoted_contents
 
-#include_code quoted_contents noir_stdlib/src/meta/format_string.nr rust
+```rust title="quoted_contents" showLineNumbers 
+pub comptime fn quoted_contents(self) -> Quoted {}
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/format_string.nr#L6-L8" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/format_string.nr#L6-L8</a></sub></sup>
+
 
 Returns the format string contents (that is, without the leading and trailing double quotes) as a `Quoted` value.
 
 ### as_quoted_str
 
-#include_code as_quoted_str noir_stdlib/src/meta/format_string.nr rust
+```rust title="as_quoted_str" showLineNumbers 
+pub comptime fn as_quoted_str(self) -> Quoted {
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/format_string.nr#L11-L13" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/format_string.nr#L11-L13</a></sub></sup>
+
 
 Returns the format string contents (with the leading and trailing double quotes) as a `Quoted` string literal (not a format string literal).
 
 Example:
 
-#include_code as_quoted_str_test test_programs/compile_success_empty/comptime_fmt_strings/src/main.nr rust
+```rust title="as_quoted_str_test" showLineNumbers 
+comptime {
+        let x = 1;
+        let f: str<_> = f"x = {x}".as_quoted_str!();
+        assert_eq(f, "x = 0x01");
+    }
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/compile_success_empty/comptime_fmt_strings/src/main.nr#L19-L25" target="_blank" rel="noopener noreferrer">Source code: test_programs/compile_success_empty/comptime_fmt_strings/src/main.nr#L19-L25</a></sub></sup>
+

--- a/docs/versioned_docs/version-v1.0.0-beta.19/noir/standard_library/meta/ctstring.md
+++ b/docs/versioned_docs/version-v1.0.0-beta.19/noir/standard_library/meta/ctstring.md
@@ -17,7 +17,13 @@ afterward.
 
 ### AsCtString
 
-#include_code as-ctstring noir_stdlib/src/meta/ctstring.nr rust
+```rust title="as-ctstring" showLineNumbers 
+pub trait AsCtString {
+    comptime fn as_ctstring(self) -> CtString;
+}
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/ctstring.nr#L44-L48" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/ctstring.nr#L44-L48</a></sub></sup>
+
 
 Converts an object into a compile-time string.
 
@@ -32,25 +38,41 @@ impl<let N: u32, T> AsCtString for fmtstr<N, T> { ... }
 
 ### new
 
-#include_code new noir_stdlib/src/meta/ctstring.nr rust
+```rust title="new" showLineNumbers 
+pub comptime fn new() -> Self {
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/ctstring.nr#L4-L6" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/ctstring.nr#L4-L6</a></sub></sup>
+
 
 Creates an empty `CtString`.
 
 ### append_str
 
-#include_code append_str noir_stdlib/src/meta/ctstring.nr rust
+```rust title="append_str" showLineNumbers 
+pub comptime fn append_str<let N: u32>(self, s: str<N>) -> Self {
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/ctstring.nr#L12-L14" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/ctstring.nr#L12-L14</a></sub></sup>
+
 
 Returns a new CtString with the given str appended onto the end.
 
 ### append_fmtstr
 
-#include_code append_fmtstr noir_stdlib/src/meta/ctstring.nr rust
+```rust title="append_fmtstr" showLineNumbers 
+pub comptime fn append_fmtstr<let N: u32, T>(self, s: fmtstr<N, T>) -> Self {
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/ctstring.nr#L18-L20" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/ctstring.nr#L18-L20</a></sub></sup>
+
 
 Returns a new CtString with the given fmtstr appended onto the end.
 
 ### as_quoted_str
 
-#include_code as_quoted_str noir_stdlib/src/meta/ctstring.nr rust
+```rust title="as_quoted_str" showLineNumbers 
+pub comptime fn as_quoted_str(self) -> Quoted {
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/ctstring.nr#L27-L29" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/ctstring.nr#L27-L29</a></sub></sup>
+
 
 Returns a quoted string literal from this string's contents.
 
@@ -61,7 +83,14 @@ literal at this function's call site.
 
 Example:
 
-#include_code as_quoted_str_example noir_stdlib/src/meta/ctstring.nr rust
+```rust title="as_quoted_str_example" showLineNumbers 
+let my_ctstring = "foo bar".as_ctstring();
+            let my_str: str<7> = my_ctstring.as_quoted_str!();
+
+            assert_eq(crate::meta::type_of(my_str), quote { str<7> }.as_type());
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/ctstring.nr#L95-L100" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/ctstring.nr#L95-L100</a></sub></sup>
+
 
 ## Trait Implementations
 

--- a/docs/versioned_docs/version-v1.0.0-beta.19/noir/standard_library/meta/expr.md
+++ b/docs/versioned_docs/version-v1.0.0-beta.19/noir/standard_library/meta/expr.md
@@ -9,95 +9,152 @@ description: Introspect and transform quoted expressions at compile time—inspe
 
 ### as_array
 
-#include_code as_array noir_stdlib/src/meta/expr.nr rust
+```rust title="as_array" showLineNumbers 
+pub comptime fn as_array(self) -> Option<[Expr]> {}
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L10-L12" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L10-L12</a></sub></sup>
+
 
 If this expression is an array, this returns a vector of each element in the array.
 
 ### as_assert
 
-#include_code as_assert noir_stdlib/src/meta/expr.nr rust
+```rust title="as_assert" showLineNumbers 
+pub comptime fn as_assert(self) -> Option<(Expr, Option<Expr>)> {}
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L16-L18" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L16-L18</a></sub></sup>
+
 
 If this expression is an assert, this returns the assert expression and the optional message.
 
 ### as_assert_eq
 
-#include_code as_assert_eq noir_stdlib/src/meta/expr.nr rust
+```rust title="as_assert_eq" showLineNumbers 
+pub comptime fn as_assert_eq(self) -> Option<(Expr, Expr, Option<Expr>)> {}
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L23-L25" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L23-L25</a></sub></sup>
+
 
 If this expression is an assert_eq, this returns the left-hand-side and right-hand-side
 expressions, together with the optional message.
 
 ### as_assign
 
-#include_code as_assign noir_stdlib/src/meta/expr.nr rust
+```rust title="as_assign" showLineNumbers 
+pub comptime fn as_assign(self) -> Option<(Expr, Expr)> {}
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L30-L32" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L30-L32</a></sub></sup>
+
 
 If this expression is an assignment, this returns a tuple with the left hand side
 and right hand side in order.
 
 ### as_binary_op
 
-#include_code as_binary_op noir_stdlib/src/meta/expr.nr rust
+```rust title="as_binary_op" showLineNumbers 
+pub comptime fn as_binary_op(self) -> Option<(Expr, BinaryOp, Expr)> {}
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L37-L39" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L37-L39</a></sub></sup>
+
 
 If this expression is a binary operator operation `<lhs> <op> <rhs>`,
 return the left-hand side, operator, and the right-hand side of the operation.
 
 ### as_block
 
-#include_code as_block noir_stdlib/src/meta/expr.nr rust
+```rust title="as_block" showLineNumbers 
+pub comptime fn as_block(self) -> Option<[Expr]> {}
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L44-L46" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L44-L46</a></sub></sup>
+
 
 If this expression is a block `{ stmt1; stmt2; ...; stmtN }`, return
 a vector containing each statement.
 
 ### as_bool
 
-#include_code as_bool noir_stdlib/src/meta/expr.nr rust
+```rust title="as_bool" showLineNumbers 
+pub comptime fn as_bool(self) -> Option<bool> {}
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L50-L52" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L50-L52</a></sub></sup>
+
 
 If this expression is a boolean literal, return that literal.
 
 ### as_cast
 
-#include_code as_cast noir_stdlib/src/meta/expr.nr rust
+```rust title="as_cast" showLineNumbers 
+#[builtin(expr_as_cast)]
+    pub comptime fn as_cast(self) -> Option<(Expr, UnresolvedType)> {}
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L56-L59" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L56-L59</a></sub></sup>
+
 
 If this expression is a cast expression (`expr as type`), returns the casted
 expression and the type to cast to.
 
 ### as_comptime
 
-#include_code as_comptime noir_stdlib/src/meta/expr.nr rust
+```rust title="as_comptime" showLineNumbers 
+pub comptime fn as_comptime(self) -> Option<[Expr]> {}
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L64-L66" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L64-L66</a></sub></sup>
+
 
 If this expression is a `comptime { stmt1; stmt2; ...; stmtN }` block,
 return each statement in the block.
 
 ### as_constructor
 
-#include_code as_constructor noir_stdlib/src/meta/expr.nr rust
+```rust title="as_constructor" showLineNumbers 
+pub comptime fn as_constructor(self) -> Option<(UnresolvedType, [(Quoted, Expr)])> {}
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L71-L73" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L71-L73</a></sub></sup>
+
 
 If this expression is a constructor `Type { field1: expr1, ..., fieldN: exprN }`,
 return the type and the fields.
 
 ### as_for
 
-#include_code as_for noir_stdlib/src/meta/expr.nr rust
+```rust title="as_for" showLineNumbers 
+pub comptime fn as_for(self) -> Option<(Quoted, Expr, Expr)> {}
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L78-L80" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L78-L80</a></sub></sup>
+
 
 If this expression is a for statement over a single expression, return the identifier,
 the expression and the for loop body.
 
 ### as_for_range
 
-#include_code as_for noir_stdlib/src/meta/expr.nr rust
+```rust title="as_for" showLineNumbers 
+pub comptime fn as_for(self) -> Option<(Quoted, Expr, Expr)> {}
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L78-L80" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L78-L80</a></sub></sup>
+
 
 If this expression is a for statement over a range, return the identifier,
 the range start, the range end and the for loop body.
 
 ### as_function_call
 
-#include_code as_function_call noir_stdlib/src/meta/expr.nr rust
+```rust title="as_function_call" showLineNumbers 
+pub comptime fn as_function_call(self) -> Option<(Expr, [Expr])> {}
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L92-L94" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L92-L94</a></sub></sup>
+
 
 If this expression is a function call `foo(arg1, ..., argN)`, return
 the function and a vector of each argument.
 
 ### as_if
 
-#include_code as_if noir_stdlib/src/meta/expr.nr rust
+```rust title="as_if" showLineNumbers 
+pub comptime fn as_if(self) -> Option<(Expr, Expr, Option<Expr>)> {}
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L100-L102" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L100-L102</a></sub></sup>
+
 
 If this expression is an `if condition { then_branch } else { else_branch }`,
 return the condition, then branch, and else branch. If there is no else branch,
@@ -105,90 +162,144 @@ return the condition, then branch, and else branch. If there is no else branch,
 
 ### as_index
 
-#include_code as_index noir_stdlib/src/meta/expr.nr rust
+```rust title="as_index" showLineNumbers 
+pub comptime fn as_index(self) -> Option<(Expr, Expr)> {}
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L107-L109" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L107-L109</a></sub></sup>
+
 
 If this expression is an index into an array `array[index]`, return the
 array and the index.
 
 ### as_integer
 
-#include_code as_integer noir_stdlib/src/meta/expr.nr rust
+```rust title="as_integer" showLineNumbers 
+pub comptime fn as_integer(self) -> Option<(Field, bool)> {}
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L114-L116" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L114-L116</a></sub></sup>
+
 
 If this expression is an integer literal, return the integer as a field
 as well as whether the integer is negative (true) or not (false).
 
 ### as_lambda
 
-#include_code as_lambda noir_stdlib/src/meta/expr.nr rust
+```rust title="as_lambda" showLineNumbers 
+pub comptime fn as_lambda(
+        self,
+    ) -> Option<([(Expr, Option<UnresolvedType>)], Option<UnresolvedType>, Expr)> {}
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L120-L124" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L120-L124</a></sub></sup>
+
 
 If this expression is a lambda, returns the parameters, return type and body.
 
 ### as_let
 
-#include_code as_let noir_stdlib/src/meta/expr.nr rust
+```rust title="as_let" showLineNumbers 
+pub comptime fn as_let(self) -> Option<(Expr, Option<UnresolvedType>, Expr)> {}
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L129-L131" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L129-L131</a></sub></sup>
+
 
 If this expression is a let statement, returns the let pattern as an `Expr`,
 the optional type annotation, and the assigned expression.
 
 ### as_member_access
 
-#include_code as_member_access noir_stdlib/src/meta/expr.nr rust
+```rust title="as_member_access" showLineNumbers 
+pub comptime fn as_member_access(self) -> Option<(Expr, Quoted)> {}
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L136-L138" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L136-L138</a></sub></sup>
+
 
 If this expression is a member access `foo.bar`, return the struct/tuple
 expression and the field. The field will be represented as a quoted value.
 
 ### as_method_call
 
-#include_code as_method_call noir_stdlib/src/meta/expr.nr rust
+```rust title="as_method_call" showLineNumbers 
+pub comptime fn as_method_call(self) -> Option<(Expr, Quoted, [UnresolvedType], [Expr])> {}
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L143-L145" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L143-L145</a></sub></sup>
+
 
 If this expression is a method call `foo.bar::<generic1, ..., genericM>(arg1, ..., argN)`, return
 the receiver, method name, a vector of each generic argument, and a vector of each argument.
 
 ### as_repeated_element_array
 
-#include_code as_repeated_element_array noir_stdlib/src/meta/expr.nr rust
+```rust title="as_repeated_element_array" showLineNumbers 
+pub comptime fn as_repeated_element_array(self) -> Option<(Expr, Expr)> {}
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L150-L152" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L150-L152</a></sub></sup>
+
 
 If this expression is a repeated element array `[elem; length]`, return
 the repeated element and the length expressions.
 
 ### as_repeated_element_vector
 
-#include_code as_repeated_element_vector noir_stdlib/src/meta/expr.nr rust
+```rust title="as_repeated_element_vector" showLineNumbers 
+pub comptime fn as_repeated_element_vector(self) -> Option<(Expr, Expr)> {}
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L157-L159" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L157-L159</a></sub></sup>
+
 
 If this expression is a repeated element vector `[elem; length]`, return
 the repeated element and the length expressions.
 
 ### as_vector
 
-#include_code as_vector noir_stdlib/src/meta/expr.nr rust
+```rust title="as_vector" showLineNumbers 
+pub comptime fn as_vector(self) -> Option<[Expr]> {}
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L171-L173" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L171-L173</a></sub></sup>
+
 
 If this expression is a vector literal `@[elem1, ..., elemN]`,
 return each element of the vector.
 
 ### as_tuple
 
-#include_code as_tuple noir_stdlib/src/meta/expr.nr rust
+```rust title="as_tuple" showLineNumbers 
+pub comptime fn as_tuple(self) -> Option<[Expr]> {}
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L185-L187" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L185-L187</a></sub></sup>
+
 
 If this expression is a tuple `(field1, ..., fieldN)`,
 return each element of the tuple.
 
 ### as_unary_op
 
-#include_code as_unary_op noir_stdlib/src/meta/expr.nr rust
+```rust title="as_unary_op" showLineNumbers 
+pub comptime fn as_unary_op(self) -> Option<(UnaryOp, Expr)> {}
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L192-L194" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L192-L194</a></sub></sup>
+
 
 If this expression is a unary operation `<op> <rhs>`,
 return the unary operator as well as the right-hand side expression.
 
 ### as_unsafe
 
-#include_code as_unsafe noir_stdlib/src/meta/expr.nr rust
+```rust title="as_unsafe" showLineNumbers 
+pub comptime fn as_unsafe(self) -> Option<[Expr]> {}
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L199-L201" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L199-L201</a></sub></sup>
+
 
 If this expression is an `unsafe { stmt1; ...; stmtN }` block,
 return each statement inside in a vector.
 
 ### has_semicolon
 
-#include_code has_semicolon noir_stdlib/src/meta/expr.nr rust
+```rust title="has_semicolon" showLineNumbers 
+pub comptime fn has_semicolon(self) -> bool {}
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L220-L222" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L220-L222</a></sub></sup>
+
 
 `true` if this expression is trailed by a semicolon. E.g.
 
@@ -207,19 +318,31 @@ comptime {
 
 ### is_break
 
-#include_code is_break noir_stdlib/src/meta/expr.nr rust
+```rust title="is_break" showLineNumbers 
+pub comptime fn is_break(self) -> bool {}
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L226-L228" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L226-L228</a></sub></sup>
+
 
 `true` if this expression is `break`.
 
 ### is_continue
 
-#include_code is_continue noir_stdlib/src/meta/expr.nr rust
+```rust title="is_continue" showLineNumbers 
+pub comptime fn is_continue(self) -> bool {}
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L232-L234" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L232-L234</a></sub></sup>
+
 
 `true` if this expression is `continue`.
 
 ### modify
 
-#include_code modify noir_stdlib/src/meta/expr.nr rust
+```rust title="modify" showLineNumbers 
+pub comptime fn modify<Env>(self, f: fn[Env](Expr) -> Option<Expr>) -> Expr {
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L243-L245" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L243-L245</a></sub></sup>
+
 
 Applies a mapping function to this expression and to all of its sub-expressions.
 `f` will be applied to each sub-expression first, then applied to the expression itself.
@@ -231,13 +354,21 @@ for expressions that are integers, doubling them, would return `(@[2], @[4, 6])`
 
 ### quoted
 
-#include_code quoted noir_stdlib/src/meta/expr.nr rust
+```rust title="quoted" showLineNumbers 
+pub comptime fn quoted(self) -> Quoted {
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L280-L282" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L280-L282</a></sub></sup>
+
 
 Returns this expression as a `Quoted` value. It's the same as `quote { $self }`.
 
 ### resolve
 
-#include_code resolve noir_stdlib/src/meta/expr.nr rust
+```rust title="resolve" showLineNumbers 
+pub comptime fn resolve(self, in_function: Option<FunctionDefinition>) -> TypedExpr {}
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L296-L298" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L296-L298</a></sub></sup>
+
 
 Resolves and type-checks this expression and returns the result as a `TypedExpr`.
 

--- a/docs/versioned_docs/version-v1.0.0-beta.19/noir/standard_library/meta/function_def.md
+++ b/docs/versioned_docs/version-v1.0.0-beta.19/noir/standard_library/meta/function_def.md
@@ -10,7 +10,11 @@ a function definition in the source program.
 
 ### add_attribute
 
-#include_code add_attribute noir_stdlib/src/meta/function_def.nr rust
+```rust title="add_attribute" showLineNumbers 
+pub comptime fn add_attribute<let N: u32>(self, attribute: str<N>) {}
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/function_def.nr#L3-L5" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/function_def.nr#L3-L5</a></sub></sup>
+
 
 Adds an attribute to the function. This is only valid
 on functions in the current crate which have not yet been resolved.
@@ -18,7 +22,11 @@ This means any functions called at compile-time are invalid targets for this met
 
 ### as_typed_expr
 
-#include_code as_typed_expr noir_stdlib/src/meta/function_def.nr rust
+```rust title="as_typed_expr" showLineNumbers 
+pub comptime fn as_typed_expr(self) -> TypedExpr {}
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/function_def.nr#L8-L10" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/function_def.nr#L8-L10</a></sub></sup>
+
 
 Returns this function as a `TypedExpr`, which can be unquoted. For example:
 
@@ -29,7 +37,11 @@ let _ = quote { $typed_expr(1, 2, 3); };
 
 ### body
 
-#include_code body noir_stdlib/src/meta/function_def.nr rust
+```rust title="body" showLineNumbers 
+pub comptime fn body(self) -> Expr {}
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/function_def.nr#L13-L15" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/function_def.nr#L13-L15</a></sub></sup>
+
 
 Returns the body of the function as an expression. This is only valid
 on functions in the current crate which have not yet been resolved.
@@ -37,43 +49,71 @@ This means any functions called at compile-time are invalid targets for this met
 
 ### has_named_attribute
 
-#include_code has_named_attribute noir_stdlib/src/meta/function_def.nr rust
+```rust title="has_named_attribute" showLineNumbers 
+pub comptime fn has_named_attribute<let N: u32>(self, name: str<N>) -> bool {}
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/function_def.nr#L18-L20" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/function_def.nr#L18-L20</a></sub></sup>
+
 
 Returns true if this function has a custom attribute with the given name.
 
 ### is_unconstrained
 
-#include_code is_unconstrained noir_stdlib/src/meta/function_def.nr rust
+```rust title="is_unconstrained" showLineNumbers 
+pub comptime fn is_unconstrained(self) -> bool {}
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/function_def.nr#L23-L25" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/function_def.nr#L23-L25</a></sub></sup>
+
 
 Returns true if this function is unconstrained.
 
 ### module
 
-#include_code module noir_stdlib/src/meta/function_def.nr rust
+```rust title="module" showLineNumbers 
+pub comptime fn module(self) -> Module {}
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/function_def.nr#L28-L30" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/function_def.nr#L28-L30</a></sub></sup>
+
 
 Returns the module where the function is defined.
 
 ### name
 
-#include_code name noir_stdlib/src/meta/function_def.nr rust
+```rust title="name" showLineNumbers 
+pub comptime fn name(self) -> Quoted {}
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/function_def.nr#L33-L35" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/function_def.nr#L33-L35</a></sub></sup>
+
 
 Returns the name of the function.
 
 ### parameters
 
-#include_code parameters noir_stdlib/src/meta/function_def.nr rust
+```rust title="parameters" showLineNumbers 
+pub comptime fn parameters(self) -> [(Quoted, Type)] {}
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/function_def.nr#L38-L40" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/function_def.nr#L38-L40</a></sub></sup>
+
 
 Returns each parameter of the function as a tuple of (parameter pattern, parameter type).
 
 ### return_type
 
-#include_code return_type noir_stdlib/src/meta/function_def.nr rust
+```rust title="return_type" showLineNumbers 
+pub comptime fn return_type(self) -> Type {}
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/function_def.nr#L43-L45" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/function_def.nr#L43-L45</a></sub></sup>
+
 
 The return type of the function.
 
 ### set_body
 
-#include_code set_body noir_stdlib/src/meta/function_def.nr rust
+```rust title="set_body" showLineNumbers 
+pub comptime fn set_body(self, body: Expr) {}
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/function_def.nr#L48-L50" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/function_def.nr#L48-L50</a></sub></sup>
+
 
 Mutate the function body to a new expression. This is only valid
 on functions in the current crate which have not yet been resolved.
@@ -81,7 +121,11 @@ This means any functions called at compile-time are invalid targets for this met
 
 ### set_parameters
 
-#include_code set_parameters noir_stdlib/src/meta/function_def.nr rust
+```rust title="set_parameters" showLineNumbers 
+pub comptime fn set_parameters(self, parameters: [(Quoted, Type)]) {}
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/function_def.nr#L53-L55" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/function_def.nr#L53-L55</a></sub></sup>
+
 
 Mutates the function's parameters to a new set of parameters. This is only valid
 on functions in the current crate which have not yet been resolved.
@@ -92,7 +136,11 @@ each parameter pattern to be a syntactically valid parameter.
 
 ### set_return_type
 
-#include_code set_return_type noir_stdlib/src/meta/function_def.nr rust
+```rust title="set_return_type" showLineNumbers 
+pub comptime fn set_return_type(self, return_type: Type) {}
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/function_def.nr#L58-L60" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/function_def.nr#L58-L60</a></sub></sup>
+
 
 Mutates the function's return type to a new type. This is only valid
 on functions in the current crate which have not yet been resolved.
@@ -100,7 +148,11 @@ This means any functions called at compile-time are invalid targets for this met
 
 ### set_return_public
 
-#include_code set_return_public noir_stdlib/src/meta/function_def.nr rust
+```rust title="set_return_public" showLineNumbers 
+pub comptime fn set_return_public(self, public: bool) {}
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/function_def.nr#L63-L65" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/function_def.nr#L63-L65</a></sub></sup>
+
 
 Mutates the function's return visibility to public (if `true` is given) or private (if `false` is given).
 This is only valid on functions in the current crate which have not yet been resolved.
@@ -108,7 +160,11 @@ This means any functions called at compile-time are invalid targets for this met
 
 ### set_unconstrained
 
-#include_code set_unconstrained noir_stdlib/src/meta/function_def.nr rust
+```rust title="set_unconstrained" showLineNumbers 
+pub comptime fn set_unconstrained(self, value: bool) {}
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/function_def.nr#L71-L73" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/function_def.nr#L71-L73</a></sub></sup>
+
 
 Mutates the function to be unconstrained (if `true` is given) or not (if `false` is given).
 This is only valid on functions in the current crate which have not yet been resolved.
@@ -116,7 +172,11 @@ This means any functions called at compile-time are invalid targets for this met
 
 ### visibility
 
-#include_code visibility noir_stdlib/src/meta/function_def.nr rust
+```rust title="visibility" showLineNumbers 
+pub comptime fn visibility(self) -> Quoted {}
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/function_def.nr#L76-L78" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/function_def.nr#L76-L78</a></sub></sup>
+
 
 Returns the function's visibility as a `Quoted` value, which will be one of:
 - `quote { }`: the function is private

--- a/docs/versioned_docs/version-v1.0.0-beta.19/noir/standard_library/meta/index.md
+++ b/docs/versioned_docs/version-v1.0.0-beta.19/noir/standard_library/meta/index.md
@@ -11,7 +11,11 @@ and types used for inspecting and modifying Noir programs.
 
 ### type_of
 
-#include_code type_of noir_stdlib/src/meta/mod.nr rust
+```rust title="type_of" showLineNumbers 
+pub comptime fn type_of<T>(x: T) -> Type {}
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/mod.nr#L29-L31" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/mod.nr#L29-L31</a></sub></sup>
+
 
 Returns the type of a variable at compile-time.
 
@@ -27,7 +31,11 @@ comptime {
 
 ### unquote
 
-#include_code unquote noir_stdlib/src/meta/mod.nr rust
+```rust title="unquote" showLineNumbers 
+pub comptime fn unquote(code: Quoted) -> Quoted {
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/mod.nr#L21-L23" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/mod.nr#L21-L23</a></sub></sup>
+
 
 Unquotes the passed-in token stream where this function was called.
 
@@ -43,7 +51,12 @@ comptime {
 
 ### derive
 
-#include_code derive noir_stdlib/src/meta/mod.nr rust
+```rust title="derive" showLineNumbers 
+#[varargs]
+pub comptime fn derive(s: TypeDefinition, traits: [TraitDefinition]) -> Quoted {
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/mod.nr#L50-L53" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/mod.nr#L50-L53</a></sub></sup>
+
 
 Attribute placed on type definitions.
 
@@ -69,7 +82,11 @@ fn main() {
 
 ### derive_via
 
-#include_code derive_via_signature noir_stdlib/src/meta/mod.nr rust
+```rust title="derive_via_signature" showLineNumbers 
+pub comptime fn derive_via(t: TraitDefinition, f: DeriveFunction) {
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/mod.nr#L70-L72" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/mod.nr#L70-L72</a></sub></sup>
+
 
 Attribute placed on trait definitions.
 
@@ -105,11 +122,44 @@ comptime fn derive_do_nothing(s: TypeDefinition) -> Quoted {
 As another example, `derive_eq` in the stdlib is used to derive the `Eq`
 trait for any type definition. It makes use of `make_trait_impl` to do this:
 
-#include_code derive_eq noir_stdlib/src/cmp.nr rust
+```rust title="derive_eq" showLineNumbers 
+comptime fn derive_eq(s: TypeDefinition) -> Quoted {
+    let signature = quote { fn eq(_self: Self, _other: Self) -> bool };
+    let for_each_field = |name| quote { (_self.$name == _other.$name) };
+    let body = |fields| {
+        if s.fields_as_written().len() == 0 {
+            quote { true }
+        } else {
+            fields
+        }
+    };
+    crate::meta::make_trait_impl(
+        s,
+        quote { $crate::cmp::Eq },
+        signature,
+        for_each_field,
+        quote { & },
+        body,
+    )
+}
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/cmp.nr#L10-L30" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/cmp.nr#L10-L30</a></sub></sup>
+
 
 ### make_trait_impl
 
-#include_code make_trait_impl noir_stdlib/src/meta/mod.nr rust
+```rust title="make_trait_impl" showLineNumbers 
+pub comptime fn make_trait_impl<Env1, Env2>(
+    s: TypeDefinition,
+    trait_name: Quoted,
+    function_signature: Quoted,
+    for_each_field: fn[Env1](Quoted) -> Quoted,
+    join_fields_with: Quoted,
+    body: fn[Env2](Quoted) -> Quoted,
+) -> Quoted {
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/mod.nr#L89-L98" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/mod.nr#L89-L98</a></sub></sup>
+
 
 A helper function to more easily create trait impls while deriving traits.
 
@@ -134,8 +184,42 @@ way to write your derive handler. The arguments are as follows:
 
 Example deriving `Hash`:
 
-#include_code derive_hash noir_stdlib/src/hash/mod.nr rust
+```rust title="derive_hash" showLineNumbers 
+comptime fn derive_hash(s: TypeDefinition) -> Quoted {
+    let name = quote { $crate::hash::Hash };
+    let signature = quote { fn hash<H>(_self: Self, _state: &mut H) where H: $crate::hash::Hasher };
+    let for_each_field = |name| quote { _self.$name.hash(_state); };
+    crate::meta::make_trait_impl(
+        s,
+        name,
+        signature,
+        for_each_field,
+        quote {},
+        |fields| fields,
+    )
+}
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/hash/mod.nr#L157-L171" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/hash/mod.nr#L157-L171</a></sub></sup>
+
 
 Example deriving `Ord`:
 
-#include_code derive_ord noir_stdlib/src/cmp.nr rust
+```rust title="derive_ord" showLineNumbers 
+comptime fn derive_ord(s: TypeDefinition) -> Quoted {
+    let name = quote { $crate::cmp::Ord };
+    let signature = quote { fn cmp(_self: Self, _other: Self) -> $crate::cmp::Ordering };
+    let for_each_field = |name| quote {
+        if result == $crate::cmp::Ordering::equal() {
+            result = _self.$name.cmp(_other.$name);
+        }
+    };
+    let body = |fields| quote {
+        let mut result = $crate::cmp::Ordering::equal();
+        $fields
+        result
+    };
+    crate::meta::make_trait_impl(s, name, signature, for_each_field, quote {}, body)
+}
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/cmp.nr#L223-L239" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/cmp.nr#L223-L239</a></sub></sup>
+

--- a/docs/versioned_docs/version-v1.0.0-beta.19/noir/standard_library/meta/module.md
+++ b/docs/versioned_docs/version-v1.0.0-beta.19/noir/standard_library/meta/module.md
@@ -11,7 +11,11 @@ declarations in the source program.
 
 ### add_item
 
-#include_code add_item noir_stdlib/src/meta/module.nr rust
+```rust title="add_item" showLineNumbers 
+pub comptime fn add_item(self, item: Quoted) {}
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/module.nr#L5-L7" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/module.nr#L5-L7</a></sub></sup>
+
 
 Adds a top-level item (a function, a struct, a global, etc.) to the module.
 Adding multiple items in one go is also valid if the `Quoted` value has multiple items in it.
@@ -19,48 +23,118 @@ Note that the items are type-checked as if they are inside the module they are b
 
 ### child_modules
 
-#include_code child_modules noir_stdlib/src/meta/module.nr rust
+```rust title="child_modules" showLineNumbers 
+pub comptime fn child_modules(self) -> [Module] {}
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/module.nr#L30-L32" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/module.nr#L30-L32</a></sub></sup>
+
 
 Returns all the child modules of the current module.
 
-#include_code child_modules_example test_programs/compile_success_empty/comptime_module/src/main.nr rust
+```rust title="child_modules_example" showLineNumbers 
+mod my_module {
+    pub mod child1 {}
+    pub mod child2 {}
+    pub mod child3 {
+        pub mod nested_child {}
+    }
+}
+
+#[test]
+fn child_modules_test() {
+    comptime {
+        let my_module = quote [my_module].as_module().unwrap();
+        let children = my_module.child_modules().map(Module::name);
+
+        // The order children are returned in is left unspecified.
+        assert_eq(children, [quote [child1], quote [child2], quote [child3]].as_vector());
+    }
+}
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/compile_success_empty/comptime_module/src/main.nr#L150-L169" target="_blank" rel="noopener noreferrer">Source code: test_programs/compile_success_empty/comptime_module/src/main.nr#L150-L169</a></sub></sup>
+
 
 ### functions
 
-#include_code functions noir_stdlib/src/meta/module.nr rust
+```rust title="functions" showLineNumbers 
+pub comptime fn functions(self) -> [FunctionDefinition] {}
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/module.nr#L20-L22" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/module.nr#L20-L22</a></sub></sup>
+
 
 Returns each function defined in the module.
 
 ### has_named_attribute
 
-#include_code has_named_attribute noir_stdlib/src/meta/module.nr rust
+```rust title="has_named_attribute" showLineNumbers 
+pub comptime fn has_named_attribute<let N: u32>(self, name: str<N>) -> bool {}
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/module.nr#L10-L12" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/module.nr#L10-L12</a></sub></sup>
+
 
 Returns true if this module has a custom attribute with the given name.
 
 ### is_contract
 
-#include_code is_contract noir_stdlib/src/meta/module.nr rust
+```rust title="is_contract" showLineNumbers 
+pub comptime fn is_contract(self) -> bool {}
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/module.nr#L15-L17" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/module.nr#L15-L17</a></sub></sup>
+
 
 `true` if this module is a contract module (was declared via `contract foo { ... }`).
 
 ### name
 
-#include_code name noir_stdlib/src/meta/module.nr rust
+```rust title="name" showLineNumbers 
+pub comptime fn name(self) -> Quoted {}
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/module.nr#L35-L37" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/module.nr#L35-L37</a></sub></sup>
+
 
 Returns the name of the module.
 The top-level module in each crate has no name and is thus empty.
 
 ### parent
 
-#include_code parent noir_stdlib/src/meta/module.nr rust
+```rust title="parent" showLineNumbers 
+pub comptime fn parent(self) -> Option<Module> {}
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/module.nr#L40-L42" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/module.nr#L40-L42</a></sub></sup>
+
 
 Returns the parent module of the given module, if any.
 
-#include_code parent_example test_programs/compile_success_empty/comptime_module/src/main.nr rust
+```rust title="parent_example" showLineNumbers 
+mod module1 {
+    pub mod module2 {}
+}
+
+#[test]
+fn parent_test() {
+    comptime {
+        let my_module2 = quote [module1::module2].as_module().unwrap();
+        assert_eq(my_module2.name(), quote [module2]);
+
+        let my_module1 = my_module2.parent().unwrap();
+        assert_eq(my_module1.name(), quote [module1]);
+
+        // The top-level module in each crate has no name
+        let top_level_module = my_module1.parent().unwrap();
+        assert_eq(top_level_module.name(), quote []);
+    }
+}
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/compile_success_empty/comptime_module/src/main.nr#L129-L148" target="_blank" rel="noopener noreferrer">Source code: test_programs/compile_success_empty/comptime_module/src/main.nr#L129-L148</a></sub></sup>
+
 
 ### structs
 
-#include_code structs noir_stdlib/src/meta/module.nr rust
+```rust title="structs" showLineNumbers 
+pub comptime fn structs(self) -> [TypeDefinition] {}
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/module.nr#L25-L27" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/module.nr#L25-L27</a></sub></sup>
+
 
 Returns each struct defined in the module.
 

--- a/docs/versioned_docs/version-v1.0.0-beta.19/noir/standard_library/meta/op.md
+++ b/docs/versioned_docs/version-v1.0.0-beta.19/noir/standard_library/meta/op.md
@@ -16,31 +16,51 @@ Represents a unary operator. One of `-`, `!`, `&mut`, or `*`.
 
 #### is_minus
 
-#include_code is_minus noir_stdlib/src/meta/op.nr rust
+```rust title="is_minus" showLineNumbers 
+pub fn is_minus(self) -> bool {
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/op.nr#L26-L28" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L26-L28</a></sub></sup>
+
 
 Returns `true` if this operator is `-`.
 
 #### is_not
 
-#include_code is_not noir_stdlib/src/meta/op.nr rust
+```rust title="is_not" showLineNumbers 
+pub fn is_not(self) -> bool {
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/op.nr#L32-L34" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L32-L34</a></sub></sup>
+
 
 `true` if this operator is `!`
 
 #### is_mutable_reference
 
-#include_code is_mutable_reference noir_stdlib/src/meta/op.nr rust
+```rust title="is_mutable_reference" showLineNumbers 
+pub fn is_mutable_reference(self) -> bool {
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/op.nr#L38-L40" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L38-L40</a></sub></sup>
+
 
 `true` if this operator is `&mut`
 
 #### is_dereference
 
-#include_code is_dereference noir_stdlib/src/meta/op.nr rust
+```rust title="is_dereference" showLineNumbers 
+pub fn is_dereference(self) -> bool {
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/op.nr#L44-L46" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L44-L46</a></sub></sup>
+
 
 `true` if this operator is `*`
 
 #### quoted
 
-#include_code unary_quoted noir_stdlib/src/meta/op.nr rust
+```rust title="unary_quoted" showLineNumbers 
+pub comptime fn quoted(self) -> Quoted {
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/op.nr#L50-L52" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L50-L52</a></sub></sup>
+
 
 Returns this operator as a `Quoted` value.
 
@@ -59,97 +79,161 @@ Represents a binary operator. One of `+`, `-`, `*`, `/`, `%`, `==`, `!=`, `<`, `
 
 #### is_add
 
-#include_code is_add noir_stdlib/src/meta/op.nr rust
+```rust title="is_add" showLineNumbers 
+pub fn is_add(self) -> bool {
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/op.nr#L88-L90" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L88-L90</a></sub></sup>
+
 
 `true` if this operator is `+`
 
 #### is_subtract
 
-#include_code is_subtract noir_stdlib/src/meta/op.nr rust
+```rust title="is_subtract" showLineNumbers 
+pub fn is_subtract(self) -> bool {
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/op.nr#L94-L96" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L94-L96</a></sub></sup>
+
 
 `true` if this operator is `-`
 
 #### is_multiply
 
-#include_code is_multiply noir_stdlib/src/meta/op.nr rust
+```rust title="is_multiply" showLineNumbers 
+pub fn is_multiply(self) -> bool {
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/op.nr#L100-L102" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L100-L102</a></sub></sup>
+
 
 `true` if this operator is `*`
 
 #### is_divide
 
-#include_code is_divide noir_stdlib/src/meta/op.nr rust
+```rust title="is_divide" showLineNumbers 
+pub fn is_divide(self) -> bool {
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/op.nr#L106-L108" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L106-L108</a></sub></sup>
+
 
 `true` if this operator is `/`
 
 #### is_modulo
 
-#include_code is_modulo noir_stdlib/src/meta/op.nr rust
+```rust title="is_modulo" showLineNumbers 
+pub fn is_modulo(self) -> bool {
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/op.nr#L178-L180" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L178-L180</a></sub></sup>
+
 
 `true` if this operator is `%`
 
 #### is_equal
 
-#include_code is_equal noir_stdlib/src/meta/op.nr rust
+```rust title="is_equal" showLineNumbers 
+pub fn is_equal(self) -> bool {
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/op.nr#L112-L114" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L112-L114</a></sub></sup>
+
 
 `true` if this operator is `==`
 
 #### is_not_equal
 
-#include_code is_not_equal noir_stdlib/src/meta/op.nr rust
+```rust title="is_not_equal" showLineNumbers 
+pub fn is_not_equal(self) -> bool {
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/op.nr#L118-L120" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L118-L120</a></sub></sup>
+
 
 `true` if this operator is `!=`
 
 #### is_less_than
 
-#include_code is_less_than noir_stdlib/src/meta/op.nr rust
+```rust title="is_less_than" showLineNumbers 
+pub fn is_less_than(self) -> bool {
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/op.nr#L124-L126" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L124-L126</a></sub></sup>
+
 
 `true` if this operator is `<`
 
 #### is_less_than_or_equal
 
-#include_code is_less_than_or_equal noir_stdlib/src/meta/op.nr rust
+```rust title="is_less_than_or_equal" showLineNumbers 
+pub fn is_less_than_or_equal(self) -> bool {
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/op.nr#L130-L132" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L130-L132</a></sub></sup>
+
 
 `true` if this operator is `<=`
 
 #### is_greater_than
 
-#include_code is_greater_than noir_stdlib/src/meta/op.nr rust
+```rust title="is_greater_than" showLineNumbers 
+pub fn is_greater_than(self) -> bool {
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/op.nr#L136-L138" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L136-L138</a></sub></sup>
+
 
 `true` if this operator is `>`
 
 #### is_greater_than_or_equal
 
-#include_code is_greater_than_or_equal noir_stdlib/src/meta/op.nr rust
+```rust title="is_greater_than_or_equal" showLineNumbers 
+pub fn is_greater_than_or_equal(self) -> bool {
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/op.nr#L142-L144" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L142-L144</a></sub></sup>
+
 
 `true` if this operator is `>=`
 
 #### is_and
 
-#include_code is_and noir_stdlib/src/meta/op.nr rust
+```rust title="is_and" showLineNumbers 
+pub fn is_and(self) -> bool {
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/op.nr#L148-L150" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L148-L150</a></sub></sup>
+
 
 `true` if this operator is `&`
 
 #### is_or
 
-#include_code is_or noir_stdlib/src/meta/op.nr rust
+```rust title="is_or" showLineNumbers 
+pub fn is_or(self) -> bool {
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/op.nr#L154-L156" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L154-L156</a></sub></sup>
+
 
 `true` if this operator is `|`
 
 #### is_shift_right
 
-#include_code is_shift_right noir_stdlib/src/meta/op.nr rust
+```rust title="is_shift_right" showLineNumbers 
+pub fn is_shift_right(self) -> bool {
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/op.nr#L166-L168" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L166-L168</a></sub></sup>
+
 
 `true` if this operator is `>>`
 
 #### is_shift_left
 
-#include_code is_shift_left noir_stdlib/src/meta/op.nr rust
+```rust title="is_shift_left" showLineNumbers 
+pub fn is_shift_left(self) -> bool {
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/op.nr#L172-L174" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L172-L174</a></sub></sup>
+
 
 `true` if this operator is `<<`
 
 #### quoted
 
-#include_code binary_quoted noir_stdlib/src/meta/op.nr rust
+```rust title="binary_quoted" showLineNumbers 
+pub comptime fn quoted(self) -> Quoted {
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/op.nr#L184-L186" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L184-L186</a></sub></sup>
+
 
 Returns this operator as a `Quoted` value.
 

--- a/docs/versioned_docs/version-v1.0.0-beta.19/noir/standard_library/meta/quoted.md
+++ b/docs/versioned_docs/version-v1.0.0-beta.19/noir/standard_library/meta/quoted.md
@@ -10,29 +10,67 @@ quoted token streams and is the result of the `quote { ... }` expression.
 
 ### as_expr
 
-#include_code as_expr noir_stdlib/src/meta/quoted.nr rust
+```rust title="as_expr" showLineNumbers 
+pub comptime fn as_expr(self) -> Option<Expr> {}
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/quoted.nr#L6-L8" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/quoted.nr#L6-L8</a></sub></sup>
+
 
 Parses the quoted token stream as an expression. Returns `Option::none()` if
 the expression failed to parse.
 
 Example:
 
-#include_code as_expr_example test_programs/noir_test_success/comptime_expr/src/main.nr rust
+```rust title="as_expr_example" showLineNumbers 
+#[test]
+    fn test_expr_as_function_call() {
+        comptime {
+            let expr = quote { foo(42) }.as_expr().unwrap();
+            let (_function, args) = expr.as_function_call().unwrap();
+            assert_eq(args.len(), 1);
+            assert_eq(args[0].as_integer().unwrap(), (42, false));
+        }
+    }
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/noir_test_success/comptime_expr/src/main.nr#L336-L346" target="_blank" rel="noopener noreferrer">Source code: test_programs/noir_test_success/comptime_expr/src/main.nr#L336-L346</a></sub></sup>
+
 
 ### as_module
 
-#include_code as_module noir_stdlib/src/meta/quoted.nr rust
+```rust title="as_module" showLineNumbers 
+pub comptime fn as_module(self) -> Option<Module> {}
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/quoted.nr#L11-L13" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/quoted.nr#L11-L13</a></sub></sup>
+
 
 Interprets this token stream as a module path leading to the name of a module.
 Returns `Option::none()` if the module isn't found or this token stream cannot be parsed as a path.
 
 Example:
 
-#include_code as_module_example test_programs/compile_success_empty/comptime_module/src/main.nr rust
+```rust title="as_module_example" showLineNumbers 
+mod baz {
+    pub mod qux {}
+}
+
+#[test]
+fn as_module_test() {
+    comptime {
+        let my_mod = quote { baz::qux }.as_module().unwrap();
+        assert_eq(my_mod.name(), quote { qux });
+    }
+}
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/compile_success_empty/comptime_module/src/main.nr#L115-L127" target="_blank" rel="noopener noreferrer">Source code: test_programs/compile_success_empty/comptime_module/src/main.nr#L115-L127</a></sub></sup>
+
 
 ### as_trait_constraint
 
-#include_code as_trait_constraint noir_stdlib/src/meta/quoted.nr rust
+```rust title="as_trait_constraint" showLineNumbers 
+pub comptime fn as_trait_constraint(self) -> TraitConstraint {}
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/quoted.nr#L16-L18" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/quoted.nr#L16-L18</a></sub></sup>
+
 
 Interprets this token stream as a trait constraint (without an object type).
 Note that this function panics instead of returning `Option::none()` if the token
@@ -40,20 +78,58 @@ stream does not parse and resolve to a valid trait constraint.
 
 Example:
 
-#include_code implements_example test_programs/compile_success_empty/comptime_type/src/main.nr rust
+```rust title="implements_example" showLineNumbers 
+pub fn function_with_where<T>(_x: T)
+where
+    T: SomeTrait<i32>,
+{
+    comptime {
+        let t = quote { T }.as_type();
+        let some_trait_i32 = quote { SomeTrait<i32> }.as_trait_constraint();
+        assert(t.implements(some_trait_i32));
+
+        assert(t.get_trait_impl(some_trait_i32).is_none());
+    }
+}
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/compile_success_empty/comptime_type/src/main.nr#L160-L173" target="_blank" rel="noopener noreferrer">Source code: test_programs/compile_success_empty/comptime_type/src/main.nr#L160-L173</a></sub></sup>
+
 
 ### as_type
 
-#include_code as_type noir_stdlib/src/meta/quoted.nr rust
+```rust title="as_type" showLineNumbers 
+pub comptime fn as_type(self) -> Type {}
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/quoted.nr#L21-L23" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/quoted.nr#L21-L23</a></sub></sup>
+
 
 Interprets this token stream as a resolved type. Panics if the token
 stream doesn't parse to a type or if the type isn't a valid type in scope.
 
-#include_code implements_example test_programs/compile_success_empty/comptime_type/src/main.nr rust
+```rust title="implements_example" showLineNumbers 
+pub fn function_with_where<T>(_x: T)
+where
+    T: SomeTrait<i32>,
+{
+    comptime {
+        let t = quote { T }.as_type();
+        let some_trait_i32 = quote { SomeTrait<i32> }.as_trait_constraint();
+        assert(t.implements(some_trait_i32));
+
+        assert(t.get_trait_impl(some_trait_i32).is_none());
+    }
+}
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/compile_success_empty/comptime_type/src/main.nr#L160-L173" target="_blank" rel="noopener noreferrer">Source code: test_programs/compile_success_empty/comptime_type/src/main.nr#L160-L173</a></sub></sup>
+
 
 ### tokens
 
-#include_code tokens noir_stdlib/src/meta/quoted.nr rust
+```rust title="tokens" showLineNumbers 
+pub comptime fn tokens(self) -> [Quoted] {}
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/quoted.nr#L26-L28" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/quoted.nr#L26-L28</a></sub></sup>
+
 
 Returns a vector of the individual tokens that form this token stream.
 

--- a/docs/versioned_docs/version-v1.0.0-beta.19/noir/standard_library/meta/struct_def.md
+++ b/docs/versioned_docs/version-v1.0.0-beta.19/noir/standard_library/meta/struct_def.md
@@ -10,13 +10,21 @@ This type corresponds to `struct Name { field1: Type1, ... }` and `enum Name { V
 
 ### add_attribute
 
-#include_code add_attribute noir_stdlib/src/meta/type_def.nr rust
+```rust title="add_attribute" showLineNumbers 
+pub comptime fn add_attribute<let N: u32>(self, attribute: str<N>) {}
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/type_def.nr#L5-L7" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/type_def.nr#L5-L7</a></sub></sup>
+
 
 Adds an attribute to the data type.
 
 ### add_generic
 
-#include_code add_generic noir_stdlib/src/meta/type_def.nr rust
+```rust title="add_generic" showLineNumbers 
+pub comptime fn add_generic<let N: u32>(self, generic_name: str<N>) -> Type {}
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/type_def.nr#L10-L12" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/type_def.nr#L10-L12</a></sub></sup>
+
 
 Adds an generic to the type. Returns the new generic type.
 Errors if the given generic name isn't a single identifier or if
@@ -30,25 +38,50 @@ that are not used in function signatures.
 
 Example:
 
-#include_code add-generic-example test_programs/compile_success_empty/comptime_struct_definition/src/main.nr rust
+```rust title="add-generic-example" showLineNumbers 
+comptime fn add_generic(s: TypeDefinition) {
+        assert_eq(s.generics().len(), 0);
+        let new_generic = s.add_generic("T");
+
+        let generics = s.generics();
+        assert_eq(generics.len(), 1);
+        let (typ, numeric) = generics[0];
+        assert_eq(typ, new_generic);
+        assert(numeric.is_none());
+    }
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/compile_success_empty/comptime_struct_definition/src/main.nr#L47-L58" target="_blank" rel="noopener noreferrer">Source code: test_programs/compile_success_empty/comptime_struct_definition/src/main.nr#L47-L58</a></sub></sup>
+
 
 ### as_type
 
-#include_code as_type noir_stdlib/src/meta/type_def.nr rust
+```rust title="as_type" showLineNumbers 
+pub comptime fn as_type(self) -> Type {}
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/type_def.nr#L17-L19" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/type_def.nr#L17-L19</a></sub></sup>
+
 
 Returns this type definition as a type in the source program. If this definition has
 any generics, the generics are also included as-is.
 
 ### as_type_with_generics
 
-#include_code as_type_with_generics noir_stdlib/src/meta/type_def.nr rust
+```rust title="as_type_with_generics" showLineNumbers 
+pub comptime fn as_type_with_generics(self, generics: [Type]) -> Option<Type> {}
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/type_def.nr#L28-L30" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/type_def.nr#L28-L30</a></sub></sup>
+
 
 Returns a type from this type definition using the given generic arguments. Returns `Option::none()`
 if an incorrect amount of generic arguments are given for this type.
 
 ### generics
 
-#include_code generics noir_stdlib/src/meta/type_def.nr rust
+```rust title="generics" showLineNumbers 
+pub comptime fn generics(self) -> [(Type, Option<Type>)] {}
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/type_def.nr#L40-L42" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/type_def.nr#L40-L42</a></sub></sup>
+
 
 Returns each generic on this type definition. Each generic is represented as a tuple containing the type,
 and an optional containing the numeric type if it's a numeric generic.
@@ -77,7 +110,11 @@ comptime fn example(foo: TypeDefinition) {
 
 ### fields
 
-#include_code fields noir_stdlib/src/meta/type_def.nr rust
+```rust title="fields" showLineNumbers 
+pub comptime fn fields(self, generic_args: [Type]) -> [(Quoted, Type, Quoted)] {}
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/type_def.nr#L48-L50" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/type_def.nr#L48-L50</a></sub></sup>
+
 
 Returns (name, type, visibility) tuples of each field in this struct type.
 Any generic types used in each field type is automatically substituted with the
@@ -85,7 +122,11 @@ provided generic arguments.
 
 ### fields_as_written
 
-#include_code fields_as_written noir_stdlib/src/meta/type_def.nr rust
+```rust title="fields_as_written" showLineNumbers 
+pub comptime fn fields_as_written(self) -> [(Quoted, Type, Quoted)] {}
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/type_def.nr#L57-L59" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/type_def.nr#L57-L59</a></sub></sup>
+
 
 Returns (name, type, visibility) tuples of each field in this struct type. Each type is as-is
 with any generic arguments unchanged. Unless the field types are not needed,
@@ -94,19 +135,31 @@ function if possible.
 
 ### has_named_attribute
 
-#include_code has_named_attribute noir_stdlib/src/meta/type_def.nr rust
+```rust title="has_named_attribute" showLineNumbers 
+pub comptime fn has_named_attribute<let N: u32>(self, name: str<N>) -> bool {}
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/type_def.nr#L33-L35" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/type_def.nr#L33-L35</a></sub></sup>
+
 
 Returns true if this type has a custom attribute with the given name.
 
 ### module
 
-#include_code module noir_stdlib/src/meta/type_def.nr rust
+```rust title="module" showLineNumbers 
+pub comptime fn module(self) -> Module {}
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/type_def.nr#L62-L64" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/type_def.nr#L62-L64</a></sub></sup>
+
 
 Returns the module where the type is defined.
 
 ### name
 
-#include_code name noir_stdlib/src/meta/type_def.nr rust
+```rust title="name" showLineNumbers 
+pub comptime fn name(self) -> Quoted {}
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/type_def.nr#L67-L69" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/type_def.nr#L67-L69</a></sub></sup>
+
 
 Returns the name of this type
 
@@ -115,7 +168,11 @@ not be the full path to the type definition, nor will it include any generics.
 
 ### set_fields
 
-#include_code set_fields noir_stdlib/src/meta/type_def.nr rust
+```rust title="set_fields" showLineNumbers 
+pub comptime fn set_fields(self, new_fields: [(Quoted, Type, Quoted)]) {}
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/type_def.nr#L76-L78" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/type_def.nr#L76-L78</a></sub></sup>
+
 
 Sets the fields of this struct to the given fields list where each element
 is a pair of the field's name and the field's type. Expects each field name

--- a/docs/versioned_docs/version-v1.0.0-beta.19/noir/standard_library/meta/trait_def.md
+++ b/docs/versioned_docs/version-v1.0.0-beta.19/noir/standard_library/meta/trait_def.md
@@ -10,7 +10,11 @@ represents trait definitions such as `trait Foo { .. }` at the top-level of a pr
 
 ### as_trait_constraint
 
-#include_code as_trait_constraint noir_stdlib/src/meta/trait_def.nr rust
+```rust title="as_trait_constraint" showLineNumbers 
+pub comptime fn as_trait_constraint(_self: Self) -> TraitConstraint {}
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/trait_def.nr#L6-L8" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/trait_def.nr#L6-L8</a></sub></sup>
+
 
 Converts this trait into a trait constraint. If there are any generics on this
 trait, they will be kept as-is without instantiating or replacing them.

--- a/docs/versioned_docs/version-v1.0.0-beta.19/noir/standard_library/meta/trait_impl.md
+++ b/docs/versioned_docs/version-v1.0.0-beta.19/noir/standard_library/meta/trait_impl.md
@@ -10,7 +10,11 @@ implementation such as `impl Foo for Bar { ... }`.
 
 ### trait_generic_args
 
-#include_code trait_generic_args noir_stdlib/src/meta/trait_impl.nr rust
+```rust title="trait_generic_args" showLineNumbers 
+pub comptime fn trait_generic_args(self) -> [Type] {}
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/trait_impl.nr#L3-L5" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/trait_impl.nr#L3-L5</a></sub></sup>
+
 
 Returns any generic arguments on the trait of this trait implementation, if any.
 
@@ -35,7 +39,11 @@ comptime {
 
 ### methods
 
-#include_code methods noir_stdlib/src/meta/trait_impl.nr rust
+```rust title="methods" showLineNumbers 
+pub comptime fn methods(self) -> [FunctionDefinition] {}
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/trait_impl.nr#L8-L10" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/trait_impl.nr#L8-L10</a></sub></sup>
+
 
 Returns each method in this trait impl.
 

--- a/docs/versioned_docs/version-v1.0.0-beta.19/noir/standard_library/meta/typ.md
+++ b/docs/versioned_docs/version-v1.0.0-beta.19/noir/standard_library/meta/typ.md
@@ -8,7 +8,11 @@ a type in the source program.
 
 ## Functions
 
-#include_code fresh_type_variable noir_stdlib/src/meta/typ.nr rust
+```rust title="fresh_type_variable" showLineNumbers 
+pub comptime fn fresh_type_variable() -> Type {}
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/typ.nr#L57-L59" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/typ.nr#L57-L59</a></sub></sup>
+
 
 Creates and returns an unbound type variable. This is a special kind of type internal
 to type checking which will type check with any other type. When it is type checked
@@ -27,14 +31,57 @@ fail.
 
 Example:
 
-#include_code serialize-setup test_programs/compile_success_empty/comptime_type/src/main.nr rust
-#include_code fresh-type-variable-example test_programs/compile_success_empty/comptime_type/src/main.nr rust
+```rust title="serialize-setup" showLineNumbers 
+trait Serialize<let N: u32> {}
+
+impl Serialize<1> for Field {}
+
+impl<T, let N: u32, let M: u32> Serialize<N * M> for [T; N]
+where
+    T: Serialize<M>,
+{}
+
+impl<T, U, let N: u32, let M: u32> Serialize<N + M> for (T, U)
+where
+    T: Serialize<N>,
+    U: Serialize<M>,
+{}
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/compile_success_empty/comptime_type/src/main.nr#L14-L29" target="_blank" rel="noopener noreferrer">Source code: test_programs/compile_success_empty/comptime_type/src/main.nr#L14-L29</a></sub></sup>
+
+```rust title="fresh-type-variable-example" showLineNumbers 
+let typevar1 = std::meta::typ::fresh_type_variable();
+        let constraint = quote { Serialize<$typevar1> }.as_trait_constraint();
+        let field_type = quote { Field }.as_type();
+
+        // Search for a trait impl (binding typevar1 to 1 when the impl is found):
+        assert(field_type.implements(constraint));
+
+        // typevar1 should be bound to the "1" generic now:
+        assert_eq(typevar1.as_constant().unwrap(), 1);
+
+        // If we want to do the same with a different type, we need to
+        // create a new type variable now that `typevar1` is bound
+        let typevar2 = std::meta::typ::fresh_type_variable();
+        let constraint = quote { Serialize<$typevar2> }.as_trait_constraint();
+        let array_type = quote { [(Field, Field); 5] }.as_type();
+        assert(array_type.implements(constraint));
+
+        // Now typevar2 should be bound to the serialized pair size 2 times the array length 5
+        assert_eq(typevar2.as_constant().unwrap(), 10);
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/compile_success_empty/comptime_type/src/main.nr#L129-L149" target="_blank" rel="noopener noreferrer">Source code: test_programs/compile_success_empty/comptime_type/src/main.nr#L129-L149</a></sub></sup>
+
 
 ## Methods
 
 ### as_array
 
-#include_code as_array noir_stdlib/src/meta/typ.nr rust
+```rust title="as_array" showLineNumbers 
+pub comptime fn as_array(self) -> Option<(Type, Type)> {}
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/typ.nr#L76-L78" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/typ.nr#L76-L78</a></sub></sup>
+
 
 If this type is an array, return a pair of (element type, size type).
 
@@ -52,52 +99,84 @@ comptime {
 
 ### as_constant
 
-#include_code as_constant noir_stdlib/src/meta/typ.nr rust
+```rust title="as_constant" showLineNumbers 
+pub comptime fn as_constant(self) -> Option<u32> {}
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/typ.nr#L83-L85" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/typ.nr#L83-L85</a></sub></sup>
+
 
 If this type is a constant integer (such as the `3` in the array type `[Field; 3]`),
 return the numeric constant.
 
 ### as_integer
 
-#include_code as_integer noir_stdlib/src/meta/typ.nr rust
+```rust title="as_integer" showLineNumbers 
+pub comptime fn as_integer(self) -> Option<(bool, u8)> {}
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/typ.nr#L90-L92" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/typ.nr#L90-L92</a></sub></sup>
+
 
 If this is an integer type, return a boolean which is `true`
 if the type is signed, as well as the number of bits of this integer type.
 
 ### as_mutable_reference
 
-#include_code as_mutable_reference noir_stdlib/src/meta/typ.nr rust
+```rust title="as_mutable_reference" showLineNumbers 
+pub comptime fn as_mutable_reference(self) -> Option<Type> {}
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/typ.nr#L96-L98" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/typ.nr#L96-L98</a></sub></sup>
+
 
 If this is a mutable reference type `&mut T`, returns the mutable type `T`.
 
 ### as_vector
 
-#include_code as_vector noir_stdlib/src/meta/typ.nr rust
+```rust title="as_vector" showLineNumbers 
+pub comptime fn as_vector(self) -> Option<Type> {}
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/typ.nr#L102-L104" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/typ.nr#L102-L104</a></sub></sup>
+
 
 If this is a vector type, return the element type of the vector.
 
 ### as_str
 
-#include_code as_str noir_stdlib/src/meta/typ.nr rust
+```rust title="as_str" showLineNumbers 
+pub comptime fn as_str(self) -> Option<Type> {}
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/typ.nr#L113-L115" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/typ.nr#L113-L115</a></sub></sup>
+
 
 If this is a `str<N>` type, returns the length `N` as a type.
 
 ### as_data_type
 
-#include_code as_data_type noir_stdlib/src/meta/typ.nr rust
+```rust title="as_data_type" showLineNumbers 
+pub comptime fn as_data_type(self) -> Option<(TypeDefinition, [Type])> {}
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/typ.nr#L124-L126" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/typ.nr#L124-L126</a></sub></sup>
+
 
 If this is a struct type, returns the struct in addition to
 any generic arguments on this type.
 
 ### as_tuple
 
-#include_code as_tuple noir_stdlib/src/meta/typ.nr rust
+```rust title="as_tuple" showLineNumbers 
+pub comptime fn as_tuple(self) -> Option<[Type]> {}
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/typ.nr#L130-L132" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/typ.nr#L130-L132</a></sub></sup>
+
 
 If this is a tuple type, returns each element type of the tuple.
 
 ### get_trait_impl
 
-#include_code get_trait_impl noir_stdlib/src/meta/typ.nr rust
+```rust title="get_trait_impl" showLineNumbers 
+pub comptime fn get_trait_impl(self, constraint: TraitConstraint) -> Option<TraitImpl> {}
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/typ.nr#L153-L155" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/typ.nr#L153-L155</a></sub></sup>
+
 
 Retrieves the trait implementation that implements the given
 trait constraint for this type. If the trait constraint is not
@@ -120,7 +199,11 @@ comptime {
 
 ### implements
 
-#include_code implements noir_stdlib/src/meta/typ.nr rust
+```rust title="implements" showLineNumbers 
+pub comptime fn implements(self, constraint: TraitConstraint) -> bool {}
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/typ.nr#L176-L178" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/typ.nr#L176-L178</a></sub></sup>
+
 
 `true` if this type implements the given trait. Note that unlike
 `get_trait_impl` this will also return true for any `where` constraints
@@ -143,19 +226,31 @@ fn foo<T>() where T: Default {
 
 ### is_bool
 
-#include_code is_bool noir_stdlib/src/meta/typ.nr rust
+```rust title="is_bool" showLineNumbers 
+pub comptime fn is_bool(self) -> bool {}
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/typ.nr#L182-L184" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/typ.nr#L182-L184</a></sub></sup>
+
 
 `true` if this type is `bool`.
 
 ### is_field
 
-#include_code is_field noir_stdlib/src/meta/typ.nr rust
+```rust title="is_field" showLineNumbers 
+pub comptime fn is_field(self) -> bool {}
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/typ.nr#L188-L190" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/typ.nr#L188-L190</a></sub></sup>
+
 
 `true` if this type is `Field`.
 
 ### is_unit
 
-#include_code is_unit noir_stdlib/src/meta/typ.nr rust
+```rust title="is_unit" showLineNumbers 
+pub comptime fn is_unit(self) -> bool {}
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/typ.nr#L194-L196" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/typ.nr#L194-L196</a></sub></sup>
+
 
 `true` if this type is the unit `()` type.
 

--- a/docs/versioned_docs/version-v1.0.0-beta.19/noir/standard_library/meta/typed_expr.md
+++ b/docs/versioned_docs/version-v1.0.0-beta.19/noir/standard_library/meta/typed_expr.md
@@ -9,12 +9,20 @@ description: Resolved, type-checked expressions—retrieve types, access referen
 
 ### get_type
 
-#include_code as_function_definition noir_stdlib/src/meta/typed_expr.nr rust
+```rust title="as_function_definition" showLineNumbers 
+pub comptime fn as_function_definition(self) -> Option<FunctionDefinition> {}
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/typed_expr.nr#L7-L9" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/typed_expr.nr#L7-L9</a></sub></sup>
+
 
 If this expression refers to a function definitions, returns it. Otherwise returns `Option::none()`.
 
 ### get_type
 
-#include_code get_type noir_stdlib/src/meta/typed_expr.nr rust
+```rust title="get_type" showLineNumbers 
+pub comptime fn get_type(self) -> Option<Type> {}
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/typed_expr.nr#L13-L15" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/typed_expr.nr#L13-L15</a></sub></sup>
+
 
 Returns the type of the expression, or `Option::none()` if there were errors when the expression was previously resolved.

--- a/docs/versioned_docs/version-v1.0.0-beta.19/noir/standard_library/meta/unresolved_type.md
+++ b/docs/versioned_docs/version-v1.0.0-beta.19/noir/standard_library/meta/unresolved_type.md
@@ -9,30 +9,50 @@ description: Work with the syntactic form of types—inspect references, vectors
 
 ### as_mutable_reference
 
-#include_code as_mutable_reference noir_stdlib/src/meta/unresolved_type.nr rust
+```rust title="as_mutable_reference" showLineNumbers 
+pub comptime fn as_mutable_reference(self) -> Option<UnresolvedType> {}
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/unresolved_type.nr#L8-L10" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/unresolved_type.nr#L8-L10</a></sub></sup>
+
 
 If this is a mutable reference type `&mut T`, returns the mutable type `T`.
 
 ### as_vector
 
-#include_code as_vector noir_stdlib/src/meta/unresolved_type.nr rust
+```rust title="as_vector" showLineNumbers 
+pub comptime fn as_vector(self) -> Option<UnresolvedType> {}
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/unresolved_type.nr#L14-L16" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/unresolved_type.nr#L14-L16</a></sub></sup>
+
 
 If this is a vector `@[T]`, returns the element type `T`.
 
 ### is_bool
 
-#include_code is_bool noir_stdlib/src/meta/unresolved_type.nr rust
+```rust title="is_bool" showLineNumbers 
+pub comptime fn is_bool(self) -> bool {}
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/unresolved_type.nr#L25-L27" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/unresolved_type.nr#L25-L27</a></sub></sup>
+
 
 Returns `true` if this type is `bool`.
 
 ### is_field
 
-#include_code is_field noir_stdlib/src/meta/unresolved_type.nr rust
+```rust title="is_field" showLineNumbers 
+pub comptime fn is_field(self) -> bool {}
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/unresolved_type.nr#L31-L33" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/unresolved_type.nr#L31-L33</a></sub></sup>
+
 
 Returns true if this type refers to the Field type.
 
 ### is_unit
 
-#include_code is_unit noir_stdlib/src/meta/unresolved_type.nr rust
+```rust title="is_unit" showLineNumbers 
+pub comptime fn is_unit(self) -> bool {}
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/unresolved_type.nr#L37-L39" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/unresolved_type.nr#L37-L39</a></sub></sup>
+
 
 Returns true if this type is the unit `()` type.

--- a/docs/versioned_docs/version-v1.0.0-beta.19/noir/standard_library/traits.md
+++ b/docs/versioned_docs/version-v1.0.0-beta.19/noir/standard_library/traits.md
@@ -8,7 +8,13 @@ keywords: [traits, trait, interface, protocol, default, add, eq]
 
 ### `std::default::Default`
 
-#include_code default-trait noir_stdlib/src/default.nr rust
+```rust title="default-trait" showLineNumbers 
+pub trait Default {
+    fn default() -> Self;
+}
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/default.nr#L4-L8" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/default.nr#L4-L8</a></sub></sup>
+
 
 Constructs a default value of a type.
 
@@ -57,12 +63,200 @@ except vectors whose length is unknown and thus defaulted to zero.
 
 ### `std::convert::From`
 
-#include_code from-trait noir_stdlib/src/convert.nr rust
+```rust title="from-trait" showLineNumbers 
+pub trait From<T> {
+    fn from(input: T) -> Self;
+}
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/convert.nr#L1-L5" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/convert.nr#L1-L5</a></sub></sup>
+
 
 The `From` trait defines how to convert from a given type `T` to the type on which the trait is implemented.
 
 The Noir standard library provides a number of implementations of `From` between primitive types.
-#include_code from-impls noir_stdlib/src/convert.nr rust
+```rust title="from-impls" showLineNumbers 
+// Unsigned integers
+
+impl From<u8> for u16 {
+    fn from(value: u8) -> u16 {
+        value as u16
+    }
+}
+
+impl From<u8> for u32 {
+    fn from(value: u8) -> u32 {
+        value as u32
+    }
+}
+
+impl From<u16> for u32 {
+    fn from(value: u16) -> u32 {
+        value as u32
+    }
+}
+
+impl From<u8> for u64 {
+    fn from(value: u8) -> u64 {
+        value as u64
+    }
+}
+
+impl From<u16> for u64 {
+    fn from(value: u16) -> u64 {
+        value as u64
+    }
+}
+
+impl From<u32> for u64 {
+    fn from(value: u32) -> u64 {
+        value as u64
+    }
+}
+
+impl From<u8> for u128 {
+    fn from(value: u8) -> u128 {
+        value as u128
+    }
+}
+
+impl From<u16> for u128 {
+    fn from(value: u16) -> u128 {
+        value as u128
+    }
+}
+
+impl From<u32> for u128 {
+    fn from(value: u32) -> u128 {
+        value as u128
+    }
+}
+impl From<u64> for u128 {
+    fn from(value: u64) -> u128 {
+        value as u128
+    }
+}
+
+impl From<u8> for Field {
+    fn from(value: u8) -> Field {
+        value as Field
+    }
+}
+
+impl From<u16> for Field {
+    fn from(value: u16) -> Field {
+        value as Field
+    }
+}
+
+impl From<u32> for Field {
+    fn from(value: u32) -> Field {
+        value as Field
+    }
+}
+impl From<u64> for Field {
+    fn from(value: u64) -> Field {
+        value as Field
+    }
+}
+
+impl From<u128> for Field {
+    fn from(value: u128) -> Field {
+        value as Field
+    }
+}
+
+// Signed integers
+
+impl From<i8> for i16 {
+    fn from(value: i8) -> i16 {
+        value as i16
+    }
+}
+
+impl From<i8> for i32 {
+    fn from(value: i8) -> i32 {
+        value as i32
+    }
+}
+
+impl From<i16> for i32 {
+    fn from(value: i16) -> i32 {
+        value as i32
+    }
+}
+
+impl From<i8> for i64 {
+    fn from(value: i8) -> i64 {
+        value as i64
+    }
+}
+
+impl From<i16> for i64 {
+    fn from(value: i16) -> i64 {
+        value as i64
+    }
+}
+
+impl From<i32> for i64 {
+    fn from(value: i32) -> i64 {
+        value as i64
+    }
+}
+
+// Booleans
+impl From<bool> for u8 {
+    fn from(value: bool) -> u8 {
+        value as u8
+    }
+}
+impl From<bool> for u16 {
+    fn from(value: bool) -> u16 {
+        value as u16
+    }
+}
+impl From<bool> for u32 {
+    fn from(value: bool) -> u32 {
+        value as u32
+    }
+}
+impl From<bool> for u64 {
+    fn from(value: bool) -> u64 {
+        value as u64
+    }
+}
+impl From<bool> for u128 {
+    fn from(value: bool) -> u128 {
+        value as u128
+    }
+}
+impl From<bool> for i8 {
+    fn from(value: bool) -> i8 {
+        value as i8
+    }
+}
+impl From<bool> for i16 {
+    fn from(value: bool) -> i16 {
+        value as i16
+    }
+}
+impl From<bool> for i32 {
+    fn from(value: bool) -> i32 {
+        value as i32
+    }
+}
+impl From<bool> for i64 {
+    fn from(value: bool) -> i64 {
+        value as i64
+    }
+}
+impl From<bool> for Field {
+    fn from(value: bool) -> Field {
+        value as Field
+    }
+}
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/convert.nr#L28-L208" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/convert.nr#L28-L208</a></sub></sup>
+
 
 #### When to implement `From`
 
@@ -82,7 +276,22 @@ The `Into` trait is defined as the reciprocal of `From`. It should be easy to co
 
 For this reason, implementing `From` on a type will automatically generate a matching `Into` implementation. One should always prefer implementing `From` over `Into` as implementing `Into` will not generate a matching `From` implementation.
 
-#include_code into-trait noir_stdlib/src/convert.nr rust
+```rust title="into-trait" showLineNumbers 
+pub trait Into<T> {
+    fn into(self) -> T;
+}
+
+impl<T, U> Into<T> for U
+where
+    T: From<U>,
+{
+    fn into(self) -> T {
+        T::from(self)
+    }
+}
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/convert.nr#L13-L26" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/convert.nr#L13-L26</a></sub></sup>
+
 
 `Into` is most useful when passing function arguments where the types don't quite match up with what the function expects. In this case, the compiler has enough type information to perform the necessary conversion by just appending `.into()` onto the arguments in question.
 
@@ -92,7 +301,13 @@ For this reason, implementing `From` on a type will automatically generate a mat
 
 ### `std::cmp::Eq`
 
-#include_code eq-trait noir_stdlib/src/cmp.nr rust
+```rust title="eq-trait" showLineNumbers 
+pub trait Eq {
+    fn eq(self, other: Self) -> bool;
+}
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/cmp.nr#L4-L8" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/cmp.nr#L4-L8</a></sub></sup>
+
 
 Returns `true` if `self` is equal to `other`. Implementing this trait on a type
 allows the type to be used with `==` and `!=`.
@@ -135,7 +350,13 @@ impl<A, B, C, D, E> Eq for (A, B, C, D, E)
 
 ### `std::cmp::Ord`
 
-#include_code ord-trait noir_stdlib/src/cmp.nr rust
+```rust title="ord-trait" showLineNumbers 
+pub trait Ord {
+    fn cmp(self, other: Self) -> Ordering;
+}
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/cmp.nr#L217-L221" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/cmp.nr#L217-L221</a></sub></sup>
+
 
 `a.cmp(b)` compares two values returning `Ordering::less()` if `a < b`,
 `Ordering::equal()` if `a == b`, or `Ordering::greater()` if `a > b`.
@@ -190,10 +411,34 @@ These traits abstract over addition, subtraction, multiplication, and division r
 Implementing these traits for a given type will also allow that type to be used with the corresponding operator
 for that trait (`+` for Add, etc) in addition to the normal method names.
 
-#include_code add-trait noir_stdlib/src/ops/arith.nr rust
-#include_code sub-trait noir_stdlib/src/ops/arith.nr rust
-#include_code mul-trait noir_stdlib/src/ops/arith.nr rust
-#include_code div-trait noir_stdlib/src/ops/arith.nr rust
+```rust title="add-trait" showLineNumbers 
+pub trait Add {
+    fn add(self, other: Self) -> Self;
+}
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/ops/arith.nr#L3-L7" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/ops/arith.nr#L3-L7</a></sub></sup>
+
+```rust title="sub-trait" showLineNumbers 
+pub trait Sub {
+    fn sub(self, other: Self) -> Self;
+}
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/ops/arith.nr#L67-L71" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/ops/arith.nr#L67-L71</a></sub></sup>
+
+```rust title="mul-trait" showLineNumbers 
+pub trait Mul {
+    fn mul(self, other: Self) -> Self;
+}
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/ops/arith.nr#L131-L135" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/ops/arith.nr#L131-L135</a></sub></sup>
+
+```rust title="div-trait" showLineNumbers 
+pub trait Div {
+    fn div(self, other: Self) -> Self;
+}
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/ops/arith.nr#L195-L199" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/ops/arith.nr#L195-L199</a></sub></sup>
+
 
 The implementations block below is given for the `Add` trait, but the same types that implement
 `Add` also implement `Sub`, `Mul`, and `Div`.
@@ -215,7 +460,13 @@ impl Add for u64 { .. }
 
 ### `std::ops::Rem`
 
-#include_code rem-trait noir_stdlib/src/ops/arith.nr rust
+```rust title="rem-trait" showLineNumbers 
+pub trait Rem {
+    fn rem(self, other: Self) -> Self;
+}
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/ops/arith.nr#L259-L263" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/ops/arith.nr#L259-L263</a></sub></sup>
+
 
 `Rem::rem(a, b)` is the remainder function returning the result of what is
 left after dividing `a` and `b`. Implementing `Rem` allows the `%` operator
@@ -238,27 +489,146 @@ impl Rem for i64 { fn rem(self, other: i64) -> i64 { self % other } }
 
 ### `std::ops::Neg`
 
-#include_code neg-trait noir_stdlib/src/ops/arith.nr rust
+```rust title="neg-trait" showLineNumbers 
+pub trait Neg {
+    fn neg(self) -> Self;
+}
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/ops/arith.nr#L317-L321" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/ops/arith.nr#L317-L321</a></sub></sup>
+
 
 `Neg::neg` is equivalent to the unary negation operator `-`.
 
 Implementations:
-#include_code neg-trait-impls noir_stdlib/src/ops/arith.nr rust
+```rust title="neg-trait-impls" showLineNumbers 
+impl Neg for Field {
+    fn neg(self) -> Field {
+        -self
+    }
+}
+
+impl Neg for i8 {
+    fn neg(self) -> i8 {
+        -self
+    }
+}
+impl Neg for i16 {
+    fn neg(self) -> i16 {
+        -self
+    }
+}
+impl Neg for i32 {
+    fn neg(self) -> i32 {
+        -self
+    }
+}
+impl Neg for i64 {
+    fn neg(self) -> i64 {
+        -self
+    }
+}
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/ops/arith.nr#L323-L350" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/ops/arith.nr#L323-L350</a></sub></sup>
+
 
 ### `std::ops::Not`
 
-#include_code not-trait noir_stdlib/src/ops/bit.nr rust
+```rust title="not-trait" showLineNumbers 
+pub trait Not {
+    fn not(self: Self) -> Self;
+}
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/ops/bit.nr#L1-L5" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/ops/bit.nr#L1-L5</a></sub></sup>
+
 
 `Not::not` is equivalent to the unary bitwise NOT operator `!`.
 
 Implementations:
-#include_code not-trait-impls noir_stdlib/src/ops/bit.nr rust
+```rust title="not-trait-impls" showLineNumbers 
+impl Not for bool {
+    fn not(self) -> bool {
+        !self
+    }
+}
+
+impl Not for u128 {
+    fn not(self) -> u128 {
+        !self
+    }
+}
+impl Not for u64 {
+    fn not(self) -> u64 {
+        !self
+    }
+}
+impl Not for u32 {
+    fn not(self) -> u32 {
+        !self
+    }
+}
+impl Not for u16 {
+    fn not(self) -> u16 {
+        !self
+    }
+}
+impl Not for u8 {
+    fn not(self) -> u8 {
+        !self
+    }
+}
+impl Not for u1 {
+    fn not(self) -> u1 {
+        !self
+    }
+}
+
+impl Not for i8 {
+    fn not(self) -> i8 {
+        !self
+    }
+}
+impl Not for i16 {
+    fn not(self) -> i16 {
+        !self
+    }
+}
+impl Not for i32 {
+    fn not(self) -> i32 {
+        !self
+    }
+}
+impl Not for i64 {
+    fn not(self) -> i64 {
+        !self
+    }
+}
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/ops/bit.nr#L7-L65" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/ops/bit.nr#L7-L65</a></sub></sup>
+
 
 ### `std::ops::{ BitOr, BitAnd, BitXor }`
 
-#include_code bitor-trait noir_stdlib/src/ops/bit.nr rust
-#include_code bitand-trait noir_stdlib/src/ops/bit.nr rust
-#include_code bitxor-trait noir_stdlib/src/ops/bit.nr rust
+```rust title="bitor-trait" showLineNumbers 
+pub trait BitOr {
+    fn bitor(self, other: Self) -> Self;
+}
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/ops/bit.nr#L67-L71" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/ops/bit.nr#L67-L71</a></sub></sup>
+
+```rust title="bitand-trait" showLineNumbers 
+pub trait BitAnd {
+    fn bitand(self, other: Self) -> Self;
+}
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/ops/bit.nr#L131-L135" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/ops/bit.nr#L131-L135</a></sub></sup>
+
+```rust title="bitxor-trait" showLineNumbers 
+pub trait BitXor {
+    fn bitxor(self, other: Self) -> Self;
+}
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/ops/bit.nr#L195-L199" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/ops/bit.nr#L195-L199</a></sub></sup>
+
 
 Traits for the bitwise operations `|`, `&`, and `^`.
 
@@ -285,8 +655,20 @@ impl BitOr for i64 { fn bitor(self, other: i64) -> i64 { self | other } }
 
 ### `std::ops::{ Shl, Shr }`
 
-#include_code shl-trait noir_stdlib/src/ops/bit.nr rust
-#include_code shr-trait noir_stdlib/src/ops/bit.nr rust
+```rust title="shl-trait" showLineNumbers 
+pub trait Shl {
+    fn shl(self, other: Self) -> Self;
+}
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/ops/bit.nr#L259-L263" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/ops/bit.nr#L259-L263</a></sub></sup>
+
+```rust title="shr-trait" showLineNumbers 
+pub trait Shr {
+    fn shr(self, other: Self) -> Self;
+}
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/ops/bit.nr#L317-L321" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/ops/bit.nr#L317-L321</a></sub></sup>
+
 
 Traits for a bit shift left and bit shift right.
 
@@ -314,7 +696,14 @@ impl Shl for u64 { fn shl(self, other: u64) -> u64 { self << other } }
 
 `Append` can abstract over types that can be appended to - usually container types:
 
-#include_code append-trait noir_stdlib/src/append.nr rust
+```rust title="append-trait" showLineNumbers 
+pub trait Append {
+    fn empty() -> Self;
+    fn append(self, other: Self) -> Self;
+}
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/append.nr#L9-L14" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/append.nr#L9-L14</a></sub></sup>
+
 
 `Append` requires two methods:
 

--- a/docs/versioned_docs/version-v1.0.0-beta.19/tutorials/noirjs_app.md
+++ b/docs/versioned_docs/version-v1.0.0-beta.19/tutorials/noirjs_app.md
@@ -56,7 +56,13 @@ touch circuit/src/main.nr circuit/Nargo.toml
 
 To make our program interesting, let's give it a real use-case scenario: Bob wants to prove he is older than 18, without disclosing his age. Open `main.nr` and write:
 
-#include_code age_check examples/browser/src/main.nr rust
+```rust title="age_check" showLineNumbers 
+fn main(age: u8) {
+    assert(age > 18);
+}
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/examples/browser/src/main.nr#L1-L5" target="_blank" rel="noopener noreferrer">Source code: examples/browser/src/main.nr#L1-L5</a></sub></sup>
+
 
 This program accepts a private input called age, and simply proves this number is higher than 18. But to run this code, we need to give the compiler a `Nargo.toml` with at least a name and a type:
 
@@ -94,14 +100,50 @@ touch index.html index.js
 
 And add something useful to our HTML file:
 
-#include_code index examples/browser/index.html html
+```html title="index" showLineNumbers 
+<!DOCTYPE html>
+<head>
+  <style>
+    .outer {
+        display: flex;
+        justify-content: space-between;
+        width: 100%;
+    }
+    .inner {
+        width: 45%;
+        border: 1px solid black;
+        padding: 10px;
+        word-wrap: break-word;
+    }
+  </style>
+</head>
+<body>
+  <script type="module" src="/index.js"></script>
+  <h1>Noir app</h1>
+  <div class="input-area">
+    <input id="age" type="number" placeholder="Enter age" />
+    <button id="submit">Submit Age</button>
+  </div>
+  <div class="outer">
+    <div id="logs" class="inner"><h2>Logs</h2></div>
+    <div id="results" class="inner"><h2>Proof</h2></div>
+  </div>
+</body>
+</html>
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/examples/browser/index.html#L1-L31" target="_blank" rel="noopener noreferrer">Source code: examples/browser/index.html#L1-L31</a></sub></sup>
+
 
 It _could_ be a beautiful UI... Depending on which universe you live in. In any case, we're using some scary CSS to make two boxes that will show cool things on the screen.
 
 As for the JS, real madmen could just `console.log` everything, but let's say we want to see things happening (the true initial purpose of JS... right?). Here's some boilerplate for that. Just paste it in `index.js`:
 
 ```js
-#include_code show_function examples/browser/index.js raw
+const show = (id, content) => {
+  const container = document.getElementById(id);
+  container.appendChild(document.createTextNode(content));
+  container.appendChild(document.createElement('br'));
+};
 
 document.getElementById('submit').addEventListener('click', async () => {
   try {
@@ -136,17 +178,45 @@ At this point in the tutorial, your folder structure should look like this:
 
 We're starting with the good stuff now. We want to execute our circuit to get the witness, and then feed that witness to Barretenberg. Luckily, both packages are quite easy to work with. Let's import them at the top of the file and initialize the WASM modules:
 
-#include_code imports examples/browser/index.js js
+```js title="imports" showLineNumbers 
+import { Barretenberg, UltraHonkBackend } from '@aztec/bb.js';
+import { Noir } from '@noir-lang/noir_js';
+import initNoirC from '@noir-lang/noirc_abi';
+import initACVM from '@noir-lang/acvm_js';
+import acvm from '@noir-lang/acvm_js/web/acvm_js_bg.wasm?url';
+import noirc from '@noir-lang/noirc_abi/web/noirc_abi_wasm_bg.wasm?url';
+import circuit from './target/circuit.json';
+// Initialize WASM modules
+await Promise.all([initACVM(fetch(acvm)), initNoirC(fetch(noirc))]);
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/examples/browser/index.js#L1-L11" target="_blank" rel="noopener noreferrer">Source code: examples/browser/index.js#L1-L11</a></sub></sup>
+
 
 And instantiate them inside our try-catch block:
 
-#include_code init examples/browser/index.js js
+```js title="init" showLineNumbers 
+show('logs', 'Creating Noir...');
+    const noir = new Noir(circuit);
+    show('logs', 'Creating Barretenberg...');
+    const barretenbergAPI = await Barretenberg.new();
+    show('logs', 'Creating UltraHonkBackend...');
+    const backend = new UltraHonkBackend(circuit.bytecode, barretenbergAPI);
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/examples/browser/index.js#L23-L30" target="_blank" rel="noopener noreferrer">Source code: examples/browser/index.js#L23-L30</a></sub></sup>
+
 
 ## Executing and proving
 
 Now for the app itself. We're capturing whatever is in the input when people press the submit button. Inside our `try` block, let's just grab that input and get its value. Noir will gladly execute it, and give us a witness:
 
-#include_code execute examples/browser/index.js js
+```js title="execute" showLineNumbers 
+const age = document.getElementById('age').value;
+    show('logs', 'Generating witness... ⏳');
+    const { witness } = await noir.execute({ age });
+    show('logs', 'Generated witness... ✅');
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/examples/browser/index.js#L31-L36" target="_blank" rel="noopener noreferrer">Source code: examples/browser/index.js#L31-L36</a></sub></sup>
+
 
 :::note
 
@@ -156,7 +226,14 @@ For the remainder of the tutorial, everything will be happening inside the `try`
 
 Now we're ready to prove stuff! Let's feed some inputs to our circuit and calculate the proof:
 
-#include_code prove examples/browser/index.js js
+```js title="prove" showLineNumbers 
+show('logs', 'Generating proof... ⏳');
+    const proof = await backend.generateProof(witness);
+    show('logs', 'Generated proof... ✅');
+    show('results', proof.proof);
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/examples/browser/index.js#L37-L42" target="_blank" rel="noopener noreferrer">Source code: examples/browser/index.js#L37-L42</a></sub></sup>
+
 
 Our program is technically **done** . You're probably eager to see stuff happening! To serve this in a convenient way, we can use a bundler like `vite` by creating a `vite.config.js` file:
 
@@ -167,7 +244,35 @@ touch vite.config.js
 Noir needs to load two WASM modules, but Vite doesn't include them by default in the bundle. We need to add the configuration below to `vite.config.js` to make it work.
 We also need to target ESNext since `bb.js` uses top-level await, which isn't supported in some browsers.
 
-#include_code config examples/browser/vite.config.js js
+```js title="config" showLineNumbers 
+import { defineConfig } from 'vite';
+import { nodePolyfills } from 'vite-plugin-node-polyfills';
+
+export default defineConfig({
+  plugins: [
+    nodePolyfills({
+      // Whether to polyfill specific globals.
+      globals: {
+        Buffer: true,
+        global: true,
+        process: true,
+      },
+      // Whether to polyfill `node:` protocol imports.
+      protocolImports: true,
+    }),
+  ],
+  optimizeDeps: {
+    exclude: ['@aztec/bb.js'],
+  },
+  resolve: {
+    alias: {
+      pino: 'pino/browser.js',
+    },
+  },
+});
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/examples/browser/vite.config.js#L1-L27" target="_blank" rel="noopener noreferrer">Source code: examples/browser/vite.config.js#L1-L27</a></sub></sup>
+
 
 This should be enough for vite. We don't even need to install it, just run:
 
@@ -187,7 +292,13 @@ By the way, if you're human, you shouldn't be able to understand anything on the
 
 Time to celebrate, yes! But we shouldn't trust machines so blindly. Let's add these lines to see our proof being verified:
 
-#include_code verify examples/browser/index.js js
+```js title="verify" showLineNumbers 
+show('logs', 'Verifying proof... ⌛');
+    const isValid = await backend.verifyProof(proof);
+    show('logs', `Proof is ${isValid ? 'valid' : 'invalid'}... ✅`);
+```
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/examples/browser/index.js#L44-L48" target="_blank" rel="noopener noreferrer">Source code: examples/browser/index.js#L44-L48</a></sub></sup>
+
 
 You have successfully generated a client-side Noir web app!
 


### PR DESCRIPTION
## Summary

- The v1.0.0-beta.19 versioned docs (added in #11724) were copied from raw `docs/docs/` without running the preprocessor, leaving **261 unresolved `#include_code` macros** across 26 files
- This re-runs the preprocessor against the `v1.0.0-beta.19` tag sources to properly resolve all code snippets into inline code blocks

## Test plan

- [x] Verified `grep -r '#include_code' docs/versioned_docs/version-v1.0.0-beta.19/ | wc -l` returns 0
- [x] Spot-checked `tutorials/noirjs_app.md` — code blocks render correctly with source links
- [ ] Verify docs site builds cleanly with `cd docs && yarn build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)