### PR TITLE
chore(ssa): Always inline single caller functions

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/opt/inlining.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/inlining.rs
@@ -1009,10 +1009,13 @@ mod tests {
 
     #[test]
     fn inliner_disabled() {
+        // At minimum aggressiveness, cost-based inlining is disabled.
+        // Use two call sites so the single-caller heuristic does not apply.
         let src = "
         brillig(inline) fn foo f0 {
           b0():
             v1 = call f1() -> Field
+            v2 = call f1() -> Field
             return v1
         }
         brillig(inline) fn bar f1 {
@@ -1267,9 +1270,11 @@ mod tests {
 
     #[test]
     fn inline_always_function() {
+        // Two call sites so the single-caller heuristic does not apply.
         let src = "
         brillig(inline) fn main f0 {
             b0():
+              call f1()
               call f1()
               return
         }
@@ -1287,8 +1292,8 @@ mod tests {
         }
         ");
 
-        // Check that with a minimum inliner aggressiveness we do not inline a function
-        // not marked with `inline_always`
+        // Without inline_always, the function is not inlined at minimum aggressiveness
+        // (two callers means the single-caller heuristic does not apply).
         let no_inline_always_src = &src.replace("inline_always", "inline");
         let ssa = Ssa::from_str(no_inline_always_src).unwrap();
         let ssa = ssa.inline_functions(i64::MIN, MAX_INSTRUCTIONS).unwrap();
@@ -1899,11 +1904,15 @@ mod simple_functions {
 
     #[test]
     fn does_not_inline_function_with_multiple_instructions() {
+        // f1 has >10 instructions (not simple) and is called from two sites,
+        // so it is not eligible for single-caller inlining. At minimum
+        // aggressiveness, cost-model inlining also does not apply.
         let src = "
         brillig(inline) fn main f0 {
           b0(v0: Field):
             v1 = call f1(v0) -> Field
-            return v1
+            v2 = call f1(v1) -> Field
+            return v2
         }
 
         brillig(inline) fn foo f1 {

--- a/compiler/noirc_evaluator/src/ssa/opt/inlining/inline_info.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/inlining/inline_info.rs
@@ -262,9 +262,15 @@ fn compute_function_should_be_inlined(
     let is_simple_function = entry_block.successors().next().is_none()
         && instruction_weight < small_function_max_instructions;
 
+    // Single-caller inlining has zero code duplication: the function body exists
+    // in exactly one place before and after inlining. Aggressiveness controls
+    // duplication tolerance, so it should not gate this decision.
+    let called_once = times == 1;
+
     let should_inline = !runtime.is_inline_never()
         && (is_simple_function
             || net_cost < aggressiveness
+            || called_once
             || runtime.is_inline_always()
             || should_inline_no_pred_function
             || contains_static_assertion
@@ -648,5 +654,153 @@ mod tests {
 
         let f1 = infos.get(&Id::test_new(1)).expect("Should analyze f1");
         assert!(!f1.should_inline, "Brillig entry points should never be inlined");
+    }
+
+    #[test]
+    fn called_once_non_simple_function_is_inlined() {
+        // f1 is a non-simple Brillig function (has control flow via jmpif, so
+        // entry block has successors) called exactly once by main.
+        // Even at minimum aggressiveness, it should be inlined because
+        // single-caller inlining has zero code duplication.
+        let src = "
+        brillig(inline) fn main f0 {
+          b0(v0: u1):
+            v2 = call f1(v0) -> u1
+            return v2
+        }
+        brillig(inline) fn big f1 {
+          b0(v0: u1):
+            jmpif v0 then: b1(), else: b2()
+          b1():
+            jmp b3(u1 1)
+          b2():
+            jmp b3(u1 0)
+          b3(v1: u1):
+            return v1
+        }
+        ";
+
+        let ssa = Ssa::from_str(src).unwrap();
+        let call_graph = CallGraph::from_ssa_weighted(&ssa);
+        let infos = compute_inline_infos(&ssa, &call_graph, false, MAX_INSTRUCTIONS, i64::MIN);
+
+        let f1 = infos.get(&Id::test_new(1)).expect("Should analyze f1");
+        assert!(
+            f1.should_inline,
+            "A non-simple function called exactly once should be inlined regardless of aggressiveness"
+        );
+    }
+
+    #[test]
+    fn called_twice_non_simple_function_not_inlined_at_min_aggressiveness() {
+        // f1 is called twice (once by f2, once by f3). It should NOT be inlined
+        // at minimum aggressiveness since the single-caller heuristic does not apply.
+        let src = "
+        brillig(inline) fn main f0 {
+          b0(v0: u1):
+            v2 = call f2(v0) -> u1
+            v3 = call f3(v0) -> u1
+            return v2
+        }
+        brillig(inline) fn big f1 {
+          b0(v0: u1):
+            jmpif v0 then: b1(), else: b2()
+          b1():
+            jmp b3(u1 1)
+          b2():
+            jmp b3(u1 0)
+          b3(v1: u1):
+            return v1
+        }
+        brillig(inline) fn caller_a f2 {
+          b0(v0: u1):
+            v1 = call f1(v0) -> u1
+            return v1
+        }
+        brillig(inline) fn caller_b f3 {
+          b0(v0: u1):
+            v1 = call f1(v0) -> u1
+            return v1
+        }
+        ";
+
+        let ssa = Ssa::from_str(src).unwrap();
+        let call_graph = CallGraph::from_ssa_weighted(&ssa);
+        let infos = compute_inline_infos(&ssa, &call_graph, false, MAX_INSTRUCTIONS, i64::MIN);
+
+        let f1 = infos.get(&Id::test_new(1)).expect("Should analyze f1");
+        assert!(
+            !f1.should_inline,
+            "A non-simple function called more than once should NOT be inlined at minimum aggressiveness"
+        );
+    }
+
+    #[test]
+    fn called_once_inline_never_not_inlined() {
+        // f1 is called once but marked inline_never. The inline_never attribute
+        // must take precedence over the single-caller heuristic.
+        let src = "
+        brillig(inline) fn main f0 {
+          b0(v0: u1):
+            v2 = call f1(v0) -> u1
+            return v2
+        }
+        brillig(inline_never) fn never f1 {
+          b0(v0: u1):
+            jmpif v0 then: b1(), else: b2()
+          b1():
+            jmp b3(u1 1)
+          b2():
+            jmp b3(u1 0)
+          b3(v1: u1):
+            return v1
+        }
+        ";
+
+        let ssa = Ssa::from_str(src).unwrap();
+        let call_graph = CallGraph::from_ssa_weighted(&ssa);
+        let infos = compute_inline_infos(&ssa, &call_graph, false, MAX_INSTRUCTIONS, i64::MIN);
+
+        let f1 = infos.get(&Id::test_new(1)).expect("Should analyze f1");
+        assert!(
+            !f1.should_inline,
+            "inline_never must take precedence over the single-caller heuristic"
+        );
+    }
+
+    #[test]
+    fn called_once_recursive_not_inlined() {
+        // f1 is self-recursive and called once externally by main.
+        // Recursive Brillig functions early-return before reaching the
+        // should_inline decision, so the single-caller heuristic has no effect.
+        let src = "
+        brillig(inline) fn main f0 {
+          b0(v0: u1):
+            v2 = call f1(v0) -> u1
+            return v2
+        }
+        brillig(inline) fn recursive f1 {
+          b0(v0: u1):
+            jmpif v0 then: b1(), else: b2()
+          b1():
+            v2 = call f1(v0) -> u1
+            jmp b3(v2)
+          b2():
+            jmp b3(u1 0)
+          b3(v1: u1):
+            return v1
+        }
+        ";
+
+        let ssa = Ssa::from_str(src).unwrap();
+        let call_graph = CallGraph::from_ssa_weighted(&ssa);
+        let infos = compute_inline_infos(&ssa, &call_graph, false, MAX_INSTRUCTIONS, i64::MIN);
+
+        let f1 = infos.get(&Id::test_new(1)).expect("Should analyze f1");
+        assert!(f1.is_recursive, "f1 should be detected as recursive");
+        assert!(
+            !f1.should_inline,
+            "Recursive functions should not be inlined even if called once externally"
+        );
     }
 }


### PR DESCRIPTION
# Description

## Problem

No issue, but something I noticed when looking at the regressions from https://github.com/noir-lang/noir/pull/12243. The extra load/stores that we were failing to remove would have been resolved upon inlining the function. These functions were single-caller functions whose being inlined would not have altered the program's final byte code size. 

At minimum inliner aggressiveness, functions called exactly once are not inlined because `net_cost < i64::MIN` is mathematically impossible. Single-caller functions that aren't "simple" (>10 instructions or multi-block) miss out on inlining even though it has zero code duplication and always saves call overhead.

## Summary

- Added `called_once` condition to `should_inline` 
- Updated 3 existing tests that assumed i64::MIN fully disables inlining, changed to use multiple callers so they correctly test cost-based behavior, not single-caller behavior
- Added 4 new tests: positive case, multi-caller negative control, inline_never precedence, recursive function guard

By the point in `compute_function_should_be_inlined` where should_inline is evaluated, all recursive Brillig functions, ACIR functions, and entry points have already returned early. So `times == 1` only applies to non-recursive, non-entry-point Brillig functions.

## Additional Context



## User Documentation

Check one:
- [X] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
