### PR TITLE
fix(nargo): emit a clean CLI error for invalid --oracle-resolver instead of panicking

### DIFF
--- a/tooling/nargo/src/foreign_calls/rpc.rs
+++ b/tooling/nargo/src/foreign_calls/rpc.rs
@@ -201,7 +201,17 @@ fn build_http_client(target: &str) -> HttpClient {
         client_builder = client_builder.request_timeout(timeout_duration);
     }
 
-    client_builder.build(target).expect("Invalid oracle resolver URL")
+    // The bad-URL case is reachable from a public CLI flag (`--oracle-resolver`).
+    // Surface it as a clear error and exit non-zero rather than panicking with
+    // the "This is a bug" handler — the URL came from the user, not from us
+    // (#12504).
+    match client_builder.build(target) {
+        Ok(client) => client,
+        Err(err) => {
+            eprintln!("Error: --oracle-resolver value '{target}' is not a valid URL: {err}");
+            std::process::exit(1);
+        }
+    }
 }
 
 impl<F> ForeignCallExecutor<F> for RPCForeignCallExecutor


### PR DESCRIPTION
Fixes #12504.

`build_http_client` called `expect("Invalid oracle resolver URL")` on a value built from a user-facing CLI flag. Any non-URL string (e.g. `localhost:8080`) tripped the global panic handler with the "This is a bug. We may have already fixed this in newer versions of Nargo" message — confusing because the bug is in the user's input, not in nargo.

Print a clear `Error: --oracle-resolver value '...' is not a valid URL` line and `exit(1)` instead. Threading the error all the way back to the CLI layer would touch six call sites and several public types; bailing here is the smaller intervention that addresses the user-facing complaint.