### PR TITLE
fix: don't compute similarly named types in LSP single-file mode

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/types/similarly_named_types.rs
+++ b/compiler/noirc_frontend/src/elaborator/types/similarly_named_types.rs
@@ -1,6 +1,10 @@
 use noirc_errors::Location;
 
-use crate::{DataType, Type, elaborator::Elaborator, hir::def_map::fully_qualified_module_path};
+use crate::{
+    DataType, Type,
+    elaborator::Elaborator,
+    hir::{LspMode, def_map::fully_qualified_module_path},
+};
 
 /// A type that is similarly named to another type, but is actually a different type.
 /// The other type is given in the other element of the tuple returned by [`Elaborator::compute_similarly_named_types`].
@@ -25,6 +29,12 @@ impl Elaborator<'_> {
         actual: &Type,
         expected: &Type,
     ) -> Vec<(SimilarlyNamedType, SimilarlyNamedType)> {
+        // Because in single-file mode errors are not shown to the user, computing this extra information is not needed,
+        // and it avoids running into this error in LSP: https://github.com/noir-lang/noir/issues/12463
+        if matches!(self.interner.lsp_mode, Some(LspMode::SingleFile)) {
+            return vec![];
+        }
+
         let mut similar_types = Vec::new();
         self.compute_similarly_named_types_helper(actual, expected, &mut similar_types);
         similar_types

--- a/compiler/noirc_frontend/src/hir/mod.rs
+++ b/compiler/noirc_frontend/src/hir/mod.rs
@@ -79,6 +79,14 @@ pub enum FunctionNameMatch {
     Contains(Vec<String>),
 }
 
+#[derive(Debug)]
+pub enum LspMode {
+    // In full mode all files are type-checked, and errors are published and shown to the user.
+    Full,
+    // In single file mode only a single file is type-checked and errors are not shown to the user.
+    SingleFile,
+}
+
 impl Context<'_, '_> {
     pub fn new(file_manager: FileManager, parsed_files: ParsedFiles) -> Context<'static, 'static> {
         Context {
@@ -317,8 +325,8 @@ impl Context<'_, '_> {
     }
 
     /// Activates LSP mode, which will track references for all definitions.
-    pub fn activate_lsp_mode(&mut self) {
-        self.def_interner.lsp_mode = true;
+    pub fn activate_lsp_mode(&mut self, mode: LspMode) {
+        self.def_interner.lsp_mode = Some(mode);
     }
 
     pub fn disable_comptime_printing(&mut self) {

--- a/compiler/noirc_frontend/src/locations.rs
+++ b/compiler/noirc_frontend/src/locations.rs
@@ -223,7 +223,7 @@ impl NodeInterner {
         location: Location,
         is_self_type: bool,
     ) {
-        if !self.lsp_mode {
+        if self.lsp_mode.is_none() {
             return;
         }
 
@@ -242,7 +242,7 @@ impl NodeInterner {
         referenced: ReferenceId,
         referenced_location: Location,
     ) {
-        if !self.lsp_mode {
+        if self.lsp_mode.is_none() {
             return;
         }
 
@@ -423,7 +423,7 @@ impl NodeInterner {
         visibility: ItemVisibility,
         defining_module: Option<ModuleId>,
     ) {
-        if !self.lsp_mode {
+        if self.lsp_mode.is_none() {
             return;
         }
 

--- a/compiler/noirc_frontend/src/node_interner/mod.rs
+++ b/compiler/noirc_frontend/src/node_interner/mod.rs
@@ -18,6 +18,7 @@ use crate::ast::{
     UnresolvedTypeExpression,
 };
 use crate::graph::CrateId;
+use crate::hir::LspMode;
 use crate::hir::comptime;
 use crate::hir::def_collector::dc_crate::{CompilationError, UnresolvedTrait, UnresolvedTypeAlias};
 use crate::hir::def_collector::errors::DefCollectorErrorKind;
@@ -249,7 +250,7 @@ pub struct NodeInterner {
     interned_patterns: Arena<Pattern>,
 
     /// Determines whether to run in LSP mode. In LSP mode references are tracked.
-    pub(crate) lsp_mode: bool,
+    pub(crate) lsp_mode: Option<LspMode>,
 
     /// Store the location of the references in the graph.
     /// Edges are directed from reference nodes to referenced nodes.
@@ -518,7 +519,7 @@ impl Default for NodeInterner {
             interned_statement_kinds: Default::default(),
             interned_unresolved_type_data: Default::default(),
             interned_patterns: Default::default(),
-            lsp_mode: false,
+            lsp_mode: None,
             location_indices: LocationIndices::default(),
             reference_graph: DiGraph::new(),
             reference_graph_indices: HashMap::default(),
@@ -1424,7 +1425,7 @@ impl NodeInterner {
     }
 
     pub fn is_in_lsp_mode(&self) -> bool {
-        self.lsp_mode
+        self.lsp_mode.is_some()
     }
 
     /// Sets the ordered generics and associated types for the given trait impl.

--- a/tooling/lsp/src/lib.rs
+++ b/tooling/lsp/src/lib.rs
@@ -36,7 +36,7 @@ use noirc_frontend::{
     ParsedModule,
     graph::{CrateGraph, CrateId, CrateName},
     hir::{
-        Context, FunctionNameMatch, ParsedFiles,
+        Context, FunctionNameMatch, LspMode, ParsedFiles,
         def_map::{CrateDefMap, parse_file},
     },
     node_interner::NodeInterner,
@@ -358,7 +358,7 @@ pub(crate) fn prepare_package<'file_manager, 'parsed_files>(
     package: &Package,
 ) -> (Context<'file_manager, 'parsed_files>, CrateId) {
     let (mut context, crate_id) = nargo::prepare_package(file_manager, parsed_files, package);
-    context.activate_lsp_mode();
+    context.activate_lsp_mode(LspMode::Full);
     (context, crate_id)
 }
 

--- a/tooling/lsp/src/notifications/mod.rs
+++ b/tooling/lsp/src/notifications/mod.rs
@@ -23,9 +23,9 @@ use noirc_driver::{CrateName, NOIR_ARTIFACT_VERSION_STRING};
 use noirc_errors::reporter::CustomLabel;
 use noirc_errors::{CustomDiagnostic, DiagnosticKind, Location};
 use noirc_frontend::elaborator::{FrontendOptions, UnstableFeature};
-use noirc_frontend::hir::Context;
 use noirc_frontend::hir::def_collector::dc_crate::{CompilationErrors, DefCollector};
 use noirc_frontend::hir::def_map::{CrateDefMap, LocalModuleId};
+use noirc_frontend::hir::{Context, LspMode};
 use noirc_frontend::parse_program;
 
 use crate::types::{
@@ -438,6 +438,7 @@ pub(crate) fn process_workspace_for_single_file_change(
     let def_collector = DefCollector::new(crate_def_map);
     let mut context =
         Context::from_existing(&file_manager, &parsed_files, node_interner, def_maps, crate_graph);
+    context.activate_lsp_mode(LspMode::SingleFile);
 
     // Here we enable all options because we won't show errors to users, so it's easier to
     // assume all unstable features are enabled.


### PR DESCRIPTION
## Problem Resolved

Resolves https://github.com/noir-lang/noir/issues/12463

## Summary of Changes

I decided to fix this because I think the chances of LSP crashing because of this are high (some days ago I opened Aztec-Packages after a while of not opening it, tried doing some changes and quickly bumped into this).

The fix here might not be ideal... but I can't think of any other way to fix this right now...

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
