### PR TITLE
feat(opt): Consider immutable references to be valid targets of mem2reg in more cases

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/mod.rs
@@ -157,10 +157,6 @@ pub fn primary_passes(options: &SsaEvaluatorOptions) -> Vec<SsaPass<'_>> {
             .and_then(Ssa::remove_unused_instructions)
             .and_then(Ssa::remove_redundant_params),
         SsaPass::new(Ssa::defunctionalize, "Defunctionalization"),
-        SsaPass::new(
-            Ssa::lower_refs_at_acir_brillig_boundary,
-            "Lower refs at ACIR/Brillig boundary",
-        ),
         SsaPass::new_try(Ssa::inline_simple_functions, "Inlining simple functions")
             .and_then(Ssa::remove_unreachable_functions),
         SsaPass::new(Ssa::mem2reg_brillig, "Mem2Reg")

--- a/compiler/noirc_evaluator/src/ssa/opt/lower_refs_at_acir_brillig_boundary.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/lower_refs_at_acir_brillig_boundary.rs
@@ -27,6 +27,7 @@
 //!
 //! - This pass must be run after defunctionalization.
 
+#![allow(unused)]
 use std::sync::Arc;
 
 use iter_extended::vecmap;

--- a/compiler/noirc_evaluator/src/ssa/opt/mem2reg.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/mem2reg.rs
@@ -23,7 +23,7 @@ use crate::ssa::{
         dom::DominatorTree,
         function::Function,
         function_inserter::FunctionInserter,
-        instruction::{Instruction, InstructionId, TerminatorInstruction},
+        instruction::{Instruction, TerminatorInstruction},
         post_order::PostOrder,
         types::Type,
         value::ValueId,
@@ -66,7 +66,7 @@ impl Function {
         // ValueId of the `allocate` instruction result. These are all iterated over at some point
         // so it is important we use a deterministic order so that block arguments always correspond
         // to block parameters in the same order.
-        let (variables, def_sites) =
+        let (variables, def_sites, used_in_calls) =
             collect_eligible_variables_and_def_sites(inserter.function, &blocks);
 
         if variables.is_empty() {
@@ -105,7 +105,7 @@ impl Function {
             &block_states,
             &cfg,
         );
-        commit(&mut inserter, &variables, blocks);
+        commit(&mut inserter, &variables, &used_in_calls, blocks);
     }
 }
 
@@ -365,10 +365,11 @@ fn get_terminator_args_mut(
 ///
 /// This function is very simple and will produce incorrect results for first-class references
 /// that are aliased, or stored in arrays, etc. It does handle immutable references that are
-/// passed as arguments to `Call` instructions: at each such call site, a fresh `Allocate` +
-/// `Store(current_value)` is emitted immediately before the call and the call's argument is
-/// rewritten to point at the fresh allocation. That keeps the callee's view unchanged (it
-/// can only `Load` through an `&T`) while freeing the original allocation to be optimized out.
+/// passed as arguments to `Call` instructions: those references are left in place (the original
+/// `Allocate` + `Store` are preserved by `commit`) so the callee can dereference them at runtime.
+/// The SSA-builder invariant that an immutable reference is never aliased by a mutable reference
+/// means the callee only ever `Load`s through the reference, so keeping the existing stores is
+/// safe and avoids emitting a redundant allocation per call site.
 ///
 /// Note that this function will also replace any instances of the reference being stored to
 /// with its current value in the block. Most of the time, this locally renames the reference
@@ -398,15 +399,6 @@ fn abstract_interpret_block(
                     inserter.map_value(result, *value);
                 }
             }
-            Instruction::Call { .. } => {
-                rematerialize_immutable_refs_before_call(
-                    &mut inserter.function.dfg,
-                    block,
-                    *instruction_id,
-                    entry_state,
-                    &exit_state,
-                );
-            }
             _ => (),
         }
         inserter.function.dfg[block].instructions_mut().push(*instruction_id);
@@ -415,66 +407,18 @@ fn abstract_interpret_block(
     exit_state
 }
 
-/// For each argument of a `Call` that is one of our eligible variables, emit a fresh
-/// `Allocate` + `Store(current_value)` into `block` and rewrite the call to pass the
-/// new allocation. By construction, any eligible variable reaching this point is an
-/// immutable reference (mutable references with first-class uses were disqualified
-/// during eligibility collection).
-fn rematerialize_immutable_refs_before_call(
-    dfg: &mut DataFlowGraph,
-    block: BasicBlockId,
-    call_id: InstructionId,
-    entry_state: &StateVec,
-    exit_state: &StateVec,
-) {
-    let Instruction::Call { func, arguments } = &dfg[call_id] else {
-        return;
-    };
-
-    // Scan the arguments first to avoid cloning `arguments` if we don't need to.
-    if !arguments.iter().any(|arg| exit_state.contains_key(arg) || entry_state.contains_key(arg)) {
-        return;
-    }
-
-    let func = *func;
-    let mut new_arguments = arguments.clone();
-
-    let call_stack = dfg.get_instruction_call_stack_id(call_id);
-
-    for arg in &mut new_arguments {
-        let Some(&current_value) = exit_state.get(arg).or_else(|| entry_state.get(arg)) else {
-            continue;
-        };
-        let ref_type = dfg.type_of_value(*arg).into_owned();
-        let Type::Reference(elem_type, _) = ref_type else {
-            continue;
-        };
-
-        let ctrl_typevars = Some(vec![Type::Reference(elem_type, false)]);
-        let new_alloc = dfg.insert_instruction_and_results_without_simplification(
-            Instruction::Allocate,
-            block,
-            ctrl_typevars,
-            call_stack,
-        );
-        let address = new_alloc.first();
-
-        let store = Instruction::Store { address, value: current_value };
-        dfg.insert_instruction_and_results_without_simplification(store, block, None, call_stack);
-
-        *arg = address;
-    }
-
-    dfg[call_id] = Instruction::Call { func, arguments: new_arguments };
-}
-
 /// Return a map from each eligible variable to the block it was declared in,
-/// along with the set of blocks where each variable is stored to (definition sites).
+/// along with the set of blocks where each variable is stored to (definition sites),
+/// and the set of variables that are passed as arguments to a `Call`.
 ///
 /// Only includes variables that are eligible for mem2reg optimization,
 /// i.e. those that are allocated but never used in a first-class manner.
 /// The main exception being immutable references which can be used in a first-class manner
 /// since functions (or other instructions) using them cannot modify their inner value.
+///
+/// Variables in the returned `used_in_calls` set are still eligible for load forwarding but
+/// their `Allocate` and `Store` instructions must be preserved so the call site still has a
+/// valid reference to dereference at runtime.
 ///
 /// Very important detail: when a user writes `let mut x = 0; .. &x ...` the SSA builder
 /// reuses the mutable reference created for x, rather than an immutable one. Without this
@@ -482,7 +426,7 @@ fn rematerialize_immutable_refs_before_call(
 fn collect_eligible_variables_and_def_sites(
     function: &Function,
     blocks: &[BasicBlockId],
-) -> (BTreeMap<ValueId, BasicBlockId>, HashMap<ValueId, HashSet<BasicBlockId>>) {
+) -> (BTreeMap<ValueId, BasicBlockId>, HashMap<ValueId, HashSet<BasicBlockId>>, HashSet<ValueId>) {
     // Map each variable to the block it was declared in
     let mut variables = BTreeMap::default();
     // Map each variable to the set of blocks that contain stores to it
@@ -491,6 +435,10 @@ fn collect_eligible_variables_and_def_sites(
     // Allocate results whose type is `Type::Reference(_, false)`. Only these are
     // allowed to survive a first-class use as a `Call` argument.
     let mut immutable_variables: HashSet<ValueId> = HashSet::default();
+
+    // Eligible variables that are passed to a `Call`. Their `Allocate`/`Store` must be kept
+    // so the callee has a valid reference; only `Load`s through them may be eliminated.
+    let mut used_in_calls: HashSet<ValueId> = HashSet::default();
 
     // Workaround for https://github.com/noir-lang/noir/issues/11482
     // If the declaration block of an allocate has no starting store then it isn't eligible for mem2reg.
@@ -527,7 +475,9 @@ fn collect_eligible_variables_and_def_sites(
                     variables.remove(func);
                     def_sites.remove(func);
                     for arg in arguments {
-                        if !immutable_variables.contains(arg) {
+                        if immutable_variables.contains(arg) {
+                            used_in_calls.insert(*arg);
+                        } else {
                             variables.remove(arg);
                             def_sites.remove(arg);
                         }
@@ -549,15 +499,20 @@ fn collect_eligible_variables_and_def_sites(
 
     variables.retain(|address, _| variables_with_stores_in_decl_block.contains(address));
     def_sites.retain(|address, _| variables.contains_key(address));
-    (variables, def_sites)
+    used_in_calls.retain(|address| variables.contains_key(address));
+    (variables, def_sites, used_in_calls)
 }
 
 /// Commit to all changes made by the pass:
 /// - Map any values mapped from the inserter to their new values in the function
-/// - Remove all Allocate, Load, and Store instructions from the eligible variables
+/// - Remove `Load` instructions for all eligible variables (the value has been forwarded)
+/// - Remove `Allocate` and `Store` instructions for eligible variables, except for those
+///   in `used_in_calls`: those references are still consumed by a call, so their
+///   allocation and stores must remain so the callee has something to dereference.
 fn commit(
     inserter: &mut FunctionInserter,
     variables: &BTreeMap<ValueId, BasicBlockId>,
+    used_in_calls: &HashSet<ValueId>,
     blocks: Vec<BasicBlockId>,
 ) {
     for block in blocks {
@@ -569,11 +524,12 @@ fn commit(
             let keep = match instruction {
                 Instruction::Allocate => {
                     let address = inserter.function.dfg.instruction_results(*instruction_id)[0];
-                    !variables.contains_key(&address)
+                    !variables.contains_key(&address) || used_in_calls.contains(&address)
                 }
-                Instruction::Load { address } | Instruction::Store { address, value: _ } => {
-                    !variables.contains_key(address)
+                Instruction::Store { address, value: _ } => {
+                    !variables.contains_key(address) || used_in_calls.contains(address)
                 }
+                Instruction::Load { address } => !variables.contains_key(address),
                 _ => true,
             };
 
@@ -1556,9 +1512,7 @@ brillig(inline) fn main f0 {
             v0 = allocate -> &Field
             store Field 1 at v0
             call f1(v0)
-            v3 = allocate -> &Field
-            store Field 1 at v3
-            call f1(v3)
+            call f1(v0)
             return
         }
         brillig(inline) fn bar f1 {
@@ -1599,52 +1553,6 @@ brillig(inline) fn main f0 {
         }
         brillig(inline) fn bar f1 {
           b0(v0: &Field, v1: &Field):
-            return
-        }
-        ");
-    }
-
-    #[test]
-    fn immutable_ref_rematerialized_with_merged_value() {
-        let src = "
-            brillig(inline) fn main f0 {
-              b0(v0: u1):
-                v1 = allocate -> &Field
-                store Field 1 at v1
-                jmpif v0 then: b1(), else: b2()
-              b1():
-                store Field 2 at v1
-                jmp b3()
-              b2():
-                store Field 3 at v1
-                jmp b3()
-              b3():
-                call f1(v1)
-                return
-            }
-            brillig(inline) fn bar f1 {
-              b0(v0: &Field):
-                return
-            }
-        ";
-        let ssa = Ssa::from_str(src).unwrap();
-        let ssa = ssa.mem2reg();
-        assert_ssa_snapshot!(ssa, @r"
-        brillig(inline) fn main f0 {
-          b0(v0: u1):
-            jmpif v0 then: b1(), else: b2()
-          b1():
-            jmp b3(Field 2)
-          b2():
-            jmp b3(Field 3)
-          b3(v1: Field):
-            v4 = allocate -> &Field
-            store v1 at v4
-            call f1(v4)
-            return
-        }
-        brillig(inline) fn bar f1 {
-          b0(v0: &Field):
             return
         }
         ");

--- a/compiler/noirc_evaluator/src/ssa/opt/mem2reg.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/mem2reg.rs
@@ -430,13 +430,16 @@ fn rematerialize_immutable_refs_before_call(
     let Instruction::Call { func, arguments } = &dfg[call_id] else {
         return;
     };
-    let func = *func;
 
-    // TODO: Can we avoid cloning the arguments until after we've identified we should rewrite them
+    // Scan the arguments first to avoid cloning `arguments` if we don't need to.
+    if !arguments.iter().any(|arg| exit_state.contains_key(arg) || entry_state.contains_key(arg)) {
+        return;
+    }
+
+    let func = *func;
     let mut new_arguments = arguments.clone();
 
     let call_stack = dfg.get_instruction_call_stack_id(call_id);
-    let mut rewritten = false;
 
     for arg in &mut new_arguments {
         let Some(&current_value) = exit_state.get(arg).or_else(|| entry_state.get(arg)) else {
@@ -460,12 +463,9 @@ fn rematerialize_immutable_refs_before_call(
         dfg.insert_instruction_and_results_without_simplification(store, block, None, call_stack);
 
         *arg = address;
-        rewritten = true;
     }
 
-    if rewritten {
-        dfg[call_id] = Instruction::Call { func, arguments: new_arguments };
-    }
+    dfg[call_id] = Instruction::Call { func, arguments: new_arguments };
 }
 
 /// Return a map from each eligible variable to the block it was declared in,

--- a/compiler/noirc_evaluator/src/ssa/opt/mem2reg.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/mem2reg.rs
@@ -475,6 +475,10 @@ fn rematerialize_immutable_refs_before_call(
 /// i.e. those that are allocated but never used in a first-class manner.
 /// The main exception being immutable references which can be used in a first-class manner
 /// since functions (or other instructions) using them cannot modify their inner value.
+///
+/// Very important detail: when a user writes `let mut x = 0; .. &x ...` the SSA builder
+/// reuses the mutable reference created for x, rather than an immutable one. Without this
+/// we couldn't assume any given immutable reference isn't mutably aliased.
 fn collect_eligible_variables_and_def_sites(
     function: &Function,
     blocks: &[BasicBlockId],

--- a/compiler/noirc_evaluator/src/ssa/opt/mem2reg.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/mem2reg.rs
@@ -23,8 +23,9 @@ use crate::ssa::{
         dom::DominatorTree,
         function::Function,
         function_inserter::FunctionInserter,
-        instruction::{Instruction, TerminatorInstruction},
+        instruction::{Instruction, InstructionId, TerminatorInstruction},
         post_order::PostOrder,
+        types::Type,
         value::ValueId,
     },
     ssa_gen::Ssa,
@@ -363,7 +364,11 @@ fn get_terminator_args_mut(
 /// Any references not included in the result are assumed to be unchanged.
 ///
 /// This function is very simple and will produce incorrect results for first-class references
-/// that are aliased, passed to functions, or stored in arrays, etc.
+/// that are aliased, or stored in arrays, etc. It does handle immutable references that are
+/// passed as arguments to `Call` instructions: at each such call site, a fresh `Allocate` +
+/// `Store(current_value)` is emitted immediately before the call and the call's argument is
+/// rewritten to point at the fresh allocation. That keeps the callee's view unchanged (it
+/// can only `Load` through an `&T`) while freeing the original allocation to be optimized out.
 ///
 /// Note that this function will also replace any instances of the reference being stored to
 /// with its current value in the block. Most of the time, this locally renames the reference
@@ -393,12 +398,74 @@ fn abstract_interpret_block(
                     inserter.map_value(result, *value);
                 }
             }
+            Instruction::Call { .. } => {
+                rematerialize_immutable_refs_before_call(
+                    &mut inserter.function.dfg,
+                    block,
+                    *instruction_id,
+                    entry_state,
+                    &exit_state,
+                );
+            }
             _ => (),
         }
+        inserter.function.dfg[block].instructions_mut().push(*instruction_id);
     }
 
-    *inserter.function.dfg[block].instructions_mut() = instructions;
     exit_state
+}
+
+/// For each argument of a `Call` that is one of our eligible variables, emit a fresh
+/// `Allocate` + `Store(current_value)` into `block` and rewrite the call to pass the
+/// new allocation. By construction, any eligible variable reaching this point is an
+/// immutable reference (mutable references with first-class uses were disqualified
+/// during eligibility collection).
+fn rematerialize_immutable_refs_before_call(
+    dfg: &mut DataFlowGraph,
+    block: BasicBlockId,
+    call_id: InstructionId,
+    entry_state: &StateVec,
+    exit_state: &StateVec,
+) {
+    let Instruction::Call { func, arguments } = &dfg[call_id] else {
+        return;
+    };
+    let func = *func;
+
+    // TODO: Can we avoid cloning the arguments until after we've identified we should rewrite them
+    let mut new_arguments = arguments.clone();
+
+    let call_stack = dfg.get_instruction_call_stack_id(call_id);
+    let mut rewritten = false;
+
+    for arg in &mut new_arguments {
+        let Some(&current_value) = exit_state.get(arg).or_else(|| entry_state.get(arg)) else {
+            continue;
+        };
+        let ref_type = dfg.type_of_value(*arg).into_owned();
+        let Type::Reference(elem_type, _) = ref_type else {
+            continue;
+        };
+
+        let ctrl_typevars = Some(vec![Type::Reference(elem_type, false)]);
+        let new_alloc = dfg.insert_instruction_and_results_without_simplification(
+            Instruction::Allocate,
+            block,
+            ctrl_typevars,
+            call_stack,
+        );
+        let address = new_alloc.first();
+
+        let store = Instruction::Store { address, value: current_value };
+        dfg.insert_instruction_and_results_without_simplification(store, block, None, call_stack);
+
+        *arg = address;
+        rewritten = true;
+    }
+
+    if rewritten {
+        dfg[call_id] = Instruction::Call { func, arguments: new_arguments };
+    }
 }
 
 /// Return a map from each eligible variable to the block it was declared in,
@@ -406,6 +473,8 @@ fn abstract_interpret_block(
 ///
 /// Only includes variables that are eligible for mem2reg optimization,
 /// i.e. those that are allocated but never used in a first-class manner.
+/// The main exception being immutable references which can be used in a first-class manner
+/// since functions (or other instructions) using them cannot modify their inner value.
 fn collect_eligible_variables_and_def_sites(
     function: &Function,
     blocks: &[BasicBlockId],
@@ -414,6 +483,10 @@ fn collect_eligible_variables_and_def_sites(
     let mut variables = BTreeMap::default();
     // Map each variable to the set of blocks that contain stores to it
     let mut def_sites: HashMap<ValueId, HashSet<BasicBlockId>> = HashMap::default();
+
+    // Allocate results whose type is `Type::Reference(_, false)`. Only these are
+    // allowed to survive a first-class use as a `Call` argument.
+    let mut immutable_variables: HashSet<ValueId> = HashSet::default();
 
     // Workaround for https://github.com/noir-lang/noir/issues/11482
     // If the declaration block of an allocate has no starting store then it isn't eligible for mem2reg.
@@ -427,11 +500,15 @@ fn collect_eligible_variables_and_def_sites(
                 Instruction::Allocate => {
                     let address = function.dfg.instruction_results(*instruction_id)[0];
                     variables.insert(address, block_id);
+                    if matches!(*function.dfg.type_of_value(address), Type::Reference(_, false)) {
+                        immutable_variables.insert(address);
+                    }
                 }
                 Instruction::Load { .. } => (),
                 // Storing to an address is fine, but storing an address prevents optimizing it out.
                 Instruction::Store { address, value } => {
                     variables.remove(value);
+                    def_sites.remove(value);
 
                     if variables.contains_key(address) {
                         def_sites.entry(*address).or_default().insert(block_id);
@@ -439,6 +516,17 @@ fn collect_eligible_variables_and_def_sites(
 
                     if variables.get(address) == Some(&block_id) {
                         variables_with_stores_in_decl_block.insert(*address);
+                    }
+                }
+                // We allow immutable references to be passed to calls and still be valid mem2reg targets.
+                Instruction::Call { func, arguments } => {
+                    variables.remove(func);
+                    def_sites.remove(func);
+                    for arg in arguments {
+                        if !immutable_variables.contains(arg) {
+                            variables.remove(arg);
+                            def_sites.remove(arg);
+                        }
                     }
                 }
                 // Any other use of an address (in arrays, functions, etc) is also first-class and prevents optimization.
@@ -1373,5 +1461,261 @@ brillig(inline) fn main f0 {
             return v1
         }
         ");
+    }
+
+    #[test]
+    fn immutable_ref_passed_to_call_is_rematerialized() {
+        let src = "
+            brillig(inline) fn main f0 {
+              b0():
+                v0 = allocate -> &Field
+                store Field 5 at v0
+                call f1(v0)
+                return
+            }
+            brillig(inline) fn bar f1 {
+              b0(v0: &Field):
+                return
+            }
+        ";
+        let ssa = Ssa::from_str(src).unwrap();
+        let ssa = ssa.mem2reg();
+        assert_ssa_snapshot!(ssa, @r"
+        brillig(inline) fn main f0 {
+          b0():
+            v0 = allocate -> &Field
+            store Field 5 at v0
+            call f1(v0)
+            return
+        }
+        brillig(inline) fn bar f1 {
+          b0(v0: &Field):
+            return
+        }
+        ");
+    }
+
+    #[test]
+    fn immutable_ref_used_in_load_and_call() {
+        let src = "
+            brillig(inline) fn main f0 {
+              b0():
+                v0 = allocate -> &Field
+                store Field 7 at v0
+                v1 = load v0 -> Field
+                call f1(v0)
+                return v1
+            }
+            brillig(inline) fn bar f1 {
+              b0(v0: &Field):
+                return
+            }
+        ";
+        let ssa = Ssa::from_str(src).unwrap();
+        let ssa = ssa.mem2reg();
+        assert_ssa_snapshot!(ssa, @r"
+        brillig(inline) fn main f0 {
+          b0():
+            v0 = allocate -> &Field
+            store Field 7 at v0
+            call f1(v0)
+            return Field 7
+        }
+        brillig(inline) fn bar f1 {
+          b0(v0: &Field):
+            return
+        }
+        ");
+    }
+
+    #[test]
+    fn immutable_ref_used_in_multiple_calls() {
+        let src = "
+            brillig(inline) fn main f0 {
+              b0():
+                v0 = allocate -> &Field
+                store Field 1 at v0
+                call f1(v0)
+                call f1(v0)
+                return
+            }
+            brillig(inline) fn bar f1 {
+              b0(v0: &Field):
+                return
+            }
+        ";
+        let ssa = Ssa::from_str(src).unwrap();
+        let ssa = ssa.mem2reg();
+        assert_ssa_snapshot!(ssa, @r"
+        brillig(inline) fn main f0 {
+          b0():
+            v0 = allocate -> &Field
+            store Field 1 at v0
+            call f1(v0)
+            v3 = allocate -> &Field
+            store Field 1 at v3
+            call f1(v3)
+            return
+        }
+        brillig(inline) fn bar f1 {
+          b0(v0: &Field):
+            return
+        }
+        ");
+    }
+
+    #[test]
+    fn multiple_immutable_refs_in_one_call() {
+        let src = "
+            brillig(inline) fn main f0 {
+              b0():
+                v0 = allocate -> &Field
+                store Field 11 at v0
+                v1 = allocate -> &Field
+                store Field 22 at v1
+                call f1(v0, v1)
+                return
+            }
+            brillig(inline) fn bar f1 {
+              b0(v0: &Field, v1: &Field):
+                return
+            }
+        ";
+        let ssa = Ssa::from_str(src).unwrap();
+        let ssa = ssa.mem2reg();
+        assert_ssa_snapshot!(ssa, @r"
+        brillig(inline) fn main f0 {
+          b0():
+            v0 = allocate -> &Field
+            store Field 11 at v0
+            v2 = allocate -> &Field
+            store Field 22 at v2
+            call f1(v0, v2)
+            return
+        }
+        brillig(inline) fn bar f1 {
+          b0(v0: &Field, v1: &Field):
+            return
+        }
+        ");
+    }
+
+    #[test]
+    fn immutable_ref_rematerialized_with_merged_value() {
+        let src = "
+            brillig(inline) fn main f0 {
+              b0(v0: u1):
+                v1 = allocate -> &Field
+                store Field 1 at v1
+                jmpif v0 then: b1(), else: b2()
+              b1():
+                store Field 2 at v1
+                jmp b3()
+              b2():
+                store Field 3 at v1
+                jmp b3()
+              b3():
+                call f1(v1)
+                return
+            }
+            brillig(inline) fn bar f1 {
+              b0(v0: &Field):
+                return
+            }
+        ";
+        let ssa = Ssa::from_str(src).unwrap();
+        let ssa = ssa.mem2reg();
+        assert_ssa_snapshot!(ssa, @r"
+        brillig(inline) fn main f0 {
+          b0(v0: u1):
+            jmpif v0 then: b1(), else: b2()
+          b1():
+            jmp b3(Field 2)
+          b2():
+            jmp b3(Field 3)
+          b3(v1: Field):
+            v4 = allocate -> &Field
+            store v1 at v4
+            call f1(v4)
+            return
+        }
+        brillig(inline) fn bar f1 {
+          b0(v0: &Field):
+            return
+        }
+        ");
+    }
+
+    #[test]
+    fn mutable_ref_passed_to_call_not_optimized() {
+        let src = "
+            brillig(inline) fn main f0 {
+              b0():
+                v0 = allocate -> &mut Field
+                store Field 5 at v0
+                call f1(v0)
+                return
+            }
+            brillig(inline) fn bar f1 {
+              b0(v0: &mut Field):
+                return
+            }
+        ";
+        assert_ssa_does_not_change(src, Ssa::mem2reg);
+    }
+
+    // We could optimize this case still and rematerialize the reference
+    // before the return, though that results in identical code for this example anyway.
+    #[test]
+    fn immutable_ref_returned_not_optimized() {
+        let src = "
+            brillig(inline) fn main f0 {
+              b0():
+                v0 = allocate -> &Field
+                store Field 5 at v0
+                return v0
+            }
+        ";
+        assert_ssa_does_not_change(src, Ssa::mem2reg);
+    }
+
+    #[test]
+    fn immutable_ref_stored_as_value_not_optimized() {
+        let src = "
+            brillig(inline) fn main f0 {
+              b0():
+                v0 = allocate -> &Field
+                store Field 5 at v0
+                v1 = allocate -> &mut &Field
+                store v0 at v1
+                v2 = load v0 -> Field
+                return v2
+            }
+        ";
+        let ssa = Ssa::from_str(src).unwrap();
+        let ssa = ssa.mem2reg();
+        assert_ssa_snapshot!(ssa, @r"
+        brillig(inline) fn main f0 {
+          b0():
+            v0 = allocate -> &Field
+            store Field 5 at v0
+            v2 = load v0 -> Field
+            return v2
+        }
+        ");
+    }
+
+    #[test]
+    fn immutable_ref_in_make_array_not_optimized() {
+        let src = "
+            brillig(inline) fn main f0 {
+              b0():
+                v0 = allocate -> &Field
+                store Field 5 at v0
+                v1 = make_array [v0] : [&Field; 1]
+                return v1
+            }
+        ";
+        assert_ssa_does_not_change(src, Ssa::mem2reg);
     }
 }

--- a/compiler/noirc_evaluator/src/ssa/opt/mem2reg.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/mem2reg.rs
@@ -135,8 +135,8 @@ type ParamLocations = BTreeMap<ValueId, HashSet<BasicBlockId>>;
 /// of the blocks where the variable is stored to. This is the minimal set of blocks where
 /// values from different control-flow paths could merge.
 fn compute_param_locations(
-    variables: &BTreeMap<ValueId, BasicBlockId>,
-    def_sites: &HashMap<ValueId, HashSet<BasicBlockId>>,
+    variables: &Variables,
+    def_sites: &DefSites,
     dom_frontiers: &HashMap<BasicBlockId, HashSet<BasicBlockId>>,
 ) -> ParamLocations {
     let mut result = BTreeMap::new();
@@ -178,16 +178,16 @@ fn iterated_dominance_frontier(
 /// Each block's visible set is its idom's visible set plus any variables declared locally.
 fn compute_visible_vars(
     blocks: &[BasicBlockId],
-    variables: &BTreeMap<ValueId, BasicBlockId>,
+    variables: &Variables,
     dom_tree: &DominatorTree,
-) -> HashMap<BasicBlockId, BTreeMap<ValueId, BasicBlockId>> {
+) -> HashMap<BasicBlockId, Variables> {
     // Group variables by their declaration block
     let mut vars_by_decl_block: HashMap<BasicBlockId, Vec<ValueId>> = HashMap::default();
     for (var, decl_block) in variables {
         vars_by_decl_block.entry(*decl_block).or_default().push(*var);
     }
 
-    let mut visible: HashMap<BasicBlockId, BTreeMap<ValueId, BasicBlockId>> = HashMap::default();
+    let mut visible: HashMap<BasicBlockId, Variables> = HashMap::default();
     for &block in blocks {
         let mut vars = match dom_tree.immediate_dominator(block) {
             Some(idom) => visible[&idom].clone(),
@@ -209,7 +209,7 @@ fn compute_visible_vars(
 /// For all other blocks, the entry value is inherited from the predecessor's exit state.
 fn add_block_params_and_find_exit_states(
     blocks: &[BasicBlockId],
-    visible_vars: &HashMap<BasicBlockId, BTreeMap<ValueId, BasicBlockId>>,
+    visible_vars: &HashMap<BasicBlockId, Variables>,
     param_locations: &ParamLocations,
     inserter: &mut FunctionInserter,
     block_states: &mut BlockStates,
@@ -239,7 +239,7 @@ fn add_block_params_and_find_exit_states(
 /// - If this block is in the variable's IDF: add a fresh block parameter
 /// - Otherwise: inherit the value from a visited predecessor's exit state
 fn compute_entry_state(
-    visible_vars: &BTreeMap<ValueId, BasicBlockId>,
+    visible_vars: &Variables,
     param_locations: &ParamLocations,
     block: BasicBlockId,
     dfg: &mut DataFlowGraph,
@@ -295,7 +295,7 @@ fn get_value_from_visited_predecessor(
 /// Only blocks in a variable's IDF have block parameters that need arguments wired.
 fn add_terminator_arguments(
     blocks: &[BasicBlockId],
-    variables: &BTreeMap<ValueId, BasicBlockId>,
+    variables: &Variables,
     param_locations: &ParamLocations,
     inserter: &mut FunctionInserter,
     block_states: &BlockStates,
@@ -407,6 +407,12 @@ fn abstract_interpret_block(
     exit_state
 }
 
+/// Maps an allocate result to the block it was allocated in
+type Variables = BTreeMap<ValueId, BasicBlockId>;
+
+/// Maps each allocate result to the set of blocks with stores to it
+type DefSites = HashMap<ValueId, HashSet<BasicBlockId>>;
+
 /// Return a map from each eligible variable to the block it was declared in,
 /// along with the set of blocks where each variable is stored to (definition sites),
 /// and the set of variables that are passed as arguments to a `Call`.
@@ -426,11 +432,11 @@ fn abstract_interpret_block(
 fn collect_eligible_variables_and_def_sites(
     function: &Function,
     blocks: &[BasicBlockId],
-) -> (BTreeMap<ValueId, BasicBlockId>, HashMap<ValueId, HashSet<BasicBlockId>>, HashSet<ValueId>) {
+) -> (Variables, DefSites, HashSet<ValueId>) {
     // Map each variable to the block it was declared in
-    let mut variables = BTreeMap::default();
+    let mut variables = Variables::default();
     // Map each variable to the set of blocks that contain stores to it
-    let mut def_sites: HashMap<ValueId, HashSet<BasicBlockId>> = HashMap::default();
+    let mut def_sites = DefSites::default();
 
     // Allocate results whose type is `Type::Reference(_, false)`. Only these are
     // allowed to survive a first-class use as a `Call` argument.
@@ -511,7 +517,7 @@ fn collect_eligible_variables_and_def_sites(
 ///   allocation and stores must remain so the callee has something to dereference.
 fn commit(
     inserter: &mut FunctionInserter,
-    variables: &BTreeMap<ValueId, BasicBlockId>,
+    variables: &Variables,
     used_in_calls: &HashSet<ValueId>,
     blocks: Vec<BasicBlockId>,
 ) {


### PR DESCRIPTION
# Description

## Problem

Resolves https://github.com/noir-lang/noir/issues/12322

## Summary

Allows immutable references to be valid variables for mem2reg to optimize even if they're used as arguments in Call instructions. When this happens we create a new allocation + store before the call so that the original immutable ref is still fine to be optimized out.

## Additional Context

The core change here only works because of a quirk of the ssa builder: if a user writes `let mut x = ..; ... &x ...`, we create a mutable reference Allocate result for `x`, and the `&x` _still uses the mutable reference type that was created_. So we can generally assume any local immutable variable we find isn't aliased by a mutable one.

`rematerialize_immutable_refs_before_call` is essentially the `lower_refs_at_acir_brillig_boundary` pass but only applies for mem2reg variables so we can't get rid of the pass.

We could do this with any instruction type I think, but there is a cost. What was before 1 immutable ref allocate + store used at N locations would now become N allocates + stores, so I'm limiting this to just calls for now. Ideally we'd have some cost or dominator analysis to reuse existing references though.

Edit: Actually, if an immutable reference is used in a call it'd be better to flag it later on so that the original allocate is just not removed in the first place. Then we can get rid of the rematerialize step too.

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
