### PR TITLE
chore: remove some Value methods

### DIFF
--- a/compiler/noirc_frontend/src/hir/comptime/interpreter/infix.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter/infix.rs
@@ -23,7 +23,10 @@ pub(super) fn evaluate_infix(
     let shr_overflow = || InterpreterError::BinaryOperationOverflow { operator: ">>", location };
     let math_error = |operator| InterpreterError::BinaryOperationOverflow { location, operator };
 
-    if matches!(operator.kind, BinaryOpKind::Divide | BinaryOpKind::Modulo) && rhs_value.is_zero() {
+    if matches!(operator.kind, BinaryOpKind::Divide | BinaryOpKind::Modulo)
+        && let Value::Integer(rhs_value) = rhs_value
+        && rhs_value.is_zero()
+    {
         return Err(InterpreterError::InvalidValuesForBinary {
             lhs: lhs_type,
             rhs: rhs_type,

--- a/compiler/noirc_frontend/src/hir/comptime/value.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/value.rs
@@ -685,14 +685,6 @@ impl Value {
         Ok(tokens)
     }
 
-    pub(crate) fn is_zero(&self) -> bool {
-        use Value::*;
-        match self {
-            Integer(value) => value.is_zero(),
-            _ => false,
-        }
-    }
-
     pub(crate) fn contains_function_or_closure(&self) -> bool {
         match self {
             Value::Function(..) => true,
@@ -761,15 +753,6 @@ impl Value {
                 let value = self.display(elaborator.interner).to_string();
                 Err(InterpreterError::CannotInlineMacro { value, typ, location })
             }
-        }
-    }
-
-    /// True if this value is negative.
-    /// Defaults to false if this value is not negative or is not an integer.
-    pub fn is_negative(&self) -> bool {
-        match self {
-            Value::Integer(int) => int.is_negative(),
-            _ => false,
         }
     }
 


### PR DESCRIPTION
## Problem Resolved

Resolves a couple of points mentioned in https://app.audithub.dev/app/organizations/161/projects/600/project-viewer?version=1408&issueId=910

## Summary of Changes

- `is_negative` was unused, so it's removed
- `is_zero` was used in only one place, answering `false` for non-integer values. Now it has been moved to its single caller.

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
