### PR TITLE
chore: remove `allowed-tools` from skills

### DIFF
--- a/.claude/skills/bisect-ssa-pass/SKILL.md
+++ b/.claude/skills/bisect-ssa-pass/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: bisect-ssa-pass
 description: Workflow for debugging SSA pass semantic preservation using the noir-ssa CLI. Use when a program's behavior changes incorrectly during the SSA pipeline - bisects passes to identify which one breaks semantics. The `pass_vs_prev` fuzzer finds such issues automatically.
-allowed-tools: Bash, Read, Grep, Glob, Write
 ---
 
 # Noir SSA Bisection Debugging

--- a/.claude/skills/debug-fuzzer-failure/SKILL.md
+++ b/.claude/skills/debug-fuzzer-failure/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: debug-fuzzer-failure
 description: End-to-end workflow for debugging SSA fuzzer failures from CI. Extracts a reproduction case from GitHub Actions logs, then bisects SSA passes to identify the bug. Use when a `pass_vs_prev` or similar fuzzer test fails in CI.
-allowed-tools: Bash, Read, Grep, Glob, Write, WebFetch
 ---
 
 # Debugging SSA Fuzzer Failures

--- a/.claude/skills/extract-fuzzer-repro/SKILL.md
+++ b/.claude/skills/extract-fuzzer-repro/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: extract-fuzzer-repro
 description: Extract a Noir reproduction project from fuzzer failure logs in GitHub Actions. Use when a CI fuzzer test fails and you need to create a local reproduction.
-allowed-tools: Bash, Read, Write
 ---
 
 # Extract Fuzzer Reproduction from GitHub Actions

--- a/.claude/skills/noir-optimize-acir/SKILL.md
+++ b/.claude/skills/noir-optimize-acir/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: noir-optimize-acir
 description: Workflow for measuring and optimizing the ACIR circuit size of a constrained Noir program. Use when asked to optimize a Noir program's gate count or circuit size.
-allowed-tools: Bash, Read, Grep, Glob
 ---
 
 # ACIR Optimization Loop


### PR DESCRIPTION
## Problem Resolved

Resolves <!-- Link to GitHub Issue -->

## Summary of Changes

This is triggering a warning as not being supported.

## User Documentation

Check one:
- [ ] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
