### PR TITLE
fix(ssa): Unrolling blocks with multiple parameters and constant JmpIf 

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/opt/unrolling.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/unrolling.rs
@@ -1824,6 +1824,16 @@ impl<'f> LoopIteration<'f> {
 
                 self.source_block = self.get_original_block(destination);
 
+                // The body block's instructions will be inlined directly into the
+                // current insert_block, not into the fresh destination block created
+                // by `get_or_insert_block`. Map the destination's block params to the
+                // jmp arguments so that inlined instructions resolve to the actual
+                // values rather than the fresh block's (now unreachable) params.
+                let destination_params = self.dfg().block_parameters(destination).to_vec();
+                for (param, arg) in destination_params.iter().zip(&arguments) {
+                    self.inserter.map_value(*param, *arg);
+                }
+
                 let jmp = TerminatorInstruction::Jmp { destination, arguments, call_stack };
                 self.inserter.function.dfg.set_block_terminator(self.insert_block, jmp);
                 vec![destination]
@@ -3138,6 +3148,7 @@ mod tests {
             }
         ";
         let ssa = Ssa::from_str(src).unwrap();
+        let _ = ssa.interpret(vec![]).unwrap();
 
         // After mem2reg_simple, no loads/stores remain — the cost model must recognize
         // the loop-internal terminator costs as boilerplate.
@@ -3156,6 +3167,8 @@ mod tests {
 
         let (ssa, errors) = try_unroll_loops(ssa);
         assert_eq!(errors.len(), 0, "Unroll should have no errors");
+        let _ = ssa.interpret(vec![]).unwrap();
+
         // Loop has been unrolled
         assert_ssa_snapshot!(ssa, @r"
         brillig(inline) predicate_pure fn main f0 {
@@ -3166,22 +3179,22 @@ mod tests {
           b1():
             v33 = array_get v32, index u32 6 -> Field
             constrain v33 == Field 27
-            v34 = array_get v9, index u32 6 -> Field
+            v34 = array_get v5, index u32 6 -> Field
             v35 = eq v34, Field 27
             constrain v35 == u1 0
             return
           b2(v0: [Field; 10]):
             v14 = array_set v11, index u32 0, value Field 27
-            jmp b3(v0)
+            jmp b3(v11)
           b3(v1: [Field; 10]):
             v16 = array_set v14, index u32 1, value Field 27
-            jmp b4(v1)
+            jmp b4(v11)
           b4(v2: [Field; 10]):
             v18 = array_set v16, index u32 2, value Field 27
-            jmp b5(v2)
+            jmp b5(v11)
           b5(v3: [Field; 10]):
             v20 = array_set v18, index u32 3, value Field 27
-            jmp b6(v3)
+            jmp b6(v11)
           b6(v4: [Field; 10]):
             v22 = array_set v20, index u32 4, value Field 27
             jmp b7()
@@ -3193,13 +3206,13 @@ mod tests {
             jmp b9(v5)
           b9(v6: [Field; 10]):
             v26 = array_set v24, index u32 6, value Field 27
-            jmp b10(v6)
+            jmp b10(v5)
           b10(v7: [Field; 10]):
             v28 = array_set v26, index u32 7, value Field 27
-            jmp b11(v7)
+            jmp b11(v5)
           b11(v8: [Field; 10]):
             v30 = array_set v28, index u32 8, value Field 27
-            jmp b12(v8)
+            jmp b12(v5)
           b12(v9: [Field; 10]):
             v32 = array_set v30, index u32 9, value Field 27
             jmp b1()
@@ -3535,5 +3548,39 @@ mod tests {
         ssa_after = ssa_after.loop_invariant_code_motion();
         let after = ssa_after.interpret(vec![Value::bool(false)]);
         assert_eq!(before, after, "LICM should preserve semantics");
+    }
+
+    /// Regression: when a jmpif in the loop header evaluates to a constant,
+    /// the body block's instructions are inlined directly into the unroll
+    /// target. The body block's params must be mapped to the jmp arguments
+    /// so inlined instructions resolve correctly — otherwise they reference
+    /// dangling params from the (now unreachable) fresh block copy.
+    #[test]
+    fn unroll_with_body_block_params() {
+        let src = "
+        acir(inline) fn main f0 {
+          b0(v0: u32):
+            jmp b1(u32 0, u32 0)
+          b1(v1: u32, v2: u32):
+            v3 = lt v1, u32 5
+            jmpif v3 then: b2(v2), else: b3(v2)
+          b2(v4: u32):
+            v5 = add v4, u32 10
+            v6 = unchecked_add v1, u32 1
+            jmp b1(v6, v5)
+          b3(v7: u32):
+            return v7
+        }
+        ";
+        let ssa = Ssa::from_str(src).unwrap();
+        let (ssa, _) = try_unroll_loops(ssa);
+        assert_ssa_snapshot!(ssa, @r"
+        acir(inline) fn main f0 {
+          b0(v0: u32):
+            jmp b1(u32 50)
+          b1(v1: u32):
+            return v1
+        }
+        ");
     }
 }


### PR DESCRIPTION
# Description

## Problem

Unblocks https://github.com/noir-lang/noir/pull/12047#pullrequestreview-4032928859. We cannot remove `remove_params_from_blocks_with_identical_terminator_args` due to this unroller bug. 

`get_or_insert_block` creates a fresh body block and `remember_block_params_from_block` maps `old params -> new params`. But when the jmpif resolves to a constant, the body is inlined directly into the unroll target. The fresh block is never jumped to, leaving its params dangling.

## Summary

- When a loop header's jmpif evaluates to a constant during unrolling, the body block's params are now mapped to the jmp arguments. Previously they mapped to params of a fresh block copy that becomes unreachable, producing dangling value references.
- Added `unroll_with_body_block_params` test. Minimal SSA with a body block param that previously caused panics after unrolling

For `unroll_with_body_block_params` we used to get this output from unrolling:
```
acir(inline) fn main f0 {
  b0(v0: u32):
    v14 = add v13, u32 10
    v16 = add v15, u32 10
    v19 = add v18, u32 10
    v22 = add v21, u32 10
    v25 = add v24, u32 10
    jmp b3(v25)
  b3(v4: u32):
    return v4
}
```
As you can see `v13` does not exist. While in the fixed test we now pass `u32 50` as the jmp arg. 

## Additional Context

`remove_redundant_params` added in https://github.com/noir-lang/noir/pull/12047 is not enough to fix this problem. If you look at the `unroll_with_body_block_params` unit test we have multiple params but neither are redundant. `remove_params_from_blocks_with_identical_terminator_args` was inadvertently avoiding this bug as that final phase removes redundant params from body blocks before we got to unrolling. 

## User Documentation

Check one:
- [X] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
