### PR TITLE
chore: use EXIT trap to clean up temporary Nargo.toml in test scripts

### DIFF
--- a/test_programs/format.sh
+++ b/test_programs/format.sh
@@ -37,7 +37,7 @@ done
 }
 
 echo "[workspace]" > Nargo.toml
-trap 'rm -f Nargo.toml' EXIT
+trap 'rm -f "$current_dir/Nargo.toml"' EXIT
 echo "members = [" >> Nargo.toml
 
 collect_dirs compile_success_empty

--- a/test_programs/gates_report_brillig.sh
+++ b/test_programs/gates_report_brillig.sh
@@ -20,7 +20,7 @@ test_dirs=$(ls $base_path)
 # This allows us to generate a gates report using `nargo info` for all of them at once.
 
 echo "[workspace]" > Nargo.toml
-trap 'rm -f Nargo.toml' EXIT
+trap 'rm -f "$current_dir/Nargo.toml"' EXIT
 echo "members = [" >> Nargo.toml
 
 for dir in $test_dirs; do

--- a/test_programs/gates_report_brillig_execution.sh
+++ b/test_programs/gates_report_brillig_execution.sh
@@ -30,7 +30,7 @@ test_dirs=$(ls $base_path)
 # This allows us to generate a gates report using `nargo info` for all of them at once.
 
 echo "[workspace]" > Nargo.toml
-trap 'rm -f Nargo.toml' EXIT
+trap 'rm -f "$current_dir/Nargo.toml"' EXIT
 echo "members = [" >> Nargo.toml
 
 for dir in $test_dirs; do


### PR DESCRIPTION
## Summary

- Several scripts in `test_programs/` create a temporary `Nargo.toml` workspace file, run a command, then delete it. If the script crashes or the command fails, the `rm` at the end never runs and the file is left behind — this caused issues like Jake experienced.
- Replaced the manual `rm Nargo.toml` at the end of each script with a `trap 'rm -f "$current_dir/Nargo.toml"' EXIT` immediately after the file is created. The trap fires on any exit (success, error, or signal), ensuring cleanup always happens.

**Affected scripts:** `format.sh`, `gates_report_brillig.sh`, `gates_report_brillig_execution.sh`

## Test plan

- [ ] Verify scripts still clean up `Nargo.toml` on successful runs
- [ ] Verify `Nargo.toml` is cleaned up when a script fails mid-execution