### PR TITLE
fix(security): Panic on invalid field-to-byte conversion in blackbox utilities

### DIFF
--- a/acvm-repo/acvm/src/pwg/blackbox/utils.rs
+++ b/acvm-repo/acvm/src/pwg/blackbox/utils.rs
@@ -9,11 +9,9 @@ pub(crate) fn to_u8_array<const N: usize, F: AcirField>(
 ) -> Result<[u8; N], OpcodeResolutionError<F>> {
     let mut result = [0; N];
     for (it, input) in result.iter_mut().zip_eq(inputs) {
-        let byte: u8 = input_to_value(initial_witness, *input)?
-            .try_into_u128()
-            .expect("expected input to fit into a u128")
-            .try_into()
-            .expect("expected input to fit into a u8");
+        let value = input_to_value(initial_witness, *input)?;
+        input_to_value(initial_witness, FunctionInput { num_bits: 8, ..*input })?;
+        let byte = value.try_into_u128().unwrap_or_default() as u8;
         *it = byte;
     }
     Ok(result)
@@ -25,11 +23,9 @@ pub(crate) fn to_u8_vec<F: AcirField>(
 ) -> Result<Vec<u8>, OpcodeResolutionError<F>> {
     let mut result = Vec::with_capacity(inputs.len());
     for input in inputs {
-        let byte: u8 = input_to_value(initial_witness, *input)?
-            .try_into_u128()
-            .expect("expected input to fit into a u8")
-            .try_into()
-            .expect("expected input to fit into a u8");
+        let value = input_to_value(initial_witness, *input)?;
+        input_to_value(initial_witness, FunctionInput { num_bits: 8, ..*input })?;
+        let byte = value.try_into_u128().unwrap_or_default() as u8;
         result.push(byte);
     }
     Ok(result)


### PR DESCRIPTION
## Summary

Security: Panic on invalid field-to-byte conversion in blackbox utilities

## Problem

**Severity**: `Medium` | **File**: `acvm-repo/acvm/src/pwg/blackbox/utils.rs:L12`

The conversion helpers use `.expect(...)` when narrowing witness values to `u8`. If a circuit or witness provides out-of-range values, the process panics instead of returning a recoverable error. In services that evaluate untrusted circuits/witnesses, this can be used for denial-of-service.

## Solution

Replace `.expect(...)` with fallible error handling (`map_err`/`?`) and propagate an `OpcodeResolutionError` for invalid byte ranges. Apply the same fix in both `to_u8_array` and `to_u8_vec`.

## Changes

- `acvm-repo/acvm/src/pwg/blackbox/utils.rs` (modified)