### PR TITLE
fix: follow bindings when working with comptime types

### DIFF
--- a/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
@@ -1107,7 +1107,7 @@ where
     F: FnOnce(Type) -> IResult<Option<Value>>,
 {
     let value = check_one_argument(arguments, location)?;
-    let typ = get_type(value)?.follow_bindings();
+    let typ = get_type(value)?;
 
     let option_value = f(typ)?;
 

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin/builtin_helpers.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin/builtin_helpers.rs
@@ -322,7 +322,7 @@ pub(crate) fn get_trait_impl((value, location): (Value, Location)) -> IResult<Tr
 
 pub(crate) fn get_type((value, location): (Value, Location)) -> IResult<Type> {
     match value {
-        Value::Type(typ) => Ok(typ),
+        Value::Type(typ) => Ok(typ.follow_bindings()),
         value => type_mismatch(value, Type::Quoted(QuotedType::Type), location),
     }
 }

--- a/test_programs/compile_success_empty/comptime_type/src/main.nr
+++ b/test_programs/compile_success_empty/comptime_type/src/main.nr
@@ -28,6 +28,10 @@ where
 {}
 // docs:end:serialize-setup
 
+type FieldAlias = Field;
+type BoolAlias = bool;
+type UnitAlias = ();
+
 fn main() {
     comptime {
         // Check type_of works correctly (relies on Eq for Type)
@@ -43,6 +47,8 @@ fn main() {
         // Check Type::is_field
         assert(field_type_1.is_field());
         assert(!i32_type.is_field());
+
+        assert(quote { FieldAlias }.as_type().is_field());
 
         // Check Type::as_integer
         assert(field_type_1.as_integer().is_none());
@@ -93,6 +99,8 @@ fn main() {
         let yes = true;
         let bool_type = type_of(yes);
         assert(bool_type.is_bool());
+
+        assert(quote { BoolAlias }.as_type().is_bool());
 
         // Check Type::as_data_type
         assert(u8_type.as_data_type().is_none());
@@ -150,6 +158,8 @@ fn main() {
         // Check Type::is_unit
         let unit = quote { () }.as_type();
         assert(unit.is_unit());
+
+        assert(quote { UnitAlias }.as_type().is_unit());
 
         // Check Type::as_mutable_reference
         let typ = quote { &mut Field }.as_type();

--- a/tooling/nargo_cli/tests/snapshots/compile_success_empty/comptime_type/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_empty/comptime_type/execute__tests__expanded.snap
@@ -31,6 +31,12 @@ where
     U: Serialize<M>,
 {}
 
+type FieldAlias = Field;
+
+type BoolAlias = bool;
+
+type UnitAlias = ();
+
 fn main() {
     ()
 }


### PR DESCRIPTION
## Problem Resolved

Resolves https://github.com/AztecProtocol/noir-claude/issues/850

## Summary of Changes



## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
