### PR TITLE
chore: Add assertions we've used all fields when constructing comptime structs

### DIFF
--- a/compiler/noirc_frontend/src/hir/comptime/value.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/value.rs
@@ -343,8 +343,9 @@ impl Value {
                     let field = field.unwrap_or_clone().into_expression(elaborator, location)?;
                     ordered_fields.push((Ident::new(name.to_string(), location), field));
                 }
-                let typ = Type::DataType(data_type, generics);
+                assert!(fields.is_empty(), "There should be no remaining fields to add");
 
+                let typ = Type::DataType(data_type, generics);
                 let quoted_type_id = elaborator.interner.push_quoted_type(typ);
 
                 let typ = UnresolvedTypeData::Resolved(quoted_type_id);
@@ -539,6 +540,7 @@ impl Value {
                     ordered_fields.push((Ident::new(name.to_string(), location), field));
                 }
 
+                assert!(fields.is_empty(), "There should be no remaining fields to add");
                 HirExpression::Constructor(HirConstructorExpression {
                     r#type: data_type,
                     struct_generics: generics,


### PR DESCRIPTION
# Description

## Problem

Resolves https://app.audithub.dev/app/organizations/161/projects/600/project-viewer?version=1408&issueId=881

## Summary

Adds a quick missing assertion suggested by the auditors.

## Additional Context



## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
