### PR TITLE
fix(ssa): Simplify LSF to only run on single block functions

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/mod.rs
@@ -149,13 +149,10 @@ pub fn primary_passes(options: &SsaEvaluatorOptions) -> Vec<SsaPass<'_>> {
         SsaPass::new(Ssa::array_get_optimization, "ArrayGet optimization"),
         SsaPass::new(Ssa::expand_signed_checks, "expand signed checks"),
         SsaPass::new(Ssa::remove_unreachable_functions, "Removing Unreachable Functions"),
-        // Use brillig-only mem2reg at positions 1 and 2 (before inlining).
+        // Use brillig-only mem2reg before inlining.
         // Running ACIR mem2reg this early creates block parameters that cascade through
         // inlining and unrolling, causing regressions in unrolled-loop-heavy programs.
-        // LSF is safe here — it forwards same-block store->load without block parameters.
-        SsaPass::new(Ssa::mem2reg_brillig, "Mem2Reg")
-            .and_then(Ssa::load_store_forwarding)
-            .and_then(Ssa::remove_redundant_params),
+        SsaPass::new(Ssa::mem2reg_brillig, "Mem2Reg").and_then(Ssa::remove_redundant_params),
         SsaPass::new(Ssa::defunctionalize, "Defunctionalization"),
         SsaPass::new(
             Ssa::lower_refs_at_acir_brillig_boundary,
@@ -163,9 +160,7 @@ pub fn primary_passes(options: &SsaEvaluatorOptions) -> Vec<SsaPass<'_>> {
         ),
         SsaPass::new_try(Ssa::inline_simple_functions, "Inlining simple functions")
             .and_then(Ssa::remove_unreachable_functions),
-        SsaPass::new(Ssa::mem2reg_brillig, "Mem2Reg")
-            .and_then(Ssa::load_store_forwarding)
-            .and_then(Ssa::remove_redundant_params),
+        SsaPass::new(Ssa::mem2reg_brillig, "Mem2Reg").and_then(Ssa::remove_redundant_params),
         SsaPass::new(Ssa::array_set_optimization, "ArraySet optimization"),
         SsaPass::new(Ssa::array_get_optimization, "ArrayGet optimization"),
         SsaPass::new(Ssa::purity_analysis, "Purity Analysis"),
@@ -188,11 +183,7 @@ pub fn primary_passes(options: &SsaEvaluatorOptions) -> Vec<SsaPass<'_>> {
             },
             "Inlining",
         ),
-        // Run mem2reg with block span limit for ACIR, then load_store_forwarding to handle
-        // same-block store->load patterns without creating block parameters.
-        SsaPass::new(Ssa::mem2reg, "Mem2Reg")
-            .and_then(Ssa::load_store_forwarding)
-            .and_then(Ssa::remove_redundant_params),
+        SsaPass::new(Ssa::mem2reg, "Mem2Reg").and_then(Ssa::remove_redundant_params),
         SsaPass::new(Ssa::array_set_optimization, "ArraySet optimization"),
         SsaPass::new(Ssa::array_get_optimization, "ArrayGet optimization"),
         // Running DIE here might remove some unused instructions mem2reg could not eliminate.
@@ -233,11 +224,7 @@ pub fn primary_passes(options: &SsaEvaluatorOptions) -> Vec<SsaPass<'_>> {
             "Unrolling",
         ),
         SsaPass::new(Ssa::simplify_cfg, "Simplifying"),
-        // After unrolling there are no loops left, so load_store_forwarding has no
-        // loop-alias overhead. This is the most impactful position for ACIR store->load forwarding.
-        SsaPass::new(Ssa::mem2reg, "Mem2Reg")
-            .and_then(Ssa::load_store_forwarding)
-            .and_then(Ssa::remove_redundant_params),
+        SsaPass::new(Ssa::mem2reg, "Mem2Reg").and_then(Ssa::remove_redundant_params),
         SsaPass::new(Ssa::remove_bit_shifts, "Removing Bit Shifts"),
         SsaPass::new(Ssa::array_set_optimization, "ArraySet optimization"),
         SsaPass::new(Ssa::array_get_optimization, "ArrayGet optimization"),
@@ -271,6 +258,8 @@ pub fn primary_passes(options: &SsaEvaluatorOptions) -> Vec<SsaPass<'_>> {
             },
             "Inlining",
         ),
+        // Run LSF once when we are guaranteed for every function to be inlined (including no_predicates).
+        SsaPass::new(Ssa::load_store_forwarding, "Load-Store Forwarding"),
         SsaPass::new(Ssa::array_set_optimization, "ArraySet optimization"),
         SsaPass::new(Ssa::array_get_optimization, "ArrayGet optimization"),
         SsaPass::new_try(Ssa::remove_if_else, "Remove IfElse"),

--- a/compiler/noirc_evaluator/src/ssa/opt/load_store_forwarding.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/load_store_forwarding.rs
@@ -1,56 +1,42 @@
-//! Per-block load/store forwarding pass.
+//! Single-block load/store forwarding pass.
 //!
-//! This pass performs simple, fast, per-block optimizations:
+//! This pass performs simple, fast optimizations on single-block functions:
 //! - **Load forwarding**: If a load reads from an address whose value is already known
-//!   (from a prior store in the same block), replace the load with the known value.
+//!   (from a prior store), replace the load with the known value.
 //! - **Dead store elimination**: If two stores write to the same address with no
 //!   intervening load, the first store is dead and can be removed.
 //!
-//! This pass does not track values across block boundaries (that is handled by
-//! `mem2reg` which promotes variables to block parameters). It is designed
-//! to be fast on large, single-block ACIR functions that result from inlining,
-//! unrolling, and flattening.
+//! This pass only runs on single-block functions. Multi-block functions are
+//! handled by `mem2reg` which promotes variables to block parameters.
+//! After inlining, unrolling, and flattening, ACIR functions are single-block.
+//! Brillig functions with multiple blocks are skipped.
 //!
 //! ## Alias handling
 //!
-//! This pass does not consume a standalone alias analysis. Instead it uses two
-//! conservative heuristics to stay sound:
+//! Alias reasoning uses allocation identity via [`may_alias`]:
+//! - Two different `allocate` results never alias (each is a fresh, unique address).
+//! - Different reference types never alias (`&mut Field` vs `&mut u32`).
+//! - Any other pair of same-typed addresses may alias (conservative).
 //!
-//! 1. **Clear-on-unknown-store**: When a store targets an address that is neither
-//!    a block-local allocation nor already tracked in `known_values`, it may be an
-//!    alias (e.g. a reference extracted via `array_get`). All known values are
-//!    conservatively cleared. See [`forward_loads_and_stores_in_block`].
+//! This handles references extracted via `array_get` with dynamic indices:
+//! the result is a new ValueId that could alias any same-typed allocation.
+//! Constant-index `array_get` on reference arrays is simplified by the DFG
+//! simplifier during re-insertion, resolving the alias.
 //!
-//! 2. **Call invalidation**: When a reference is passed to a call, its known value
-//!    is invalidated. When a container that holds references (array/tuple) is passed,
-//!    all known values are cleared since the callee could extract and write through
-//!    any contained reference.
-//!
-//! 3. **Loop-carried alias detection**: Before forwarding, `analyze_loop_aliases`
-//!    scans all loops for stores that write a reference value into a reference
-//!    address (`store ref_value at ref_address`). These create cross-iteration
-//!    aliases: the stored reference can alias a "local" variable that is
-//!    re-initialized in a later iteration, bypassing heuristic (1). When a store
-//!    targets an address in the loop-alias set, all known values are conservatively
-//!    cleared. This allows forwarding in loop blocks that lack such patterns while
-//!    staying sound for those that have them.
-//!
-//! Once this pass consumes a standalone alias analysis (see [#12005]), the ad-hoc
-//! loop-alias heuristic can be replaced with precise alias queries.
-//!
-//! [#12005]: https://github.com/noir-lang/noir/issues/12005
+//! Calls are handled conservatively: simple reference arguments invalidate
+//! that specific address; containers or nested references clear all state.
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 
 use crate::ssa::{
     ir::{
         basic_block::BasicBlockId,
+        dfg::DataFlowGraph,
         function::Function,
         function_inserter::FunctionInserter,
         instruction::{Instruction, InstructionId},
         post_order::PostOrder,
         value::ValueId,
     },
-    opt::{LoopOrder, Loops},
     ssa_gen::Ssa,
 };
 
@@ -65,207 +51,110 @@ impl Ssa {
 }
 
 impl Function {
-    /// Runs load/store forwarding on this function by iterating all blocks in reverse
-    /// post-order and applying per-block forwarding and dead store elimination.
     pub(crate) fn load_store_forwarding(&mut self) {
-        let loop_aliases = analyze_loop_aliases(self);
-
         let mut inserter = FunctionInserter::new(self);
         let blocks = PostOrder::with_function(inserter.function).into_vec_reverse();
 
-        // Single pass in RPO: forward loads/stores and remap instructions.
-        // RPO guarantees predecessors are visited before successors (in acyclic
-        // graphs), so value mappings from forwarded loads are always available
-        // before blocks that use those values.
-        for block in &blocks {
-            let block = *block;
-            let instructions_to_remove =
-                forward_loads_and_stores_in_block(&mut inserter, block, &loop_aliases);
-
-            if !instructions_to_remove.is_empty() {
-                inserter.function.dfg[block]
-                    .instructions_mut()
-                    .retain(|id| !instructions_to_remove.contains(id));
-            }
-
-            // Re-insert instructions through the DFG simplify path. This resolves
-            // value mappings from load forwarding AND triggers simplification
-            // (e.g. `lt v2, u32 3` folds to a constant when v2 was forwarded).
-            // Instructions marked for removal (forwarded loads, dead stores) are skipped.
-            let instructions = inserter.function.dfg[block].take_instructions();
-            for instruction_id in &instructions {
-                if !instructions_to_remove.contains(instruction_id) {
-                    inserter.push_instruction(*instruction_id, block, true);
-                }
-            }
-            inserter.map_terminator_in_place(block);
+        // Only run on single-block functions. Multi-block functions rely on
+        // mem2reg for cross-block promotion; Brillig natively supports loads/stores.
+        if blocks.len() > 1 {
+            return;
         }
+
+        let allocations = collect_allocations(inserter.function, &blocks);
+
+        let block = blocks[0];
+        let instructions_to_remove =
+            forward_loads_and_stores_in_block(&mut inserter, block, &allocations);
+
+        if !instructions_to_remove.is_empty() {
+            inserter.function.dfg[block]
+                .instructions_mut()
+                .retain(|id| !instructions_to_remove.contains(id));
+        }
+
+        // Re-insert instructions through the DFG simplify path. This resolves
+        // value mappings from load forwarding AND triggers simplification
+        // (e.g. `lt v2, u32 3` folds to a constant when v2 was forwarded).
+        let instructions = inserter.function.dfg[block].take_instructions();
+        for instruction_id in &instructions {
+            if !instructions_to_remove.contains(instruction_id) {
+                inserter.push_instruction(*instruction_id, block, true);
+            }
+        }
+        inserter.map_terminator_in_place(block);
         inserter.map_data_bus_in_place();
     }
 }
 
-/// Identify addresses involved in loop-carried alias patterns.
-///
-/// A loop-carried alias occurs in two forms:
-///
-/// 1. **Store of a reference inside a loop** (`store ref_value at ref_address`):
-///    The stored reference can alias a local variable that gets re-initialized
-///    in a later iteration, making the per-block "clear-on-unknown-store"
-///    heuristic insufficient.
-///
-/// 2. **Reference-typed block parameters on loop headers**: If `mem2reg`
-///    has already promoted a `store ref at ref` to a block parameter, the
-///    aliasing is implicit. A reference-typed loop header parameter and the
-///    corresponding jmp arguments from within the loop body create the same
-///    cross-iteration aliasing.
-fn analyze_loop_aliases(function: &Function) -> HashSet<ValueId> {
-    use crate::ssa::ir::instruction::TerminatorInstruction;
-
-    let loops = Loops::find_all(function, LoopOrder::OutsideIn);
-    let mut aliases: HashSet<ValueId> = HashSet::default();
-    for loop_info in &loops.yet_to_unroll {
-        // Form 1: store of a reference inside a loop block.
-        for block_id in &loop_info.blocks {
-            let block = &function.dfg[*block_id];
-            for instruction_id in block.instructions() {
-                if let Instruction::Store { address, value } = &function.dfg[*instruction_id]
-                    && function.dfg.value_is_reference(*value)
-                {
-                    aliases.insert(*address);
-                    aliases.insert(*value);
-                }
-            }
-        }
-
-        // Form 2: reference-typed block parameters on the loop header.
-        // If mem2reg promoted `store ref at ref` to a block parameter,
-        // the corresponding jmp arguments from within the loop carry the alias.
-        let header = loop_info.header;
-        let header_params = function.dfg[header].parameters();
-        let ref_param_indices: Vec<usize> = header_params
-            .iter()
-            .enumerate()
-            .filter(|(_, param)| function.dfg.value_is_reference(**param))
-            .map(|(idx, param)| {
-                aliases.insert(*param);
-                idx
-            })
-            .collect();
-
-        if !ref_param_indices.is_empty() {
-            for block_id in &loop_info.blocks {
-                let block = &function.dfg[*block_id];
-                match block.terminator() {
-                    Some(TerminatorInstruction::Jmp { destination, arguments, .. })
-                        if *destination == header =>
-                    {
-                        for &idx in &ref_param_indices {
-                            if let Some(arg) = arguments.get(idx) {
-                                aliases.insert(*arg);
-                            }
-                        }
-                    }
-                    Some(TerminatorInstruction::JmpIf {
-                        then_destination,
-                        then_arguments,
-                        else_destination,
-                        else_arguments,
-                        ..
-                    }) => {
-                        if *then_destination == header {
-                            for &idx in &ref_param_indices {
-                                if let Some(arg) = then_arguments.get(idx) {
-                                    aliases.insert(*arg);
-                                }
-                            }
-                        }
-                        if *else_destination == header {
-                            for &idx in &ref_param_indices {
-                                if let Some(arg) = else_arguments.get(idx) {
-                                    aliases.insert(*arg);
-                                }
-                            }
-                        }
-                    }
-                    _ => {}
-                }
+/// Collect all ValueIds produced by Allocate instructions.
+fn collect_allocations(function: &Function, blocks: &[BasicBlockId]) -> HashSet<ValueId> {
+    let mut allocations = HashSet::default();
+    for block in blocks {
+        for instruction_id in function.dfg[*block].instructions() {
+            if let Instruction::Allocate = &function.dfg[*instruction_id] {
+                let result = function.dfg.instruction_results(*instruction_id)[0];
+                allocations.insert(result);
             }
         }
     }
-    aliases
+    allocations
+}
+
+/// Returns true if two addresses might refer to the same memory.
+///
+/// Conservative: returns true (MayAlias) when uncertain.
+/// - Same ValueId -> always alias.
+/// - Different reference types -> never alias.
+/// - Both from different `allocate` instructions -> never alias.
+/// - Otherwise -> may alias.
+fn may_alias(a: ValueId, b: ValueId, allocations: &HashSet<ValueId>, dfg: &DataFlowGraph) -> bool {
+    if a == b {
+        return true;
+    }
+    if dfg.type_of_value(a) != dfg.type_of_value(b) {
+        return false;
+    }
+    if allocations.contains(&a) && allocations.contains(&b) {
+        return false;
+    }
+    true
 }
 
 /// Perform load/store forwarding within a single block.
 ///
 /// Returns the set of instructions to remove from the block.
-///
-/// ## Alias safety: clear-on-unknown-store
-///
-/// Instructions like `MakeArray`, `ArraySet`, `ArrayGet`, `IncrementRc`, etc. move
-/// references around but don't modify pointed-to memory, so we keep known values
-/// through them. Soundness is maintained by the Store handler: when a store writes
-/// to an address that is neither a local allocation nor already in `known_values`,
-/// it could be an alias (e.g. extracted via `array_get`), so we conservatively
-/// clear all known values. Calls are handled separately since the callee could
-/// dereference and write through any reference argument.
 fn forward_loads_and_stores_in_block(
     inserter: &mut FunctionInserter,
     block: BasicBlockId,
-    loop_aliases: &HashSet<ValueId>,
+    allocations: &HashSet<ValueId>,
 ) -> HashSet<InstructionId> {
-    // Maps address -> last stored value (after resolving through the inserter)
     let mut known_values: HashMap<ValueId, ValueId> = HashMap::default();
-    // Maps address -> last store instruction (candidate for dead store elimination)
     let mut last_stores: HashMap<ValueId, InstructionId> = HashMap::default();
-    let mut instructions_to_remove: HashSet<InstructionId> = HashSet::default();
-    // Maps address -> last load result (for load-to-load forwarding).
-    // Kept separate from known_values so that load entries don't interfere
-    // with the store handler's clear-on-unknown-store alias heuristic.
     let mut last_loads: HashMap<ValueId, ValueId> = HashMap::default();
-    // Track addresses from Allocate instructions in this block.
-    // These are definitionally fresh and cannot alias anything else.
-    let mut local_allocations: HashSet<ValueId> = HashSet::default();
+    let mut instructions_to_remove: HashSet<InstructionId> = HashSet::default();
 
     let instructions = inserter.function.dfg[block].instructions().to_vec();
 
     for instruction_id in instructions {
         let instruction = &inserter.function.dfg[instruction_id];
         match instruction {
-            Instruction::Allocate => {
-                let result = inserter.function.dfg.instruction_results(instruction_id)[0];
-                local_allocations.insert(result);
-            }
             Instruction::Store { address, value } => {
-                let is_loop_aliased = loop_aliases.contains(address);
                 let address = inserter.resolve(*address);
                 let value = inserter.resolve(*value);
+                let dfg = &inserter.function.dfg;
 
-                if is_loop_aliased {
-                    // This address participates in a loop-carried alias pattern:
-                    // a reference stored here in one iteration may alias a "local"
-                    // variable in a subsequent iteration. Conservatively clear all
-                    // known values to prevent stale forwarding.
-                    known_values.clear();
-                    last_loads.clear();
-                    last_stores.clear();
-                } else if !known_values.contains_key(&address)
-                    && !local_allocations.contains(&address)
-                {
-                    // This address wasn't allocated locally and wasn't seen in a prior
-                    // store — it could be an alias of an existing known reference
-                    // (e.g. extracted via array_get). Clear known values for addresses
-                    // of the same type, since different-typed references cannot alias.
-                    let store_type = inserter.function.dfg.type_of_value(address);
-                    let can_alias =
-                        |addr: &ValueId| inserter.function.dfg.type_of_value(*addr) == store_type;
-                    known_values.retain(|addr, _| !can_alias(addr));
-                    last_loads.retain(|addr, _| !can_alias(addr));
-                    last_stores.retain(|addr, _| !can_alias(addr));
-                } else if let Some(prev_store) = last_stores.get(&address) {
-                    // Previous store to this known/local address with no intervening
-                    // load is dead.
+                // Dead store elimination: exact address match only.
+                if let Some(prev_store) = last_stores.get(&address) {
                     instructions_to_remove.insert(*prev_store);
                 }
+
+                // Clear aliased entries (Y != address where may_alias).
+                let aliases =
+                    |k: &ValueId| *k != address && may_alias(address, *k, allocations, dfg);
+                known_values.retain(|k, _| !aliases(k));
+                last_loads.retain(|k, _| !aliases(k));
+                last_stores.retain(|k, _| !aliases(k));
 
                 // A store supersedes any prior load from this address.
                 last_loads.remove(&address);
@@ -276,77 +165,43 @@ fn forward_loads_and_stores_in_block(
                 let address = inserter.resolve(*address);
 
                 if let Some(value) = known_values.get(&address) {
-                    // Store-to-load: we know the value from a prior store.
                     let result = inserter.function.dfg.instruction_results(instruction_id)[0];
                     inserter.map_value(result, *value);
                     instructions_to_remove.insert(instruction_id);
                 } else if let Some(prev_result) = last_loads.get(&address) {
-                    // Load-to-load: no store to this address since the last load,
-                    // so we can reuse the previous load's result.
                     let result = inserter.function.dfg.instruction_results(instruction_id)[0];
                     inserter.map_value(result, *prev_result);
                     instructions_to_remove.insert(instruction_id);
                 } else {
-                    // No known value — record for future load-to-load forwarding.
                     let result = inserter.function.dfg.instruction_results(instruction_id)[0];
                     last_loads.insert(address, result);
                 }
 
-                // This address was loaded from, so the last store to it is not dead.
-                last_stores.remove(&address);
+                // Mark aliased stores as used (not dead).
+                let dfg = &inserter.function.dfg;
+                last_stores.retain(|k, _| !may_alias(address, *k, allocations, dfg));
             }
             Instruction::Call { .. } => {
-                // A call could dereference and modify any reference argument.
-                // For direct references we only invalidate that specific address.
-                // For containers (arrays/tuples) holding references, we can't know
-                // which addresses they hold, so we conservatively clear everything.
-                //
-                // Additionally, if a reference's inner type also contains a reference
-                // (e.g. `&mut &mut Field`), the callee can chase the indirection and
-                // write through the inner reference, so we must clear all known values.
-                //
-                // We also remove passed references from local_allocations: once an
-                // address escapes to a callee, it may be returned as an alias, so the
-                // "local and non-aliasing" invariant no longer holds.
+                // Simple reference (`&mut T` where T has no refs): invalidate that address.
+                // Container or nested reference: clear all state.
                 instruction.for_each_value(|value| {
                     let value = inserter.resolve(value);
                     let typ = inserter.function.dfg.type_of_value(value);
-                    // Simple reference to a non-reference type (e.g. &mut Field):
-                    // only invalidate this specific address. Also remove from
-                    // local_allocations since the address now escapes to the callee
-                    // and may be returned as an alias.
-                    //
-                    // Everything else that contains a reference — double-references
-                    // (&mut &mut Field), containers ([&mut Field; N]), etc. — requires
-                    // clearing all state since the callee can chase indirections or
-                    // extract inner references and write through them.
                     let is_simple_ref = matches!(typ.reference_element_type(), Some(inner) if !inner.contains_reference());
                     if is_simple_ref {
                         known_values.remove(&value);
                         last_loads.remove(&value);
                         last_stores.remove(&value);
-                        local_allocations.remove(&value);
                     } else if typ.contains_reference() {
                         known_values.clear();
                         last_loads.clear();
                         last_stores.clear();
-                        local_allocations.clear();
                     }
                 });
             }
-            _ => {
-                // MakeArray, ArraySet, ArrayGet, IfElse, IncrementRc, DecrementRc, etc.
-                // don't modify pointed-to memory — they just move references around.
-                // Safe to keep known values. The Store handler's clear-on-unknown-store
-                // ensures soundness if an alias is later written through.
-            }
+            _ => {}
         }
     }
-
-    // Any remaining entries in last_stores are stores with no subsequent load in
-    // this block. We do NOT remove them here because they may be needed by successor
-    // blocks or by later passes. Only truly dead stores (overwritten before being
-    // read) are removed above.
 
     instructions_to_remove
 }
@@ -690,15 +545,8 @@ mod tests {
     }
 
     #[test]
-    fn forwarding_in_later_block_remaps_earlier_block() {
-        // Regression test: the SSA text format assigns block IDs in declaration
-        // order, but RPO iteration follows the CFG. The block that creates the
-        // forwarding mapping (b2) must be visited before the block that uses
-        // the forwarded value (b1). RPO guarantees this since b2 is a
-        // predecessor of b1 in the CFG: b0 -> b2 -> b1.
-        //
-        // b2 has allocate+store+load in the same block, so per-block forwarding
-        // maps v2 -> u32 10. b1 uses v2 in an add.
+    fn multi_block_not_optimized() {
+        // Multi-block functions are skipped — only single-block functions are optimized.
         let src = "
         brillig(inline) fn main f0 {
           b0():
@@ -713,28 +561,12 @@ mod tests {
             jmp b1()
         }
         ";
-        let ssa = Ssa::from_str(src).unwrap();
-        let ssa = ssa.load_store_forwarding();
-
-        // v2 (load result from b2) must be forwarded to u32 10 in b1's add.
-        assert_ssa_snapshot!(ssa, @r"
-        brillig(inline) fn main f0 {
-          b0():
-            jmp b2()
-          b1():
-            return u32 11
-          b2():
-            v0 = allocate -> &mut u32
-            store u32 10 at v0
-            jmp b1()
-        }
-        ");
+        assert_ssa_does_not_change(src, Ssa::load_store_forwarding);
     }
 
     #[test]
-    fn forwarding_in_loop_block_without_aliases() {
-        // A loop block with store+load to a local allocation and no reference
-        // stores should benefit from forwarding (no loop-carried aliases).
+    fn loop_not_optimized() {
+        // Multi-block (loop) functions are skipped entirely.
         let src = "
         brillig(inline) fn main f0 {
           b0(v100: u1):
@@ -748,21 +580,7 @@ mod tests {
             return v1
         }
         ";
-        let ssa = Ssa::from_str(src).unwrap();
-        let ssa = ssa.load_store_forwarding();
-
-        assert_ssa_snapshot!(ssa, @r"
-        brillig(inline) fn main f0 {
-          b0(v0: u1):
-            jmp b1()
-          b1():
-            v1 = allocate -> &mut Field
-            store Field 42 at v1
-            jmpif v0 then: b1(), else: b2()
-          b2():
-            return Field 42
-        }
-        ");
+        assert_ssa_does_not_change(src, Ssa::load_store_forwarding);
     }
 
     #[test]
@@ -953,6 +771,251 @@ mod tests {
         }
         ";
         // v0 and v1 could alias, so load v0 after store to v1 must NOT be forwarded.
+        assert_ssa_does_not_change(src, Ssa::load_store_forwarding);
+    }
+
+    // --- Regression tests for issues #12217-#12232 ---
+    // Multi-block tests: the pass skips these entirely (single-block restriction).
+
+    #[test]
+    fn regression_12217_loop_alias_via_call_input() {
+        // Loop-carried alias established via function call input. Multi-block -> skipped.
+        let src = "
+        brillig(inline) fn bar f0 {
+          b0(v0: &mut Field, v1: Field):
+            v2 = allocate -> &mut &mut Field
+            store v0 at v2
+            v3 = allocate -> &mut Field
+            store v1 at v3
+            jmp b1()
+          b1():
+            store Field 3735928559 at v3
+            v5 = load v2 -> &mut Field
+            v6 = load v5 -> Field
+            store v6 at v3
+            call f1(v3, v2)
+            jmp b1()
+        }
+        brillig(inline) fn foo f1 {
+          b0(v0: &mut Field, v1: &mut &mut Field):
+            store v0 at v1
+            return
+        }
+        ";
+        assert_ssa_does_not_change(src, Ssa::load_store_forwarding);
+    }
+
+    #[test]
+    fn regression_12219_loop_alias_via_call_return() {
+        // Loop-carried alias via returned reference from call. Multi-block -> skipped.
+        let src = "
+        brillig(inline) fn bar f0 {
+          b0(v0: &mut Field, v1: Field):
+            v2 = allocate -> &mut &mut Field
+            store v0 at v2
+            v3 = allocate -> &mut Field
+            store v1 at v3
+            jmp b1()
+          b1():
+            store Field 3735928559 at v3
+            v5 = load v2 -> &mut Field
+            v6 = load v5 -> Field
+            store v6 at v3
+            v7 = call f1(v3) -> &mut Field
+            store v7 at v2
+            jmp b1()
+        }
+        brillig(inline) fn f1 f1 {
+          b0(v0: &mut Field):
+            return v0
+        }
+        ";
+        assert_ssa_does_not_change(src, Ssa::load_store_forwarding);
+    }
+
+    #[test]
+    fn regression_12220_loop_alias_via_array_get() {
+        // Loop-carried alias via array_get with variable index. Multi-block -> skipped.
+        let src = "
+        brillig(inline) fn bar f0 {
+          b0(v0: &mut Field, v1: Field, v_idx: u32):
+            v2 = allocate -> &mut &mut Field
+            store v0 at v2
+            v3 = allocate -> &mut Field
+            store v1 at v3
+            jmp b1()
+          b1():
+            store Field 3735928559 at v3
+            v5 = load v2 -> &mut Field
+            v6 = load v5 -> Field
+            store v6 at v3
+            v8 = make_array [v3, v0] : [&mut Field; 2]
+            v9 = array_get v8, index v_idx -> &mut Field
+            store v9 at v2
+            jmp b1()
+        }
+        ";
+        assert_ssa_does_not_change(src, Ssa::load_store_forwarding);
+    }
+
+    #[test]
+    fn regression_12221_loop_alias_via_jmpif() {
+        // Loop-carried alias via jmpif passing ref to non-header block. Multi-block -> skipped.
+        let src = "
+        brillig(inline) fn bar f0 {
+          b0(v0: &mut Field, v1: Field, v_cond: u1):
+            v2 = allocate -> &mut &mut Field
+            store v0 at v2
+            v3 = allocate -> &mut Field
+            store v1 at v3
+            jmp b1()
+          b1():
+            store Field 3735928559 at v3
+            v5 = load v2 -> &mut Field
+            v6 = load v5 -> Field
+            store v6 at v3
+            jmpif v_cond then: b2(v3), else: b3()
+          b2(v7: &mut Field):
+            store v7 at v2
+            jmp b1()
+          b3():
+            jmp b1()
+        }
+        ";
+        assert_ssa_does_not_change(src, Ssa::load_store_forwarding);
+    }
+
+    #[test]
+    fn regression_12222_loop_nested_refs_form1() {
+        // Array containing references stored in loop (Form 1 misses nested refs). Multi-block -> skipped.
+        let src = "
+        brillig(inline) fn bar f0 {
+          b0(v0: &mut Field, v1: Field):
+            v2 = allocate -> &mut [&mut Field; 2]
+            v3 = allocate -> &mut Field
+            store v1 at v3
+            v4 = make_array [v0, v0] : [&mut Field; 2]
+            store v4 at v2
+            jmp b1()
+          b1():
+            store Field 3735928559 at v3
+            v5 = load v2 -> [&mut Field; 2]
+            v6 = array_get v5, index u32 0 -> &mut Field
+            v7 = load v6 -> Field
+            store v7 at v3
+            v8 = make_array [v3, v0] : [&mut Field; 2]
+            store v8 at v2
+            jmp b1()
+        }
+        ";
+        assert_ssa_does_not_change(src, Ssa::load_store_forwarding);
+    }
+
+    #[test]
+    fn regression_12223_loop_nested_refs_form2() {
+        // Loop header block param of array-of-refs type (Form 2 misses nested refs). Multi-block -> skipped.
+        let src = "
+        brillig(inline) fn bar f0 {
+          b0(v0: &mut Field, v1: Field):
+            v2 = allocate -> &mut Field
+            store v1 at v2
+            v3 = make_array [v0, v0] : [&mut Field; 2]
+            jmp b1(v3)
+          b1(v_arr: [&mut Field; 2]):
+            store Field 3735928559 at v2
+            v5 = array_get v_arr, index u32 0 -> &mut Field
+            v6 = load v5 -> Field
+            store v6 at v2
+            v8 = make_array [v2, v0] : [&mut Field; 2]
+            jmp b1(v8)
+        }
+        ";
+        assert_ssa_does_not_change(src, Ssa::load_store_forwarding);
+    }
+
+    #[test]
+    fn regression_12232_loop_load_ignores_carried_aliases() {
+        // Loads at loop-carried alias addresses don't invalidate caches. Multi-block -> skipped.
+        let src = "
+        brillig(inline) fn main f0 {
+          b0(v0: &mut Field):
+            v1 = allocate -> &mut &mut Field
+            store v0 at v1
+            jmp b1()
+          b1():
+            store Field 1 at v0
+            v3 = load v1 -> &mut Field
+            store Field 2 at v0
+            v4 = load v3 -> Field
+            store v3 at v1
+            jmp b1()
+        }
+        ";
+        assert_ssa_does_not_change(src, Ssa::load_store_forwarding);
+    }
+
+    // --- Single-block regression tests: verify may_alias handles these correctly ---
+
+    #[test]
+    fn regression_12225_load_to_load_through_array_get_alias() {
+        // array_get with dynamic index creates an alias. A store to the original
+        // allocation must invalidate last_loads for the alias.
+        let src = "
+        brillig(inline) fn main f0 {
+          b0(v_idx: u32):
+            v1 = allocate -> &mut Field
+            store Field 42 at v1
+            v2 = allocate -> &mut Field
+            store Field 7 at v2
+            v3 = make_array [v1, v2] : [&mut Field; 2]
+            v4 = array_get v3, index v_idx -> &mut Field
+            v5 = load v4 -> Field
+            store Field 99 at v1
+            v6 = load v4 -> Field
+            return v5, v6
+        }
+        ";
+        // v4 may alias v1. After `store 99 at v1`, `load v4` must NOT forward
+        // the stale load result from before the store.
+        assert_ssa_does_not_change(src, Ssa::load_store_forwarding);
+    }
+
+    #[test]
+    fn regression_12230_load_does_not_mark_aliased_store_as_used() {
+        // Two params could alias. Loading from v1 must mark the store to v0 as
+        // used, preventing incorrect dead store elimination.
+        let src = "
+        brillig(inline) fn main f0 {
+          b0(v0: &mut Field, v1: &mut Field):
+            store Field 1 at v0
+            v2 = load v1 -> Field
+            store Field 2 at v0
+            return v2
+        }
+        ";
+        // If v0 == v1, eliminating `store Field 1 at v0` would be incorrect
+        // because `load v1` reads it.
+        assert_ssa_does_not_change(src, Ssa::load_store_forwarding);
+    }
+
+    #[test]
+    fn regression_12231_local_allocation_aliased_by_array_get() {
+        // A local allocation can be aliased via array_get with a dynamic index.
+        // Storing to the allocation must clear the alias's known value.
+        let src = "
+        brillig(inline) fn main f0 {
+          b0(v0: &mut Field, v_idx: u32):
+            v1 = allocate -> &mut Field
+            v2 = make_array [v0, v1] : [&mut Field; 2]
+            v3 = array_get v2, index v_idx -> &mut Field
+            store Field 0 at v3
+            store Field 1 at v1
+            v4 = load v3 -> Field
+            return v4
+        }
+        ";
+        // v3 may alias v1. After `store 1 at v1`, `load v3` must NOT forward
+        // the stale Field 0.
         assert_ssa_does_not_change(src, Ssa::load_store_forwarding);
     }
 }

--- a/compiler/noirc_evaluator/src/ssa/opt/load_store_forwarding.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/load_store_forwarding.rs
@@ -103,7 +103,7 @@ fn collect_allocations(function: &Function, blocks: &[BasicBlockId]) -> HashSet<
 
 /// Returns true if two addresses might refer to the same memory.
 ///
-/// Conservative: returns true (MayAlias) when uncertain.
+/// Conservative: returns true when uncertain.
 /// - Same ValueId -> always alias.
 /// - Different reference types -> never alias.
 /// - Both from different `allocate` instructions -> never alias.


### PR DESCRIPTION
# Description

## Problem

Resolves https://github.com/noir-lang/noir/issues/12217
Resolves https://github.com/noir-lang/noir/issues/12219
Resolves https://github.com/noir-lang/noir/issues/12220
Resolves https://github.com/noir-lang/noir/issues/12221
Resolves https://github.com/noir-lang/noir/issues/12222
Resolves https://github.com/noir-lang/noir/issues/12223
Resolves https://github.com/noir-lang/noir/issues/12225
Resolves https://github.com/noir-lang/noir/issues/12230
Resolves https://github.com/noir-lang/noir/issues/12231
Resolves https://github.com/noir-lang/noir/issues/12232

## Summary

Most additions are tests. LSF went from 350 lines to 200 lines

- Restricted LSF to single-block functions (resolves all loop aliasing bugs)
- Replaced `local_allocations` heuristic with `may_alias` (#12225, #12230, #12231)
- Removed 4 early LSF pipeline positions, single post no_predicates-inlining run
- Added regression tests for issues linked above

## Additional Context



## User Documentation

Check one:
- [X] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
