### PR TITLE
chore(ssa,brillig): three more small audit cleanups (#12258, #12293, #12302)

### DIFF
--- a/compiler/noirc_evaluator/src/brillig/brillig_gen.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen.rs
@@ -253,39 +253,35 @@ mod entry_point {
         29: sp[5] = const u32 7
         30: sp[11] = u32 add sp[3], sp[5]
         31: sp[5] = const u32 8
-        32: @4 = const u32 0
-        33: @3 = u32 add sp[1], @4
-        34: store sp[4] at @3
-        35: sp[4] = u32 add sp[2], sp[5]
-        36: sp[5] = const u32 9
-        37: @4 = const u32 1
-        38: @3 = u32 add sp[1], @4
-        39: store sp[6] at @3
-        40: sp[6] = u32 add sp[3], sp[5]
-        41: sp[3] = const u32 10
-        42: sp[5] = u32 add sp[2], sp[3]
-        43: @4 = const u32 0
-        44: @3 = u32 add sp[1], @4
-        45: sp[3] = load @3
-        46: @4 = const u32 2
-        47: @3 = u32 add sp[1], @4
-        48: store sp[7] at @3
-        49: @4 = const u32 1
+        32: store sp[4] at sp[1]
+        33: sp[4] = u32 add sp[2], sp[5]
+        34: sp[5] = const u32 9
+        35: @4 = const u32 1
+        36: @3 = u32 add sp[1], @4
+        37: store sp[6] at @3
+        38: sp[6] = u32 add sp[3], sp[5]
+        39: sp[3] = const u32 10
+        40: sp[5] = u32 add sp[2], sp[3]
+        41: sp[3] = load sp[1]
+        42: @4 = const u32 2
+        43: @3 = u32 add sp[1], @4
+        44: store sp[7] at @3
+        45: @4 = const u32 1
+        46: @3 = u32 add sp[1], @4
+        47: sp[7] = load @3
+        48: sp[2] = u32 add sp[3], sp[7]
+        49: @4 = const u32 2
         50: @3 = u32 add sp[1], @4
         51: sp[7] = load @3
-        52: sp[2] = u32 add sp[3], sp[7]
-        53: @4 = const u32 2
-        54: @3 = u32 add sp[1], @4
-        55: sp[7] = load @3
-        56: sp[3] = u32 add sp[2], sp[7]
-        57: sp[2] = u32 add sp[3], sp[8]
-        58: sp[3] = u32 add sp[2], sp[9]
-        59: sp[2] = u32 add sp[3], sp[10]
-        60: sp[3] = u32 add sp[2], sp[11]
-        61: sp[2] = u32 add sp[3], sp[4]
-        62: sp[3] = u32 add sp[2], sp[6]
-        63: sp[2] = u32 add sp[3], sp[5]
-        64: return
+        52: sp[3] = u32 add sp[2], sp[7]
+        53: sp[2] = u32 add sp[3], sp[8]
+        54: sp[3] = u32 add sp[2], sp[9]
+        55: sp[2] = u32 add sp[3], sp[10]
+        56: sp[3] = u32 add sp[2], sp[11]
+        57: sp[2] = u32 add sp[3], sp[4]
+        58: sp[3] = u32 add sp[2], sp[6]
+        59: sp[2] = u32 add sp[3], sp[5]
+        60: return
         ");
     }
 }

--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_block.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_block.rs
@@ -237,7 +237,8 @@ impl<'block, Registers: RegisterAllocator> BrilligBlock<'block, Registers> {
         }
 
         let var = *self.function_context.ssa_value_allocations.get(&value_id).unwrap();
-        let offset = sm.get_spill_offset(&value_id).unwrap_or_else(|| sm.allocate_spill_offset());
+        let prior_offset = sm.get_spill_offset(&value_id);
+        let offset = prior_offset.unwrap_or_else(|| sm.allocate_spill_offset());
         sm.remove_from_lru(&value_id);
         if permanent {
             sm.record_permanent_spill(value_id, offset, var);
@@ -245,7 +246,10 @@ impl<'block, Registers: RegisterAllocator> BrilligBlock<'block, Registers> {
             sm.record_spill(value_id, offset, var);
         }
 
-        if emit_store {
+        // Only store when we've just allocated the slot. If the value already had a slot,
+        // the slot still holds the correct value (SSA values are immutable) so the store
+        // would be redundant.
+        if emit_store && prior_offset.is_none() {
             self.codegen_spill_store(offset, var.extract_register());
         }
 

--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_block.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_block.rs
@@ -205,19 +205,15 @@ impl<'block, Registers: RegisterAllocator> BrilligBlock<'block, Registers> {
         }
     }
 
-    /// Emit a 3-instruction sequence to store `source_reg` into the spill region
-    /// at the given offset relative to the per-frame spill base pointer.
+    /// Emit a store of `source_reg` into the spill region at the given offset relative
+    /// to the per-frame spill base pointer.
+    ///
+    /// At offset 0 this is a single store against the spill base pointer; at any other
+    /// offset it emits a 3-instruction sequence (const + add + store) via the scratch
+    /// registers.
     fn codegen_spill_store(&mut self, offset: usize, source_reg: MemoryAddress) {
-        let (scratch_addr, scratch_offset) = ReservedRegisters::spill_scratch();
-        self.brillig_context
-            .const_instruction(SingleAddrVariable::new_usize(scratch_offset), offset.into());
-        self.brillig_context.memory_op_instruction(
-            ReservedRegisters::spill_base_pointer(),
-            scratch_offset,
-            scratch_addr,
-            BrilligBinaryOp::Add,
-        );
-        self.brillig_context.store_instruction(scratch_addr, source_reg);
+        let addr = self.codegen_spill_slot_address(offset);
+        self.brillig_context.store_instruction(addr, source_reg);
     }
 
     /// Spill a value: record it in the spill manager, optionally emit a store to its slot,
@@ -256,9 +252,25 @@ impl<'block, Registers: RegisterAllocator> BrilligBlock<'block, Registers> {
         self.variables.remove_variable(&value_id, self.function_context, self.brillig_context);
     }
 
-    /// Emit a 3-instruction sequence to load a value from the spill region
-    /// at the given offset into `dest_reg`.
+    /// Emit a load from the spill region at the given offset into `dest_reg`.
+    ///
+    /// At offset 0 this is a single load from the spill base pointer; at any other
+    /// offset it emits a 3-instruction sequence (const + add + load) via the scratch
+    /// registers.
     fn codegen_spill_load(&mut self, offset: usize, dest_reg: MemoryAddress) {
+        let addr = self.codegen_spill_slot_address(offset);
+        self.brillig_context.load_instruction(dest_reg, addr);
+    }
+
+    /// Return a register holding `spill_base + offset`.
+    ///
+    /// For offset 0 this returns the spill base pointer directly, emitting no opcodes.
+    /// Otherwise it materializes the address into the scratch register via a
+    /// 2-instruction const + add sequence.
+    fn codegen_spill_slot_address(&mut self, offset: usize) -> MemoryAddress {
+        if offset == 0 {
+            return ReservedRegisters::spill_base_pointer();
+        }
         let (scratch_addr, scratch_offset) = ReservedRegisters::spill_scratch();
         self.brillig_context
             .const_instruction(SingleAddrVariable::new_usize(scratch_offset), offset.into());
@@ -268,7 +280,7 @@ impl<'block, Registers: RegisterAllocator> BrilligBlock<'block, Registers> {
             scratch_addr,
             BrilligBinaryOp::Add,
         );
-        self.brillig_context.load_instruction(dest_reg, scratch_addr);
+        scratch_addr
     }
 
     /// Spill the least-recently-used value to the spill region

--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/tests/spill.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/tests/spill.rs
@@ -39,18 +39,18 @@ fn brillig_spill_and_reload() {
 
     let main = &brillig.ssa_function_to_brillig[&Id::test_new(0)];
     // Bytecode layout:
-    //   0-3:   Prologue — save spill base (sp[1]), reserve 1 spill slot
-    //   4:     v2 = v0 + v1
-    //   5:     Init constant 2
-    //   6-8:   Spill v2 → spill[0]  (const offset, add addr, store)
-    //   9:     v3 = v0 + 2  (reuses sp[4] freed by spill)
-    //   10:    Init constant 3
-    //   11:    v4 = v1 + 3
-    //   12-14: Reload v2 from spill[0]  (const offset, add addr, load)
-    //   15:    v5 = v2 + v3
-    //   16:    v6 = v5 + v4
-    //   17:    Move result to return slot
-    //   18:    Return
+    //   0-2: Prologue — save spill base (sp[1]), reserve 1 spill slot
+    //   3:   v2 = v0 + v1
+    //   4:   Init constant 2
+    //   5:   Spill v2 → spill[0]  (single store, offset 0 uses sp[1] directly)
+    //   6:   v3 = v0 + 2  (reuses sp[4] freed by spill)
+    //   7:   Init constant 3
+    //   8:   v4 = v1 + 3
+    //   9:   Reload v2 from spill[0]  (single load, offset 0 uses sp[1] directly)
+    //   10:  v5 = v2 + v3
+    //   11:  v6 = v5 + v4
+    //   12:  Move result to return slot
+    //   13:  Return
     assert_artifact_snapshot!(main, @r"
     fn main
      0: sp[1] = @1
@@ -58,19 +58,15 @@ fn brillig_spill_and_reload() {
      2: @1 = u32 add @1, @3
      3: sp[4] = u32 add sp[2], sp[3]
      4: sp[5] = const u32 2
-     5: @4 = const u32 0
-     6: @3 = u32 add sp[1], @4
-     7: store sp[4] at @3
-     8: sp[4] = u32 add sp[2], sp[5]
-     9: sp[2] = const u32 3
-    10: sp[5] = u32 add sp[3], sp[2]
-    11: @4 = const u32 0
-    12: @3 = u32 add sp[1], @4
-    13: sp[3] = load @3
-    14: sp[2] = u32 add sp[3], sp[4]
-    15: sp[3] = u32 add sp[2], sp[5]
-    16: sp[2] = sp[3]
-    17: return
+     5: store sp[4] at sp[1]
+     6: sp[4] = u32 add sp[2], sp[5]
+     7: sp[2] = const u32 3
+     8: sp[5] = u32 add sp[3], sp[2]
+     9: sp[3] = load sp[1]
+    10: sp[2] = u32 add sp[3], sp[4]
+    11: sp[3] = u32 add sp[2], sp[5]
+    12: sp[2] = sp[3]
+    13: return
     ");
 }
 
@@ -103,46 +99,42 @@ fn brillig_spill_successor_params() {
 
     let main = &brillig.ssa_function_to_brillig[&Id::test_new(0)];
     // Bytecode layout:
-    //   0-3:   Prologue — save spill base (sp[1]), reserve 3 spill slots
-    //   4-6:   Spill v0 → spill[0]  (const 0, add addr, store)
-    //   7-9:   Spill v0 → spill[1]  (const 1, add addr, store)
-    //   10-12: Spill v0 → spill[2]  (const 2, add addr, store)
-    //   13:    Jump to b1
-    //   14-16: Reload v1 from spill[0]  (const 0, add addr, load)
-    //   17-19: Reload v2 from spill[1]  (const 1, add addr, load)
-    //   20:    v4 = v1 + v2
-    //   21-23: Reload v3 from spill[2]  (const 2, add addr, load)
-    //   24:    v5 = v4 + v3
-    //   25:    Move result to return slot
-    //   26:    Return
+    //   0-2:   Prologue — save spill base (sp[1]), reserve 3 spill slots
+    //   3:     Spill v0 → spill[0]  (single store, offset 0 uses sp[1] directly)
+    //   4-6:   Spill v0 → spill[1]  (const 1, add addr, store)
+    //   7-9:   Spill v0 → spill[2]  (const 2, add addr, store)
+    //   10:    Jump to b1
+    //   11:    Reload v1 from spill[0]  (single load, offset 0 uses sp[1] directly)
+    //   12-14: Reload v2 from spill[1]  (const 1, add addr, load)
+    //   15:    v4 = v1 + v2
+    //   16-18: Reload v3 from spill[2]  (const 2, add addr, load)
+    //   19:    v5 = v4 + v3
+    //   20:    Move result to return slot
+    //   21:    Return
     assert_artifact_snapshot!(main, @r"
     fn main
      0: sp[1] = @1
      1: @3 = const u32 3
      2: @1 = u32 add @1, @3
-     3: @4 = const u32 0
-     4: @3 = u32 add sp[1], @4
-     5: store sp[2] at @3
-     6: @4 = const u32 1
-     7: @3 = u32 add sp[1], @4
-     8: store sp[2] at @3
-     9: @4 = const u32 2
-    10: @3 = u32 add sp[1], @4
-    11: store sp[2] at @3
-    12: jump to 0 // -> 13: f0/b1
-    13: @4 = const u32 0 // f0/b1
-    14: @3 = u32 add sp[1], @4
-    15: sp[3] = load @3
-    16: @4 = const u32 1
+     3: store sp[2] at sp[1]
+     4: @4 = const u32 1
+     5: @3 = u32 add sp[1], @4
+     6: store sp[2] at @3
+     7: @4 = const u32 2
+     8: @3 = u32 add sp[1], @4
+     9: store sp[2] at @3
+    10: jump to 0 // -> 11: f0/b1
+    11: sp[3] = load sp[1] // f0/b1
+    12: @4 = const u32 1
+    13: @3 = u32 add sp[1], @4
+    14: sp[4] = load @3
+    15: sp[2] = u32 add sp[3], sp[4]
+    16: @4 = const u32 2
     17: @3 = u32 add sp[1], @4
     18: sp[4] = load @3
-    19: sp[2] = u32 add sp[3], sp[4]
-    20: @4 = const u32 2
-    21: @3 = u32 add sp[1], @4
-    22: sp[4] = load @3
-    23: sp[3] = u32 add sp[2], sp[4]
-    24: sp[2] = sp[3]
-    25: return
+    19: sp[3] = u32 add sp[2], sp[4]
+    20: sp[2] = sp[3]
+    21: return
     ");
 }
 

--- a/compiler/noirc_evaluator/src/ssa/opt/flatten_cfg.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/flatten_cfg.rs
@@ -1046,11 +1046,7 @@ impl<'f> Context<'f> {
             }
             Instruction::RangeCheck { value, max_bit_size, assert_message } => {
                 // Replace value with `value * predicate` to zero out value when predicate is inactive.
-
-                // Condition needs to be cast to argument type in order to multiply them together.
-                let casted_condition =
-                    self.cast_condition_to_value_type(condition, value, call_stack);
-                let predicate_value = self.mul_by_condition(value, casted_condition, call_stack);
+                let predicate_value = self.mul_by_condition(value, condition, call_stack);
                 // Issue #8617: update the value to be the predicated value.
                 // This ensures that the value has the correct bit size in all cases.
                 self.predicate_value(value, predicate_value);
@@ -1110,9 +1106,7 @@ impl<'f> Context<'f> {
         match intrinsic {
             Intrinsic::ToBits(_) | Intrinsic::ToRadix(_) => {
                 let field = arguments[0];
-                let casted_condition =
-                    self.cast_condition_to_value_type(condition, field, call_stack);
-                let field = self.mul_by_condition(field, casted_condition, call_stack);
+                let field = self.mul_by_condition(field, condition, call_stack);
 
                 arguments[0] = field;
 


### PR DESCRIPTION
## Summary

Three micro-refactors from milestone 49 (Group 11 audit). No behavior change; all 1342 `noirc_evaluator` tests and 8221 `nargo_cli --test execute` tests pass.

- **#12258** — `flatten_cfg`: the `RangeCheck` and `ToBits`/`ToRadix` arms of the side-effects handler cast the condition to the value's type and then hand it to `mul_by_condition`, which casts a second time internally. Drop the outer cast.
- **#12302** — `brillig_block`: the spill store/load codegen always emitted `const offset; add sp[1], offset -> addr; store/load at addr`, but for offset 0 `sp[1]` (the spill base pointer) already addresses the slot. Share the address materialization through a small helper that short-circuits at offset 0, saving two opcodes per access to the first spill slot.
- **#12293** — `brillig_block`: when the LRU evicts a value that was previously spilled and reloaded, `spill_value` re-emits a 3-opcode store into the existing slot. Because SSA values are immutable, the slot already holds the correct bytes — skip the store when `get_spill_offset` already returns a slot.

Three commits on the branch, one per issue, so review is straightforward.

## Test plan

- [x] `cargo nextest run -p noirc_evaluator` — 1342 passed, 15 skipped
- [x] `cargo nextest run -p nargo_cli --test execute` — 8221 passed
- [x] `cargo clippy -p noirc_evaluator --release --all-targets` — clean
- [x] `cargo fmt --all -- --check` — clean

## Snapshot updates

The offset-0 shortcut shifts three existing snapshots by four instructions each:

- `brillig_spill_and_reload` — 18 → 14 instructions
- `brillig_spill_successor_params` — 26 → 22 instructions
- `entry_point_setup_with_spill_support` — 65 → 61 instructions

Each diff is purely the collapse of `const 0; add sp[1], 0 -> addr; store/load at addr` into `store/load at sp[1]`. Prose bytecode-layout comments above the spill snapshots are updated to match.

Resolves #12258, #12293, #12302.

🤖 Generated with [Claude Code](https://claude.com/claude-code)