### PR TITLE
feat(monomorphization): add error for using print and static_assert …

### DIFF
--- a/compiler/noirc_frontend/src/monomorphization/errors.rs
+++ b/compiler/noirc_frontend/src/monomorphization/errors.rs
@@ -31,6 +31,7 @@ pub enum MonomorphizationError {
     VectorWithNestedArrayReturnedFromOracle { typ: String, location: Location },
     InvalidTypeForEntryPoint { invalid_type: InvalidType, location: Location },
     ComplexType { complexity: usize, max_complexity: usize, location: Location },
+    CannotUseFunctionAsValue { name: String, location: Location },
 }
 
 impl MonomorphizationError {
@@ -61,7 +62,8 @@ impl MonomorphizationError {
             | MonomorphizationError::ReferenceReturnedFromOracle { location, .. }
             | MonomorphizationError::VectorWithNestedArrayReturnedFromOracle { location, .. }
             | MonomorphizationError::InvalidTypeForEntryPoint { location, .. }
-            | MonomorphizationError::ComplexType { location, .. } => *location,
+            | MonomorphizationError::ComplexType { location, .. }
+            | MonomorphizationError::CannotUseFunctionAsValue { location, .. } => *location,
             MonomorphizationError::InterpreterError(error) => error.location(),
         }
     }
@@ -198,6 +200,13 @@ impl From<MonomorphizationError> for CustomDiagnostic {
                     "Type is too complex (complexity: {complexity}, max: {max_complexity})",
                 );
                 let secondary = "This usually happens with exponentially growing types. Consider simplifying the type structure.".to_string();
+                return CustomDiagnostic::simple_error(message, secondary, *location);
+            }
+            MonomorphizationError::CannotUseFunctionAsValue { name, location } => {
+                let message = format!(
+                    "`{name}` cannot be used as a function value; it must be called directly"
+                );
+                let secondary = "Used as a value here".to_string();
                 return CustomDiagnostic::simple_error(message, secondary, *location);
             }
         };

--- a/compiler/noirc_frontend/src/monomorphization/mod.rs
+++ b/compiler/noirc_frontend/src/monomorphization/mod.rs
@@ -1444,6 +1444,15 @@ impl<'interner> Monomorphizer<'interner> {
             evaluate_builtin,
         )?;
 
+        // `static_assert` and the `print` oracle cannot be higher-order values because the compiler
+        // adds arguments to their call during monomorphization.
+        if evaluate_builtin && let Some(name) = special_function_name(&definition) {
+            return Err(MonomorphizationError::CannotUseFunctionAsValue {
+                name: name.to_string(),
+                location,
+            });
+        }
+
         if self.function_is_oracle(func_id)
             && let Type::Function(_args, ret, _env, _unconstrained) = typ
         {
@@ -2908,6 +2917,23 @@ impl<'interner> Monomorphizer<'interner> {
         self.interner.function_modifiers(&func_id).attributes.function.as_ref().is_some_and(
             |(attribute, _)| matches!(attribute.kind, FunctionAttributeKind::Oracle(..)),
         )
+    }
+}
+
+/// If this definition refers to a builtin or oracle whose call site requires
+/// special handling in `function_call` (printable type info append), return
+/// the user-facing name. Otherwise return `None`. Such functions cannot be
+/// used as first-class values because the special handling only fires for
+/// direct calls.
+fn special_function_name(definition: &Definition) -> Option<&str> {
+    match definition {
+        Definition::Builtin(name) if name == "static_assert" => Some(name),
+        Definition::Oracle(name)
+            if matches!(ForeignCall::lookup(name), Some(ForeignCall::Print)) =>
+        {
+            Some(name)
+        }
+        _ => None,
     }
 }
 

--- a/compiler/noirc_frontend/src/monomorphization/tests.rs
+++ b/compiler/noirc_frontend/src/monomorphization/tests.rs
@@ -1553,3 +1553,86 @@ fn outer_immref_from_brillig_is_rejected() {
     ";
     check_monomorphization_error_using_features(src, &[], true);
 }
+
+const STATIC_ASSERT_STDLIB: &str = "
+    #[builtin(static_assert)]
+    pub fn static_assert<T>(predicate: bool, message: T) {}
+";
+
+#[test]
+fn static_assert_used_as_value_in_let_is_rejected() {
+    let src = r#"
+    fn main() {
+        let f = static_assert;
+        f(true, "msg");
+    }
+    "#;
+    let err = get_monomorphized_with_stdlib(src, &[STATIC_ASSERT_STDLIB]).unwrap_err();
+    assert!(
+        matches!(&err, MonomorphizationError::CannotUseFunctionAsValue { name, .. } if name == "static_assert"),
+        "expected CannotUseFunctionAsValue for static_assert, got: {err:?}"
+    );
+}
+
+#[test]
+fn static_assert_passed_as_argument_is_rejected() {
+    let src = r#"
+    fn main() {
+        call_it(static_assert);
+    }
+
+    fn call_it(f: fn(bool, str<3>) -> ()) {
+        f(true, "msg");
+    }
+    "#;
+    let err = get_monomorphized_with_stdlib(src, &[STATIC_ASSERT_STDLIB]).unwrap_err();
+    assert!(
+        matches!(&err, MonomorphizationError::CannotUseFunctionAsValue { name, .. } if name == "static_assert"),
+        "expected CannotUseFunctionAsValue for static_assert, got: {err:?}"
+    );
+}
+
+#[test]
+fn static_assert_in_block_callee_is_rejected() {
+    // The block expression evaluates to the static_assert function value, which is then called.
+    // Even though the program "looks like" a direct call, the value form goes through monomorphization.
+    let src = r#"
+    fn main() {
+        ({ static_assert })(true, "msg");
+    }
+    "#;
+    let err = get_monomorphized_with_stdlib(src, &[STATIC_ASSERT_STDLIB]).unwrap_err();
+    assert!(
+        matches!(&err, MonomorphizationError::CannotUseFunctionAsValue { name, .. } if name == "static_assert"),
+        "expected CannotUseFunctionAsValue for static_assert, got: {err:?}"
+    );
+}
+
+#[test]
+fn print_oracle_used_as_value_is_rejected() {
+    let src = r#"
+    fn main() {
+        // Safety: test
+        unsafe {
+            let p = print_oracle;
+            p(true, 1);
+        }
+    }
+    "#;
+    let err = get_monomorphized_with_stdlib(src, &[stdlib_src::PRINT]).unwrap_err();
+    assert!(
+        matches!(&err, MonomorphizationError::CannotUseFunctionAsValue { name, .. } if name == "print"),
+        "expected CannotUseFunctionAsValue for print oracle, got: {err:?}"
+    );
+}
+
+#[test]
+fn static_assert_called_directly_still_works() {
+    let src = r#"
+    fn main() {
+        static_assert(true, "msg");
+    }
+    "#;
+    get_monomorphized_with_stdlib(src, &[STATIC_ASSERT_STDLIB])
+        .expect("direct call to static_assert should still monomorphize");
+}


### PR DESCRIPTION
…as values

## Problem Resolved

Resolves audithub issue: Indirect `static_assert` and `print` calls do not compile
https://app.audithub.dev/app/organizations/161/projects/787/project-viewer?version=1681&issueId=997


## Summary of Changes
static_assert and print cannot be used as values anymore.
This is a breaking change in theory, but in practice, using them as values would have panic the compiler so it cannot
break existing program.


## User Documentation

Check one:
- [X] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
