### PR TITLE
fix(ssa interpreter): Clarify overflow error

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/interpreter/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/interpreter/mod.rs
@@ -1535,7 +1535,11 @@ macro_rules! apply_int_binop_opt {
         let operator = binary.operator;
 
         let overflow = || {
-            if matches!(operator, BinaryOp::Div | BinaryOp::Mod) {
+            // For `Div`/`Mod`, `checked_div`/`checked_rem` return `None` either because
+            // the divisor is zero or because the operation overflows
+            // (e.g. signed `MIN / -1`). Distinguish the two by inspecting the divisor.
+            if matches!(operator, BinaryOp::Div | BinaryOp::Mod) && rhs.convert_to_field().is_zero()
+            {
                 let lhs_id = binary.lhs;
                 let rhs_id = binary.rhs;
                 let lhs = lhs.to_string();

--- a/compiler/noirc_evaluator/src/ssa/interpreter/tests/instructions.rs
+++ b/compiler/noirc_evaluator/src/ssa/interpreter/tests/instructions.rs
@@ -316,6 +316,40 @@ fn div_zero() {
 }
 
 #[test]
+fn div_signed_overflow() {
+    let error = expect_error(
+        "
+        acir(inline) fn main f0 {
+          b0():
+            v0 = div i32 2147483648, i32 4294967295
+            return v0
+        }
+    ",
+    );
+    assert!(
+        matches!(error, InterpreterError::Overflow { .. }),
+        "expected Overflow for i32::MIN / -1, got {error:?}"
+    );
+}
+
+#[test]
+fn mod_signed_overflow() {
+    let error = expect_error(
+        "
+        acir(inline) fn main f0 {
+          b0():
+            v0 = mod i32 2147483648, i32 4294967295
+            return v0
+        }
+    ",
+    );
+    assert!(
+        matches!(error, InterpreterError::Overflow { .. }),
+        "expected Overflow for i32::MIN % -1, got {error:?}"
+    );
+}
+
+#[test]
 fn r#mod() {
     let value = expect_value(
         "


### PR DESCRIPTION
## Problem Resolved

Resolves https://github.com/noir-lang/noir/issues/12470

## Summary of Changes

Changes `int_min / -1` to be an overflow error instead of a division by 0 error in the ssa interpreter

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
