### PR TITLE
chore(docs): Bump versions in docs dropdown to 4

### DIFF
--- a/docs/scripts/setStable.ts
+++ b/docs/scripts/setStable.ts
@@ -4,7 +4,7 @@ const axios = require('axios');
 
 const GITHUB_PAGES = 3;
 const IGNORE_VERSIONS = ['0.16.0'];
-const NUMBER_OF_VERSIONS_TO_SHOW = 2;
+const NUMBER_OF_VERSIONS_TO_SHOW = 4;
 
 const MAX_RETRIES = 3;
 const INITIAL_DELAY_MS = 1000;


### PR DESCRIPTION
# Description

## Problem

The Noir docs currently offers readers the option to pick between viewing docs of the 2 latest versions of Noir. As v1.0.0-beta.20 is released, this means readers can access beta.20's and beta.19's docs but not older ones.

There are projects (e.g. Aztec.nr) that are built on older versions of Noir (e.g. v1.0.0-beta.18) that could benefit from access to older docs still.

## Summary

Bumps versions of docs shown to 4 in the `setStable.ts` script.

## User Documentation

Check one:
- [ ] No user documentation needed.
- [x] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
