### PR TITLE
fix: Replace equality with try_unify

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/trait_impls.rs
+++ b/compiler/noirc_frontend/src/elaborator/trait_impls.rs
@@ -465,11 +465,7 @@ impl Elaborator<'_> {
         for override_trait_constraint in override_meta.trait_constraints.clone() {
             let override_constraint_is_from_impl =
                 trait_impl_where_clause.iter().any(|impl_constraint| {
-                    impl_constraint.typ == override_trait_constraint.typ
-                        && impl_constraint.trait_bound.trait_id
-                            == override_trait_constraint.trait_bound.trait_id
-                        && impl_constraint.trait_bound.trait_generics
-                            == override_trait_constraint.trait_bound.trait_generics
+                    constraints_unify(impl_constraint, &override_trait_constraint).is_ok()
                 });
             if override_constraint_is_from_impl {
                 continue;
@@ -1061,4 +1057,50 @@ impl Elaborator<'_> {
             wildcard_allowed,
         )
     }
+}
+
+/// Returns true if the impl-level `where` constraint and the method-level
+/// override constraint refer to the same trait on the same type with the same
+/// trait generics. Note that no type bindings are committed on success.
+fn constraints_unify(
+    impl_constraint: &TraitConstraint,
+    override_constraint: &TraitConstraint,
+) -> bool {
+    constraints_unify_helper(impl_constraint, override_constraint).is_some()
+}
+
+/// Helper so we can use `?` without `try` blocks being stable
+fn constraints_unify_helper(
+    impl_constraint: &TraitConstraint,
+    override_constraint: &TraitConstraint,
+) -> Option<()> {
+    // This just lets us early-return `None` for `false` conditions
+    let require = |cond: bool| cond.then_some(());
+
+    require(impl_constraint.trait_bound.trait_id != override_constraint.trait_bound.trait_id)?;
+
+    let mut bindings = TypeBindings::default();
+    impl_constraint.typ.try_unify(&override_constraint.typ, &mut bindings).ok()?;
+
+    let impl_generics = &impl_constraint.trait_bound.trait_generics;
+    let override_generics = &override_constraint.trait_bound.trait_generics;
+
+    require(impl_generics.ordered.len() != override_generics.ordered.len())?;
+
+    let generics = impl_generics.ordered.iter().zip(&override_generics.ordered);
+    for (impl_generic, override_generic) in generics {
+        impl_generic.try_unify(override_generic, &mut bindings).ok()?;
+    }
+
+    require(impl_generics.named.len() != override_generics.named.len())?;
+
+    let named_override_generics = &override_generics.named;
+    for impl_named in &impl_generics.named {
+        let override_named = named_override_generics
+            .iter()
+            .find(|named| named.name.as_str() == impl_named.name.as_str())?;
+
+        impl_named.typ.try_unify(&override_named.typ, &mut bindings).ok()?;
+    }
+    Some(())
 }

--- a/compiler/noirc_frontend/src/elaborator/trait_impls.rs
+++ b/compiler/noirc_frontend/src/elaborator/trait_impls.rs
@@ -1079,7 +1079,7 @@ fn constraints_unify(
     let impl_generics = &impl_constraint.trait_bound.trait_generics;
     let override_generics = &override_constraint.trait_bound.trait_generics;
 
-    require(impl_generics.ordered.len() != override_generics.ordered.len())?;
+    require(impl_generics.ordered.len() == override_generics.ordered.len())?;
 
     let generics = impl_generics.ordered.iter().zip(&override_generics.ordered);
     for (impl_generic, override_generic) in generics {

--- a/compiler/noirc_frontend/src/elaborator/trait_impls.rs
+++ b/compiler/noirc_frontend/src/elaborator/trait_impls.rs
@@ -1071,7 +1071,7 @@ fn constraints_unify(
     // This just lets us early-return `None` for `false` conditions
     let require = |cond: bool| cond.then_some(());
 
-    require(impl_constraint.trait_bound.trait_id != override_constraint.trait_bound.trait_id)?;
+    require(impl_constraint.trait_bound.trait_id == override_constraint.trait_bound.trait_id)?;
 
     let mut bindings = TypeBindings::default();
     impl_constraint.typ.try_unify(&override_constraint.typ, &mut bindings).ok()?;

--- a/compiler/noirc_frontend/src/elaborator/trait_impls.rs
+++ b/compiler/noirc_frontend/src/elaborator/trait_impls.rs
@@ -465,7 +465,7 @@ impl Elaborator<'_> {
         for override_trait_constraint in override_meta.trait_constraints.clone() {
             let override_constraint_is_from_impl =
                 trait_impl_where_clause.iter().any(|impl_constraint| {
-                    constraints_unify(impl_constraint, &override_trait_constraint).is_ok()
+                    constraints_unify(impl_constraint, &override_trait_constraint).is_some()
                 });
             if override_constraint_is_from_impl {
                 continue;
@@ -1062,15 +1062,9 @@ impl Elaborator<'_> {
 /// Returns true if the impl-level `where` constraint and the method-level
 /// override constraint refer to the same trait on the same type with the same
 /// trait generics. Note that no type bindings are committed on success.
+///
+/// Returns a `Option` so we can use `?` without `try` blocks being stable
 fn constraints_unify(
-    impl_constraint: &TraitConstraint,
-    override_constraint: &TraitConstraint,
-) -> bool {
-    constraints_unify_helper(impl_constraint, override_constraint).is_some()
-}
-
-/// Helper so we can use `?` without `try` blocks being stable
-fn constraints_unify_helper(
     impl_constraint: &TraitConstraint,
     override_constraint: &TraitConstraint,
 ) -> Option<()> {

--- a/compiler/noirc_frontend/src/elaborator/trait_impls.rs
+++ b/compiler/noirc_frontend/src/elaborator/trait_impls.rs
@@ -1086,7 +1086,7 @@ fn constraints_unify(
         impl_generic.try_unify(override_generic, &mut bindings).ok()?;
     }
 
-    require(impl_generics.named.len() != override_generics.named.len())?;
+    require(impl_generics.named.len() == override_generics.named.len())?;
 
     let named_override_generics = &override_generics.named;
     for impl_named in &impl_generics.named {

--- a/compiler/noirc_frontend/src/tests/traits/trait_impl_constraints.rs
+++ b/compiler/noirc_frontend/src/tests/traits/trait_impl_constraints.rs
@@ -314,6 +314,91 @@ fn non_equivalent_generic_positions() {
 }
 
 #[test]
+fn impl_stricter_than_trait_type_alias_in_constraint_typ() {
+    // The impl-level where clause uses a type alias that expands to `A`.
+    // The method-level constraint uses `A` directly. The two are equivalent,
+    // so the method constraint should be recognized as covered by the impl
+    // constraint (i.e. no "impl has stricter requirements than trait" error).
+    //
+    // An "unnecessary trait constraint" warning is emitted at each site because
+    // the method-level constraint is semantically redundant with the impl-level
+    // constraint — that is exactly the condition under which the shortcut we
+    // are testing should apply.
+    let src = r#"
+    trait Bar {}
+
+    type Alias<T> = T;
+
+    trait MyTrait<T> {
+        fn foo<U>();
+    }
+
+    impl<A> MyTrait<A> for () where Alias<A>: Bar {
+                                              ^^^ Constraint for `Alias<A>: Bar` is not needed, another matching impl is already in scope
+                                              ~~~ Unnecessary trait constraint in where clause
+        fn foo<B>() where A: Bar {}
+           ^^^ Constraint for `Alias<A>: Bar` is not needed, another matching impl is already in scope
+           ~~~ Unnecessary trait constraint in where clause
+    }
+
+    fn main() {}
+    "#;
+    check_errors(src);
+}
+
+#[test]
+fn impl_stricter_than_trait_type_alias_in_trait_generics() {
+    // The impl-level constraint uses a type alias inside the trait generics
+    // (`A: Bar<Alias<A>>`), while the method uses the expanded form
+    // (`A: Bar<A>`). They are equivalent after alias resolution.
+    let src = r#"
+    trait Bar<T> {}
+
+    type Alias<T> = T;
+
+    trait MyTrait<T> {
+        fn foo<U>();
+    }
+
+    impl<A> MyTrait<A> for () where A: Bar<Alias<A>> {
+                                       ^^^ Constraint for `A: Bar` is not needed, another matching impl is already in scope
+                                       ~~~ Unnecessary trait constraint in where clause
+        fn foo<B>() where A: Bar<A> {}
+           ^^^ Constraint for `A: Bar` is not needed, another matching impl is already in scope
+           ~~~ Unnecessary trait constraint in where clause
+    }
+
+    fn main() {}
+    "#;
+    check_errors(src);
+}
+
+#[test]
+fn impl_stricter_than_trait_reordered_named_trait_generics() {
+    // The impl-level constraint lists the named (associated type) generics in
+    // one order while the method-level constraint lists them in a different
+    // order. These are equivalent and the method constraint should be
+    // recognized as covered by the impl constraint.
+    let src = r#"
+    trait HasTwoAssoc {
+        type First;
+        type Second;
+    }
+
+    trait MyTrait<T> {
+        fn foo<U>();
+    }
+
+    impl<A> MyTrait<A> for () where A: HasTwoAssoc<First = Field, Second = u32> {
+        fn foo<B>() where A: HasTwoAssoc<Second = u32, First = Field> {}
+    }
+
+    fn main() {}
+    "#;
+    assert_no_errors(src);
+}
+
+#[test]
 fn impl_block_with_cross_trait_where_clause() {
     let src = r#"
     trait Validate {


### PR DESCRIPTION
# Description

## Problem

Resolves https://app.audithub.dev/app/organizations/161/projects/599/project-viewer?version=1406&issueId=855

## Summary

Replaces direct equality on types with several `try_unify` calls.

## Additional Context



## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
