### PR TITLE
fix: don't crash on duplicate trait impl

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/impls.rs
+++ b/compiler/noirc_frontend/src/elaborator/impls.rs
@@ -180,11 +180,9 @@ impl Elaborator<'_> {
                 };
 
                 // Handle method shadowing when a duplicate method name is found
-                if result.is_err() {
-                    let existing = module.find_func_with_name(method.name_ident()).expect(
-                        "declare_function should only error if there is an existing function",
-                    );
-
+                if result.is_err()
+                    && let Some(existing) = module.find_func_with_name(method.name_ident())
+                {
                     // Inherent impls take precedence over trait impls for qualified calls.
                     // If the existing method is from a trait impl, remove it from module scope
                     // so that `TypeName::method` resolves to the inherent impl version.

--- a/compiler/noirc_frontend/src/tests/traits/trait_impl_validation.rs
+++ b/compiler/noirc_frontend/src/tests/traits/trait_impl_validation.rs
@@ -503,3 +503,31 @@ fn overlapping_generic_impls() {
     "#;
     check_errors(src);
 }
+
+#[test]
+fn does_not_crash_when_trait_impl_is_defined_multiple_times() {
+    let src = r#"
+    pub struct Wrap { }
+
+    trait Marker1 { 
+        fn mark(); 
+    } 
+    trait Marker2 { 
+        fn mark(); 
+    }
+
+    impl Marker1 for Wrap { 
+        fn mark() { } 
+    } 
+    impl Marker2 for Wrap { 
+         ~~~~~~~ Previous impl defined here
+        fn mark() {} 
+    } 
+    impl Marker2 for Wrap { 
+                     ^^^^ Impl for type `Wrap` overlaps with existing impl
+                     ~~~~ Overlapping impl
+        fn mark() {} 
+    }
+    "#;
+    check_errors(src);
+}


### PR DESCRIPTION
## Problem Resolved

Resolves https://app.audithub.dev/app/organizations/161/projects/787/project-viewer?version=1681&issueId=1002

## Summary of Changes

To be honest this part of the code doesn't seem completely right (especially the `remove_function` call that comes later on) but at least like this it doesn't crash (if we can't find the function it must be that we were adding a trait function, and in that case I think there's nothing to remove).

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
