### PR TITLE
chore: Add CLI options for the limits in Brillig constraints check

### DIFF
--- a/compiler/noirc_driver/src/lib.rs
+++ b/compiler/noirc_driver/src/lib.rs
@@ -19,6 +19,7 @@ use noirc_evaluator::brillig::brillig_ir::{
 };
 use noirc_evaluator::create_program;
 use noirc_evaluator::errors::RuntimeError;
+use noirc_evaluator::ssa::checks;
 use noirc_evaluator::ssa::opt::{
     CONSTANT_FOLDING_MAX_ITER, DEFAULT_MAX_SPECIALIZATIONS_PER_FN,
     DEFAULT_SPECIALIZATION_THRESHOLD, FORCE_UNROLL_THRESHOLD, INLINING_MAX_INSTRUCTIONS,
@@ -162,6 +163,15 @@ pub struct CompileOptions {
     #[arg(long)]
     pub skip_brillig_constraints_check: bool,
 
+    /// Maximum size of arrays in Brillig call outputs to try to constrain on a per-item basis.
+    #[arg(long, hide = true, default_value_t = checks::DEFAULT_MAX_ARRAY_OUTPUT_LENGTH)]
+    pub brillig_constraints_check_max_array_output_length: u32,
+
+    /// Maximum distance to travel looking for an intersect in the ancestors
+    /// of constrained values with the inputs/outputs of Brillig calls.
+    #[arg(long, hide = true, default_value_t = checks::DEFAULT_MAX_ANCESTOR_DISTANCE)]
+    pub brillig_constraints_check_max_ancestor_distance: u32,
+
     /// Flag to turn on extra Brillig bytecode to be generated to guard against invalid states in testing.
     #[arg(long, hide = true)]
     pub enable_brillig_debug_assertions: bool,
@@ -178,12 +188,12 @@ pub struct CompileOptions {
 
     /// Maximum number of iterations to do in constant folding, as long as new values are being hoisted.
     /// A value of 0 effectively disables constant folding.
-    #[arg(long, hide = true, allow_hyphen_values = true, default_value_t = CONSTANT_FOLDING_MAX_ITER)]
+    #[arg(long, hide = true, default_value_t = CONSTANT_FOLDING_MAX_ITER)]
     pub constant_folding_max_iter: usize,
 
     /// Setting to decide the maximum weight threshold at which we designate a function
     /// as "small" and thus to always be inlined.
-    #[arg(long, hide = true, allow_hyphen_values = true, default_value_t = INLINING_MAX_INSTRUCTIONS)]
+    #[arg(long, hide = true, default_value_t = INLINING_MAX_INSTRUCTIONS)]
     pub small_function_max_instructions: usize,
 
     /// Setting the maximum acceptable increase in Brillig bytecode size due to
@@ -282,6 +292,9 @@ impl Default for CompileOptions {
             show_artifact_paths: false,
             skip_underconstrained_check: false,
             skip_brillig_constraints_check: false,
+            brillig_constraints_check_max_array_output_length:
+                checks::DEFAULT_MAX_ARRAY_OUTPUT_LENGTH,
+            brillig_constraints_check_max_ancestor_distance: checks::DEFAULT_MAX_ANCESTOR_DISTANCE,
             enable_brillig_debug_assertions: false,
             count_array_copies: false,
             inliner_aggressiveness: i64::MAX,
@@ -328,6 +341,10 @@ impl CompileOptions {
             emit_ssa: if self.emit_ssa { Some(package_build_path) } else { None },
             skip_underconstrained_check: self.skip_underconstrained_check,
             skip_brillig_constraints_check: self.skip_brillig_constraints_check,
+            brillig_constraints_check_max_array_output_length: self
+                .brillig_constraints_check_max_array_output_length,
+            brillig_constraints_check_max_ancestor_distance: self
+                .brillig_constraints_check_max_ancestor_distance,
             inliner_aggressiveness: self.inliner_aggressiveness,
             constant_folding_max_iter: self.constant_folding_max_iter,
             small_function_max_instruction: self.small_function_max_instructions,

--- a/compiler/noirc_evaluator/src/ssa/checks/check_for_missing_brillig_constraints.rs
+++ b/compiler/noirc_evaluator/src/ssa/checks/check_for_missing_brillig_constraints.rs
@@ -62,7 +62,7 @@ use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
 ///
 /// The higher this value the longer it will take to check them all,
 /// which can slow down the compilation of larger rollup circuits.
-const MAX_ARRAY_OUTPUT_LENGTH: u32 = 64;
+pub const DEFAULT_MAX_ARRAY_OUTPUT_LENGTH: u32 = 64;
 
 /// Limit how far back the BFS traverses to try to find a relation between
 /// the ancestors of constrained values and Brillig inputs/outputs.
@@ -71,13 +71,17 @@ const MAX_ARRAY_OUTPUT_LENGTH: u32 = 64;
 /// such as `rollup-checkpoint-root` and `rollup-checkpoint-root-single-block`,
 /// which have hundreds of thousands of constraints that we need to check,
 /// even though they are only checked against a few dozen of Brillig outputs.
-const MAX_ANCESTOR_DISTANCE: u32 = 10;
+pub const DEFAULT_MAX_ANCESTOR_DISTANCE: u32 = 10;
 
 impl Ssa {
     /// Detect Brillig calls left unconstrained with manual asserts
     /// and return a vector of bug reports if any have been found
     #[allow(clippy::needless_pass_by_ref_mut)]
-    pub(crate) fn check_for_missing_brillig_constraints(&mut self) -> Vec<SsaReport> {
+    pub(crate) fn check_for_missing_brillig_constraints(
+        &mut self,
+        max_array_output_length: u32,
+        max_ancestor_distance: u32,
+    ) -> Vec<SsaReport> {
         // Skip the check if there are no Brillig functions involved
         if !self.functions.values().any(|func| func.runtime().is_brillig()) {
             return vec![];
@@ -88,7 +92,7 @@ impl Ssa {
             .filter(|func| func.runtime().is_acir() && has_call_to_brillig(func, &self.functions))
             .par_bridge()
             .flat_map(|func| {
-                Context::new(func)
+                Context::new(func, max_array_output_length, max_ancestor_distance)
                     .build_tainted(func, &self.functions)
                     .build_parent_graph(func)
                     .constrain_tainted(func, &self.functions)
@@ -157,7 +161,12 @@ impl TaintedDescendants {
     ///
     /// Populates `single_outputs` and `array_outputs` according to the result types.
     /// Leaves `arg_ancestors` to be populated later.
-    fn new(func: &Function, arguments: Vec<ValueId>, result_ids: &[ValueId]) -> Self {
+    fn new(
+        func: &Function,
+        arguments: Vec<ValueId>,
+        result_ids: &[ValueId],
+        max_array_output_length: u32,
+    ) -> Self {
         let mut single_outputs = HashSet::new();
         let mut array_outputs = HashMap::new();
         for result_id in result_ids {
@@ -165,7 +174,7 @@ impl TaintedDescendants {
                 // If the result value is an array, create an empty descendant set for
                 // every element to be accessed further on and record the indices
                 // of the resulting sets for future reference
-                Some(length) if length.0 > 0 && length.0 <= MAX_ARRAY_OUTPUT_LENGTH => {
+                Some(length) if length.0 > 0 && length.0 <= max_array_output_length => {
                     let mut index_outputs = HashMap::new();
                     for i in 0..length.0 {
                         index_outputs.insert(i, HashSet::new());
@@ -216,6 +225,7 @@ impl TaintedDescendants {
         equivalences: &HashMap<ValueId, Vec<ValueId>>,
         all_tainted: &ValueSet,
         all_constrained: &mut ValueSet,
+        max_ancestor_distance: u32,
     ) -> bool {
         // Make sure this constraint has something to do with the outputs.
         if !constrained_values.iter().any(|v| self.constrainable.contains(v)) {
@@ -235,6 +245,7 @@ impl TaintedDescendants {
                 equivalences,
                 all_tainted,
                 all_constrained,
+                max_ancestor_distance,
             )
         {
             return false;
@@ -242,9 +253,9 @@ impl TaintedDescendants {
 
         // Remove any results that have been directly or indirectly constrained.
         self.single_outputs.retain(|output| {
-            let constrained = constrained_values
-                .iter()
-                .any(|value| any_ancestor(*value, |a| a == *output, parents, equivalences));
+            let constrained = constrained_values.iter().any(|value| {
+                any_ancestor(*value, |a| a == *output, parents, equivalences, max_ancestor_distance)
+            });
 
             if constrained {
                 all_constrained.insert(*output);
@@ -255,9 +266,9 @@ impl TaintedDescendants {
 
         self.array_outputs.retain(|array, index_outputs| {
             // If the array itself is not an ancestor of the constrained value, then we don't have to check the items.
-            let can_constrain = constrained_values
-                .iter()
-                .any(|value| any_ancestor(*value, |a| a == *array, parents, equivalences));
+            let can_constrain = constrained_values.iter().any(|value| {
+                any_ancestor(*value, |a| a == *array, parents, equivalences, max_ancestor_distance)
+            });
 
             if !can_constrain {
                 return true;
@@ -271,7 +282,13 @@ impl TaintedDescendants {
                     return true;
                 }
                 let constrained = constrained_values.iter().any(|value| {
-                    any_ancestor(*value, |a| descendants.contains(&a), parents, equivalences)
+                    any_ancestor(
+                        *value,
+                        |a| descendants.contains(&a),
+                        parents,
+                        equivalences,
+                        max_ancestor_distance,
+                    )
                 });
 
                 if constrained {
@@ -298,6 +315,7 @@ impl TaintedDescendants {
         equivalences: &HashMap<ValueId, Vec<ValueId>>,
         all_tainted: &ValueSet,
         all_constrained: &ValueSet,
+        max_ancestor_distance: u32,
     ) -> bool {
         for &cv in constrained_values {
             // We want to avoid using tainted inputs to constrain Brillig outputs.
@@ -308,13 +326,14 @@ impl TaintedDescendants {
             if all_tainted.contains(&cv)
                 && (
                     // Tainted and hasn't been constrained.
-                    !any_ancestor(cv, |a| all_constrained.contains(&a), parents, equivalences)
+                    !any_ancestor(cv, |a| all_constrained.contains(&a), parents, equivalences, max_ancestor_distance)
                     // Tainted because it's the output of this call itself.
                     || any_ancestor(
                         cv,
                         |a| self.single_outputs.contains(&a) || self.array_outputs.contains_key(&a),
                         parents,
                         equivalences,
+                        max_ancestor_distance
                     )
                 )
             {
@@ -322,7 +341,13 @@ impl TaintedDescendants {
             }
             // arg_ancestors contains the arguments themselves and all their transitive ancestors.
             // BFS from cv to check if cv or any ancestor of cv is in arg_ancestors.
-            if any_ancestor(cv, |a| self.arg_ancestors.contains(&a), parents, equivalences) {
+            if any_ancestor(
+                cv,
+                |a| self.arg_ancestors.contains(&a),
+                parents,
+                equivalences,
+                max_ancestor_distance,
+            ) {
                 return true;
             }
         }
@@ -383,16 +408,24 @@ struct Context {
     /// If `v1` and `v2` are equivalent, any ancestor of `v1` is also an ancestor of `v2`
     /// and vice versa. BFS follows these edges alongside `parents` edges.
     equivalences: HashMap<ValueId, Vec<ValueId>>,
+
+    /// Maximum length of an array for which we consider constraining items per index.
+    max_array_output_length: u32,
+
+    /// Maximum distance to travel looking for an intersecting ancestor.
+    max_ancestor_distance: u32,
 }
 
 impl Context {
-    fn new(func: &Function) -> Self {
+    fn new(func: &Function, max_array_output_length: u32, max_ancestor_distance: u32) -> Self {
         Self {
             post_order: PostOrder::with_function(func).into_vec(),
             tainted: HashMap::default(),
             constraints: HashSet::default(),
             parents: HashMap::default(),
             equivalences: HashMap::default(),
+            max_array_output_length,
+            max_ancestor_distance,
         }
     }
 
@@ -574,7 +607,7 @@ impl Context {
 
                     // Only extend if we will not exceed the traversal limit to reach them.
                     if let Some(dist) = min_dist
-                        && dist < MAX_ANCESTOR_DISTANCE
+                        && dist < self.max_ancestor_distance
                     {
                         all_constrainable.extend(results.iter().map(|r| (*r, dist + 1)));
                         self.extend_constrainable(&arguments, &results);
@@ -623,7 +656,12 @@ impl Context {
 
                     // Skip if we have a similar one already.
                     if !visited {
-                        let tainted = TaintedDescendants::new(func, arguments, &results);
+                        let tainted = TaintedDescendants::new(
+                            func,
+                            arguments,
+                            &results,
+                            self.max_array_output_length,
+                        );
                         self.tainted.insert(*instruction_id, tainted);
                         // Look out for constraints on these outputs.
                         // We don't need to consider the inputs: the constraints which are relevant will have to constrain
@@ -710,6 +748,7 @@ impl Context {
                             equivalences,
                             &all_tainted,
                             &mut all_constrained,
+                            self.max_ancestor_distance,
                         );
 
                         if constrained {
@@ -904,21 +943,36 @@ fn any_ancestor(
     predicate: impl Fn(ValueId) -> bool,
     parents: &HashMap<ValueId, Vec<ValueId>>,
     equivalences: &HashMap<ValueId, Vec<ValueId>>,
+    max_ancestor_distance: u32,
 ) -> bool {
     let mut found = false;
     bfs_traverse_ancestors(&[start], parents, equivalences, |a, d| {
         if predicate(a) {
             found = true;
         }
-        !found && d <= MAX_ANCESTOR_DISTANCE
+        !found && d <= max_ancestor_distance
     });
     found
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::ssa::Ssa;
+    use crate::ssa::{
+        Ssa,
+        checks::check_for_missing_brillig_constraints::{
+            DEFAULT_MAX_ANCESTOR_DISTANCE, DEFAULT_MAX_ARRAY_OUTPUT_LENGTH,
+        },
+    };
+    use noirc_artifacts::ssa::SsaReport;
     use tracing_test::traced_test;
+
+    fn check_for_missing_brillig_constraints_in_ssa(src: &str) -> Vec<SsaReport> {
+        let mut ssa = Ssa::from_str(src).unwrap();
+        ssa.check_for_missing_brillig_constraints(
+            DEFAULT_MAX_ARRAY_OUTPUT_LENGTH,
+            DEFAULT_MAX_ANCESTOR_DISTANCE,
+        )
+    }
 
     #[test]
     #[traced_test]
@@ -984,8 +1038,7 @@ mod tests {
         }
         "#;
 
-        let mut ssa = Ssa::from_str(program).unwrap();
-        let ssa_level_warnings = ssa.check_for_missing_brillig_constraints();
+        let ssa_level_warnings = check_for_missing_brillig_constraints_in_ssa(program);
         assert_eq!(ssa_level_warnings.len(), 1);
     }
 
@@ -1015,8 +1068,7 @@ mod tests {
         }
         "#;
 
-        let mut ssa = Ssa::from_str(program).unwrap();
-        let ssa_level_warnings = ssa.check_for_missing_brillig_constraints();
+        let ssa_level_warnings = check_for_missing_brillig_constraints_in_ssa(program);
         assert_eq!(ssa_level_warnings.len(), 1);
     }
 
@@ -1045,8 +1097,7 @@ mod tests {
         }
         "#;
 
-        let mut ssa = Ssa::from_str(program).unwrap();
-        let ssa_level_warnings = ssa.check_for_missing_brillig_constraints();
+        let ssa_level_warnings = check_for_missing_brillig_constraints_in_ssa(program);
         assert_eq!(ssa_level_warnings.len(), 0);
     }
 
@@ -1074,8 +1125,7 @@ mod tests {
         }
         "#;
 
-        let mut ssa = Ssa::from_str(program).unwrap();
-        let ssa_level_warnings = ssa.check_for_missing_brillig_constraints();
+        let ssa_level_warnings = check_for_missing_brillig_constraints_in_ssa(program);
         assert_eq!(ssa_level_warnings.len(), 0);
     }
 
@@ -1128,8 +1178,7 @@ mod tests {
         }
         "#;
 
-        let mut ssa = Ssa::from_str(program).unwrap();
-        let ssa_level_warnings = ssa.check_for_missing_brillig_constraints();
+        let ssa_level_warnings = check_for_missing_brillig_constraints_in_ssa(program);
         assert_eq!(ssa_level_warnings.len(), 1);
     }
 
@@ -1157,8 +1206,7 @@ mod tests {
         }
         "#;
 
-        let mut ssa = Ssa::from_str(program).unwrap();
-        let ssa_level_warnings = ssa.check_for_missing_brillig_constraints();
+        let ssa_level_warnings = check_for_missing_brillig_constraints_in_ssa(program);
         assert_eq!(ssa_level_warnings.len(), 2);
     }
 
@@ -1191,8 +1239,7 @@ mod tests {
         }
         "#;
 
-        let mut ssa = Ssa::from_str(program).unwrap();
-        let ssa_level_warnings = ssa.check_for_missing_brillig_constraints();
+        let ssa_level_warnings = check_for_missing_brillig_constraints_in_ssa(program);
         assert_eq!(ssa_level_warnings.len(), 0);
     }
 
@@ -1218,8 +1265,7 @@ mod tests {
         }
         "#;
 
-        let mut ssa = Ssa::from_str(program).unwrap();
-        let ssa_level_warnings = ssa.check_for_missing_brillig_constraints();
+        let ssa_level_warnings = check_for_missing_brillig_constraints_in_ssa(program);
         assert_eq!(ssa_level_warnings.len(), 1);
     }
 
@@ -1247,8 +1293,7 @@ mod tests {
         }
         "#;
 
-        let mut ssa = Ssa::from_str(program).unwrap();
-        let ssa_level_warnings = ssa.check_for_missing_brillig_constraints();
+        let ssa_level_warnings = check_for_missing_brillig_constraints_in_ssa(program);
         assert_eq!(ssa_level_warnings.len(), 0);
     }
 
@@ -1320,8 +1365,7 @@ mod tests {
 
         "#;
 
-        let mut ssa = Ssa::from_str(program).unwrap();
-        let ssa_level_warnings = ssa.check_for_missing_brillig_constraints();
+        let ssa_level_warnings = check_for_missing_brillig_constraints_in_ssa(program);
         assert_eq!(ssa_level_warnings.len(), 0);
     }
 
@@ -1348,8 +1392,7 @@ mod tests {
         }
         "#;
 
-        let mut ssa = Ssa::from_str(program).unwrap();
-        let ssa_level_warnings = ssa.check_for_missing_brillig_constraints();
+        let ssa_level_warnings = check_for_missing_brillig_constraints_in_ssa(program);
         assert_eq!(ssa_level_warnings.len(), 0);
     }
 
@@ -1373,8 +1416,7 @@ mod tests {
         }
         "#;
 
-        let mut ssa = Ssa::from_str(program).unwrap();
-        let ssa_level_warnings = ssa.check_for_missing_brillig_constraints();
+        let ssa_level_warnings = check_for_missing_brillig_constraints_in_ssa(program);
         assert_eq!(ssa_level_warnings.len(), 2);
     }
 
@@ -1406,8 +1448,7 @@ mod tests {
         }
         "#;
 
-        let mut ssa = Ssa::from_str(program).unwrap();
-        let ssa_level_warnings = ssa.check_for_missing_brillig_constraints();
+        let ssa_level_warnings = check_for_missing_brillig_constraints_in_ssa(program);
         assert_eq!(ssa_level_warnings.len(), 0);
     }
 
@@ -1432,8 +1473,7 @@ mod tests {
         }
         "#;
 
-        let mut ssa = Ssa::from_str(program).unwrap();
-        let ssa_level_warnings = ssa.check_for_missing_brillig_constraints();
+        let ssa_level_warnings = check_for_missing_brillig_constraints_in_ssa(program);
         assert_eq!(ssa_level_warnings.len(), 0);
     }
 
@@ -1458,8 +1498,7 @@ mod tests {
         }
         "#;
 
-        let mut ssa = Ssa::from_str(program).unwrap();
-        let ssa_level_warnings = ssa.check_for_missing_brillig_constraints();
+        let ssa_level_warnings = check_for_missing_brillig_constraints_in_ssa(program);
         assert_eq!(ssa_level_warnings.len(), 0);
     }
 
@@ -1495,8 +1534,7 @@ mod tests {
         }
         "#;
 
-        let mut ssa = Ssa::from_str(program).unwrap();
-        let ssa_level_warnings = ssa.check_for_missing_brillig_constraints();
+        let ssa_level_warnings = check_for_missing_brillig_constraints_in_ssa(program);
         assert_eq!(ssa_level_warnings.len(), 0);
     }
 
@@ -1517,8 +1555,7 @@ mod tests {
         }
         "#;
 
-        let mut ssa = Ssa::from_str(program).unwrap();
-        let ssa_level_warnings = ssa.check_for_missing_brillig_constraints();
+        let ssa_level_warnings = check_for_missing_brillig_constraints_in_ssa(program);
         assert_eq!(ssa_level_warnings.len(), 0);
     }
 
@@ -1540,8 +1577,7 @@ mod tests {
         }
         "#;
 
-        let mut ssa = Ssa::from_str(program).unwrap();
-        let ssa_level_warnings = ssa.check_for_missing_brillig_constraints();
+        let ssa_level_warnings = check_for_missing_brillig_constraints_in_ssa(program);
         assert_eq!(ssa_level_warnings.len(), 0);
     }
 
@@ -1564,8 +1600,7 @@ mod tests {
         }
         "#;
 
-        let mut ssa = Ssa::from_str(program).unwrap();
-        let ssa_level_warnings = ssa.check_for_missing_brillig_constraints();
+        let ssa_level_warnings = check_for_missing_brillig_constraints_in_ssa(program);
         assert_eq!(ssa_level_warnings.len(), 0, "Expected no warnings but found some.");
     }
 
@@ -1590,8 +1625,7 @@ mod tests {
         }
         "#;
 
-        let mut ssa = Ssa::from_str(program).unwrap();
-        let ssa_level_warnings = ssa.check_for_missing_brillig_constraints();
+        let ssa_level_warnings = check_for_missing_brillig_constraints_in_ssa(program);
         assert_eq!(ssa_level_warnings.len(), 0, "Expected no warnings but found some.");
     }
 
@@ -1616,8 +1650,7 @@ mod tests {
         }
         "#;
 
-        let mut ssa = Ssa::from_str(program).unwrap();
-        let ssa_level_warnings = ssa.check_for_missing_brillig_constraints();
+        let ssa_level_warnings = check_for_missing_brillig_constraints_in_ssa(program);
         assert_eq!(
             ssa_level_warnings.len(),
             0,
@@ -1647,8 +1680,7 @@ mod tests {
         }
         "#;
 
-        let mut ssa = Ssa::from_str(program).unwrap();
-        let ssa_level_warnings = ssa.check_for_missing_brillig_constraints();
+        let ssa_level_warnings = check_for_missing_brillig_constraints_in_ssa(program);
         assert_eq!(
             ssa_level_warnings.len(),
             0,
@@ -1680,8 +1712,7 @@ mod tests {
         }
         "#;
 
-        let mut ssa = Ssa::from_str(program).unwrap();
-        let ssa_level_warnings = ssa.check_for_missing_brillig_constraints();
+        let ssa_level_warnings = check_for_missing_brillig_constraints_in_ssa(program);
         assert_eq!(
             ssa_level_warnings.len(),
             0,
@@ -1705,8 +1736,7 @@ mod tests {
         }
         "#;
 
-        let mut ssa = Ssa::from_str(program).unwrap();
-        let ssa_level_warnings = ssa.check_for_missing_brillig_constraints();
+        let ssa_level_warnings = check_for_missing_brillig_constraints_in_ssa(program);
         assert_eq!(
             ssa_level_warnings.len(),
             1,
@@ -1730,8 +1760,7 @@ mod tests {
         }
         "#;
 
-        let mut ssa = Ssa::from_str(program).unwrap();
-        let ssa_level_warnings = ssa.check_for_missing_brillig_constraints();
+        let ssa_level_warnings = check_for_missing_brillig_constraints_in_ssa(program);
         assert_eq!(ssa_level_warnings.len(), 1);
     }
 
@@ -1756,8 +1785,7 @@ mod tests {
         }
         "#;
 
-        let mut ssa = Ssa::from_str(program).unwrap();
-        let ssa_level_warnings = ssa.check_for_missing_brillig_constraints();
+        let ssa_level_warnings = check_for_missing_brillig_constraints_in_ssa(program);
         assert_eq!(ssa_level_warnings.len(), 0);
     }
 
@@ -1795,8 +1823,7 @@ mod tests {
         }
         "#;
 
-        let mut ssa = Ssa::from_str(program).unwrap();
-        let ssa_level_warnings = ssa.check_for_missing_brillig_constraints();
+        let ssa_level_warnings = check_for_missing_brillig_constraints_in_ssa(program);
         assert_eq!(ssa_level_warnings.len(), 0);
     }
 
@@ -1819,8 +1846,7 @@ mod tests {
         }
         "#;
 
-        let mut ssa = Ssa::from_str(program).unwrap();
-        let ssa_level_warnings = ssa.check_for_missing_brillig_constraints();
+        let ssa_level_warnings = check_for_missing_brillig_constraints_in_ssa(program);
         assert_eq!(ssa_level_warnings.len(), 0);
     }
 }

--- a/compiler/noirc_evaluator/src/ssa/checks/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/checks/mod.rs
@@ -7,6 +7,10 @@ use crate::ssa::ir::{function::Function, value::ValueId};
 mod check_for_missing_brillig_constraints;
 mod check_for_underconstrained_values;
 
+pub use check_for_missing_brillig_constraints::{
+    DEFAULT_MAX_ANCESTOR_DISTANCE, DEFAULT_MAX_ARRAY_OUTPUT_LENGTH,
+};
+
 /// Return `true` if a [ValueId] identifies a numeric constant in the DFG.
 fn is_numeric_constant(func: &Function, value: ValueId) -> bool {
     func.dfg.get_numeric_constant(value).is_some()

--- a/compiler/noirc_evaluator/src/ssa/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/mod.rs
@@ -42,7 +42,7 @@ pub use builder::{SsaBuilder, SsaPass};
 
 mod artifact;
 mod builder;
-mod checks;
+pub mod checks;
 pub mod function_builder;
 pub mod interpreter;
 pub mod ir;
@@ -98,6 +98,11 @@ pub struct SsaEvaluatorOptions {
 
     /// Skip the missing Brillig call constraints check
     pub skip_brillig_constraints_check: bool,
+    /// Maximum size of arrays in Brillig call outputs to try to constrain on a per-item basis.
+    pub brillig_constraints_check_max_array_output_length: u32,
+    /// Maximum distance to travel looking for an intersect in the ancestors
+    /// of constrained values with the inputs/outputs of Brillig calls.
+    pub brillig_constraints_check_max_ancestor_distance: u32,
 
     /// The higher the value, the more inlined Brillig functions will be.
     pub inliner_aggressiveness: i64,
@@ -417,7 +422,12 @@ pub fn optimize_ssa_builder_into_acir(
         ssa_level_warnings.extend(time(
             "After Check for Missing Brillig Call Constraints",
             options.print_codegen_timings,
-            || ssa.check_for_missing_brillig_constraints(),
+            || {
+                ssa.check_for_missing_brillig_constraints(
+                    options.brillig_constraints_check_max_array_output_length,
+                    options.brillig_constraints_check_max_ancestor_distance,
+                )
+            },
         ));
     }
 

--- a/compiler/noirc_evaluator/src/ssa/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/mod.rs
@@ -11,7 +11,19 @@ use std::{
     path::PathBuf,
 };
 
-use crate::{acir::ssa::Artifacts, brillig::BrilligOptions, errors::RuntimeError};
+use crate::{
+    acir::ssa::Artifacts,
+    brillig::BrilligOptions,
+    errors::RuntimeError,
+    ssa::{
+        checks::{DEFAULT_MAX_ANCESTOR_DISTANCE, DEFAULT_MAX_ARRAY_OUTPUT_LENGTH},
+        opt::{
+            CONSTANT_FOLDING_MAX_ITER, DEFAULT_MAX_SPECIALIZATIONS_PER_FN,
+            DEFAULT_SPECIALIZATION_THRESHOLD, FORCE_UNROLL_THRESHOLD, INLINING_MAX_INSTRUCTIONS,
+            MAX_UNROLL_ITERATIONS,
+        },
+    },
+};
 use acvm::{
     FieldElement,
     acir::{
@@ -137,6 +149,32 @@ pub struct SsaEvaluatorOptions {
 
     /// A list of SSA pass messages to skip, for testing purposes.
     pub skip_passes: Vec<String>,
+}
+
+/// Defaults used in tests.
+impl Default for SsaEvaluatorOptions {
+    fn default() -> Self {
+        Self {
+            ssa_logging: SsaLogging::None,
+            ssa_logging_hide_unchanged: false,
+            brillig_options: BrilligOptions::default(),
+            print_codegen_timings: false,
+            emit_ssa: None,
+            skip_underconstrained_check: true,
+            skip_brillig_constraints_check: true,
+            brillig_constraints_check_max_array_output_length: DEFAULT_MAX_ARRAY_OUTPUT_LENGTH,
+            brillig_constraints_check_max_ancestor_distance: DEFAULT_MAX_ANCESTOR_DISTANCE,
+            inliner_aggressiveness: 0,
+            constant_folding_max_iter: CONSTANT_FOLDING_MAX_ITER,
+            small_function_max_instruction: INLINING_MAX_INSTRUCTIONS,
+            max_bytecode_increase_percent: None,
+            max_unroll_iterations: MAX_UNROLL_ITERATIONS,
+            force_unroll_threshold: FORCE_UNROLL_THRESHOLD,
+            specialization_threshold: DEFAULT_SPECIALIZATION_THRESHOLD,
+            max_specializations_per_fn: DEFAULT_MAX_SPECIALIZATIONS_PER_FN,
+            skip_passes: Vec::new(),
+        }
+    }
 }
 
 pub struct ArtifactsAndWarnings(pub Artifacts, pub Vec<SsaReport>);

--- a/compiler/noirc_evaluator/src/ssa/opt/flatten_cfg/branch_analysis.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/flatten_cfg/branch_analysis.rs
@@ -288,7 +288,7 @@ mod tests {
     use crate::{
         brillig::BrilligOptions,
         ssa::{
-            SsaEvaluatorOptions,
+            SsaEvaluatorOptions, checks,
             function_builder::FunctionBuilder,
             ir::{basic_block::BasicBlockId, cfg::ControlFlowGraph, map::Id, types::Type},
             opt::{
@@ -648,6 +648,9 @@ mod tests {
             emit_ssa: None,
             skip_underconstrained_check: true,
             skip_brillig_constraints_check: true,
+            brillig_constraints_check_max_array_output_length:
+                checks::DEFAULT_MAX_ARRAY_OUTPUT_LENGTH,
+            brillig_constraints_check_max_ancestor_distance: checks::DEFAULT_MAX_ANCESTOR_DISTANCE,
             inliner_aggressiveness: 0,
             constant_folding_max_iter: constant_folding::DEFAULT_MAX_ITER,
             small_function_max_instruction: inlining::MAX_SIMPLE_FUNCTION_WEIGHT,

--- a/compiler/noirc_evaluator/src/ssa/opt/flatten_cfg/branch_analysis.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/flatten_cfg/branch_analysis.rs
@@ -285,20 +285,13 @@ impl<'cfg> Context<'cfg> {
 #[cfg(test)]
 mod tests {
 
-    use crate::{
-        brillig::BrilligOptions,
-        ssa::{
-            SsaEvaluatorOptions, checks,
-            function_builder::FunctionBuilder,
-            ir::{basic_block::BasicBlockId, cfg::ControlFlowGraph, map::Id, types::Type},
-            opt::{
-                DEFAULT_MAX_SPECIALIZATIONS_PER_FN, DEFAULT_SPECIALIZATION_THRESHOLD,
-                FORCE_UNROLL_THRESHOLD, MAX_UNROLL_ITERATIONS, constant_folding,
-                flatten_cfg::branch_analysis::find_branch_ends, inlining,
-            },
-            primary_passes,
-            ssa_gen::Ssa,
-        },
+    use crate::ssa::{
+        SsaEvaluatorOptions,
+        function_builder::FunctionBuilder,
+        ir::{basic_block::BasicBlockId, cfg::ControlFlowGraph, map::Id, types::Type},
+        opt::flatten_cfg::branch_analysis::find_branch_ends,
+        primary_passes,
+        ssa_gen::Ssa,
     };
 
     #[test]
@@ -641,27 +634,7 @@ mod tests {
     }
 
     fn run_pipeline_up_to_pass(mut ssa: Ssa, stop_before_pass: &str) -> Ssa {
-        let options = SsaEvaluatorOptions {
-            ssa_logging: crate::ssa::SsaLogging::None,
-            brillig_options: BrilligOptions::default(),
-            print_codegen_timings: false,
-            emit_ssa: None,
-            skip_underconstrained_check: true,
-            skip_brillig_constraints_check: true,
-            brillig_constraints_check_max_array_output_length:
-                checks::DEFAULT_MAX_ARRAY_OUTPUT_LENGTH,
-            brillig_constraints_check_max_ancestor_distance: checks::DEFAULT_MAX_ANCESTOR_DISTANCE,
-            inliner_aggressiveness: 0,
-            constant_folding_max_iter: constant_folding::DEFAULT_MAX_ITER,
-            small_function_max_instruction: inlining::MAX_SIMPLE_FUNCTION_WEIGHT,
-            max_bytecode_increase_percent: None,
-            max_unroll_iterations: MAX_UNROLL_ITERATIONS,
-            force_unroll_threshold: FORCE_UNROLL_THRESHOLD,
-            specialization_threshold: DEFAULT_SPECIALIZATION_THRESHOLD,
-            max_specializations_per_fn: DEFAULT_MAX_SPECIALIZATIONS_PER_FN,
-            skip_passes: Vec::new(),
-            ssa_logging_hide_unchanged: false,
-        };
+        let options = SsaEvaluatorOptions::default();
         let pipeline = primary_passes(&options);
         for pass in pipeline {
             if pass.msg() == stop_before_pass {

--- a/compiler/noirc_evaluator/src/ssa/opt/hint.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/hint.rs
@@ -5,40 +5,12 @@ mod tests {
 
     use crate::{
         assert_ssa_snapshot,
-        brillig::BrilligOptions,
         errors::RuntimeError,
-        ssa::{
-            Ssa, SsaBuilder, SsaEvaluatorOptions, SsaLogging,
-            checks::{DEFAULT_MAX_ANCESTOR_DISTANCE, DEFAULT_MAX_ARRAY_OUTPUT_LENGTH},
-            opt::{
-                DEFAULT_MAX_SPECIALIZATIONS_PER_FN, DEFAULT_SPECIALIZATION_THRESHOLD,
-                FORCE_UNROLL_THRESHOLD, MAX_UNROLL_ITERATIONS, constant_folding, inlining,
-            },
-            primary_passes,
-        },
+        ssa::{Ssa, SsaBuilder, SsaEvaluatorOptions, primary_passes},
     };
 
     fn run_all_passes(ssa: Ssa) -> Result<Ssa, RuntimeError> {
-        let options = &SsaEvaluatorOptions {
-            ssa_logging: SsaLogging::None,
-            brillig_options: BrilligOptions::default(),
-            print_codegen_timings: false,
-            emit_ssa: None,
-            skip_underconstrained_check: true,
-            skip_brillig_constraints_check: true,
-            brillig_constraints_check_max_array_output_length: DEFAULT_MAX_ARRAY_OUTPUT_LENGTH,
-            brillig_constraints_check_max_ancestor_distance: DEFAULT_MAX_ANCESTOR_DISTANCE,
-            inliner_aggressiveness: 0,
-            max_bytecode_increase_percent: None,
-            max_unroll_iterations: MAX_UNROLL_ITERATIONS,
-            constant_folding_max_iter: constant_folding::DEFAULT_MAX_ITER,
-            small_function_max_instruction: inlining::MAX_SIMPLE_FUNCTION_WEIGHT,
-            force_unroll_threshold: FORCE_UNROLL_THRESHOLD,
-            specialization_threshold: DEFAULT_SPECIALIZATION_THRESHOLD,
-            max_specializations_per_fn: DEFAULT_MAX_SPECIALIZATIONS_PER_FN,
-            skip_passes: Default::default(),
-            ssa_logging_hide_unchanged: false,
-        };
+        let options = SsaEvaluatorOptions::default();
 
         let builder = SsaBuilder::from_ssa(
             ssa,
@@ -47,7 +19,7 @@ mod tests {
             false,
             None,
         );
-        Ok(builder.run_passes(&primary_passes(options))?.finish())
+        Ok(builder.run_passes(&primary_passes(&options))?.finish())
     }
 
     /// Test that the `std::hint::black_box` function prevents some of the optimizations.

--- a/compiler/noirc_evaluator/src/ssa/opt/hint.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/hint.rs
@@ -9,6 +9,7 @@ mod tests {
         errors::RuntimeError,
         ssa::{
             Ssa, SsaBuilder, SsaEvaluatorOptions, SsaLogging,
+            checks::{DEFAULT_MAX_ANCESTOR_DISTANCE, DEFAULT_MAX_ARRAY_OUTPUT_LENGTH},
             opt::{
                 DEFAULT_MAX_SPECIALIZATIONS_PER_FN, DEFAULT_SPECIALIZATION_THRESHOLD,
                 FORCE_UNROLL_THRESHOLD, MAX_UNROLL_ITERATIONS, constant_folding, inlining,
@@ -25,6 +26,8 @@ mod tests {
             emit_ssa: None,
             skip_underconstrained_check: true,
             skip_brillig_constraints_check: true,
+            brillig_constraints_check_max_array_output_length: DEFAULT_MAX_ARRAY_OUTPUT_LENGTH,
+            brillig_constraints_check_max_ancestor_distance: DEFAULT_MAX_ANCESTOR_DISTANCE,
             inliner_aggressiveness: 0,
             max_bytecode_increase_percent: None,
             max_unroll_iterations: MAX_UNROLL_ITERATIONS,

--- a/tooling/ast_fuzzer/fuzz/src/lib.rs
+++ b/tooling/ast_fuzzer/fuzz/src/lib.rs
@@ -5,19 +5,9 @@ use noir_ast_fuzzer::compare::{
     CompareInterpretedResult, HasPrograms,
 };
 use noirc_abi::input_parser::Format;
-use noirc_evaluator::ssa::checks::{
-    DEFAULT_MAX_ANCESTOR_DISTANCE, DEFAULT_MAX_ARRAY_OUTPUT_LENGTH,
-};
-use noirc_evaluator::ssa::opt::{
-    CONSTANT_FOLDING_MAX_ITER, DEFAULT_MAX_SPECIALIZATIONS_PER_FN,
-    DEFAULT_SPECIALIZATION_THRESHOLD, FORCE_UNROLL_THRESHOLD, INLINING_MAX_INSTRUCTIONS,
-    MAX_UNROLL_ITERATIONS,
-};
+
+use noirc_evaluator::ssa::{self, SsaEvaluatorOptions, SsaProgramArtifact};
 use noirc_evaluator::ssa::{SsaPass, primary_passes};
-use noirc_evaluator::{
-    brillig::BrilligOptions,
-    ssa::{self, SsaEvaluatorOptions, SsaProgramArtifact},
-};
 use noirc_frontend::monomorphization::ast::Program;
 
 pub mod targets;
@@ -34,23 +24,7 @@ fn show_ssa() -> bool {
 pub fn default_ssa_options() -> SsaEvaluatorOptions {
     ssa::SsaEvaluatorOptions {
         ssa_logging: if show_ssa() { ssa::SsaLogging::All } else { ssa::SsaLogging::None },
-        brillig_options: BrilligOptions::default(),
-        print_codegen_timings: false,
-        emit_ssa: None,
-        skip_underconstrained_check: true,
-        skip_brillig_constraints_check: true,
-        brillig_constraints_check_max_array_output_length: DEFAULT_MAX_ARRAY_OUTPUT_LENGTH,
-        brillig_constraints_check_max_ancestor_distance: DEFAULT_MAX_ANCESTOR_DISTANCE,
-        inliner_aggressiveness: 0,
-        constant_folding_max_iter: CONSTANT_FOLDING_MAX_ITER,
-        small_function_max_instruction: INLINING_MAX_INSTRUCTIONS,
-        max_bytecode_increase_percent: None,
-        max_unroll_iterations: MAX_UNROLL_ITERATIONS,
-        force_unroll_threshold: FORCE_UNROLL_THRESHOLD,
-        specialization_threshold: DEFAULT_SPECIALIZATION_THRESHOLD,
-        max_specializations_per_fn: DEFAULT_MAX_SPECIALIZATIONS_PER_FN,
-        skip_passes: Default::default(),
-        ssa_logging_hide_unchanged: false,
+        ..Default::default()
     }
 }
 

--- a/tooling/ast_fuzzer/fuzz/src/lib.rs
+++ b/tooling/ast_fuzzer/fuzz/src/lib.rs
@@ -5,6 +5,9 @@ use noir_ast_fuzzer::compare::{
     CompareInterpretedResult, HasPrograms,
 };
 use noirc_abi::input_parser::Format;
+use noirc_evaluator::ssa::checks::{
+    DEFAULT_MAX_ANCESTOR_DISTANCE, DEFAULT_MAX_ARRAY_OUTPUT_LENGTH,
+};
 use noirc_evaluator::ssa::opt::{
     CONSTANT_FOLDING_MAX_ITER, DEFAULT_MAX_SPECIALIZATIONS_PER_FN,
     DEFAULT_SPECIALIZATION_THRESHOLD, FORCE_UNROLL_THRESHOLD, INLINING_MAX_INSTRUCTIONS,
@@ -36,6 +39,8 @@ pub fn default_ssa_options() -> SsaEvaluatorOptions {
         emit_ssa: None,
         skip_underconstrained_check: true,
         skip_brillig_constraints_check: true,
+        brillig_constraints_check_max_array_output_length: DEFAULT_MAX_ARRAY_OUTPUT_LENGTH,
+        brillig_constraints_check_max_ancestor_distance: DEFAULT_MAX_ANCESTOR_DISTANCE,
         inliner_aggressiveness: 0,
         constant_folding_max_iter: CONSTANT_FOLDING_MAX_ITER,
         small_function_max_instruction: INLINING_MAX_INSTRUCTIONS,

--- a/tooling/ast_fuzzer/tests/parser.rs
+++ b/tooling/ast_fuzzer/tests/parser.rs
@@ -11,6 +11,7 @@ use noirc_evaluator::{
     brillig::BrilligOptions,
     ssa::{
         self,
+        checks::{DEFAULT_MAX_ANCESTOR_DISTANCE, DEFAULT_MAX_ARRAY_OUTPUT_LENGTH},
         opt::{
             CONSTANT_FOLDING_MAX_ITER, DEFAULT_MAX_SPECIALIZATIONS_PER_FN,
             DEFAULT_SPECIALIZATION_THRESHOLD, FORCE_UNROLL_THRESHOLD, INLINING_MAX_INSTRUCTIONS,
@@ -48,6 +49,8 @@ fn arb_ssa_roundtrip() {
             emit_ssa: None,
             skip_underconstrained_check: true,
             skip_brillig_constraints_check: true,
+            brillig_constraints_check_max_array_output_length: DEFAULT_MAX_ARRAY_OUTPUT_LENGTH,
+            brillig_constraints_check_max_ancestor_distance: DEFAULT_MAX_ANCESTOR_DISTANCE,
             inliner_aggressiveness: 0,
             constant_folding_max_iter: CONSTANT_FOLDING_MAX_ITER,
             small_function_max_instruction: INLINING_MAX_INSTRUCTIONS,

--- a/tooling/ast_fuzzer/tests/parser.rs
+++ b/tooling/ast_fuzzer/tests/parser.rs
@@ -7,19 +7,9 @@ use std::time::Duration;
 
 use arbtest::arbtest;
 use noir_ast_fuzzer::{Config, DisplayAstAsNoir, arb_program};
-use noirc_evaluator::{
-    brillig::BrilligOptions,
-    ssa::{
-        self,
-        checks::{DEFAULT_MAX_ANCESTOR_DISTANCE, DEFAULT_MAX_ARRAY_OUTPUT_LENGTH},
-        opt::{
-            CONSTANT_FOLDING_MAX_ITER, DEFAULT_MAX_SPECIALIZATIONS_PER_FN,
-            DEFAULT_SPECIALIZATION_THRESHOLD, FORCE_UNROLL_THRESHOLD, INLINING_MAX_INSTRUCTIONS,
-            MAX_UNROLL_ITERATIONS,
-        },
-        primary_passes,
-        ssa_gen::{self, Ssa},
-    },
+use noirc_evaluator::ssa::{
+    self, primary_passes,
+    ssa_gen::{self, Ssa},
 };
 
 fn seed_from_env() -> Option<u64> {
@@ -42,26 +32,7 @@ fn arb_ssa_roundtrip() {
         let config = Config::default();
         let program = arb_program(u, config)?;
 
-        let options = ssa::SsaEvaluatorOptions {
-            ssa_logging: ssa::SsaLogging::None,
-            brillig_options: BrilligOptions::default(),
-            print_codegen_timings: false,
-            emit_ssa: None,
-            skip_underconstrained_check: true,
-            skip_brillig_constraints_check: true,
-            brillig_constraints_check_max_array_output_length: DEFAULT_MAX_ARRAY_OUTPUT_LENGTH,
-            brillig_constraints_check_max_ancestor_distance: DEFAULT_MAX_ANCESTOR_DISTANCE,
-            inliner_aggressiveness: 0,
-            constant_folding_max_iter: CONSTANT_FOLDING_MAX_ITER,
-            small_function_max_instruction: INLINING_MAX_INSTRUCTIONS,
-            max_bytecode_increase_percent: None,
-            max_unroll_iterations: MAX_UNROLL_ITERATIONS,
-            force_unroll_threshold: FORCE_UNROLL_THRESHOLD,
-            specialization_threshold: DEFAULT_SPECIALIZATION_THRESHOLD,
-            max_specializations_per_fn: DEFAULT_MAX_SPECIALIZATIONS_PER_FN,
-            skip_passes: Default::default(),
-            ssa_logging_hide_unchanged: false,
-        };
+        let options = ssa::SsaEvaluatorOptions::default();
         let pipeline = primary_passes(&options);
         let last_pass = u.choose_index(pipeline.len())?;
         let passes = &pipeline[0..last_pass];

--- a/tooling/ast_fuzzer/tests/smoke.rs
+++ b/tooling/ast_fuzzer/tests/smoke.rs
@@ -17,6 +17,7 @@ use noirc_evaluator::{
     brillig::BrilligOptions,
     ssa::{
         self,
+        checks::{DEFAULT_MAX_ANCESTOR_DISTANCE, DEFAULT_MAX_ARRAY_OUTPUT_LENGTH},
         opt::{
             CONSTANT_FOLDING_MAX_ITER, DEFAULT_MAX_SPECIALIZATIONS_PER_FN,
             DEFAULT_SPECIALIZATION_THRESHOLD, FORCE_UNROLL_THRESHOLD, INLINING_MAX_INSTRUCTIONS,
@@ -48,6 +49,8 @@ fn arb_program_can_be_executed() {
             emit_ssa: None,
             skip_underconstrained_check: true,
             skip_brillig_constraints_check: true,
+            brillig_constraints_check_max_array_output_length: DEFAULT_MAX_ARRAY_OUTPUT_LENGTH,
+            brillig_constraints_check_max_ancestor_distance: DEFAULT_MAX_ANCESTOR_DISTANCE,
             inliner_aggressiveness: 0,
             constant_folding_max_iter: CONSTANT_FOLDING_MAX_ITER,
             small_function_max_instruction: INLINING_MAX_INSTRUCTIONS,

--- a/tooling/ast_fuzzer/tests/smoke.rs
+++ b/tooling/ast_fuzzer/tests/smoke.rs
@@ -13,18 +13,7 @@ use bn254_blackbox_solver::Bn254BlackBoxSolver;
 use nargo::{NargoError, foreign_calls::DefaultForeignCallBuilder};
 use noir_ast_fuzzer::{Config, DisplayAstAsNoir, arb_inputs, arb_program, program_abi};
 use noirc_abi::input_parser::Format;
-use noirc_evaluator::{
-    brillig::BrilligOptions,
-    ssa::{
-        self,
-        checks::{DEFAULT_MAX_ANCESTOR_DISTANCE, DEFAULT_MAX_ARRAY_OUTPUT_LENGTH},
-        opt::{
-            CONSTANT_FOLDING_MAX_ITER, DEFAULT_MAX_SPECIALIZATIONS_PER_FN,
-            DEFAULT_SPECIALIZATION_THRESHOLD, FORCE_UNROLL_THRESHOLD, INLINING_MAX_INSTRUCTIONS,
-            MAX_UNROLL_ITERATIONS,
-        },
-    },
-};
+use noirc_evaluator::ssa;
 
 fn seed_from_env() -> Option<u64> {
     let Ok(seed) = std::env::var("NOIR_AST_FUZZER_SEED") else { return None };
@@ -42,26 +31,7 @@ fn arb_program_can_be_executed() {
         let program = arb_program(u, config)?;
         let abi = program_abi(&program);
 
-        let options = ssa::SsaEvaluatorOptions {
-            ssa_logging: ssa::SsaLogging::None,
-            brillig_options: BrilligOptions::default(),
-            print_codegen_timings: false,
-            emit_ssa: None,
-            skip_underconstrained_check: true,
-            skip_brillig_constraints_check: true,
-            brillig_constraints_check_max_array_output_length: DEFAULT_MAX_ARRAY_OUTPUT_LENGTH,
-            brillig_constraints_check_max_ancestor_distance: DEFAULT_MAX_ANCESTOR_DISTANCE,
-            inliner_aggressiveness: 0,
-            constant_folding_max_iter: CONSTANT_FOLDING_MAX_ITER,
-            small_function_max_instruction: INLINING_MAX_INSTRUCTIONS,
-            max_bytecode_increase_percent: None,
-            max_unroll_iterations: MAX_UNROLL_ITERATIONS,
-            force_unroll_threshold: FORCE_UNROLL_THRESHOLD,
-            specialization_threshold: DEFAULT_SPECIALIZATION_THRESHOLD,
-            max_specializations_per_fn: DEFAULT_MAX_SPECIALIZATIONS_PER_FN,
-            skip_passes: Default::default(),
-            ssa_logging_hide_unchanged: false,
-        };
+        let options = ssa::SsaEvaluatorOptions::default();
 
         // Print the AST if something goes wrong, then panic.
         let print_ast_and_panic = |msg: &str| -> ! {

--- a/tooling/ssa_verification/src/acir_instruction_builder.rs
+++ b/tooling/ssa_verification/src/acir_instruction_builder.rs
@@ -7,23 +7,12 @@ use acvm::{
 };
 use std::collections::BTreeSet;
 
+use noirc_evaluator::ssa::ssa_gen::Ssa;
 use noirc_evaluator::ssa::{
-    SsaEvaluatorOptions,
-    ir::map::Id,
-    opt::{
-        DEFAULT_MAX_SPECIALIZATIONS_PER_FN, DEFAULT_SPECIALIZATION_THRESHOLD,
-        FORCE_UNROLL_THRESHOLD, MAX_UNROLL_ITERATIONS,
-    },
-    optimize_ssa_builder_into_acir, primary_passes,
+    SsaEvaluatorOptions, ir::map::Id, optimize_ssa_builder_into_acir, primary_passes,
 };
 use noirc_evaluator::ssa::{SsaLogging, ir::function::Function};
-use noirc_evaluator::ssa::{
-    checks::{DEFAULT_MAX_ANCESTOR_DISTANCE, DEFAULT_MAX_ARRAY_OUTPUT_LENGTH},
-    opt::{CONSTANT_FOLDING_MAX_ITER, INLINING_MAX_INSTRUCTIONS},
-    ssa_gen::Ssa,
-};
 
-use noirc_evaluator::brillig::BrilligOptions;
 use noirc_evaluator::ssa::{
     SsaBuilder,
     function_builder::FunctionBuilder,
@@ -251,26 +240,7 @@ fn ssa_to_acir_program(ssa: Ssa) -> AcirProgram<FieldElement> {
         print_codegen_timings,
         files,
     );
-    let ssa_evaluator_options = SsaEvaluatorOptions {
-        ssa_logging: SsaLogging::None,
-        print_codegen_timings: false,
-        emit_ssa: { None },
-        skip_underconstrained_check: true,
-        skip_brillig_constraints_check: true,
-        brillig_constraints_check_max_array_output_length: DEFAULT_MAX_ARRAY_OUTPUT_LENGTH,
-        brillig_constraints_check_max_ancestor_distance: DEFAULT_MAX_ANCESTOR_DISTANCE,
-        inliner_aggressiveness: 0,
-        constant_folding_max_iter: CONSTANT_FOLDING_MAX_ITER,
-        small_function_max_instruction: INLINING_MAX_INSTRUCTIONS,
-        max_bytecode_increase_percent: None,
-        max_unroll_iterations: MAX_UNROLL_ITERATIONS,
-        force_unroll_threshold: FORCE_UNROLL_THRESHOLD,
-        specialization_threshold: DEFAULT_SPECIALIZATION_THRESHOLD,
-        max_specializations_per_fn: DEFAULT_MAX_SPECIALIZATIONS_PER_FN,
-        brillig_options: BrilligOptions::default(),
-        skip_passes: vec![],
-        ssa_logging_hide_unchanged: false,
-    };
+    let ssa_evaluator_options = SsaEvaluatorOptions::default();
     let (acir_functions, brillig, _) = match optimize_ssa_builder_into_acir(
         builder,
         &ssa_evaluator_options,

--- a/tooling/ssa_verification/src/acir_instruction_builder.rs
+++ b/tooling/ssa_verification/src/acir_instruction_builder.rs
@@ -18,6 +18,7 @@ use noirc_evaluator::ssa::{
 };
 use noirc_evaluator::ssa::{SsaLogging, ir::function::Function};
 use noirc_evaluator::ssa::{
+    checks::{DEFAULT_MAX_ANCESTOR_DISTANCE, DEFAULT_MAX_ARRAY_OUTPUT_LENGTH},
     opt::{CONSTANT_FOLDING_MAX_ITER, INLINING_MAX_INSTRUCTIONS},
     ssa_gen::Ssa,
 };
@@ -256,6 +257,8 @@ fn ssa_to_acir_program(ssa: Ssa) -> AcirProgram<FieldElement> {
         emit_ssa: { None },
         skip_underconstrained_check: true,
         skip_brillig_constraints_check: true,
+        brillig_constraints_check_max_array_output_length: DEFAULT_MAX_ARRAY_OUTPUT_LENGTH,
+        brillig_constraints_check_max_ancestor_distance: DEFAULT_MAX_ANCESTOR_DISTANCE,
         inliner_aggressiveness: 0,
         constant_folding_max_iter: CONSTANT_FOLDING_MAX_ITER,
         small_function_max_instruction: INLINING_MAX_INSTRUCTIONS,


### PR DESCRIPTION
# Description

## Problem

Follow up for https://github.com/noir-lang/noir/pull/12026#pullrequestreview-4131439380

## Summary

Adds new CLI options:
* `--brillig-constraints-check-max-array-output-length`: the maximum size of array outputs from Brillig calls which we try to constrain item-by-item
* `--brillig-constraints-check-max-ancestor-distance`: the maximum distance we traverse looking for ancestors that intersect between constrained values and Brillig inputs and outputs

Also added `SsaEvaluatorOptions::default()` to stop having to repeat the same defaults in tests. 

## Additional Context



## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
