### PR TITLE
feat(ci): add ContFuzzer-compatible fuzzer containers

### DIFF
--- a/.github/workflows/build_ast_arbtest.yml
+++ b/.github/workflows/build_ast_arbtest.yml
@@ -1,0 +1,83 @@
+name: Build AST Arbtest Fuzzer Container
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'tooling/ast_fuzzer/**'
+      - '.github/workflows/build_ast_arbtest.yml'
+  schedule:
+    - cron: '0 0,12 * * *'
+  workflow_dispatch:
+    inputs:
+      commit:
+        description: "Git commit SHA to build (overrides branch; leave empty to use branch or current ref)"
+        required: false
+        default: ""
+      branch:
+        description: "Git branch to clone (leave empty to build from the dispatched ref)"
+        required: false
+        default: ""
+
+jobs:
+  build:
+    if: github.repository == 'noir-lang/noir'
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Free up disk space on runner
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
+        with:
+          large-packages: false
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        id: build
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
+        with:
+          context: .
+          file: tooling/ast_fuzzer/arbtest-container/Dockerfile
+          push: true
+          tags: |
+            ghcr.io/noir-lang/contfuzzer-ast-arbtest:latest
+            ghcr.io/noir-lang/contfuzzer-ast-arbtest:${{ github.sha }}
+          build-args: |
+            CI_BUILD=true
+            COMMIT=${{ github.event_name == 'workflow_dispatch' && github.event.inputs.commit || '' }}
+            BRANCH=${{ github.event_name == 'workflow_dispatch' && github.event.inputs.branch || '' }}
+          labels: |
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.event_name == 'workflow_dispatch' && github.event.inputs.commit != '' && github.event.inputs.commit || github.sha }}
+            org.opencontainers.image.revision.branch=${{ github.event_name == 'workflow_dispatch' && github.event.inputs.branch != '' && github.event.inputs.branch || github.ref_name }}
+
+      - name: Install oras
+        uses: oras-project/setup-oras@22ce207df3b08e061f537244349aac6ae1d214f6 # v1.2.4
+
+      - name: Extract and attach fuzzer manifest
+        run: |
+          docker create --name manifest-extract ghcr.io/noir-lang/contfuzzer-ast-arbtest:${{ github.sha }}
+          docker cp manifest-extract:/fuzzer_manifest.json ./fuzzer_manifest.json
+          docker rm manifest-extract
+          oras attach ghcr.io/noir-lang/contfuzzer-ast-arbtest@${{ steps.build.outputs.digest }} \
+            --artifact-type application/vnd.contfuzzer.manifest+json \
+            fuzzer_manifest.json
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@7e8b541eb2e61bf99390e1afd4be13a184e9ebc5 # v3.10.1
+
+      - name: Sign image
+        run: |
+          cosign sign --yes \
+            ghcr.io/noir-lang/contfuzzer-ast-arbtest@${{ steps.build.outputs.digest }}

--- a/.github/workflows/build_ast_fuzzer.yml
+++ b/.github/workflows/build_ast_fuzzer.yml
@@ -1,0 +1,83 @@
+name: Build AST Fuzzer Container
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'tooling/ast_fuzzer/**'
+      - '.github/workflows/build_ast_fuzzer.yml'
+  schedule:
+    - cron: '10 0,12 * * *'
+  workflow_dispatch:
+    inputs:
+      commit:
+        description: "Git commit SHA to build (overrides branch; leave empty to use branch or current ref)"
+        required: false
+        default: ""
+      branch:
+        description: "Git branch to clone (leave empty to build from the dispatched ref)"
+        required: false
+        default: ""
+
+jobs:
+  build:
+    if: github.repository == 'noir-lang/noir'
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Free up disk space on runner
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
+        with:
+          large-packages: false
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        id: build
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
+        with:
+          context: .
+          file: tooling/ast_fuzzer/contfuzzer-container/Dockerfile
+          push: true
+          tags: |
+            ghcr.io/noir-lang/contfuzzer-ast-fuzzer:latest
+            ghcr.io/noir-lang/contfuzzer-ast-fuzzer:${{ github.sha }}
+          build-args: |
+            CI=true
+            COMMIT=${{ github.event_name == 'workflow_dispatch' && github.event.inputs.commit || '' }}
+            BRANCH=${{ github.event_name == 'workflow_dispatch' && github.event.inputs.branch || '' }}
+          labels: |
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.event_name == 'workflow_dispatch' && github.event.inputs.commit != '' && github.event.inputs.commit || github.sha }}
+            org.opencontainers.image.revision.branch=${{ github.event_name == 'workflow_dispatch' && github.event.inputs.branch != '' && github.event.inputs.branch || github.ref_name }}
+
+      - name: Install oras
+        uses: oras-project/setup-oras@22ce207df3b08e061f537244349aac6ae1d214f6 # v1.2.4
+
+      - name: Extract and attach fuzzer manifest
+        run: |
+          docker create --name manifest-extract ghcr.io/noir-lang/contfuzzer-ast-fuzzer:${{ github.sha }}
+          docker cp manifest-extract:/fuzzer_manifest.json ./fuzzer_manifest.json
+          docker rm manifest-extract
+          oras attach ghcr.io/noir-lang/contfuzzer-ast-fuzzer@${{ steps.build.outputs.digest }} \
+            --artifact-type application/vnd.contfuzzer.manifest+json \
+            fuzzer_manifest.json
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@7e8b541eb2e61bf99390e1afd4be13a184e9ebc5 # v3.10.1
+
+      - name: Sign image
+        run: |
+          cosign sign --yes \
+            ghcr.io/noir-lang/contfuzzer-ast-fuzzer@${{ steps.build.outputs.digest }}

--- a/.github/workflows/build_ssa_fuzzer.yml
+++ b/.github/workflows/build_ssa_fuzzer.yml
@@ -1,0 +1,83 @@
+name: Build SSA Fuzzer Container
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'tooling/ssa_fuzzer/**'
+      - '.github/workflows/build_ssa_fuzzer.yml'
+  schedule:
+    - cron: '20 0,12 * * *'
+  workflow_dispatch:
+    inputs:
+      commit:
+        description: "Git commit SHA to build (overrides branch; leave empty to use branch or current ref)"
+        required: false
+        default: ""
+      branch:
+        description: "Git branch to clone (leave empty to build from the dispatched ref)"
+        required: false
+        default: ""
+
+jobs:
+  build:
+    if: github.repository == 'noir-lang/noir'
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Free up disk space on runner
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
+        with:
+          large-packages: false
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        id: build
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
+        with:
+          context: .
+          file: tooling/ssa_fuzzer/contfuzzer-container/Dockerfile
+          push: true
+          tags: |
+            ghcr.io/noir-lang/contfuzzer-ssa-fuzzer:latest
+            ghcr.io/noir-lang/contfuzzer-ssa-fuzzer:${{ github.sha }}
+          build-args: |
+            CI=true
+            COMMIT=${{ github.event_name == 'workflow_dispatch' && github.event.inputs.commit || '' }}
+            BRANCH=${{ github.event_name == 'workflow_dispatch' && github.event.inputs.branch || '' }}
+          labels: |
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.event_name == 'workflow_dispatch' && github.event.inputs.commit != '' && github.event.inputs.commit || github.sha }}
+            org.opencontainers.image.revision.branch=${{ github.event_name == 'workflow_dispatch' && github.event.inputs.branch != '' && github.event.inputs.branch || github.ref_name }}
+
+      - name: Install oras
+        uses: oras-project/setup-oras@22ce207df3b08e061f537244349aac6ae1d214f6 # v1.2.4
+
+      - name: Extract and attach fuzzer manifest
+        run: |
+          docker create --name manifest-extract ghcr.io/noir-lang/contfuzzer-ssa-fuzzer:${{ github.sha }}
+          docker cp manifest-extract:/fuzzer_manifest.json ./fuzzer_manifest.json
+          docker rm manifest-extract
+          oras attach ghcr.io/noir-lang/contfuzzer-ssa-fuzzer@${{ steps.build.outputs.digest }} \
+            --artifact-type application/vnd.contfuzzer.manifest+json \
+            fuzzer_manifest.json
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@7e8b541eb2e61bf99390e1afd4be13a184e9ebc5 # v3.10.1
+
+      - name: Sign image
+        run: |
+          cosign sign --yes \
+            ghcr.io/noir-lang/contfuzzer-ssa-fuzzer@${{ steps.build.outputs.digest }}

--- a/tooling/ast_fuzzer/arbtest-container/Dockerfile
+++ b/tooling/ast_fuzzer/arbtest-container/Dockerfile
@@ -1,0 +1,95 @@
+# ContFuzzer-compatible container for the AST fuzzer (arbtest variant).
+#
+# Pre-builds the test binary during docker build, then runs it directly
+# at runtime — no cargo needed. This avoids cargo fingerprint invalidation,
+# network access requirements, and git safe.directory issues.
+#
+# Build:
+#   docker build -t contfuzzer-ast-arbtest -f tooling/ast_fuzzer/arbtest-container/Dockerfile .
+#
+# Build from a specific noir commit:
+#   docker build --build-arg COMMIT=abc123 -t contfuzzer-ast-arbtest .
+#
+# Run standalone (platform-like flags):
+#   docker run --read-only --tmpfs /tmp:size=512m \
+#       --user 65534:10001 \
+#       -v /tmp/crashes:/crashes -v /tmp/output:/output \
+#       -e FUZZ_MODE=fuzz -e FUZZ_TARGET=comptime_vs_brillig_direct -e FUZZ_TIMEOUT=300 \
+#       contfuzzer-ast-arbtest
+
+# ── Builder ────────────────────────────────────────────────────────────
+FROM --platform=linux/amd64 rust:1.89.0-bookworm AS builder
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        build-essential \
+        cmake \
+        git \
+        pkg-config \
+        libssl-dev \
+        ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# Source the noir workspace. Resolution order:
+#   COMMIT set:   clone from GitHub and checkout that commit (wins over BRANCH/CI).
+#   BRANCH set:   shallow-clone that branch from GitHub.
+#   CI_BUILD set: use the already checked-out repo COPY'd into the context.
+#   default:      shallow-clone master from GitHub.
+ARG COMMIT=""
+ARG BRANCH=""
+ARG CI_BUILD=""
+COPY . /noir-context
+RUN if [ -n "$COMMIT" ]; then \
+        rm -rf /noir-context && \
+        git clone https://github.com/noir-lang/noir.git --depth 1 /noir && \
+        cd /noir && git fetch origin "$COMMIT" --depth 1 && git checkout "$COMMIT"; \
+    elif [ -n "$BRANCH" ]; then \
+        rm -rf /noir-context && \
+        git clone --depth 1 --branch "$BRANCH" https://github.com/noir-lang/noir.git /noir; \
+    elif [ -n "$CI_BUILD" ]; then \
+        mv /noir-context /noir; \
+    else \
+        rm -rf /noir-context && \
+        git clone https://github.com/noir-lang/noir.git --depth 1 /noir; \
+    fi
+
+WORKDIR /noir
+
+# Build the test binary. cargo test --no-run compiles but doesn't execute.
+# The binary lands at target/release/deps/noir_ast_fuzzer_fuzz-<hash>.
+RUN cargo test --release -p noir_ast_fuzzer_fuzz --no-run
+
+# Find the test binary and copy it to a known location.
+# There's exactly one executable matching this pattern.
+# Copy the test binary and create per-target symlinks so the platform's
+# image scanner finds an entry in /targets/ for every manifest target.
+# All 6 targets live inside the same binary — the entrypoint passes the
+# target name as a substring filter at runtime.
+RUN mkdir -p /targets/fuzzing && \
+    TEST_BIN=$(find target/release/deps -name 'noir_ast_fuzzer_fuzz-*' -type f -executable | head -1) && \
+    test -n "$TEST_BIN" || { echo "FATAL: test binary not found"; exit 1; } && \
+    cp "$TEST_BIN" /targets/fuzzing/noir_ast_fuzzer_fuzz && \
+    for t in acir_vs_brillig min_vs_full pass_vs_prev orig_vs_morph \
+             comptime_vs_brillig_nargo comptime_vs_brillig_direct; do \
+        printf '#!/bin/sh\nexec /targets/fuzzing/noir_ast_fuzzer_fuzz "$@"\n' \
+            > "/targets/fuzzing/$t" && chmod +x "/targets/fuzzing/$t"; \
+    done
+
+# ── Runtime ────────────────────────────────────────────────────────────
+FROM --platform=linux/amd64 ubuntu:24.04
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        libstdc++6 \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /targets /targets
+
+COPY tooling/ast_fuzzer/arbtest-container/entrypoint.sh /entrypoint.sh
+COPY tooling/ast_fuzzer/arbtest-container/fuzzer_manifest.json /fuzzer_manifest.json
+RUN chmod +x /entrypoint.sh
+
+# World-readable — platform runs as UID 65534 (nobody).
+RUN chmod -R a+rX /targets
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/tooling/ast_fuzzer/arbtest-container/entrypoint.sh
+++ b/tooling/ast_fuzzer/arbtest-container/entrypoint.sh
@@ -1,0 +1,247 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Platform runs as UID 65534:GID 10001 — ensure files written to bind mounts
+# (/crashes, /corpus, /output) are group-accessible for the worker process.
+umask 000
+
+# ContFuzzer AST fuzzer entrypoint (arbtest variant).
+#
+# Runs the pre-built test binary directly — no cargo at runtime.
+# The binary is built during docker build and copied to /targets/fuzzing/.
+#
+# Each target (e.g. comptime_vs_brillig_direct) is a #[test] function
+# inside the binary. The test name is passed as a substring filter.
+#
+# Platform contract (FUZZ_* env vars):
+#   FUZZ_MODE          fuzz | reproduce | regress
+#   FUZZ_TARGET        target name (e.g. comptime_vs_brillig_direct)
+#   FUZZ_CORPUS_DIR    /corpus (regress: seed files to replay)
+#   FUZZ_CRASH_DIR     /crashes
+#   FUZZ_OUTPUT_DIR    /output
+#   FUZZ_TIMEOUT       total seconds for the job (outer loop budget)
+#   FUZZ_REPRODUCE_DIR /reproduce-input (reproduce mode only)
+#   FUZZ_CRASH_FILE    path to seed file (reproduce mode only)
+#
+# Unused (no coverage in arbtest mode):
+#   FUZZ_JOBS, FUZZ_MEMORY
+
+: "${FUZZ_MODE:=fuzz}"
+: "${FUZZ_TARGET:=}"
+: "${FUZZ_CORPUS_DIR:=/corpus}"
+: "${FUZZ_CRASH_DIR:=/crashes}"
+: "${FUZZ_OUTPUT_DIR:=/output}"
+: "${FUZZ_TIMEOUT:=0}"
+: "${FUZZ_REPRODUCE_DIR:=}"
+: "${FUZZ_CRASH_FILE:=}"
+
+# Per-iteration budget for arbtest (seconds). Each test run fuzzes
+# for this long, then exits 0 if no crash. The outer loop restarts it
+# until FUZZ_TIMEOUT is reached or a crash is found.
+: "${ARBTEST_BUDGET:=60}"
+
+TEST_BINARY="/targets/fuzzing/noir_ast_fuzzer_fuzz"
+
+if [ -z "$FUZZ_TARGET" ]; then
+    echo "ERROR: FUZZ_TARGET is required" >&2
+    exit 2
+fi
+
+if [ ! -x "$TEST_BINARY" ]; then
+    echo "ERROR: Test binary not found: $TEST_BINARY" >&2
+    exit 2
+fi
+
+mkdir -p "$FUZZ_CORPUS_DIR" "$FUZZ_CRASH_DIR" "$FUZZ_OUTPUT_DIR" 2>/dev/null || true
+
+# Strip ANSI escape codes from a string.
+_strip_ansi() {
+    sed 's/\x1b\[[0-9;]*m//g'
+}
+
+# Extract the arbtest seed from test output.
+# arbtest prints: "    Seed: \x1b[1m0x<16 hex>\x1b[0m"
+_extract_seed() {
+    _strip_ansi | grep -oP 'Seed:\s*\K0x[0-9a-fA-F]+' | head -1
+}
+
+# Run the test binary with a specific target filter.
+# The binary is a Rust test harness — target name is a substring filter.
+_run_test() {
+    "$TEST_BINARY" "$FUZZ_TARGET" --test-threads=1 "$@"
+}
+
+# ── Reproduce mode ────────────────────────────────────────────────────
+if [ "$FUZZ_MODE" = "reproduce" ]; then
+    # The platform mounts a seed file. Read the seed hex from it.
+    if [ -n "$FUZZ_CRASH_FILE" ] && [ -f "$FUZZ_CRASH_FILE" ]; then
+        SEED_FILE="$FUZZ_CRASH_FILE"
+    else
+        SEARCH_DIR="${FUZZ_REPRODUCE_DIR:-$FUZZ_CRASH_DIR}"
+        SEED_FILE=$(find "$SEARCH_DIR" -type f | head -1)
+    fi
+    if [ -z "$SEED_FILE" ]; then
+        echo "ERROR: No seed file found for reproduce" >&2
+        exit 2
+    fi
+
+    SEED=$(cat "$SEED_FILE" | _strip_ansi | grep -oP '0x[0-9a-fA-F]+' | head -1)
+    if [ -z "$SEED" ]; then
+        SEED=$(cat "$SEED_FILE" | tr -d '[:space:]')
+    fi
+    if [ -z "$SEED" ]; then
+        echo "ERROR: Could not extract seed from $SEED_FILE" >&2
+        exit 2
+    fi
+
+    echo "Reproducing with seed: $SEED"
+    export NOIR_AST_FUZZER_SEED="$SEED"
+    export RUST_BACKTRACE=1
+
+    set +e
+    _run_test 2>&1 | tee "$FUZZ_OUTPUT_DIR/reproduce.log"
+    EXIT_CODE=${PIPESTATUS[0]}
+    set -e
+
+    if [ $EXIT_CODE -ne 0 ]; then
+        echo "Crash reproduced (seed=$SEED, exit=$EXIT_CODE)"
+        exit 1
+    else
+        echo "Seed $SEED did not reproduce a crash"
+        exit 0
+    fi
+fi
+
+# ── Regress mode ──────────────────────────────────────────────────────
+if [ "$FUZZ_MODE" = "regress" ]; then
+    export RUST_BACKTRACE=1
+    export RUST_MIN_STACK="${RUST_MIN_STACK:-8388608}"
+
+    SEED_FILES=$(find "$FUZZ_CORPUS_DIR" -type f 2>/dev/null | sort)
+    if [ -z "$SEED_FILES" ]; then
+        echo "No seed files found in $FUZZ_CORPUS_DIR — nothing to regress"
+        exit 0
+    fi
+
+    TOTAL=$(echo "$SEED_FILES" | wc -l | tr -d ' ')
+    CURRENT=0
+    FAILURES=0
+
+    echo "Regressing $TOTAL seed(s)..."
+
+    while IFS= read -r SEED_FILE; do
+        CURRENT=$((CURRENT + 1))
+        SEED=$(cat "$SEED_FILE" | _strip_ansi | grep -oP '0x[0-9a-fA-F]+' | head -1)
+        if [ -z "$SEED" ]; then
+            SEED=$(cat "$SEED_FILE" | tr -d '[:space:]')
+        fi
+        if [ -z "$SEED" ]; then
+            echo "[$CURRENT/$TOTAL] SKIP $(basename "$SEED_FILE") — no seed found"
+            continue
+        fi
+
+        echo "[$CURRENT/$TOTAL] Testing seed $SEED..."
+        export NOIR_AST_FUZZER_SEED="$SEED"
+
+        # Write directly to the sidecar path. Shell redirection respects
+        # umask (unlike mktemp which forces 0600), so the file is created
+        # world-readable. If the seed passes, we delete it.
+        SIDECAR="$FUZZ_OUTPUT_DIR/seed-${SEED#0x}_result.txt"
+        set +e
+        _run_test 2>&1 | tee "$SIDECAR"
+        EXIT_CODE=${PIPESTATUS[0]}
+        set -e
+
+        if [ $EXIT_CODE -ne 0 ]; then
+            FAILURES=$((FAILURES + 1))
+            echo "[$CURRENT/$TOTAL] CRASH seed $SEED"
+            echo "$SEED" > "$FUZZ_CRASH_DIR/seed-${SEED#0x}"
+        else
+            echo "[$CURRENT/$TOTAL] OK seed $SEED"
+            rm -f "$SIDECAR"
+        fi
+    done <<< "$SEED_FILES"
+
+    echo "Regress complete: $FAILURES/$TOTAL failed"
+    if [ "$FAILURES" -gt 0 ]; then
+        exit 1
+    fi
+    exit 0
+fi
+
+# ── Fuzz mode ─────────────────────────────────────────────────────────
+if [ "$FUZZ_MODE" != "fuzz" ]; then
+    echo "ERROR: Unsupported FUZZ_MODE=$FUZZ_MODE (this container supports: fuzz, reproduce, regress)" >&2
+    exit 2
+fi
+
+export NOIR_AST_FUZZER_FORCE_NON_DETERMINISTIC=1
+export NOIR_AST_FUZZER_BUDGET_SECS="$ARBTEST_BUDGET"
+# No backtrace in fuzz mode — the comparison failure output from the fuzzer
+# is what matters; Rust backtraces just add noise and bloat the 10 MiB log cap.
+# export RUST_BACKTRACE=1
+export RUST_MIN_STACK="${RUST_MIN_STACK:-8388608}"
+
+START_TIME=$(date +%s)
+ITERATION=0
+CRASH_FOUND=0
+
+while true; do
+    ITERATION=$((ITERATION + 1))
+    ELAPSED=$(( $(date +%s) - START_TIME ))
+
+    if [ "$FUZZ_TIMEOUT" -gt 0 ] 2>/dev/null && [ "$ELAPSED" -ge "$FUZZ_TIMEOUT" ]; then
+        echo "Total timeout reached after ${ELAPSED}s (${ITERATION} iterations)"
+        break
+    fi
+
+    if [ "$FUZZ_TIMEOUT" -gt 0 ] 2>/dev/null; then
+        REMAINING=$((FUZZ_TIMEOUT - ELAPSED))
+        if [ "$REMAINING" -le 0 ]; then
+            break
+        fi
+        if [ "$REMAINING" -lt "$ARBTEST_BUDGET" ]; then
+            export NOIR_AST_FUZZER_BUDGET_SECS="$REMAINING"
+        fi
+    fi
+
+    echo "=== Iteration $ITERATION (elapsed: ${ELAPSED}s) ==="
+
+    # Tee to a per-iteration log. On success it's deleted; on crash it
+    # becomes the sidecar (renamed once we know the seed).
+    ITER_LOG="$FUZZ_OUTPUT_DIR/iter-${ITERATION}.log"
+
+    set +e
+    _run_test 2>&1 | tee "$ITER_LOG"
+    EXIT_CODE=${PIPESTATUS[0]}
+    set -e
+
+    if [ $EXIT_CODE -ne 0 ]; then
+        CRASH_FOUND=1
+        echo "Crash detected in iteration $ITERATION (exit=$EXIT_CODE)"
+
+        SEED=$(cat "$ITER_LOG" | _extract_seed)
+
+        if [ -n "$SEED" ]; then
+            echo "$SEED" > "$FUZZ_CRASH_DIR/seed-${SEED#0x}"
+            echo "Seed written to $FUZZ_CRASH_DIR/seed-${SEED#0x}"
+
+            # Rename the log to the sidecar name the platform expects.
+            mv "$ITER_LOG" "$FUZZ_OUTPUT_DIR/seed-${SEED#0x}_result.txt"
+            echo "Sidecar written to $FUZZ_OUTPUT_DIR/seed-${SEED#0x}_result.txt"
+        else
+            echo "WARN: Could not extract seed from crash output" >&2
+            mv "$ITER_LOG" "$FUZZ_CRASH_DIR/crash-iter-${ITERATION}"
+        fi
+
+        break
+    fi
+
+    rm -f "$ITER_LOG"
+done
+
+if [ "$CRASH_FOUND" -eq 1 ]; then
+    exit 1
+else
+    exit 0
+fi

--- a/tooling/ast_fuzzer/arbtest-container/fuzzer_manifest.json
+++ b/tooling/ast_fuzzer/arbtest-container/fuzzer_manifest.json
@@ -1,0 +1,59 @@
+{
+  "schema": "2",
+  "targets": [
+    {
+      "name": "acir_vs_brillig",
+      "display_name": "AST arbtest: ACIR vs Brillig differential",
+      "language": "rust",
+      "fuzzer_engine": "libfuzzer",
+      "source_path": "tooling/ast_fuzzer",
+      "modes": ["fuzz", "reproduce", "regress"],
+      "resources": { "cpus": 2, "memory_gb": 4 }
+    },
+    {
+      "name": "min_vs_full",
+      "display_name": "AST arbtest: Minimal vs Full pipeline",
+      "language": "rust",
+      "fuzzer_engine": "libfuzzer",
+      "source_path": "tooling/ast_fuzzer",
+      "modes": ["fuzz", "reproduce", "regress"],
+      "resources": { "cpus": 2, "memory_gb": 4 }
+    },
+    {
+      "name": "pass_vs_prev",
+      "display_name": "AST arbtest: Pass vs Previous differential",
+      "language": "rust",
+      "fuzzer_engine": "libfuzzer",
+      "source_path": "tooling/ast_fuzzer",
+      "modes": ["fuzz", "reproduce", "regress"],
+      "resources": { "cpus": 2, "memory_gb": 4 }
+    },
+    {
+      "name": "orig_vs_morph",
+      "display_name": "AST arbtest: Original vs Morphed differential",
+      "language": "rust",
+      "fuzzer_engine": "libfuzzer",
+      "source_path": "tooling/ast_fuzzer",
+      "modes": ["fuzz", "reproduce", "regress"],
+      "resources": { "cpus": 2, "memory_gb": 4 }
+    },
+    {
+      "name": "comptime_vs_brillig_nargo",
+      "display_name": "AST arbtest: Comptime vs Brillig (nargo)",
+      "language": "rust",
+      "fuzzer_engine": "libfuzzer",
+      "source_path": "tooling/ast_fuzzer",
+      "modes": ["fuzz", "reproduce", "regress"],
+      "resources": { "cpus": 2, "memory_gb": 4 }
+    },
+    {
+      "name": "comptime_vs_brillig_direct",
+      "display_name": "AST arbtest: Comptime vs Brillig (direct)",
+      "language": "rust",
+      "fuzzer_engine": "libfuzzer",
+      "source_path": "tooling/ast_fuzzer",
+      "modes": ["fuzz", "reproduce", "regress"],
+      "resources": { "cpus": 2, "memory_gb": 4 }
+    }
+  ]
+}

--- a/tooling/ast_fuzzer/contfuzzer-container/Dockerfile
+++ b/tooling/ast_fuzzer/contfuzzer-container/Dockerfile
@@ -1,0 +1,117 @@
+# ContFuzzer-compatible container for the AST fuzzer.
+#
+# Builds all 6 libFuzzer targets that differentially test the Noir AST
+# compilation pipeline. Each target compares two execution paths — when
+# they disagree, the binary panics and libFuzzer catches it as a crash.
+#
+# Targets:
+#   acir_vs_brillig, min_vs_full, pass_vs_prev, orig_vs_morph,
+#   comptime_vs_brillig_nargo, comptime_vs_brillig_direct
+#
+# Build:
+#   docker build -t contfuzzer-ast-fuzzer -f tooling/ast_fuzzer/contfuzzer-container/Dockerfile .
+#
+# Run standalone (platform-like flags):
+#   docker run --read-only --tmpfs /tmp:size=512m \
+#       --user 65534:10001 \
+#       -v /tmp/corpus:/corpus -v /tmp/crashes:/crashes -v /tmp/output:/output \
+#       -e FUZZ_MODE=fuzz -e FUZZ_TARGET=acir_vs_brillig -e FUZZ_TIMEOUT=60 \
+#       contfuzzer-ast-fuzzer
+
+# ── Builder ────────────────────────────────────────────────────────────
+FROM --platform=linux/amd64 rustlang/rust:nightly-bookworm AS builder
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        build-essential cmake clang llvm-dev libclang-dev git \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN cargo install cargo-fuzz
+
+# Source the noir workspace. Resolution order:
+#   COMMIT set: clone from GitHub and checkout that commit (wins over BRANCH/CI).
+#   BRANCH set: shallow-clone that branch from GitHub.
+#   CI set:     use the already checked-out repo COPY'd into the context.
+#   default:    shallow-clone master from GitHub.
+ARG COMMIT=""
+ARG BRANCH=""
+ARG CI=""
+COPY . /noir-context
+RUN if [ -n "$COMMIT" ]; then \
+        rm -rf /noir-context && \
+        git clone https://github.com/noir-lang/noir.git --depth 1 /noir && \
+        cd /noir && git fetch origin "$COMMIT" --depth 1 && git checkout "$COMMIT"; \
+    elif [ -n "$BRANCH" ]; then \
+        rm -rf /noir-context && \
+        git clone --depth 1 --branch "$BRANCH" https://github.com/noir-lang/noir.git /noir; \
+    elif [ -n "$CI" ]; then \
+        mv /noir-context /noir; \
+    else \
+        rm -rf /noir-context && \
+        git clone https://github.com/noir-lang/noir.git --depth 1 /noir; \
+    fi
+
+WORKDIR /noir/tooling/ast_fuzzer
+
+# Build all 6 fuzz targets (ASan + libFuzzer instrumentation).
+RUN cargo +nightly fuzz build acir_vs_brillig --fuzz-dir ./fuzz
+RUN cargo +nightly fuzz build min_vs_full --fuzz-dir ./fuzz
+RUN cargo +nightly fuzz build pass_vs_prev --fuzz-dir ./fuzz
+RUN cargo +nightly fuzz build orig_vs_morph --fuzz-dir ./fuzz
+RUN cargo +nightly fuzz build comptime_vs_brillig_nargo --fuzz-dir ./fuzz
+RUN cargo +nightly fuzz build comptime_vs_brillig_direct --fuzz-dir ./fuzz
+
+# Build coverage-instrumented variants for FUZZ_MODE=coverage.
+# Uses -Cinstrument-coverage instead of ASan — produces binaries that emit
+# .profraw files for llvm-cov when LLVM_PROFILE_FILE is set.
+RUN mkdir -p /tmp/empty-corpus && \
+    cargo +nightly fuzz coverage acir_vs_brillig --fuzz-dir ./fuzz -- /tmp/empty-corpus || true
+RUN mkdir -p /tmp/empty-corpus && \
+    cargo +nightly fuzz coverage min_vs_full --fuzz-dir ./fuzz -- /tmp/empty-corpus || true
+RUN mkdir -p /tmp/empty-corpus && \
+    cargo +nightly fuzz coverage pass_vs_prev --fuzz-dir ./fuzz -- /tmp/empty-corpus || true
+RUN mkdir -p /tmp/empty-corpus && \
+    cargo +nightly fuzz coverage orig_vs_morph --fuzz-dir ./fuzz -- /tmp/empty-corpus || true
+RUN mkdir -p /tmp/empty-corpus && \
+    cargo +nightly fuzz coverage comptime_vs_brillig_nargo --fuzz-dir ./fuzz -- /tmp/empty-corpus || true
+RUN mkdir -p /tmp/empty-corpus && \
+    cargo +nightly fuzz coverage comptime_vs_brillig_direct --fuzz-dir ./fuzz -- /tmp/empty-corpus || true
+
+# Copy both variants into /targets/{fuzzing,coverage}/.
+# Fuzz binaries: target/<triple>/release/<target>
+# Coverage binaries: fuzz/coverage/<triple>/release/<target>
+RUN mkdir -p /targets/fuzzing /targets/coverage && \
+    for target in acir_vs_brillig min_vs_full pass_vs_prev orig_vs_morph comptime_vs_brillig_nargo comptime_vs_brillig_direct; do \
+        cp /noir/target/*/release/$target /targets/fuzzing/ && \
+        find /noir/tooling/ast_fuzzer/fuzz -path "*/coverage/*/release/$target" \
+            -exec cp {} /targets/coverage/ \; && \
+        test -x /targets/fuzzing/$target || { echo "FATAL: $target fuzzing binary missing"; exit 1; } && \
+        test -x /targets/coverage/$target || echo "WARN: $target coverage binary missing — coverage mode will be unavailable"; \
+    done
+
+# ── Runtime ────────────────────────────────────────────────────────────
+FROM --platform=linux/amd64 ubuntu:24.04
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        libstdc++6 \
+        llvm-18 \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /targets /targets
+
+# Source tree for llvm-cov HTML reports — path must match the builder's /noir
+# so llvm-cov can resolve source locations embedded in the coverage binary.
+COPY --from=builder /noir /noir
+
+# Use the standard ContFuzzer libFuzzer adapter entrypoint.
+COPY --from=builder /noir/tooling/ast_fuzzer/contfuzzer-container/entrypoint.sh /entrypoint.sh
+COPY --from=builder /noir/tooling/ast_fuzzer/contfuzzer-container/fuzzer_manifest.json /fuzzer_manifest.json
+RUN chmod +x /entrypoint.sh
+
+# World-readable — platform runs as UID 65534 (nobody).
+RUN chmod -R a+rX /targets /noir
+
+WORKDIR /noir/tooling/ast_fuzzer
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/tooling/ast_fuzzer/contfuzzer-container/entrypoint.sh
+++ b/tooling/ast_fuzzer/contfuzzer-container/entrypoint.sh
@@ -1,0 +1,195 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Platform runs as UID 65534:GID 10001 — ensure files written to bind mounts
+# (/crashes, /corpus, /output) are group-accessible for the worker process.
+umask 000
+
+# ContFuzzer AST fuzzer entrypoint (multi-target).
+#
+# Two build variants in /targets/:
+#   /targets/fuzzing/<target>   — ASan + libFuzzer (fuzz, minimize, reproduce, regress)
+#   /targets/coverage/<target>  — coverage-instrumented (coverage mode -> profraw -> llvm-cov)
+#
+# Platform contract (FUZZ_* env vars):
+#   FUZZ_MODE          fuzz | coverage | minimize | reproduce | regress
+#   FUZZ_TARGET        target name (e.g. acir_vs_brillig, min_vs_full, ...)
+#   FUZZ_CORPUS_DIR    /corpus
+#   FUZZ_CRASH_DIR     /crashes
+#   FUZZ_OUTPUT_DIR    /output
+#   FUZZ_TIMEOUT       seconds
+#   FUZZ_JOBS          parallel workers
+#   FUZZ_MEMORY        memory limit e.g. "8g"
+#   FUZZ_REPRODUCE_DIR /reproduce-input (reproduce mode only)
+#   FUZZ_CRASH_FILE    path to crash file (reproduce mode only)
+
+: "${FUZZ_MODE:=fuzz}"
+: "${FUZZ_TARGET:=}"
+: "${FUZZ_CORPUS_DIR:=/corpus}"
+: "${FUZZ_CRASH_DIR:=/crashes}"
+: "${FUZZ_OUTPUT_DIR:=/output}"
+: "${FUZZ_TIMEOUT:=0}"
+: "${FUZZ_JOBS:=1}"
+: "${FUZZ_MEMORY:=}"
+: "${FUZZ_REPRODUCE_DIR:=}"
+: "${FUZZ_CRASH_FILE:=}"
+
+_parse_memory_mb() {
+    local mem="${1:-}"
+    case "$mem" in
+        *g) echo $(( ${mem%g} * 1024 )) ;;
+        *m) echo "${mem%m}" ;;
+        *)  echo "" ;;
+    esac
+}
+
+# ── Binary resolution ──────────────────────────────────────────────────
+# Select build variant based on FUZZ_MODE.
+case "$FUZZ_MODE" in
+    fuzz|minimize|regress|reproduce) VARIANT="fuzzing" ;;
+    coverage)                        VARIANT="coverage" ;;
+    *)
+        echo "ERROR: Unknown FUZZ_MODE=$FUZZ_MODE" >&2
+        exit 2
+        ;;
+esac
+
+if [ -z "$FUZZ_TARGET" ]; then
+    echo "ERROR: FUZZ_TARGET is required" >&2
+    exit 2
+fi
+
+BINARY="/targets/$VARIANT/$FUZZ_TARGET"
+if [ ! -x "$BINARY" ]; then
+    echo "ERROR: Binary not found: $BINARY" >&2
+    echo "Available in /targets/$VARIANT/:" >&2
+    ls -1 "/targets/$VARIANT/" 2>/dev/null || echo "  (none)" >&2
+    exit 2
+fi
+
+mkdir -p "$FUZZ_CORPUS_DIR" "$FUZZ_CRASH_DIR" "$FUZZ_OUTPUT_DIR" 2>/dev/null || true
+
+# ── Build command arguments ────────────────────────────────────────────
+case "$FUZZ_MODE" in
+    fuzz)
+        ARGS=()
+        ARGS+=("$FUZZ_CORPUS_DIR")
+        ARGS+=("-artifact_prefix=$FUZZ_CRASH_DIR/")
+        if [ "$FUZZ_TIMEOUT" -gt 0 ] 2>/dev/null; then
+            ARGS+=("-max_total_time=$FUZZ_TIMEOUT")
+        fi
+        if [ "$FUZZ_JOBS" -gt 1 ] 2>/dev/null; then
+            ARGS+=("-jobs=$FUZZ_JOBS" "-workers=$FUZZ_JOBS")
+        fi
+        if [ -n "$FUZZ_MEMORY" ]; then
+            RSS_MB=$(_parse_memory_mb "$FUZZ_MEMORY")
+            [ -n "$RSS_MB" ] && ARGS+=("-rss_limit_mb=$RSS_MB")
+        fi
+        ;;
+
+    coverage)
+        ARGS=()
+        ARGS+=("$FUZZ_CORPUS_DIR")
+        ARGS+=("-runs=0")
+        mkdir -p "$FUZZ_OUTPUT_DIR/coverage" 2>/dev/null || true
+        export LLVM_PROFILE_FILE="$FUZZ_OUTPUT_DIR/coverage/default.profraw"
+        ;;
+
+    minimize)
+        MERGE_DIR=$(mktemp -d)
+        ARGS=("-merge=1" "$MERGE_DIR" "$FUZZ_CORPUS_DIR")
+        ;;
+
+    reproduce)
+        export TRIAGE="${TRIAGE:-FULL}"
+        if [ -n "$FUZZ_CRASH_FILE" ] && [ -f "$FUZZ_CRASH_FILE" ]; then
+            CRASH_FILE="$FUZZ_CRASH_FILE"
+        else
+            SEARCH_DIR="${FUZZ_REPRODUCE_DIR:-$FUZZ_CRASH_DIR}"
+            CRASH_FILE=$(find "$SEARCH_DIR" -type f | head -1)
+        fi
+        if [ -z "$CRASH_FILE" ]; then
+            echo "ERROR: No crash file found for reproduce" >&2
+            exit 2
+        fi
+        ARGS=("$CRASH_FILE")
+        ;;
+
+    regress)
+        ARGS=()
+        ARGS+=("$FUZZ_CORPUS_DIR")
+        ARGS+=("-runs=0")
+        ARGS+=("-artifact_prefix=$FUZZ_CRASH_DIR/")
+        ;;
+esac
+
+# ── Execute ────────────────────────────────────────────────────────────
+# libFuzzer with -jobs=N writes fuzz-{N}.log to the current working directory.
+# Must cd to a writable location on a read-only rootfs.
+cd "$FUZZ_OUTPUT_DIR"
+
+set +e
+"$BINARY" "${ARGS[@]}"
+EXIT_CODE=$?
+set -e
+
+# ── Post-processing ───────────────────────────────────────────────────
+
+# Minimize: swap merged corpus back.
+if [ "$FUZZ_MODE" = "minimize" ] && [ -d "${MERGE_DIR:-}" ]; then
+    rm -rf "${FUZZ_CORPUS_DIR:?}/"*
+    mv "$MERGE_DIR"/* "$FUZZ_CORPUS_DIR/" 2>/dev/null || true
+    rm -rf "$MERGE_DIR"
+fi
+
+# Coverage: profraw -> profdata -> coverage.json + HTML report.
+# Platform ingests /output/coverage/coverage.json (coverage/service.py:80).
+if [ "$FUZZ_MODE" = "coverage" ] && [ -f "$FUZZ_OUTPUT_DIR/coverage/default.profraw" ]; then
+    echo "Merging coverage data..."
+    llvm-profdata-18 merge -sparse "$FUZZ_OUTPUT_DIR/coverage/default.profraw" \
+        -o "$FUZZ_OUTPUT_DIR/coverage/fuzz.profdata"
+
+    echo "Generating coverage.json (platform ingestion)..."
+    llvm-cov-18 export "$BINARY" \
+        -instr-profile="$FUZZ_OUTPUT_DIR/coverage/fuzz.profdata" \
+        -summary-only \
+        > "$FUZZ_OUTPUT_DIR/coverage/coverage.json"
+
+    echo "Generating coverage.lcov (per-file line-level data)..."
+    llvm-cov-18 export "$BINARY" \
+        -instr-profile="$FUZZ_OUTPUT_DIR/coverage/fuzz.profdata" \
+        -format=lcov \
+        > "$FUZZ_OUTPUT_DIR/coverage/coverage.lcov"
+
+    echo "Generating HTML coverage report..."
+    llvm-cov-18 show "$BINARY" \
+        -instr-profile="$FUZZ_OUTPUT_DIR/coverage/fuzz.profdata" \
+        -format=html \
+        -output-dir="$FUZZ_OUTPUT_DIR/coverage/cov-html" \
+        -show-line-counts-or-regions \
+        --show-branches=percent \
+        --show-directory-coverage
+
+    echo "Generating content hashes for cross-fuzzer dedup..."
+    _hash_tmp=$(mktemp)
+    grep '^SF:' "$FUZZ_OUTPUT_DIR/coverage/coverage.lcov" | cut -d: -f2- | sort -u | while IFS= read -r fpath; do
+        if [ -f "$fpath" ]; then
+            hash=$(sha256sum "$fpath" | cut -d' ' -f1)
+            printf '"%s":"%s"\n' "$fpath" "$hash" >> "$_hash_tmp"
+        fi
+    done
+    printf '{%s}' "$(paste -sd, "$_hash_tmp")" > "$FUZZ_OUTPUT_DIR/coverage/coverage_hashes.json"
+    rm -f "$_hash_tmp"
+
+    echo "Coverage artifacts written to $FUZZ_OUTPUT_DIR/coverage/"
+fi
+
+# libFuzzer exit codes:
+#   0  = clean (timeout reached, no crash)
+#   1  = crash found (sanitizer/panic)
+#   77 = libFuzzer-detected issue (OOM, leak, timeout)
+case $EXIT_CODE in
+    0)   exit 0 ;;
+    77)  exit 137 ;;
+    *)   exit $EXIT_CODE ;;
+esac

--- a/tooling/ast_fuzzer/contfuzzer-container/fuzzer_manifest.json
+++ b/tooling/ast_fuzzer/contfuzzer-container/fuzzer_manifest.json
@@ -1,0 +1,59 @@
+{
+  "schema": "2",
+  "targets": [
+    {
+      "name": "acir_vs_brillig",
+      "display_name": "AST: ACIR vs Brillig differential",
+      "language": "rust",
+      "fuzzer_engine": "libfuzzer",
+      "source_path": "tooling/ast_fuzzer",
+      "modes": ["fuzz", "coverage", "minimize", "reproduce", "regress"],
+      "resources": { "cpus": 4, "memory_gb": 8 }
+    },
+    {
+      "name": "min_vs_full",
+      "display_name": "AST: Minimal vs Full pipeline",
+      "language": "rust",
+      "fuzzer_engine": "libfuzzer",
+      "source_path": "tooling/ast_fuzzer",
+      "modes": ["fuzz", "coverage", "minimize", "reproduce", "regress"],
+      "resources": { "cpus": 4, "memory_gb": 8 }
+    },
+    {
+      "name": "pass_vs_prev",
+      "display_name": "AST: Pass vs Previous differential",
+      "language": "rust",
+      "fuzzer_engine": "libfuzzer",
+      "source_path": "tooling/ast_fuzzer",
+      "modes": ["fuzz", "coverage", "minimize", "reproduce", "regress"],
+      "resources": { "cpus": 4, "memory_gb": 8 }
+    },
+    {
+      "name": "orig_vs_morph",
+      "display_name": "AST: Original vs Morphed differential",
+      "language": "rust",
+      "fuzzer_engine": "libfuzzer",
+      "source_path": "tooling/ast_fuzzer",
+      "modes": ["fuzz", "coverage", "minimize", "reproduce", "regress"],
+      "resources": { "cpus": 4, "memory_gb": 8 }
+    },
+    {
+      "name": "comptime_vs_brillig_nargo",
+      "display_name": "AST: Comptime vs Brillig (nargo)",
+      "language": "rust",
+      "fuzzer_engine": "libfuzzer",
+      "source_path": "tooling/ast_fuzzer",
+      "modes": ["fuzz", "coverage", "minimize", "reproduce", "regress"],
+      "resources": { "cpus": 4, "memory_gb": 8 }
+    },
+    {
+      "name": "comptime_vs_brillig_direct",
+      "display_name": "AST: Comptime vs Brillig (direct)",
+      "language": "rust",
+      "fuzzer_engine": "libfuzzer",
+      "source_path": "tooling/ast_fuzzer",
+      "modes": ["fuzz", "coverage", "minimize", "reproduce", "regress"],
+      "resources": { "cpus": 4, "memory_gb": 8 }
+    }
+  ]
+}

--- a/tooling/ssa_fuzzer/contfuzzer-container/Dockerfile
+++ b/tooling/ssa_fuzzer/contfuzzer-container/Dockerfile
@@ -1,0 +1,99 @@
+# ContFuzzer-compatible container for the SSA fuzzer (acir_vs_brillig target).
+#
+# Builds the libFuzzer binary that differentially tests ACIR vs Brillig
+# execution of randomly generated SSA programs. When the two runtimes
+# disagree, the binary panics — libFuzzer catches it as a crash.
+#
+# Build:
+#   docker build -t contfuzzer-ssa-fuzzer .
+#
+# Build from a specific noir commit:
+#   docker build --build-arg COMMIT=abc123 -t contfuzzer-ssa-fuzzer .
+#
+# Run standalone (platform-like flags):
+#   docker run --read-only --tmpfs /tmp:size=512m \
+#       --user 65534:10001 \
+#       -v /tmp/corpus:/corpus -v /tmp/crashes:/crashes -v /tmp/output:/output \
+#       -e FUZZ_MODE=fuzz -e FUZZ_TARGET=acir_vs_brillig -e FUZZ_TIMEOUT=60 \
+#       contfuzzer-ssa-fuzzer
+
+# ── Builder ────────────────────────────────────────────────────────────
+FROM --platform=linux/amd64 rustlang/rust:nightly-bookworm AS builder
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        build-essential cmake clang llvm-dev libclang-dev git \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN cargo install cargo-fuzz
+
+# Source the noir workspace. Resolution order:
+#   COMMIT set: clone from GitHub and checkout that commit (wins over BRANCH/CI).
+#   BRANCH set: shallow-clone that branch from GitHub.
+#   CI set:     use the already checked-out repo COPY'd into the context.
+#   default:    shallow-clone master from GitHub.
+ARG COMMIT=""
+ARG BRANCH=""
+ARG CI=""
+COPY . /noir-context
+RUN if [ -n "$COMMIT" ]; then \
+        rm -rf /noir-context && \
+        git clone https://github.com/noir-lang/noir.git --depth 1 /noir && \
+        cd /noir && git fetch origin "$COMMIT" --depth 1 && git checkout "$COMMIT"; \
+    elif [ -n "$BRANCH" ]; then \
+        rm -rf /noir-context && \
+        git clone --depth 1 --branch "$BRANCH" https://github.com/noir-lang/noir.git /noir; \
+    elif [ -n "$CI" ]; then \
+        mv /noir-context /noir; \
+    else \
+        rm -rf /noir-context && \
+        git clone https://github.com/noir-lang/noir.git --depth 1 /noir; \
+    fi
+
+WORKDIR /noir/tooling/ssa_fuzzer
+
+# Build the acir_vs_brillig fuzz target (ASan + libFuzzer instrumentation).
+RUN cargo +nightly fuzz build acir_vs_brillig --fuzz-dir ./fuzzer
+
+# Build a coverage-instrumented variant for FUZZ_MODE=coverage.
+# Uses -Cinstrument-coverage instead of ASan — produces a binary that emits
+# .profraw files for llvm-cov when LLVM_PROFILE_FILE is set.
+RUN mkdir -p /tmp/empty-corpus && \
+    cargo +nightly fuzz coverage acir_vs_brillig --fuzz-dir ./fuzzer -- /tmp/empty-corpus || true
+
+# Copy both variants into /targets/{fuzzing,coverage}/.
+# Fuzz binary: target/<triple>/release/acir_vs_brillig
+# Coverage binary: fuzzer/coverage/<triple>/release/acir_vs_brillig
+RUN mkdir -p /targets/fuzzing /targets/coverage && \
+    cp /noir/target/*/release/acir_vs_brillig /targets/fuzzing/ && \
+    find /noir/tooling/ssa_fuzzer/fuzzer -path "*/coverage/*/release/acir_vs_brillig" \
+        -exec cp {} /targets/coverage/ \; && \
+    test -x /targets/fuzzing/acir_vs_brillig || { echo "FATAL: fuzzing binary missing"; exit 1; } && \
+    test -x /targets/coverage/acir_vs_brillig || echo "WARN: coverage binary missing — coverage mode will be unavailable"
+
+# ── Runtime ────────────────────────────────────────────────────────────
+FROM --platform=linux/amd64 ubuntu:24.04
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        libstdc++6 \
+        llvm-18 \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /targets /targets
+
+# Source tree for llvm-cov HTML reports — path must match the builder's /noir
+# so llvm-cov can resolve source locations embedded in the coverage binary.
+COPY --from=builder /noir /noir
+
+# Use the standard ContFuzzer libFuzzer adapter entrypoint.
+# It translates FUZZ_* env vars into libFuzzer CLI arguments.
+# Copy entrypoint from the source tree (always at /noir after builder stage).
+COPY --from=builder /noir/tooling/ssa_fuzzer/contfuzzer-container/entrypoint.sh /entrypoint.sh
+COPY --from=builder /noir/tooling/ssa_fuzzer/contfuzzer-container/fuzzer_manifest.json /fuzzer_manifest.json
+RUN chmod +x /entrypoint.sh
+
+# World-readable — platform runs as UID 65534 (nobody).
+RUN chmod -R a+rX /targets /noir
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/tooling/ssa_fuzzer/contfuzzer-container/README.md
+++ b/tooling/ssa_fuzzer/contfuzzer-container/README.md
@@ -1,0 +1,57 @@
+# SSA Fuzzer — ContFuzzer Container
+
+ContFuzzer-compatible container for the `acir_vs_brillig` fuzz target.
+
+Differentially tests ACIR vs Brillig execution of randomly generated SSA
+programs. When the two runtimes produce different results, the fuzzer
+crashes — ContFuzzer ingests the crash as a finding.
+
+## Build
+
+```bash
+docker build -t contfuzzer-ssa-fuzzer .
+
+# Pin to a specific noir commit:
+docker build --build-arg COMMIT=abc123 -t contfuzzer-ssa-fuzzer .
+```
+
+## Run standalone (platform-like flags)
+
+```bash
+mkdir -p /tmp/{corpus,crashes,output}
+
+docker run --rm --read-only --tmpfs /tmp:size=512m \
+    --user 65534:10001 \
+    -v /tmp/corpus:/corpus \
+    -v /tmp/crashes:/crashes \
+    -v /tmp/output:/output \
+    -e FUZZ_MODE=fuzz \
+    -e FUZZ_TARGET=acir_vs_brillig \
+    -e FUZZ_TIMEOUT=60 \
+    -e FUZZ_JOBS=4 \
+    contfuzzer-ssa-fuzzer
+```
+
+## Register with ContFuzzer
+
+```bash
+curl -X POST http://localhost:8000/api/{org}/{project}/fuzzers/ingest \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d "{
+    \"image_digest\": \"contfuzzer-ssa-fuzzer:latest\",
+    \"repo\": \"noir-lang/noir\",
+    \"branch\": \"master\",
+    \"manifest\": $(cat fuzzer_manifest.json)
+  }"
+```
+
+## What it does NOT include
+
+- **Redis integration** — the upstream `acir_vs_brillig` target optionally
+  pushes to Redis via `REDIS_URL`. This container does not set that variable,
+  so the fuzzer runs standalone without Redis.
+- **Triage mode** — the upstream `TRIAGE` env var is not used. Triage SSA
+  pass output by re-running a crash locally with `TRIAGE=FULL`.
+- **`brillig` target** — requires a Node.js simulator and transpiler binary
+  at runtime. Not compatible with ContFuzzer's read-only container contract.

--- a/tooling/ssa_fuzzer/contfuzzer-container/entrypoint.sh
+++ b/tooling/ssa_fuzzer/contfuzzer-container/entrypoint.sh
@@ -1,0 +1,197 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Platform runs as UID 65534:GID 10001 — ensure files written to bind mounts
+# (/crashes, /corpus, /output) are group-accessible for the worker process.
+umask 000
+
+# ContFuzzer SSA fuzzer entrypoint (multi-variant).
+#
+# Two build variants in /targets/:
+#   /targets/fuzzing/<target>   — ASan + libFuzzer (fuzz, minimize, reproduce, regress)
+#   /targets/coverage/<target>  — coverage-instrumented (coverage mode → profraw → llvm-cov)
+#
+# Platform contract (FUZZ_* env vars):
+#   FUZZ_MODE          fuzz | coverage | minimize | reproduce | regress
+#   FUZZ_TARGET        target name (e.g. acir_vs_brillig)
+#   FUZZ_CORPUS_DIR    /corpus
+#   FUZZ_CRASH_DIR     /crashes
+#   FUZZ_OUTPUT_DIR    /output
+#   FUZZ_TIMEOUT       seconds
+#   FUZZ_JOBS          parallel workers
+#   FUZZ_MEMORY        memory limit e.g. "8g"
+#   FUZZ_REPRODUCE_DIR /reproduce-input (reproduce mode only)
+#   FUZZ_CRASH_FILE    path to crash file (reproduce mode only)
+
+: "${FUZZ_MODE:=fuzz}"
+: "${FUZZ_TARGET:=}"
+: "${FUZZ_CORPUS_DIR:=/corpus}"
+: "${FUZZ_CRASH_DIR:=/crashes}"
+: "${FUZZ_OUTPUT_DIR:=/output}"
+: "${FUZZ_TIMEOUT:=0}"
+: "${FUZZ_JOBS:=1}"
+: "${FUZZ_MEMORY:=}"
+: "${FUZZ_REPRODUCE_DIR:=}"
+: "${FUZZ_CRASH_FILE:=}"
+
+_parse_memory_mb() {
+    local mem="${1:-}"
+    case "$mem" in
+        *g) echo $(( ${mem%g} * 1024 )) ;;
+        *m) echo "${mem%m}" ;;
+        *)  echo "" ;;
+    esac
+}
+
+# ── Binary resolution ──────────────────────────────────────────────────
+# Select build variant based on FUZZ_MODE.
+case "$FUZZ_MODE" in
+    fuzz|minimize|regress|reproduce) VARIANT="fuzzing" ;;
+    coverage)                        VARIANT="coverage" ;;
+    *)
+        echo "ERROR: Unknown FUZZ_MODE=$FUZZ_MODE" >&2
+        exit 2
+        ;;
+esac
+
+if [ -z "$FUZZ_TARGET" ]; then
+    echo "ERROR: FUZZ_TARGET is required" >&2
+    exit 2
+fi
+
+BINARY="/targets/$VARIANT/$FUZZ_TARGET"
+if [ ! -x "$BINARY" ]; then
+    echo "ERROR: Binary not found: $BINARY" >&2
+    echo "Available in /targets/$VARIANT/:" >&2
+    ls -1 "/targets/$VARIANT/" 2>/dev/null || echo "  (none)" >&2
+    exit 2
+fi
+
+mkdir -p "$FUZZ_CORPUS_DIR" "$FUZZ_CRASH_DIR" "$FUZZ_OUTPUT_DIR" 2>/dev/null || true
+
+# ── Build command arguments ────────────────────────────────────────────
+case "$FUZZ_MODE" in
+    fuzz)
+        ARGS=()
+        ARGS+=("$FUZZ_CORPUS_DIR")
+        ARGS+=("-artifact_prefix=$FUZZ_CRASH_DIR/")
+        if [ "$FUZZ_TIMEOUT" -gt 0 ] 2>/dev/null; then
+            ARGS+=("-max_total_time=$FUZZ_TIMEOUT")
+        fi
+        if [ "$FUZZ_JOBS" -gt 1 ] 2>/dev/null; then
+            ARGS+=("-jobs=$FUZZ_JOBS" "-workers=$FUZZ_JOBS")
+        fi
+        if [ -n "$FUZZ_MEMORY" ]; then
+            RSS_MB=$(_parse_memory_mb "$FUZZ_MEMORY")
+            [ -n "$RSS_MB" ] && ARGS+=("-rss_limit_mb=$RSS_MB")
+        fi
+        ;;
+
+    coverage)
+        ARGS=()
+        ARGS+=("$FUZZ_CORPUS_DIR")
+        ARGS+=("-runs=0")
+        mkdir -p "$FUZZ_OUTPUT_DIR/coverage" 2>/dev/null || true
+        export LLVM_PROFILE_FILE="$FUZZ_OUTPUT_DIR/coverage/default.profraw"
+        ;;
+
+    minimize)
+        MERGE_DIR=$(mktemp -d)
+        ARGS=("-merge=1" "$MERGE_DIR" "$FUZZ_CORPUS_DIR")
+        ;;
+
+    reproduce)
+        # Always enable triage on reproduce — dumps SSA pass trace to stderr
+        # so the platform captures it in the job log alongside the crash.
+        export TRIAGE="${TRIAGE:-FULL}"
+        if [ -n "$FUZZ_CRASH_FILE" ] && [ -f "$FUZZ_CRASH_FILE" ]; then
+            CRASH_FILE="$FUZZ_CRASH_FILE"
+        else
+            SEARCH_DIR="${FUZZ_REPRODUCE_DIR:-$FUZZ_CRASH_DIR}"
+            CRASH_FILE=$(find "$SEARCH_DIR" -type f | head -1)
+        fi
+        if [ -z "$CRASH_FILE" ]; then
+            echo "ERROR: No crash file found for reproduce" >&2
+            exit 2
+        fi
+        ARGS=("$CRASH_FILE")
+        ;;
+
+    regress)
+        ARGS=()
+        ARGS+=("$FUZZ_CORPUS_DIR")
+        ARGS+=("-runs=0")
+        ARGS+=("-artifact_prefix=$FUZZ_CRASH_DIR/")
+        ;;
+esac
+
+# ── Execute ────────────────────────────────────────────────────────────
+# libFuzzer with -jobs=N writes fuzz-{N}.log to the current working directory.
+# Must cd to a writable location on a read-only rootfs.
+cd "$FUZZ_OUTPUT_DIR"
+
+set +e
+"$BINARY" "${ARGS[@]}"
+EXIT_CODE=$?
+set -e
+
+# ── Post-processing ───────────────────────────────────────────────────
+
+# Minimize: swap merged corpus back.
+if [ "$FUZZ_MODE" = "minimize" ] && [ -d "${MERGE_DIR:-}" ]; then
+    rm -rf "${FUZZ_CORPUS_DIR:?}/"*
+    mv "$MERGE_DIR"/* "$FUZZ_CORPUS_DIR/" 2>/dev/null || true
+    rm -rf "$MERGE_DIR"
+fi
+
+# Coverage: profraw → profdata → coverage.json + HTML report.
+# Platform ingests /output/coverage/coverage.json (coverage/service.py:80).
+if [ "$FUZZ_MODE" = "coverage" ] && [ -f "$FUZZ_OUTPUT_DIR/coverage/default.profraw" ]; then
+    echo "Merging coverage data..."
+    llvm-profdata-18 merge -sparse "$FUZZ_OUTPUT_DIR/coverage/default.profraw" \
+        -o "$FUZZ_OUTPUT_DIR/coverage/fuzz.profdata"
+
+    echo "Generating coverage.json (platform ingestion)..."
+    llvm-cov-18 export "$BINARY" \
+        -instr-profile="$FUZZ_OUTPUT_DIR/coverage/fuzz.profdata" \
+        -summary-only \
+        > "$FUZZ_OUTPUT_DIR/coverage/coverage.json"
+
+    echo "Generating coverage.lcov (per-file line-level data)..."
+    llvm-cov-18 export "$BINARY" \
+        -instr-profile="$FUZZ_OUTPUT_DIR/coverage/fuzz.profdata" \
+        -format=lcov \
+        > "$FUZZ_OUTPUT_DIR/coverage/coverage.lcov"
+
+    echo "Generating HTML coverage report..."
+    llvm-cov-18 show "$BINARY" \
+        -instr-profile="$FUZZ_OUTPUT_DIR/coverage/fuzz.profdata" \
+        -format=html \
+        -output-dir="$FUZZ_OUTPUT_DIR/coverage/cov-html" \
+        -show-line-counts-or-regions \
+        --show-branches=percent \
+        --show-directory-coverage
+
+    echo "Generating content hashes for cross-fuzzer dedup..."
+    _hash_tmp=$(mktemp)
+    grep '^SF:' "$FUZZ_OUTPUT_DIR/coverage/coverage.lcov" | cut -d: -f2- | sort -u | while IFS= read -r fpath; do
+        if [ -f "$fpath" ]; then
+            hash=$(sha256sum "$fpath" | cut -d' ' -f1)
+            printf '"%s":"%s"\n' "$fpath" "$hash" >> "$_hash_tmp"
+        fi
+    done
+    printf '{%s}' "$(paste -sd, "$_hash_tmp")" > "$FUZZ_OUTPUT_DIR/coverage/coverage_hashes.json"
+    rm -f "$_hash_tmp"
+
+    echo "Coverage artifacts written to $FUZZ_OUTPUT_DIR/coverage/"
+fi
+
+# libFuzzer exit codes:
+#   0  = clean (timeout reached, no crash)
+#   1  = crash found (sanitizer/panic)
+#   77 = libFuzzer-detected issue (OOM, leak, timeout)
+case $EXIT_CODE in
+    0)   exit 0 ;;
+    77)  exit 137 ;;
+    *)   exit $EXIT_CODE ;;
+esac

--- a/tooling/ssa_fuzzer/contfuzzer-container/fuzzer_manifest.json
+++ b/tooling/ssa_fuzzer/contfuzzer-container/fuzzer_manifest.json
@@ -1,0 +1,14 @@
+{
+  "schema": "2",
+  "targets": [
+    {
+      "name": "acir_vs_brillig",
+      "display_name": "SSA: ACIR vs Brillig differential",
+      "language": "rust",
+      "fuzzer_engine": "libfuzzer",
+      "source_path": "tooling/ssa_fuzzer",
+      "modes": ["fuzz", "coverage", "minimize", "reproduce", "regress"],
+      "resources": { "cpus": 4, "memory_gb": 8 }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds three ContFuzzer-compatible container builds so the Noir AST and SSA fuzzers can run on the ContFuzzer platform:

- **`ghcr.io/noir-lang/contfuzzer-ast-arbtest`** — arbtest-based AST fuzzer, pre-built test binary, no cargo at runtime.
- **`ghcr.io/noir-lang/contfuzzer-ast-fuzzer`** — libFuzzer AST fuzzer covering all 6 differential targets (`acir_vs_brillig`, `min_vs_full`, `pass_vs_prev`, `orig_vs_morph`, `comptime_vs_brillig_nargo`, `comptime_vs_brillig_direct`).
- **`ghcr.io/noir-lang/contfuzzer-ssa-fuzzer`** — libFuzzer SSA fuzzer (`acir_vs_brillig`).

Each image ships a ContFuzzer-style entrypoint that translates `FUZZ_*` env vars into libFuzzer CLI args, attaches a `fuzzer_manifest.json` via `oras`, and is signed with keyless `cosign`.

Workflow behavior:
- Push to `master` triggers a build only when the relevant fuzzer tree or the workflow file changes.
- A twice-daily staggered cron (`0,12 UTC`, minutes 0/10/20) keeps images fresh against compiler/acvm changes.
- `workflow_dispatch` accepts `commit` and `branch` inputs; the Dockerfiles honor them in priority order **COMMIT > BRANCH > CI COPY > default master**, and OCI labels reflect the effective values.

## Test plan

- [ ] `build_ast_arbtest.yml` runs green on push to this branch's merge with `master`.
- [ ] `build_ast_fuzzer.yml` runs green.
- [ ] `build_ssa_fuzzer.yml` runs green.
- [ ] Pulled image runs in ContFuzzer-like invocation: `docker run --read-only --tmpfs /tmp:size=512m --user 65534:10001 -e FUZZ_MODE=fuzz -e FUZZ_TARGET=<t> -e FUZZ_TIMEOUT=60 …` for each image.
- [ ] `cosign verify` against keyless identity for the workflow ref succeeds.
- [ ] `oras discover` lists the attached `fuzzer_manifest.json` for each image.
- [ ] Manual `workflow_dispatch` with a `branch` input produces an image whose `org.opencontainers.image.revision.branch` label matches.