### PR TITLE
feat(ssa): Extend dead store elimination to multi-block functions

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/opt/die.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/die.rs
@@ -151,7 +151,7 @@ impl Function {
         &mut self,
         insert_out_of_bounds_checks: bool,
     ) -> HashMap<BasicBlockId, Vec<ValueId>> {
-        let mut context = Context::new();
+        let mut context = Context::default();
 
         // Forward pre-scan: count Load instructions per address so that the
         // reverse pass can determine when a store's address has no live loads.
@@ -212,6 +212,7 @@ struct DIEResult {
     unused_parameters: HashMap<FunctionId, HashMap<BasicBlockId, Vec<ValueId>>>,
 }
 /// Per function context for tracking unused values and which instructions to remove.
+#[derive(Default)]
 struct Context {
     used_values: HashSet<ValueId>,
     instructions_to_remove: HashSet<InstructionId>,
@@ -239,16 +240,6 @@ struct Context {
 }
 
 impl Context {
-    fn new() -> Self {
-        Self {
-            used_values: HashSet::default(),
-            instructions_to_remove: HashSet::default(),
-            rc_instructions: Vec::new(),
-            live_load_counts: HashMap::default(),
-            parameter_keep_list: HashMap::default(),
-        }
-    }
-
     /// Steps backwards through the instruction of the given block, amassing a set of used values
     /// as it goes, and at the same time marking instructions for removal if they haven't appeared
     /// in the set thus far.


### PR DESCRIPTION
## Summary

Extends the dead store elimination in DIE to work across multi-block functions, removing the single-block restriction from #12020.

Uses a two-scan approach to avoid multiple DIE passes:
- **Forward pre-scan**: counts Load instructions per address (`live_load_counts`)
- **Reverse pass** (existing DIE): decrements counts as dead loads are removed; a store is dead when its address is a local allocation, doesn't escape, and has zero live loads

This handles cascading within a single pass — a dead load's removal decrements the count, which can make the corresponding store dead too.

## Test plan

- [x] `dead_store_removed_in_multi_block_brillig` — store in b0 with no loads anywhere → removed
- [x] `keeps_store_when_load_in_back_edge_block` — store in loop body with live load in header → kept
- [x] `dead_load_makes_store_dead` — dead load removal cascades to make store dead
- [x] All 1312 `noirc_evaluator` tests pass
- [x] Clippy and formatting clean