### PR TITLE
fix(frontend): Check that `Type::Forall` has no fewer generics than the function

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/variable.rs
+++ b/compiler/noirc_frontend/src/elaborator/variable.rs
@@ -877,6 +877,9 @@ impl Elaborator<'_> {
     ) -> (Type, TypeBindings) {
         match turbofish_generics {
             Some(turbofish_generics) => {
+                let forall_generic_count =
+                    if let Type::Forall(generics, _) = &typ { generics.len() } else { 0 };
+
                 if turbofish_generics.len() != function_generic_count {
                     let type_check_err = TypeCheckError::IncorrectTurbofishGenericCount {
                         expected_count: function_generic_count,
@@ -885,13 +888,24 @@ impl Elaborator<'_> {
                     };
                     self.push_err(CompilationError::TypeError(type_check_err));
                     typ.instantiate_with_bindings(bindings, self.interner)
+                } else if forall_generic_count < function_generic_count {
+                    // In the next branch, calling instantiate_with_bindings_and_turbofish asserts that
+                    // turbofish_generics.len() + implicit_generic_count == forall_generic_count,
+                    // but if we have less generics in forall than the the turbo fish than this will never hold.
+                    // This is the case when the function generics have duplicates, which are filtered out.
+                    // This means some duplicate error has already been reported, so there is no point trying.
+                    self.push_err(TypeCheckError::expecting_other_error(
+                        "forall has fewer generics than function",
+                        location,
+                    ));
+                    (Type::Error, bindings)
                 } else {
                     // Fetch the count of any implicit generics on the function, such as
                     // for a method within a generic impl.
-                    let implicit_generic_count = match &typ {
-                        Type::Forall(generics, _) => generics.len() - function_generic_count,
-                        _ => 0,
-                    };
+                    let implicit_generic_count = forall_generic_count
+                        .checked_sub(function_generic_count)
+                        .expect("forall should have at least as many generics as the function");
+
                     typ.instantiate_with_bindings_and_turbofish(
                         bindings,
                         turbofish_generics,

--- a/test_programs/compile_failure/regression_11932/Nargo.toml
+++ b/test_programs/compile_failure/regression_11932/Nargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "regression_11932"
+type = "bin"
+authors = [""]
+
+[dependencies]

--- a/test_programs/compile_failure/regression_11932/src/main.nr
+++ b/test_programs/compile_failure/regression_11932/src/main.nr
@@ -1,0 +1,8 @@
+fn bar<A, A>(_x: A, _y: A) {}
+fn foo<let N: u32, let N: u32>() {}
+
+fn main() {
+    foo::<1>();
+    foo::<1, 2>();
+    bar::<u32, u32>(0, 1);
+}

--- a/tooling/nargo_cli/tests/snapshots/compile_failure/regression_11932/execute__tests__stderr.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_failure/regression_11932/execute__tests__stderr.snap
@@ -1,0 +1,30 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: stderr
+---
+error: duplicate definitions of A found
+  ┌─ src/main.nr:1:8
+  │
+1 │ fn bar<A, A>(_x: A, _y: A) {}
+  │        -  - second definition found here
+  │        │   
+  │        first definition found here
+  │
+
+error: duplicate definitions of N found
+  ┌─ src/main.nr:2:12
+  │
+2 │ fn foo<let N: u32, let N: u32>() {}
+  │            ------      ------ second definition found here
+  │            │            
+  │            first definition found here
+  │
+
+error: Expected 2 generics from this function, but 1 was provided
+  ┌─ src/main.nr:5:5
+  │
+5 │     foo::<1>();
+  │     --------
+  │
+
+Aborting due to 3 previous errors


### PR DESCRIPTION
# Description

## Problem

Resolves #11932 

## Summary

Fixes `Elaborator::instantiate` to handle the situation when a `Type::Forall` has fewer type variables than indicated by `FunctionModifiers::generic_count` by returning `Type::Error` and setting up an expectation for an error.

## Additional Context

Say we have something like `fn foo<T, T>(x: T, y: T)`. `Elaborator::define_function_meta` calls `Elaborator::add_function_generics_to_scope` with the unresolved `func_generics`, which in turn calls `Elaborator::add_generics`. 

In `add_generics` any duplicate names are filtered out, and only the first entry is added to `Elaborator::generics`. Note that although all generics are _returned_ by `add_generics`, when we are back in `add_function_generics_to_scope`, we discard the result, and redefine `func_generics` based on `Elaborator::generics`, which is how the duplicates are discarded. 

Back in `define_function_meta` the `generics` returned from `add_function_generics_to_scope` are wrapped in a `Type::Forall`, where the two `T`s above will become a single `TypeVariable`. 

I don't know if this makes sense or, whether we should have kept the same number of generics. The duplication is certainly an error, so I guess whichever version avoids later panics is good. 

When we get to `instantiate_with_bindings_and_turbofish` we have an assertion that the counts should check out, and name resolution should have not called this method unless there were no errors with this part, so I added extra error handling to `instantiate`, but do let me know if you think keeping the duplicates in `Forall` type variables would be a better course of action.



## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
