### PR TITLE
chore(stdlib): Collapse if statements in bit decomposition 

### DIFF
--- a/noir_stdlib/src/field/mod.nr
+++ b/noir_stdlib/src/field/mod.nr
@@ -37,11 +37,9 @@ impl Field {
             assert(bits.len() <= p.len());
             let mut ok = bits.len() != p.len();
             for i in 0..N {
-                if !ok {
-                    if (bits[N - 1 - i] != p[N - 1 - i]) {
-                        assert(p[N - 1 - i] == 1);
-                        ok = true;
-                    }
+                if !ok & (bits[N - 1 - i] != p[N - 1 - i]) {
+                    assert(p[N - 1 - i] == 1);
+                    ok = true;
                 }
             }
             assert(ok);
@@ -69,11 +67,9 @@ impl Field {
             assert(bits.len() <= p.len());
             let mut ok = bits.len() != p.len();
             for i in 0..N {
-                if !ok {
-                    if (bits[i] != p[i]) {
-                        assert(p[i] == 1);
-                        ok = true;
-                    }
+                if !ok & (bits[i] != p[i]) {
+                    assert(p[i] == 1);
+                    ok = true;
                 }
             }
             assert(ok);
@@ -106,11 +102,9 @@ impl Field {
             assert(bytes.len() <= p.len());
             let mut ok = bytes.len() != p.len();
             for i in 0..N {
-                if !ok {
-                    if (bytes[N - 1 - i] != p[N - 1 - i]) {
-                        assert(bytes[N - 1 - i] < p[N - 1 - i]);
-                        ok = true;
-                    }
+                if !ok & (bytes[N - 1 - i] != p[N - 1 - i]) {
+                    assert(bytes[N - 1 - i] < p[N - 1 - i]);
+                    ok = true;
                 }
             }
             assert(ok);
@@ -143,11 +137,9 @@ impl Field {
             assert(bytes.len() <= p.len());
             let mut ok = bytes.len() != p.len();
             for i in 0..N {
-                if !ok {
-                    if (bytes[i] != p[i]) {
-                        assert(bytes[i] < p[i]);
-                        ok = true;
-                    }
+                if !ok & (bytes[i] != p[i]) {
+                    assert(bytes[i] < p[i]);
+                    ok = true;
                 }
             }
             assert(ok);


### PR DESCRIPTION
# Description

## Problem

Resolves `to_bytes_integration` regression in https://github.com/noir-lang/noir/pull/12091

## Summary

We attempted to optimize for these cases in the compiler https://github.com/noir-lang/noir/pull/12116. It seems that we did not account for all cases of redundant merges. I checked the stdlib and realized we could just collapse the if statements manually. This is something Noir devs need to be aware of when writing nested conditionals. Ideally we would optimize this fully in the compiler but best to avoid it if we can. 

## Additional Context



## User Documentation

Check one:
- [X] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
