### PR TITLE
chore!: remove deprecated `StructDefinition`

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/path_resolution.rs
+++ b/compiler/noirc_frontend/src/elaborator/path_resolution.rs
@@ -931,12 +931,6 @@ impl Elaborator<'_> {
         let typ = primitive_type.to_type();
         let mut errors = Vec::new();
 
-        if primitive_type == PrimitiveType::StructDefinition {
-            errors.push(PathResolutionError::StructDefinitionDeprecated {
-                location: path.segments[0].ident.location(),
-            });
-        }
-
         if path.segments.len() == 1 {
             let item = PathResolutionItem::PrimitiveType(primitive_type);
             return Some(Ok(PathResolution { item, errors }));

--- a/compiler/noirc_frontend/src/elaborator/primitive_types.rs
+++ b/compiler/noirc_frontend/src/elaborator/primitive_types.rs
@@ -38,7 +38,6 @@ pub enum PrimitiveType {
     Module,
     Quoted,
     Str,
-    StructDefinition,
     TraitConstraint,
     TraitDefinition,
     TraitImpl,
@@ -70,7 +69,6 @@ impl PrimitiveType {
             "Module" => Some(Self::Module),
             "Quoted" => Some(Self::Quoted),
             "str" => Some(Self::Str),
-            "StructDefinition" => Some(Self::StructDefinition),
             "TraitConstraint" => Some(Self::TraitConstraint),
             "TraitDefinition" => Some(Self::TraitDefinition),
             "TraitImpl" => Some(Self::TraitImpl),
@@ -106,9 +104,7 @@ impl PrimitiveType {
             Self::TraitConstraint => Type::Quoted(QuotedType::TraitConstraint),
             Self::TraitDefinition => Type::Quoted(QuotedType::TraitDefinition),
             Self::TraitImpl => Type::Quoted(QuotedType::TraitImpl),
-            Self::StructDefinition | Self::TypeDefinition => {
-                Type::Quoted(QuotedType::TypeDefinition)
-            }
+            Self::TypeDefinition => Type::Quoted(QuotedType::TypeDefinition),
             Self::TypedExpr => Type::Quoted(QuotedType::TypedExpr),
             Self::Type => Type::Quoted(QuotedType::Type),
             Self::UnresolvedType => Type::Quoted(QuotedType::UnresolvedType),
@@ -138,7 +134,6 @@ impl PrimitiveType {
             | Self::Module
             | Self::Quoted
             | Self::Str
-            | Self::StructDefinition
             | Self::TraitConstraint
             | Self::TraitDefinition
             | Self::TraitImpl
@@ -170,7 +165,6 @@ impl PrimitiveType {
             Self::Module => "Module",
             Self::Quoted => "Quoted",
             Self::Str => "str",
-            Self::StructDefinition => "StructDefinition",
             Self::TraitConstraint => "TraitConstraint",
             Self::TraitDefinition => "TraitDefinition",
             Self::TraitImpl => "TraitImpl",
@@ -208,7 +202,6 @@ impl Elaborator<'_> {
             | PrimitiveType::U128
             | PrimitiveType::Module
             | PrimitiveType::Quoted
-            | PrimitiveType::StructDefinition
             | PrimitiveType::TraitConstraint
             | PrimitiveType::TraitDefinition
             | PrimitiveType::TraitImpl
@@ -290,7 +283,6 @@ impl Elaborator<'_> {
             | PrimitiveType::U128
             | PrimitiveType::Module
             | PrimitiveType::Quoted
-            | PrimitiveType::StructDefinition
             | PrimitiveType::TraitConstraint
             | PrimitiveType::TraitDefinition
             | PrimitiveType::TraitImpl

--- a/compiler/noirc_frontend/src/hir/resolution/import.rs
+++ b/compiler/noirc_frontend/src/hir/resolution/import.rs
@@ -60,16 +60,13 @@ pub enum PathResolutionError {
     UnresolvedWithPossibleTraitsToImport { ident: Ident, traits: Vec<String> },
     #[error("Multiple applicable items in scope")]
     MultipleTraitsInScope { ident: Ident, traits: Vec<String> },
-    #[error("`StructDefinition` is deprecated. It has been renamed to `TypeDefinition`")]
-    StructDefinitionDeprecated { location: Location },
 }
 
 impl PathResolutionError {
     pub fn location(&self) -> Location {
         match self {
             PathResolutionError::NoSuper(location)
-            | PathResolutionError::TurbofishNotAllowedOnItem { location, .. }
-            | PathResolutionError::StructDefinitionDeprecated { location } => *location,
+            | PathResolutionError::TurbofishNotAllowedOnItem { location, .. } => *location,
             PathResolutionError::Unresolved(ident)
             | PathResolutionError::Private(ident)
             | PathResolutionError::NotAModule { ident, .. }
@@ -141,14 +138,6 @@ impl<'a> From<&'a PathResolutionError> for CustomDiagnostic {
                         traits.join(", ")
                     ),
                     ident.location(),
-                )
-            }
-            PathResolutionError::StructDefinitionDeprecated { location } => {
-                CustomDiagnostic::simple_warning(
-                    "`StructDefinition` is deprecated. It has been renamed to `TypeDefinition`"
-                        .to_string(),
-                    String::new(),
-                    *location,
                 )
             }
         }

--- a/tooling/nargo_doc/src/lib.rs
+++ b/tooling/nargo_doc/src/lib.rs
@@ -921,9 +921,6 @@ pub(crate) fn convert_primitive_type(
             PrimitiveTypeKind::FunctionDefinition
         }
         noirc_frontend::elaborator::PrimitiveType::Module => PrimitiveTypeKind::Module,
-        noirc_frontend::elaborator::PrimitiveType::StructDefinition => {
-            PrimitiveTypeKind::TypeDefinition
-        }
         noirc_frontend::elaborator::PrimitiveType::TraitDefinition => {
             PrimitiveTypeKind::TraitDefinition
         }


### PR DESCRIPTION
# Description

## Problem

No issue.

## Summary

`StructDefinition` has been renamed to `TypeDefinition` a long time ago so maybe it can be safely removed now.

## Additional Context



## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
