### PR TITLE
chore: enhance memory access safety with bounds checking on memory length

### DIFF
--- a/acvm-repo/brillig_vm/src/foreign_call.rs
+++ b/acvm-repo/brillig_vm/src/foreign_call.rs
@@ -75,46 +75,46 @@ impl<F: AcirField, B: BlackBoxFunctionSolver<F>> VM<'_, F, B> {
             // but it is cumbersome, and the cleanest solution is not to send the extra empty
             // items at all. To do this, however, we need infer which input is the vector length.
             let mut vector_length: Option<u32> = None;
+            let mut resolved_inputs = Vec::with_capacity(inputs.len());
 
-            let resolved_inputs = inputs
-                .iter()
-                .zip_eq(input_value_types)
-                .map(|(input, input_type)| {
-                    let mut input = self.get_memory_values(*input, input_type);
-                    // Truncate vectors to their semantic length, which we remember from the preceding field.
-                    match input_type {
-                        HeapValueType::Simple(BitSize::Integer(IntegerBitSize::U32)) => {
-                            // If we have a single u32 we may have a vector representation, so store this input.
-                            // On the next iteration, if we have a vector then we know we have the dynamic length
-                            // for that vector.
-                            let ForeignCallParam::Single(length) = input else {
-                                unreachable!("expected u32; got {input:?}");
-                            };
-                            vector_length = Some(length.to_u128() as u32);
-                        }
-                        HeapValueType::Vector { value_types } => {
-                            let Some(length) = vector_length else {
-                                unreachable!(
-                                    "ICE: expected the semantic vector length to precede a vector input"
-                                );
-                            };
-                            // Get rid of any items beyond the flattened length.
-                            let flattened_length =
-                                vector_flattened_length(value_types, SemanticLength(length));
-                            let ForeignCallParam::Array(fields) = &mut input else {
-                                unreachable!("ICE: expected Array parameter for vector content");
-                            };
-                            fields.truncate(assert_usize(flattened_length.0));
-                            vector_length = None;
-                        }
-                        _ => {
-                            // Otherwise we are not dealing with a u32 followed by a vector.
-                            vector_length = None;
-                        }
+            for (input, input_type) in inputs.iter().zip_eq(input_value_types) {
+                let mut input = match self.get_memory_values(*input, input_type) {
+                    Ok(input) => input,
+                    Err(e) => return self.fail(e),
+                };
+                // Truncate vectors to their semantic length, which we remember from the preceding field.
+                match input_type {
+                    HeapValueType::Simple(BitSize::Integer(IntegerBitSize::U32)) => {
+                        // If we have a single u32 we may have a vector representation, so store this input.
+                        // On the next iteration, if we have a vector then we know we have the dynamic length
+                        // for that vector.
+                        let ForeignCallParam::Single(length) = input else {
+                            unreachable!("expected u32; got {input:?}");
+                        };
+                        vector_length = Some(length.to_u128() as u32);
                     }
-                    input
-                })
-                .collect::<Vec<_>>();
+                    HeapValueType::Vector { value_types } => {
+                        let Some(length) = vector_length else {
+                            unreachable!(
+                                "ICE: expected the semantic vector length to precede a vector input"
+                            );
+                        };
+                        // Get rid of any items beyond the flattened length.
+                        let flattened_length =
+                            vector_flattened_length(value_types, SemanticLength(length));
+                        let ForeignCallParam::Array(fields) = &mut input else {
+                            unreachable!("ICE: expected Array parameter for vector content");
+                        };
+                        fields.truncate(assert_usize(flattened_length.0));
+                        vector_length = None;
+                    }
+                    _ => {
+                        // Otherwise we are not dealing with a u32 followed by a vector.
+                        vector_length = None;
+                    }
+                }
+                resolved_inputs.push(input);
+            }
 
             return self.wait_for_foreign_call(function.to_owned(), resolved_inputs);
         }
@@ -139,10 +139,10 @@ impl<F: AcirField, B: BlackBoxFunctionSolver<F>> VM<'_, F, B> {
         &self,
         input: ValueOrArray,
         value_type: &HeapValueType,
-    ) -> ForeignCallParam<F> {
+    ) -> Result<ForeignCallParam<F>, String> {
         match (input, value_type) {
             (ValueOrArray::MemoryAddress(value_addr), HeapValueType::Simple(_)) => {
-                ForeignCallParam::Single(self.memory.read(value_addr).to_field())
+                Ok(ForeignCallParam::Single(self.memory.read(value_addr).to_field()))
             }
             (
                 ValueOrArray::HeapArray(HeapArray { pointer, size }),
@@ -154,11 +154,12 @@ impl<F: AcirField, B: BlackBoxFunctionSolver<F>> VM<'_, F, B> {
                 assert_eq!(semi_flattened_size, size);
 
                 let start = self.memory.read_ref(pointer);
-                self.read_slice_of_values_from_memory(start, size, value_types)
+                Ok(self
+                    .read_slice_of_values_from_memory(start, size, value_types)
                     .into_iter()
                     .map(|mem_value| mem_value.to_field())
                     .collect::<Vec<_>>()
-                    .into()
+                    .into())
             }
             (
                 ValueOrArray::HeapVector(HeapVector { pointer, size: size_addr }),
@@ -167,11 +168,28 @@ impl<F: AcirField, B: BlackBoxFunctionSolver<F>> VM<'_, F, B> {
                 let start = self.memory.read_ref(pointer);
                 let size = self.memory.read(size_addr).to_u32();
                 let size = SemiFlattenedLength(size);
-                self.read_slice_of_values_from_memory(start, size, value_types)
+
+                // Validate that the vector size does not exceed memory bounds.
+                let start_index = assert_usize(start.unwrap_direct());
+                let size_usize = assert_usize(size.0);
+                if let Some(end) = start_index.checked_add(size_usize)
+                    && end <= self.memory.len()
+                {
+                } else {
+                    return Err(format!(
+                        "HeapVector out of bounds: reading {} elements from address {start_index} \
+                         exceeds memory size {}",
+                        size.0,
+                        self.memory.len()
+                    ));
+                }
+
+                Ok(self
+                    .read_slice_of_values_from_memory(start, size, value_types)
                     .into_iter()
                     .map(|mem_value| mem_value.to_field())
                     .collect::<Vec<_>>()
-                    .into()
+                    .into())
             }
             _ => {
                 unreachable!("Unexpected value type {value_type:?} for input {input:?}");

--- a/acvm-repo/brillig_vm/src/lib.rs
+++ b/acvm-repo/brillig_vm/src/lib.rs
@@ -394,7 +394,18 @@ impl<'a, F: AcirField, B: BlackBoxFunctionSolver<F>> VM<'a, F, B> {
             Opcode::CalldataCopy { destination_address, size_address, offset_address } => {
                 let size = assert_usize(self.memory.read(*size_address).to_u32());
                 let offset = assert_usize(self.memory.read(*offset_address).to_u32());
-                let values: Vec<_> = self.calldata[offset..(offset + size)]
+                let end = if let Some(end) = offset.checked_add(size)
+                    && end <= self.calldata.len()
+                {
+                    end
+                } else {
+                    return self.fail(format!(
+                        "CalldataCopy out of bounds: offset {offset} + size {size} \
+                         exceeds calldata length {}",
+                        self.calldata.len()
+                    ));
+                };
+                let values: Vec<_> = self.calldata[offset..end]
                     .iter()
                     .map(|value| MemoryValue::new_field(*value))
                     .collect();

--- a/acvm-repo/brillig_vm/src/memory.rs
+++ b/acvm-repo/brillig_vm/src/memory.rs
@@ -430,7 +430,21 @@ impl<F: AcirField> Memory<F> {
     /// Reads the value at the address and returns it as a direct memory address,
     /// without dereferencing the pointer itself to a numeric value.
     pub fn read_ref(&self, ptr: MemoryAddress) -> MemoryAddress {
-        MemoryAddress::direct(self.read(ptr).to_u32())
+        let resolved = assert_usize(self.resolve(ptr));
+        if resolved >= self.inner.len() {
+            panic!(
+                "read_ref: address {ptr:?} (resolved to {resolved}) is out of bounds (memory size: {})",
+                self.inner.len()
+            );
+        }
+        let value = self.inner[resolved];
+        let MemoryValue::U32(addr) = value else {
+            panic!(
+                "read_ref: expected a U32 pointer at address {ptr:?}, but found {value} ({})",
+                value.bit_size()
+            );
+        };
+        MemoryAddress::direct(addr)
     }
 
     /// Sets `ptr` to point at `address`.
@@ -449,7 +463,14 @@ impl<F: AcirField> Memory<F> {
             return &[];
         }
         let resolved_addr = assert_usize(self.resolve(address));
-        &self.inner[resolved_addr..(resolved_addr + len)]
+        let end = resolved_addr.checked_add(len).expect("read_slice: address + len overflows");
+        assert!(
+            end <= self.inner.len(),
+            "read_slice: out of bounds — reading {len} elements from address {resolved_addr} \
+             exceeds memory size {}. Callers should validate sizes before calling read_slice.",
+            self.inner.len()
+        );
+        &self.inner[resolved_addr..end]
     }
 
     /// Sets the value at `address` to `value`
@@ -502,6 +523,11 @@ impl<F: AcirField> Memory<F> {
         {
             self.stack_pointer = *sp;
         }
+    }
+
+    /// Returns the number of memory slots currently allocated.
+    pub(crate) fn len(&self) -> usize {
+        self.inner.len()
     }
 
     /// Returns the values of the memory
@@ -645,7 +671,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "range end index 30 out of range for slice of length 0")]
+    #[should_panic(expected = "read_slice: out of bounds")]
     fn read_vector_from_non_existent_memory() {
         let memory = Memory::<FieldElement>::default();
         let _ = memory.read_slice(MemoryAddress::direct(20), 10);


### PR DESCRIPTION
# Description

## Problem

Resolves Claudebox issues: 
https://github.com/AztecProtocol/noir-claude/issues/664
https://github.com/AztecProtocol/noir-claude/issues/635
https://github.com/AztecProtocol/noir-claude/issues/637
https://github.com/AztecProtocol/noir-claude/issues/670

## Summary
- 664: Fixed. Error if reading out-of-bound memory, instead of panic. All call sites of `read_slice` fail if reading out-of-memory, so that it is safe to panic in `read_slice`
- 635: Fixed. Error if destination is out-of-bound (instead of panic)
- 637: Won't fix. It makes sense to return 0 on unallocated memory read, instead of panic.
- 670: Won't fix. It makes sense to return 0 on unallocated memory read, and panic when  dereferencing a null pointer.
I added a specific `panic!` that checks the length before reading the address. So the error will be more meaningful.


## Additional Context



## User Documentation

Check one:
- [ ] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
