### PR TITLE
feat(cli): `nargo test --force-comptime`

### DIFF
--- a/compiler/noirc_frontend/src/hir/comptime/errors.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/errors.rs
@@ -595,7 +595,7 @@ impl<'a> From<&'a InterpreterError> for CustomDiagnostic {
                 CustomDiagnostic::simple_error(msg, secondary, *location)
             }
             InterpreterError::IndexOutOfBounds { index, length, location } => {
-                let msg = format!("{index} is out of bounds for the array of length {length}");
+                let msg = format!("Index out of bounds: {index} is out of bounds for the array of length {length}");
                 CustomDiagnostic::simple_error(msg, String::new(), *location)
             }
             InterpreterError::ExpectedStructToHaveField { typ, field_name, location } => {

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
@@ -1881,7 +1881,8 @@ impl Context<'_, '_> {
         let crate_id = func_meta.source_crate;
         let local_id = func_meta.source_module;
         let location = func_meta.location;
-        let enabled_unstable_features = &self.required_unstable_features[&crate_id].clone();
+        let enabled_unstable_features =
+            &self.required_unstable_features.get(&crate_id).cloned().unwrap_or_default();
         let cli_options = ElaboratorOptions {
             debug_comptime_in_file: None,
 

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
@@ -662,7 +662,7 @@ fn vector_remove(
 
     if index >= values.len() {
         let message = format!(
-            "vector_remove: index {index} is out of bounds for a vector of length {}",
+            "Index out of bounds: vector_remove: index {index} is out of bounds for a vector of length {}",
             values.len()
         );
         return failing_constraint(message, location, call_stack);
@@ -725,7 +725,7 @@ fn vector_insert(
     // If index is equal to the length, the insert is equivalent to a push
     if index > values.len() {
         let message = format!(
-            "vector_insert: index {index} is out of bounds for a vector of length {}",
+            "Index out of bounds: vector_insert: index {index} is out of bounds for a vector of length {}",
             values.len()
         );
         return failing_constraint(message, location, call_stack);

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
@@ -657,7 +657,11 @@ fn vector_remove(
     let index = get_u32(index)? as usize;
 
     if values.is_empty() {
-        return failing_constraint("vector_remove called on empty vector", location, call_stack);
+        return failing_constraint(
+            "Index out of bounds: vector_remove called on empty vector",
+            location,
+            call_stack,
+        );
     }
 
     if index >= values.len() {
@@ -692,7 +696,11 @@ fn vector_pop_front(
         Some(element) => {
             Ok(Value::Tuple(vec![Shared::new(element), Shared::new(Value::Vector(values, typ))]))
         }
-        None => failing_constraint("vector_pop_front called on empty vector", location, call_stack),
+        None => failing_constraint(
+            "Index out of bounds: vector_pop_front called on empty vector",
+            location,
+            call_stack,
+        ),
     }
 }
 
@@ -708,7 +716,11 @@ fn vector_pop_back(
         Some(element) => {
             Ok(Value::Tuple(vec![Shared::new(Value::Vector(values, typ)), Shared::new(element)]))
         }
-        None => failing_constraint("vector_pop_back called on empty vector", location, call_stack),
+        None => failing_constraint(
+            "Index out of bounds: vector_pop_back called on empty vector",
+            location,
+            call_stack,
+        ),
     }
 }
 

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
@@ -953,9 +953,6 @@ fn to_le_radix(
 
 fn compute_to_radix_le(field: FieldElement, radix: u32) -> Vec<u8> {
     assert_ne!(radix, 0, "ICE: Radix must be greater than 0");
-    let bit_size = u32::BITS - (radix - 1).leading_zeros();
-    let radix_big = BigUint::from(radix);
-    assert_eq!(BigUint::from(2u128).pow(bit_size), radix_big, "ICE: Radix must be a power of 2");
     let big_integer = BigUint::from_bytes_be(&field.to_be_bytes());
 
     // Decompose the integer into its radix digits in little endian form.

--- a/tooling/nargo/src/ops/mod.rs
+++ b/tooling/nargo/src/ops/mod.rs
@@ -11,7 +11,8 @@ pub use self::fuzz::{
 };
 pub use self::test::{
     FuzzConfig, TestStatus, check_expected_failure_message, fuzz_test, run_or_fuzz_test, run_test,
-    test_status_program_compile_fail, test_status_program_compile_pass,
+    test_status_comptime_interpret_result, test_status_program_compile_fail,
+    test_status_program_compile_pass,
 };
 
 mod check;

--- a/tooling/nargo/src/ops/test.rs
+++ b/tooling/nargo/src/ops/test.rs
@@ -385,7 +385,11 @@ pub fn check_expected_failure_message(
     let expected_failure_message_matches = failed_assertion
         .as_ref()
         .or_else(|| error_diagnostic.as_ref().map(|file_diagnostic| &file_diagnostic.message))
-        .is_some_and(|message| message.contains(expected_failure_message));
+        .is_some_and(|message| {
+            let expected = expected_failure_message.to_lowercase();
+            message.to_lowercase().contains(&expected)
+        });
+
     if expected_failure_message_matches {
         return TestStatus::Pass;
     }

--- a/tooling/nargo/src/ops/test.rs
+++ b/tooling/nargo/src/ops/test.rs
@@ -15,6 +15,7 @@ use noirc_errors::CustomDiagnostic;
 use noirc_frontend::{
     hir::{
         Context,
+        comptime::{InterpreterError, Value},
         def_map::{FuzzingHarness, TestFunction},
     },
     token::{FuzzingScope, TestScope},
@@ -306,6 +307,7 @@ where
         }
     }
 }
+
 /// Test function failed to compile
 ///
 /// Note: This could be because the compiler was able to deduce
@@ -363,6 +365,31 @@ pub fn test_status_program_compile_pass(
         circuit_execution_err.user_defined_failure_message(&abi.error_types),
         diagnostic,
     )
+}
+
+pub fn test_status_comptime_interpret_result(
+    result: Result<Value, InterpreterError>,
+    test_function: &TestFunction,
+) -> TestStatus {
+    match result {
+        Err(InterpreterError::Unimplemented { .. }) => {
+            // Most likely called an unknown oracle function.
+            TestStatus::Skipped
+        }
+        Err(error) if !test_function.should_fail() => {
+            TestStatus::CompileError(CustomDiagnostic::from(&error))
+        }
+        Err(error) => check_expected_failure_message(
+            test_function,
+            None,
+            Some(CustomDiagnostic::from(&error)),
+        ),
+        Ok(_) if test_function.should_fail() => TestStatus::Fail {
+            message: "error: Test passed when it should have failed".to_string(),
+            error_diagnostic: None,
+        },
+        Ok(_) => TestStatus::Pass,
+    }
 }
 
 pub fn check_expected_failure_message(

--- a/tooling/nargo_cli/build.rs
+++ b/tooling/nargo_cli/build.rs
@@ -47,6 +47,9 @@ fn main() -> Result<(), String> {
     generate_comptime_interpret_execution_success_tests(&mut test_file, &test_dir);
     generate_comptime_interpret_execution_failure_tests(&mut test_file, &test_dir);
 
+    generate_comptime_interpret_noir_test_success_tests(&mut test_file, &test_dir);
+    generate_comptime_interpret_noir_test_failure_tests(&mut test_file, &test_dir);
+
     generate_brillig_small_stack_execution_success_tests(&mut test_file, &test_dir);
 
     generate_fuzzing_failure_tests(&mut test_file, &test_dir);
@@ -626,6 +629,62 @@ fn generate_comptime_interpret_execution_failure_tests(test_file: &mut File, tes
                   nargo_execute_comptime_expect_failure(test_program_dir);
               }}
               "#
+        )
+        .unwrap();
+    }
+    writeln!(test_file, "}}").unwrap();
+}
+
+fn generate_comptime_interpret_noir_test_success_tests(test_file: &mut File, test_data_dir: &Path) {
+    let test_type = "noir_test_success";
+    let test_cases = read_test_cases(test_data_dir, test_type);
+
+    writeln!(
+        test_file,
+        "mod comptime_interpret_{test_type} {{
+        use super::*;
+    "
+    )
+    .unwrap();
+    for (test_name, test_dir) in test_cases {
+        let test_dir = test_dir.display();
+        write!(
+            test_file,
+            r#"
+            #[test]
+            fn test_{test_name}() {{
+                let test_program_dir = PathBuf::from("{test_dir}");
+                nargo_test_comptime(test_program_dir);
+            }}
+            "#
+        )
+        .unwrap();
+    }
+    writeln!(test_file, "}}").unwrap();
+}
+
+fn generate_comptime_interpret_noir_test_failure_tests(test_file: &mut File, test_data_dir: &Path) {
+    let test_type = "noir_test_failure";
+    let test_cases = read_test_cases(test_data_dir, test_type);
+
+    writeln!(
+        test_file,
+        "mod comptime_interpret_{test_type} {{
+        use super::*;
+    "
+    )
+    .unwrap();
+    for (test_name, test_dir) in test_cases {
+        let test_dir = test_dir.display();
+        write!(
+            test_file,
+            r#"
+            #[test]
+            fn test_{test_name}() {{
+                let test_program_dir = PathBuf::from("{test_dir}");
+                nargo_test_comptime_expect_failure(test_program_dir);
+            }}
+            "#
         )
         .unwrap();
     }

--- a/tooling/nargo_cli/build.rs
+++ b/tooling/nargo_cli/build.rs
@@ -178,6 +178,11 @@ const IGNORED_COMPTIME_INTERPRET_EXECUTION_FAILURE_TESTS: [&str; 0] = [];
 const IGNORED_COMPTIME_INTERPRET_EXECUTION_STDOUT_CHECK_TESTS: [&str; 4] =
     ["debug_logs", "regression_10156", "regression_10158", "regression_9578"];
 
+const IGNORED_COMPTIME_INTERPRET_NOIR_TESTS: [&str; 1] = [
+    // For some reason at comptime a `comptime` function is considered a constant.
+    "comptime_globals",
+];
+
 /// `nargo execute --minimal-ssa` ignored tests
 const IGNORED_MINIMAL_EXECUTION_TESTS: [&str; 17] = [
     // internal error: entered unreachable code: unsupported function call type Intrinsic(AssertConstant)
@@ -647,6 +652,9 @@ fn generate_comptime_interpret_noir_test_success_tests(test_file: &mut File, tes
     )
     .unwrap();
     for (test_name, test_dir) in test_cases {
+        if IGNORED_COMPTIME_INTERPRET_NOIR_TESTS.contains(&test_name.as_str()) {
+            continue;
+        }
         let test_dir = test_dir.display();
         write!(
             test_file,

--- a/tooling/nargo_cli/src/cli/test_cmd.rs
+++ b/tooling/nargo_cli/src/cli/test_cmd.rs
@@ -1,9 +1,11 @@
 use std::{
+    cell::RefCell,
     cmp::max,
     collections::{BTreeMap, HashMap},
     fmt::Display,
     panic::{UnwindSafe, catch_unwind},
     path::PathBuf,
+    rc::Rc,
     sync::{
         Mutex,
         mpsc::{self, Sender},
@@ -28,7 +30,10 @@ use nargo::{
 };
 use nargo_toml::PackageSelection;
 use noirc_driver::{CompileOptions, check_crate};
-use noirc_frontend::hir::{FunctionNameMatch, ParsedFiles, def_map::TestFunction};
+use noirc_errors::CustomDiagnostic;
+use noirc_frontend::hir::{
+    FunctionNameMatch, ParsedFiles, comptime::InterpreterError, def_map::TestFunction,
+};
 
 use crate::errors::CliError;
 
@@ -112,6 +117,12 @@ pub(crate) struct TestCommand {
     /// Show progress of fuzzing (default: false)
     #[arg(long)]
     fuzz_show_progress: bool,
+
+    /// Force comptime execution
+    ///
+    /// This only works with tests that don't have arguments and don't call Oracles.
+    #[arg(long, hide = true)]
+    force_comptime: bool,
 }
 
 impl WorkspaceCommand for TestCommand {
@@ -615,7 +626,9 @@ impl<'a> TestRunner<'a> {
         root_path: Option<PathBuf>,
         package_name: String,
     ) -> (TestStatus, String) {
-        if (self.args.no_fuzz && has_arguments) || (self.args.only_fuzz && !has_arguments) {
+        if ((self.args.no_fuzz || self.args.force_comptime) && has_arguments)
+            || (self.args.only_fuzz && !has_arguments)
+        {
             return (TestStatus::Skipped, String::new());
         }
 
@@ -643,6 +656,23 @@ impl<'a> TestRunner<'a> {
                 Err(err) => nargo::ops::test_status_program_compile_fail(err, test_function),
             };
             return (status, String::new());
+        }
+
+        if self.args.force_comptime {
+            let output = Rc::new(RefCell::new(Vec::new()));
+            context.set_comptime_printing(output.clone());
+            let status = match context.interpret_function(test_function.id, Vec::new()) {
+                Err(InterpreterError::Unimplemented { .. }) => {
+                    // Most likely called an unknown oracle function.
+                    TestStatus::Skipped
+                }
+                Err(error) => TestStatus::CompileError(CustomDiagnostic::from(&error)),
+                Ok(_) => TestStatus::Pass,
+            };
+            context.interpreter_output = None;
+            let output = Rc::try_unwrap(output).expect("context no longer has it");
+            let output = String::from_utf8(output.into_inner()).expect("not UTF-8");
+            return (status, output);
         }
 
         let blackbox_solver = S::default();

--- a/tooling/nargo_cli/src/cli/test_cmd.rs
+++ b/tooling/nargo_cli/src/cli/test_cmd.rs
@@ -30,10 +30,7 @@ use nargo::{
 };
 use nargo_toml::PackageSelection;
 use noirc_driver::{CompileOptions, check_crate};
-use noirc_errors::CustomDiagnostic;
-use noirc_frontend::hir::{
-    FunctionNameMatch, ParsedFiles, comptime::InterpreterError, def_map::TestFunction,
-};
+use noirc_frontend::hir::{FunctionNameMatch, ParsedFiles, def_map::TestFunction};
 
 use crate::errors::CliError;
 
@@ -661,21 +658,8 @@ impl<'a> TestRunner<'a> {
         if self.args.force_comptime {
             let output = Rc::new(RefCell::new(Vec::new()));
             context.set_comptime_printing(output.clone());
-            let status = match context.interpret_function(test_function.id, Vec::new()) {
-                Err(InterpreterError::Unimplemented { .. }) => {
-                    // Most likely called an unknown oracle function.
-                    TestStatus::Skipped
-                }
-                Err(error) if !test_function.should_fail() => {
-                    TestStatus::CompileError(CustomDiagnostic::from(&error))
-                }
-                Err(error) => nargo::ops::check_expected_failure_message(
-                    test_function,
-                    None,
-                    Some(CustomDiagnostic::from(&error)),
-                ),
-                Ok(_) => TestStatus::Pass,
-            };
+            let result = context.interpret_function(test_function.id, Vec::new());
+            let status = nargo::ops::test_status_comptime_interpret_result(result, test_function);
             context.interpreter_output = None;
             let output = Rc::try_unwrap(output).expect("context no longer has it");
             let output = String::from_utf8(output.into_inner()).expect("not UTF-8");

--- a/tooling/nargo_cli/src/cli/test_cmd.rs
+++ b/tooling/nargo_cli/src/cli/test_cmd.rs
@@ -666,7 +666,14 @@ impl<'a> TestRunner<'a> {
                     // Most likely called an unknown oracle function.
                     TestStatus::Skipped
                 }
-                Err(error) => TestStatus::CompileError(CustomDiagnostic::from(&error)),
+                Err(error) if !test_function.should_fail() => {
+                    TestStatus::CompileError(CustomDiagnostic::from(&error))
+                }
+                Err(error) => nargo::ops::check_expected_failure_message(
+                    test_function,
+                    None,
+                    Some(CustomDiagnostic::from(&error)),
+                ),
                 Ok(_) => TestStatus::Pass,
             };
             context.interpreter_output = None;

--- a/tooling/nargo_cli/tests/execute.rs
+++ b/tooling/nargo_cli/tests/execute.rs
@@ -476,6 +476,20 @@ mod tests {
         drop(target_dir);
     }
 
+    fn nargo_test_comptime(test_program_dir: PathBuf) {
+        let (mut nargo, target_dir) = setup_nargo(&test_program_dir);
+        nargo.arg("test").arg("--force-comptime");
+        noir_test_success(nargo);
+        drop(target_dir);
+    }
+
+    fn nargo_test_comptime_expect_failure(test_program_dir: PathBuf) {
+        let (mut nargo, target_dir) = setup_nargo(&test_program_dir);
+        nargo.arg("test").arg("--force-comptime");
+        noir_test_failure(nargo);
+        drop(target_dir);
+    }
+
     fn nargo_execute_brillig_small_stack(test_program_dir: PathBuf) {
         let (mut nargo, target_dir) = setup_nargo(&test_program_dir);
         nargo.arg("execute").arg("--force").arg("--force-brillig");

--- a/tooling/nargo_cli/tests/snapshots/execution_failure/conditional_pop_back_from_empty_vector/execute__tests__comptime_stderr.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_failure/conditional_pop_back_from_empty_vector/execute__tests__comptime_stderr.snap
@@ -2,7 +2,7 @@
 source: tooling/nargo_cli/tests/execute.rs
 expression: stderr
 ---
-error: vector_pop_back called on empty vector
+error: Index out of bounds: vector_pop_back called on empty vector
    ┌─ src/main.nr:11:20
    │
 11 │     let (_, ret) = s.pop_back();

--- a/tooling/nargo_cli/tests/snapshots/execution_failure/conditional_pop_front_from_empty_vector/execute__tests__comptime_stderr.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_failure/conditional_pop_front_from_empty_vector/execute__tests__comptime_stderr.snap
@@ -2,7 +2,7 @@
 source: tooling/nargo_cli/tests/execute.rs
 expression: stderr
 ---
-error: vector_pop_front called on empty vector
+error: Index out of bounds: vector_pop_front called on empty vector
    ┌─ src/main.nr:11:20
    │
 11 │     let (ret, _) = s.pop_front();

--- a/tooling/nargo_cli/tests/snapshots/execution_failure/conditional_remove_from_empty_vector/execute__tests__comptime_stderr.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_failure/conditional_remove_from_empty_vector/execute__tests__comptime_stderr.snap
@@ -2,7 +2,7 @@
 source: tooling/nargo_cli/tests/execute.rs
 expression: stderr
 ---
-error: vector_remove called on empty vector
+error: Index out of bounds: vector_remove called on empty vector
    ┌─ src/main.nr:11:20
    │
 11 │     let (_, ret) = s.remove(0);

--- a/tooling/nargo_cli/tests/snapshots/execution_failure/dyn_index_fail_nested_array/execute__tests__comptime_stderr.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_failure/dyn_index_fail_nested_array/execute__tests__comptime_stderr.snap
@@ -2,7 +2,7 @@
 source: tooling/nargo_cli/tests/execute.rs
 expression: stderr
 ---
-error: 4 is out of bounds for the array of length 3
+error: Index out of bounds: 4 is out of bounds for the array of length 3
   ┌─ src/main.nr:7:12
   │
 7 │     assert(x[y + 2].a == 5);

--- a/tooling/nargo_cli/tests/snapshots/execution_failure/dynamic_index_failure/execute__tests__comptime_stderr.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_failure/dynamic_index_failure/execute__tests__comptime_stderr.snap
@@ -2,7 +2,7 @@
 source: tooling/nargo_cli/tests/execute.rs
 expression: stderr
 ---
-error: 14 is out of bounds for the array of length 5
+error: Index out of bounds: 14 is out of bounds for the array of length 5
   ┌─ src/main.nr:6:12
   │
 6 │     assert(x[idx] != 0);

--- a/tooling/nargo_cli/tests/snapshots/execution_failure/fold_dyn_index_fail/execute__tests__comptime_stderr.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_failure/fold_dyn_index_fail/execute__tests__comptime_stderr.snap
@@ -2,7 +2,7 @@
 source: tooling/nargo_cli/tests/execute.rs
 expression: stderr
 ---
-error: 14 is out of bounds for the array of length 5
+error: Index out of bounds: 14 is out of bounds for the array of length 5
   ┌─ src/main.nr:9:12
   │
 9 │     assert(x[idx] != 0);

--- a/tooling/nargo_cli/tests/snapshots/execution_failure/lambda_from_empty_array_dyn_index/execute__tests__comptime_stderr.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_failure/lambda_from_empty_array_dyn_index/execute__tests__comptime_stderr.snap
@@ -2,7 +2,7 @@
 source: tooling/nargo_cli/tests/execute.rs
 expression: stderr
 ---
-error: 0 is out of bounds for the array of length 0
+error: Index out of bounds: 0 is out of bounds for the array of length 0
   ┌─ src/main.nr:5:5
   │
 5 │     lambdas[x - 1](());

--- a/tooling/nargo_cli/tests/snapshots/execution_failure/regression_7759/execute__tests__comptime_stderr.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_failure/regression_7759/execute__tests__comptime_stderr.snap
@@ -2,7 +2,7 @@
 source: tooling/nargo_cli/tests/execute.rs
 expression: stderr
 ---
-error: 2147483648 is out of bounds for the array of length 2
+error: Index out of bounds: 2147483648 is out of bounds for the array of length 2
   ┌─ src/main.nr:3:5
   │
 3 │     v7[index]

--- a/tooling/nargo_cli/tests/snapshots/execution_failure/regression_9266/execute__tests__comptime_stderr.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_failure/regression_9266/execute__tests__comptime_stderr.snap
@@ -2,7 +2,7 @@
 source: tooling/nargo_cli/tests/execute.rs
 expression: stderr
 ---
-error: vector_pop_back called on empty vector
+error: Index out of bounds: vector_pop_back called on empty vector
   ┌─ src/main.nr:4:18
   │
 4 │     let (_, f) = a.pop_back();

--- a/tooling/nargo_cli/tests/snapshots/execution_failure/regression_9489/execute__tests__comptime_stderr.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_failure/regression_9489/execute__tests__comptime_stderr.snap
@@ -2,7 +2,7 @@
 source: tooling/nargo_cli/tests/execute.rs
 expression: stderr
 ---
-error: vector_pop_front called on empty vector
+error: Index out of bounds: vector_pop_front called on empty vector
   ┌─ src/main.nr:3:13
   │
 3 │     let _ = G_A.pop_front().0;

--- a/tooling/nargo_cli/tests/snapshots/execution_failure/regression_databus_out_of_bounds/execute__tests__comptime_stderr.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_failure/regression_databus_out_of_bounds/execute__tests__comptime_stderr.snap
@@ -2,7 +2,7 @@
 source: tooling/nargo_cli/tests/execute.rs
 expression: stderr
 ---
-error: 7 is out of bounds for the array of length 4
+error: Index out of bounds: 7 is out of bounds for the array of length 4
   ┌─ src/main.nr:7:5
   │
 7 │     y[i]

--- a/tooling/nargo_cli/tests/snapshots/execution_failure/unused_array_get_unknown_index_out_of_bounds/execute__tests__comptime_stderr.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_failure/unused_array_get_unknown_index_out_of_bounds/execute__tests__comptime_stderr.snap
@@ -2,7 +2,7 @@
 source: tooling/nargo_cli/tests/execute.rs
 expression: stderr
 ---
-error: 10 is out of bounds for the array of length 3
+error: Index out of bounds: 10 is out of bounds for the array of length 3
   ┌─ src/main.nr:3:13
   │
 3 │     let _ = array[x]; // Index out of bounds

--- a/tooling/nargo_cli/tests/snapshots/execution_failure/unused_array_set_unknown_index_out_of_bounds/execute__tests__comptime_stderr.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_failure/unused_array_set_unknown_index_out_of_bounds/execute__tests__comptime_stderr.snap
@@ -2,7 +2,7 @@
 source: tooling/nargo_cli/tests/execute.rs
 expression: stderr
 ---
-error: 10 is out of bounds for the array of length 3
+error: Index out of bounds: 10 is out of bounds for the array of length 3
   ┌─ src/main.nr:3:5
   │
 3 │     array[x] = 1; // Index out of bounds

--- a/tooling/nargo_cli/tests/snapshots/execution_failure/unused_vector_get_known_index_out_of_bounds/execute__tests__comptime_stderr.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_failure/unused_vector_get_known_index_out_of_bounds/execute__tests__comptime_stderr.snap
@@ -2,7 +2,7 @@
 source: tooling/nargo_cli/tests/execute.rs
 expression: stderr
 ---
-error: 10 is out of bounds for the array of length 3
+error: Index out of bounds: 10 is out of bounds for the array of length 3
   ┌─ src/main.nr:3:13
   │
 3 │     let _ = vector[10]; // Index out of bounds

--- a/tooling/nargo_cli/tests/snapshots/execution_failure/unused_vector_get_unknown_index_out_of_bounds/execute__tests__comptime_stderr.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_failure/unused_vector_get_unknown_index_out_of_bounds/execute__tests__comptime_stderr.snap
@@ -2,7 +2,7 @@
 source: tooling/nargo_cli/tests/execute.rs
 expression: stderr
 ---
-error: 10 is out of bounds for the array of length 3
+error: Index out of bounds: 10 is out of bounds for the array of length 3
   ┌─ src/main.nr:3:13
   │
 3 │     let _ = vector[x]; // Index out of bounds

--- a/tooling/nargo_cli/tests/snapshots/execution_failure/vector_access_failure/execute__tests__comptime_stderr.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_failure/vector_access_failure/execute__tests__comptime_stderr.snap
@@ -2,7 +2,7 @@
 source: tooling/nargo_cli/tests/execute.rs
 expression: stderr
 ---
-error: 3 is out of bounds for the array of length 3
+error: Index out of bounds: 3 is out of bounds for the array of length 3
    ┌─ src/main.nr:12:13
    │
 12 │     assert((vector[3] == 0) & (vector[2] != y));

--- a/tooling/nargo_cli/tests/snapshots/execution_failure/vector_insert_failure/execute__tests__comptime_stderr.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_failure/vector_insert_failure/execute__tests__comptime_stderr.snap
@@ -2,7 +2,7 @@
 source: tooling/nargo_cli/tests/execute.rs
 expression: stderr
 ---
-error: vector_insert: index 10 is out of bounds for a vector of length 3
+error: Index out of bounds: vector_insert: index 10 is out of bounds for a vector of length 3
    ┌─ src/main.nr:10:14
    │
 10 │     vector = vector.insert(10, 100);

--- a/tooling/nargo_cli/tests/snapshots/execution_failure/vector_pop_back_oob/execute__tests__comptime_stderr.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_failure/vector_pop_back_oob/execute__tests__comptime_stderr.snap
@@ -2,7 +2,7 @@
 source: tooling/nargo_cli/tests/execute.rs
 expression: stderr
 ---
-error: vector_pop_back called on empty vector
+error: Index out of bounds: vector_pop_back called on empty vector
   ┌─ src/main.nr:9:23
   │
 9 │         let (s2, x) = vector.pop_back();

--- a/tooling/nargo_cli/tests/snapshots/execution_failure/vector_pop_front_oob/execute__tests__comptime_stderr.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_failure/vector_pop_front_oob/execute__tests__comptime_stderr.snap
@@ -2,7 +2,7 @@
 source: tooling/nargo_cli/tests/execute.rs
 expression: stderr
 ---
-error: vector_pop_front called on empty vector
+error: Index out of bounds: vector_pop_front called on empty vector
   ┌─ src/main.nr:9:23
   │
 9 │         let (x, s2) = vector.pop_front();

--- a/tooling/nargo_cli/tests/snapshots/execution_failure/vector_remove_failure/execute__tests__comptime_stderr.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_failure/vector_remove_failure/execute__tests__comptime_stderr.snap
@@ -16,7 +16,7 @@ warning: unused variable removed_elem
    │                          ------------ unused variable
    │
 
-error: vector_remove: index 10 is out of bounds for a vector of length 3
+error: Index out of bounds: vector_remove: index 10 is out of bounds for a vector of length 3
    ┌─ src/main.nr:10:42
    │
 10 │     let (removed_vector, removed_elem) = vector.remove(10);

--- a/tooling/nargo_cli/tests/snapshots/execution_failure/vector_remove_oob/execute__tests__comptime_stderr.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_failure/vector_remove_oob/execute__tests__comptime_stderr.snap
@@ -2,7 +2,7 @@
 source: tooling/nargo_cli/tests/execute.rs
 expression: stderr
 ---
-error: vector_remove called on empty vector
+error: Index out of bounds: vector_remove called on empty vector
   ┌─ src/main.nr:9:23
   │
 9 │         let (s2, x) = vector.remove(0);

--- a/tooling/nargo_cli/tests/stdlib-tests.rs
+++ b/tooling/nargo_cli/tests/stdlib-tests.rs
@@ -10,7 +10,7 @@ use std::io::Write;
 use std::{collections::BTreeMap, path::PathBuf};
 
 use nargo::{
-    ops::{TestStatus, report_errors, run_test},
+    ops::{TestStatus, report_errors, run_test, test_status_comptime_interpret_result},
     package::{Package, PackageType},
     parse_all, prepare_package,
 };
@@ -39,16 +39,28 @@ impl Options {
     }
 }
 
+/// Controls which execution mode is forced during stdlib testing.
+#[derive(Clone, Copy)]
+enum Force {
+    /// Standard ACIR compilation with no overrides.
+    Nothing,
+    /// Force all functions to compile as Brillig (unconstrained).
+    Brillig,
+    /// Execute tests directly in the comptime interpreter, bypassing SSA compilation.
+    Comptime,
+}
+
 /// Inliner aggressiveness results in different SSA.
 /// Inlining happens if `inline_cost - retain_cost < aggressiveness` (see `inlining.rs`).
 /// NB the CLI uses maximum aggressiveness.
 ///
-/// Even with the same inlining aggressiveness, forcing Brillig can trigger different behavior.
+/// Even with the same inlining aggressiveness, forcing Brillig or using the comptime
+/// interpreter can trigger different behavior.
 #[test_matrix(
-    [false, true],
+    [Force::Nothing, Force::Brillig, Force::Comptime],
     [i64::MIN, 0, i64::MAX]
 )]
-fn run_stdlib_tests(force_brillig: bool, inliner_aggressiveness: i64) {
+fn run_stdlib_tests(force: Force, inliner_aggressiveness: i64) {
     let opts = Options::parse();
 
     let mut file_manager = file_manager_with_stdlib(&PathBuf::from("."));
@@ -90,26 +102,39 @@ fn run_stdlib_tests(force_brillig: bool, inliner_aggressiveness: i64) {
                 Ok(guard) => guard,
                 Err(poisoned) => poisoned.into_inner(), // Ignore, it happened during execution.
             };
-            let status = std::panic::catch_unwind(move || {
-                run_test(
-                    &bn254_blackbox_solver::Bn254BlackBoxSolver,
-                    &mut context,
-                    &test_function,
-                    std::io::stdout(),
-                    &CompileOptions { force_brillig, inliner_aggressiveness, ..Default::default() },
-                    |output, base| {
-                        DefaultForeignCallBuilder::default()
-                            .with_output(output)
-                            .build_with_base(base)
-                    },
-                )
-            });
-            let status = match status {
-                Ok(status) => status,
-                Err(_panic_cause) => TestStatus::Fail {
-                    message: "panicked; see details in the end summary".to_string(),
-                    error_diagnostic: None,
-                },
+            let status = match force {
+                Force::Nothing | Force::Brillig => {
+                    let force_brillig = matches!(force, Force::Brillig);
+                    let result = std::panic::catch_unwind(move || {
+                        run_test(
+                            &bn254_blackbox_solver::Bn254BlackBoxSolver,
+                            &mut context,
+                            &test_function,
+                            std::io::stdout(),
+                            &CompileOptions {
+                                force_brillig,
+                                inliner_aggressiveness,
+                                ..Default::default()
+                            },
+                            |output, base| {
+                                DefaultForeignCallBuilder::default()
+                                    .with_output(output)
+                                    .build_with_base(base)
+                            },
+                        )
+                    });
+                    match result {
+                        Ok(status) => status,
+                        Err(_panic_cause) => TestStatus::Fail {
+                            message: "panicked; see details in the end summary".to_string(),
+                            error_diagnostic: None,
+                        },
+                    }
+                }
+                Force::Comptime => {
+                    let result = context.interpret_function(test_function.id, Vec::new());
+                    test_status_comptime_interpret_result(result, &test_function)
+                }
             };
             (test_name, status)
         })

--- a/tooling/nargo_cli/tests/stdlib-tests.rs
+++ b/tooling/nargo_cli/tests/stdlib-tests.rs
@@ -132,8 +132,17 @@ fn run_stdlib_tests(force: Force, inliner_aggressiveness: i64) {
                     }
                 }
                 Force::Comptime => {
-                    let result = context.interpret_function(test_function.id, Vec::new());
-                    test_status_comptime_interpret_result(result, &test_function)
+                    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                        let result = context.interpret_function(test_function.id, Vec::new());
+                        test_status_comptime_interpret_result(result, &test_function)
+                    }));
+                    match result {
+                        Ok(status) => status,
+                        Err(_panic_cause) => TestStatus::Fail {
+                            message: "panicked; see details in the end summary".to_string(),
+                            error_diagnostic: None,
+                        },
+                    }
                 }
             };
             (test_name, status)


### PR DESCRIPTION
## Problem Resolved

Related to https://github.com/noir-lang/noir/issues/10531

## Summary of Changes

Adds a `--force-comptime` option to the `nargo test` command, similar to how it exists for `nargo execute`. 

This is in support of a follow up allow us to observe the locations of the expressions visited during comptime execution. By allowing the tester to run via comptime, we should be able to produce a test coverage report that closely matches the locations we can visit in the HIR when we compile the module.

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
