### PR TITLE
chore(docs): Remove stale experimental warnings

### DIFF
--- a/docs/docs/noir/concepts/data_bus.mdx
+++ b/docs/docs/noir/concepts/data_bus.mdx
@@ -3,9 +3,6 @@ title: Data Bus
 description: Use call_data and return_data to enable a backend optimization for more efficient recursion, with examples and constraints.
 sidebar_position: 13
 ---
-import Experimental from '@site/src/components/Notes/_experimental.mdx';
-
-<Experimental />
 
 The data bus is an optimization that the backend can use to make recursion more efficient.
 In order to use it, you must define some inputs of the program entry points (usually the `main()`

--- a/docs/docs/noir/concepts/data_types/coercions.md
+++ b/docs/docs/noir/concepts/data_types/coercions.md
@@ -83,7 +83,6 @@ Note that:
 - Conversions are only from the actual type to the expected type, never the other way around.
 - Conversions are only performed on the outermost type, they're never performed within a nested type.
 - `CtString` is a compile-time only type, so this conversion is only valid in [comptime code](../../concepts/comptime.md).
-- `&T` requires the experimental `-Zownership` flag to be enabled.
 
 Examples:
 ```rust

--- a/docs/docs/noir/concepts/data_types/vectors.mdx
+++ b/docs/docs/noir/concepts/data_types/vectors.mdx
@@ -5,10 +5,6 @@ keywords: [noir, vector type, methods, examples, subarrays]
 sidebar_position: 5
 ---
 
-import Experimental from '@site/src/components/Notes/_experimental.mdx';
-
-<Experimental />
-
 A vector is a dynamically-sized view into a sequence of elements. They can be resized at runtime, but because they don't own the data, they cannot be returned from a circuit. You can treat vectors as arrays without a constrained size.
 
 ```rust

--- a/docs/docs/noir/concepts/oracles.mdx
+++ b/docs/docs/noir/concepts/oracles.mdx
@@ -11,10 +11,6 @@ keywords:
 sidebar_position: 6
 ---
 
-import Experimental from '@site/src/components/Notes/_experimental.mdx';
-
-<Experimental />
-
 Noir has support for Oracles via RPC calls. This means Noir will make an RPC call and use the return value for proof generation.
 
 Since Oracles are not resolved by Noir, they are [`unconstrained` functions](./unconstrained.md)


### PR DESCRIPTION
## Problem Resolved

Some of our previously experimental features were documented with warnings that weren't removed when maturing, confuse users of their readiness and maturity. 

## Summary of Changes

Remove stale experimental warnings in the docs of:
- Data bus
- Coercions (`&T` specifically)
- Oracles
- Vectors

## User Documentation

Check one:
- [ ] No user documentation needed.
- [x] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
