### PR TITLE
chore: add CI check for include_code in versioned_docs

### DIFF
--- a/.github/workflows/docs-pr.yml
+++ b/.github/workflows/docs-pr.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Check for unprocessed include_code directives in versioned docs
         run: |
           if grep -r 'include_code' docs/versioned_docs/; then
-            echo "::error::Found include_code directives in versioned_docs. Run the preprocessing step before committing versioned docs."
+            echo "::error::Found include_code directives in versioned_docs. See docs/README.md#cutting-a-new-version for how to correctly cut a versioned docs snapshot."
             exit 1
           fi
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -188,21 +188,13 @@ We aim to have every documentation version matching the versions of Noir. Howeve
 
 Please contact any member of the DevRel[^1] team if you believe a new docs version should be cut.
 
-### Cutting a new version of the docs
+### Documentation structure
 
-The Noir documentation is versioned according to the [Docusaurus documentation](https://docusaurus.io/docs/versioning). In the `versioned_docs` and `versioned_sidebar` folders you will find the docs and configs for the previous versions. If any change needs to be made to older versions, please do them in this folder.
+The Noir documentation is versioned according to the [Docusaurus documentation](https://docusaurus.io/docs/versioning). In the `versioned_docs` and `versioned_sidebars` folders you will find the docs and configs for the previous versions. If any change needs to be made to older versions, please do them in those folders.
 
 In the docs folder, you'll find the current, unreleased version, which we call `dev`. Any change in this folder will be reflected in the next release of the documentation.
 
-While the versioning is intended to be managed by the core maintainers, we feel it's important for external contributors to understand why and how is it maintained. To bump to a new version, run the following command, replacing with the intended version:
-
-```bash
-yarn docusaurus docs:version <new_version_tag>
-```
-
-This should create a new version by copying the docs folder and the sidebars.js file to the relevant folders, as well as adding this version to versions.json.
-
-You can then open a Pull Request according to the [PR section](#pull-requests)
+New versions are cut automatically by the release workflow. See [`docs/README.md`](docs/README.md#cutting-a-new-version) for details.
 
 ## Changelog
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -87,6 +87,35 @@ yarn production:serve
 ```
 Access at: `http://localhost:3000/docs/`
 
+## Cutting a New Version
+
+When a new Noir version is released, a versioned snapshot of the docs needs to be created. This is
+normally done automatically by the release workflow (`.github/workflows/release.yml`), but can also
+be done manually.
+
+From the _docs_ directory, run:
+
+```sh
+yarn cut_version <VERSION>
+```
+
+For example: `yarn cut_version v1.0.0-beta.20`
+
+This script does three things:
+
+1. Removes the new version from `versions.json` (since `yarn version::stables` will have added it
+   from the GitHub release, but the versioned docs snapshot doesn't exist yet).
+2. Builds the docs (running preprocessing to resolve `#include_code` directives and generate the
+   Nargo CLI reference).
+3. Runs `yarn docusaurus docs:version <VERSION>` to snapshot the current docs into
+   `versioned_docs/version-<VERSION>/` and create a matching sidebar in `versioned_sidebars/`.
+
+After this, the new version will appear in the version dropdown on the site.
+
+> **Important**: The `#include_code` directives must be resolved _before_ the snapshot is taken.
+> The `versioned_docs/` directory should never contain raw `#include_code` directives — CI will
+> reject PRs that introduce them.
+
 ## Quick Commands Reference
 
 All commands should be run from the `docs` directory:
@@ -98,4 +127,5 @@ All commands should be run from the `docs` directory:
 | `yarn build` | Build production site |
 | `yarn serve` | Serve built site locally |
 | `yarn version::stables` | Update stable versions list |
+| `yarn cut_version <VERSION>` | Cut a new versioned docs snapshot |
 | `yarn clean` | Clean build artifacts |


### PR DESCRIPTION
## Summary
- Adds a `check_no_include_code` job to the docs PR workflow that fails if any `include_code` directives are found in `docs/versioned_docs/`.
- Prevents the case where someone copies the docs folder without running the preprocessing step first.

## Test plan
- [x] Verify the new CI job passes on PRs that don't touch versioned_docs
- [x] Verify it would fail if an `include_code` directive were present in versioned_docs