### PR TITLE
chore(github): Deprecate Dev Rel auto-tags on documentation PRs

### DIFF
--- a/.github/workflows/docs-pr.yml
+++ b/.github/workflows/docs-pr.yml
@@ -143,16 +143,3 @@ jobs:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
         timeout-minutes: 1
-
-  add_comment:
-    needs: [deploy_preview]
-    runs-on: ubuntu-22.04
-    permissions:
-      pull-requests: write
-    steps:
-      - name: Tag dev rel in comment
-        uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # v3
-        with:
-          message: |
-            FYI @noir-lang/developerrelations on Noir doc changes.
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Context

In https://github.com/noir-lang/noir/pull/4375, we added auto-tagging of Dev Rel on all PRs involving documentation changes.

## Summary of Changes

@critesjosh have you found value in them?
Happy to keep things as is if yes. If not, we can merge this PR and remove the automation.

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [ ] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
