### PR TITLE
fix: Error on overflow for type-level integer arithmetic

### DIFF
--- a/compiler/noirc_frontend/src/hir/type_check/errors.rs
+++ b/compiler/noirc_frontend/src/hir/type_check/errors.rs
@@ -65,6 +65,8 @@ pub enum TypeCheckError {
     },
     #[error("Evaluating `{op}` on `{lhs}`, `{rhs}` failed")]
     FailingBinaryOp { op: BinaryTypeOperator, lhs: String, rhs: String, location: Location },
+    #[error("The value `{value}` does not fit in {target}")]
+    ConstantOverflow { value: SignedField, target: &'static str, location: Location },
     #[error("Type {typ:?} cannot be used in a {place:?}")]
     TypeCannotBeUsed { typ: Type, place: &'static str, location: Location },
     #[error("Expected type {expected_typ:?} is not the same as {expr_typ:?}")]
@@ -308,6 +310,7 @@ impl TypeCheckError {
             | TypeCheckError::OverflowingConstant { location, .. }
             | TypeCheckError::UnderflowingConstant { location, .. }
             | TypeCheckError::FailingBinaryOp { location, .. }
+            | TypeCheckError::ConstantOverflow { location, .. }
             | TypeCheckError::TypeCannotBeUsed { location, .. }
             | TypeCheckError::TypeMismatch { expr_location: location, .. }
             | TypeCheckError::TypeMismatchWithSource { location, .. }
@@ -561,6 +564,7 @@ impl<'a> From<&'a TypeCheckError> for Diagnostic {
             | TypeCheckError::OverflowingConstant { location, .. }
             | TypeCheckError::UnderflowingConstant { location, .. }
             | TypeCheckError::FailingBinaryOp { location, .. }
+            | TypeCheckError::ConstantOverflow { location, .. }
             | TypeCheckError::FieldModulo { location }
             | TypeCheckError::FieldNot { location }
             | TypeCheckError::ConstrainedReferenceToUnconstrained { location }

--- a/compiler/noirc_frontend/src/hir_def/types.rs
+++ b/compiler/noirc_frontend/src/hir_def/types.rs
@@ -3344,41 +3344,55 @@ impl BinaryTypeOperator {
             Some(maximum_size) => {
                 if maximum_size.to_u128() == u128::MAX {
                     // For u128 operations we need to use u128
-                    let a = a.to_u128();
-                    let b = b.to_u128();
+                    let overflow_err = |value| TypeCheckError::ConstantOverflow {
+                        value,
+                        target: "u128",
+                        location,
+                    };
+                    let a_val = a.try_to_unsigned::<u128>().ok_or_else(|| overflow_err(a))?;
+                    let b_val = b.try_to_unsigned::<u128>().ok_or_else(|| overflow_err(b))?;
 
                     let err = TypeCheckError::FailingBinaryOp {
                         op: self,
-                        lhs: a.to_string(),
-                        rhs: b.to_string(),
+                        lhs: a_val.to_string(),
+                        rhs: b_val.to_string(),
                         location,
                     };
                     let result = match self {
-                        BinaryTypeOperator::Addition => a.checked_add(b).ok_or(err)?,
-                        BinaryTypeOperator::Subtraction => a.checked_sub(b).ok_or(err)?,
-                        BinaryTypeOperator::Multiplication => a.checked_mul(b).ok_or(err)?,
-                        BinaryTypeOperator::Division => a.checked_div(b).ok_or(err)?,
-                        BinaryTypeOperator::Modulo => a.checked_rem(b).ok_or(err)?,
+                        BinaryTypeOperator::Addition => a_val.checked_add(b_val).ok_or(err)?,
+                        BinaryTypeOperator::Subtraction => a_val.checked_sub(b_val).ok_or(err)?,
+                        BinaryTypeOperator::Multiplication => {
+                            a_val.checked_mul(b_val).ok_or(err)?
+                        }
+                        BinaryTypeOperator::Division => a_val.checked_div(b_val).ok_or(err)?,
+                        BinaryTypeOperator::Modulo => a_val.checked_rem(b_val).ok_or(err)?,
                     };
 
                     Ok(result.into())
                 } else {
                     // Every other type first in i128, allowing both positive and negative values
-                    let a = a.to_i128();
-                    let b = b.to_i128();
+                    let overflow_err = |value| TypeCheckError::ConstantOverflow {
+                        value,
+                        target: "i128",
+                        location,
+                    };
+                    let a_val = a.try_to_signed::<i128>().ok_or_else(|| overflow_err(a))?;
+                    let b_val = b.try_to_signed::<i128>().ok_or_else(|| overflow_err(b))?;
 
                     let err = TypeCheckError::FailingBinaryOp {
                         op: self,
-                        lhs: a.to_string(),
-                        rhs: b.to_string(),
+                        lhs: a_val.to_string(),
+                        rhs: b_val.to_string(),
                         location,
                     };
                     let result = match self {
-                        BinaryTypeOperator::Addition => a.checked_add(b).ok_or(err)?,
-                        BinaryTypeOperator::Subtraction => a.checked_sub(b).ok_or(err)?,
-                        BinaryTypeOperator::Multiplication => a.checked_mul(b).ok_or(err)?,
-                        BinaryTypeOperator::Division => a.checked_div(b).ok_or(err)?,
-                        BinaryTypeOperator::Modulo => a.checked_rem(b).ok_or(err)?,
+                        BinaryTypeOperator::Addition => a_val.checked_add(b_val).ok_or(err)?,
+                        BinaryTypeOperator::Subtraction => a_val.checked_sub(b_val).ok_or(err)?,
+                        BinaryTypeOperator::Multiplication => {
+                            a_val.checked_mul(b_val).ok_or(err)?
+                        }
+                        BinaryTypeOperator::Division => a_val.checked_div(b_val).ok_or(err)?,
+                        BinaryTypeOperator::Modulo => a_val.checked_rem(b_val).ok_or(err)?,
                     };
 
                     kind.ensure_value_fits(result.into(), location)

--- a/compiler/noirc_frontend/src/tests/arithmetic_generics.rs
+++ b/compiler/noirc_frontend/src/tests/arithmetic_generics.rs
@@ -2,12 +2,14 @@
 
 use core::panic;
 
+use crate::hir::def_collector::dc_crate::CompilationError;
+use crate::hir::resolution::errors::ResolverError;
 use crate::hir::type_check::TypeCheckError;
 use crate::hir_def::types::BinaryTypeOperator;
 use crate::monomorphization::errors::MonomorphizationError;
 use crate::signed_field::SignedField;
 use crate::test_utils::get_monomorphized;
-use crate::tests::{assert_no_errors, check_errors};
+use crate::tests::{assert_no_errors, check_errors, get_program_errors};
 
 #[test]
 fn arithmetic_generics_canonicalization_deduplication_regression() {
@@ -286,4 +288,30 @@ fn numeric_generic_arithmetic_in_return_type_concat() {
     }
     "#;
     assert_no_errors(src);
+}
+
+#[test]
+fn type_level_constant_overflow_produces_error() {
+    // Regression test: field-backed constants that don't fit in i128 should
+    // produce a TypeCheckError and should not panic.
+    let source = r#"
+        global N: T::u32 = 5;
+
+        fn main(_a: [Field; (30 + (N / 2))]) {
+        }
+    "#;
+
+    let errors = get_program_errors(source);
+    assert!(!errors.is_empty(), "Expected a compilation error for overflowing type constant");
+
+    let found = errors.iter().any(|e| {
+        matches!(
+            e,
+            CompilationError::ResolverError(ResolverError::BinaryOpError {
+                err,
+                ..
+            }) if matches!(**err, TypeCheckError::ConstantOverflow { .. })
+        )
+    });
+    assert!(found, "Expected TypeLevelConstantOverflow error, got: {errors:?}");
 }


### PR DESCRIPTION
# Description

## Problem

Resolves AuditHub issue: Type-level integer arithmetic panics on field-backed constants
https://app.audithub.dev/app/organizations/161/projects/599/project-viewer?version=1406&issueId=953

## Summary
Implemented the recommendations to make type-level integer folding non-panicking:
1. Replace direct calls to SignedField::to_u128() / to_i128() in BinaryTypeOperator::function() with checked conversions such as try_to_unsigned::<u128>() and try_to_signed::<i128>().
2. If conversion fails, return a normal TypeCheckError rather than panicking.
3. Preserve the existing diagnostic flow in convert_expression_type() so invalid array-length arithmetic is reported as a user-facing error.
4. Add regression tests covering field-backed constants in array-length arithmetic and asserting a diagnostic instead of an ICE.


## Additional Context



## User Documentation

Check one:
- [X] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
