### PR TITLE
chore(acvm): Use existing big int methods for num_bits on a field element

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,7 +42,6 @@ dependencies = [
  "ark-bls12-381",
  "ark-bn254 0.5.0",
  "ark-ff 0.5.0",
- "ark-std 0.5.0",
  "cfg-if",
  "criterion",
  "hex",

--- a/acvm-repo/acir_field/Cargo.toml
+++ b/acvm-repo/acir_field/Cargo.toml
@@ -23,7 +23,6 @@ serde.workspace = true
 ark-bn254.workspace = true
 ark-bls12-381 = { workspace = true, optional = true }
 ark-ff.workspace = true
-ark-std.workspace = true
 
 cfg-if.workspace = true
 

--- a/acvm-repo/acir_field/src/field_element.rs
+++ b/acvm-repo/acir_field/src/field_element.rs
@@ -1,6 +1,5 @@
 use ark_ff::PrimeField;
 use ark_ff::Zero;
-use ark_std::io::Write;
 use num_bigint::BigUint;
 use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
@@ -317,9 +316,14 @@ impl<F: PrimeField> AcirField for FieldElement<F> {
 
     /// This is the number of bits required to represent this specific field element
     fn num_bits(&self) -> u32 {
-        let mut bit_counter = BitCounter::default();
-        self.0.serialize_uncompressed(&mut bit_counter).unwrap();
-        bit_counter.bits()
+        let bigint = self.0.into_bigint();
+        let limbs = bigint.as_ref();
+        for (i, &limb) in limbs.iter().enumerate().rev() {
+            if limb != 0 {
+                return (i as u32) * 64 + (64 - limb.leading_zeros());
+            }
+        }
+        0
     }
 
     fn to_u128(self) -> u128 {
@@ -520,52 +524,6 @@ impl<F: PrimeField> Sub for FieldElement<F> {
 impl<F: PrimeField> SubAssign for FieldElement<F> {
     fn sub_assign(&mut self, rhs: FieldElement<F>) {
         self.0.sub_assign(&rhs.0);
-    }
-}
-
-#[derive(Default, Debug)]
-struct BitCounter {
-    /// Total number of non-zero bytes we found.
-    count: usize,
-    /// Total bytes we found.
-    total: usize,
-    /// The last non-zero byte we found.
-    head_byte: u8,
-}
-
-impl BitCounter {
-    fn bits(&self) -> u32 {
-        // If we don't have a non-zero byte then the field element is zero,
-        // which we consider to require a zero bits to represent.
-        if self.count == 0 {
-            return 0;
-        }
-
-        let num_bits_for_head_byte = self.head_byte.ilog2();
-
-        // Each remaining byte in the byte decomposition requires 8 bits.
-        //
-        // Note: count will panic if it goes over usize::MAX.
-        // This may not be suitable for devices whose usize < u16
-        let tail_length = (self.count - 1) as u32;
-        8 * tail_length + num_bits_for_head_byte + 1
-    }
-}
-
-impl Write for BitCounter {
-    fn write(&mut self, buf: &[u8]) -> ark_std::io::Result<usize> {
-        for byte in buf {
-            self.total += 1;
-            if *byte != 0 {
-                self.count = self.total;
-                self.head_byte = *byte;
-            }
-        }
-        Ok(buf.len())
-    }
-
-    fn flush(&mut self) -> ark_std::io::Result<()> {
-        Ok(())
     }
 }
 


### PR DESCRIPTION
# Description

## Problem

No issue, just a low hanging fruit optimization 

## Summary

Old 14.4 ns vs New 5 ns (65% improvement)

We also got rid of the `BitCounter` structure and the `ark-std` dependency in `acir_field`

## Additional Context



## User Documentation

Check one:
- [X] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
