### PR TITLE
fix(brillig): Differentiate LHS and RHS bit size in SHL and SHR

### DIFF
--- a/acvm-repo/brillig_vm/src/arithmetic.rs
+++ b/acvm-repo/brillig_vm/src/arithmetic.rs
@@ -191,10 +191,19 @@ pub(crate) fn evaluate_binary_int_op<F: AcirField>(
             (MemoryValue::U128(lhs), MemoryValue::U128(rhs), IntegerBitSize::U128) => {
                 Ok(MemoryValue::U128(evaluate_binary_int_op_shifts(op, lhs, rhs)?))
             }
-            _ => Err(BrilligArithmeticError::MismatchedLhsBitSize {
-                lhs_bit_size: lhs.bit_size().to_u32::<F>(),
-                op_bit_size: bit_size.into(),
-            }),
+            (lhs, _, _) if lhs.bit_size() != BitSize::Integer(bit_size) => {
+                Err(BrilligArithmeticError::MismatchedLhsBitSize {
+                    lhs_bit_size: lhs.bit_size().to_u32::<F>(),
+                    op_bit_size: bit_size.into(),
+                })
+            }
+            (_, rhs, _) if rhs.bit_size() != BitSize::Integer(bit_size) => {
+                Err(BrilligArithmeticError::MismatchedRhsBitSize {
+                    rhs_bit_size: rhs.bit_size().to_u32::<F>(),
+                    op_bit_size: bit_size.into(),
+                })
+            }
+            _ => unreachable!("Invalid arguments are covered by the two arms above."),
         },
     }
 }
@@ -540,6 +549,25 @@ mod int_ops {
             ),
             Ok(MemoryValue::<FieldElement>::U8(0u8))
         );
+        // Both LHS and RHS has to match the operation bit size.
+        assert_eq!(
+            evaluate_binary_int_op(
+                &BinaryIntOp::Shr,
+                MemoryValue::<FieldElement>::U16(1),
+                MemoryValue::<FieldElement>::U8(1),
+                IntegerBitSize::U8
+            ),
+            Err(BrilligArithmeticError::MismatchedLhsBitSize { lhs_bit_size: 16, op_bit_size: 8 })
+        );
+        assert_eq!(
+            evaluate_binary_int_op(
+                &BinaryIntOp::Shr,
+                MemoryValue::<FieldElement>::U8(1),
+                MemoryValue::<FieldElement>::U16(1),
+                IntegerBitSize::U8
+            ),
+            Err(BrilligArithmeticError::MismatchedRhsBitSize { rhs_bit_size: 16, op_bit_size: 8 })
+        );
     }
 
     #[test]
@@ -559,6 +587,25 @@ mod int_ops {
                 IntegerBitSize::U8
             ),
             Ok(MemoryValue::<FieldElement>::U8(0u8))
+        );
+        // Both LHS and RHS has to match the operation bit size.
+        assert_eq!(
+            evaluate_binary_int_op(
+                &BinaryIntOp::Shr,
+                MemoryValue::<FieldElement>::U16(1),
+                MemoryValue::<FieldElement>::U8(1),
+                IntegerBitSize::U8
+            ),
+            Err(BrilligArithmeticError::MismatchedLhsBitSize { lhs_bit_size: 16, op_bit_size: 8 })
+        );
+        assert_eq!(
+            evaluate_binary_int_op(
+                &BinaryIntOp::Shr,
+                MemoryValue::<FieldElement>::U8(1),
+                MemoryValue::<FieldElement>::U16(1),
+                IntegerBitSize::U8
+            ),
+            Err(BrilligArithmeticError::MismatchedRhsBitSize { rhs_bit_size: 16, op_bit_size: 8 })
         );
     }
 


### PR DESCRIPTION
# Description

## Problem

Resolves https://cantina.xyz/code/24c6f940-d8af-4a25-9b28-b2e42dea31fe/findings/16

## Summary

Fixes the error reporting of SHL and SHR in Brillig when the RHS bit size does not match the operation.

## Additional Context



## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
