### PR TITLE
chore(fuzz): Increase `constrain` frequency in the AST fuzzer

### DIFF
--- a/tooling/ast_fuzzer/src/lib.rs
+++ b/tooling/ast_fuzzer/src/lib.rs
@@ -107,7 +107,7 @@ impl Default for Config {
             ("let", 25),
             ("call", 5),
             ("print", 10),
-            ("constrain", 4),
+            ("constrain", 8),
         ]);
         let stmt_freqs_brillig = Freqs::new(&[
             ("break", 45),
@@ -121,7 +121,7 @@ impl Default for Config {
             ("let", 20),
             ("call", 5),
             ("print", 15),
-            ("constrain", 15),
+            ("constrain", 25),
         ]);
         Self {
             max_globals: 3,

--- a/tooling/ast_fuzzer/src/program/func.rs
+++ b/tooling/ast_fuzzer/src/program/func.rs
@@ -1421,9 +1421,9 @@ impl<'a> FunctionContext<'a> {
 
     /// Generate a `println` statement, if there is some printable local variable.
     ///
-    /// For now this only works in unconstrained code. For constrained code we will
-    /// need to generate a proxy function, which we can do as a follow-up pass,
-    /// as it has to be done once per function signature.
+    /// This works as-is in unconstrained functions. In constrained functions
+    /// we need to generate a proxy function, which happens in a follow-up pass,
+    /// once per function signature.
     fn gen_print(&mut self, u: &mut Unstructured) -> arbitrary::Result<Option<Expression>> {
         let opts = self
             .locals


### PR DESCRIPTION
# Description

## Problem

Resolves intermittent CI failure.

## Summary

Increases the frequency of generating a constraint in the AST fuzzer after https://github.com/noir-lang/noir/pull/12290 caused it to be relatively lower than the expected `1..=3` range in the `calibration` test.


## Additional Context

Example of a failed run in https://github.com/noir-lang/noir/actions/runs/24408786827/job/71301797803?pr=11512

Tested by running `cargo test -p noir_ast_fuzzer --test calibration -- --nocapture` and expecting `2/100` in the output for both ACIR and Brillig.

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
