### PR TITLE
fix(ssa): avoid overflow incrementing u128::MAX

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/ir/integer.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/integer.rs
@@ -76,21 +76,15 @@ impl IntegerConstant {
         }
     }
 
-    /// Decrement the value by 1, saturating at the minimum value.
-    ///
-    /// # panics
-    ///
-    /// Panics if the decrement causes an overflow.
-    pub(crate) fn dec(self) -> Self {
+    /// Decrement the value by 1. Returns None if the decrement would cause an underflow.
+    pub(crate) fn dec(self) -> Option<Self> {
         match self {
-            Self::Signed { value, bit_size } => Self::Signed {
-                value: value.checked_sub(1).expect("ICE: overflow while decrementing constant"),
-                bit_size,
-            },
-            Self::Unsigned { value, bit_size } => Self::Unsigned {
-                value: value.checked_sub(1).expect("ICE: overflow while decrementing constant"),
-                bit_size,
-            },
+            Self::Signed { value, bit_size } => {
+                value.checked_sub(1).map(|value| Self::Signed { value, bit_size })
+            }
+            Self::Unsigned { value, bit_size } => {
+                value.checked_sub(1).map(|value| Self::Unsigned { value, bit_size })
+            }
         }
     }
 

--- a/compiler/noirc_evaluator/src/ssa/ir/integer.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/integer.rs
@@ -64,21 +64,15 @@ impl IntegerConstant {
         }
     }
 
-    /// Increment the value by 1
-    ///
-    /// # Panics
-    ///
-    /// Panics if the increment causes an overflow.
-    pub(crate) fn inc(self) -> Self {
+    /// Increment the value by 1. Returns None if the increment would cause an overlfow.
+    pub(crate) fn inc(self) -> Option<Self> {
         match self {
-            Self::Signed { value, bit_size } => Self::Signed {
-                value: value.checked_add(1).expect("ICE: overflow while incrementing constant"),
-                bit_size,
-            },
-            Self::Unsigned { value, bit_size } => Self::Unsigned {
-                value: value.checked_add(1).expect("ICE: overflow while incrementing constant"),
-                bit_size,
-            },
+            Self::Signed { value, bit_size } => {
+                value.checked_add(1).map(|value| Self::Signed { value, bit_size })
+            }
+            Self::Unsigned { value, bit_size } => {
+                value.checked_add(1).map(|value| Self::Unsigned { value, bit_size })
+            }
         }
     }
 

--- a/compiler/noirc_evaluator/src/ssa/ir/integer.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/integer.rs
@@ -64,7 +64,7 @@ impl IntegerConstant {
         }
     }
 
-    /// Increment the value by 1. Returns None if the increment would cause an overlfow.
+    /// Increment the value by 1. Returns None if the increment would cause an overflow.
     pub(crate) fn inc(self) -> Option<Self> {
         match self {
             Self::Signed { value, bit_size } => {

--- a/compiler/noirc_evaluator/src/ssa/opt/loop_invariant/simplify.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/loop_invariant/simplify.rs
@@ -155,7 +155,7 @@ impl LoopInvariantContext<'_> {
             _ => None,
         }?;
 
-        let (upper_field, upper_type) = upper.dec().into_numeric_constant();
+        let (upper_field, upper_type) = upper.dec()?.into_numeric_constant();
         let (lower_field, lower_type) = lower.into_numeric_constant();
 
         let min_iter = self.inserter.function.dfg.make_constant(lower_field, lower_type);

--- a/compiler/noirc_evaluator/src/ssa/opt/loop_invariant/simplify.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/loop_invariant/simplify.rs
@@ -322,7 +322,7 @@ impl LoopInvariantContext<'_> {
                 true if lower_bound >= constant => SimplifyResult::SimplifiedTo(self.false_value),
                 // `const < i`
                 false if lower_bound > constant => SimplifyResult::SimplifiedTo(self.true_value),
-                false if upper_bound <= constant.inc() => {
+                false if constant.inc().is_some_and(|constant| upper_bound <= constant) => {
                     // If `const >= upper_bound - 1` then it will never be less than `i`.
                     SimplifyResult::SimplifiedTo(self.false_value)
                 }

--- a/compiler/noirc_evaluator/src/ssa/opt/unrolling.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/unrolling.rs
@@ -769,7 +769,7 @@ impl Loop {
                 // If `b2` is the loop body: Loop exits when v == rhs; upper = rhs + 1.
                 // If `b3` is the loop body: Loop exits when v == rhs; upper = rhs.
                 let const_rhs = dfg.get_integer_constant(*rhs)?;
-                if then_branch_is_body { Some(const_rhs.inc()) } else { Some(const_rhs) }
+                if then_branch_is_body { const_rhs.inc() } else { Some(const_rhs) }
             }
             Instruction::Not(operand) => {
                 if *operand != induction_var {

--- a/compiler/noirc_evaluator/src/ssa/ssa_gen/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/ssa_gen/mod.rs
@@ -702,7 +702,9 @@ impl FunctionContext<'_> {
             let max_value = if bit_size == 128 { u128::MAX } else { (1u128 << bit_size) - 1 };
 
             if end_constant.into_numeric_constant().0.to_u128() < max_value {
-                let end_constant_plus_one = end_constant.inc();
+                let end_constant_plus_one = end_constant.inc().expect(
+                    "Expected to be able to increment end_constant as it's less than max_value",
+                );
                 end_index = self
                     .builder
                     .numeric_constant(end_constant_plus_one.into_numeric_constant().0, index_type);

--- a/test_programs/execution_success/regression_12494/Nargo.toml
+++ b/test_programs/execution_success/regression_12494/Nargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "regression_12494"
+type = "bin"
+authors = [""]
+
+[dependencies]

--- a/test_programs/execution_success/regression_12494/Prover.toml
+++ b/test_programs/execution_success/regression_12494/Prover.toml
@@ -1,0 +1,1 @@
+return = false

--- a/test_programs/execution_success/regression_12494/src/main.nr
+++ b/test_programs/execution_success/regression_12494/src/main.nr
@@ -1,0 +1,9 @@
+fn main() -> pub bool {
+    let mut hit: bool = false;
+    for i in 0..3_u128 {
+        if 340282366920938463463374607431768211455 < i {
+            hit = true;
+        }
+    }
+    hit
+}

--- a/tooling/nargo_cli/tests/snapshots/execution_success/regression_12494/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/regression_12494/execute__tests__expanded.snap
@@ -1,0 +1,13 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: expanded_code
+---
+fn main() -> pub bool {
+    let mut hit: bool = false;
+    for i in 0_u128..3_u128 {
+        if 340282366920938463463374607431768211455_u128 < i {
+            hit = true;
+        }
+    }
+    hit
+}

--- a/tooling/nargo_cli/tests/snapshots/execution_success/regression_12494/execute__tests__stdout.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/regression_12494/execute__tests__stdout.snap
@@ -1,0 +1,5 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: stdout
+---
+[regression_12494] Circuit output: false


### PR DESCRIPTION
## Problem Resolved

Resolves https://github.com/noir-lang/noir/issues/12494

## Summary of Changes

I also made a similar change to `dec` since the only place it's used already returns `Option`, so I thought that made sense.

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
