### PR TITLE
chore: disable build scripts on yarn dependencies

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -2,6 +2,7 @@ compressionLevel: mixed
 
 enableGlobalCache: false
 
+enableScripts: false
 npmMinimalAgeGate: 10080 # 1 week
 
 logFilters:

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -2,6 +2,9 @@ compressionLevel: mixed
 
 enableGlobalCache: false
 
+# Disable postinstall scripts to prevent potential security issues with untrusted packages.
+# Packages that require postinstall scripts should be reviewed and added to the allowlist if necessary:
+# https://yarnpkg.com/configuration/manifest#dependenciesMeta.built
 enableScripts: false
 npmMinimalAgeGate: 10080 # 1 week
 


### PR DESCRIPTION
## Problem Resolved

Resolves <!-- Link to GitHub Issue -->

## Summary of Changes

This PR disables postinstall scripts by default when installing npm packages and we should whitelist these when they are necessary.

## User Documentation

Check one:
- [ ] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
