### PR TITLE
chore(brillig): Assert non-empty blocks in `decide_allocation_point`

### DIFF
--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/constant_allocation.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/constant_allocation.rs
@@ -148,13 +148,12 @@ impl ConstantAllocation {
         used_in_blocks: &[BasicBlockId],
         func: &Function,
     ) -> BasicBlockId {
-        assert!(!used_in_blocks.is_empty(), "At least one block must use the constant");
         // Find the common dominator of all the blocks where the constant is used.
         let common_dominator = used_in_blocks
             .iter()
             .copied()
             .reduce(|a, b| self.dominator_tree.common_dominator(a, b))
-            .unwrap_or(used_in_blocks[0]);
+            .expect("At least one block must use the constant");
 
         // If the value only contains constants, it's safe to hoist outside of any loop.
         // Technically we know this is going to be true, because we only collected values which are `Value::NumericConstant`.


### PR DESCRIPTION
# Description

## Problem

Resolves https://cantina.xyz/code/24c6f940-d8af-4a25-9b28-b2e42dea31fe/findings/22

## Summary

Asserts that we aren't calling `decide_allocation_point` with an empty sequence of blocks.

## Additional Context

This should never be empty, because `collect_constant_usage` goes through the blocks looking for constants used in instructions, so we always have a block to start with. Should that change in the future, this should provide a nicer error message.


## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
