### PR TITLE
fix: avoid nondeterminism when reporting "Type annotation needed"

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/variable.rs
+++ b/compiler/noirc_frontend/src/elaborator/variable.rs
@@ -24,7 +24,7 @@ use crate::node_interner::{
     DefinitionId, DefinitionInfo, DefinitionKind, ExprId, TraitImplKind, TypeAliasId,
 };
 use crate::{Kind, Type, TypeBindings, TypeVariable};
-use iter_extended::vecmap;
+use iter_extended::{btree_map, vecmap};
 use noirc_errors::Location;
 
 /// The result of [`Elaborator::resolve_variable`].
@@ -896,9 +896,10 @@ impl Elaborator<'_> {
 
         if push_required_type_variables {
             // Record required type variables in a predictable order to avoid nondeterminism in error messages.
-            let required_type_variables = btree_map(bindings.values(), |(type_variable, _, typ)| {
-                (type_variable.id(), typ.clone())
-            });
+            let required_type_variables =
+                btree_map(bindings.values(), |(type_variable, _, typ)| {
+                    (type_variable.id(), typ.clone())
+                });
 
             for (type_variable_id, typ) in required_type_variables {
                 self.push_required_type_variable(


### PR DESCRIPTION
# Description

## Problem

Resolves an issue I noticed is happening in some PRs

## Summary

See for example https://github.com/noir-lang/noir/actions/runs/23858312386/job/69559675287?pr=11991 for a case where the error messages order changes.

## Additional Context

This introduces an allocation but I don't know how else it can be done.

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
