### PR TITLE
fix(ssa): add try_evaluate_static_assert to minimal_passes

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/mod.rs
@@ -407,6 +407,16 @@ pub fn minimal_passes() -> Vec<SsaPass<'static>> {
         // which was called in the AST not being called in the SSA. Such functions would cause
         // panics later, when we are looking for global allocations.
         SsaPass::new(Ssa::remove_unreachable_functions, "Removing Unreachable Functions"),
+        // `static_assert` / `assert_constant` intrinsics aren't lowered by
+        // any of the passes above. Brillig codegen treats them as
+        // `unreachable!()` (code_gen_call.rs:417), so without this pass a
+        // `static_assert(false)` ICE'd `--minimal-ssa` (#12503). The
+        // `try_…` variant mirrors `primary_passes` and turns failing
+        // asserts into a normal user-facing diagnostic.
+        SsaPass::new(
+            Ssa::try_evaluate_static_assert_and_assert_constant,
+            "`static_assert` and `assert_constant`",
+        ),
     ]
 }
 


### PR DESCRIPTION
Fixes #12503.

`minimal_passes()` did not include the `evaluate_static_assert_and_assert_constant` SSA pass. The Brillig codegen layer at `code_gen_call.rs:417` treats residual `Intrinsic::StaticAssert` / `Intrinsic::AssertConstant` as `unreachable!()`, on the assumption that the eval pass has already lowered them. Without the pass, `nargo execute --minimal-ssa` ICE'd on `std::static_assert(false, ...)` instead of producing a normal `error: intentional` diagnostic.

Add `Ssa::try_evaluate_static_assert_and_assert_constant` to the minimal-passes list, matching what `primary_passes()` already does.