### PR TITLE
fix(brillig): fix register spill bug and refactor SpillRecord state into an enum

### DIFF
--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_block.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_block.rs
@@ -238,12 +238,16 @@ impl<'block, Registers: RegisterAllocator> BrilligBlock<'block, Registers> {
         // For a permanent spill, try to promote an existing record first.
         // ensure_permanent_spill() modifies the record, so capture the pre-call state first.
         if permanent {
-            // A reloaded value has a record but is not currently spilled — it holds a register
-            // that must be freed when the permanent-spill short-circuit fires.
-            let was_reloaded =
-                !sm.is_spilled(&value_id) && sm.get_spill_offset(&value_id).is_some();
+            // A transient-reloaded value has a record that is not yet permanent and is not
+            // currently spilled — it holds a register that must be freed when promoted to a
+            // permanent spill. Values that were already permanently spilled must not have their
+            // register freed here, as they may still be live (e.g. the condition register of a
+            // jmpif instruction that gets spill_non_param_live_ins called multiple times).
+            let was_transient_reloaded = !sm.is_spilled(&value_id)
+                && sm.get_spill_offset(&value_id).is_some()
+                && sm.get_permanent_spill_offset(&value_id).is_none();
             if sm.ensure_permanent_spill(&value_id) {
-                if was_reloaded {
+                if was_transient_reloaded {
                     sm.remove_from_lru(&value_id);
                     self.variables.remove_variable(
                         &value_id,

--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_block.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_block.rs
@@ -238,14 +238,11 @@ impl<'block, Registers: RegisterAllocator> BrilligBlock<'block, Registers> {
         // For a permanent spill, try to promote an existing record first.
         // ensure_permanent_spill() modifies the record, so capture the pre-call state first.
         if permanent {
-            // A transient-reloaded value has a record that is not yet permanent and is not
-            // currently spilled — it holds a register that must be freed when promoted to a
-            // permanent spill. Values that were already permanently spilled must not have their
-            // register freed here, as they may still be live (e.g. the condition register of a
-            // jmpif instruction that gets spill_non_param_live_ins called multiple times).
-            let was_transient_reloaded = !sm.is_spilled(&value_id)
-                && sm.get_spill_offset(&value_id).is_some()
-                && sm.get_permanent_spill_offset(&value_id).is_none();
+            // A TransientReloaded value holds a register that must be freed when promoted to
+            // a permanent spill. Values already in PermanentReloaded state must not have their
+            // register freed here — they may still be live (e.g. the condition register of a
+            // jmpif instruction when spill_non_param_live_ins fires multiple times).
+            let was_transient_reloaded = sm.is_transient_reloaded(&value_id);
             if sm.ensure_permanent_spill(&value_id) {
                 if was_transient_reloaded {
                     sm.remove_from_lru(&value_id);

--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_block.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_block.rs
@@ -235,8 +235,27 @@ impl<'block, Registers: RegisterAllocator> BrilligBlock<'block, Registers> {
             .as_mut()
             .expect("ICE: spill_value called without spill manager");
 
-        // Check fist permanent because ensure_permanent_spill() modifies the record.
-        if (permanent && sm.ensure_permanent_spill(&value_id)) || sm.is_spilled(&value_id) {
+        // For a permanent spill, try to promote an existing record first.
+        // ensure_permanent_spill() modifies the record, so capture the pre-call state first.
+        if permanent {
+            // A reloaded value has a record but is not currently spilled — it holds a register
+            // that must be freed when the permanent-spill short-circuit fires.
+            let was_reloaded =
+                !sm.is_spilled(&value_id) && sm.get_spill_offset(&value_id).is_some();
+            if sm.ensure_permanent_spill(&value_id) {
+                if was_reloaded {
+                    sm.remove_from_lru(&value_id);
+                    self.variables.remove_variable(
+                        &value_id,
+                        self.function_context,
+                        self.brillig_context,
+                    );
+                }
+                return;
+            }
+        }
+
+        if sm.is_spilled(&value_id) {
             return;
         }
 

--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/spill_manager.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/spill_manager.rs
@@ -211,10 +211,14 @@ impl SpillManager {
                 // Re-evicting a permanently-spilled value: keep permanent, slot data is valid.
                 record.status = SpillStatus::Permanent;
             }
-            _ => {
-                // New transient spill or re-evicting a transient-reloaded value.
+            SpillStatus::TransientReloaded | SpillStatus::Transient => {
                 record.status = SpillStatus::Transient;
                 record.variable = variable;
+            }
+            SpillStatus::Permanent => {
+                unreachable!(
+                    "record_spill called on a Permanent record — is_spilled should have caught this as a double-spill"
+                );
             }
         }
     }

--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/spill_manager.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/spill_manager.rs
@@ -13,6 +13,28 @@ use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 use crate::brillig::brillig_ir::brillig_variable::BrilligVariable;
 use crate::ssa::ir::value::ValueId;
 
+/// Lifecycle state of a spill record.
+///
+/// Transitions:
+/// - First eviction → `Transient` or `Permanent`
+/// - Reloaded into a register → `TransientReloaded` or `PermanentReloaded`
+/// - Evicted again by LRU → back to `Transient` or `Permanent`
+/// - Block boundary → `PermanentReloaded` becomes `Permanent`; `Transient` must not survive
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(crate) enum SpillStatus {
+    /// Within-block spill: value is in the spill slot, not in a register.
+    Transient,
+    /// Was transiently spilled then reloaded into a register.
+    /// The spill slot is still allocated and the register holds the live value.
+    TransientReloaded,
+    /// Permanent spill: the slot is the source of truth across block boundaries.
+    /// Value is not currently in a register.
+    Permanent,
+    /// Permanently spilled, but currently also loaded into a register.
+    /// The slot remains authoritative; the register is a transient copy.
+    PermanentReloaded,
+}
+
 /// Tracks register values that have been spilled to the spill region in heap memory.
 ///
 /// When register pressure exceeds the stack frame limit, the SpillManager coordinates
@@ -38,11 +60,8 @@ pub(crate) struct SpillRecord {
     pub(crate) offset: usize,
     /// Original variable (for type/register info on reload).
     pub(crate) variable: BrilligVariable,
-    /// Whether this spill slot is permanent (must survive across blocks).
-    /// Otherwise, the spill slot is transient and can be re-used.
-    pub(crate) is_permanent: bool,
-    /// Whether the value is currently spilled (has no valid register).
-    pub(crate) is_currently_spilled: bool,
+    /// Current lifecycle state of this spill record.
+    pub(crate) status: SpillStatus,
 }
 
 impl SpillManager {
@@ -59,7 +78,7 @@ impl SpillManager {
     /// Prepare spill state for a new block.
     ///
     /// 1. Asserts that no transient spills leaked from the previous block
-    ///    (all currently-spilled entries must also be permanent).
+    ///    (only `Permanent` and `PermanentReloaded` records may survive).
     /// 2. Restores permanently-spilled values by marking them as currently spilled.
     /// 3. Removes spilled values from the live-in set (they have no register).
     /// 4. Updates the LRU: retains existing entries still live-in and not spilled
@@ -68,7 +87,7 @@ impl SpillManager {
     pub(crate) fn begin_block(&mut self, live_in: &mut HashSet<ValueId>) {
         // No transient spills should survive across block boundaries.
         assert!(
-            self.records.values().all(|r| !r.is_currently_spilled || r.is_permanent),
+            self.records.values().all(|r| r.status != SpillStatus::Transient),
             "Transient spill leaked across block boundary"
         );
         self.restore_permanent_spills();
@@ -76,15 +95,26 @@ impl SpillManager {
         self.reset_lru_for_block(live_in);
     }
 
-    /// Check if a value is currently spilled.
+    /// Check if a value is currently spilled (in memory, not in a register).
     pub(crate) fn is_spilled(&self, value_id: &ValueId) -> bool {
-        self.records.get(value_id).is_some_and(|r| r.is_currently_spilled)
+        matches!(
+            self.records.get(value_id),
+            Some(r) if matches!(r.status, SpillStatus::Transient | SpillStatus::Permanent)
+        )
+    }
+
+    /// Check if a value was transiently spilled and has since been reloaded into a register.
+    pub(crate) fn is_transient_reloaded(&self, value_id: &ValueId) -> bool {
+        matches!(self.records.get(value_id), Some(r) if r.status == SpillStatus::TransientReloaded)
     }
 
     /// Check if a value has a permanent spill slot.
     #[cfg(test)]
     pub(crate) fn has_permanent_slot(&self, value_id: &ValueId) -> bool {
-        self.records.get(value_id).is_some_and(|r| r.is_permanent)
+        matches!(
+            self.records.get(value_id),
+            Some(r) if matches!(r.status, SpillStatus::Permanent | SpillStatus::PermanentReloaded)
+        )
     }
 
     /// Move a value to the back of the LRU (most recently used).
@@ -104,17 +134,21 @@ impl SpillManager {
     /// Remove a value from the spill tracking.
     ///
     /// Permanent spill slots are never freed — they must remain valid across all blocks.
-    /// For permanent records, this just clears `is_currently_spilled`.
-    /// For transient records, the record is removed entirely and the slot is freed.
+    /// For `Permanent` records, this transitions to `PermanentReloaded` (value is live in
+    /// a register again). For transient records, the record is removed and the slot is freed.
     ///
     /// TODO(<https://github.com/noir-lang/noir/issues/11695>) - Free globally dead permanent spill slots
     pub(crate) fn remove_spill(&mut self, value_id: &ValueId) {
         if let Entry::Occupied(mut entry) = self.records.entry(*value_id) {
-            if entry.get().is_permanent {
-                entry.get_mut().is_currently_spilled = false;
-            } else {
-                let record = entry.remove();
-                self.free_spill_slots.push(record.offset);
+            match entry.get().status {
+                SpillStatus::Permanent => {
+                    entry.get_mut().status = SpillStatus::PermanentReloaded;
+                }
+                SpillStatus::PermanentReloaded => {}
+                SpillStatus::Transient | SpillStatus::TransientReloaded => {
+                    let record = entry.remove();
+                    self.free_spill_slots.push(record.offset);
+                }
             }
         }
     }
@@ -156,9 +190,8 @@ impl SpillManager {
     ///
     /// If the value already has a record (e.g., it was reloaded and then
     /// re-evicted by LRU), this updates the existing record:
-    /// - Permanent records: just re-marks as currently spilled, preserving the
-    ///   permanent offset. The slot already has valid data when operating over SSA where variables are immutable.
-    /// - Transient records: updates the offset and variable to the new values.
+    /// - `PermanentReloaded`: transitions back to `Permanent` (slot data is still valid).
+    /// - `TransientReloaded`: transitions back to `Transient`, updating the variable.
     pub(crate) fn record_spill(
         &mut self,
         value_id: ValueId,
@@ -169,21 +202,28 @@ impl SpillManager {
         let record = self.records.entry(value_id).or_insert(SpillRecord {
             offset,
             variable,
-            is_permanent: false,
-            is_currently_spilled: true,
+            status: SpillStatus::Transient,
         });
         // Always preserve the offset, so we don't leak free slots.
         assert_eq!(offset, record.offset, "Spill of {value_id} orphaned existing slot");
-        record.is_currently_spilled = true;
-        if !record.is_permanent {
-            // Transient record from a previous spill/reload cycle — update it.
-            record.variable = variable;
+        match record.status {
+            SpillStatus::PermanentReloaded => {
+                // Re-evicting a permanently-spilled value: keep permanent, slot data is valid.
+                record.status = SpillStatus::Permanent;
+            }
+            _ => {
+                // New transient spill or re-evicting a transient-reloaded value.
+                record.status = SpillStatus::Transient;
+                record.variable = variable;
+            }
         }
     }
 
     /// Get the spill record for a value if it is currently spilled.
     pub(crate) fn get_spill(&self, value_id: &ValueId) -> Option<&SpillRecord> {
-        self.records.get(value_id).filter(|r| r.is_currently_spilled)
+        self.records
+            .get(value_id)
+            .filter(|r| matches!(r.status, SpillStatus::Transient | SpillStatus::Permanent))
     }
 
     /// Reset the LRU for a new block, retaining ordering from the previous block.
@@ -194,7 +234,12 @@ impl SpillManager {
     /// determinism.
     fn reset_lru_for_block(&mut self, live_in: &HashSet<ValueId>) {
         let records = &self.records;
-        let is_spilled = |v: &ValueId| records.get(v).is_some_and(|r| r.is_currently_spilled);
+        let is_spilled = |v: &ValueId| {
+            matches!(
+                records.get(v),
+                Some(r) if matches!(r.status, SpillStatus::Transient | SpillStatus::Permanent)
+            )
+        };
 
         // Retain existing entries that are still live-in and not spilled.
         self.lru_order.retain(|v| live_in.contains(v) && !is_spilled(v));
@@ -209,7 +254,7 @@ impl SpillManager {
 
     /// Record a value as permanently spilled.
     ///
-    /// If the value already has a transient spill record, it is promoted to permanent.
+    /// If the value already has a transient spill record, it is promoted to `Permanent`.
     /// The permanent record ensures consistency regardless of what happens during
     /// block processing.
     pub(crate) fn record_permanent_spill(
@@ -222,21 +267,18 @@ impl SpillManager {
             .entry(value_id)
             .and_modify(|record| {
                 assert_eq!(record.offset, offset);
-                record.is_permanent = true;
-                record.is_currently_spilled = true;
+                record.status = SpillStatus::Permanent;
                 record.variable = variable;
             })
-            .or_insert(SpillRecord {
-                offset,
-                variable,
-                is_permanent: true,
-                is_currently_spilled: true,
-            });
+            .or_insert(SpillRecord { offset, variable, status: SpillStatus::Permanent });
     }
 
     /// Get the permanent spill slot offset for a value, if any.
     pub(crate) fn get_permanent_spill_offset(&self, value_id: &ValueId) -> Option<usize> {
-        self.records.get(value_id).filter(|r| r.is_permanent).map(|r| r.offset)
+        self.records
+            .get(value_id)
+            .filter(|r| matches!(r.status, SpillStatus::Permanent | SpillStatus::PermanentReloaded))
+            .map(|r| r.offset)
     }
 
     /// Get the spill slot offset for a value, if any.
@@ -249,45 +291,48 @@ impl SpillManager {
 
     /// Re-mark permanently-spilled values as currently spilled at block entry.
     ///
-    /// A reload in a previous block clears `is_currently_spilled`, but the
+    /// A reload in a previous block sets the status to `PermanentReloaded`, but the
     /// value must be reloaded again in every block that uses it (since the
     /// permanent spill slot is always the source of truth).
     pub(crate) fn restore_permanent_spills(&mut self) {
         for record in self.records.values_mut() {
-            if record.is_permanent {
-                record.is_currently_spilled = true;
+            if record.status == SpillStatus::PermanentReloaded {
+                record.status = SpillStatus::Permanent;
             }
         }
     }
 
-    /// Clear the `is_currently_spilled` flag WITHOUT freeing the spill slot.
+    /// Mark a spilled value as reloaded into a register, without freeing the spill slot.
     ///
-    /// This is used when reloading a spilled value. The slot's data must remain valid
-    /// because the reload code may execute again in a loop iteration. Only `remove_spill`
-    /// (used when the value is truly dead) should free the slot.
+    /// - `Transient` → `TransientReloaded`
+    /// - `Permanent` → `PermanentReloaded`
+    ///
+    /// The slot's data must remain valid because the reload code may execute
+    /// again in a loop iteration. Only `remove_spill` (used when the value is
+    /// truly dead) should free the slot.
     pub(crate) fn unmark_spilled(&mut self, value_id: &ValueId) {
         if let Some(record) = self.records.get_mut(value_id) {
-            record.is_currently_spilled = false;
+            record.status = match record.status {
+                SpillStatus::Transient => SpillStatus::TransientReloaded,
+                SpillStatus::Permanent => SpillStatus::PermanentReloaded,
+                other => other,
+            };
         }
     }
 
     /// Ensure a value has a permanent spill slot.
     ///
-    /// Handles all cases where a record already exists with a single lookup:
-    /// - Permanent + currently spilled -> no-op (slot has correct data)
-    /// - Currently spilled but not permanent -> promote to permanent
-    /// - Permanent but not currently spilled (reloaded) -> re-mark as spilled
-    /// - Not currently spilled (reloaded) and not permanent -> re-mark as spilled and permanent
+    /// Any existing record — regardless of its current state — is promoted to
+    /// `Permanent` (the slot is the source of truth and the value is not in a register).
     ///
     /// # Returns
-    /// * `true` if a record already exists (caller should skip further processing),
-    /// * `false` if no record exists (first encounter - caller must allocate a slot).
+    /// * `true` if a record already existed (caller should skip further processing),
+    /// * `false` if no record exists (first encounter — caller must allocate a slot).
     pub(crate) fn ensure_permanent_spill(&mut self, value_id: &ValueId) -> bool {
         let Some(record) = self.records.get_mut(value_id) else {
             return false;
         };
-        record.is_permanent = true;
-        record.is_currently_spilled = true;
+        record.status = SpillStatus::Permanent;
         true
     }
 }
@@ -301,7 +346,7 @@ mod tests {
         ssa::ir::map::Id,
     };
 
-    use super::SpillManager;
+    use super::{SpillManager, SpillStatus};
 
     fn test_var(n: u32) -> BrilligVariable {
         BrilligVariable::SingleAddr(SingleAddrVariable::new(MemoryAddress::relative(n), 32))
@@ -349,8 +394,7 @@ mod tests {
 
         let record = sm.get_spill(&v0).unwrap();
         assert_eq!(record.offset, 0);
-        assert!(!record.is_permanent);
-        assert!(record.is_currently_spilled);
+        assert_eq!(record.status, SpillStatus::Transient);
 
         // Victim should skip v0 (spilled) and return v1
         assert_eq!(sm.lru_victim(), Some(v1));
@@ -544,33 +588,26 @@ mod tests {
         // Case 1: No record -> returns false
         assert!(!sm.ensure_permanent_spill(&v3));
 
-        // Case 2: Permanent + currently spilled -> returns true, no state change
+        // Case 2: Permanent -> returns true, stays Permanent
         let off0 = sm.allocate_spill_offset();
         sm.record_permanent_spill(v0, off0, test_var(0));
-        assert!(sm.is_spilled(&v0));
-        assert!(sm.has_permanent_slot(&v0));
+        assert_eq!(sm.records[&v0].status, SpillStatus::Permanent);
         assert!(sm.ensure_permanent_spill(&v0));
-        // State unchanged
-        assert!(sm.is_spilled(&v0));
-        assert!(sm.has_permanent_slot(&v0));
+        assert_eq!(sm.records[&v0].status, SpillStatus::Permanent);
 
-        // Case 3: Transient spill (not permanent) -> returns true, promoted to permanent
+        // Case 3: Transient -> returns true, promoted to Permanent
         let off1 = sm.allocate_spill_offset();
         sm.record_spill(v1, off1, test_var(1));
-        assert!(sm.is_spilled(&v1));
-        assert!(!sm.has_permanent_slot(&v1));
+        assert_eq!(sm.records[&v1].status, SpillStatus::Transient);
         assert!(sm.ensure_permanent_spill(&v1));
-        assert!(sm.is_spilled(&v1));
-        assert!(sm.has_permanent_slot(&v1));
+        assert_eq!(sm.records[&v1].status, SpillStatus::Permanent);
 
-        // Case 4: Permanent but reloaded (not currently spilled) -> returns true, re-marked as spilled
+        // Case 4: PermanentReloaded -> returns true, re-marked as Permanent
         let off2 = sm.allocate_spill_offset();
         sm.record_permanent_spill(v2, off2, test_var(2));
         sm.unmark_spilled(&v2);
-        assert!(!sm.is_spilled(&v2));
-        assert!(sm.has_permanent_slot(&v2));
+        assert_eq!(sm.records[&v2].status, SpillStatus::PermanentReloaded);
         assert!(sm.ensure_permanent_spill(&v2));
-        assert!(sm.is_spilled(&v2));
-        assert!(sm.has_permanent_slot(&v2));
+        assert_eq!(sm.records[&v2].status, SpillStatus::Permanent);
     }
 }

--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/tests/spill.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/tests/spill.rs
@@ -230,3 +230,140 @@ fn brillig_spill_case4_diamond_wrong_output() {
     );
     assert_eq!(result, vec![FieldElement::from(87u32)]);
 }
+
+/// Fixed-behavior snapshot for issue #12266.
+///
+/// `v3 = v0 + v1` transient-spills `v0`. `v4 = v3 + v0` reloads `v0` into a
+/// fresh register, leaving its record in "transient + reloaded" state. The
+/// terminator `jmp b1(v0, v1, v2)` permanent-spills `v0` via the
+/// `spill_non_param_live_ins` short-circuit, then reloads every arg to write
+/// it into b1's eagerly-spilled param slot. The fix frees the reloaded
+/// register immediately when the permanent-spill short-circuit fires, so the
+/// final reload fits without any extra eviction.
+///
+/// We know there is no leak because the jump-argument setup goes straight from
+/// storing the second argument to reloading `v2`. The buggy compiler inserted
+/// an extra `const u32 0; add; store sp[2] at @3` spill in between, which is
+/// absent here.
+#[test]
+fn brillig_spill_does_not_leak_reloaded_permanent_values_bytecode() {
+    let src = "
+    brillig(inline) fn main f0 {
+      b0(v0: u32, v1: u32, v2: u32):
+        v3 = unchecked_add v0, v1
+        v4 = unchecked_add v3, v0
+        jmp b1(v0, v1, v2)
+      b1(v5: u32, v6: u32, v7: u32):
+        v8 = unchecked_add v0, v1
+        v9 = unchecked_add v8, v2
+        return v9
+    }
+    ";
+
+    let layout = LayoutConfig::new(5, 16, MAX_SCRATCH_SPACE);
+    let options = BrilligOptions { layout, ..Default::default() };
+    let brillig = ssa_to_brillig_artifacts_with_options(src, &options);
+    let main = &brillig.ssa_function_to_brillig[&Id::test_new(0)];
+    // Fixed snapshot: after storing the second jump argument at 44-46, the code
+    // immediately reloads `v2` at 47-49. There is no extra spill of `v0`
+    // between those steps, which is the leak fingerprint from the buggy path.
+    assert_artifact_snapshot!(main, @r"
+    fn main
+     0: sp[1] = @1
+     1: @3 = const u32 7
+     2: @1 = u32 add @1, @3
+     3: @4 = const u32 0
+     4: @3 = u32 add sp[1], @4
+     5: store sp[2] at @3
+     6: @4 = const u32 4
+     7: @3 = u32 add sp[1], @4
+     8: store sp[3] at @3
+     9: @4 = const u32 0
+    10: @3 = u32 add sp[1], @4
+    11: sp[3] = load @3
+    12: @4 = const u32 5
+    13: @3 = u32 add sp[1], @4
+    14: store sp[4] at @3
+    15: @4 = const u32 4
+    16: @3 = u32 add sp[1], @4
+    17: sp[4] = load @3
+    18: sp[2] = u32 add sp[3], sp[4]
+    19: @4 = const u32 6
+    20: @3 = u32 add sp[1], @4
+    21: store sp[2] at @3
+    22: @4 = const u32 0
+    23: @3 = u32 add sp[1], @4
+    24: store sp[3] at @3
+    25: @4 = const u32 6
+    26: @3 = u32 add sp[1], @4
+    27: sp[3] = load @3
+    28: @4 = const u32 4
+    29: @3 = u32 add sp[1], @4
+    30: store sp[4] at @3
+    31: @4 = const u32 0
+    32: @3 = u32 add sp[1], @4
+    33: sp[4] = load @3
+    34: sp[2] = u32 add sp[3], sp[4]
+    35: @4 = const u32 0
+    36: @3 = u32 add sp[1], @4
+    37: sp[2] = load @3
+    38: @4 = const u32 1
+    39: @3 = u32 add sp[1], @4
+    40: store sp[2] at @3
+    41: @4 = const u32 4
+    42: @3 = u32 add sp[1], @4
+    43: sp[3] = load @3
+    44: @4 = const u32 2
+    45: @3 = u32 add sp[1], @4
+    46: store sp[3] at @3
+    47: @4 = const u32 5
+    48: @3 = u32 add sp[1], @4
+    49: sp[4] = load @3
+    50: @4 = const u32 3
+    51: @3 = u32 add sp[1], @4
+    52: store sp[4] at @3
+    53: jump to 0 // -> 54: f0/b1
+    54: @4 = const u32 0 // f0/b1
+    55: @3 = u32 add sp[1], @4
+    56: sp[3] = load @3
+    57: @4 = const u32 4
+    58: @3 = u32 add sp[1], @4
+    59: sp[4] = load @3
+    60: sp[2] = u32 add sp[3], sp[4]
+    61: @4 = const u32 5
+    62: @3 = u32 add sp[1], @4
+    63: sp[4] = load @3
+    64: sp[3] = u32 add sp[2], sp[4]
+    65: sp[2] = sp[3]
+    66: return
+    ");
+}
+
+/// Regression for issue #12266.
+///
+/// On the previously buggy path, `spill_non_param_live_ins` marked reloaded values as
+/// spilled without releasing their registers. With this 4-parameter shape and a
+/// 2-register Brillig layout, that stale state reaches the next block as an
+/// active transient spill and ICEs with "Transient spill leaked across block boundary"
+/// at [begin_block][crate::brillig::brillig_gen::spill_manager::SpillManager::begin_block].
+#[test]
+fn brillig_spill_does_not_cause_transient_spill_leak() {
+    let src = "
+    brillig(inline) fn main f0 {
+      b0(v0: u32, v1: u32, v2: u32, v3: u32):
+        v4 = unchecked_add v0, v1
+        v5 = unchecked_add v4, v0
+        v6 = unchecked_add v5, v2
+        v7 = unchecked_add v6, v1
+        jmp b1(v0, v1, v2, v3)
+      b1(v8: u32, v9: u32, v10: u32, v11: u32):
+        v12 = unchecked_add v0, v1
+        v13 = unchecked_add v12, v3
+        return v13
+    }";
+
+    let layout = LayoutConfig::new(4, 16, MAX_SCRATCH_SPACE);
+    let options = BrilligOptions { layout, ..Default::default() };
+    let brillig = ssa_to_brillig_artifacts_with_options(src, &options);
+    let _ = &brillig.ssa_function_to_brillig[&Id::test_new(0)];
+}

--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/tests/spill.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/tests/spill.rs
@@ -264,70 +264,54 @@ fn brillig_spill_does_not_leak_reloaded_permanent_values_bytecode() {
      0: sp[1] = @1
      1: @3 = const u32 7
      2: @1 = u32 add @1, @3
-     3: @4 = const u32 0
-     4: @3 = u32 add sp[1], @4
-     5: store sp[2] at @3
-     6: @4 = const u32 4
-     7: @3 = u32 add sp[1], @4
-     8: store sp[3] at @3
-     9: @4 = const u32 0
-    10: @3 = u32 add sp[1], @4
-    11: sp[3] = load @3
-    12: @4 = const u32 5
-    13: @3 = u32 add sp[1], @4
-    14: store sp[4] at @3
-    15: @4 = const u32 4
+     3: store sp[2] at sp[1]
+     4: @4 = const u32 4
+     5: @3 = u32 add sp[1], @4
+     6: store sp[3] at @3
+     7: sp[3] = load sp[1]
+     8: @4 = const u32 5
+     9: @3 = u32 add sp[1], @4
+    10: store sp[4] at @3
+    11: @4 = const u32 4
+    12: @3 = u32 add sp[1], @4
+    13: sp[4] = load @3
+    14: sp[2] = u32 add sp[3], sp[4]
+    15: @4 = const u32 6
     16: @3 = u32 add sp[1], @4
-    17: sp[4] = load @3
-    18: sp[2] = u32 add sp[3], sp[4]
-    19: @4 = const u32 6
-    20: @3 = u32 add sp[1], @4
-    21: store sp[2] at @3
-    22: @4 = const u32 0
-    23: @3 = u32 add sp[1], @4
-    24: store sp[3] at @3
-    25: @4 = const u32 6
-    26: @3 = u32 add sp[1], @4
-    27: sp[3] = load @3
-    28: @4 = const u32 4
-    29: @3 = u32 add sp[1], @4
-    30: store sp[4] at @3
-    31: @4 = const u32 0
-    32: @3 = u32 add sp[1], @4
-    33: sp[4] = load @3
-    34: sp[2] = u32 add sp[3], sp[4]
-    35: @4 = const u32 0
-    36: @3 = u32 add sp[1], @4
-    37: sp[2] = load @3
-    38: @4 = const u32 1
-    39: @3 = u32 add sp[1], @4
-    40: store sp[2] at @3
+    17: store sp[2] at @3
+    18: @4 = const u32 6
+    19: @3 = u32 add sp[1], @4
+    20: sp[3] = load @3
+    21: sp[4] = load sp[1]
+    22: sp[2] = u32 add sp[3], sp[4]
+    23: sp[2] = load sp[1]
+    24: @4 = const u32 1
+    25: @3 = u32 add sp[1], @4
+    26: store sp[2] at @3
+    27: @4 = const u32 4
+    28: @3 = u32 add sp[1], @4
+    29: sp[3] = load @3
+    30: @4 = const u32 2
+    31: @3 = u32 add sp[1], @4
+    32: store sp[3] at @3
+    33: @4 = const u32 5
+    34: @3 = u32 add sp[1], @4
+    35: sp[4] = load @3
+    36: @4 = const u32 3
+    37: @3 = u32 add sp[1], @4
+    38: store sp[4] at @3
+    39: jump to 0 // -> 40: f0/b1
+    40: sp[3] = load sp[1] // f0/b1
     41: @4 = const u32 4
     42: @3 = u32 add sp[1], @4
-    43: sp[3] = load @3
-    44: @4 = const u32 2
-    45: @3 = u32 add sp[1], @4
-    46: store sp[3] at @3
-    47: @4 = const u32 5
-    48: @3 = u32 add sp[1], @4
-    49: sp[4] = load @3
-    50: @4 = const u32 3
-    51: @3 = u32 add sp[1], @4
-    52: store sp[4] at @3
-    53: jump to 0 // -> 54: f0/b1
-    54: @4 = const u32 0 // f0/b1
-    55: @3 = u32 add sp[1], @4
-    56: sp[3] = load @3
-    57: @4 = const u32 4
-    58: @3 = u32 add sp[1], @4
-    59: sp[4] = load @3
-    60: sp[2] = u32 add sp[3], sp[4]
-    61: @4 = const u32 5
-    62: @3 = u32 add sp[1], @4
-    63: sp[4] = load @3
-    64: sp[3] = u32 add sp[2], sp[4]
-    65: sp[2] = sp[3]
-    66: return
+    43: sp[4] = load @3
+    44: sp[2] = u32 add sp[3], sp[4]
+    45: @4 = const u32 5
+    46: @3 = u32 add sp[1], @4
+    47: sp[4] = load @3
+    48: sp[3] = u32 add sp[2], sp[4]
+    49: sp[2] = sp[3]
+    50: return
     ");
 }
 

--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/tests/spill.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/tests/spill.rs
@@ -367,3 +367,53 @@ fn brillig_spill_does_not_cause_transient_spill_leak() {
     let brillig = ssa_to_brillig_artifacts_with_options(src, &options);
     let _ = &brillig.ssa_function_to_brillig[&Id::test_new(0)];
 }
+
+/// Regression: the condition register of a `jmpif` was freed by the second
+/// `spill_non_param_live_ins` call inside `jmp_setup`, then reused for a u32 arg.
+///
+/// Both the condition `v3` and the then-arg `v2` are non-param live-ins to `b1`
+/// (`v2` appears as the IfElse else-value). The first `spill_non_param_live_ins`
+/// permanently spills both. `convert_ssa_single_addr_value` reloads `v3` into
+/// R_cond. Inside `jmp_setup`, `spill_non_param_live_ins` fires a second time.
+/// The buggy code detected that `v3` had a spill record and was not currently
+/// marked spilled (`was_reloaded`), and freed R_cond. `convert_ssa_value(v2)` then
+/// reloaded `v2` (u32) into the freed R_cond slot. `JumpIf R_cond` failed at
+/// runtime with "condition value is not a boolean: Bit size for value 32".
+///
+/// The fix checks `was_transient_reloaded` instead, which excludes already-permanent
+/// records, so R_cond is kept alive through the `JumpIf`.
+#[test]
+fn brillig_spill_jmpif_condition_register_reuse() {
+    let src = "
+    brillig(inline) fn main f0 {
+      b0(v0: u32, v1: u32, v2: u32):
+        v3 = eq v0, v1
+        v4 = not v3
+        jmpif v3 then: b1(v2), else: b2()
+      b1(v5: u32):
+        v6 = if v3 then v5 else (if v4) v2
+        jmp b3(v6)
+      b2():
+        jmp b3(v1)
+      b3(v7: u32):
+        return v7
+    }
+    ";
+
+    // 5 usable registers (sp[2..6]). The 3 params plus the two successor-block params
+    // (v5 for b1, v7 for b3) fill all 5 slots; the successor params are immediately
+    // spilled and freed, leaving exactly enough room for v3 and v4. By the time
+    // jmpif fires, v2, v3, and v4 are all in registers and all get permanently
+    // spilled by spill_non_param_live_ins(b1). Both v3 and v2 end up as non-param
+    // live-ins to b1, triggering the double-call pattern that exposed the bug.
+    let layout = LayoutConfig::new(7, 16, MAX_SCRATCH_SPACE);
+    let options = BrilligOptions { layout, ..Default::default() };
+
+    // v0=1, v1=1 → v3=true → then-branch taken; v5=v2=42, v6=42.
+    let result = execute_brillig_from_ssa_with_options(
+        src,
+        vec![FieldElement::from(1u32), FieldElement::from(1u32), FieldElement::from(42u32)],
+        &options,
+    );
+    assert_eq!(result, vec![FieldElement::from(42u32)]);
+}


### PR DESCRIPTION
## Problem Resolved

Resolves #12266
Resolves #12262

## Summary of Changes

Alternative to #12344

I decided to start from scratch, using Claude, to see if it would reach the same fix as in #12344 (also because I wasn't sure if all the tracing stuff was wanted). The fix was similar (not exactly the same) but still had the bug. Then I wrote a test similar to the one in #12344 and told Claude to fix it, and it found the case. Then, I told it to create a small test to show the bug so it's easier to understand.

Finally, I also implemented #12262 (using Cluade too, letting it choose the names) because I also think it leads to clearer code.

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
