### PR TITLE
fix: Error when missing trait items

### DIFF
--- a/compiler/noirc_frontend/src/hir/comptime/errors.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/errors.rs
@@ -190,6 +190,10 @@ pub enum InterpreterError {
     NoImpl {
         location: Location,
     },
+    NoTraitItemInImpl {
+        item_name: String,
+        location: Location,
+    },
     NoMatchingImplFound {
         error: NoMatchingImplFoundError,
     },
@@ -390,6 +394,7 @@ impl InterpreterError {
             | InterpreterError::Unimplemented { location, .. }
             | InterpreterError::InvalidInComptimeContext { location, .. }
             | InterpreterError::NoImpl { location, .. }
+            | InterpreterError::NoTraitItemInImpl { location, .. }
             | InterpreterError::ImplMethodTypeMismatch { location, .. }
             | InterpreterError::DebugEvaluateComptime { location, .. }
             | InterpreterError::BlackBoxError(_, location)
@@ -715,6 +720,10 @@ impl<'a> From<&'a InterpreterError> for CustomDiagnostic {
             }
             InterpreterError::NoImpl { location } => {
                 let msg = "No impl found due to prior type error".into();
+                CustomDiagnostic::simple_error(msg, String::new(), *location)
+            }
+            InterpreterError::NoTraitItemInImpl { item_name, location } => {
+                let msg = format!("No method or constant named `{item_name}` found in impl due to prior type error");
                 CustomDiagnostic::simple_error(msg, String::new(), *location)
             }
             InterpreterError::ImplMethodTypeMismatch { expected, actual, location } => {

--- a/compiler/noirc_frontend/src/monomorphization/mod.rs
+++ b/compiler/noirc_frontend/src/monomorphization/mod.rs
@@ -3174,7 +3174,7 @@ fn bind_trait_impl_func_generics_to_trait_func_generics(
 /// Look up a specific member of a trait, then look through the trait methods
 /// and associated constants until an item with a matching name is found.
 ///
-/// Panics if the name cannot be matched to anything.
+/// Error if the name cannot be matched to anything.
 pub(crate) fn resolve_trait_item(
     interner: &mut NodeInterner,
     method_id: TraitItemId,
@@ -3213,7 +3213,8 @@ pub(crate) fn resolve_trait_item(
         }
     }
 
-    unreachable!("No method or constant named `{name}` in impl")
+    let location = interner.expr_location(&expr_id);
+    Err(InterpreterError::NoTraitItemInImpl { item_name: name.to_string(), location })
 }
 
 pub(crate) enum TraitItem {

--- a/compiler/noirc_frontend/src/tests/traits/trait_associated_items.rs
+++ b/compiler/noirc_frontend/src/tests/traits/trait_associated_items.rs
@@ -2057,3 +2057,29 @@ fn associated_type_diamond_ambiguity_on_generic() {
     "#;
     check_errors(src);
 }
+
+/// Regression test: associated constant with mismatched type between trait and impl
+/// used to crash the compiler with `unreachable!` in `resolve_trait_item` when
+/// accessed from a comptime block.
+#[test]
+fn associated_constant_type_mismatch_does_not_crash() {
+    let src = r#"
+    trait Serialize {
+        let N: Field;
+    }
+
+    impl Serialize for Field {
+        let N: u32 = 1;
+            ^ The numeric generic is not of type `Field`
+            ~ expected `Field`, found `u32`
+    }
+
+    fn main() {
+        comptime {
+            let _x = <Field as Serialize>::N;
+                      ^^^^^^^^^^^^^^^^^^ No method or constant named `N` found in impl due to prior type error
+        }
+    }
+    "#;
+    check_errors(src);
+}


### PR DESCRIPTION
# Description

## Problem

Resolves AuditHub issue: Resolving associated constant in trait impl crashes the compiler
https://app.audithub.dev/app/organizations/161/projects/599/project-viewer?version=1406&issueId=820

## Summary
Error instead of panic.


## Additional Context



## User Documentation

Check one:
- [X] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
