### PR TITLE
fix(coverage): several fixes

### DIFF
--- a/examples/coverage/coverage_report.sh
+++ b/examples/coverage/coverage_report.sh
@@ -10,12 +10,6 @@ NARGO=${NARGO:-nargo}
 GENERATED=target/coverage/lcov.info
 REFERENCE=lcov.info
 
-# Strip the machine-specific prefix from SF: records so the file is
-# portable and can be checked into Git.  Everything before the last
-# occurrence of "examples/" is removed (greedy .* backtracks to the
-# rightmost match), leaving paths of the form "SF:examples/coverage/src/...".
-sed -i.bak 's|SF:.*/examples/|SF:examples/|' "$GENERATED" && rm -f "${GENERATED}.bak"
-
 if [ -f "$REFERENCE" ]; then
     echo "Verifying coverage report..."
     diff "$REFERENCE" "$GENERATED"

--- a/examples/coverage/lcov.info
+++ b/examples/coverage/lcov.info
@@ -4,13 +4,21 @@ FN:1,double
 FN:5,add
 FN:11,moo::triple
 FN:20,multi_line_function_decl
+FN:52,<u32 as Quadruple>::quadrupled
+FN:52,<u64 as Quadruple>::quadrupled
 FN:52,Quadruple::quadrupled
+FN:58,<u32 as Quadruple>::doubled
+FN:64,<u64 as Quadruple>::doubled
 FNDA:0,double
 FNDA:0,add
 FNDA:0,moo::triple
 FNDA:0,multi_line_function_decl
+FNDA:0,<u32 as Quadruple>::quadrupled
+FNDA:0,<u64 as Quadruple>::quadrupled
 FNDA:0,Quadruple::quadrupled
-FNF:5
+FNDA:0,<u32 as Quadruple>::doubled
+FNDA:0,<u64 as Quadruple>::doubled
+FNF:9
 FNH:0
 DA:1,0
 DA:2,0
@@ -32,9 +40,11 @@ DA:42,0
 DA:43,0
 DA:52,0
 DA:53,0
+DA:58,0
 DA:59,0
+DA:64,0
 DA:65,0
-LF:22
+LF:24
 LH:0
 end_of_record
 TN:test_add

--- a/examples/coverage/lcov.info
+++ b/examples/coverage/lcov.info
@@ -2,11 +2,11 @@ TN:
 SF:examples/coverage/src/lib.nr
 FN:1,double
 FN:5,add
-FN:10,triple
-FN:18,multi_line_function_decl
+FN:11,moo::triple
+FN:20,multi_line_function_decl
 FNDA:0,double
 FNDA:0,add
-FNDA:0,triple
+FNDA:0,moo::triple
 FNDA:0,multi_line_function_decl
 FNF:4
 FNH:0
@@ -14,11 +14,9 @@ DA:1,0
 DA:2,0
 DA:5,0
 DA:6,0
-DA:10,0
 DA:11,0
-DA:18,0
-DA:31,0
-DA:32,0
+DA:12,0
+DA:20,0
 DA:33,0
 DA:34,0
 DA:35,0
@@ -28,6 +26,8 @@ DA:38,0
 DA:39,0
 DA:40,0
 DA:41,0
+DA:42,0
+DA:43,0
 LF:18
 LH:0
 end_of_record

--- a/examples/coverage/lcov.info
+++ b/examples/coverage/lcov.info
@@ -4,11 +4,13 @@ FN:1,double
 FN:5,add
 FN:11,moo::triple
 FN:20,multi_line_function_decl
+FN:52,Quadruple::quadrupled
 FNDA:0,double
 FNDA:0,add
 FNDA:0,moo::triple
 FNDA:0,multi_line_function_decl
-FNF:4
+FNDA:0,Quadruple::quadrupled
+FNF:5
 FNH:0
 DA:1,0
 DA:2,0
@@ -28,7 +30,11 @@ DA:40,0
 DA:41,0
 DA:42,0
 DA:43,0
-LF:18
+DA:52,0
+DA:53,0
+DA:59,0
+DA:65,0
+LF:22
 LH:0
 end_of_record
 TN:test_add
@@ -52,4 +58,25 @@ DA:1,1
 DA:2,3
 LF:2
 LH:2
+end_of_record
+TN:test_quadrupled
+SF:src/lib.nr
+FN:52,<u32 as Quadruple>::quadrupled
+FN:52,<u64 as Quadruple>::quadrupled
+FN:58,<u32 as Quadruple>::doubled
+FN:64,<u64 as Quadruple>::doubled
+FNDA:1,<u32 as Quadruple>::quadrupled
+FNDA:1,<u64 as Quadruple>::quadrupled
+FNDA:2,<u32 as Quadruple>::doubled
+FNDA:2,<u64 as Quadruple>::doubled
+FNF:4
+FNH:4
+DA:52,2
+DA:53,10
+DA:58,2
+DA:59,6
+DA:64,2
+DA:65,6
+LF:6
+LH:6
 end_of_record

--- a/examples/coverage/lcov.info
+++ b/examples/coverage/lcov.info
@@ -1,5 +1,5 @@
 TN:
-SF:examples/coverage/src/lib.nr
+SF:src/lib.nr
 FN:1,double
 FN:5,add
 FN:11,moo::triple
@@ -32,7 +32,7 @@ LF:18
 LH:0
 end_of_record
 TN:test_add
-SF:examples/coverage/src/lib.nr
+SF:src/lib.nr
 FN:5,add
 FNDA:1,add
 FNF:1
@@ -43,7 +43,7 @@ LF:2
 LH:2
 end_of_record
 TN:test_double
-SF:examples/coverage/src/lib.nr
+SF:src/lib.nr
 FN:1,double
 FNDA:1,double
 FNF:1

--- a/examples/coverage/src/lib.nr
+++ b/examples/coverage/src/lib.nr
@@ -44,6 +44,28 @@ where
     ]
 }
 
+// Two impls of the same trait method live in this file. They should appear in the
+// coverage report under distinct, fully-qualified names so the entries don't collide.
+// `quadrupled` is a trait function with a default body and is reported under the trait.
+pub trait Quadruple {
+    fn doubled(self) -> Self;
+    fn quadrupled(self) -> Self {
+        self.doubled().doubled()
+    }
+}
+
+impl Quadruple for u32 {
+    fn doubled(self) -> u32 {
+        self * 2
+    }
+}
+
+impl Quadruple for u64 {
+    fn doubled(self) -> u64 {
+        self * 2
+    }
+}
+
 #[test]
 fn test_double() {
     assert_eq(double(3), 6);
@@ -52,4 +74,10 @@ fn test_double() {
 #[test]
 fn test_add() {
     assert_eq(add(2, 3), 5);
+}
+
+#[test]
+fn test_quadrupled() {
+    assert_eq(3u32.quadrupled(), 12);
+    assert_eq(3u64.quadrupled(), 12);
 }

--- a/examples/coverage/src/lib.nr
+++ b/examples/coverage/src/lib.nr
@@ -6,9 +6,11 @@ pub fn add(x: u32, y: u32) -> u32 {
     x + y
 }
 
-// Not covered by any test; should appear as uncovered in the report.
-pub fn triple(x: u32) -> u32 {
-    x * 3
+mod moo {
+    // Not covered by any test; should appear as uncovered in the report.
+    pub fn triple(x: u32) -> u32 {
+        x * 3
+    }
 }
 
 // Function declaration spanning multiple lines. We should see:

--- a/tooling/nargo_cli/src/cli/test_cmd/coverage.rs
+++ b/tooling/nargo_cli/src/cli/test_cmd/coverage.rs
@@ -63,7 +63,14 @@ pub(super) fn baseline_in_package(context: &Context, crate_id: CrateId) -> Repor
             if let Some(func_id) = def_id.as_function()
                 && !test_func_ids.contains(&func_id)
             {
-                let file = context.def_interner.function_meta(&func_id).location.file;
+                let func_meta = context.def_interner.function_meta(&func_id);
+
+                // Don't track trait functions or other functions without bodies.
+                if func_meta.is_stub() {
+                    continue;
+                }
+
+                let file = func_meta.location.file;
 
                 // Remember this function, so we can emit their name and where they are later.
                 functions_by_file.entry(file).or_default().push(func_id);

--- a/tooling/nargo_cli/src/cli/test_cmd/coverage.rs
+++ b/tooling/nargo_cli/src/cli/test_cmd/coverage.rs
@@ -59,27 +59,42 @@ pub(super) fn baseline_in_package(context: &Context, crate_id: CrateId) -> Repor
         def_map.get_all_test_functions(&context.def_interner).map(|f| f.id).collect();
 
     let mut functions_by_file: HashMap<FileId, Vec<FuncId>> = HashMap::new();
+    let record_func = |func_id: FuncId,
+                       offsets_by_file: &mut HashMap<FileId, Vec<u32>>,
+                       functions_by_file: &mut HashMap<FileId, Vec<FuncId>>| {
+        if test_func_ids.contains(&func_id) {
+            return;
+        }
+        let func_meta = context.def_interner.function_meta(&func_id);
+
+        // Don't track trait functions or other functions without bodies.
+        if func_meta.is_stub() {
+            return;
+        }
+
+        let file = func_meta.location.file;
+        functions_by_file.entry(file).or_default().push(func_id);
+
+        // Ensure the file shows up in `offsets_by_file` so it gets a section even
+        // if every function in it has an empty body.
+        offsets_by_file.entry(file).or_default();
+    };
+
     for (_, module) in def_map.modules().iter() {
         for def_id in module.value_definitions() {
-            if let Some(func_id) = def_id.as_function()
-                && !test_func_ids.contains(&func_id)
-            {
-                let func_meta = context.def_interner.function_meta(&func_id);
-
-                // Don't track trait functions or other functions without bodies.
-                if func_meta.is_stub() {
-                    continue;
-                }
-
-                let file = func_meta.location.file;
-
-                // Remember this function, so we can emit their name and where they are later.
-                functions_by_file.entry(file).or_default().push(func_id);
-
-                // Make sure we have an entry in offsets as well, so we can iterate over the files
-                // even if all functions had empty bodies.
-                offsets_by_file.entry(file).or_default();
+            if let Some(func_id) = def_id.as_function() {
+                record_func(func_id, &mut offsets_by_file, &mut functions_by_file);
             }
+        }
+    }
+
+    // Trait impl methods aren't reachable through `module.value_definitions()` — they
+    // live in the trait impl, not in any module's name scope. Enumerate them directly
+    // so the baseline includes impl methods that no test ever calls.
+    for impl_id in context.def_interner.get_trait_implementations_in_crate(crate_id) {
+        let trait_impl = context.def_interner.get_trait_implementation(impl_id);
+        for func_id in trait_impl.borrow().methods.clone() {
+            record_func(func_id, &mut offsets_by_file, &mut functions_by_file);
         }
     }
 

--- a/tooling/nargo_cli/src/cli/test_cmd/coverage.rs
+++ b/tooling/nargo_cli/src/cli/test_cmd/coverage.rs
@@ -215,8 +215,36 @@ fn file_path(context: &Context, file_id: FileId) -> Option<PathBuf> {
     context.file_manager.as_file_map().get_name(file_id).ok().map(|p| p.into_path_buf())
 }
 
+/// Returns a fully-qualified name for `func_id` to use in the coverage report.
+///
+/// Methods inside a trait impl get a `<Type as Trait>::method` qualification so distinct
+/// impls of the same trait method don't collapse onto a single display name (which would
+/// cause duplicate `FN`/`FNDA` entries to merge into one in `lcov.info`).
+///
+/// Trait functions defined inside `trait { ... }` need no extra label work: the trait
+/// itself is a module, so the module path already qualifies them as `<module>::<Trait>::<fn>`.
 fn fully_qualified_function_name(context: &Context, meta: &FuncMeta, func_id: &FuncId) -> String {
-    context.fully_qualified_function_name(&meta.source_crate, &func_id)
+    let interner = &context.def_interner;
+    let def_maps = &context.def_maps;
+    let def_map = &def_maps[&meta.source_crate];
+
+    let module_id = interner.function_module(*func_id);
+    let module = module_id.module(def_maps);
+    let module_path =
+        def_map.get_module_path_with_separator(module_id.local_id, module.parent, "::");
+
+    let name = interner.function_name(func_id);
+
+    let label = if let Some(trait_impl_id) = meta.trait_impl {
+        let trait_impl = interner.get_trait_implementation(trait_impl_id);
+        let trait_impl = trait_impl.borrow();
+        let trait_def = interner.get_trait(trait_impl.trait_id);
+        format!("<{} as {}>::{}", trait_impl.typ, trait_def.name, name)
+    } else {
+        name.to_string()
+    };
+
+    if module_path.is_empty() { label } else { format!("{module_path}::{label}") }
 }
 
 /// Returns the path where coverage data for `package_name` should be written.

--- a/tooling/nargo_cli/src/cli/test_cmd/coverage.rs
+++ b/tooling/nargo_cli/src/cli/test_cmd/coverage.rs
@@ -86,7 +86,9 @@ pub(super) fn baseline_in_package(context: &Context, crate_id: CrateId) -> Repor
     let line_starts = LineStartsCache::new(context);
 
     for (file_id, byte_offsets) in &offsets_by_file {
-        let Some(path) = context.file_manager.path(*file_id) else { continue };
+        let Some(path) = context.file_manager.as_file_map().get_name(*file_id).ok() else {
+            continue;
+        };
         let Some(line_starts) = line_starts.build(file_id) else { continue };
 
         let mut functions = function::Functions::new();
@@ -111,7 +113,7 @@ pub(super) fn baseline_in_package(context: &Context, crate_id: CrateId) -> Repor
                 .or_insert(line::Value { count: 0, checksum: None });
         }
 
-        let key = section::Key { test_name: String::new(), source_file: path.to_path_buf() };
+        let key = section::Key { test_name: String::new(), source_file: path.into_path_buf() };
         let value = section::Value { functions, branches: Branches::default(), lines };
         report.sections.insert(key, value);
     }
@@ -194,10 +196,12 @@ pub(super) fn tracker_to_report(
     let mut report = Report::new();
 
     for (file_id, (functions, lines)) in data {
-        let Some(path) = context.file_manager.path(file_id) else { continue };
+        let Some(path) = context.file_manager.as_file_map().get_name(file_id).ok() else {
+            continue;
+        };
 
         let key =
-            section::Key { test_name: test_name.to_string(), source_file: path.to_path_buf() };
+            section::Key { test_name: test_name.to_string(), source_file: path.into_path_buf() };
         let value = section::Value { functions, branches: Branches::default(), lines };
         if !value.is_empty() {
             report.sections.insert(key, value);

--- a/tooling/nargo_cli/src/cli/test_cmd/coverage.rs
+++ b/tooling/nargo_cli/src/cli/test_cmd/coverage.rs
@@ -216,7 +216,7 @@ pub(super) fn tracker_to_report(
             continue;
         };
 
-        let key = section::Key { test_name: test_name.to_string(), source_file };
+        let key = section::Key { test_name: sanitize_test_name(test_name), source_file };
         let value = section::Value { functions, branches: Branches::default(), lines };
         if !value.is_empty() {
             report.sections.insert(key, value);
@@ -228,6 +228,14 @@ pub(super) fn tracker_to_report(
 
 fn file_path(context: &Context, file_id: FileId) -> Option<PathBuf> {
     context.file_manager.as_file_map().get_name(file_id).ok().map(|p| p.into_path_buf())
+}
+
+/// `lcov` rejects `:` in the `TN:` (test name) field — without sanitization it logs
+/// "invalid characters removed from testname" and silently rewrites them. We do the
+/// same rewrite up front so the file is accepted cleanly: `module::test_name` becomes
+/// `module__test_name`.
+fn sanitize_test_name(test_name: &str) -> String {
+    test_name.replace(':', "_")
 }
 
 /// Returns a fully-qualified name for `func_id` to use in the coverage report.

--- a/tooling/nargo_cli/src/cli/test_cmd/coverage.rs
+++ b/tooling/nargo_cli/src/cli/test_cmd/coverage.rs
@@ -86,7 +86,7 @@ pub(super) fn baseline_in_package(context: &Context, crate_id: CrateId) -> Repor
     let line_starts = LineStartsCache::new(context);
 
     for (file_id, byte_offsets) in &offsets_by_file {
-        let Some(path) = context.file_manager.as_file_map().get_name(*file_id).ok() else {
+        let Some(source_file) = file_path(context, *file_id) else {
             continue;
         };
         let Some(line_starts) = line_starts.build(file_id) else { continue };
@@ -113,7 +113,7 @@ pub(super) fn baseline_in_package(context: &Context, crate_id: CrateId) -> Repor
                 .or_insert(line::Value { count: 0, checksum: None });
         }
 
-        let key = section::Key { test_name: String::new(), source_file: path.into_path_buf() };
+        let key = section::Key { test_name: String::new(), source_file };
         let value = section::Value { functions, branches: Branches::default(), lines };
         report.sections.insert(key, value);
     }
@@ -196,12 +196,11 @@ pub(super) fn tracker_to_report(
     let mut report = Report::new();
 
     for (file_id, (functions, lines)) in data {
-        let Some(path) = context.file_manager.as_file_map().get_name(file_id).ok() else {
+        let Some(source_file) = file_path(context, file_id) else {
             continue;
         };
 
-        let key =
-            section::Key { test_name: test_name.to_string(), source_file: path.into_path_buf() };
+        let key = section::Key { test_name: test_name.to_string(), source_file };
         let value = section::Value { functions, branches: Branches::default(), lines };
         if !value.is_empty() {
             report.sections.insert(key, value);
@@ -209,6 +208,10 @@ pub(super) fn tracker_to_report(
     }
 
     report
+}
+
+fn file_path(context: &Context, file_id: FileId) -> Option<PathBuf> {
+    context.file_manager.as_file_map().get_name(file_id).ok().map(|p| p.into_path_buf())
 }
 
 /// Returns the path where coverage data for `package_name` should be written.

--- a/tooling/nargo_cli/src/cli/test_cmd/coverage.rs
+++ b/tooling/nargo_cli/src/cli/test_cmd/coverage.rs
@@ -94,7 +94,7 @@ pub(super) fn baseline_in_package(context: &Context, crate_id: CrateId) -> Repor
 
         for &func_id in functions_by_file.get(file_id).map_or([].as_slice(), Vec::as_slice) {
             let meta = context.def_interner.function_meta(&func_id);
-            let name = context.def_interner.function_name(&func_id).to_string();
+            let name = context.fully_qualified_function_name(&meta.source_crate, &func_id);
             let start_line = offset_to_line(meta.location.span.start(), &line_starts);
             functions.insert(
                 function::Key { name },
@@ -177,7 +177,7 @@ pub(super) fn tracker_to_report(
             continue;
         };
         let start_line = offset_to_line(meta.location.span.start(), line_starts);
-        let name = context.def_interner.function_name(&func_id).to_string();
+        let name = context.fully_qualified_function_name(&meta.source_crate, &func_id);
 
         functions
             .entry(function::Key { name })

--- a/tooling/nargo_cli/src/cli/test_cmd/coverage.rs
+++ b/tooling/nargo_cli/src/cli/test_cmd/coverage.rs
@@ -14,6 +14,7 @@ use noirc_errors::Location;
 use noirc_frontend::graph::CrateId;
 use noirc_frontend::hir::Context;
 use noirc_frontend::hir::comptime::EvaluationTracker;
+use noirc_frontend::hir_def::function::FuncMeta;
 use noirc_frontend::node_interner::FuncId;
 
 /// Returns the location of every expression in the crate that should appear in the coverage
@@ -96,7 +97,7 @@ pub(super) fn baseline_in_package(context: &Context, crate_id: CrateId) -> Repor
 
         for &func_id in functions_by_file.get(file_id).map_or([].as_slice(), Vec::as_slice) {
             let meta = context.def_interner.function_meta(&func_id);
-            let name = context.fully_qualified_function_name(&meta.source_crate, &func_id);
+            let name = fully_qualified_function_name(context, meta, &func_id);
             let start_line = offset_to_line(meta.location.span.start(), &line_starts);
             functions.insert(
                 function::Key { name },
@@ -179,7 +180,7 @@ pub(super) fn tracker_to_report(
             continue;
         };
         let start_line = offset_to_line(meta.location.span.start(), line_starts);
-        let name = context.fully_qualified_function_name(&meta.source_crate, &func_id);
+        let name = fully_qualified_function_name(context, meta, &func_id);
 
         functions
             .entry(function::Key { name })
@@ -212,6 +213,10 @@ pub(super) fn tracker_to_report(
 
 fn file_path(context: &Context, file_id: FileId) -> Option<PathBuf> {
     context.file_manager.as_file_map().get_name(file_id).ok().map(|p| p.into_path_buf())
+}
+
+fn fully_qualified_function_name(context: &Context, meta: &FuncMeta, func_id: &FuncId) -> String {
+    context.fully_qualified_function_name(&meta.source_crate, &func_id)
 }
 
 /// Returns the path where coverage data for `package_name` should be written.


### PR DESCRIPTION
## Problem Resolved

Resolves #12539
Resolves #12538

## Summary of Changes

Fixes the above issues and some more that Claude and I spotted while checking the stdlib coverage.

With this we can run `lcov --summary` on the stdlib:

```
$ lcov --summary target/coverage/lcov.info
Reading tracefile target/coverage/lcov.info.
Summary coverage rate:
  source files: 38
  lines.......: 40.9% (916 of 2242 lines)
  functions...: 38.6% (233 of 603 functions)
Message summary:
  no messages were reported
```

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
