### PR TITLE
fix: support turbofish generics

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/enums.rs
+++ b/compiler/noirc_frontend/src/elaborator/enums.rs
@@ -767,7 +767,7 @@ impl Elaborator<'_> {
         variables_defined: &mut Vec<Ident>,
     ) -> Pattern {
         let (actual_type, expected_arg_types, variant_index) = match &resolution {
-            PathResolutionItem::Global(id) => {
+            PathResolutionItem::Global(id, _) => {
                 // variant constant
                 self.elaborate_global_if_unresolved(id);
                 let global = self.interner.get_global(*id);

--- a/compiler/noirc_frontend/src/elaborator/path_resolution.rs
+++ b/compiler/noirc_frontend/src/elaborator/path_resolution.rs
@@ -44,8 +44,8 @@ pub(crate) enum PathResolutionItem {
     TraitAssociatedType(TraitAssociatedTypeId),
 
     // These are values
-    /// A reference to a global value.
-    Global(GlobalId),
+    /// A reference to a global value, optionally with turbofish generics from the parent type
+    Global(GlobalId, Option<(TypeId, Option<Turbofish>)>),
     /// A function call on a module, for example `some::module::function()`.
     ModuleFunction(FuncId),
     Method(TypeId, Option<Turbofish>, FuncId),
@@ -120,7 +120,7 @@ impl PathResolutionItem {
                 let trait_ = interner.get_trait(associated_type.trait_id);
                 format!("associated type `{}::{}`", trait_.name, associated_type.name)
             }
-            PathResolutionItem::Global(id) => {
+            PathResolutionItem::Global(id, _) => {
                 let global = interner.get_global_definition(*id);
                 format!("global `{}`", global.name)
             }
@@ -1128,7 +1128,15 @@ fn merge_intermediate_path_resolution_item_with_module_def_id(
         ModuleDefId::TypeAliasId(type_alias_id) => PathResolutionItem::TypeAlias(type_alias_id),
         ModuleDefId::TraitId(trait_id) => PathResolutionItem::Trait(trait_id),
         ModuleDefId::TraitAssociatedTypeId(id) => PathResolutionItem::TraitAssociatedType(id),
-        ModuleDefId::GlobalId(global_id) => PathResolutionItem::Global(global_id),
+        ModuleDefId::GlobalId(global_id) => PathResolutionItem::Global(
+            global_id,
+            match intermediate_item {
+                IntermediatePathResolutionItem::Type(type_id, generics) => {
+                    Some((type_id, generics))
+                }
+                _ => None,
+            },
+        ),
         ModuleDefId::FunctionId(func_id) => match intermediate_item {
             IntermediatePathResolutionItem::SelfType => PathResolutionItem::SelfMethod(func_id),
             IntermediatePathResolutionItem::Module => PathResolutionItem::ModuleFunction(func_id),

--- a/compiler/noirc_frontend/src/elaborator/scope.rs
+++ b/compiler/noirc_frontend/src/elaborator/scope.rs
@@ -118,7 +118,7 @@ impl Elaborator<'_> {
 
         let expected = "value";
         match item {
-            PathResolutionItem::Global(global) => {
+            PathResolutionItem::Global(global, _) => {
                 let global = self.interner.get_global(global);
                 let item_as_value = ItemAsValue::Definition { id: global.definition_id, item };
                 Ok(item_as_value)

--- a/compiler/noirc_frontend/src/elaborator/types.rs
+++ b/compiler/noirc_frontend/src/elaborator/types.rs
@@ -927,7 +927,7 @@ impl Elaborator<'_> {
     /// Look up a path as a global used as a numeric type (e.g. `global N: u32 = 5;`
     fn lookup_global_type(&mut self, path: &TypedPath, mode: PathResolutionMode) -> Option<Type> {
         match self.resolve_path_inner(path.clone(), PathResolutionTarget::Value, mode) {
-            Ok(PathResolution { item: PathResolutionItem::Global(id), errors }) => {
+            Ok(PathResolution { item: PathResolutionItem::Global(id, _), errors }) => {
                 self.push_errors(errors);
 
                 if let Some(current_item) = self.current_item {

--- a/compiler/noirc_frontend/src/elaborator/variable.rs
+++ b/compiler/noirc_frontend/src/elaborator/variable.rs
@@ -273,6 +273,22 @@ impl Elaborator<'_> {
                 self.push_err(TypeCheckError::expecting_other_error(message, location));
             }
 
+            // For globals (e.g. no-arg enum variants like `E::<u32>::A`), bind the
+            // turbofish type generics to the forall type variables of the global's type.
+            if !type_generics.is_empty()
+                && let Some(def_id) = definition_id
+            {
+                let typ = self.interner.definition_type(def_id);
+                if let Type::Forall(typevars, _) = &typ {
+                    for (type_var, type_generic) in typevars.iter().zip(type_generics) {
+                        bindings.insert(
+                            type_var.id(),
+                            (type_var.clone(), type_var.kind(), type_generic),
+                        );
+                    }
+                }
+            }
+
             None
         };
 
@@ -526,6 +542,11 @@ impl Elaborator<'_> {
                 };
                 (generics, None)
             }
+            PathResolutionItem::Global(_, Some((struct_id, generics))) => {
+                let generics =
+                    self.resolve_struct_id_turbofish_generics(struct_id, generics, &mut errors);
+                (generics, None)
+            }
             PathResolutionItem::Method(_, None, _)
             | PathResolutionItem::TraitFunction(_, None, _)
             | PathResolutionItem::Module(..)
@@ -534,7 +555,7 @@ impl Elaborator<'_> {
             | PathResolutionItem::PrimitiveType(..)
             | PathResolutionItem::Trait(..)
             | PathResolutionItem::TraitAssociatedType(..)
-            | PathResolutionItem::Global(..)
+            | PathResolutionItem::Global(_, None)
             | PathResolutionItem::ModuleFunction(..)
             | PathResolutionItem::TraitConstant(..) => (Vec::new(), None),
         };

--- a/compiler/noirc_frontend/src/tests/enums.rs
+++ b/compiler/noirc_frontend/src/tests/enums.rs
@@ -379,6 +379,21 @@ fn cannot_determine_type_of_generic_argument_in_enum_constructor() {
 }
 
 #[test]
+fn turbofish_on_no_arg_enum_variant_binds_generic() {
+    let src = r#"
+    enum E<T> {
+        A,
+        B(T),
+    }
+
+    fn main() {
+        let _ = E::<u32>::A;
+    }
+    "#;
+    assert_no_errors(src);
+}
+
+#[test]
 fn impl_on_enum() {
     let src = r#"
     enum Foo { Bar }


### PR DESCRIPTION
# Description

## Problem

Resolves AuditHub issue: Turbofish on generic enum unit-variant construction is dropped
https://app.audithub.dev/app/organizations/161/projects/599/project-viewer?version=1406&issueId=939

## Summary
support turbofish generics in global path resolution.


## Additional Context



## User Documentation

Check one:
- [X] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
