### PR TITLE
fix: prevent potential overflow for i128

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/opt/expand_signed_math.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/expand_signed_math.rs
@@ -148,7 +148,9 @@ impl Context<'_, '_, '_> {
         // negative value by -1. For example dividing -128 i8 by -1 would give 128, but that
         // does not fit i8. So the first thing we do is check for this case.
         let min_negative_value = self.numeric_constant(1_u128 << (bit_size - 1), unsigned_typ);
-        let minus_one = self.numeric_constant((1_u128 << bit_size) - 1, unsigned_typ);
+        let max_for_bit_size =
+            if bit_size == 128 { u128::MAX - 1 } else { (1_u128 << bit_size) - 1 };
+        let minus_one = self.numeric_constant(max_for_bit_size, unsigned_typ);
         let lhs_is_min_negative_value =
             self.insert_binary(lhs_unsigned, BinaryOp::Eq, min_negative_value);
         let rhs_is_minus_one = self.insert_binary(rhs_unsigned, BinaryOp::Eq, minus_one);


### PR DESCRIPTION
# Description

## Problem

Resolves https://github.com/AztecProtocol/noir-claude/issues/710

## Summary

In reality no overflow can happen because there's no `i128` type, but in case we add it in the future the code won't panic then.

## Additional Context



## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
