### PR TITLE
feat(fuzzer): enable print generation in ACIR functions

### DIFF
--- a/tooling/ast_fuzzer/src/lib.rs
+++ b/tooling/ast_fuzzer/src/lib.rs
@@ -106,6 +106,7 @@ impl Default for Config {
             ("for", 37),
             ("let", 25),
             ("call", 5),
+            ("print", 10),
             ("constrain", 4),
         ]);
         let stmt_freqs_brillig = Freqs::new(&[

--- a/tooling/ast_fuzzer/src/program/func.rs
+++ b/tooling/ast_fuzzer/src/program/func.rs
@@ -1193,6 +1193,12 @@ impl<'a> FunctionContext<'a> {
             return Ok(e);
         }
 
+        if freq.enabled_when("print", !self.config().avoid_print)
+            && let Some(e) = self.gen_print(u)?
+        {
+            return Ok(e);
+        }
+
         if self.unconstrained() {
             // Get loop out of the way quick, as it's always disabled for ACIR.
             if freq.enabled_when("loop", self.budget > 1) {
@@ -1209,13 +1215,6 @@ impl<'a> FunctionContext<'a> {
 
             if freq.enabled_when("continue", self.in_loop && !self.config().avoid_loop_control) {
                 return Ok(Expression::Continue);
-            }
-
-            // For now only try prints in unconstrained code, were we don't need to create a proxy.
-            if freq.enabled_when("print", !self.config().avoid_print)
-                && let Some(e) = self.gen_print(u)?
-            {
-                return Ok(e);
             }
         }
 


### PR DESCRIPTION
As #12147 gives us an easy way to print in ACIR, it's enough to do a couple simple tweaks now to enable this. Adding `print` to freqs for ACIR.

Closes #8605