### PR TITLE
fix(ssa): Make `get_bit_size_from_ssa_type` match `ssa_type_to_parameter` for `Function`

### DIFF
--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_fn.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_fn.rs
@@ -156,7 +156,7 @@ impl FunctionContext {
     /// Panics if called with a vector type, as a vector's memory layout cannot be inferred without runtime data.
     pub(crate) fn ssa_type_to_parameter(typ: &Type) -> BrilligParameter {
         match typ {
-            Type::Numeric(_) | Type::Reference(_) => {
+            Type::Numeric(_) | Type::Reference(_) | Type::Function => {
                 BrilligParameter::SingleAddr(get_bit_size_from_ssa_type(typ))
             }
             Type::Array(item_type, size) => BrilligParameter::Array(
@@ -165,10 +165,6 @@ impl FunctionContext {
             ),
             Type::Vector(_) => {
                 panic!("ICE: Vector parameters cannot be derived from type information")
-            }
-            // Treat functions as field values
-            Type::Function => {
-                BrilligParameter::SingleAddr(get_bit_size_from_ssa_type(&Type::field()))
             }
         }
     }

--- a/compiler/noirc_evaluator/src/brillig/brillig_ir/brillig_variable.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_ir/brillig_variable.rs
@@ -184,8 +184,9 @@ pub(crate) fn get_bit_size_from_ssa_type(typ: &Type) -> u32 {
         Type::Reference(_) => BRILLIG_MEMORY_ADDRESSING_BIT_SIZE,
         // NB. function references are converted to a constant when
         // translating from SSA to Brillig (to allow for debugger
-        // instrumentation to work properly)
-        Type::Function => 32,
+        // instrumentation to work properly).
+        // They are passed to foreign functions as a Field, carrying their ID.
+        Type::Function => Type::field().bit_size(),
         typ => typ.bit_size(),
     }
 }


### PR DESCRIPTION

# Description

## Problem

Resolves https://cantina.xyz/code/24c6f940-d8af-4a25-9b28-b2e42dea31fe/findings/1

## Summary

`ssa_type_to_parameter` used the bit size of `Field` while `get_bit_size_from_ssa_type` used 32 for `Type::Function`. 

## Additional Context

The latter function is used directly in Brillig gen, but I think due to the `defunctionalize` pass we shouldn't see `Function` types at that point. We do pass functions as `Field` to foreign calls, though, so I went with that.


## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
