### PR TITLE
fix: don't resolve to trait method if a direct method exists

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/types.rs
+++ b/compiler/noirc_frontend/src/elaborator/types.rs
@@ -1616,7 +1616,7 @@ impl Elaborator<'_> {
 
             trait_methods = Some(type_trait_methods);
         } else if direct_method.is_some() {
-            // If there's no turbofish, but there's a direct method, let the lookup continue reguarly
+            // If there's no turbofish, but there's a direct method, let the lookup continue regularly
             // (outside of this method) as the resolution will not be a trait method.
             return None;
         }

--- a/compiler/noirc_frontend/src/elaborator/types.rs
+++ b/compiler/noirc_frontend/src/elaborator/types.rs
@@ -1547,14 +1547,14 @@ impl Elaborator<'_> {
         let method_name = last_segment.ident.as_str();
         let mut trait_methods = None;
 
+        let check_self_param = false;
+        let direct_method = self.interner.lookup_direct_method(&typ, method_name, check_self_param);
+
         // When turbofish generics are provided, use type-directed method lookup to pick the
         // correct impl. Without turbofish, fall through to module-based lookup, which handles
         // Self::method resolution, visibility checking, and associated constants correctly.
         if turbofish.is_some() {
-            let check_self_param = false;
-            if let Some(func_id) =
-                self.interner.lookup_direct_method(&typ, method_name, check_self_param)
-            {
+            if let Some(func_id) = direct_method {
                 self.push_errors(errors);
                 let mut all_errors = path_resolution.errors;
 
@@ -1615,6 +1615,10 @@ impl Elaborator<'_> {
             }
 
             trait_methods = Some(type_trait_methods);
+        } else if direct_method.is_some() {
+            // If there's no turbofish, but there's a direct method, let the lookup continue reguarly
+            // (outside of this method) as the resolution will not be a trait method.
+            return None;
         }
 
         let has_self_arg = false;

--- a/compiler/noirc_frontend/src/tests/traits/trait_method_resolution.rs
+++ b/compiler/noirc_frontend/src/tests/traits/trait_method_resolution.rs
@@ -1054,3 +1054,28 @@ fn trait_method_and_struct_method_with_same_name() {
     "#;
     assert_no_errors(src);
 }
+
+#[test]
+fn trait_method_and_struct_method_with_same_name_and_turbofish() {
+    let src = r#"
+    pub struct MyStruct<T> {}
+    impl<T> MyStruct<T> {
+        fn foo() -> i32 {
+            0
+        }
+    }
+
+    pub trait MyTrait<T> {
+        fn foo();
+    }
+
+    impl<T> MyTrait<T> for MyStruct<T> {
+        fn foo() {
+            // This method should resolve to the impl method, not the trait method,
+            // and we verify this by checking that the return type is correct (i32, not ()).
+            let _: i32 = MyStruct::<T>::foo();
+        }
+    }
+    "#;
+    assert_no_errors(src);
+}

--- a/compiler/noirc_frontend/src/tests/traits/trait_method_resolution.rs
+++ b/compiler/noirc_frontend/src/tests/traits/trait_method_resolution.rs
@@ -1029,3 +1029,28 @@ fn type_path_generic_tuple_method() {
     "#;
     check_monomorphization_error(src);
 }
+
+#[test]
+fn trait_method_and_struct_method_with_same_name() {
+    let src = r#"
+    pub struct MyStruct {}
+    impl MyStruct {
+        fn foo() -> i32 {
+            0
+        }
+    }
+
+    pub trait MyTrait {
+        fn foo();
+    }
+
+    impl MyTrait for MyStruct {
+        fn foo() {
+            // This method should resolve to the impl method, not the trait method,
+            // and we verify this by checking that the return type is correct (i32, not ()).
+            let _: i32 = MyStruct::foo();
+        }
+    }
+    "#;
+    assert_no_errors(src);
+}


### PR DESCRIPTION
## Problem Resolved

Resolves #12393

## Summary of Changes

Before #12381, `resolve_type_trait_method` used to lookup `Type::method` where `method` resolved to some trait method that `Type` implemented. However, it first checked if a direct method exists and, if so, early returned from that method as the direct method should have precedence (and that is resolved outside of `resolve_type_trait_method`). Then #12381 changed that to return the direct method, but only if the type had turbofish specified on it (in that case we need to find the precise impl that corresponds to those turbofish). But by doing that it removed the check that if there's no turbofish specified, but there's a direct method, then it should early return. This PR brings back that early return.

Note: I'm thinking that here we end up doing a direct method lookup and discarding the result in some cases, only to later do that lookup again (though in a different way). It would be nice to have to do less lookups here, but looking at the code, and especially `resolve_trait_generic_path`, it seems we were already doing many small lookups depending on what the path looks like, so this would be a larger refactor that should be done separately.

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
