### PR TITLE
fix: assert location is the entire assert

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/expressions.rs
+++ b/compiler/noirc_frontend/src/elaborator/expressions.rs
@@ -1068,7 +1068,7 @@ impl Elaborator<'_> {
 
         self.unify_or_type_mismatch(&expr_type, &Type::Bool, expr_location);
 
-        (HirExpression::Constrain(HirConstrainExpression(expr_id, location.file, msg)), Type::Unit)
+        (HirExpression::Constrain(HirConstrainExpression(expr_id, location, msg)), Type::Unit)
     }
 
     /// Elaborate a struct constructor.

--- a/compiler/noirc_frontend/src/hir_def/expr.rs
+++ b/compiler/noirc_frontend/src/hir_def/expr.rs
@@ -236,7 +236,7 @@ pub struct HirMethodCallExpression {
 #[derive(Debug, Clone)]
 pub struct HirConstrainExpression(
     /*condition*/ pub ExprId,
-    pub FileId,
+    pub Location,
     /*message*/ pub Option<ExprId>,
 );
 

--- a/compiler/noirc_frontend/src/monomorphization/mod.rs
+++ b/compiler/noirc_frontend/src/monomorphization/mod.rs
@@ -828,7 +828,7 @@ impl<'interner> Monomorphizer<'interner> {
 
             HirExpression::Constrain(constrain) => {
                 let expr = self.expr(constrain.0)?;
-                let location = self.interner.expr_location(&constrain.0);
+                let location = constrain.1;
                 let assert_message = constrain
                     .2
                     .map(|assert_msg_expr| {

--- a/tooling/nargo_cli/tests/snapshots/execution_failure/assert_msg_runtime/execute__tests__acir_stderr.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_failure/assert_msg_runtime/execute__tests__acir_stderr.snap
@@ -3,13 +3,13 @@ source: tooling/nargo_cli/tests/execute.rs
 expression: stderr
 ---
 error: Assertion failed: Expected x == y, but x is 0x05 and y is 0x0a
-  ┌─ src/main.nr:6:15
+  ┌─ src/main.nr:6:5
   │
 6 │     assert_eq(x, y, f"Expected x == y, but x is {x} and y is {y}");
-  │               ----
+  │     --------------------------------------------------------------
   │
   = Call stack:
     1: main
-            at src/main.nr:6:15
+            at src/main.nr:6:5
 
 Failed assertion

--- a/tooling/nargo_cli/tests/snapshots/execution_failure/assert_msg_runtime/execute__tests__brillig_stderr.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_failure/assert_msg_runtime/execute__tests__brillig_stderr.snap
@@ -3,13 +3,13 @@ source: tooling/nargo_cli/tests/execute.rs
 expression: stderr
 ---
 error: Assertion failed: Expected x == y, but x is 0x05 and y is 0x0a
-  ┌─ src/main.nr:6:15
+  ┌─ src/main.nr:6:5
   │
 6 │     assert_eq(x, y, f"Expected x == y, but x is {x} and y is {y}");
-  │               ----
+  │     --------------------------------------------------------------
   │
   = Call stack:
     1: main
-            at src/main.nr:6:15
+            at src/main.nr:6:5
 
 Failed assertion

--- a/tooling/nargo_cli/tests/snapshots/execution_failure/brillig_assert_fail/execute__tests__acir_stderr.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_failure/brillig_assert_fail/execute__tests__acir_stderr.snap
@@ -13,15 +13,15 @@ bug: Input to Brillig function is in a separate subgraph to output
             at src/main.nr:6:26
 
 error: Failed to solve program: 'Failed to solve brillig function'
-   ┌─ src/main.nr:10:12
+   ┌─ src/main.nr:10:5
    │
 10 │     assert(x);
-   │            -
+   │     ---------
    │
    = Call stack:
      1: main
              at src/main.nr:6:26
      2: conditional
-             at src/main.nr:10:12
+             at src/main.nr:10:5
 
 Failed to solve program: 'Failed to solve brillig function'

--- a/tooling/nargo_cli/tests/snapshots/execution_failure/brillig_assert_fail/execute__tests__brillig_stderr.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_failure/brillig_assert_fail/execute__tests__brillig_stderr.snap
@@ -3,15 +3,15 @@ source: tooling/nargo_cli/tests/execute.rs
 expression: stderr
 ---
 error: Failed to solve program: 'Failed to solve brillig function'
-   ┌─ src/main.nr:10:12
+   ┌─ src/main.nr:10:5
    │
 10 │     assert(x);
-   │            -
+   │     ---------
    │
    = Call stack:
      1: main
              at src/main.nr:6:26
      2: conditional
-             at src/main.nr:10:12
+             at src/main.nr:10:5
 
 Failed to solve program: 'Failed to solve brillig function'

--- a/tooling/nargo_cli/tests/snapshots/execution_failure/brillig_assert_msg_runtime/execute__tests__acir_stderr.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_failure/brillig_assert_msg_runtime/execute__tests__acir_stderr.snap
@@ -13,15 +13,15 @@ bug: Input to Brillig function is in a separate subgraph to output
             at src/main.nr:3:26
 
 error: Assertion failed: Expected x to equal 10, but got 0x05
-  ┌─ src/main.nr:9:12
+  ┌─ src/main.nr:9:5
   │
 9 │     assert(x == 10, f"Expected x to equal 10, but got {x}");
-  │            -------
+  │     -------------------------------------------------------
   │
   = Call stack:
     1: main
             at src/main.nr:3:26
     2: conditional
-            at src/main.nr:9:12
+            at src/main.nr:9:5
 
 Failed assertion

--- a/tooling/nargo_cli/tests/snapshots/execution_failure/brillig_assert_msg_runtime/execute__tests__brillig_stderr.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_failure/brillig_assert_msg_runtime/execute__tests__brillig_stderr.snap
@@ -3,15 +3,15 @@ source: tooling/nargo_cli/tests/execute.rs
 expression: stderr
 ---
 error: Assertion failed: Expected x to equal 10, but got 0x05
-  ┌─ src/main.nr:9:12
+  ┌─ src/main.nr:9:5
   │
 9 │     assert(x == 10, f"Expected x to equal 10, but got {x}");
-  │            -------
+  │     -------------------------------------------------------
   │
   = Call stack:
     1: main
             at src/main.nr:3:26
     2: conditional
-            at src/main.nr:9:12
+            at src/main.nr:9:5
 
 Failed assertion

--- a/tooling/nargo_cli/tests/snapshots/execution_failure/fold_nested_brillig_assert_fail/execute__tests__acir_stderr.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_failure/fold_nested_brillig_assert_fail/execute__tests__acir_stderr.snap
@@ -13,10 +13,10 @@ bug: Brillig function call isn't properly covered by a manual constraint
              at src/main.nr:19:9
 
 error: Failed to solve program: 'Failed to solve brillig function'
-   ┌─ src/main.nr:28:12
+   ┌─ src/main.nr:28:5
    │
 28 │     assert(x);
-   │            -
+   │     ---------
    │
    = Call stack:
      1: main
@@ -28,6 +28,6 @@ error: Failed to solve program: 'Failed to solve brillig function'
      4: conditional_wrapper
              at src/main.nr:24:5
      5: conditional
-             at src/main.nr:28:12
+             at src/main.nr:28:5
 
 Failed to solve program: 'Failed to solve brillig function'

--- a/tooling/nargo_cli/tests/snapshots/execution_failure/fold_nested_brillig_assert_fail/execute__tests__brillig_stderr.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_failure/fold_nested_brillig_assert_fail/execute__tests__brillig_stderr.snap
@@ -3,10 +3,10 @@ source: tooling/nargo_cli/tests/execute.rs
 expression: stderr
 ---
 error: Failed to solve program: 'Failed to solve brillig function'
-   ┌─ src/main.nr:28:12
+   ┌─ src/main.nr:28:5
    │
 28 │     assert(x);
-   │            -
+   │     ---------
    │
    = Call stack:
      1: main
@@ -18,6 +18,6 @@ error: Failed to solve program: 'Failed to solve brillig function'
      4: conditional_wrapper
              at src/main.nr:24:5
      5: conditional
-             at src/main.nr:28:12
+             at src/main.nr:28:5
 
 Failed to solve program: 'Failed to solve brillig function'

--- a/tooling/nargo_cli/tests/snapshots/execution_failure/option_expect/execute__tests__acir_stderr.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_failure/option_expect/execute__tests__acir_stderr.snap
@@ -3,27 +3,27 @@ source: tooling/nargo_cli/tests/execute.rs
 expression: stderr
 ---
 bug: Assertion is always false
-   ┌─ std/option.nr:67:16
+   ┌─ std/option.nr:67:9
    │
 67 │         assert(self.is_some(), message);
-   │                -------------- As a result, the compiled circuit is ensured to fail. Other assertions may also fail during execution
+   │         ------------------------------- As a result, the compiled circuit is ensured to fail. Other assertions may also fail during execution
    │
    = Call stack:
      1: main
              at src/main.nr:7:12
      2: Option<T>::expect
-             at std/option.nr:67:16
+             at std/option.nr:67:9
 
 error: Assertion failed: Should have the value 0x03
-   ┌─ std/option.nr:67:16
+   ┌─ std/option.nr:67:9
    │
 67 │         assert(self.is_some(), message);
-   │                --------------
+   │         -------------------------------
    │
    = Call stack:
      1: main
              at src/main.nr:7:12
      2: Option<T>::expect
-             at std/option.nr:67:16
+             at std/option.nr:67:9
 
 Failed assertion

--- a/tooling/nargo_cli/tests/snapshots/execution_failure/option_expect/execute__tests__brillig_stderr.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_failure/option_expect/execute__tests__brillig_stderr.snap
@@ -3,15 +3,15 @@ source: tooling/nargo_cli/tests/execute.rs
 expression: stderr
 ---
 error: Assertion failed: Should have the value 0x03
-   ┌─ std/option.nr:67:16
+   ┌─ std/option.nr:67:9
    │
 67 │         assert(self.is_some(), message);
-   │                --------------
+   │         -------------------------------
    │
    = Call stack:
      1: main
              at src/main.nr:7:12
      2: Option<T>::expect
-             at std/option.nr:67:16
+             at std/option.nr:67:9
 
 Failed assertion

--- a/tooling/nargo_cli/tests/snapshots/execution_failure/regression_10929/execute__tests__acir_stderr.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_failure/regression_10929/execute__tests__acir_stderr.snap
@@ -3,35 +3,35 @@ source: tooling/nargo_cli/tests/execute.rs
 expression: stderr
 ---
 bug: Assertion is always false: QPA
-   ┌─ src/main.nr:8:17
+   ┌─ src/main.nr:6:9
    │  
- 8 │ ╭                 if b {
+ 6 │ ╭         assert(
+ 7 │ │             (
+ 8 │ │                 if b {
  9 │ │                     // safety:
-10 │ │                     unsafe {
-11 │ │                         func_3()
    · │
-15 │ │                 }
-16 │ │                     != 0_u128
-   │ ╰─────────────────────────────' As a result, the compiled circuit is ensured to fail. Other assertions may also fail during execution
+18 │ │             "QPA",
+19 │ │         );
+   │ ╰─────────' As a result, the compiled circuit is ensured to fail. Other assertions may also fail during execution
    │  
    = Call stack:
      1: main
-             at src/main.nr:8:17
+             at src/main.nr:6:9
 
 error: Assertion failed: QPA
-   ┌─ src/main.nr:8:17
+   ┌─ src/main.nr:6:9
    │  
- 8 │ ╭                 if b {
+ 6 │ ╭         assert(
+ 7 │ │             (
+ 8 │ │                 if b {
  9 │ │                     // safety:
-10 │ │                     unsafe {
-11 │ │                         func_3()
    · │
-15 │ │                 }
-16 │ │                     != 0_u128
-   │ ╰─────────────────────────────'
+18 │ │             "QPA",
+19 │ │         );
+   │ ╰─────────'
    │  
    = Call stack:
      1: main
-             at src/main.nr:8:17
+             at src/main.nr:6:9
 
 Failed assertion

--- a/tooling/nargo_cli/tests/snapshots/execution_failure/regression_10929/execute__tests__brillig_stderr.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_failure/regression_10929/execute__tests__brillig_stderr.snap
@@ -3,19 +3,19 @@ source: tooling/nargo_cli/tests/execute.rs
 expression: stderr
 ---
 error: Assertion failed: QPA
-   ┌─ src/main.nr:8:17
+   ┌─ src/main.nr:6:9
    │  
- 8 │ ╭                 if b {
+ 6 │ ╭         assert(
+ 7 │ │             (
+ 8 │ │                 if b {
  9 │ │                     // safety:
-10 │ │                     unsafe {
-11 │ │                         func_3()
    · │
-15 │ │                 }
-16 │ │                     != 0_u128
-   │ ╰─────────────────────────────'
+18 │ │             "QPA",
+19 │ │         );
+   │ ╰─────────'
    │  
    = Call stack:
      1: main
-             at src/main.nr:8:17
+             at src/main.nr:6:9
 
 Failed assertion

--- a/tooling/nargo_cli/tests/snapshots/execution_failure/regression_5202/execute__tests__acir_stderr.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_failure/regression_5202/execute__tests__acir_stderr.snap
@@ -3,23 +3,23 @@ source: tooling/nargo_cli/tests/execute.rs
 expression: stderr
 ---
 bug: Assertion is always false
-   ┌─ src/main.nr:45:15
+   ┌─ src/main.nr:45:5
    │
 45 │     assert_eq(magic, false);
-   │               ------------ As a result, the compiled circuit is ensured to fail. Other assertions may also fail during execution
+   │     ----------------------- As a result, the compiled circuit is ensured to fail. Other assertions may also fail during execution
    │
    = Call stack:
      1: main
-             at src/main.nr:45:15
+             at src/main.nr:45:5
 
 error: Failed constraint
-   ┌─ src/main.nr:45:15
+   ┌─ src/main.nr:45:5
    │
 45 │     assert_eq(magic, false);
-   │               ------------
+   │     -----------------------
    │
    = Call stack:
      1: main
-             at src/main.nr:45:15
+             at src/main.nr:45:5
 
 Failed to solve program: 'Cannot satisfy constraint'

--- a/tooling/nargo_cli/tests/snapshots/execution_failure/regression_5202/execute__tests__brillig_stderr.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_failure/regression_5202/execute__tests__brillig_stderr.snap
@@ -3,13 +3,13 @@ source: tooling/nargo_cli/tests/execute.rs
 expression: stderr
 ---
 error: Failed to solve program: 'Failed to solve brillig function'
-   ┌─ src/main.nr:45:15
+   ┌─ src/main.nr:45:5
    │
 45 │     assert_eq(magic, false);
-   │               ------------
+   │     -----------------------
    │
    = Call stack:
      1: main
-             at src/main.nr:45:15
+             at src/main.nr:45:5
 
 Failed to solve program: 'Failed to solve brillig function'

--- a/tooling/nargo_cli/tests/snapshots/execution_failure/regression_7128/execute__tests__acir_stderr.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_failure/regression_7128/execute__tests__acir_stderr.snap
@@ -3,13 +3,13 @@ source: tooling/nargo_cli/tests/execute.rs
 expression: stderr
 ---
 error: Assertion failed: soundness violation
-   ┌─ src/main.nr:23:12
+   ┌─ src/main.nr:23:5
    │
 23 │     assert(out0 != 0, "soundness violation");
-   │            ---------
+   │     ----------------------------------------
    │
    = Call stack:
      1: main
-             at src/main.nr:23:12
+             at src/main.nr:23:5
 
 Failed assertion

--- a/tooling/nargo_cli/tests/snapshots/execution_failure/regression_7128/execute__tests__brillig_stderr.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_failure/regression_7128/execute__tests__brillig_stderr.snap
@@ -3,13 +3,13 @@ source: tooling/nargo_cli/tests/execute.rs
 expression: stderr
 ---
 error: Assertion failed: soundness violation
-   ┌─ src/main.nr:23:12
+   ┌─ src/main.nr:23:5
    │
 23 │     assert(out0 != 0, "soundness violation");
-   │            ---------
+   │     ----------------------------------------
    │
    = Call stack:
      1: main
-             at src/main.nr:23:12
+             at src/main.nr:23:5
 
 Failed assertion

--- a/tooling/nargo_cli/tests/snapshots/execution_failure/workspace_fail/execute__tests__acir_stderr.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_failure/workspace_fail/execute__tests__acir_stderr.snap
@@ -3,13 +3,13 @@ source: tooling/nargo_cli/tests/execute.rs
 expression: stderr
 ---
 error: Failed constraint
-  ┌─ crates/a/src/main.nr:2:12
+  ┌─ crates/a/src/main.nr:2:5
   │
 2 │     assert(x == y);
-  │            ------
+  │     --------------
   │
   = Call stack:
     1: main
-            at crates/a/src/main.nr:2:12
+            at crates/a/src/main.nr:2:5
 
 Failed to solve program: 'Cannot satisfy constraint'

--- a/tooling/nargo_cli/tests/snapshots/execution_failure/workspace_fail/execute__tests__brillig_stderr.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_failure/workspace_fail/execute__tests__brillig_stderr.snap
@@ -3,13 +3,13 @@ source: tooling/nargo_cli/tests/execute.rs
 expression: stderr
 ---
 error: Failed to solve program: 'Failed to solve brillig function'
-  ┌─ crates/a/src/main.nr:2:12
+  ┌─ crates/a/src/main.nr:2:5
   │
 2 │     assert(x == y);
-  │            ------
+  │     --------------
   │
   = Call stack:
     1: main
-            at crates/a/src/main.nr:2:12
+            at crates/a/src/main.nr:2:5
 
 Failed to solve program: 'Failed to solve brillig function'

--- a/tooling/noir_js/test/node/execute.test.ts
+++ b/tooling/noir_js/test/node/execute.test.ts
@@ -58,7 +58,9 @@ it('circuit with a nested assertion should fail with the resolved call stack', a
     expect(knownError.noirCallStack![0]).to.match(
       /^at make_assertion\(x, y\) \(.*assert_msg_runtime\/src\/main.nr:2:5\)$/,
     );
-    expect(knownError.noirCallStack![1]).to.match(/^at x < y \(.*assert_msg_runtime\/src\/main.nr:7:12\)$/);
+    expect(knownError.noirCallStack![1]).to.match(
+      /^at assert\(x < y, f"Expected x < y but got \{x\} < \{y\}"\) \(.*assert_msg_runtime\/src\/main.nr:7:5\)$/,
+    );
   }
 });
 


### PR DESCRIPTION
## Problem Resolved

Resolves #3175

## Summary of Changes

<img width="1487" height="278" alt="image" src="https://github.com/user-attachments/assets/8f2682f4-2016-4fac-b263-dd4342a0dcd1" />


## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
