### PR TITLE
test(fmt): cover index lvalue op-assign and comment newline

### DIFF
--- a/tooling/nargo_fmt/src/formatter/comments_and_whitespace.rs
+++ b/tooling/nargo_fmt/src/formatter/comments_and_whitespace.rs
@@ -334,6 +334,10 @@ mod tests {
     };
     use test_case::test_case;
 
+    fn normalize_expected_newlines(expected: &str) -> String {
+        if cfg!(windows) { expected.replace('\n', "\r\n") } else { expected.to_owned() }
+    }
+
     fn assert_format_wrapping_comments(src: &str, expected: &str, comment_width: usize) {
         let config = Config { wrap_comments: true, comment_width, ..Config::default() };
         assert_format_with_config(src, expected, config);
@@ -833,6 +837,22 @@ mod foo;
     1
 ];\n";
         assert_format(src, expected);
+    }
+
+    #[test]
+    fn format_lvalue_index_with_comment() {
+        let src = "fn foo(mut bar: [Field; 2]) {
+    bar[// hello
+    1] = 2;
+}";
+        let expected = "fn foo(mut bar: [Field; 2]) {
+    bar[
+        // hello
+        1
+    ] = 2;
+}
+";
+        assert_format(src, &normalize_expected_newlines(expected));
     }
 
     #[test]

--- a/tooling/nargo_fmt/src/formatter/lvalue.rs
+++ b/tooling/nargo_fmt/src/formatter/lvalue.rs
@@ -29,9 +29,27 @@ impl ChunkFormatter<'_, '_> {
                 group.text(self.chunk(|formatter| {
                     formatter.write_left_bracket();
                 }));
+
+                // Keep index comment/newline behavior consistent with rvalue index expressions.
+                let comments_chunk = self.skip_comments_and_whitespace_chunk();
+                let comments_chunk_has_newlines = comments_chunk.has_newlines;
+
+                if comments_chunk_has_newlines {
+                    group.increase_indentation();
+                    group.line();
+                }
+
+                group.leading_comment(comments_chunk);
+
                 let mut index_group = ChunkGroup::new();
                 self.format_expression(index, &mut index_group);
                 group.group(index_group);
+
+                if comments_chunk_has_newlines {
+                    group.decrease_indentation();
+                    group.line();
+                }
+
                 group.text(self.chunk(|formatter| {
                     formatter.write_right_bracket();
                 }));

--- a/tooling/nargo_fmt/src/formatter/statement.rs
+++ b/tooling/nargo_fmt/src/formatter/statement.rs
@@ -401,6 +401,10 @@ impl ChunkFormatter<'_, '_> {
 mod tests {
     use crate::{assert_format, assert_format_with_max_width};
 
+    fn normalize_expected_newlines(expected: &str) -> String {
+        if cfg!(windows) { expected.replace('\n', "\r\n") } else { expected.to_owned() }
+    }
+
     #[test]
     fn format_expression_statement() {
         let src = " fn foo() { 1 } ";
@@ -616,6 +620,25 @@ mod tests {
 }
 ";
         assert_format(src, expected);
+    }
+
+    #[test]
+    fn format_op_assign_to_index_with_block() {
+        let src = "fn main(mut array: [Field; 3]) {
+    array[{
+    1;
+    2
+    }] += 3;
+}
+";
+        let expected = "fn main(mut array: [Field; 3]) {
+    array[{
+        1;
+        2
+    }] += 3;
+}
+";
+        assert_format(src, &normalize_expected_newlines(expected));
     }
 
     #[test]


### PR DESCRIPTION
 # Description
                                                                                                                                                                                                    
  ## Problem                                                                                                                                                                                        
                                                                                                                                                                                                    
  Resolves <!-- Link to GitHub Issue -->                                                                                                                                                            
                                                                                                                                                                                                    
  The formatter had a regression coverage gap around index lvalues: we covered basic `array[{...}] = ...` and rvalue index comment formatting, but we did not cover `op-assign` with block index or lvalue index newline-comment cases. This made it easier for index-lvalue formatting regressions to slip through.                                                                                  
                                                                                                                                                                                                    
  ## Summary                                                                                                                                                                                        

  - Added a regression test for `op-assign` with block index in lvalue:                                                                                                                             
    - `array[{ ... }] += value`                                                                                                                                                                     
  - Added a regression test for newline comments inside lvalue index:                                                                                                                               
    - `bar[// comment\n1] = ...`                                                                                                                                                                    
  - Aligned lvalue index comment/newline formatting behavior with existing rvalue index formatting logic.
                                                                                                                                                                                                    
  ## Additional Context
                                                                                                                                                                                                    
  - This follows the same regression area as `fix(fmt): indent block inside index assignment` (`#12133`) and extends coverage to high-risk combinations that were still missing.                    
  - Scope is intentionally minimal and limited to formatter behavior plus targeted tests.
                                                                                                                                                                                                    
  ## User Documentation
                                                                                                                                                                                                    
  Check one:
  - [x] No user documentation needed.                                                                                                                                                               
  - [ ] Changes in _docs/_ included in this PR.
  - [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.                                                                                                        
                                                                                                                                                                                                    
  # PR Checklist                                                                                                                                                                                    
                                                                                                                                                                                                    
  - [x] I have tested the changes locally.                                                                                                                                                          
  - [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings. 