### PR TITLE
fix(brillig): Protect against memory address overflows

### DIFF
--- a/acvm-repo/brillig/src/opcodes.rs
+++ b/acvm-repo/brillig/src/opcodes.rs
@@ -653,8 +653,6 @@ impl std::fmt::Display for BinaryIntOp {
 
 #[cfg(test)]
 mod tests {
-    use std::u32;
-
     use crate::MemoryAddress;
 
     use super::{BitSize, IntegerBitSize};

--- a/acvm-repo/brillig_vm/src/memory.rs
+++ b/acvm-repo/brillig_vm/src/memory.rs
@@ -494,8 +494,6 @@ impl<F: AcirField> Memory<F> {
 
 #[cfg(test)]
 mod tests {
-    use std::u32;
-
     use super::*;
     use acir::FieldElement;
     use test_case::test_case;


### PR DESCRIPTION
# Description

## Problem

Resolves https://cantina.xyz/code/24c6f940-d8af-4a25-9b28-b2e42dea31fe/findings/6

## Summary

Use `checked_add` when offsetting memory addresses.

## Additional Context



## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
