### PR TITLE
fix: prevent force_unroll blowup for large zero-useful-cost loops

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/opt/unrolling.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/unrolling.rs
@@ -2691,15 +2691,15 @@ mod tests {
     /// but total_cost is high due to the many instructions.
     fn brillig_unroll_large_body_test_case(num_adds: usize, iterations: usize) -> Ssa {
         assert!(num_adds >= 1, "need at least one add");
-        let mut body_instrs = String::new();
+        let mut body_instructions = String::new();
         // v8 = load result, v9 = first add
         let mut next_v = 9;
         // First add uses the loaded value (v8) and induction variable (v1)
-        body_instrs += &format!("            v{next_v} = add v8, v1\n");
+        body_instructions += &format!("            v{next_v} = add v8, v1\n");
         next_v += 1;
         // Chain more adds, each using the previous result + induction variable
         for _ in 1..num_adds {
-            body_instrs += &format!("            v{next_v} = add v{}, v1\n", next_v - 1);
+            body_instructions += &format!("            v{next_v} = add v{}, v1\n", next_v - 1);
             next_v += 1;
         }
         let store_val = next_v - 1;
@@ -2716,7 +2716,7 @@ mod tests {
             jmpif v5 then: b3(), else: b2()
           b3():
             v8 = load v2 -> u32
-{body_instrs}            store v{store_val} at v2
+{body_instructions}            store v{store_val} at v2
             v{inc_v} = unchecked_add v1, u32 1
             jmp b1(v{inc_v})
           b2():


### PR DESCRIPTION
## Summary

When `useful_cost == 0`, `unrolled_cost = 0 * iterations = 0`, so `force_unroll` approves arbitrarily large loops. This was exposed when `inc_rc` removal dropped `useful_cost` from 3 to 0 for a 754-iteration scalar-multiplication loop in `noir_bigcurve`, causing it to be fully unrolled into ~300k lines.

Instead of flooring per-iteration cost at 1 (which blocks all zero-useful-cost loops with >128 iterations, including legitimate ones like `regression_4709`), this PR adds a `safe_to_force` guard: when `useful_cost == 0`, also check that the loop body's `total_cost <= force_unroll_threshold`. Small loop bodies are safe to unroll even if the folding prediction is wrong, while large bodies must not be force-unrolled.

| Case | total_cost | iterations | Behavior |
|------|-----------|------------|----------|
| regression_4709 outer loop | 24 | 257 | Unrolled (24 ≤ 128) |
| noir_bigcurve scalar-mul | ~1870 | 754 | Blocked (1870 > 128) |

regression_4709 `--force-brillig`: 25 Brillig opcodes (matches master).

## Test plan

- [x] New test `force_unroll_allows_small_body_zero_useful_cost` verifies small foldable loops ARE unrolled
- [x] New test `force_unroll_blocks_large_body_zero_useful_cost` verifies large foldable loops are NOT force-unrolled
- [x] All 49 existing unrolling tests pass
- [x] All 1295 evaluator lib tests pass"