### PR TITLE
fix(brillig): Mark `ConditionalMov::destination` as `write` in `brillig_check`

### DIFF
--- a/compiler/noirc_evaluator/src/brillig/brillig_check.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_check.rs
@@ -494,10 +494,11 @@ trait OpcodeAddressVisitor {
                     self.write_value_or_array(destination, location);
                 }
             }
-            Opcode::ConditionalMov { source_a, source_b, condition, .. } => {
+            Opcode::ConditionalMov { source_a, source_b, condition, destination } => {
                 self.read(condition, location);
                 self.read(source_a, location);
                 self.read(source_b, location);
+                self.write(destination, location);
             }
             Opcode::BlackBox(black_box_op) => self.visit_black_box_op(black_box_op, location),
             Opcode::Trap { revert_data } => self.read_heap_vector(revert_data, location),


### PR DESCRIPTION
# Description

## Problem

Resolves https://cantina.xyz/code/24c6f940-d8af-4a25-9b28-b2e42dea31fe/findings/13

## Summary

Fixes `OpcodeAddressVisitor::visit_opcode` to call `write` with `ConditionalMov::destination`.

## Additional Context

I think this was a remnant from when it was only tracking reads.


## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
