### PR TITLE
fix: incorrect type_def_generics implemented return type

### DIFF
--- a/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
@@ -506,7 +506,7 @@ fn type_def_generics(
         })
         .collect();
 
-    Ok(Value::Vector(generics, vector_item_type))
+    Ok(Value::Vector(generics, Type::Vector(Box::new(vector_item_type))))
 }
 
 fn type_def_hash(arguments: Vec<(Value, Location)>, location: Location) -> IResult<Value> {

--- a/test_programs/compile_success_empty/comptime_type_def_generics_type/Nargo.toml
+++ b/test_programs/compile_success_empty/comptime_type_def_generics_type/Nargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "comptime_type_def_generics_type"
+type = "bin"
+authors = [""]
+
+[dependencies]

--- a/test_programs/compile_success_empty/comptime_type_def_generics_type/src/main.nr
+++ b/test_programs/compile_success_empty/comptime_type_def_generics_type/src/main.nr
@@ -1,0 +1,13 @@
+#[test_attr]
+pub struct Pair<T> {
+    x: T,
+    y: T,
+}
+
+comptime fn test_attr(pair_def: TypeDefinition) {
+    let generics = pair_def.generics();
+    let generics_type = std::meta::type_of(generics);
+    let _ = generics_type.as_vector().unwrap();
+}
+
+fn main() {}

--- a/tooling/nargo_cli/tests/snapshots/compile_success_empty/comptime_type_def_generics_type/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_empty/comptime_type_def_generics_type/execute__tests__expanded.snap
@@ -1,0 +1,16 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: expanded_code
+---
+pub struct Pair<T> {
+    x: T,
+    y: T,
+}
+
+comptime fn test_attr(pair_def: TypeDefinition) {
+    let generics: [(Type, Option<Type>)] = pair_def.generics();
+    let generics_type: Type = std::meta::type_of(generics);
+    let _: Type = generics_type.as_vector().unwrap();
+}
+
+fn main() {}


### PR DESCRIPTION
## Problem Resolved

Resolves https://app.audithub.dev/app/organizations/161/projects/600/project-viewer?version=1408&issueId=872

## Summary of Changes

The value `Value::Vector` must always have a `Type::Vector` as its type, but this wasn't the case here.

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
