### PR TITLE
chore(frontend): unify trait super-bounds with where clause

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/mod.rs
+++ b/compiler/noirc_frontend/src/elaborator/mod.rs
@@ -796,7 +796,6 @@ impl<'context> Elaborator<'context> {
 
         self.add_trait_impl_assumed_trait_implementations(trait_impl.impl_id);
         self.check_trait_impl_where_clause_matches_trait_where_clause(&trait_impl);
-        self.check_parent_traits_are_implemented(&trait_impl);
         self.remove_trait_impl_assumed_trait_implementations(trait_impl.impl_id);
 
         for (module, function, noir_function) in &trait_impl.methods.functions {

--- a/compiler/noirc_frontend/src/elaborator/trait_impls.rs
+++ b/compiler/noirc_frontend/src/elaborator/trait_impls.rs
@@ -584,6 +584,9 @@ impl Elaborator<'_> {
         }
     }
 
+    /// Verifies that the impl satisfies every obligation the trait's where clause
+    /// places on it, including the super-trait bounds that are stored in the trait's
+    /// where clause as constraints on `Self`.
     #[tracing::instrument(level = "trace", skip_all)]
     pub(super) fn check_trait_impl_where_clause_matches_trait_where_clause(
         &mut self,
@@ -613,10 +616,24 @@ impl Elaborator<'_> {
             return;
         };
 
+        let Some(object_type) = &trait_impl.resolved_object_type else {
+            self.push_err(TypeCheckError::expecting_other_error(
+                "check_trait_impl_where_clause_matches_trait_where_clause: missing object type",
+                trait_impl.object_type.location,
+            ));
+            return;
+        };
+
         let impl_trait = the_trait.name.to_string();
         let ordered_generics = self.interner.get_ordered_generics_for_impl(impl_id);
 
+        // Bind Self to the object type of the impl so that parent-trait bounds
+        // (which are stored in the trait's where clause as constraints on Self)
+        // get checked against the concrete impl type.
+        let self_var = the_trait.self_type_typevar.clone();
+        let self_kind = self_var.kind();
         let mut bindings = TypeBindings::default();
+        bindings.insert(self_var.id(), (self_var, self_kind, object_type.clone()));
         bind_ordered_generics(&the_trait.generics, ordered_generics, &mut bindings);
 
         self.check_trait_bounds_are_satisfied(
@@ -721,67 +738,6 @@ impl Elaborator<'_> {
                 _ => (),
             }
         }
-    }
-
-    #[tracing::instrument(level = "trace", skip_all)]
-    pub(super) fn check_parent_traits_are_implemented(&mut self, trait_impl: &UnresolvedTraitImpl) {
-        let Some(trait_id) = trait_impl.trait_id else {
-            self.push_err(TypeCheckError::expecting_other_error(
-                "check_parent_traits_are_implemented: missing trait ID",
-                trait_impl.object_type.location,
-            ));
-            return;
-        };
-
-        let Some(object_type) = &trait_impl.resolved_object_type else {
-            self.push_err(TypeCheckError::expecting_other_error(
-                "check_parent_traits_are_implemented: missing object type",
-                trait_impl.object_type.location,
-            ));
-            return;
-        };
-
-        let Some(the_trait) = self.interner.try_get_trait(trait_id) else {
-            self.push_err(TypeCheckError::expecting_other_error(
-                "check_parent_traits_are_implemented: missing trait",
-                trait_impl.object_type.location,
-            ));
-            return;
-        };
-
-        let Some(impl_id) = trait_impl.impl_id else {
-            self.push_err(TypeCheckError::expecting_other_error(
-                "check_parent_traits_are_implemented: missing impl ID",
-                trait_impl.object_type.location,
-            ));
-            return;
-        };
-
-        let impl_trait = the_trait.name.to_string();
-        let ordered_generics = self.interner.get_ordered_generics_for_impl(impl_id);
-
-        let mut bindings = TypeBindings::default();
-        bind_ordered_generics(&the_trait.generics, ordered_generics, &mut bindings);
-
-        // Note: we only check if the immediate parents are implemented, we don't check recursively.
-        // Why? If a parent isn't implemented, we get an error. If a parent is implemented, we'll
-        // do the same check for the parent, so this trait's parents parents will be checked, so the
-        // recursion is guaranteed.
-        //
-        // Convert parent trait bounds (ResolvedTraitBound) to TraitConstraints using
-        // {Self, ResolvedTraitBound} where Self is the object type being implemented for.
-        let constraints: Vec<TraitConstraint> = the_trait
-            .trait_bounds
-            .iter()
-            .map(|bound| TraitConstraint { typ: object_type.clone(), trait_bound: bound.clone() })
-            .collect();
-
-        self.check_trait_bounds_are_satisfied(
-            constraints,
-            &impl_trait,
-            &trait_impl.object_type.location,
-            &mut bindings,
-        );
     }
 
     /// Prepares a trait impl for function metadata definition.

--- a/compiler/noirc_frontend/src/elaborator/traits.rs
+++ b/compiler/noirc_frontend/src/elaborator/traits.rs
@@ -295,14 +295,11 @@ impl Elaborator<'_> {
             // Lower super-trait bounds (`trait Foo: Bar`) into where-clause constraints
             // keyed on `Self`, so that parent bounds and explicit where-clause entries
             // share a single representation on `Trait`.
-            let self_type = self
-                .self_type
-                .clone()
-                .expect("Expected Self type to be set inside collect_traits");
+            let self_type =
+                self.self_type.clone().expect("Expected Self type to be set inside collect_traits");
             let mut where_clause = where_clause;
             for trait_bound in resolved_trait_bounds {
-                where_clause
-                    .push(TraitConstraint { typ: self_type.clone(), trait_bound });
+                where_clause.push(TraitConstraint { typ: self_type.clone(), trait_bound });
             }
 
             self.interner.update_trait(*trait_id, |trait_def| {

--- a/compiler/noirc_frontend/src/elaborator/traits.rs
+++ b/compiler/noirc_frontend/src/elaborator/traits.rs
@@ -292,10 +292,20 @@ impl Elaborator<'_> {
                 self.interner.add_trait_dependency(DependencyId::Trait(bound.trait_id), *trait_id);
             }
 
-            // TODO (https://github.com/noir-lang/noir/issues/10642):
-            // combine `where_clause` and `resolved_trait_bounds`
+            // Lower super-trait bounds (`trait Foo: Bar`) into where-clause constraints
+            // keyed on `Self`, so that parent bounds and explicit where-clause entries
+            // share a single representation on `Trait`.
+            let self_type = self
+                .self_type
+                .clone()
+                .expect("Expected Self type to be set inside collect_traits");
+            let mut where_clause = where_clause;
+            for trait_bound in resolved_trait_bounds {
+                where_clause
+                    .push(TraitConstraint { typ: self_type.clone(), trait_bound });
+            }
+
             self.interner.update_trait(*trait_id, |trait_def| {
-                trait_def.set_trait_bounds(resolved_trait_bounds);
                 trait_def.set_where_clause(where_clause);
                 trait_def.set_visibility(unresolved_trait.trait_def.visibility);
                 trait_def.set_associated_type_bounds(associated_type_bounds);
@@ -600,7 +610,7 @@ impl Elaborator<'_> {
     /// associated types. This creates fresh type variables for the parent associated types
     /// so that `M::Key` syntax can be resolved via `self.trait_bounds`.
     ///
-    /// The parent trait bounds are obtained from `Trait.trait_bounds` (already resolved
+    /// The parent trait bounds are obtained from `Trait::parent_bounds` (already resolved
     /// during `collect_traits` with associated type variables) and instantiated via
     /// `instantiate_parent_trait_bound` to substitute the child trait's bindings. The
     /// named (associated) types are then replaced with fresh per-function type variables
@@ -651,7 +661,7 @@ impl Elaborator<'_> {
         let parent_bounds: Vec<_> = self
             .interner
             .try_get_trait(trait_id)
-            .map(|t| t.trait_bounds.clone())
+            .map(|t| t.parent_bounds().cloned().collect())
             .unwrap_or_default();
 
         for parent_bound in &parent_bounds {
@@ -793,8 +803,10 @@ impl Elaborator<'_> {
         }
 
         // Also add assumed implementations for the parent traits, if any
-        if let Some(trait_bounds) =
-            self.interner.try_get_trait(trait_id).map(|the_trait| the_trait.trait_bounds.clone())
+        if let Some(trait_bounds) = self
+            .interner
+            .try_get_trait(trait_id)
+            .map(|the_trait| the_trait.parent_bounds().cloned().collect::<Vec<_>>())
         {
             for parent_trait_bound in trait_bounds {
                 // Avoid looping forever in case there are cycles

--- a/compiler/noirc_frontend/src/elaborator/types.rs
+++ b/compiler/noirc_frontend/src/elaborator/types.rs
@@ -395,7 +395,7 @@ impl Elaborator<'_> {
         }
 
         let parent_trait_ids: Vec<_> =
-            the_trait.trait_bounds.iter().map(|bound| bound.trait_id).collect();
+            the_trait.parent_bounds().map(|bound| bound.trait_id).collect();
         for parent_id in parent_trait_ids {
             self.collect_associated_type_in_parent_traits(parent_id, name, found, visited);
         }
@@ -413,7 +413,7 @@ impl Elaborator<'_> {
         }
 
         let the_trait = self.interner.get_trait(trait_id);
-        let parent_bounds = the_trait.trait_bounds.clone();
+        let parent_bounds: Vec<_> = the_trait.parent_bounds().cloned().collect();
         let self_type = self.self_type.as_ref()?;
 
         for parent_bound in &parent_bounds {
@@ -1457,7 +1457,8 @@ impl Elaborator<'_> {
             matches.push((method, the_trait.id));
         }
 
-        for trait_bound in &the_trait.trait_bounds {
+        let parent_bounds: Vec<_> = the_trait.parent_bounds().cloned().collect();
+        for trait_bound in &parent_bounds {
             let parent_trait = self.interner.get_trait(trait_bound.trait_id);
             let constraint =
                 TraitConstraint { typ: constraint.typ.clone(), trait_bound: trait_bound.clone() };
@@ -2857,9 +2858,8 @@ impl Elaborator<'_> {
         }
 
         // Search in the parent traits, if any.
-        // Note that `trait_bounds` represent `Foo: Bar + Baz`,
-        // but `Foo where Self: Bar + Baz` appears in `trait_constraints` instead.
-        for parent_trait_bound in &the_trait.trait_bounds {
+        let parent_bounds: Vec<_> = the_trait.parent_bounds().cloned().collect();
+        for parent_trait_bound in &parent_bounds {
             if let Some(the_trait) = self.interner.try_get_trait(parent_trait_bound.trait_id) {
                 let parent_trait_bound =
                     self.instantiate_parent_trait_bound(trait_bound, parent_trait_bound);

--- a/compiler/noirc_frontend/src/hir/printer/mod.rs
+++ b/compiler/noirc_frontend/src/hir/printer/mod.rs
@@ -388,12 +388,21 @@ impl<'context, 'string> ItemPrinter<'context, 'string> {
         self.push_str(&trait_.name.to_string());
         self.show_generics(&trait_.generics);
 
-        if !trait_.trait_bounds.is_empty() {
+        let parent_bounds: Vec<_> = trait_.parent_bounds().cloned().collect();
+        if !parent_bounds.is_empty() {
             self.push_str(": ");
-            self.show_trait_bounds(&trait_.trait_bounds);
+            self.show_trait_bounds(&parent_bounds);
         }
 
-        self.show_where_clause(&trait_.where_clause);
+        // Filter out the parent bounds we already printed with colon syntax.
+        let self_id = trait_.self_type_typevar.id();
+        let where_only: Vec<_> = trait_
+            .where_clause
+            .iter()
+            .filter(|c| !matches!(&c.typ, Type::TypeVariable(v) if v.id() == self_id))
+            .cloned()
+            .collect();
+        self.show_where_clause(&where_only);
         self.push_str(" {\n");
         self.increase_indent();
 

--- a/compiler/noirc_frontend/src/hir_def/traits.rs
+++ b/compiler/noirc_frontend/src/hir_def/traits.rs
@@ -81,9 +81,10 @@ pub struct Trait {
     /// the correct Self type is for that particular impl block.
     pub self_type_typevar: TypeVariable,
 
-    /// The resolved trait bounds (for example in `trait Foo: Bar + Baz`, this would be `Bar + Baz`)
-    pub trait_bounds: Vec<ResolvedTraitBound>,
-
+    /// The trait's where clause. Super-trait bounds (`trait Foo: Bar`) are lowered into
+    /// this list as `TraitConstraint { typ: Self, trait_bound: Bar }` so that parent
+    /// bounds and where-clause constraints share a single representation. Use
+    /// [`Trait::parent_bounds`] to extract just the parent-trait bounds.
     pub where_clause: Vec<TraitConstraint>,
 
     pub all_generics: ResolvedGenerics,
@@ -216,12 +217,20 @@ impl Trait {
         self.methods = methods;
     }
 
-    pub fn set_trait_bounds(&mut self, trait_bounds: Vec<ResolvedTraitBound>) {
-        self.trait_bounds = trait_bounds;
-    }
-
     pub fn set_where_clause(&mut self, where_clause: Vec<TraitConstraint>) {
         self.where_clause = where_clause;
+    }
+
+    /// The parent-trait bounds of this trait (the `Bar` in `trait Foo: Bar`).
+    ///
+    /// Parent bounds are stored in `where_clause` as constraints whose `typ` is this
+    /// trait's `Self` type variable; this accessor filters them back out.
+    pub fn parent_bounds(&self) -> impl Iterator<Item = &ResolvedTraitBound> {
+        let self_id = self.self_type_typevar.id();
+        self.where_clause.iter().filter_map(move |c| match &c.typ {
+            Type::TypeVariable(v) if v.id() == self_id => Some(&c.trait_bound),
+            _ => None,
+        })
     }
 
     pub fn set_visibility(&mut self, visibility: ItemVisibility) {

--- a/compiler/noirc_frontend/src/node_interner/mod.rs
+++ b/compiler/noirc_frontend/src/node_interner/mod.rs
@@ -597,7 +597,6 @@ impl NodeInterner {
             method_ids: unresolved_trait.method_ids.clone(),
             associated_types,
             associated_type_bounds: HashMap::default(),
-            trait_bounds: Vec::new(),
             where_clause: Vec::new(),
             all_generics: Vec::new(),
             associated_constant_ids,
@@ -1279,7 +1278,6 @@ impl NodeInterner {
             location: Location::dummy(),
             visibility: ItemVisibility::Public,
             self_type_typevar: TypeVariable::unbound(self_type_typevar, Kind::Normal),
-            trait_bounds: vec![],
             where_clause: vec![],
             all_generics: vec![],
             associated_constant_ids: Default::default(),
@@ -1606,7 +1604,8 @@ impl NodeInterner {
 
         // Now collect bindings from the associated types of every parent trait that
         // is implemented for the object type.
-        for parent_bound in &the_trait.trait_bounds {
+        let parent_bounds: Vec<_> = the_trait.parent_bounds().cloned().collect();
+        for parent_bound in &parent_bounds {
             // Find the implementation, if it exists.
             let trait_id = parent_bound.trait_id;
             match self.lookup_trait_implementation(

--- a/compiler/noirc_frontend/src/node_interner/trait_impl.rs
+++ b/compiler/noirc_frontend/src/node_interner/trait_impl.rs
@@ -617,15 +617,15 @@ impl NodeInterner {
         entries.retain(|(_, kind)| !matches!(kind, TraitImplKind::Assumed { .. }));
 
         // Also remove assumed implementations for the parent traits, if any
-        if let Some(trait_bounds) =
-            self.try_get_trait(trait_id).map(|the_trait| the_trait.trait_bounds.clone())
-        {
-            for parent_trait_bound in trait_bounds {
-                self.remove_assumed_trait_implementations_for_trait_and_parents(
-                    parent_trait_bound.trait_id,
-                    visited_trait_ids,
-                );
-            }
+        let parent_trait_ids: Vec<TraitId> = self
+            .try_get_trait(trait_id)
+            .map(|the_trait| the_trait.parent_bounds().map(|b| b.trait_id).collect())
+            .unwrap_or_default();
+        for parent_trait_id in parent_trait_ids {
+            self.remove_assumed_trait_implementations_for_trait_and_parents(
+                parent_trait_id,
+                visited_trait_ids,
+            );
         }
     }
 }

--- a/compiler/noirc_frontend/src/tests/traits/trait_qualified_paths.rs
+++ b/compiler/noirc_frontend/src/tests/traits/trait_qualified_paths.rs
@@ -196,8 +196,8 @@ fn uses_self_type_in_trait_where_clause() {
     struct Bar {}
 
     impl Foo for Bar {
-                 ^^^ The trait bound `_: Trait` is not satisfied
-                 ~~~ The trait `Trait` is not implemented for `_`
+                 ^^^ The trait bound `Bar: Trait` is not satisfied
+                 ~~~ The trait `Trait` is not implemented for `Bar`
 
     }
 

--- a/tooling/nargo_cli/tests/snapshots/compile_success_empty/trait_default_method_uses_op/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_empty/trait_default_method_uses_op/execute__tests__expanded.snap
@@ -3,10 +3,7 @@ source: tooling/nargo_cli/tests/execute.rs
 expression: expanded_code
 ---
 pub trait Foo: Eq {
-    fn foo<T>(self) -> bool
-    where
-        Self: Eq,
-    {
+    fn foo<T>(self) -> bool {
         self == self
     }
 }

--- a/tooling/nargo_cli/tests/snapshots/compile_success_empty/trait_inheritance/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_empty/trait_inheritance/execute__tests__expanded.snap
@@ -7,16 +7,11 @@ trait Foo {
 }
 
 trait Bar: Foo {
-    fn bar(self) -> Field
-    where
-        Self: Foo,
-    {
+    fn bar(self) -> Field {
         self.foo() + 1_Field
     }
 
-    fn baz(self) -> Field
-    where
-        Self: Foo;
+    fn baz(self) -> Field;
 }
 
 struct Struct {

--- a/tooling/nargo_cli/tests/snapshots/compile_success_empty/trait_inheritence_call_method_on_self/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_empty/trait_inheritence_call_method_on_self/execute__tests__expanded.snap
@@ -3,14 +3,9 @@ source: tooling/nargo_cli/tests/execute.rs
 expression: expanded_code
 ---
 pub trait Empty: Eq {
-    fn empty() -> Self
-    where
-        Self: Eq;
+    fn empty() -> Self;
 
-    fn is_empty(self) -> bool
-    where
-        Self: Eq,
-    {
+    fn is_empty(self) -> bool {
         self.eq(Empty::empty())
     }
 }

--- a/tooling/nargo_doc/src/lib.rs
+++ b/tooling/nargo_doc/src/lib.rs
@@ -254,7 +254,8 @@ impl DocItemBuilder<'_> {
                 let trait_impls = vecmap(item_trait.trait_impls, |trait_impl| {
                     self.convert_trait_impl(trait_impl)
                 });
-                let parents = vecmap(&trait_.trait_bounds, |bound| self.convert_trait_bound(bound));
+                let parent_bounds: Vec<_> = trait_.parent_bounds().cloned().collect();
+                let parents = vecmap(&parent_bounds, |bound| self.convert_trait_bound(bound));
 
                 let mut associated_types = Vec::new();
                 let mut associated_constants = Vec::new();


### PR DESCRIPTION
## Problem Resolved

Resolves #10310 
Resolves #11492 

## Summary of Changes

Super-trait bounds (the `Bar` in `trait Foo: Bar`) and trait-level where-clause constraints represent the same thing: obligations the impl must satisfy. Previously they were stored in two separate fields on `Trait` (`trait_bounds` and `where_clause`), forcing every traversal and check to read both. Unify storage by lowering parent bounds into `where_clause` as `TraitConstraint { typ: Self, trait_bound }` entries, and expose a `Trait::parent_bounds` accessor that filters them back out.

With the unified representation:

- `check_trait_impl_where_clause_matches_trait_where_clause` now binds Self to the impl's object type, so it checks both the explicit where clause and the parent bounds in one pass. `check_parent_traits_are_implemented` is redundant and deleted, along with its 30-line bailout preamble.
- The printer's per-method where-clause deduplication now correctly removes the synthesised `where Self: Parent` bounds from each method's output, fixing the duplicate noted by the existing XXX comment in `resolve_trait_methods`.

Where Self was previously unbound and rendered as `_` in `The trait bound _: Trait is not satisfied`, it now substitutes the impl's object type (`Bar: Trait`).

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
