### PR TITLE
chore(tooling): Distinguish trait associated constants from error values

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/lints.rs
+++ b/compiler/noirc_frontend/src/elaborator/lints.rs
@@ -535,6 +535,7 @@ fn can_return_without_recursing(interner: &NodeInterner, func_id: FuncId, expr_i
             HirStatement::Comptime(_)
             | HirStatement::Break
             | HirStatement::Continue
+            | HirStatement::TraitAssociatedConstant
             | HirStatement::Error => true,
         })
     };

--- a/compiler/noirc_frontend/src/hir/comptime/hir_to_display_ast.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/hir_to_display_ast.rs
@@ -64,6 +64,7 @@ impl HirStatement {
             }
             HirStatement::Semi(expr) => StatementKind::Semi(expr.to_display_ast(interner)),
             HirStatement::Error => StatementKind::Error,
+            HirStatement::TraitAssociatedConstant => StatementKind::Error,
             HirStatement::Comptime(statement) => {
                 StatementKind::Comptime(Box::new(statement.to_display_ast(interner)))
             }

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
@@ -1304,7 +1304,7 @@ impl<'local, 'interner> Interpreter<'local, 'interner> {
                 self.evaluate(expression)?;
                 Ok(Value::Unit)
             }
-            HirStatement::Error => {
+            HirStatement::Error | HirStatement::TraitAssociatedConstant => {
                 let location = self.elaborator.interner.id_location(statement);
                 Err(InterpreterError::ErrorNodeEncountered { location })
             }

--- a/compiler/noirc_frontend/src/hir/def_collector/dc_mod.rs
+++ b/compiler/noirc_frontend/src/hir/def_collector/dc_mod.rs
@@ -43,6 +43,7 @@ use super::{
 use crate::hir::Context;
 use crate::hir::def_map::{CrateDefMap, LocalModuleId, MAIN_FUNCTION, ModuleData, ModuleId};
 use crate::hir::resolution::import::ImportDirective;
+use crate::hir_def::stmt::HirStatement;
 
 /// Given a module collect all definitions into ModuleData
 struct ModCollector<'a> {
@@ -629,6 +630,16 @@ impl ModCollector<'_> {
                             false,
                             false,
                             ItemVisibility::Public,
+                        );
+
+                        // Trait-level associated constants have no value (only impls do), so
+                        // mark the placeholder statement as `TraitAssociatedConstant` rather than
+                        // leaving the `HirStatement::Error` that `push_empty_global` defaults to.
+                        let placeholder_stmt =
+                            context.def_interner.get_global(global_id).let_statement;
+                        context.def_interner.replace_statement(
+                            placeholder_stmt,
+                            HirStatement::TraitAssociatedConstant,
                         );
 
                         if let Err((first_def, second_def)) = self.def_collector.def_map

--- a/compiler/noirc_frontend/src/hir/printer/items/hir_def.rs
+++ b/compiler/noirc_frontend/src/hir/printer/items/hir_def.rs
@@ -649,6 +649,9 @@ impl ItemPrinter<'_, '_> {
             }
             HirStatement::Comptime(_) => unreachable!("comptime should not happen"),
             HirStatement::Error => unreachable!("error should not happen"),
+            HirStatement::TraitAssociatedConstant => {
+                unreachable!("trait associated constant placeholder should not appear in printer")
+            }
         }
     }
 
@@ -973,6 +976,7 @@ impl ItemPrinter<'_, '_> {
             HirStatement::Semi(expr_id) => self.expression_id_has_unsafe(*expr_id),
             HirStatement::Comptime(stmt_id) => self.statement_id_has_unsafe(*stmt_id),
             HirStatement::Error => false,
+            HirStatement::TraitAssociatedConstant => false,
         }
     }
 

--- a/compiler/noirc_frontend/src/hir_def/stmt.rs
+++ b/compiler/noirc_frontend/src/hir_def/stmt.rs
@@ -21,6 +21,12 @@ pub enum HirStatement {
     Expression(ExprId),
     Semi(ExprId),
     Comptime(StmtId),
+    /// Placeholder for a trait-level associated constant declaration like `let N: u32;`
+    /// inside a `trait` body. These declarations have no value (only impls do), so the
+    /// `GlobalInfo::let_statement` field for such globals points at this variant rather
+    /// than at a real `HirStatement::Let`. Distinct from `Error` so consumers walking
+    /// module globals can tell trait associated constants apart from broken globals.
+    TraitAssociatedConstant,
     Error,
 }
 

--- a/compiler/noirc_frontend/src/monomorphization/mod.rs
+++ b/compiler/noirc_frontend/src/monomorphization/mod.rs
@@ -1054,6 +1054,9 @@ impl<'interner> Monomorphizer<'interner> {
             HirStatement::Break => Ok(ast::Expression::Break),
             HirStatement::Continue => Ok(ast::Expression::Continue),
             HirStatement::Error => unreachable!(),
+            HirStatement::TraitAssociatedConstant => {
+                unreachable!("trait-associated-constant placeholder reached monomorphization")
+            }
 
             // All `comptime` statements & expressions should be removed before runtime.
             HirStatement::Comptime(_) => unreachable!("comptime statement in runtime code"),

--- a/compiler/noirc_frontend/src/node_interner/globals.rs
+++ b/compiler/noirc_frontend/src/node_interner/globals.rs
@@ -126,7 +126,7 @@ impl NodeInterner {
         match def {
             Node::Statement(hir_stmt) => match hir_stmt {
                 HirStatement::Let(let_stmt) => Some(let_stmt.clone()),
-                HirStatement::Error => None,
+                HirStatement::Error | HirStatement::TraitAssociatedConstant => None,
                 _other => None,
             },
             _ => panic!("ice: all globals should correspond to a statement in the interner"),

--- a/compiler/noirc_frontend/src/tests/lambdas.rs
+++ b/compiler/noirc_frontend/src/tests/lambdas.rs
@@ -285,6 +285,9 @@ fn find_lambda_captures(stmts: &[StmtId], interner: &NodeInterner, result: &mut 
             HirStatement::Loop(block) => block,
             HirStatement::While(_, block) => block,
             HirStatement::Error => panic!("Invalid HirStatement!"),
+            HirStatement::TraitAssociatedConstant => {
+                panic!("Unexpected trait associated constant placeholder")
+            }
             HirStatement::Break => panic!("Unexpected break"),
             HirStatement::Continue => panic!("Unexpected continue"),
             HirStatement::Comptime(_) => panic!("Unexpected comptime"),

--- a/compiler/noirc_frontend/src/tests/traits/trait_associated_items.rs
+++ b/compiler/noirc_frontend/src/tests/traits/trait_associated_items.rs
@@ -2083,3 +2083,61 @@ fn associated_constant_type_mismatch_does_not_crash() {
     "#;
     check_errors(src);
 }
+
+#[test]
+fn trait_associated_constant_global_uses_placeholder_statement() {
+    use crate::hir::def_map::ModuleDefId;
+    use crate::hir_def::stmt::HirStatement;
+
+    let src = r#"
+    pub trait Foo {
+        let N: u32;
+    }
+
+    impl Foo for u32 {
+        let N: u32 = 0u32;
+    }
+
+    fn main() {}
+    "#;
+
+    let context = assert_no_errors(src);
+
+    let mut found_trait_constant_global = false;
+    for def_map in context.def_maps.values() {
+        for (_, module_data) in def_map.modules().iter() {
+            for module_def in module_data.definitions().definitions() {
+                if let ModuleDefId::GlobalId(global_id) = module_def {
+                    let info = context.def_interner.get_global(*global_id);
+                    if info.ident.as_str() == "N" {
+                        match context.def_interner.statement(&info.let_statement) {
+                            HirStatement::TraitAssociatedConstant => {
+                                found_trait_constant_global = true;
+                            }
+                            HirStatement::Let(_) => {} // the impl-side let is fine
+                            other => panic!("unexpected statement for global N: {other:?}"),
+                        }
+                    }
+                }
+            }
+        }
+    }
+    assert!(
+        found_trait_constant_global,
+        "expected at least one global named N backed by HirStatement::TraitAssociatedConstant",
+    );
+}
+
+#[test]
+fn trait_associated_constant_duplicate_is_an_error() {
+    let src = r#"
+    pub trait Foo {
+        let N: u32;
+            ~ First trait associated item found here
+        let N: u8;
+            ^ Duplicate definitions of trait associated item with name N found
+            ~ Second trait associated item found here
+    }
+    "#;
+    check_errors(src);
+}


### PR DESCRIPTION
## Problem Resolved

Resolves https://github.com/noir-lang/noir/issues/12392

## Summary of Changes

Adds a statement kind to distinguish trait associated constants from error values since these are not expected to be resolved to another expression/statement even in a program without errors.

This should only have observable changes for tooling like Lampe that directly hooks into the Noir compiler.

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
