### PR TITLE
chore: Turn `CallStack` into a newtype 

### DIFF
--- a/compiler/noirc_driver/src/lib.rs
+++ b/compiler/noirc_driver/src/lib.rs
@@ -1016,10 +1016,11 @@ fn ssa_report_to_custom_diagnostic(error: SsaReport) -> CustomDiagnostic {
                         ("This variable contains a value which is constrained to be a constant. Consider removing this value as additional return values increase proving/verification time".to_string(), call_stack)
                     },
                 };
-            let call_stack = vecmap(call_stack, |location| location);
-            let location = call_stack.last().expect("Expected RuntimeError to have a location");
-            let diagnostic =
-                CustomDiagnostic::simple_warning(message, secondary_message, *location);
+            let location = call_stack.last_or_dummy();
+            if location.is_dummy() {
+                tracing::warn!("expected SsaReport::Warning to have a location");
+            }
+            let diagnostic = CustomDiagnostic::simple_warning(message, secondary_message, location);
             diagnostic.with_call_stack(call_stack)
         }
         SsaReport::Bug(bug) => {
@@ -1038,9 +1039,11 @@ fn ssa_report_to_custom_diagnostic(error: SsaReport) -> CustomDiagnostic {
                         ("As a result, the compiled circuit is ensured to fail. Other assertions may also fail during execution".to_string(), call_stack)
                     }
                 };
-            let call_stack = vecmap(call_stack, |location| location);
-            let location = call_stack.last().expect("Expected RuntimeError to have a location");
-            let diagnostic = CustomDiagnostic::simple_bug(message, secondary_message, *location);
+            let location = call_stack.last_or_dummy();
+            if location.is_dummy() {
+                tracing::warn!("expected SsaReport::Bug to have a location");
+            }
+            let diagnostic = CustomDiagnostic::simple_bug(message, secondary_message, location);
             diagnostic.with_call_stack(call_stack)
         }
     }

--- a/compiler/noirc_errors/src/call_stack.rs
+++ b/compiler/noirc_errors/src/call_stack.rs
@@ -21,7 +21,8 @@ impl CallStack {
 
     /// Check if the call stack is empty.
     ///
-    /// A call stack can be non-empty and end still end in a dummy location.
+    /// A call stack can be non-empty and still end in a dummy location,
+    /// for example if we are using the SSA parser, with no source files.
     pub fn is_empty(&self) -> bool {
         self.0.is_empty()
     }

--- a/compiler/noirc_errors/src/call_stack.rs
+++ b/compiler/noirc_errors/src/call_stack.rs
@@ -4,7 +4,63 @@ use std::hash::BuildHasher;
 
 use crate::Location;
 
-pub type CallStack = Vec<Location>;
+/// A non-empty list of [Location]s.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub struct CallStack(Vec<Location>);
+
+impl CallStack {
+    /// Construct a new call stack from a potentially empty list of [Location]s.
+    pub fn new(locations: Vec<Location>) -> Self {
+        Self(locations)
+    }
+
+    /// Constructor to use when we don't have location information.
+    pub fn empty() -> Self {
+        Self::new(Vec::new())
+    }
+
+    /// Check if the call stack is empty.
+    ///
+    /// A call stack can be non-empty and end still end in a dummy location.
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// Get the last location, or a dummy one if it's empty.
+    pub fn last_or_dummy(&self) -> Location {
+        self.0.last().copied().unwrap_or(Location::dummy())
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+}
+
+impl IntoIterator for CallStack {
+    type Item = Location;
+
+    type IntoIter = <Vec<Location> as IntoIterator>::IntoIter;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
+
+impl<'a> IntoIterator for &'a CallStack {
+    type Item = &'a Location;
+    type IntoIter = std::slice::Iter<'a, Location>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.iter()
+    }
+}
+
+impl AsRef<[Location]> for CallStack {
+    fn as_ref(&self) -> &[Location] {
+        &self.0
+    }
+}
+
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct CallStackId(u32);
 
@@ -42,7 +98,7 @@ impl LocationNode {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CallStackHelper {
-    pub locations: Vec<LocationNode>,
+    locations: Vec<LocationNode>,
 }
 
 impl Default for CallStackHelper {
@@ -55,6 +111,10 @@ impl Default for CallStackHelper {
 }
 
 impl CallStackHelper {
+    pub fn locations(&self) -> &[LocationNode] {
+        &self.locations
+    }
+
     /// Construct a CallStack from a CallStackId
     pub fn get_call_stack(&self, mut call_stack: CallStackId) -> CallStack {
         let mut result = Vec::new();
@@ -63,7 +123,7 @@ impl CallStackHelper {
             call_stack = parent;
         }
         result.reverse();
-        result
+        CallStack::new(result)
     }
 
     /// Returns a new [CallStackId] which extends the `call_stack` with the provided `locations`.
@@ -121,5 +181,17 @@ impl CallStackHelper {
     /// Get (or create) a CallStackId corresponding to the given locations.
     pub fn get_or_insert_locations(&mut self, locations: &CallStack) -> CallStackId {
         self.extend_call_stack(CallStackId::root(), locations)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::call_stack::{CallStackHelper, CallStackId};
+
+    #[test]
+    fn root_call_stack_is_empty() {
+        let helper = CallStackHelper::default();
+        let root_call_stack = helper.get_call_stack(CallStackId::root());
+        assert!(root_call_stack.is_empty());
     }
 }

--- a/compiler/noirc_errors/src/call_stack.rs
+++ b/compiler/noirc_errors/src/call_stack.rs
@@ -31,6 +31,13 @@ impl CallStack {
         self.0.last().copied().unwrap_or(Location::dummy())
     }
 
+    /// Get the last location, unless the call stack is empty.
+    ///
+    /// Note that the last location may be a dummy.
+    pub fn last(&self) -> Option<&Location> {
+        self.0.last()
+    }
+
     pub fn len(&self) -> usize {
         self.0.len()
     }

--- a/compiler/noirc_errors/src/position.rs
+++ b/compiler/noirc_errors/src/position.rs
@@ -92,7 +92,7 @@ impl Location {
     }
 
     pub fn is_dummy(&self) -> bool {
-        self.file == FileId::dummy()
+        *self == Location::dummy()
     }
 }
 

--- a/compiler/noirc_errors/src/position.rs
+++ b/compiler/noirc_errors/src/position.rs
@@ -90,6 +90,10 @@ impl Location {
             self
         }
     }
+
+    pub fn is_dummy(&self) -> bool {
+        self.file == FileId::dummy()
+    }
 }
 
 impl Ord for Location {

--- a/compiler/noirc_errors/src/reporter.rs
+++ b/compiler/noirc_errors/src/reporter.rs
@@ -39,19 +39,6 @@ pub struct ReportedErrors {
 }
 
 impl CustomDiagnostic {
-    /// Avoid showing secondary messages with dummy locations, because they are
-    /// displayed on top of a source file that has nothing to do with them,
-    /// which is more confusing than just showing the primary message.
-    fn secondaries(secondary_message: String, secondary_location: Location) -> Vec<CustomLabel> {
-        if secondary_location.is_dummy() {
-            // Note that empty secondary messages are allowed: in frontend unit tests
-            // they carry the span information for the primary message.
-            vec![]
-        } else {
-            vec![CustomLabel::new(secondary_message, secondary_location)]
-        }
-    }
-
     pub fn from_message(msg: &str, file: fm::FileId) -> CustomDiagnostic {
         Self {
             file,
@@ -74,7 +61,7 @@ impl CustomDiagnostic {
         CustomDiagnostic {
             file: secondary_location.file,
             message: primary_message,
-            secondaries: Self::secondaries(secondary_message, secondary_location),
+            secondaries: vec![CustomLabel::new(secondary_message, secondary_location)],
             notes: Vec::new(),
             kind,
             deprecated: false,
@@ -130,7 +117,7 @@ impl CustomDiagnostic {
         CustomDiagnostic {
             file: secondary_location.file,
             message: primary_message,
-            secondaries: Self::secondaries(secondary_message, secondary_location),
+            secondaries: vec![CustomLabel::new(secondary_message, secondary_location)],
             notes: Vec::new(),
             kind: DiagnosticKind::Bug,
             deprecated: false,
@@ -277,6 +264,11 @@ fn convert_diagnostic(
     let secondary_labels = cd
         .secondaries
         .iter()
+        .filter(|custom_label|
+            // Some secondary messages come with dummy locations.
+            // Displaying these on whatever the first file ID (id = 0)
+            // would be more confusing than displaying only the primary.
+            !custom_label.location.is_dummy())
         .map(|custom_label| {
             let location = custom_label.location;
             let span = location.span;

--- a/compiler/noirc_errors/src/reporter.rs
+++ b/compiler/noirc_errors/src/reporter.rs
@@ -39,6 +39,17 @@ pub struct ReportedErrors {
 }
 
 impl CustomDiagnostic {
+    /// Avoid showing secondary messages with dummy locations, because they are
+    /// displayed on top of a source file that has nothing to do with them,
+    /// which is more confusing than just showing the primary message.
+    fn secondaries(secondary_message: String, secondary_location: Location) -> Vec<CustomLabel> {
+        if secondary_message.is_empty() || secondary_location.is_dummy() {
+            vec![]
+        } else {
+            vec![CustomLabel::new(secondary_message, secondary_location)]
+        }
+    }
+
     pub fn from_message(msg: &str, file: fm::FileId) -> CustomDiagnostic {
         Self {
             file,
@@ -61,7 +72,7 @@ impl CustomDiagnostic {
         CustomDiagnostic {
             file: secondary_location.file,
             message: primary_message,
-            secondaries: vec![CustomLabel::new(secondary_message, secondary_location)],
+            secondaries: Self::secondaries(secondary_message, secondary_location),
             notes: Vec::new(),
             kind,
             deprecated: false,
@@ -117,7 +128,7 @@ impl CustomDiagnostic {
         CustomDiagnostic {
             file: secondary_location.file,
             message: primary_message,
-            secondaries: vec![CustomLabel::new(secondary_message, secondary_location)],
+            secondaries: Self::secondaries(secondary_message, secondary_location),
             notes: Vec::new(),
             kind: DiagnosticKind::Bug,
             deprecated: false,

--- a/compiler/noirc_errors/src/reporter.rs
+++ b/compiler/noirc_errors/src/reporter.rs
@@ -43,7 +43,9 @@ impl CustomDiagnostic {
     /// displayed on top of a source file that has nothing to do with them,
     /// which is more confusing than just showing the primary message.
     fn secondaries(secondary_message: String, secondary_location: Location) -> Vec<CustomLabel> {
-        if secondary_message.is_empty() || secondary_location.is_dummy() {
+        if secondary_location.is_dummy() {
+            // Note that empty secondary messages are allowed: in frontend unit tests
+            // they carry the span information for the primary message.
             vec![]
         } else {
             vec![CustomLabel::new(secondary_message, secondary_location)]

--- a/compiler/noirc_errors/src/reporter.rs
+++ b/compiler/noirc_errors/src/reporter.rs
@@ -1,6 +1,7 @@
 use std::io::IsTerminal;
 
 use crate::Location;
+use crate::call_stack::CallStack;
 use crate::function_locations::FunctionLocations;
 use codespan_reporting::diagnostic::{Diagnostic, Label};
 use codespan_reporting::files::Files;
@@ -20,7 +21,7 @@ pub struct CustomDiagnostic {
 
     /// An optional call stack to display the full runtime call stack
     /// leading up to a runtime error. If this is empty it will not be displayed.
-    pub call_stack: Vec<Location>,
+    pub call_stack: CallStack,
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
@@ -47,7 +48,7 @@ impl CustomDiagnostic {
             kind: DiagnosticKind::Error,
             deprecated: false,
             unnecessary: false,
-            call_stack: Default::default(),
+            call_stack: CallStack::empty(),
         }
     }
 
@@ -65,7 +66,7 @@ impl CustomDiagnostic {
             kind,
             deprecated: false,
             unnecessary: false,
-            call_stack: Default::default(),
+            call_stack: CallStack::empty(),
         }
     }
 
@@ -121,11 +122,11 @@ impl CustomDiagnostic {
             kind: DiagnosticKind::Bug,
             deprecated: false,
             unnecessary: false,
-            call_stack: Default::default(),
+            call_stack: CallStack::empty(),
         }
     }
 
-    pub fn with_call_stack(mut self, call_stack: Vec<Location>) -> Self {
+    pub fn with_call_stack(mut self, call_stack: CallStack) -> Self {
         self.call_stack = call_stack;
         self
     }
@@ -282,13 +283,13 @@ fn convert_diagnostic(
 pub fn stack_trace<'files>(
     files: &'files impl Files<'files, FileId = fm::FileId>,
     function_locations: &FunctionLocations,
-    call_stack: &[Location],
+    call_stack: &CallStack,
 ) -> String {
     if call_stack.is_empty() {
         return String::new();
     }
 
-    let repeating_sequences = find_repeating_sequences(call_stack);
+    let repeating_sequences = find_repeating_sequences(call_stack.as_ref());
 
     // Compute the length of the longest frame number so we show them like this:
     //   1: ..

--- a/compiler/noirc_evaluator/src/acir/mod.rs
+++ b/compiler/noirc_evaluator/src/acir/mod.rs
@@ -552,7 +552,7 @@ impl<'a> Context<'a> {
             Instruction::Noop => (),
         }
 
-        self.acir_context.set_call_stack(CallStack::new());
+        self.acir_context.set_call_stack(CallStack::empty());
         Ok(warnings)
     }
 

--- a/compiler/noirc_evaluator/src/acir/types.rs
+++ b/compiler/noirc_evaluator/src/acir/types.rs
@@ -165,7 +165,7 @@ impl AcirValue {
             AcirValue::Var(var, _) => Ok(var),
             AcirValue::DynamicArray(_) | AcirValue::Array(_) => Err(InternalError::General {
                 message: "Called AcirValue::into_var on an array".to_string(),
-                call_stack: CallStack::new(),
+                call_stack: CallStack::empty(),
             }),
         }
     }
@@ -175,7 +175,7 @@ impl AcirValue {
             AcirValue::Var(var, _) => Ok(*var),
             AcirValue::DynamicArray(_) | AcirValue::Array(_) => Err(InternalError::General {
                 message: "Called AcirValue::borrow_var on an array".to_string(),
-                call_stack: CallStack::new(),
+                call_stack: CallStack::empty(),
             }),
         }
     }

--- a/compiler/noirc_evaluator/src/brillig/brillig_gen.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen.rs
@@ -86,7 +86,7 @@ pub(crate) fn gen_brillig_for(
         let Some(artifact) = artifact else {
             return Err(InternalError::General {
                 message: format!("Cannot find linked fn {unresolved_fn_label}"),
-                call_stack: CallStack::new(),
+                call_stack: CallStack::empty(),
             }
             .into());
         };

--- a/compiler/noirc_evaluator/src/errors.rs
+++ b/compiler/noirc_evaluator/src/errors.rs
@@ -8,7 +8,6 @@
 //!
 //! An Error of the latter is an error in the implementation of the compiler
 use acvm::FieldElement;
-use iter_extended::vecmap;
 use noirc_errors::{CustomDiagnostic, Location, call_stack::CallStack};
 
 use thiserror::Error;
@@ -157,7 +156,7 @@ impl RuntimeError {
 
 impl From<RuntimeError> for CustomDiagnostic {
     fn from(error: RuntimeError) -> CustomDiagnostic {
-        let call_stack = vecmap(error.call_stack(), |location| *location);
+        let call_stack = error.call_stack().clone();
         let diagnostic = error.into_diagnostic();
         diagnostic.with_call_stack(call_stack)
     }
@@ -175,23 +174,16 @@ impl RuntimeError {
                 )
             }
             RuntimeError::SsaValidationError { message, call_stack} => {
-                // At the moment SSA validation error is just a caught panic, it doesn't have a call stack.
                 let location =
-                    call_stack.last().copied().unwrap_or_else(Location::dummy);
+                    call_stack.last_or_dummy();
 
-                let mut diagnostic = CustomDiagnostic::simple_error(
-                    format!("SSA validation error: {message}"),
-                    String::new(),
-                    location,
+                let mut diagnostic = CustomDiagnostic::from_message(
+                    &format!("SSA validation error: {message}"),
+                    location.file
                 );
 
                 if std::env::var(SHOW_INVALID_SSA_ENV_KEY).is_err() {
                     diagnostic.notes.push(format!("Set the {SHOW_INVALID_SSA_ENV_KEY} env var to see the SSA."));
-                }
-
-                if call_stack.is_empty() {
-                    // Clear it otherwise it points to the top of the file.
-                    diagnostic.secondaries.clear();
                 }
 
                 diagnostic
@@ -200,7 +192,7 @@ impl RuntimeError {
                 let primary_message = self.to_string();
                 // Unrolling sometimes has to produce an empty call stack.
                 let location =
-                    self.call_stack().last().copied().unwrap_or_else(Location::dummy);
+                    self.call_stack().last_or_dummy();
 
                 CustomDiagnostic::simple_error(
                     primary_message,
@@ -210,10 +202,9 @@ impl RuntimeError {
             }
             _ => {
                 let message = self.to_string();
-                let location =
-                    self.call_stack().last().unwrap_or_else(|| panic!("Expected RuntimeError to have a location. Error message: {message}"));
+                let location = self.call_stack().last_or_dummy();
 
-                CustomDiagnostic::simple_error(message, String::new(), *location)
+                CustomDiagnostic::simple_error(message, String::new(), location)
             }
         }
     }

--- a/compiler/noirc_evaluator/src/ssa/checks/check_for_missing_brillig_constraints.rs
+++ b/compiler/noirc_evaluator/src/ssa/checks/check_for_missing_brillig_constraints.rs
@@ -333,11 +333,11 @@ impl DependencyContext {
             {
                 // Skip already visited locations (happens often in unrolled functions)
                 let call_stack = function.dfg.get_instruction_call_stack(*instruction);
-                let location = call_stack.last_or_dummy();
+                let location = call_stack.last();
 
                 // If there is no call stack (happens for tests), consider unvisited
                 let visited =
-                    !location.is_dummy() && self.visited_locations.contains(&(*callee, location));
+                    location.is_some_and(|loc| self.visited_locations.contains(&(*callee, *loc)));
 
                 if !visited {
                     let results = function.dfg.instruction_results(*instruction);
@@ -371,8 +371,8 @@ impl DependencyContext {
                         });
                     }
 
-                    if !location.is_dummy() {
-                        self.visited_locations.insert((*callee, location));
+                    if let Some(loc) = location {
+                        self.visited_locations.insert((*callee, *loc));
                     }
                 }
             }

--- a/compiler/noirc_evaluator/src/ssa/checks/check_for_missing_brillig_constraints.rs
+++ b/compiler/noirc_evaluator/src/ssa/checks/check_for_missing_brillig_constraints.rs
@@ -333,7 +333,7 @@ impl DependencyContext {
             {
                 // Skip already visited locations (happens often in unrolled functions)
                 let call_stack = function.dfg.get_instruction_call_stack(*instruction);
-                let location = call_stack.last();
+                let location = call_stack.last().filter(|loc| !loc.is_dummy());
 
                 // If there is no call stack (happens for tests), consider unvisited
                 let visited =

--- a/compiler/noirc_evaluator/src/ssa/checks/check_for_missing_brillig_constraints.rs
+++ b/compiler/noirc_evaluator/src/ssa/checks/check_for_missing_brillig_constraints.rs
@@ -333,11 +333,11 @@ impl DependencyContext {
             {
                 // Skip already visited locations (happens often in unrolled functions)
                 let call_stack = function.dfg.get_instruction_call_stack(*instruction);
-                let location = call_stack.last();
+                let location = call_stack.last_or_dummy();
 
                 // If there is no call stack (happens for tests), consider unvisited
                 let visited =
-                    location.is_some_and(|loc| self.visited_locations.contains(&(*callee, *loc)));
+                    !location.is_dummy() && self.visited_locations.contains(&(*callee, location));
 
                 if !visited {
                     let results = function.dfg.instruction_results(*instruction);
@@ -371,8 +371,8 @@ impl DependencyContext {
                         });
                     }
 
-                    if let Some(location) = location {
-                        self.visited_locations.insert((*callee, *location));
+                    if !location.is_dummy() {
+                        self.visited_locations.insert((*callee, location));
                     }
                 }
             }

--- a/compiler/noirc_evaluator/src/ssa/ir/dfg.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/dfg.rs
@@ -812,7 +812,7 @@ impl DataFlowGraph {
     pub(crate) fn get_value_call_stack(&self, value: ValueId) -> CallStack {
         match &self.values[value] {
             Value::Instruction { instruction, .. } => self.get_instruction_call_stack(*instruction),
-            _ => CallStack::new(),
+            _ => CallStack::empty(),
         }
     }
 

--- a/compiler/noirc_evaluator/src/ssa/ir/dfg.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/dfg.rs
@@ -798,7 +798,7 @@ impl DataFlowGraph {
 
     pub(crate) fn get_instruction_call_stack(&self, instruction: InstructionId) -> CallStack {
         let call_stack = self.get_instruction_call_stack_id(instruction);
-        self.call_stack_data.get_call_stack(call_stack)
+        self.get_call_stack(call_stack)
     }
 
     pub(crate) fn get_instruction_call_stack_id(&self, instruction: InstructionId) -> CallStackId {

--- a/compiler/noirc_evaluator/src/ssa/ir/dfg/simplify/value_merger.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/dfg/simplify/value_merger.rs
@@ -2,7 +2,7 @@ use acvm::{
     FieldElement,
     acir::brillig::lengths::{ElementTypesLength, SemanticLength, SemiFlattenedLength},
 };
-use noirc_errors::{Location, call_stack::CallStackId};
+use noirc_errors::call_stack::{CallStack, CallStackId};
 use rustc_hash::FxHashMap as HashMap;
 
 use crate::{
@@ -61,7 +61,7 @@ impl<'a> ValueMerger<'a> {
     /// Choose a call stack to return with the [RuntimeError].
     ///
     /// If the call stack of the value is empty, it returns the call stack of the if-then-else itself.
-    fn get_call_stack(&self, value: ValueId) -> Vec<Location> {
+    fn get_call_stack(&self, value: ValueId) -> CallStack {
         // The value points at one of the problematic references, while the instruction would
         // point at where we got the if-then-else; it's not clear which one is more useful.
         let call_stack = self.dfg.get_value_call_stack(value);

--- a/compiler/noirc_evaluator/src/ssa/ir/printer.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/printer.rs
@@ -291,9 +291,9 @@ fn write_location_information(
 ) -> std::io::Result<()> {
     use codespan_files::Files;
     use std::io::Write;
-    let call_stack = dfg.get_instruction_call_stack(instruction);
+    let location = dfg.get_instruction_call_stack(instruction).last_or_dummy();
 
-    if let Some(location) = call_stack.last()
+    if !location.is_dummy()
         && let Ok(name) = fm.as_file_map().get_name(location.file)
     {
         let files = fm.as_file_map();

--- a/compiler/noirc_evaluator/src/ssa/ir/printer.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/printer.rs
@@ -291,9 +291,10 @@ fn write_location_information(
 ) -> std::io::Result<()> {
     use codespan_files::Files;
     use std::io::Write;
-    let location = dfg.get_instruction_call_stack(instruction).last_or_dummy();
+    let call_stack = dfg.get_instruction_call_stack(instruction);
 
-    if !location.is_dummy()
+    if let Some(location) = call_stack.last()
+        && !location.is_dummy()
         && let Ok(name) = fm.as_file_map().get_name(location.file)
     {
         let files = fm.as_file_map();

--- a/compiler/noirc_evaluator/src/ssa/opt/inlining.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/inlining.rs
@@ -13,7 +13,7 @@ use acvm::acir::AcirField;
 use im::HashMap;
 use iter_extended::vecmap;
 use itertools::Itertools;
-use noirc_errors::{Location, call_stack::CallStackId};
+use noirc_errors::call_stack::{CallStack, CallStackId};
 
 use crate::ssa::{
     function_builder::FunctionBuilder,
@@ -527,7 +527,7 @@ impl<'function> PerFunctionContext<'function> {
     fn validate_callee(
         &self,
         callee: &Function,
-        call_stack: Vec<Location>,
+        call_stack: CallStack,
     ) -> Result<(), RuntimeError> {
         if self.entry_function.runtime().is_brillig() && callee.runtime().is_acir() {
             // If the caller is Brillig and the called function is ACIR,

--- a/compiler/noirc_evaluator/src/ssa/opt/unrolling.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/unrolling.rs
@@ -348,7 +348,7 @@ impl Function {
             if self.runtime().is_acir() {
                 return LoopUnrollResult::Failed(
                     loop_.header,
-                    RuntimeError::UnknownLoopBound { call_stack: CallStack::new() },
+                    RuntimeError::UnknownLoopBound { call_stack: CallStack::empty() },
                 );
             }
             return LoopUnrollResult::Skipped;
@@ -865,7 +865,7 @@ impl Loop {
             Ok(pre_header.remove(0))
         } else {
             // We can come back into the header from multiple blocks, so we can't unroll this.
-            Err(CallStack::new())
+            Err(CallStack::empty())
         }
     }
 
@@ -1622,7 +1622,7 @@ fn get_induction_variable(dfg: &DataFlowGraph, block: BasicBlockId) -> Result<Va
             }
         }
         Some(terminator) => Err(dfg.get_call_stack(terminator.call_stack())),
-        None => Err(CallStack::new()),
+        None => Err(CallStack::empty()),
     }
 }
 
@@ -1648,7 +1648,7 @@ fn get_header_arguments(
             Ok(arguments.clone())
         }
         Some(terminator) => Err(dfg.get_call_stack(terminator.call_stack())),
-        None => Err(CallStack::new()),
+        None => Err(CallStack::empty()),
     }
 }
 

--- a/compiler/noirc_evaluator/src/ssa/parser/into_ssa.rs
+++ b/compiler/noirc_evaluator/src/ssa/parser/into_ssa.rs
@@ -6,7 +6,10 @@ use std::{
 
 use acvm::acir::circuit::ErrorSelector;
 use itertools::Itertools;
-use noirc_errors::{Location, call_stack::CallStackId};
+use noirc_errors::{
+    Location,
+    call_stack::{CallStack, CallStackId},
+};
 
 use crate::ssa::{
     function_builder::{
@@ -165,7 +168,7 @@ impl Translator {
 
                 // In our ACIR generation tests we want to make sure that `brillig_locations` in the `GeneratedAcir` was accurately set.
                 // Thus, we set a dummy location here so that translated instructions have a location associated with them.
-                let stack = vec![Location::dummy()];
+                let stack = CallStack::new(vec![Location::dummy()]);
                 let call_stack_data = &mut self.builder.current_function.dfg.call_stack_data;
                 let call_stack = call_stack_data.get_or_insert_locations(&stack);
                 self.builder.set_call_stack(call_stack);

--- a/compiler/noirc_evaluator/src/ssa/ssa_gen/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/ssa_gen/mod.rs
@@ -165,7 +165,7 @@ fn validate_ssa_or_err(ssa: Ssa) -> Result<Ssa, RuntimeError> {
         } else {
             format!("{payload:?}")
         };
-        let err = RuntimeError::SsaValidationError { message, call_stack: CallStack::default() };
+        let err = RuntimeError::SsaValidationError { message, call_stack: CallStack::empty() };
         Err(err)
     } else {
         Ok(ssa)
@@ -1558,7 +1558,7 @@ impl FunctionContext<'_> {
         let loop_end = current_loop.loop_end;
         self.builder.terminate_with_jmp(loop_end, Vec::new());
 
-        Err(RuntimeError::BreakOrContinue { call_stack: CallStack::default() })
+        Err(RuntimeError::BreakOrContinue { call_stack: CallStack::empty() })
     }
 
     fn codegen_continue(&mut self) -> Result<Values, RuntimeError> {
@@ -1572,7 +1572,7 @@ impl FunctionContext<'_> {
             self.builder.terminate_with_jmp(loop_.loop_entry, vec![]);
         }
 
-        Err(RuntimeError::BreakOrContinue { call_stack: CallStack::default() })
+        Err(RuntimeError::BreakOrContinue { call_stack: CallStack::empty() })
     }
 
     /// Evaluate the given expression, increment the reference count of each array within,

--- a/compiler/noirc_frontend/src/hir/comptime/errors.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/errors.rs
@@ -12,7 +12,7 @@ use crate::{
     token::Token,
 };
 use acvm::{BlackBoxResolutionError, FieldElement};
-use noirc_errors::{CustomDiagnostic, Location};
+use noirc_errors::{CustomDiagnostic, Location, call_stack::CallStack};
 
 /// The possible errors that can halt the interpreter.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -533,7 +533,7 @@ impl<'a> From<&'a InterpreterError> for CustomDiagnostic {
                 };
                 let diagnostic = CustomDiagnostic::simple_error(primary, secondary, *location);
 
-                diagnostic.with_call_stack(call_stack.into_iter().copied().collect())
+                diagnostic.with_call_stack(CallStack::new(call_stack.into_iter().copied().collect()))
             }
             InterpreterError::NonIntegerUsedInLoop { typ, location } => {
                 let msg = format!("Non-integer type `{typ}` used in for loop");
@@ -870,7 +870,7 @@ impl<'a> From<&'a InterpreterError> for CustomDiagnostic {
                     "Exceeded the recursion limit".to_string(),
                     *location,
                 );
-                diagnostic.with_call_stack(call_stack.into_iter().copied().collect())
+                diagnostic.with_call_stack(CallStack::new(call_stack.into_iter().copied().collect()))
             }
             InterpreterError::EvaluationDepthOverflow { location, call_stack } => {
                 let diagnostic = CustomDiagnostic::simple_error(
@@ -879,7 +879,7 @@ impl<'a> From<&'a InterpreterError> for CustomDiagnostic {
                         .to_string(),
                     *location,
                 );
-                diagnostic.with_call_stack(call_stack.into_iter().copied().collect())
+                diagnostic.with_call_stack(CallStack::new(call_stack.into_iter().copied().collect()))
             }
             InterpreterError::AttributeRecursionLimitExceeded { location } => {
                 CustomDiagnostic::simple_error(

--- a/tooling/debugger/src/context.rs
+++ b/tooling/debugger/src/context.rs
@@ -17,7 +17,7 @@ use nargo::errors::{ExecutionError, Location, ResolvedOpcodeLocation, execution_
 use noirc_artifacts::debug::{DebugArtifact, DebugFile, DebugInfo, StackFrame};
 
 use noirc_artifacts::program::CompiledProgram;
-use noirc_errors::call_stack::CallStackId;
+use noirc_errors::call_stack::{CallStack, CallStackId};
 use noirc_printable_type::{PrintableType, PrintableValue};
 use thiserror::Error;
 
@@ -546,7 +546,7 @@ impl<'a, B: BlackBoxFunctionSolver<FieldElement>> DebugContext<'a, B> {
                         .location_tree
                         .get_call_stack(call_stack_id)
                 } else {
-                    vec![]
+                    CallStack::empty()
                 }
             })
             .into_iter()
@@ -1049,7 +1049,7 @@ fn add_opcode_locations_map(
 ) {
     for (opcode_location, source_locations) in opcode_to_locations {
         let source_locations = debug_info.location_tree.get_call_stack(*source_locations);
-        source_locations.iter().for_each(|source_location| {
+        source_locations.into_iter().for_each(|source_location| {
             let span = source_location.span;
             let file_id = source_location.file;
             let Some(file) = simple_files.get(&file_id) else {

--- a/tooling/debugger/src/source_code_printer.rs
+++ b/tooling/debugger/src/source_code_printer.rs
@@ -247,8 +247,8 @@ mod tests {
     use crate::source_code_printer::render_location;
     use acvm::acir::circuit::AcirOpcodeLocation;
     use fm::FileManager;
-    use noirc_artifacts::debug::{DebugArtifact, DebugInfo, LocationNodeDebugInfo, LocationTree};
-    use noirc_errors::call_stack::CallStackId;
+    use noirc_artifacts::debug::{DebugArtifact, DebugInfo, LocationTree};
+    use noirc_errors::call_stack::{CallStackHelper, CallStackId};
     use noirc_errors::{Location, Span};
     use std::collections::BTreeMap;
     use std::ops::Range;
@@ -292,13 +292,9 @@ mod tests {
         // we just use a dummy to construct debug_symbols
         let mut opcode_locations = BTreeMap::<AcirOpcodeLocation, CallStackId>::new();
         opcode_locations.insert(AcirOpcodeLocation::new(42), CallStackId::new(1));
-        let mut location_tree = LocationTree::default();
-        location_tree
-            .locations
-            .push(LocationNodeDebugInfo { parent: None, value: Location::dummy() });
-        location_tree
-            .locations
-            .push(LocationNodeDebugInfo { parent: Some(CallStackId::root()), value: loc });
+        let mut call_stack = CallStackHelper::default();
+        call_stack.add_location_to_root(loc);
+        let location_tree = LocationTree::from(&call_stack);
 
         let debug_symbols = vec![DebugInfo::new(
             BTreeMap::default(),

--- a/tooling/nargo/src/errors.rs
+++ b/tooling/nargo/src/errors.rs
@@ -10,7 +10,11 @@ use acvm::{
 };
 use noirc_abi::{Abi, AbiErrorType, display_abi_error};
 use noirc_artifacts::debug::DebugInfo;
-use noirc_errors::{CustomDiagnostic, call_stack::CallStackId, reporter::ReportedErrors};
+use noirc_errors::{
+    CustomDiagnostic,
+    call_stack::{CallStack, CallStackId},
+    reporter::ReportedErrors,
+};
 
 pub use noirc_errors::Location;
 
@@ -114,7 +118,7 @@ pub enum ExecutionError<F: AcirField> {
 fn extract_locations_from_error<F: AcirField>(
     error: &ExecutionError<F>,
     debug: &[DebugInfo],
-) -> Option<Vec<Location>> {
+) -> Option<CallStack> {
     let mut opcode_locations = match error {
         ExecutionError::SolvingError(
             OpcodeResolutionError::BrilligFunctionFailed { .. },
@@ -170,7 +174,7 @@ fn extract_locations_from_error<F: AcirField>(
         ExecutionError::SolvingError(..) => None,
     };
 
-    Some(
+    Some(CallStack::new(
         opcode_locations
             .iter()
             .flat_map(|resolved_location| {
@@ -190,7 +194,7 @@ fn extract_locations_from_error<F: AcirField>(
                     .get_call_stack(call_stack_id)
             })
             .collect(),
-    )
+    ))
 }
 
 fn extract_message_from_error(
@@ -229,7 +233,8 @@ fn extract_message_from_error(
     }
 }
 
-/// Tries to generate a runtime diagnostic from a nargo error. It will successfully do so if it's a runtime error with a call stack.
+/// Tries to generate a runtime diagnostic from a nargo error.
+/// It will successfully do so if it's a runtime error with a non-empty call stack.
 pub fn try_to_diagnose_runtime_error(
     nargo_err: &NargoError<FieldElement>,
     abi: &Abi,
@@ -241,9 +246,12 @@ pub fn try_to_diagnose_runtime_error(
         }
         _ => return None,
     };
+    if source_locations.is_empty() {
+        return None;
+    }
     // The location of the error itself will be the location at the top
     // of the call stack (the last item in the Vec).
-    let location = *source_locations.last()?;
+    let location = source_locations.last_or_dummy();
     let message = extract_message_from_error(&abi.error_types, nargo_err);
     let error = CustomDiagnostic::simple_error(message, String::new(), location);
     Some(error.with_call_stack(source_locations))

--- a/tooling/nargo/src/ops/check.rs
+++ b/tooling/nargo/src/ops/check.rs
@@ -15,7 +15,7 @@ pub fn check_program(compiled_program: &CompiledProgram) -> Result<(), ErrorsAnd
                     compiled_program.debug[i].location_tree.get_call_stack(*call_stack);
                 CustomDiagnostic::from_message(
                     &format!("Circuit \"{}\" is not solvable", circuit.function_name),
-                    call_stack[0].file,
+                    call_stack.last_or_dummy().file,
                 )
                 .with_call_stack(call_stack)
             } else {

--- a/tooling/nargo_doc/src/lib.rs
+++ b/tooling/nargo_doc/src/lib.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 use fm::FileManager;
 use iter_extended::vecmap;
 use noirc_driver::CrateId;
+use noirc_errors::call_stack::CallStack;
 use noirc_errors::reporter::CustomLabel;
 use noirc_errors::{CustomDiagnostic, DiagnosticKind, Location, Span};
 use noirc_frontend::ast::{DocComment, IntegerBitSize, ItemVisibility};
@@ -110,7 +111,7 @@ impl From<&BrokenLink> for CustomDiagnostic {
             kind: DiagnosticKind::Warning,
             deprecated: false,
             unnecessary: false,
-            call_stack: vec![],
+            call_stack: CallStack::empty(),
         }
     }
 }

--- a/tooling/noirc_artifacts/src/debug.rs
+++ b/tooling/noirc_artifacts/src/debug.rs
@@ -373,13 +373,13 @@ impl DebugInfo {
         }
     }
 
-    pub fn acir_opcode_location(&self, loc: &AcirOpcodeLocation) -> Option<Vec<Location>> {
+    pub fn acir_opcode_location(&self, loc: &AcirOpcodeLocation) -> Option<CallStack> {
         self.acir_locations
             .get(loc)
             .map(|call_stack_id| self.location_tree.get_call_stack(*call_stack_id))
     }
 
-    pub fn opcode_location(&self, loc: &OpcodeLocation) -> Option<Vec<Location>> {
+    pub fn opcode_location(&self, loc: &OpcodeLocation) -> Option<CallStack> {
         match loc {
             OpcodeLocation::Brillig { .. } => None, //TODO: need brillig function id in order to look into brillig_locations
             OpcodeLocation::Acir(loc) => self.acir_opcode_location(&AcirOpcodeLocation::new(*loc)),
@@ -393,13 +393,24 @@ pub struct LocationNodeDebugInfo {
     pub value: Location,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Default, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, Hash)]
 pub struct LocationTree {
-    pub locations: Vec<LocationNodeDebugInfo>,
+    locations: Vec<LocationNodeDebugInfo>,
+}
+
+impl Default for LocationTree {
+    fn default() -> Self {
+        let helper = CallStackHelper::default();
+        Self::from(&helper)
+    }
 }
 
 impl LocationTree {
-    /// Construct a CallStack from a CallStackId
+    pub fn locations(&self) -> &[LocationNodeDebugInfo] {
+        &self.locations
+    }
+
+    /// Construct a [CallStack] from a [CallStackId]
     pub fn get_call_stack(&self, mut call_stack: CallStackId) -> CallStack {
         let mut result = Vec::new();
         while let Some(parent) = self.locations[call_stack.index()].parent {
@@ -407,7 +418,7 @@ impl LocationTree {
             call_stack = parent;
         }
         result.reverse();
-        result
+        CallStack::new(result)
     }
 }
 
@@ -416,7 +427,7 @@ impl From<&CallStackHelper> for LocationTree {
         // Clone the locations into a LocationTree
         LocationTree {
             locations: helper
-                .locations
+                .locations()
                 .iter()
                 .map(|node| LocationNodeDebugInfo { value: node.value, parent: node.parent })
                 .collect(),

--- a/tooling/noirc_artifacts/src/debug.rs
+++ b/tooling/noirc_artifacts/src/debug.rs
@@ -393,16 +393,9 @@ pub struct LocationNodeDebugInfo {
     pub value: Location,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, Hash, Default)]
 pub struct LocationTree {
     locations: Vec<LocationNodeDebugInfo>,
-}
-
-impl Default for LocationTree {
-    fn default() -> Self {
-        let helper = CallStackHelper::default();
-        Self::from(&helper)
-    }
 }
 
 impl LocationTree {

--- a/tooling/profiler/src/flamegraph.rs
+++ b/tooling/profiler/src/flamegraph.rs
@@ -8,6 +8,7 @@ use fm::codespan_files::Files;
 use inferno::flamegraph::{Options, TextTruncateDirection, from_lines};
 use noirc_artifacts::debug::DebugInfo;
 use noirc_errors::Location;
+use noirc_errors::call_stack::CallStack;
 use noirc_errors::reporter::line_and_column_from_span;
 use noirc_evaluator::brillig::ProcedureId;
 use rustc_hash::FxHashMap as HashMap;
@@ -177,9 +178,9 @@ fn find_callsite_labels<'files>(
 ) -> Vec<String> {
     let mut procedure_id = None;
     let source_locations = match opcode_location {
-        OpcodeLocation::Acir(idx) => {
-            debug_symbols.acir_opcode_location(&AcirOpcodeLocation::new(*idx)).unwrap_or_default()
-        }
+        OpcodeLocation::Acir(idx) => debug_symbols
+            .acir_opcode_location(&AcirOpcodeLocation::new(*idx))
+            .unwrap_or_else(CallStack::empty),
         OpcodeLocation::Brillig { .. } => {
             if let (Some(brillig_function_id), Some(brillig_location)) =
                 (brillig_function_id, opcode_location.to_brillig_location())
@@ -198,13 +199,14 @@ fn find_callsite_labels<'files>(
                 if let Some(brillig_locations) = brillig_locations {
                     brillig_locations
                         .get(&brillig_location)
-                        .map(|call_stack| debug_symbols.location_tree.get_call_stack(*call_stack))
-                        .unwrap_or_default()
+                        .map_or_else(CallStack::empty, |call_stack| {
+                            debug_symbols.location_tree.get_call_stack(*call_stack)
+                        })
                 } else {
-                    vec![]
+                    CallStack::empty()
                 }
             } else {
-                vec![]
+                CallStack::empty()
             }
         }
     };
@@ -309,7 +311,7 @@ mod tests {
     use noirc_artifacts::debug::{DebugInfo, LocationTree};
     use noirc_errors::{
         Location, Span,
-        call_stack::{CallStackHelper, CallStackId},
+        call_stack::{CallStack, CallStackHelper, CallStackId},
     };
     use std::{collections::BTreeMap, path::Path};
 
@@ -371,23 +373,25 @@ mod tests {
         let mut opcode_locations = BTreeMap::<AcirOpcodeLocation, CallStackId>::new();
         let mut call_stack_hlp = CallStackHelper::default();
         // main::foo::baz::whatever
-        let call_stack_id = call_stack_hlp.get_or_insert_locations(&vec![
+        let call_stack_id = call_stack_hlp.get_or_insert_locations(&CallStack::new(vec![
             main_declaration_location,
             main_foo_call_location,
             foo_baz_call_location,
             baz_whatever_call_location,
-        ]);
+        ]));
         opcode_locations.insert(AcirOpcodeLocation::new(0), call_stack_id);
         // main::bar::whatever
-        let call_stack_id = call_stack_hlp.get_or_insert_locations(&vec![
+        let call_stack_id = call_stack_hlp.get_or_insert_locations(&CallStack::new(vec![
             main_declaration_location,
             main_bar_call_location,
             bar_whatever_call_location,
-        ]);
+        ]));
         opcode_locations.insert(AcirOpcodeLocation::new(1), call_stack_id);
         // main::whatever
-        let call_stack_id = call_stack_hlp
-            .get_or_insert_locations(&vec![main_declaration_location, main_whatever_call_location]);
+        let call_stack_id = call_stack_hlp.get_or_insert_locations(&CallStack::new(vec![
+            main_declaration_location,
+            main_whatever_call_location,
+        ]));
         opcode_locations.insert(AcirOpcodeLocation::new(2), call_stack_id);
 
         opcode_locations.insert(AcirOpcodeLocation::new(42), CallStackId::new(1));

--- a/tooling/ssa_executor/src/compiler.rs
+++ b/tooling/ssa_executor/src/compiler.rs
@@ -60,7 +60,7 @@ pub fn optimize_ssa_into_acir(
             let error_msg = panic_message.lock().unwrap().clone();
             Err(RuntimeError::InternalError(InternalError::General {
                 message: format!("Panic occurred: {error_msg}"),
-                call_stack: CallStack::default(),
+                call_stack: CallStack::empty(),
             }))
         }
     }


### PR DESCRIPTION
# Description

## Problem

While working on https://github.com/noir-lang/noir/pull/11512 the compiler crashed on the following program:
```noir
fn main(c: bool, i: u32, j: u32, v: bool) -> pub bool {
    let mut a: [bool; 0] = [];
    if c {
        a[i] = v;
    }
    a[j]
}
``` 

This can still be reproduced at 5c2ab1e83b:

```console
❯ cargo run -q -p nargo_cli -- compile --force
The application panicked (crashed).
Message:  Expected RuntimeError to have a location
Location: compiler/noirc_driver/src/lib.rs:1042
```

The error disappeared after fixing the SSA optimization to not be applied on 0-length arrays, however the assumption that SSA errors always have locations is evidently false.

## Summary

* Changes `CallStack` from a type alias into a newtype wrapper, with some utility methods that make it easer to see where we are constructing empty call stacks. 
* Relaxes the above panic to a warning emitted via tracing, reporting the error with a dummy location instead.
* Hides secondary messages with dummy locations, to avoid the error being pointed at random Noir source code.

## Additional Context

Initially I wanted to enforce that `CallStack` must be a non-empty list of `Location`s, so we cannot create an error with an empty call stack (at least it should have the dummy), however the `CallStackHelper` returns an empty list for the root, so empty is a valid value. Also, when the error is created we are just looking up the call stack of the instruction at hand.

I tried to assert in `DataFlowGraph::insert_instruction_without_simplification` that the call stack is not empty, but that seems to be a common case (e.g. `make_array` above already fails; if we look in `codegen_literal`, only `Integer` uses `set_location`).

I also thought that perhaps a call stack ending in `Location::dummy()` could be considered empty as well, but left it as it was to not change that behaviour. Such a call stack is constructed by the parser.

With these changes the program above fails with the following output:
```console
❯ cargo run -q -p nargo_cli -- compile --force
bug: Assertion is always false: Index out of bounds
```

This isn't great, as it doesn't point at where the problem is, but at least it's not crashing.

I checked why we don't have location for this "Index out of bounds" constraint. It happens to be added by `remove_unreachable_instructions`, where it inherits the location of the instruction that is removed. In this case the fact that the `array_get` or `array_set` that it replaced didn't have a location was probably fixed by https://github.com/noir-lang/noir/pull/11512/commits/6a01ca2144f9e5d4f5bec02a1f5df89ea8885961 which suggests that the _condition_ didn't have a location, which was used to look up the call stack before. That also inherits the location of something else, and as I mentioned instructions are already missing locations during codegen:

```
dummy location for MakeArray { elements: [], typ: Array([Numeric(Unsigned { bit_size: 1 })], SemanticLength(0)) }
dummy location for Allocate
dummy location for Store { address: Id(5), value: Id(4) }
dummy location for Load { address: Id(5) }
non-dummy location for ArraySet { array: Id(6), index: Id(1), value: Id(3), mutable: false }: 50/106:110
non-dummy location for Binary(Binary { lhs: Id(1), rhs: Id(7), operator: Add { unchecked: true } }): 50/106:110
non-dummy location for Store { address: Id(5), value: Id(8) }: 50/106:110
non-dummy location for Load { address: Id(5) }: 50/106:110
non-dummy location for ArrayGet { array: Id(10), index: Id(2) }: 50/126:130
```

I think the issue of instructions not having locations would warrant a separate issue, should we want to do something about it.

The wrapper doesn't achieve much safety, but it does give us an easier way of looking up the places where we construct empty call stacks.

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
