### PR TITLE
chore: add regression test for inserting into an empty vector

### DIFF
--- a/test_programs/execution_success/vector_insert_empty_oob_2/Nargo.toml
+++ b/test_programs/execution_success/vector_insert_empty_oob_2/Nargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "vector_insert_empty_oob_2"
+type = "bin"
+authors = [""]
+
+[dependencies]

--- a/test_programs/execution_success/vector_insert_empty_oob_2/Prover.toml
+++ b/test_programs/execution_success/vector_insert_empty_oob_2/Prover.toml
@@ -1,0 +1,2 @@
+arr = [0]
+cond = true

--- a/test_programs/execution_success/vector_insert_empty_oob_2/src/main.nr
+++ b/test_programs/execution_success/vector_insert_empty_oob_2/src/main.nr
@@ -1,0 +1,9 @@
+fn main(arr: [u32; 1], cond: bool) {
+    let slice = arr.as_slice();
+    let (empty, _) = slice.remove(0);
+
+    if cond {
+        let inserted = empty.insert(0, 5);
+        assert_eq(inserted.len(), 1);
+    }
+}

--- a/tooling/nargo_cli/tests/snapshots/execution_success/vector_insert_empty_oob_2/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/vector_insert_empty_oob_2/execute__tests__expanded.snap
@@ -1,0 +1,12 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: expanded_code
+---
+fn main(arr: [u32; 1], cond: bool) {
+    let slice: [u32] = arr.as_slice();
+    let (empty, _): ([u32], u32) = slice.remove(0_u32);
+    if cond {
+        let inserted: [u32] = empty.insert(0_u32, 5_u32);
+        assert(inserted.len() == 1_u32);
+    }
+}

--- a/tooling/nargo_cli/tests/snapshots/execution_success/vector_insert_empty_oob_2/execute__tests__stdout.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/vector_insert_empty_oob_2/execute__tests__stdout.snap
@@ -1,0 +1,5 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: stdout
+---
+


### PR DESCRIPTION
# Description

## Problem

Resolves https://app.audithub.dev/app/organizations/161/projects/462/project-viewer?version=1133&issueId=635

## Summary

In reality this was already fixed by https://github.com/noir-lang/noir/pull/11703 because another auditor found the same issue, so here I'm just including the regression test for the relevant issue (#11730 already has regressions tests but they aren't exactly the same, so...)

## Additional Context



## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
