### PR TITLE
fix: lookup method on struct with turbofish separately

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/types.rs
+++ b/compiler/noirc_frontend/src/elaborator/types.rs
@@ -19,7 +19,7 @@ use crate::{
         AsTraitPath, BinaryOpKind, GenericTypeArgs, Ident, PathKind, UnaryOp, UnresolvedType,
         UnresolvedTypeData, UnresolvedTypeExpression, WILDCARD_TYPE,
     },
-    elaborator::{UnstableFeature, path_resolution::PathResolution},
+    elaborator::{Turbofish, UnstableFeature, path_resolution::PathResolution},
     hir::{
         comptime::Integer,
         def_collector::dc_crate::CompilationError,
@@ -1576,20 +1576,12 @@ impl Elaborator<'_> {
                     }
                 }
 
-                let item = match path_resolution.item {
-                    PathResolutionItem::Type(type_id) => {
-                        PathResolutionItem::Method(type_id, turbofish, func_id)
-                    }
-                    PathResolutionItem::TypeAlias(type_alias_id) => {
-                        PathResolutionItem::TypeAliasFunction(type_alias_id, turbofish, func_id)
-                    }
-                    PathResolutionItem::PrimitiveType(primitive_type) => {
-                        PathResolutionItem::PrimitiveFunction(primitive_type, turbofish, func_id)
-                    }
-                    _ => unreachable!("An early return should have triggered before in this case"),
-                };
-                let method = TraitPathResolutionMethod::NotATraitMethod(func_id);
-                return Some(TraitPathResolution { method, item: Some(item), errors: all_errors });
+                return Some(Self::type_method_or_trait_method_func_id_resolution(
+                    path_resolution.item,
+                    turbofish,
+                    func_id,
+                    all_errors,
+                ));
             }
 
             let has_self_arg = false;
@@ -1644,20 +1636,12 @@ impl Elaborator<'_> {
                     errors.push(error);
                 }
 
-                let method = TraitPathResolutionMethod::NotATraitMethod(func_id);
-                let item = match path_resolution.item {
-                    PathResolutionItem::Type(type_id) => {
-                        PathResolutionItem::Method(type_id, turbofish, func_id)
-                    }
-                    PathResolutionItem::TypeAlias(type_alias_id) => {
-                        PathResolutionItem::TypeAliasFunction(type_alias_id, turbofish, func_id)
-                    }
-                    PathResolutionItem::PrimitiveType(primitive_type) => {
-                        PathResolutionItem::PrimitiveFunction(primitive_type, turbofish, func_id)
-                    }
-                    _ => unreachable!("An early return should have triggered before in this case"),
-                };
-                Some(TraitPathResolution { method, item: Some(item), errors })
+                Some(Self::type_method_or_trait_method_func_id_resolution(
+                    path_resolution.item,
+                    turbofish,
+                    func_id,
+                    errors,
+                ))
             }
             HirMethodReference::TraitItemId(HirTraitMethodReference {
                 definition,
@@ -1685,6 +1669,28 @@ impl Elaborator<'_> {
                 Some(TraitPathResolution { method, item: Some(item), errors })
             }
         }
+    }
+
+    fn type_method_or_trait_method_func_id_resolution(
+        path_resolution_item: PathResolutionItem,
+        turbofish: Option<Turbofish>,
+        func_id: FuncId,
+        errors: Vec<PathResolutionError>,
+    ) -> TraitPathResolution {
+        let item = match path_resolution_item {
+            PathResolutionItem::Type(type_id) => {
+                PathResolutionItem::Method(type_id, turbofish, func_id)
+            }
+            PathResolutionItem::TypeAlias(type_alias_id) => {
+                PathResolutionItem::TypeAliasFunction(type_alias_id, turbofish, func_id)
+            }
+            PathResolutionItem::PrimitiveType(primitive_type) => {
+                PathResolutionItem::PrimitiveFunction(primitive_type, turbofish, func_id)
+            }
+            _ => unreachable!("An early return should have triggered before in this case"),
+        };
+        let method = TraitPathResolutionMethod::NotATraitMethod(func_id);
+        TraitPathResolution { method, item: Some(item), errors }
     }
 
     /// Try to resolve a [TypedPath] to a trait method path.

--- a/compiler/noirc_frontend/src/elaborator/types.rs
+++ b/compiler/noirc_frontend/src/elaborator/types.rs
@@ -1480,7 +1480,10 @@ impl Elaborator<'_> {
     /// Without turbofish, returns `None` so the caller falls back to module-based lookup, which
     /// handles `Self::method`, visibility checks, and associated constants correctly.
     #[tracing::instrument(level = "trace", skip_all)]
-    fn resolve_type_trait_method(&mut self, path: &TypedPath) -> Option<TraitPathResolution> {
+    fn resolve_type_method_or_trait_method(
+        &mut self,
+        path: &TypedPath,
+    ) -> Option<TraitPathResolution> {
         if path.segments.len() < 2 {
             return None;
         }
@@ -1667,7 +1670,7 @@ impl Elaborator<'_> {
         self.resolve_trait_static_method_by_self(path)
             .or_else(|| self.resolve_trait_static_method(path))
             .or_else(|| self.resolve_trait_method_by_named_generic(path))
-            .or_else(|| self.resolve_type_trait_method(path))
+            .or_else(|| self.resolve_type_method_or_trait_method(path))
     }
 
     /// Unify two types, modifying both in the process.

--- a/compiler/noirc_frontend/src/elaborator/types.rs
+++ b/compiler/noirc_frontend/src/elaborator/types.rs
@@ -1535,10 +1535,48 @@ impl Elaborator<'_> {
 
         let method_name = last_segment.ident.as_str();
 
-        // If we can find a method on the type, this is definitely not a trait method
-        let check_self_param = false;
-        if self.interner.lookup_direct_method(&typ, method_name, check_self_param).is_some() {
-            return None;
+        // When turbofish generics are provided, use type-directed method lookup to pick the
+        // correct impl. Without turbofish, fall through to module-based lookup, which handles
+        // Self::method resolution, visibility checking, and associated constants correctly.
+        if turbofish.is_some() {
+            let check_self_param = false;
+            if let Some(func_id) =
+                self.interner.lookup_direct_method(&typ, method_name, check_self_param)
+            {
+                self.push_errors(errors);
+                let all_errors = path_resolution.errors;
+                let item = match path_resolution.item {
+                    PathResolutionItem::Type(type_id) => {
+                        PathResolutionItem::Method(type_id, turbofish, func_id)
+                    }
+                    PathResolutionItem::TypeAlias(type_alias_id) => {
+                        PathResolutionItem::TypeAliasFunction(type_alias_id, turbofish, func_id)
+                    }
+                    PathResolutionItem::PrimitiveType(primitive_type) => {
+                        PathResolutionItem::PrimitiveFunction(primitive_type, turbofish, func_id)
+                    }
+                    _ => unreachable!("An early return should have triggered before in this case"),
+                };
+                let method = TraitPathResolutionMethod::NotATraitMethod(func_id);
+                return Some(TraitPathResolution { method, item: Some(item), errors: all_errors });
+            }
+
+            let has_self_arg = false;
+            let trait_methods = self.interner.lookup_trait_methods(&typ, method_name, has_self_arg);
+
+            // If no method matches the turbofish type but the name is a known method for this
+            // type (just incompatible), report an error. If the name isn't a method at all
+            // (e.g. it's an associated constant), return None and let the fallback handle it.
+            if trait_methods.is_empty() && self.interner.has_method_with_name(&typ, method_name) {
+                self.push_errors(errors);
+                let mut all_errors = path_resolution.errors;
+                all_errors.push(PathResolutionError::Unresolved(last_segment.ident.clone()));
+                return Some(TraitPathResolution {
+                    method: TraitPathResolutionMethod::MultipleTraitsInScope,
+                    item: None,
+                    errors: all_errors,
+                });
+            }
         }
 
         let has_self_arg = false;

--- a/compiler/noirc_frontend/src/elaborator/types.rs
+++ b/compiler/noirc_frontend/src/elaborator/types.rs
@@ -23,8 +23,11 @@ use crate::{
     hir::{
         comptime::Integer,
         def_collector::dc_crate::CompilationError,
-        def_map::{ModuleDefId, fully_qualified_module_path},
-        resolution::{errors::ResolverError, import::PathResolutionError},
+        def_map::{ModuleDefId, ModuleId, fully_qualified_module_path},
+        resolution::{
+            errors::ResolverError, import::PathResolutionError,
+            visibility::item_in_module_is_visible,
+        },
         type_check::{
             Source, TypeCheckError,
             generics::{Generic, TraitGenerics},
@@ -1552,7 +1555,26 @@ impl Elaborator<'_> {
                 self.interner.lookup_direct_method(&typ, method_name, check_self_param)
             {
                 self.push_errors(errors);
-                let all_errors = path_resolution.errors;
+                let mut all_errors = path_resolution.errors;
+
+                let visibility = self.interner.function_visibility(func_id);
+                if let Some(func_meta) = self.interner.try_function_meta(&func_id) {
+                    let source_module = ModuleId {
+                        krate: func_meta.source_crate,
+                        local_id: func_meta.source_module,
+                    };
+                    let importing_module =
+                        ModuleId { krate: self.crate_id, local_id: self.local_module() };
+                    if !item_in_module_is_visible(
+                        self.def_maps,
+                        importing_module,
+                        source_module,
+                        visibility,
+                    ) {
+                        all_errors.push(PathResolutionError::Private(last_segment.ident.clone()));
+                    }
+                }
+
                 let item = match path_resolution.item {
                     PathResolutionItem::Type(type_id) => {
                         PathResolutionItem::Method(type_id, turbofish, func_id)

--- a/compiler/noirc_frontend/src/elaborator/types.rs
+++ b/compiler/noirc_frontend/src/elaborator/types.rs
@@ -1603,6 +1603,7 @@ impl Elaborator<'_> {
                     .map(|t| t.to_string())
                     .collect();
                 all_errors.push(PathResolutionError::UnresolvedMethodForType {
+                    typ: typ.to_string(),
                     ident: last_segment.ident.clone(),
                     available_impls,
                 });

--- a/compiler/noirc_frontend/src/elaborator/types.rs
+++ b/compiler/noirc_frontend/src/elaborator/types.rs
@@ -1545,6 +1545,7 @@ impl Elaborator<'_> {
         };
 
         let method_name = last_segment.ident.as_str();
+        let mut trait_methods = None;
 
         // When turbofish generics are provided, use type-directed method lookup to pick the
         // correct impl. Without turbofish, fall through to module-based lookup, which handles
@@ -1592,12 +1593,15 @@ impl Elaborator<'_> {
             }
 
             let has_self_arg = false;
-            let trait_methods = self.interner.lookup_trait_methods(&typ, method_name, has_self_arg);
+            let type_trait_methods =
+                self.interner.lookup_trait_methods(&typ, method_name, has_self_arg);
 
             // If no method matches the turbofish type but the name is a known method for this
             // type (just incompatible), report an error. If the name isn't a method at all
             // (e.g. it's an associated constant), return None and let the fallback handle it.
-            if trait_methods.is_empty() && self.interner.has_method_with_name(&typ, method_name) {
+            if type_trait_methods.is_empty()
+                && self.interner.has_method_with_name(&typ, method_name)
+            {
                 self.push_errors(errors);
                 let mut all_errors = path_resolution.errors;
                 let available_impls = self
@@ -1616,10 +1620,13 @@ impl Elaborator<'_> {
                     errors: all_errors,
                 });
             }
+
+            trait_methods = Some(type_trait_methods);
         }
 
         let has_self_arg = false;
-        let trait_methods = self.interner.lookup_trait_methods(&typ, method_name, has_self_arg);
+        let trait_methods = trait_methods
+            .unwrap_or_else(|| self.interner.lookup_trait_methods(&typ, method_name, has_self_arg));
 
         if trait_methods.is_empty() {
             return None;

--- a/compiler/noirc_frontend/src/elaborator/types.rs
+++ b/compiler/noirc_frontend/src/elaborator/types.rs
@@ -1575,7 +1575,16 @@ impl Elaborator<'_> {
             if trait_methods.is_empty() && self.interner.has_method_with_name(&typ, method_name) {
                 self.push_errors(errors);
                 let mut all_errors = path_resolution.errors;
-                all_errors.push(PathResolutionError::Unresolved(last_segment.ident.clone()));
+                let available_impls = self
+                    .interner
+                    .get_direct_method_impl_types(&typ, method_name)
+                    .into_iter()
+                    .map(|t| t.to_string())
+                    .collect();
+                all_errors.push(PathResolutionError::UnresolvedMethodForType {
+                    ident: last_segment.ident.clone(),
+                    available_impls,
+                });
                 return Some(TraitPathResolution {
                     method: TraitPathResolutionMethod::MultipleTraitsInScope,
                     item: None,

--- a/compiler/noirc_frontend/src/elaborator/types.rs
+++ b/compiler/noirc_frontend/src/elaborator/types.rs
@@ -1473,7 +1473,12 @@ impl Elaborator<'_> {
         matches
     }
 
-    /// This resolves a method in the form `Type::method` where `method` is a trait method
+    /// Resolves a path of the form `Type::method` or `Type::<turbofish>::method`.
+    ///
+    /// When turbofish generics are present, uses type-directed lookup to select the correct impl
+    /// (e.g. `S::<u32, u64>::foo` picks the impl whose self type unifies with `S<u32, u64>`).
+    /// Without turbofish, returns `None` so the caller falls back to module-based lookup, which
+    /// handles `Self::method`, visibility checks, and associated constants correctly.
     #[tracing::instrument(level = "trace", skip_all)]
     fn resolve_type_trait_method(&mut self, path: &TypedPath) -> Option<TraitPathResolution> {
         if path.segments.len() < 2 {

--- a/compiler/noirc_frontend/src/hir/resolution/import.rs
+++ b/compiler/noirc_frontend/src/hir/resolution/import.rs
@@ -61,8 +61,8 @@ pub enum PathResolutionError {
     UnresolvedWithPossibleTraitsToImport { ident: Ident, traits: Vec<String> },
     #[error("Multiple applicable items in scope")]
     MultipleTraitsInScope { ident: Ident, traits: Vec<String> },
-    #[error("Could not resolve '{ident}' in path")]
-    UnresolvedMethodForType { ident: Ident, available_impls: Vec<String> },
+    #[error("No function named '{ident}' found for '{typ}' in the current scope")]
+    UnresolvedMethodForType { typ: String, ident: Ident, available_impls: Vec<String> },
 }
 
 impl PathResolutionError {
@@ -142,12 +142,12 @@ impl<'a> From<&'a PathResolutionError> for CustomDiagnostic {
                     ident.location(),
                 )
             }
-            PathResolutionError::UnresolvedMethodForType { ident, available_impls } => {
+            PathResolutionError::UnresolvedMethodForType { typ: _, ident, available_impls } => {
                 let secondary = if available_impls.is_empty() {
                     String::new()
                 } else {
                     let impls = vecmap(available_impls, |t| format!("`{t}`"));
-                    format!("the method was found for: {}", impls.join(", "))
+                    format!("the function was found for: {}", impls.join(", "))
                 };
                 CustomDiagnostic::simple_error(error.to_string(), secondary, ident.location())
             }

--- a/compiler/noirc_frontend/src/hir/resolution/import.rs
+++ b/compiler/noirc_frontend/src/hir/resolution/import.rs
@@ -61,6 +61,8 @@ pub enum PathResolutionError {
     UnresolvedWithPossibleTraitsToImport { ident: Ident, traits: Vec<String> },
     #[error("Multiple applicable items in scope")]
     MultipleTraitsInScope { ident: Ident, traits: Vec<String> },
+    #[error("Could not resolve '{ident}' in path")]
+    UnresolvedMethodForType { ident: Ident, available_impls: Vec<String> },
 }
 
 impl PathResolutionError {
@@ -73,9 +75,8 @@ impl PathResolutionError {
             | PathResolutionError::NotAModule { ident, .. }
             | PathResolutionError::TraitMethodNotInScope { ident, .. }
             | PathResolutionError::MultipleTraitsInScope { ident, .. }
-            | PathResolutionError::UnresolvedWithPossibleTraitsToImport { ident, .. } => {
-                ident.location()
-            }
+            | PathResolutionError::UnresolvedWithPossibleTraitsToImport { ident, .. }
+            | PathResolutionError::UnresolvedMethodForType { ident, .. } => ident.location(),
         }
     }
 }
@@ -140,6 +141,15 @@ impl<'a> From<&'a PathResolutionError> for CustomDiagnostic {
                     ),
                     ident.location(),
                 )
+            }
+            PathResolutionError::UnresolvedMethodForType { ident, available_impls } => {
+                let secondary = if available_impls.is_empty() {
+                    String::new()
+                } else {
+                    let impls = vecmap(available_impls, |t| format!("`{t}`"));
+                    format!("the method was found for: {}", impls.join(", "))
+                };
+                CustomDiagnostic::simple_error(error.to_string(), secondary, ident.location())
             }
         }
     }

--- a/compiler/noirc_frontend/src/node_interner/mod.rs
+++ b/compiler/noirc_frontend/src/node_interner/mod.rs
@@ -1107,6 +1107,16 @@ impl NodeInterner {
         self.methods.get(&key).is_some_and(|h| h.contains_key(method_name))
     }
 
+    /// Returns the self types of all direct (inherent) impls that define `method_name` for
+    /// the given type's method key, regardless of type compatibility.
+    pub fn get_direct_method_impl_types(&self, typ: &Type, method_name: &str) -> Vec<Type> {
+        let Some(key) = get_type_method_key(typ) else { return Vec::new() };
+        let Some(methods) = self.methods.get(&key).and_then(|h| h.get(method_name)) else {
+            return Vec::new();
+        };
+        methods.direct.iter().map(|m| m.typ.clone()).collect()
+    }
+
     /// Looks up methods that apply to the given type but are defined in traits.
     pub fn lookup_trait_methods(
         &self,

--- a/compiler/noirc_frontend/src/node_interner/mod.rs
+++ b/compiler/noirc_frontend/src/node_interner/mod.rs
@@ -1100,6 +1100,13 @@ impl NodeInterner {
         methods.find_direct_method(typ, check_self_param, self)
     }
 
+    /// Returns true if any method (direct or trait impl) is registered under `method_name`
+    /// for the type's method key, regardless of type compatibility.
+    pub fn has_method_with_name(&self, typ: &Type, method_name: &str) -> bool {
+        let Some(key) = get_type_method_key(typ) else { return false };
+        self.methods.get(&key).is_some_and(|h| h.contains_key(method_name))
+    }
+
     /// Looks up methods that apply to the given type but are defined in traits.
     pub fn lookup_trait_methods(
         &self,

--- a/compiler/noirc_frontend/src/tests/turbofish.rs
+++ b/compiler/noirc_frontend/src/tests/turbofish.rs
@@ -996,3 +996,27 @@ fn struct_turbofish_mixed_generics() {
     "#;
     assert_no_errors(src);
 }
+
+#[test]
+fn struct_turbofish_mixed_generics_visibility_error() {
+    let src = r#"
+    struct S<A, B> {}
+
+    mod moo {
+        impl<T> super::S<T, u64> {
+            fn foo() {}
+        }
+
+        impl super::S<u32, u32> {
+            fn foo() {}
+        }
+    }
+
+    fn main() {
+        S::<u32, u64>::foo();
+                       ^^^ foo is private and not visible from the current module
+                       ~~~ foo is private
+    }
+    "#;
+    check_errors(src);
+}

--- a/compiler/noirc_frontend/src/tests/turbofish.rs
+++ b/compiler/noirc_frontend/src/tests/turbofish.rs
@@ -735,7 +735,7 @@ fn concrete_impl_with_dual_turbofish_mismatch() {
     fn main() {
         let x: Field = 10;
         S::<bool>::foo::<Field>(x);
-        ^^^^^^^^^^^^^^^^^^^^^^^ Expected type u32, found type bool
+                   ^^^ Could not resolve 'foo' in path
     }
     "#;
     check_errors(src);
@@ -834,7 +834,7 @@ fn partially_concrete_impl_turbofish_mismatch_on_concrete_param() {
     fn main() {
         let x: bool = true;
         let _result: bool = S::<bool, bool>::foo(x);
-                            ^^^^^^^^^^^^^^^^^^^^ Expected type u32, found type bool
+                                             ^^^ Could not resolve 'foo' in path
     }
     "#;
     check_errors(src);
@@ -955,4 +955,41 @@ fn concrete_impl_dual_turbofish_type_mismatch() {
     }
     "#;
     check_errors(src);
+}
+
+#[test]
+fn struct_turbofish_same_generic() {
+    let src = r#"
+    struct S<A, B> {}
+
+    impl<T> S<T, T> {
+        fn foo() {}
+    }
+
+    fn main() {
+        S::<u32, u64>::foo();
+                       ^^^ Could not resolve 'foo' in path
+    }
+    "#;
+    check_errors(src);
+}
+
+#[test]
+fn struct_turbofish_mixed_generics() {
+    let src = r#"
+    struct S<A, B> {}
+
+    impl<T> S<T, u64> {
+        fn foo() {}
+    }
+
+    impl S<u32, u32> {
+        fn foo() {}
+    }
+
+    fn main() {
+        S::<u32, u64>::foo();
+    }
+    "#;
+    assert_no_errors(src);
 }

--- a/compiler/noirc_frontend/src/tests/turbofish.rs
+++ b/compiler/noirc_frontend/src/tests/turbofish.rs
@@ -735,8 +735,8 @@ fn concrete_impl_with_dual_turbofish_mismatch() {
     fn main() {
         let x: Field = 10;
         S::<bool>::foo::<Field>(x);
-                   ^^^ Could not resolve 'foo' in path
-                   ~~~ the method was found for: `S<u32>`
+                   ^^^ No function named 'foo' found for 'S<bool>' in the current scope
+                   ~~~ the function was found for: `S<u32>`
     }
     "#;
     check_errors(src);
@@ -835,8 +835,8 @@ fn partially_concrete_impl_turbofish_mismatch_on_concrete_param() {
     fn main() {
         let x: bool = true;
         let _result: bool = S::<bool, bool>::foo(x);
-                                             ^^^ Could not resolve 'foo' in path
-                                             ~~~ the method was found for: `S<u32, B>`
+                                             ^^^ No function named 'foo' found for 'S<bool, bool>' in the current scope
+                                             ~~~ the function was found for: `S<u32, B>`
     }
     "#;
     check_errors(src);
@@ -970,8 +970,8 @@ fn struct_turbofish_same_generic() {
 
     fn main() {
         S::<u32, u64>::foo();
-                       ^^^ Could not resolve 'foo' in path
-                       ~~~ the method was found for: `S<T, T>`
+                       ^^^ No function named 'foo' found for 'S<u32, u64>' in the current scope
+                       ~~~ the function was found for: `S<T, T>`
     }
     "#;
     check_errors(src);

--- a/compiler/noirc_frontend/src/tests/turbofish.rs
+++ b/compiler/noirc_frontend/src/tests/turbofish.rs
@@ -736,6 +736,7 @@ fn concrete_impl_with_dual_turbofish_mismatch() {
         let x: Field = 10;
         S::<bool>::foo::<Field>(x);
                    ^^^ Could not resolve 'foo' in path
+                   ~~~ the method was found for: `S<u32>`
     }
     "#;
     check_errors(src);
@@ -835,6 +836,7 @@ fn partially_concrete_impl_turbofish_mismatch_on_concrete_param() {
         let x: bool = true;
         let _result: bool = S::<bool, bool>::foo(x);
                                              ^^^ Could not resolve 'foo' in path
+                                             ~~~ the method was found for: `S<u32, B>`
     }
     "#;
     check_errors(src);
@@ -969,6 +971,7 @@ fn struct_turbofish_same_generic() {
     fn main() {
         S::<u32, u64>::foo();
                        ^^^ Could not resolve 'foo' in path
+                       ~~~ the method was found for: `S<T, T>`
     }
     "#;
     check_errors(src);


### PR DESCRIPTION
## Problem Resolved

Resolves https://app.audithub.dev/app/organizations/161/projects/599/project-viewer?version=1406&issueId=947

## Summary of Changes

Addresses the last comment in that issue. That specific comment is related to the issue but I ended up fixing it in a completely different way. The problem is that methods are stored in two places: `ModuleData` and `NodeInterner`. `ModuleData` doesn't keep the concrete generics of each impl, so I think only the first or the last one ends up being stored. However, we can get the precise method (given concrete turbofish) from the NodeInterner, using `lookup_direct_method`, so this is what's done here: it's a special-case path, similar to some other special-case paths we already have.

The error message changed a bit, but I made it so that it looks more like what Rust produces.

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
