### PR TITLE
fix(lsp): hover on numeric generic

### DIFF
--- a/tooling/lsp/src/requests/hover.rs
+++ b/tooling/lsp/src/requests/hover.rs
@@ -550,4 +550,12 @@ Like a tomato"
         )
         .await;
     }
+
+    #[test]
+    async fn hover_on_numeric_generic() {
+        let hover_text =
+            get_hover_text("workspace", "two/src/lib.nr", Position { line: 126, character: 12 })
+                .await;
+        assert_eq!(&hover_text, "    let N: u32");
+    }
 }

--- a/tooling/lsp/src/requests/hover/from_reference.rs
+++ b/tooling/lsp/src/requests/hover/from_reference.rs
@@ -613,38 +613,49 @@ fn format_alias(id: TypeAliasId, args: &ProcessRequestCallbackArgs) -> String {
 
 fn format_local(id: DefinitionId, args: &ProcessRequestCallbackArgs) -> String {
     let definition_info = args.interner.definition(id);
-    if let DefinitionKind::Global(global_id) = &definition_info.kind {
-        return format_global(*global_id, args);
-    }
 
-    let DefinitionKind::Local(expr_id) = definition_info.kind else {
-        panic!("Expected a local reference to reference a local definition")
-    };
-    let typ = args.interner.definition_type(id);
+    match &definition_info.kind {
+        DefinitionKind::Global(global_id) => format_global(*global_id, args),
+        DefinitionKind::Local(expr_id) => {
+            let typ = args.interner.definition_type(id);
 
-    let mut string = String::new();
-    string.push_str("    ");
-    if definition_info.comptime {
-        string.push_str("comptime ");
-    }
-    if expr_id.is_some() {
-        string.push_str("let ");
-    }
-    if definition_info.mutable {
-        if expr_id.is_none() {
-            string.push_str("let ");
+            let mut string = String::new();
+            string.push_str("    ");
+            if definition_info.comptime {
+                string.push_str("comptime ");
+            }
+            if expr_id.is_some() {
+                string.push_str("let ");
+            }
+            if definition_info.mutable {
+                if expr_id.is_none() {
+                    string.push_str("let ");
+                }
+                string.push_str("mut ");
+            }
+            string.push_str(&definition_info.name);
+            if !matches!(typ, Type::Error) {
+                string.push_str(": ");
+                string.push_str(&format!("{typ}"));
+            }
+
+            string.push_str(&go_to_type_links(&typ, args.interner, args.files));
+
+            string
         }
-        string.push_str("mut ");
+        DefinitionKind::NumericGeneric(_, typ) => {
+            let mut string = String::new();
+            string.push_str("    ");
+            string.push_str("let ");
+            string.push_str(&definition_info.name);
+            string.push_str(": ");
+            string.push_str(&typ.to_string());
+            string
+        }
+        other => {
+            panic!("Unexpected definition kind: {other:?}")
+        }
     }
-    string.push_str(&definition_info.name);
-    if !matches!(typ, Type::Error) {
-        string.push_str(": ");
-        string.push_str(&format!("{typ}"));
-    }
-
-    string.push_str(&go_to_type_links(&typ, args.interner, args.files));
-
-    string
 }
 
 fn format_generics(generics: &ResolvedGenerics, string: &mut String) {

--- a/tooling/lsp/test_programs/workspace/two/src/lib.nr
+++ b/tooling/lsp/test_programs/workspace/two/src/lib.nr
@@ -122,3 +122,7 @@ fn doc_comments_test() {}
 fn use_invalid_global() {
     let _ = one::subone::valid_global;
 }
+
+fn hover_on_numeric_generic<let N: u32>() {
+    println(N);
+}


### PR DESCRIPTION
# Description

## Problem

Akosh noticed that hovering over a numeric generic crashes the LS.

## Summary

Rust here provides a bit more information, it shows which function or type the numeric generic belongs to, but I don't know if we have that information. In any case it's better at least showing the generic's type instead of crashing.

## Additional Context



## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
