### PR TITLE
chore: add LSF regression test

### DIFF
--- a/test_programs/execution_success/brillig_mutable_reference_lsf_bug/Nargo.toml
+++ b/test_programs/execution_success/brillig_mutable_reference_lsf_bug/Nargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "brillig_mutable_reference_lsf_bug"
+type = "bin"
+authors = [""]
+
+[dependencies]

--- a/test_programs/execution_success/brillig_mutable_reference_lsf_bug/Prover.toml
+++ b/test_programs/execution_success/brillig_mutable_reference_lsf_bug/Prover.toml
@@ -1,0 +1,1 @@
+return = true

--- a/test_programs/execution_success/brillig_mutable_reference_lsf_bug/src/main.nr
+++ b/test_programs/execution_success/brillig_mutable_reference_lsf_bug/src/main.nr
@@ -1,0 +1,20 @@
+unconstrained fn foo(cond: bool) -> bool {
+    let mut b = false;
+    let c = if cond { &mut b } else { &mut false };
+    b = !b;
+    b = *c;
+    b
+}
+
+fn main() -> pub bool {
+    let expected = comptime {
+        unsafe {
+            foo(true)
+        }
+    };
+    let result = unsafe { foo(true) };
+    assert(result == expected);
+    unsafe {
+        foo(true)
+    }
+}

--- a/tooling/nargo_cli/tests/snapshots/execution_success/brillig_mutable_reference_lsf_bug/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/brillig_mutable_reference_lsf_bug/execute__tests__expanded.snap
@@ -1,0 +1,22 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: expanded_code
+---
+unconstrained fn foo(cond: bool) -> bool {
+    let mut b: bool = false;
+    let c: &mut bool = if cond { &mut b } else { &mut false };
+    b = !b;
+    b = *c;
+    b
+}
+
+fn main() -> pub bool {
+    let expected: bool = true;
+    // Safety: comment added by `nargo expand`
+    let result: bool = unsafe { foo(true) };
+    assert(result == expected);
+    // Safety: comment added by `nargo expand`
+    unsafe {
+        foo(true)
+    }
+}

--- a/tooling/nargo_cli/tests/snapshots/execution_success/brillig_mutable_reference_lsf_bug/execute__tests__stdout.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/brillig_mutable_reference_lsf_bug/execute__tests__stdout.snap
@@ -1,0 +1,5 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: stdout
+---
+[brillig_mutable_reference_lsf_bug] Circuit output: true


### PR DESCRIPTION
# Description

## Problem

Resolves https://github.com/noir-lang/noir/security/advisories/GHSA-mfqg-6wvq-m7mr

## Summary

This was fixed in https://github.com/noir-lang/noir/pull/12243 so this is just adding one more regression test.

## Additional Context



## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
