### PR TITLE
chore(docs): Remove documentation of u1 type

### DIFF
--- a/docs/docs/noir/concepts/data_types/integers.md
+++ b/docs/docs/noir/concepts/data_types/integers.md
@@ -7,7 +7,7 @@ sidebar_position: 1
 
 An integer type is a range constrained field type.
 The Noir frontend supports both unsigned and signed integer types.
-The allowed sizes are 1, 8, 16, 32, 64 and 128 bits. ([currently only unsigned integers for 128 bits](https://github.com/noir-lang/noir/issues/7591))
+The allowed sizes are 8, 16, 32, 64 and 128 bits. ([currently only unsigned integers for 128 bits](https://github.com/noir-lang/noir/issues/7591))
 
 :::info
 

--- a/docs/versioned_docs/version-v1.0.0-beta.20/noir/concepts/data_types/integers.md
+++ b/docs/versioned_docs/version-v1.0.0-beta.20/noir/concepts/data_types/integers.md
@@ -7,7 +7,7 @@ sidebar_position: 1
 
 An integer type is a range constrained field type.
 The Noir frontend supports both unsigned and signed integer types.
-The allowed sizes are 1, 8, 16, 32, 64 and 128 bits. ([currently only unsigned integers for 128 bits](https://github.com/noir-lang/noir/issues/7591))
+The allowed sizes are 8, 16, 32, 64 and 128 bits. ([currently only unsigned integers for 128 bits](https://github.com/noir-lang/noir/issues/7591))
 
 :::info
 


### PR DESCRIPTION
# Description

## Summary

The `u1` type was removed in https://github.com/noir-lang/noir/pull/11753, but corresponding documentations were not updated.

This PR updates the corresponding documentations.

## User Documentation

Check one:
- [ ] No user documentation needed.
- [x] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
