### PR TITLE
chore: Update `noir_stdlib` version to match that of `nargo`

### DIFF
--- a/noir_stdlib/Nargo.toml
+++ b/noir_stdlib/Nargo.toml
@@ -2,5 +2,5 @@
 name = "std"
 type = "lib"
 authors = [""]
-version = "1.0.0-beta.14"
+version = "1.0.0-beta.15"
 [dependencies]

--- a/noir_stdlib/Nargo.toml
+++ b/noir_stdlib/Nargo.toml
@@ -2,5 +2,7 @@
 name = "std"
 type = "lib"
 authors = [""]
-version = "1.0.0-beta.15"
+# x-release-please-start-version
+version = "1.0.0-beta.20"
+# x-release-please-end
 [dependencies]

--- a/noir_stdlib/docs/std/aes128/fn.aes128_encrypt.html
+++ b/noir_stdlib/docs/std/aes128/fn.aes128_encrypt.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2>In module aes128</h2>
 <h3>Functions</h3><ul class="item-list">
 <li><a href="fn.aes128_encrypt.html">aes128_encrypt</a></div></li>

--- a/noir_stdlib/docs/std/aes128/fn.aes128_encrypt.html
+++ b/noir_stdlib/docs/std/aes128/fn.aes128_encrypt.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2>In module aes128</h2>
 <h3>Functions</h3><ul class="item-list">
 <li><a href="fn.aes128_encrypt.html">aes128_encrypt</a></div></li>

--- a/noir_stdlib/docs/std/aes128/index.html
+++ b/noir_stdlib/docs/std/aes128/index.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2><a href="#mod">Module aes128</a></h2>
 <h3>Module items</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/aes128/index.html
+++ b/noir_stdlib/docs/std/aes128/index.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2><a href="#mod">Module aes128</a></h2>
 <h3>Module items</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/append/index.html
+++ b/noir_stdlib/docs/std/append/index.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2><a href="#mod">Module append</a></h2>
 <h3>Module items</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/append/index.html
+++ b/noir_stdlib/docs/std/append/index.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2><a href="#mod">Module append</a></h2>
 <h3>Module items</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/append/trait.Append.html
+++ b/noir_stdlib/docs/std/append/trait.Append.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2><a href="#trait">Trait Append</a></h2>
 <h3>Required methods</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/append/trait.Append.html
+++ b/noir_stdlib/docs/std/append/trait.Append.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2><a href="#trait">Trait Append</a></h2>
 <h3>Required methods</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/array/index.html
+++ b/noir_stdlib/docs/std/array/index.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2><a href="#mod">Module array</a></h2>
 <h2>In crate array</h2>
 <h3>Modules</h3><ul class="item-list">

--- a/noir_stdlib/docs/std/array/index.html
+++ b/noir_stdlib/docs/std/array/index.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2><a href="#mod">Module array</a></h2>
 <h2>In crate array</h2>
 <h3>Modules</h3><ul class="item-list">

--- a/noir_stdlib/docs/std/cmp/fn.max.html
+++ b/noir_stdlib/docs/std/cmp/fn.max.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2>In module cmp</h2>
 <h3>Structs</h3><ul class="item-list">
 <li><a href="struct.Ordering.html">Ordering</a></div></li>

--- a/noir_stdlib/docs/std/cmp/fn.max.html
+++ b/noir_stdlib/docs/std/cmp/fn.max.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2>In module cmp</h2>
 <h3>Structs</h3><ul class="item-list">
 <li><a href="struct.Ordering.html">Ordering</a></div></li>

--- a/noir_stdlib/docs/std/cmp/fn.min.html
+++ b/noir_stdlib/docs/std/cmp/fn.min.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2>In module cmp</h2>
 <h3>Structs</h3><ul class="item-list">
 <li><a href="struct.Ordering.html">Ordering</a></div></li>

--- a/noir_stdlib/docs/std/cmp/fn.min.html
+++ b/noir_stdlib/docs/std/cmp/fn.min.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2>In module cmp</h2>
 <h3>Structs</h3><ul class="item-list">
 <li><a href="struct.Ordering.html">Ordering</a></div></li>

--- a/noir_stdlib/docs/std/cmp/index.html
+++ b/noir_stdlib/docs/std/cmp/index.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2><a href="#mod">Module cmp</a></h2>
 <h3>Module items</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/cmp/index.html
+++ b/noir_stdlib/docs/std/cmp/index.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2><a href="#mod">Module cmp</a></h2>
 <h3>Module items</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/cmp/struct.Ordering.html
+++ b/noir_stdlib/docs/std/cmp/struct.Ordering.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2><a href="#struct">Struct Ordering</a></h2>
 <h3>Methods</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/cmp/struct.Ordering.html
+++ b/noir_stdlib/docs/std/cmp/struct.Ordering.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2><a href="#struct">Struct Ordering</a></h2>
 <h3>Methods</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/cmp/trait.Eq.html
+++ b/noir_stdlib/docs/std/cmp/trait.Eq.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2><a href="#trait">Trait Eq</a></h2>
 <h3>Required methods</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/cmp/trait.Eq.html
+++ b/noir_stdlib/docs/std/cmp/trait.Eq.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2><a href="#trait">Trait Eq</a></h2>
 <h3>Required methods</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/cmp/trait.Ord.html
+++ b/noir_stdlib/docs/std/cmp/trait.Ord.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2><a href="#trait">Trait Ord</a></h2>
 <h3>Required methods</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/cmp/trait.Ord.html
+++ b/noir_stdlib/docs/std/cmp/trait.Ord.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2><a href="#trait">Trait Ord</a></h2>
 <h3>Required methods</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/collections/bounded_vec/index.html
+++ b/noir_stdlib/docs/std/collections/bounded_vec/index.html
@@ -16,7 +16,7 @@
 <h1><a href="../../../index.html">noir_stdlib</a></h1>
 <div><a href="../../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2><a href="#mod">Module bounded_vec</a></h2>
 <h3>Module items</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/collections/bounded_vec/index.html
+++ b/noir_stdlib/docs/std/collections/bounded_vec/index.html
@@ -16,7 +16,7 @@
 <h1><a href="../../../index.html">noir_stdlib</a></h1>
 <div><a href="../../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2><a href="#mod">Module bounded_vec</a></h2>
 <h3>Module items</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/collections/bounded_vec/struct.BoundedVec.html
+++ b/noir_stdlib/docs/std/collections/bounded_vec/struct.BoundedVec.html
@@ -16,7 +16,7 @@
 <h1><a href="../../../index.html">noir_stdlib</a></h1>
 <div><a href="../../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2><a href="#struct">Struct BoundedVec</a></h2>
 <h3>Methods</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/collections/bounded_vec/struct.BoundedVec.html
+++ b/noir_stdlib/docs/std/collections/bounded_vec/struct.BoundedVec.html
@@ -16,7 +16,7 @@
 <h1><a href="../../../index.html">noir_stdlib</a></h1>
 <div><a href="../../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2><a href="#struct">Struct BoundedVec</a></h2>
 <h3>Methods</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/collections/index.html
+++ b/noir_stdlib/docs/std/collections/index.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2><a href="#mod">Module collections</a></h2>
 <h3>Module items</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/collections/index.html
+++ b/noir_stdlib/docs/std/collections/index.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2><a href="#mod">Module collections</a></h2>
 <h3>Module items</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/collections/umap/index.html
+++ b/noir_stdlib/docs/std/collections/umap/index.html
@@ -16,7 +16,7 @@
 <h1><a href="../../../index.html">noir_stdlib</a></h1>
 <div><a href="../../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2><a href="#mod">Module umap</a></h2>
 <h3>Module items</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/collections/umap/index.html
+++ b/noir_stdlib/docs/std/collections/umap/index.html
@@ -16,7 +16,7 @@
 <h1><a href="../../../index.html">noir_stdlib</a></h1>
 <div><a href="../../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2><a href="#mod">Module umap</a></h2>
 <h3>Module items</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/collections/umap/struct.UHashMap.html
+++ b/noir_stdlib/docs/std/collections/umap/struct.UHashMap.html
@@ -16,7 +16,7 @@
 <h1><a href="../../../index.html">noir_stdlib</a></h1>
 <div><a href="../../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2><a href="#struct">Struct UHashMap</a></h2>
 <h3>Methods</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/collections/umap/struct.UHashMap.html
+++ b/noir_stdlib/docs/std/collections/umap/struct.UHashMap.html
@@ -16,7 +16,7 @@
 <h1><a href="../../../index.html">noir_stdlib</a></h1>
 <div><a href="../../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2><a href="#struct">Struct UHashMap</a></h2>
 <h3>Methods</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/compat/fn.is_bn254.html
+++ b/noir_stdlib/docs/std/compat/fn.is_bn254.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2>In module compat</h2>
 <h3>Functions</h3><ul class="item-list">
 <li><a href="fn.is_bn254.html">is_bn254</a></div></li>

--- a/noir_stdlib/docs/std/compat/fn.is_bn254.html
+++ b/noir_stdlib/docs/std/compat/fn.is_bn254.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2>In module compat</h2>
 <h3>Functions</h3><ul class="item-list">
 <li><a href="fn.is_bn254.html">is_bn254</a></div></li>

--- a/noir_stdlib/docs/std/compat/index.html
+++ b/noir_stdlib/docs/std/compat/index.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2><a href="#mod">Module compat</a></h2>
 <h3>Module items</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/compat/index.html
+++ b/noir_stdlib/docs/std/compat/index.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2><a href="#mod">Module compat</a></h2>
 <h3>Module items</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/convert/index.html
+++ b/noir_stdlib/docs/std/convert/index.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2><a href="#mod">Module convert</a></h2>
 <h3>Module items</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/convert/index.html
+++ b/noir_stdlib/docs/std/convert/index.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2><a href="#mod">Module convert</a></h2>
 <h3>Module items</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/convert/trait.AsPrimitive.html
+++ b/noir_stdlib/docs/std/convert/trait.AsPrimitive.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2><a href="#trait">Trait AsPrimitive</a></h2>
 <h3>Required methods</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/convert/trait.AsPrimitive.html
+++ b/noir_stdlib/docs/std/convert/trait.AsPrimitive.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2><a href="#trait">Trait AsPrimitive</a></h2>
 <h3>Required methods</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/convert/trait.From.html
+++ b/noir_stdlib/docs/std/convert/trait.From.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2><a href="#trait">Trait From</a></h2>
 <h3>Required methods</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/convert/trait.From.html
+++ b/noir_stdlib/docs/std/convert/trait.From.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2><a href="#trait">Trait From</a></h2>
 <h3>Required methods</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/convert/trait.Into.html
+++ b/noir_stdlib/docs/std/convert/trait.Into.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2><a href="#trait">Trait Into</a></h2>
 <h3>Required methods</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/convert/trait.Into.html
+++ b/noir_stdlib/docs/std/convert/trait.Into.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2><a href="#trait">Trait Into</a></h2>
 <h3>Required methods</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/default/index.html
+++ b/noir_stdlib/docs/std/default/index.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2><a href="#mod">Module default</a></h2>
 <h3>Module items</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/default/index.html
+++ b/noir_stdlib/docs/std/default/index.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2><a href="#mod">Module default</a></h2>
 <h3>Module items</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/default/trait.Default.html
+++ b/noir_stdlib/docs/std/default/trait.Default.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2><a href="#trait">Trait Default</a></h2>
 <h3>Required methods</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/default/trait.Default.html
+++ b/noir_stdlib/docs/std/default/trait.Default.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2><a href="#trait">Trait Default</a></h2>
 <h3>Required methods</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/ecdsa_secp256k1/fn.verify_signature.html
+++ b/noir_stdlib/docs/std/ecdsa_secp256k1/fn.verify_signature.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2>In module ecdsa_secp256k1</h2>
 <h3>Functions</h3><ul class="item-list">
 <li><a href="fn.verify_signature.html">verify_signature</a></div></li>

--- a/noir_stdlib/docs/std/ecdsa_secp256k1/fn.verify_signature.html
+++ b/noir_stdlib/docs/std/ecdsa_secp256k1/fn.verify_signature.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2>In module ecdsa_secp256k1</h2>
 <h3>Functions</h3><ul class="item-list">
 <li><a href="fn.verify_signature.html">verify_signature</a></div></li>

--- a/noir_stdlib/docs/std/ecdsa_secp256k1/index.html
+++ b/noir_stdlib/docs/std/ecdsa_secp256k1/index.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2><a href="#mod">Module ecdsa_secp256k1</a></h2>
 <h3>Module items</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/ecdsa_secp256k1/index.html
+++ b/noir_stdlib/docs/std/ecdsa_secp256k1/index.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2><a href="#mod">Module ecdsa_secp256k1</a></h2>
 <h3>Module items</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/ecdsa_secp256r1/fn.verify_signature.html
+++ b/noir_stdlib/docs/std/ecdsa_secp256r1/fn.verify_signature.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2>In module ecdsa_secp256r1</h2>
 <h3>Functions</h3><ul class="item-list">
 <li><a href="fn.verify_signature.html">verify_signature</a></div></li>

--- a/noir_stdlib/docs/std/ecdsa_secp256r1/fn.verify_signature.html
+++ b/noir_stdlib/docs/std/ecdsa_secp256r1/fn.verify_signature.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2>In module ecdsa_secp256r1</h2>
 <h3>Functions</h3><ul class="item-list">
 <li><a href="fn.verify_signature.html">verify_signature</a></div></li>

--- a/noir_stdlib/docs/std/ecdsa_secp256r1/index.html
+++ b/noir_stdlib/docs/std/ecdsa_secp256r1/index.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2><a href="#mod">Module ecdsa_secp256r1</a></h2>
 <h3>Module items</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/ecdsa_secp256r1/index.html
+++ b/noir_stdlib/docs/std/ecdsa_secp256r1/index.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2><a href="#mod">Module ecdsa_secp256r1</a></h2>
 <h3>Module items</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/embedded_curve_ops/fn.embedded_curve_add.html
+++ b/noir_stdlib/docs/std/embedded_curve_ops/fn.embedded_curve_add.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2>In module embedded_curve_ops</h2>
 <h3>Structs</h3><ul class="item-list">
 <li><a href="struct.EmbeddedCurvePoint.html">EmbeddedCurvePoint</a></div></li>

--- a/noir_stdlib/docs/std/embedded_curve_ops/fn.embedded_curve_add.html
+++ b/noir_stdlib/docs/std/embedded_curve_ops/fn.embedded_curve_add.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2>In module embedded_curve_ops</h2>
 <h3>Structs</h3><ul class="item-list">
 <li><a href="struct.EmbeddedCurvePoint.html">EmbeddedCurvePoint</a></div></li>

--- a/noir_stdlib/docs/std/embedded_curve_ops/fn.fixed_base_scalar_mul.html
+++ b/noir_stdlib/docs/std/embedded_curve_ops/fn.fixed_base_scalar_mul.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2>In module embedded_curve_ops</h2>
 <h3>Structs</h3><ul class="item-list">
 <li><a href="struct.EmbeddedCurvePoint.html">EmbeddedCurvePoint</a></div></li>

--- a/noir_stdlib/docs/std/embedded_curve_ops/fn.fixed_base_scalar_mul.html
+++ b/noir_stdlib/docs/std/embedded_curve_ops/fn.fixed_base_scalar_mul.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2>In module embedded_curve_ops</h2>
 <h3>Structs</h3><ul class="item-list">
 <li><a href="struct.EmbeddedCurvePoint.html">EmbeddedCurvePoint</a></div></li>

--- a/noir_stdlib/docs/std/embedded_curve_ops/fn.multi_scalar_mul.html
+++ b/noir_stdlib/docs/std/embedded_curve_ops/fn.multi_scalar_mul.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2>In module embedded_curve_ops</h2>
 <h3>Structs</h3><ul class="item-list">
 <li><a href="struct.EmbeddedCurvePoint.html">EmbeddedCurvePoint</a></div></li>

--- a/noir_stdlib/docs/std/embedded_curve_ops/fn.multi_scalar_mul.html
+++ b/noir_stdlib/docs/std/embedded_curve_ops/fn.multi_scalar_mul.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2>In module embedded_curve_ops</h2>
 <h3>Structs</h3><ul class="item-list">
 <li><a href="struct.EmbeddedCurvePoint.html">EmbeddedCurvePoint</a></div></li>

--- a/noir_stdlib/docs/std/embedded_curve_ops/index.html
+++ b/noir_stdlib/docs/std/embedded_curve_ops/index.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2><a href="#mod">Module embedded_curve_ops</a></h2>
 <h3>Module items</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/embedded_curve_ops/index.html
+++ b/noir_stdlib/docs/std/embedded_curve_ops/index.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2><a href="#mod">Module embedded_curve_ops</a></h2>
 <h3>Module items</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/embedded_curve_ops/struct.EmbeddedCurvePoint.html
+++ b/noir_stdlib/docs/std/embedded_curve_ops/struct.EmbeddedCurvePoint.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2><a href="#struct">Struct EmbeddedCurvePoint</a></h2>
 <h3>Fields</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/embedded_curve_ops/struct.EmbeddedCurvePoint.html
+++ b/noir_stdlib/docs/std/embedded_curve_ops/struct.EmbeddedCurvePoint.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2><a href="#struct">Struct EmbeddedCurvePoint</a></h2>
 <h3>Fields</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/embedded_curve_ops/struct.EmbeddedCurveScalar.html
+++ b/noir_stdlib/docs/std/embedded_curve_ops/struct.EmbeddedCurveScalar.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2><a href="#struct">Struct EmbeddedCurveScalar</a></h2>
 <h3>Fields</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/embedded_curve_ops/struct.EmbeddedCurveScalar.html
+++ b/noir_stdlib/docs/std/embedded_curve_ops/struct.EmbeddedCurveScalar.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2><a href="#struct">Struct EmbeddedCurveScalar</a></h2>
 <h3>Fields</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/field/bn254/fn.assert_gt.html
+++ b/noir_stdlib/docs/std/field/bn254/fn.assert_gt.html
@@ -16,7 +16,7 @@
 <h1><a href="../../../index.html">noir_stdlib</a></h1>
 <div><a href="../../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2>In module bn254</h2>
 <h3>Functions</h3><ul class="item-list">
 <li><a href="fn.assert_gt.html">assert_gt</a></div></li>

--- a/noir_stdlib/docs/std/field/bn254/fn.assert_gt.html
+++ b/noir_stdlib/docs/std/field/bn254/fn.assert_gt.html
@@ -16,7 +16,7 @@
 <h1><a href="../../../index.html">noir_stdlib</a></h1>
 <div><a href="../../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2>In module bn254</h2>
 <h3>Functions</h3><ul class="item-list">
 <li><a href="fn.assert_gt.html">assert_gt</a></div></li>

--- a/noir_stdlib/docs/std/field/bn254/fn.assert_lt.html
+++ b/noir_stdlib/docs/std/field/bn254/fn.assert_lt.html
@@ -16,7 +16,7 @@
 <h1><a href="../../../index.html">noir_stdlib</a></h1>
 <div><a href="../../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2>In module bn254</h2>
 <h3>Functions</h3><ul class="item-list">
 <li><a href="fn.assert_gt.html">assert_gt</a></div></li>

--- a/noir_stdlib/docs/std/field/bn254/fn.assert_lt.html
+++ b/noir_stdlib/docs/std/field/bn254/fn.assert_lt.html
@@ -16,7 +16,7 @@
 <h1><a href="../../../index.html">noir_stdlib</a></h1>
 <div><a href="../../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2>In module bn254</h2>
 <h3>Functions</h3><ul class="item-list">
 <li><a href="fn.assert_gt.html">assert_gt</a></div></li>

--- a/noir_stdlib/docs/std/field/bn254/fn.decompose.html
+++ b/noir_stdlib/docs/std/field/bn254/fn.decompose.html
@@ -16,7 +16,7 @@
 <h1><a href="../../../index.html">noir_stdlib</a></h1>
 <div><a href="../../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2>In module bn254</h2>
 <h3>Functions</h3><ul class="item-list">
 <li><a href="fn.assert_gt.html">assert_gt</a></div></li>

--- a/noir_stdlib/docs/std/field/bn254/fn.decompose.html
+++ b/noir_stdlib/docs/std/field/bn254/fn.decompose.html
@@ -16,7 +16,7 @@
 <h1><a href="../../../index.html">noir_stdlib</a></h1>
 <div><a href="../../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2>In module bn254</h2>
 <h3>Functions</h3><ul class="item-list">
 <li><a href="fn.assert_gt.html">assert_gt</a></div></li>

--- a/noir_stdlib/docs/std/field/bn254/fn.gt.html
+++ b/noir_stdlib/docs/std/field/bn254/fn.gt.html
@@ -16,7 +16,7 @@
 <h1><a href="../../../index.html">noir_stdlib</a></h1>
 <div><a href="../../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2>In module bn254</h2>
 <h3>Functions</h3><ul class="item-list">
 <li><a href="fn.assert_gt.html">assert_gt</a></div></li>

--- a/noir_stdlib/docs/std/field/bn254/fn.gt.html
+++ b/noir_stdlib/docs/std/field/bn254/fn.gt.html
@@ -16,7 +16,7 @@
 <h1><a href="../../../index.html">noir_stdlib</a></h1>
 <div><a href="../../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2>In module bn254</h2>
 <h3>Functions</h3><ul class="item-list">
 <li><a href="fn.assert_gt.html">assert_gt</a></div></li>

--- a/noir_stdlib/docs/std/field/bn254/fn.lt.html
+++ b/noir_stdlib/docs/std/field/bn254/fn.lt.html
@@ -16,7 +16,7 @@
 <h1><a href="../../../index.html">noir_stdlib</a></h1>
 <div><a href="../../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2>In module bn254</h2>
 <h3>Functions</h3><ul class="item-list">
 <li><a href="fn.assert_gt.html">assert_gt</a></div></li>

--- a/noir_stdlib/docs/std/field/bn254/fn.lt.html
+++ b/noir_stdlib/docs/std/field/bn254/fn.lt.html
@@ -16,7 +16,7 @@
 <h1><a href="../../../index.html">noir_stdlib</a></h1>
 <div><a href="../../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2>In module bn254</h2>
 <h3>Functions</h3><ul class="item-list">
 <li><a href="fn.assert_gt.html">assert_gt</a></div></li>

--- a/noir_stdlib/docs/std/field/bn254/index.html
+++ b/noir_stdlib/docs/std/field/bn254/index.html
@@ -16,7 +16,7 @@
 <h1><a href="../../../index.html">noir_stdlib</a></h1>
 <div><a href="../../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2><a href="#mod">Module bn254</a></h2>
 <h3>Module items</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/field/bn254/index.html
+++ b/noir_stdlib/docs/std/field/bn254/index.html
@@ -16,7 +16,7 @@
 <h1><a href="../../../index.html">noir_stdlib</a></h1>
 <div><a href="../../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2><a href="#mod">Module bn254</a></h2>
 <h3>Module items</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/field/fn.bytes32_to_field.html
+++ b/noir_stdlib/docs/std/field/fn.bytes32_to_field.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2>In module field</h2>
 <h3>Modules</h3><ul class="item-list">
 <li><a href="bn254/index.html">bn254</a></div></li>

--- a/noir_stdlib/docs/std/field/fn.bytes32_to_field.html
+++ b/noir_stdlib/docs/std/field/fn.bytes32_to_field.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2>In module field</h2>
 <h3>Modules</h3><ul class="item-list">
 <li><a href="bn254/index.html">bn254</a></div></li>

--- a/noir_stdlib/docs/std/field/fn.modulus_be_bits.html
+++ b/noir_stdlib/docs/std/field/fn.modulus_be_bits.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2>In module field</h2>
 <h3>Modules</h3><ul class="item-list">
 <li><a href="bn254/index.html">bn254</a></div></li>

--- a/noir_stdlib/docs/std/field/fn.modulus_be_bits.html
+++ b/noir_stdlib/docs/std/field/fn.modulus_be_bits.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2>In module field</h2>
 <h3>Modules</h3><ul class="item-list">
 <li><a href="bn254/index.html">bn254</a></div></li>

--- a/noir_stdlib/docs/std/field/fn.modulus_be_bytes.html
+++ b/noir_stdlib/docs/std/field/fn.modulus_be_bytes.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2>In module field</h2>
 <h3>Modules</h3><ul class="item-list">
 <li><a href="bn254/index.html">bn254</a></div></li>

--- a/noir_stdlib/docs/std/field/fn.modulus_be_bytes.html
+++ b/noir_stdlib/docs/std/field/fn.modulus_be_bytes.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2>In module field</h2>
 <h3>Modules</h3><ul class="item-list">
 <li><a href="bn254/index.html">bn254</a></div></li>

--- a/noir_stdlib/docs/std/field/fn.modulus_le_bits.html
+++ b/noir_stdlib/docs/std/field/fn.modulus_le_bits.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2>In module field</h2>
 <h3>Modules</h3><ul class="item-list">
 <li><a href="bn254/index.html">bn254</a></div></li>

--- a/noir_stdlib/docs/std/field/fn.modulus_le_bits.html
+++ b/noir_stdlib/docs/std/field/fn.modulus_le_bits.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2>In module field</h2>
 <h3>Modules</h3><ul class="item-list">
 <li><a href="bn254/index.html">bn254</a></div></li>

--- a/noir_stdlib/docs/std/field/fn.modulus_le_bytes.html
+++ b/noir_stdlib/docs/std/field/fn.modulus_le_bytes.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2>In module field</h2>
 <h3>Modules</h3><ul class="item-list">
 <li><a href="bn254/index.html">bn254</a></div></li>

--- a/noir_stdlib/docs/std/field/fn.modulus_le_bytes.html
+++ b/noir_stdlib/docs/std/field/fn.modulus_le_bytes.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2>In module field</h2>
 <h3>Modules</h3><ul class="item-list">
 <li><a href="bn254/index.html">bn254</a></div></li>

--- a/noir_stdlib/docs/std/field/fn.modulus_num_bits.html
+++ b/noir_stdlib/docs/std/field/fn.modulus_num_bits.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2>In module field</h2>
 <h3>Modules</h3><ul class="item-list">
 <li><a href="bn254/index.html">bn254</a></div></li>

--- a/noir_stdlib/docs/std/field/fn.modulus_num_bits.html
+++ b/noir_stdlib/docs/std/field/fn.modulus_num_bits.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2>In module field</h2>
 <h3>Modules</h3><ul class="item-list">
 <li><a href="bn254/index.html">bn254</a></div></li>

--- a/noir_stdlib/docs/std/field/index.html
+++ b/noir_stdlib/docs/std/field/index.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2><a href="#mod">Module field</a></h2>
 <h3>Module items</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/field/index.html
+++ b/noir_stdlib/docs/std/field/index.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2><a href="#mod">Module field</a></h2>
 <h3>Module items</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/fn.as_witness.html
+++ b/noir_stdlib/docs/std/fn.as_witness.html
@@ -16,7 +16,7 @@
 <h1><a href="../index.html">noir_stdlib</a></h1>
 <div><a href="../all.html">All items</a></div>
 <h2 id="crate-name"><a href="index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2>In crate std</h2>
 <h3>Modules</h3><ul class="item-list">
 <li><a href="aes128/index.html">aes128</a></div></li>

--- a/noir_stdlib/docs/std/fn.as_witness.html
+++ b/noir_stdlib/docs/std/fn.as_witness.html
@@ -16,7 +16,7 @@
 <h1><a href="../index.html">noir_stdlib</a></h1>
 <div><a href="../all.html">All items</a></div>
 <h2 id="crate-name"><a href="index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2>In crate std</h2>
 <h3>Modules</h3><ul class="item-list">
 <li><a href="aes128/index.html">aes128</a></div></li>

--- a/noir_stdlib/docs/std/fn.assert_constant.html
+++ b/noir_stdlib/docs/std/fn.assert_constant.html
@@ -16,7 +16,7 @@
 <h1><a href="../index.html">noir_stdlib</a></h1>
 <div><a href="../all.html">All items</a></div>
 <h2 id="crate-name"><a href="index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2>In crate std</h2>
 <h3>Modules</h3><ul class="item-list">
 <li><a href="aes128/index.html">aes128</a></div></li>

--- a/noir_stdlib/docs/std/fn.assert_constant.html
+++ b/noir_stdlib/docs/std/fn.assert_constant.html
@@ -16,7 +16,7 @@
 <h1><a href="../index.html">noir_stdlib</a></h1>
 <div><a href="../all.html">All items</a></div>
 <h2 id="crate-name"><a href="index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2>In crate std</h2>
 <h3>Modules</h3><ul class="item-list">
 <li><a href="aes128/index.html">aes128</a></div></li>

--- a/noir_stdlib/docs/std/fn.print.html
+++ b/noir_stdlib/docs/std/fn.print.html
@@ -16,7 +16,7 @@
 <h1><a href="../index.html">noir_stdlib</a></h1>
 <div><a href="../all.html">All items</a></div>
 <h2 id="crate-name"><a href="index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2>In crate std</h2>
 <h3>Modules</h3><ul class="item-list">
 <li><a href="aes128/index.html">aes128</a></div></li>

--- a/noir_stdlib/docs/std/fn.print.html
+++ b/noir_stdlib/docs/std/fn.print.html
@@ -16,7 +16,7 @@
 <h1><a href="../index.html">noir_stdlib</a></h1>
 <div><a href="../all.html">All items</a></div>
 <h2 id="crate-name"><a href="index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2>In crate std</h2>
 <h3>Modules</h3><ul class="item-list">
 <li><a href="aes128/index.html">aes128</a></div></li>

--- a/noir_stdlib/docs/std/fn.println.html
+++ b/noir_stdlib/docs/std/fn.println.html
@@ -16,7 +16,7 @@
 <h1><a href="../index.html">noir_stdlib</a></h1>
 <div><a href="../all.html">All items</a></div>
 <h2 id="crate-name"><a href="index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2>In crate std</h2>
 <h3>Modules</h3><ul class="item-list">
 <li><a href="aes128/index.html">aes128</a></div></li>

--- a/noir_stdlib/docs/std/fn.println.html
+++ b/noir_stdlib/docs/std/fn.println.html
@@ -16,7 +16,7 @@
 <h1><a href="../index.html">noir_stdlib</a></h1>
 <div><a href="../all.html">All items</a></div>
 <h2 id="crate-name"><a href="index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2>In crate std</h2>
 <h3>Modules</h3><ul class="item-list">
 <li><a href="aes128/index.html">aes128</a></div></li>

--- a/noir_stdlib/docs/std/fn.static_assert.html
+++ b/noir_stdlib/docs/std/fn.static_assert.html
@@ -16,7 +16,7 @@
 <h1><a href="../index.html">noir_stdlib</a></h1>
 <div><a href="../all.html">All items</a></div>
 <h2 id="crate-name"><a href="index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2>In crate std</h2>
 <h3>Modules</h3><ul class="item-list">
 <li><a href="aes128/index.html">aes128</a></div></li>

--- a/noir_stdlib/docs/std/fn.static_assert.html
+++ b/noir_stdlib/docs/std/fn.static_assert.html
@@ -16,7 +16,7 @@
 <h1><a href="../index.html">noir_stdlib</a></h1>
 <div><a href="../all.html">All items</a></div>
 <h2 id="crate-name"><a href="index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2>In crate std</h2>
 <h3>Modules</h3><ul class="item-list">
 <li><a href="aes128/index.html">aes128</a></div></li>

--- a/noir_stdlib/docs/std/fn.verify_proof_with_type.html
+++ b/noir_stdlib/docs/std/fn.verify_proof_with_type.html
@@ -16,7 +16,7 @@
 <h1><a href="../index.html">noir_stdlib</a></h1>
 <div><a href="../all.html">All items</a></div>
 <h2 id="crate-name"><a href="index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2>In crate std</h2>
 <h3>Modules</h3><ul class="item-list">
 <li><a href="aes128/index.html">aes128</a></div></li>

--- a/noir_stdlib/docs/std/fn.verify_proof_with_type.html
+++ b/noir_stdlib/docs/std/fn.verify_proof_with_type.html
@@ -16,7 +16,7 @@
 <h1><a href="../index.html">noir_stdlib</a></h1>
 <div><a href="../all.html">All items</a></div>
 <h2 id="crate-name"><a href="index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2>In crate std</h2>
 <h3>Modules</h3><ul class="item-list">
 <li><a href="aes128/index.html">aes128</a></div></li>

--- a/noir_stdlib/docs/std/hash/fn.blake2s.html
+++ b/noir_stdlib/docs/std/hash/fn.blake2s.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2>In module hash</h2>
 <h3>Modules</h3><ul class="item-list">
 <li><a href="keccak/index.html">keccak</a></div></li>

--- a/noir_stdlib/docs/std/hash/fn.blake2s.html
+++ b/noir_stdlib/docs/std/hash/fn.blake2s.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2>In module hash</h2>
 <h3>Modules</h3><ul class="item-list">
 <li><a href="keccak/index.html">keccak</a></div></li>

--- a/noir_stdlib/docs/std/hash/fn.blake3.html
+++ b/noir_stdlib/docs/std/hash/fn.blake3.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2>In module hash</h2>
 <h3>Modules</h3><ul class="item-list">
 <li><a href="keccak/index.html">keccak</a></div></li>

--- a/noir_stdlib/docs/std/hash/fn.blake3.html
+++ b/noir_stdlib/docs/std/hash/fn.blake3.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2>In module hash</h2>
 <h3>Modules</h3><ul class="item-list">
 <li><a href="keccak/index.html">keccak</a></div></li>

--- a/noir_stdlib/docs/std/hash/fn.derive_generators.html
+++ b/noir_stdlib/docs/std/hash/fn.derive_generators.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2>In module hash</h2>
 <h3>Modules</h3><ul class="item-list">
 <li><a href="keccak/index.html">keccak</a></div></li>

--- a/noir_stdlib/docs/std/hash/fn.derive_generators.html
+++ b/noir_stdlib/docs/std/hash/fn.derive_generators.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2>In module hash</h2>
 <h3>Modules</h3><ul class="item-list">
 <li><a href="keccak/index.html">keccak</a></div></li>

--- a/noir_stdlib/docs/std/hash/fn.keccakf1600.html
+++ b/noir_stdlib/docs/std/hash/fn.keccakf1600.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2>In module hash</h2>
 <h3>Modules</h3><ul class="item-list">
 <li><a href="keccak/index.html">keccak</a></div></li>

--- a/noir_stdlib/docs/std/hash/fn.keccakf1600.html
+++ b/noir_stdlib/docs/std/hash/fn.keccakf1600.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2>In module hash</h2>
 <h3>Modules</h3><ul class="item-list">
 <li><a href="keccak/index.html">keccak</a></div></li>

--- a/noir_stdlib/docs/std/hash/fn.pedersen_commitment.html
+++ b/noir_stdlib/docs/std/hash/fn.pedersen_commitment.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2>In module hash</h2>
 <h3>Modules</h3><ul class="item-list">
 <li><a href="keccak/index.html">keccak</a></div></li>

--- a/noir_stdlib/docs/std/hash/fn.pedersen_commitment.html
+++ b/noir_stdlib/docs/std/hash/fn.pedersen_commitment.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2>In module hash</h2>
 <h3>Modules</h3><ul class="item-list">
 <li><a href="keccak/index.html">keccak</a></div></li>

--- a/noir_stdlib/docs/std/hash/fn.pedersen_commitment_with_separator.html
+++ b/noir_stdlib/docs/std/hash/fn.pedersen_commitment_with_separator.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2>In module hash</h2>
 <h3>Modules</h3><ul class="item-list">
 <li><a href="keccak/index.html">keccak</a></div></li>

--- a/noir_stdlib/docs/std/hash/fn.pedersen_commitment_with_separator.html
+++ b/noir_stdlib/docs/std/hash/fn.pedersen_commitment_with_separator.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2>In module hash</h2>
 <h3>Modules</h3><ul class="item-list">
 <li><a href="keccak/index.html">keccak</a></div></li>

--- a/noir_stdlib/docs/std/hash/fn.pedersen_hash.html
+++ b/noir_stdlib/docs/std/hash/fn.pedersen_hash.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2>In module hash</h2>
 <h3>Modules</h3><ul class="item-list">
 <li><a href="keccak/index.html">keccak</a></div></li>

--- a/noir_stdlib/docs/std/hash/fn.pedersen_hash.html
+++ b/noir_stdlib/docs/std/hash/fn.pedersen_hash.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2>In module hash</h2>
 <h3>Modules</h3><ul class="item-list">
 <li><a href="keccak/index.html">keccak</a></div></li>

--- a/noir_stdlib/docs/std/hash/fn.pedersen_hash_with_separator.html
+++ b/noir_stdlib/docs/std/hash/fn.pedersen_hash_with_separator.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2>In module hash</h2>
 <h3>Modules</h3><ul class="item-list">
 <li><a href="keccak/index.html">keccak</a></div></li>

--- a/noir_stdlib/docs/std/hash/fn.pedersen_hash_with_separator.html
+++ b/noir_stdlib/docs/std/hash/fn.pedersen_hash_with_separator.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2>In module hash</h2>
 <h3>Modules</h3><ul class="item-list">
 <li><a href="keccak/index.html">keccak</a></div></li>

--- a/noir_stdlib/docs/std/hash/fn.poseidon2_permutation.html
+++ b/noir_stdlib/docs/std/hash/fn.poseidon2_permutation.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2>In module hash</h2>
 <h3>Modules</h3><ul class="item-list">
 <li><a href="keccak/index.html">keccak</a></div></li>

--- a/noir_stdlib/docs/std/hash/fn.poseidon2_permutation.html
+++ b/noir_stdlib/docs/std/hash/fn.poseidon2_permutation.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2>In module hash</h2>
 <h3>Modules</h3><ul class="item-list">
 <li><a href="keccak/index.html">keccak</a></div></li>

--- a/noir_stdlib/docs/std/hash/fn.sha256_compression.html
+++ b/noir_stdlib/docs/std/hash/fn.sha256_compression.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2>In module hash</h2>
 <h3>Modules</h3><ul class="item-list">
 <li><a href="keccak/index.html">keccak</a></div></li>

--- a/noir_stdlib/docs/std/hash/fn.sha256_compression.html
+++ b/noir_stdlib/docs/std/hash/fn.sha256_compression.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2>In module hash</h2>
 <h3>Modules</h3><ul class="item-list">
 <li><a href="keccak/index.html">keccak</a></div></li>

--- a/noir_stdlib/docs/std/hash/index.html
+++ b/noir_stdlib/docs/std/hash/index.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2><a href="#mod">Module hash</a></h2>
 <h3>Module items</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/hash/index.html
+++ b/noir_stdlib/docs/std/hash/index.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2><a href="#mod">Module hash</a></h2>
 <h3>Module items</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/hash/keccak/fn.keccakf1600.html
+++ b/noir_stdlib/docs/std/hash/keccak/fn.keccakf1600.html
@@ -16,7 +16,7 @@
 <h1><a href="../../../index.html">noir_stdlib</a></h1>
 <div><a href="../../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2>In module keccak</h2>
 <h3>Functions</h3><ul class="item-list">
 <li><a href="fn.keccakf1600.html">keccakf1600</a></div></li>

--- a/noir_stdlib/docs/std/hash/keccak/fn.keccakf1600.html
+++ b/noir_stdlib/docs/std/hash/keccak/fn.keccakf1600.html
@@ -16,7 +16,7 @@
 <h1><a href="../../../index.html">noir_stdlib</a></h1>
 <div><a href="../../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2>In module keccak</h2>
 <h3>Functions</h3><ul class="item-list">
 <li><a href="fn.keccakf1600.html">keccakf1600</a></div></li>

--- a/noir_stdlib/docs/std/hash/keccak/index.html
+++ b/noir_stdlib/docs/std/hash/keccak/index.html
@@ -16,7 +16,7 @@
 <h1><a href="../../../index.html">noir_stdlib</a></h1>
 <div><a href="../../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2><a href="#mod">Module keccak</a></h2>
 <h3>Module items</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/hash/keccak/index.html
+++ b/noir_stdlib/docs/std/hash/keccak/index.html
@@ -16,7 +16,7 @@
 <h1><a href="../../../index.html">noir_stdlib</a></h1>
 <div><a href="../../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2><a href="#mod">Module keccak</a></h2>
 <h3>Module items</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/hash/struct.BuildHasherDefault.html
+++ b/noir_stdlib/docs/std/hash/struct.BuildHasherDefault.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2><a href="#struct">Struct BuildHasherDefault</a></h2>
 <h3>Trait implementations</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/hash/struct.BuildHasherDefault.html
+++ b/noir_stdlib/docs/std/hash/struct.BuildHasherDefault.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2><a href="#struct">Struct BuildHasherDefault</a></h2>
 <h3>Trait implementations</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/hash/trait.BuildHasher.html
+++ b/noir_stdlib/docs/std/hash/trait.BuildHasher.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2><a href="#trait">Trait BuildHasher</a></h2>
 <h3>Required methods</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/hash/trait.BuildHasher.html
+++ b/noir_stdlib/docs/std/hash/trait.BuildHasher.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2><a href="#trait">Trait BuildHasher</a></h2>
 <h3>Required methods</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/hash/trait.Hash.html
+++ b/noir_stdlib/docs/std/hash/trait.Hash.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2><a href="#trait">Trait Hash</a></h2>
 <h3>Required methods</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/hash/trait.Hash.html
+++ b/noir_stdlib/docs/std/hash/trait.Hash.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2><a href="#trait">Trait Hash</a></h2>
 <h3>Required methods</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/hash/trait.Hasher.html
+++ b/noir_stdlib/docs/std/hash/trait.Hasher.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2><a href="#trait">Trait Hasher</a></h2>
 <h3>Required methods</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/hash/trait.Hasher.html
+++ b/noir_stdlib/docs/std/hash/trait.Hasher.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2><a href="#trait">Trait Hasher</a></h2>
 <h3>Required methods</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/hint/fn.black_box.html
+++ b/noir_stdlib/docs/std/hint/fn.black_box.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2>In module hint</h2>
 <h3>Functions</h3><ul class="item-list">
 <li><a href="fn.black_box.html">black_box</a></div></li>

--- a/noir_stdlib/docs/std/hint/fn.black_box.html
+++ b/noir_stdlib/docs/std/hint/fn.black_box.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2>In module hint</h2>
 <h3>Functions</h3><ul class="item-list">
 <li><a href="fn.black_box.html">black_box</a></div></li>

--- a/noir_stdlib/docs/std/hint/index.html
+++ b/noir_stdlib/docs/std/hint/index.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2><a href="#mod">Module hint</a></h2>
 <h3>Module items</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/hint/index.html
+++ b/noir_stdlib/docs/std/hint/index.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2><a href="#mod">Module hint</a></h2>
 <h3>Module items</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/index.html
+++ b/noir_stdlib/docs/std/index.html
@@ -16,7 +16,7 @@
 <h1><a href="../index.html">noir_stdlib</a></h1>
 <div><a href="../all.html">All items</a></div>
 <h2 id="crate-name"><a href="index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h3>Crate items</h3>
 <ul class="sidebar-list">
 <li><a href="#modules">Modules</a></li>

--- a/noir_stdlib/docs/std/index.html
+++ b/noir_stdlib/docs/std/index.html
@@ -16,7 +16,7 @@
 <h1><a href="../index.html">noir_stdlib</a></h1>
 <div><a href="../all.html">All items</a></div>
 <h2 id="crate-name"><a href="index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h3>Crate items</h3>
 <ul class="sidebar-list">
 <li><a href="#modules">Modules</a></li>

--- a/noir_stdlib/docs/std/mem/fn.array_refcount.html
+++ b/noir_stdlib/docs/std/mem/fn.array_refcount.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2>In module mem</h2>
 <h3>Functions</h3><ul class="item-list">
 <li><a href="fn.array_refcount.html">array_refcount</a></div></li>

--- a/noir_stdlib/docs/std/mem/fn.array_refcount.html
+++ b/noir_stdlib/docs/std/mem/fn.array_refcount.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2>In module mem</h2>
 <h3>Functions</h3><ul class="item-list">
 <li><a href="fn.array_refcount.html">array_refcount</a></div></li>

--- a/noir_stdlib/docs/std/mem/fn.checked_transmute.html
+++ b/noir_stdlib/docs/std/mem/fn.checked_transmute.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2>In module mem</h2>
 <h3>Functions</h3><ul class="item-list">
 <li><a href="fn.array_refcount.html">array_refcount</a></div></li>

--- a/noir_stdlib/docs/std/mem/fn.checked_transmute.html
+++ b/noir_stdlib/docs/std/mem/fn.checked_transmute.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2>In module mem</h2>
 <h3>Functions</h3><ul class="item-list">
 <li><a href="fn.array_refcount.html">array_refcount</a></div></li>

--- a/noir_stdlib/docs/std/mem/fn.vector_refcount.html
+++ b/noir_stdlib/docs/std/mem/fn.vector_refcount.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2>In module mem</h2>
 <h3>Functions</h3><ul class="item-list">
 <li><a href="fn.array_refcount.html">array_refcount</a></div></li>

--- a/noir_stdlib/docs/std/mem/fn.vector_refcount.html
+++ b/noir_stdlib/docs/std/mem/fn.vector_refcount.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2>In module mem</h2>
 <h3>Functions</h3><ul class="item-list">
 <li><a href="fn.array_refcount.html">array_refcount</a></div></li>

--- a/noir_stdlib/docs/std/mem/fn.zeroed.html
+++ b/noir_stdlib/docs/std/mem/fn.zeroed.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2>In module mem</h2>
 <h3>Functions</h3><ul class="item-list">
 <li><a href="fn.array_refcount.html">array_refcount</a></div></li>

--- a/noir_stdlib/docs/std/mem/fn.zeroed.html
+++ b/noir_stdlib/docs/std/mem/fn.zeroed.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2>In module mem</h2>
 <h3>Functions</h3><ul class="item-list">
 <li><a href="fn.array_refcount.html">array_refcount</a></div></li>

--- a/noir_stdlib/docs/std/mem/index.html
+++ b/noir_stdlib/docs/std/mem/index.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2><a href="#mod">Module mem</a></h2>
 <h3>Module items</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/mem/index.html
+++ b/noir_stdlib/docs/std/mem/index.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2><a href="#mod">Module mem</a></h2>
 <h3>Module items</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/meta/ctstring/index.html
+++ b/noir_stdlib/docs/std/meta/ctstring/index.html
@@ -16,7 +16,7 @@
 <h1><a href="../../../index.html">noir_stdlib</a></h1>
 <div><a href="../../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2><a href="#mod">Module ctstring</a></h2>
 <h3>Module items</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/meta/ctstring/index.html
+++ b/noir_stdlib/docs/std/meta/ctstring/index.html
@@ -16,7 +16,7 @@
 <h1><a href="../../../index.html">noir_stdlib</a></h1>
 <div><a href="../../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2><a href="#mod">Module ctstring</a></h2>
 <h3>Module items</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/meta/ctstring/trait.AsCtString.html
+++ b/noir_stdlib/docs/std/meta/ctstring/trait.AsCtString.html
@@ -16,7 +16,7 @@
 <h1><a href="../../../index.html">noir_stdlib</a></h1>
 <div><a href="../../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2><a href="#trait">Trait AsCtString</a></h2>
 <h3>Required methods</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/meta/ctstring/trait.AsCtString.html
+++ b/noir_stdlib/docs/std/meta/ctstring/trait.AsCtString.html
@@ -16,7 +16,7 @@
 <h1><a href="../../../index.html">noir_stdlib</a></h1>
 <div><a href="../../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2><a href="#trait">Trait AsCtString</a></h2>
 <h3>Required methods</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/meta/expr/index.html
+++ b/noir_stdlib/docs/std/meta/expr/index.html
@@ -16,7 +16,7 @@
 <h1><a href="../../../index.html">noir_stdlib</a></h1>
 <div><a href="../../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2><a href="#mod">Module expr</a></h2>
 <h2>In module meta</h2>
 <h3>Modules</h3><ul class="item-list">

--- a/noir_stdlib/docs/std/meta/expr/index.html
+++ b/noir_stdlib/docs/std/meta/expr/index.html
@@ -16,7 +16,7 @@
 <h1><a href="../../../index.html">noir_stdlib</a></h1>
 <div><a href="../../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2><a href="#mod">Module expr</a></h2>
 <h2>In module meta</h2>
 <h3>Modules</h3><ul class="item-list">

--- a/noir_stdlib/docs/std/meta/fn.derive.html
+++ b/noir_stdlib/docs/std/meta/fn.derive.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2>In module meta</h2>
 <h3>Modules</h3><ul class="item-list">
 <li><a href="ctstring/index.html">ctstring</a></div></li>

--- a/noir_stdlib/docs/std/meta/fn.derive.html
+++ b/noir_stdlib/docs/std/meta/fn.derive.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2>In module meta</h2>
 <h3>Modules</h3><ul class="item-list">
 <li><a href="ctstring/index.html">ctstring</a></div></li>

--- a/noir_stdlib/docs/std/meta/fn.derive_via.html
+++ b/noir_stdlib/docs/std/meta/fn.derive_via.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2>In module meta</h2>
 <h3>Modules</h3><ul class="item-list">
 <li><a href="ctstring/index.html">ctstring</a></div></li>

--- a/noir_stdlib/docs/std/meta/fn.derive_via.html
+++ b/noir_stdlib/docs/std/meta/fn.derive_via.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2>In module meta</h2>
 <h3>Modules</h3><ul class="item-list">
 <li><a href="ctstring/index.html">ctstring</a></div></li>

--- a/noir_stdlib/docs/std/meta/fn.make_trait_impl.html
+++ b/noir_stdlib/docs/std/meta/fn.make_trait_impl.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2>In module meta</h2>
 <h3>Modules</h3><ul class="item-list">
 <li><a href="ctstring/index.html">ctstring</a></div></li>

--- a/noir_stdlib/docs/std/meta/fn.make_trait_impl.html
+++ b/noir_stdlib/docs/std/meta/fn.make_trait_impl.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2>In module meta</h2>
 <h3>Modules</h3><ul class="item-list">
 <li><a href="ctstring/index.html">ctstring</a></div></li>

--- a/noir_stdlib/docs/std/meta/fn.type_of.html
+++ b/noir_stdlib/docs/std/meta/fn.type_of.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2>In module meta</h2>
 <h3>Modules</h3><ul class="item-list">
 <li><a href="ctstring/index.html">ctstring</a></div></li>

--- a/noir_stdlib/docs/std/meta/fn.type_of.html
+++ b/noir_stdlib/docs/std/meta/fn.type_of.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2>In module meta</h2>
 <h3>Modules</h3><ul class="item-list">
 <li><a href="ctstring/index.html">ctstring</a></div></li>

--- a/noir_stdlib/docs/std/meta/fn.unquote.html
+++ b/noir_stdlib/docs/std/meta/fn.unquote.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2>In module meta</h2>
 <h3>Modules</h3><ul class="item-list">
 <li><a href="ctstring/index.html">ctstring</a></div></li>

--- a/noir_stdlib/docs/std/meta/fn.unquote.html
+++ b/noir_stdlib/docs/std/meta/fn.unquote.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2>In module meta</h2>
 <h3>Modules</h3><ul class="item-list">
 <li><a href="ctstring/index.html">ctstring</a></div></li>

--- a/noir_stdlib/docs/std/meta/format_string/index.html
+++ b/noir_stdlib/docs/std/meta/format_string/index.html
@@ -16,7 +16,7 @@
 <h1><a href="../../../index.html">noir_stdlib</a></h1>
 <div><a href="../../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2><a href="#mod">Module format_string</a></h2>
 <h2>In module meta</h2>
 <h3>Modules</h3><ul class="item-list">

--- a/noir_stdlib/docs/std/meta/format_string/index.html
+++ b/noir_stdlib/docs/std/meta/format_string/index.html
@@ -16,7 +16,7 @@
 <h1><a href="../../../index.html">noir_stdlib</a></h1>
 <div><a href="../../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2><a href="#mod">Module format_string</a></h2>
 <h2>In module meta</h2>
 <h3>Modules</h3><ul class="item-list">

--- a/noir_stdlib/docs/std/meta/function_def/index.html
+++ b/noir_stdlib/docs/std/meta/function_def/index.html
@@ -16,7 +16,7 @@
 <h1><a href="../../../index.html">noir_stdlib</a></h1>
 <div><a href="../../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2><a href="#mod">Module function_def</a></h2>
 <h2>In module meta</h2>
 <h3>Modules</h3><ul class="item-list">

--- a/noir_stdlib/docs/std/meta/function_def/index.html
+++ b/noir_stdlib/docs/std/meta/function_def/index.html
@@ -16,7 +16,7 @@
 <h1><a href="../../../index.html">noir_stdlib</a></h1>
 <div><a href="../../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2><a href="#mod">Module function_def</a></h2>
 <h2>In module meta</h2>
 <h3>Modules</h3><ul class="item-list">

--- a/noir_stdlib/docs/std/meta/index.html
+++ b/noir_stdlib/docs/std/meta/index.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2><a href="#mod">Module meta</a></h2>
 <h3>Module items</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/meta/index.html
+++ b/noir_stdlib/docs/std/meta/index.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2><a href="#mod">Module meta</a></h2>
 <h3>Module items</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/meta/module/index.html
+++ b/noir_stdlib/docs/std/meta/module/index.html
@@ -16,7 +16,7 @@
 <h1><a href="../../../index.html">noir_stdlib</a></h1>
 <div><a href="../../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2><a href="#mod">Module module</a></h2>
 <h2>In module meta</h2>
 <h3>Modules</h3><ul class="item-list">

--- a/noir_stdlib/docs/std/meta/module/index.html
+++ b/noir_stdlib/docs/std/meta/module/index.html
@@ -16,7 +16,7 @@
 <h1><a href="../../../index.html">noir_stdlib</a></h1>
 <div><a href="../../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2><a href="#mod">Module module</a></h2>
 <h2>In module meta</h2>
 <h3>Modules</h3><ul class="item-list">

--- a/noir_stdlib/docs/std/meta/op/index.html
+++ b/noir_stdlib/docs/std/meta/op/index.html
@@ -16,7 +16,7 @@
 <h1><a href="../../../index.html">noir_stdlib</a></h1>
 <div><a href="../../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2><a href="#mod">Module op</a></h2>
 <h3>Module items</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/meta/op/index.html
+++ b/noir_stdlib/docs/std/meta/op/index.html
@@ -16,7 +16,7 @@
 <h1><a href="../../../index.html">noir_stdlib</a></h1>
 <div><a href="../../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2><a href="#mod">Module op</a></h2>
 <h3>Module items</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/meta/op/struct.BinaryOp.html
+++ b/noir_stdlib/docs/std/meta/op/struct.BinaryOp.html
@@ -16,7 +16,7 @@
 <h1><a href="../../../index.html">noir_stdlib</a></h1>
 <div><a href="../../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2><a href="#struct">Struct BinaryOp</a></h2>
 <h3>Methods</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/meta/op/struct.BinaryOp.html
+++ b/noir_stdlib/docs/std/meta/op/struct.BinaryOp.html
@@ -16,7 +16,7 @@
 <h1><a href="../../../index.html">noir_stdlib</a></h1>
 <div><a href="../../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2><a href="#struct">Struct BinaryOp</a></h2>
 <h3>Methods</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/meta/op/struct.UnaryOp.html
+++ b/noir_stdlib/docs/std/meta/op/struct.UnaryOp.html
@@ -16,7 +16,7 @@
 <h1><a href="../../../index.html">noir_stdlib</a></h1>
 <div><a href="../../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2><a href="#struct">Struct UnaryOp</a></h2>
 <h3>Methods</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/meta/op/struct.UnaryOp.html
+++ b/noir_stdlib/docs/std/meta/op/struct.UnaryOp.html
@@ -16,7 +16,7 @@
 <h1><a href="../../../index.html">noir_stdlib</a></h1>
 <div><a href="../../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2><a href="#struct">Struct UnaryOp</a></h2>
 <h3>Methods</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/meta/quoted/index.html
+++ b/noir_stdlib/docs/std/meta/quoted/index.html
@@ -16,7 +16,7 @@
 <h1><a href="../../../index.html">noir_stdlib</a></h1>
 <div><a href="../../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2><a href="#mod">Module quoted</a></h2>
 <h2>In module meta</h2>
 <h3>Modules</h3><ul class="item-list">

--- a/noir_stdlib/docs/std/meta/quoted/index.html
+++ b/noir_stdlib/docs/std/meta/quoted/index.html
@@ -16,7 +16,7 @@
 <h1><a href="../../../index.html">noir_stdlib</a></h1>
 <div><a href="../../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2><a href="#mod">Module quoted</a></h2>
 <h2>In module meta</h2>
 <h3>Modules</h3><ul class="item-list">

--- a/noir_stdlib/docs/std/meta/trait_constraint/index.html
+++ b/noir_stdlib/docs/std/meta/trait_constraint/index.html
@@ -16,7 +16,7 @@
 <h1><a href="../../../index.html">noir_stdlib</a></h1>
 <div><a href="../../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2><a href="#mod">Module trait_constraint</a></h2>
 <h2>In module meta</h2>
 <h3>Modules</h3><ul class="item-list">

--- a/noir_stdlib/docs/std/meta/trait_constraint/index.html
+++ b/noir_stdlib/docs/std/meta/trait_constraint/index.html
@@ -16,7 +16,7 @@
 <h1><a href="../../../index.html">noir_stdlib</a></h1>
 <div><a href="../../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2><a href="#mod">Module trait_constraint</a></h2>
 <h2>In module meta</h2>
 <h3>Modules</h3><ul class="item-list">

--- a/noir_stdlib/docs/std/meta/trait_def/index.html
+++ b/noir_stdlib/docs/std/meta/trait_def/index.html
@@ -16,7 +16,7 @@
 <h1><a href="../../../index.html">noir_stdlib</a></h1>
 <div><a href="../../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2><a href="#mod">Module trait_def</a></h2>
 <h2>In module meta</h2>
 <h3>Modules</h3><ul class="item-list">

--- a/noir_stdlib/docs/std/meta/trait_def/index.html
+++ b/noir_stdlib/docs/std/meta/trait_def/index.html
@@ -16,7 +16,7 @@
 <h1><a href="../../../index.html">noir_stdlib</a></h1>
 <div><a href="../../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2><a href="#mod">Module trait_def</a></h2>
 <h2>In module meta</h2>
 <h3>Modules</h3><ul class="item-list">

--- a/noir_stdlib/docs/std/meta/trait_impl/index.html
+++ b/noir_stdlib/docs/std/meta/trait_impl/index.html
@@ -16,7 +16,7 @@
 <h1><a href="../../../index.html">noir_stdlib</a></h1>
 <div><a href="../../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2><a href="#mod">Module trait_impl</a></h2>
 <h2>In module meta</h2>
 <h3>Modules</h3><ul class="item-list">

--- a/noir_stdlib/docs/std/meta/trait_impl/index.html
+++ b/noir_stdlib/docs/std/meta/trait_impl/index.html
@@ -16,7 +16,7 @@
 <h1><a href="../../../index.html">noir_stdlib</a></h1>
 <div><a href="../../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2><a href="#mod">Module trait_impl</a></h2>
 <h2>In module meta</h2>
 <h3>Modules</h3><ul class="item-list">

--- a/noir_stdlib/docs/std/meta/typ/fn.fresh_type_variable.html
+++ b/noir_stdlib/docs/std/meta/typ/fn.fresh_type_variable.html
@@ -16,7 +16,7 @@
 <h1><a href="../../../index.html">noir_stdlib</a></h1>
 <div><a href="../../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2>In module typ</h2>
 <h3>Functions</h3><ul class="item-list">
 <li><a href="fn.fresh_type_variable.html">fresh_type_variable</a></div></li>

--- a/noir_stdlib/docs/std/meta/typ/fn.fresh_type_variable.html
+++ b/noir_stdlib/docs/std/meta/typ/fn.fresh_type_variable.html
@@ -16,7 +16,7 @@
 <h1><a href="../../../index.html">noir_stdlib</a></h1>
 <div><a href="../../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2>In module typ</h2>
 <h3>Functions</h3><ul class="item-list">
 <li><a href="fn.fresh_type_variable.html">fresh_type_variable</a></div></li>

--- a/noir_stdlib/docs/std/meta/typ/index.html
+++ b/noir_stdlib/docs/std/meta/typ/index.html
@@ -16,7 +16,7 @@
 <h1><a href="../../../index.html">noir_stdlib</a></h1>
 <div><a href="../../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2><a href="#mod">Module typ</a></h2>
 <h3>Module items</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/meta/typ/index.html
+++ b/noir_stdlib/docs/std/meta/typ/index.html
@@ -16,7 +16,7 @@
 <h1><a href="../../../index.html">noir_stdlib</a></h1>
 <div><a href="../../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2><a href="#mod">Module typ</a></h2>
 <h3>Module items</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/meta/type.DeriveFunction.html
+++ b/noir_stdlib/docs/std/meta/type.DeriveFunction.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2>In module meta</h2>
 <h3>Modules</h3><ul class="item-list">
 <li><a href="ctstring/index.html">ctstring</a></div></li>

--- a/noir_stdlib/docs/std/meta/type.DeriveFunction.html
+++ b/noir_stdlib/docs/std/meta/type.DeriveFunction.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2>In module meta</h2>
 <h3>Modules</h3><ul class="item-list">
 <li><a href="ctstring/index.html">ctstring</a></div></li>

--- a/noir_stdlib/docs/std/meta/type_def/index.html
+++ b/noir_stdlib/docs/std/meta/type_def/index.html
@@ -16,7 +16,7 @@
 <h1><a href="../../../index.html">noir_stdlib</a></h1>
 <div><a href="../../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2><a href="#mod">Module type_def</a></h2>
 <h2>In module meta</h2>
 <h3>Modules</h3><ul class="item-list">

--- a/noir_stdlib/docs/std/meta/type_def/index.html
+++ b/noir_stdlib/docs/std/meta/type_def/index.html
@@ -16,7 +16,7 @@
 <h1><a href="../../../index.html">noir_stdlib</a></h1>
 <div><a href="../../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2><a href="#mod">Module type_def</a></h2>
 <h2>In module meta</h2>
 <h3>Modules</h3><ul class="item-list">

--- a/noir_stdlib/docs/std/meta/typed_expr/index.html
+++ b/noir_stdlib/docs/std/meta/typed_expr/index.html
@@ -16,7 +16,7 @@
 <h1><a href="../../../index.html">noir_stdlib</a></h1>
 <div><a href="../../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2><a href="#mod">Module typed_expr</a></h2>
 <h2>In module meta</h2>
 <h3>Modules</h3><ul class="item-list">

--- a/noir_stdlib/docs/std/meta/typed_expr/index.html
+++ b/noir_stdlib/docs/std/meta/typed_expr/index.html
@@ -16,7 +16,7 @@
 <h1><a href="../../../index.html">noir_stdlib</a></h1>
 <div><a href="../../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2><a href="#mod">Module typed_expr</a></h2>
 <h2>In module meta</h2>
 <h3>Modules</h3><ul class="item-list">

--- a/noir_stdlib/docs/std/meta/unresolved_type/index.html
+++ b/noir_stdlib/docs/std/meta/unresolved_type/index.html
@@ -16,7 +16,7 @@
 <h1><a href="../../../index.html">noir_stdlib</a></h1>
 <div><a href="../../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2><a href="#mod">Module unresolved_type</a></h2>
 <h2>In module meta</h2>
 <h3>Modules</h3><ul class="item-list">

--- a/noir_stdlib/docs/std/meta/unresolved_type/index.html
+++ b/noir_stdlib/docs/std/meta/unresolved_type/index.html
@@ -16,7 +16,7 @@
 <h1><a href="../../../index.html">noir_stdlib</a></h1>
 <div><a href="../../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2><a href="#mod">Module unresolved_type</a></h2>
 <h2>In module meta</h2>
 <h3>Modules</h3><ul class="item-list">

--- a/noir_stdlib/docs/std/ops/index.html
+++ b/noir_stdlib/docs/std/ops/index.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2><a href="#mod">Module ops</a></h2>
 <h3>Module items</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/ops/index.html
+++ b/noir_stdlib/docs/std/ops/index.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2><a href="#mod">Module ops</a></h2>
 <h3>Module items</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/ops/trait.Add.html
+++ b/noir_stdlib/docs/std/ops/trait.Add.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2><a href="#trait">Trait Add</a></h2>
 <h3>Required methods</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/ops/trait.Add.html
+++ b/noir_stdlib/docs/std/ops/trait.Add.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2><a href="#trait">Trait Add</a></h2>
 <h3>Required methods</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/ops/trait.BitAnd.html
+++ b/noir_stdlib/docs/std/ops/trait.BitAnd.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2><a href="#trait">Trait BitAnd</a></h2>
 <h3>Required methods</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/ops/trait.BitAnd.html
+++ b/noir_stdlib/docs/std/ops/trait.BitAnd.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2><a href="#trait">Trait BitAnd</a></h2>
 <h3>Required methods</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/ops/trait.BitOr.html
+++ b/noir_stdlib/docs/std/ops/trait.BitOr.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2><a href="#trait">Trait BitOr</a></h2>
 <h3>Required methods</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/ops/trait.BitOr.html
+++ b/noir_stdlib/docs/std/ops/trait.BitOr.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2><a href="#trait">Trait BitOr</a></h2>
 <h3>Required methods</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/ops/trait.BitXor.html
+++ b/noir_stdlib/docs/std/ops/trait.BitXor.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2><a href="#trait">Trait BitXor</a></h2>
 <h3>Required methods</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/ops/trait.BitXor.html
+++ b/noir_stdlib/docs/std/ops/trait.BitXor.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2><a href="#trait">Trait BitXor</a></h2>
 <h3>Required methods</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/ops/trait.Div.html
+++ b/noir_stdlib/docs/std/ops/trait.Div.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2><a href="#trait">Trait Div</a></h2>
 <h3>Required methods</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/ops/trait.Div.html
+++ b/noir_stdlib/docs/std/ops/trait.Div.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2><a href="#trait">Trait Div</a></h2>
 <h3>Required methods</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/ops/trait.Mul.html
+++ b/noir_stdlib/docs/std/ops/trait.Mul.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2><a href="#trait">Trait Mul</a></h2>
 <h3>Required methods</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/ops/trait.Mul.html
+++ b/noir_stdlib/docs/std/ops/trait.Mul.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2><a href="#trait">Trait Mul</a></h2>
 <h3>Required methods</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/ops/trait.Neg.html
+++ b/noir_stdlib/docs/std/ops/trait.Neg.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2><a href="#trait">Trait Neg</a></h2>
 <h3>Required methods</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/ops/trait.Neg.html
+++ b/noir_stdlib/docs/std/ops/trait.Neg.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2><a href="#trait">Trait Neg</a></h2>
 <h3>Required methods</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/ops/trait.Not.html
+++ b/noir_stdlib/docs/std/ops/trait.Not.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2><a href="#trait">Trait Not</a></h2>
 <h3>Required methods</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/ops/trait.Not.html
+++ b/noir_stdlib/docs/std/ops/trait.Not.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2><a href="#trait">Trait Not</a></h2>
 <h3>Required methods</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/ops/trait.Rem.html
+++ b/noir_stdlib/docs/std/ops/trait.Rem.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2><a href="#trait">Trait Rem</a></h2>
 <h3>Required methods</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/ops/trait.Rem.html
+++ b/noir_stdlib/docs/std/ops/trait.Rem.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2><a href="#trait">Trait Rem</a></h2>
 <h3>Required methods</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/ops/trait.Shl.html
+++ b/noir_stdlib/docs/std/ops/trait.Shl.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2><a href="#trait">Trait Shl</a></h2>
 <h3>Required methods</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/ops/trait.Shl.html
+++ b/noir_stdlib/docs/std/ops/trait.Shl.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2><a href="#trait">Trait Shl</a></h2>
 <h3>Required methods</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/ops/trait.Shr.html
+++ b/noir_stdlib/docs/std/ops/trait.Shr.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2><a href="#trait">Trait Shr</a></h2>
 <h3>Required methods</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/ops/trait.Shr.html
+++ b/noir_stdlib/docs/std/ops/trait.Shr.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2><a href="#trait">Trait Shr</a></h2>
 <h3>Required methods</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/ops/trait.Sub.html
+++ b/noir_stdlib/docs/std/ops/trait.Sub.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2><a href="#trait">Trait Sub</a></h2>
 <h3>Required methods</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/ops/trait.Sub.html
+++ b/noir_stdlib/docs/std/ops/trait.Sub.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2><a href="#trait">Trait Sub</a></h2>
 <h3>Required methods</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/ops/trait.WrappingAdd.html
+++ b/noir_stdlib/docs/std/ops/trait.WrappingAdd.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2><a href="#trait">Trait WrappingAdd</a></h2>
 <h3>Required methods</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/ops/trait.WrappingAdd.html
+++ b/noir_stdlib/docs/std/ops/trait.WrappingAdd.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2><a href="#trait">Trait WrappingAdd</a></h2>
 <h3>Required methods</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/ops/trait.WrappingMul.html
+++ b/noir_stdlib/docs/std/ops/trait.WrappingMul.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2><a href="#trait">Trait WrappingMul</a></h2>
 <h3>Required methods</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/ops/trait.WrappingMul.html
+++ b/noir_stdlib/docs/std/ops/trait.WrappingMul.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2><a href="#trait">Trait WrappingMul</a></h2>
 <h3>Required methods</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/ops/trait.WrappingSub.html
+++ b/noir_stdlib/docs/std/ops/trait.WrappingSub.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2><a href="#trait">Trait WrappingSub</a></h2>
 <h3>Required methods</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/ops/trait.WrappingSub.html
+++ b/noir_stdlib/docs/std/ops/trait.WrappingSub.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2><a href="#trait">Trait WrappingSub</a></h2>
 <h3>Required methods</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/option/index.html
+++ b/noir_stdlib/docs/std/option/index.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2><a href="#mod">Module option</a></h2>
 <h3>Module items</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/option/index.html
+++ b/noir_stdlib/docs/std/option/index.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2><a href="#mod">Module option</a></h2>
 <h3>Module items</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/option/struct.Option.html
+++ b/noir_stdlib/docs/std/option/struct.Option.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2><a href="#struct">Struct Option</a></h2>
 <h3>Methods</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/option/struct.Option.html
+++ b/noir_stdlib/docs/std/option/struct.Option.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2><a href="#struct">Struct Option</a></h2>
 <h3>Methods</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/panic/fn.panic.html
+++ b/noir_stdlib/docs/std/panic/fn.panic.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2>In module panic</h2>
 <h3>Functions</h3><ul class="item-list">
 <li><a href="fn.panic.html">panic</a></div></li>

--- a/noir_stdlib/docs/std/panic/fn.panic.html
+++ b/noir_stdlib/docs/std/panic/fn.panic.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2>In module panic</h2>
 <h3>Functions</h3><ul class="item-list">
 <li><a href="fn.panic.html">panic</a></div></li>

--- a/noir_stdlib/docs/std/panic/index.html
+++ b/noir_stdlib/docs/std/panic/index.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2><a href="#mod">Module panic</a></h2>
 <h3>Module items</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/panic/index.html
+++ b/noir_stdlib/docs/std/panic/index.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2><a href="#mod">Module panic</a></h2>
 <h3>Module items</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/prelude/index.html
+++ b/noir_stdlib/docs/std/prelude/index.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2><a href="#mod">Module prelude</a></h2>
 <h3>Module items</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/prelude/index.html
+++ b/noir_stdlib/docs/std/prelude/index.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2><a href="#mod">Module prelude</a></h2>
 <h3>Module items</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/primitive.CtString.html
+++ b/noir_stdlib/docs/std/primitive.CtString.html
@@ -16,7 +16,7 @@
 <h1><a href="../index.html">noir_stdlib</a></h1>
 <div><a href="../all.html">All items</a></div>
 <h2 id="crate-name"><a href="index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2><a href="#primitive">Primitive type CtString</a></h2>
 <h3>Methods</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/primitive.CtString.html
+++ b/noir_stdlib/docs/std/primitive.CtString.html
@@ -16,7 +16,7 @@
 <h1><a href="../index.html">noir_stdlib</a></h1>
 <div><a href="../all.html">All items</a></div>
 <h2 id="crate-name"><a href="index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2><a href="#primitive">Primitive type CtString</a></h2>
 <h3>Methods</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/primitive.Expr.html
+++ b/noir_stdlib/docs/std/primitive.Expr.html
@@ -16,7 +16,7 @@
 <h1><a href="../index.html">noir_stdlib</a></h1>
 <div><a href="../all.html">All items</a></div>
 <h2 id="crate-name"><a href="index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2><a href="#primitive">Primitive type Expr</a></h2>
 <h3>Methods</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/primitive.Expr.html
+++ b/noir_stdlib/docs/std/primitive.Expr.html
@@ -16,7 +16,7 @@
 <h1><a href="../index.html">noir_stdlib</a></h1>
 <div><a href="../all.html">All items</a></div>
 <h2 id="crate-name"><a href="index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2><a href="#primitive">Primitive type Expr</a></h2>
 <h3>Methods</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/primitive.Field.html
+++ b/noir_stdlib/docs/std/primitive.Field.html
@@ -16,7 +16,7 @@
 <h1><a href="../index.html">noir_stdlib</a></h1>
 <div><a href="../all.html">All items</a></div>
 <h2 id="crate-name"><a href="index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2><a href="#primitive">Primitive type Field</a></h2>
 <h3>Methods</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/primitive.Field.html
+++ b/noir_stdlib/docs/std/primitive.Field.html
@@ -16,7 +16,7 @@
 <h1><a href="../index.html">noir_stdlib</a></h1>
 <div><a href="../all.html">All items</a></div>
 <h2 id="crate-name"><a href="index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2><a href="#primitive">Primitive type Field</a></h2>
 <h3>Methods</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/primitive.FunctionDefinition.html
+++ b/noir_stdlib/docs/std/primitive.FunctionDefinition.html
@@ -16,7 +16,7 @@
 <h1><a href="../index.html">noir_stdlib</a></h1>
 <div><a href="../all.html">All items</a></div>
 <h2 id="crate-name"><a href="index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2><a href="#primitive">Primitive type FunctionDefinition</a></h2>
 <h3>Methods</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/primitive.FunctionDefinition.html
+++ b/noir_stdlib/docs/std/primitive.FunctionDefinition.html
@@ -16,7 +16,7 @@
 <h1><a href="../index.html">noir_stdlib</a></h1>
 <div><a href="../all.html">All items</a></div>
 <h2 id="crate-name"><a href="index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2><a href="#primitive">Primitive type FunctionDefinition</a></h2>
 <h3>Methods</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/primitive.Module.html
+++ b/noir_stdlib/docs/std/primitive.Module.html
@@ -16,7 +16,7 @@
 <h1><a href="../index.html">noir_stdlib</a></h1>
 <div><a href="../all.html">All items</a></div>
 <h2 id="crate-name"><a href="index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2><a href="#primitive">Primitive type Module</a></h2>
 <h3>Methods</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/primitive.Module.html
+++ b/noir_stdlib/docs/std/primitive.Module.html
@@ -16,7 +16,7 @@
 <h1><a href="../index.html">noir_stdlib</a></h1>
 <div><a href="../all.html">All items</a></div>
 <h2 id="crate-name"><a href="index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2><a href="#primitive">Primitive type Module</a></h2>
 <h3>Methods</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/primitive.Quoted.html
+++ b/noir_stdlib/docs/std/primitive.Quoted.html
@@ -16,7 +16,7 @@
 <h1><a href="../index.html">noir_stdlib</a></h1>
 <div><a href="../all.html">All items</a></div>
 <h2 id="crate-name"><a href="index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2><a href="#primitive">Primitive type Quoted</a></h2>
 <h3>Methods</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/primitive.Quoted.html
+++ b/noir_stdlib/docs/std/primitive.Quoted.html
@@ -16,7 +16,7 @@
 <h1><a href="../index.html">noir_stdlib</a></h1>
 <div><a href="../all.html">All items</a></div>
 <h2 id="crate-name"><a href="index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2><a href="#primitive">Primitive type Quoted</a></h2>
 <h3>Methods</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/primitive.TraitConstraint.html
+++ b/noir_stdlib/docs/std/primitive.TraitConstraint.html
@@ -16,7 +16,7 @@
 <h1><a href="../index.html">noir_stdlib</a></h1>
 <div><a href="../all.html">All items</a></div>
 <h2 id="crate-name"><a href="index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2><a href="#primitive">Primitive type TraitConstraint</a></h2>
 <h3>Trait implementations</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/primitive.TraitConstraint.html
+++ b/noir_stdlib/docs/std/primitive.TraitConstraint.html
@@ -16,7 +16,7 @@
 <h1><a href="../index.html">noir_stdlib</a></h1>
 <div><a href="../all.html">All items</a></div>
 <h2 id="crate-name"><a href="index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2><a href="#primitive">Primitive type TraitConstraint</a></h2>
 <h3>Trait implementations</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/primitive.TraitDefinition.html
+++ b/noir_stdlib/docs/std/primitive.TraitDefinition.html
@@ -16,7 +16,7 @@
 <h1><a href="../index.html">noir_stdlib</a></h1>
 <div><a href="../all.html">All items</a></div>
 <h2 id="crate-name"><a href="index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2><a href="#primitive">Primitive type TraitDefinition</a></h2>
 <h3>Methods</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/primitive.TraitDefinition.html
+++ b/noir_stdlib/docs/std/primitive.TraitDefinition.html
@@ -16,7 +16,7 @@
 <h1><a href="../index.html">noir_stdlib</a></h1>
 <div><a href="../all.html">All items</a></div>
 <h2 id="crate-name"><a href="index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2><a href="#primitive">Primitive type TraitDefinition</a></h2>
 <h3>Methods</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/primitive.TraitImpl.html
+++ b/noir_stdlib/docs/std/primitive.TraitImpl.html
@@ -16,7 +16,7 @@
 <h1><a href="../index.html">noir_stdlib</a></h1>
 <div><a href="../all.html">All items</a></div>
 <h2 id="crate-name"><a href="index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2><a href="#primitive">Primitive type TraitImpl</a></h2>
 <h3>Methods</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/primitive.TraitImpl.html
+++ b/noir_stdlib/docs/std/primitive.TraitImpl.html
@@ -16,7 +16,7 @@
 <h1><a href="../index.html">noir_stdlib</a></h1>
 <div><a href="../all.html">All items</a></div>
 <h2 id="crate-name"><a href="index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2><a href="#primitive">Primitive type TraitImpl</a></h2>
 <h3>Methods</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/primitive.Type.html
+++ b/noir_stdlib/docs/std/primitive.Type.html
@@ -16,7 +16,7 @@
 <h1><a href="../index.html">noir_stdlib</a></h1>
 <div><a href="../all.html">All items</a></div>
 <h2 id="crate-name"><a href="index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2><a href="#primitive">Primitive type Type</a></h2>
 <h3>Methods</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/primitive.Type.html
+++ b/noir_stdlib/docs/std/primitive.Type.html
@@ -16,7 +16,7 @@
 <h1><a href="../index.html">noir_stdlib</a></h1>
 <div><a href="../all.html">All items</a></div>
 <h2 id="crate-name"><a href="index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2><a href="#primitive">Primitive type Type</a></h2>
 <h3>Methods</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/primitive.TypeDefinition.html
+++ b/noir_stdlib/docs/std/primitive.TypeDefinition.html
@@ -16,7 +16,7 @@
 <h1><a href="../index.html">noir_stdlib</a></h1>
 <div><a href="../all.html">All items</a></div>
 <h2 id="crate-name"><a href="index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2><a href="#primitive">Primitive type TypeDefinition</a></h2>
 <h3>Methods</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/primitive.TypeDefinition.html
+++ b/noir_stdlib/docs/std/primitive.TypeDefinition.html
@@ -16,7 +16,7 @@
 <h1><a href="../index.html">noir_stdlib</a></h1>
 <div><a href="../all.html">All items</a></div>
 <h2 id="crate-name"><a href="index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2><a href="#primitive">Primitive type TypeDefinition</a></h2>
 <h3>Methods</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/primitive.TypedExpr.html
+++ b/noir_stdlib/docs/std/primitive.TypedExpr.html
@@ -16,7 +16,7 @@
 <h1><a href="../index.html">noir_stdlib</a></h1>
 <div><a href="../all.html">All items</a></div>
 <h2 id="crate-name"><a href="index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2><a href="#primitive">Primitive type TypedExpr</a></h2>
 <h3>Methods</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/primitive.TypedExpr.html
+++ b/noir_stdlib/docs/std/primitive.TypedExpr.html
@@ -16,7 +16,7 @@
 <h1><a href="../index.html">noir_stdlib</a></h1>
 <div><a href="../all.html">All items</a></div>
 <h2 id="crate-name"><a href="index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2><a href="#primitive">Primitive type TypedExpr</a></h2>
 <h3>Methods</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/primitive.UnresolvedType.html
+++ b/noir_stdlib/docs/std/primitive.UnresolvedType.html
@@ -16,7 +16,7 @@
 <h1><a href="../index.html">noir_stdlib</a></h1>
 <div><a href="../all.html">All items</a></div>
 <h2 id="crate-name"><a href="index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2><a href="#primitive">Primitive type UnresolvedType</a></h2>
 <h3>Methods</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/primitive.UnresolvedType.html
+++ b/noir_stdlib/docs/std/primitive.UnresolvedType.html
@@ -16,7 +16,7 @@
 <h1><a href="../index.html">noir_stdlib</a></h1>
 <div><a href="../all.html">All items</a></div>
 <h2 id="crate-name"><a href="index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2><a href="#primitive">Primitive type UnresolvedType</a></h2>
 <h3>Methods</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/primitive.array.html
+++ b/noir_stdlib/docs/std/primitive.array.html
@@ -16,7 +16,7 @@
 <h1><a href="../index.html">noir_stdlib</a></h1>
 <div><a href="../all.html">All items</a></div>
 <h2 id="crate-name"><a href="index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2><a href="#primitive">Primitive type array</a></h2>
 <h3>Methods</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/primitive.array.html
+++ b/noir_stdlib/docs/std/primitive.array.html
@@ -16,7 +16,7 @@
 <h1><a href="../index.html">noir_stdlib</a></h1>
 <div><a href="../all.html">All items</a></div>
 <h2 id="crate-name"><a href="index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2><a href="#primitive">Primitive type array</a></h2>
 <h3>Methods</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/primitive.bool.html
+++ b/noir_stdlib/docs/std/primitive.bool.html
@@ -16,7 +16,7 @@
 <h1><a href="../index.html">noir_stdlib</a></h1>
 <div><a href="../all.html">All items</a></div>
 <h2 id="crate-name"><a href="index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2><a href="#primitive">Primitive type bool</a></h2>
 <h3>Trait implementations</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/primitive.bool.html
+++ b/noir_stdlib/docs/std/primitive.bool.html
@@ -16,7 +16,7 @@
 <h1><a href="../index.html">noir_stdlib</a></h1>
 <div><a href="../all.html">All items</a></div>
 <h2 id="crate-name"><a href="index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2><a href="#primitive">Primitive type bool</a></h2>
 <h3>Trait implementations</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/primitive.fmtstr.html
+++ b/noir_stdlib/docs/std/primitive.fmtstr.html
@@ -16,7 +16,7 @@
 <h1><a href="../index.html">noir_stdlib</a></h1>
 <div><a href="../all.html">All items</a></div>
 <h2 id="crate-name"><a href="index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2><a href="#primitive">Primitive type fmtstr</a></h2>
 <h3>Methods</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/primitive.fmtstr.html
+++ b/noir_stdlib/docs/std/primitive.fmtstr.html
@@ -16,7 +16,7 @@
 <h1><a href="../index.html">noir_stdlib</a></h1>
 <div><a href="../all.html">All items</a></div>
 <h2 id="crate-name"><a href="index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2><a href="#primitive">Primitive type fmtstr</a></h2>
 <h3>Methods</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/primitive.i16.html
+++ b/noir_stdlib/docs/std/primitive.i16.html
@@ -16,7 +16,7 @@
 <h1><a href="../index.html">noir_stdlib</a></h1>
 <div><a href="../all.html">All items</a></div>
 <h2 id="crate-name"><a href="index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2><a href="#primitive">Primitive type i16</a></h2>
 <h3>Trait implementations</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/primitive.i16.html
+++ b/noir_stdlib/docs/std/primitive.i16.html
@@ -16,7 +16,7 @@
 <h1><a href="../index.html">noir_stdlib</a></h1>
 <div><a href="../all.html">All items</a></div>
 <h2 id="crate-name"><a href="index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2><a href="#primitive">Primitive type i16</a></h2>
 <h3>Trait implementations</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/primitive.i32.html
+++ b/noir_stdlib/docs/std/primitive.i32.html
@@ -16,7 +16,7 @@
 <h1><a href="../index.html">noir_stdlib</a></h1>
 <div><a href="../all.html">All items</a></div>
 <h2 id="crate-name"><a href="index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2><a href="#primitive">Primitive type i32</a></h2>
 <h3>Trait implementations</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/primitive.i32.html
+++ b/noir_stdlib/docs/std/primitive.i32.html
@@ -16,7 +16,7 @@
 <h1><a href="../index.html">noir_stdlib</a></h1>
 <div><a href="../all.html">All items</a></div>
 <h2 id="crate-name"><a href="index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2><a href="#primitive">Primitive type i32</a></h2>
 <h3>Trait implementations</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/primitive.i64.html
+++ b/noir_stdlib/docs/std/primitive.i64.html
@@ -16,7 +16,7 @@
 <h1><a href="../index.html">noir_stdlib</a></h1>
 <div><a href="../all.html">All items</a></div>
 <h2 id="crate-name"><a href="index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2><a href="#primitive">Primitive type i64</a></h2>
 <h3>Trait implementations</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/primitive.i64.html
+++ b/noir_stdlib/docs/std/primitive.i64.html
@@ -16,7 +16,7 @@
 <h1><a href="../index.html">noir_stdlib</a></h1>
 <div><a href="../all.html">All items</a></div>
 <h2 id="crate-name"><a href="index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2><a href="#primitive">Primitive type i64</a></h2>
 <h3>Trait implementations</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/primitive.i8.html
+++ b/noir_stdlib/docs/std/primitive.i8.html
@@ -16,7 +16,7 @@
 <h1><a href="../index.html">noir_stdlib</a></h1>
 <div><a href="../all.html">All items</a></div>
 <h2 id="crate-name"><a href="index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2><a href="#primitive">Primitive type i8</a></h2>
 <h3>Trait implementations</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/primitive.i8.html
+++ b/noir_stdlib/docs/std/primitive.i8.html
@@ -16,7 +16,7 @@
 <h1><a href="../index.html">noir_stdlib</a></h1>
 <div><a href="../all.html">All items</a></div>
 <h2 id="crate-name"><a href="index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2><a href="#primitive">Primitive type i8</a></h2>
 <h3>Trait implementations</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/primitive.str.html
+++ b/noir_stdlib/docs/std/primitive.str.html
@@ -16,7 +16,7 @@
 <h1><a href="../index.html">noir_stdlib</a></h1>
 <div><a href="../all.html">All items</a></div>
 <h2 id="crate-name"><a href="index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2><a href="#primitive">Primitive type str</a></h2>
 <h3>Methods</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/primitive.str.html
+++ b/noir_stdlib/docs/std/primitive.str.html
@@ -16,7 +16,7 @@
 <h1><a href="../index.html">noir_stdlib</a></h1>
 <div><a href="../all.html">All items</a></div>
 <h2 id="crate-name"><a href="index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2><a href="#primitive">Primitive type str</a></h2>
 <h3>Methods</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/primitive.u128.html
+++ b/noir_stdlib/docs/std/primitive.u128.html
@@ -16,7 +16,7 @@
 <h1><a href="../index.html">noir_stdlib</a></h1>
 <div><a href="../all.html">All items</a></div>
 <h2 id="crate-name"><a href="index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2><a href="#primitive">Primitive type u128</a></h2>
 <h3>Trait implementations</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/primitive.u128.html
+++ b/noir_stdlib/docs/std/primitive.u128.html
@@ -16,7 +16,7 @@
 <h1><a href="../index.html">noir_stdlib</a></h1>
 <div><a href="../all.html">All items</a></div>
 <h2 id="crate-name"><a href="index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2><a href="#primitive">Primitive type u128</a></h2>
 <h3>Trait implementations</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/primitive.u16.html
+++ b/noir_stdlib/docs/std/primitive.u16.html
@@ -16,7 +16,7 @@
 <h1><a href="../index.html">noir_stdlib</a></h1>
 <div><a href="../all.html">All items</a></div>
 <h2 id="crate-name"><a href="index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2><a href="#primitive">Primitive type u16</a></h2>
 <h3>Trait implementations</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/primitive.u16.html
+++ b/noir_stdlib/docs/std/primitive.u16.html
@@ -16,7 +16,7 @@
 <h1><a href="../index.html">noir_stdlib</a></h1>
 <div><a href="../all.html">All items</a></div>
 <h2 id="crate-name"><a href="index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2><a href="#primitive">Primitive type u16</a></h2>
 <h3>Trait implementations</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/primitive.u32.html
+++ b/noir_stdlib/docs/std/primitive.u32.html
@@ -16,7 +16,7 @@
 <h1><a href="../index.html">noir_stdlib</a></h1>
 <div><a href="../all.html">All items</a></div>
 <h2 id="crate-name"><a href="index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2><a href="#primitive">Primitive type u32</a></h2>
 <h3>Trait implementations</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/primitive.u32.html
+++ b/noir_stdlib/docs/std/primitive.u32.html
@@ -16,7 +16,7 @@
 <h1><a href="../index.html">noir_stdlib</a></h1>
 <div><a href="../all.html">All items</a></div>
 <h2 id="crate-name"><a href="index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2><a href="#primitive">Primitive type u32</a></h2>
 <h3>Trait implementations</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/primitive.u64.html
+++ b/noir_stdlib/docs/std/primitive.u64.html
@@ -16,7 +16,7 @@
 <h1><a href="../index.html">noir_stdlib</a></h1>
 <div><a href="../all.html">All items</a></div>
 <h2 id="crate-name"><a href="index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2><a href="#primitive">Primitive type u64</a></h2>
 <h3>Trait implementations</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/primitive.u64.html
+++ b/noir_stdlib/docs/std/primitive.u64.html
@@ -16,7 +16,7 @@
 <h1><a href="../index.html">noir_stdlib</a></h1>
 <div><a href="../all.html">All items</a></div>
 <h2 id="crate-name"><a href="index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2><a href="#primitive">Primitive type u64</a></h2>
 <h3>Trait implementations</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/primitive.u8.html
+++ b/noir_stdlib/docs/std/primitive.u8.html
@@ -16,7 +16,7 @@
 <h1><a href="../index.html">noir_stdlib</a></h1>
 <div><a href="../all.html">All items</a></div>
 <h2 id="crate-name"><a href="index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2><a href="#primitive">Primitive type u8</a></h2>
 <h3>Trait implementations</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/primitive.u8.html
+++ b/noir_stdlib/docs/std/primitive.u8.html
@@ -16,7 +16,7 @@
 <h1><a href="../index.html">noir_stdlib</a></h1>
 <div><a href="../all.html">All items</a></div>
 <h2 id="crate-name"><a href="index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2><a href="#primitive">Primitive type u8</a></h2>
 <h3>Trait implementations</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/primitive.vector.html
+++ b/noir_stdlib/docs/std/primitive.vector.html
@@ -16,7 +16,7 @@
 <h1><a href="../index.html">noir_stdlib</a></h1>
 <div><a href="../all.html">All items</a></div>
 <h2 id="crate-name"><a href="index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2><a href="#primitive">Primitive type vector</a></h2>
 <h3>Methods</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/primitive.vector.html
+++ b/noir_stdlib/docs/std/primitive.vector.html
@@ -16,7 +16,7 @@
 <h1><a href="../index.html">noir_stdlib</a></h1>
 <div><a href="../all.html">All items</a></div>
 <h2 id="crate-name"><a href="index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2><a href="#primitive">Primitive type vector</a></h2>
 <h3>Methods</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/runtime/fn.is_unconstrained.html
+++ b/noir_stdlib/docs/std/runtime/fn.is_unconstrained.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2>In module runtime</h2>
 <h3>Functions</h3><ul class="item-list">
 <li><a href="fn.is_unconstrained.html">is_unconstrained</a></div></li>

--- a/noir_stdlib/docs/std/runtime/fn.is_unconstrained.html
+++ b/noir_stdlib/docs/std/runtime/fn.is_unconstrained.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2>In module runtime</h2>
 <h3>Functions</h3><ul class="item-list">
 <li><a href="fn.is_unconstrained.html">is_unconstrained</a></div></li>

--- a/noir_stdlib/docs/std/runtime/index.html
+++ b/noir_stdlib/docs/std/runtime/index.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2><a href="#mod">Module runtime</a></h2>
 <h3>Module items</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/runtime/index.html
+++ b/noir_stdlib/docs/std/runtime/index.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2><a href="#mod">Module runtime</a></h2>
 <h3>Module items</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/string/index.html
+++ b/noir_stdlib/docs/std/string/index.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2><a href="#mod">Module string</a></h2>
 <h2>In crate string</h2>
 <h3>Modules</h3><ul class="item-list">

--- a/noir_stdlib/docs/std/string/index.html
+++ b/noir_stdlib/docs/std/string/index.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2><a href="#mod">Module string</a></h2>
 <h2>In crate string</h2>
 <h3>Modules</h3><ul class="item-list">

--- a/noir_stdlib/docs/std/test/index.html
+++ b/noir_stdlib/docs/std/test/index.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2><a href="#mod">Module test</a></h2>
 <h3>Module items</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/test/index.html
+++ b/noir_stdlib/docs/std/test/index.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2><a href="#mod">Module test</a></h2>
 <h3>Module items</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/test/struct.OracleMock.html
+++ b/noir_stdlib/docs/std/test/struct.OracleMock.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2><a href="#struct">Struct OracleMock</a></h2>
 <h3>Methods</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/test/struct.OracleMock.html
+++ b/noir_stdlib/docs/std/test/struct.OracleMock.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2><a href="#struct">Struct OracleMock</a></h2>
 <h3>Methods</h3>
 <ul class="sidebar-list">

--- a/noir_stdlib/docs/std/vector/index.html
+++ b/noir_stdlib/docs/std/vector/index.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.15</div>
+<div id="crate-version">1.0.0-beta.20</div>
 <h2><a href="#mod">Module vector</a></h2>
 <h2>In crate vector</h2>
 <h3>Modules</h3><ul class="item-list">

--- a/noir_stdlib/docs/std/vector/index.html
+++ b/noir_stdlib/docs/std/vector/index.html
@@ -16,7 +16,7 @@
 <h1><a href="../../index.html">noir_stdlib</a></h1>
 <div><a href="../../all.html">All items</a></div>
 <h2 id="crate-name"><a href="../index.html">std</a></h2>
-<div id="crate-version">1.0.0-beta.14</div>
+<div id="crate-version">1.0.0-beta.15</div>
 <h2><a href="#mod">Module vector</a></h2>
 <h2>In crate vector</h2>
 <h3>Modules</h3><ul class="item-list">

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -15,6 +15,7 @@
       "include-component-in-tag": false,
       "extra-files": [
         "Cargo.toml",
+        "noir_stdlib/Nargo.toml",
         "acvm-repo/acir/Cargo.toml",
         "acvm-repo/acir_field/Cargo.toml",
         "acvm-repo/acvm/Cargo.toml",


### PR DESCRIPTION
## Problem Resolved

I wanted to update Lampe to use the latest release of `nargo`, which is https://github.com/noir-lang/noir/commit/b4236c1957d0c26cb65d82adc9e5447b6ff1d629 so I opened https://github.com/reilabs/lampe/pull/254

(I had to do this to get the latest `noir-schnorr` compiled, because the Noir compiler embedded in Lampe expects the `is_infinite` field for an `EmbeddedCurvePoint`, which the library no longer has, as it is built against a newer version of the stdlib).

Lampe contains a mirror of our `noir_stdlib`, which was at version `std-1.0.0-beta.14` before, and this is the version which appears in Lean files when referring to various types in the library. 

There are quite a few changes in our stdlib since their latest mirror: 
* `EmbeddedCurvePoint::is_infinite` has been removed: this needs an update in the proofs Lampe has for the stdlib
* read-only references have been added: this currently won't compile with `lampe`

So these are breaking changes, and yet our stdlib version hasn't been changed.

## Summary of Changes

Bumps the stdlib version to match the current beta.20 of Noir / nargo, and updates `release-please` to keep them in sync. 

This doesn't affect the existing release, but perhaps by the time Lampe picks it up, we'll have a newer one. 

## User Documentation

Check one:
- [ ] No user documentation needed.
- [x] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
