### PR TITLE
chore: Rename mem2reg_simple to mem2reg

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/mod.rs
@@ -153,7 +153,7 @@ pub fn primary_passes(options: &SsaEvaluatorOptions) -> Vec<SsaPass<'_>> {
         // Running ACIR mem2reg this early creates block parameters that cascade through
         // inlining and unrolling, causing regressions in unrolled-loop-heavy programs.
         // LSF is safe here — it forwards same-block store->load without block parameters.
-        SsaPass::new(Ssa::mem2reg_simple_brillig, "Mem2Reg Simple")
+        SsaPass::new(Ssa::mem2reg_brillig, "Mem2Reg")
             .and_then(Ssa::load_store_forwarding)
             .and_then(Ssa::remove_redundant_params),
         SsaPass::new(Ssa::defunctionalize, "Defunctionalization"),
@@ -163,7 +163,7 @@ pub fn primary_passes(options: &SsaEvaluatorOptions) -> Vec<SsaPass<'_>> {
         ),
         SsaPass::new_try(Ssa::inline_simple_functions, "Inlining simple functions")
             .and_then(Ssa::remove_unreachable_functions),
-        SsaPass::new(Ssa::mem2reg_simple_brillig, "Mem2Reg Simple")
+        SsaPass::new(Ssa::mem2reg_brillig, "Mem2Reg")
             .and_then(Ssa::load_store_forwarding)
             .and_then(Ssa::remove_redundant_params),
         SsaPass::new(Ssa::array_set_optimization, "ArraySet optimization"),
@@ -190,7 +190,7 @@ pub fn primary_passes(options: &SsaEvaluatorOptions) -> Vec<SsaPass<'_>> {
         ),
         // Run mem2reg with block span limit for ACIR, then load_store_forwarding to handle
         // same-block store->load patterns without creating block parameters.
-        SsaPass::new(Ssa::mem2reg_simple, "Mem2Reg Simple")
+        SsaPass::new(Ssa::mem2reg, "Mem2Reg")
             .and_then(Ssa::load_store_forwarding)
             .and_then(Ssa::remove_redundant_params),
         SsaPass::new(Ssa::array_set_optimization, "ArraySet optimization"),
@@ -235,7 +235,7 @@ pub fn primary_passes(options: &SsaEvaluatorOptions) -> Vec<SsaPass<'_>> {
         SsaPass::new(Ssa::simplify_cfg, "Simplifying"),
         // After unrolling there are no loops left, so load_store_forwarding has no
         // loop-alias overhead. This is the most impactful position for ACIR store->load forwarding.
-        SsaPass::new(Ssa::mem2reg_simple, "Mem2Reg Simple")
+        SsaPass::new(Ssa::mem2reg, "Mem2Reg")
             .and_then(Ssa::load_store_forwarding)
             .and_then(Ssa::remove_redundant_params),
         SsaPass::new(Ssa::remove_bit_shifts, "Removing Bit Shifts"),
@@ -250,11 +250,11 @@ pub fn primary_passes(options: &SsaEvaluatorOptions) -> Vec<SsaPass<'_>> {
         SsaPass::new(Ssa::simplify_cfg, "Simplifying"),
         SsaPass::new(Ssa::flatten_cfg, "Flattening"),
         SsaPass::new(Ssa::array_set_window_optimization, "ArraySet Window optimization"),
-        // Run mem2reg_simple on all functions after flattening to handle cross-block promotion
+        // Run mem2reg on all functions after flattening to handle cross-block promotion
         // (Brillig still multi-block; ACIR is single-block so this is trivial for ACIR).
         // Then run load_store_forwarding to handle aliased references within blocks
-        // (which mem2reg_simple doesn't handle). Finally free memory before inlining.
-        SsaPass::new(Ssa::mem2reg_simple, "Mem2Reg Simple")
+        // (which mem2reg doesn't handle). Finally free memory before inlining.
+        SsaPass::new(Ssa::mem2reg, "Mem2Reg")
             .and_then(Ssa::load_store_forwarding)
             .and_then(Ssa::remove_unused_instructions)
             .and_then(Ssa::remove_redundant_params),

--- a/compiler/noirc_evaluator/src/ssa/opt/basic_conditional.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/basic_conditional.rs
@@ -690,7 +690,7 @@ mod tests {
     }
 
     /// Diamond-shaped conditional where the entry JmpIf carries then/else arguments
-    /// (as emitted by mem2reg_simple). Both branches receive a promoted variable value
+    /// (as emitted by mem2reg). Both branches receive a promoted variable value
     /// as a block parameter. The optimization should still fire and produce merged output.
     #[test]
     fn jmpif_with_then_and_else_args_diamond() {

--- a/compiler/noirc_evaluator/src/ssa/opt/flatten_cfg.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/flatten_cfg.rs
@@ -1537,7 +1537,7 @@ mod tests {
 
         let ssa = Ssa::from_str(src).unwrap();
 
-        let ssa = ssa.flatten_cfg().mem2reg_simple();
+        let ssa = ssa.flatten_cfg().mem2reg();
 
         let main = ssa.main();
         let ret = match main.dfg[main.entry_block()].terminator() {
@@ -1922,7 +1922,7 @@ mod tests {
 
         let ssa = Ssa::from_str(src).unwrap();
 
-        let ssa = ssa.flatten_cfg().mem2reg_simple().fold_constants(1);
+        let ssa = ssa.flatten_cfg().mem2reg().fold_constants(1);
 
         let main = ssa.main();
 
@@ -1987,7 +1987,7 @@ mod tests {
 
         let ssa = Ssa::from_str(src).unwrap();
 
-        let ssa = ssa.flatten_cfg().mem2reg_simple().fold_constants(1);
+        let ssa = ssa.flatten_cfg().mem2reg().fold_constants(1);
 
         assert_ssa_snapshot!(ssa, @r"
         acir(inline) fn main f0 {
@@ -2029,7 +2029,7 @@ mod tests {
 
         let ssa = ssa
             .flatten_cfg()
-            .mem2reg_simple()
+            .mem2reg()
             .remove_if_else()
             .unwrap()
             .fold_constants(1)
@@ -2200,7 +2200,7 @@ mod tests {
 
     /// Regression test: when JmpIf's else_destination IS the exit/merge block
     /// (no separate else block), the else_arguments carry the "no-change" value
-    /// directly to the merge. This is the pattern mem2reg_simple produces when
+    /// directly to the merge. This is the pattern mem2reg produces when
     /// the else branch has no stores (just falls through to the merge block).
     #[test]
     fn flatten_jmpif_else_args_to_exit_block() {
@@ -2382,10 +2382,8 @@ mod merge_provenance_tests {
         let promoted_ssa = Ssa::from_str(promoted_src).unwrap();
         let store_load_ssa = Ssa::from_str(store_load_src).unwrap();
 
-        let promoted_flat =
-            promoted_ssa.flatten_cfg().mem2reg_simple().dead_instruction_elimination();
-        let store_load_flat =
-            store_load_ssa.flatten_cfg().mem2reg_simple().dead_instruction_elimination();
+        let promoted_flat = promoted_ssa.flatten_cfg().mem2reg().dead_instruction_elimination();
+        let store_load_flat = store_load_ssa.flatten_cfg().mem2reg().dead_instruction_elimination();
 
         let count = |ssa: &Ssa| -> usize {
             let main = ssa.main();

--- a/compiler/noirc_evaluator/src/ssa/opt/load_store_forwarding.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/load_store_forwarding.rs
@@ -7,7 +7,7 @@
 //!   intervening load, the first store is dead and can be removed.
 //!
 //! This pass does not track values across block boundaries (that is handled by
-//! `mem2reg_simple` which promotes variables to block parameters). It is designed
+//! `mem2reg` which promotes variables to block parameters). It is designed
 //! to be fast on large, single-block ACIR functions that result from inlining,
 //! unrolling, and flattening.
 //!
@@ -113,7 +113,7 @@ impl Function {
 ///    in a later iteration, making the per-block "clear-on-unknown-store"
 ///    heuristic insufficient.
 ///
-/// 2. **Reference-typed block parameters on loop headers**: If `mem2reg_simple`
+/// 2. **Reference-typed block parameters on loop headers**: If `mem2reg`
 ///    has already promoted a `store ref at ref` to a block parameter, the
 ///    aliasing is implicit. A reference-typed loop header parameter and the
 ///    corresponding jmp arguments from within the loop body create the same
@@ -138,7 +138,7 @@ fn analyze_loop_aliases(function: &Function) -> HashSet<ValueId> {
         }
 
         // Form 2: reference-typed block parameters on the loop header.
-        // If mem2reg_simple promoted `store ref at ref` to a block parameter,
+        // If mem2reg promoted `store ref at ref` to a block parameter,
         // the corresponding jmp arguments from within the loop carry the alias.
         let header = loop_info.header;
         let header_params = function.dfg[header].parameters();

--- a/compiler/noirc_evaluator/src/ssa/opt/mem2reg.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/mem2reg.rs
@@ -1,16 +1,9 @@
-//! Mem2reg algorithm adapted from the paper: <https://bernsteinbear.com/assets/img/bebenita-ssa.pdf>
-//!
-//! The goal is for this new, simpler to eventually replace our existing mem2reg algorithm in `ssa/opt/mem2reg.rs`.
-//! The pre-existing pass however can optimize in more/different cases than this pass. For example,
-//! it can still optimize out stores/loads in some cases even when the reference is aliased. That
-//! other pass has a larger surface area for bugs though and this one is simpler so the goal is to
-//! replace the old pass with this one plus any other, separate passes needed for the features
-//! unhandled here (such as alias analysis).
+//! Mem2reg algorithm adapted from the paper: <https://dl.acm.org/doi/pdf/10.1145/115372.115320>
 //!
 //! ## Block parameter placement
 //!
 //! When a variable is stored in multiple blocks, this pass places block parameters only at the
-//! **iterated dominance frontier** (IDF) of those definition sites. This is the minimal set of
+//! iterated dominance frontier (IDF) of those definition sites. This is the minimal set of
 //! blocks where values from different control-flow paths could merge, following the standard
 //! algorithm from Cytron et al. (1991). For variables stored in a single block, the dominance
 //! frontier is often empty, meaning no block parameters are needed at all — the value simply

--- a/compiler/noirc_evaluator/src/ssa/opt/mem2reg.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/mem2reg.rs
@@ -38,21 +38,21 @@ use crate::ssa::{
 };
 
 impl Ssa {
-    /// Run mem2reg_simple on all functions (both ACIR and Brillig).
+    /// Run mem2reg on all functions (both ACIR and Brillig).
     #[tracing::instrument(level = "trace", skip_all)]
-    pub(crate) fn mem2reg_simple(mut self) -> Ssa {
+    pub(crate) fn mem2reg(mut self) -> Ssa {
         for function in self.functions.values_mut() {
-            function.mem2reg_simple();
+            function.mem2reg();
         }
         self
     }
 
-    /// Run mem2reg_simple only on Brillig functions.
+    /// Run mem2reg only on Brillig functions.
     #[tracing::instrument(level = "trace", skip_all)]
-    pub(crate) fn mem2reg_simple_brillig(mut self) -> Ssa {
+    pub(crate) fn mem2reg_brillig(mut self) -> Ssa {
         for function in self.functions.values_mut() {
             if function.runtime().is_brillig() {
-                function.mem2reg_simple();
+                function.mem2reg();
             }
         }
         self
@@ -60,7 +60,7 @@ impl Ssa {
 }
 
 impl Function {
-    pub(crate) fn mem2reg_simple(&mut self) {
+    pub(crate) fn mem2reg(&mut self) {
         let cfg = ControlFlowGraph::with_function(self);
         let post_order = PostOrder::with_cfg(&cfg);
         let mut dom_tree = DominatorTree::with_cfg_and_post_order(&cfg, &post_order);
@@ -423,7 +423,7 @@ fn collect_eligible_variables_and_def_sites(
     let mut def_sites: HashMap<ValueId, HashSet<BasicBlockId>> = HashMap::default();
 
     // Workaround for https://github.com/noir-lang/noir/issues/11482
-    // If the declaration block of an allocate has no starting store then it isn't eligible for mem2reg_simple.
+    // If the declaration block of an allocate has no starting store then it isn't eligible for mem2reg.
     let mut variables_with_stores_in_decl_block = HashSet::default();
 
     for block_id in blocks.iter().copied() {
@@ -527,7 +527,7 @@ mod tests {
         }
         ";
         let ssa = Ssa::from_str(src).unwrap();
-        let ssa = ssa.mem2reg_simple();
+        let ssa = ssa.mem2reg();
 
         assert_ssa_snapshot!(ssa, @r"
         brillig(inline) fn func f0 {
@@ -559,7 +559,7 @@ mod tests {
         }
         ";
         let ssa = Ssa::from_str(src).unwrap();
-        let ssa = ssa.mem2reg_simple();
+        let ssa = ssa.mem2reg();
 
         assert_ssa_snapshot!(ssa, @r"
         brillig(inline) fn func f0 {
@@ -589,7 +589,7 @@ mod tests {
             }
             ";
         let ssa = Ssa::from_str(src).unwrap();
-        let ssa = ssa.mem2reg_simple();
+        let ssa = ssa.mem2reg();
         // Expect the allocate/load/store to be removed and the constant propagated to the return.
         assert_ssa_snapshot!(ssa, @r"
         brillig(inline) fn func f0 {
@@ -621,7 +621,7 @@ mod tests {
             }
             ";
         let ssa = Ssa::from_str(src).unwrap();
-        let ssa = ssa.mem2reg_simple();
+        let ssa = ssa.mem2reg();
         assert_ssa_snapshot!(ssa, @r"
         brillig(inline) fn func f0 {
           b0(v0: u1):
@@ -651,7 +651,7 @@ mod tests {
             }
             ";
         let ssa = Ssa::from_str(src).unwrap();
-        let ssa = ssa.mem2reg_simple();
+        let ssa = ssa.mem2reg();
         assert_ssa_snapshot!(ssa, @r"
             brillig(inline) fn func f0 {
               b0():
@@ -685,7 +685,7 @@ mod tests {
             }
             ";
         let ssa = Ssa::from_str(src).unwrap();
-        let ssa = ssa.mem2reg_simple();
+        let ssa = ssa.mem2reg();
         // Should handle merging from three different paths
         assert_ssa_snapshot!(ssa, @r"
         brillig(inline) fn func f0 {
@@ -722,7 +722,7 @@ mod tests {
                 return v5
             }
             ";
-        assert_ssa_does_not_change(src, Ssa::mem2reg_simple);
+        assert_ssa_does_not_change(src, Ssa::mem2reg);
     }
 
     #[test]
@@ -745,7 +745,7 @@ mod tests {
             }
             ";
         let ssa = Ssa::from_str(src).unwrap();
-        let ssa = ssa.mem2reg_simple();
+        let ssa = ssa.mem2reg();
         // b2 path should pass the initial value (Field 5), b1 passes (Field 10)
         assert_ssa_snapshot!(ssa, @r"
         brillig(inline) fn func f0 {
@@ -776,7 +776,7 @@ mod tests {
             }
             ";
         let ssa = Ssa::from_str(src).unwrap();
-        let ssa = ssa.mem2reg_simple();
+        let ssa = ssa.mem2reg();
         // Only the last store should matter
         assert_ssa_snapshot!(ssa, @r"
             brillig(inline) fn func f0 {
@@ -812,7 +812,7 @@ mod tests {
             }
             ";
         let ssa = Ssa::from_str(src).unwrap();
-        let ssa = ssa.mem2reg_simple();
+        let ssa = ssa.mem2reg();
         // Should properly merge all three stores: from b2, b3, b4
         assert_ssa_snapshot!(ssa, @r"
         brillig(inline) fn func f0 {
@@ -1006,7 +1006,7 @@ brillig(inline) fn main f0 {
         ";
 
         let ssa = Ssa::from_str(src).unwrap();
-        let ssa = ssa.mem2reg_simple();
+        let ssa = ssa.mem2reg();
         assert_ssa_snapshot!(ssa, @r"
         brillig(inline) fn main f0 {
           b0(v0: [u32; 5], v1: [u32; 5], v2: u32, v3: u32):
@@ -1183,7 +1183,7 @@ brillig(inline) fn main f0 {
             }";
 
         let ssa = Ssa::from_str(src).unwrap();
-        let ssa = ssa.mem2reg_simple();
+        let ssa = ssa.mem2reg();
         assert_ssa_snapshot!(ssa, @r"
         brillig(inline) fn to_le_bits f0 {
           b0(v0: Field):
@@ -1243,7 +1243,7 @@ brillig(inline) fn main f0 {
             }";
 
         let ssa = Ssa::from_str(src).unwrap();
-        let ssa = ssa.mem2reg_simple();
+        let ssa = ssa.mem2reg();
         assert_ssa_snapshot!(ssa, @r"
         brillig(inline) fn main f0 {
           b0(v0: u1):
@@ -1292,7 +1292,7 @@ brillig(inline) fn main f0 {
         ";
 
         let ssa = Ssa::from_str(src).unwrap();
-        let ssa = ssa.mem2reg_simple();
+        let ssa = ssa.mem2reg();
         assert_ssa_snapshot!(ssa, @r"
         brillig(inline) predicate_pure fn main f0 {
           b0():
@@ -1349,7 +1349,7 @@ brillig(inline) fn main f0 {
         let ssa = Ssa::from_str(src).unwrap();
 
         // b3 is the only IDF block (merge of b1 and b2); b2, b4, b5 should have no extra params.
-        let ssa = ssa.mem2reg_simple();
+        let ssa = ssa.mem2reg();
 
         // Without IDF optimization, b2/b4/b5 would each get an unnecessary block parameter
         // for v1 that the cleanup pass would later remove:

--- a/compiler/noirc_evaluator/src/ssa/opt/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/mod.rs
@@ -31,7 +31,7 @@ mod load_store_forwarding;
 mod loop_invariant;
 mod lower_refs_at_acir_brillig_boundary;
 mod make_constrain_not_equal;
-mod mem2reg_simple;
+mod mem2reg;
 mod mutable_array_set;
 mod normalize_value_ids;
 mod preprocess_fns;

--- a/compiler/noirc_evaluator/src/ssa/opt/preprocess_fns.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/preprocess_fns.rs
@@ -66,7 +66,7 @@ impl Ssa {
                 &callee_costs,
             );
             // Reduce the number of redundant stores/loads after unrolling
-            function.mem2reg_simple();
+            function.mem2reg();
             function.load_store_forwarding();
             function.remove_redundant_params();
 

--- a/compiler/noirc_evaluator/src/ssa/opt/remove_redundant_params.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/remove_redundant_params.rs
@@ -41,7 +41,7 @@
 //!
 //! ## Pipeline placement
 //!
-//! Chained after every `mem2reg_simple` call in the pipeline. `mem2reg_simple` is likely to generate
+//! Chained after every `mem2reg` call in the pipeline. `mem2reg` is likely to generate
 //! redundant parameters when promoting memory variables.  
 
 use itertools::Itertools;

--- a/compiler/noirc_evaluator/src/ssa/opt/remove_unreachable_functions.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/remove_unreachable_functions.rs
@@ -10,7 +10,7 @@
 //! - A function is reachable if it is stored in a reference (e.g., in a `Store` instruction) from another reachable function.
 //!   Even if not immediately called, it may later be dynamically loaded and invoked.
 //!   This marking is conservative but ensures correctness. We should instead rely on
-//!   [crate::ssa::opt::mem2reg_simple] for resolving loads/stores.
+//!   [crate::ssa::opt::mem2reg] for resolving loads/stores.
 //! - A function is reachable if it is used in a block terminator (e.g., returned from a function)
 //!
 //! The pass builds a call graph based upon the definition of reachability above.

--- a/compiler/noirc_evaluator/src/ssa/opt/unrolling.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/unrolling.rs
@@ -37,7 +37,7 @@
 //!
 //! Conditions:
 //!   - Pre-condition: The first block parameter of each loop header is the induction variable.
-//!     Loop headers may have additional parameters for promoted mutable variables (e.g. from mem2reg_simple).
+//!     Loop headers may have additional parameters for promoted mutable variables (e.g. from mem2reg).
 //!   - Pre-condition: No loop header has a JmpIf with a constant condition (run simplify_cfg first).
 //!   - Pre-condition: The SSA must be optimized to a point at which loop bounds are known.
 //!     Some passes such as inlining and mem2reg are de-facto required before running this pass on arbitrary noir code.
@@ -737,8 +737,8 @@ impl Loop {
             _ => {
                 // Certain patterns can cause other instructions to be hoisted into the loop
                 // header, or at least what looks to be the loop header.
-                // `func_1` in `regression_mem2reg_unknown_array_aliases` is one such example
-                // if `mem2reg_simple` is performed on it before unrolling.
+                // `func_1` in `regression_mem2regunknown_array_aliases` is one such example
+                // if `mem2reg` is performed on it before unrolling.
                 None
             }
         }
@@ -888,7 +888,7 @@ impl Loop {
 
         // Collect all header parameters before mutably borrowing context.
         // The first parameter is the induction variable; additional parameters are
-        // promoted mutable variables (e.g. from mem2reg_simple).
+        // promoted mutable variables (e.g. from mem2reg).
         let header_params: Vec<ValueId> = context.dfg()[loop_header_id].parameters().to_vec();
 
         // Map each header parameter to the corresponding argument value from the previous iteration
@@ -1629,7 +1629,7 @@ fn get_induction_variable(dfg: &DataFlowGraph, block: BasicBlockId) -> Result<Va
 /// Get all arguments of the jump into the loop header from the pre-header block.
 ///
 /// The first argument is the induction variable (must be a numeric constant).
-/// Additional arguments are promoted mutable variables (e.g. from mem2reg_simple).
+/// Additional arguments are promoted mutable variables (e.g. from mem2reg).
 /// Returns `Err` if the block does not end with a `Jmp`, has no arguments, or the
 /// first argument is not a numeric constant.
 fn get_header_arguments(
@@ -1674,7 +1674,7 @@ struct LoopIteration<'f> {
 
     /// All back-edge arguments (and the block they were found in) for the next loop iteration.
     /// The first element is the new induction variable; additional elements are promoted
-    /// mutable variables (e.g. from mem2reg_simple).
+    /// mutable variables (e.g. from mem2reg).
     /// This is None until we visit the block which jumps back to the start of the
     /// loop, at which point we record the arguments and the block they were found in.
     induction_value: Option<(BasicBlockId, Vec<ValueId>)>,
@@ -1923,7 +1923,7 @@ impl<'f> LoopIteration<'f> {
 /// Unrolling leaves some duplicate instructions which can potentially be removed.
 fn simplify_between_unrolls(function: &mut Function) {
     // Do a mem2reg after the last unroll to aid simplify_cfg
-    function.mem2reg_simple();
+    function.mem2reg();
     // Resolves constants, but merge blocks still have 2 predecessors
     function.simplify_instructions();
     // Eliminates dead jmpif branches, collapses merge blocks
@@ -1931,7 +1931,7 @@ fn simplify_between_unrolls(function: &mut Function) {
     // Re-simplify after branch elimination
     function.simplify_instructions();
     // Do another mem2reg after simplify_cfg to aid the next unroll
-    function.mem2reg_simple();
+    function.mem2reg();
 }
 
 /// Decide if the new bytecode size is acceptable, compared to the original.
@@ -3194,13 +3194,13 @@ mod tests {
         );
     }
 
-    /// Regression test: after mem2reg_simple, loop headers can have multiple parameters
+    /// Regression test: after mem2reg, loop headers can have multiple parameters
     /// (induction variable + promoted mutable variables). Blocks outside the loop (like
     /// the exit block b3) reference these header params directly. After unrolling, these
     /// references must remain valid.
     #[test]
     fn unroll_loop_with_multi_param_header() {
-        // Simplified main from vector_loop after mem2reg_simple.
+        // Simplified main from vector_loop after mem2reg.
         // b1 has 3 params: v1 (induction), v2 (promoted u32), v3 (promoted [Field]).
         // b3 (exit) references v2 and v3 from b1 directly.
         let src = "
@@ -3259,7 +3259,7 @@ mod tests {
     /// the loop should still be identified as small enough to unroll.
     /// This is the SSA for the `brillig_cow_assign` integration test post mem2reg.
     #[test]
-    fn test_brillig_unroll_after_mem2reg_simple() {
+    fn test_brillig_unroll_after_mem2reg() {
         let src = "
             brillig(inline) predicate_pure fn main f0 {
                 b0():
@@ -3291,7 +3291,7 @@ mod tests {
         let ssa = Ssa::from_str(src).unwrap();
         let _ = ssa.interpret(vec![]).unwrap();
 
-        // After mem2reg_simple, no loads/stores remain — the cost model must recognize
+        // After mem2reg, no loads/stores remain — the cost model must recognize
         // the loop-internal terminator costs as boilerplate.
         let stats = loop0_stats(&ssa);
         assert_eq!(
@@ -3361,7 +3361,7 @@ mod tests {
         ");
     }
 
-    /// Regression test: after mem2reg_simple promotes loads/stores to block parameters,
+    /// Regression test: after mem2reg promotes loads/stores to block parameters,
     /// `count_useless_cost` must propagate constants through Jmp arguments to non-header
     /// block parameters. Without this, nested loops over constant 2D arrays won't see
     /// inner loop accumulators as constant, inflating useful_cost and preventing unrolling.
@@ -3777,7 +3777,7 @@ mod upper_loop_bound_resolution {
 
     use super::{FORCE_UNROLL_THRESHOLD, MAX_UNROLL_ITERATIONS};
 
-    /// Regression test for vector_loop: after mem2reg_simple promotes the vector length
+    /// Regression test for vector_loop: after mem2reg promotes the vector length
     /// allocation to a block parameter, the iterative unrolling must still resolve the
     /// sum loop's bound to a constant through the vector_push_back simplification chain.
     ///
@@ -3846,7 +3846,7 @@ mod upper_loop_bound_resolution {
         ";
         let ssa = Ssa::from_str(src).unwrap();
 
-        // let ssa = ssa.mem2reg_simple().load_store_forwarding().simplify_cfg().mem2reg_simple();
+        // let ssa = ssa.mem2reg().load_store_forwarding().simplify_cfg().mem2reg();
         // println!("{}", ssa.print_with(None));
         // This should successfully unroll all loops, including the sum loop whose bound
         // depends on the vector length accumulated through vector_push_back calls.


### PR DESCRIPTION
# Description

## Problem

Resolves https://github.com/noir-lang/noir/issues/12214 and https://github.com/noir-lang/noir/issues/8982

## Summary

mem2reg is dead. Long live mem2reg.

## Additional Context



## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
