### PR TITLE
chore: remove dead code in type_check_operator_method

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/types.rs
+++ b/compiler/noirc_frontend/src/elaborator/types.rs
@@ -2214,7 +2214,7 @@ impl Elaborator<'_> {
         is_ord: bool,
     ) {
         let method_type = self.interner.definition_type(trait_method_id.item_id);
-        let (method_type, mut bindings) = method_type.instantiate(self.interner);
+        let (method_type, bindings) = method_type.instantiate(self.interner);
 
         match method_type {
             Type::Function(mut args, ret, env, _unconstrained) => {
@@ -2312,26 +2312,12 @@ impl Elaborator<'_> {
             }
         }
 
-        // We must also remember to apply these substitutions to the object_type
-        // referenced by the selected trait impl, if one has yet to be selected.
-        let impl_kind = self.interner.get_selected_impl_for_expression(expr_id);
-        if let Some(TraitImplKind::Assumed { object_type, trait_generics }) = impl_kind {
-            let the_trait = self.interner.get_trait(trait_method_id.trait_id);
-            let object_type = object_type.substitute(&bindings);
-            bindings.insert(
-                the_trait.self_type_typevar.id(),
-                (
-                    the_trait.self_type_typevar.clone(),
-                    the_trait.self_type_typevar.kind(),
-                    object_type.clone(),
-                ),
-            );
-
-            self.interner.select_impl_for_expression(
-                expr_id,
-                TraitImplKind::Assumed { object_type, trait_generics },
-            );
-        }
+        // The expr_id is freshly created by the caller and the trait constraint is deferred
+        // to function end (check_and_pop_function_context), so no impl should be selected yet.
+        assert!(
+            self.interner.get_selected_impl_for_expression(expr_id).is_none(),
+            "type_check_operator_method: expected no impl to be selected yet for this expression"
+        );
 
         self.interner.store_instantiation_bindings(expr_id, bindings);
     }


### PR DESCRIPTION
I noticed this while investigating https://github.com/AztecProtocol/noir-claude/issues/689

## Summary

- Removes an unreachable `if` block in `type_check_operator_method` that attempted to re-substitute an `Assumed` trait impl's `object_type` and `trait_generics`
- The block was dead code because the `expr_id` is freshly created by the caller and the trait constraint is deferred to function end (`check_and_pop_function_context`), so `get_selected_impl_for_expression` always returned `None`
- Replaces it with an `assert!` to guard the invariant

## Test plan

- [x] `noirc_frontend` tests pass (1592 tests)
- [x] `binary_operator_overloading` integration tests pass (16 variants)
- [x] Clean build with no warnings