### PR TITLE
fix: disallow`impl Trait` in invalid type positions

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/enums.rs
+++ b/compiler/noirc_frontend/src/elaborator/enums.rs
@@ -147,6 +147,9 @@ impl Elaborator<'_> {
             self.resolving_ids.insert(*type_id);
 
             let wildcard_allowed = WildcardAllowed::No(WildcardDisallowedContext::EnumVariant);
+            let previous_impl_trait_context = self
+                .impl_trait_is_disallowed
+                .replace(super::types::ImplTraitDisallowedContext::EnumVariant);
             for (i, variant) in typ.enum_def.variants.iter().enumerate() {
                 let parameters = variant.item.parameters.as_ref();
                 let types = parameters.map(|params| {
@@ -173,6 +176,8 @@ impl Elaborator<'_> {
                 let location = variant.item.name.location();
                 self.interner.add_definition_location(reference_id, location);
             }
+
+            self.impl_trait_is_disallowed = previous_impl_trait_context;
 
             self.resolving_ids.remove(type_id);
 

--- a/compiler/noirc_frontend/src/elaborator/mod.rs
+++ b/compiler/noirc_frontend/src/elaborator/mod.rs
@@ -311,6 +311,14 @@ pub struct Elaborator<'context> {
     /// array[i_0] = 10;
     /// ```
     lvalue_index_counter: usize,
+
+    /// Set when resolving types in positions where `impl Trait` is not allowed
+    /// (e.g., struct fields, globals, type aliases, enum variants).
+    /// `impl Trait` is only valid in function parameter and return type positions.
+    ///
+    /// This is stored as a field rather than checked at the call site so that it
+    /// propagates through recursive `resolve_type` calls.
+    pub(super) impl_trait_is_disallowed: Option<types::ImplTraitDisallowedContext>,
 }
 
 #[derive(Copy, Clone)]
@@ -382,6 +390,7 @@ impl<'context> Elaborator<'context> {
             comptime_evaluation_halted: false,
             macro_expansion_depth: 0,
             lvalue_index_counter: 0,
+            impl_trait_is_disallowed: None,
         }
     }
 
@@ -725,6 +734,8 @@ impl<'context> Elaborator<'context> {
         let generics = self.add_generics(&alias.type_alias_def.generics);
         self.current_item = Some(DependencyId::Alias(alias_id));
         let wildcard_allowed = types::WildcardAllowed::No(WildcardDisallowedContext::TypeAlias);
+        let previous_impl_trait_context =
+            self.impl_trait_is_disallowed.replace(types::ImplTraitDisallowedContext::TypeAlias);
         let (typ, num_expr) = if let Some(num_type) = alias.type_alias_def.numeric_type {
             let num_type = self.resolve_type(num_type, wildcard_allowed);
             let kind = Kind::numeric(num_type);
@@ -759,6 +770,8 @@ impl<'context> Elaborator<'context> {
         } else {
             (self.use_type(alias.type_alias_def.typ, wildcard_allowed), None)
         };
+
+        self.impl_trait_is_disallowed = previous_impl_trait_context;
 
         if !visibility.is_private() {
             self.check_type_is_not_more_private_then_item(name, visibility, &typ, location);

--- a/compiler/noirc_frontend/src/elaborator/statements.rs
+++ b/compiler/noirc_frontend/src/elaborator/statements.rs
@@ -136,7 +136,13 @@ impl Elaborator<'_> {
             WildcardAllowed::Yes
         };
 
+        let previous_impl_trait_context = if global_id.is_some() {
+            self.impl_trait_is_disallowed.replace(super::types::ImplTraitDisallowedContext::Global)
+        } else {
+            self.impl_trait_is_disallowed
+        };
         let annotated_type = self.resolve_inferred_type(let_stmt.r#type, wildcard_allowed);
+        self.impl_trait_is_disallowed = previous_impl_trait_context;
 
         // After resolving the type we'll elaborate the global's value. The value is interpreted
         // at compile time, so we need to switch to a comptime context. For example using `Quoted`

--- a/compiler/noirc_frontend/src/elaborator/structs.rs
+++ b/compiler/noirc_frontend/src/elaborator/structs.rs
@@ -97,12 +97,16 @@ impl Elaborator<'_> {
             this.add_existing_generics(&unresolved.generics, &struct_def.borrow().generics);
 
             let wildcard_allowed = WildcardAllowed::No(WildcardDisallowedContext::StructField);
+            let previous_impl_trait_context = this
+                .impl_trait_is_disallowed
+                .replace(super::types::ImplTraitDisallowedContext::StructField);
             let fields = vecmap(&unresolved.fields, |field| {
                 let visibility = field.item.visibility;
                 let name = field.item.name.clone();
                 let typ = this.resolve_type(field.item.typ.clone(), wildcard_allowed);
                 StructField { visibility, name, typ }
             });
+            this.impl_trait_is_disallowed = previous_impl_trait_context;
 
             this.resolving_ids.remove(&struct_id);
 

--- a/compiler/noirc_frontend/src/elaborator/types.rs
+++ b/compiler/noirc_frontend/src/elaborator/types.rs
@@ -71,6 +71,19 @@ pub enum WildcardAllowed {
     No(WildcardDisallowedContext),
 }
 
+/// Context for positions where `impl Trait` is not allowed as a type.
+/// `impl Trait` is only meaningful in function signatures (parameters and return types).
+///
+/// This context is stored on the `Elaborator` and checked in the `TraitAsType` arm of
+/// type resolution. The variant is used to produce a position-specific error message.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ImplTraitDisallowedContext {
+    StructField,
+    EnumVariant,
+    Global,
+    TypeAlias,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum WildcardDisallowedContext {
     AssociatedType,
@@ -205,6 +218,13 @@ impl Elaborator<'_> {
                 self.resolve_named_type(path, args, mode, wildcard_allowed)
             }
             TraitAsType(path, args) => {
+                if let Some(context) = self.impl_trait_is_disallowed {
+                    self.push_err(ResolverError::ImplTraitTypeDisallowed {
+                        location: path.location,
+                        context,
+                    });
+                    return Type::Error;
+                }
                 self.use_unstable_feature(UnstableFeature::TraitAsType, path.location);
                 let path = self.validate_path(path);
                 self.resolve_trait_as_type(path, args, mode)

--- a/compiler/noirc_frontend/src/hir/resolution/errors.rs
+++ b/compiler/noirc_frontend/src/hir/resolution/errors.rs
@@ -208,6 +208,11 @@ pub enum ResolverError {
     TraitImplOnAssociatedType { location: Location },
     #[error("The placeholder `_` is not allowed within types on item signatures for functions")]
     WildcardTypeDisallowed { location: Location, context: WildcardDisallowedContext },
+    #[error("`impl Trait` is not allowed in this position")]
+    ImplTraitTypeDisallowed {
+        location: Location,
+        context: crate::elaborator::types::ImplTraitDisallowedContext,
+    },
     #[error("References are not allowed in globals")]
     ReferencesNotAllowedInGlobals { location: Location },
     #[error("Functions marked with #[oracle] must have no body")]
@@ -300,6 +305,7 @@ impl ResolverError {
             | ResolverError::AmbiguousAssociatedType { location, .. }
             | ResolverError::TraitImplOnAssociatedType { location }
             | ResolverError::WildcardTypeDisallowed { location, .. }
+            | ResolverError::ImplTraitTypeDisallowed { location, .. }
             | ResolverError::ReferencesNotAllowedInGlobals { location }
             | ResolverError::OracleWithBody { location }
             | ResolverError::BuiltinWithBody { location }
@@ -934,6 +940,27 @@ impl<'a> From<&'a ResolverError> for Diagnostic {
                 Diagnostic::simple_error(
                     format!("The placeholder `_` is not allowed in {context}"),
                     String::new(),
+                    *location,
+                )
+            }
+            ResolverError::ImplTraitTypeDisallowed { location, context } => {
+                let context = match context {
+                    crate::elaborator::types::ImplTraitDisallowedContext::StructField => {
+                        "struct field types"
+                    }
+                    crate::elaborator::types::ImplTraitDisallowedContext::EnumVariant => {
+                        "enum variant types"
+                    }
+                    crate::elaborator::types::ImplTraitDisallowedContext::Global => {
+                        "global definitions"
+                    }
+                    crate::elaborator::types::ImplTraitDisallowedContext::TypeAlias => {
+                        "type alias definitions"
+                    }
+                };
+                Diagnostic::simple_error(
+                    format!("`impl Trait` is not allowed in {context}"),
+                    "Use a generic type parameter instead".to_string(),
                     *location,
                 )
             }

--- a/compiler/noirc_frontend/src/tests/aliases.rs
+++ b/compiler/noirc_frontend/src/tests/aliases.rs
@@ -515,13 +515,22 @@ fn regression_10352_slice() {
 #[test]
 fn regression_10352_trait_as_type() {
     let src = r#"
-    trait Foo<T> {}
+    struct Foo {
+        x: impl Bar,
+                ^^^ `impl Trait` is not allowed in struct field types
+                ~~~ Use a generic type parameter instead
+    }
 
-    type Alias = impl Foo<Alias>;
+    trait Bar {
+        fn bar(self);
+    }
+    impl Bar for Foo {
+        fn bar(self) {
+            self.x.bar();
+        }
+    }
 
-    fn main(_: Alias) {}
-               ^^^^^ Binding `Alias` here to the `_` inside would create a cyclic type
-               ~~~~~ Cyclic types have unlimited size and are prohibited in Noir
+    fn main(_a: Foo) {}
     "#;
     check_errors_using_features(src, &[UnstableFeature::TraitAsType]);
 }
@@ -769,6 +778,8 @@ fn regression_10764_trait_as_type_with_empty_trait() {
     trait Foo { }
 
     type Bar = impl Foo;
+                    ^^^ `impl Trait` is not allowed in type alias definitions
+                    ~~~ Use a generic type parameter instead
 
     impl Foo for Bar {
                  ^^^ Cannot define a trait impl on values of type `Bar`
@@ -815,6 +826,8 @@ fn regression_10764_trait_as_type() {
     }
 
     type Bar = impl Foo;
+                    ^^^ `impl Trait` is not allowed in type alias definitions
+                    ~~~ Use a generic type parameter instead
 
     impl Foo for Bar {
                  ^^^ Cannot define a trait impl on values of type `Bar`
@@ -867,10 +880,14 @@ fn regression_10764_underscore() {
 fn regression_10764_trait_as_type_impl() {
     let src = r#"
     trait Foo {
+          ^^^ unused trait Foo
+          ~~~ unused trait
         fn foo(self);
     }
 
     type Bar = impl Foo;
+                    ^^^ `impl Trait` is not allowed in type alias definitions
+                    ~~~ Use a generic type parameter instead
 
     impl Bar {
          ^^^ Non-enum, non-struct type used in impl


### PR DESCRIPTION
# Description

## Problem

Resolves AuditHub issue: `impl Trait` is accepted in struct field types
https://app.audithub.dev/app/organizations/161/projects/599/project-viewer?version=1406&issueId=966

## Summary
Record when an impl is used in an invalid position, and error when trying to resolve such an impl.


## Additional Context



## User Documentation

Check one:
- [X] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
