### PR TITLE
fix(ssa): assert that there's no i128 in expand_signed_math

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/opt/expand_signed_math.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/expand_signed_math.rs
@@ -148,8 +148,8 @@ impl Context<'_, '_, '_> {
         // negative value by -1. For example dividing -128 i8 by -1 would give 128, but that
         // does not fit i8. So the first thing we do is check for this case.
         let min_negative_value = self.numeric_constant(1_u128 << (bit_size - 1), unsigned_typ);
-        let max_for_bit_size =
-            if bit_size == 128 { u128::MAX - 1 } else { (1_u128 << bit_size) - 1 };
+        assert!(bit_size <= 64, "There's no i128 so bit_size should be at most 64");
+        let max_for_bit_size = (1_u128 << bit_size) - 1;
         let minus_one = self.numeric_constant(max_for_bit_size, unsigned_typ);
         let lhs_is_min_negative_value =
             self.insert_binary(lhs_unsigned, BinaryOp::Eq, min_negative_value);


### PR DESCRIPTION
## Problem Resolved

Resolves https://github.com/noir-lang/noir/security/advisories/GHSA-2v53-vfw3-w489

## Summary of Changes

Rather than fixing the math for a scenario that can't be hit, for now we can assert that that scenario will never happen. If we ever add an `i128` type, it'll surely hit that assertion and then we can implement it correctly.

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
