### PR TITLE
fix(docs): use canonical paths in llms.txt links

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -237,11 +237,7 @@ export default {
         version: versions[0],
         addMdExtension: false,
         pathTransformation: {
-          ignorePaths: [
-            'versioned_docs',
-            `version-${versions[0]}`,
-            `versioned_docs/version-${versions[0]}`,
-          ],
+          ignorePaths: [`versioned_docs/version-${versions[0]}`],
           addPaths: ['docs'],
         },
       },

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -230,11 +230,20 @@ export default {
       {
         generateLLMsTxt: true,
         generateLLMsFullTxt: true,
-        docsDir: `versioned_docs/version-${versions[0]}/`,
+        docsDir: `versioned_docs/version-${versions[0]}`,
         title: 'Noir Language Documentation',
         excludeImports: true,
         ignoreFiles: [],
         version: versions[0],
+        addMdExtension: false,
+        pathTransformation: {
+          ignorePaths: [
+            'versioned_docs',
+            `version-${versions[0]}`,
+            `versioned_docs/version-${versions[0]}`,
+          ],
+          addPaths: ['docs'],
+        },
       },
     ],
   ],

--- a/docs/package.json
+++ b/docs/package.json
@@ -36,7 +36,7 @@
     "@docusaurus/tsconfig": "^3.9.2",
     "@docusaurus/types": "^3.9.2",
     "@types/prettier": "^3.0.0",
-    "docusaurus-plugin-llms": "^0.3.0",
+    "docusaurus-plugin-llms": "^0.4.0",
     "docusaurus-plugin-typedoc": "1.4.2",
     "eslint-plugin-prettier": "^5.5.5",
     "netlify-cli": "^24.0.1",

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -11433,7 +11433,7 @@ __metadata:
     "@types/prettier": "npm:^3.0.0"
     axios: "npm:^1.15.0"
     clsx: "npm:^2.1.1"
-    docusaurus-plugin-llms: "npm:^0.3.0"
+    docusaurus-plugin-llms: "npm:^0.4.0"
     docusaurus-plugin-typedoc: "npm:1.4.2"
     eslint-plugin-prettier: "npm:^5.5.5"
     hast-util-is-element: "npm:^3.0.0"
@@ -11455,16 +11455,16 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"docusaurus-plugin-llms@npm:^0.3.0":
-  version: 0.3.0
-  resolution: "docusaurus-plugin-llms@npm:0.3.0"
+"docusaurus-plugin-llms@npm:^0.4.0":
+  version: 0.4.0
+  resolution: "docusaurus-plugin-llms@npm:0.4.0"
   dependencies:
     gray-matter: "npm:^4.0.3"
     minimatch: "npm:^9.0.3"
     yaml: "npm:^2.8.1"
   peerDependencies:
     "@docusaurus/core": ^3.0.0
-  checksum: 10/f89aa2cbde080cee3c5c3873a896d92c09630a9eb06051424fd85acd18893e06ab9b4c7a67e43ea1007e33cac66adb05c81e5ed2bc328798400f5ff537d13331
+  checksum: 10/12f3b05f7d4f5cb54ab9b9713ba4b4a2618f46c4513b71a6cd0cd2e35d56c6190258f273acc6dfd4947d7fa1cde15386b2f08fb74f0cd2a4b4e1ad7080f17f6c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- Bump `docusaurus-plugin-llms` from `^0.3.0` to `^0.4.0`
- Configure `pathTransformation` so generated `llms.txt` / `llms-full.txt` URLs strip the `versioned_docs/version-*/` prefix and resolve to the canonical `/docs/...` paths actually served by the site
- Drop the trailing slash on `docsDir` and set `addMdExtension: false` to match the new plugin's path expectations

## Test plan
- [ ] Build the docs site locally (`cd docs && yarn build`) and confirm `llms.txt` / `llms-full.txt` contain canonical `/docs/...` links rather than `versioned_docs/version-*` paths
- [ ] Spot-check a handful of links from the generated `llms.txt` resolve to live pages on the deployed site

closes: #12440

🤖 Generated with [Claude Code](https://claude.com/claude-code)