### PR TITLE
chore: enable Dependabot for Rust crate updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,13 @@ updates:
         patterns:
           - "actions/**"
 
+  # Maintain dependencies for Rust crates
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+
   # Enable version updates for npm
   - package-ecosystem: "npm"
     directory: "/"


### PR DESCRIPTION
## Summary
- Adds a `cargo` package ecosystem entry to `.github/dependabot.yml`
- Dependabot will check for Rust crate updates weekly, with a limit of 5 open PRs

## Test plan
- Verify Dependabot starts opening PRs for outdated Rust dependencies after merge