### PR TITLE
fix(constant_folding): don't deduplicate calls that return arrays that are later mutated

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/ir/instruction.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/instruction.rs
@@ -377,8 +377,10 @@ pub enum Instruction {
     ArrayGet { array: ValueId, index: ValueId },
 
     /// Creates a new array with the new value at the given index. All other elements are identical
-    /// to those in the given array. This will not modify the original array unless `mutable` is
+    /// to those in the given array.
+    /// In ACIR this will not modify the original array unless `mutable` is
     /// set. This flag is off by default and only enabled when optimizations determine it is safe.
+    /// In Brillig, this might modify the original array if the array's reference count is 1.
     ArraySet { array: ValueId, index: ValueId, value: ValueId, mutable: bool },
 
     /// An instruction to increment the reference count of a value.

--- a/compiler/noirc_evaluator/src/ssa/opt/constant_folding/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/constant_folding/mod.rs
@@ -698,6 +698,17 @@ impl Context {
             _ => false,
         };
 
+        // A Call in Brillig that returns an array whose type is mutated through block parameters
+        // must not be cached. RPO visits loop exit blocks before loop bodies, so it can happen
+        // that an array that was returned from a call is later mutated in the exit block,
+        // so we must take this case into account.
+        let call_returns_mutated_brillig_array = dfg.runtime().is_brillig()
+            && matches!(instruction, Instruction::Call { .. })
+            && instruction_results.iter().any(|result| {
+                let typ = dfg.type_of_value(*result);
+                typ.is_array() && self.mutated_block_param_array_types.contains(&*typ)
+            });
+
         let cache_instruction = || {
             let predicate = self.cache_predicate(side_effects_enabled_var, instruction, dfg);
 
@@ -733,6 +744,7 @@ impl Context {
         };
 
         match can_be_deduplicated {
+            _ if call_returns_mutated_brillig_array => {}
             CanBeDeduplicated::Always => cache_instruction(),
             CanBeDeduplicated::UnderSamePredicate if use_constraint_info => cache_instruction(),
             // We also allow deduplicating MakeArray instructions whose type isn't mutated
@@ -3371,5 +3383,32 @@ mod test {
             return
         }
         "#);
+    }
+
+    #[test]
+    fn constant_folding_does_not_deduplicate_call_that_returns_array_that_is_later_mutated() {
+        let src = "
+        brillig(inline) predicate_pure fn main f0 {
+          b0():
+            v3 = call f1() -> [u1; 1]
+            jmp b1(v3, u32 0)
+          b1(v0: [u1; 1], v1: u32):
+            v6 = eq v1, u32 1
+            jmpif v6 then: b2(), else: b3()
+          b2():
+            v10 = call f1() -> [u1; 1]
+            return v10
+          b3():
+            v7 = add v1, u32 1
+            v9 = array_set v0, index u32 0, value u1 0
+            jmp b1(v9, v7)
+        }
+        brillig(inline_never) predicate_pure fn g f1 {
+          b0():
+            v1 = make_array [u1 1] : [u1; 1]
+            return v1
+        }
+        ";
+        assert_ssa_does_not_change(src, |ssa| ssa.fold_constants_using_constraints(3));
     }
 }

--- a/test_programs/execution_success/constant_folding_mutated_returned_array_bug/Nargo.toml
+++ b/test_programs/execution_success/constant_folding_mutated_returned_array_bug/Nargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "constant_folding_mutated_returned_array_bug"
+type = "bin"
+authors = [""]
+
+[dependencies]

--- a/test_programs/execution_success/constant_folding_mutated_returned_array_bug/Prover.toml
+++ b/test_programs/execution_success/constant_folding_mutated_returned_array_bug/Prover.toml
@@ -1,0 +1,1 @@
+return = [true]

--- a/test_programs/execution_success/constant_folding_mutated_returned_array_bug/src/main.nr
+++ b/test_programs/execution_success/constant_folding_mutated_returned_array_bug/src/main.nr
@@ -1,0 +1,18 @@
+unconstrained fn main() -> pub [bool; 1] {
+    f()
+}
+
+#[inline_never]
+unconstrained fn g() -> [bool; 1] {
+    [true]
+}
+
+unconstrained fn f() -> [bool; 1] {
+    let mut b = g();
+    let mut i: u32 = 0;
+    while i != 1 {
+        i += 1;
+        b[0] = false;
+    }
+    g()
+}

--- a/tooling/nargo_cli/tests/snapshots/execution_success/constant_folding_mutated_returned_array_bug/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/constant_folding_mutated_returned_array_bug/execute__tests__expanded.snap
@@ -1,0 +1,22 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: expanded_code
+---
+unconstrained fn main() -> pub [bool; 1] {
+    f()
+}
+
+#[inline_never]
+unconstrained fn g() -> [bool; 1] {
+    [true]
+}
+
+unconstrained fn f() -> [bool; 1] {
+    let mut b: [bool; 1] = g();
+    let mut i: u32 = 0_u32;
+    while i != 1_u32 {
+        i = i + 1_u32;
+        b[0_u32] = false;
+    }
+    g()
+}

--- a/tooling/nargo_cli/tests/snapshots/execution_success/constant_folding_mutated_returned_array_bug/execute__tests__stdout.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/constant_folding_mutated_returned_array_bug/execute__tests__stdout.snap
@@ -1,0 +1,5 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: stdout
+---
+[constant_folding_mutated_returned_array_bug] Circuit output: [true]


### PR DESCRIPTION
## Problem Resolved

Resolves https://github.com/noir-lang/noir/security/advisories/GHSA-wvh3-mhm3-7wwv

## Summary of Changes

At first it was a bit hard to understand why `array_set` would modify an array if it was not `mut` but Claude made me remember that in Brillig that's the case when RC is 1, so I also updated the ArraySet docs to mention this.

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
