### PR TITLE
chore: expose GITHUB_TOKEN to yarn version::stables script

### DIFF
--- a/.github/workflows/docs-pr.yml
+++ b/.github/workflows/docs-pr.yml
@@ -98,7 +98,6 @@ jobs:
         run: yarn version::stables
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NODE_DEBUG: http,https
 
       - name: Build docs
         working-directory: docs

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -34,7 +34,6 @@ jobs:
         run: yarn version::stables
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NODE_DEBUG: http,https
 
       - name: Build docs for deploying
         working-directory: docs


### PR DESCRIPTION
# Description

## Problem

CI sometimes fails when deploying the docs preview.

## Summary

For example:

https://github.com/noir-lang/noir/actions/runs/23060102890/job/66984081813

I'm not exactly sure what `yarn version::stables` end up running, but I think it might be this:

https://github.com/noir-lang/noir/blob/f60c8efa29e74dc730dd58678f492977b3091631/docs/package.json#L11

Inside that script we try to authenticate requests using a GITHUB_TOKEN env var:

https://github.com/noir-lang/noir/blob/f60c8efa29e74dc730dd58678f492977b3091631/docs/scripts/setStable.ts#L38

However, the env var was never set when invoking `yarn version::stables`.

With authenticated requests we get 5000 requests per hour instead of 60.

Because I'm not entirely sure I'm fixing it the right way, there's one extra commit so I can inspect the logs. Then I'll revert that second commit.

## Additional Context



## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
