### PR TITLE
chore(test): Simplified LSF with tuple gen opt

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/ssa_gen/context.rs
+++ b/compiler/noirc_evaluator/src/ssa/ssa_gen/context.rs
@@ -697,6 +697,27 @@ impl<'a> FunctionContext<'a> {
                 self.index_lvalue(array, index, location)?.2
             }
             ast::LValue::MemberAccess { object, field_index } => {
+                // Optimization: for MemberAccess { Ident(mutable), N }, extract only the
+                // Nth allocation and store directly to it.
+                if let ast::LValue::Ident(ident) = object.as_ref() {
+                    let (variable, should_auto_deref) = self.ident_lvalue(ident);
+                    if should_auto_deref {
+                        if let Tree::Branch(_) = &variable {
+                            let field_ref = Self::get_field(variable, *field_index);
+                            return Ok(LValue::Dereference { reference: field_ref });
+                        }
+                    }
+                }
+                // Optimization: for MemberAccess { Dereference { ref, element_type }, N }
+                // where element_type is a tuple, extract only the field's reference and
+                // store directly to it instead of loading/storing all fields.
+                if let ast::LValue::Dereference { reference, element_type } = object.as_ref() {
+                    if let ast::Type::Tuple(_) = element_type {
+                        let (ref_values, _) = self.extract_current_value_recursive(reference)?;
+                        let field_ref = Self::get_field(ref_values, *field_index);
+                        return Ok(LValue::Dereference { reference: field_ref });
+                    }
+                }
                 let (old_object, object_lvalue) = self.extract_current_value_recursive(object)?;
                 let object_lvalue = Box::new(object_lvalue);
                 LValue::MemberAccess { old_object, object_lvalue, index: *field_index }
@@ -787,6 +808,36 @@ impl<'a> FunctionContext<'a> {
                 Ok((element, index_lvalue))
             }
             ast::LValue::MemberAccess { object, field_index: index } => {
+                // Optimization: for MemberAccess { Ident(mutable), N }, extract only the
+                // Nth allocation and dereference just that field.
+                if let ast::LValue::Ident(ident) = object.as_ref() {
+                    let (variable, should_auto_deref) = self.ident_lvalue(ident);
+                    if should_auto_deref {
+                        if let Tree::Branch(_) = &variable {
+                            if let ast::Type::Tuple(field_types) = &*ident.typ {
+                                let field_ref = Self::get_field(variable, *index);
+                                let field_type = &field_types[*index];
+                                let dereferenced = self.dereference_lvalue(&field_ref, field_type);
+                                return Ok((
+                                    dereferenced,
+                                    LValue::Dereference { reference: field_ref },
+                                ));
+                            }
+                        }
+                    }
+                }
+                // Optimization: for MemberAccess { Dereference { ref, element_type }, N }
+                // where element_type is a tuple, extract only the field's reference and
+                // dereference just that field instead of all fields.
+                if let ast::LValue::Dereference { reference, element_type } = object.as_ref() {
+                    if let ast::Type::Tuple(field_types) = element_type {
+                        let (ref_values, _) = self.extract_current_value_recursive(reference)?;
+                        let field_ref = Self::get_field(ref_values, *index);
+                        let field_type = &field_types[*index];
+                        let dereferenced = self.dereference_lvalue(&field_ref, field_type);
+                        return Ok((dereferenced, LValue::Dereference { reference: field_ref }));
+                    }
+                }
                 let (old_object, object_lvalue) = self.extract_current_value_recursive(object)?;
                 let object_lvalue = Box::new(object_lvalue);
                 let element = Self::get_field_ref(&old_object, *index).clone();

--- a/compiler/noirc_evaluator/src/ssa/ssa_gen/context.rs
+++ b/compiler/noirc_evaluator/src/ssa/ssa_gen/context.rs
@@ -699,24 +699,22 @@ impl<'a> FunctionContext<'a> {
             ast::LValue::MemberAccess { object, field_index } => {
                 // Optimization: for MemberAccess { Ident(mutable), N }, extract only the
                 // Nth allocation and store directly to it.
-                if let ast::LValue::Ident(ident) = object.as_ref() {
-                    let (variable, should_auto_deref) = self.ident_lvalue(ident);
-                    if should_auto_deref {
-                        if let Tree::Branch(_) = &variable {
-                            let field_ref = Self::get_field(variable, *field_index);
-                            return Ok(LValue::Dereference { reference: field_ref });
-                        }
-                    }
+                if let ast::LValue::Ident(ident) = object.as_ref()
+                    && let (variable, true) = self.ident_lvalue(ident)
+                    && let Tree::Branch(_) = &variable
+                {
+                    let field_ref = Self::get_field(variable, *field_index);
+                    return Ok(LValue::Dereference { reference: field_ref });
                 }
                 // Optimization: for MemberAccess { Dereference { ref, element_type }, N }
                 // where element_type is a tuple, extract only the field's reference and
                 // store directly to it instead of loading/storing all fields.
-                if let ast::LValue::Dereference { reference, element_type } = object.as_ref() {
-                    if let ast::Type::Tuple(_) = element_type {
-                        let (ref_values, _) = self.extract_current_value_recursive(reference)?;
-                        let field_ref = Self::get_field(ref_values, *field_index);
-                        return Ok(LValue::Dereference { reference: field_ref });
-                    }
+                if let ast::LValue::Dereference { reference, element_type } = object.as_ref()
+                    && let ast::Type::Tuple(_) = element_type
+                {
+                    let (ref_values, _) = self.extract_current_value_recursive(reference)?;
+                    let field_ref = Self::get_field(ref_values, *field_index);
+                    return Ok(LValue::Dereference { reference: field_ref });
                 }
                 let (old_object, object_lvalue) = self.extract_current_value_recursive(object)?;
                 let object_lvalue = Box::new(object_lvalue);
@@ -810,33 +808,27 @@ impl<'a> FunctionContext<'a> {
             ast::LValue::MemberAccess { object, field_index: index } => {
                 // Optimization: for MemberAccess { Ident(mutable), N }, extract only the
                 // Nth allocation and dereference just that field.
-                if let ast::LValue::Ident(ident) = object.as_ref() {
-                    let (variable, should_auto_deref) = self.ident_lvalue(ident);
-                    if should_auto_deref {
-                        if let Tree::Branch(_) = &variable {
-                            if let ast::Type::Tuple(field_types) = &*ident.typ {
-                                let field_ref = Self::get_field(variable, *index);
-                                let field_type = &field_types[*index];
-                                let dereferenced = self.dereference_lvalue(&field_ref, field_type);
-                                return Ok((
-                                    dereferenced,
-                                    LValue::Dereference { reference: field_ref },
-                                ));
-                            }
-                        }
-                    }
+                if let ast::LValue::Ident(ident) = object.as_ref()
+                    && let (variable, true) = self.ident_lvalue(ident)
+                    && let Tree::Branch(_) = &variable
+                    && let ast::Type::Tuple(field_types) = &*ident.typ
+                {
+                    let field_ref = Self::get_field(variable, *index);
+                    let field_type = &field_types[*index];
+                    let dereferenced = self.dereference_lvalue(&field_ref, field_type);
+                    return Ok((dereferenced, LValue::Dereference { reference: field_ref }));
                 }
                 // Optimization: for MemberAccess { Dereference { ref, element_type }, N }
                 // where element_type is a tuple, extract only the field's reference and
                 // dereference just that field instead of all fields.
-                if let ast::LValue::Dereference { reference, element_type } = object.as_ref() {
-                    if let ast::Type::Tuple(field_types) = element_type {
-                        let (ref_values, _) = self.extract_current_value_recursive(reference)?;
-                        let field_ref = Self::get_field(ref_values, *index);
-                        let field_type = &field_types[*index];
-                        let dereferenced = self.dereference_lvalue(&field_ref, field_type);
-                        return Ok((dereferenced, LValue::Dereference { reference: field_ref }));
-                    }
+                if let ast::LValue::Dereference { reference, element_type } = object.as_ref()
+                    && let ast::Type::Tuple(field_types) = element_type
+                {
+                    let (ref_values, _) = self.extract_current_value_recursive(reference)?;
+                    let field_ref = Self::get_field(ref_values, *index);
+                    let field_type = &field_types[*index];
+                    let dereferenced = self.dereference_lvalue(&field_ref, field_type);
+                    return Ok((dereferenced, LValue::Dereference { reference: field_ref }));
                 }
                 let (old_object, object_lvalue) = self.extract_current_value_recursive(object)?;
                 let object_lvalue = Box::new(object_lvalue);

--- a/compiler/noirc_evaluator/src/ssa/ssa_gen/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/ssa_gen/mod.rs
@@ -1246,15 +1246,15 @@ impl FunctionContext<'_> {
         // Optimization: for ExtractTupleField(Dereference(x), N), extract the field's
         // reference first, then dereference only that field. This avoids loading all
         // fields of a struct through &mut self when only one field is needed.
-        if let Expression::Unary(unary) = tuple {
-            if matches!(unary.operator, UnaryOp::Dereference { .. }) && !unary.skip {
-                if let ast::Type::Tuple(fields) = &unary.result_type {
-                    let field_type = &fields[field_index];
-                    let references = self.codegen_expression(&unary.rhs)?;
-                    let field_ref = Self::get_field(references, field_index);
-                    return Ok(self.dereference(&field_ref, field_type));
-                }
-            }
+        if let Expression::Unary(unary) = tuple
+            && matches!(unary.operator, UnaryOp::Dereference { .. })
+            && !unary.skip
+            && let ast::Type::Tuple(fields) = &unary.result_type
+        {
+            let field_type = &fields[field_index];
+            let references = self.codegen_expression(&unary.rhs)?;
+            let field_ref = Self::get_field(references, field_index);
+            return Ok(self.dereference(&field_ref, field_type));
         }
 
         // For mutable locals (Ident case), codegen_expression returns unevaluated

--- a/compiler/noirc_evaluator/src/ssa/ssa_gen/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/ssa_gen/mod.rs
@@ -248,9 +248,12 @@ impl FunctionContext<'_> {
         }
     }
 
-    /// Codegen an identifier, automatically loading its value if it is mutable.
+    /// Codegen an identifier. Returns unevaluated `Value::Mutable` wrappers for mutable
+    /// locals — consumers call `.eval()` (or `into_value_list()`, `codegen_non_tuple_expression()`,
+    /// etc.) when they actually need the loaded values. This avoids eagerly loading all fields
+    /// of a mutable struct when only one field is subsequently accessed.
     fn codegen_ident(&mut self, ident: &ast::Ident) -> Values {
-        self.codegen_ident_reference(ident).map(|value| value.eval(self).into())
+        self.codegen_ident_reference(ident)
     }
 
     fn codegen_literal(&mut self, literal: &ast::Literal) -> Result<Values, RuntimeError> {
@@ -1240,6 +1243,23 @@ impl FunctionContext<'_> {
         tuple: &Expression,
         field_index: usize,
     ) -> Result<Values, RuntimeError> {
+        // Optimization: for ExtractTupleField(Dereference(x), N), extract the field's
+        // reference first, then dereference only that field. This avoids loading all
+        // fields of a struct through &mut self when only one field is needed.
+        if let Expression::Unary(unary) = tuple {
+            if matches!(unary.operator, UnaryOp::Dereference { .. }) && !unary.skip {
+                if let ast::Type::Tuple(fields) = &unary.result_type {
+                    let field_type = &fields[field_index];
+                    let references = self.codegen_expression(&unary.rhs)?;
+                    let field_ref = Self::get_field(references, field_index);
+                    return Ok(self.dereference(&field_ref, field_type));
+                }
+            }
+        }
+
+        // For mutable locals (Ident case), codegen_expression returns unevaluated
+        // Mutable values. get_field extracts just the needed field, so only that
+        // field's allocation is loaded when the caller evaluates the result.
         let tuple = self.codegen_expression(tuple)?;
         Ok(Self::get_field(tuple, field_index))
     }

--- a/compiler/noirc_evaluator/src/ssa/ssa_gen/tests.rs
+++ b/compiler/noirc_evaluator/src/ssa/ssa_gen/tests.rs
@@ -729,3 +729,156 @@ fn mut_ref_and_immutable_ref_to_same_data_ssa() {
     }
     ");
 }
+
+/// Accessing a single field of `&mut self` (a flattened struct passed as individual references)
+/// should only load that field's reference, not all fields.
+#[test]
+fn mut_ref_struct_field_access_only_loads_needed_field() {
+    let src = "
+    struct Counter {
+        storage: [Field; 4],
+        len: u32,
+        counter: Field,
+    }
+
+    impl Counter {
+        fn next_counter(&mut self) -> Field {
+            let counter = self.counter;
+            self.counter += 1;
+            counter
+        }
+    }
+
+    unconstrained fn main() {
+        let mut c = Counter { storage: [0; 4], len: 0, counter: 0 };
+        let _ = c.next_counter();
+    }
+    ";
+    let ssa = get_initial_ssa(src).unwrap();
+    // next_counter should only load/store v2 (counter ref), not v0 (storage ref) or v1 (len ref)
+    assert_ssa_snapshot!(ssa, @r"
+    brillig(inline) fn main f0 {
+      b0():
+        v1 = make_array [Field 0, Field 0, Field 0, Field 0] : [Field; 4]
+        v2 = allocate -> &mut [Field; 4]
+        store v1 at v2
+        v3 = allocate -> &mut u32
+        store u32 0 at v3
+        v5 = allocate -> &mut Field
+        store Field 0 at v5
+        v7 = call f1(v2, v3, v5) -> Field
+        return
+    }
+    brillig(inline) fn next_counter f1 {
+      b0(v0: &mut [Field; 4], v1: &mut u32, v2: &mut Field):
+        v3 = load v2 -> Field
+        v4 = load v2 -> Field
+        v6 = add v4, Field 1
+        store v6 at v2
+        return v3
+    }
+    ");
+}
+
+/// Assigning to a single field of `&mut self` should only store to that field's reference,
+/// not load/store all fields.
+#[test]
+fn mut_ref_struct_field_assign_only_stores_needed_field() {
+    let src = "
+    struct Pair {
+        a: Field,
+        b: Field,
+    }
+
+    impl Pair {
+        fn set_b(&mut self, val: Field) {
+            self.b = val;
+        }
+    }
+
+    unconstrained fn main() {
+        let mut p = Pair { a: 0, b: 0 };
+        p.set_b(42);
+    }
+    ";
+    let ssa = get_initial_ssa(src).unwrap();
+    // set_b should only store to v1 (b ref), not load/store v0 (a ref)
+    assert_ssa_snapshot!(ssa, @r"
+    brillig(inline) fn main f0 {
+      b0():
+        v0 = allocate -> &mut Field
+        store Field 0 at v0
+        v2 = allocate -> &mut Field
+        store Field 0 at v2
+        call f1(v0, v2, Field 42)
+        return
+    }
+    brillig(inline) fn set_b f1 {
+      b0(v0: &mut Field, v1: &mut Field, v2: Field):
+        store v2 at v1
+        return
+    }
+    ");
+}
+
+/// Accessing a single field of a `let mut` local struct should only load that field's
+/// allocation, not all fields.
+#[test]
+fn mut_local_struct_field_access_only_loads_needed_field() {
+    let src = "
+    struct Pair {
+        a: Field,
+        b: Field,
+    }
+
+    unconstrained fn main() {
+        let mut p = Pair { a: 0, b: 0 };
+        assert(p.b == 0);
+    }
+    ";
+    let ssa = get_initial_ssa(src).unwrap();
+    // Reading p.b should only load from v2, not v0
+    assert_ssa_snapshot!(ssa, @r"
+    brillig(inline) fn main f0 {
+      b0():
+        v0 = allocate -> &mut Field
+        store Field 0 at v0
+        v2 = allocate -> &mut Field
+        store Field 0 at v2
+        v3 = load v2 -> Field
+        v4 = eq v3, Field 0
+        constrain v3 == Field 0
+        return
+    }
+    ");
+}
+
+/// Assigning to a single field of a `let mut` local struct should only store to that
+/// field's allocation, not load/store all fields.
+#[test]
+fn mut_local_struct_field_assign_only_stores_needed_field() {
+    let src = "
+    struct Pair {
+        a: Field,
+        b: Field,
+    }
+
+    unconstrained fn main() {
+        let mut p = Pair { a: 0, b: 0 };
+        p.b = 42;
+    }
+    ";
+    let ssa = get_initial_ssa(src).unwrap();
+    // Assigning p.b = 42 should only store to v2, no loads/stores of v0
+    assert_ssa_snapshot!(ssa, @r"
+    brillig(inline) fn main f0 {
+      b0():
+        v0 = allocate -> &mut Field
+        store Field 0 at v0
+        v2 = allocate -> &mut Field
+        store Field 0 at v2
+        store Field 42 at v2
+        return
+    }
+    ");
+}


### PR DESCRIPTION
# Description

## Problem

Tests https://github.com/noir-lang/noir/pull/12243 with https://github.com/noir-lang/noir/pull/12241

## Summary



## Additional Context



## User Documentation

Check one:
- [X] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
