### PR TITLE
chore(fuzz): Include `inline_never` and `no_predicates` in AST fuzzing

### DIFF
--- a/compiler/noirc_frontend/src/monomorphization/ast.rs
+++ b/compiler/noirc_frontend/src/monomorphization/ast.rs
@@ -5,6 +5,7 @@ use acvm::FieldElement;
 use iter_extended::vecmap;
 use noirc_artifacts::debug::{DebugFunctions, DebugTypes, DebugVariables};
 use noirc_errors::Location;
+use strum_macros::EnumIter;
 
 use crate::token::FmtStrFragment;
 use crate::{
@@ -434,7 +435,18 @@ pub type Parameters =
 /// Represents how an Acir function should be inlined.
 /// This type is only relevant for ACIR functions as we do not inline any Brillig functions
 #[derive(
-    Default, Clone, Copy, PartialEq, Eq, Debug, Hash, Serialize, Deserialize, PartialOrd, Ord,
+    Default,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    Debug,
+    Hash,
+    Serialize,
+    Deserialize,
+    PartialOrd,
+    Ord,
+    EnumIter,
 )]
 pub enum InlineType {
     /// The most basic entry point can expect all its functions to be inlined.

--- a/tooling/ast_fuzzer/src/program/mod.rs
+++ b/tooling/ast_fuzzer/src/program/mod.rs
@@ -319,16 +319,21 @@ impl Context {
             Visibility::Private
         };
 
+        let inline_type = if is_main {
+            InlineType::default()
+        } else {
+            // Automatically include any new inline type, except the ones we don't want: #[fold] is deprecated
+            let choices =
+                InlineType::iter().filter(|it| !matches!(it, InlineType::Fold)).collect::<Vec<_>>();
+            *u.choose(&choices)?
+        };
+
         let decl = FunctionDeclaration {
             name: if is_main { "main".to_string() } else { format!("func_{i}") },
             params,
             return_type,
             return_visibility,
-            inline_type: if is_main {
-                InlineType::default()
-            } else {
-                *u.choose(&[InlineType::Inline, InlineType::InlineAlways])?
-            },
+            inline_type,
             unconstrained,
         };
 

--- a/tooling/ast_fuzzer/src/program/mod.rs
+++ b/tooling/ast_fuzzer/src/program/mod.rs
@@ -323,8 +323,11 @@ impl Context {
             InlineType::default()
         } else {
             // Automatically include any new inline type, except the ones we don't want: #[fold] is deprecated
-            let choices =
-                InlineType::iter().filter(|it| !matches!(it, InlineType::Fold)).collect::<Vec<_>>();
+            let choices = InlineType::iter()
+                .filter(|it| {
+                    *it != InlineType::Fold && !(*it == InlineType::NoPredicates && unconstrained)
+                })
+                .collect::<Vec<_>>();
             *u.choose(&choices)?
         };
 


### PR DESCRIPTION
# Description

## Problem

@rkarabut pointed out that:

> just slapping inline_never on functions leads to discovering new bugs (on accident), 
> for example https://github.com/noir-lang/noir/security/advisories/GHSA-35h6-769r-84c9
> (otherwise would have to keep recursive call in foo to keep it from inlining)

## Summary

Includes all `InlineType` variants in the AST fuzzer except:
* `#[fold]`, which is deprecated
* `#[no_predicate]` on `unconstrained` functions

## Additional Context

`#[inline_never]` was introduced after the AST fuzzer was created, and at the time I only included `#[inline]` and `#[inline_always]` as choices. 

`InlineType::into_unconstrained` shows that we _can_ compile unconstrained functions with `#[no_predicate]`, but we do that when the original function was constrained. The frontend does not allow placing `#[no_predicate]` on unconstrained functions. These have access to more language features, such as `while` and `loop`, which might not work with `#[no_predicate]`. An example where trying to combine the two caused failures was in https://github.com/noir-lang/noir/actions/runs/24503632468/job/71618431630?pr=12328

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
