### PR TITLE
chore: add support for braced expressions in generics

### DIFF
--- a/compiler/noirc_frontend/src/parser/parser/generics.rs
+++ b/compiler/noirc_frontend/src/parser/parser/generics.rs
@@ -314,6 +314,21 @@ mod tests {
     }
 
     #[test]
+    fn parse_braced_expression_in_generic() {
+        let src = "<{ 1 + 2 }>";
+        let generics = parse_generic_type_args_no_errors(src);
+        assert_eq!(generics.ordered_args.len(), 1);
+        assert_eq!(generics.ordered_args[0].to_string(), "(1 + 2)");
+    }
+
+    #[test]
+    fn parse_braced_as_trait_path_in_generic() {
+        let src = "<{ <Foo as MyTrait>::N + <Bar as MyTrait>::N }>";
+        let generics = parse_generic_type_args_no_errors(src);
+        assert_eq!(generics.ordered_args.len(), 1);
+    }
+
+    #[test]
     fn parse_generic_trait_bound_not_allowed() {
         let src = "
         N: Trait

--- a/compiler/noirc_frontend/src/parser/parser/type_expression.rs
+++ b/compiler/noirc_frontend/src/parser/parser/type_expression.rs
@@ -136,6 +136,7 @@ impl Parser<'_> {
     ///     | VariableTypeExpression
     ///     | AsTraitPathTypeExpression
     ///     | ParenthesizedTypeExpression
+    ///     | BracedTypeExpression
     fn parse_atom_type_expression(&mut self) -> Option<UnresolvedTypeExpression> {
         if let Some(type_expr) = self.parse_constant_type_expression() {
             return Some(type_expr);
@@ -150,6 +151,10 @@ impl Parser<'_> {
         }
 
         if let Some(type_expr) = self.parse_parenthesized_type_expression() {
+            return Some(type_expr);
+        }
+
+        if let Some(type_expr) = self.parse_braced_type_expression() {
             return Some(type_expr);
         }
 
@@ -186,6 +191,29 @@ impl Parser<'_> {
             }
         } else {
             None
+        }
+    }
+
+    /// BracedTypeExpression = '{' Expression '}'
+    ///
+    /// Allows using a full expression as a numeric generic argument by wrapping it in braces,
+    /// For example: `foo::<{ <Foo as MyTrait>::N + <Bar as MyTrait>::N }>()`
+    fn parse_braced_type_expression(&mut self) -> Option<UnresolvedTypeExpression> {
+        if !self.eat_left_brace() {
+            return None;
+        }
+
+        let start_location = self.previous_token_location;
+        let expr = self.parse_expression_or_error();
+        self.eat_or_error(Token::RightBrace);
+        let location = self.location_since(start_location);
+
+        match UnresolvedTypeExpression::from_expr(expr, location) {
+            Ok(type_expr) => Some(type_expr),
+            Err(error) => {
+                self.errors.push(error);
+                None
+            }
         }
     }
 
@@ -289,6 +317,12 @@ impl Parser<'_> {
 
         if let Some(typ) = self.parse_parenthesized_type_or_type_expression() {
             return Some(typ);
+        }
+
+        if let Some(type_expr) = self.parse_braced_type_expression() {
+            let typ = UnresolvedTypeData::Expression(type_expr);
+            let location = self.location_since(start_location);
+            return Some(UnresolvedType { typ, location });
         }
 
         self.parse_type()


### PR DESCRIPTION
# Description

## Problem

Resolves: syntax like `generic_fn::<Foo as MyTrait>::N + <Bar as MyTrait>::N>();` is supported by using braces:
`generic_fn::{<Foo as MyTrait>::N + <Bar as MyTrait>::N>}();`

## Summary
Support braces in the parser to delimitate expressions for use in generics


## Additional Context



## User Documentation

Check one:
- [X] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
