### PR TITLE
chore(brillig): Add bit size check for `U1` in `MemoryValue::new_integer`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -881,6 +881,7 @@ dependencies = [
  "proptest",
  "proptest-derive",
  "serde",
+ "test-case",
  "thiserror 2.0.18",
 ]
 

--- a/acvm-repo/brillig_vm/Cargo.toml
+++ b/acvm-repo/brillig_vm/Cargo.toml
@@ -26,6 +26,7 @@ thiserror.workspace = true
 serde.workspace = true
 proptest.workspace = true
 proptest-derive.workspace = true
+test-case.workspace = true
 
 [features]
 bn254 = ["acir/bn254"]

--- a/acvm-repo/brillig_vm/src/memory.rs
+++ b/acvm-repo/brillig_vm/src/memory.rs
@@ -109,7 +109,11 @@ impl<F: std::fmt::Display> MemoryValue<F> {
     /// Builds an integer-typed memory value.
     pub fn new_integer(value: u128, bit_size: IntegerBitSize) -> Self {
         match bit_size {
-            IntegerBitSize::U1 => MemoryValue::U1(value != 0),
+            IntegerBitSize::U1 => MemoryValue::U1(match value {
+                0 => false,
+                1 => true,
+                _ => panic!("{value} is out of 1 bit range"),
+            }),
             IntegerBitSize::U8 => {
                 MemoryValue::U8(value.try_into().expect("{value} is out of 8 bits range"))
             }
@@ -490,6 +494,7 @@ impl<F: AcirField> Memory<F> {
 mod tests {
     use super::*;
     use acir::FieldElement;
+    use test_case::test_case;
 
     #[test]
     fn direct_write_and_read() {
@@ -632,5 +637,15 @@ mod tests {
         let mut memory = Memory::<FieldElement>::default();
         // Attempting to resize beyond i32::MAX should panic
         memory.resize_to_fit(Memory::<FieldElement>::MAX_MEMORY_SIZE + 1);
+    }
+
+    #[test_case(IntegerBitSize::U1, 2)]
+    #[test_case(IntegerBitSize::U8, 256)]
+    #[test_case(IntegerBitSize::U16, u128::from(u16::MAX) + 1)]
+    #[test_case(IntegerBitSize::U32, u128::from(u32::MAX) + 1)]
+    #[test_case(IntegerBitSize::U64, u128::from(u64::MAX) + 1)]
+    #[should_panic(expected = "range")]
+    fn memory_value_new_integer_out_of_range(bit_size: IntegerBitSize, value: u128) {
+        let _ = MemoryValue::<FieldElement>::new_integer(value, bit_size);
     }
 }


### PR DESCRIPTION
# Description

## Problem

Resolves https://cantina.xyz/code/24c6f940-d8af-4a25-9b28-b2e42dea31fe/findings/2

## Summary

Adds bit range check for `U1` in `MemoryValue::new_integer` to match the other types. Now only 0 and 1 are valid values.

## Additional Context



## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
