### PR TITLE
chore: handle missing error in codegen_if

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/ssa_gen/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/ssa_gen/mod.rs
@@ -1001,7 +1001,9 @@ impl FunctionContext<'_> {
             self.builder.switch_to_block(end_block);
         } else {
             // In the case we have no 'else', the 'else' block is actually the end block.
-            self.builder.terminate_with_jmp(else_block, vec![]);
+            self.codegen_unless_break_or_continue(then_result, |this, _| {
+                this.builder.terminate_with_jmp(else_block, vec![]);
+            })?;
             self.builder.switch_to_block(else_block);
         }
 


### PR DESCRIPTION
# Description

## Problem

Resolves Claude issue https://github.com/AztecProtocol/noir-claude/issues/699

## Summary
No regression test as this is not a real issue, but a potential one because some errors during codegen of the then branch where not always handled.


## Additional Context



## User Documentation

Check one:
- [X] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
