### PR TITLE
chore(stdlib): Add `EmbeddedCurvePoint::new`

### DIFF
--- a/noir_stdlib/docs/std/embedded_curve_ops/struct.EmbeddedCurvePoint.html
+++ b/noir_stdlib/docs/std/embedded_curve_ops/struct.EmbeddedCurvePoint.html
@@ -28,6 +28,7 @@
 <li><a href="#double">double</a></li>
 <li><a href="#generator">generator</a></li>
 <li><a href="#is_infinite">is_infinite</a></li>
+<li><a href="#new">new</a></li>
 <li><a href="#point_at_infinity">point_at_infinity</a></li>
 </ul>
 <h3>Trait implementations</h3>
@@ -68,7 +69,12 @@ x and y denotes the Weierstrass coordinates of the point.</p>
 <div class="padded-description"></div><h2>Implementations</h2>
 <h3><code class="code-header">impl <a href="../../std/embedded_curve_ops/struct.EmbeddedCurvePoint.html" class="struct">EmbeddedCurvePoint</a></code></h3>
 
-<div class="padded-methods"><code id="double" class="code-header">pub fn <a href="#double"><span class="fn">double</span></a>(self) -> Self</code>
+<div class="padded-methods"><code id="new" class="code-header">pub fn <a href="#new"><span class="fn">new</span></a>(x: <a href="../../std/primitive.Field.html" class="primitive">Field</a>, y: <a href="../../std/primitive.Field.html" class="primitive">Field</a>) -> Self</code>
+
+<div class="padded-description"><div class="comments">
+<p>Create a new point using the provided (x, y) pair</p>
+</div>
+</div><code id="double" class="code-header">pub fn <a href="#double"><span class="fn">double</span></a>(self) -> Self</code>
 
 <div class="padded-description"><div class="comments">
 <p>Elliptic curve point doubling operation

--- a/noir_stdlib/src/embedded_curve_ops.nr
+++ b/noir_stdlib/src/embedded_curve_ops.nr
@@ -11,6 +11,11 @@ pub struct EmbeddedCurvePoint {
 }
 
 impl EmbeddedCurvePoint {
+    /// Create a new point using the provided (x, y) pair
+    pub fn new(x: Field, y: Field) -> Self {
+        EmbeddedCurvePoint { x, y }
+    }
+
     /// Elliptic curve point doubling operation
     /// returns the doubled point of a point P, i.e P+P
     pub fn double(self) -> EmbeddedCurvePoint {

--- a/test_programs/execution_success/regression_5045/src/main.nr
+++ b/test_programs/execution_success/regression_5045/src/main.nr
@@ -8,7 +8,7 @@ fn main(is_active: bool) {
     };
 
     if is_active {
-        let bad = EmbeddedCurvePoint { x: 0, y: 5 };
+        let bad = EmbeddedCurvePoint::new(0, 5);
         let d = bad.double();
         let e = std::embedded_curve_ops::multi_scalar_mul(
             [a, bad],

--- a/test_programs/execution_success/regression_7744/src/main.nr
+++ b/test_programs/execution_success/regression_7744/src/main.nr
@@ -4,7 +4,7 @@ use std::embedded_curve_ops::{embedded_curve_add, EmbeddedCurvePoint};
 
 // is_active = false
 fn main(is_active: bool) -> pub EmbeddedCurvePoint {
-    let bad = EmbeddedCurvePoint { x: 0, y: 5 };
+    let bad = EmbeddedCurvePoint::new(0, 5);
     if is_active {
         embedded_curve_add(bad, bad)
     } else {

--- a/tooling/nargo_cli/tests/snapshots/execution_success/regression_5045/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/regression_5045/execute__tests__expanded.snap
@@ -10,7 +10,7 @@ fn main(is_active: bool) {
         y: 2726875754519434671146873023426441956600113087238248464305840046775215989920_Field,
     };
     if is_active {
-        let bad: EmbeddedCurvePoint = EmbeddedCurvePoint { x: 0_Field, y: 5_Field };
+        let bad: EmbeddedCurvePoint = EmbeddedCurvePoint::new(0_Field, 5_Field);
         let d: EmbeddedCurvePoint = bad.double();
         let e: EmbeddedCurvePoint = std::embedded_curve_ops::multi_scalar_mul(
             [a, bad],

--- a/tooling/nargo_cli/tests/snapshots/execution_success/regression_7744/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/regression_7744/execute__tests__expanded.snap
@@ -5,7 +5,7 @@ expression: expanded_code
 use std::embedded_curve_ops::{embedded_curve_add, EmbeddedCurvePoint};
 
 fn main(is_active: bool) -> pub EmbeddedCurvePoint {
-    let bad: EmbeddedCurvePoint = EmbeddedCurvePoint { x: 0_Field, y: 5_Field };
+    let bad: EmbeddedCurvePoint = EmbeddedCurvePoint::new(0_Field, 5_Field);
     if is_active {
         embedded_curve_add(bad, bad)
     } else {


### PR DESCRIPTION
# Description

## Problem

Noticed in https://github.com/reilabs/lampe/issues/255 that methods get the correct type path with `lampe` but struct literals don't. Since `EmbeddedCurveScala::new` exists, why not have `EmbeddedCurvePoint::new` as well.

## Summary

Adds `EmbeddedCurvePoint::new`.

## Additional Context



## User Documentation

Check one:
- [ ] No user documentation needed.
- [x] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
