### PR TITLE
fix(acir): Just refer to `pop` in error message when the vector is empty

### DIFF
--- a/compiler/noirc_evaluator/src/acir/call/intrinsics/vector_ops.rs
+++ b/compiler/noirc_evaluator/src/acir/call/intrinsics/vector_ops.rs
@@ -322,7 +322,7 @@ impl Context<'_> {
             // This is different from the previous check as this is a runtime check.
             let zero = self.acir_context.add_constant(FieldElement::zero());
             let assert_message = self.acir_context.generate_assertion_message_payload(
-                "Attempt to pop_front from an empty vector".to_string(),
+                "Attempt to pop from an empty vector".to_string(),
             );
             self.acir_context.assert_neq_var(
                 vector_length_var,

--- a/tooling/nargo_cli/tests/snapshots/execution_failure/conditional_pop_back_from_empty_vector/execute__tests__acir_stderr.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_failure/conditional_pop_back_from_empty_vector/execute__tests__acir_stderr.snap
@@ -2,7 +2,7 @@
 source: tooling/nargo_cli/tests/execute.rs
 expression: stderr
 ---
-error: Assertion failed: Attempt to pop_front from an empty vector
+error: Assertion failed: Attempt to pop from an empty vector
    ┌─ src/main.nr:11:20
    │
 11 │     let (_, ret) = s.pop_back();

--- a/tooling/nargo_cli/tests/snapshots/execution_failure/conditional_pop_front_from_empty_vector/execute__tests__acir_stderr.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_failure/conditional_pop_front_from_empty_vector/execute__tests__acir_stderr.snap
@@ -2,7 +2,7 @@
 source: tooling/nargo_cli/tests/execute.rs
 expression: stderr
 ---
-error: Assertion failed: Attempt to pop_front from an empty vector
+error: Assertion failed: Attempt to pop from an empty vector
    ┌─ src/main.nr:11:20
    │
 11 │     let (ret, _) = s.pop_front();


### PR DESCRIPTION
# Description

## Problem

Resolves https://cantina.xyz/code/24c6f940-d8af-4a25-9b28-b2e42dea31fe/findings/20

## Summary

Instead of `pop_front` and `pop_back` just say `pop`. The check on constant 0 length does the same already.

## Additional Context



## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
