### PR TITLE
chore(test): Add regression test to protect against coalescing vs spilling bug

### DIFF
--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/tests/coalescing.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/tests/coalescing.rs
@@ -1,6 +1,12 @@
 use acvm::FieldElement;
 
-use crate::brillig::brillig_gen::tests::execute_brillig_from_ssa;
+use crate::brillig::brillig_gen::tests::{
+    execute_brillig_from_ssa, execute_brillig_from_ssa_with_options,
+};
+use crate::brillig::{
+    BrilligOptions,
+    brillig_ir::{LayoutConfig, registers::MAX_SCRATCH_SPACE},
+};
 
 /// Regression test from fuzzer: arg-side coalesced value (v1) outlives the block
 /// param (v4) it shares a register with. When v4 dies in b1, the register was
@@ -97,4 +103,74 @@ fn coalescing_multiple_pairs_both_outlive() {
     // b2: v6 = 11 + 12 = 23
     let result = execute_brillig_from_ssa(src, vec![FieldElement::from(10u64)]);
     assert_eq!(result, vec![FieldElement::from(23u64)]);
+}
+
+/// Regression test for the interaction between arg-side coalescing and spilling.
+///
+/// # Bug
+///
+/// `FunctionContext::new` disables coalescing when spilling is needed
+/// (see the comment "Disable coalescing when spilling is enabled") because
+/// the two mechanisms interact unsafely:
+///
+/// When a successor block param (`v4`) is eagerly spilled in `convert_block_params`,
+/// its register (`R`) is freed and returned to the allocator's free pool. An
+/// instruction result that is arg-side coalesced with `v4` (`v2 -> v4`) reuses `R`
+/// by reading `ssa_value_allocations[v4]` — but crucially it does **not** remove
+/// `R` from the free pool, since the coalescing path bypasses `allocate_register`.
+///
+/// The freed register `R` is therefore still available for the next allocation.
+/// When the subsequent instruction (`v3`) calls `allocate_register`, it pops `R`
+/// from the free pool and also maps to `R`. Both `v2` and `v3` now alias the same
+/// register. `v3`'s computation overwrites `R`, so the jmp that passes `v2` to
+/// `b1` actually delivers `v3`'s value instead.
+///
+/// # Scenario (stack size 5 → 3 usable slots sp[2..4])
+///
+/// ```text
+/// convert_block_params(b0):
+///   define v4 → sp[4]; eagerly spill → sp[4] freed; pool = {sp[4]}
+///
+/// define v2 (coalesced with v4):
+///   ssa_value_allocations[v2] = sp[4]  (sp[4] stays in free pool!)
+///   compute: sp[4] = v0 + v1 = 10
+///
+/// define v3 (no coalescing):
+///   allocate_register() pops sp[4] from pool → v3 = sp[4]  ← collision!
+///   compute: sp[4] = v1 * v0 = 21
+///
+/// jmp b1(v2): reads sp[4] = 21 → writes 21 to v4's spill slot
+/// b1: loads v4 from spill slot = 21, returns 21   ← wrong!
+/// ```
+///
+/// # Current protection
+///
+/// `FunctionContext::new` sets `coalescing = CoalescingMap::default()` (empty)
+/// whenever `spill_manager.is_some()`. This test therefore currently **passes**
+/// (coalescing is a no-op when spilling is active).
+///
+/// The test is designed to **fail** if that guard is removed without a proper fix,
+/// serving as the regression anchor for the future proper fix.
+#[test]
+fn coalescing_spill_arg_register_aliased_by_subsequent_allocation() {
+    let src = "
+    brillig(inline) fn main f0 {
+      b0(v0: u32, v1: u32):
+        v2 = unchecked_add v0, v1
+        v3 = unchecked_mul v1, v0
+        jmp b1(v2)
+      b1(v4: u32):
+        return v4
+    }
+    ";
+    // v0=3, v1=7 → v2 = 3+7 = 10 (correct), v3 = 7*3 = 21 (the wrong value)
+    // Without the fix: b1 returns 21 instead of 10.
+    let layout = LayoutConfig::new(6, 16, MAX_SCRATCH_SPACE);
+    let options = BrilligOptions { layout, ..Default::default() };
+    let result = execute_brillig_from_ssa_with_options(
+        src,
+        vec![FieldElement::from(3u64), FieldElement::from(7u64)],
+        &options,
+    );
+    assert_eq!(result, vec![FieldElement::from(10u64)]);
 }

--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/tests/mod.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/tests/mod.rs
@@ -46,8 +46,16 @@ pub(crate) fn execute_brillig_from_ssa(
     src: &str,
     calldata: Vec<FieldElement>,
 ) -> Vec<FieldElement> {
+    execute_brillig_from_ssa_with_options(src, calldata, &BrilligOptions::default())
+}
+
+pub(crate) fn execute_brillig_from_ssa_with_options(
+    src: &str,
+    calldata: Vec<FieldElement>,
+    options: &BrilligOptions,
+) -> Vec<FieldElement> {
     let ssa = Ssa::from_str(src).unwrap();
-    let brillig = ssa.to_brillig(&BrilligOptions::default());
+    let brillig = ssa.to_brillig(options);
     let func = ssa.main();
     let arguments: Vec<_> = func
         .parameters()
@@ -57,7 +65,7 @@ pub(crate) fn execute_brillig_from_ssa(
             FunctionContext::ssa_type_to_parameter(&typ)
         })
         .collect();
-    let generated = gen_brillig_for(func, arguments, &brillig, &BrilligOptions::default()).unwrap();
+    let generated = gen_brillig_for(func, arguments, &brillig, options).unwrap();
     execute_bytecode(&generated.byte_code, calldata)
 }
 


### PR DESCRIPTION
# Description

## Problem

Related to https://github.com/noir-lang/noir/issues/11909

## Summary

### What was done

#### New helper: `execute_brillig_from_ssa_with_options`

Added to [tests/mod.rs](compiler/noirc_evaluator/src/brillig/brillig_gen/tests/mod.rs) — a variant of the existing helper that accepts a custom `BrilligOptions` (including a tight `LayoutConfig`). The old `execute_brillig_from_ssa` now delegates to it.

#### New regression test: `coalescing_spill_arg_register_aliased_by_subsequent_allocation`

Added to [tests/coalescing.rs](compiler/noirc_evaluator/src/brillig/brillig_gen/tests/coalescing.rs).

### The bug it captures

In `b0(v0, v1)` with stack size 6 (4 usable slots: `sp[2..5]`):

1. `b1`'s param `v4` is eagerly spilled in `convert_block_params` → register `sp[4]` freed and returned to the allocator's free pool.
2. `v2 = unchecked_add v0, v1` is **arg-side coalesced** with `v4`: it reads `ssa_value_allocations[v4] = sp[4]` **without removing `sp[4]` from the free pool** (the coalescing path bypasses `allocate_register`).
3. `v3 = unchecked_mul v1, v0` calls `allocate_register()` → pops `sp[4]` from the free pool → **both `v2` and `v3` alias `sp[4]`**.
4. `v3`'s computation (`7 * 3 = 21`) overwrites `sp[4]`, clobbering `v2`'s value (`3 + 7 = 10`).
5. The `jmp b1(v2)` writes `sp[4] = 21` to `v4`'s spill slot; `b1` returns `21` instead of `10`.

### Current status

The test **currently passes** because the workaround at
[brillig_fn.rs:95-100](compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_fn.rs#L95-L100)
disables coalescing whenever spilling is enabled. Removing that guard without a
proper fix causes the test to **fail** with `left: [21], right: [10]`.


## Additional Context



## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
