### PR TITLE
chore: only install npm packages over a week old

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -2,7 +2,7 @@ compressionLevel: mixed
 
 enableGlobalCache: false
 
-npmMinimalAgeGate: 10080
+npmMinimalAgeGate: 10080 # 1 week
 
 logFilters:
   - code: YN0013


### PR DESCRIPTION
# Description

## Problem

Resolves <!-- Link to GitHub Issue -->

## Summary

This PR adds a minimum release age for NPM packages of 1 week (~10k seconds) to make it less likely that we'll be hit by supply chain attacks

## Additional Context



## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
