### PR TITLE
fix: use repeated array literal in monomorphization zeroed

### DIFF
--- a/compiler/noirc_frontend/src/monomorphization/builtin.rs
+++ b/compiler/noirc_frontend/src/monomorphization/builtin.rs
@@ -164,10 +164,12 @@ impl Monomorphizer<'_> {
             ast::Type::Unit => ast::Expression::Literal(ast::Literal::Unit),
             ast::Type::Array(length, element_type) => {
                 let element = self.zeroed_value_of_type(element_type, location);
-                ast::Expression::Literal(ast::Literal::Array(ast::ArrayLiteral {
-                    contents: vec![element; *length as usize],
+                ast::Expression::Literal(ast::Literal::Repeated {
+                    element: Box::new(element),
+                    length: *length,
+                    is_vector: false,
                     typ: ast::Type::Array(*length, element_type.clone()),
-                }))
+                })
             }
             ast::Type::String(length) => {
                 ast::Expression::Literal(ast::Literal::Str("\0".repeat(*length as usize)))

--- a/compiler/noirc_frontend/src/monomorphization/tests.rs
+++ b/compiler/noirc_frontend/src/monomorphization/tests.rs
@@ -1155,10 +1155,10 @@ fn evaluates_builtin_zeroed() {
 
     // Note that the zeroed value of a `str<3>` is `"\0\0\0"`, which prints as "".
     insta::assert_snapshot!(program, @"
-fn main$f0() -> () {
-    let _a$l0 = [(0, \"\0\0\0\"), (0, \"\0\0\0\")]
-}
-");
+    fn main$f0() -> () {
+        let _a$l0 = [(0, \"\0\0\0\"); 2]
+    }
+    ");
 }
 
 #[test]
@@ -1176,10 +1176,10 @@ fn evaluates_builtin_zeroed_function() {
         let _f$l4 = (zeroed_lambda$f1, zeroed_lambda$f2)
     }
     fn zeroed_lambda$f1(_$l0: u32, _$l1: str<3>) -> [Field; 2] {
-        [0, 0]
+        [0; 2]
     }
     unconstrained fn zeroed_lambda$f2(_$l2: u32, _$l3: str<3>) -> [Field; 2] {
-        [0, 0]
+        [0; 2]
     }
     ");
 }


### PR DESCRIPTION
# Description

## Problem

Resolves https://github.com/AztecProtocol/noir-claude/issues/671

## Summary

It's a bit better to use a repeated array literal, though a huge array, written one way or another, is not going to really work in the end, so maybe the issue wasn't "high".

## Additional Context



## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
