### PR TITLE
chore: bump external pinned commits

### DIFF
--- a/.github/benchmark_projects.yml
+++ b/.github/benchmark_projects.yml
@@ -1,4 +1,4 @@
-define: &AZ_COMMIT e88ecdf581dbb7ade7bdc883d7da2ba86137f8e0
+define: &AZ_COMMIT d2eb0fa3a03a6858c741673bdd9c39cabd61eef6
 projects:
   private-kernel-inner:
     repo: AztecProtocol/aztec-packages

--- a/EXTERNAL_NOIR_LIBRARIES.yml
+++ b/EXTERNAL_NOIR_LIBRARIES.yml
@@ -1,4 +1,4 @@
-define: &AZ_COMMIT e88ecdf581dbb7ade7bdc883d7da2ba86137f8e0
+define: &AZ_COMMIT d2eb0fa3a03a6858c741673bdd9c39cabd61eef6
 libraries:
   noir_check_shuffle:
     repo: noir-lang/noir_check_shuffle


### PR DESCRIPTION

Automated update of the pinned commit of [aztec-packages](https://github.com/AztecProtocol/aztec-packages) repository against which we run benchmarks.
