### PR TITLE
fix: fmtstr with functions in globals didn't compile

### DIFF
--- a/compiler/noirc_frontend/src/hir/comptime/value.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/value.rs
@@ -713,11 +713,11 @@ impl Value {
                 values.iter().any(|value| value.contains_function_or_closure())
             }
             Value::Pointer(shared, _, _) => shared.borrow().contains_function_or_closure(),
+            Value::FormatString(_, typ, _) => typ.contains_function(),
             Value::Unit
             | Value::Bool(_)
             | Value::Integer(_)
             | Value::String(_)
-            | Value::FormatString(_, _, _)
             | Value::CtString(_)
             | Value::Quoted(_)
             | Value::TypeDefinition(_)

--- a/test_programs/compile_success_empty/fmtstr_with_function_in_global/Nargo.toml
+++ b/test_programs/compile_success_empty/fmtstr_with_function_in_global/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "fmtstr_with_function_in_global"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.31.0"
+
+[dependencies]

--- a/test_programs/compile_success_empty/fmtstr_with_function_in_global/src/main.nr
+++ b/test_programs/compile_success_empty/fmtstr_with_function_in_global/src/main.nr
@@ -1,0 +1,7 @@
+global function_in_fmtstr: fmtstr<16, (fn() -> (),)> = f"function: {func}";
+
+fn func() {}
+
+fn main() {
+    let _ = function_in_fmtstr;
+}

--- a/tooling/nargo_cli/tests/snapshots/compile_success_empty/fmtstr_with_function_in_global/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_empty/fmtstr_with_function_in_global/execute__tests__expanded.snap
@@ -1,0 +1,14 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: expanded_code
+---
+global function_in_fmtstr: fmtstr<16, (fn(),)> = {
+    let func = func;
+    f"function: {func}"
+};
+
+fn func() {}
+
+fn main() {
+    let _: fmtstr<16, (fn(),)> = function_in_fmtstr;
+}


### PR DESCRIPTION
# Description

## Problem

Resolves https://app.audithub.dev/app/organizations/161/projects/787/project-viewer?issueId=993&version=1681
Resolves https://app.audithub.dev/app/organizations/161/projects/600/project-viewer?version=1408&issueId=913

## Summary



## Additional Context



## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
