### PR TITLE
fix: don't drop inline trait constraints when generated via metaprogramming

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/comptime.rs
+++ b/compiler/noirc_frontend/src/elaborator/comptime.rs
@@ -585,14 +585,14 @@ impl<'context> Elaborator<'context> {
         let local_module = self.local_module();
 
         match item.kind {
-            ItemKind::Function(function) => {
+            ItemKind::Function(mut function) => {
                 let module_id = self.module_id();
 
                 if let Some(id) = dc_mod::collect_function(
                     self.interner,
                     self.def_maps.get_mut(&self.crate_id).unwrap(),
                     self.usage_tracker,
-                    &function,
+                    &mut function,
                     module_id,
                     item.doc_comments,
                     &mut self.errors,

--- a/compiler/noirc_frontend/src/hir/def_collector/dc_mod.rs
+++ b/compiler/noirc_frontend/src/hir/def_collector/dc_mod.rs
@@ -191,12 +191,7 @@ impl ModCollector<'_> {
         let mut errors = CompilationErrors::default();
         let module_id = ModuleId { krate, local_id: self.module_id };
 
-        for mut r#impl in impls {
-            desugar_generic_trait_bounds_and_reorder_where_clause(
-                &mut r#impl.generics,
-                &mut r#impl.where_clause,
-            );
-
+        for r#impl in impls {
             collect_impl(
                 &mut context.def_interner,
                 &mut self.def_collector.items,
@@ -219,11 +214,6 @@ impl ModCollector<'_> {
         let mut errors = CompilationErrors::default();
 
         for mut trait_impl in impls {
-            desugar_generic_trait_bounds_and_reorder_where_clause(
-                &mut trait_impl.impl_generics,
-                &mut trait_impl.where_clause,
-            );
-
             let (mut unresolved_functions, associated_types, associated_constants) =
                 collect_trait_impl_items(
                     &mut context.def_interner,
@@ -296,12 +286,12 @@ impl ModCollector<'_> {
 
         let module = ModuleId { krate, local_id: self.module_id };
 
-        for function in functions {
+        for mut function in functions {
             let Some(func_id) = collect_function(
                 &mut context.def_interner,
                 &mut self.def_collector.def_map,
                 &mut context.usage_tracker,
-                &function.item,
+                &mut function.item,
                 module,
                 function.doc_comments,
                 &mut errors,
@@ -315,13 +305,7 @@ impl ModCollector<'_> {
             // and replace it
             // With this method we iterate each function in the Crate and not each module
             // This may not be great because we have to pull the module_data for each function
-            let mut noir_function = function.item;
-            desugar_generic_trait_bounds_and_reorder_where_clause(
-                &mut noir_function.def.generics,
-                &mut noir_function.def.where_clause,
-            );
-
-            unresolved_functions.push_fn(self.module_id, func_id, noir_function);
+            unresolved_functions.push_fn(self.module_id, func_id, function.item);
         }
 
         self.def_collector.items.functions.push(unresolved_functions);
@@ -1108,11 +1092,16 @@ pub fn collect_function(
     interner: &mut NodeInterner,
     def_map: &mut CrateDefMap,
     usage_tracker: &mut UsageTracker,
-    function: &NoirFunction,
+    function: &mut NoirFunction,
     module: ModuleId,
     doc_comments: Vec<DocComment>,
     errors: &mut CompilationErrors,
 ) -> Option<crate::node_interner::FuncId> {
+    desugar_generic_trait_bounds_and_reorder_where_clause(
+        &mut function.def.generics,
+        &mut function.def.where_clause,
+    );
+
     if let Some(field) = function.attributes().get_field_attribute()
         && !is_native_field(&field)
     {
@@ -1419,11 +1408,16 @@ pub fn collect_enum(
 pub fn collect_impl(
     interner: &mut NodeInterner,
     items: &mut CollectedItems,
-    r#impl: TypeImpl,
+    mut r#impl: TypeImpl,
     file_id: FileId,
     module_id: ModuleId,
     errors: &mut CompilationErrors,
 ) {
+    desugar_generic_trait_bounds_and_reorder_where_clause(
+        &mut r#impl.generics,
+        &mut r#impl.where_clause,
+    );
+
     let mut unresolved_functions =
         UnresolvedFunctions { file_id, functions: Vec::new(), trait_id: None, self_type: None };
 
@@ -1557,6 +1551,11 @@ pub(crate) fn collect_trait_impl_items(
     local_id: LocalModuleId,
     errors: &mut CompilationErrors,
 ) -> (UnresolvedFunctions, AssociatedTypes, AssociatedConstants) {
+    desugar_generic_trait_bounds_and_reorder_where_clause(
+        &mut trait_impl.impl_generics,
+        &mut trait_impl.where_clause,
+    );
+
     let mut unresolved_functions =
         UnresolvedFunctions { file_id, functions: Vec::new(), trait_id: None, self_type: None };
 

--- a/compiler/noirc_frontend/src/tests/metaprogramming.rs
+++ b/compiler/noirc_frontend/src/tests/metaprogramming.rs
@@ -1623,3 +1623,100 @@ fn runtime_variable_in_macro_gives_specific_error() {
     "#;
     check_errors(src);
 }
+
+#[test]
+fn function_generated_with_constraint_does_not_drop_constraint() {
+    let src = r#"
+    pub trait Constraint {}
+    pub trait Target {
+        fn run(self);
+    }
+    pub struct Wrapper<T> {
+        inner: T,
+    }
+    impl Constraint for i32 {}
+
+    pub struct Marker {}
+
+    #[generate_function]
+    comptime fn generate_function(_: FunctionDefinition) -> Quoted {
+        quote {
+            fn run<T: Constraint>(_: T) {}
+        }
+    }
+
+    fn main() {
+        run(true);
+        ^^^ No matching impl found for `bool: Constraint`
+        ~~~ No impl for `bool: Constraint`
+    }
+    "#;
+    check_errors(src);
+}
+
+#[test]
+fn impl_generated_with_constraint_does_not_drop_constraint() {
+    let src = r#"
+    pub trait Constraint {}
+    pub trait Target {
+        fn run(self);
+    }
+    pub struct Wrapper<T> {
+        inner: T,
+    }
+    impl Constraint for i32 {}
+
+    #[generate_impl]
+    pub struct Marker {}
+
+    comptime fn generate_impl(_s: TypeDefinition) -> Quoted {
+        quote {
+            impl<T: Constraint> Wrapper<T> {
+                fn run(_self: Self) { 
+                }
+            }
+        }
+    }
+
+    fn main() {
+        let w = Wrapper { inner: false };
+        w.run();
+        ^^^^^ No matching impl found for `bool: Constraint`
+        ~~~~~ No impl for `bool: Constraint`
+    }
+    "#;
+    check_errors(src);
+}
+
+#[test]
+fn trait_impl_generated_with_constraint_does_not_drop_constraint() {
+    let src = r#"
+    pub trait Constraint {}
+    pub trait Target {
+        fn run(self);
+    }
+    pub struct Wrapper<T> {
+        inner: T,
+    }
+    impl Constraint for i32 {}
+
+    #[generate_impl]
+    pub struct Marker {}
+
+    comptime fn generate_impl(_s: TypeDefinition) -> Quoted {
+        quote {
+            impl<T: Constraint> Target for Wrapper<T> {
+                fn run(_self: Self) { }
+            }
+        }
+    }
+
+    fn main() {
+        let w = Wrapper { inner: false };
+        w.run();
+        ^^^^^ No matching impl found for `bool: Constraint`
+        ~~~~~ No impl for `bool: Constraint`
+    }
+    "#;
+    check_errors(src);
+}


### PR DESCRIPTION

## Problem Resolved

Resolves https://github.com/AztecProtocol/noir-claude/issues/906

## Summary of Changes

Simply moves the desugaring into `collect_` functions, which are the ones called for regularly defined items and ones created via metaprogramming.

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
