### PR TITLE
fix(frontend): Block private inherent impl methods from leaking across modules

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/path_resolution.rs
+++ b/compiler/noirc_frontend/src/elaborator/path_resolution.rs
@@ -776,16 +776,7 @@ impl Elaborator<'_> {
             module_def_id,
         );
 
-        if !item_in_module_is_visible(
-            self.def_maps,
-            importing_module,
-            current_module_id,
-            visibility,
-        ) {
-            errors.push(PathResolutionError::Private(name.clone()));
-        }
-
-        // For inherent impl methods, also check visibility against the impl's defining module
+        // For inherent impl methods, check visibility against the impl's defining module
         // (source_module), not just the type's module where the method was declared for lookup.
         // This prevents private methods defined in `impl super::S` inside `mod private` from
         // being accessible outside `mod private` via `S::method()`.
@@ -796,16 +787,21 @@ impl Elaborator<'_> {
         {
             let source_module =
                 ModuleId { krate: func_meta.source_crate, local_id: func_meta.source_module };
-            if source_module != current_module_id
-                && !item_in_module_is_visible(
-                    self.def_maps,
-                    importing_module,
-                    source_module,
-                    visibility,
-                )
-            {
+            if !item_in_module_is_visible(
+                self.def_maps,
+                importing_module,
+                source_module,
+                visibility,
+            ) {
                 errors.push(PathResolutionError::Private(name));
             }
+        } else if !item_in_module_is_visible(
+            self.def_maps,
+            importing_module,
+            current_module_id,
+            visibility,
+        ) {
+            errors.push(PathResolutionError::Private(name));
         }
 
         item

--- a/compiler/noirc_frontend/src/hir/resolution/visibility.rs
+++ b/compiler/noirc_frontend/src/hir/resolution/visibility.rs
@@ -192,16 +192,7 @@ pub fn method_call_is_visible(
             }
 
             if let Some(struct_id) = func_meta.type_id {
-                if !struct_member_is_visible(
-                    struct_id,
-                    modifiers.visibility,
-                    current_module,
-                    def_maps,
-                ) {
-                    return false;
-                }
-
-                // For inherent impl methods, also check visibility against the impl's
+                // For inherent impl methods, check visibility against the impl's
                 // defining module (source_module). This prevents private methods defined
                 // in `impl super::S` inside `mod private` from being callable outside
                 // `mod private` via `s.method()`.
@@ -221,7 +212,12 @@ pub fn method_call_is_visible(
                     }
                 }
 
-                return true;
+                return struct_member_is_visible(
+                    struct_id,
+                    modifiers.visibility,
+                    current_module,
+                    def_maps,
+                );
             }
 
             if object_type.is_primitive() {

--- a/compiler/noirc_frontend/src/tests/visibility.rs
+++ b/compiler/noirc_frontend/src/tests/visibility.rs
@@ -891,3 +891,122 @@ fn allows_private_inherent_impl_method_via_dot_from_within_impl_block() {
     "#;
     assert_no_errors(src);
 }
+
+#[test]
+fn errors_once_not_twice_for_private_inherent_impl_method_in_separate_modules() {
+    // Regression test: when the struct and impl are in different modules (neither is the
+    // caller's module), we should only get ONE "private" error, not two.
+    let src = r#"
+    mod types {
+        pub struct S {}
+    }
+
+    mod impls {
+        impl super::types::S {
+            fn secret() -> u32 {
+                42
+            }
+        }
+    }
+
+    fn main() {
+        let _ = types::S::secret();
+                          ^^^^^^ secret is private and not visible from the current module
+                          ~~~~~~ secret is private
+    }
+    "#;
+    check_errors(src);
+}
+
+#[test]
+fn private_inherent_impl_method_accessible_via_dot_notation_from_impl_module() {
+    let src = r#"
+    mod types {
+        pub struct S {
+            pub x: u32,
+        }
+    }
+
+    mod impls {
+        impl super::types::S {
+            fn secret(self) -> u32 {
+                self.x
+            }
+        }
+
+        pub fn caller() -> u32 {
+            let s = super::types::S { x: 1 };
+            s.secret()
+        }
+    }
+
+    fn main() {
+        let _ = impls::caller();
+    }
+    "#;
+    assert_no_errors(src);
+}
+
+#[test]
+fn private_inherent_impl_method_accessible_via_qualified_path_from_impl_module() {
+    let src = r#"
+    mod types {
+        pub struct S {}
+    }
+
+    mod impls {
+        impl super::types::S {
+            fn secret() -> u32 {
+                42
+            }
+        }
+
+        pub fn caller() -> u32 {
+            super::types::S::secret()
+        }
+    }
+
+    fn main() {
+        let _ = impls::caller();
+    }
+    "#;
+    assert_no_errors(src);
+}
+
+#[test]
+fn private_inherent_impl_method_accessible_from_nested_child_of_impl_module() {
+    let src = r#"
+    mod moo {
+        pub struct S {
+            pub x: u32,
+        }
+    }
+
+    mod private {
+        impl crate::moo::S {
+            fn one() -> u32 {
+                1
+            }
+            fn two(self) -> u32 {
+                self.x
+            }
+        }
+
+        mod nested {
+            pub fn foo() -> u32 {
+                let s = crate::moo::S { x: 1 };
+                crate::moo::S::one() + s.two()
+            }
+        }
+
+        pub fn caller() -> u32 {
+            nested::foo()
+        }
+    }
+
+    fn main() {
+        let _ = private::caller();
+    }
+    "#;
+    assert_no_errors(src);
+}


### PR DESCRIPTION
# Description

## Problem

Resolves https://app.audithub.dev/app/organizations/161/projects/599/project-viewer?version=1406&issueId=929

## Summary

When inherent impl methods are declared, they're placed in the type's module (not the impl's module) for discoverability. The visibility check at call sites only verified access against the type's module (which is the caller's own module when the type is defined there) instead of also checking against the impl's defining module.

Changes
- For qualified access (`S::method()`): after the existing visibility check against the type's module, added an additional check against the function's `source_module` (the impl's defining module) for inherent impl methods.
- For dot access (`s.method()`): in `method_call_is_visible`, after confirming struct member visibility, added a check against the function's `source_module` when the impl is defined in a different module than the type.  
- New unit tests 

## Additional Context



## User Documentation

Check one:
- [X] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
