### PR TITLE
chore: run LSF after mem2reg-brillig

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/mod.rs
@@ -152,7 +152,10 @@ pub fn primary_passes(options: &SsaEvaluatorOptions) -> Vec<SsaPass<'_>> {
         // Use brillig-only mem2reg before inlining.
         // Running ACIR mem2reg this early creates block parameters that cascade through
         // inlining and unrolling, causing regressions in unrolled-loop-heavy programs.
-        SsaPass::new(Ssa::mem2reg_brillig, "Mem2Reg").and_then(Ssa::remove_redundant_params),
+        SsaPass::new(Ssa::mem2reg_brillig, "Mem2Reg")
+            .and_then(Ssa::load_store_forwarding_brillig)
+            .and_then(Ssa::remove_unused_instructions)
+            .and_then(Ssa::remove_redundant_params),
         SsaPass::new(Ssa::defunctionalize, "Defunctionalization"),
         SsaPass::new(
             Ssa::lower_refs_at_acir_brillig_boundary,
@@ -160,7 +163,10 @@ pub fn primary_passes(options: &SsaEvaluatorOptions) -> Vec<SsaPass<'_>> {
         ),
         SsaPass::new_try(Ssa::inline_simple_functions, "Inlining simple functions")
             .and_then(Ssa::remove_unreachable_functions),
-        SsaPass::new(Ssa::mem2reg_brillig, "Mem2Reg").and_then(Ssa::remove_redundant_params),
+        SsaPass::new(Ssa::mem2reg_brillig, "Mem2Reg")
+            .and_then(Ssa::load_store_forwarding_brillig)
+            .and_then(Ssa::remove_unused_instructions)
+            .and_then(Ssa::remove_redundant_params),
         SsaPass::new(Ssa::array_set_optimization, "ArraySet optimization"),
         SsaPass::new(Ssa::array_get_optimization, "ArrayGet optimization"),
         SsaPass::new(Ssa::purity_analysis, "Purity Analysis"),
@@ -183,7 +189,10 @@ pub fn primary_passes(options: &SsaEvaluatorOptions) -> Vec<SsaPass<'_>> {
             },
             "Inlining",
         ),
-        SsaPass::new(Ssa::mem2reg, "Mem2Reg").and_then(Ssa::remove_redundant_params),
+        SsaPass::new(Ssa::mem2reg, "Mem2Reg")
+            .and_then(Ssa::load_store_forwarding)
+            .and_then(Ssa::remove_unused_instructions)
+            .and_then(Ssa::remove_redundant_params),
         SsaPass::new(Ssa::array_set_optimization, "ArraySet optimization"),
         SsaPass::new(Ssa::array_get_optimization, "ArrayGet optimization"),
         // Running DIE here might remove some unused instructions mem2reg could not eliminate.
@@ -224,7 +233,10 @@ pub fn primary_passes(options: &SsaEvaluatorOptions) -> Vec<SsaPass<'_>> {
             "Unrolling",
         ),
         SsaPass::new(Ssa::simplify_cfg, "Simplifying"),
-        SsaPass::new(Ssa::mem2reg, "Mem2Reg").and_then(Ssa::remove_redundant_params),
+        SsaPass::new(Ssa::mem2reg, "Mem2Reg")
+            .and_then(Ssa::load_store_forwarding)
+            .and_then(Ssa::remove_unused_instructions)
+            .and_then(Ssa::remove_redundant_params),
         SsaPass::new(Ssa::remove_bit_shifts, "Removing Bit Shifts"),
         SsaPass::new(Ssa::array_set_optimization, "ArraySet optimization"),
         SsaPass::new(Ssa::array_get_optimization, "ArrayGet optimization"),

--- a/compiler/noirc_evaluator/src/ssa/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/mod.rs
@@ -153,7 +153,7 @@ pub fn primary_passes(options: &SsaEvaluatorOptions) -> Vec<SsaPass<'_>> {
         // Running ACIR mem2reg this early creates block parameters that cascade through
         // inlining and unrolling, causing regressions in unrolled-loop-heavy programs.
         SsaPass::new(Ssa::mem2reg_brillig, "Mem2Reg")
-            .and_then(Ssa::load_store_forwarding_brillig)
+            .and_then(Ssa::load_store_forwarding)
             .and_then(Ssa::remove_unused_instructions)
             .and_then(Ssa::remove_redundant_params),
         SsaPass::new(Ssa::defunctionalize, "Defunctionalization"),
@@ -164,7 +164,7 @@ pub fn primary_passes(options: &SsaEvaluatorOptions) -> Vec<SsaPass<'_>> {
         SsaPass::new_try(Ssa::inline_simple_functions, "Inlining simple functions")
             .and_then(Ssa::remove_unreachable_functions),
         SsaPass::new(Ssa::mem2reg_brillig, "Mem2Reg")
-            .and_then(Ssa::load_store_forwarding_brillig)
+            .and_then(Ssa::load_store_forwarding)
             .and_then(Ssa::remove_unused_instructions)
             .and_then(Ssa::remove_redundant_params),
         SsaPass::new(Ssa::array_set_optimization, "ArraySet optimization"),

--- a/compiler/noirc_evaluator/src/ssa/opt/load_store_forwarding.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/load_store_forwarding.rs
@@ -48,16 +48,6 @@ impl Ssa {
         }
         self
     }
-
-    #[tracing::instrument(level = "trace", skip(self))]
-    pub(crate) fn load_store_forwarding_brillig(mut self) -> Ssa {
-        for function in self.functions.values_mut() {
-            if function.runtime().is_brillig() {
-                function.load_store_forwarding();
-            }
-        }
-        self
-    }
 }
 
 impl Function {

--- a/compiler/noirc_evaluator/src/ssa/opt/load_store_forwarding.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/load_store_forwarding.rs
@@ -48,6 +48,16 @@ impl Ssa {
         }
         self
     }
+
+    #[tracing::instrument(level = "trace", skip(self))]
+    pub(crate) fn load_store_forwarding_brillig(mut self) -> Ssa {
+        for function in self.functions.values_mut() {
+            if function.runtime().is_brillig() {
+                function.load_store_forwarding();
+            }
+        }
+        self
+    }
 }
 
 impl Function {


### PR DESCRIPTION
# Description

## Problem

No issue.

## Summary

I'm re-auditing load_store_forwarding after [this PR](https://github.com/noir-lang/noir/pull/12243) greatly simplified it.

I was curious about the regressions so I'm thinking we could try two things:
1. Maybe LSF could still run for functions with multiple blocks, as long as there are no loops ([comment here](https://github.com/noir-lang/noir/pull/12243#issuecomment-4253159066))
2. Maybe LSF could run after mem2reg, when that runs only for brillig, but also just run LSF for brillig functions here

At least locally I noticed that doing 2 undoes some of the regressions introduced by #12243, but I don't know if it'll make things slow to compile.

## Additional Context



## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
