### PR TITLE
chore(acvm): Optimize Expression evaluate by avoiding unnecessary lookups and avoid temp allocs

### DIFF
--- a/acvm-repo/acvm/src/pwg/arithmetic.rs
+++ b/acvm-repo/acvm/src/pwg/arithmetic.rs
@@ -38,19 +38,18 @@ impl ExpressionSolver {
         let (mul_constant, mut unknown) = match opcode.mul_terms.len() {
             0 => (F::zero(), None),
             1 => {
-                let (c, _, _) = opcode.mul_terms[0];
-                if c.is_zero() {
-                    // Zero-coefficient mul term contributes nothing.
-                    (F::zero(), None)
-                } else {
-                    match Self::solve_mul_term_helper(&opcode.mul_terms[0], initial_witness) {
-                        MulTerm::Solved(val) => (val, None),
-                        MulTerm::OneUnknown(coeff, witness) => {
-                            let unknown =
-                                if coeff.is_zero() { None } else { Some((coeff, witness)) };
-                            (F::zero(), unknown)
-                        }
-                        MulTerm::TooManyUnknowns => {
+                match Self::solve_mul_term_helper(&opcode.mul_terms[0], initial_witness) {
+                    MulTerm::Solved(val) => (val, None),
+                    MulTerm::OneUnknown(coeff, witness) => {
+                        let unknown = if coeff.is_zero() { None } else { Some((coeff, witness)) };
+                        (F::zero(), unknown)
+                    }
+                    MulTerm::TooManyUnknowns => {
+                        let (c, _, _) = opcode.mul_terms[0];
+                        if c.is_zero() {
+                            // Zero-coefficient mul term contributes nothing.
+                            (F::zero(), None)
+                        } else {
                             // Both witnesses unknown — always unsolvable for a single mul term.
                             return Err(OpcodeResolutionError::OpcodeNotSolvable(
                                 OpcodeNotSolvable::ExpressionHasTooManyUnknowns(opcode.clone()),


### PR DESCRIPTION
# Description

## Problem

No issue, just part of an investigation of witness execution quick wins

## Summary

`bench_poseidon_hash_100` avg of 5 runs:
Nightly: 14.76ms
This branch: 12.45ms (~15% improvement)

## Additional Context

A meaningful general improvement https://github.com/noir-lang/noir/pull/11936#issuecomment-4100828700. Multiple runs of the ACVM benchmarks https://github.com/noir-lang/noir/pull/11936#pullrequestreview-3983943792 is showing ~25-35% improvements in `purely_sequential_opcodes` and `perfectly_parallel_opcodes`. 

## User Documentation

Check one:
- [X] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
