### PR TITLE
fix: Always clone array indexes

### DIFF
--- a/compiler/noirc_frontend/src/ownership/mod.rs
+++ b/compiler/noirc_frontend/src/ownership/mod.rs
@@ -212,9 +212,15 @@ impl Context {
                 Some((should_clone, elements.swap_remove(*index)))
             }
             Expression::Index(index) => {
-                let (should_clone, _) =
+                let (base_should_clone, _) =
                     self.handle_extract_expression_rec(&mut index.collection)?;
                 self.handle_expression(&mut index.index);
+                // A dynamic index can extract an inner element whose reference count
+                // is not bumped by moving the outer collection. If the extracted type
+                // contains an array, the inner array may still alias the collection,
+                // so an outer extract site must clone regardless of last-use status.
+                let should_clone =
+                    base_should_clone || contains_array_or_str_type(&index.element_type);
                 Some((should_clone, index.element_type.clone()))
             }
             _ => None,
@@ -295,22 +301,20 @@ impl Context {
             panic!("handle_index given non-index expression: {index_expr}");
         };
 
-        // Try to walk the accessor chain (idents, tuple field extractions, and other indexes)
-        // to find the base variable and determine whether we need to clone based on its last use.
-        // This avoids cloning when the base variable is being consumed (last use).
-        if let Some((should_clone, _)) = self.handle_extract_expression_rec(&mut index.collection) {
+        // A dynamic index can extract an inner array that still shares memory with
+        // the original collection. Even at the base's last use, moving only transfers
+        // the outer array's reference count -- the inner element's RC is not bumped.
+        // Whenever the extracted element contains an array we must clone it.
+        if self.handle_extract_expression_rec(&mut index.collection).is_some() {
             self.handle_expression(&mut index.index);
-            if should_clone && contains_array_or_str_type(&index.element_type) {
-                clone_expr(index_expr);
-            }
         } else {
-            // Collection is a complex expression (function call, block, etc.),
-            // fall back to always cloning the extracted element.
+            // Collection is a complex expression (function call, block, etc.);
+            // sub-expressions are handled normally.
             self.handle_reference_expression(&mut index.collection);
             self.handle_expression(&mut index.index);
-            if contains_array_or_str_type(&index.element_type) {
-                clone_expr(index_expr);
-            }
+        }
+        if contains_array_or_str_type(&index.element_type) {
+            clone_expr(index_expr);
         }
     }
 

--- a/compiler/noirc_frontend/src/ownership/suboptimal_cloning_tests.rs
+++ b/compiler/noirc_frontend/src/ownership/suboptimal_cloning_tests.rs
@@ -115,7 +115,7 @@ fn nested_tuple_extraction_disjoint_subfields() {
 /// Suboptimal: both `arr[0]` and `arr[1]` get `.clone()`. The ownership pass
 /// always clones an indexed element whose type contains an array — a dynamic
 /// index cannot be proved disjoint from other uses of the same collection, so
-/// moving the outer array doesn't guarantee the inner slot is unaliased. If
+/// moving the outer array doesn't guarantee the inner slot is not aliased. If
 /// the analysis tracked that the constant indexes 0 and 1 are disjoint and
 /// that `arr` has no further uses, both clones could be avoided.
 #[test]

--- a/compiler/noirc_frontend/src/ownership/suboptimal_cloning_tests.rs
+++ b/compiler/noirc_frontend/src/ownership/suboptimal_cloning_tests.rs
@@ -112,10 +112,12 @@ fn nested_tuple_extraction_disjoint_subfields() {
 /// Two disjoint indexes into a nested array. Each index accesses a different
 /// element, so they don't alias.
 ///
-/// Suboptimal: `arr[0]` gets `.clone()` because the last-use analysis treats
-/// both `arr[0]` and `arr[1]` as uses of the whole variable `arr`. If the
-/// analysis tracked that the constant indexes 0 and 1 are disjoint, the clone
-/// could be avoided.
+/// Suboptimal: both `arr[0]` and `arr[1]` get `.clone()`. The ownership pass
+/// always clones an indexed element whose type contains an array — a dynamic
+/// index cannot be proved disjoint from other uses of the same collection, so
+/// moving the outer array doesn't guarantee the inner slot is unaliased. If
+/// the analysis tracked that the constant indexes 0 and 1 are disjoint and
+/// that `arr` has no further uses, both clones could be avoided.
 #[test]
 fn nested_array_two_disjoint_indexes() {
     let src = "
@@ -127,14 +129,37 @@ fn nested_array_two_disjoint_indexes() {
     ";
 
     let program = get_monomorphized(src).unwrap();
-    // arr$l0[0].clone() is arguably necessary since arr is used again,
-    // but could be avoided if we knew the indexes don't alias (different constants).
-    // arr$l0[1] is now correctly moved — this is the last use of arr.
     insta::assert_snapshot!(program, @r"
     unconstrained fn main$f0() -> () {
         let arr$l0 = [[1, 2], [3, 4]];
         let _a$l1 = arr$l0[0].clone();
-        let _b$l2 = arr$l0[1]
+        let _b$l2 = arr$l0[1].clone()
+    }
+    ");
+}
+
+/// Nested array index: `arr[0][1]` on a 3D array. Even when the base variable
+/// has no further uses, each dynamic index step extracts an inner array whose
+/// reference count is not bumped by moving the outer array. The ownership
+/// pass conservatively clones.
+///
+/// Suboptimal: when the indexes are constants and `arr` has no further uses,
+/// the compiler could in principle prove that no aliasing occurs and drop
+/// the clone.
+#[test]
+fn nested_array_double_index_is_cloned() {
+    let src = "
+    unconstrained fn main() {
+        let arr = [[[1, 2], [3, 4]], [[5, 6], [7, 8]]];
+        let _val = arr[0][1];
+    }
+    ";
+
+    let program = get_monomorphized(src).unwrap();
+    insta::assert_snapshot!(program, @r"
+    unconstrained fn main$f0() -> () {
+        let arr$l0 = [[[1, 2], [3, 4]], [[5, 6], [7, 8]]];
+        let _val$l1 = arr$l0[0][1].clone()
     }
     ");
 }

--- a/compiler/noirc_frontend/src/ownership/tests.rs
+++ b/compiler/noirc_frontend/src/ownership/tests.rs
@@ -1055,28 +1055,6 @@ fn clone_inserted_on_index_then_collection_in_lvalue() {
     ");
 }
 
-/// Nested array index: `arr[0][1]` on a 3D array. When the base variable has
-/// no further uses, the indexed element can be moved without cloning.
-#[test]
-fn nested_array_double_index_is_moved() {
-    let src = "
-    unconstrained fn main() {
-        let arr = [[[1, 2], [3, 4]], [[5, 6], [7, 8]]];
-        let _val = arr[0][1];
-    }
-    ";
-
-    let program = get_monomorphized(src).unwrap();
-
-    // No clone needed — arr is not used again and the intermediate arr[0] is a temporary
-    insta::assert_snapshot!(program, @r"
-    unconstrained fn main$f0() -> () {
-        let arr$l0 = [[[1, 2], [3, 4]], [[5, 6], [7, 8]]];
-        let _val$l1 = arr$l0[0][1]
-    }
-    ");
-}
-
 #[test]
 fn clones_non_moved_variable_because_of_reference_even_if_unused() {
     // Similar to the above test, but shows that even when taking a reference
@@ -1609,7 +1587,7 @@ fn clone_inner_array_passed_alongside_outer() {
     insta::assert_snapshot!(program, @r"
     unconstrained fn main$f0() -> () {
         let a$l0 = [[true], [false]];
-        foo$f1(a$l0.clone(), a$l0[1]);
+        foo$f1(a$l0.clone(), a$l0[1].clone());
     }
     unconstrained fn foo$f1(_a$l1: [[bool; 1]; 2], mut b$l2: [bool; 1]) -> () {
         b$l2[0] = (!b$l2[0])
@@ -1646,7 +1624,7 @@ fn clone_inner_array_field_extracted_through_index() {
             let arr$l1 = [false];
             (arr$l1)
         }];
-        foo$f1(a$l2.clone(), a$l2[1].0);
+        foo$f1(a$l2.clone(), a$l2[1].0.clone());
     }
     unconstrained fn foo$f1(_a$l3: [([bool; 1],); 2], mut b$l4: [bool; 1]) -> () {
         b$l4[0] = (!b$l4[0])

--- a/compiler/noirc_frontend/src/ownership/tests.rs
+++ b/compiler/noirc_frontend/src/ownership/tests.rs
@@ -1587,6 +1587,73 @@ fn confirmed_move_for_variable_reassigned_in_the_loop() {
     ");
 }
 
+/// Regression: when a nested array is passed alongside one of its inner arrays
+/// (`foo(a, a[1])`), `a[1]` is the textually-last use of `a`, but moving `a`
+/// only transfers the outer array's reference count. The inner array at
+/// `a[1]` still aliases the slot inside the cloned outer `a`, so a mutation
+/// of the inner array via `mut b` inside `foo` would leak back through the
+/// outer argument. `a[1]` must therefore always be cloned.
+#[test]
+fn clone_inner_array_passed_alongside_outer() {
+    let src = "
+    unconstrained fn main() {
+        let a = [[true], [false]];
+        foo(a, a[1]);
+    }
+    unconstrained fn foo(_a: [[bool; 1]; 2], mut b: [bool; 1]) {
+        b[0] = !b[0];
+    }
+    ";
+
+    let program = get_monomorphized(src).unwrap();
+    insta::assert_snapshot!(program, @r"
+    unconstrained fn main$f0() -> () {
+        let a$l0 = [[true], [false]];
+        foo$f1(a$l0.clone(), a$l0[1]);
+    }
+    unconstrained fn foo$f1(_a$l1: [[bool; 1]; 2], mut b$l2: [bool; 1]) -> () {
+        b$l2[0] = (!b$l2[0])
+    }
+    ");
+}
+
+/// Regression: same shape as `clone_inner_array_passed_alongside_outer`, but
+/// the inner array is reached through a struct field after a dynamic index
+/// (`foo(a, a[1].arr)`). The extracted `.arr` still shares memory with the
+/// slot inside `a`, so moving `a` isn't enough — `a[1].arr` must also be
+/// cloned.
+#[test]
+fn clone_inner_array_field_extracted_through_index() {
+    let src = "
+    struct Entry { arr: [bool; 1] }
+
+    unconstrained fn main() {
+        let a = [Entry { arr: [true] }, Entry { arr: [false] }];
+        foo(a, a[1].arr);
+    }
+    unconstrained fn foo(_a: [Entry; 2], mut b: [bool; 1]) {
+        b[0] = !b[0];
+    }
+    ";
+
+    let program = get_monomorphized(src).unwrap();
+    insta::assert_snapshot!(program, @r"
+    unconstrained fn main$f0() -> () {
+        let a$l2 = [{
+            let arr$l0 = [true];
+            (arr$l0)
+        }, {
+            let arr$l1 = [false];
+            (arr$l1)
+        }];
+        foo$f1(a$l2.clone(), a$l2[1].0);
+    }
+    unconstrained fn foo$f1(_a$l3: [([bool; 1],); 2], mut b$l4: [bool; 1]) -> () {
+        b$l4[0] = (!b$l4[0])
+    }
+    ");
+}
+
 #[test]
 fn no_confirmed_move_for_variable_reassigned_in_loop_in_disabled_if() {
     // Same as confirmed_move_for_variable_reassigned_in_the_loop,

--- a/compiler/noirc_frontend/src/ownership/tests.rs
+++ b/compiler/noirc_frontend/src/ownership/tests.rs
@@ -1598,7 +1598,7 @@ fn clone_inner_array_passed_alongside_outer() {
 /// Regression: same shape as `clone_inner_array_passed_alongside_outer`, but
 /// the inner array is reached through a struct field after a dynamic index
 /// (`foo(a, a[1].arr)`). The extracted `.arr` still shares memory with the
-/// slot inside `a`, so moving `a` isn't enough — `a[1].arr` must also be
+/// slot inside `a`, so cloning `a` isn't enough — `a[1].arr` must also be
 /// cloned.
 #[test]
 fn clone_inner_array_field_extracted_through_index() {

--- a/test_programs/execution_success/nested_array_index_clone_regression/Nargo.toml
+++ b/test_programs/execution_success/nested_array_index_clone_regression/Nargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "nested_array_index_clone_regression"
+type = "bin"
+authors = [""]
+
+[dependencies]

--- a/test_programs/execution_success/nested_array_index_clone_regression/src/main.nr
+++ b/test_programs/execution_success/nested_array_index_clone_regression/src/main.nr
@@ -1,0 +1,42 @@
+// Regression test for a bug in the ownership pass: when a nested array is
+// passed alongside one of its inner arrays (`foo(a, a[1])`), the inner array
+// `a[1]` was incorrectly marked as a "last move" and not cloned. The inner
+// element aliased the slot inside the cloned outer `a`, so a mutation of `b`
+// inside `foo` leaked back through the outer argument.
+//
+// The same pattern applies when the inner array is reached through a struct
+// field (`foo(a, a[1].arr)`).
+//
+// The `println` calls before each `assert_eq` observe the runtime value of
+// `a`, preventing constant folding from masking the aliasing.
+
+struct Entry {
+    arr: [bool; 1],
+}
+
+#[inline_never]
+unconstrained fn mutate_flat(a: [[bool; 1]; 2], mut b: [bool; 1]) {
+    b[0] = !b[0];
+    println(b);
+    println(a);
+    assert_eq(a, [[true], [false]]);
+    assert_eq(b, [true]);
+}
+
+#[inline_never]
+unconstrained fn mutate_field(a: [Entry; 2], mut b: [bool; 1]) {
+    b[0] = !b[0];
+    println(b);
+    println(a);
+    assert_eq(a[0].arr, [true]);
+    assert_eq(a[1].arr, [false]);
+    assert_eq(b, [true]);
+}
+
+unconstrained fn main() {
+    let flat = [[true], [false]];
+    mutate_flat(flat, flat[1]);
+
+    let fields = [Entry { arr: [true] }, Entry { arr: [false] }];
+    mutate_field(fields, fields[1].arr);
+}

--- a/tooling/nargo_cli/tests/snapshots/execution_success/nested_array_index_clone_regression/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/nested_array_index_clone_regression/execute__tests__expanded.snap
@@ -1,0 +1,33 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: expanded_code
+---
+struct Entry {
+    arr: [bool; 1],
+}
+
+#[inline_never]
+unconstrained fn mutate_flat(a: [[bool; 1]; 2], mut b: [bool; 1]) {
+    b[0_u32] = !b[0_u32];
+    println(b);
+    println(a);
+    assert(a == [[true], [false]]);
+    assert(b == [true]);
+}
+
+#[inline_never]
+unconstrained fn mutate_field(a: [Entry; 2], mut b: [bool; 1]) {
+    b[0_u32] = !b[0_u32];
+    println(b);
+    println(a);
+    assert(a[0_u32].arr == [true]);
+    assert(a[1_u32].arr == [false]);
+    assert(b == [true]);
+}
+
+unconstrained fn main() {
+    let flat: [[bool; 1]; 2] = [[true], [false]];
+    mutate_flat(flat, flat[1_u32]);
+    let fields: [Entry; 2] = [Entry { arr: [true] }, Entry { arr: [false] }];
+    mutate_field(fields, fields[1_u32].arr);
+}

--- a/tooling/nargo_cli/tests/snapshots/execution_success/nested_array_index_clone_regression/execute__tests__stdout.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/nested_array_index_clone_regression/execute__tests__stdout.snap
@@ -1,0 +1,8 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: stdout
+---
+[true]
+[[true], [false]]
+[true]
+[Entry { arr: [true] }, Entry { arr: [false] }]


### PR DESCRIPTION
# Description

## Problem

Resolves https://github.com/noir-lang/noir/security/advisories/GHSA-35h6-769r-84c9

## Summary



## Additional Context


## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
