### PR TITLE
chore: address docs accuracy findings

### DIFF
--- a/docs/docs/explainers/explainer-writing-noir.md
+++ b/docs/docs/explainers/explainer-writing-noir.md
@@ -68,7 +68,6 @@ Fortunately for Noir developers, when needing a particular function a Rust imple
 A few things to do when converting Rust code to Noir:
 - `println!` is not a macro, use `println` function (same for `assert_eq`)
 - No early `return` in function. Use constrain via assertion instead
-- No passing by reference. Remove `&` operator to pass by value (copy)
 - No boolean operators (`&&`, `||`). Use bitwise operators (`&`, `|`) with boolean values
 - No type `usize`. Use types `u8`, `u32`, `u64`, ...
 - `main` return must be public, `pub`
@@ -178,7 +177,7 @@ Use an [unconstrained function](../noir/concepts/unconstrained.md) to perform ga
 
 Eg division generates more gates than multiplication, so calculating the quotient in an unconstrained function then constraining the product for the quotient and divisor (+ any remainder) equals the dividend will be more efficient.
 
-Use `  if is_unconstrained() { /`, to conditionally execute code if being called in an unconstrained vs constrained way.
+Use `if is_unconstrained() { ... }` to conditionally execute code if being called in an unconstrained vs constrained way.
 
 ## Advanced
 

--- a/docs/docs/getting_started/noir_installation.md
+++ b/docs/docs/getting_started/noir_installation.md
@@ -89,7 +89,7 @@ The default backend for Noir (Barretenberg) doesn't provide Windows binaries at 
 
 Step 1: Follow the instructions [here](https://learn.microsoft.com/en-us/windows/wsl/install) to install and run WSL.
 
-step 2: Follow the [Noirup instructions](#installing-noirup).
+Step 2: Follow the [Noirup instructions](#installing-noirup).
 
 ## Setting up shell completions
 

--- a/docs/docs/getting_started/project_breakdown.md
+++ b/docs/docs/getting_started/project_breakdown.md
@@ -37,7 +37,7 @@ Example Nargo.toml:
 name = "noir_starter"
 type = "bin"
 authors = ["Alice"]
-compiler_version = "0.9.0"
+compiler_version = ">=1.0.0"
 description = "Getting started with Noir"
 entry = "circuit/main.nr"
 license = "MIT"
@@ -61,7 +61,7 @@ The package section defines a number of fields including:
 - `name` (**required**) - the name of the package
 - `type` (**required**) - can be "bin", "lib", or "contract" to specify whether its a binary, library or Aztec contract
 - `authors` (optional) - authors of the project
-- `compiler_version` - specifies the version of the compiler to use. This is enforced by the compiler and follow's [Rust's versioning](https://doc.rust-lang.org/cargo/reference/manifest.html#the-version-field), so a `compiler_version = 0.18.0` will enforce Nargo version 0.18.0, `compiler_version = ^0.18.0` will enforce anything above 0.18.0 but below 0.19.0, etc. For more information, see how [Rust handles these operators](https://docs.rs/semver/latest/semver/enum.Op.html)
+- `compiler_version` - specifies the version of the compiler to use. This is enforced by the compiler and follows [Rust's versioning](https://doc.rust-lang.org/cargo/reference/manifest.html#the-version-field), so a `compiler_version = 0.18.0` will enforce Nargo version 0.18.0, `compiler_version = ^0.18.0` will enforce anything above 0.18.0 but below 0.19.0, etc. For more information, see how [Rust handles these operators](https://docs.rs/semver/latest/semver/enum.Op.html)
 - `compiler_unstable_features` (optional) - A list of unstable features required by this package to compile.
 - `description` (optional)
 - `entry` (optional) - a relative filepath to use as the entry point into your package (overrides the default of `src/lib.nr` or `src/main.nr`)
@@ -73,8 +73,9 @@ The package section defines a number of fields including:
 
 This is where you will specify any dependencies for your project. See the [Dependencies page](../noir/modules_packages_crates/dependencies.md) for more info.
 
-`./proofs/` and `./contract/` directories will not be immediately visible until you create a proof or
-verifier contract respectively.
+A `./proofs/` directory and a `./src/contract.sol` verifier contract will not be immediately visible until
+you create a proof or verifier contract respectively. These artifacts are produced by your proving
+backend (for example, Barretenberg's `bb`), not by `nargo` itself.
 
 ### main.nr
 

--- a/docs/docs/noir/concepts/data_bus.mdx
+++ b/docs/docs/noir/concepts/data_bus.mdx
@@ -15,10 +15,12 @@ These modifiers are incompatible with `pub` and `mut` modifiers.
 ## Example
 
 ```rust
-fn main(mut x: u32, y: call_data u32, z: call_data [u32;4] ) -> return_data u32 {
+fn main(mut x: u32, y: call_data(0) u32, z: call_data(0) [u32; 4]) -> return_data u32 {
   let a = z[x];
-  a+y
+  a + y
 }
 ```
+
+Each `call_data` parameter takes an identifier (`call_data(<id>) T`) which groups parameters into the same call-data array — parameters sharing an identifier end up in the same read-only array, while different identifiers produce independent ones.
 
 As a result, both call_data and return_data will be treated as private inputs and encapsulated into a read-only array each, for the backend to process.

--- a/docs/docs/noir/concepts/data_types/arrays.md
+++ b/docs/docs/noir/concepts/data_types/arrays.md
@@ -23,7 +23,7 @@ fn main(x : u64, y : u64) {
 }
 ```
 
-Here, both `my_arr` and `your_arr` are instantiated as an array containing two `Field` elements.
+Here, both `my_arr` and `your_arr` are instantiated as an array containing two `u64` elements.
 
 Array elements can be accessed using indexing:
 
@@ -135,8 +135,8 @@ fn foo(x: Field, array: [Field; 10]) -> Field {
 
 ## Types
 
-You can create arrays of primitive types or structs. There is not yet support for nested arrays
-(arrays of arrays) or arrays of structs that contain arrays.
+You can create arrays of primitive types, structs, nested arrays, and arrays of structs that
+contain arrays. See the multidimensional array example above.
 
 ## Methods
 

--- a/docs/docs/noir/concepts/data_types/vectors.mdx
+++ b/docs/docs/noir/concepts/data_types/vectors.mdx
@@ -28,7 +28,7 @@ It is important to note that vectors are not references to arrays. In Noir,
 
 View the corresponding test file [here][test-file].
 
-[test-file]: https://github.com/noir-lang/noir/blob/f387ec1475129732f72ba294877efdf6857135ac/crates/nargo_cli/tests/test_data_ssa_refactor/vectors/src/main.nr
+[test-file]: https://github.com/noir-lang/noir/blob/master/test_programs/execution_success/array_to_vector/src/main.nr
 
 ## Methods
 

--- a/docs/docs/noir/concepts/functions.md
+++ b/docs/docs/noir/concepts/functions.md
@@ -68,15 +68,16 @@ returned.
 
 If you're writing a binary, the `main` function is the starting point of your program. You can pass all types of expressions to it, as long as they have a fixed size at compile time:
 
-```rust
-fn main(x : Field) // this is fine: passing a Field
-fn main(x : [Field; 2]) // this is also fine: passing a Field with known size at compile-time
-fn main(x : (Field, bool)) // 👌: passing a (Field, bool) tuple means size 2
-fn main(x : str<5>) // this is fine, as long as you pass a string of size 5
+Valid signatures (fixed-size types):
 
-fn main(x : [Field]) // can't compile, has variable size
-fn main(....// i think you got it by now
-```
+- `fn main(x: Field)` — a single `Field`.
+- `fn main(x: [Field; 2])` — a fixed-size array whose length is known at compile time.
+- `fn main(x: (Field, bool))` — a tuple of two fixed-size elements.
+- `fn main(x: str<5>)` — a string whose length is known at compile time.
+
+Invalid signatures (variable-size types):
+
+- `fn main(x: [Field])` — can't compile, has variable size.
 
 Keep in mind [tests](../../tooling/tests.md) don't differentiate between `main` and any other function. The following snippet passes tests, but won't compile or prove:
 

--- a/docs/docs/noir/concepts/functions.md
+++ b/docs/docs/noir/concepts/functions.md
@@ -70,10 +70,10 @@ If you're writing a binary, the `main` function is the starting point of your pr
 
 Valid signatures (fixed-size types):
 
-- `fn main(x: Field)` — a single `Field`.
-- `fn main(x: [Field; 2])` — a fixed-size array whose length is known at compile time.
-- `fn main(x: (Field, bool))` — a tuple of two fixed-size elements.
-- `fn main(x: str<5>)` — a string whose length is known at compile time.
+- `fn main(x: Field)` - a single `Field`.
+- `fn main(x: [Field; 2])` - a fixed-size array whose length is known at compile time.
+- `fn main(x: (Field, bool))` - a tuple of two fixed-size elements.
+- `fn main(x: str<5>)` - a string whose length is known at compile time.
 
 Invalid signatures (variable-size types):
 

--- a/docs/docs/noir/concepts/functions.md
+++ b/docs/docs/noir/concepts/functions.md
@@ -77,7 +77,7 @@ Valid signatures (fixed-size types):
 
 Invalid signatures (variable-size types):
 
-- `fn main(x: [Field])` — can't compile, has variable size.
+- `fn main(x: [Field])` - can't compile, has variable size.
 
 Keep in mind [tests](../../tooling/tests.md) don't differentiate between `main` and any other function. The following snippet passes tests, but won't compile or prove:
 

--- a/docs/docs/noir/concepts/unconstrained.md
+++ b/docs/docs/noir/concepts/unconstrained.md
@@ -130,10 +130,11 @@ unconstrained fn factor(v0: Field) -> [Field; 2] {
     ...
 }
 
-fn main f0 (foo: Field) -> [Field; 2] {
+fn main(foo: Field) -> pub [Field; 2] {
+    // Safety: factored is constrained below by `assert(factored[0] * factored[1] == foo)`
     let factored = unsafe { factor(foo) };
     assert(factored[0] * factored[1] == foo);
-    return factored
+    factored
 }
 ```
 
@@ -152,11 +153,11 @@ unconstrained fn unconstrained_add(v0: Field, v1: Field) -> Field {
     v0 + v1
 }
 
-fn main f0 (v0: Field, v1: Field) {
+fn main(v0: Field, v1: Field) {
     let foo = v0 + v1;
+    // Safety: `bar` is constrained below by `assert(foo == bar)`
     let bar = unsafe { unconstrained_add(v0, v1) };
     assert(foo == bar);
-    return bar
 }
 ```
 

--- a/docs/docs/noir/modules_packages_crates/dependencies.md
+++ b/docs/docs/noir/modules_packages_crates/dependencies.md
@@ -83,7 +83,7 @@ You can also import only the specific parts of dependency that you want to use, 
 
 ```rust
 use std::hash::blake3;
-use std::scalar_mul::fixed_base_embedded_curve;
+use std::embedded_curve_ops::fixed_base_scalar_mul;
 ```
 
 Lastly, You can import multiple items in the same line by enclosing them in curly braces:

--- a/docs/docs/noir/standard_library/is_unconstrained.md
+++ b/docs/docs/noir/standard_library/is_unconstrained.md
@@ -34,7 +34,7 @@ In order to improve the performance in an unconstrained context you can use the 
 
 
 ```rust 
-use dep::std::runtime::is_unconstrained;
+use std::runtime::is_unconstrained;
 
 fn my_expensive_computation(){
   ...

--- a/docs/docs/noir/standard_library/logging.md
+++ b/docs/docs/noir/standard_library/logging.md
@@ -25,7 +25,7 @@ You can print the output of both statements in your Noir code by using the `narg
 
 It is recommended to use `nargo execute` if you want to debug failing constraints with `println` or `print` statements. This is due to every input in a test being a constant rather than a witness, so we issue an error during compilation while we only print during execution (which comes after compilation). Neither `println`, nor `print` are callable for failed constraints caught at compile time.
 
-Both `print` and `println` are generic functions which can work on integers, fields, strings, and even structs or expressions. Note however, that vectors are currently unsupported. For example:
+Both `print` and `println` are generic functions which can work on integers, fields, strings, and even structs or expressions. For example:
 
 ```rust
 struct Person {

--- a/docs/docs/noir/standard_library/meta/expr.md
+++ b/docs/docs/noir/standard_library/meta/expr.md
@@ -83,10 +83,11 @@ the expression and the for loop body.
 
 ### as_for_range
 
-#include_code as_for noir_stdlib/src/meta/expr.nr rust
+#include_code as_for_range noir_stdlib/src/meta/expr.nr rust
 
 If this expression is a for statement over a range, return the identifier,
-the range start, the range end and the for loop body.
+the range start, the range end, whether the range is inclusive, and the
+for loop body.
 
 ### as_function_call
 

--- a/docs/docs/noir/standard_library/meta/typ.md
+++ b/docs/docs/noir/standard_library/meta/typ.md
@@ -86,7 +86,7 @@ If this is a `str<N>` type, returns the length `N` as a type.
 
 #include_code as_data_type noir_stdlib/src/meta/typ.nr rust
 
-If this is a struct type, returns the struct in addition to
+If this is a struct or enum type, returns the type definition in addition to
 any generic arguments on this type.
 
 ### as_tuple

--- a/docs/docs/noir/standard_library/meta/typed_expr.md
+++ b/docs/docs/noir/standard_library/meta/typed_expr.md
@@ -7,11 +7,11 @@ description: Resolved, type-checked expressions—retrieve types, access referen
 
 ## Methods
 
-### get_type
+### as_function_definition
 
 #include_code as_function_definition noir_stdlib/src/meta/typed_expr.nr rust
 
-If this expression refers to a function definitions, returns it. Otherwise returns `Option::none()`.
+If this expression refers to a function definition, returns it. Otherwise returns `Option::none()`.
 
 ### get_type
 

--- a/docs/docs/noir/standard_library/options.md
+++ b/docs/docs/noir/standard_library/options.md
@@ -3,7 +3,7 @@ title: Option<T> Type
 description: Express presence or absence safely with `Option<T>`—construct, inspect, and transform values without nulls.
 ---
 
-The `Option<T>` type is a way to express that a value might be present (`Some(T))` or absent (`None`). It's a safer way to handle potential absence of values, compared to using nulls in many other languages.
+The `Option<T>` type is a way to express that a value might be present (`Some(T)`) or absent (`None`). It's a safer way to handle potential absence of values, compared to using nulls in many other languages.
 
 ```rust
 struct Option<T> {
@@ -21,7 +21,7 @@ fn main() {
 }
 ```
 
-See [this test](https://github.com/noir-lang/noir/blob/5cbfb9c4a06c8865c98ff2b594464b037d821a5c/crates/nargo_cli/tests/test_data/option/src/main.nr) for a more comprehensive set of examples of each of the methods described below.
+See [this test](https://github.com/noir-lang/noir/blob/master/test_programs/compile_success_empty/option/src/main.nr) for a more comprehensive set of examples of each of the methods described below.
 
 ## Methods
 
@@ -39,7 +39,7 @@ Returns true if the Option is None.
 
 ### is_some
 
-Returns true of the Option is Some.
+Returns true if the Option is Some.
 
 ### unwrap
 

--- a/docs/docs/reference/noir_codegen.md
+++ b/docs/docs/reference/noir_codegen.md
@@ -91,8 +91,8 @@ Consider a Noir library with this function:
 
 ```rust
 #[export]
-fn not_equal(x: Field, y: Field) -> bool {
-    x != y
+fn is_equal(x: Field, y: Field) -> bool {
+    x == y
 }
 ```
 

--- a/docs/docs/tutorials/noirjs_app.md
+++ b/docs/docs/tutorials/noirjs_app.md
@@ -16,14 +16,14 @@ You can find the complete app code for this guide [here](https://github.com/noir
 
 Before we start, we want to make sure we have Node installed. If you don't have it already you can install it [here](https://nodejs.org/en/download), we recommend using [Yarn](https://yarnpkg.com/getting-started/install) as our package manager for this tutorial.
 
-We'll also need version 1.0.0-beta.15 nargo installed, see the Noir [installation guide](../getting_started/noir_installation.md) for details.
+We'll also need version 1.0.0-beta.20 nargo installed, see the Noir [installation guide](../getting_started/noir_installation.md) for details.
 
 Let's go barebones. Doing the bare minimum is not only simple, but also allows you to easily adapt it to almost any frontend framework.
 
 Barebones means we can immediately start with the dependencies even on an empty folder 😈:
 
 ```bash
-yarn add @noir-lang/noir_js@1.0.0-beta.15 @aztec/bb.js@3.0.0-nightly.20251104 buffer vite vite-plugin-node-polyfills@0.17.0
+yarn add @noir-lang/noir_js@1.0.0-beta.20 @aztec/bb.js@3.0.0-nightly.20251104 buffer vite vite-plugin-node-polyfills@0.17.0
 ```
 
 Wait, what are these dependencies?
@@ -33,7 +33,7 @@ Wait, what are these dependencies?
 
 :::info
 
-In this guide, we will install versions pinned to 1.0.0-beta.15. These work with Barretenberg version 3.0.0-nightly.20251104, so we are using that one version too. Feel free to try with older or later versions, though!
+In this guide, we will install versions pinned to 1.0.0-beta.20. These work with Barretenberg version 3.0.0-nightly.20251104, so we are using that one version too. Feel free to try with older or later versions, though!
 
 :::
 
@@ -47,7 +47,7 @@ It's not just you. We also enjoy syntax highlighting. [Check out the Language Se
 
 :::
 
-All you need is a `main.nr` and a `Nargo.toml` file. You can follow the [noirup](../getting_started/noir_installation.md) installation and just run `noirup -v 1.0.0-beta.15`, or just create them by hand:
+All you need is a `main.nr` and a `Nargo.toml` file. You can follow the [noirup](../getting_started/noir_installation.md) installation and just run `noirup -v 1.0.0-beta.20`, or just create them by hand:
 
 ```bash
 mkdir -p circuit/src

--- a/docs/versioned_docs/version-v1.0.0-beta.20/explainers/explainer-writing-noir.md
+++ b/docs/versioned_docs/version-v1.0.0-beta.20/explainers/explainer-writing-noir.md
@@ -68,7 +68,6 @@ Fortunately for Noir developers, when needing a particular function a Rust imple
 A few things to do when converting Rust code to Noir:
 - `println!` is not a macro, use `println` function (same for `assert_eq`)
 - No early `return` in function. Use constrain via assertion instead
-- No passing by reference. Remove `&` operator to pass by value (copy)
 - No boolean operators (`&&`, `||`). Use bitwise operators (`&`, `|`) with boolean values
 - No type `usize`. Use types `u8`, `u32`, `u64`, ...
 - `main` return must be public, `pub`
@@ -178,7 +177,7 @@ Use an [unconstrained function](../noir/concepts/unconstrained.md) to perform ga
 
 Eg division generates more gates than multiplication, so calculating the quotient in an unconstrained function then constraining the product for the quotient and divisor (+ any remainder) equals the dividend will be more efficient.
 
-Use `  if is_unconstrained() { /`, to conditionally execute code if being called in an unconstrained vs constrained way.
+Use `if is_unconstrained() { ... }` to conditionally execute code if being called in an unconstrained vs constrained way.
 
 ## Advanced
 

--- a/docs/versioned_docs/version-v1.0.0-beta.20/getting_started/noir_installation.md
+++ b/docs/versioned_docs/version-v1.0.0-beta.20/getting_started/noir_installation.md
@@ -89,7 +89,7 @@ The default backend for Noir (Barretenberg) doesn't provide Windows binaries at 
 
 Step 1: Follow the instructions [here](https://learn.microsoft.com/en-us/windows/wsl/install) to install and run WSL.
 
-step 2: Follow the [Noirup instructions](#installing-noirup).
+Step 2: Follow the [Noirup instructions](#installing-noirup).
 
 ## Setting up shell completions
 

--- a/docs/versioned_docs/version-v1.0.0-beta.20/getting_started/project_breakdown.md
+++ b/docs/versioned_docs/version-v1.0.0-beta.20/getting_started/project_breakdown.md
@@ -37,7 +37,7 @@ Example Nargo.toml:
 name = "noir_starter"
 type = "bin"
 authors = ["Alice"]
-compiler_version = "0.9.0"
+compiler_version = ">=1.0.0"
 description = "Getting started with Noir"
 entry = "circuit/main.nr"
 license = "MIT"
@@ -61,7 +61,7 @@ The package section defines a number of fields including:
 - `name` (**required**) - the name of the package
 - `type` (**required**) - can be "bin", "lib", or "contract" to specify whether its a binary, library or Aztec contract
 - `authors` (optional) - authors of the project
-- `compiler_version` - specifies the version of the compiler to use. This is enforced by the compiler and follow's [Rust's versioning](https://doc.rust-lang.org/cargo/reference/manifest.html#the-version-field), so a `compiler_version = 0.18.0` will enforce Nargo version 0.18.0, `compiler_version = ^0.18.0` will enforce anything above 0.18.0 but below 0.19.0, etc. For more information, see how [Rust handles these operators](https://docs.rs/semver/latest/semver/enum.Op.html)
+- `compiler_version` - specifies the version of the compiler to use. This is enforced by the compiler and follows [Rust's versioning](https://doc.rust-lang.org/cargo/reference/manifest.html#the-version-field), so a `compiler_version = 0.18.0` will enforce Nargo version 0.18.0, `compiler_version = ^0.18.0` will enforce anything above 0.18.0 but below 0.19.0, etc. For more information, see how [Rust handles these operators](https://docs.rs/semver/latest/semver/enum.Op.html)
 - `compiler_unstable_features` (optional) - A list of unstable features required by this package to compile.
 - `description` (optional)
 - `entry` (optional) - a relative filepath to use as the entry point into your package (overrides the default of `src/lib.nr` or `src/main.nr`)
@@ -73,8 +73,9 @@ The package section defines a number of fields including:
 
 This is where you will specify any dependencies for your project. See the [Dependencies page](../noir/modules_packages_crates/dependencies.md) for more info.
 
-`./proofs/` and `./contract/` directories will not be immediately visible until you create a proof or
-verifier contract respectively.
+A `./proofs/` directory and a `./src/contract.sol` verifier contract will not be immediately visible until
+you create a proof or verifier contract respectively. These artifacts are produced by your proving
+backend (for example, Barretenberg's `bb`), not by `nargo` itself.
 
 ### main.nr
 

--- a/docs/versioned_docs/version-v1.0.0-beta.20/noir/concepts/comptime.md
+++ b/docs/versioned_docs/version-v1.0.0-beta.20/noir/concepts/comptime.md
@@ -142,7 +142,7 @@ comptime fn quote_one() -> Quoted {
         }
     }
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/mod.nr#L131-L151" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/mod.nr#L131-L151</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/meta/mod.nr#L131-L151" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/mod.nr#L131-L151</a></sub></sup>
 
 
 For those familiar with quoting from other languages (primarily lisps), Noir's `quote` is actually a _quasiquote_.
@@ -254,7 +254,7 @@ comptime fn concatenate(q1: Quoted, q2: Quoted) -> Quoted {
         }
     }
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/mod.nr#L266-L299" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/mod.nr#L266-L299</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/meta/mod.nr#L266-L299" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/mod.nr#L266-L299</a></sub></sup>
 
 
 ### $crate
@@ -332,7 +332,7 @@ trait FieldCount {
         }
     }
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/mod.nr#L153-L175" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/mod.nr#L153-L175</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/meta/mod.nr#L153-L175" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/mod.nr#L153-L175</a></sub></sup>
 
 
 ### Calling annotations with additional arguments
@@ -352,7 +352,7 @@ When this is done, these additional arguments are passed to the attribute functi
         assert_eq(fields[0].1, typ);
     }
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/mod.nr#L177-L188" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/mod.nr#L177-L188</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/meta/mod.nr#L177-L188" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/mod.nr#L177-L188</a></sub></sup>
 
 
 We can also take any number of arguments by adding the `varargs` attribute:
@@ -368,7 +368,7 @@ We can also take any number of arguments by adding the `varargs` attribute:
         assert_eq(args.len(), 3);
     }
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/mod.nr#L190-L200" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/mod.nr#L190-L200</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/meta/mod.nr#L190-L200" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/mod.nr#L190-L200</a></sub></sup>
 
 
 ### Attribute Evaluation Order
@@ -501,7 +501,7 @@ pub comptime fn derive(s: TypeDefinition, traits: [TraitDefinition]) -> Quoted {
     result
 }
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/mod.nr#L33-L66" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/mod.nr#L33-L66</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/meta/mod.nr#L33-L66" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/mod.nr#L33-L66</a></sub></sup>
 
 
 Registering a derive function could be done as follows:
@@ -512,7 +512,7 @@ pub comptime fn derive_via(t: TraitDefinition, f: DeriveFunction) {
     HANDLERS.insert(t, f);
 }
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/mod.nr#L68-L75" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/mod.nr#L68-L75</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/meta/mod.nr#L68-L75" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/mod.nr#L68-L75</a></sub></sup>
 
 
 ```rust title="big-derive-usage-example" showLineNumbers 
@@ -574,5 +574,5 @@ pub comptime fn derive_via(t: TraitDefinition, f: DeriveFunction) {
         )
     }
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/mod.nr#L202-L260" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/mod.nr#L202-L260</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/meta/mod.nr#L202-L260" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/mod.nr#L202-L260</a></sub></sup>
 

--- a/docs/versioned_docs/version-v1.0.0-beta.20/noir/concepts/data_bus.mdx
+++ b/docs/versioned_docs/version-v1.0.0-beta.20/noir/concepts/data_bus.mdx
@@ -15,10 +15,12 @@ These modifiers are incompatible with `pub` and `mut` modifiers.
 ## Example
 
 ```rust
-fn main(mut x: u32, y: call_data u32, z: call_data [u32;4] ) -> return_data u32 {
+fn main(mut x: u32, y: call_data(0) u32, z: call_data(0) [u32; 4]) -> return_data u32 {
   let a = z[x];
-  a+y
+  a + y
 }
 ```
+
+Each `call_data` parameter takes an identifier (`call_data(<id>) T`) which groups parameters into the same call-data array — parameters sharing an identifier end up in the same read-only array, while different identifiers produce independent ones.
 
 As a result, both call_data and return_data will be treated as private inputs and encapsulated into a read-only array each, for the backend to process.

--- a/docs/versioned_docs/version-v1.0.0-beta.20/noir/concepts/data_types/arrays.md
+++ b/docs/versioned_docs/version-v1.0.0-beta.20/noir/concepts/data_types/arrays.md
@@ -23,7 +23,7 @@ fn main(x : u64, y : u64) {
 }
 ```
 
-Here, both `my_arr` and `your_arr` are instantiated as an array containing two `Field` elements.
+Here, both `my_arr` and `your_arr` are instantiated as an array containing two `u64` elements.
 
 Array elements can be accessed using indexing:
 
@@ -133,8 +133,8 @@ fn foo(x: Field, array: [Field; 10]) -> Field {
 
 ## Types
 
-You can create arrays of primitive types or structs. There is not yet support for nested arrays
-(arrays of arrays) or arrays of structs that contain arrays.
+You can create arrays of primitive types, structs, nested arrays, and arrays of structs that
+contain arrays. See the multidimensional array example above.
 
 ## Methods
 

--- a/docs/versioned_docs/version-v1.0.0-beta.20/noir/concepts/data_types/fields.md
+++ b/docs/versioned_docs/version-v1.0.0-beta.20/noir/concepts/data_types/fields.md
@@ -40,7 +40,7 @@ Transforms the field into an array of bits, Little Endian.
 ```rust title="to_le_bits" showLineNumbers 
 pub fn to_le_bits<let N: u32>(self: Self) -> [bool; N] {
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/field/mod.nr#L29-L31" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/field/mod.nr#L29-L31</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/field/mod.nr#L29-L31" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/field/mod.nr#L29-L31</a></sub></sup>
 
 
 example:
@@ -52,7 +52,7 @@ fn test_to_le_bits() {
         assert_eq(bits, [false, true, false, false, false, false, false, false]);
     }
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/field/mod.nr#L356-L362" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/field/mod.nr#L356-L362</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/field/mod.nr#L356-L362" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/field/mod.nr#L356-L362</a></sub></sup>
 
 
 
@@ -63,7 +63,7 @@ Transforms the field into an array of bits, Big Endian.
 ```rust title="to_be_bits" showLineNumbers 
 pub fn to_be_bits<let N: u32>(self: Self) -> [bool; N] {
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/field/mod.nr#L61-L63" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/field/mod.nr#L61-L63</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/field/mod.nr#L61-L63" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/field/mod.nr#L61-L63</a></sub></sup>
 
 
 example:
@@ -75,7 +75,7 @@ fn test_to_be_bits() {
         assert_eq(bits, [false, false, false, false, false, false, true, false]);
     }
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/field/mod.nr#L347-L353" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/field/mod.nr#L347-L353</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/field/mod.nr#L347-L353" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/field/mod.nr#L347-L353</a></sub></sup>
 
 
 
@@ -86,7 +86,7 @@ Transforms into an array of bytes, Little Endian
 ```rust title="to_le_bytes" showLineNumbers 
 pub fn to_le_bytes<let N: u32>(self: Self) -> [u8; N] {
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/field/mod.nr#L93-L95" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/field/mod.nr#L93-L95</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/field/mod.nr#L93-L95" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/field/mod.nr#L93-L95</a></sub></sup>
 
 
 example:
@@ -99,7 +99,7 @@ fn test_to_le_bytes() {
         assert_eq(Field::from_le_bytes::<8>(bytes), field);
     }
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/field/mod.nr#L375-L382" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/field/mod.nr#L375-L382</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/field/mod.nr#L375-L382" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/field/mod.nr#L375-L382</a></sub></sup>
 
 
 ### to_be_bytes
@@ -109,7 +109,7 @@ Transforms into an array of bytes, Big Endian
 ```rust title="to_be_bytes" showLineNumbers 
 pub fn to_be_bytes<let N: u32>(self: Self) -> [u8; N] {
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/field/mod.nr#L130-L132" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/field/mod.nr#L130-L132</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/field/mod.nr#L130-L132" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/field/mod.nr#L130-L132</a></sub></sup>
 
 
 example:
@@ -122,7 +122,7 @@ fn test_to_be_bytes() {
         assert_eq(Field::from_be_bytes::<8>(bytes), field);
     }
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/field/mod.nr#L365-L372" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/field/mod.nr#L365-L372</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/field/mod.nr#L365-L372" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/field/mod.nr#L365-L372</a></sub></sup>
 
 
 ### pow_32
@@ -150,7 +150,7 @@ Adds a constraint to specify that the field can be represented with `bit_size` n
 ```rust title="assert_max_bit_size" showLineNumbers 
 pub fn assert_max_bit_size<let BIT_SIZE: u32>(self) {
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/field/mod.nr#L10-L12" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/field/mod.nr#L10-L12</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/field/mod.nr#L10-L12" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/field/mod.nr#L10-L12</a></sub></sup>
 
 
 example:
@@ -164,10 +164,10 @@ fn main() {
 
 ### sgn0
 
-Parity of (prime) Field element, i.e. sgn0(x mod p) = 0 if x ∈ \{0, ..., p-1\} is even, otherwise sgn0(x mod p) = 1.
+Parity of (prime) Field element, i.e. sgn0(x mod p) = false if x ∈ \{0, ..., p-1\} is even, otherwise sgn0(x mod p) = true.
 
 ```rust
-fn sgn0(self) -> u1
+fn sgn0(self) -> bool
 ```
 
 

--- a/docs/versioned_docs/version-v1.0.0-beta.20/noir/concepts/data_types/vectors.mdx
+++ b/docs/versioned_docs/version-v1.0.0-beta.20/noir/concepts/data_types/vectors.mdx
@@ -28,7 +28,7 @@ It is important to note that vectors are not references to arrays. In Noir,
 
 View the corresponding test file [here][test-file].
 
-[test-file]: https://github.com/noir-lang/noir/blob/f387ec1475129732f72ba294877efdf6857135ac/crates/nargo_cli/tests/test_data_ssa_refactor/vectors/src/main.nr
+[test-file]: https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/test_programs/execution_success/array_to_vector/src/main.nr
 
 ## Methods
 

--- a/docs/versioned_docs/version-v1.0.0-beta.20/noir/concepts/functions.md
+++ b/docs/versioned_docs/version-v1.0.0-beta.20/noir/concepts/functions.md
@@ -68,15 +68,16 @@ returned.
 
 If you're writing a binary, the `main` function is the starting point of your program. You can pass all types of expressions to it, as long as they have a fixed size at compile time:
 
-```rust
-fn main(x : Field) // this is fine: passing a Field
-fn main(x : [Field; 2]) // this is also fine: passing a Field with known size at compile-time
-fn main(x : (Field, bool)) // 👌: passing a (Field, bool) tuple means size 2
-fn main(x : str<5>) // this is fine, as long as you pass a string of size 5
+Valid signatures (fixed-size types):
 
-fn main(x : [Field]) // can't compile, has variable size
-fn main(....// i think you got it by now
-```
+- `fn main(x: Field)` — a single `Field`.
+- `fn main(x: [Field; 2])` — a fixed-size array whose length is known at compile time.
+- `fn main(x: (Field, bool))` — a tuple of two fixed-size elements.
+- `fn main(x: str<5>)` — a string whose length is known at compile time.
+
+Invalid signatures (variable-size types):
+
+- `fn main(x: [Field])` — can't compile, has variable size.
 
 Keep in mind [tests](../../tooling/tests.md) don't differentiate between `main` and any other function. The following snippet passes tests, but won't compile or prove:
 

--- a/docs/versioned_docs/version-v1.0.0-beta.20/noir/concepts/functions.md
+++ b/docs/versioned_docs/version-v1.0.0-beta.20/noir/concepts/functions.md
@@ -70,14 +70,14 @@ If you're writing a binary, the `main` function is the starting point of your pr
 
 Valid signatures (fixed-size types):
 
-- `fn main(x: Field)` — a single `Field`.
-- `fn main(x: [Field; 2])` — a fixed-size array whose length is known at compile time.
-- `fn main(x: (Field, bool))` — a tuple of two fixed-size elements.
-- `fn main(x: str<5>)` — a string whose length is known at compile time.
+- `fn main(x: Field)` - a single `Field`.
+- `fn main(x: [Field; 2])` - a fixed-size array whose length is known at compile time.
+- `fn main(x: (Field, bool))` - a tuple of two fixed-size elements.
+- `fn main(x: str<5>)` - a string whose length is known at compile time.
 
 Invalid signatures (variable-size types):
 
-- `fn main(x: [Field])` — can't compile, has variable size.
+- `fn main(x: [Field])` - can't compile, has variable size.
 
 Keep in mind [tests](../../tooling/tests.md) don't differentiate between `main` and any other function. The following snippet passes tests, but won't compile or prove:
 

--- a/docs/versioned_docs/version-v1.0.0-beta.20/noir/concepts/generics.md
+++ b/docs/versioned_docs/version-v1.0.0-beta.20/noir/concepts/generics.md
@@ -234,7 +234,7 @@ fn main() {
     pop([]);
 }
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/compile_failure/arithmetic_generics_underflow/src/main.nr#L1-L14" target="_blank" rel="noopener noreferrer">Source code: test_programs/compile_failure/arithmetic_generics_underflow/src/main.nr#L1-L14</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/test_programs/compile_failure/arithmetic_generics_underflow/src/main.nr#L1-L14" target="_blank" rel="noopener noreferrer">Source code: test_programs/compile_failure/arithmetic_generics_underflow/src/main.nr#L1-L14</a></sub></sup>
 
 
 This also applies if there is underflow in an intermediate calculation:
@@ -271,5 +271,5 @@ fn push_zero<let N: u32>(array: [Field; N]) -> [Field; N + 1] {
     result
 }
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/compile_failure/arithmetic_generics_intermediate_underflow/src/main.nr#L1-L32" target="_blank" rel="noopener noreferrer">Source code: test_programs/compile_failure/arithmetic_generics_intermediate_underflow/src/main.nr#L1-L32</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/test_programs/compile_failure/arithmetic_generics_intermediate_underflow/src/main.nr#L1-L32" target="_blank" rel="noopener noreferrer">Source code: test_programs/compile_failure/arithmetic_generics_intermediate_underflow/src/main.nr#L1-L32</a></sub></sup>
 

--- a/docs/versioned_docs/version-v1.0.0-beta.20/noir/concepts/unconstrained.md
+++ b/docs/versioned_docs/version-v1.0.0-beta.20/noir/concepts/unconstrained.md
@@ -26,70 +26,66 @@ An in depth example might help drive the point home. Let's look at how we can op
 fn main(num: u64) -> pub [u8; 8] {
     let mut out: [u8; 8] = [0; 8];
     for i in 0..8 {
-        out[i] = (num >> (56 - (i * 8)) as u64 & 0xff) as u8;
+        out[i] = (num >> (56 - (i as u64 * 8))) as u8;
     }
-
     out
 }
 ```
 
 ```
-Total ACIR opcodes generated for language PLONKCSat { width: 3 }: 91
-Backend circuit size: 3619
+$ nargo info
++---------+----------------------------+--------------+-----------------+
+| Package | Function                   | ACIR Opcodes | Brillig Opcodes |
++=========+============================+==============+=================+
+| short   | main                       | 65           | 8               |
++---------+----------------------------+--------------+-----------------+
+| short   | directive_integer_quotient | N/A          | 8               |
++---------+----------------------------+--------------+-----------------+
 ```
 
-A lot of the operations in this function are optimized away by the compiler (all the bit-shifts turn into divisions by constants). However we can save a bunch of gates by casting to u8 a bit earlier. This automatically truncates the bit-shifted value to fit in a u8 which allows us to remove the AND against 0xff. This saves us ~480 gates in total.
+A lot of the operations in this function are optimized away by the compiler (all the bit-shifts turn into divisions by constants).
+
+Those are some nice savings already but we can do better. This code is all constrained so we're proving every step of calculating `out` using num, but we don't actually care about how we calculate this, just that it's correct. This is where unconstrained code comes in.
+
+It turns out that truncating a `u64` into a `u8` is hard to do inside a snark, each time we do as `u8` we lay down 4 ACIR opcodes which get converted into multiple gates. It's actually much easier to calculate `num` from `out` than the other way around. All we need to do is multiply each element of `out` by a constant and add them all together, both relatively easy operations inside a snark.
+
+We can then run `u64_to_u8` as unconstrained code (Brillig) in order to calculate `out`, then use that result in our constrained function and assert that if we were to do the reverse calculation we'd get back `num`. This looks a little like the below:
 
 ```rust
-fn main(num: u72) -> pub [u8; 8] {
-    let mut out: [u8; 8] = [0; 8];
-    for i in 0..8 {
-        out[i] = (num >> (56 - (i * 8)) as u8;
-    }
-
-    out
-}
-```
-
-```
-Total ACIR opcodes generated for language PLONKCSat { width: 3 }: 75
-Backend circuit size: 3143
-```
-
-Those are some nice savings already but we can do better. This code is all constrained so we're proving every step of calculating out using num, but we don't actually care about how we calculate this, just that it's correct. This is where brillig comes in.
-
-It turns out that truncating a u72 into a u8 is hard to do inside a snark, each time we do as u8 we lay down 4 ACIR opcodes which get converted into multiple gates. It's actually much easier to calculate num from out than the other way around. All we need to do is multiply each element of out by a constant and add them all together, both relatively easy operations inside a snark.
-
-We can then run `u72_to_u8` as unconstrained brillig code in order to calculate out, then use that result in our constrained function and assert that if we were to do the reverse calculation we'd get back num. This looks a little like the below:
-
-```rust
-fn main(num: u72) -> pub [u8; 8] {
+fn main(num: u64) -> pub [u8; 8] {
     // Safety: 'out' is properly constrained below in 'assert(num == reconstructed_num);'
-    let out = unsafe { u72_to_u8(num) };
+    let out = unsafe { u64_to_u8(num) };
 
-    let mut reconstructed_num: u72 = 0;
+    let mut reconstructed_num = 0;
     for i in 0..8 {
-        reconstructed_num += (out[i] as u72 << (56 - (8 * i)));
+        reconstructed_num += (out[i] as u64 << (56 - (8 * i as u64)));
     }
     assert(num == reconstructed_num);
     out
 }
 
-unconstrained fn u72_to_u8(num: u72) -> [u8; 8] {
+unconstrained fn u64_to_u8(num: u64) -> [u8; 8] {
     let mut out: [u8; 8] = [0; 8];
     for i in 0..8 {
-        out[i] = (num >> (56 - (i * 8))) as u8;
+        out[i] = (num >> (56 - (i as u64 * 8))) as u8;
     }
     out
 }
 ```
 
 ```
-Total ACIR opcodes generated for language PLONKCSat { width: 3 }: 78
-Backend circuit size: 2902
+$ nargo info
++---------+-----------+--------------+-----------------+
+| Package | Function  | ACIR Opcodes | Brillig Opcodes |
++=========+===========+==============+=================+
+| short   | main      | 33           | 114             |
++---------+-----------+--------------+-----------------+
+| short   | u64_to_u8 | N/A          | 114             |
++---------+-----------+--------------+-----------------+
 ```
 
-This ends up taking off another ~250 gates from our circuit! We've ended up with more ACIR opcodes than before but they're easier for the backend to prove (resulting in fewer gates).
+This ends up taking off another 32 ACIR opcodes from our circuit!
+We've ended up with more Brillig opcodes than before but it is often faster for the backend to run more unconstrained code (Brillig) to verify it with fewer constrained opcodes (ACIR) later.
 
 Note that in order to invoke unconstrained functions we need to wrap them in an `unsafe` block,
 to make it clear that the call is unconstrained.
@@ -124,10 +120,11 @@ unconstrained fn factor(v0: Field) -> [Field; 2] {
     ...
 }
 
-fn main f0 (foo: Field) -> [Field; 2] {
+fn main(foo: Field) -> pub [Field; 2] {
+    // Safety: factored is constrained below by `assert(factored[0] * factored[1] == foo)`
     let factored = unsafe { factor(foo) };
     assert(factored[0] * factored[1] == foo);
-    return factored
+    factored
 }
 ```
 
@@ -146,11 +143,11 @@ unconstrained fn unconstrained_add(v0: Field, v1: Field) -> Field {
     v0 + v1
 }
 
-fn main f0 (v0: Field, v1: Field) {
+fn main(v0: Field, v1: Field) {
     let foo = v0 + v1;
+    // Safety: `bar` is constrained below by `assert(foo == bar)`
     let bar = unsafe { unconstrained_add(v0, v1) };
     assert(foo == bar);
-    return bar
 }
 ```
 

--- a/docs/versioned_docs/version-v1.0.0-beta.20/noir/modules_packages_crates/dependencies.md
+++ b/docs/versioned_docs/version-v1.0.0-beta.20/noir/modules_packages_crates/dependencies.md
@@ -83,7 +83,7 @@ You can also import only the specific parts of dependency that you want to use, 
 
 ```rust
 use std::hash::blake3;
-use std::scalar_mul::fixed_base_embedded_curve;
+use std::embedded_curve_ops::fixed_base_scalar_mul;
 ```
 
 Lastly, You can import multiple items in the same line by enclosing them in curly braces:

--- a/docs/versioned_docs/version-v1.0.0-beta.20/noir/standard_library/black_box_fns.md
+++ b/docs/versioned_docs/version-v1.0.0-beta.20/noir/standard_library/black_box_fns.md
@@ -28,4 +28,4 @@ Here is a list of the current black box functions:
 
 Most black box functions are included as part of the Noir standard library, however `AND`, `XOR` and `RANGE` are used as part of the Noir language syntax. For instance, using the bitwise operator `&` will invoke the `AND` black box function.
 
-You can view the black box functions defined in the ACVM code [here](https://github.com/noir-lang/noir/blob/master/acvm-repo/acir/src/circuit/black_box_functions.rs).
+You can view the black box functions defined in the ACVM code [here](https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/acvm-repo/acir/src/circuit/black_box_functions.rs).

--- a/docs/versioned_docs/version-v1.0.0-beta.20/noir/standard_library/containers/boundedvec.md
+++ b/docs/versioned_docs/version-v1.0.0-beta.20/noir/standard_library/containers/boundedvec.md
@@ -56,7 +56,7 @@ fn good() -> BoundedVec<Field, 10> {
     v2
 }
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/noir_test_success/bounded_vec/src/main.nr#L6-L15" target="_blank" rel="noopener noreferrer">Source code: test_programs/noir_test_success/bounded_vec/src/main.nr#L6-L15</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/test_programs/noir_test_success/bounded_vec/src/main.nr#L6-L15" target="_blank" rel="noopener noreferrer">Source code: test_programs/noir_test_success/bounded_vec/src/main.nr#L6-L15</a></sub></sup>
 
 
 This defaulting of `MaxLen` (and numeric generics in general) to zero may change in future noir versions
@@ -108,7 +108,7 @@ fn sum_of_first_three<let N: u32>(v: BoundedVec<u32, N>) -> u32 {
     first + second + third
 }
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/noir_test_success/bounded_vec/src/main.nr#L42-L52" target="_blank" rel="noopener noreferrer">Source code: test_programs/noir_test_success/bounded_vec/src/main.nr#L42-L52</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/test_programs/noir_test_success/bounded_vec/src/main.nr#L42-L52" target="_blank" rel="noopener noreferrer">Source code: test_programs/noir_test_success/bounded_vec/src/main.nr#L42-L52</a></sub></sup>
 
 
 ### set
@@ -170,7 +170,7 @@ fn set_unchecked_example() {
     println(vec);
 }
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/noir_test_success/bounded_vec/src/main.nr#L55-L79" target="_blank" rel="noopener noreferrer">Source code: test_programs/noir_test_success/bounded_vec/src/main.nr#L55-L79</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/test_programs/noir_test_success/bounded_vec/src/main.nr#L55-L79" target="_blank" rel="noopener noreferrer">Source code: test_programs/noir_test_success/bounded_vec/src/main.nr#L55-L79</a></sub></sup>
 
 
 
@@ -196,7 +196,7 @@ let mut v: BoundedVec<Field, 2> = BoundedVec::new();
     // Panics with failed assertion "push out of bounds"
     v.push(3);
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/noir_test_success/bounded_vec/src/main.nr#L83-L91" target="_blank" rel="noopener noreferrer">Source code: test_programs/noir_test_success/bounded_vec/src/main.nr#L83-L91</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/test_programs/noir_test_success/bounded_vec/src/main.nr#L83-L91" target="_blank" rel="noopener noreferrer">Source code: test_programs/noir_test_success/bounded_vec/src/main.nr#L83-L91</a></sub></sup>
 
 
 ### pop
@@ -225,7 +225,7 @@ let mut v: BoundedVec<Field, 2> = BoundedVec::new();
     // error: cannot pop from an empty vector
     // let _ = v.pop();
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/noir_test_success/bounded_vec/src/main.nr#L96-L108" target="_blank" rel="noopener noreferrer">Source code: test_programs/noir_test_success/bounded_vec/src/main.nr#L96-L108</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/test_programs/noir_test_success/bounded_vec/src/main.nr#L96-L108" target="_blank" rel="noopener noreferrer">Source code: test_programs/noir_test_success/bounded_vec/src/main.nr#L96-L108</a></sub></sup>
 
 
 ### len
@@ -254,7 +254,7 @@ let mut v: BoundedVec<Field, 4> = BoundedVec::new();
     let _ = v.pop();
     assert(v.len() == 2);
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/noir_test_success/bounded_vec/src/main.nr#L113-L128" target="_blank" rel="noopener noreferrer">Source code: test_programs/noir_test_success/bounded_vec/src/main.nr#L113-L128</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/test_programs/noir_test_success/bounded_vec/src/main.nr#L113-L128" target="_blank" rel="noopener noreferrer">Source code: test_programs/noir_test_success/bounded_vec/src/main.nr#L113-L128</a></sub></sup>
 
 
 ### max_len
@@ -275,7 +275,7 @@ let mut v: BoundedVec<Field, 5> = BoundedVec::new();
     v.push(10);
     assert(v.max_len() == 5);
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/noir_test_success/bounded_vec/src/main.nr#L133-L139" target="_blank" rel="noopener noreferrer">Source code: test_programs/noir_test_success/bounded_vec/src/main.nr#L133-L139</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/test_programs/noir_test_success/bounded_vec/src/main.nr#L133-L139" target="_blank" rel="noopener noreferrer">Source code: test_programs/noir_test_success/bounded_vec/src/main.nr#L133-L139</a></sub></sup>
 
 
 ### storage
@@ -300,7 +300,7 @@ let mut v: BoundedVec<Field, 5> = BoundedVec::new();
     v.push(57);
     assert(v.storage() == [57, 0, 0, 0, 0]);
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/noir_test_success/bounded_vec/src/main.nr#L144-L151" target="_blank" rel="noopener noreferrer">Source code: test_programs/noir_test_success/bounded_vec/src/main.nr#L144-L151</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/test_programs/noir_test_success/bounded_vec/src/main.nr#L144-L151" target="_blank" rel="noopener noreferrer">Source code: test_programs/noir_test_success/bounded_vec/src/main.nr#L144-L151</a></sub></sup>
 
 
 ### extend_from_array
@@ -324,7 +324,7 @@ let mut vec: BoundedVec<Field, 3> = BoundedVec::new();
     assert(vec.get(0) == 2);
     assert(vec.get(1) == 4);
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/noir_test_success/bounded_vec/src/main.nr#L156-L163" target="_blank" rel="noopener noreferrer">Source code: test_programs/noir_test_success/bounded_vec/src/main.nr#L156-L163</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/test_programs/noir_test_success/bounded_vec/src/main.nr#L156-L163" target="_blank" rel="noopener noreferrer">Source code: test_programs/noir_test_success/bounded_vec/src/main.nr#L156-L163</a></sub></sup>
 
 
 ### extend_from_bounded_vec
@@ -351,7 +351,7 @@ let mut v1: BoundedVec<Field, 5> = BoundedVec::new();
     assert(v1.storage() == [1, 2, 3, 0, 0]);
     assert(v2.storage() == [1, 2, 3, 0, 0, 0, 0]);
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/noir_test_success/bounded_vec/src/main.nr#L168-L177" target="_blank" rel="noopener noreferrer">Source code: test_programs/noir_test_success/bounded_vec/src/main.nr#L168-L177</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/test_programs/noir_test_success/bounded_vec/src/main.nr#L168-L177" target="_blank" rel="noopener noreferrer">Source code: test_programs/noir_test_success/bounded_vec/src/main.nr#L168-L177</a></sub></sup>
 
 
 ### from_array
@@ -393,7 +393,7 @@ let vec: BoundedVec<u32, 4> = BoundedVec::from_parts([1, 2, 3, 0], 3);
             let vec2: BoundedVec<u32, 4> = BoundedVec::from_parts([1, 2, 3, 2], 3);
             assert_eq(vec1, vec2);
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/collections/bounded_vec.nr#L1155-L1164" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/collections/bounded_vec.nr#L1155-L1164</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/collections/bounded_vec.nr#L1155-L1164" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/collections/bounded_vec.nr#L1155-L1164</a></sub></sup>
 
 
 ### from_parts_unchecked
@@ -425,7 +425,7 @@ let vec: BoundedVec<u32, 4> = BoundedVec::from_parts_unchecked([1, 2, 3, 0], 3);
             // fails because elements past the length are still checked in eq
             assert(vec1 != vec2);
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/collections/bounded_vec.nr#L1169-L1180" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/collections/bounded_vec.nr#L1169-L1180</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/collections/bounded_vec.nr#L1169-L1180" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/collections/bounded_vec.nr#L1169-L1180</a></sub></sup>
 
 
 ### map
@@ -442,7 +442,7 @@ Example:
 let vec: BoundedVec<u32, 4> = BoundedVec::from_array([1, 2, 3, 4]);
             let result = vec.map(|value| value * 2);
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/collections/bounded_vec.nr#L805-L808" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/collections/bounded_vec.nr#L805-L808</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/collections/bounded_vec.nr#L805-L808" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/collections/bounded_vec.nr#L805-L808</a></sub></sup>
 
 
 ### mapi
@@ -460,7 +460,7 @@ Example:
 let vec: BoundedVec<u32, 4> = BoundedVec::from_array([1, 2, 3, 4]);
             let result = vec.mapi(|i, value| i + value * 2);
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/collections/bounded_vec.nr#L866-L869" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/collections/bounded_vec.nr#L866-L869</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/collections/bounded_vec.nr#L866-L869" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/collections/bounded_vec.nr#L866-L869</a></sub></sup>
 
 
 ### for_each
@@ -477,7 +477,7 @@ Example:
 let vec: BoundedVec<u32, 3> = BoundedVec::from_array([1, 2, 3]);
             vec.for_each(|value| { *acc_ref += value; });
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/collections/bounded_vec.nr#L922-L925" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/collections/bounded_vec.nr#L922-L925</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/collections/bounded_vec.nr#L922-L925" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/collections/bounded_vec.nr#L922-L925</a></sub></sup>
 
 
 ### for_eachi
@@ -494,7 +494,7 @@ Example:
 let vec: BoundedVec<u32, 3> = BoundedVec::from_array([1, 2, 3]);
             vec.for_eachi(|i, value| { *acc_ref += i * value; });
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/collections/bounded_vec.nr#L994-L997" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/collections/bounded_vec.nr#L994-L997</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/collections/bounded_vec.nr#L994-L997" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/collections/bounded_vec.nr#L994-L997</a></sub></sup>
 
 
 ### any
@@ -515,5 +515,5 @@ let mut v: BoundedVec<u32, 3> = BoundedVec::new();
     let all_even = !v.any(|elem: u32| elem % 2 != 0);
     assert(all_even);
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/noir_test_success/bounded_vec/src/main.nr#L244-L250" target="_blank" rel="noopener noreferrer">Source code: test_programs/noir_test_success/bounded_vec/src/main.nr#L244-L250</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/test_programs/noir_test_success/bounded_vec/src/main.nr#L244-L250" target="_blank" rel="noopener noreferrer">Source code: test_programs/noir_test_success/bounded_vec/src/main.nr#L244-L250</a></sub></sup>
 

--- a/docs/versioned_docs/version-v1.0.0-beta.20/noir/standard_library/containers/uhashmap.md
+++ b/docs/versioned_docs/version-v1.0.0-beta.20/noir/standard_library/containers/uhashmap.md
@@ -38,7 +38,7 @@ where
 {
     fn default() -> Self {
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/collections/umap.nr#L451-L457" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/collections/umap.nr#L451-L457</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/collections/umap.nr#L451-L457" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/collections/umap.nr#L451-L457</a></sub></sup>
 
 
 Creates a fresh, empty UHashMap.
@@ -52,7 +52,7 @@ Example:
 let hashmap: UHashMap<u8, u32, BuildHasherDefault<Poseidon2Hasher>> = UHashMap::default();
     assert(hashmap.is_empty());
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/execution_success/uhashmap/src/main.nr#L205-L208" target="_blank" rel="noopener noreferrer">Source code: test_programs/execution_success/uhashmap/src/main.nr#L205-L208</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/test_programs/execution_success/uhashmap/src/main.nr#L205-L208" target="_blank" rel="noopener noreferrer">Source code: test_programs/execution_success/uhashmap/src/main.nr#L205-L208</a></sub></sup>
 
 
 Because `UHashMap` has so many generic arguments that are likely to be the same throughout
@@ -61,7 +61,7 @@ your program, it may be helpful to create a type alias:
 ```rust title="type_alias" showLineNumbers 
 type MyMap = UHashMap<u8, u32, BuildHasherDefault<Poseidon2Hasher>>;
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/execution_success/uhashmap/src/main.nr#L199-L201" target="_blank" rel="noopener noreferrer">Source code: test_programs/execution_success/uhashmap/src/main.nr#L199-L201</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/test_programs/execution_success/uhashmap/src/main.nr#L199-L201" target="_blank" rel="noopener noreferrer">Source code: test_programs/execution_success/uhashmap/src/main.nr#L199-L201</a></sub></sup>
 
 
 ### with_hasher
@@ -72,7 +72,7 @@ pub fn with_hasher(_build_hasher: B) -> Self
         B: BuildHasher,
     {
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/collections/umap.nr#L72-L77" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/collections/umap.nr#L72-L77</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/collections/umap.nr#L72-L77" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/collections/umap.nr#L72-L77</a></sub></sup>
 
 
 Creates a hash map with an existing `BuildHasher`. This can be used to ensure multiple
@@ -86,7 +86,7 @@ let my_hasher: BuildHasherDefault<Poseidon2Hasher> = Default::default();
         UHashMap::with_hasher(my_hasher);
     assert(hashmap.is_empty());
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/execution_success/uhashmap/src/main.nr#L209-L214" target="_blank" rel="noopener noreferrer">Source code: test_programs/execution_success/uhashmap/src/main.nr#L209-L214</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/test_programs/execution_success/uhashmap/src/main.nr#L209-L214" target="_blank" rel="noopener noreferrer">Source code: test_programs/execution_success/uhashmap/src/main.nr#L209-L214</a></sub></sup>
 
 
 ### get
@@ -98,7 +98,7 @@ pub unconstrained fn get(&self, key: K) -> Option<V>
         B: BuildHasher,
     {
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/collections/umap.nr#L275-L281" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/collections/umap.nr#L275-L281</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/collections/umap.nr#L275-L281" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/collections/umap.nr#L275-L281</a></sub></sup>
 
 
 Retrieves a value from the hash map, returning `Option::none()` if it was not found.
@@ -115,7 +115,7 @@ fn get_example(map: &UHashMap<Field, Field, BuildHasherDefault<Poseidon2Hasher>>
     }
 }
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/execution_success/uhashmap/src/main.nr#L294-L303" target="_blank" rel="noopener noreferrer">Source code: test_programs/execution_success/uhashmap/src/main.nr#L294-L303</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/test_programs/execution_success/uhashmap/src/main.nr#L294-L303" target="_blank" rel="noopener noreferrer">Source code: test_programs/execution_success/uhashmap/src/main.nr#L294-L303</a></sub></sup>
 
 
 ### insert
@@ -127,7 +127,7 @@ pub unconstrained fn insert(&mut self, key: K, value: V)
         B: BuildHasher,
     {
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/collections/umap.nr#L303-L309" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/collections/umap.nr#L303-L309</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/collections/umap.nr#L303-L309" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/collections/umap.nr#L303-L309</a></sub></sup>
 
 
 Inserts a new key-value pair into the map. If the key was already in the map, its
@@ -140,7 +140,7 @@ let mut map: UHashMap<Field, Field, BuildHasherDefault<Poseidon2Hasher>> = UHash
     map.insert(12, 42);
     assert(map.len() == 1);
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/execution_success/uhashmap/src/main.nr#L215-L219" target="_blank" rel="noopener noreferrer">Source code: test_programs/execution_success/uhashmap/src/main.nr#L215-L219</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/test_programs/execution_success/uhashmap/src/main.nr#L215-L219" target="_blank" rel="noopener noreferrer">Source code: test_programs/execution_success/uhashmap/src/main.nr#L215-L219</a></sub></sup>
 
 
 ### remove
@@ -152,7 +152,7 @@ pub unconstrained fn remove(&mut self, key: K)
         B: BuildHasher,
     {
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/collections/umap.nr#L370-L376" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/collections/umap.nr#L370-L376</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/collections/umap.nr#L370-L376" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/collections/umap.nr#L370-L376</a></sub></sup>
 
 
 Removes the given key-value pair from the map. If the key was not already present
@@ -168,7 +168,7 @@ map.remove(12);
     map.remove(12);
     assert(map.is_empty());
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/execution_success/uhashmap/src/main.nr#L222-L229" target="_blank" rel="noopener noreferrer">Source code: test_programs/execution_success/uhashmap/src/main.nr#L222-L229</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/test_programs/execution_success/uhashmap/src/main.nr#L222-L229" target="_blank" rel="noopener noreferrer">Source code: test_programs/execution_success/uhashmap/src/main.nr#L222-L229</a></sub></sup>
 
 
 ### is_empty
@@ -176,7 +176,7 @@ map.remove(12);
 ```rust title="is_empty" showLineNumbers 
 pub fn is_empty(&self) -> bool {
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/collections/umap.nr#L116-L118" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/collections/umap.nr#L116-L118</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/collections/umap.nr#L116-L118" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/collections/umap.nr#L116-L118</a></sub></sup>
 
 
 True if the length of the hash map is empty.
@@ -192,7 +192,7 @@ assert(map.is_empty());
     map.remove(1);
     assert(map.is_empty());
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/execution_success/uhashmap/src/main.nr#L230-L238" target="_blank" rel="noopener noreferrer">Source code: test_programs/execution_success/uhashmap/src/main.nr#L230-L238</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/test_programs/execution_success/uhashmap/src/main.nr#L230-L238" target="_blank" rel="noopener noreferrer">Source code: test_programs/execution_success/uhashmap/src/main.nr#L230-L238</a></sub></sup>
 
 
 ### len
@@ -200,7 +200,7 @@ assert(map.is_empty());
 ```rust title="len" showLineNumbers 
 pub fn len(&self) -> u32 {
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/collections/umap.nr#L261-L263" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/collections/umap.nr#L261-L263</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/collections/umap.nr#L261-L263" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/collections/umap.nr#L261-L263</a></sub></sup>
 
 
 Returns the current length of this hash map.
@@ -223,7 +223,7 @@ Example:
     map.remove(1);
     assert(map.len() == 2);
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/execution_success/uhashmap/src/main.nr#L239-L254" target="_blank" rel="noopener noreferrer">Source code: test_programs/execution_success/uhashmap/src/main.nr#L239-L254</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/test_programs/execution_success/uhashmap/src/main.nr#L239-L254" target="_blank" rel="noopener noreferrer">Source code: test_programs/execution_success/uhashmap/src/main.nr#L239-L254</a></sub></sup>
 
 
 ### clear
@@ -231,7 +231,7 @@ Example:
 ```rust title="clear" showLineNumbers 
 pub fn clear(&mut self) {
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/collections/umap.nr#L96-L98" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/collections/umap.nr#L96-L98</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/collections/umap.nr#L96-L98" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/collections/umap.nr#L96-L98</a></sub></sup>
 
 
 Clears the hash map, removing all key-value pairs from it.
@@ -243,7 +243,7 @@ assert(!map.is_empty());
     map.clear();
     assert(map.is_empty());
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/execution_success/uhashmap/src/main.nr#L261-L265" target="_blank" rel="noopener noreferrer">Source code: test_programs/execution_success/uhashmap/src/main.nr#L261-L265</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/test_programs/execution_success/uhashmap/src/main.nr#L261-L265" target="_blank" rel="noopener noreferrer">Source code: test_programs/execution_success/uhashmap/src/main.nr#L261-L265</a></sub></sup>
 
 
 ### contains_key
@@ -255,7 +255,7 @@ pub fn contains_key(&self, key: K) -> bool
         B: BuildHasher,
     {
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/collections/umap.nr#L104-L110" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/collections/umap.nr#L104-L110</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/collections/umap.nr#L104-L110" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/collections/umap.nr#L104-L110</a></sub></sup>
 
 
 True if the hash map contains the given key. Unlike `get`, this will not also return
@@ -271,7 +271,7 @@ if map.contains_key(7) {
         println("No value for key 7!");
     }
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/execution_success/uhashmap/src/main.nr#L266-L273" target="_blank" rel="noopener noreferrer">Source code: test_programs/execution_success/uhashmap/src/main.nr#L266-L273</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/test_programs/execution_success/uhashmap/src/main.nr#L266-L273" target="_blank" rel="noopener noreferrer">Source code: test_programs/execution_success/uhashmap/src/main.nr#L266-L273</a></sub></sup>
 
 
 ### entries
@@ -279,7 +279,7 @@ if map.contains_key(7) {
 ```rust title="entries" showLineNumbers 
 pub fn entries(&self) -> [(K, V)] {
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/collections/umap.nr#L124-L126" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/collections/umap.nr#L124-L126</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/collections/umap.nr#L124-L126" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/collections/umap.nr#L124-L126</a></sub></sup>
 
 
 Returns a vector of each key-value pair present in the hash map.
@@ -300,7 +300,7 @@ let entries = map.entries();
         }
     }
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/execution_success/uhashmap/src/main.nr#L306-L317" target="_blank" rel="noopener noreferrer">Source code: test_programs/execution_success/uhashmap/src/main.nr#L306-L317</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/test_programs/execution_success/uhashmap/src/main.nr#L306-L317" target="_blank" rel="noopener noreferrer">Source code: test_programs/execution_success/uhashmap/src/main.nr#L306-L317</a></sub></sup>
 
 
 ### keys
@@ -308,7 +308,7 @@ let entries = map.entries();
 ```rust title="keys" showLineNumbers 
 pub fn keys(&self) -> [K] {
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/collections/umap.nr#L147-L149" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/collections/umap.nr#L147-L149</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/collections/umap.nr#L147-L149" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/collections/umap.nr#L147-L149</a></sub></sup>
 
 
 Returns a vector of each key present in the hash map.
@@ -326,7 +326,7 @@ let keys = map.keys();
         println(f"{key} -> {value}");
     }
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/execution_success/uhashmap/src/main.nr#L318-L326" target="_blank" rel="noopener noreferrer">Source code: test_programs/execution_success/uhashmap/src/main.nr#L318-L326</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/test_programs/execution_success/uhashmap/src/main.nr#L318-L326" target="_blank" rel="noopener noreferrer">Source code: test_programs/execution_success/uhashmap/src/main.nr#L318-L326</a></sub></sup>
 
 
 ### values
@@ -334,7 +334,7 @@ let keys = map.keys();
 ```rust title="values" showLineNumbers 
 pub fn values(&self) -> [V] {
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/collections/umap.nr#L169-L171" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/collections/umap.nr#L169-L171</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/collections/umap.nr#L169-L171" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/collections/umap.nr#L169-L171</a></sub></sup>
 
 
 Returns a vector of each value present in the hash map.
@@ -350,7 +350,7 @@ let values = map.values();
         println(f"Found value {value}");
     }
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/execution_success/uhashmap/src/main.nr#L327-L333" target="_blank" rel="noopener noreferrer">Source code: test_programs/execution_success/uhashmap/src/main.nr#L327-L333</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/test_programs/execution_success/uhashmap/src/main.nr#L327-L333" target="_blank" rel="noopener noreferrer">Source code: test_programs/execution_success/uhashmap/src/main.nr#L327-L333</a></sub></sup>
 
 
 ### iter_mut
@@ -362,7 +362,7 @@ pub unconstrained fn iter_mut(&mut self, f: fn(K, V) -> (K, V))
         B: BuildHasher,
     {
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/collections/umap.nr#L190-L196" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/collections/umap.nr#L190-L196</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/collections/umap.nr#L190-L196" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/collections/umap.nr#L190-L196</a></sub></sup>
 
 
 Iterates through each key-value pair of the UHashMap, setting each key-value pair to the
@@ -381,7 +381,7 @@ Example:
 // Add 1 to each key in the map, and double the value associated with that key.
     map.iter_mut(|k, v| (k + 1, v * 2));
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/execution_success/uhashmap/src/main.nr#L339-L342" target="_blank" rel="noopener noreferrer">Source code: test_programs/execution_success/uhashmap/src/main.nr#L339-L342</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/test_programs/execution_success/uhashmap/src/main.nr#L339-L342" target="_blank" rel="noopener noreferrer">Source code: test_programs/execution_success/uhashmap/src/main.nr#L339-L342</a></sub></sup>
 
 
 ### iter_keys_mut
@@ -393,7 +393,7 @@ pub unconstrained fn iter_keys_mut(&mut self, f: fn(K) -> K)
         B: BuildHasher,
     {
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/collections/umap.nr#L210-L216" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/collections/umap.nr#L210-L216</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/collections/umap.nr#L210-L216" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/collections/umap.nr#L210-L216</a></sub></sup>
 
 
 Iterates through the UHashMap, mutating each key to the result returned from
@@ -412,7 +412,7 @@ Example:
 // Double each key, leaving the value associated with that key untouched
     map.iter_keys_mut(|k| k * 2);
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/execution_success/uhashmap/src/main.nr#L343-L346" target="_blank" rel="noopener noreferrer">Source code: test_programs/execution_success/uhashmap/src/main.nr#L343-L346</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/test_programs/execution_success/uhashmap/src/main.nr#L343-L346" target="_blank" rel="noopener noreferrer">Source code: test_programs/execution_success/uhashmap/src/main.nr#L343-L346</a></sub></sup>
 
 
 ### iter_values_mut
@@ -420,7 +420,7 @@ Example:
 ```rust title="iter_values_mut" showLineNumbers 
 pub fn iter_values_mut(&mut self, f: fn(V) -> V) {
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/collections/umap.nr#L232-L234" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/collections/umap.nr#L232-L234</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/collections/umap.nr#L232-L234" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/collections/umap.nr#L232-L234</a></sub></sup>
 
 
 Iterates through the UHashMap, applying the given function to each value and mutating the
@@ -433,7 +433,7 @@ Example:
 // Halve each value
     map.iter_values_mut(|v| v / 2);
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/execution_success/uhashmap/src/main.nr#L347-L350" target="_blank" rel="noopener noreferrer">Source code: test_programs/execution_success/uhashmap/src/main.nr#L347-L350</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/test_programs/execution_success/uhashmap/src/main.nr#L347-L350" target="_blank" rel="noopener noreferrer">Source code: test_programs/execution_success/uhashmap/src/main.nr#L347-L350</a></sub></sup>
 
 
 ### retain
@@ -441,7 +441,7 @@ Example:
 ```rust title="retain" showLineNumbers 
 pub fn retain(&mut self, f: fn(K, V) -> bool) {
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/collections/umap.nr#L245-L247" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/collections/umap.nr#L245-L247</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/collections/umap.nr#L245-L247" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/collections/umap.nr#L245-L247</a></sub></sup>
 
 
 Retains only the key-value pairs for which the given function returns true.
@@ -452,7 +452,7 @@ Example:
 ```rust title="retain_example" showLineNumbers 
 map.retain(|k, v| (k != 0) & (v != 0));
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/execution_success/uhashmap/src/main.nr#L277-L279" target="_blank" rel="noopener noreferrer">Source code: test_programs/execution_success/uhashmap/src/main.nr#L277-L279</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/test_programs/execution_success/uhashmap/src/main.nr#L277-L279" target="_blank" rel="noopener noreferrer">Source code: test_programs/execution_success/uhashmap/src/main.nr#L277-L279</a></sub></sup>
 
 
 ## Trait Implementations
@@ -466,7 +466,7 @@ where
 {
     fn default() -> Self {
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/collections/umap.nr#L451-L457" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/collections/umap.nr#L451-L457</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/collections/umap.nr#L451-L457" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/collections/umap.nr#L451-L457</a></sub></sup>
 
 
 Constructs an empty UHashMap.
@@ -477,7 +477,7 @@ Example:
 let hashmap: UHashMap<u8, u32, BuildHasherDefault<Poseidon2Hasher>> = UHashMap::default();
     assert(hashmap.is_empty());
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/execution_success/uhashmap/src/main.nr#L205-L208" target="_blank" rel="noopener noreferrer">Source code: test_programs/execution_success/uhashmap/src/main.nr#L205-L208</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/test_programs/execution_success/uhashmap/src/main.nr#L205-L208" target="_blank" rel="noopener noreferrer">Source code: test_programs/execution_success/uhashmap/src/main.nr#L205-L208</a></sub></sup>
 
 
 ### eq
@@ -491,7 +491,7 @@ where
 {
     fn eq(self, other: UHashMap<K, V, B>) -> bool {
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/collections/umap.nr#L416-L424" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/collections/umap.nr#L416-L424</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/collections/umap.nr#L416-L424" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/collections/umap.nr#L416-L424</a></sub></sup>
 
 
 Checks if two UHashMaps are equal.
@@ -510,5 +510,5 @@ let mut map1: UHashMap<Field, u64, BuildHasherDefault<Poseidon2Hasher>> = UHashM
 
     assert(map1 == map2);
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/execution_success/uhashmap/src/main.nr#L280-L291" target="_blank" rel="noopener noreferrer">Source code: test_programs/execution_success/uhashmap/src/main.nr#L280-L291</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/test_programs/execution_success/uhashmap/src/main.nr#L280-L291" target="_blank" rel="noopener noreferrer">Source code: test_programs/execution_success/uhashmap/src/main.nr#L280-L291</a></sub></sup>
 

--- a/docs/versioned_docs/version-v1.0.0-beta.20/noir/standard_library/cryptographic_primitives/ciphers.mdx
+++ b/docs/versioned_docs/version-v1.0.0-beta.20/noir/standard_library/cryptographic_primitives/ciphers.mdx
@@ -35,7 +35,7 @@ pub fn aes128_encrypt<let N: u32>(
 #[foreign(aes128_encrypt)]
 fn aes128_encrypt_padded_input<let N: u32>(input: [u8; N], iv: [u8; 16], key: [u8; 16]) -> [u8; N] {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/aes128.nr#L1-L23" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/aes128.nr#L1-L23</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/aes128.nr#L1-L23" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/aes128.nr#L1-L23</a></sub></sup>
 
 
 ```rust

--- a/docs/versioned_docs/version-v1.0.0-beta.20/noir/standard_library/cryptographic_primitives/ecdsa_sig_verification.mdx
+++ b/docs/versioned_docs/version-v1.0.0-beta.20/noir/standard_library/cryptographic_primitives/ecdsa_sig_verification.mdx
@@ -36,7 +36,7 @@ pub fn verify_signature(
     message_hash: [u8; 32],
 ) -> bool
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/ecdsa_secp256k1.nr#L1-L23" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/ecdsa_secp256k1.nr#L1-L23</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/ecdsa_secp256k1.nr#L1-L23" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/ecdsa_secp256k1.nr#L1-L23</a></sub></sup>
 
 
 example:
@@ -77,7 +77,7 @@ pub fn verify_signature(
     message_hash: [u8; 32],
 ) -> bool
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/ecdsa_secp256r1.nr#L2-L24" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/ecdsa_secp256r1.nr#L2-L24</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/ecdsa_secp256r1.nr#L2-L24" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/ecdsa_secp256r1.nr#L2-L24</a></sub></sup>
 
 
 example:

--- a/docs/versioned_docs/version-v1.0.0-beta.20/noir/standard_library/cryptographic_primitives/embedded_curve_ops.mdx
+++ b/docs/versioned_docs/version-v1.0.0-beta.20/noir/standard_library/cryptographic_primitives/embedded_curve_ops.mdx
@@ -28,7 +28,7 @@ pub fn multi_scalar_mul<let N: u32>(
     scalars: [EmbeddedCurveScalar; N],
 ) -> EmbeddedCurvePoint
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/embedded_curve_ops.nr#L141-L146" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/embedded_curve_ops.nr#L141-L146</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/embedded_curve_ops.nr#L141-L146" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/embedded_curve_ops.nr#L141-L146</a></sub></sup>
 
 
 example
@@ -52,7 +52,7 @@ The function accepts a single scalar on the input represented as 2 fields.
 ```rust title="fixed_base_scalar_mul" showLineNumbers 
 pub fn fixed_base_scalar_mul(scalar: EmbeddedCurveScalar) -> EmbeddedCurvePoint
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/embedded_curve_ops.nr#L151-L153" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/embedded_curve_ops.nr#L151-L153</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/embedded_curve_ops.nr#L151-L153" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/embedded_curve_ops.nr#L151-L153</a></sub></sup>
 
 
 example
@@ -85,7 +85,7 @@ pub fn embedded_curve_add(
     point2: EmbeddedCurvePoint,
 ) -> EmbeddedCurvePoint {
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/embedded_curve_ops.nr#L171-L176" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/embedded_curve_ops.nr#L171-L176</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/embedded_curve_ops.nr#L171-L176" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/embedded_curve_ops.nr#L171-L176</a></sub></sup>
 
 
 example

--- a/docs/versioned_docs/version-v1.0.0-beta.20/noir/standard_library/cryptographic_primitives/hashes.mdx
+++ b/docs/versioned_docs/version-v1.0.0-beta.20/noir/standard_library/cryptographic_primitives/hashes.mdx
@@ -34,7 +34,7 @@ This is a different function than sha256. See [this library](https://github.com/
 ```rust title="sha256_compression" showLineNumbers 
 pub fn sha256_compression(input: [u32; 16], state: [u32; 8]) -> [u32; 8] {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/hash/mod.nr#L15-L17" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/hash/mod.nr#L15-L17</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/hash/mod.nr#L15-L17" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/hash/mod.nr#L15-L17</a></sub></sup>
 
 
 <BlackBoxInfo to="../black_box_fns"/>
@@ -46,7 +46,7 @@ Given an array of bytes, returns an array with the Blake2 hash
 ```rust title="blake2s" showLineNumbers 
 pub fn blake2s<let N: u32>(input: [u8; N]) -> [u8; 32]
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/hash/mod.nr#L32-L34" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/hash/mod.nr#L32-L34</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/hash/mod.nr#L32-L34" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/hash/mod.nr#L32-L34</a></sub></sup>
 
 
 example:
@@ -67,7 +67,7 @@ Given an array of bytes, returns an array with the Blake3 hash
 ```rust title="blake3" showLineNumbers 
 pub fn blake3<let N: u32>(input: [u8; N]) -> [u8; 32]
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/hash/mod.nr#L37-L39" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/hash/mod.nr#L37-L39</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/hash/mod.nr#L37-L39" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/hash/mod.nr#L37-L39</a></sub></sup>
 
 
 example:
@@ -88,7 +88,7 @@ Given an array of Fields, returns the Pedersen hash.
 ```rust title="pedersen_hash" showLineNumbers 
 pub fn pedersen_hash<let N: u32>(input: [Field; N]) -> Field
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/hash/mod.nr#L74-L76" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/hash/mod.nr#L74-L76</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/hash/mod.nr#L74-L76" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/hash/mod.nr#L74-L76</a></sub></sup>
 
 
 example:
@@ -99,7 +99,7 @@ fn main(x: Field, y: Field, expected_hash: Field) {
     assert_eq(hash, expected_hash);
 }
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/execution_success/pedersen_hash/src/main.nr#L1-L6" target="_blank" rel="noopener noreferrer">Source code: test_programs/execution_success/pedersen_hash/src/main.nr#L1-L6</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/test_programs/execution_success/pedersen_hash/src/main.nr#L1-L6" target="_blank" rel="noopener noreferrer">Source code: test_programs/execution_success/pedersen_hash/src/main.nr#L1-L6</a></sub></sup>
 
 
 <BlackBoxInfo to="../black_box_fns" />
@@ -111,7 +111,7 @@ Given an array of Fields, returns the Pedersen commitment.
 ```rust title="pedersen_commitment" showLineNumbers 
 pub fn pedersen_commitment<let N: u32>(input: [Field; N]) -> EmbeddedCurvePoint {
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/hash/mod.nr#L55-L57" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/hash/mod.nr#L55-L57</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/hash/mod.nr#L55-L57" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/hash/mod.nr#L55-L57</a></sub></sup>
 
 
 example:
@@ -123,7 +123,7 @@ fn main(x: Field, y: Field, expected_commitment: std::embedded_curve_ops::Embedd
     assert_eq(commitment.y, expected_commitment.y);
 }
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/execution_success/pedersen_commitment/src/main.nr#L1-L7" target="_blank" rel="noopener noreferrer">Source code: test_programs/execution_success/pedersen_commitment/src/main.nr#L1-L7</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/test_programs/execution_success/pedersen_commitment/src/main.nr#L1-L7" target="_blank" rel="noopener noreferrer">Source code: test_programs/execution_success/pedersen_commitment/src/main.nr#L1-L7</a></sub></sup>
 
 
 <BlackBoxInfo to="../black_box_fns"/>
@@ -135,7 +135,7 @@ Given an initial `[u64; 25]` state, returns the state resulting from applying a 
 ```rust title="keccakf1600" showLineNumbers 
 pub fn keccakf1600(input: [u64; 25]) -> [u64; 25] {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/hash/mod.nr#L20-L22" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/hash/mod.nr#L20-L22</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/hash/mod.nr#L20-L22" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/hash/mod.nr#L20-L22</a></sub></sup>
 
 
 <BlackBoxInfo to="../black_box_fns"/>

--- a/docs/versioned_docs/version-v1.0.0-beta.20/noir/standard_library/fmtstr.md
+++ b/docs/versioned_docs/version-v1.0.0-beta.20/noir/standard_library/fmtstr.md
@@ -12,7 +12,7 @@ description: Format string literals at compile time—inspect raw contents or em
 ```rust title="quoted_contents" showLineNumbers 
 pub comptime fn quoted_contents(self) -> Quoted {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/format_string.nr#L6-L8" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/format_string.nr#L6-L8</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/meta/format_string.nr#L6-L8" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/format_string.nr#L6-L8</a></sub></sup>
 
 
 Returns the format string contents (that is, without the leading and trailing double quotes) as a `Quoted` value.
@@ -22,7 +22,7 @@ Returns the format string contents (that is, without the leading and trailing do
 ```rust title="as_quoted_str" showLineNumbers 
 pub comptime fn as_quoted_str(self) -> Quoted {
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/format_string.nr#L11-L13" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/format_string.nr#L11-L13</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/meta/format_string.nr#L11-L13" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/format_string.nr#L11-L13</a></sub></sup>
 
 
 Returns the format string contents (with the leading and trailing double quotes) as a `Quoted` string literal (not a format string literal).
@@ -36,5 +36,5 @@ comptime {
         assert_eq(f, "x = 0x01");
     }
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/compile_success_empty/comptime_fmt_strings/src/main.nr#L19-L25" target="_blank" rel="noopener noreferrer">Source code: test_programs/compile_success_empty/comptime_fmt_strings/src/main.nr#L19-L25</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/test_programs/compile_success_empty/comptime_fmt_strings/src/main.nr#L19-L25" target="_blank" rel="noopener noreferrer">Source code: test_programs/compile_success_empty/comptime_fmt_strings/src/main.nr#L19-L25</a></sub></sup>
 

--- a/docs/versioned_docs/version-v1.0.0-beta.20/noir/standard_library/is_unconstrained.md
+++ b/docs/versioned_docs/version-v1.0.0-beta.20/noir/standard_library/is_unconstrained.md
@@ -34,7 +34,7 @@ In order to improve the performance in an unconstrained context you can use the 
 
 
 ```rust 
-use dep::std::runtime::is_unconstrained;
+use std::runtime::is_unconstrained;
 
 fn my_expensive_computation(){
   ...

--- a/docs/versioned_docs/version-v1.0.0-beta.20/noir/standard_library/logging.md
+++ b/docs/versioned_docs/version-v1.0.0-beta.20/noir/standard_library/logging.md
@@ -24,7 +24,7 @@ You can print the output of both statements in your Noir code by using the `narg
 
 It is recommended to use `nargo execute` if you want to debug failing constraints with `println` or `print` statements. This is due to every input in a test being a constant rather than a witness, so we issue an error during compilation while we only print during execution (which comes after compilation). Neither `println`, nor `print` are callable for failed constraints caught at compile time.
 
-Both `print` and `println` are generic functions which can work on integers, fields, strings, and even structs or expressions. Note however, that vectors are currently unsupported. For example:
+Both `print` and `println` are generic functions which can work on integers, fields, strings, and even structs or expressions. For example:
 
 ```rust
 struct Person {

--- a/docs/versioned_docs/version-v1.0.0-beta.20/noir/standard_library/meta/ctstring.md
+++ b/docs/versioned_docs/version-v1.0.0-beta.20/noir/standard_library/meta/ctstring.md
@@ -22,7 +22,7 @@ pub trait AsCtString {
     comptime fn as_ctstring(self) -> CtString;
 }
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/ctstring.nr#L44-L48" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/ctstring.nr#L44-L48</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/meta/ctstring.nr#L44-L48" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/ctstring.nr#L44-L48</a></sub></sup>
 
 
 Converts an object into a compile-time string.
@@ -41,7 +41,7 @@ impl<let N: u32, T> AsCtString for fmtstr<N, T> { ... }
 ```rust title="new" showLineNumbers 
 pub comptime fn new() -> Self {
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/ctstring.nr#L4-L6" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/ctstring.nr#L4-L6</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/meta/ctstring.nr#L4-L6" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/ctstring.nr#L4-L6</a></sub></sup>
 
 
 Creates an empty `CtString`.
@@ -51,7 +51,7 @@ Creates an empty `CtString`.
 ```rust title="append_str" showLineNumbers 
 pub comptime fn append_str<let N: u32>(self, s: str<N>) -> Self {
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/ctstring.nr#L12-L14" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/ctstring.nr#L12-L14</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/meta/ctstring.nr#L12-L14" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/ctstring.nr#L12-L14</a></sub></sup>
 
 
 Returns a new CtString with the given str appended onto the end.
@@ -61,7 +61,7 @@ Returns a new CtString with the given str appended onto the end.
 ```rust title="append_fmtstr" showLineNumbers 
 pub comptime fn append_fmtstr<let N: u32, T>(self, s: fmtstr<N, T>) -> Self {
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/ctstring.nr#L18-L20" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/ctstring.nr#L18-L20</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/meta/ctstring.nr#L18-L20" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/ctstring.nr#L18-L20</a></sub></sup>
 
 
 Returns a new CtString with the given fmtstr appended onto the end.
@@ -71,7 +71,7 @@ Returns a new CtString with the given fmtstr appended onto the end.
 ```rust title="as_quoted_str" showLineNumbers 
 pub comptime fn as_quoted_str(self) -> Quoted {
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/ctstring.nr#L27-L29" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/ctstring.nr#L27-L29</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/meta/ctstring.nr#L27-L29" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/ctstring.nr#L27-L29</a></sub></sup>
 
 
 Returns a quoted string literal from this string's contents.
@@ -89,7 +89,7 @@ let my_ctstring = "foo bar".as_ctstring();
 
             assert_eq(crate::meta::type_of(my_str), quote { str<7> }.as_type());
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/ctstring.nr#L95-L100" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/ctstring.nr#L95-L100</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/meta/ctstring.nr#L95-L100" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/ctstring.nr#L95-L100</a></sub></sup>
 
 
 ## Trait Implementations

--- a/docs/versioned_docs/version-v1.0.0-beta.20/noir/standard_library/meta/expr.md
+++ b/docs/versioned_docs/version-v1.0.0-beta.20/noir/standard_library/meta/expr.md
@@ -12,7 +12,7 @@ description: Introspect and transform quoted expressions at compile time—inspe
 ```rust title="as_array" showLineNumbers 
 pub comptime fn as_array(self) -> Option<[Expr]> {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L10-L12" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L10-L12</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/meta/expr.nr#L10-L12" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L10-L12</a></sub></sup>
 
 
 If this expression is an array, this returns a vector of each element in the array.
@@ -22,7 +22,7 @@ If this expression is an array, this returns a vector of each element in the arr
 ```rust title="as_assert" showLineNumbers 
 pub comptime fn as_assert(self) -> Option<(Expr, Option<Expr>)> {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L16-L18" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L16-L18</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/meta/expr.nr#L16-L18" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L16-L18</a></sub></sup>
 
 
 If this expression is an assert, this returns the assert expression and the optional message.
@@ -32,7 +32,7 @@ If this expression is an assert, this returns the assert expression and the opti
 ```rust title="as_assert_eq" showLineNumbers 
 pub comptime fn as_assert_eq(self) -> Option<(Expr, Expr, Option<Expr>)> {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L23-L25" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L23-L25</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/meta/expr.nr#L23-L25" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L23-L25</a></sub></sup>
 
 
 If this expression is an assert_eq, this returns the left-hand-side and right-hand-side
@@ -43,7 +43,7 @@ expressions, together with the optional message.
 ```rust title="as_assign" showLineNumbers 
 pub comptime fn as_assign(self) -> Option<(Expr, Expr)> {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L30-L32" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L30-L32</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/meta/expr.nr#L30-L32" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L30-L32</a></sub></sup>
 
 
 If this expression is an assignment, this returns a tuple with the left hand side
@@ -54,7 +54,7 @@ and right hand side in order.
 ```rust title="as_binary_op" showLineNumbers 
 pub comptime fn as_binary_op(self) -> Option<(Expr, BinaryOp, Expr)> {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L37-L39" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L37-L39</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/meta/expr.nr#L37-L39" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L37-L39</a></sub></sup>
 
 
 If this expression is a binary operator operation `<lhs> <op> <rhs>`,
@@ -65,7 +65,7 @@ return the left-hand side, operator, and the right-hand side of the operation.
 ```rust title="as_block" showLineNumbers 
 pub comptime fn as_block(self) -> Option<[Expr]> {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L44-L46" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L44-L46</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/meta/expr.nr#L44-L46" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L44-L46</a></sub></sup>
 
 
 If this expression is a block `{ stmt1; stmt2; ...; stmtN }`, return
@@ -76,7 +76,7 @@ a vector containing each statement.
 ```rust title="as_bool" showLineNumbers 
 pub comptime fn as_bool(self) -> Option<bool> {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L50-L52" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L50-L52</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/meta/expr.nr#L50-L52" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L50-L52</a></sub></sup>
 
 
 If this expression is a boolean literal, return that literal.
@@ -87,7 +87,7 @@ If this expression is a boolean literal, return that literal.
 #[builtin(expr_as_cast)]
     pub comptime fn as_cast(self) -> Option<(Expr, UnresolvedType)> {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L56-L59" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L56-L59</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/meta/expr.nr#L56-L59" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L56-L59</a></sub></sup>
 
 
 If this expression is a cast expression (`expr as type`), returns the casted
@@ -98,7 +98,7 @@ expression and the type to cast to.
 ```rust title="as_comptime" showLineNumbers 
 pub comptime fn as_comptime(self) -> Option<[Expr]> {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L64-L66" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L64-L66</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/meta/expr.nr#L64-L66" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L64-L66</a></sub></sup>
 
 
 If this expression is a `comptime { stmt1; stmt2; ...; stmtN }` block,
@@ -109,7 +109,7 @@ return each statement in the block.
 ```rust title="as_constructor" showLineNumbers 
 pub comptime fn as_constructor(self) -> Option<(UnresolvedType, [(Quoted, Expr)])> {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L71-L73" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L71-L73</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/meta/expr.nr#L71-L73" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L71-L73</a></sub></sup>
 
 
 If this expression is a constructor `Type { field1: expr1, ..., fieldN: exprN }`,
@@ -120,7 +120,7 @@ return the type and the fields.
 ```rust title="as_for" showLineNumbers 
 pub comptime fn as_for(self) -> Option<(Quoted, Expr, Expr)> {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L78-L80" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L78-L80</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/meta/expr.nr#L78-L80" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L78-L80</a></sub></sup>
 
 
 If this expression is a for statement over a single expression, return the identifier,
@@ -128,21 +128,22 @@ the expression and the for loop body.
 
 ### as_for_range
 
-```rust title="as_for" showLineNumbers 
-pub comptime fn as_for(self) -> Option<(Quoted, Expr, Expr)> {}
+```rust title="as_for_range" showLineNumbers 
+pub comptime fn as_for_range(self) -> Option<(Quoted, Expr, Expr, bool, Expr)> {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L78-L80" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L78-L80</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/meta/expr.nr#L84-L87" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L84-L87</a></sub></sup>
 
 
 If this expression is a for statement over a range, return the identifier,
-the range start, the range end and the for loop body.
+the range start, the range end, whether the range is inclusive, and the
+for loop body.
 
 ### as_function_call
 
 ```rust title="as_function_call" showLineNumbers 
 pub comptime fn as_function_call(self) -> Option<(Expr, [Expr])> {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L92-L94" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L92-L94</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/meta/expr.nr#L92-L94" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L92-L94</a></sub></sup>
 
 
 If this expression is a function call `foo(arg1, ..., argN)`, return
@@ -153,7 +154,7 @@ the function and a vector of each argument.
 ```rust title="as_if" showLineNumbers 
 pub comptime fn as_if(self) -> Option<(Expr, Expr, Option<Expr>)> {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L100-L102" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L100-L102</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/meta/expr.nr#L100-L102" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L100-L102</a></sub></sup>
 
 
 If this expression is an `if condition { then_branch } else { else_branch }`,
@@ -165,7 +166,7 @@ return the condition, then branch, and else branch. If there is no else branch,
 ```rust title="as_index" showLineNumbers 
 pub comptime fn as_index(self) -> Option<(Expr, Expr)> {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L107-L109" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L107-L109</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/meta/expr.nr#L107-L109" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L107-L109</a></sub></sup>
 
 
 If this expression is an index into an array `array[index]`, return the
@@ -176,7 +177,7 @@ array and the index.
 ```rust title="as_integer" showLineNumbers 
 pub comptime fn as_integer(self) -> Option<Field> {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L116-L118" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L116-L118</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/meta/expr.nr#L116-L118" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L116-L118</a></sub></sup>
 
 
 If this expression is an integer literal, return the integer as a field.
@@ -189,7 +190,7 @@ pub comptime fn as_lambda(
         self,
     ) -> Option<([(Expr, Option<UnresolvedType>)], Option<UnresolvedType>, Expr)> {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L122-L126" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L122-L126</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/meta/expr.nr#L122-L126" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L122-L126</a></sub></sup>
 
 
 If this expression is a lambda, returns the parameters, return type and body.
@@ -199,7 +200,7 @@ If this expression is a lambda, returns the parameters, return type and body.
 ```rust title="as_let" showLineNumbers 
 pub comptime fn as_let(self) -> Option<(Expr, Option<UnresolvedType>, Expr)> {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L131-L133" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L131-L133</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/meta/expr.nr#L131-L133" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L131-L133</a></sub></sup>
 
 
 If this expression is a let statement, returns the let pattern as an `Expr`,
@@ -210,7 +211,7 @@ the optional type annotation, and the assigned expression.
 ```rust title="as_member_access" showLineNumbers 
 pub comptime fn as_member_access(self) -> Option<(Expr, Quoted)> {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L138-L140" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L138-L140</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/meta/expr.nr#L138-L140" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L138-L140</a></sub></sup>
 
 
 If this expression is a member access `foo.bar`, return the struct/tuple
@@ -221,7 +222,7 @@ expression and the field. The field will be represented as a quoted value.
 ```rust title="as_method_call" showLineNumbers 
 pub comptime fn as_method_call(self) -> Option<(Expr, Quoted, [UnresolvedType], [Expr])> {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L145-L147" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L145-L147</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/meta/expr.nr#L145-L147" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L145-L147</a></sub></sup>
 
 
 If this expression is a method call `foo.bar::<generic1, ..., genericM>(arg1, ..., argN)`, return
@@ -232,7 +233,7 @@ the receiver, method name, a vector of each generic argument, and a vector of ea
 ```rust title="as_repeated_element_array" showLineNumbers 
 pub comptime fn as_repeated_element_array(self) -> Option<(Expr, Expr)> {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L152-L154" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L152-L154</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/meta/expr.nr#L152-L154" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L152-L154</a></sub></sup>
 
 
 If this expression is a repeated element array `[elem; length]`, return
@@ -243,7 +244,7 @@ the repeated element and the length expressions.
 ```rust title="as_repeated_element_vector" showLineNumbers 
 pub comptime fn as_repeated_element_vector(self) -> Option<(Expr, Expr)> {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L159-L161" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L159-L161</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/meta/expr.nr#L159-L161" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L159-L161</a></sub></sup>
 
 
 If this expression is a repeated element vector `[elem; length]`, return
@@ -254,7 +255,7 @@ the repeated element and the length expressions.
 ```rust title="as_vector" showLineNumbers 
 pub comptime fn as_vector(self) -> Option<[Expr]> {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L173-L175" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L173-L175</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/meta/expr.nr#L173-L175" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L173-L175</a></sub></sup>
 
 
 If this expression is a vector literal `@[elem1, ..., elemN]`,
@@ -265,7 +266,7 @@ return each element of the vector.
 ```rust title="as_tuple" showLineNumbers 
 pub comptime fn as_tuple(self) -> Option<[Expr]> {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L187-L189" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L187-L189</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/meta/expr.nr#L187-L189" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L187-L189</a></sub></sup>
 
 
 If this expression is a tuple `(field1, ..., fieldN)`,
@@ -276,7 +277,7 @@ return each element of the tuple.
 ```rust title="as_unary_op" showLineNumbers 
 pub comptime fn as_unary_op(self) -> Option<(UnaryOp, Expr)> {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L194-L196" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L194-L196</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/meta/expr.nr#L194-L196" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L194-L196</a></sub></sup>
 
 
 If this expression is a unary operation `<op> <rhs>`,
@@ -287,7 +288,7 @@ return the unary operator as well as the right-hand side expression.
 ```rust title="as_unsafe" showLineNumbers 
 pub comptime fn as_unsafe(self) -> Option<[Expr]> {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L201-L203" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L201-L203</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/meta/expr.nr#L201-L203" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L201-L203</a></sub></sup>
 
 
 If this expression is an `unsafe { stmt1; ...; stmtN }` block,
@@ -298,7 +299,7 @@ return each statement inside in a vector.
 ```rust title="has_semicolon" showLineNumbers 
 pub comptime fn has_semicolon(self) -> bool {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L222-L224" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L222-L224</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/meta/expr.nr#L222-L224" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L222-L224</a></sub></sup>
 
 
 `true` if this expression is trailed by a semicolon. E.g.
@@ -321,7 +322,7 @@ comptime {
 ```rust title="is_break" showLineNumbers 
 pub comptime fn is_break(self) -> bool {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L228-L230" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L228-L230</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/meta/expr.nr#L228-L230" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L228-L230</a></sub></sup>
 
 
 `true` if this expression is `break`.
@@ -331,7 +332,7 @@ pub comptime fn is_break(self) -> bool {}
 ```rust title="is_continue" showLineNumbers 
 pub comptime fn is_continue(self) -> bool {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L234-L236" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L234-L236</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/meta/expr.nr#L234-L236" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L234-L236</a></sub></sup>
 
 
 `true` if this expression is `continue`.
@@ -341,7 +342,7 @@ pub comptime fn is_continue(self) -> bool {}
 ```rust title="modify" showLineNumbers 
 pub comptime fn modify<Env>(self, f: fn[Env](Expr) -> Option<Expr>) -> Expr {
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L245-L247" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L245-L247</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/meta/expr.nr#L245-L247" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L245-L247</a></sub></sup>
 
 
 Applies a mapping function to this expression and to all of its sub-expressions.
@@ -357,7 +358,7 @@ for expressions that are integers, doubling them, would return `(@[2], @[4, 6])`
 ```rust title="quoted" showLineNumbers 
 pub comptime fn quoted(self) -> Quoted {
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L282-L284" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L282-L284</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/meta/expr.nr#L282-L284" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L282-L284</a></sub></sup>
 
 
 Returns this expression as a `Quoted` value. It's the same as `quote { $self }`.
@@ -367,7 +368,7 @@ Returns this expression as a `Quoted` value. It's the same as `quote { $self }`.
 ```rust title="resolve" showLineNumbers 
 pub comptime fn resolve(self, in_function: Option<FunctionDefinition>) -> TypedExpr {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/expr.nr#L298-L300" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L298-L300</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/meta/expr.nr#L298-L300" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/expr.nr#L298-L300</a></sub></sup>
 
 
 Resolves and type-checks this expression and returns the result as a `TypedExpr`.

--- a/docs/versioned_docs/version-v1.0.0-beta.20/noir/standard_library/meta/function_def.md
+++ b/docs/versioned_docs/version-v1.0.0-beta.20/noir/standard_library/meta/function_def.md
@@ -13,7 +13,7 @@ a function definition in the source program.
 ```rust title="as_typed_expr" showLineNumbers 
 pub comptime fn as_typed_expr(self) -> TypedExpr {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/function_def.nr#L3-L5" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/function_def.nr#L3-L5</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/meta/function_def.nr#L3-L5" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/function_def.nr#L3-L5</a></sub></sup>
 
 
 Returns this function as a `TypedExpr`, which can be unquoted. For example:
@@ -28,7 +28,7 @@ let _ = quote { $typed_expr(1, 2, 3); };
 ```rust title="body" showLineNumbers 
 pub comptime fn body(self) -> Expr {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/function_def.nr#L8-L10" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/function_def.nr#L8-L10</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/meta/function_def.nr#L8-L10" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/function_def.nr#L8-L10</a></sub></sup>
 
 
 Returns the body of the function as an expression. This is only valid
@@ -40,7 +40,7 @@ This means any functions called at compile-time are invalid targets for this met
 ```rust title="disable" showLineNumbers 
 pub comptime fn disable(self, error_message: CtString) {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/function_def.nr#L13-L15" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/function_def.nr#L13-L15</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/meta/function_def.nr#L13-L15" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/function_def.nr#L13-L15</a></sub></sup>
 
 
 Disables calling the given function, issuing an error with the provided message if it is ever called.
@@ -64,7 +64,7 @@ untrusted dependencies to ensure their bodies are as expected.
 ```rust title="has_named_attribute" showLineNumbers 
 pub comptime fn has_named_attribute<let N: u32>(self, name: str<N>) -> bool {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/function_def.nr#L18-L20" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/function_def.nr#L18-L20</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/meta/function_def.nr#L18-L20" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/function_def.nr#L18-L20</a></sub></sup>
 
 
 Returns true if this function has a custom attribute with the given name.
@@ -74,7 +74,7 @@ Returns true if this function has a custom attribute with the given name.
 ```rust title="is_unconstrained" showLineNumbers 
 pub comptime fn is_unconstrained(self) -> bool {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/function_def.nr#L23-L25" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/function_def.nr#L23-L25</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/meta/function_def.nr#L23-L25" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/function_def.nr#L23-L25</a></sub></sup>
 
 
 Returns true if this function is unconstrained.
@@ -84,7 +84,7 @@ Returns true if this function is unconstrained.
 ```rust title="module" showLineNumbers 
 pub comptime fn module(self) -> Module {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/function_def.nr#L28-L30" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/function_def.nr#L28-L30</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/meta/function_def.nr#L28-L30" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/function_def.nr#L28-L30</a></sub></sup>
 
 
 Returns the module where the function is defined.
@@ -94,7 +94,7 @@ Returns the module where the function is defined.
 ```rust title="name" showLineNumbers 
 pub comptime fn name(self) -> Quoted {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/function_def.nr#L33-L35" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/function_def.nr#L33-L35</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/meta/function_def.nr#L33-L35" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/function_def.nr#L33-L35</a></sub></sup>
 
 
 Returns the name of the function.
@@ -104,7 +104,7 @@ Returns the name of the function.
 ```rust title="parameters" showLineNumbers 
 pub comptime fn parameters(self) -> [(Quoted, Type)] {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/function_def.nr#L38-L40" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/function_def.nr#L38-L40</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/meta/function_def.nr#L38-L40" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/function_def.nr#L38-L40</a></sub></sup>
 
 
 Returns each parameter of the function as a tuple of (parameter pattern, parameter type).
@@ -114,7 +114,7 @@ Returns each parameter of the function as a tuple of (parameter pattern, paramet
 ```rust title="return_type" showLineNumbers 
 pub comptime fn return_type(self) -> Type {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/function_def.nr#L43-L45" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/function_def.nr#L43-L45</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/meta/function_def.nr#L43-L45" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/function_def.nr#L43-L45</a></sub></sup>
 
 
 The return type of the function.
@@ -124,7 +124,7 @@ The return type of the function.
 ```rust title="visibility" showLineNumbers 
 pub comptime fn visibility(self) -> Quoted {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/function_def.nr#L48-L50" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/function_def.nr#L48-L50</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/meta/function_def.nr#L48-L50" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/function_def.nr#L48-L50</a></sub></sup>
 
 
 Returns the function's visibility as a `Quoted` value, which will be one of:

--- a/docs/versioned_docs/version-v1.0.0-beta.20/noir/standard_library/meta/index.md
+++ b/docs/versioned_docs/version-v1.0.0-beta.20/noir/standard_library/meta/index.md
@@ -14,7 +14,7 @@ and types used for inspecting and modifying Noir programs.
 ```rust title="type_of" showLineNumbers 
 pub comptime fn type_of<T>(x: T) -> Type {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/mod.nr#L29-L31" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/mod.nr#L29-L31</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/meta/mod.nr#L29-L31" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/mod.nr#L29-L31</a></sub></sup>
 
 
 Returns the type of a variable at compile-time.
@@ -34,7 +34,7 @@ comptime {
 ```rust title="unquote" showLineNumbers 
 pub comptime fn unquote(code: Quoted) -> Quoted {
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/mod.nr#L21-L23" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/mod.nr#L21-L23</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/meta/mod.nr#L21-L23" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/mod.nr#L21-L23</a></sub></sup>
 
 
 Unquotes the passed-in token stream where this function was called.
@@ -55,7 +55,7 @@ comptime {
 #[varargs]
 pub comptime fn derive(s: TypeDefinition, traits: [TraitDefinition]) -> Quoted {
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/mod.nr#L50-L53" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/mod.nr#L50-L53</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/meta/mod.nr#L50-L53" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/mod.nr#L50-L53</a></sub></sup>
 
 
 Attribute placed on type definitions.
@@ -85,7 +85,7 @@ fn main() {
 ```rust title="derive_via_signature" showLineNumbers 
 pub comptime fn derive_via(t: TraitDefinition, f: DeriveFunction) {
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/mod.nr#L70-L72" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/mod.nr#L70-L72</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/meta/mod.nr#L70-L72" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/mod.nr#L70-L72</a></sub></sup>
 
 
 Attribute placed on trait definitions.
@@ -143,7 +143,7 @@ comptime fn derive_eq(s: TypeDefinition) -> Quoted {
     )
 }
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/cmp.nr#L12-L32" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/cmp.nr#L12-L32</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/cmp.nr#L12-L32" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/cmp.nr#L12-L32</a></sub></sup>
 
 
 ### make_trait_impl
@@ -158,7 +158,7 @@ pub comptime fn make_trait_impl<Env1, Env2>(
     body: fn[Env2](Quoted) -> Quoted,
 ) -> Quoted {
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/mod.nr#L89-L98" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/mod.nr#L89-L98</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/meta/mod.nr#L89-L98" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/mod.nr#L89-L98</a></sub></sup>
 
 
 A helper function to more easily create trait impls while deriving traits.
@@ -199,7 +199,7 @@ comptime fn derive_hash(s: TypeDefinition) -> Quoted {
     )
 }
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/hash/mod.nr#L145-L159" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/hash/mod.nr#L145-L159</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/hash/mod.nr#L145-L159" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/hash/mod.nr#L145-L159</a></sub></sup>
 
 
 Example deriving `Ord`:
@@ -221,5 +221,5 @@ comptime fn derive_ord(s: TypeDefinition) -> Quoted {
     crate::meta::make_trait_impl(s, name, signature, for_each_field, quote {}, body)
 }
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/cmp.nr#L247-L263" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/cmp.nr#L247-L263</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/cmp.nr#L247-L263" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/cmp.nr#L247-L263</a></sub></sup>
 

--- a/docs/versioned_docs/version-v1.0.0-beta.20/noir/standard_library/meta/module.md
+++ b/docs/versioned_docs/version-v1.0.0-beta.20/noir/standard_library/meta/module.md
@@ -14,7 +14,7 @@ declarations in the source program.
 ```rust title="child_modules" showLineNumbers 
 pub comptime fn child_modules(self) -> [Module] {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/module.nr#L25-L27" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/module.nr#L25-L27</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/meta/module.nr#L25-L27" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/module.nr#L25-L27</a></sub></sup>
 
 
 Returns all the child modules of the current module.
@@ -39,7 +39,7 @@ fn child_modules_test() {
     }
 }
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/compile_success_empty/comptime_module/src/main.nr#L135-L154" target="_blank" rel="noopener noreferrer">Source code: test_programs/compile_success_empty/comptime_module/src/main.nr#L135-L154</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/test_programs/compile_success_empty/comptime_module/src/main.nr#L135-L154" target="_blank" rel="noopener noreferrer">Source code: test_programs/compile_success_empty/comptime_module/src/main.nr#L135-L154</a></sub></sup>
 
 
 ### functions
@@ -47,7 +47,7 @@ fn child_modules_test() {
 ```rust title="functions" showLineNumbers 
 pub comptime fn functions(self) -> [FunctionDefinition] {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/module.nr#L15-L17" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/module.nr#L15-L17</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/meta/module.nr#L15-L17" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/module.nr#L15-L17</a></sub></sup>
 
 
 Returns each function defined in the module.
@@ -57,7 +57,7 @@ Returns each function defined in the module.
 ```rust title="has_named_attribute" showLineNumbers 
 pub comptime fn has_named_attribute<let N: u32>(self, name: str<N>) -> bool {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/module.nr#L5-L7" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/module.nr#L5-L7</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/meta/module.nr#L5-L7" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/module.nr#L5-L7</a></sub></sup>
 
 
 Returns true if this module has a custom attribute with the given name.
@@ -67,7 +67,7 @@ Returns true if this module has a custom attribute with the given name.
 ```rust title="is_contract" showLineNumbers 
 pub comptime fn is_contract(self) -> bool {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/module.nr#L10-L12" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/module.nr#L10-L12</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/meta/module.nr#L10-L12" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/module.nr#L10-L12</a></sub></sup>
 
 
 `true` if this module is a contract module (was declared via `contract foo { ... }`).
@@ -77,7 +77,7 @@ pub comptime fn is_contract(self) -> bool {}
 ```rust title="name" showLineNumbers 
 pub comptime fn name(self) -> Quoted {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/module.nr#L30-L32" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/module.nr#L30-L32</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/meta/module.nr#L30-L32" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/module.nr#L30-L32</a></sub></sup>
 
 
 Returns the name of the module.
@@ -88,7 +88,7 @@ The top-level module in each crate has no name and is thus empty.
 ```rust title="parent" showLineNumbers 
 pub comptime fn parent(self) -> Option<Module> {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/module.nr#L35-L37" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/module.nr#L35-L37</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/meta/module.nr#L35-L37" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/module.nr#L35-L37</a></sub></sup>
 
 
 Returns the parent module of the given module, if any.
@@ -113,7 +113,7 @@ fn parent_test() {
     }
 }
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/compile_success_empty/comptime_module/src/main.nr#L114-L133" target="_blank" rel="noopener noreferrer">Source code: test_programs/compile_success_empty/comptime_module/src/main.nr#L114-L133</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/test_programs/compile_success_empty/comptime_module/src/main.nr#L114-L133" target="_blank" rel="noopener noreferrer">Source code: test_programs/compile_success_empty/comptime_module/src/main.nr#L114-L133</a></sub></sup>
 
 
 ### structs
@@ -121,7 +121,7 @@ fn parent_test() {
 ```rust title="structs" showLineNumbers 
 pub comptime fn structs(self) -> [TypeDefinition] {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/module.nr#L20-L22" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/module.nr#L20-L22</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/meta/module.nr#L20-L22" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/module.nr#L20-L22</a></sub></sup>
 
 
 Returns each struct defined in the module.

--- a/docs/versioned_docs/version-v1.0.0-beta.20/noir/standard_library/meta/op.md
+++ b/docs/versioned_docs/version-v1.0.0-beta.20/noir/standard_library/meta/op.md
@@ -19,7 +19,7 @@ Represents a unary operator. One of `-`, `!`, `&mut`, or `*`.
 ```rust title="is_minus" showLineNumbers 
 pub fn is_minus(self) -> bool {
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/op.nr#L26-L28" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L26-L28</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/meta/op.nr#L26-L28" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L26-L28</a></sub></sup>
 
 
 Returns `true` if this operator is `-`.
@@ -29,7 +29,7 @@ Returns `true` if this operator is `-`.
 ```rust title="is_not" showLineNumbers 
 pub fn is_not(self) -> bool {
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/op.nr#L32-L34" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L32-L34</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/meta/op.nr#L32-L34" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L32-L34</a></sub></sup>
 
 
 `true` if this operator is `!`
@@ -39,7 +39,7 @@ pub fn is_not(self) -> bool {
 ```rust title="is_mutable_reference" showLineNumbers 
 pub fn is_mutable_reference(self) -> bool {
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/op.nr#L38-L40" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L38-L40</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/meta/op.nr#L38-L40" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L38-L40</a></sub></sup>
 
 
 `true` if this operator is `&mut`
@@ -49,7 +49,7 @@ pub fn is_mutable_reference(self) -> bool {
 ```rust title="is_dereference" showLineNumbers 
 pub fn is_dereference(self) -> bool {
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/op.nr#L44-L46" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L44-L46</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/meta/op.nr#L44-L46" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L44-L46</a></sub></sup>
 
 
 `true` if this operator is `*`
@@ -59,7 +59,7 @@ pub fn is_dereference(self) -> bool {
 ```rust title="unary_quoted" showLineNumbers 
 pub comptime fn quoted(self) -> Quoted {
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/op.nr#L50-L52" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L50-L52</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/meta/op.nr#L50-L52" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L50-L52</a></sub></sup>
 
 
 Returns this operator as a `Quoted` value.
@@ -82,7 +82,7 @@ Represents a binary operator. One of `+`, `-`, `*`, `/`, `%`, `==`, `!=`, `<`, `
 ```rust title="is_add" showLineNumbers 
 pub fn is_add(self) -> bool {
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/op.nr#L88-L90" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L88-L90</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/meta/op.nr#L88-L90" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L88-L90</a></sub></sup>
 
 
 `true` if this operator is `+`
@@ -92,7 +92,7 @@ pub fn is_add(self) -> bool {
 ```rust title="is_subtract" showLineNumbers 
 pub fn is_subtract(self) -> bool {
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/op.nr#L94-L96" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L94-L96</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/meta/op.nr#L94-L96" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L94-L96</a></sub></sup>
 
 
 `true` if this operator is `-`
@@ -102,7 +102,7 @@ pub fn is_subtract(self) -> bool {
 ```rust title="is_multiply" showLineNumbers 
 pub fn is_multiply(self) -> bool {
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/op.nr#L100-L102" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L100-L102</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/meta/op.nr#L100-L102" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L100-L102</a></sub></sup>
 
 
 `true` if this operator is `*`
@@ -112,7 +112,7 @@ pub fn is_multiply(self) -> bool {
 ```rust title="is_divide" showLineNumbers 
 pub fn is_divide(self) -> bool {
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/op.nr#L106-L108" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L106-L108</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/meta/op.nr#L106-L108" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L106-L108</a></sub></sup>
 
 
 `true` if this operator is `/`
@@ -122,7 +122,7 @@ pub fn is_divide(self) -> bool {
 ```rust title="is_modulo" showLineNumbers 
 pub fn is_modulo(self) -> bool {
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/op.nr#L178-L180" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L178-L180</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/meta/op.nr#L178-L180" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L178-L180</a></sub></sup>
 
 
 `true` if this operator is `%`
@@ -132,7 +132,7 @@ pub fn is_modulo(self) -> bool {
 ```rust title="is_equal" showLineNumbers 
 pub fn is_equal(self) -> bool {
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/op.nr#L112-L114" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L112-L114</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/meta/op.nr#L112-L114" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L112-L114</a></sub></sup>
 
 
 `true` if this operator is `==`
@@ -142,7 +142,7 @@ pub fn is_equal(self) -> bool {
 ```rust title="is_not_equal" showLineNumbers 
 pub fn is_not_equal(self) -> bool {
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/op.nr#L118-L120" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L118-L120</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/meta/op.nr#L118-L120" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L118-L120</a></sub></sup>
 
 
 `true` if this operator is `!=`
@@ -152,7 +152,7 @@ pub fn is_not_equal(self) -> bool {
 ```rust title="is_less_than" showLineNumbers 
 pub fn is_less_than(self) -> bool {
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/op.nr#L124-L126" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L124-L126</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/meta/op.nr#L124-L126" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L124-L126</a></sub></sup>
 
 
 `true` if this operator is `<`
@@ -162,7 +162,7 @@ pub fn is_less_than(self) -> bool {
 ```rust title="is_less_than_or_equal" showLineNumbers 
 pub fn is_less_than_or_equal(self) -> bool {
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/op.nr#L130-L132" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L130-L132</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/meta/op.nr#L130-L132" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L130-L132</a></sub></sup>
 
 
 `true` if this operator is `<=`
@@ -172,7 +172,7 @@ pub fn is_less_than_or_equal(self) -> bool {
 ```rust title="is_greater_than" showLineNumbers 
 pub fn is_greater_than(self) -> bool {
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/op.nr#L136-L138" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L136-L138</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/meta/op.nr#L136-L138" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L136-L138</a></sub></sup>
 
 
 `true` if this operator is `>`
@@ -182,7 +182,7 @@ pub fn is_greater_than(self) -> bool {
 ```rust title="is_greater_than_or_equal" showLineNumbers 
 pub fn is_greater_than_or_equal(self) -> bool {
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/op.nr#L142-L144" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L142-L144</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/meta/op.nr#L142-L144" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L142-L144</a></sub></sup>
 
 
 `true` if this operator is `>=`
@@ -192,7 +192,7 @@ pub fn is_greater_than_or_equal(self) -> bool {
 ```rust title="is_and" showLineNumbers 
 pub fn is_and(self) -> bool {
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/op.nr#L148-L150" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L148-L150</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/meta/op.nr#L148-L150" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L148-L150</a></sub></sup>
 
 
 `true` if this operator is `&`
@@ -202,7 +202,7 @@ pub fn is_and(self) -> bool {
 ```rust title="is_or" showLineNumbers 
 pub fn is_or(self) -> bool {
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/op.nr#L154-L156" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L154-L156</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/meta/op.nr#L154-L156" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L154-L156</a></sub></sup>
 
 
 `true` if this operator is `|`
@@ -212,7 +212,7 @@ pub fn is_or(self) -> bool {
 ```rust title="is_shift_right" showLineNumbers 
 pub fn is_shift_right(self) -> bool {
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/op.nr#L166-L168" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L166-L168</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/meta/op.nr#L166-L168" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L166-L168</a></sub></sup>
 
 
 `true` if this operator is `>>`
@@ -222,7 +222,7 @@ pub fn is_shift_right(self) -> bool {
 ```rust title="is_shift_left" showLineNumbers 
 pub fn is_shift_left(self) -> bool {
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/op.nr#L172-L174" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L172-L174</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/meta/op.nr#L172-L174" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L172-L174</a></sub></sup>
 
 
 `true` if this operator is `<<`
@@ -232,7 +232,7 @@ pub fn is_shift_left(self) -> bool {
 ```rust title="binary_quoted" showLineNumbers 
 pub comptime fn quoted(self) -> Quoted {
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/op.nr#L184-L186" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L184-L186</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/meta/op.nr#L184-L186" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/op.nr#L184-L186</a></sub></sup>
 
 
 Returns this operator as a `Quoted` value.

--- a/docs/versioned_docs/version-v1.0.0-beta.20/noir/standard_library/meta/quoted.md
+++ b/docs/versioned_docs/version-v1.0.0-beta.20/noir/standard_library/meta/quoted.md
@@ -13,7 +13,7 @@ quoted token streams and is the result of the `quote { ... }` expression.
 ```rust title="as_expr" showLineNumbers 
 pub comptime fn as_expr(self) -> Option<Expr> {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/quoted.nr#L6-L8" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/quoted.nr#L6-L8</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/meta/quoted.nr#L6-L8" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/quoted.nr#L6-L8</a></sub></sup>
 
 
 Parses the quoted token stream as an expression. Returns `Option::none()` if
@@ -32,7 +32,7 @@ Example:
         }
     }
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/noir_test_success/comptime_expr/src/main.nr#L340-L350" target="_blank" rel="noopener noreferrer">Source code: test_programs/noir_test_success/comptime_expr/src/main.nr#L340-L350</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/test_programs/noir_test_success/comptime_expr/src/main.nr#L340-L350" target="_blank" rel="noopener noreferrer">Source code: test_programs/noir_test_success/comptime_expr/src/main.nr#L340-L350</a></sub></sup>
 
 
 ### as_module
@@ -40,7 +40,7 @@ Example:
 ```rust title="as_module" showLineNumbers 
 pub comptime fn as_module(self) -> Option<Module> {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/quoted.nr#L11-L13" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/quoted.nr#L11-L13</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/meta/quoted.nr#L11-L13" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/quoted.nr#L11-L13</a></sub></sup>
 
 
 Interprets this token stream as a module path leading to the name of a module.
@@ -61,7 +61,7 @@ fn as_module_test() {
     }
 }
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/compile_success_empty/comptime_module/src/main.nr#L100-L112" target="_blank" rel="noopener noreferrer">Source code: test_programs/compile_success_empty/comptime_module/src/main.nr#L100-L112</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/test_programs/compile_success_empty/comptime_module/src/main.nr#L100-L112" target="_blank" rel="noopener noreferrer">Source code: test_programs/compile_success_empty/comptime_module/src/main.nr#L100-L112</a></sub></sup>
 
 
 ### as_trait_constraint
@@ -69,7 +69,7 @@ fn as_module_test() {
 ```rust title="as_trait_constraint" showLineNumbers 
 pub comptime fn as_trait_constraint(self) -> TraitConstraint {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/quoted.nr#L16-L18" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/quoted.nr#L16-L18</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/meta/quoted.nr#L16-L18" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/quoted.nr#L16-L18</a></sub></sup>
 
 
 Interprets this token stream as a trait constraint (without an object type).
@@ -92,7 +92,7 @@ where
     }
 }
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/compile_success_empty/comptime_type/src/main.nr#L160-L173" target="_blank" rel="noopener noreferrer">Source code: test_programs/compile_success_empty/comptime_type/src/main.nr#L160-L173</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/test_programs/compile_success_empty/comptime_type/src/main.nr#L160-L173" target="_blank" rel="noopener noreferrer">Source code: test_programs/compile_success_empty/comptime_type/src/main.nr#L160-L173</a></sub></sup>
 
 
 ### as_type
@@ -100,7 +100,7 @@ where
 ```rust title="as_type" showLineNumbers 
 pub comptime fn as_type(self) -> Type {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/quoted.nr#L21-L23" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/quoted.nr#L21-L23</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/meta/quoted.nr#L21-L23" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/quoted.nr#L21-L23</a></sub></sup>
 
 
 Interprets this token stream as a resolved type. Panics if the token
@@ -120,7 +120,7 @@ where
     }
 }
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/compile_success_empty/comptime_type/src/main.nr#L160-L173" target="_blank" rel="noopener noreferrer">Source code: test_programs/compile_success_empty/comptime_type/src/main.nr#L160-L173</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/test_programs/compile_success_empty/comptime_type/src/main.nr#L160-L173" target="_blank" rel="noopener noreferrer">Source code: test_programs/compile_success_empty/comptime_type/src/main.nr#L160-L173</a></sub></sup>
 
 
 ### tokens
@@ -128,7 +128,7 @@ where
 ```rust title="tokens" showLineNumbers 
 pub comptime fn tokens(self) -> [Quoted] {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/quoted.nr#L26-L28" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/quoted.nr#L26-L28</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/meta/quoted.nr#L26-L28" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/quoted.nr#L26-L28</a></sub></sup>
 
 
 Returns a vector of the individual tokens that form this token stream.

--- a/docs/versioned_docs/version-v1.0.0-beta.20/noir/standard_library/meta/trait_def.md
+++ b/docs/versioned_docs/version-v1.0.0-beta.20/noir/standard_library/meta/trait_def.md
@@ -13,7 +13,7 @@ represents trait definitions such as `trait Foo { .. }` at the top-level of a pr
 ```rust title="as_trait_constraint" showLineNumbers 
 pub comptime fn as_trait_constraint(_self: Self) -> TraitConstraint {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/trait_def.nr#L6-L8" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/trait_def.nr#L6-L8</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/meta/trait_def.nr#L6-L8" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/trait_def.nr#L6-L8</a></sub></sup>
 
 
 Converts this trait into a trait constraint. If there are any generics on this

--- a/docs/versioned_docs/version-v1.0.0-beta.20/noir/standard_library/meta/trait_impl.md
+++ b/docs/versioned_docs/version-v1.0.0-beta.20/noir/standard_library/meta/trait_impl.md
@@ -13,7 +13,7 @@ implementation such as `impl Foo for Bar { ... }`.
 ```rust title="trait_generic_args" showLineNumbers 
 pub comptime fn trait_generic_args(self) -> [Type] {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/trait_impl.nr#L3-L5" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/trait_impl.nr#L3-L5</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/meta/trait_impl.nr#L3-L5" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/trait_impl.nr#L3-L5</a></sub></sup>
 
 
 Returns any generic arguments on the trait of this trait implementation, if any.
@@ -42,7 +42,7 @@ comptime {
 ```rust title="methods" showLineNumbers 
 pub comptime fn methods(self) -> [FunctionDefinition] {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/trait_impl.nr#L8-L10" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/trait_impl.nr#L8-L10</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/meta/trait_impl.nr#L8-L10" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/trait_impl.nr#L8-L10</a></sub></sup>
 
 
 Returns each method in this trait impl.

--- a/docs/versioned_docs/version-v1.0.0-beta.20/noir/standard_library/meta/typ.md
+++ b/docs/versioned_docs/version-v1.0.0-beta.20/noir/standard_library/meta/typ.md
@@ -11,7 +11,7 @@ a type in the source program.
 ```rust title="fresh_type_variable" showLineNumbers 
 pub comptime fn fresh_type_variable() -> Type {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/typ.nr#L57-L59" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/typ.nr#L57-L59</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/meta/typ.nr#L57-L59" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/typ.nr#L57-L59</a></sub></sup>
 
 
 Creates and returns an unbound type variable. This is a special kind of type internal
@@ -47,7 +47,7 @@ where
     U: Serialize<M>,
 {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/compile_success_empty/comptime_type/src/main.nr#L14-L29" target="_blank" rel="noopener noreferrer">Source code: test_programs/compile_success_empty/comptime_type/src/main.nr#L14-L29</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/test_programs/compile_success_empty/comptime_type/src/main.nr#L14-L29" target="_blank" rel="noopener noreferrer">Source code: test_programs/compile_success_empty/comptime_type/src/main.nr#L14-L29</a></sub></sup>
 
 ```rust title="fresh-type-variable-example" showLineNumbers 
 let typevar1 = std::meta::typ::fresh_type_variable();
@@ -70,7 +70,7 @@ let typevar1 = std::meta::typ::fresh_type_variable();
         // Now typevar2 should be bound to the serialized pair size 2 times the array length 5
         assert_eq(typevar2.as_constant().unwrap(), 10);
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/test_programs/compile_success_empty/comptime_type/src/main.nr#L129-L149" target="_blank" rel="noopener noreferrer">Source code: test_programs/compile_success_empty/comptime_type/src/main.nr#L129-L149</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/test_programs/compile_success_empty/comptime_type/src/main.nr#L129-L149" target="_blank" rel="noopener noreferrer">Source code: test_programs/compile_success_empty/comptime_type/src/main.nr#L129-L149</a></sub></sup>
 
 
 ## Methods
@@ -80,7 +80,7 @@ let typevar1 = std::meta::typ::fresh_type_variable();
 ```rust title="as_array" showLineNumbers 
 pub comptime fn as_array(self) -> Option<(Type, Type)> {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/typ.nr#L76-L78" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/typ.nr#L76-L78</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/meta/typ.nr#L76-L78" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/typ.nr#L76-L78</a></sub></sup>
 
 
 If this type is an array, return a pair of (element type, size type).
@@ -102,7 +102,7 @@ comptime {
 ```rust title="as_constant" showLineNumbers 
 pub comptime fn as_constant(self) -> Option<u32> {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/typ.nr#L83-L85" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/typ.nr#L83-L85</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/meta/typ.nr#L83-L85" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/typ.nr#L83-L85</a></sub></sup>
 
 
 If this type is a constant integer (such as the `3` in the array type `[Field; 3]`),
@@ -113,7 +113,7 @@ return the numeric constant.
 ```rust title="as_integer" showLineNumbers 
 pub comptime fn as_integer(self) -> Option<(bool, u8)> {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/typ.nr#L90-L92" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/typ.nr#L90-L92</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/meta/typ.nr#L90-L92" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/typ.nr#L90-L92</a></sub></sup>
 
 
 If this is an integer type, return a boolean which is `true`
@@ -124,7 +124,7 @@ if the type is signed, as well as the number of bits of this integer type.
 ```rust title="as_mutable_reference" showLineNumbers 
 pub comptime fn as_mutable_reference(self) -> Option<Type> {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/typ.nr#L96-L98" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/typ.nr#L96-L98</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/meta/typ.nr#L96-L98" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/typ.nr#L96-L98</a></sub></sup>
 
 
 If this is a mutable reference type `&mut T`, returns the mutable type `T`.
@@ -134,7 +134,7 @@ If this is a mutable reference type `&mut T`, returns the mutable type `T`.
 ```rust title="as_vector" showLineNumbers 
 pub comptime fn as_vector(self) -> Option<Type> {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/typ.nr#L102-L104" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/typ.nr#L102-L104</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/meta/typ.nr#L102-L104" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/typ.nr#L102-L104</a></sub></sup>
 
 
 If this is a vector type, return the element type of the vector.
@@ -144,7 +144,7 @@ If this is a vector type, return the element type of the vector.
 ```rust title="as_str" showLineNumbers 
 pub comptime fn as_str(self) -> Option<Type> {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/typ.nr#L113-L115" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/typ.nr#L113-L115</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/meta/typ.nr#L113-L115" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/typ.nr#L113-L115</a></sub></sup>
 
 
 If this is a `str<N>` type, returns the length `N` as a type.
@@ -154,10 +154,10 @@ If this is a `str<N>` type, returns the length `N` as a type.
 ```rust title="as_data_type" showLineNumbers 
 pub comptime fn as_data_type(self) -> Option<(TypeDefinition, [Type])> {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/typ.nr#L124-L126" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/typ.nr#L124-L126</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/meta/typ.nr#L124-L126" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/typ.nr#L124-L126</a></sub></sup>
 
 
-If this is a struct type, returns the struct in addition to
+If this is a struct or enum type, returns the type definition in addition to
 any generic arguments on this type.
 
 ### as_tuple
@@ -165,7 +165,7 @@ any generic arguments on this type.
 ```rust title="as_tuple" showLineNumbers 
 pub comptime fn as_tuple(self) -> Option<[Type]> {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/typ.nr#L130-L132" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/typ.nr#L130-L132</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/meta/typ.nr#L130-L132" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/typ.nr#L130-L132</a></sub></sup>
 
 
 If this is a tuple type, returns each element type of the tuple.
@@ -175,7 +175,7 @@ If this is a tuple type, returns each element type of the tuple.
 ```rust title="get_trait_impl" showLineNumbers 
 pub comptime fn get_trait_impl(self, constraint: TraitConstraint) -> Option<TraitImpl> {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/typ.nr#L153-L155" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/typ.nr#L153-L155</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/meta/typ.nr#L153-L155" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/typ.nr#L153-L155</a></sub></sup>
 
 
 Retrieves the trait implementation that implements the given
@@ -202,7 +202,7 @@ comptime {
 ```rust title="implements" showLineNumbers 
 pub comptime fn implements(self, constraint: TraitConstraint) -> bool {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/typ.nr#L176-L178" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/typ.nr#L176-L178</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/meta/typ.nr#L176-L178" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/typ.nr#L176-L178</a></sub></sup>
 
 
 `true` if this type implements the given trait. Note that unlike
@@ -229,7 +229,7 @@ fn foo<T>() where T: Default {
 ```rust title="is_bool" showLineNumbers 
 pub comptime fn is_bool(self) -> bool {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/typ.nr#L182-L184" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/typ.nr#L182-L184</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/meta/typ.nr#L182-L184" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/typ.nr#L182-L184</a></sub></sup>
 
 
 `true` if this type is `bool`.
@@ -239,7 +239,7 @@ pub comptime fn is_bool(self) -> bool {}
 ```rust title="is_field" showLineNumbers 
 pub comptime fn is_field(self) -> bool {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/typ.nr#L188-L190" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/typ.nr#L188-L190</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/meta/typ.nr#L188-L190" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/typ.nr#L188-L190</a></sub></sup>
 
 
 `true` if this type is `Field`.
@@ -249,7 +249,7 @@ pub comptime fn is_field(self) -> bool {}
 ```rust title="is_unit" showLineNumbers 
 pub comptime fn is_unit(self) -> bool {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/typ.nr#L194-L196" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/typ.nr#L194-L196</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/meta/typ.nr#L194-L196" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/typ.nr#L194-L196</a></sub></sup>
 
 
 `true` if this type is the unit `()` type.

--- a/docs/versioned_docs/version-v1.0.0-beta.20/noir/standard_library/meta/type_def.md
+++ b/docs/versioned_docs/version-v1.0.0-beta.20/noir/standard_library/meta/type_def.md
@@ -13,7 +13,7 @@ This type corresponds to `struct Name { field1: Type1, ... }` and `enum Name { V
 ```rust title="add_abi" showLineNumbers 
 pub comptime fn add_abi(self, abi_argument: CtString) {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/type_def.nr#L5-L7" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/type_def.nr#L5-L7</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/meta/type_def.nr#L5-L7" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/type_def.nr#L5-L7</a></sub></sup>
 
 
 Adds an abi attribute to the data type with the specified argument.
@@ -23,7 +23,7 @@ Adds an abi attribute to the data type with the specified argument.
 ```rust title="as_type" showLineNumbers 
 pub comptime fn as_type(self) -> Type {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/type_def.nr#L12-L14" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/type_def.nr#L12-L14</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/meta/type_def.nr#L12-L14" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/type_def.nr#L12-L14</a></sub></sup>
 
 
 Returns this type definition as a type in the source program. If this definition has
@@ -34,7 +34,7 @@ any generics, the generics are also included as-is.
 ```rust title="as_type_with_generics" showLineNumbers 
 pub comptime fn as_type_with_generics(self, generics: [Type]) -> Option<Type> {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/type_def.nr#L23-L25" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/type_def.nr#L23-L25</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/meta/type_def.nr#L23-L25" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/type_def.nr#L23-L25</a></sub></sup>
 
 
 Returns a type from this type definition using the given generic arguments. Returns `Option::none()`
@@ -45,7 +45,7 @@ if an incorrect amount of generic arguments are given for this type.
 ```rust title="generics" showLineNumbers 
 pub comptime fn generics(self) -> [(Type, Option<Type>)] {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/type_def.nr#L35-L37" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/type_def.nr#L35-L37</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/meta/type_def.nr#L35-L37" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/type_def.nr#L35-L37</a></sub></sup>
 
 
 Returns each generic on this type definition. Each generic is represented as a tuple containing the type,
@@ -78,7 +78,7 @@ comptime fn example(foo: TypeDefinition) {
 ```rust title="fields" showLineNumbers 
 pub comptime fn fields(self, generic_args: [Type]) -> [(Quoted, Type, Quoted)] {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/type_def.nr#L43-L45" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/type_def.nr#L43-L45</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/meta/type_def.nr#L43-L45" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/type_def.nr#L43-L45</a></sub></sup>
 
 
 Returns (name, type, visibility) tuples of each field in this struct type.
@@ -90,7 +90,7 @@ provided generic arguments.
 ```rust title="fields_as_written" showLineNumbers 
 pub comptime fn fields_as_written(self) -> [(Quoted, Type, Quoted)] {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/type_def.nr#L52-L54" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/type_def.nr#L52-L54</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/meta/type_def.nr#L52-L54" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/type_def.nr#L52-L54</a></sub></sup>
 
 
 Returns (name, type, visibility) tuples of each field in this struct type. Each type is as-is
@@ -103,7 +103,7 @@ function if possible.
 ```rust title="has_named_attribute" showLineNumbers 
 pub comptime fn has_named_attribute<let N: u32>(self, name: str<N>) -> bool {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/type_def.nr#L28-L30" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/type_def.nr#L28-L30</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/meta/type_def.nr#L28-L30" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/type_def.nr#L28-L30</a></sub></sup>
 
 
 Returns true if this type has a custom attribute with the given name.
@@ -113,7 +113,7 @@ Returns true if this type has a custom attribute with the given name.
 ```rust title="module" showLineNumbers 
 pub comptime fn module(self) -> Module {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/type_def.nr#L57-L59" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/type_def.nr#L57-L59</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/meta/type_def.nr#L57-L59" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/type_def.nr#L57-L59</a></sub></sup>
 
 
 Returns the module where the type is defined.
@@ -123,7 +123,7 @@ Returns the module where the type is defined.
 ```rust title="name" showLineNumbers 
 pub comptime fn name(self) -> Quoted {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/type_def.nr#L62-L64" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/type_def.nr#L62-L64</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/meta/type_def.nr#L62-L64" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/type_def.nr#L62-L64</a></sub></sup>
 
 
 Returns the name of this type

--- a/docs/versioned_docs/version-v1.0.0-beta.20/noir/standard_library/meta/typed_expr.md
+++ b/docs/versioned_docs/version-v1.0.0-beta.20/noir/standard_library/meta/typed_expr.md
@@ -7,22 +7,22 @@ description: Resolved, type-checked expressions—retrieve types, access referen
 
 ## Methods
 
-### get_type
+### as_function_definition
 
 ```rust title="as_function_definition" showLineNumbers 
 pub comptime fn as_function_definition(self) -> Option<FunctionDefinition> {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/typed_expr.nr#L7-L9" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/typed_expr.nr#L7-L9</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/meta/typed_expr.nr#L7-L9" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/typed_expr.nr#L7-L9</a></sub></sup>
 
 
-If this expression refers to a function definitions, returns it. Otherwise returns `Option::none()`.
+If this expression refers to a function definition, returns it. Otherwise returns `Option::none()`.
 
 ### get_type
 
 ```rust title="get_type" showLineNumbers 
 pub comptime fn get_type(self) -> Option<Type> {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/typed_expr.nr#L13-L15" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/typed_expr.nr#L13-L15</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/meta/typed_expr.nr#L13-L15" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/typed_expr.nr#L13-L15</a></sub></sup>
 
 
 Returns the type of the expression, or `Option::none()` if there were errors when the expression was previously resolved.

--- a/docs/versioned_docs/version-v1.0.0-beta.20/noir/standard_library/meta/unresolved_type.md
+++ b/docs/versioned_docs/version-v1.0.0-beta.20/noir/standard_library/meta/unresolved_type.md
@@ -12,7 +12,7 @@ description: Work with the syntactic form of types—inspect references, vectors
 ```rust title="as_mutable_reference" showLineNumbers 
 pub comptime fn as_mutable_reference(self) -> Option<UnresolvedType> {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/unresolved_type.nr#L8-L10" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/unresolved_type.nr#L8-L10</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/meta/unresolved_type.nr#L8-L10" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/unresolved_type.nr#L8-L10</a></sub></sup>
 
 
 If this is a mutable reference type `&mut T`, returns the mutable type `T`.
@@ -22,7 +22,7 @@ If this is a mutable reference type `&mut T`, returns the mutable type `T`.
 ```rust title="as_vector" showLineNumbers 
 pub comptime fn as_vector(self) -> Option<UnresolvedType> {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/unresolved_type.nr#L14-L16" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/unresolved_type.nr#L14-L16</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/meta/unresolved_type.nr#L14-L16" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/unresolved_type.nr#L14-L16</a></sub></sup>
 
 
 If this is a vector `@[T]`, returns the element type `T`.
@@ -32,7 +32,7 @@ If this is a vector `@[T]`, returns the element type `T`.
 ```rust title="is_bool" showLineNumbers 
 pub comptime fn is_bool(self) -> bool {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/unresolved_type.nr#L25-L27" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/unresolved_type.nr#L25-L27</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/meta/unresolved_type.nr#L25-L27" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/unresolved_type.nr#L25-L27</a></sub></sup>
 
 
 Returns `true` if this type is `bool`.
@@ -42,7 +42,7 @@ Returns `true` if this type is `bool`.
 ```rust title="is_field" showLineNumbers 
 pub comptime fn is_field(self) -> bool {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/unresolved_type.nr#L31-L33" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/unresolved_type.nr#L31-L33</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/meta/unresolved_type.nr#L31-L33" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/unresolved_type.nr#L31-L33</a></sub></sup>
 
 
 Returns true if this type refers to the Field type.
@@ -52,7 +52,7 @@ Returns true if this type refers to the Field type.
 ```rust title="is_unit" showLineNumbers 
 pub comptime fn is_unit(self) -> bool {}
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/meta/unresolved_type.nr#L37-L39" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/unresolved_type.nr#L37-L39</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/meta/unresolved_type.nr#L37-L39" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/meta/unresolved_type.nr#L37-L39</a></sub></sup>
 
 
 Returns true if this type is the unit `()` type.

--- a/docs/versioned_docs/version-v1.0.0-beta.20/noir/standard_library/options.md
+++ b/docs/versioned_docs/version-v1.0.0-beta.20/noir/standard_library/options.md
@@ -3,7 +3,7 @@ title: Option<T> Type
 description: Express presence or absence safely with `Option<T>`—construct, inspect, and transform values without nulls.
 ---
 
-The `Option<T>` type is a way to express that a value might be present (`Some(T))` or absent (`None`). It's a safer way to handle potential absence of values, compared to using nulls in many other languages.
+The `Option<T>` type is a way to express that a value might be present (`Some(T)`) or absent (`None`). It's a safer way to handle potential absence of values, compared to using nulls in many other languages.
 
 ```rust
 struct Option<T> {
@@ -21,7 +21,7 @@ fn main() {
 }
 ```
 
-See [this test](https://github.com/noir-lang/noir/blob/5cbfb9c4a06c8865c98ff2b594464b037d821a5c/crates/nargo_cli/tests/test_data/option/src/main.nr) for a more comprehensive set of examples of each of the methods described below.
+See [this test](https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/test_programs/compile_success_empty/option/src/main.nr) for a more comprehensive set of examples of each of the methods described below.
 
 ## Methods
 
@@ -39,7 +39,7 @@ Returns true if the Option is None.
 
 ### is_some
 
-Returns true of the Option is Some.
+Returns true if the Option is Some.
 
 ### unwrap
 

--- a/docs/versioned_docs/version-v1.0.0-beta.20/noir/standard_library/traits.md
+++ b/docs/versioned_docs/version-v1.0.0-beta.20/noir/standard_library/traits.md
@@ -13,7 +13,7 @@ pub trait Default {
     fn default() -> Self;
 }
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/default.nr#L7-L11" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/default.nr#L7-L11</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/default.nr#L7-L11" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/default.nr#L7-L11</a></sub></sup>
 
 
 Constructs a default value of a type.
@@ -68,7 +68,7 @@ pub trait From<T> {
     fn from(input: T) -> Self;
 }
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/convert.nr#L2-L6" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/convert.nr#L2-L6</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/convert.nr#L2-L6" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/convert.nr#L2-L6</a></sub></sup>
 
 
 The `From` trait defines how to convert from a given type `T` to the type on which the trait is implemented.
@@ -255,7 +255,7 @@ impl From<bool> for Field {
     }
 }
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/convert.nr#L30-L210" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/convert.nr#L30-L210</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/convert.nr#L30-L210" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/convert.nr#L30-L210</a></sub></sup>
 
 
 #### When to implement `From`
@@ -290,7 +290,7 @@ where
     }
 }
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/convert.nr#L15-L28" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/convert.nr#L15-L28</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/convert.nr#L15-L28" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/convert.nr#L15-L28</a></sub></sup>
 
 
 `Into` is most useful when passing function arguments where the types don't quite match up with what the function expects. In this case, the compiler has enough type information to perform the necessary conversion by just appending `.into()` onto the arguments in question.
@@ -306,7 +306,7 @@ pub trait Eq {
     fn eq(self, other: Self) -> bool;
 }
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/cmp.nr#L6-L10" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/cmp.nr#L6-L10</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/cmp.nr#L6-L10" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/cmp.nr#L6-L10</a></sub></sup>
 
 
 Returns `true` if `self` is equal to `other`. Implementing this trait on a type
@@ -355,7 +355,7 @@ pub trait Ord {
     fn cmp(self, other: Self) -> Ordering;
 }
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/cmp.nr#L241-L245" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/cmp.nr#L241-L245</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/cmp.nr#L241-L245" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/cmp.nr#L241-L245</a></sub></sup>
 
 
 `a.cmp(b)` compares two values returning `Ordering::less()` if `a < b`,
@@ -416,28 +416,28 @@ pub trait Add {
     fn add(self, other: Self) -> Self;
 }
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/ops/arith.nr#L3-L7" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/ops/arith.nr#L3-L7</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/ops/arith.nr#L3-L7" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/ops/arith.nr#L3-L7</a></sub></sup>
 
 ```rust title="sub-trait" showLineNumbers 
 pub trait Sub {
     fn sub(self, other: Self) -> Self;
 }
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/ops/arith.nr#L61-L65" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/ops/arith.nr#L61-L65</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/ops/arith.nr#L61-L65" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/ops/arith.nr#L61-L65</a></sub></sup>
 
 ```rust title="mul-trait" showLineNumbers 
 pub trait Mul {
     fn mul(self, other: Self) -> Self;
 }
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/ops/arith.nr#L119-L123" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/ops/arith.nr#L119-L123</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/ops/arith.nr#L119-L123" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/ops/arith.nr#L119-L123</a></sub></sup>
 
 ```rust title="div-trait" showLineNumbers 
 pub trait Div {
     fn div(self, other: Self) -> Self;
 }
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/ops/arith.nr#L177-L181" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/ops/arith.nr#L177-L181</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/ops/arith.nr#L177-L181" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/ops/arith.nr#L177-L181</a></sub></sup>
 
 
 The implementations block below is given for the `Add` trait, but the same types that implement
@@ -465,7 +465,7 @@ pub trait Rem {
     fn rem(self, other: Self) -> Self;
 }
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/ops/arith.nr#L235-L239" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/ops/arith.nr#L235-L239</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/ops/arith.nr#L235-L239" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/ops/arith.nr#L235-L239</a></sub></sup>
 
 
 `Rem::rem(a, b)` is the remainder function returning the result of what is
@@ -494,7 +494,7 @@ pub trait Neg {
     fn neg(self) -> Self;
 }
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/ops/arith.nr#L287-L291" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/ops/arith.nr#L287-L291</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/ops/arith.nr#L287-L291" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/ops/arith.nr#L287-L291</a></sub></sup>
 
 
 `Neg::neg` is equivalent to the unary negation operator `-`.
@@ -528,7 +528,7 @@ impl Neg for i64 {
     }
 }
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/ops/arith.nr#L293-L320" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/ops/arith.nr#L293-L320</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/ops/arith.nr#L293-L320" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/ops/arith.nr#L293-L320</a></sub></sup>
 
 
 ### `std::ops::Not`
@@ -538,7 +538,7 @@ pub trait Not {
     fn not(self: Self) -> Self;
 }
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/ops/bit.nr#L1-L5" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/ops/bit.nr#L1-L5</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/ops/bit.nr#L1-L5" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/ops/bit.nr#L1-L5</a></sub></sup>
 
 
 `Not::not` is equivalent to the unary bitwise NOT operator `!`.
@@ -597,7 +597,7 @@ impl Not for i64 {
     }
 }
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/ops/bit.nr#L7-L59" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/ops/bit.nr#L7-L59</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/ops/bit.nr#L7-L59" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/ops/bit.nr#L7-L59</a></sub></sup>
 
 
 ### `std::ops::{ BitOr, BitAnd, BitXor }`
@@ -607,21 +607,21 @@ pub trait BitOr {
     fn bitor(self, other: Self) -> Self;
 }
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/ops/bit.nr#L61-L65" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/ops/bit.nr#L61-L65</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/ops/bit.nr#L61-L65" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/ops/bit.nr#L61-L65</a></sub></sup>
 
 ```rust title="bitand-trait" showLineNumbers 
 pub trait BitAnd {
     fn bitand(self, other: Self) -> Self;
 }
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/ops/bit.nr#L119-L123" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/ops/bit.nr#L119-L123</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/ops/bit.nr#L119-L123" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/ops/bit.nr#L119-L123</a></sub></sup>
 
 ```rust title="bitxor-trait" showLineNumbers 
 pub trait BitXor {
     fn bitxor(self, other: Self) -> Self;
 }
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/ops/bit.nr#L177-L181" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/ops/bit.nr#L177-L181</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/ops/bit.nr#L177-L181" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/ops/bit.nr#L177-L181</a></sub></sup>
 
 
 Traits for the bitwise operations `|`, `&`, and `^`.
@@ -654,14 +654,14 @@ pub trait Shl {
     fn shl(self, other: Self) -> Self;
 }
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/ops/bit.nr#L235-L239" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/ops/bit.nr#L235-L239</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/ops/bit.nr#L235-L239" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/ops/bit.nr#L235-L239</a></sub></sup>
 
 ```rust title="shr-trait" showLineNumbers 
 pub trait Shr {
     fn shr(self, other: Self) -> Self;
 }
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/ops/bit.nr#L287-L291" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/ops/bit.nr#L287-L291</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/ops/bit.nr#L287-L291" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/ops/bit.nr#L287-L291</a></sub></sup>
 
 
 Traits for a bit shift left and bit shift right.
@@ -696,7 +696,7 @@ pub trait Append {
     fn append(self, other: Self) -> Self;
 }
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/noir_stdlib/src/append.nr#L9-L14" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/append.nr#L9-L14</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/noir_stdlib/src/append.nr#L9-L14" target="_blank" rel="noopener noreferrer">Source code: noir_stdlib/src/append.nr#L9-L14</a></sub></sup>
 
 
 `Append` requires two methods:

--- a/docs/versioned_docs/version-v1.0.0-beta.20/reference/noir_codegen.md
+++ b/docs/versioned_docs/version-v1.0.0-beta.20/reference/noir_codegen.md
@@ -91,8 +91,8 @@ Consider a Noir library with this function:
 
 ```rust
 #[export]
-fn not_equal(x: Field, y: Field) -> bool {
-    x != y
+fn is_equal(x: Field, y: Field) -> bool {
+    x == y
 }
 ```
 

--- a/docs/versioned_docs/version-v1.0.0-beta.20/tutorials/noirjs_app.md
+++ b/docs/versioned_docs/version-v1.0.0-beta.20/tutorials/noirjs_app.md
@@ -16,14 +16,14 @@ You can find the complete app code for this guide [here](https://github.com/noir
 
 Before we start, we want to make sure we have Node installed. If you don't have it already you can install it [here](https://nodejs.org/en/download), we recommend using [Yarn](https://yarnpkg.com/getting-started/install) as our package manager for this tutorial.
 
-We'll also need version 1.0.0-beta.15 nargo installed, see the Noir [installation guide](../getting_started/noir_installation.md) for details.
+We'll also need version 1.0.0-beta.20 nargo installed, see the Noir [installation guide](../getting_started/noir_installation.md) for details.
 
 Let's go barebones. Doing the bare minimum is not only simple, but also allows you to easily adapt it to almost any frontend framework.
 
 Barebones means we can immediately start with the dependencies even on an empty folder 😈:
 
 ```bash
-yarn add @noir-lang/noir_js@1.0.0-beta.15 @aztec/bb.js@3.0.0-nightly.20251104 buffer vite vite-plugin-node-polyfills@0.17.0
+yarn add @noir-lang/noir_js@1.0.0-beta.20 @aztec/bb.js@3.0.0-nightly.20251104 buffer vite vite-plugin-node-polyfills@0.17.0
 ```
 
 Wait, what are these dependencies?
@@ -33,7 +33,7 @@ Wait, what are these dependencies?
 
 :::info
 
-In this guide, we will install versions pinned to 1.0.0-beta.15. These work with Barretenberg version 3.0.0-nightly.20251104, so we are using that one version too. Feel free to try with older or later versions, though!
+In this guide, we will install versions pinned to 1.0.0-beta.20. These work with Barretenberg version 3.0.0-nightly.20251104, so we are using that one version too. Feel free to try with older or later versions, though!
 
 :::
 
@@ -47,7 +47,7 @@ It's not just you. We also enjoy syntax highlighting. [Check out the Language Se
 
 :::
 
-All you need is a `main.nr` and a `Nargo.toml` file. You can follow the [noirup](../getting_started/noir_installation.md) installation and just run `noirup -v 1.0.0-beta.15`, or just create them by hand:
+All you need is a `main.nr` and a `Nargo.toml` file. You can follow the [noirup](../getting_started/noir_installation.md) installation and just run `noirup -v 1.0.0-beta.20`, or just create them by hand:
 
 ```bash
 mkdir -p circuit/src
@@ -61,7 +61,7 @@ fn main(age: u8) {
     assert(age > 18);
 }
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/examples/browser/src/main.nr#L1-L5" target="_blank" rel="noopener noreferrer">Source code: examples/browser/src/main.nr#L1-L5</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/examples/browser/src/main.nr#L1-L5" target="_blank" rel="noopener noreferrer">Source code: examples/browser/src/main.nr#L1-L5</a></sub></sup>
 
 
 This program accepts a private input called age, and simply proves this number is higher than 18. But to run this code, we need to give the compiler a `Nargo.toml` with at least a name and a type:
@@ -131,7 +131,7 @@ And add something useful to our HTML file:
 </body>
 </html>
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/examples/browser/index.html#L1-L31" target="_blank" rel="noopener noreferrer">Source code: examples/browser/index.html#L1-L31</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/examples/browser/index.html#L1-L31" target="_blank" rel="noopener noreferrer">Source code: examples/browser/index.html#L1-L31</a></sub></sup>
 
 
 It _could_ be a beautiful UI... Depending on which universe you live in. In any case, we're using some scary CSS to make two boxes that will show cool things on the screen.
@@ -189,7 +189,7 @@ import circuit from './target/circuit.json';
 // Initialize WASM modules
 await Promise.all([initACVM(fetch(acvm)), initNoirC(fetch(noirc))]);
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/examples/browser/index.js#L1-L11" target="_blank" rel="noopener noreferrer">Source code: examples/browser/index.js#L1-L11</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/examples/browser/index.js#L1-L11" target="_blank" rel="noopener noreferrer">Source code: examples/browser/index.js#L1-L11</a></sub></sup>
 
 
 And instantiate them inside our try-catch block:
@@ -203,7 +203,7 @@ show('logs', 'Creating Noir...');
     show('logs', 'Creating UltraHonkBackend...');
     const backend = new UltraHonkBackend(circuit.bytecode, barretenbergAPI);
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/examples/browser/index.js#L23-L31" target="_blank" rel="noopener noreferrer">Source code: examples/browser/index.js#L23-L31</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/examples/browser/index.js#L23-L31" target="_blank" rel="noopener noreferrer">Source code: examples/browser/index.js#L23-L31</a></sub></sup>
 
 
 ## Executing and proving
@@ -216,7 +216,7 @@ const age = document.getElementById('age').value;
     const { witness } = await noir.execute({ age });
     show('logs', 'Generated witness... ✅');
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/examples/browser/index.js#L32-L37" target="_blank" rel="noopener noreferrer">Source code: examples/browser/index.js#L32-L37</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/examples/browser/index.js#L32-L37" target="_blank" rel="noopener noreferrer">Source code: examples/browser/index.js#L32-L37</a></sub></sup>
 
 
 :::note
@@ -233,7 +233,7 @@ show('logs', 'Generating proof... ⏳');
     show('logs', 'Generated proof... ✅');
     show('results', proof.proof);
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/examples/browser/index.js#L38-L43" target="_blank" rel="noopener noreferrer">Source code: examples/browser/index.js#L38-L43</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/examples/browser/index.js#L38-L43" target="_blank" rel="noopener noreferrer">Source code: examples/browser/index.js#L38-L43</a></sub></sup>
 
 
 Our program is technically **done** . You're probably eager to see stuff happening! To serve this in a convenient way, we can use a bundler like `vite` by creating a `vite.config.js` file:
@@ -272,7 +272,7 @@ export default defineConfig({
   },
 });
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/examples/browser/vite.config.js#L1-L27" target="_blank" rel="noopener noreferrer">Source code: examples/browser/vite.config.js#L1-L27</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/examples/browser/vite.config.js#L1-L27" target="_blank" rel="noopener noreferrer">Source code: examples/browser/vite.config.js#L1-L27</a></sub></sup>
 
 
 This should be enough for vite. We don't even need to install it, just run:
@@ -298,7 +298,7 @@ show('logs', 'Verifying proof... ⌛');
     const isValid = await backend.verifyProof(proof);
     show('logs', `Proof is ${isValid ? 'valid' : 'invalid'}... ✅`);
 ```
-> <sup><sub><a href="https://github.com/noir-lang/noir/blob/master/examples/browser/index.js#L45-L49" target="_blank" rel="noopener noreferrer">Source code: examples/browser/index.js#L45-L49</a></sub></sup>
+> <sup><sub><a href="https://github.com/noir-lang/noir/blob/v1.0.0-beta.20/examples/browser/index.js#L45-L49" target="_blank" rel="noopener noreferrer">Source code: examples/browser/index.js#L45-L49</a></sub></sup>
 
 
 You have successfully generated a client-side Noir web app!


### PR DESCRIPTION
## Summary

Addresses a recent accuracy audit of the documentation covering 27 findings (NDI-01 through NDI-27). Fixes land in both the live docs under `docs/docs/` and the frozen `v1.0.0-beta.20` snapshot under `docs/versioned_docs/`.

Categories:
- **Broken code examples** — invalid Noir in `unconstrained.md` (`fn main f0 (...)` + explicit `return`), malformed pseudo-code fence in `functions.md`, truncated `if is_unconstrained() { /` snippet in the explainer, mismatched-paren / unsupported-`u72` snippet in the versioned `unconstrained.md`.
- **Wrong / stale API references** — `std::scalar_mul::fixed_base_embedded_curve` → `std::embedded_curve_ops::fixed_base_scalar_mul`, deprecated `dep::` prefix, stale `call_data` syntax (`call_data T` → `call_data(<id>) T`), `as_for_range` include-code mis-routed to `as_for`, `as_data_type` described as "struct type" instead of "struct or enum type", codegen example defining `not_equal` but generating `is_equal_*`.
- **Prose that contradicts the code** — "No passing by reference" (references are supported), "vectors are currently unsupported" for `print`/`println` (they're supported for constrained callers via builtin handling), "nested arrays are unsupported" (shown working on the same page), arrays-of-`u64` described as containing `Field` elements.
- **Version pins / paths** — `compiler_version = "0.9.0"` → `">=1.0.0"`, NoirJS tutorial `1.0.0-beta.15` → `1.0.0-beta.20`, `./contract/` → `./src/contract.sol`, versioned `sgn0 -> u1` → `-> bool`.
- **Dead / unpinned links** — commit-pinned `crates/nargo_cli/...` links repointed at current `test_programs/...` paths; 250 `blob/master` source links across 26 files in the versioned snapshot rewritten to `blob/v1.0.0-beta.20` so the snapshot is actually pinned.
- **Typos / cosmetics** — `follow's` → `follows`, `step 2:` → `Step 2:`, `Some(T))` → `Some(T)`, `Returns true of` → `Returns true if`, duplicate `### get_type` heading in `typed_expr.md`.

## Test plan

- [ ] `yarn build` inside `docs/` completes cleanly
- [ ] Spot-check rendered pages for the rewritten code examples (`unconstrained`, `functions`, `data_bus`, `explainer-writing-noir`, `noir_codegen`)
- [ ] Verify the versioned `blob/v1.0.0-beta.20/...` links resolve (sample: `noir/standard_library/meta/expr.md`, `noir/concepts/data_types/fields.md`)
- [ ] Verify the repointed test-file links in `options.md` / `vectors.mdx` resolve against `master` (live) and `v1.0.0-beta.20` (versioned)