### PR TITLE
chore: a brillig function taking an array and having an array_set is impure

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/opt/pure.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/pure.rs
@@ -245,7 +245,13 @@ impl Function {
                         | Instruction::Call { .. }
                         | Instruction::Allocate
                         | Instruction::EnableSideEffectsIf { .. }
-                        | Instruction::Noop => (),
+                        | Instruction::Noop => {
+                            // This can't possibly move a Brillig array input.
+                            // A `call` could mutate a Brillig array input, but if that is the case
+                            // the the call itself will be marked as impure, and so then this function will
+                            // be impure... but that is a check that is done later on.
+                        }
+
                         Instruction::Load { .. }
                         | Instruction::Store { .. }
                         | Instruction::ArraySet { .. }

--- a/compiler/noirc_evaluator/src/ssa/opt/pure.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/pure.rs
@@ -905,4 +905,45 @@ mod tests {
         let purities = &ssa.main().dfg.function_purities;
         assert_eq!(purities[&FunctionId::test_new(0)], Purity::PureWithPredicate);
     }
+
+    #[test]
+    fn considers_array_set_to_any_array_as_impure_if_entry_point_has_an_array() {
+        // `v6 = array_set v2, ...` ends up operating on `v0` because it's being passed
+        // in `b1(...)` as `v2`. So even if `array_set v2` doesn't directly operate on a function parameter,
+        // it can end up operating on one, indirectly. This test ensures we catch this case.
+        let src = "
+        brillig(inline_never) fn f f1 {
+          b0(v0: [u1; 1]):
+            jmp b1(u32 0, v0)
+          b1(v1: u32, v2: [u1; 1]):
+            v4 = eq v1, u32 0
+            jmpif v4 then: b2(), else: b3()
+          b2():
+            v6 = array_set v2, index u32 0, value u1 0
+            v8 = unchecked_add v1, u32 1
+            jmp b1(v8, v6)
+          b3():
+            return v2
+        }
+        ";
+
+        let ssa = Ssa::from_str(src).unwrap();
+        let ssa = ssa.purity_analysis();
+
+        assert_ssa_snapshot!(ssa, @r"
+        brillig(inline_never) impure fn f f0 {
+          b0(v0: [u1; 1]):
+            jmp b1(u32 0, v0)
+          b1(v1: u32, v2: [u1; 1]):
+            v4 = eq v1, u32 0
+            jmpif v4 then: b2(), else: b3()
+          b2():
+            v6 = array_set v2, index u32 0, value u1 0
+            v8 = unchecked_add v1, u32 1
+            jmp b1(v8, v6)
+          b3():
+            return v2
+        }
+        ");
+    }
 }

--- a/compiler/noirc_evaluator/src/ssa/opt/pure.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/pure.rs
@@ -15,6 +15,7 @@ use std::sync::Arc;
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 
 use crate::ssa::ir::call_graph::CallGraph;
+use crate::ssa::ir::types::Type;
 use crate::ssa::{
     ir::{
         function::{Function, FunctionId},
@@ -126,11 +127,29 @@ impl Function {
             return Purity::Impure;
         }
 
-        let is_brillig_and_contains_array_in_entry_point = self.runtime().is_brillig()
-            && self.parameters().iter().any(|param| {
-                let typ = self.dfg.type_of_value(*param);
-                typ.contains_an_array()
-            });
+        // Collect all parameters that are arrays or contain arrays, but only for Brillig.
+        // If we detect an array_set potentially operating on a brillig array input, the entire
+        // function becomes impure.
+        let brillig_array_inputs = if self.runtime().is_brillig() {
+            self.parameters()
+                .iter()
+                .filter(|param| {
+                    let typ = self.dfg.type_of_value(**param);
+                    typ.contains_an_array()
+                })
+                .collect::<HashSet<_>>()
+        } else {
+            HashSet::default()
+        };
+        let has_brillig_array_input = !brillig_array_inputs.is_empty();
+
+        // Records whether there's an `array_set`, `inc_rc` or `dec_rc` in this function.
+        let mut has_array_set_or_rc = false;
+
+        // Records whether a brillig array input was used in an instruction that could have moved
+        // it to another value. Examples include `store`, `array_set`, and even `array_get` for parameters
+        // that have nested arrays.
+        let mut brillig_array_input_was_moved = false;
 
         let mut result = if self.runtime().is_acir() {
             Purity::Pure
@@ -148,7 +167,8 @@ impl Function {
                 // parameters or returned, we can ignore them.
                 // We even ignore Constrain instructions. As long as the external parameters are
                 // identical, we should be constraining the same values anyway.
-                match &self.dfg[*instruction] {
+                let ins = &self.dfg[*instruction];
+                match ins {
                     Instruction::Constrain(..)
                     | Instruction::ConstrainNotEqual(..)
                     | Instruction::RangeCheck { .. } => result = Purity::PureWithPredicate,
@@ -158,18 +178,14 @@ impl Function {
                     // - The array index is out of bounds.
                     // For both cases we can still treat them as pure if the arguments are known
                     // constants.
-                    ins @ (Instruction::Binary(_)
-                    | Instruction::ArrayGet { .. }) => {
+                    Instruction::Binary(_) | Instruction::ArrayGet { .. } => {
                         if ins.requires_acir_gen_predicate(&self.dfg) {
                             result = Purity::PureWithPredicate;
                         }
                     }
-                    ins @ Instruction::ArraySet { .. } => {
-                      if is_brillig_and_contains_array_in_entry_point {
-                        return Purity::Impure;
-                      } else if ins.requires_acir_gen_predicate(&self.dfg) {
-                            result = Purity::PureWithPredicate;
-                      }
+                    Instruction::ArraySet { .. } => {
+                      has_array_set_or_rc = true;
+                      result = Purity::PureWithPredicate;
                     }
                     Instruction::Call { func, .. } => {
                         match &self.dfg[*func] {
@@ -211,22 +227,81 @@ impl Function {
                     | Instruction::MakeArray { .. }
                     | Instruction::Noop => (),
 
-                    Instruction::IncrementRc { value }
-                    | Instruction::DecrementRc { value } => {
-                      if self.parameters().contains(value) || self.dfg.is_global(*value) {
-                        return Purity::Impure
-                      }
+                    Instruction::IncrementRc { .. } | Instruction::DecrementRc { .. } => {
+                        has_array_set_or_rc = true;
+                    }
+                }
+
+                // Separately, check if any instruction could be moving a Brillig array input.
+                if has_brillig_array_input {
+                    match ins {
+                        Instruction::Binary(_)
+                        | Instruction::Cast(..)
+                        | Instruction::Not(_)
+                        | Instruction::Truncate { .. }
+                        | Instruction::Constrain(..)
+                        | Instruction::ConstrainNotEqual(..)
+                        | Instruction::RangeCheck { .. }
+                        | Instruction::Call { .. }
+                        | Instruction::Allocate
+                        | Instruction::EnableSideEffectsIf { .. }
+                        | Instruction::Noop => (),
+                        Instruction::Load { .. }
+                        | Instruction::Store { .. }
+                        | Instruction::ArraySet { .. }
+                        | Instruction::IncrementRc { .. }
+                        | Instruction::DecrementRc { .. }
+                        | Instruction::IfElse { .. }
+                        | Instruction::MakeArray { .. } => {
+                            // Check if any of these instructions is operating on a Brillig array input
+                            brillig_array_input_was_moved |= has_brillig_array_input
+                                && ins.any_value(|value| brillig_array_inputs.contains(&value));
+                        }
+                        Instruction::ArrayGet { array, index: _ } => {
+                            // For ArrayGet we do something slightly different: if it operates on a Brillig array input
+                            // array, an array could be moved if it's nested inside `array` (for example if the type
+                            // is `[[Field; 2]; 3]`. However, if the `array` is an array without nested arrays, no
+                            // array will be moved here. We consider this case specifically because fetching from a
+                            // non-nested Brillig array input is a common pattern.
+                            if brillig_array_inputs.contains(array) {
+                                let typ = self.dfg.type_of_value(*array);
+                                let typ = typ.as_ref();
+                                match typ {
+                                    Type::Array(items, _) | Type::Vector(items) => {
+                                        if items.iter().any(|item| item.contains_an_array()) {
+                                            brillig_array_input_was_moved = true;
+                                        }
+                                    }
+                                    Type::Numeric(_) | Type::Reference(_, _) | Type::Function => (),
+                                }
+                            }
+                        }
                     }
                 }
             }
 
             // If the function returns a reference it is impure
             let terminator = self.dfg[block].terminator();
-            if let Some(TerminatorInstruction::Return { return_values, .. }) = terminator
-                && return_values.iter().any(&contains_reference)
-            {
-                return Purity::Impure;
+            if let Some(terminator) = terminator {
+                if let TerminatorInstruction::Return { return_values, .. } = terminator
+                    && return_values.iter().any(&contains_reference)
+                {
+                    return Purity::Impure;
+                }
+
+                // Also check if any Brillig array input is moved in a terminator
+                if has_brillig_array_input
+                    && terminator.any_value(|value| brillig_array_inputs.contains(&value))
+                {
+                    brillig_array_input_was_moved = true;
+                }
             }
+        }
+
+        // If a Brillig array input was moved, and we found any instruction that could mutate it
+        // (`array_set`, `inc_rc` or `dec_rc`) then we consider the function impure.
+        if has_array_set_or_rc && brillig_array_input_was_moved {
+            return Purity::Impure;
         }
 
         result
@@ -943,6 +1018,133 @@ mod tests {
             jmp b1(v8, v6)
           b3():
             return v2
+        }
+        ");
+    }
+
+    #[test]
+    fn does_not_consider_impure_if_brillig_array_input_is_not_moved_even_though_there_is_an_array_set()
+     {
+        // Even though there's an array_set, which *could* operate on a brillig array input,
+        // we notice that v0 is never moved around so it can't be the target of any array_set.
+        // v0 is used in an `array_get`, but since v0 is an array and doesn't have nested arrays
+        // in it, no array is actually moved.
+        let src = "
+        brillig(inline_never) fn f f0 {
+          b0(v0: [u1; 1]):
+            v4 = make_array [u1 0] : [u1; 1]
+            v6 = array_get v0, index u32 0 -> u1
+            jmp b1(u32 0, v4)
+          b1(v1: u32, v2: [u1; 1]):
+            v7 = eq v1, u32 0
+            jmpif v7 then: b2(), else: b3()
+          b2():
+            v8 = array_set v2, index u32 0, value u1 0
+            v10 = unchecked_add v1, u32 1
+            jmp b1(v10, v8)
+          b3():
+            return v2
+        }
+        ";
+
+        let ssa = Ssa::from_str(src).unwrap();
+        let ssa = ssa.purity_analysis();
+
+        assert_ssa_snapshot!(ssa, @r"
+        brillig(inline_never) predicate_pure fn f f0 {
+          b0(v0: [u1; 1]):
+            v4 = make_array [u1 0] : [u1; 1]
+            v6 = array_get v0, index u32 0 -> u1
+            jmp b1(u32 0, v4)
+          b1(v1: u32, v2: [u1; 1]):
+            v7 = eq v1, u32 0
+            jmpif v7 then: b2(), else: b3()
+          b2():
+            v8 = array_set v2, index u32 0, value u1 0
+            v10 = unchecked_add v1, u32 1
+            jmp b1(v10, v8)
+          b3():
+            return v2
+        }
+        ");
+    }
+
+    #[test]
+    fn considers_impure_if_brillig_input_array_is_stored_and_there_is_an_array_set() {
+        let src = "
+        brillig(inline_never) fn f f0 {
+          b0(v0: [u1; 1]):
+            v1 = allocate -> &mut [u1; 1]
+            store v0 at v1
+            v2 = load v1 -> [u1; 1]
+            v5 = array_set v2, index u32 0, value u1 0
+            return v0
+        }
+        ";
+
+        let ssa = Ssa::from_str(src).unwrap();
+        let ssa = ssa.purity_analysis();
+
+        assert_ssa_snapshot!(ssa, @r"
+        brillig(inline_never) impure fn f f0 {
+          b0(v0: [u1; 1]):
+            v1 = allocate -> &mut [u1; 1]
+            store v0 at v1
+            v2 = load v1 -> [u1; 1]
+            v5 = array_set v2, index u32 0, value u1 0
+            return v0
+        }
+        ");
+    }
+
+    #[test]
+    fn considers_impure_if_brillig_input_array_is_stored_and_there_is_an_inc_rc() {
+        let src = "
+        brillig(inline_never) fn f f0 {
+          b0(v0: [u1; 1]):
+            v1 = allocate -> &mut [u1; 1]
+            store v0 at v1
+            v2 = load v1 -> [u1; 1]
+            inc_rc v2
+            return v0
+        }
+        ";
+
+        let ssa = Ssa::from_str(src).unwrap();
+        let ssa = ssa.purity_analysis();
+
+        assert_ssa_snapshot!(ssa, @r"
+        brillig(inline_never) impure fn f f0 {
+          b0(v0: [u1; 1]):
+            v1 = allocate -> &mut [u1; 1]
+            store v0 at v1
+            v2 = load v1 -> [u1; 1]
+            inc_rc v2
+            return v0
+        }
+        ");
+    }
+
+    #[test]
+    fn considers_impure_if_brillig_input_nested_array_is_moved_and_there_is_a_dec_rc() {
+        let src = "
+        brillig(inline_never) fn f f0 {
+          b0(v0: [[u1; 1]; 1]):
+            v1 = array_get v0, index u32 0 -> [u1; 1]
+            inc_rc v1
+            return
+        }
+        ";
+
+        let ssa = Ssa::from_str(src).unwrap();
+        let ssa = ssa.purity_analysis();
+
+        assert_ssa_snapshot!(ssa, @r"
+        brillig(inline_never) impure fn f f0 {
+          b0(v0: [[u1; 1]; 1]):
+            v2 = array_get v0, index u32 0 -> [u1; 1]
+            inc_rc v2
+            return
         }
         ");
     }

--- a/compiler/noirc_evaluator/src/ssa/opt/pure.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/pure.rs
@@ -126,6 +126,12 @@ impl Function {
             return Purity::Impure;
         }
 
+        let is_brillig_and_contains_array_in_entry_point = self.runtime().is_brillig()
+            && self.parameters().iter().any(|param| {
+                let typ = self.dfg.type_of_value(*param);
+                typ.contains_an_array()
+            });
+
         let mut result = if self.runtime().is_acir() {
             Purity::Pure
         } else {
@@ -158,9 +164,9 @@ impl Function {
                             result = Purity::PureWithPredicate;
                         }
                     }
-                    ins @ Instruction::ArraySet { array, .. } => {
-                      if self.runtime().is_brillig() && (self.parameters().contains(array) || self.dfg.is_global(*array)) {
-                          return Purity::Impure;
+                    ins @ Instruction::ArraySet { .. } => {
+                      if is_brillig_and_contains_array_in_entry_point {
+                        return Purity::Impure;
                       } else if ins.requires_acir_gen_predicate(&self.dfg) {
                             result = Purity::PureWithPredicate;
                       }

--- a/test_programs/execution_success/brillig_array_input_indirectly_mutated/Nargo.toml
+++ b/test_programs/execution_success/brillig_array_input_indirectly_mutated/Nargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "brillig_array_input_indirectly_mutated"
+type = "bin"
+authors = [""]
+
+[dependencies]

--- a/test_programs/execution_success/brillig_array_input_indirectly_mutated/Prover.toml
+++ b/test_programs/execution_success/brillig_array_input_indirectly_mutated/Prover.toml
@@ -1,0 +1,1 @@
+return = [true]

--- a/test_programs/execution_success/brillig_array_input_indirectly_mutated/src/main.nr
+++ b/test_programs/execution_success/brillig_array_input_indirectly_mutated/src/main.nr
@@ -1,0 +1,12 @@
+unconstrained fn main() -> pub [bool; 1] {
+    let _ = f([true]);
+    [true]
+}
+
+#[inline_never]
+unconstrained fn f(mut b: [bool; 1]) -> [bool; 1] {
+    for _ in 0_u32..=0_u32 {
+        b[0] = false;
+    }
+    b
+}

--- a/tooling/nargo_cli/tests/snapshots/execution_success/brillig_array_input_indirectly_mutated/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/brillig_array_input_indirectly_mutated/execute__tests__expanded.snap
@@ -1,0 +1,16 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: expanded_code
+---
+unconstrained fn main() -> pub [bool; 1] {
+    let _: [bool; 1] = f([true]);
+    [true]
+}
+
+#[inline_never]
+unconstrained fn f(mut b: [bool; 1]) -> [bool; 1] {
+    for _ in 0_u32..=0_u32 {
+        b[0_u32] = false;
+    }
+    b
+}

--- a/tooling/nargo_cli/tests/snapshots/execution_success/brillig_array_input_indirectly_mutated/execute__tests__stdout.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/brillig_array_input_indirectly_mutated/execute__tests__stdout.snap
@@ -1,0 +1,5 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: stdout
+---
+[brillig_array_input_indirectly_mutated] Circuit output: [true]


### PR DESCRIPTION
## Problem Resolved

Resolves https://github.com/noir-lang/noir/security/advisories/GHSA-qqxj-59g5-7jcv

## Summary of Changes

As explained in the issue, the purity analysis checked whether an `array_set` was operating on a brillig array input. If so, it considered the function as impure. However, the array input could have been moved to some other value, for example a terminator argument, and then an array_set could be operating on the corresponding block parameter, but this wasn't caught.

The first commit fixes this by considering any brillig function that has an array input (or an array nested in an input) together with an array_set operating on **any** value as impure. This produced a pretty large regression in fold_2_to_17.

Looking at the new SSA in fold_2_to_17 I noticed that it has an input array, it has `array_set`, but the only place the input array is used is in an `array_get`. Then it means that it can't be that any `array_set` in the function is operating on an input, because the input "doesn't move around".

To solve the regression, the third commit improves the logic a bit:
- It tracks whether an array input could have been moved (for example it was used in an array_set, a load, a store, etc.)
- It also tracks whether there's any array_set, inc_rc or dec_rc in the function

If the two conditions hold, then it could mean that an input array is being mutated, so we conservatively consider the function as impure.

There's an edge case: for `array_get`, if it's operating on an input array that doesn't have nested arrays in it, then no array is moved. However, if it's operating on an input that has a nested array, then that nested array could be moving here, so we conservatively consider the function to be impure.

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
