### PR TITLE
fix(frontend): Always validate macro calls

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/expressions.rs
+++ b/compiler/noirc_frontend/src/elaborator/expressions.rs
@@ -708,8 +708,10 @@ impl Elaborator<'_> {
                 .unwrap_or((HirExpression::Error, Type::Error));
         }
 
-        // Other cases just return the call (ignoring has_errors since we're not calling interpreter)
+        // In comptime context, macro calls are not immediately expanded but still need validation:
+        // the callee must be a comptime function and the return type must be Quoted.
         if is_macro_call && self.in_comptime_context() {
+            self.validate_macro_call(hir_call.func, &typ, location);
             typ = self.interner.next_type_variable();
         }
 
@@ -790,8 +792,10 @@ impl Elaborator<'_> {
                 .unwrap_or((HirExpression::Error, Type::Error));
         }
 
-        // Other cases just return the call (ignoring has_errors since we're not calling interpreter)
+        // In comptime context, macro calls are not immediately expanded but still need validation:
+        // the callee must be a comptime function and the return type must be Quoted.
         if is_macro_call && self.in_comptime_context() {
+            self.validate_macro_call(function_call.func, &typ, location);
             typ = self.interner.next_type_variable();
         }
 
@@ -1723,6 +1727,27 @@ impl Elaborator<'_> {
         }
     }
 
+    /// Validate a macro call without executing it.
+    /// Checks that the callee is a comptime function and the return type is `Quoted`.
+    fn validate_macro_call(
+        &mut self,
+        func: ExprId,
+        return_type: &Type,
+        location: Location,
+    ) -> Option<FuncId> {
+        self.unify(return_type, &Type::Quoted(QuotedType::Quoted), || {
+            TypeCheckError::MacroReturningNonExpr { typ: return_type.clone(), location }
+        });
+
+        match self.try_get_comptime_function(func, location) {
+            Ok(function) => Some(function),
+            Err(error) => {
+                self.push_err(error);
+                None
+            }
+        }
+    }
+
     /// Call a macro function and inlines its code at the call site.
     /// This will also perform a type check to ensure that the return type is an `Expr` value.
     fn call_macro(
@@ -1732,17 +1757,7 @@ impl Elaborator<'_> {
         location: Location,
         return_type: Type,
     ) -> Option<(HirExpression, Type)> {
-        self.unify(&return_type, &Type::Quoted(QuotedType::Quoted), || {
-            TypeCheckError::MacroReturningNonExpr { typ: return_type.clone(), location }
-        });
-
-        let function = match self.try_get_comptime_function(func, location) {
-            Ok(function) => function,
-            Err(error) => {
-                self.push_err(error);
-                return None;
-            }
-        };
+        let function = self.validate_macro_call(func, &return_type, location)?;
 
         let mut interpreter = self.setup_interpreter();
         let mut comptime_args = Vec::new();

--- a/compiler/noirc_frontend/src/tests/metaprogramming.rs
+++ b/compiler/noirc_frontend/src/tests/metaprogramming.rs
@@ -1499,3 +1499,68 @@ fn path_inside_module_attribute() {
     "#;
     assert_no_errors(src);
 }
+
+// Regression: macro-call validation was bypassed inside comptime blocks
+#[test]
+fn non_comptime_macro_call_in_comptime_block() {
+    let src = r#"
+    fn not_comptime() -> Field {
+        7
+    }
+
+    fn main() {
+        let _x: Field = comptime {
+            not_comptime!()
+            ^^^^^^^^^^^^^^^ This macro call is to a non-comptime function
+            ~~~~~~~~~~~~~~~ Macro calls must be to comptime functions
+            ^^^^^^^^^^^^^^^ Expected macro call to return a `Quoted` but found a(n) `Field`
+            ~~~~~~~~~~~~~~~ Macro calls must return quoted values, otherwise there is no code to insert.
+            ~~~~~~~~~~~~~~~ Hint: remove the `!` from the end of the function name.
+        };
+    }
+    "#;
+    check_errors(src);
+}
+
+// Regression: comptime fn returning non-Quoted accepted as macro in comptime block
+#[test]
+fn comptime_fn_returning_non_quoted_macro_call_in_comptime_block() {
+    let src = r#"
+    comptime fn bad_macro() -> Field {
+        42
+    }
+
+    fn main() {
+        let _x: Field = comptime {
+            bad_macro!()
+            ^^^^^^^^^^^^ Expected macro call to return a `Quoted` but found a(n) `Field`
+            ~~~~~~~~~~~~ Macro calls must return quoted values, otherwise there is no code to insert.
+            ~~~~~~~~~~~~ Hint: remove the `!` from the end of the function name.
+        };
+    }
+    "#;
+    check_errors(src);
+}
+
+// Regression: function-value macro call accepted in comptime block
+#[test]
+fn function_value_macro_call_in_comptime_block() {
+    let src = r#"
+    fn not_comptime() -> Field {
+        7
+    }
+
+    fn main() {
+        let _x: Field = comptime {
+            let f = not_comptime;
+            f!()
+            ^^^^ Invalid syntax in macro call
+            ~~~~ Macro calls must call a comptime function directly, they cannot use higher-order functions
+            ^^^^ Expected macro call to return a `Quoted` but found a(n) `Field`
+            ~~~~ Macro calls must return quoted values, otherwise there is no code to insert.
+            ~~~~ Hint: remove the `!` from the end of the function name.
+        };
+    }
+    "#;
+    check_errors(src);
+}


### PR DESCRIPTION
# Description

## Problem

Resolves https://app.audithub.dev/app/organizations/161/projects/599/project-viewer?version=1406&issueId=890

## Summary

In elaborate_call and elaborate_method_call (expressions.rs:712-714, 794-796), the `is_macro_call && self.in_comptime_context()` branch simply assigned a fresh type variable without running any validation, while the non-comptime branch routed through `call_macro` which enforced both checks.

Added a `validate_macro_call` helper method that runs the same two checks as `call_macro` (return type must be `Quoted`, callee must be a comptime function) without actually executing the macro. Both comptime context branches in `elaborate_call` and `elaborate_method_call` now call this validation before assigning the type variable.

Added unit tests to verify we block the logic outlined in the linked issue. 

## Additional Context


## User Documentation

Check one:
- [X] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
