### PR TITLE
chore(brillig): Use ConditionalMove in a few more places

### DIFF
--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_call/code_gen_call.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_call/code_gen_call.rs
@@ -139,25 +139,29 @@ impl<Registers: RegisterAllocator> BrilligBlock<'_, Registers> {
                         BrilligBinaryOp::Equals,
                     );
 
-                    self.brillig_context.codegen_branch(is_length_zero.address, |ctx, is_zero| {
-                        if is_zero {
-                            ctx.mov_instruction(length_addr, calculated_semantic_length.address);
-                        } else {
-                            let length_equals = ctx.allocate_single_addr_bool();
-                            ctx.binary_instruction(
-                                length,
-                                *calculated_semantic_length,
-                                *length_equals,
-                                BrilligBinaryOp::Equals,
-                            );
-                            ctx.codegen_constrain(
-                                *length_equals,
-                                Some(
-                                    "semantic length returned from oracle does not match data"
-                                        .to_string(),
-                                ),
-                            );
-                        }
+                    // If length is zero, use calculated_semantic_length; otherwise keep current length
+                    self.brillig_context.conditional_move_instruction(
+                        is_length_zero.address,
+                        calculated_semantic_length.address,
+                        length_addr,
+                        length_addr,
+                    );
+                    // If length was non-zero, assert it matches the calculated length
+                    self.brillig_context.codegen_if_not(is_length_zero.address, |ctx| {
+                        let length_equals = ctx.allocate_single_addr_bool();
+                        ctx.binary_instruction(
+                            length,
+                            *calculated_semantic_length,
+                            *length_equals,
+                            BrilligBinaryOp::Equals,
+                        );
+                        ctx.codegen_constrain(
+                            *length_equals,
+                            Some(
+                                "semantic length returned from oracle does not match data"
+                                    .to_string(),
+                            ),
+                        );
                     });
                 }
             } else {

--- a/compiler/noirc_evaluator/src/brillig/brillig_ir.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_ir.rs
@@ -273,13 +273,12 @@ impl<F: AcirField + DebugToString, Registers: RegisterAllocator> BrilligContext<
         self.binary_instruction(*zero, num, *twos_complement, BrilligBinaryOp::Sub);
 
         // absolute_value = result_is_negative ? twos_complement : num
-        self.codegen_branch(result_is_negative.address, |ctx, is_negative| {
-            if is_negative {
-                ctx.mov_instruction(absolute_value.address, twos_complement.address);
-            } else {
-                ctx.mov_instruction(absolute_value.address, num.address);
-            }
-        });
+        self.conditional_move_instruction(
+            result_is_negative.address,
+            twos_complement.address,
+            num.address,
+            absolute_value.address,
+        );
     }
 
     pub(crate) fn convert_signed_division(


### PR DESCRIPTION
# Description

## Problem

No issue, just some low hanging fruit

## Summary

We were not utilizing `ConditionalMov` everywhere we could in Brillig gen. 

## Additional Context



## User Documentation

Check one:
- [X] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
