### PR TITLE
chore: don't skip cases in test_name_shadowing

### DIFF
--- a/compiler/noirc_frontend/src/tests/name_shadowing.rs
+++ b/compiler/noirc_frontend/src/tests/name_shadowing.rs
@@ -2,7 +2,6 @@
 use crate::tests::assert_no_errors;
 
 use super::get_program_errors;
-use std::collections::HashSet;
 
 #[test]
 fn resolve_shadowing() {
@@ -408,31 +407,11 @@ fn test_name_shadowing() {
         "trait_fn7",
     ];
 
-    // TODO(https://github.com/noir-lang/noir/issues/4973):
-    // Name resolution panic from name shadowing test
-    let cases_to_skip = [
-        (1, 21),
-        (2, 11),
-        (2, 21),
-        (3, 11),
-        (3, 18),
-        (3, 21),
-        (4, 21),
-        (5, 11),
-        (5, 21),
-        (6, 11),
-        (6, 18),
-        (6, 21),
-    ];
-    let cases_to_skip: HashSet<(usize, usize)> = cases_to_skip.into_iter().collect();
-
     for (i, x) in names_to_collapse.iter().enumerate() {
-        for (j, y) in names_to_collapse.iter().enumerate().filter(|(j, _)| i < *j) {
-            if !cases_to_skip.contains(&(i, j)) {
-                let modified_src = src.replace(x, y);
-                let errors = get_program_errors(&modified_src);
-                assert!(!errors.is_empty(), "Expected errors, got: {errors:?}");
-            }
+        for (_, y) in names_to_collapse.iter().enumerate().filter(|(j, _)| i < *j) {
+            let modified_src = src.replace(x, y);
+            let errors = get_program_errors(&modified_src);
+            assert!(!errors.is_empty(), "Expected errors, got: {errors:?}");
         }
     }
 }


### PR DESCRIPTION
## Problem Resolved

Resolves #4973

## Summary of Changes

It seems name shadowing never panics anymore.

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
