### PR TITLE
fix: use `changed |= ...` in compute_dominator_tree

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/ir/dom.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/dom.rs
@@ -221,7 +221,7 @@ impl DominatorTree {
             changed = false;
             for &block_id in entry_free_post_order.iter().rev() {
                 let immediate_dominator = self.compute_immediate_dominator(block_id, cfg);
-                changed = self
+                changed |= self
                     .nodes
                     .get_mut(&block_id)
                     .expect("Assigned in first pass")


### PR DESCRIPTION
## Problem Resolved

Resolves https://github.com/AztecProtocol/noir-claude/issues/801

## Summary of Changes



## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
