### PR TITLE
fix: Use bytes in Hir strings

### DIFF
--- a/compiler/noirc_driver/src/abi_gen.rs
+++ b/compiler/noirc_driver/src/abi_gen.rs
@@ -234,7 +234,16 @@ pub(super) fn value_from_hir_expression(context: &Context, expression: HirExpres
                 }
             },
             HirLiteral::Bool(value) => AbiValue::Boolean { value },
-            HirLiteral::Str(value) => AbiValue::String { value },
+            HirLiteral::Str(value) => match String::from_utf8(value) {
+                Ok(value) => AbiValue::String { value },
+                Err(error) => {
+                    let value = vecmap(error.into_bytes(), |byte| AbiValue::Integer {
+                        sign: false,
+                        value: format!("{byte:x}"),
+                    });
+                    AbiValue::Array { value }
+                }
+            },
             HirLiteral::Integer(value) => AbiValue::Integer { value: value.to_hex(), sign: false },
             _ => unreachable!("Literal cannot be used in the abi"),
         },

--- a/compiler/noirc_evaluator/src/ssa/ssa_gen/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/ssa_gen/mod.rs
@@ -1513,7 +1513,7 @@ impl FunctionContext<'_> {
         let (assert_message_expression, assert_message_typ) = assert_message_payload.as_ref();
 
         if let Expression::Literal(ast::Literal::Str(static_string)) = assert_message_expression {
-            let message = String::from_utf8_lossy(&static_string).into_owned();
+            let message = String::from_utf8_lossy(static_string).into_owned();
             Ok(Some(ConstrainError::StaticString(message)))
         } else {
             let error_type = ErrorType::Dynamic(assert_message_typ.clone());

--- a/compiler/noirc_evaluator/src/ssa/ssa_gen/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/ssa_gen/mod.rs
@@ -338,7 +338,7 @@ impl FunctionContext<'_> {
 
                 // A caller needs multiple pieces of information to make use of a format string
                 // The message string, the number of fields to be formatted, and the fields themselves
-                let string = self.codegen_string(&string);
+                let string = self.codegen_string(string.as_bytes());
                 let field_count = self
                     .builder
                     .numeric_constant(u128::from(*number_of_fields), NumericType::NativeField);
@@ -357,8 +357,8 @@ impl FunctionContext<'_> {
         try_vecmap(elements, |element| self.codegen_expression(element))
     }
 
-    fn codegen_string(&mut self, string: &str) -> Values {
-        let elements = vecmap(string.as_bytes(), |byte| {
+    fn codegen_string(&mut self, bytes: &[u8]) -> Values {
+        let elements = vecmap(bytes, |byte| {
             self.builder.numeric_constant(u128::from(*byte), NumericType::char()).into()
         });
         let typ = Self::convert_non_tuple_type(&ast::Type::String(elements.len() as u32));
@@ -1513,7 +1513,8 @@ impl FunctionContext<'_> {
         let (assert_message_expression, assert_message_typ) = assert_message_payload.as_ref();
 
         if let Expression::Literal(ast::Literal::Str(static_string)) = assert_message_expression {
-            Ok(Some(ConstrainError::StaticString(static_string.clone())))
+            let message = String::from_utf8_lossy(&static_string).into_owned();
+            Ok(Some(ConstrainError::StaticString(message)))
         } else {
             let error_type = ErrorType::Dynamic(assert_message_typ.clone());
             let selector = error_type.selector();

--- a/compiler/noirc_frontend/src/elaborator/expressions.rs
+++ b/compiler/noirc_frontend/src/elaborator/expressions.rs
@@ -370,7 +370,7 @@ impl Elaborator<'_> {
                     "ICE: Elaborator::elaborate_literal: str.len() is expected to fit into a u32",
                 );
                 let len = Type::constant_u32(len);
-                (Lit(HirLiteral::Str(str)), Type::String(Box::new(len)))
+                (Lit(HirLiteral::Str(str.into_bytes())), Type::String(Box::new(len)))
             }
             Literal::FmtStr(fragments, length) => self.elaborate_fmt_string(fragments, length),
             Literal::Array(array_literal) => {

--- a/compiler/noirc_frontend/src/hir/comptime/hir_to_display_ast.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/hir_to_display_ast.rs
@@ -106,8 +106,9 @@ impl HirExpression {
                 // displaying these values anyway
                 ExpressionKind::Literal(Literal::Integer(*value, None))
             }
-            HirExpression::Literal(HirLiteral::Str(string)) => {
-                ExpressionKind::Literal(Literal::Str(string.clone()))
+            HirExpression::Literal(HirLiteral::Str(bytes)) => {
+                // [String::from_utf8_lossy] here should be okay since this is only for display purposes
+                ExpressionKind::Literal(Literal::Str(String::from_utf8_lossy(bytes).into_owned()))
             }
             HirExpression::Literal(HirLiteral::FmtStr(fragments, _exprs, length)) => {
                 // TODO: Is throwing away the exprs here valid?

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
@@ -787,7 +787,7 @@ impl<'local, 'interner> Interpreter<'local, 'interner> {
             HirLiteral::Unit => Ok(Value::Unit),
             HirLiteral::Bool(value) => Ok(Value::Bool(value)),
             HirLiteral::Integer(value) => self.evaluate_field_as_integer(value, id),
-            HirLiteral::Str(string) => Ok(Value::String(Rc::new(string.bytes().collect()))),
+            HirLiteral::Str(string) => Ok(Value::String(Rc::new(string))),
             HirLiteral::FmtStr(fragments, captures, length) => {
                 self.evaluate_format_string(fragments, captures, length, id)
             }

--- a/compiler/noirc_frontend/src/hir/comptime/value.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/value.rs
@@ -483,8 +483,7 @@ impl Value {
             Value::Bool(value) => HirExpression::Literal(HirLiteral::Bool(value)),
             Value::Integer(int) => int.into_hir_expression(),
             Value::String(bytes) => {
-                let string = String::from_utf8_lossy(&bytes);
-                HirExpression::Literal(HirLiteral::Str(string.to_string()))
+                HirExpression::Literal(HirLiteral::Str(Rc::unwrap_or_clone(bytes)))
             }
             Value::FormatString(fragments, _typ, length) => {
                 let mut captures = Vec::new();

--- a/compiler/noirc_frontend/src/hir/printer/items/hir_def.rs
+++ b/compiler/noirc_frontend/src/hir/printer/items/hir_def.rs
@@ -673,7 +673,8 @@ impl ItemPrinter<'_, '_> {
                 self.push_str("_");
                 self.push_str(&typ.to_string());
             }
-            HirLiteral::Str(string) => {
+            HirLiteral::Str(bytes) => {
+                let string = String::from_utf8_lossy(&bytes);
                 self.push_str(&format!("{string:?}"));
             }
             HirLiteral::FmtStr(fmt_str_fragments, _expr_ids, _) => {

--- a/compiler/noirc_frontend/src/hir_def/expr.rs
+++ b/compiler/noirc_frontend/src/hir_def/expr.rs
@@ -129,7 +129,7 @@ pub enum HirLiteral {
     Vector(HirArrayLiteral),
     Bool(bool),
     Integer(FieldElement),
-    Str(String),
+    Str(Vec<u8>),
     FmtStr(Vec<FmtStrFragment>, Vec<ExprId>, u32 /* length */),
     Unit,
 }

--- a/compiler/noirc_frontend/src/monomorphization/ast.rs
+++ b/compiler/noirc_frontend/src/monomorphization/ast.rs
@@ -290,7 +290,7 @@ pub enum Literal {
     Integer(FieldElement, Type, Location),
     Bool(bool),
     Unit,
-    Str(String),
+    Str(Vec<u8>),
     FmtStr(
         Vec<FmtStrFragment>,
         /* Number of variables in the format string. */ u64,

--- a/compiler/noirc_frontend/src/monomorphization/builtin.rs
+++ b/compiler/noirc_frontend/src/monomorphization/builtin.rs
@@ -182,7 +182,7 @@ impl Monomorphizer<'_> {
                 })
             }
             ast::Type::String(length) => {
-                ast::Expression::Literal(ast::Literal::Str("\0".repeat(*length as usize)))
+                ast::Expression::Literal(ast::Literal::Str(vec![0; *length as usize]))
             }
             ast::Type::FmtString(length, fields) => {
                 let zeroed_tuple = self.zeroed_value_of_type(fields, location);

--- a/compiler/noirc_frontend/src/monomorphization/mod.rs
+++ b/compiler/noirc_frontend/src/monomorphization/mod.rs
@@ -2730,7 +2730,7 @@ impl<'interner> Monomorphizer<'interner> {
             HirMatch::Failure { .. } => {
                 let false_ = Box::new(ast::Expression::Literal(ast::Literal::Bool(false)));
                 let msg = "match failure";
-                let msg_expr = ast::Expression::Literal(ast::Literal::Str(msg.to_string()));
+                let msg_expr = ast::Expression::Literal(ast::Literal::Str(msg.as_bytes().to_vec()));
 
                 let length: u32 = msg.len().try_into().expect(
                     "ICE: Monomorphizer::match_expr: msg.len() is expected to fit into a u32",
@@ -3268,5 +3268,5 @@ fn append_printable_type_info_inner(typ: &Type, arguments: &mut Vec<ast::Express
     let abi_as_string =
         serde_json::to_string(&printable_type).expect("ICE: expected PrintableType to serialize");
 
-    arguments.push(ast::Expression::Literal(ast::Literal::Str(abi_as_string)));
+    arguments.push(ast::Expression::Literal(ast::Literal::Str(abi_as_string.into_bytes())));
 }

--- a/compiler/noirc_frontend/src/monomorphization/printer.rs
+++ b/compiler/noirc_frontend/src/monomorphization/printer.rs
@@ -279,11 +279,7 @@ impl AstPrinter {
             Literal::Str(s) => {
                 // This is just for display purposes so a lossy conversion is okay
                 let s = String::from_utf8_lossy(s);
-                if s.contains("\"") {
-                    write!(f, "r#\"{s}\"#")
-                } else {
-                    write!(f, "\"{s}\"")
-                }
+                if s.contains("\"") { write!(f, "r#\"{s}\"#") } else { write!(f, "\"{s}\"") }
             }
             Literal::FmtStr(fragments, _, _) => {
                 write!(f, "f\"")?;

--- a/compiler/noirc_frontend/src/monomorphization/printer.rs
+++ b/compiler/noirc_frontend/src/monomorphization/printer.rs
@@ -277,6 +277,8 @@ impl AstPrinter {
             }
             Literal::Bool(x) => x.fmt(f),
             Literal::Str(s) => {
+                // This is just for display purposes so a lossy conversion is okay
+                let s = String::from_utf8_lossy(s);
                 if s.contains("\"") {
                     write!(f, "r#\"{s}\"#")
                 } else {

--- a/test_programs/execution_success/regression_12269/Nargo.toml
+++ b/test_programs/execution_success/regression_12269/Nargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "regression_12269"
+type = "bin"
+authors = [""]
+
+[dependencies]

--- a/test_programs/execution_success/regression_12269/src/main.nr
+++ b/test_programs/execution_success/regression_12269/src/main.nr
@@ -1,0 +1,7 @@
+global BROKEN_BYTES: [u8; 4] = [102, 111, 128, 111];
+global S: str<4> = BROKEN_BYTES.as_str_unchecked();
+
+fn main() {
+    // This breaks SSA before #12269, causing a length mismatch in expected types
+    println(S);
+}

--- a/tooling/ast_fuzzer/src/program/expr.rs
+++ b/tooling/ast_fuzzer/src/program/expr.rs
@@ -70,13 +70,9 @@ pub fn gen_literal(
             ))
         }
         Type::String(len) => {
-            let mut s = String::new();
-            for _ in 0..*len {
-                // ASCII range would be 0x20..=0x7e
-                let ascii_char = u.int_in_range(65..=90).map(char::from)?;
-                s.push(ascii_char);
-            }
-            Expression::Literal(Literal::Str(s))
+            // ASCII range would be 0x20..=0x7e
+            let bytes = (0..*len).map(|_| u.int_in_range(65..=90)).collect::<Result<_, _>>()?;
+            Expression::Literal(Literal::Str(bytes))
         }
         Type::Array(len, item_type) => {
             // Randomly choose between Array and Repeated literal

--- a/tooling/nargo_cli/build.rs
+++ b/tooling/nargo_cli/build.rs
@@ -205,7 +205,7 @@ const IGNORED_MINIMAL_EXECUTION_TESTS: [&str; 16] = [
 /// might not be worth it.
 /// Others are ignored because of existing bugs in `nargo expand`.
 /// As the bugs are fixed these tests should be removed from this list.
-const IGNORED_NARGO_EXPAND_EXECUTION_TESTS: [&str; 10] = [
+const IGNORED_NARGO_EXPAND_EXECUTION_TESTS: [&str; 11] = [
     // There's nothing special about this program but making it work with a custom entry would involve
     // having to parse the Nargo.toml file, etc., which is not worth it
     "custom_entry",
@@ -222,6 +222,8 @@ const IGNORED_NARGO_EXPAND_EXECUTION_TESTS: [&str; 10] = [
     "regression_10466",
     // bug
     "trait_associated_constant",
+    // Globals evaluate to invalid utf-8 which don't display correctly in a source file
+    "regression_12269",
     // There's no "src/main.nr" here so it's trickier to make this work
     "workspace",
     // There's no "src/main.nr" here so it's trickier to make this work

--- a/tooling/nargo_cli/tests/snapshots/execution_success/regression_12269/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/regression_12269/execute__tests__expanded.snap
@@ -1,0 +1,11 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: expanded_code
+---
+global BROKEN_BYTES: [u8; 4] = [102, 111, 128, 111];
+
+global S: str<4> = "fo�o";
+
+fn main() {
+    println(S);
+}

--- a/tooling/nargo_cli/tests/snapshots/execution_success/regression_12269/execute__tests__stdout.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/regression_12269/execute__tests__stdout.snap
@@ -1,0 +1,5 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: stdout
+---
+fo�o


### PR DESCRIPTION
# Description

## Problem

Resolves https://app.audithub.dev/app/organizations/161/projects/600/project-viewer?version=1408&issueId=882

Follow-up for https://github.com/noir-lang/noir/pull/12068

## Summary

Changes `into_runtime_hir_expression` to avoid lossy string conversions. For this I ended up modifying our Hir strings to store bytes directly. We could do the same approach into_expression does and lower to a call to as_str_unchecked but I thought this was less straightforward.

## Additional Context



## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
