### PR TITLE
feat: warn on unused impl functions

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/expressions.rs
+++ b/compiler/noirc_frontend/src/elaborator/expressions.rs
@@ -908,6 +908,8 @@ impl Elaborator<'_> {
             .func_id(self.interner)
             .expect("Expected trait function to be a DefinitionKind::Function");
 
+        self.usage_tracker.mark_impl_function_as_used(&func_id);
+
         let function_type = self.interner.function_meta(&func_id).typ.clone();
         self.try_add_mutable_reference_to_object(&function_type, &mut object_type, &mut object);
 

--- a/compiler/noirc_frontend/src/elaborator/impls.rs
+++ b/compiler/noirc_frontend/src/elaborator/impls.rs
@@ -203,6 +203,17 @@ impl Elaborator<'_> {
             // Trait impl methods are already declared in NodeInterner::add_trait_implementation
             if trait_id.is_none() {
                 self.declare_methods(self_type, &function_ids);
+
+                for (_, method_id, method) in &functions.functions {
+                    if !method.def.attributes.has_allow("dead_code") {
+                        let name = method.name_ident().clone();
+                        self.usage_tracker.add_unused_impl_function(
+                            *method_id,
+                            name,
+                            method.def.visibility,
+                        );
+                    }
+                }
             }
         // We can define methods on primitive types only if we're in the stdlib
         } else if trait_id.is_none() && *self_type != Type::Error {

--- a/compiler/noirc_frontend/src/elaborator/variable.rs
+++ b/compiler/noirc_frontend/src/elaborator/variable.rs
@@ -170,6 +170,8 @@ impl Elaborator<'_> {
 
         let mut bindings = TypeBindings::default();
         let generics = if let Some(DefinitionKind::Function(func_id)) = &definition_kind {
+            self.usage_tracker.mark_impl_function_as_used(func_id);
+
             // If there's a self type, bind it to the self type generic
             if let Some(self_generic) = self_generic {
                 let func_generics = &self.interner.function_meta(func_id).all_generics;

--- a/compiler/noirc_frontend/src/hir/def_collector/dc_crate.rs
+++ b/compiler/noirc_frontend/src/hir/def_collector/dc_crate.rs
@@ -768,6 +768,16 @@ impl DefCollector {
             })
             .collect::<Vec<_>>();
 
+        for (func_id, ident) in context.usage_tracker.unused_impl_functions() {
+            let func_meta = context.def_interner.function_meta(func_id);
+            if func_meta.source_crate == crate_id {
+                unused_errors.push(CompilationError::ResolverError(ResolverError::UnusedItem {
+                    ident: ident.clone(),
+                    item: UnusedItem::Function(*func_id),
+                }));
+            }
+        }
+
         // Make sure errors always show up in the same order when compiling the same codebase
         unused_errors.sort_by_key(|error| error.location());
 

--- a/compiler/noirc_frontend/src/tests/runtime.rs
+++ b/compiler/noirc_frontend/src/tests/runtime.rs
@@ -402,8 +402,8 @@ fn disallows_export_attribute_on_impl_method() {
 
         impl Foo {
             #[export]
-            fn foo() { }
-               ^^^ The `#[export]` attribute is disallowed on `impl` methods
+            pub fn foo() { }
+                   ^^^ The `#[export]` attribute is disallowed on `impl` methods
         }
     ";
     check_errors(src);

--- a/compiler/noirc_frontend/src/tests/structs.rs
+++ b/compiler/noirc_frontend/src/tests/structs.rs
@@ -61,7 +61,7 @@ fn uses_self_type_for_struct_function_call() {
             1
         }
 
-        fn two() -> Field {
+        pub fn two() -> Field {
             Self::one() + Self::one()
         }
     }
@@ -81,7 +81,7 @@ fn errors_with_better_message_when_trying_to_invoke_struct_field_that_is_a_funct
         }
 
         impl Foo {
-            fn call(self) -> bool {
+            pub fn call(self) -> bool {
                 self.wrapped(1)
                 ^^^^^^^^^^^^^^^ Cannot invoke function field 'wrapped' on type 'Foo' as a method
                 ~~~~~~~~~~~~~~~ to call the function stored in 'wrapped', surround the field access with parentheses: '(', ')'
@@ -97,11 +97,11 @@ fn check_impl_duplicate_method_without_self() {
     pub struct Foo {}
 
     impl Foo {
-        fn foo() {}
-           ~~~ Previous impl defined here
-        fn foo() {}
-           ^^^ Impl for type `Foo` overlaps with existing impl
-           ~~~ Overlapping impl
+        pub fn foo() {}
+               ~~~ Previous impl defined here
+        pub fn foo() {}
+               ^^^ Impl for type `Foo` overlaps with existing impl
+               ~~~ Overlapping impl
     }
     ";
     check_errors(src);
@@ -381,14 +381,14 @@ fn overlapping_inherent_impls() {
         struct Foo<T> { _x: T }
 
         impl<T> Foo<T> {
-            fn method(_self: Self) {}
-               ^^^^^^ Impl for type `Foo<i32>` overlaps with existing impl
-               ~~~~~~ Overlapping impl
+            pub fn method(_self: Self) {}
+                   ^^^^^^ Impl for type `Foo<i32>` overlaps with existing impl
+                   ~~~~~~ Overlapping impl
         }
 
         impl Foo<i32> {
-            fn method(_self: Self) {}
-               ~~~~~~ Previous impl defined here
+            pub fn method(_self: Self) {}
+                   ~~~~~~ Previous impl defined here
         }
 
         fn main() {
@@ -405,11 +405,11 @@ fn non_overlapping_inherent_impls() {
         struct Foo<T> { _x: T }
 
         impl Foo<i32> {
-            fn method(_self: Self) {}
+            pub fn method(_self: Self) {}
         }
 
         impl Foo<u64> {
-            fn method(_self: Self) {}
+            pub fn method(_self: Self) {}
         }
 
         fn main() {
@@ -491,14 +491,14 @@ fn trait_as_type_non_overlapping() {
 
         // These impls should not overlap - one uses i32, the other uses u64
         impl Foo<i32> {
-            fn method(_self: Self) -> impl MyTrait<i32> {
+            pub fn method(_self: Self) -> impl MyTrait<i32> {
                 // This return type is TraitAsType with NamedGeneric inside
                 MyImpl { _x: 0 }
             }
         }
 
         impl Foo<u64> {
-            fn method(_self: Self) -> impl MyTrait<u64> {
+            pub fn method(_self: Self) -> impl MyTrait<u64> {
                 MyImpl { _x: 0 }
             }
         }
@@ -526,17 +526,17 @@ fn trait_as_type_overlapping() {
         struct Foo<T> { _x: T }
 
         impl<T> Foo<T> {
-            fn method(_self: Self) -> impl MyTrait<T> {
-               ^^^^^^ Impl for type `Foo<i32>` overlaps with existing impl
-               ~~~~~~ Overlapping impl
+            pub fn method(_self: Self) -> impl MyTrait<T> {
+                   ^^^^^^ Impl for type `Foo<i32>` overlaps with existing impl
+                   ~~~~~~ Overlapping impl
                 // This return type is TraitAsType with NamedGeneric inside
                 MyImpl { _x: _self._x }
             }
         }
 
         impl Foo<i32> {
-            fn method(_self: Self) -> impl MyTrait<i32> {
-               ~~~~~~ Previous impl defined here
+            pub fn method(_self: Self) -> impl MyTrait<i32> {
+                   ~~~~~~ Previous impl defined here
                 MyImpl { _x: _self._x }
             }
         }
@@ -561,13 +561,13 @@ fn returns_trait_as_type() {
 
         // Non-overlapping impls with TraitAsType in return position
         impl Container<i32> {
-            fn get(_self: Self) -> impl MyTrait<i32, Field> {
+            pub fn get(_self: Self) -> impl MyTrait<i32, Field> {
                 MyImpl { _x: _self._x, _y: 0 }
             }
         }
 
         impl Container<u64> {
-            fn get(_self: Self) -> impl MyTrait<u64, bool> {
+            pub fn get(_self: Self) -> impl MyTrait<u64, bool> {
                 MyImpl { _x: _self._x, _y: false }
             }
         }
@@ -606,17 +606,17 @@ fn returns_trait_as_type_overlap() {
 
         impl<T> Foo<T> {
             // Returns impl Trait1<T>
-            fn method(_self: Self) -> impl Trait1<T> {
-               ^^^^^^ Impl for type `Foo<i32>` overlaps with existing impl
-               ~~~~~~ Overlapping impl
+            pub fn method(_self: Self) -> impl Trait1<T> {
+                   ~~~~~~ Previous impl defined here
                 Impl1 { _x: _self._x }
             }
         }
 
         impl Foo<i32> {
             // Returns impl Trait2<i32> - different trait, but still overlaps!
-            fn method(_self: Self) -> impl Trait2<i32> {
-               ~~~~~~ Previous impl defined here
+            pub fn method(_self: Self) -> impl Trait2<i32> {
+                   ^^^^^^ Impl for type `Foo<T>` overlaps with existing impl
+                   ~~~~~~ Overlapping impl
                 Impl2 { _x: _self._x }
             }
         }

--- a/compiler/noirc_frontend/src/tests/traits/trait_impl_constraints.rs
+++ b/compiler/noirc_frontend/src/tests/traits/trait_impl_constraints.rs
@@ -41,7 +41,7 @@ fn impl_stricter_than_trait_no_trait_method_constraints() {
     }
 
     impl<T> MyType<T> {
-        fn do_thing_with_serialization_with_extra_steps(self) -> Field {
+        pub fn do_thing_with_serialization_with_extra_steps(self) -> Field {
             process_array(serialize_thing(self))
         }
     }

--- a/compiler/noirc_frontend/src/tests/traits/trait_qualified_paths.rs
+++ b/compiler/noirc_frontend/src/tests/traits/trait_qualified_paths.rs
@@ -527,7 +527,7 @@ fn self_with_non_associated_item_access() {
     struct Inner {}
 
     impl Inner {
-        fn method() -> u32 { 42 }
+        pub fn method() -> u32 { 42 }
     }
 
     trait MyTrait {

--- a/compiler/noirc_frontend/src/tests/turbofish.rs
+++ b/compiler/noirc_frontend/src/tests/turbofish.rs
@@ -729,7 +729,7 @@ fn concrete_impl_with_dual_turbofish_mismatch() {
     struct S<T> {}
 
     impl S<u32> {
-        fn foo<U>(_x: U) {}
+        pub fn foo<U>(_x: U) {}
     }
 
     fn main() {
@@ -827,7 +827,7 @@ fn partially_concrete_impl_turbofish_mismatch_on_concrete_param() {
     struct S<A, B> {}
 
     impl<B> S<u32, B> {
-        fn foo(x: B) -> B {
+        pub fn foo(x: B) -> B {
             x
         }
     }
@@ -965,7 +965,7 @@ fn struct_turbofish_same_generic() {
     struct S<A, B> {}
 
     impl<T> S<T, T> {
-        fn foo() {}
+        pub fn foo() {}
     }
 
     fn main() {
@@ -983,11 +983,11 @@ fn struct_turbofish_mixed_generics() {
     struct S<A, B> {}
 
     impl<T> S<T, u64> {
-        fn foo() {}
+        pub fn foo() {}
     }
 
     impl S<u32, u32> {
-        fn foo() {}
+        pub fn foo() {}
     }
 
     fn main() {
@@ -1009,6 +1009,8 @@ fn struct_turbofish_mixed_generics_visibility_error() {
 
         impl super::S<u32, u32> {
             fn foo() {}
+               ^^^ unused function foo
+               ~~~ unused function
         }
     }
 

--- a/compiler/noirc_frontend/src/tests/unused_items.rs
+++ b/compiler/noirc_frontend/src/tests/unused_items.rs
@@ -427,3 +427,70 @@ fn allow_dead_code_on_unused_enum() {
     ";
     assert_no_errors(src);
 }
+
+#[test]
+fn errors_on_unused_impl_function() {
+    let src = "
+    pub struct Foo {}
+
+    impl Foo {
+        fn foo() {}
+           ^^^ unused function foo
+           ~~~ unused function
+    }
+
+    fn main() {}
+    ";
+    check_errors(src);
+}
+
+#[test]
+fn does_not_error_on_unused_impl_function() {
+    let src = "
+    pub struct Foo {}
+
+    impl Foo {
+        fn foo() {}
+    }
+
+    fn main() {
+        let _ = Foo::foo();
+    }
+    ";
+    assert_no_errors(src);
+}
+
+#[test]
+fn does_not_error_on_used_impl_method() {
+    let src = "
+    pub struct Foo {}
+
+    impl Foo {
+        fn foo(self) {
+            let _ = self;
+        }
+    }
+
+    fn main() {
+        Foo {}.foo();
+    }
+    ";
+    assert_no_errors(src);
+}
+
+#[test]
+fn does_not_error_on_unused_impl_method_if_marked_as_allow_dead_code() {
+    let src = "
+    pub struct Foo {}
+
+    impl Foo {
+        #[allow(dead_code)]
+        fn foo(self) {
+            let _ = self;
+        }
+    }
+
+    fn main() {}
+    ";
+    assert_no_errors(src);
+}

--- a/compiler/noirc_frontend/src/tests/visibility.rs
+++ b/compiler/noirc_frontend/src/tests/visibility.rs
@@ -285,7 +285,7 @@ fn does_not_error_if_calling_private_struct_function_from_same_struct() {
     }
 
     impl Foo {
-        fn foo() {
+        pub fn foo() {
             Foo::bar()
         }
 
@@ -317,7 +317,7 @@ fn error_if_calling_private_struct_function_from_extension() {
             fn y(_self: Self) -> u32 {
                 0
             }
-            fn e(self: Self) {
+            pub fn e(self: Self) {
                 self.private_extension();
                      ^^^^^^^^^^^^^^^^^ private_extension is private and not visible from the current module
                      ~~~~~~~~~~~~~~~~~ private_extension is private
@@ -661,7 +661,7 @@ fn private_impl_method_on_another_module_1() {
             let _ = self;
         }
 
-        fn bar(self) {
+        pub fn bar(self) {
             self.foo();
         }
     }
@@ -683,7 +683,7 @@ fn private_impl_method_on_another_module_2() {
     }
 
     impl bar::Foo<i64> {
-        fn bar(self) {
+        pub fn bar(self) {
             let _ = self;
             let foo = bar::Foo::<i32> {};
             foo.foo();

--- a/compiler/noirc_frontend/src/usage_tracker.rs
+++ b/compiler/noirc_frontend/src/usage_tracker.rs
@@ -34,6 +34,7 @@ impl UnusedItem {
 #[derive(Debug, Default)]
 pub struct UsageTracker {
     unused_items: HashMap<ModuleId, HashMap<Ident, UnusedItem>>,
+    unused_impl_functions: HashMap<FuncId, Ident>,
 }
 
 impl UsageTracker {
@@ -75,6 +76,28 @@ impl UsageTracker {
         if let Some(items) = self.unused_items.get_mut(&current_mod_id) {
             items.remove(name);
         }
+    }
+
+    /// Register an inherent impl function as unused.
+    pub(crate) fn add_unused_impl_function(
+        &mut self,
+        func_id: FuncId,
+        name: Ident,
+        visibility: ItemVisibility,
+    ) {
+        if visibility != ItemVisibility::Public && name.span().start() < name.span().end() {
+            self.unused_impl_functions.insert(func_id, name);
+        }
+    }
+
+    /// Marks an inherent impl function as used.
+    pub(crate) fn mark_impl_function_as_used(&mut self, func_id: &FuncId) {
+        self.unused_impl_functions.remove(func_id);
+    }
+
+    /// Get all the unused impl functions.
+    pub fn unused_impl_functions(&self) -> &HashMap<FuncId, Ident> {
+        &self.unused_impl_functions
     }
 
     /// Get all the unused items per module.

--- a/noir_stdlib/docs/std/embedded_curve_ops/struct.EmbeddedCurveScalar.html
+++ b/noir_stdlib/docs/std/embedded_curve_ops/struct.EmbeddedCurveScalar.html
@@ -25,7 +25,6 @@
 </ul>
 <h3>Methods</h3>
 <ul class="sidebar-list">
-<li><a href="#from_bytes">from_bytes</a></li>
 <li><a href="#from_field">from_field</a></li>
 <li><a href="#new">new</a></li>
 </ul>
@@ -73,11 +72,6 @@ It may not fit into a Field element, so it is represented with two Field element
 
 <div class="padded-description"><div class="comments">
 <p>Create a scalar from the given bn254 field value</p>
-</div>
-</div><code id="from_bytes" class="code-header">pub fn <a href="#from_bytes"><span class="fn">from_bytes</span></a>(bytes: [<a href="../../std/primitive.u8.html" class="primitive">u8</a>; 64], offset: <a href="../../std/primitive.u32.html" class="primitive">u32</a>) -> Self</code>
-
-<div class="padded-description"><div class="comments">
-<p>Take the first (after the specified offset) 16 bytes of the input as the lo value, and the next 16 bytes as the hi value</p>
 </div>
 </div></div><h2>Trait implementations</h2>
 <h3 id="impl-Eq-for-EmbeddedCurveScalar"><code class="code-header">impl <a href="../../std/cmp/trait.Eq.html" class="trait">Eq</a> for <a href="../../std/embedded_curve_ops/struct.EmbeddedCurveScalar.html" class="struct">EmbeddedCurveScalar</a></code></h3>

--- a/noir_stdlib/docs/std/embedded_curve_ops/struct.EmbeddedCurveScalar.html
+++ b/noir_stdlib/docs/std/embedded_curve_ops/struct.EmbeddedCurveScalar.html
@@ -25,6 +25,7 @@
 </ul>
 <h3>Methods</h3>
 <ul class="sidebar-list">
+<li><a href="#from_bytes">from_bytes</a></li>
 <li><a href="#from_field">from_field</a></li>
 <li><a href="#new">new</a></li>
 </ul>
@@ -72,6 +73,11 @@ It may not fit into a Field element, so it is represented with two Field element
 
 <div class="padded-description"><div class="comments">
 <p>Create a scalar from the given bn254 field value</p>
+</div>
+</div><code id="from_bytes" class="code-header">pub fn <a href="#from_bytes"><span class="fn">from_bytes</span></a>(bytes: [<a href="../../std/primitive.u8.html" class="primitive">u8</a>; 64], offset: <a href="../../std/primitive.u32.html" class="primitive">u32</a>) -> Self</code>
+
+<div class="padded-description"><div class="comments">
+<p>Take the first (after the specified offset) 16 bytes of the input as the lo value, and the next 16 bytes as the hi value</p>
 </div>
 </div></div><h2>Trait implementations</h2>
 <h3 id="impl-Eq-for-EmbeddedCurveScalar"><code class="code-header">impl <a href="../../std/cmp/trait.Eq.html" class="trait">Eq</a> for <a href="../../std/embedded_curve_ops/struct.EmbeddedCurveScalar.html" class="struct">EmbeddedCurveScalar</a></code></h3>

--- a/noir_stdlib/src/embedded_curve_ops.nr
+++ b/noir_stdlib/src/embedded_curve_ops.nr
@@ -101,21 +101,6 @@ impl EmbeddedCurveScalar {
         let (a, b) = crate::field::bn254::decompose(scalar);
         EmbeddedCurveScalar { lo: a, hi: b }
     }
-
-    /// Take the first (after the specified offset) 16 bytes of the input as the lo value, and the next 16 bytes as the hi value
-    #[field(bn254)]
-    pub fn from_bytes(bytes: [u8; 64], offset: u32) -> EmbeddedCurveScalar {
-        let mut v = 1;
-        let mut lo = 0 as Field;
-        let mut hi = 0 as Field;
-        for i in 0..16 {
-            lo = lo + (bytes[offset + 31 - i] as Field) * v;
-            hi = hi + (bytes[offset + 15 - i] as Field) * v;
-            v = v * 256;
-        }
-        let sig_s = crate::embedded_curve_ops::EmbeddedCurveScalar { lo, hi };
-        sig_s
-    }
 }
 
 impl Eq for EmbeddedCurveScalar {

--- a/noir_stdlib/src/embedded_curve_ops.nr
+++ b/noir_stdlib/src/embedded_curve_ops.nr
@@ -104,7 +104,7 @@ impl EmbeddedCurveScalar {
 
     /// Take the first (after the specified offset) 16 bytes of the input as the lo value, and the next 16 bytes as the hi value
     #[field(bn254)]
-    pub(crate) fn from_bytes(bytes: [u8; 64], offset: u32) -> EmbeddedCurveScalar {
+    pub fn from_bytes(bytes: [u8; 64], offset: u32) -> EmbeddedCurveScalar {
         let mut v = 1;
         let mut lo = 0 as Field;
         let mut hi = 0 as Field;

--- a/noir_stdlib/src/hash/poseidon2.nr
+++ b/noir_stdlib/src/hash/poseidon2.nr
@@ -11,11 +11,6 @@ pub(crate) struct Poseidon2 {
 }
 
 impl Poseidon2 {
-    #[no_predicates]
-    pub(crate) fn hash<let N: u32>(input: [Field; N], message_size: u32) -> Field {
-        Poseidon2::hash_internal(input, message_size, message_size != N)
-    }
-
     pub(crate) fn new(iv: Field) -> Poseidon2 {
         let mut result =
             Poseidon2 { cache: [0; 3], state: [0; 4], cache_size: 0, squeeze_mode: false };
@@ -57,29 +52,6 @@ impl Poseidon2 {
 
         // Pop one item off the top of the permutation and return it.
         self.state[0]
-    }
-
-    fn hash_internal<let N: u32>(
-        input: [Field; N],
-        in_len: u32,
-        is_variable_length: bool,
-    ) -> Field {
-        let two_pow_64 = 18446744073709551616;
-        let iv: Field = (in_len as Field) * two_pow_64;
-        let mut sponge = Poseidon2::new(iv);
-        for i in 0..input.len() {
-            if i < in_len {
-                sponge.absorb(input[i]);
-            }
-        }
-
-        // In the case where the hash preimage is variable-length, we append `1` to the end of the input, to distinguish
-        // from fixed-length hashes. (the combination of this additional field element + the hash IV ensures
-        // fixed-length and variable-length hashes do not collide)
-        if is_variable_length {
-            sponge.absorb(1);
-        }
-        sponge.squeeze()
     }
 }
 

--- a/test_programs/compile_failure/impl_not_found_for_inner_impl/src/main.nr
+++ b/test_programs/compile_failure/impl_not_found_for_inner_impl/src/main.nr
@@ -32,7 +32,7 @@ where
 }
 
 impl<T> MyType<T> {
-    fn do_thing_with_serialization_with_extra_steps(self) -> Field {
+    pub fn do_thing_with_serialization_with_extra_steps(self) -> Field {
         process_array(serialize_thing(self))
     }
 }

--- a/test_programs/compile_failure/turbofish_after_self_not_allowed/src/main.nr
+++ b/test_programs/compile_failure/turbofish_after_self_not_allowed/src/main.nr
@@ -1,7 +1,7 @@
 struct Foo {}
 
 impl Foo {
-    fn new() -> Self {
+    pub fn new() -> Self {
         Self::<hello> {}
     }
 }

--- a/test_programs/compile_failure/wildcards_in_wrong_places/src/main.nr
+++ b/test_programs/compile_failure/wildcards_in_wrong_places/src/main.nr
@@ -7,7 +7,7 @@ pub struct Foo {
 }
 
 impl Foo {
-    fn foo(_: [_; _]) -> [_; _] {
+    pub fn foo(_: [_; _]) -> [_; _] {
         [1]
     }
 }

--- a/test_programs/compile_success_contract/contract_with_impl/src/main.nr
+++ b/test_programs/compile_success_contract/contract_with_impl/src/main.nr
@@ -4,7 +4,7 @@ contract Foo {
     }
 
     impl T {
-        fn t(self) {
+        pub fn t(self) {
             let _ = self;
         }
     }

--- a/test_programs/compile_success_empty/generic_trait_bounds/src/main.nr
+++ b/test_programs/compile_success_empty/generic_trait_bounds/src/main.nr
@@ -9,7 +9,7 @@ pub fn foo<T: Trait>(x: T) {
 pub struct Foo {}
 
 impl Foo {
-    fn foo<T: Trait>(x: T) {
+    pub fn foo<T: Trait>(x: T) {
         x.foo();
     }
 }
@@ -30,7 +30,7 @@ impl Trait2 for Foo {
 pub struct Bar<T> {}
 
 impl<T: Trait> Bar<T> {
-    fn bar(x: T) {
+    pub fn bar(x: T) {
         x.foo();
     }
 

--- a/test_programs/compile_success_empty/method_call_regression/src/main.nr
+++ b/test_programs/compile_success_empty/method_call_regression/src/main.nr
@@ -12,7 +12,7 @@ struct Struct<A, B> {
 
 // Before the fix, this candidate is searched first, binding ? to `u8` permanently.
 impl Struct<u8, u8> {
-    fn foo(self) {
+    pub fn foo(self) {
         let _ = self;
     }
 }
@@ -24,7 +24,7 @@ impl Struct<u8, u8> {
 // method is actually selected. So this candidate is now valid since
 // `Struct<u32, ()>` unifies with `Struct<?, ()>` with `? = u32`.
 impl Struct<u32, ()> {
-    fn foo(self) {
+    pub fn foo(self) {
         let _ = self;
     }
 }

--- a/test_programs/compile_success_empty/no_duplicate_methods/src/main.nr
+++ b/test_programs/compile_success_empty/no_duplicate_methods/src/main.nr
@@ -24,7 +24,7 @@ impl ToField2 for Foo {
 }
 
 impl Foo {
-    fn to_field(self) -> Field {
+    pub fn to_field(self) -> Field {
         self.x
     }
 }

--- a/test_programs/compile_success_empty/numeric_generics/src/main.nr
+++ b/test_programs/compile_success_empty/numeric_generics/src/main.nr
@@ -23,7 +23,7 @@ struct MyStruct<let S: u32> {
 }
 
 impl<let S: u32> MyStruct<S> {
-    fn insert(mut self: Self, index: Field, elem: Field) -> Self {
+    pub fn insert(mut self: Self, index: Field, elem: Field) -> Self {
         // Regression test for numeric generics on impls
         assert(index as u64 < S as u64);
 

--- a/test_programs/compile_success_empty/numeric_generics_explicit/src/main.nr
+++ b/test_programs/compile_success_empty/numeric_generics_explicit/src/main.nr
@@ -39,7 +39,7 @@ struct MyStruct<let S: u32> {
 
 // Used in an impl
 impl<let S: u32> MyStruct<S> {
-    fn insert(mut self: Self, index: Field, elem: Field) -> Self {
+    pub fn insert(mut self: Self, index: Field, elem: Field) -> Self {
         // Regression test for numeric generics on impls
         assert(index as u32 < S);
 

--- a/test_programs/compile_success_empty/quoted_as_type/src/main.nr
+++ b/test_programs/compile_success_empty/quoted_as_type/src/main.nr
@@ -11,7 +11,7 @@ struct Foo<T> {}
 
 // Ensure we call the Foo<Field> impl
 impl Foo<u32> {
-    fn do_nothing(_self: Self) {
+    pub fn do_nothing(_self: Self) {
         assert(false);
     }
 }

--- a/test_programs/compile_success_empty/type_path/src/main.nr
+++ b/test_programs/compile_success_empty/type_path/src/main.nr
@@ -19,7 +19,7 @@ fn main() {
 pub struct Foo {}
 
 impl Foo {
-    fn static() {}
+    pub fn static() {}
 }
 
 trait Trait {

--- a/tooling/nargo_cli/tests/snapshots/compile_failure/wildcards_in_wrong_places/execute__tests__stderr.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_failure/wildcards_in_wrong_places/execute__tests__stderr.snap
@@ -73,31 +73,31 @@ error: The placeholder `_` is not allowed in trait constraints
    │
 
 error: The placeholder `_` is not allowed in function parameter types
-   ┌─ src/main.nr:10:16
+   ┌─ src/main.nr:10:20
    │
-10 │     fn foo(_: [_; _]) -> [_; _] {
-   │                -
+10 │     pub fn foo(_: [_; _]) -> [_; _] {
+   │                    -
    │
 
 error: The placeholder `_` is not allowed in function parameter types
-   ┌─ src/main.nr:10:19
+   ┌─ src/main.nr:10:23
    │
-10 │     fn foo(_: [_; _]) -> [_; _] {
-   │                   -
-   │
-
-error: The placeholder `_` is not allowed in function return types
-   ┌─ src/main.nr:10:27
-   │
-10 │     fn foo(_: [_; _]) -> [_; _] {
-   │                           -
+10 │     pub fn foo(_: [_; _]) -> [_; _] {
+   │                       -
    │
 
 error: The placeholder `_` is not allowed in function return types
-   ┌─ src/main.nr:10:30
+   ┌─ src/main.nr:10:31
    │
-10 │     fn foo(_: [_; _]) -> [_; _] {
-   │                              -
+10 │     pub fn foo(_: [_; _]) -> [_; _] {
+   │                               -
+   │
+
+error: The placeholder `_` is not allowed in function return types
+   ┌─ src/main.nr:10:34
+   │
+10 │     pub fn foo(_: [_; _]) -> [_; _] {
+   │                                  -
    │
 
 error: The placeholder `_` is not allowed in function parameter types

--- a/tooling/nargo_cli/tests/snapshots/compile_success_contract/contract_with_impl/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_contract/contract_with_impl/execute__tests__expanded.snap
@@ -8,7 +8,7 @@ contract Foo {
     }
 
     impl T {
-        fn t(self) {
+        pub fn t(self) {
             let _: Self = self;
         }
     }

--- a/tooling/nargo_cli/tests/snapshots/compile_success_empty/generic_trait_bounds/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_empty/generic_trait_bounds/execute__tests__expanded.snap
@@ -16,7 +16,7 @@ where
 pub struct Foo {}
 
 impl Foo {
-    fn foo<T>(x: T)
+    pub fn foo<T>(x: T)
     where
         T: Trait,
     {
@@ -46,7 +46,7 @@ trait Trait2 {
 pub struct Bar<T> {}
 
 impl<T> Bar<T> {
-    fn bar(x: T)
+    pub fn bar(x: T)
     where
         T: Trait,
     {

--- a/tooling/nargo_cli/tests/snapshots/compile_success_empty/method_call_regression/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_empty/method_call_regression/execute__tests__expanded.snap
@@ -13,13 +13,13 @@ struct Struct<A, B> {
 }
 
 impl Struct<u8, u8> {
-    fn foo(self) {
+    pub fn foo(self) {
         let _: Self = self;
     }
 }
 
 impl Struct<u32, ()> {
-    fn foo(self) {
+    pub fn foo(self) {
         let _: Self = self;
     }
 }

--- a/tooling/nargo_cli/tests/snapshots/compile_success_empty/no_duplicate_methods/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_empty/no_duplicate_methods/execute__tests__expanded.snap
@@ -15,7 +15,7 @@ pub struct Foo {
 }
 
 impl Foo {
-    fn to_field(self) -> Field {
+    pub fn to_field(self) -> Field {
         self.x
     }
 }

--- a/tooling/nargo_cli/tests/snapshots/compile_success_empty/numeric_generics/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_empty/numeric_generics/execute__tests__expanded.snap
@@ -24,7 +24,7 @@ struct MyStruct<let S: u32> {
 }
 
 impl<let S: u32> MyStruct<S> {
-    fn insert(mut self, index: Field, elem: Field) -> Self {
+    pub fn insert(mut self, index: Field, elem: Field) -> Self {
         assert((index as u64) < (S as u64));
         self.data[index as u32] = elem;
         self

--- a/tooling/nargo_cli/tests/snapshots/compile_success_empty/numeric_generics_explicit/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_empty/numeric_generics_explicit/execute__tests__expanded.snap
@@ -33,7 +33,7 @@ struct MyStruct<let S: u32> {
 }
 
 impl<let S: u32> MyStruct<S> {
-    fn insert(mut self, index: Field, elem: Field) -> Self {
+    pub fn insert(mut self, index: Field, elem: Field) -> Self {
         assert((index as u32) < S);
         self.data[index as u32] = elem;
         self

--- a/tooling/nargo_cli/tests/snapshots/compile_success_empty/quoted_as_type/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_empty/quoted_as_type/execute__tests__expanded.snap
@@ -28,7 +28,7 @@ impl Foo<Field> {
 }
 
 impl Foo<u32> {
-    fn do_nothing(_self: Self) {
+    pub fn do_nothing(_self: Self) {
         assert(false);
     }
 }

--- a/tooling/nargo_cli/tests/snapshots/compile_success_empty/type_path/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_empty/type_path/execute__tests__expanded.snap
@@ -12,7 +12,7 @@ fn main() {
 pub struct Foo {}
 
 impl Foo {
-    fn static() {}
+    pub fn static() {}
 }
 
 trait Trait {


### PR DESCRIPTION
## Problem Resolved

Resolves #12417

## Summary of Changes

`EmbeddedScalarCurve` had an unused, documented `pub(crate) fn from_bytes`. Since it was documented I made it public, but let me know if we should maybe remove it... after all it was inaccessible before, so...

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
