### PR TITLE
chore(brillig): clean up small audit findings in variable_liveness

### DIFF
--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_block.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_block.rs
@@ -724,10 +724,9 @@ impl<'block, Registers: RegisterAllocator> BrilligBlock<'block, Registers> {
         }
 
         if !self.building_globals {
-            let dead_variables = self
-                .last_uses
-                .get(&instruction_id)
-                .expect("Last uses for instruction should have been computed");
+            // Instructions with no last uses are omitted from `last_uses` to save memory;
+            // a missing entry is equivalent to an empty set.
+            let dead_variables = self.last_uses.get(&instruction_id).into_iter().flatten();
 
             for dead_variable in dead_variables {
                 // Globals are reserved throughout the entirety of the program

--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/variable_liveness.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/variable_liveness.rs
@@ -289,8 +289,7 @@ impl VariableLiveness {
 
                 let block = &func.dfg[block_id];
 
-                // Check if all successors (except back edges) have been processed
-                let mut all_successors_processed = true;
+                // Collect successors (except back edges) that have not yet been processed.
                 let mut unprocessed_successors = Vec::new();
 
                 for successor_id in block.successors() {
@@ -301,18 +300,16 @@ impl VariableLiveness {
                     }
                     // If successor hasn't been processed yet, we need to process it first
                     if !self.live_in.contains_key(&successor_id) {
-                        all_successors_processed = false;
                         unprocessed_successors.push(successor_id);
                     }
                 }
 
-                // Push this block back with processed = true (for after successors)
+                // Push this block back with processed = true (for after successors).
+                // If every successor was already processed, `unprocessed_successors` is empty and
+                // the block below is a no-op.
                 stack.push((block_id, true));
-                if !all_successors_processed {
-                    // Push unprocessed successors with processed = false
-                    for successor_id in unprocessed_successors {
-                        stack.push((successor_id, false));
-                    }
+                for successor_id in unprocessed_successors {
+                    stack.push((successor_id, false));
                 }
             }
         }
@@ -412,8 +409,12 @@ impl VariableLiveness {
                 // If we don't, then they will only be removed by DIE, as they don't have an actual last use.
                 instruction_last_uses.extend(unused_instruction_results);
 
-                // Remember that we can deallocate these after this instruction.
-                block_last_uses.insert(*instruction_id, instruction_last_uses);
+                // Remember that we can deallocate these after this instruction. Skip
+                // instructions with no last uses to keep the map small; consumers default to
+                // an empty set for missing keys.
+                if !instruction_last_uses.is_empty() {
+                    block_last_uses.insert(*instruction_id, instruction_last_uses);
+                }
             }
 
             self.last_uses.insert(block_id, block_last_uses);


### PR DESCRIPTION
## Summary

Two micro-refactors in `variable_liveness.rs` from milestone 49 (Group 11 audit). No behavior change.

- #12292 — drop the redundant `all_successors_processed` bool in `compute_live_in`. The subsequent for-loop is already a no-op when `unprocessed_successors` is empty.
- #12295 — stop inserting empty `HashSet`s into the `last_uses` map when an instruction has no last uses. The only consumer (`BrilligBlock::compile_ssa_instruction`) now treats a missing key as the empty set, so no one pays memory for the common case of instructions that don't kill any value.

## Test plan

- [x] `cargo nextest run -p noirc_evaluator` — 1342 passed
- [x] `cargo nextest run -p nargo_cli --test execute` — 8221 passed
- [x] `cargo clippy -p noirc_evaluator --release --all-targets` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)