### PR TITLE
fix(lsp): autocomplete in type generics

### DIFF
--- a/tooling/lsp/src/requests/completion.rs
+++ b/tooling/lsp/src/requests/completion.rs
@@ -247,9 +247,20 @@ impl<'a> NodeFinder<'a> {
             return;
         }
 
+        // First try to autocomplete in the path generics
+        for segment in &path.segments {
+            if let Some(generics) = &segment.generics {
+                for generic in generics {
+                    generic.accept(self);
+                }
+            }
+        }
+
         let after_colons = self.byte == Some(b':');
 
         let mut idents: Vec<Ident> = Vec::new();
+
+        let mut found_segment_to_complete = false;
 
         // Find in which ident we are in, and in which part of it
         // (it could be that we are completing in the middle of an ident)
@@ -259,6 +270,7 @@ impl<'a> NodeFinder<'a> {
             // Check if we are at the end of the ident
             if self.byte_index == ident.span().end() as usize {
                 idents.push(ident.clone());
+                found_segment_to_complete = true;
                 break;
             }
 
@@ -277,15 +289,21 @@ impl<'a> NodeFinder<'a> {
                 );
                 idents.push(ident);
                 in_the_middle = true;
+                found_segment_to_complete = true;
                 break;
             }
 
             idents.push(ident.clone());
 
-            // Stop if the cursor is right after this ident and '::'
-            if after_colons && self.byte_index == ident.span().end() as usize + 2 {
+            // Stop if the cursor is right after this segment and '::'
+            if after_colons && self.byte_index == segment.location.span.end() as usize + 2 {
+                found_segment_to_complete = true;
                 break;
             }
+        }
+
+        if !found_segment_to_complete {
+            return;
         }
 
         if idents.len() < path.segments.len() {
@@ -1741,7 +1759,8 @@ impl Visitor for NodeFinder<'_> {
         constructor_expression: &ConstructorExpression,
         _: Span,
     ) -> bool {
-        let UnresolvedTypeData::Named(path, _, _) = &constructor_expression.typ.typ else {
+        let UnresolvedTypeData::Named(path, generic_type_args, _) = &constructor_expression.typ.typ
+        else {
             return true;
         };
 
@@ -1756,6 +1775,8 @@ impl Visitor for NodeFinder<'_> {
             self.complete_constructor_field_name(constructor_expression);
             return false;
         }
+
+        generic_type_args.accept(self);
 
         for (_field_name, expression) in &constructor_expression.fields {
             expression.accept(self);

--- a/tooling/lsp/src/requests/completion/tests.rs
+++ b/tooling/lsp/src/requests/completion/tests.rs
@@ -3619,4 +3619,50 @@ fn main() {
         )
         .await;
     }
+
+    #[test]
+    async fn autocompletes_type_in_generic_call() {
+        let src = r#"
+        pub struct FooBar {}
+
+        pub struct Generic<T> {}
+
+        fn main() {
+            Generic::<FooB>|<>::new()
+        }
+        "#;
+
+        assert_completion(
+            src,
+            vec![simple_completion_item(
+                "FooBar",
+                CompletionItemKind::STRUCT,
+                Some("FooBar".to_string()),
+            )],
+        )
+        .await;
+    }
+
+    #[test]
+    async fn autocompletes_type_in_generic_constructor() {
+        let src = r#"
+        pub struct FooBar {}
+
+        pub struct Generic<T> {}
+
+        fn main() {
+            Generic::< FooB>|< > {}
+        }
+        "#;
+
+        assert_completion(
+            src,
+            vec![simple_completion_item(
+                "FooBar",
+                CompletionItemKind::STRUCT,
+                Some("FooBar".to_string()),
+            )],
+        )
+        .await;
+    }
 }


### PR DESCRIPTION
# Description

## Problem

Something I noticed while working on something else.

## Summary

I noticed that types weren't being suggested in path segment generics, so this PR fixes that.

For example, these two completions weren't triggered, and writing them manually was pretty slow:

![lsp-complete-in-generics](https://github.com/user-attachments/assets/d8273d3b-1ed8-41d9-aa8e-e3c75d588dba)


## Additional Context



## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
