### PR TITLE
fix: check mutability in `*&mut x` elaboration optimization

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/expressions.rs
+++ b/compiler/noirc_frontend/src/elaborator/expressions.rs
@@ -533,10 +533,15 @@ impl Elaborator<'_> {
         // Simplify `*&x` and `*&mut x` to just `x`
         if let UnaryOp::Dereference { .. } = prefix.operator
             && let ExpressionKind::Prefix(ref inner) = prefix.rhs.kind
-            && matches!(inner.operator, UnaryOp::Reference { .. })
+            && let UnaryOp::Reference { mutable } = inner.operator
         {
             let ExpressionKind::Prefix(inner) = prefix.rhs.kind else { unreachable!() };
-            return self.elaborate_expression(inner.rhs);
+            let rhs_location = inner.rhs.location;
+            let (rhs, typ) = self.elaborate_expression(inner.rhs);
+            if mutable {
+                self.check_can_mutate(rhs, rhs_location);
+            }
+            return (rhs, typ);
         }
 
         let rhs_location = prefix.rhs.location;

--- a/compiler/noirc_frontend/src/monomorphization/tests.rs
+++ b/compiler/noirc_frontend/src/monomorphization/tests.rs
@@ -1465,7 +1465,7 @@ fn main() {{
 fn deref_of_ref_is_simplified() {
     let src = "
         unconstrained fn main() {
-            let x: Field = 5;
+            let mut x: Field = 5;
             let y = *&mut x;
             assert(y == 5);
         }
@@ -1474,7 +1474,7 @@ fn deref_of_ref_is_simplified() {
     // `*&mut x` should be simplified to just `x` during elaboration
     insta::assert_snapshot!(program, @r"
     unconstrained fn main$f0() -> () {
-        let x$l0 = 5;
+        let mut x$l0 = 5;
         let y$l1 = x$l0;
         assert((y$l1 == 5));
     }

--- a/compiler/noirc_frontend/src/tests/references.rs
+++ b/compiler/noirc_frontend/src/tests/references.rs
@@ -286,3 +286,15 @@ fn disallows_mutating_non_mutable_reference_inside_mutable_reference() {
     "#;
     check_errors_using_features(src, &[UnstableFeature::Ownership]);
 }
+
+#[test]
+fn cannot_take_mut_ref_of_immutable_variable_in_deref() {
+    let src = r#"
+    fn main() {
+        let x: Field = 5;
+        let _y = *&mut x;
+                       ^ Cannot mutate immutable variable `x`
+    }
+    "#;
+    check_errors(src);
+}


### PR DESCRIPTION
## Summary
- The `*&mut x` optimization in `elaborate_prefix` was using a wildcard match on `UnaryOp::Reference { .. }`, bypassing `check_can_mutate` for mutable references to immutable variables.
- Now destructures the `mutable` field and calls `check_can_mutate` when the reference is mutable, so `*&mut x` on an immutable `x` is correctly rejected.

## Test plan
- Added `cannot_take_mut_ref_of_immutable_variable_in_deref` frontend test asserting the error.
- Updated existing `deref_of_ref_is_simplified` monomorphization test to use `let mut x`.