### PR TITLE
chore(brillig): Increment the array-copy-counter in the `vector_copy` procedure

### DIFF
--- a/compiler/noirc_evaluator/src/brillig/brillig_ir/procedures/vector_copy.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_ir/procedures/vector_copy.rs
@@ -70,6 +70,11 @@ pub(super) fn compile_vector_copy_procedure<F: AcirField + DebugToString>(
             // Copying a vector this way is an implicit side effect of setting an item by index through a mutable variable;
             // unlike with pop and push, we won't end up with a new vector handle, so we can split the RC between the old and the new.
             ctx.codegen_decrement_rc(source_vector.pointer, rc.address);
+
+            // Increase our array copy counter if that flag is set
+            if ctx.count_arrays_copied {
+                ctx.codegen_increment_array_copy_counter();
+            }
         }
     });
 }


### PR DESCRIPTION
# Description

## Problem

Resolves https://cantina.xyz/code/24c6f940-d8af-4a25-9b28-b2e42dea31fe/findings/21

## Summary

Changes the `vector_copy` procedure to increment the array-copy-counter the same way to how it's done in the `array_copy` procedure.

## Additional Context

This is a debug only codegen that prints the final array copy count when the program exits, and can be turned on using a CLI argument. Since vectors are also backed by arrays, it makes sense to track them the same way.


## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
