### PR TITLE
fix(docs): resolve #include_code macros in v1.0.0-beta.19 versioned docs

### DIFF
--- a/docs/versioned_docs/version-v1.0.0-beta.19/noir/concepts/comptime.md
+++ b/docs/versioned_docs/version-v1.0.0-beta.19/noir/concepts/comptime.md
@@ -140,7 +140,7 @@ comptime fn quote_one() -> Quoted {
         }
     }
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/mod.nr#L131-L151" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/mod.nr#L131-L151</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/meta/mod.nr#L131-L151" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/mod.nr#L131-L151</a></sub></sup>
 
 
 For those familiar with quoting from other languages (primarily lisps), Noir's `quote` is actually a _quasiquote_.
@@ -252,7 +252,7 @@ comptime fn concatenate(q1: Quoted, q2: Quoted) -> Quoted {
         }
     }
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/mod.nr#L266-L299" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/mod.nr#L266-L299</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/meta/mod.nr#L266-L299" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/mod.nr#L266-L299</a></sub></sup>
 
 
 ### $crate
@@ -330,7 +330,7 @@ trait FieldCount {
         }
     }
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/mod.nr#L153-L175" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/mod.nr#L153-L175</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/meta/mod.nr#L153-L175" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/mod.nr#L153-L175</a></sub></sup>
 
 
 ### Calling annotations with additional arguments
@@ -350,7 +350,7 @@ When this is done, these additional arguments are passed to the attribute functi
         assert_eq(fields[0].1, typ);
     }
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/mod.nr#L177-L188" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/mod.nr#L177-L188</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/meta/mod.nr#L177-L188" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/mod.nr#L177-L188</a></sub></sup>
 
 
 We can also take any number of arguments by adding the `varargs` attribute:
@@ -366,7 +366,7 @@ We can also take any number of arguments by adding the `varargs` attribute:
         assert_eq(args.len(), 3);
     }
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/mod.nr#L190-L200" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/mod.nr#L190-L200</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/meta/mod.nr#L190-L200" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/mod.nr#L190-L200</a></sub></sup>
 
 
 ### Attribute Evaluation Order
@@ -499,7 +499,7 @@ pub comptime fn derive(s: TypeDefinition, traits: [TraitDefinition]) -> Quoted {
     result
 }
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/mod.nr#L33-L66" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/mod.nr#L33-L66</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/meta/mod.nr#L33-L66" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/mod.nr#L33-L66</a></sub></sup>
 
 
 Registering a derive function could be done as follows:
@@ -510,7 +510,7 @@ pub comptime fn derive_via(t: TraitDefinition, f: DeriveFunction) {
     HANDLERS.insert(t, f);
 }
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/mod.nr#L68-L75" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/mod.nr#L68-L75</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/meta/mod.nr#L68-L75" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/mod.nr#L68-L75</a></sub></sup>
 
 
 ```rust title="big-derive-usage-example" showLineNumbers 
@@ -572,5 +572,5 @@ pub comptime fn derive_via(t: TraitDefinition, f: DeriveFunction) {
         )
     }
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/mod.nr#L202-L260" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/mod.nr#L202-L260</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/meta/mod.nr#L202-L260" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/mod.nr#L202-L260</a></sub></sup>
 

--- a/docs/versioned_docs/version-v1.0.0-beta.19/noir/concepts/data_types/fields.md
+++ b/docs/versioned_docs/version-v1.0.0-beta.19/noir/concepts/data_types/fields.md
@@ -40,7 +40,7 @@ Transforms the field into an array of bits, Little Endian.
 ```rust title="to_le_bits" showLineNumbers 
 pub fn to_le_bits<let N: u32>(self: Self) -> [u1; N] {
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/field/mod.nr#L29-L31" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/field/mod.nr#L29-L31</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/field/mod.nr#L29-L31" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/field/mod.nr#L29-L31</a></sub></sup>
 
 
 example:
@@ -52,7 +52,7 @@ fn test_to_le_bits() {
         assert_eq(bits, [0, 1, 0, 0, 0, 0, 0, 0]);
     }
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/field/mod.nr#L356-L362" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/field/mod.nr#L356-L362</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/field/mod.nr#L356-L362" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/field/mod.nr#L356-L362</a></sub></sup>
 
 
 
@@ -63,7 +63,7 @@ Transforms the field into an array of bits, Big Endian.
 ```rust title="to_be_bits" showLineNumbers 
 pub fn to_be_bits<let N: u32>(self: Self) -> [u1; N] {
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/field/mod.nr#L61-L63" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/field/mod.nr#L61-L63</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/field/mod.nr#L61-L63" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/field/mod.nr#L61-L63</a></sub></sup>
 
 
 example:
@@ -75,7 +75,7 @@ fn test_to_be_bits() {
         assert_eq(bits, [0, 0, 0, 0, 0, 0, 1, 0]);
     }
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/field/mod.nr#L347-L353" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/field/mod.nr#L347-L353</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/field/mod.nr#L347-L353" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/field/mod.nr#L347-L353</a></sub></sup>
 
 
 
@@ -86,7 +86,7 @@ Transforms into an array of bytes, Little Endian
 ```rust title="to_le_bytes" showLineNumbers 
 pub fn to_le_bytes<let N: u32>(self: Self) -> [u8; N] {
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/field/mod.nr#L93-L95" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/field/mod.nr#L93-L95</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/field/mod.nr#L93-L95" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/field/mod.nr#L93-L95</a></sub></sup>
 
 
 example:
@@ -99,7 +99,7 @@ fn test_to_le_bytes() {
         assert_eq(Field::from_le_bytes::<8>(bytes), field);
     }
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/field/mod.nr#L375-L382" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/field/mod.nr#L375-L382</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/field/mod.nr#L375-L382" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/field/mod.nr#L375-L382</a></sub></sup>
 
 
 ### to_be_bytes
@@ -109,7 +109,7 @@ Transforms into an array of bytes, Big Endian
 ```rust title="to_be_bytes" showLineNumbers 
 pub fn to_be_bytes<let N: u32>(self: Self) -> [u8; N] {
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/field/mod.nr#L130-L132" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/field/mod.nr#L130-L132</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/field/mod.nr#L130-L132" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/field/mod.nr#L130-L132</a></sub></sup>
 
 
 example:
@@ -122,7 +122,7 @@ fn test_to_be_bytes() {
         assert_eq(Field::from_be_bytes::<8>(bytes), field);
     }
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/field/mod.nr#L365-L372" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/field/mod.nr#L365-L372</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/field/mod.nr#L365-L372" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/field/mod.nr#L365-L372</a></sub></sup>
 
 
 ### pow_32
@@ -150,7 +150,7 @@ Adds a constraint to specify that the field can be represented with `bit_size` n
 ```rust title="assert_max_bit_size" showLineNumbers 
 pub fn assert_max_bit_size<let BIT_SIZE: u32>(self) {
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/field/mod.nr#L10-L12" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/field/mod.nr#L10-L12</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/field/mod.nr#L10-L12" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/field/mod.nr#L10-L12</a></sub></sup>
 
 
 example:

--- a/docs/versioned_docs/version-v1.0.0-beta.19/noir/concepts/data_types/integers.md
+++ b/docs/versioned_docs/version-v1.0.0-beta.19/noir/concepts/data_types/integers.md
@@ -125,7 +125,7 @@ fn wrapping_mul(self, y: Self) -> Self;
 Example of how it is used:
 
 ```rust
-use std::ops::WrappingAdd
+use std::ops::WrappingAdd;
 fn main(x: u8, y: u8) -> pub u8 {
     x.wrapping_add(y)
 }

--- a/docs/versioned_docs/version-v1.0.0-beta.19/noir/concepts/generics.md
+++ b/docs/versioned_docs/version-v1.0.0-beta.19/noir/concepts/generics.md
@@ -221,7 +221,7 @@ fn main() {
     pop([]);
 }
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/compile_failure/arithmetic_generics_underflow/src/main.nr#L1-L14" target="_blank" rel="noopener noreferrer">Source code: test_programs/compile_failure/arithmetic_generics_underflow/src/main.nr#L1-L14</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/test_programs/compile_failure/arithmetic_generics_underflow/src/main.nr#L1-L14" target="_blank" rel="noopener noreferrer">Source code: test_programs/compile_failure/arithmetic_generics_underflow/src/main.nr#L1-L14</a></sub></sup>
 
 
 This also applies if there is underflow in an intermediate calculation:
@@ -258,5 +258,5 @@ fn push_zero<let N: u32>(array: [Field; N]) -> [Field; N + 1] {
     result
 }
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/compile_failure/arithmetic_generics_intermediate_underflow/src/main.nr#L1-L32" target="_blank" rel="noopener noreferrer">Source code: test_programs/compile_failure/arithmetic_generics_intermediate_underflow/src/main.nr#L1-L32</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/test_programs/compile_failure/arithmetic_generics_intermediate_underflow/src/main.nr#L1-L32" target="_blank" rel="noopener noreferrer">Source code: test_programs/compile_failure/arithmetic_generics_intermediate_underflow/src/main.nr#L1-L32</a></sub></sup>
 

--- a/docs/versioned_docs/version-v1.0.0-beta.19/noir/standard_library/black_box_fns.md
+++ b/docs/versioned_docs/version-v1.0.0-beta.19/noir/standard_library/black_box_fns.md
@@ -28,4 +28,4 @@ Here is a list of the current black box functions:
 
 Most black box functions are included as part of the Noir standard library, however `AND`, `XOR` and `RANGE` are used as part of the Noir language syntax. For instance, using the bitwise operator `&` will invoke the `AND` black box function.
 
-You can view the black box functions defined in the ACVM code [here](https://github.com/noir-lang/noir/blob/master/acvm-repo/acir/src/circuit/black_box_functions.rs).
+You can view the black box functions defined in the ACVM code [here](https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/acvm-repo/acir/src/circuit/black_box_functions.rs).

--- a/docs/versioned_docs/version-v1.0.0-beta.19/noir/standard_library/containers/boundedvec.md
+++ b/docs/versioned_docs/version-v1.0.0-beta.19/noir/standard_library/containers/boundedvec.md
@@ -62,7 +62,7 @@ fn good() -> BoundedVec<Field, 10> {
     v2
 }
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/noir_test_success/bounded_vec/src/main.nr#L6-L15" target="_blank" rel="noopener noreferrer">Source code: test_programs/noir_test_success/bounded_vec/src/main.nr#L6-L15</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/test_programs/noir_test_success/bounded_vec/src/main.nr#L6-L15" target="_blank" rel="noopener noreferrer">Source code: test_programs/noir_test_success/bounded_vec/src/main.nr#L6-L15</a></sub></sup>
 
 
 This defaulting of `MaxLen` (and numeric generics in general) to zero may change in future noir versions
@@ -114,7 +114,7 @@ fn sum_of_first_three<let N: u32>(v: BoundedVec<u32, N>) -> u32 {
     first + second + third
 }
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/noir_test_success/bounded_vec/src/main.nr#L42-L52" target="_blank" rel="noopener noreferrer">Source code: test_programs/noir_test_success/bounded_vec/src/main.nr#L42-L52</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/test_programs/noir_test_success/bounded_vec/src/main.nr#L42-L52" target="_blank" rel="noopener noreferrer">Source code: test_programs/noir_test_success/bounded_vec/src/main.nr#L42-L52</a></sub></sup>
 
 
 ### set
@@ -176,7 +176,7 @@ fn set_unchecked_example() {
     println(vec);
 }
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/noir_test_success/bounded_vec/src/main.nr#L55-L79" target="_blank" rel="noopener noreferrer">Source code: test_programs/noir_test_success/bounded_vec/src/main.nr#L55-L79</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/test_programs/noir_test_success/bounded_vec/src/main.nr#L55-L79" target="_blank" rel="noopener noreferrer">Source code: test_programs/noir_test_success/bounded_vec/src/main.nr#L55-L79</a></sub></sup>
 
 
 
@@ -202,7 +202,7 @@ let mut v: BoundedVec<Field, 2> = BoundedVec::new();
     // Panics with failed assertion "push out of bounds"
     v.push(3);
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/noir_test_success/bounded_vec/src/main.nr#L83-L91" target="_blank" rel="noopener noreferrer">Source code: test_programs/noir_test_success/bounded_vec/src/main.nr#L83-L91</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/test_programs/noir_test_success/bounded_vec/src/main.nr#L83-L91" target="_blank" rel="noopener noreferrer">Source code: test_programs/noir_test_success/bounded_vec/src/main.nr#L83-L91</a></sub></sup>
 
 
 ### pop
@@ -231,7 +231,7 @@ let mut v: BoundedVec<Field, 2> = BoundedVec::new();
     // error: cannot pop from an empty vector
     // let _ = v.pop();
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/noir_test_success/bounded_vec/src/main.nr#L96-L108" target="_blank" rel="noopener noreferrer">Source code: test_programs/noir_test_success/bounded_vec/src/main.nr#L96-L108</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/test_programs/noir_test_success/bounded_vec/src/main.nr#L96-L108" target="_blank" rel="noopener noreferrer">Source code: test_programs/noir_test_success/bounded_vec/src/main.nr#L96-L108</a></sub></sup>
 
 
 ### len
@@ -260,7 +260,7 @@ let mut v: BoundedVec<Field, 4> = BoundedVec::new();
     let _ = v.pop();
     assert(v.len() == 2);
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/noir_test_success/bounded_vec/src/main.nr#L113-L128" target="_blank" rel="noopener noreferrer">Source code: test_programs/noir_test_success/bounded_vec/src/main.nr#L113-L128</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/test_programs/noir_test_success/bounded_vec/src/main.nr#L113-L128" target="_blank" rel="noopener noreferrer">Source code: test_programs/noir_test_success/bounded_vec/src/main.nr#L113-L128</a></sub></sup>
 
 
 ### max_len
@@ -281,7 +281,7 @@ let mut v: BoundedVec<Field, 5> = BoundedVec::new();
     v.push(10);
     assert(v.max_len() == 5);
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/noir_test_success/bounded_vec/src/main.nr#L133-L139" target="_blank" rel="noopener noreferrer">Source code: test_programs/noir_test_success/bounded_vec/src/main.nr#L133-L139</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/test_programs/noir_test_success/bounded_vec/src/main.nr#L133-L139" target="_blank" rel="noopener noreferrer">Source code: test_programs/noir_test_success/bounded_vec/src/main.nr#L133-L139</a></sub></sup>
 
 
 ### storage
@@ -306,7 +306,7 @@ let mut v: BoundedVec<Field, 5> = BoundedVec::new();
     v.push(57);
     assert(v.storage() == [57, 0, 0, 0, 0]);
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/noir_test_success/bounded_vec/src/main.nr#L144-L151" target="_blank" rel="noopener noreferrer">Source code: test_programs/noir_test_success/bounded_vec/src/main.nr#L144-L151</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/test_programs/noir_test_success/bounded_vec/src/main.nr#L144-L151" target="_blank" rel="noopener noreferrer">Source code: test_programs/noir_test_success/bounded_vec/src/main.nr#L144-L151</a></sub></sup>
 
 
 ### extend_from_array
@@ -330,7 +330,7 @@ let mut vec: BoundedVec<Field, 3> = BoundedVec::new();
     assert(vec.get(0) == 2);
     assert(vec.get(1) == 4);
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/noir_test_success/bounded_vec/src/main.nr#L156-L163" target="_blank" rel="noopener noreferrer">Source code: test_programs/noir_test_success/bounded_vec/src/main.nr#L156-L163</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/test_programs/noir_test_success/bounded_vec/src/main.nr#L156-L163" target="_blank" rel="noopener noreferrer">Source code: test_programs/noir_test_success/bounded_vec/src/main.nr#L156-L163</a></sub></sup>
 
 
 ### extend_from_bounded_vec
@@ -357,7 +357,7 @@ let mut v1: BoundedVec<Field, 5> = BoundedVec::new();
     assert(v1.storage() == [1, 2, 3, 0, 0]);
     assert(v2.storage() == [1, 2, 3, 0, 0, 0, 0]);
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/noir_test_success/bounded_vec/src/main.nr#L168-L177" target="_blank" rel="noopener noreferrer">Source code: test_programs/noir_test_success/bounded_vec/src/main.nr#L168-L177</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/test_programs/noir_test_success/bounded_vec/src/main.nr#L168-L177" target="_blank" rel="noopener noreferrer">Source code: test_programs/noir_test_success/bounded_vec/src/main.nr#L168-L177</a></sub></sup>
 
 
 ### from_array
@@ -399,7 +399,7 @@ let vec: BoundedVec<u32, 4> = BoundedVec::from_parts([1, 2, 3, 0], 3);
             let vec2: BoundedVec<u32, 4> = BoundedVec::from_parts([1, 2, 3, 2], 3);
             assert_eq(vec1, vec2);
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/collections/bounded_vec.nr#L1120-L1129" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/collections/bounded_vec.nr#L1120-L1129</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/collections/bounded_vec.nr#L1120-L1129" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/collections/bounded_vec.nr#L1120-L1129</a></sub></sup>
 
 
 ### from_parts_unchecked
@@ -431,7 +431,7 @@ let vec: BoundedVec<u32, 4> = BoundedVec::from_parts_unchecked([1, 2, 3, 0], 3);
             // fails because elements past the length are still checked in eq
             assert(vec1 != vec2);
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/collections/bounded_vec.nr#L1134-L1145" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/collections/bounded_vec.nr#L1134-L1145</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/collections/bounded_vec.nr#L1134-L1145" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/collections/bounded_vec.nr#L1134-L1145</a></sub></sup>
 
 
 ### map
@@ -448,7 +448,7 @@ Example:
 let vec: BoundedVec<u32, 4> = BoundedVec::from_array([1, 2, 3, 4]);
             let result = vec.map(|value| value * 2);
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/collections/bounded_vec.nr#L770-L773" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/collections/bounded_vec.nr#L770-L773</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/collections/bounded_vec.nr#L770-L773" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/collections/bounded_vec.nr#L770-L773</a></sub></sup>
 
 
 ### mapi
@@ -466,7 +466,7 @@ Example:
 let vec: BoundedVec<u32, 4> = BoundedVec::from_array([1, 2, 3, 4]);
             let result = vec.mapi(|i, value| i + value * 2);
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/collections/bounded_vec.nr#L831-L834" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/collections/bounded_vec.nr#L831-L834</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/collections/bounded_vec.nr#L831-L834" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/collections/bounded_vec.nr#L831-L834</a></sub></sup>
 
 
 ### for_each
@@ -483,7 +483,7 @@ Example:
 let vec: BoundedVec<u32, 3> = BoundedVec::from_array([1, 2, 3]);
             vec.for_each(|value| { *acc_ref += value; });
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/collections/bounded_vec.nr#L887-L890" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/collections/bounded_vec.nr#L887-L890</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/collections/bounded_vec.nr#L887-L890" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/collections/bounded_vec.nr#L887-L890</a></sub></sup>
 
 
 ### for_eachi
@@ -500,7 +500,7 @@ Example:
 let vec: BoundedVec<u32, 3> = BoundedVec::from_array([1, 2, 3]);
             vec.for_eachi(|i, value| { *acc_ref += i * value; });
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/collections/bounded_vec.nr#L959-L962" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/collections/bounded_vec.nr#L959-L962</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/collections/bounded_vec.nr#L959-L962" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/collections/bounded_vec.nr#L959-L962</a></sub></sup>
 
 
 ### any
@@ -521,5 +521,5 @@ let mut v: BoundedVec<u32, 3> = BoundedVec::new();
     let all_even = !v.any(|elem: u32| elem % 2 != 0);
     assert(all_even);
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/noir_test_success/bounded_vec/src/main.nr#L244-L250" target="_blank" rel="noopener noreferrer">Source code: test_programs/noir_test_success/bounded_vec/src/main.nr#L244-L250</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/test_programs/noir_test_success/bounded_vec/src/main.nr#L244-L250" target="_blank" rel="noopener noreferrer">Source code: test_programs/noir_test_success/bounded_vec/src/main.nr#L244-L250</a></sub></sup>
 

--- a/docs/versioned_docs/version-v1.0.0-beta.19/noir/standard_library/containers/hashmap.md
+++ b/docs/versioned_docs/version-v1.0.0-beta.19/noir/standard_library/containers/hashmap.md
@@ -45,7 +45,7 @@ where
     /// ```
     fn default() -> Self {
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/collections/map.nr#L677-L691" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/collections/map.nr#L677-L691</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/collections/map.nr#L677-L691" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/collections/map.nr#L677-L691</a></sub></sup>
 
 
 Creates a fresh, empty HashMap.
@@ -61,7 +61,7 @@ Example:
 let hashmap: HashMap<u8, u32, 10, BuildHasherDefault<Poseidon2Hasher>> = HashMap::default();
     assert(hashmap.is_empty());
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/execution_success/hashmap/src/main.nr#L232-L235" target="_blank" rel="noopener noreferrer">Source code: test_programs/execution_success/hashmap/src/main.nr#L232-L235</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/test_programs/execution_success/hashmap/src/main.nr#L232-L235" target="_blank" rel="noopener noreferrer">Source code: test_programs/execution_success/hashmap/src/main.nr#L232-L235</a></sub></sup>
 
 
 Because `HashMap` has so many generic arguments that are likely to be the same throughout
@@ -70,7 +70,7 @@ your program, it may be helpful to create a type alias:
 ```rust title="type_alias" showLineNumbers 
 type MyMap = HashMap<u8, u32, 10, BuildHasherDefault<Poseidon2Hasher>>;
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/execution_success/hashmap/src/main.nr#L226-L228" target="_blank" rel="noopener noreferrer">Source code: test_programs/execution_success/hashmap/src/main.nr#L226-L228</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/test_programs/execution_success/hashmap/src/main.nr#L226-L228" target="_blank" rel="noopener noreferrer">Source code: test_programs/execution_success/hashmap/src/main.nr#L226-L228</a></sub></sup>
 
 
 ### with_hasher
@@ -81,7 +81,7 @@ pub fn with_hasher(_build_hasher: B) -> Self
         B: BuildHasher,
     {
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/collections/map.nr#L104-L109" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/collections/map.nr#L104-L109</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/collections/map.nr#L104-L109" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/collections/map.nr#L104-L109</a></sub></sup>
 
 
 Creates a hashmap with an existing `BuildHasher`. This can be used to ensure multiple
@@ -95,7 +95,7 @@ let my_hasher: BuildHasherDefault<Poseidon2Hasher> = Default::default();
         HashMap::with_hasher(my_hasher);
     assert(hashmap.is_empty());
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/execution_success/hashmap/src/main.nr#L236-L241" target="_blank" rel="noopener noreferrer">Source code: test_programs/execution_success/hashmap/src/main.nr#L236-L241</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/test_programs/execution_success/hashmap/src/main.nr#L236-L241" target="_blank" rel="noopener noreferrer">Source code: test_programs/execution_success/hashmap/src/main.nr#L236-L241</a></sub></sup>
 
 
 ### get
@@ -107,7 +107,7 @@ pub fn get(self, key: K) -> Option<V>
         B: BuildHasher,
     {
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/collections/map.nr#L467-L473" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/collections/map.nr#L467-L473</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/collections/map.nr#L467-L473" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/collections/map.nr#L467-L473</a></sub></sup>
 
 
 Retrieves a value from the hashmap, returning `Option::none()` if it was not found.
@@ -123,7 +123,7 @@ fn get_example(map: HashMap<Field, Field, 5, BuildHasherDefault<Poseidon2Hasher>
     }
 }
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/execution_success/hashmap/src/main.nr#L321-L329" target="_blank" rel="noopener noreferrer">Source code: test_programs/execution_success/hashmap/src/main.nr#L321-L329</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/test_programs/execution_success/hashmap/src/main.nr#L321-L329" target="_blank" rel="noopener noreferrer">Source code: test_programs/execution_success/hashmap/src/main.nr#L321-L329</a></sub></sup>
 
 
 ### insert
@@ -135,7 +135,7 @@ pub fn insert(&mut self, key: K, value: V)
         B: BuildHasher,
     {
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/collections/map.nr#L507-L513" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/collections/map.nr#L507-L513</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/collections/map.nr#L507-L513" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/collections/map.nr#L507-L513</a></sub></sup>
 
 
 Inserts a new key-value pair into the map. If the key was already in the map, its
@@ -148,7 +148,7 @@ let mut map: HashMap<Field, Field, 5, BuildHasherDefault<Poseidon2Hasher>> = Has
     map.insert(12, 42);
     assert(map.len() == 1);
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/execution_success/hashmap/src/main.nr#L242-L246" target="_blank" rel="noopener noreferrer">Source code: test_programs/execution_success/hashmap/src/main.nr#L242-L246</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/test_programs/execution_success/hashmap/src/main.nr#L242-L246" target="_blank" rel="noopener noreferrer">Source code: test_programs/execution_success/hashmap/src/main.nr#L242-L246</a></sub></sup>
 
 
 ### remove
@@ -160,7 +160,7 @@ pub fn remove(&mut self, key: K)
         B: BuildHasher,
     {
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/collections/map.nr#L561-L567" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/collections/map.nr#L561-L567</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/collections/map.nr#L561-L567" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/collections/map.nr#L561-L567</a></sub></sup>
 
 
 Removes the given key-value pair from the map. If the key was not already present
@@ -176,7 +176,7 @@ map.remove(12);
     map.remove(12);
     assert(map.is_empty());
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/execution_success/hashmap/src/main.nr#L249-L256" target="_blank" rel="noopener noreferrer">Source code: test_programs/execution_success/hashmap/src/main.nr#L249-L256</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/test_programs/execution_success/hashmap/src/main.nr#L249-L256" target="_blank" rel="noopener noreferrer">Source code: test_programs/execution_success/hashmap/src/main.nr#L249-L256</a></sub></sup>
 
 
 ### is_empty
@@ -184,7 +184,7 @@ map.remove(12);
 ```rust title="is_empty" showLineNumbers 
 pub fn is_empty(self) -> bool {
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/collections/map.nr#L167-L169" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/collections/map.nr#L167-L169</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/collections/map.nr#L167-L169" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/collections/map.nr#L167-L169</a></sub></sup>
 
 
 True if the length of the hash map is empty.
@@ -200,7 +200,7 @@ assert(map.is_empty());
     map.remove(1);
     assert(map.is_empty());
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/execution_success/hashmap/src/main.nr#L257-L265" target="_blank" rel="noopener noreferrer">Source code: test_programs/execution_success/hashmap/src/main.nr#L257-L265</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/test_programs/execution_success/hashmap/src/main.nr#L257-L265" target="_blank" rel="noopener noreferrer">Source code: test_programs/execution_success/hashmap/src/main.nr#L257-L265</a></sub></sup>
 
 
 ### len
@@ -208,7 +208,7 @@ assert(map.is_empty());
 ```rust title="len" showLineNumbers 
 pub fn len(self) -> u32 {
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/collections/map.nr#L426-L428" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/collections/map.nr#L426-L428</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/collections/map.nr#L426-L428" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/collections/map.nr#L426-L428</a></sub></sup>
 
 
 Returns the current length of this hash map.
@@ -231,7 +231,7 @@ Example:
     map.remove(1);
     assert(map.len() == 2);
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/execution_success/hashmap/src/main.nr#L266-L281" target="_blank" rel="noopener noreferrer">Source code: test_programs/execution_success/hashmap/src/main.nr#L266-L281</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/test_programs/execution_success/hashmap/src/main.nr#L266-L281" target="_blank" rel="noopener noreferrer">Source code: test_programs/execution_success/hashmap/src/main.nr#L266-L281</a></sub></sup>
 
 
 ### capacity
@@ -239,7 +239,7 @@ Example:
 ```rust title="capacity" showLineNumbers 
 pub fn capacity(_self: Self) -> u32 {
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/collections/map.nr#L448-L450" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/collections/map.nr#L448-L450</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/collections/map.nr#L448-L450" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/collections/map.nr#L448-L450</a></sub></sup>
 
 
 Returns the maximum capacity of this hashmap. This is always equal to the capacity
@@ -259,7 +259,7 @@ let empty_map: HashMap<Field, Field, 42, BuildHasherDefault<Poseidon2Hasher>> =
     assert(empty_map.len() == 0);
     assert(empty_map.capacity() == 42);
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/execution_success/hashmap/src/main.nr#L282-L287" target="_blank" rel="noopener noreferrer">Source code: test_programs/execution_success/hashmap/src/main.nr#L282-L287</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/test_programs/execution_success/hashmap/src/main.nr#L282-L287" target="_blank" rel="noopener noreferrer">Source code: test_programs/execution_success/hashmap/src/main.nr#L282-L287</a></sub></sup>
 
 
 ### clear
@@ -267,7 +267,7 @@ let empty_map: HashMap<Field, Field, 42, BuildHasherDefault<Poseidon2Hasher>> =
 ```rust title="clear" showLineNumbers 
 pub fn clear(&mut self) {
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/collections/map.nr#L124-L126" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/collections/map.nr#L124-L126</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/collections/map.nr#L124-L126" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/collections/map.nr#L124-L126</a></sub></sup>
 
 
 Clears the hashmap, removing all key-value pairs from it.
@@ -279,7 +279,7 @@ assert(!map.is_empty());
     map.clear();
     assert(map.is_empty());
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/execution_success/hashmap/src/main.nr#L288-L292" target="_blank" rel="noopener noreferrer">Source code: test_programs/execution_success/hashmap/src/main.nr#L288-L292</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/test_programs/execution_success/hashmap/src/main.nr#L288-L292" target="_blank" rel="noopener noreferrer">Source code: test_programs/execution_success/hashmap/src/main.nr#L288-L292</a></sub></sup>
 
 
 ### contains_key
@@ -291,7 +291,7 @@ pub fn contains_key(self, key: K) -> bool
         B: BuildHasher,
     {
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/collections/map.nr#L144-L150" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/collections/map.nr#L144-L150</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/collections/map.nr#L144-L150" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/collections/map.nr#L144-L150</a></sub></sup>
 
 
 True if the hashmap contains the given key. Unlike `get`, this will not also return
@@ -307,7 +307,7 @@ if map.contains_key(7) {
         println("No value for key 7!");
     }
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/execution_success/hashmap/src/main.nr#L293-L300" target="_blank" rel="noopener noreferrer">Source code: test_programs/execution_success/hashmap/src/main.nr#L293-L300</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/test_programs/execution_success/hashmap/src/main.nr#L293-L300" target="_blank" rel="noopener noreferrer">Source code: test_programs/execution_success/hashmap/src/main.nr#L293-L300</a></sub></sup>
 
 
 ### entries
@@ -315,7 +315,7 @@ if map.contains_key(7) {
 ```rust title="entries" showLineNumbers 
 pub fn entries(self) -> BoundedVec<(K, V), N> {
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/collections/map.nr#L191-L193" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/collections/map.nr#L191-L193</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/collections/map.nr#L191-L193" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/collections/map.nr#L191-L193</a></sub></sup>
 
 
 Returns a vector of each key-value pair present in the hashmap.
@@ -336,7 +336,7 @@ let entries = map.entries();
         }
     }
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/execution_success/hashmap/src/main.nr#L332-L343" target="_blank" rel="noopener noreferrer">Source code: test_programs/execution_success/hashmap/src/main.nr#L332-L343</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/test_programs/execution_success/hashmap/src/main.nr#L332-L343" target="_blank" rel="noopener noreferrer">Source code: test_programs/execution_success/hashmap/src/main.nr#L332-L343</a></sub></sup>
 
 
 ### keys
@@ -344,7 +344,7 @@ let entries = map.entries();
 ```rust title="keys" showLineNumbers 
 pub fn keys(self) -> BoundedVec<K, N> {
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/collections/map.nr#L229-L231" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/collections/map.nr#L229-L231</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/collections/map.nr#L229-L231" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/collections/map.nr#L229-L231</a></sub></sup>
 
 
 Returns a vector of each key present in the hashmap.
@@ -364,7 +364,7 @@ let keys = map.keys();
         }
     }
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/execution_success/hashmap/src/main.nr#L344-L354" target="_blank" rel="noopener noreferrer">Source code: test_programs/execution_success/hashmap/src/main.nr#L344-L354</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/test_programs/execution_success/hashmap/src/main.nr#L344-L354" target="_blank" rel="noopener noreferrer">Source code: test_programs/execution_success/hashmap/src/main.nr#L344-L354</a></sub></sup>
 
 
 ### values
@@ -372,7 +372,7 @@ let keys = map.keys();
 ```rust title="values" showLineNumbers 
 pub fn values(self) -> BoundedVec<V, N> {
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/collections/map.nr#L265-L267" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/collections/map.nr#L265-L267</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/collections/map.nr#L265-L267" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/collections/map.nr#L265-L267</a></sub></sup>
 
 
 Returns a vector of each value present in the hashmap.
@@ -391,7 +391,7 @@ let values = map.values();
         }
     }
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/execution_success/hashmap/src/main.nr#L355-L364" target="_blank" rel="noopener noreferrer">Source code: test_programs/execution_success/hashmap/src/main.nr#L355-L364</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/test_programs/execution_success/hashmap/src/main.nr#L355-L364" target="_blank" rel="noopener noreferrer">Source code: test_programs/execution_success/hashmap/src/main.nr#L355-L364</a></sub></sup>
 
 
 ### iter_mut
@@ -403,7 +403,7 @@ pub fn iter_mut(&mut self, f: fn(K, V) -> (K, V))
         B: BuildHasher,
     {
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/collections/map.nr#L301-L307" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/collections/map.nr#L301-L307</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/collections/map.nr#L301-L307" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/collections/map.nr#L301-L307</a></sub></sup>
 
 
 Iterates through each key-value pair of the HashMap, setting each key-value pair to the
@@ -422,7 +422,7 @@ Example:
 // Add 1 to each key in the map, and double the value associated with that key.
     map.iter_mut(|k, v| (k + 1, v * 2));
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/execution_success/hashmap/src/main.nr#L368-L371" target="_blank" rel="noopener noreferrer">Source code: test_programs/execution_success/hashmap/src/main.nr#L368-L371</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/test_programs/execution_success/hashmap/src/main.nr#L368-L371" target="_blank" rel="noopener noreferrer">Source code: test_programs/execution_success/hashmap/src/main.nr#L368-L371</a></sub></sup>
 
 
 ### iter_keys_mut
@@ -434,7 +434,7 @@ pub fn iter_keys_mut(&mut self, f: fn(K) -> K)
         B: BuildHasher,
     {
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/collections/map.nr#L339-L345" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/collections/map.nr#L339-L345</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/collections/map.nr#L339-L345" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/collections/map.nr#L339-L345</a></sub></sup>
 
 
 Iterates through the HashMap, mutating each key to the result returned from
@@ -453,7 +453,7 @@ Example:
 // Double each key, leaving the value associated with that key untouched
     map.iter_keys_mut(|k| k * 2);
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/execution_success/hashmap/src/main.nr#L372-L375" target="_blank" rel="noopener noreferrer">Source code: test_programs/execution_success/hashmap/src/main.nr#L372-L375</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/test_programs/execution_success/hashmap/src/main.nr#L372-L375" target="_blank" rel="noopener noreferrer">Source code: test_programs/execution_success/hashmap/src/main.nr#L372-L375</a></sub></sup>
 
 
 ### iter_values_mut
@@ -461,7 +461,7 @@ Example:
 ```rust title="iter_values_mut" showLineNumbers 
 pub fn iter_values_mut(&mut self, f: fn(V) -> V) {
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/collections/map.nr#L371-L373" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/collections/map.nr#L371-L373</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/collections/map.nr#L371-L373" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/collections/map.nr#L371-L373</a></sub></sup>
 
 
 Iterates through the HashMap, applying the given function to each value and mutating the
@@ -474,7 +474,7 @@ Example:
 // Halve each value
     map.iter_values_mut(|v| v / 2);
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/execution_success/hashmap/src/main.nr#L376-L379" target="_blank" rel="noopener noreferrer">Source code: test_programs/execution_success/hashmap/src/main.nr#L376-L379</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/test_programs/execution_success/hashmap/src/main.nr#L376-L379" target="_blank" rel="noopener noreferrer">Source code: test_programs/execution_success/hashmap/src/main.nr#L376-L379</a></sub></sup>
 
 
 ### retain
@@ -482,7 +482,7 @@ Example:
 ```rust title="retain" showLineNumbers 
 pub fn retain(&mut self, f: fn(K, V) -> bool) {
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/collections/map.nr#L391-L393" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/collections/map.nr#L391-L393</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/collections/map.nr#L391-L393" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/collections/map.nr#L391-L393</a></sub></sup>
 
 
 Retains only the key-value pairs for which the given function returns true.
@@ -493,7 +493,7 @@ Example:
 ```rust title="retain_example" showLineNumbers 
 map.retain(|k, v| (k != 0) & (v != 0));
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/execution_success/hashmap/src/main.nr#L304-L306" target="_blank" rel="noopener noreferrer">Source code: test_programs/execution_success/hashmap/src/main.nr#L304-L306</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/test_programs/execution_success/hashmap/src/main.nr#L304-L306" target="_blank" rel="noopener noreferrer">Source code: test_programs/execution_success/hashmap/src/main.nr#L304-L306</a></sub></sup>
 
 
 ## Trait Implementations
@@ -515,7 +515,7 @@ where
     /// ```
     fn default() -> Self {
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/collections/map.nr#L677-L691" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/collections/map.nr#L677-L691</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/collections/map.nr#L677-L691" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/collections/map.nr#L677-L691</a></sub></sup>
 
 
 Constructs an empty HashMap.
@@ -526,7 +526,7 @@ Example:
 let hashmap: HashMap<u8, u32, 10, BuildHasherDefault<Poseidon2Hasher>> = HashMap::default();
     assert(hashmap.is_empty());
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/execution_success/hashmap/src/main.nr#L232-L235" target="_blank" rel="noopener noreferrer">Source code: test_programs/execution_success/hashmap/src/main.nr#L232-L235</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/test_programs/execution_success/hashmap/src/main.nr#L232-L235" target="_blank" rel="noopener noreferrer">Source code: test_programs/execution_success/hashmap/src/main.nr#L232-L235</a></sub></sup>
 
 
 ### eq
@@ -556,7 +556,7 @@ where
     /// ```
     fn eq(self, other: HashMap<K, V, N, B>) -> bool {
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/collections/map.nr#L627-L651" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/collections/map.nr#L627-L651</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/collections/map.nr#L627-L651" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/collections/map.nr#L627-L651</a></sub></sup>
 
 
 Checks if two HashMaps are equal.
@@ -575,5 +575,5 @@ let mut map1: HashMap<Field, u64, 4, BuildHasherDefault<Poseidon2Hasher>> = Hash
 
     assert(map1 == map2);
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/execution_success/hashmap/src/main.nr#L307-L318" target="_blank" rel="noopener noreferrer">Source code: test_programs/execution_success/hashmap/src/main.nr#L307-L318</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/test_programs/execution_success/hashmap/src/main.nr#L307-L318" target="_blank" rel="noopener noreferrer">Source code: test_programs/execution_success/hashmap/src/main.nr#L307-L318</a></sub></sup>
 

--- a/docs/versioned_docs/version-v1.0.0-beta.19/noir/standard_library/cryptographic_primitives/ciphers.mdx
+++ b/docs/versioned_docs/version-v1.0.0-beta.19/noir/standard_library/cryptographic_primitives/ciphers.mdx
@@ -35,7 +35,7 @@ pub fn aes128_encrypt<let N: u32>(
 #[foreign(aes128_encrypt)]
 fn aes128_encrypt_padded_input<let N: u32>(input: [u8; N], iv: [u8; 16], key: [u8; 16]) -> [u8; N] {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/aes128.nr#L1-L23" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/aes128.nr#L1-L23</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/aes128.nr#L1-L23" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/aes128.nr#L1-L23</a></sub></sup>
 
 
 ```rust

--- a/docs/versioned_docs/version-v1.0.0-beta.19/noir/standard_library/cryptographic_primitives/ecdsa_sig_verification.mdx
+++ b/docs/versioned_docs/version-v1.0.0-beta.19/noir/standard_library/cryptographic_primitives/ecdsa_sig_verification.mdx
@@ -36,7 +36,7 @@ pub fn verify_signature(
     message_hash: [u8; 32],
 ) -> bool
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/ecdsa_secp256k1.nr#L1-L23" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/ecdsa_secp256k1.nr#L1-L23</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/ecdsa_secp256k1.nr#L1-L23" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/ecdsa_secp256k1.nr#L1-L23</a></sub></sup>
 
 
 example:
@@ -63,7 +63,7 @@ pub fn verify_signature(
     message_hash: [u8; 32],
 ) -> bool
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/ecdsa_secp256r1.nr#L1-L8" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/ecdsa_secp256r1.nr#L1-L8</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/ecdsa_secp256r1.nr#L1-L8" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/ecdsa_secp256r1.nr#L1-L8</a></sub></sup>
 
 
 example:

--- a/docs/versioned_docs/version-v1.0.0-beta.19/noir/standard_library/cryptographic_primitives/embedded_curve_ops.mdx
+++ b/docs/versioned_docs/version-v1.0.0-beta.19/noir/standard_library/cryptographic_primitives/embedded_curve_ops.mdx
@@ -28,7 +28,7 @@ pub fn multi_scalar_mul<let N: u32>(
     scalars: [EmbeddedCurveScalar; N],
 ) -> EmbeddedCurvePoint
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/embedded_curve_ops.nr#L142-L147" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/embedded_curve_ops.nr#L142-L147</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/embedded_curve_ops.nr#L142-L147" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/embedded_curve_ops.nr#L142-L147</a></sub></sup>
 
 
 example
@@ -48,7 +48,7 @@ The function accepts a single scalar on the input represented as 2 fields.
 ```rust title="fixed_base_scalar_mul" showLineNumbers 
 pub fn fixed_base_scalar_mul(scalar: EmbeddedCurveScalar) -> EmbeddedCurvePoint
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/embedded_curve_ops.nr#L159-L161" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/embedded_curve_ops.nr#L159-L161</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/embedded_curve_ops.nr#L159-L161" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/embedded_curve_ops.nr#L159-L161</a></sub></sup>
 
 
 example
@@ -78,7 +78,7 @@ pub fn embedded_curve_add(
     point2: EmbeddedCurvePoint,
 ) -> EmbeddedCurvePoint {
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/embedded_curve_ops.nr#L172-L177" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/embedded_curve_ops.nr#L172-L177</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/embedded_curve_ops.nr#L172-L177" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/embedded_curve_ops.nr#L172-L177</a></sub></sup>
 
 
 example

--- a/docs/versioned_docs/version-v1.0.0-beta.19/noir/standard_library/cryptographic_primitives/hashes.mdx
+++ b/docs/versioned_docs/version-v1.0.0-beta.19/noir/standard_library/cryptographic_primitives/hashes.mdx
@@ -34,7 +34,7 @@ This is a different function than sha256. See [this library](https://github.com/
 ```rust title="sha256_compression" showLineNumbers 
 pub fn sha256_compression(input: [u32; 16], state: [u32; 8]) -> [u32; 8] {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/hash/mod.nr#L11-L13" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/hash/mod.nr#L11-L13</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/hash/mod.nr#L11-L13" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/hash/mod.nr#L11-L13</a></sub></sup>
 
 
 <BlackBoxInfo to="../black_box_fns"/>
@@ -46,7 +46,7 @@ Given an array of bytes, returns an array with the Blake2 hash
 ```rust title="blake2s" showLineNumbers 
 pub fn blake2s<let N: u32>(input: [u8; N]) -> [u8; 32]
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/hash/mod.nr#L28-L30" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/hash/mod.nr#L28-L30</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/hash/mod.nr#L28-L30" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/hash/mod.nr#L28-L30</a></sub></sup>
 
 
 example:
@@ -67,7 +67,7 @@ Given an array of bytes, returns an array with the Blake3 hash
 ```rust title="blake3" showLineNumbers 
 pub fn blake3<let N: u32>(input: [u8; N]) -> [u8; 32]
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/hash/mod.nr#L33-L35" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/hash/mod.nr#L33-L35</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/hash/mod.nr#L33-L35" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/hash/mod.nr#L33-L35</a></sub></sup>
 
 
 example:
@@ -88,7 +88,7 @@ Given an array of Fields, returns the Pedersen hash.
 ```rust title="pedersen_hash" showLineNumbers 
 pub fn pedersen_hash<let N: u32>(input: [Field; N]) -> Field
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/hash/mod.nr#L71-L73" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/hash/mod.nr#L71-L73</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/hash/mod.nr#L71-L73" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/hash/mod.nr#L71-L73</a></sub></sup>
 
 
 example:
@@ -99,7 +99,7 @@ fn main(x: Field, y: Field, expected_hash: Field) {
     assert_eq(hash, expected_hash);
 }
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/execution_success/pedersen_hash/src/main.nr#L1-L6" target="_blank" rel="noopener noreferrer">Source code: test_programs/execution_success/pedersen_hash/src/main.nr#L1-L6</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/test_programs/execution_success/pedersen_hash/src/main.nr#L1-L6" target="_blank" rel="noopener noreferrer">Source code: test_programs/execution_success/pedersen_hash/src/main.nr#L1-L6</a></sub></sup>
 
 
 <BlackBoxInfo to="../black_box_fns" />
@@ -111,7 +111,7 @@ Given an array of Fields, returns the Pedersen commitment.
 ```rust title="pedersen_commitment" showLineNumbers 
 pub fn pedersen_commitment<let N: u32>(input: [Field; N]) -> EmbeddedCurvePoint {
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/hash/mod.nr#L51-L53" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/hash/mod.nr#L51-L53</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/hash/mod.nr#L51-L53" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/hash/mod.nr#L51-L53</a></sub></sup>
 
 
 example:
@@ -123,7 +123,7 @@ fn main(x: Field, y: Field, expected_commitment: std::embedded_curve_ops::Embedd
     assert_eq(commitment.y, expected_commitment.y);
 }
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/execution_success/pedersen_commitment/src/main.nr#L1-L7" target="_blank" rel="noopener noreferrer">Source code: test_programs/execution_success/pedersen_commitment/src/main.nr#L1-L7</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/test_programs/execution_success/pedersen_commitment/src/main.nr#L1-L7" target="_blank" rel="noopener noreferrer">Source code: test_programs/execution_success/pedersen_commitment/src/main.nr#L1-L7</a></sub></sup>
 
 
 <BlackBoxInfo to="../black_box_fns"/>
@@ -135,7 +135,7 @@ Given an initial `[u64; 25]` state, returns the state resulting from applying a 
 ```rust title="keccakf1600" showLineNumbers 
 pub fn keccakf1600(input: [u64; 25]) -> [u64; 25] {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/hash/mod.nr#L16-L18" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/hash/mod.nr#L16-L18</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/hash/mod.nr#L16-L18" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/hash/mod.nr#L16-L18</a></sub></sup>
 
 
 <BlackBoxInfo to="../black_box_fns"/>

--- a/docs/versioned_docs/version-v1.0.0-beta.19/noir/standard_library/fmtstr.md
+++ b/docs/versioned_docs/version-v1.0.0-beta.19/noir/standard_library/fmtstr.md
@@ -12,7 +12,7 @@ description: Format string literals at compile time—inspect raw contents or em
 ```rust title="quoted_contents" showLineNumbers 
 pub comptime fn quoted_contents(self) -> Quoted {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/format_string.nr#L6-L8" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/format_string.nr#L6-L8</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/meta/format_string.nr#L6-L8" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/format_string.nr#L6-L8</a></sub></sup>
 
 
 Returns the format string contents (that is, without the leading and trailing double quotes) as a `Quoted` value.
@@ -22,7 +22,7 @@ Returns the format string contents (that is, without the leading and trailing do
 ```rust title="as_quoted_str" showLineNumbers 
 pub comptime fn as_quoted_str(self) -> Quoted {
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/format_string.nr#L11-L13" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/format_string.nr#L11-L13</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/meta/format_string.nr#L11-L13" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/format_string.nr#L11-L13</a></sub></sup>
 
 
 Returns the format string contents (with the leading and trailing double quotes) as a `Quoted` string literal (not a format string literal).
@@ -36,5 +36,5 @@ comptime {
         assert_eq(f, "x = 0x01");
     }
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/compile_success_empty/comptime_fmt_strings/src/main.nr#L19-L25" target="_blank" rel="noopener noreferrer">Source code: test_programs/compile_success_empty/comptime_fmt_strings/src/main.nr#L19-L25</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/test_programs/compile_success_empty/comptime_fmt_strings/src/main.nr#L19-L25" target="_blank" rel="noopener noreferrer">Source code: test_programs/compile_success_empty/comptime_fmt_strings/src/main.nr#L19-L25</a></sub></sup>
 

--- a/docs/versioned_docs/version-v1.0.0-beta.19/noir/standard_library/meta/ctstring.md
+++ b/docs/versioned_docs/version-v1.0.0-beta.19/noir/standard_library/meta/ctstring.md
@@ -22,7 +22,7 @@ pub trait AsCtString {
     comptime fn as_ctstring(self) -> CtString;
 }
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/ctstring.nr#L44-L48" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/ctstring.nr#L44-L48</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/meta/ctstring.nr#L44-L48" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/ctstring.nr#L44-L48</a></sub></sup>
 
 
 Converts an object into a compile-time string.
@@ -41,7 +41,7 @@ impl<let N: u32, T> AsCtString for fmtstr<N, T> { ... }
 ```rust title="new" showLineNumbers 
 pub comptime fn new() -> Self {
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/ctstring.nr#L4-L6" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/ctstring.nr#L4-L6</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/meta/ctstring.nr#L4-L6" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/ctstring.nr#L4-L6</a></sub></sup>
 
 
 Creates an empty `CtString`.
@@ -51,7 +51,7 @@ Creates an empty `CtString`.
 ```rust title="append_str" showLineNumbers 
 pub comptime fn append_str<let N: u32>(self, s: str<N>) -> Self {
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/ctstring.nr#L12-L14" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/ctstring.nr#L12-L14</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/meta/ctstring.nr#L12-L14" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/ctstring.nr#L12-L14</a></sub></sup>
 
 
 Returns a new CtString with the given str appended onto the end.
@@ -61,7 +61,7 @@ Returns a new CtString with the given str appended onto the end.
 ```rust title="append_fmtstr" showLineNumbers 
 pub comptime fn append_fmtstr<let N: u32, T>(self, s: fmtstr<N, T>) -> Self {
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/ctstring.nr#L18-L20" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/ctstring.nr#L18-L20</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/meta/ctstring.nr#L18-L20" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/ctstring.nr#L18-L20</a></sub></sup>
 
 
 Returns a new CtString with the given fmtstr appended onto the end.
@@ -71,7 +71,7 @@ Returns a new CtString with the given fmtstr appended onto the end.
 ```rust title="as_quoted_str" showLineNumbers 
 pub comptime fn as_quoted_str(self) -> Quoted {
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/ctstring.nr#L27-L29" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/ctstring.nr#L27-L29</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/meta/ctstring.nr#L27-L29" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/ctstring.nr#L27-L29</a></sub></sup>
 
 
 Returns a quoted string literal from this string's contents.
@@ -89,7 +89,7 @@ let my_ctstring = "foo bar".as_ctstring();
 
             assert_eq(crate::meta::type_of(my_str), quote { str<7> }.as_type());
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/ctstring.nr#L95-L100" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/ctstring.nr#L95-L100</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/meta/ctstring.nr#L95-L100" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/ctstring.nr#L95-L100</a></sub></sup>
 
 
 ## Trait Implementations

--- a/docs/versioned_docs/version-v1.0.0-beta.19/noir/standard_library/meta/expr.md
+++ b/docs/versioned_docs/version-v1.0.0-beta.19/noir/standard_library/meta/expr.md
@@ -12,7 +12,7 @@ description: Introspect and transform quoted expressions at compile time—inspe
 ```rust title="as_array" showLineNumbers 
 pub comptime fn as_array(self) -> Option<[Expr]> {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L10-L12" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L10-L12</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/meta/expr.nr#L10-L12" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L10-L12</a></sub></sup>
 
 
 If this expression is an array, this returns a vector of each element in the array.
@@ -22,7 +22,7 @@ If this expression is an array, this returns a vector of each element in the arr
 ```rust title="as_assert" showLineNumbers 
 pub comptime fn as_assert(self) -> Option<(Expr, Option<Expr>)> {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L16-L18" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L16-L18</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/meta/expr.nr#L16-L18" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L16-L18</a></sub></sup>
 
 
 If this expression is an assert, this returns the assert expression and the optional message.
@@ -32,7 +32,7 @@ If this expression is an assert, this returns the assert expression and the opti
 ```rust title="as_assert_eq" showLineNumbers 
 pub comptime fn as_assert_eq(self) -> Option<(Expr, Expr, Option<Expr>)> {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L23-L25" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L23-L25</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/meta/expr.nr#L23-L25" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L23-L25</a></sub></sup>
 
 
 If this expression is an assert_eq, this returns the left-hand-side and right-hand-side
@@ -43,7 +43,7 @@ expressions, together with the optional message.
 ```rust title="as_assign" showLineNumbers 
 pub comptime fn as_assign(self) -> Option<(Expr, Expr)> {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L30-L32" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L30-L32</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/meta/expr.nr#L30-L32" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L30-L32</a></sub></sup>
 
 
 If this expression is an assignment, this returns a tuple with the left hand side
@@ -54,7 +54,7 @@ and right hand side in order.
 ```rust title="as_binary_op" showLineNumbers 
 pub comptime fn as_binary_op(self) -> Option<(Expr, BinaryOp, Expr)> {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L37-L39" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L37-L39</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/meta/expr.nr#L37-L39" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L37-L39</a></sub></sup>
 
 
 If this expression is a binary operator operation `<lhs> <op> <rhs>`,
@@ -65,7 +65,7 @@ return the left-hand side, operator, and the right-hand side of the operation.
 ```rust title="as_block" showLineNumbers 
 pub comptime fn as_block(self) -> Option<[Expr]> {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L44-L46" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L44-L46</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/meta/expr.nr#L44-L46" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L44-L46</a></sub></sup>
 
 
 If this expression is a block `{ stmt1; stmt2; ...; stmtN }`, return
@@ -76,7 +76,7 @@ a vector containing each statement.
 ```rust title="as_bool" showLineNumbers 
 pub comptime fn as_bool(self) -> Option<bool> {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L50-L52" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L50-L52</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/meta/expr.nr#L50-L52" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L50-L52</a></sub></sup>
 
 
 If this expression is a boolean literal, return that literal.
@@ -87,7 +87,7 @@ If this expression is a boolean literal, return that literal.
 #[builtin(expr_as_cast)]
     pub comptime fn as_cast(self) -> Option<(Expr, UnresolvedType)> {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L56-L59" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L56-L59</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/meta/expr.nr#L56-L59" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L56-L59</a></sub></sup>
 
 
 If this expression is a cast expression (`expr as type`), returns the casted
@@ -98,7 +98,7 @@ expression and the type to cast to.
 ```rust title="as_comptime" showLineNumbers 
 pub comptime fn as_comptime(self) -> Option<[Expr]> {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L64-L66" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L64-L66</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/meta/expr.nr#L64-L66" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L64-L66</a></sub></sup>
 
 
 If this expression is a `comptime { stmt1; stmt2; ...; stmtN }` block,
@@ -109,7 +109,7 @@ return each statement in the block.
 ```rust title="as_constructor" showLineNumbers 
 pub comptime fn as_constructor(self) -> Option<(UnresolvedType, [(Quoted, Expr)])> {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L71-L73" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L71-L73</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/meta/expr.nr#L71-L73" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L71-L73</a></sub></sup>
 
 
 If this expression is a constructor `Type { field1: expr1, ..., fieldN: exprN }`,
@@ -120,7 +120,7 @@ return the type and the fields.
 ```rust title="as_for" showLineNumbers 
 pub comptime fn as_for(self) -> Option<(Quoted, Expr, Expr)> {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L78-L80" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L78-L80</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/meta/expr.nr#L78-L80" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L78-L80</a></sub></sup>
 
 
 If this expression is a for statement over a single expression, return the identifier,
@@ -131,7 +131,7 @@ the expression and the for loop body.
 ```rust title="as_for" showLineNumbers 
 pub comptime fn as_for(self) -> Option<(Quoted, Expr, Expr)> {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L78-L80" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L78-L80</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/meta/expr.nr#L78-L80" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L78-L80</a></sub></sup>
 
 
 If this expression is a for statement over a range, return the identifier,
@@ -142,7 +142,7 @@ the range start, the range end and the for loop body.
 ```rust title="as_function_call" showLineNumbers 
 pub comptime fn as_function_call(self) -> Option<(Expr, [Expr])> {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L92-L94" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L92-L94</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/meta/expr.nr#L92-L94" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L92-L94</a></sub></sup>
 
 
 If this expression is a function call `foo(arg1, ..., argN)`, return
@@ -153,7 +153,7 @@ the function and a vector of each argument.
 ```rust title="as_if" showLineNumbers 
 pub comptime fn as_if(self) -> Option<(Expr, Expr, Option<Expr>)> {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L100-L102" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L100-L102</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/meta/expr.nr#L100-L102" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L100-L102</a></sub></sup>
 
 
 If this expression is an `if condition { then_branch } else { else_branch }`,
@@ -165,7 +165,7 @@ return the condition, then branch, and else branch. If there is no else branch,
 ```rust title="as_index" showLineNumbers 
 pub comptime fn as_index(self) -> Option<(Expr, Expr)> {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L107-L109" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L107-L109</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/meta/expr.nr#L107-L109" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L107-L109</a></sub></sup>
 
 
 If this expression is an index into an array `array[index]`, return the
@@ -176,7 +176,7 @@ array and the index.
 ```rust title="as_integer" showLineNumbers 
 pub comptime fn as_integer(self) -> Option<(Field, bool)> {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L114-L116" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L114-L116</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/meta/expr.nr#L114-L116" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L114-L116</a></sub></sup>
 
 
 If this expression is an integer literal, return the integer as a field
@@ -189,7 +189,7 @@ pub comptime fn as_lambda(
         self,
     ) -> Option<([(Expr, Option<UnresolvedType>)], Option<UnresolvedType>, Expr)> {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L120-L124" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L120-L124</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/meta/expr.nr#L120-L124" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L120-L124</a></sub></sup>
 
 
 If this expression is a lambda, returns the parameters, return type and body.
@@ -199,7 +199,7 @@ If this expression is a lambda, returns the parameters, return type and body.
 ```rust title="as_let" showLineNumbers 
 pub comptime fn as_let(self) -> Option<(Expr, Option<UnresolvedType>, Expr)> {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L129-L131" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L129-L131</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/meta/expr.nr#L129-L131" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L129-L131</a></sub></sup>
 
 
 If this expression is a let statement, returns the let pattern as an `Expr`,
@@ -210,7 +210,7 @@ the optional type annotation, and the assigned expression.
 ```rust title="as_member_access" showLineNumbers 
 pub comptime fn as_member_access(self) -> Option<(Expr, Quoted)> {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L136-L138" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L136-L138</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/meta/expr.nr#L136-L138" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L136-L138</a></sub></sup>
 
 
 If this expression is a member access `foo.bar`, return the struct/tuple
@@ -221,7 +221,7 @@ expression and the field. The field will be represented as a quoted value.
 ```rust title="as_method_call" showLineNumbers 
 pub comptime fn as_method_call(self) -> Option<(Expr, Quoted, [UnresolvedType], [Expr])> {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L143-L145" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L143-L145</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/meta/expr.nr#L143-L145" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L143-L145</a></sub></sup>
 
 
 If this expression is a method call `foo.bar::<generic1, ..., genericM>(arg1, ..., argN)`, return
@@ -232,7 +232,7 @@ the receiver, method name, a vector of each generic argument, and a vector of ea
 ```rust title="as_repeated_element_array" showLineNumbers 
 pub comptime fn as_repeated_element_array(self) -> Option<(Expr, Expr)> {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L150-L152" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L150-L152</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/meta/expr.nr#L150-L152" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L150-L152</a></sub></sup>
 
 
 If this expression is a repeated element array `[elem; length]`, return
@@ -243,7 +243,7 @@ the repeated element and the length expressions.
 ```rust title="as_repeated_element_vector" showLineNumbers 
 pub comptime fn as_repeated_element_vector(self) -> Option<(Expr, Expr)> {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L157-L159" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L157-L159</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/meta/expr.nr#L157-L159" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L157-L159</a></sub></sup>
 
 
 If this expression is a repeated element vector `[elem; length]`, return
@@ -254,7 +254,7 @@ the repeated element and the length expressions.
 ```rust title="as_vector" showLineNumbers 
 pub comptime fn as_vector(self) -> Option<[Expr]> {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L171-L173" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L171-L173</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/meta/expr.nr#L171-L173" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L171-L173</a></sub></sup>
 
 
 If this expression is a vector literal `@[elem1, ..., elemN]`,
@@ -265,7 +265,7 @@ return each element of the vector.
 ```rust title="as_tuple" showLineNumbers 
 pub comptime fn as_tuple(self) -> Option<[Expr]> {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L185-L187" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L185-L187</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/meta/expr.nr#L185-L187" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L185-L187</a></sub></sup>
 
 
 If this expression is a tuple `(field1, ..., fieldN)`,
@@ -276,7 +276,7 @@ return each element of the tuple.
 ```rust title="as_unary_op" showLineNumbers 
 pub comptime fn as_unary_op(self) -> Option<(UnaryOp, Expr)> {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L192-L194" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L192-L194</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/meta/expr.nr#L192-L194" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L192-L194</a></sub></sup>
 
 
 If this expression is a unary operation `<op> <rhs>`,
@@ -287,7 +287,7 @@ return the unary operator as well as the right-hand side expression.
 ```rust title="as_unsafe" showLineNumbers 
 pub comptime fn as_unsafe(self) -> Option<[Expr]> {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L199-L201" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L199-L201</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/meta/expr.nr#L199-L201" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L199-L201</a></sub></sup>
 
 
 If this expression is an `unsafe { stmt1; ...; stmtN }` block,
@@ -298,7 +298,7 @@ return each statement inside in a vector.
 ```rust title="has_semicolon" showLineNumbers 
 pub comptime fn has_semicolon(self) -> bool {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L220-L222" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L220-L222</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/meta/expr.nr#L220-L222" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L220-L222</a></sub></sup>
 
 
 `true` if this expression is trailed by a semicolon. E.g.
@@ -321,7 +321,7 @@ comptime {
 ```rust title="is_break" showLineNumbers 
 pub comptime fn is_break(self) -> bool {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L226-L228" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L226-L228</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/meta/expr.nr#L226-L228" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L226-L228</a></sub></sup>
 
 
 `true` if this expression is `break`.
@@ -331,7 +331,7 @@ pub comptime fn is_break(self) -> bool {}
 ```rust title="is_continue" showLineNumbers 
 pub comptime fn is_continue(self) -> bool {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L232-L234" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L232-L234</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/meta/expr.nr#L232-L234" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L232-L234</a></sub></sup>
 
 
 `true` if this expression is `continue`.
@@ -341,7 +341,7 @@ pub comptime fn is_continue(self) -> bool {}
 ```rust title="modify" showLineNumbers 
 pub comptime fn modify<Env>(self, f: fn[Env](Expr) -> Option<Expr>) -> Expr {
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L243-L245" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L243-L245</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/meta/expr.nr#L243-L245" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L243-L245</a></sub></sup>
 
 
 Applies a mapping function to this expression and to all of its sub-expressions.
@@ -357,7 +357,7 @@ for expressions that are integers, doubling them, would return `(@[2], @[4, 6])`
 ```rust title="quoted" showLineNumbers 
 pub comptime fn quoted(self) -> Quoted {
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L280-L282" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L280-L282</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/meta/expr.nr#L280-L282" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L280-L282</a></sub></sup>
 
 
 Returns this expression as a `Quoted` value. It's the same as `quote { $self }`.
@@ -367,7 +367,7 @@ Returns this expression as a `Quoted` value. It's the same as `quote { $self }`.
 ```rust title="resolve" showLineNumbers 
 pub comptime fn resolve(self, in_function: Option<FunctionDefinition>) -> TypedExpr {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L296-L298" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L296-L298</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/meta/expr.nr#L296-L298" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L296-L298</a></sub></sup>
 
 
 Resolves and type-checks this expression and returns the result as a `TypedExpr`.

--- a/docs/versioned_docs/version-v1.0.0-beta.19/noir/standard_library/meta/function_def.md
+++ b/docs/versioned_docs/version-v1.0.0-beta.19/noir/standard_library/meta/function_def.md
@@ -13,7 +13,7 @@ a function definition in the source program.
 ```rust title="add_attribute" showLineNumbers 
 pub comptime fn add_attribute<let N: u32>(self, attribute: str<N>) {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/function_def.nr#L3-L5" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/function_def.nr#L3-L5</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/meta/function_def.nr#L3-L5" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/function_def.nr#L3-L5</a></sub></sup>
 
 
 Adds an attribute to the function. This is only valid
@@ -25,7 +25,7 @@ This means any functions called at compile-time are invalid targets for this met
 ```rust title="as_typed_expr" showLineNumbers 
 pub comptime fn as_typed_expr(self) -> TypedExpr {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/function_def.nr#L8-L10" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/function_def.nr#L8-L10</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/meta/function_def.nr#L8-L10" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/function_def.nr#L8-L10</a></sub></sup>
 
 
 Returns this function as a `TypedExpr`, which can be unquoted. For example:
@@ -40,7 +40,7 @@ let _ = quote { $typed_expr(1, 2, 3); };
 ```rust title="body" showLineNumbers 
 pub comptime fn body(self) -> Expr {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/function_def.nr#L13-L15" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/function_def.nr#L13-L15</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/meta/function_def.nr#L13-L15" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/function_def.nr#L13-L15</a></sub></sup>
 
 
 Returns the body of the function as an expression. This is only valid
@@ -52,7 +52,7 @@ This means any functions called at compile-time are invalid targets for this met
 ```rust title="has_named_attribute" showLineNumbers 
 pub comptime fn has_named_attribute<let N: u32>(self, name: str<N>) -> bool {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/function_def.nr#L18-L20" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/function_def.nr#L18-L20</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/meta/function_def.nr#L18-L20" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/function_def.nr#L18-L20</a></sub></sup>
 
 
 Returns true if this function has a custom attribute with the given name.
@@ -62,7 +62,7 @@ Returns true if this function has a custom attribute with the given name.
 ```rust title="is_unconstrained" showLineNumbers 
 pub comptime fn is_unconstrained(self) -> bool {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/function_def.nr#L23-L25" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/function_def.nr#L23-L25</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/meta/function_def.nr#L23-L25" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/function_def.nr#L23-L25</a></sub></sup>
 
 
 Returns true if this function is unconstrained.
@@ -72,7 +72,7 @@ Returns true if this function is unconstrained.
 ```rust title="module" showLineNumbers 
 pub comptime fn module(self) -> Module {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/function_def.nr#L28-L30" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/function_def.nr#L28-L30</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/meta/function_def.nr#L28-L30" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/function_def.nr#L28-L30</a></sub></sup>
 
 
 Returns the module where the function is defined.
@@ -82,7 +82,7 @@ Returns the module where the function is defined.
 ```rust title="name" showLineNumbers 
 pub comptime fn name(self) -> Quoted {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/function_def.nr#L33-L35" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/function_def.nr#L33-L35</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/meta/function_def.nr#L33-L35" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/function_def.nr#L33-L35</a></sub></sup>
 
 
 Returns the name of the function.
@@ -92,7 +92,7 @@ Returns the name of the function.
 ```rust title="parameters" showLineNumbers 
 pub comptime fn parameters(self) -> [(Quoted, Type)] {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/function_def.nr#L38-L40" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/function_def.nr#L38-L40</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/meta/function_def.nr#L38-L40" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/function_def.nr#L38-L40</a></sub></sup>
 
 
 Returns each parameter of the function as a tuple of (parameter pattern, parameter type).
@@ -102,7 +102,7 @@ Returns each parameter of the function as a tuple of (parameter pattern, paramet
 ```rust title="return_type" showLineNumbers 
 pub comptime fn return_type(self) -> Type {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/function_def.nr#L43-L45" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/function_def.nr#L43-L45</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/meta/function_def.nr#L43-L45" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/function_def.nr#L43-L45</a></sub></sup>
 
 
 The return type of the function.
@@ -112,7 +112,7 @@ The return type of the function.
 ```rust title="set_body" showLineNumbers 
 pub comptime fn set_body(self, body: Expr) {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/function_def.nr#L48-L50" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/function_def.nr#L48-L50</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/meta/function_def.nr#L48-L50" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/function_def.nr#L48-L50</a></sub></sup>
 
 
 Mutate the function body to a new expression. This is only valid
@@ -124,7 +124,7 @@ This means any functions called at compile-time are invalid targets for this met
 ```rust title="set_parameters" showLineNumbers 
 pub comptime fn set_parameters(self, parameters: [(Quoted, Type)]) {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/function_def.nr#L53-L55" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/function_def.nr#L53-L55</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/meta/function_def.nr#L53-L55" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/function_def.nr#L53-L55</a></sub></sup>
 
 
 Mutates the function's parameters to a new set of parameters. This is only valid
@@ -139,7 +139,7 @@ each parameter pattern to be a syntactically valid parameter.
 ```rust title="set_return_type" showLineNumbers 
 pub comptime fn set_return_type(self, return_type: Type) {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/function_def.nr#L58-L60" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/function_def.nr#L58-L60</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/meta/function_def.nr#L58-L60" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/function_def.nr#L58-L60</a></sub></sup>
 
 
 Mutates the function's return type to a new type. This is only valid
@@ -151,7 +151,7 @@ This means any functions called at compile-time are invalid targets for this met
 ```rust title="set_return_public" showLineNumbers 
 pub comptime fn set_return_public(self, public: bool) {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/function_def.nr#L63-L65" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/function_def.nr#L63-L65</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/meta/function_def.nr#L63-L65" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/function_def.nr#L63-L65</a></sub></sup>
 
 
 Mutates the function's return visibility to public (if `true` is given) or private (if `false` is given).
@@ -163,7 +163,7 @@ This means any functions called at compile-time are invalid targets for this met
 ```rust title="set_unconstrained" showLineNumbers 
 pub comptime fn set_unconstrained(self, value: bool) {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/function_def.nr#L71-L73" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/function_def.nr#L71-L73</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/meta/function_def.nr#L71-L73" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/function_def.nr#L71-L73</a></sub></sup>
 
 
 Mutates the function to be unconstrained (if `true` is given) or not (if `false` is given).
@@ -175,7 +175,7 @@ This means any functions called at compile-time are invalid targets for this met
 ```rust title="visibility" showLineNumbers 
 pub comptime fn visibility(self) -> Quoted {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/function_def.nr#L76-L78" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/function_def.nr#L76-L78</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/meta/function_def.nr#L76-L78" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/function_def.nr#L76-L78</a></sub></sup>
 
 
 Returns the function's visibility as a `Quoted` value, which will be one of:

--- a/docs/versioned_docs/version-v1.0.0-beta.19/noir/standard_library/meta/index.md
+++ b/docs/versioned_docs/version-v1.0.0-beta.19/noir/standard_library/meta/index.md
@@ -14,7 +14,7 @@ and types used for inspecting and modifying Noir programs.
 ```rust title="type_of" showLineNumbers 
 pub comptime fn type_of<T>(x: T) -> Type {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/mod.nr#L29-L31" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/mod.nr#L29-L31</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/meta/mod.nr#L29-L31" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/mod.nr#L29-L31</a></sub></sup>
 
 
 Returns the type of a variable at compile-time.
@@ -34,7 +34,7 @@ comptime {
 ```rust title="unquote" showLineNumbers 
 pub comptime fn unquote(code: Quoted) -> Quoted {
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/mod.nr#L21-L23" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/mod.nr#L21-L23</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/meta/mod.nr#L21-L23" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/mod.nr#L21-L23</a></sub></sup>
 
 
 Unquotes the passed-in token stream where this function was called.
@@ -55,7 +55,7 @@ comptime {
 #[varargs]
 pub comptime fn derive(s: TypeDefinition, traits: [TraitDefinition]) -> Quoted {
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/mod.nr#L50-L53" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/mod.nr#L50-L53</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/meta/mod.nr#L50-L53" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/mod.nr#L50-L53</a></sub></sup>
 
 
 Attribute placed on type definitions.
@@ -85,7 +85,7 @@ fn main() {
 ```rust title="derive_via_signature" showLineNumbers 
 pub comptime fn derive_via(t: TraitDefinition, f: DeriveFunction) {
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/mod.nr#L70-L72" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/mod.nr#L70-L72</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/meta/mod.nr#L70-L72" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/mod.nr#L70-L72</a></sub></sup>
 
 
 Attribute placed on trait definitions.
@@ -143,7 +143,7 @@ comptime fn derive_eq(s: TypeDefinition) -> Quoted {
     )
 }
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/cmp.nr#L10-L30" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/cmp.nr#L10-L30</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/cmp.nr#L10-L30" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/cmp.nr#L10-L30</a></sub></sup>
 
 
 ### make_trait_impl
@@ -158,7 +158,7 @@ pub comptime fn make_trait_impl<Env1, Env2>(
     body: fn[Env2](Quoted) -> Quoted,
 ) -> Quoted {
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/mod.nr#L89-L98" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/mod.nr#L89-L98</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/meta/mod.nr#L89-L98" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/mod.nr#L89-L98</a></sub></sup>
 
 
 A helper function to more easily create trait impls while deriving traits.
@@ -199,7 +199,7 @@ comptime fn derive_hash(s: TypeDefinition) -> Quoted {
     )
 }
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/hash/mod.nr#L157-L171" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/hash/mod.nr#L157-L171</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/hash/mod.nr#L157-L171" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/hash/mod.nr#L157-L171</a></sub></sup>
 
 
 Example deriving `Ord`:
@@ -221,5 +221,5 @@ comptime fn derive_ord(s: TypeDefinition) -> Quoted {
     crate::meta::make_trait_impl(s, name, signature, for_each_field, quote {}, body)
 }
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/cmp.nr#L223-L239" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/cmp.nr#L223-L239</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/cmp.nr#L223-L239" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/cmp.nr#L223-L239</a></sub></sup>
 

--- a/docs/versioned_docs/version-v1.0.0-beta.19/noir/standard_library/meta/module.md
+++ b/docs/versioned_docs/version-v1.0.0-beta.19/noir/standard_library/meta/module.md
@@ -14,7 +14,7 @@ declarations in the source program.
 ```rust title="add_item" showLineNumbers 
 pub comptime fn add_item(self, item: Quoted) {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/module.nr#L5-L7" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/module.nr#L5-L7</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/meta/module.nr#L5-L7" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/module.nr#L5-L7</a></sub></sup>
 
 
 Adds a top-level item (a function, a struct, a global, etc.) to the module.
@@ -26,7 +26,7 @@ Note that the items are type-checked as if they are inside the module they are b
 ```rust title="child_modules" showLineNumbers 
 pub comptime fn child_modules(self) -> [Module] {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/module.nr#L30-L32" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/module.nr#L30-L32</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/meta/module.nr#L30-L32" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/module.nr#L30-L32</a></sub></sup>
 
 
 Returns all the child modules of the current module.
@@ -51,7 +51,7 @@ fn child_modules_test() {
     }
 }
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/compile_success_empty/comptime_module/src/main.nr#L150-L169" target="_blank" rel="noopener noreferrer">Source code: test_programs/compile_success_empty/comptime_module/src/main.nr#L150-L169</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/test_programs/compile_success_empty/comptime_module/src/main.nr#L150-L169" target="_blank" rel="noopener noreferrer">Source code: test_programs/compile_success_empty/comptime_module/src/main.nr#L150-L169</a></sub></sup>
 
 
 ### functions
@@ -59,7 +59,7 @@ fn child_modules_test() {
 ```rust title="functions" showLineNumbers 
 pub comptime fn functions(self) -> [FunctionDefinition] {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/module.nr#L20-L22" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/module.nr#L20-L22</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/meta/module.nr#L20-L22" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/module.nr#L20-L22</a></sub></sup>
 
 
 Returns each function defined in the module.
@@ -69,7 +69,7 @@ Returns each function defined in the module.
 ```rust title="has_named_attribute" showLineNumbers 
 pub comptime fn has_named_attribute<let N: u32>(self, name: str<N>) -> bool {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/module.nr#L10-L12" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/module.nr#L10-L12</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/meta/module.nr#L10-L12" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/module.nr#L10-L12</a></sub></sup>
 
 
 Returns true if this module has a custom attribute with the given name.
@@ -79,7 +79,7 @@ Returns true if this module has a custom attribute with the given name.
 ```rust title="is_contract" showLineNumbers 
 pub comptime fn is_contract(self) -> bool {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/module.nr#L15-L17" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/module.nr#L15-L17</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/meta/module.nr#L15-L17" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/module.nr#L15-L17</a></sub></sup>
 
 
 `true` if this module is a contract module (was declared via `contract foo { ... }`).
@@ -89,7 +89,7 @@ pub comptime fn is_contract(self) -> bool {}
 ```rust title="name" showLineNumbers 
 pub comptime fn name(self) -> Quoted {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/module.nr#L35-L37" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/module.nr#L35-L37</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/meta/module.nr#L35-L37" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/module.nr#L35-L37</a></sub></sup>
 
 
 Returns the name of the module.
@@ -100,7 +100,7 @@ The top-level module in each crate has no name and is thus empty.
 ```rust title="parent" showLineNumbers 
 pub comptime fn parent(self) -> Option<Module> {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/module.nr#L40-L42" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/module.nr#L40-L42</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/meta/module.nr#L40-L42" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/module.nr#L40-L42</a></sub></sup>
 
 
 Returns the parent module of the given module, if any.
@@ -125,7 +125,7 @@ fn parent_test() {
     }
 }
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/compile_success_empty/comptime_module/src/main.nr#L129-L148" target="_blank" rel="noopener noreferrer">Source code: test_programs/compile_success_empty/comptime_module/src/main.nr#L129-L148</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/test_programs/compile_success_empty/comptime_module/src/main.nr#L129-L148" target="_blank" rel="noopener noreferrer">Source code: test_programs/compile_success_empty/comptime_module/src/main.nr#L129-L148</a></sub></sup>
 
 
 ### structs
@@ -133,7 +133,7 @@ fn parent_test() {
 ```rust title="structs" showLineNumbers 
 pub comptime fn structs(self) -> [TypeDefinition] {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/module.nr#L25-L27" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/module.nr#L25-L27</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/meta/module.nr#L25-L27" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/module.nr#L25-L27</a></sub></sup>
 
 
 Returns each struct defined in the module.

--- a/docs/versioned_docs/version-v1.0.0-beta.19/noir/standard_library/meta/op.md
+++ b/docs/versioned_docs/version-v1.0.0-beta.19/noir/standard_library/meta/op.md
@@ -19,7 +19,7 @@ Represents a unary operator. One of `-`, `!`, `&mut`, or `*`.
 ```rust title="is_minus" showLineNumbers 
 pub fn is_minus(self) -> bool {
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/op.nr#L26-L28" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L26-L28</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/meta/op.nr#L26-L28" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L26-L28</a></sub></sup>
 
 
 Returns `true` if this operator is `-`.
@@ -29,7 +29,7 @@ Returns `true` if this operator is `-`.
 ```rust title="is_not" showLineNumbers 
 pub fn is_not(self) -> bool {
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/op.nr#L32-L34" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L32-L34</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/meta/op.nr#L32-L34" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L32-L34</a></sub></sup>
 
 
 `true` if this operator is `!`
@@ -39,7 +39,7 @@ pub fn is_not(self) -> bool {
 ```rust title="is_mutable_reference" showLineNumbers 
 pub fn is_mutable_reference(self) -> bool {
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/op.nr#L38-L40" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L38-L40</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/meta/op.nr#L38-L40" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L38-L40</a></sub></sup>
 
 
 `true` if this operator is `&mut`
@@ -49,7 +49,7 @@ pub fn is_mutable_reference(self) -> bool {
 ```rust title="is_dereference" showLineNumbers 
 pub fn is_dereference(self) -> bool {
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/op.nr#L44-L46" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L44-L46</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/meta/op.nr#L44-L46" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L44-L46</a></sub></sup>
 
 
 `true` if this operator is `*`
@@ -59,7 +59,7 @@ pub fn is_dereference(self) -> bool {
 ```rust title="unary_quoted" showLineNumbers 
 pub comptime fn quoted(self) -> Quoted {
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/op.nr#L50-L52" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L50-L52</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/meta/op.nr#L50-L52" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L50-L52</a></sub></sup>
 
 
 Returns this operator as a `Quoted` value.
@@ -82,7 +82,7 @@ Represents a binary operator. One of `+`, `-`, `*`, `/`, `%`, `==`, `!=`, `<`, `
 ```rust title="is_add" showLineNumbers 
 pub fn is_add(self) -> bool {
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/op.nr#L88-L90" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L88-L90</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/meta/op.nr#L88-L90" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L88-L90</a></sub></sup>
 
 
 `true` if this operator is `+`
@@ -92,7 +92,7 @@ pub fn is_add(self) -> bool {
 ```rust title="is_subtract" showLineNumbers 
 pub fn is_subtract(self) -> bool {
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/op.nr#L94-L96" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L94-L96</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/meta/op.nr#L94-L96" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L94-L96</a></sub></sup>
 
 
 `true` if this operator is `-`
@@ -102,7 +102,7 @@ pub fn is_subtract(self) -> bool {
 ```rust title="is_multiply" showLineNumbers 
 pub fn is_multiply(self) -> bool {
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/op.nr#L100-L102" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L100-L102</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/meta/op.nr#L100-L102" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L100-L102</a></sub></sup>
 
 
 `true` if this operator is `*`
@@ -112,7 +112,7 @@ pub fn is_multiply(self) -> bool {
 ```rust title="is_divide" showLineNumbers 
 pub fn is_divide(self) -> bool {
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/op.nr#L106-L108" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L106-L108</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/meta/op.nr#L106-L108" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L106-L108</a></sub></sup>
 
 
 `true` if this operator is `/`
@@ -122,7 +122,7 @@ pub fn is_divide(self) -> bool {
 ```rust title="is_modulo" showLineNumbers 
 pub fn is_modulo(self) -> bool {
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/op.nr#L178-L180" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L178-L180</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/meta/op.nr#L178-L180" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L178-L180</a></sub></sup>
 
 
 `true` if this operator is `%`
@@ -132,7 +132,7 @@ pub fn is_modulo(self) -> bool {
 ```rust title="is_equal" showLineNumbers 
 pub fn is_equal(self) -> bool {
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/op.nr#L112-L114" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L112-L114</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/meta/op.nr#L112-L114" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L112-L114</a></sub></sup>
 
 
 `true` if this operator is `==`
@@ -142,7 +142,7 @@ pub fn is_equal(self) -> bool {
 ```rust title="is_not_equal" showLineNumbers 
 pub fn is_not_equal(self) -> bool {
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/op.nr#L118-L120" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L118-L120</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/meta/op.nr#L118-L120" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L118-L120</a></sub></sup>
 
 
 `true` if this operator is `!=`
@@ -152,7 +152,7 @@ pub fn is_not_equal(self) -> bool {
 ```rust title="is_less_than" showLineNumbers 
 pub fn is_less_than(self) -> bool {
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/op.nr#L124-L126" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L124-L126</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/meta/op.nr#L124-L126" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L124-L126</a></sub></sup>
 
 
 `true` if this operator is `<`
@@ -162,7 +162,7 @@ pub fn is_less_than(self) -> bool {
 ```rust title="is_less_than_or_equal" showLineNumbers 
 pub fn is_less_than_or_equal(self) -> bool {
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/op.nr#L130-L132" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L130-L132</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/meta/op.nr#L130-L132" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L130-L132</a></sub></sup>
 
 
 `true` if this operator is `<=`
@@ -172,7 +172,7 @@ pub fn is_less_than_or_equal(self) -> bool {
 ```rust title="is_greater_than" showLineNumbers 
 pub fn is_greater_than(self) -> bool {
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/op.nr#L136-L138" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L136-L138</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/meta/op.nr#L136-L138" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L136-L138</a></sub></sup>
 
 
 `true` if this operator is `>`
@@ -182,7 +182,7 @@ pub fn is_greater_than(self) -> bool {
 ```rust title="is_greater_than_or_equal" showLineNumbers 
 pub fn is_greater_than_or_equal(self) -> bool {
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/op.nr#L142-L144" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L142-L144</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/meta/op.nr#L142-L144" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L142-L144</a></sub></sup>
 
 
 `true` if this operator is `>=`
@@ -192,7 +192,7 @@ pub fn is_greater_than_or_equal(self) -> bool {
 ```rust title="is_and" showLineNumbers 
 pub fn is_and(self) -> bool {
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/op.nr#L148-L150" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L148-L150</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/meta/op.nr#L148-L150" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L148-L150</a></sub></sup>
 
 
 `true` if this operator is `&`
@@ -202,7 +202,7 @@ pub fn is_and(self) -> bool {
 ```rust title="is_or" showLineNumbers 
 pub fn is_or(self) -> bool {
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/op.nr#L154-L156" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L154-L156</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/meta/op.nr#L154-L156" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L154-L156</a></sub></sup>
 
 
 `true` if this operator is `|`
@@ -212,7 +212,7 @@ pub fn is_or(self) -> bool {
 ```rust title="is_shift_right" showLineNumbers 
 pub fn is_shift_right(self) -> bool {
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/op.nr#L166-L168" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L166-L168</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/meta/op.nr#L166-L168" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L166-L168</a></sub></sup>
 
 
 `true` if this operator is `>>`
@@ -222,7 +222,7 @@ pub fn is_shift_right(self) -> bool {
 ```rust title="is_shift_left" showLineNumbers 
 pub fn is_shift_left(self) -> bool {
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/op.nr#L172-L174" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L172-L174</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/meta/op.nr#L172-L174" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L172-L174</a></sub></sup>
 
 
 `true` if this operator is `<<`
@@ -232,7 +232,7 @@ pub fn is_shift_left(self) -> bool {
 ```rust title="binary_quoted" showLineNumbers 
 pub comptime fn quoted(self) -> Quoted {
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/op.nr#L184-L186" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L184-L186</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/meta/op.nr#L184-L186" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L184-L186</a></sub></sup>
 
 
 Returns this operator as a `Quoted` value.

--- a/docs/versioned_docs/version-v1.0.0-beta.19/noir/standard_library/meta/quoted.md
+++ b/docs/versioned_docs/version-v1.0.0-beta.19/noir/standard_library/meta/quoted.md
@@ -13,7 +13,7 @@ quoted token streams and is the result of the `quote { ... }` expression.
 ```rust title="as_expr" showLineNumbers 
 pub comptime fn as_expr(self) -> Option<Expr> {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/quoted.nr#L6-L8" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/quoted.nr#L6-L8</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/meta/quoted.nr#L6-L8" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/quoted.nr#L6-L8</a></sub></sup>
 
 
 Parses the quoted token stream as an expression. Returns `Option::none()` if
@@ -32,7 +32,7 @@ Example:
         }
     }
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/noir_test_success/comptime_expr/src/main.nr#L336-L346" target="_blank" rel="noopener noreferrer">Source code: test_programs/noir_test_success/comptime_expr/src/main.nr#L336-L346</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/test_programs/noir_test_success/comptime_expr/src/main.nr#L336-L346" target="_blank" rel="noopener noreferrer">Source code: test_programs/noir_test_success/comptime_expr/src/main.nr#L336-L346</a></sub></sup>
 
 
 ### as_module
@@ -40,7 +40,7 @@ Example:
 ```rust title="as_module" showLineNumbers 
 pub comptime fn as_module(self) -> Option<Module> {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/quoted.nr#L11-L13" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/quoted.nr#L11-L13</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/meta/quoted.nr#L11-L13" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/quoted.nr#L11-L13</a></sub></sup>
 
 
 Interprets this token stream as a module path leading to the name of a module.
@@ -61,7 +61,7 @@ fn as_module_test() {
     }
 }
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/compile_success_empty/comptime_module/src/main.nr#L115-L127" target="_blank" rel="noopener noreferrer">Source code: test_programs/compile_success_empty/comptime_module/src/main.nr#L115-L127</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/test_programs/compile_success_empty/comptime_module/src/main.nr#L115-L127" target="_blank" rel="noopener noreferrer">Source code: test_programs/compile_success_empty/comptime_module/src/main.nr#L115-L127</a></sub></sup>
 
 
 ### as_trait_constraint
@@ -69,7 +69,7 @@ fn as_module_test() {
 ```rust title="as_trait_constraint" showLineNumbers 
 pub comptime fn as_trait_constraint(self) -> TraitConstraint {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/quoted.nr#L16-L18" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/quoted.nr#L16-L18</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/meta/quoted.nr#L16-L18" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/quoted.nr#L16-L18</a></sub></sup>
 
 
 Interprets this token stream as a trait constraint (without an object type).
@@ -92,7 +92,7 @@ where
     }
 }
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/compile_success_empty/comptime_type/src/main.nr#L160-L173" target="_blank" rel="noopener noreferrer">Source code: test_programs/compile_success_empty/comptime_type/src/main.nr#L160-L173</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/test_programs/compile_success_empty/comptime_type/src/main.nr#L160-L173" target="_blank" rel="noopener noreferrer">Source code: test_programs/compile_success_empty/comptime_type/src/main.nr#L160-L173</a></sub></sup>
 
 
 ### as_type
@@ -100,7 +100,7 @@ where
 ```rust title="as_type" showLineNumbers 
 pub comptime fn as_type(self) -> Type {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/quoted.nr#L21-L23" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/quoted.nr#L21-L23</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/meta/quoted.nr#L21-L23" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/quoted.nr#L21-L23</a></sub></sup>
 
 
 Interprets this token stream as a resolved type. Panics if the token
@@ -120,7 +120,7 @@ where
     }
 }
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/compile_success_empty/comptime_type/src/main.nr#L160-L173" target="_blank" rel="noopener noreferrer">Source code: test_programs/compile_success_empty/comptime_type/src/main.nr#L160-L173</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/test_programs/compile_success_empty/comptime_type/src/main.nr#L160-L173" target="_blank" rel="noopener noreferrer">Source code: test_programs/compile_success_empty/comptime_type/src/main.nr#L160-L173</a></sub></sup>
 
 
 ### tokens
@@ -128,7 +128,7 @@ where
 ```rust title="tokens" showLineNumbers 
 pub comptime fn tokens(self) -> [Quoted] {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/quoted.nr#L26-L28" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/quoted.nr#L26-L28</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/meta/quoted.nr#L26-L28" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/quoted.nr#L26-L28</a></sub></sup>
 
 
 Returns a vector of the individual tokens that form this token stream.

--- a/docs/versioned_docs/version-v1.0.0-beta.19/noir/standard_library/meta/struct_def.md
+++ b/docs/versioned_docs/version-v1.0.0-beta.19/noir/standard_library/meta/struct_def.md
@@ -13,7 +13,7 @@ This type corresponds to `struct Name { field1: Type1, ... }` and `enum Name { V
 ```rust title="add_attribute" showLineNumbers 
 pub comptime fn add_attribute<let N: u32>(self, attribute: str<N>) {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/type_def.nr#L5-L7" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/type_def.nr#L5-L7</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/meta/type_def.nr#L5-L7" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/type_def.nr#L5-L7</a></sub></sup>
 
 
 Adds an attribute to the data type.
@@ -23,7 +23,7 @@ Adds an attribute to the data type.
 ```rust title="add_generic" showLineNumbers 
 pub comptime fn add_generic<let N: u32>(self, generic_name: str<N>) -> Type {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/type_def.nr#L10-L12" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/type_def.nr#L10-L12</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/meta/type_def.nr#L10-L12" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/type_def.nr#L10-L12</a></sub></sup>
 
 
 Adds an generic to the type. Returns the new generic type.
@@ -50,7 +50,7 @@ comptime fn add_generic(s: TypeDefinition) {
         assert(numeric.is_none());
     }
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/compile_success_empty/comptime_struct_definition/src/main.nr#L47-L58" target="_blank" rel="noopener noreferrer">Source code: test_programs/compile_success_empty/comptime_struct_definition/src/main.nr#L47-L58</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/test_programs/compile_success_empty/comptime_struct_definition/src/main.nr#L47-L58" target="_blank" rel="noopener noreferrer">Source code: test_programs/compile_success_empty/comptime_struct_definition/src/main.nr#L47-L58</a></sub></sup>
 
 
 ### as_type
@@ -58,7 +58,7 @@ comptime fn add_generic(s: TypeDefinition) {
 ```rust title="as_type" showLineNumbers 
 pub comptime fn as_type(self) -> Type {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/type_def.nr#L17-L19" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/type_def.nr#L17-L19</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/meta/type_def.nr#L17-L19" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/type_def.nr#L17-L19</a></sub></sup>
 
 
 Returns this type definition as a type in the source program. If this definition has
@@ -69,7 +69,7 @@ any generics, the generics are also included as-is.
 ```rust title="as_type_with_generics" showLineNumbers 
 pub comptime fn as_type_with_generics(self, generics: [Type]) -> Option<Type> {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/type_def.nr#L28-L30" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/type_def.nr#L28-L30</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/meta/type_def.nr#L28-L30" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/type_def.nr#L28-L30</a></sub></sup>
 
 
 Returns a type from this type definition using the given generic arguments. Returns `Option::none()`
@@ -80,7 +80,7 @@ if an incorrect amount of generic arguments are given for this type.
 ```rust title="generics" showLineNumbers 
 pub comptime fn generics(self) -> [(Type, Option<Type>)] {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/type_def.nr#L40-L42" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/type_def.nr#L40-L42</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/meta/type_def.nr#L40-L42" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/type_def.nr#L40-L42</a></sub></sup>
 
 
 Returns each generic on this type definition. Each generic is represented as a tuple containing the type,
@@ -113,7 +113,7 @@ comptime fn example(foo: TypeDefinition) {
 ```rust title="fields" showLineNumbers 
 pub comptime fn fields(self, generic_args: [Type]) -> [(Quoted, Type, Quoted)] {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/type_def.nr#L48-L50" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/type_def.nr#L48-L50</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/meta/type_def.nr#L48-L50" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/type_def.nr#L48-L50</a></sub></sup>
 
 
 Returns (name, type, visibility) tuples of each field in this struct type.
@@ -125,7 +125,7 @@ provided generic arguments.
 ```rust title="fields_as_written" showLineNumbers 
 pub comptime fn fields_as_written(self) -> [(Quoted, Type, Quoted)] {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/type_def.nr#L57-L59" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/type_def.nr#L57-L59</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/meta/type_def.nr#L57-L59" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/type_def.nr#L57-L59</a></sub></sup>
 
 
 Returns (name, type, visibility) tuples of each field in this struct type. Each type is as-is
@@ -138,7 +138,7 @@ function if possible.
 ```rust title="has_named_attribute" showLineNumbers 
 pub comptime fn has_named_attribute<let N: u32>(self, name: str<N>) -> bool {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/type_def.nr#L33-L35" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/type_def.nr#L33-L35</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/meta/type_def.nr#L33-L35" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/type_def.nr#L33-L35</a></sub></sup>
 
 
 Returns true if this type has a custom attribute with the given name.
@@ -148,7 +148,7 @@ Returns true if this type has a custom attribute with the given name.
 ```rust title="module" showLineNumbers 
 pub comptime fn module(self) -> Module {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/type_def.nr#L62-L64" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/type_def.nr#L62-L64</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/meta/type_def.nr#L62-L64" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/type_def.nr#L62-L64</a></sub></sup>
 
 
 Returns the module where the type is defined.
@@ -158,7 +158,7 @@ Returns the module where the type is defined.
 ```rust title="name" showLineNumbers 
 pub comptime fn name(self) -> Quoted {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/type_def.nr#L67-L69" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/type_def.nr#L67-L69</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/meta/type_def.nr#L67-L69" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/type_def.nr#L67-L69</a></sub></sup>
 
 
 Returns the name of this type
@@ -171,7 +171,7 @@ not be the full path to the type definition, nor will it include any generics.
 ```rust title="set_fields" showLineNumbers 
 pub comptime fn set_fields(self, new_fields: [(Quoted, Type, Quoted)]) {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/type_def.nr#L76-L78" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/type_def.nr#L76-L78</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/meta/type_def.nr#L76-L78" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/type_def.nr#L76-L78</a></sub></sup>
 
 
 Sets the fields of this struct to the given fields list where each element

--- a/docs/versioned_docs/version-v1.0.0-beta.19/noir/standard_library/meta/trait_def.md
+++ b/docs/versioned_docs/version-v1.0.0-beta.19/noir/standard_library/meta/trait_def.md
@@ -13,7 +13,7 @@ represents trait definitions such as `trait Foo { .. }` at the top-level of a pr
 ```rust title="as_trait_constraint" showLineNumbers 
 pub comptime fn as_trait_constraint(_self: Self) -> TraitConstraint {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/trait_def.nr#L6-L8" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/trait_def.nr#L6-L8</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/meta/trait_def.nr#L6-L8" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/trait_def.nr#L6-L8</a></sub></sup>
 
 
 Converts this trait into a trait constraint. If there are any generics on this

--- a/docs/versioned_docs/version-v1.0.0-beta.19/noir/standard_library/meta/trait_impl.md
+++ b/docs/versioned_docs/version-v1.0.0-beta.19/noir/standard_library/meta/trait_impl.md
@@ -13,7 +13,7 @@ implementation such as `impl Foo for Bar { ... }`.
 ```rust title="trait_generic_args" showLineNumbers 
 pub comptime fn trait_generic_args(self) -> [Type] {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/trait_impl.nr#L3-L5" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/trait_impl.nr#L3-L5</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/meta/trait_impl.nr#L3-L5" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/trait_impl.nr#L3-L5</a></sub></sup>
 
 
 Returns any generic arguments on the trait of this trait implementation, if any.
@@ -42,7 +42,7 @@ comptime {
 ```rust title="methods" showLineNumbers 
 pub comptime fn methods(self) -> [FunctionDefinition] {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/trait_impl.nr#L8-L10" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/trait_impl.nr#L8-L10</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/meta/trait_impl.nr#L8-L10" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/trait_impl.nr#L8-L10</a></sub></sup>
 
 
 Returns each method in this trait impl.

--- a/docs/versioned_docs/version-v1.0.0-beta.19/noir/standard_library/meta/typ.md
+++ b/docs/versioned_docs/version-v1.0.0-beta.19/noir/standard_library/meta/typ.md
@@ -11,7 +11,7 @@ a type in the source program.
 ```rust title="fresh_type_variable" showLineNumbers 
 pub comptime fn fresh_type_variable() -> Type {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/typ.nr#L57-L59" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/typ.nr#L57-L59</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/meta/typ.nr#L57-L59" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/typ.nr#L57-L59</a></sub></sup>
 
 
 Creates and returns an unbound type variable. This is a special kind of type internal
@@ -47,7 +47,7 @@ where
     U: Serialize<M>,
 {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/compile_success_empty/comptime_type/src/main.nr#L14-L29" target="_blank" rel="noopener noreferrer">Source code: test_programs/compile_success_empty/comptime_type/src/main.nr#L14-L29</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/test_programs/compile_success_empty/comptime_type/src/main.nr#L14-L29" target="_blank" rel="noopener noreferrer">Source code: test_programs/compile_success_empty/comptime_type/src/main.nr#L14-L29</a></sub></sup>
 
 ```rust title="fresh-type-variable-example" showLineNumbers 
 let typevar1 = std::meta::typ::fresh_type_variable();
@@ -70,7 +70,7 @@ let typevar1 = std::meta::typ::fresh_type_variable();
         // Now typevar2 should be bound to the serialized pair size 2 times the array length 5
         assert_eq(typevar2.as_constant().unwrap(), 10);
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/compile_success_empty/comptime_type/src/main.nr#L129-L149" target="_blank" rel="noopener noreferrer">Source code: test_programs/compile_success_empty/comptime_type/src/main.nr#L129-L149</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/test_programs/compile_success_empty/comptime_type/src/main.nr#L129-L149" target="_blank" rel="noopener noreferrer">Source code: test_programs/compile_success_empty/comptime_type/src/main.nr#L129-L149</a></sub></sup>
 
 
 ## Methods
@@ -80,7 +80,7 @@ let typevar1 = std::meta::typ::fresh_type_variable();
 ```rust title="as_array" showLineNumbers 
 pub comptime fn as_array(self) -> Option<(Type, Type)> {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/typ.nr#L76-L78" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/typ.nr#L76-L78</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/meta/typ.nr#L76-L78" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/typ.nr#L76-L78</a></sub></sup>
 
 
 If this type is an array, return a pair of (element type, size type).
@@ -102,7 +102,7 @@ comptime {
 ```rust title="as_constant" showLineNumbers 
 pub comptime fn as_constant(self) -> Option<u32> {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/typ.nr#L83-L85" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/typ.nr#L83-L85</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/meta/typ.nr#L83-L85" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/typ.nr#L83-L85</a></sub></sup>
 
 
 If this type is a constant integer (such as the `3` in the array type `[Field; 3]`),
@@ -113,7 +113,7 @@ return the numeric constant.
 ```rust title="as_integer" showLineNumbers 
 pub comptime fn as_integer(self) -> Option<(bool, u8)> {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/typ.nr#L90-L92" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/typ.nr#L90-L92</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/meta/typ.nr#L90-L92" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/typ.nr#L90-L92</a></sub></sup>
 
 
 If this is an integer type, return a boolean which is `true`
@@ -124,7 +124,7 @@ if the type is signed, as well as the number of bits of this integer type.
 ```rust title="as_mutable_reference" showLineNumbers 
 pub comptime fn as_mutable_reference(self) -> Option<Type> {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/typ.nr#L96-L98" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/typ.nr#L96-L98</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/meta/typ.nr#L96-L98" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/typ.nr#L96-L98</a></sub></sup>
 
 
 If this is a mutable reference type `&mut T`, returns the mutable type `T`.
@@ -134,7 +134,7 @@ If this is a mutable reference type `&mut T`, returns the mutable type `T`.
 ```rust title="as_vector" showLineNumbers 
 pub comptime fn as_vector(self) -> Option<Type> {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/typ.nr#L102-L104" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/typ.nr#L102-L104</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/meta/typ.nr#L102-L104" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/typ.nr#L102-L104</a></sub></sup>
 
 
 If this is a vector type, return the element type of the vector.
@@ -144,7 +144,7 @@ If this is a vector type, return the element type of the vector.
 ```rust title="as_str" showLineNumbers 
 pub comptime fn as_str(self) -> Option<Type> {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/typ.nr#L113-L115" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/typ.nr#L113-L115</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/meta/typ.nr#L113-L115" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/typ.nr#L113-L115</a></sub></sup>
 
 
 If this is a `str<N>` type, returns the length `N` as a type.
@@ -154,7 +154,7 @@ If this is a `str<N>` type, returns the length `N` as a type.
 ```rust title="as_data_type" showLineNumbers 
 pub comptime fn as_data_type(self) -> Option<(TypeDefinition, [Type])> {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/typ.nr#L124-L126" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/typ.nr#L124-L126</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/meta/typ.nr#L124-L126" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/typ.nr#L124-L126</a></sub></sup>
 
 
 If this is a struct type, returns the struct in addition to
@@ -165,7 +165,7 @@ any generic arguments on this type.
 ```rust title="as_tuple" showLineNumbers 
 pub comptime fn as_tuple(self) -> Option<[Type]> {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/typ.nr#L130-L132" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/typ.nr#L130-L132</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/meta/typ.nr#L130-L132" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/typ.nr#L130-L132</a></sub></sup>
 
 
 If this is a tuple type, returns each element type of the tuple.
@@ -175,7 +175,7 @@ If this is a tuple type, returns each element type of the tuple.
 ```rust title="get_trait_impl" showLineNumbers 
 pub comptime fn get_trait_impl(self, constraint: TraitConstraint) -> Option<TraitImpl> {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/typ.nr#L153-L155" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/typ.nr#L153-L155</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/meta/typ.nr#L153-L155" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/typ.nr#L153-L155</a></sub></sup>
 
 
 Retrieves the trait implementation that implements the given
@@ -202,7 +202,7 @@ comptime {
 ```rust title="implements" showLineNumbers 
 pub comptime fn implements(self, constraint: TraitConstraint) -> bool {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/typ.nr#L176-L178" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/typ.nr#L176-L178</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/meta/typ.nr#L176-L178" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/typ.nr#L176-L178</a></sub></sup>
 
 
 `true` if this type implements the given trait. Note that unlike
@@ -229,7 +229,7 @@ fn foo<T>() where T: Default {
 ```rust title="is_bool" showLineNumbers 
 pub comptime fn is_bool(self) -> bool {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/typ.nr#L182-L184" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/typ.nr#L182-L184</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/meta/typ.nr#L182-L184" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/typ.nr#L182-L184</a></sub></sup>
 
 
 `true` if this type is `bool`.
@@ -239,7 +239,7 @@ pub comptime fn is_bool(self) -> bool {}
 ```rust title="is_field" showLineNumbers 
 pub comptime fn is_field(self) -> bool {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/typ.nr#L188-L190" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/typ.nr#L188-L190</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/meta/typ.nr#L188-L190" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/typ.nr#L188-L190</a></sub></sup>
 
 
 `true` if this type is `Field`.
@@ -249,7 +249,7 @@ pub comptime fn is_field(self) -> bool {}
 ```rust title="is_unit" showLineNumbers 
 pub comptime fn is_unit(self) -> bool {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/typ.nr#L194-L196" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/typ.nr#L194-L196</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/meta/typ.nr#L194-L196" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/typ.nr#L194-L196</a></sub></sup>
 
 
 `true` if this type is the unit `()` type.

--- a/docs/versioned_docs/version-v1.0.0-beta.19/noir/standard_library/meta/typed_expr.md
+++ b/docs/versioned_docs/version-v1.0.0-beta.19/noir/standard_library/meta/typed_expr.md
@@ -12,7 +12,7 @@ description: Resolved, type-checked expressions—retrieve types, access referen
 ```rust title="as_function_definition" showLineNumbers 
 pub comptime fn as_function_definition(self) -> Option<FunctionDefinition> {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/typed_expr.nr#L7-L9" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/typed_expr.nr#L7-L9</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/meta/typed_expr.nr#L7-L9" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/typed_expr.nr#L7-L9</a></sub></sup>
 
 
 If this expression refers to a function definitions, returns it. Otherwise returns `Option::none()`.
@@ -22,7 +22,7 @@ If this expression refers to a function definitions, returns it. Otherwise retur
 ```rust title="get_type" showLineNumbers 
 pub comptime fn get_type(self) -> Option<Type> {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/typed_expr.nr#L13-L15" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/typed_expr.nr#L13-L15</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/meta/typed_expr.nr#L13-L15" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/typed_expr.nr#L13-L15</a></sub></sup>
 
 
 Returns the type of the expression, or `Option::none()` if there were errors when the expression was previously resolved.

--- a/docs/versioned_docs/version-v1.0.0-beta.19/noir/standard_library/meta/unresolved_type.md
+++ b/docs/versioned_docs/version-v1.0.0-beta.19/noir/standard_library/meta/unresolved_type.md
@@ -12,7 +12,7 @@ description: Work with the syntactic form of types—inspect references, vectors
 ```rust title="as_mutable_reference" showLineNumbers 
 pub comptime fn as_mutable_reference(self) -> Option<UnresolvedType> {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/unresolved_type.nr#L8-L10" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/unresolved_type.nr#L8-L10</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/meta/unresolved_type.nr#L8-L10" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/unresolved_type.nr#L8-L10</a></sub></sup>
 
 
 If this is a mutable reference type `&mut T`, returns the mutable type `T`.
@@ -22,7 +22,7 @@ If this is a mutable reference type `&mut T`, returns the mutable type `T`.
 ```rust title="as_vector" showLineNumbers 
 pub comptime fn as_vector(self) -> Option<UnresolvedType> {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/unresolved_type.nr#L14-L16" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/unresolved_type.nr#L14-L16</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/meta/unresolved_type.nr#L14-L16" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/unresolved_type.nr#L14-L16</a></sub></sup>
 
 
 If this is a vector `@[T]`, returns the element type `T`.
@@ -32,7 +32,7 @@ If this is a vector `@[T]`, returns the element type `T`.
 ```rust title="is_bool" showLineNumbers 
 pub comptime fn is_bool(self) -> bool {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/unresolved_type.nr#L25-L27" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/unresolved_type.nr#L25-L27</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/meta/unresolved_type.nr#L25-L27" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/unresolved_type.nr#L25-L27</a></sub></sup>
 
 
 Returns `true` if this type is `bool`.
@@ -42,7 +42,7 @@ Returns `true` if this type is `bool`.
 ```rust title="is_field" showLineNumbers 
 pub comptime fn is_field(self) -> bool {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/unresolved_type.nr#L31-L33" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/unresolved_type.nr#L31-L33</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/meta/unresolved_type.nr#L31-L33" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/unresolved_type.nr#L31-L33</a></sub></sup>
 
 
 Returns true if this type refers to the Field type.
@@ -52,7 +52,7 @@ Returns true if this type refers to the Field type.
 ```rust title="is_unit" showLineNumbers 
 pub comptime fn is_unit(self) -> bool {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/unresolved_type.nr#L37-L39" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/unresolved_type.nr#L37-L39</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/meta/unresolved_type.nr#L37-L39" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/unresolved_type.nr#L37-L39</a></sub></sup>
 
 
 Returns true if this type is the unit `()` type.

--- a/docs/versioned_docs/version-v1.0.0-beta.19/noir/standard_library/traits.md
+++ b/docs/versioned_docs/version-v1.0.0-beta.19/noir/standard_library/traits.md
@@ -13,7 +13,7 @@ pub trait Default {
     fn default() -> Self;
 }
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/default.nr#L4-L8" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/default.nr#L4-L8</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/default.nr#L4-L8" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/default.nr#L4-L8</a></sub></sup>
 
 
 Constructs a default value of a type.
@@ -68,7 +68,7 @@ pub trait From<T> {
     fn from(input: T) -> Self;
 }
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/convert.nr#L1-L5" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/convert.nr#L1-L5</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/convert.nr#L1-L5" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/convert.nr#L1-L5</a></sub></sup>
 
 
 The `From` trait defines how to convert from a given type `T` to the type on which the trait is implemented.
@@ -255,7 +255,7 @@ impl From<bool> for Field {
     }
 }
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/convert.nr#L28-L208" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/convert.nr#L28-L208</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/convert.nr#L28-L208" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/convert.nr#L28-L208</a></sub></sup>
 
 
 #### When to implement `From`
@@ -290,7 +290,7 @@ where
     }
 }
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/convert.nr#L13-L26" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/convert.nr#L13-L26</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/convert.nr#L13-L26" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/convert.nr#L13-L26</a></sub></sup>
 
 
 `Into` is most useful when passing function arguments where the types don't quite match up with what the function expects. In this case, the compiler has enough type information to perform the necessary conversion by just appending `.into()` onto the arguments in question.
@@ -306,7 +306,7 @@ pub trait Eq {
     fn eq(self, other: Self) -> bool;
 }
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/cmp.nr#L4-L8" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/cmp.nr#L4-L8</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/cmp.nr#L4-L8" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/cmp.nr#L4-L8</a></sub></sup>
 
 
 Returns `true` if `self` is equal to `other`. Implementing this trait on a type
@@ -355,7 +355,7 @@ pub trait Ord {
     fn cmp(self, other: Self) -> Ordering;
 }
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/cmp.nr#L217-L221" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/cmp.nr#L217-L221</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/cmp.nr#L217-L221" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/cmp.nr#L217-L221</a></sub></sup>
 
 
 `a.cmp(b)` compares two values returning `Ordering::less()` if `a < b`,
@@ -416,28 +416,28 @@ pub trait Add {
     fn add(self, other: Self) -> Self;
 }
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/ops/arith.nr#L3-L7" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/ops/arith.nr#L3-L7</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/ops/arith.nr#L3-L7" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/ops/arith.nr#L3-L7</a></sub></sup>
 
 ```rust title="sub-trait" showLineNumbers 
 pub trait Sub {
     fn sub(self, other: Self) -> Self;
 }
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/ops/arith.nr#L67-L71" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/ops/arith.nr#L67-L71</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/ops/arith.nr#L67-L71" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/ops/arith.nr#L67-L71</a></sub></sup>
 
 ```rust title="mul-trait" showLineNumbers 
 pub trait Mul {
     fn mul(self, other: Self) -> Self;
 }
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/ops/arith.nr#L131-L135" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/ops/arith.nr#L131-L135</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/ops/arith.nr#L131-L135" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/ops/arith.nr#L131-L135</a></sub></sup>
 
 ```rust title="div-trait" showLineNumbers 
 pub trait Div {
     fn div(self, other: Self) -> Self;
 }
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/ops/arith.nr#L195-L199" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/ops/arith.nr#L195-L199</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/ops/arith.nr#L195-L199" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/ops/arith.nr#L195-L199</a></sub></sup>
 
 
 The implementations block below is given for the `Add` trait, but the same types that implement
@@ -465,7 +465,7 @@ pub trait Rem {
     fn rem(self, other: Self) -> Self;
 }
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/ops/arith.nr#L259-L263" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/ops/arith.nr#L259-L263</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/ops/arith.nr#L259-L263" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/ops/arith.nr#L259-L263</a></sub></sup>
 
 
 `Rem::rem(a, b)` is the remainder function returning the result of what is
@@ -494,7 +494,7 @@ pub trait Neg {
     fn neg(self) -> Self;
 }
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/ops/arith.nr#L317-L321" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/ops/arith.nr#L317-L321</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/ops/arith.nr#L317-L321" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/ops/arith.nr#L317-L321</a></sub></sup>
 
 
 `Neg::neg` is equivalent to the unary negation operator `-`.
@@ -528,7 +528,7 @@ impl Neg for i64 {
     }
 }
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/ops/arith.nr#L323-L350" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/ops/arith.nr#L323-L350</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/ops/arith.nr#L323-L350" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/ops/arith.nr#L323-L350</a></sub></sup>
 
 
 ### `std::ops::Not`
@@ -538,7 +538,7 @@ pub trait Not {
     fn not(self: Self) -> Self;
 }
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/ops/bit.nr#L1-L5" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/ops/bit.nr#L1-L5</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/ops/bit.nr#L1-L5" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/ops/bit.nr#L1-L5</a></sub></sup>
 
 
 `Not::not` is equivalent to the unary bitwise NOT operator `!`.
@@ -603,7 +603,7 @@ impl Not for i64 {
     }
 }
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/ops/bit.nr#L7-L65" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/ops/bit.nr#L7-L65</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/ops/bit.nr#L7-L65" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/ops/bit.nr#L7-L65</a></sub></sup>
 
 
 ### `std::ops::{ BitOr, BitAnd, BitXor }`
@@ -613,21 +613,21 @@ pub trait BitOr {
     fn bitor(self, other: Self) -> Self;
 }
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/ops/bit.nr#L67-L71" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/ops/bit.nr#L67-L71</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/ops/bit.nr#L67-L71" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/ops/bit.nr#L67-L71</a></sub></sup>
 
 ```rust title="bitand-trait" showLineNumbers 
 pub trait BitAnd {
     fn bitand(self, other: Self) -> Self;
 }
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/ops/bit.nr#L131-L135" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/ops/bit.nr#L131-L135</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/ops/bit.nr#L131-L135" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/ops/bit.nr#L131-L135</a></sub></sup>
 
 ```rust title="bitxor-trait" showLineNumbers 
 pub trait BitXor {
     fn bitxor(self, other: Self) -> Self;
 }
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/ops/bit.nr#L195-L199" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/ops/bit.nr#L195-L199</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/ops/bit.nr#L195-L199" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/ops/bit.nr#L195-L199</a></sub></sup>
 
 
 Traits for the bitwise operations `|`, `&`, and `^`.
@@ -660,14 +660,14 @@ pub trait Shl {
     fn shl(self, other: Self) -> Self;
 }
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/ops/bit.nr#L259-L263" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/ops/bit.nr#L259-L263</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/ops/bit.nr#L259-L263" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/ops/bit.nr#L259-L263</a></sub></sup>
 
 ```rust title="shr-trait" showLineNumbers 
 pub trait Shr {
     fn shr(self, other: Self) -> Self;
 }
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/ops/bit.nr#L317-L321" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/ops/bit.nr#L317-L321</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/ops/bit.nr#L317-L321" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/ops/bit.nr#L317-L321</a></sub></sup>
 
 
 Traits for a bit shift left and bit shift right.
@@ -702,7 +702,7 @@ pub trait Append {
     fn append(self, other: Self) -> Self;
 }
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/append.nr#L9-L14" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/append.nr#L9-L14</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/noir_stdlib/src/append.nr#L9-L14" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/append.nr#L9-L14</a></sub></sup>
 
 
 `Append` requires two methods:

--- a/docs/versioned_docs/version-v1.0.0-beta.19/tutorials/noirjs_app.md
+++ b/docs/versioned_docs/version-v1.0.0-beta.19/tutorials/noirjs_app.md
@@ -61,7 +61,7 @@ fn main(age: u8) {
     assert(age > 18);
 }
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/examples/browser/src/main.nr#L1-L5" target="_blank" rel="noopener noreferrer">Source code: examples/browser/src/main.nr#L1-L5</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/examples/browser/src/main.nr#L1-L5" target="_blank" rel="noopener noreferrer">Source code: examples/browser/src/main.nr#L1-L5</a></sub></sup>
 
 
 This program accepts a private input called age, and simply proves this number is higher than 18. But to run this code, we need to give the compiler a `Nargo.toml` with at least a name and a type:
@@ -131,7 +131,7 @@ And add something useful to our HTML file:
 </body>
 </html>
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/examples/browser/index.html#L1-L31" target="_blank" rel="noopener noreferrer">Source code: examples/browser/index.html#L1-L31</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/examples/browser/index.html#L1-L31" target="_blank" rel="noopener noreferrer">Source code: examples/browser/index.html#L1-L31</a></sub></sup>
 
 
 It _could_ be a beautiful UI... Depending on which universe you live in. In any case, we're using some scary CSS to make two boxes that will show cool things on the screen.
@@ -189,7 +189,7 @@ import circuit from './target/circuit.json';
 // Initialize WASM modules
 await Promise.all([initACVM(fetch(acvm)), initNoirC(fetch(noirc))]);
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/examples/browser/index.js#L1-L11" target="_blank" rel="noopener noreferrer">Source code: examples/browser/index.js#L1-L11</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/examples/browser/index.js#L1-L11" target="_blank" rel="noopener noreferrer">Source code: examples/browser/index.js#L1-L11</a></sub></sup>
 
 
 And instantiate them inside our try-catch block:
@@ -202,7 +202,7 @@ show('logs', 'Creating Noir...');
     show('logs', 'Creating UltraHonkBackend...');
     const backend = new UltraHonkBackend(circuit.bytecode, barretenbergAPI);
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/examples/browser/index.js#L23-L30" target="_blank" rel="noopener noreferrer">Source code: examples/browser/index.js#L23-L30</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/examples/browser/index.js#L23-L30" target="_blank" rel="noopener noreferrer">Source code: examples/browser/index.js#L23-L30</a></sub></sup>
 
 
 ## Executing and proving
@@ -215,7 +215,7 @@ const age = document.getElementById('age').value;
     const { witness } = await noir.execute({ age });
     show('logs', 'Generated witness... ✅');
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/examples/browser/index.js#L31-L36" target="_blank" rel="noopener noreferrer">Source code: examples/browser/index.js#L31-L36</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/examples/browser/index.js#L31-L36" target="_blank" rel="noopener noreferrer">Source code: examples/browser/index.js#L31-L36</a></sub></sup>
 
 
 :::note
@@ -232,7 +232,7 @@ show('logs', 'Generating proof... ⏳');
     show('logs', 'Generated proof... ✅');
     show('results', proof.proof);
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/examples/browser/index.js#L37-L42" target="_blank" rel="noopener noreferrer">Source code: examples/browser/index.js#L37-L42</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/examples/browser/index.js#L37-L42" target="_blank" rel="noopener noreferrer">Source code: examples/browser/index.js#L37-L42</a></sub></sup>
 
 
 Our program is technically **done** . You're probably eager to see stuff happening! To serve this in a convenient way, we can use a bundler like `vite` by creating a `vite.config.js` file:
@@ -271,7 +271,7 @@ export default defineConfig({
   },
 });
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/examples/browser/vite.config.js#L1-L27" target="_blank" rel="noopener noreferrer">Source code: examples/browser/vite.config.js#L1-L27</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/examples/browser/vite.config.js#L1-L27" target="_blank" rel="noopener noreferrer">Source code: examples/browser/vite.config.js#L1-L27</a></sub></sup>
 
 
 This should be enough for vite. We don't even need to install it, just run:
@@ -297,7 +297,7 @@ show('logs', 'Verifying proof... ⌛');
     const isValid = await backend.verifyProof(proof);
     show('logs', `Proof is ${isValid ? 'valid' : 'invalid'}... ✅`);
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/examples/browser/index.js#L44-L48" target="_blank" rel="noopener noreferrer">Source code: examples/browser/index.js#L44-L48</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.19/examples/browser/index.js#L44-L48" target="_blank" rel="noopener noreferrer">Source code: examples/browser/index.js#L44-L48</a></sub></sup>
 
 
 You have successfully generated a client-side Noir web app!


### PR DESCRIPTION
## Summary

- The v1.0.0-beta.19 versioned docs (added in #11724) were copied from raw `docs/docs/` without running the preprocessor, leaving **261 unresolved `#include_code` macros** across 26 files
- This re-runs the preprocessor against the `v1.0.0-beta.19` tag sources to properly resolve all code snippets into inline code blocks

## Test plan

- [x] Verified `grep -r '#include_code' docs/versioned_docs/version-v1.0.0-beta.19/ | wc -l` returns 0
- [x] Spot-checked `tutorials/noirjs_app.md` — code blocks render correctly with source links
- [ ] Verify docs site builds cleanly with `cd docs && yarn build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)