### PR TITLE
chore: don't invalidate cached data in LSF calls with immutable refer…

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/ir/types.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/types.rs
@@ -335,6 +335,23 @@ impl Type {
         }
     }
 
+    /// True if this is a *mutable* reference (`&mut T`), or if it is a composite
+    /// type that contains a mutable reference at any nesting level.
+    ///
+    /// An immutable reference (`&T`) is not itself writable, but it may wrap a
+    /// mutable reference deeper in the type (e.g. `&(&mut Field)`), so the
+    /// check recurses through both mutable and immutable reference layers.
+    pub(crate) fn contains_mutable_reference(&self) -> bool {
+        match self {
+            Type::Reference(_, true) => true,
+            Type::Reference(inner, false) => inner.contains_mutable_reference(),
+            Type::Array(elements, _) | Type::Vector(elements) => {
+                elements.iter().any(|elem| elem.contains_mutable_reference())
+            }
+            Type::Numeric(_) | Type::Function => false,
+        }
+    }
+
     /// True if this is a function type or if it is a composite type which contains a function.
     pub(crate) fn contains_function(&self) -> bool {
         match self {

--- a/compiler/noirc_evaluator/src/ssa/opt/load_store_forwarding.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/load_store_forwarding.rs
@@ -175,20 +175,30 @@ fn forward_loads_and_stores_in_block(
                 last_stores.retain(|k, _| !may_alias(address, *k, &allocations, dfg));
             }
             Instruction::Call { .. } => {
-                // Simple reference (`&mut T` where T has no refs): invalidate that
-                // address and all its potential aliases.
-                // Container or nested reference: clear all state.
+                // `is_simple_ref`: `&T` or `&mut T` where T itself contains no refs.
+                // `is_mutable`: the outermost reference layer is mutable.
+                //
+                // - Simple mutable ref (`&mut T`): precise invalidation — the callee
+                //   can write through it, so that address and its aliases are cleared.
+                // - Simple immutable ref (`&T`): no-op — the callee can only read.
+                // - Container or nested ref that contains a mutable reference somewhere
+                //   (e.g. `[&mut T; N]`, `&&mut T`): full clear — the callee can
+                //   extract the inner mutable ref and write through it.
+                // - Container or nested ref with only immutable references
+                //   (e.g. `[&T; N]`): no-op — no write path exists.
                 instruction.for_each_value(|value| {
                     let value = inserter.resolve(value);
                     let typ = inserter.function.dfg.type_of_value(value);
-                    let is_simple_ref = matches!(typ.reference_element_type(), Some(inner) if !inner.contains_reference());
-                    if is_simple_ref {
+                    let is_simple_ref =
+                        matches!(typ.reference_element_type(), Some(inner) if !inner.contains_reference());
+                    let is_mutable = matches!(typ.as_ref(), Type::Reference(_, true));
+                    if is_simple_ref && is_mutable {
                         let dfg = &inserter.function.dfg;
                         known_values
                             .retain(|k, _| !may_alias(value, *k, &allocations, dfg));
                         last_stores
                             .retain(|k, _| !may_alias(value, *k, &allocations, dfg));
-                    } else if typ.contains_reference() {
+                    } else if !is_simple_ref && typ.contains_mutable_reference() {
                         known_values.clear();
                         last_stores.clear();
                     }
@@ -537,6 +547,78 @@ mod tests {
         // The load should NOT be forwarded because the call receives an array
         // containing a reference, so the callee could modify the pointed-to memory.
         assert_ssa_does_not_change(src, Ssa::load_store_forwarding);
+    }
+
+    #[test]
+    fn call_with_immutable_reference_does_not_invalidate_cache() {
+        // A call that only receives an immutable reference cannot write through
+        // it, so cached values for that address must remain valid after the call.
+        let src = "
+        brillig(inline) fn main f0 {
+          b0(v0: &Field):
+            v1 = load v0 -> Field
+            call f1(v0)
+            v2 = load v0 -> Field
+            return v2
+        }
+        brillig(inline) fn f1 f1 {
+          b0(v0: &Field):
+            return
+        }
+        ";
+        let ssa = Ssa::from_str(src).unwrap();
+        let ssa = ssa.load_store_forwarding();
+
+        // The call only holds an immutable reference; it cannot modify v0's
+        // memory. The second load should be forwarded to v1.
+        assert_ssa_snapshot!(ssa, @r"
+        brillig(inline) fn main f0 {
+          b0(v0: &Field):
+            v1 = load v0 -> Field
+            call f1(v0)
+            return v1
+        }
+        brillig(inline) fn f1 f1 {
+          b0(v0: &Field):
+            return
+        }
+        ");
+    }
+
+    #[test]
+    fn call_with_array_of_immutable_references_does_not_invalidate_cache() {
+        // A call that only receives an array of immutable references cannot write
+        // through any of them, so no cached values should be invalidated.
+        let src = "
+        brillig(inline) fn main f0 {
+          b0(v0: &mut Field, v1: [&Field; 2]):
+            store Field 10 at v0
+            call f1(v1)
+            v2 = load v0 -> Field
+            return v2
+        }
+        brillig(inline) fn f1 f1 {
+          b0(v0: [&Field; 2]):
+            return
+        }
+        ";
+        let ssa = Ssa::from_str(src).unwrap();
+        let ssa = ssa.load_store_forwarding();
+
+        // The call only receives immutable references; it cannot modify v0's
+        // memory. The load should be forwarded to Field 10.
+        assert_ssa_snapshot!(ssa, @r"
+        brillig(inline) fn main f0 {
+          b0(v0: &mut Field, v1: [&Field; 2]):
+            store Field 10 at v0
+            call f1(v1)
+            return Field 10
+        }
+        brillig(inline) fn f1 f1 {
+          b0(v0: [&Field; 2]):
+            return
+        }
+        ");
     }
 
     #[test]


### PR DESCRIPTION
…ences

# Description

## Problem

Resolves #12333

## Summary

I'm trying this out. I'm not sure it will lead to better performance in our test programs, but I wanted to check it out because it's a change to LSF so it's better to have these before external audits.

## Additional Context



## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
