### PR TITLE
feat: avoid duplicated calculation of CFG

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/ir/dom.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/dom.rs
@@ -165,7 +165,7 @@ impl DominatorTree {
     #[cfg(test)]
     pub(crate) fn with_function(func: &Function) -> Self {
         let cfg = ControlFlowGraph::with_function(func);
-        let post_order = PostOrder::with_function(func);
+        let post_order = PostOrder::with_cfg(&cfg);
         Self::with_cfg_and_post_order(&cfg, &post_order)
     }
 

--- a/compiler/noirc_evaluator/src/ssa/opt/remove_truncate_after_range_check.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/remove_truncate_after_range_check.rs
@@ -28,7 +28,7 @@ impl Ssa {
 impl Function {
     fn remove_truncate_after_range_check(&mut self) {
         let cfg = ControlFlowGraph::with_function(self);
-        let post_order = PostOrder::with_function(self);
+        let post_order = PostOrder::with_cfg(&cfg);
         let mut dom_tree = DominatorTree::with_cfg_and_post_order(&cfg, &post_order);
 
         // Keeps the minimum bit size a value was range-checked against

--- a/compiler/noirc_evaluator/src/ssa/opt/unrolling.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/unrolling.rs
@@ -452,7 +452,7 @@ impl Loops {
     /// which we can use to check whether we were able to unroll all blocks.
     pub(crate) fn find_all(function: &Function, order: LoopOrder) -> Self {
         let cfg = ControlFlowGraph::with_function(function);
-        let post_order = PostOrder::with_function(function);
+        let post_order = PostOrder::with_cfg(&cfg);
         let mut dom_tree = DominatorTree::with_cfg_and_post_order(&cfg, &post_order);
 
         let mut loops = vec![];


### PR DESCRIPTION
# Description

## Problem

Resolves <!-- Link to GitHub Issue -->

## Summary

Pulling out a change from https://github.com/noir-lang/noir/pull/12161. We're unnecessarily building the CFG twice in a couple of places. We could go further but this is the limit of a clean optimization which doesn't affect interfaces.

## Additional Context



## User Documentation

Check one:
- [ ] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
