### PR TITLE
chore: error instead of panic in case of missing inputs

### DIFF
--- a/tooling/noirc_abi/src/lib.rs
+++ b/tooling/noirc_abi/src/lib.rs
@@ -333,7 +333,7 @@ impl Abi {
                 })?;
                 pointer += num_fields;
 
-                decode_value(&mut param_witness_values.into_iter(), &typ)
+                decode_value(&mut param_witness_values.into_iter(), &typ, &name)
                     .map(|input_value| (name.clone(), input_value))
             })?;
 
@@ -351,7 +351,11 @@ impl Abi {
                         .copied()
                 })
             {
-                Some(decode_value(&mut return_witness_values.into_iter(), &return_type.abi_type)?)
+                Some(decode_value(
+                    &mut return_witness_values.into_iter(),
+                    &return_type.abi_type,
+                    MAIN_RETURN_NAME,
+                )?)
             } else {
                 // Unlike for the circuit inputs, we tolerate not being able to find the witness values for the return value.
                 // This is because the user may be decoding a partial witness map for which is hasn't been calculated yet.
@@ -369,20 +373,23 @@ impl Abi {
 pub fn decode_value(
     field_iterator: &mut impl Iterator<Item = FieldElement>,
     value_type: &AbiType,
+    name: &str,
 ) -> Result<InputValue, AbiError> {
     // This function assumes that `field_iterator` contains enough `FieldElement`s in order to decode a `value_type`
     // `Abi.decode` enforces that the encoded inputs matches the expected length defined by the ABI so this is safe.
     let value = match value_type {
         AbiType::Field | AbiType::Integer { .. } | AbiType::Boolean => {
-            let field_element = field_iterator.next().unwrap();
+            let field_element =
+                field_iterator.next().ok_or_else(|| AbiError::MissingParam(name.to_string()))?;
 
             InputValue::Field(field_element)
         }
         AbiType::Array { length, typ } => {
             let length = *length as usize;
             let mut array_elements = Vec::with_capacity(length);
-            for _ in 0..length {
-                array_elements.push(decode_value(field_iterator, typ)?);
+            for i in 0..length {
+                let indexed_name = format!("{name}[{i}]");
+                array_elements.push(decode_value(field_iterator, typ, &indexed_name)?);
             }
 
             InputValue::Vec(array_elements)
@@ -396,7 +403,8 @@ pub fn decode_value(
             let mut struct_map = BTreeMap::new();
 
             for (field_key, param_type) in fields {
-                let field_value = decode_value(field_iterator, param_type)?;
+                let struct_name = format!("{name}.{field_key}");
+                let field_value = decode_value(field_iterator, param_type, &struct_name)?;
 
                 struct_map.insert(field_key.to_owned(), field_value);
             }
@@ -405,8 +413,9 @@ pub fn decode_value(
         }
         AbiType::Tuple { fields } => {
             let mut tuple_elements = Vec::with_capacity(fields.len());
-            for field_typ in fields {
-                tuple_elements.push(decode_value(field_iterator, field_typ)?);
+            for (i, field_typ) in fields.iter().enumerate() {
+                let indexed_name = format!("{name}.{i}");
+                tuple_elements.push(decode_value(field_iterator, field_typ, &indexed_name)?);
             }
 
             InputValue::Vec(tuple_elements)

--- a/tooling/noirc_abi_wasm/src/lib.rs
+++ b/tooling/noirc_abi_wasm/src/lib.rs
@@ -156,7 +156,7 @@ pub fn abi_decode_error(
             Ok(JsValue::from_str(&string))
         }
         AbiErrorType::Custom(typ) => {
-            let input_value = decode_value(&mut error_data.into_iter(), &typ)?;
+            let input_value = decode_value(&mut error_data.into_iter(), &typ, "error")?;
             let json_types = JsonTypes::try_from_input_value(&input_value, &typ)?;
             <JsValue as JsValueSerdeExt>::from_serde(&json_types)
                 .map_err(|err| err.to_string().into())


### PR DESCRIPTION
# Description

## Problem

Resolves Claudebox issue 693: https://github.com/AztecProtocol/noir-claude/issues/693

## Summary
Error instead of panic


## Additional Context



## User Documentation

Check one:
- [X] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
