### PR TITLE
chore(docs): Specify the exceptions when numbers default to `u32` instead of `Field`

### DIFF
--- a/docs/docs/noir/concepts/data_types/integers.md
+++ b/docs/docs/noir/concepts/data_types/integers.md
@@ -6,8 +6,8 @@ sidebar_position: 1
 ---
 
 An integer type is a range constrained field type.
-The Noir frontend supports both unsigned and signed integer types.
-The allowed sizes are 8, 16, 32, 64 and 128 bits. ([currently only unsigned integers for 128 bits](https://github.com/noir-lang/noir/issues/7591))
+
+The Noir frontend supports both unsigned and signed integer types. The allowed sizes are 8, 16, 32, 64 and 128 bits. (For 128 bits, [only unsigned is supported](https://github.com/noir-lang/noir/issues/7591) at the moment.)
 
 :::info
 

--- a/docs/docs/noir/concepts/data_types/integers.md
+++ b/docs/docs/noir/concepts/data_types/integers.md
@@ -15,7 +15,9 @@ When an integer is specified without a defined or inferred type, it defaults to 
 
 - Array indices
 - Loop indices
-- Bitwise operands
+- Bitwise operations
+- Comparison operations
+- A modulo (`%`) operation
 - Constants in numeric generics
 
 You can add a type suffix such as `u32` or `Field` to the end of an integer literal to explicitly specify the type.

--- a/docs/docs/noir/concepts/data_types/integers.md
+++ b/docs/docs/noir/concepts/data_types/integers.md
@@ -11,9 +11,12 @@ The allowed sizes are 8, 16, 32, 64 and 128 bits. ([currently only unsigned inte
 
 :::info
 
-When an integer is defined in Noir without a specific type, it will default to `Field` unless another type is expected at its position.
+When an integer is specified without a defined or inferred type, it defaults to `Field`. Except if they are one of the following, it defaults to `u32` instead:
 
-The one exception is for loop indices which default to `u32` since comparisons on `Field`s are not possible.
+- Array indices
+- Loop indices
+- Bitwise operands
+- Constants in numeric generics
 
 You can add a type suffix such as `u32` or `Field` to the end of an integer literal to explicitly specify the type.
 

--- a/docs/versioned_docs/version-v1.0.0-beta.20/noir/concepts/data_types/integers.md
+++ b/docs/versioned_docs/version-v1.0.0-beta.20/noir/concepts/data_types/integers.md
@@ -6,18 +6,42 @@ sidebar_position: 1
 ---
 
 An integer type is a range constrained field type.
-The Noir frontend supports both unsigned and signed integer types.
-The allowed sizes are 8, 16, 32, 64 and 128 bits. ([currently only unsigned integers for 128 bits](https://github.com/noir-lang/noir/issues/7591))
+
+The Noir frontend supports both unsigned and signed integer types. The allowed sizes are 8, 16, 32, 64 and 128 bits. (For 128 bits, [only unsigned is supported](https://github.com/noir-lang/noir/issues/7591) at the moment.)
 
 :::info
 
-When an integer is defined in Noir without a specific type, it will default to `Field` unless another type is expected at its position.
+When an integer is specified without a defined or inferred type, it defaults to `Field`. Except if they are one of the following, it defaults to `u32` instead:
 
-The one exception is for loop indices which default to `u32` since comparisons on `Field`s are not possible.
+- Array indices
+- Loop indices
+- Bitwise operands
+- Constants in numeric generics
 
 You can add a type suffix such as `u32` or `Field` to the end of an integer literal to explicitly specify the type.
 
 :::
+
+### Integer Literal Syntax
+
+Integer literals can include an optional type suffix to specify their type explicitly:
+
+```rust
+let a = 1u8;        // u8
+let b = 256_u16;    // u16
+let c = -1i8;       // i8
+let d = 42_u32;     // u32
+let e = 100_Field;  // Field
+```
+
+The supported suffixes are: `u8`, `u16`, `u32`, `u64`, `u128`, `i8`, `i16`, `i32`, `i64`, and `Field`.
+
+Underscores can be used as visual separators in numeric literals for readability. They are ignored by the compiler:
+
+```rust
+let million = 1_000_000;
+let max_u64 = 18_446_744_073_709_551_615_u64;
+```
 
 ## Unsigned Integers
 

--- a/docs/versioned_docs/version-v1.0.0-beta.20/noir/concepts/data_types/integers.md
+++ b/docs/versioned_docs/version-v1.0.0-beta.20/noir/concepts/data_types/integers.md
@@ -15,7 +15,9 @@ When an integer is specified without a defined or inferred type, it defaults to 
 
 - Array indices
 - Loop indices
-- Bitwise operands
+- Bitwise operations
+- Comparison operations
+- A modulo (`%`) operation
 - Constants in numeric generics
 
 You can add a type suffix such as `u32` or `Field` to the end of an integer literal to explicitly specify the type.


### PR DESCRIPTION
# Description

## Problem

Our current docs aren't immediately clear when integers without defined or inferred types default to `u32` instead of `Field`.

## Summary

Add a list of exceptions on the "Integers" page:

- Array indices
- Loop indices
- Bitwise operands
- Constants in numeric generics

## User Documentation

Check one:
- [ ] No user documentation needed.
- [x] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
