### PR TITLE
chore(test): Lower string length in fuzz test

### DIFF
--- a/test_programs/fuzzing_failure/string/src/main.nr
+++ b/test_programs/fuzzing_failure/string/src/main.nr
@@ -1,10 +1,10 @@
-// This program will fail when the input is "i_hate_rust"
+// This program will fail when the input is "i_hate_ice"
 #[fuzz]
-fn strings(a: str<11>) {
-    let start = "i_love_rust".as_bytes();
-    let mut password_bytes: [u8; 11] = [0; 11];
+fn strings(a: str<10>) {
+    let start = "i_love_ice".as_bytes();
+    let mut password_bytes: [u8; 10] = [0; 10];
     let begin = 2; // Where "lov" starts, to be replaced with "hat".
-    for i in 0..11 {
+    for i in 0..10 {
         if i < begin {
             password_bytes[i] = start[i];
         }
@@ -15,7 +15,7 @@ fn strings(a: str<11>) {
             password_bytes[i] = 97; // a
         }
         if i == begin + 2 {
-            password_bytes[i] = 116; // t
+            password_bytes[i] = 106; // t
         }
         if i > begin + 2 {
             password_bytes[i] = start[i];


### PR DESCRIPTION
# Description

## Problem

I occasionally have to re-run test because the `fuzzing_failure/test_strings` test couldn't find a counter example before timing out after 4 minutes, for example in https://github.com/noir-lang/noir/actions/runs/23048211989/job/66943955025?pr=11856

## Summary

Reduces the length of the string the fuzzer needs to find from 14 to ~11~ 10 characters.

## Additional Context

Run it with:
```
cargo nextest run -p nargo_cli --test execute fuzzing_failure::test_string
```

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
