### PR TITLE
chore(experiment): Remove coalescing post improved redundant phi elimination 

### DIFF
--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_fn.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_fn.rs
@@ -92,13 +92,8 @@ impl FunctionContext {
 
         let spill_manager = if needs_spill_support { Some(SpillManager::new()) } else { None };
 
-        // Disable coalescing when spilling is enabled.
-        // Shared registers currently conflicts with the spill eviction mechanism.
-        let coalescing = if spill_manager.is_some() {
-            CoalescingMap::default()
-        } else {
-            CoalescingMap::from_function(function, &liveness)
-        };
+        // Disable coalescing
+        let coalescing = CoalescingMap::default();
 
         Self {
             function_id: Some(id),

--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/coalescing.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/coalescing.rs
@@ -56,6 +56,7 @@ impl CoalescingMap {
     ///   record `arg -> param` so the instruction writes to the param's register.
     /// - Param-side: if the arg is a block parameter or instruction from another block,
     ///   record `param -> arg` so the param reuses the arg's register.
+    #[allow(dead_code)]
     pub(crate) fn from_function(func: &Function, liveness: &VariableLiveness) -> Self {
         let mut coalesced = HashMap::default();
         let cfg = liveness.cfg();


### PR DESCRIPTION
# Description

## Problem

Just testing how necessary it is to have Brillig-specific coalescing once we have improved redundant block parameters removal https://github.com/noir-lang/noir/pull/12047.

## Summary

Still a draft to see benches

## Additional Context



## User Documentation

Check one:
- [X] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
