### PR TITLE
fix(ssa validation): Fix mutable and immutable references from same type

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/validation/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/validation/mod.rs
@@ -1082,9 +1082,9 @@ impl<'f> Validator<'f> {
                 for (argument, parameter) in arguments.iter().zip_eq(block_parameters) {
                     let argument_type = self.function.dfg.type_of_value(*argument);
                     let parameter_type = self.function.dfg.type_of_value(*parameter);
-                    assert_eq!(
-                        argument_type, parameter_type,
-                        "Argument type in jmp must match block parameter type"
+                    assert!(
+                        types_equal_ignoring_reference_mutability(&argument_type, &parameter_type),
+                        "Argument type in jmp must match block parameter type\n  left: {argument_type}\n right: {parameter_type}"
                     );
                 }
             }
@@ -1132,6 +1132,25 @@ fn is_mut_ref_to_immutable_ref(arg: &Type, param: &Type) -> bool {
         (arg, param),
         (Type::Reference(a, true), Type::Reference(b, false)) if a == b
     )
+}
+
+/// Compares two types, treating mutable and immutable references as equivalent.
+fn types_equal_ignoring_reference_mutability(a: &Type, b: &Type) -> bool {
+    let all_eq = |a: &[Type], b: &[Type]| {
+        a.len() == b.len()
+            && a.iter().zip(b).all(|(a, b)| types_equal_ignoring_reference_mutability(a, b))
+    };
+
+    match (a, b) {
+        (Type::Reference(a_elem, _), Type::Reference(b_elem, _)) => {
+            types_equal_ignoring_reference_mutability(a_elem, b_elem)
+        }
+        (Type::Array(a_elems, a_len), Type::Array(b_elems, b_len)) => {
+            a_len == b_len && all_eq(a_elems, b_elems)
+        }
+        (Type::Vector(a_elems), Type::Vector(b_elems)) => all_eq(a_elems, b_elems),
+        _ => a == b,
+    }
 }
 
 fn assert_arguments_length(arguments: &[ValueId], expected: usize, object: &str) {
@@ -2148,6 +2167,69 @@ mod tests {
           b0():
             jmp b1(u8 0)
           b1(v0: u32):
+            return
+        }
+        ";
+        let _ = Ssa::from_str(src).unwrap();
+    }
+
+    #[test]
+    fn jmp_allows_reference_mutability_mismatch() {
+        // Reference mutability is a frontend concern with no meaning at the SSA
+        // level, so a `&mut T` argument is accepted by a `&T` block parameter
+        // (and vice versa).
+        let src = "
+        acir(inline) pure fn main f0 {
+          b0():
+            v0 = allocate -> &mut u32
+            jmp b1(v0)
+          b1(v1: &u32):
+            return
+        }
+        ";
+        let _ = Ssa::from_str(src).unwrap();
+
+        let src = "
+        acir(inline) pure fn main f0 {
+          b0():
+            v0 = allocate -> &u32
+            jmp b1(v0)
+          b1(v1: &mut u32):
+            return
+        }
+        ";
+        let _ = Ssa::from_str(src).unwrap();
+    }
+
+    #[test]
+    fn jmp_allows_reference_mutability_mismatch_nested_in_array() {
+        // The mutability-equivalence rule must look through composite types:
+        // `[&mut Field; 1]` should be accepted by a `[&Field; 1]` block parameter.
+        let src = "
+        acir(inline) pure fn main f0 {
+          b0():
+            v0 = allocate -> &mut Field
+            v1 = make_array [v0] : [&mut Field; 1]
+            jmp b1(v1)
+          b1(v2: [&Field; 1]):
+            return
+        }
+        ";
+        let _ = Ssa::from_str(src).unwrap();
+    }
+
+    #[test]
+    fn jmp_allows_reference_mutability_mismatch_nested_in_reference() {
+        // The mutability-equivalence rule must recurse through nested references:
+        // `&mut &mut Field` should be accepted by a `&mut &Field` block parameter.
+        let src = "
+        acir(inline) pure fn main f0 {
+          b0():
+            v0 = allocate -> &mut Field
+            v1 = allocate -> &mut &mut Field
+            store v0 at v1
+            jmp b1(v1)
+          b1(v2: &mut &Field):
             return
         }
         ";


### PR DESCRIPTION
## Problem Resolved

Resolves https://github.com/noir-lang/noir/issues/12495

## Summary of Changes

Immutable references can be created from mutable references, we should treat these types as equal for validation purposes.

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
