### PR TITLE
chore: panic on missing comptime struct field

### DIFF
--- a/compiler/noirc_frontend/src/hir/comptime/value.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/value.rs
@@ -340,7 +340,9 @@ impl Value {
                 for field in data_type.borrow().fields_raw().unwrap() {
                     let name = field.name.as_string();
                     let Some(field) = fields.remove(name) else {
-                        continue;
+                        panic!(
+                            "Expected struct value to have all fields set, missing field `{name}`"
+                        );
                     };
                     let field = field.unwrap_or_clone().into_expression(elaborator, location)?;
                     ordered_fields.push((Ident::new(name.to_string(), location), field));
@@ -532,7 +534,9 @@ impl Value {
                 for field in data_type.borrow().fields_raw().unwrap() {
                     let name = field.name.as_string();
                     let Some(field) = fields.remove(name) else {
-                        continue;
+                        panic!(
+                            "Expected struct value to have all fields set, missing field `{name}`"
+                        );
                     };
                     let field =
                         field.unwrap_or_clone().into_runtime_hir_expression(interner, location)?;


### PR DESCRIPTION
# Description

## Problem

Addresses follow-up comments in https://app.audithub.dev/app/organizations/161/projects/600/project-viewer?version=1408&issueId=881

## Summary

I originally didn't produce a panic here because in the past we allowed, in comptime, to create a struct with missing fields, and the interpreter kept running with these incorrect values. However at some point we stopped interpreting expressions after an expression errored, so I think this scenario can't happen anymore.

## Additional Context



## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
