### PR TITLE
chore(ssa): Remove all mem2reg_simple limits and pre flattening variant

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/mod.rs
@@ -188,7 +188,7 @@ pub fn primary_passes(options: &SsaEvaluatorOptions) -> Vec<SsaPass<'_>> {
         ),
         // Run mem2reg with block span limit for ACIR, then load_store_forwarding to handle
         // same-block store->load patterns without creating block parameters.
-        SsaPass::new(Ssa::mem2reg_simple_pre_flattening, "Mem2Reg Simple")
+        SsaPass::new(Ssa::mem2reg_simple, "Mem2Reg Simple")
             .and_then(Ssa::load_store_forwarding)
             .and_then(Ssa::remove_redundant_params),
         SsaPass::new(Ssa::array_set_optimization, "ArraySet optimization"),
@@ -233,7 +233,7 @@ pub fn primary_passes(options: &SsaEvaluatorOptions) -> Vec<SsaPass<'_>> {
         SsaPass::new(Ssa::simplify_cfg, "Simplifying"),
         // After unrolling there are no loops left, so load_store_forwarding has no
         // loop-alias overhead. This is the most impactful position for ACIR store->load forwarding.
-        SsaPass::new(Ssa::mem2reg_simple_pre_flattening, "Mem2Reg Simple")
+        SsaPass::new(Ssa::mem2reg_simple, "Mem2Reg Simple")
             .and_then(Ssa::load_store_forwarding)
             .and_then(Ssa::remove_redundant_params),
         SsaPass::new(Ssa::remove_bit_shifts, "Removing Bit Shifts"),

--- a/compiler/noirc_evaluator/src/ssa/opt/mem2reg_simple.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/mem2reg_simple.rs
@@ -38,28 +38,6 @@ use crate::ssa::{
     ssa_gen::Ssa,
 };
 
-/// Arbitrary limit for maximum variables optimized by this pass in each function.
-///
-/// This is because this pass can lead to regressions in certain cases (e.g. the hashmap test)
-/// where variables are modified in inner loops but not outer ones, yet the outer loops would need
-/// to pay for passing around the variables while with the `Load` approach, only the inner loops
-/// paid previously.
-const MAX_VARIABLES_OPTIMIZED: u32 = 10;
-
-// /// Maximum number of blocks a variable's declaration can dominate before we skip
-// /// promoting it in the pre-flattening pass.
-// ///
-// /// The cost of promoting a variable before flattening is O(promoted_variables × dominated_blocks)
-// /// because each promoted variable adds a block parameter to every dominated block, and the
-// /// flattener converts each conditional block into ~5 predicate opcodes (not, mul,
-// /// enable_side_effects, etc.). A variable that spans many blocks (e.g. a byte in a 254-iteration
-// /// unrolled loop) can generate thousands of extra ACIR opcodes.
-// ///
-// /// This limit filters out variables whose declaration dominates too many blocks,
-// /// keeping promotion beneficial for small CFGs (like if/else diamonds in `conditional_1`)
-// /// while avoiding regressions in deeply unrolled code (like `to_bytes_integration`).
-// const MAX_BLOCK_SPAN_PRE_FLATTENING: usize = 100;
-
 impl Ssa {
     /// Run mem2reg_simple on all functions (both ACIR and Brillig).
     ///
@@ -72,9 +50,7 @@ impl Ssa {
     #[tracing::instrument(level = "trace", skip_all)]
     pub(crate) fn mem2reg_simple(mut self) -> Ssa {
         for function in self.functions.values_mut() {
-            let max_vars =
-                if function.runtime().is_brillig() { Some(MAX_VARIABLES_OPTIMIZED) } else { None };
-            function.mem2reg_simple(max_vars, None);
+            function.mem2reg_simple(None, None);
         }
         self
     }
@@ -84,24 +60,6 @@ impl Ssa {
     pub(crate) fn mem2reg_simple_brillig(mut self) -> Ssa {
         for function in self.functions.values_mut() {
             if function.runtime().is_brillig() {
-                function.mem2reg_simple(Some(MAX_VARIABLES_OPTIMIZED), None);
-            }
-        }
-        self
-    }
-
-    /// Run mem2reg_simple on all functions before flattening.
-    ///
-    /// Brillig functions use the standard variable limit. ACIR functions use both
-    /// a variable limit and a block span limit to avoid regressions: promoting a
-    /// variable whose declaration dominates many blocks (e.g. across an unrolled loop)
-    /// generates O(variables × blocks) extra predicate opcodes after flattening.
-    #[tracing::instrument(level = "trace", skip_all)]
-    pub(crate) fn mem2reg_simple_pre_flattening(mut self) -> Ssa {
-        for function in self.functions.values_mut() {
-            if function.runtime().is_brillig() {
-                function.mem2reg_simple(Some(MAX_VARIABLES_OPTIMIZED), None);
-            } else {
                 function.mem2reg_simple(None, None);
             }
         }


### PR DESCRIPTION
# Description

## Problem

Building upon https://github.com/noir-lang/noir/pull/12091

## Summary

I want to isolate these changes for the benchmarks

## Additional Context



## User Documentation

Check one:
- [ ] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
