### PR TITLE
fix(acvm): reject malformed MSM inputs without panicking

### DIFF
--- a/acvm-repo/acvm/src/compiler/validator.rs
+++ b/acvm-repo/acvm/src/compiler/validator.rs
@@ -574,6 +574,35 @@ mod tests {
     }
 
     #[test]
+    fn test_multi_scalar_mul_with_malformed_inputs_returns_error() {
+        let circuit =
+            make_circuit(vec![Opcode::BlackBoxFuncCall(BlackBoxFuncCall::MultiScalarMul {
+                points: vec![
+                    FunctionInput::Witness(Witness(1)),
+                    FunctionInput::Witness(Witness(2)),
+                    FunctionInput::Witness(Witness(3)),
+                ],
+                scalars: vec![FunctionInput::Witness(Witness(4))],
+                predicate: FunctionInput::Witness(Witness(5)),
+                outputs: (Witness(6), Witness(7), Witness(8)),
+            })]);
+
+        let witness_map =
+            WitnessMap::from(BTreeMap::from_iter([(Witness(5), FieldElement::one())]));
+
+        let backend = Bn254BlackBoxSolver;
+        let error = validate_witness(&backend, witness_map, &circuit).unwrap_err();
+
+        assert!(matches!(
+            error,
+            crate::pwg::OpcodeResolutionError::BlackBoxFunctionFailed(
+                acir::BlackBoxFunc::MultiScalarMul,
+                _
+            )
+        ));
+    }
+
+    #[test]
     fn test_and_valid() {
         // w1 AND w2 = w3, where w1=0b1010, w2=0b1100, w3=0b1000
         let circuit = make_circuit(vec![Opcode::BlackBoxFuncCall(BlackBoxFuncCall::AND {

--- a/acvm-repo/acvm/src/pwg/blackbox/embedded_curve_ops.rs
+++ b/acvm-repo/acvm/src/pwg/blackbox/embedded_curve_ops.rs
@@ -32,13 +32,7 @@ pub(crate) fn execute_multi_scalar_mul<F: AcirField>(
     scalars: &[FunctionInput<F>],
     predicate: FunctionInput<F>,
 ) -> Result<(F, F, F), OpcodeResolutionError<F>> {
-    assert!(scalars.len().is_multiple_of(2), "Number of scalars must be even");
-    assert!(points.len().is_multiple_of(3), "Number of points must be a multiple of 3");
-    assert_eq!(
-        scalars.len() / 2,
-        points.len() / 3,
-        "Number of scalars must be the same as the number of points"
-    );
+    validate_multi_scalar_mul_inputs(points, scalars)?;
 
     let points: Result<Vec<_>, _> =
         points.iter().map(|input| input_to_value(initial_witness, *input)).collect();
@@ -62,6 +56,41 @@ pub(crate) fn execute_multi_scalar_mul<F: AcirField>(
     let (res_x, res_y, is_infinite) =
         backend.multi_scalar_mul(&points, &scalars_lo, &scalars_hi, predicate)?;
     Ok((res_x, res_y, is_infinite))
+}
+
+fn validate_multi_scalar_mul_inputs<F: AcirField>(
+    points: &[FunctionInput<F>],
+    scalars: &[FunctionInput<F>],
+) -> Result<(), OpcodeResolutionError<F>> {
+    if !scalars.len().is_multiple_of(2) {
+        return Err(OpcodeResolutionError::BlackBoxFunctionFailed(
+            acir::BlackBoxFunc::MultiScalarMul,
+            format!("expected an even number of scalar limbs, got {}", scalars.len()),
+        ));
+    }
+
+    if !points.len().is_multiple_of(3) {
+        return Err(OpcodeResolutionError::BlackBoxFunctionFailed(
+            acir::BlackBoxFunc::MultiScalarMul,
+            format!(
+                "expected point inputs in triples of (x, y, is_infinite), got {} values",
+                points.len()
+            ),
+        ));
+    }
+
+    let point_count = points.len() / 3;
+    let scalar_count = scalars.len() / 2;
+    if scalar_count != point_count {
+        return Err(OpcodeResolutionError::BlackBoxFunctionFailed(
+            acir::BlackBoxFunc::MultiScalarMul,
+            format!(
+                "expected the same number of points and scalars, got {point_count} points and {scalar_count} scalars"
+            ),
+        ));
+    }
+
+    Ok(())
 }
 
 pub(super) fn embedded_curve_add<F: AcirField>(


### PR DESCRIPTION
# Description

## Problem

Malformed MSM opcode inputs currently trip internal assertions in ACVM witness solving, which can panic instead of returning a diagnosable error.

## Summary

Validate MSM point/scalar shapes before execution and surface malformed inputs as `OpcodeResolutionError::BlackBoxFunctionFailed`.
Add a targeted validator test to lock in the malformed-input error path.

## Additional Context

This keeps the change local to the embedded curve opcode path and does not alter valid-input behavior.

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.