### PR TITLE
fix(ssa): Aliasing issues in load/store forwarding

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/opt/load_store_forwarding.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/load_store_forwarding.rs
@@ -283,28 +283,24 @@ fn forward_loads_and_stores_in_block(
                 instruction.for_each_value(|value| {
                     let value = inserter.resolve(value);
                     let typ = inserter.function.dfg.type_of_value(value);
-                    if typ.contains_reference() {
-                        if let Some(inner) = typ.reference_element_type() {
-                            if inner.contains_reference() {
-                                // Double-reference (e.g. &mut &mut Field): callee can
-                                // load the inner ref and write through it — clear all.
-                                known_values.clear();
-                                last_stores.clear();
-                                local_allocations.clear();
-                            } else {
-                                // Simple reference: only invalidate this address, but
-                                // also remove from local_allocations since the address
-                                // now escapes and may be returned as an alias.
-                                known_values.remove(&value);
-                                last_stores.remove(&value);
-                                local_allocations.remove(&value);
-                            }
-                        } else {
-                            // Container holding references (array/tuple) — clear all.
-                            known_values.clear();
-                            last_stores.clear();
-                            local_allocations.clear();
-                        }
+                    // Simple reference to a non-reference type (e.g. &mut Field):
+                    // only invalidate this specific address. Also remove from
+                    // local_allocations since the address now escapes to the callee
+                    // and may be returned as an alias.
+                    //
+                    // Everything else that contains a reference — double-references
+                    // (&mut &mut Field), containers ([&mut Field; N]), etc. — requires
+                    // clearing all state since the callee can chase indirections or
+                    // extract inner references and write through them.
+                    let is_simple_ref = matches!(typ.reference_element_type(), Some(inner) if !inner.contains_reference());
+                    if is_simple_ref {
+                        known_values.remove(&value);
+                        last_stores.remove(&value);
+                        local_allocations.remove(&value);
+                    } else if typ.contains_reference() {
+                        known_values.clear();
+                        last_stores.clear();
+                        local_allocations.clear();
                     }
                 });
             }


### PR DESCRIPTION
# Description

## Problem

Resolves https://github.com/AztecProtocol/noir-claude/issues/712 and https://github.com/AztecProtocol/noir-claude/issues/751

## Summary

1. Double-reference invalidation — When &mut &mut Field is passed to a call, only the outer ref was removed from known_values. The callee can load the inner ref and store through it, leaving stale entries. Fix: if a reference's inner type also contains a ref, clear all maps (same as the container path).
2. local_allocations not updated on Call — Passed references were removed from known_values/last_stores but stayed in local_allocations. A returned alias could then store without triggering the conservative clear.

Two regression tests added

## Additional Context



## User Documentation

Check one:
- [X] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
