### PR TITLE
chore(github): Simplify section headings and tweak experimental feature doc checkbox in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,14 +1,8 @@
-# Description
-
-## Problem
+## Problem Resolved
 
 Resolves <!-- Link to GitHub Issue -->
 
-## Summary
-
-
-
-## Additional Context
+## Summary of Changes
 
 
 
@@ -16,10 +10,10 @@ Resolves <!-- Link to GitHub Issue -->
 
 Check one:
 - [ ] No user documentation needed.
-- [ ] Changes in _docs/_ included in this PR.
-- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.
+- [ ] Documented in _docs/_.
+- [ ] **[For Experimental Features]** Tracking issue created to document this later.
 
-# PR Checklist
+## PR Checklist
 
 - [ ] I have tested the changes locally.
 - [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,7 +11,7 @@ Resolves <!-- Link to GitHub Issue -->
 Check one:
 - [ ] No user documentation needed.
 - [ ] Documented in _docs/_.
-- [ ] **[For Experimental Features]** Tracking issue created to document this later.
+- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->
 
 ## PR Checklist
 


### PR DESCRIPTION
## Summary

- Removes less necessary sections and make remaining ones more descriptive
- Tweaks experimental feature documentation checkbox to explicitly require creating tracking issues

This helps closes the gap where we forget to document experimental features going into production. 

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [ ] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
