### PR TITLE
chore: refactor spilling a value in a dedicated function

### DIFF
--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_block.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_block.rs
@@ -220,6 +220,42 @@ impl<'block, Registers: RegisterAllocator> BrilligBlock<'block, Registers> {
         self.brillig_context.store_instruction(scratch_addr, source_reg);
     }
 
+    /// Spill a value: record it in the spill manager, optionally emit a store to its slot,
+    /// and free its register. Returns the slot offset.
+    ///
+    /// Assumes spilling is enabled.
+    /// `permanent` indicates whether the spill is to be permanent.
+    /// `emit_store = false` is used only for block parameters,
+    /// whose registers don't yet contain the final value.
+    /// The Jmp terminators write the value directly into the slot later.
+    pub(crate) fn spill_value(&mut self, value_id: ValueId, permanent: bool, emit_store: bool) {
+        let sm = self
+            .function_context
+            .spill_manager
+            .as_mut()
+            .expect("ICE: spill_value called without spill manager");
+
+        // Check fist permanent because ensure_permanent_spill() modifies the record.
+        if (permanent && sm.ensure_permanent_spill(&value_id)) || sm.is_spilled(&value_id) {
+            return;
+        }
+
+        let var = *self.function_context.ssa_value_allocations.get(&value_id).unwrap();
+        let offset = sm.get_spill_offset(&value_id).unwrap_or_else(|| sm.allocate_spill_offset());
+        sm.remove_from_lru(&value_id);
+        if permanent {
+            sm.record_permanent_spill(value_id, offset, var);
+        } else {
+            sm.record_spill(value_id, offset, var);
+        }
+
+        if emit_store {
+            self.codegen_spill_store(offset, var.extract_register());
+        }
+
+        self.variables.remove_variable(&value_id, self.function_context, self.brillig_context);
+    }
+
     /// Emit a 3-instruction sequence to load a value from the spill region
     /// at the given offset into `dest_reg`.
     fn codegen_spill_load(&mut self, offset: usize, dest_reg: MemoryAddress) {
@@ -237,27 +273,10 @@ impl<'block, Registers: RegisterAllocator> BrilligBlock<'block, Registers> {
 
     /// Spill the least-recently-used value to the spill region
     fn spill_lru_value(&mut self) {
-        // Extract data from spill_manager first (borrow checker prevents mutably borrowing
-        // the spill manager while also accessing ssa_value_allocations immutably)
+        // Ask the spill_manager for the LRU variable, and then spill it.
         let sm = self.function_context.spill_manager.as_mut().unwrap();
         let victim_id = sm.lru_victim().expect("No values available to spill");
-        // Reuse the permanent spill slot if one exists (the data is already there
-        // since SSA values are immutable), or the transient one if it has just been
-        // unmarked, but still available; otherwise allocate a fresh slot.
-        let offset = sm.get_spill_offset(&victim_id).unwrap_or_else(|| sm.allocate_spill_offset());
-
-        let victim_var = *self.function_context.ssa_value_allocations.get(&victim_id).unwrap();
-        let victim_reg = victim_var.extract_register();
-
-        self.codegen_spill_store(offset, victim_reg);
-
-        // Free the victim's register so it can be reused
-        self.brillig_context.deallocate_register(victim_reg);
-        self.variables.mark_unavailable(&victim_id);
-
-        // Record the spill
-        let sm = self.function_context.spill_manager.as_mut().unwrap();
-        sm.record_spill(victim_id, offset, victim_var);
+        self.spill_value(victim_id, false, true);
     }
 
     /// Reload a previously spilled value into a freshly allocated register
@@ -322,29 +341,7 @@ impl<'block, Registers: RegisterAllocator> BrilligBlock<'block, Registers> {
                 continue;
             }
 
-            let sm = self.function_context.spill_manager.as_mut().unwrap();
-
-            // If a record already exists, ensure it is permanent and spilled.
-            if sm.ensure_permanent_spill(&value_id) {
-                continue;
-            }
-
-            // First encounter: allocate a permanent slot and store the value.
-            let var = *self.function_context.ssa_value_allocations.get(&value_id).unwrap();
-            let sm = self.function_context.spill_manager.as_mut().unwrap();
-            let off = sm.allocate_spill_offset();
-            sm.record_permanent_spill(value_id, off, var);
-
-            let source_reg = var.extract_register();
-            self.codegen_spill_store(off, source_reg);
-
-            // Free the register: the value is now safely in the spill slot.
-            // Without this, the register stays allocated but the value is marked
-            // as spilled — `lru_victim()` can't reclaim it, creating "phantom"
-            // allocations that exhaust the register space.
-            // If the value is needed later (e.g., as a Jmp argument),
-            // `convert_ssa_value` will see it's spilled and reload on demand.
-            self.brillig_context.deallocate_register(source_reg);
+            self.spill_value(value_id, true, true);
         }
     }
 
@@ -629,17 +626,9 @@ impl<'block, Registers: RegisterAllocator> BrilligBlock<'block, Registers> {
                     // Params of the current block are skipped
                     // because they already hold valid data from the predecessor.
                     if !own_params.contains(&param_id)
-                        && let Some(sm) = self.function_context.spill_manager.as_mut()
+                        && self.function_context.spill_manager.is_some()
                     {
-                        sm.remove_from_lru(&param_id);
-                        let offset = sm.allocate_spill_offset();
-                        let var =
-                            *self.function_context.ssa_value_allocations.get(&param_id).unwrap();
-                        sm.record_permanent_spill(param_id, offset, var);
-                        // Free the register — it holds no valid data.
-                        let reg = var.extract_register();
-                        self.brillig_context.deallocate_register(reg);
-                        self.variables.mark_unavailable(&param_id);
+                        self.spill_value(param_id, true, false);
                     }
                 }
                 Type::Function => unreachable!(


### PR DESCRIPTION
# Description

## Problem

Resolves #12251

## Summary
Refactor spilling a value as indicated in the issue.


## Additional Context



## User Documentation

Check one:
- [X] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
