### PR TITLE
fix: Fix `Type::instantiate_with_bindings_and_turbofish` generic order

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/variable.rs
+++ b/compiler/noirc_frontend/src/elaborator/variable.rs
@@ -23,7 +23,7 @@ use crate::node_interner::pusher::{HasLocation, PushedExpr};
 use crate::node_interner::{
     DefinitionId, DefinitionInfo, DefinitionKind, ExprId, TraitImplKind, TypeAliasId,
 };
-use crate::{Kind, Type, TypeBindings, TypeVariable};
+use crate::{Kind, Type, TypeBindings, TypeVariable, TypeVariableId};
 use iter_extended::{btree_map, vecmap};
 use noirc_errors::Location;
 
@@ -816,11 +816,13 @@ impl Elaborator<'_> {
         let t = self.type_substitute_trait_as_type(&ident);
 
         let definition = self.interner.definition(ident.id);
-        let function_generic_count = match definition.kind {
+        let direct_generic_ids = match definition.kind {
             DefinitionKind::Function(function) => {
-                self.interner.function_modifiers(&function).generic_count
+                vecmap(&self.interner.function_meta(&function).direct_generics, |generic| {
+                    generic.type_var.id()
+                })
             }
-            _ => 0,
+            _ => Vec::new(),
         };
 
         let location = self.interner.expr_location(expr_id);
@@ -829,7 +831,7 @@ impl Elaborator<'_> {
         // when the constraint below is later solved for when the function is
         // finished. How to link the two?
         let (typ, bindings) =
-            self.instantiate(t, bindings, generics, function_generic_count, location);
+            self.instantiate(t, bindings, generics, &direct_generic_ids, location);
 
         if let ImplKind::TraitItem(mut method) = ident.impl_kind {
             method.constraint.apply_bindings(&bindings);
@@ -949,11 +951,12 @@ impl Elaborator<'_> {
         typ: Type,
         bindings: TypeBindings,
         turbofish_generics: Option<Vec<Type>>,
-        function_generic_count: usize,
+        direct_generic_ids: &[TypeVariableId],
         location: Location,
     ) -> (Type, TypeBindings) {
         match turbofish_generics {
             Some(turbofish_generics) => {
+                let function_generic_count = direct_generic_ids.len();
                 let forall_generic_count =
                     if let Type::Forall(generics, _) = &typ { generics.len() } else { 0 };
 
@@ -966,28 +969,22 @@ impl Elaborator<'_> {
                     self.push_err(CompilationError::TypeError(type_check_err));
                     typ.instantiate_with_bindings(bindings, self.interner)
                 } else if forall_generic_count < function_generic_count {
-                    // In the next branch, calling instantiate_with_bindings_and_turbofish asserts that
-                    // turbofish_generics.len() + implicit_generic_count == forall_generic_count,
-                    // but if we have less generics in forall than the the turbo fish than this will never hold.
-                    // This is the case when the function generics have duplicates, which are filtered out.
-                    // This means some duplicate error has already been reported, so there is no point trying.
+                    // The next branch asserts that the number of turbofish-bound typevars matches
+                    // `direct_generic_ids`, but if the forall has fewer generics than the function
+                    // (e.g. when the function's generics have duplicates that were filtered out)
+                    // this can never hold. A duplicate error has already been reported elsewhere,
+                    // so bail out silently.
                     self.push_err(TypeCheckError::expecting_other_error(
                         "forall has fewer generics than function",
                         location,
                     ));
                     (Type::Error, bindings)
                 } else {
-                    // Fetch the count of any implicit generics on the function, such as
-                    // for a method within a generic impl.
-                    let implicit_generic_count = forall_generic_count
-                        .checked_sub(function_generic_count)
-                        .expect("forall should have at least as many generics as the function");
-
                     typ.instantiate_with_bindings_and_turbofish(
                         bindings,
                         turbofish_generics,
                         self.interner,
-                        implicit_generic_count,
+                        direct_generic_ids,
                     )
                 }
             }

--- a/compiler/noirc_frontend/src/hir_def/types.rs
+++ b/compiler/noirc_frontend/src/hir_def/types.rs
@@ -2578,29 +2578,40 @@ impl Type {
     /// is used and generic substitutions are provided manually by users.
     ///
     /// Expects the given type vector to be the same length as the Forall type variables.
+    /// `direct_generic_ids` lists the type variable ids of the function's user-declared
+    /// generics, in the same order the turbofish provides them. Any typevar in the `Forall`
+    /// quantifier whose id is not in that list is treated as an implicit generic (e.g. from
+    /// `impl Trait` desugaring or an enclosing generic impl) and receives a fresh type
+    /// variable of the matching kind.
     pub fn instantiate_with_bindings_and_turbofish(
         &self,
         bindings: TypeBindings,
         turbofish_types: Vec<Type>,
         interner: &NodeInterner,
-        implicit_generic_count: usize,
+        direct_generic_ids: &[TypeVariableId],
     ) -> (Type, TypeBindings) {
         match self {
             Type::Forall(typevars, typ) => {
+                let direct_count =
+                    typevars.iter().filter(|var| direct_generic_ids.contains(&var.id())).count();
                 assert_eq!(
-                    turbofish_types.len() + implicit_generic_count,
-                    typevars.len(),
+                    turbofish_types.len(),
+                    direct_count,
                     "Turbofish operator used with incorrect generic count which was not caught by name resolution"
                 );
 
-                let implicit_and_turbofish_bindings = (0..implicit_generic_count)
-                    .map(|_| interner.next_type_variable())
-                    .chain(turbofish_types);
-
+                let mut turbofish_iter = turbofish_types.into_iter();
                 let mut replacements: TypeBindings = typevars
                     .iter()
-                    .zip_eq(implicit_and_turbofish_bindings)
-                    .map(|(var, binding)| (var.id(), (var.clone(), var.kind(), binding)))
+                    .map(|var| {
+                        let kind = var.kind();
+                        let binding = if direct_generic_ids.contains(&var.id()) {
+                            turbofish_iter.next().expect("direct_count == turbofish_types.len()")
+                        } else {
+                            interner.next_type_variable_with_kind(kind.clone())
+                        };
+                        (var.id(), (var.clone(), kind, binding))
+                    })
                     .collect();
 
                 for (binding_key, binding_value) in bindings {

--- a/compiler/noirc_frontend/src/tests/turbofish.rs
+++ b/compiler/noirc_frontend/src/tests/turbofish.rs
@@ -1,4 +1,5 @@
-use crate::tests::{assert_no_errors, check_errors};
+use crate::elaborator::UnstableFeature;
+use crate::tests::{assert_no_errors, check_errors, get_program_using_features};
 
 #[test]
 fn turbofish_numeric_generic_nested_function_call() {
@@ -837,6 +838,105 @@ fn partially_concrete_impl_turbofish_mismatch_on_concrete_param() {
     }
     "#;
     check_errors(src);
+}
+
+#[test]
+fn regression_7648_impl_trait_numeric_generic_turbofish() {
+    let src = r#"
+    trait Foo<let N: u32> {}
+
+    impl<let N: u32> Foo<N> for [Field; N] {}
+
+    fn my_fn<let N: u32>(_input: impl Foo<N>) {}
+
+    fn main() {
+        my_fn::<0>([]);
+    }
+    "#;
+    let features = vec![UnstableFeature::TraitAsType];
+    let errors = get_program_using_features(src, &features).2;
+    assert!(errors.is_empty(), "Expected no errors but got: {errors:?}");
+}
+
+#[test]
+fn impl_trait_u64_numeric_generic_turbofish() {
+    let src = r#"
+    trait Foo<let N: u64> {}
+
+    struct Wrapper {}
+
+    global ONE: u64 = 1;
+
+    impl Foo<ONE> for Wrapper {}
+
+    fn my_fn<let N: u64>(_input: impl Foo<N>) {}
+
+    fn main() {
+        my_fn::<ONE>(Wrapper {});
+    }
+    "#;
+    let features = vec![UnstableFeature::TraitAsType];
+    let errors = get_program_using_features(src, &features).2;
+    assert!(errors.is_empty(), "Expected no errors but got: {errors:?}");
+}
+
+#[test]
+fn impl_trait_mixed_generics_with_turbofish() {
+    let src = r#"
+    trait Foo<let N: u32> {}
+
+    impl<let N: u32> Foo<N> for [Field; N] {}
+
+    fn my_fn<T, let N: u32>(_value: T, _input: impl Foo<N>) {}
+
+    fn main() {
+        my_fn::<Field, 0>(1, []);
+    }
+    "#;
+    let features = vec![UnstableFeature::TraitAsType];
+    let errors = get_program_using_features(src, &features).2;
+    assert!(errors.is_empty(), "Expected no errors but got: {errors:?}");
+}
+
+#[test]
+fn impl_trait_method_in_generic_impl_with_turbofish() {
+    let src = r#"
+    trait Foo<let N: u32> {}
+
+    impl<let N: u32> Foo<N> for [Field; N] {}
+
+    struct Container<T> {}
+
+    impl<T> Container<T> {
+        fn my_fn<let N: u32>(_self: Self, _input: impl Foo<N>) {}
+    }
+
+    fn main() {
+        let c: Container<Field> = Container {};
+        c.my_fn::<0>([]);
+    }
+    "#;
+    let features = vec![UnstableFeature::TraitAsType];
+    let errors = get_program_using_features(src, &features).2;
+    assert!(errors.is_empty(), "Expected no errors but got: {errors:?}");
+}
+
+#[test]
+fn impl_trait_without_turbofish_still_infers() {
+    let src = r#"
+    trait Foo<let N: u32> {}
+
+    impl<let N: u32> Foo<N> for [Field; N] {}
+
+    fn my_fn<let N: u32>(_input: impl Foo<N>) {}
+
+    fn main() {
+        my_fn([]);
+    }
+    "#;
+    let features = vec![UnstableFeature::TraitAsType];
+    let errors = get_program_using_features(src, &features).2;
+    assert!(errors.is_empty(), "Expected no errors but got: {errors:?}");
 }
 
 #[test]

--- a/test_programs/compile_success_empty/regression_7648/Nargo.toml
+++ b/test_programs/compile_success_empty/regression_7648/Nargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "regression_7648"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.33.0"
+compiler_unstable_features = ["trait_as_type"]
+
+[dependencies]

--- a/test_programs/compile_success_empty/regression_7648/src/main.nr
+++ b/test_programs/compile_success_empty/regression_7648/src/main.nr
@@ -1,0 +1,10 @@
+// https://github.com/noir-lang/noir/issues/7648
+trait Foo<let N: u32> {}
+
+impl<let N: u32> Foo<N> for [Field; N] {}
+
+fn my_fn<let N: u32>(_input: impl Foo<N>) {}
+
+fn main() {
+    my_fn::<0>([]);
+}

--- a/tooling/nargo_cli/build.rs
+++ b/tooling/nargo_cli/build.rs
@@ -236,7 +236,7 @@ const TESTS_WITHOUT_STDOUT_CHECK: [&str; 0] = [];
 /// These tests are ignored because of existing bugs in `nargo expand`.
 /// As the bugs are fixed these tests should be removed from this list.
 /// (some are ignored on purpose for the same reason as `IGNORED_NARGO_EXPAND_EXECUTION_TESTS`)
-const IGNORED_NARGO_EXPAND_COMPILE_SUCCESS_EMPTY_TESTS: [&str; 7] = [
+const IGNORED_NARGO_EXPAND_COMPILE_SUCCESS_EMPTY_TESTS: [&str; 8] = [
     // There's no "src/main.nr" here so it's trickier to make this work
     "overlapping_dep_and_mod",
     // this one works, but copying its `Nargo.toml` file to somewhere else doesn't work
@@ -252,6 +252,8 @@ const IGNORED_NARGO_EXPAND_COMPILE_SUCCESS_EMPTY_TESTS: [&str; 7] = [
     "workspace_reexport_bug",
     // bug
     "trait_call_in_global",
+    // `nargo expand` drops the trait generic arguments on `impl Trait<...>` parameters
+    "regression_7648",
 ];
 
 /// These tests are ignored because of existing bugs in `nargo expand`.

--- a/tooling/nargo_cli/tests/snapshots/compile_success_empty/regression_7648/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_empty/regression_7648/execute__tests__expanded.snap
@@ -1,0 +1,16 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: expanded_code
+---
+trait Foo<let N: u32> {}
+
+impl<let N: u32> Foo<N> for [Field; N] {}
+
+fn my_fn<let N: u32>(_input: impl Foo)
+where
+    impl Foo: Foo<N>,
+{}
+
+fn main() {
+    my_fn::<0>([]);
+}


### PR DESCRIPTION
# Description

## Problem

Resolves #7648 

## Summary

User-supplied generics were before the impl generics which was unexpected, changed this function to take an explicit list of generics instead.

## Additional Context



## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
