### PR TITLE
fix(cli): fail when interpret output or results change across SSA passes

### DIFF
--- a/tooling/nargo_cli/src/cli/interpret_cmd.rs
+++ b/tooling/nargo_cli/src/cli/interpret_cmd.rs
@@ -408,8 +408,7 @@ fn compare_and_update_snapshot(
 ) -> Option<String> {
     let discrepancy = previous_snapshot.as_ref().and_then(|previous_snapshot| {
         let output_changed = previous_snapshot.print_output != current_snapshot.print_output;
-        let result_changed = compare_results
-            && previous_snapshot.result != &current_snapshot.result;
+        let result_changed = compare_results && previous_snapshot.result != current_snapshot.result;
 
         if !output_changed && !result_changed {
             return None;


### PR DESCRIPTION
# Description

## Problem

Resolves #12124

`nargo interpret` currently runs the SSA interpreter after selected passes, but it does not compare interpreter observations between passes.

In practice:

- printed output can change between passes without being flagged
- if `Prover.toml` has no `return`, the interpreter result can also change between passes without being flagged

That means a pass can change observable interpreter behavior and `nargo interpret` can still appear to succeed.

## Summary

This change adds pass-to-pass checks in `nargo interpret`:

- capture the printed output for each checked pass
- compare printed output against the previous checked pass, including passes that return `Err`
- when `Prover.toml` has no `return`, also compare interpreter results against the previous checked pass
- report discrepancies as they occur, but continue through the selected passes instead of failing fast
- always advance the comparison baseline to the current checked pass

When `Prover.toml` does provide a `return`, that expected result remains the stronger oracle and is still checked directly.

## Additional Context

The original report came from a historical CI reproduction in #12011, specifically [this failing Actions job](https://github.com/noir-lang/noir/actions/runs/23961166350/job/69892846944?pr=12011). The exact pass-to-pass output drift no longer reproduces on current `master`, but `nargo interpret` should still detect this class of regression when it happens.

This PR keeps the implementation local to `nargo interpret`, which matches the quick initial direction in #12124 and the follow-up discussion on the issue.

## User Documentation
Check one:
- [x] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist
- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
