### PR TITLE
fix: allow AsTraitPath in type expression arithmetic

### DIFF
--- a/compiler/noirc_frontend/src/parser/parser/type_expression.rs
+++ b/compiler/noirc_frontend/src/parser/parser/type_expression.rs
@@ -213,7 +213,7 @@ impl Parser<'_> {
                 }
             }
             // Similarly, convert a standalone AsTraitPath expression back to the AsTraitPath type
-            // so it isn't mistakenly rejected as a type expression (e.g. in type aliases).
+            // so it isn't mistakenly rejected as a type expression in type aliases.
             UnresolvedTypeData::Expression(UnresolvedTypeExpression::AsTraitPath(
                 as_trait_path,
             )) => UnresolvedType {


### PR DESCRIPTION
## Summary
- Fixes a parser bug where `<Foo as Trait>::N + <Bar as Trait>::N` inside turbofish or type-level arithmetic was rejected
- The `type_is_type_expr()` and `type_to_type_expr()` helper functions didn't handle `AsTraitPath`, so the parser treated it as a plain type and refused to parse binary operators after it
- Adds `AsTraitPath` arms to both functions, mirroring what `parse_atom_type_expression()` already does

## Test plan
- Added parser unit test `parses_type_or_type_expression_as_trait_path_addition` that verifies `<Foo as MyTrait>::N + <Bar as MyTrait>::N` parses as a binary addition with the correct operands