### PR TITLE
chore(docs): Document snapshot-test conventions and fix cargo insta flags

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,7 +100,19 @@ cargo test -p noir_ast_fuzzer --test smoke              # Fuzz tests (quick)
 Integration tests use `insta` for snapshot testing. When adding new tests or changing outputs:
 - **Do NOT use `cargo insta review`** — it launches an interactive TUI that cannot be used from a CLI agent. Instead, read `.snap.new` files directly to review before accepting.
 - `cargo insta accept` — accept all pending snapshots non-interactively
-- `cargo insta accept --filter <pattern>` — accept specific snapshots
+- `cargo insta accept --snapshot <pattern>` — accept specific snapshots
+- `cargo insta test --accept -p <crate> --test-runner cargo-test -- <test_name>` — run a single test and accept its pending snapshot in one step, needed when the snapshot hasn't been generated yet since `cargo insta accept` alone only applies already-pending snapshots
+
+##### Bug-fix PRs with snapshot-based regression tests
+
+When fixing a bug that is caught by a snapshot assertion, split the work into **two commits** on the feature branch:
+
+1. **Red commit** — add the regression test and accept the *buggy* snapshot (the output produced by the broken code). This commit exists purely so git history preserves a machine-readable fingerprint of what the bug looked like.
+2. **Green commit** — apply the code fix, re-run the test, and accept the updated snapshot.
+
+Do not squash these two commits locally. If the PR is squash-merged into `master` the record is lost from `master`, but it is still preserved in the PR's commit list on GitHub, which is good enough.
+
+This only applies when the regression test uses a snapshot assertion. For regression tests that assert on concrete values (e.g. `assert_eq!`), a single red-then-green commit is fine — the failing assertion's expected/actual values already document the bug.
 
 #### Testing (JavaScript/TypeScript)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,6 +55,12 @@ Test cases are auto-generated from these directories by `tooling/nargo_cli/build
 - **Elaboration** (`compiler/noirc_frontend/src/elaborator/`) combines name resolution and type checking in a single pass.
 - PRs are **squash-merged** into `master`.
 
+### Code Comments
+
+A code comment must stand on its own when read against the post-change state of the file. Do not reference transitions between states ("was a `debug_assert!`, now a plain `assert!`"), the current task or fix ("added for the Y flow"), or what the code used to do. That context belongs in the commit message and PR description, where it naturally lives alongside the diff. In the code it rots the moment the PR stops being recent, leaving a reader with a narrative they cannot verify.
+
+Test: imagine cherry-picking this file into a fresh repository with no git history. If the comment would still make sense to that reader, keep it. If it only makes sense to someone who remembers the change that introduced it, move it to the commit message.
+
 ## Build & Development Commands
 
 The project uses `just` as a task runner and `cargo` for Rust builds. Minimum Rust version: 1.89.0. Run `just --list` to see all available commands.


### PR DESCRIPTION
## Summary

Three small updates to `CLAUDE.md`'s `insta` section, each standing on its own:

- Fix the `cargo insta accept` flag name: `--snapshot`, not `--filter`.
- Document `cargo insta test --accept`, which is the form needed when the pending snapshot hasn't been generated on disk yet. Plain `cargo insta accept` only applies already-pending snapshots, which was a non-obvious footgun while writing a new snapshot test from scratch.
- Add a short subsection describing the two-commit convention for bug-fix PRs with snapshot-based regression tests: first commit the buggy snapshot so git history records a machine-readable fingerprint of what the bug looked like, then commit the fix with the updated snapshot.

## Test plan

- [x] CLAUDE.md rendering checked locally
- [ ] No code changes, so nothing to exercise in CI beyond markdown/formatting checks