### PR TITLE
fix(licm): Check lower bound when simplifying checked arithmetic to unchecked

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/opt/loop_invariant.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/loop_invariant.rs
@@ -937,11 +937,70 @@ mod tests {
     };
     use crate::ssa::opt::pure::Purity;
     use crate::ssa::opt::{LoopOrder, Loops};
-    use crate::ssa::opt::{assert_normalized_ssa_equals, assert_ssa_does_not_change};
+    use crate::ssa::opt::{
+        assert_normalized_ssa_equals, assert_pass_does_not_affect_execution,
+        assert_ssa_does_not_change,
+    };
     use acvm::AcirField;
     use acvm::acir::brillig::lengths::SemanticLength;
     use noirc_frontend::monomorphization::ast::InlineType;
     use test_case::test_case;
+
+    #[test]
+    fn signed_mul_overflow_at_lower_bound_not_converted_to_unchecked() {
+        // Regression: the loop invariant pass checked only the upper bound when deciding
+        // whether to convert a signed checked mul to unchecked. For signed types, the lower
+        // bound can overflow in the opposite direction.
+        //
+        // i8 206 = -50 in two's complement. Range is -50..40.
+        //   upper check: 3 * 40 = 120 < 128  (passes, no overflow)
+        //   lower check: 3 * (-50) = -150 < -128  (overflows!)
+        //
+        // The pass must keep the mul checked so the overflow is caught at runtime.
+        let src = "
+            acir(inline) fn main f0 {
+              b0():
+                jmp b1(i8 206)
+              b1(v0: i8):
+                v1 = lt v0, i8 40
+                jmpif v1 then: b2(), else: b3()
+              b2():
+                v2 = mul v0, i8 3
+                v3 = unchecked_add v0, i8 1
+                jmp b1(v3)
+              b3():
+                return
+            }
+        ";
+        let ssa = Ssa::from_str(src).unwrap();
+        let _ =
+            assert_pass_does_not_affect_execution(ssa, Vec::new(), Ssa::loop_invariant_code_motion);
+    }
+
+    #[test]
+    fn signed_sub_overflow_at_upper_bound_not_converted_to_unchecked() {
+        // i - (-100) overflows at the upper bound: 99 - (-100) = 199 > 127.
+        // i8 206 = -50, i8 156 = -100. Range is -50..100.
+        // The pass checks only lower: -50 - (-100) = 50 (safe), missing upper: 99 - (-100) = 199.
+        let src = "
+            acir(inline) fn main f0 {
+              b0():
+                jmp b1(i8 206)
+              b1(v0: i8):
+                v1 = lt v0, i8 100
+                jmpif v1 then: b2(), else: b3()
+              b2():
+                v2 = sub v0, i8 156
+                v3 = unchecked_add v0, i8 1
+                jmp b1(v3)
+              b3():
+                return
+            }
+        ";
+        let ssa = Ssa::from_str(src).unwrap();
+        let _ =
+            assert_pass_does_not_affect_execution(ssa, Vec::new(), Ssa::loop_invariant_code_motion);
+    }
 
     #[test]
     fn hoists_casts() {

--- a/compiler/noirc_evaluator/src/ssa/opt/loop_invariant/simplify.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/loop_invariant/simplify.rs
@@ -258,8 +258,10 @@ impl LoopInvariantContext<'_> {
         };
 
         // Handle arithmetic operations:
-        // Check if we can simplify either `lower op const` or `const op upper` into an unchecked version of the operation.
-        if let Some((lhs, rhs)) = match binary.operator {
+        // Check if we can simplify into an unchecked version of the operation.
+        // For signed types, overflow can happen in both directions (underflow and overflow),
+        // so we evaluate the operation at both extremes of the induction variable range.
+        if let Some(checks) = match binary.operator {
             BinaryOp::Add { unchecked }
             | BinaryOp::Sub { unchecked }
             | BinaryOp::Mul { unchecked }
@@ -270,39 +272,38 @@ impl LoopInvariantContext<'_> {
             }
             BinaryOp::Sub { .. } => {
                 if is_induction_var_lhs {
-                    // `i - const` won't overflow if the lowest `i` doesn't.
-                    Some((lower_bound, constant))
+                    // `i - const` can overflow at either extreme of `i`.
+                    Some([(lower_bound, constant), (upper_bound, constant)])
                 } else {
-                    // `const - i` won't overflow if the highest `i` doesn't.
-                    Some((constant, upper_bound))
+                    // `const - i` can overflow at either extreme of `i`.
+                    Some([(constant, lower_bound), (constant, upper_bound)])
                 }
             }
             BinaryOp::Add { .. } | BinaryOp::Mul { .. } => {
-                // `i + const` won't overflow if the highest `i` value doesn't.
-                Some((constant, upper_bound))
+                // `i + const` / `i * const` can overflow at either extreme of `i`.
+                Some([(constant, lower_bound), (constant, upper_bound)])
             }
             BinaryOp::Div | BinaryOp::Mod => return SimplifyResult::None,
             _ => None,
         } {
-            // We evaluate this expression using the upper bounds (or lower in the case of sub)
-            // of its inputs to check whether it will ever overflow.
-            // If `eval_constant_binary_op` won't overflow we can simplify the instruction to an unchecked version.
-            let lhs = lhs.into_numeric_constant().0;
-            let rhs = rhs.into_numeric_constant().0;
-            match eval_constant_binary_op(lhs, rhs, binary.operator, operand_type) {
-                BinaryEvaluationResult::Success(..) => {
-                    // Unchecked version of the binary operation
-                    let unchecked = Instruction::Binary(Binary {
-                        operator: binary.operator.into_unchecked(),
-                        lhs: binary.lhs,
-                        rhs: binary.rhs,
-                    });
-                    return SimplifyResult::SimplifiedToInstruction(unchecked);
-                }
-                BinaryEvaluationResult::CouldNotEvaluate | BinaryEvaluationResult::Failure(..) => {
-                    return SimplifyResult::None;
+            // Evaluate the operation at both bound extremes to check whether it will ever overflow.
+            for (lhs, rhs) in checks {
+                let lhs = lhs.into_numeric_constant().0;
+                let rhs = rhs.into_numeric_constant().0;
+                match eval_constant_binary_op(lhs, rhs, binary.operator, operand_type) {
+                    BinaryEvaluationResult::Success(..) => {}
+                    BinaryEvaluationResult::CouldNotEvaluate
+                    | BinaryEvaluationResult::Failure(..) => {
+                        return SimplifyResult::None;
+                    }
                 }
             }
+            let unchecked = Instruction::Binary(Binary {
+                operator: binary.operator.into_unchecked(),
+                lhs: binary.lhs,
+                rhs: binary.rhs,
+            });
+            return SimplifyResult::SimplifiedToInstruction(unchecked);
         }
 
         // Handle comparisons. (The upper_bound is exclusive).


### PR DESCRIPTION
# Description

## Problem

Resolves https://github.com/AztecProtocol/noir-claude/issues/808

Issue is described in details there

## Summary

Add `lower_bound` to the checks before simplifying a checked arithmetic operation to unchecked. This defense is only needed for signed types, but I find it cleaner to just have the one strategy for checks rather than differentiating on unsigned/signed types. 

## Additional Context



## User Documentation

Check one:
- [X] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
