### PR TITLE
fix(fuzzer): correct type when assigning ref

### DIFF
--- a/tooling/ast_fuzzer/src/program/expr.rs
+++ b/tooling/ast_fuzzer/src/program/expr.rs
@@ -322,9 +322,12 @@ pub fn assign_ident(ident: Ident, expr: Expression) -> Expression {
 
 /// Assign a value to a mutable reference.
 pub fn assign_ref(ident: Ident, expr: Expression) -> Expression {
-    let typ = ident.typ.as_ref().clone();
+    let element_type = match ident.typ.as_ref() {
+        Type::Reference(inner, _) => inner.as_ref().clone(),
+        other => other.clone(),
+    };
     let lvalue = LValue::Ident(ident);
-    let lvalue = LValue::Dereference { reference: Box::new(lvalue), element_type: typ };
+    let lvalue = LValue::Dereference { reference: Box::new(lvalue), element_type };
     Expression::Assign(Assign { lvalue, expression: Box::new(expr) })
 }
 

--- a/tooling/ast_fuzzer/src/program/tests.rs
+++ b/tooling/ast_fuzzer/src/program/tests.rs
@@ -6,8 +6,8 @@ use noirc_evaluator::{assert_ssa_snapshot, ssa::ssa_gen};
 use noirc_frontend::{
     ast::IntegerBitSize,
     monomorphization::ast::{
-        Call, Definition, Expression, For, FuncId, Function, Ident, IdentId, InlineType, LocalId,
-        Program, Type,
+        Call, Definition, Expression, For, FuncId, Function, Ident, IdentId, InlineType, LValue,
+        LocalId, Program, Type,
     },
     shared::Visibility,
 };
@@ -242,4 +242,44 @@ fn test_recursion_limit_rewrite() {
         bar((&mut ctx_limit))
     }
     ");
+}
+
+/// `assign_ref` must set `element_type` to the inner type (`u32`), not the
+/// full reference type (`&mut u32`). Otherwise nested lvalue codegen in SSA
+/// would produce `load ref -> &mut u32` which is invalid.
+#[test]
+fn test_assign_ref_element_type() {
+    use super::expr::assign_ref;
+
+    let ref_type = Type::Reference(Rc::new(crate::program::types::U32), true);
+    let ident = Ident {
+        location: None,
+        definition: Definition::Local(LocalId(0)),
+        mutable: false,
+        name: "r".to_string(),
+        typ: Rc::new(ref_type),
+        id: IdentId(0),
+    };
+
+    let rhs = Expression::Literal(noirc_frontend::monomorphization::ast::Literal::Integer(
+        acir::FieldElement::from(0u32),
+        crate::program::types::U32,
+        Location::dummy(),
+    ));
+
+    let assign_expr = assign_ref(ident, rhs);
+    let Expression::Assign(assign) = assign_expr else {
+        panic!("expected Assign");
+    };
+
+    let LValue::Dereference { element_type, .. } = &assign.lvalue else {
+        panic!("expected LValue::Dereference, got {:?}", assign.lvalue);
+    };
+
+    // Before the fix, element_type was `&mut u32` instead of `u32`.
+    assert_eq!(
+        *element_type,
+        crate::program::types::U32,
+        "element_type should be the inner type (u32), not the reference type (&mut u32)"
+    );
 }


### PR DESCRIPTION
# Description

## Problem

Resolves blocker in fuzzer https://github.com/noir-lang/noir/actions/runs/23460598609/job/68262813377?pr=11953

## Summary

If you look at `dereference_lvalue` you will see the `element_type` is meant to be the result of the load:
https://github.com/noir-lang/noir/blob/94e13233e54cceb3cd1e7093964f272d79a41ff1/compiler/noirc_evaluator/src/ssa/ssa_gen/context.rs#L708

Which is then called here when extracting the LValue: https://github.com/noir-lang/noir/blob/94e13233e54cceb3cd1e7093964f272d79a41ff1/compiler/noirc_evaluator/src/ssa/ssa_gen/context.rs#L793

## Additional Context



## User Documentation

Check one:
- [X] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
