### PR TITLE
fix(comptime): Handle non-constant generics `to_le_radix`

### DIFF
--- a/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
@@ -903,15 +903,11 @@ fn to_le_radix(
     let value = get_field(value)?;
     let radix = get_u32(radix)?;
     let (limb_count, element_type) = if let Type::Array(element_type, length) = return_type {
-        if let Type::Constant(limb_count) = *length {
-            if limb_count.get_type().unify(&Type::u32()).is_ok() {
-                (limb_count.as_field(), element_type)
-            } else {
-                return Err(InterpreterError::TypeAnnotationsNeededForMethodCall { location });
-            }
-        } else {
-            return Err(InterpreterError::TypeAnnotationsNeededForMethodCall { location });
-        }
+        let limb_count = length
+            .evaluate_to_u32(location)
+            .map_err(|_| InterpreterError::TypeAnnotationsNeededForMethodCall { location })?
+            as usize;
+        (limb_count, element_type)
     } else {
         return Err(InterpreterError::TypeAnnotationsNeededForMethodCall { location });
     };
@@ -923,17 +919,12 @@ fn to_le_radix(
 
     // Validate that the value fits in the requested number of limbs.
     // This matches the runtime behavior in our black box solvers.
-    let Some(limb_count_u64) = limb_count.try_to_u64().map(|x| x as usize) else {
+    if limb_count < decomposed_integer.len() {
         let message = format!("Field failed to decompose into specified {limb_count} limbs");
-        return failing_constraint(message, location, call_stack);
-    };
-
-    if limb_count_u64 < decomposed_integer.len() {
-        let message = format!("Field failed to decompose into specified {limb_count_u64} limbs");
         return failing_constraint(message, location, call_stack);
     }
 
-    let decomposed_integer = vecmap(0..limb_count_u64, |i| {
+    let decomposed_integer = vecmap(0..limb_count, |i| {
         let digit = match decomposed_integer.get(i) {
             Some(digit) => *digit,
             None => 0,

--- a/test_programs/noir_test_success/to_radix_error/src/main.nr
+++ b/test_programs/noir_test_success/to_radix_error/src/main.nr
@@ -27,3 +27,16 @@ fn test_brillig() {
     // Safety: testing context
     let _ = unsafe { brillig_le_decompose(0x100000000000000000000000000000000) };
 }
+
+#[test]
+fn test_be_and_le_bits_infix() {
+    let (be, le) = to_bits::<1, 3>(13);
+    assert_eq(be, [true, true, false, true]);
+    assert_eq(le, [true, false, true, true]);
+}
+
+fn to_bits<let N: u32, let M: u32>(x: Field) -> ([bool; N + M], [bool; N + M]) {
+    let be = x.to_be_bits::<N + M>();
+    let le = x.to_le_bits::<M + N>();
+    (be, le)
+}


### PR DESCRIPTION
## Problem Resolved

Discovered while testing https://github.com/noir-lang/noir/pull/12474 on `noir-protocol-circuits`. 

Code such as the following did not compile:
```noir
fn bits_with_diff<let H: u32, let S: u32>(x: Field) {
    let _: [bool; H - S] = x.to_le_bits();
}
```

Giving errors such as this:
```
error: Object type is unknown in method call
   ┌─ std/field/mod.nr:32:20
   │
32 │         let bits = __to_le_bits(self);
   │                    ------------------
```

This happened in dozens of tests in `aztec-packages`, for example:
```
cargo run -q -p nargo_cli -- --program-dir ../aztec-packages/noir-projects/noir-protocol-circuits/crates/types test --silence-warnings --force-comptime insert_at_middle
```

## Summary of Changes

Changes the `to_le_radix` function of the comptime interpreter to use `Type::evaluate_to_u32`, rather than expect the generic parameter to be a numeric constant. 

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
