### PR TITLE
fix(comptime): Handle mutable tuple and struct patterns

### DIFF
--- a/compiler/noirc_frontend/src/debug/mod.rs
+++ b/compiler/noirc_frontend/src/debug/mod.rs
@@ -727,13 +727,13 @@ fn pattern_vars(pattern: &ast::Pattern) -> Vec<(ast::Ident, bool)> {
                 stack.push_back((pattern, true));
             }
             ast::Pattern::Tuple(patterns, _) => {
-                stack.extend(patterns.iter().map(|pattern| (pattern, false)));
+                stack.extend(patterns.iter().map(|pattern| (pattern, is_mut)));
             }
             ast::Pattern::Struct(_, fields, _) => {
                 stack.extend(fields.iter().map(|(_, pattern)| (pattern, is_mut)));
             }
             ast::Pattern::Parenthesized(pattern, _) => {
-                stack.push_back((pattern, false));
+                stack.push_back((pattern, is_mut));
             }
             ast::Pattern::Interned(_, _) => (),
         }

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
@@ -496,15 +496,34 @@ impl<'local, 'interner> Interpreter<'local, 'interner> {
         argument: Value,
         location: Location,
     ) -> IResult<()> {
+        self.define_pattern_inner(pattern, typ, argument, location, false)
+    }
+
+    /// `mutable` is `true` when this pattern is nested inside a `HirPattern::Mutable`,
+    /// in which case each leaf identifier is wrapped in a mutable `Value::Pointer`.
+    /// The wrapping must happen at each leaf rather than at the composite root: wrapping
+    /// the whole tuple/struct value would cause subsequent destructuring to see a
+    /// `Value::Pointer` instead of the expected `Value::Tuple`/`Value::Struct`.
+    fn define_pattern_inner(
+        &mut self,
+        pattern: &HirPattern,
+        typ: &Type,
+        argument: Value,
+        location: Location,
+        mutable: bool,
+    ) -> IResult<()> {
         match pattern {
             HirPattern::Identifier(identifier) => {
+                let argument = if mutable {
+                    Value::Pointer(Shared::new(argument), true, true)
+                } else {
+                    argument
+                };
                 self.define(identifier.id, argument);
                 Ok(())
             }
             HirPattern::Mutable(pattern, _) => {
-                // Create a mutable reference to store to
-                let argument = Value::Pointer(Shared::new(argument), true, true);
-                self.define_pattern(pattern, typ, argument, location)
+                self.define_pattern_inner(pattern, typ, argument, location, true)
             }
             HirPattern::Tuple(pattern_fields, _) => {
                 let typ = &typ.follow_bindings();
@@ -517,7 +536,7 @@ impl<'local, 'interner> Interpreter<'local, 'interner> {
                             pattern_fields.iter().zip_eq(type_fields).zip_eq(fields)
                         {
                             let argument = argument.borrow().clone();
-                            self.define_pattern(pattern, typ, argument, location)?;
+                            self.define_pattern_inner(pattern, typ, argument, location, mutable)?;
                         }
                         Ok(())
                     }
@@ -544,7 +563,13 @@ impl<'local, 'interner> Interpreter<'local, 'interner> {
 
                         let field = field.borrow();
                         let field_type = field.get_type().into_owned();
-                        self.define_pattern(field_pattern, &field_type, field.clone(), location)?;
+                        self.define_pattern_inner(
+                            field_pattern,
+                            &field_type,
+                            field.clone(),
+                            location,
+                            mutable,
+                        )?;
                     }
                     Ok(())
                 }

--- a/test_programs/execution_success/struct/src/main.nr
+++ b/test_programs/execution_success/struct/src/main.nr
@@ -72,4 +72,10 @@ fn main(x: Field, y: Field) {
     assert(six == 6);
 
     let Animal { legs: _, eyes: _ } = get_dog();
+
+    // Mutable pattern
+    let mut Nested { a, b } = Nested { a: 1, b: 2 };
+    b = b * 2;
+    a = a + b;
+    assert_eq(a, 5);
 }

--- a/test_programs/execution_success/tuples/src/main.nr
+++ b/test_programs/execution_success/tuples/src/main.nr
@@ -19,4 +19,10 @@ fn main(x: Field, y: Field) {
     assert(mutable.1 == 1);
     assert(mutable.2 == 7);
     assert(mutable.3 == 3);
+
+    // Mutable tuple pattern
+    let mut (a, b): (Field, Field) = (1, 2);
+    b = b * 2;
+    a = a + b;
+    assert_eq(a, 5);
 }

--- a/tooling/nargo_cli/tests/snapshots/execution_success/struct/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/struct/execute__tests__expanded.snap
@@ -73,4 +73,8 @@ fn main(x: Field, y: Field) {
     let six: Field = legs + (eyes as Field);
     assert(six == 6_Field);
     let Animal { legs: _, eyes: _ }: Animal = get_dog();
+    let mut Nested { a, b }: Nested = Nested { a: 1_Field, b: 2_Field };
+    b = b * 2_Field;
+    a = a + b;
+    assert(a == 5_Field);
 }

--- a/tooling/nargo_cli/tests/snapshots/execution_success/tuples/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/tuples/execute__tests__expanded.snap
@@ -29,4 +29,8 @@ fn main(x: Field, y: Field) {
     assert(mutable.1 == 1_Field);
     assert(mutable.2 == 7_Field);
     assert(mutable.3 == 3_Field);
+    let mut (a, b): (Field, Field) = (1_Field, 2_Field);
+    b = b * 2_Field;
+    a = a + b;
+    assert(a == 5_Field);
 }


### PR DESCRIPTION
## Problem Resolved

Resolves a problem I found while testing https://github.com/noir-lang/noir/pull/12474 on aztec-packages

```shell
cargo run -q -p nargo_cli -- --program-dir ../aztec-packages/noir-projects/noir-protocol-circuits/crates/blob test --silence-warnings test_3_blobs_batched --force-comptime
```

```
[blob] Running 1 test function
[blob] Testing blob_batching::tests::test_3_blobs_batched ... error: Expected `(BLS12_381_Fq, BLS12_381_Fq)` but a value of type `(BLS12_381_Fq, BLS12_381_Fq)` was given
    ┌─ /Users/aakoshh/nargo/github.com/noir-lang/noir_bigcurve/v0.14.0/src/curve_jac/ops.nr:284:43
    │  
284 │           let mut (_, XX_mul_3): (BN, BN) = bignum::bignum::compute_quadratic_expression(
    │ ╭───────────────────────────────────────────'
285 │ │             [[X]],
286 │ │             [[false]],
287 │ │             [[X, X, X]],
    · │
290 │ │             [],
291 │ │         );
    │ ╰─────────'
    │  


[blob] Failures:
     blob_batching::tests::test_3_blobs_batched

[blob] 1 test failed
```

## Summary of Changes

Changes `define_pattern` in the comptime interpreter to handle `HirPattern::Mutable` not by wrapping wrapping the value in `Value::Pointer` and recursing, which then caused the inner `HirPattern::Tuple` to fail because it only expected `Value::Tuple`, but rather to just pass along the a `mutable` flag, and allow every nested `HirPattern::Identifier` become a `Value::Pointer`.

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
