### PR TITLE
fix: handle zero-sized arrays in ACIR

### DIFF
--- a/compiler/noirc_evaluator/src/acir/arrays.rs
+++ b/compiler/noirc_evaluator/src/acir/arrays.rs
@@ -1373,7 +1373,11 @@ pub(super) fn array_has_constant_element_size(array_typ: &Type) -> Option<u32> {
     };
 
     let mut element_sizes = types.iter().map(|typ| typ.flattened_size());
-    let element_size = element_sizes.next().expect("must have at least one element");
-
-    if element_sizes.all(|size| size == element_size) { Some(element_size.0) } else { None }
+    if let Some(element_size) = element_sizes.next() {
+        if element_sizes.all(|size| size == element_size) { Some(element_size.0) } else { None }
+    } else {
+        // If the array has no types in it it can be because it's something like `[(); 3]` where `()` is represented
+        // as "no types". And in this case the array has constant element size because it's zero.
+        Some(0)
+    }
 }

--- a/compiler/noirc_evaluator/src/acir/call/intrinsics/vector_ops.rs
+++ b/compiler/noirc_evaluator/src/acir/call/intrinsics/vector_ops.rs
@@ -651,7 +651,12 @@ impl Context<'_> {
             };
 
         let value_types = flat_element_types(&vector_typ);
-        assert_eq!(vector_size.to_usize() % value_types.len(), 0);
+
+        // For types like `[(); 3]` we always end up with no elements and a zero-sized type
+        assert!(
+            vector_size.to_usize() == 0 && value_types.is_empty()
+                || vector_size.to_usize() % value_types.len() == 0
+        );
 
         let result = AcirValue::DynamicArray(AcirDynamicArray {
             block_id: result_block_id,

--- a/test_programs/execution_success/regression_12467/Nargo.toml
+++ b/test_programs/execution_success/regression_12467/Nargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "regression_12467"
+type = "bin"
+authors = [""]
+
+[dependencies]

--- a/test_programs/execution_success/regression_12467/Prover.toml
+++ b/test_programs/execution_success/regression_12467/Prover.toml
@@ -1,0 +1,2 @@
+idx = 0
+return = 4

--- a/test_programs/execution_success/regression_12467/src/main.nr
+++ b/test_programs/execution_success/regression_12467/src/main.nr
@@ -1,0 +1,7 @@
+struct Phantom {}
+
+fn main(idx: u32) -> pub u32 {
+    let s: [Phantom] = @[Phantom {}, Phantom {}, Phantom {}];
+    let s2 = s.insert(idx, Phantom {});
+    s2.len() as u32
+}

--- a/tooling/nargo_cli/tests/snapshots/execution_success/regression_12467/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/regression_12467/execute__tests__expanded.snap
@@ -1,0 +1,11 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: expanded_code
+---
+struct Phantom {}
+
+fn main(idx: u32) -> pub u32 {
+    let s: [Phantom] = @[Phantom {}, Phantom {}, Phantom {}];
+    let s2: [Phantom] = s.insert(idx, Phantom {});
+    s2.len() as u32
+}

--- a/tooling/nargo_cli/tests/snapshots/execution_success/regression_12467/execute__tests__stdout.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/regression_12467/execute__tests__stdout.snap
@@ -1,0 +1,5 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: stdout
+---
+[regression_12467] Circuit output: 4


### PR DESCRIPTION
## Problem Resolved

Resolves https://github.com/noir-lang/noir/issues/12467

## Summary of Changes



## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
