### PR TITLE
chore: audit cleanups across mem2reg, variable_liveness, spill_manager

### DIFF
--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/spill_manager.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/spill_manager.rs
@@ -1,10 +1,51 @@
 //! Register spill management for the Brillig code generator.
 //!
-//! When register pressure exceeds the available register count, the [`SpillManager`] coordinates
-//! evicting the least-recently-used (LRU) values to a spill region in heap memory, and reloading
-//! them on demand. It distinguishes between transient spills (temporary within a basic block)
-//! and permanent spills (values that must survive across block boundaries), allocating stable
-//! heap slots for the latter.
+//! # When spilling kicks in
+//!
+//! Most functions fit comfortably inside the per-frame register budget, in which case the
+//! code generator just uses coalescing to reuse registers and never constructs a
+//! [`SpillManager`]. Spilling activates only when [`VariableLiveness::max_live_count`]
+//! exceeds the available registers for the current [`LayoutConfig`] — i.e. there is some
+//! program point where too many values are simultaneously live. When the spill manager is
+//! active coalescing is disabled: the two are mutually exclusive allocation strategies.
+//!
+//! # Scope of decisions
+//!
+//! The spill manager operates one basic block at a time. Inside a block, spilled values can
+//! be reloaded into any free register and their heap slot re-used by a later spill, so the
+//! manager effectively acts as a pool allocator for _transient_ spills. Across blocks this
+//! is unsafe — the next block can't predict which register a predecessor left a value in —
+//! so live-across-block values (block parameters, non-param live-ins) are promoted to
+//! _permanent_ spills: their slot is reserved for the remainder of the function and every
+//! use reloads from it.
+//!
+//! Transient slots are freed as soon as the value dies; permanent slots are never freed
+//! (see <https://github.com/noir-lang/noir/issues/11695>). Each block begins with
+//! [`SpillManager::begin_block`], which (a) asserts no transient spills leaked from the
+//! previous block, (b) re-marks permanent slots as "currently spilled" so their owners
+//! must reload before use, and (c) rebuilds the LRU with this block's live-in set.
+//!
+//! # Per-use flow
+//!
+//! The code generator calls into the spill manager at a small number of well-defined points:
+//!
+//! - Before making room for a fresh value, [`BrilligBlock::ensure_register_capacity`] asks
+//!   [`SpillManager::lru_victim`] for the least-recently-used non-spilled value and spills
+//!   it via [`BrilligBlock::spill_value`]. That emits the store and frees the register.
+//! - When a spilled value is needed, [`BrilligBlock::reload_spilled_value`] allocates a
+//!   fresh register, emits the load, and calls [`SpillManager::unmark_spilled`] to record
+//!   that the value is once again in a register (the slot still holds a valid copy).
+//! - When a value is used, [`SpillManager::touch`] bumps it to the most-recently-used end
+//!   of the LRU, so that freshly-loaded and just-produced values aren't the first victims
+//!   of the next eviction.
+//! - When a value dies, [`SpillManager::remove_spill`] frees its transient slot (permanent
+//!   slots are kept for the rest of the function).
+//!
+//! [`VariableLiveness::max_live_count`]: super::variable_liveness::VariableLiveness::max_live_count
+//! [`LayoutConfig`]: crate::brillig::brillig_ir::LayoutConfig
+//! [`BrilligBlock::ensure_register_capacity`]: super::brillig_block::BrilligBlock::ensure_register_capacity
+//! [`BrilligBlock::spill_value`]: super::brillig_block::BrilligBlock::spill_value
+//! [`BrilligBlock::reload_spilled_value`]: super::brillig_block::BrilligBlock::reload_spilled_value
 
 use std::collections::hash_map::Entry;
 
@@ -15,9 +56,7 @@ use crate::ssa::ir::value::ValueId;
 
 /// Tracks register values that have been spilled to the spill region in heap memory.
 ///
-/// When register pressure exceeds the stack frame limit, the SpillManager coordinates
-/// evicting the least-recently-used values from registers to the spill region,
-/// and reloading them when needed.
+/// See the [module docs][self] for an overview of when and how the spill manager is used.
 pub(crate) struct SpillManager {
     /// Map of all spill records
     records: HashMap<ValueId, SpillRecord>,

--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/variable_liveness.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/variable_liveness.rs
@@ -212,7 +212,7 @@ impl VariableLiveness {
         back_edges: LoopMap,
     ) -> Self {
         // First pass, propagate up the live_ins skipping back edges.
-        self.compute_live_in(func, func.entry_block(), constants, &back_edges);
+        self.compute_live_in(func, constants, &back_edges);
 
         // Second pass, propagate header live_ins to the loop bodies.
         for (back_edge, loop_body) in back_edges {
@@ -222,99 +222,45 @@ impl VariableLiveness {
         self
     }
 
-    /// Starting with the entry block, traverse down all successors to compute their `live_in`,
-    /// then propagate the information back up towards the ancestors as `live_out`.
+    /// Compute `live_in` for every block in one post-order pass.
     ///
-    /// The variables live at the *beginning* of a block are the variables used by the block,
-    /// plus the variables used by the successors of the block, minus the variables defined
-    /// in the block (by definition not alive at the beginning).
+    /// In a post-order traversal, a block is visited after all of its non-back-edge
+    /// successors have been visited, so each block's `live_out` is just the union of
+    /// its already-computed successors' `live_in`s (skipping back-edges — those are
+    /// handled in the second pass, [`Self::update_live_ins_within_loop`]).
     ///
-    /// This is an iterative implementation to avoid stack overflows on complex programs.
+    /// From the paper cited in the module docs:
+    ///   `live_in[B] = used[B] ∪ (live_out[B] - defined[B])`
     fn compute_live_in(
         &mut self,
         func: &Function,
-        entry_block: BasicBlockId,
         constants: &ConstantAllocation,
         back_edges: &LoopMap,
     ) {
-        // Each entry is (block_id, processing_state)
-        // processing_state: false = need to process successors, true = ready to compute live_in
-        let mut stack = vec![(entry_block, false)];
-        let mut visited = HashSet::default();
+        for block_id in PostOrder::with_function(func).as_slice().iter().copied() {
+            let block = &func.dfg[block_id];
+            let mut live_out = HashSet::default();
 
-        while let Some((block_id, processed)) = stack.pop() {
-            if processed {
-                // All successors have been processed, now compute live_in for this block
-                let block = &func.dfg[block_id];
-                let mut live_out = HashSet::default();
-
-                // Collect the `live_in` of successors; their union is the `live_out` of the parent.
-                for successor_id in block.successors() {
-                    // Skip back edges: do not revisit the header of the loop
-                    if back_edges.contains_key(&BackEdge { start: block_id, header: successor_id })
-                    {
-                        continue;
-                    }
-                    // Add the live_in of the successor to the union that forms the live_out of the parent.
-                    live_out.extend(
-                        self.live_in
-                            .get(&successor_id)
-                            .expect("live_in for successor should have been calculated")
-                            .iter()
-                            .copied(),
-                    );
-                }
-
-                // Based on the paper mentioned in the module docs, the definition would be:
-                // live_in[BlockId] = before_def[BlockId] union (live_out[BlockId] - killed[BlockId])
-
-                // Variables used in this block, defined in this block or before.
-                let used = variables_used_in_block(block, &func.dfg);
-
-                // Variables defined in this block are not alive at the beginning.
-                let defined = self.variables_defined_in_block(block_id, &func.dfg, constants);
-
-                // Live at the beginning are the variables used, but not defined in this block, plus the ones
-                // it passes through to its successors, which are used by them, but not defined here.
-                // (Variables used by successors and defined in this block are part of `live_out`, but not `live_in`).
-                let live_in =
-                    used.union(&live_out).filter(|v| !defined.contains(v)).copied().collect();
-
-                self.live_in.insert(block_id, live_in);
-            } else {
-                // First visit: check if we've already processed this block
-                if !visited.insert(block_id) {
+            for successor_id in block.successors() {
+                // Skip back edges: the header's live_in is computed in the same pass,
+                // but the loop-body contributions are added later.
+                if back_edges.contains_key(&BackEdge { start: block_id, header: successor_id }) {
                     continue;
                 }
-
-                let block = &func.dfg[block_id];
-
-                // Check if all successors (except back edges) have been processed
-                let mut all_successors_processed = true;
-                let mut unprocessed_successors = Vec::new();
-
-                for successor_id in block.successors() {
-                    // Skip back edges
-                    if back_edges.contains_key(&BackEdge { start: block_id, header: successor_id })
-                    {
-                        continue;
-                    }
-                    // If successor hasn't been processed yet, we need to process it first
-                    if !self.live_in.contains_key(&successor_id) {
-                        all_successors_processed = false;
-                        unprocessed_successors.push(successor_id);
-                    }
-                }
-
-                // Push this block back with processed = true (for after successors)
-                stack.push((block_id, true));
-                if !all_successors_processed {
-                    // Push unprocessed successors with processed = false
-                    for successor_id in unprocessed_successors {
-                        stack.push((successor_id, false));
-                    }
-                }
+                live_out.extend(
+                    self.live_in
+                        .get(&successor_id)
+                        .expect("live_in for successor should have been calculated")
+                        .iter()
+                        .copied(),
+                );
             }
+
+            let used = variables_used_in_block(block, &func.dfg);
+            let defined = self.variables_defined_in_block(block_id, &func.dfg, constants);
+            let live_in = used.union(&live_out).filter(|v| !defined.contains(v)).copied().collect();
+
+            self.live_in.insert(block_id, live_in);
         }
     }
 

--- a/compiler/noirc_evaluator/src/ssa/opt/mem2reg.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/mem2reg.rs
@@ -453,17 +453,19 @@ fn collect_eligible_variables_and_def_sites(
                 // Any other use of an address (in arrays, functions, etc) is also first-class and prevents optimization.
                 _ => instruction.for_each_value(|value| {
                     variables.remove(&value);
-                    def_sites.remove(&value);
                 }),
             }
         }
 
         block.unwrap_terminator().for_each_value(|value| {
             variables.remove(&value);
-            def_sites.remove(&value);
         });
     }
 
+    // `def_sites` accumulates entries only when we see a store to an address still tracked in
+    // `variables`, so `variables` is the authoritative set of eligible addresses. Both retains
+    // below prune any stale entries left by first-class uses that removed an address from
+    // `variables` without clearing `def_sites`.
     variables.retain(|address, _| variables_with_stores_in_decl_block.contains(address));
     def_sites.retain(|address, _| variables.contains_key(address));
     (variables, def_sites)


### PR DESCRIPTION
## Summary

Three audit-prep cleanups from milestone 49, one per pass. No behavior change; 1342 `noirc_evaluator` tests + 8221 `nargo_cli --test execute` tests pass.

### mem2reg — #12191 (`ssa/opt/mem2reg.rs`)

`collect_eligible_variables_and_def_sites` was calling `def_sites.remove(&value)` in the first-class-use and terminator arms, even though `def_sites` entries are only inserted when a Store's address is still tracked in `variables`. The final pass already does `def_sites.retain(|address, _| variables.contains_key(address))`, so those per-instruction removes are redundant. Drop them.

### variable_liveness — #12300 (`brillig/brillig_gen/variable_liveness.rs`)

`compute_live_in` was doing a DFS that pushed each block onto the worklist twice — once to process successors first, once to compute the block's own live_in — in order to force a successors-before-parent ordering. That is exactly what `PostOrder::with_function` produces, and this file already uses it in `compute_block_param_definitions`. Replace the push-repush stack with a single post-order iteration.

The back-edge skip and the second pass (`update_live_ins_within_loop`) are unchanged.

### spill_manager — #12261 (`brillig/brillig_gen/spill_manager.rs`)

The six-line module comment didn't cover when spilling activates, why coalescing is disabled alongside it, or how transient vs permanent slots interact. Fill those in.

## Test plan

- [x] `cargo nextest run -p noirc_evaluator` — 1342 passed, 15 skipped
- [x] `cargo nextest run -p nargo_cli --test execute` — 8221 passed
- [x] `cargo clippy -p noirc_evaluator --release --all-targets` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo doc -p noirc_evaluator --no-deps --document-private-items` — no warnings

Resolves #12191, #12261, #12300.

🤖 Generated with [Claude Code](https://claude.com/claude-code)