### PR TITLE
docs: add related links to key docs pages

### DIFF
--- a/docs/docs/getting_started/quick_start.md
+++ b/docs/docs/getting_started/quick_start.md
@@ -84,3 +84,10 @@ Proving backends provide you multiple tools. The most common backend for Noir is
 Read [Barretenberg's Getting Started guide](https://barretenberg.aztec.network/docs/getting_started) to install and start using Noir with Barretenberg.
 
 Visit [Awesome Noir](https://github.com/noir-lang/awesome-noir/?tab=readme-ov-file#proving-backends) for a comprehensive list of proving backends that work with Noir.
+
+## Related
+
+- [Project Breakdown](./project_breakdown.md) explains the files created by `nargo new`.
+- [Standalone Noir Installation](./noir_installation.md) covers installation variants and version selection.
+- [Data Types](../noir/concepts/data_types/index.md) explains private and public values in more detail.
+- [Tests](../tooling/tests.md) covers the next everyday workflow after a first execution.

--- a/docs/docs/noir/concepts/data_types/index.md
+++ b/docs/docs/noir/concepts/data_types/index.md
@@ -147,3 +147,10 @@ Noir can usually infer the type of the variable from the context, so specifying 
 ```rust
 let a: [_; 4] = foo(b);
 ```
+
+## Related
+
+- [Fields](./fields.md), [Integers](./integers.md), and [Booleans](./booleans.md) cover primitive types.
+- [Arrays](./arrays.md), [Vectors](./vectors.mdx), [Tuples](./tuples.md), and [Structs](./structs.md) cover compound types.
+- [Type Casting and Coercions](./coercions.md) explains explicit casts and implicit coercions.
+- [Generics](../generics.md) expands on type parameters and numeric generics.

--- a/docs/docs/tooling/debugger.mdx
+++ b/docs/docs/tooling/debugger.mdx
@@ -22,3 +22,9 @@ In order to use either version of the debugger, you will need to install recent 
 We cover the VS Code Noir debugger more in depth in [its VS Code debugger how-to guide](../how_to/debugger/debugging_with_vs_code.mdx) and [the reference](../reference/debugger/debugger_vscode.mdx).
 
 The REPL debugger is discussed at length in [the REPL debugger how-to guide](../how_to/debugger/debugging_with_the_repl.mdx) and [the reference](../reference/debugger/debugger_repl.mdx).
+
+## Related
+
+- [Tests](./tests.md) covers running tests before stepping through failures.
+- [Profiler](./profiler.md) helps inspect performance after a program behaves correctly.
+- [Language Server](./language_server.md) covers editor integration around the debugger workflow.


### PR DESCRIPTION
## Summary

Seed draft for #12433.

Adds related-link wayfinding to the Quick Start, Data Types, and Debugger overview pages. This starts the pattern requested in the issue while keeping the first diff small.

## Notes for Codex Cloud / reviewers

- Continue the same pattern on the remaining suggested pages in #12433 if the wording feels right.
- Keep related sections short and navigational.
- No versioned docs were edited.

## Verification

Not run yet; draft handoff PR.