### PR TITLE
fix(comptime): correctly implement `is_unconstrained`

### DIFF
--- a/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
@@ -127,6 +127,11 @@ pub struct Interpreter<'local, 'interner> {
 
     /// Current evaluation depth.
     evaluation_depth: usize,
+
+    /// Whether we are inside an unconstrained context. This is set to true when entering
+    /// an unconstrained function, and it keeps being true in nested calls regardless of
+    /// them being constrained or unconstrained.
+    in_unconstrained: bool,
 }
 
 impl<'local, 'interner> Interpreter<'local, 'interner> {
@@ -140,6 +145,7 @@ impl<'local, 'interner> Interpreter<'local, 'interner> {
             bound_generics: Vec::new(),
             in_loop: false,
             evaluation_depth: 0,
+            in_unconstrained: false,
         }
     }
 
@@ -210,8 +216,14 @@ impl<'local, 'interner> Interpreter<'local, 'interner> {
             self.current_function = Some(function);
         }
 
+        let previous_in_unconstrained = self.in_unconstrained;
+        self.in_unconstrained |= meta.is_unconstrained();
+
         let result = self.call_user_defined_function(function, arguments, location);
+
         self.current_function = old_function;
+        self.in_unconstrained = previous_in_unconstrained;
+
         result
     }
 

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
@@ -139,13 +139,17 @@ impl<'local, 'interner> Interpreter<'local, 'interner> {
         elaborator: &'local mut Elaborator<'interner>,
         current_function: Option<FuncId>,
     ) -> Self {
+        let in_unconstrained = current_function.is_some_and(|function| {
+            elaborator.interner.function_meta(&function).is_unconstrained()
+        });
+
         Self {
             elaborator,
             current_function,
             bound_generics: Vec::new(),
             in_loop: false,
             evaluation_depth: 0,
-            in_unconstrained: false,
+            in_unconstrained,
         }
     }
 

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
@@ -125,7 +125,7 @@ impl Interpreter<'_, '_> {
             "expr_is_break" => expr_is_break(interner, arguments, location),
             "expr_is_continue" => expr_is_continue(interner, arguments, location),
             "expr_resolve" => expr_resolve(self, arguments, location),
-            "is_unconstrained" => Ok(Value::Bool(true)),
+            "is_unconstrained" => Ok(Value::Bool(self.in_unconstrained)),
             "field_less_than" => field_less_than(arguments, location),
             "fmtstr_as_ctstring" => fmtstr_as_ctstring(interner, arguments, location),
             "fmtstr_quoted_contents" => fmtstr_quoted_contents(interner, arguments, location),

--- a/compiler/noirc_frontend/src/hir/comptime/tests.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/tests.rs
@@ -19,7 +19,8 @@ use crate::parse_program;
 
 /// Create an interpreter for a code snippet and pass it to a test function.
 ///
-/// The stdlib is not made available as a dependency.
+/// The given source is considered the root crate and also the stdlib, in case
+/// builtins need to be tested.
 pub(crate) fn with_interpreter<T>(
     src: &str,
     f: impl FnOnce(&mut Interpreter, FuncId, &[CompilationError]) -> T,
@@ -42,7 +43,7 @@ pub(crate) fn with_interpreter<T>(
     let mut context = Context::new(file_manager, parsed_files);
     context.def_interner.populate_dummy_operator_traits();
 
-    let krate = context.crate_graph.add_crate_root(FileId::dummy());
+    let krate = context.crate_graph.add_crate_root_and_stdlib(FileId::dummy());
 
     let (module, errors) = parse_program(src, file);
     assert_eq!(errors.len(), 0);
@@ -534,4 +535,91 @@ fn main() {
         assert!(has_type_mismatch, "Expected a TypeMismatch error (expected u32, found Field)");
         assert_eq!(errors.len(), 1, "Expected exactly one error");
     });
+}
+
+#[test]
+fn is_unconstrained_returns_false() {
+    let program = "
+    #[builtin(is_unconstrained)]
+    pub fn is_unconstrained() -> bool {}
+
+    fn main() -> pub bool {
+        is_unconstrained()
+    }
+    ";
+    let result = interpret(program);
+    assert_eq!(result, Value::Bool(false));
+}
+
+#[test]
+fn is_unconstrained_returns_false_in_nested_call_1() {
+    let program = "
+    #[builtin(is_unconstrained)]
+    pub fn is_unconstrained() -> bool {}
+
+    fn main() -> pub bool {
+        foo()
+    }
+
+    fn foo() -> bool {
+        is_unconstrained()
+    }
+    ";
+    let result = interpret(program);
+    assert_eq!(result, Value::Bool(false));
+}
+
+#[test]
+fn is_unconstrained_returns_false_in_nested_call_2() {
+    let program = "
+    #[builtin(is_unconstrained)]
+    pub fn is_unconstrained() -> bool {}
+
+    fn main() -> pub bool {
+        // Safety: test
+        unsafe { foo(); }
+        bar()
+    }
+
+    unconstrained fn foo() {
+    }
+
+    fn bar() -> bool {
+        is_unconstrained()
+    }
+    ";
+    let result = interpret(program);
+    assert_eq!(result, Value::Bool(false));
+}
+
+#[test]
+fn is_unconstrained_returns_true() {
+    let program = "
+    #[builtin(is_unconstrained)]
+    pub fn is_unconstrained() -> bool {}
+
+    unconstrained fn main() -> pub bool {
+        is_unconstrained()
+    }
+    ";
+    let result = interpret(program);
+    assert_eq!(result, Value::Bool(true));
+}
+
+#[test]
+fn is_unconstrained_returns_in_nested_call() {
+    let program = "
+    #[builtin(is_unconstrained)]
+    pub fn is_unconstrained() -> bool {}
+
+    unconstrained fn main() -> pub bool {
+        foo()
+    }
+
+    fn foo() -> bool {
+        is_unconstrained()
+    }
+    ";
+    let result = interpret(program);
+    assert_eq!(result, Value::Bool(true));
 }

--- a/test_programs/compile_success_empty/comptime_vector_methods/src/main.nr
+++ b/test_programs/compile_success_empty/comptime_vector_methods/src/main.nr
@@ -1,8 +1,5 @@
 fn main() {
     comptime {
-        // Comptime scopes are counted as unconstrained
-        assert(std::runtime::is_unconstrained());
-
         let vector = [2].as_vector();
         let vector = vector.push_back(3);
         let vector = vector.push_front(1);

--- a/tooling/nargo_cli/build.rs
+++ b/tooling/nargo_cli/build.rs
@@ -157,11 +157,8 @@ const IGNORED_COMPTIME_INTERPRET_EXECUTION_TESTS: [&str; 0] = [];
 
 /// `nargo execute --force-comptime` ignored tests because of bugs or because some
 /// programs don't behave the same way in comptime (for example: reference counting).
-const PANICKING_COMPTIME_INTERPRET_EXECUTION_TESTS: [&str; 5] = [
+const PANICKING_COMPTIME_INTERPRET_EXECUTION_TESTS: [&str; 2] = [
     // These check reference counts, which aren't tracked in comptime code
-    "reference_counts_inliner_0",
-    "reference_counts_inliner_max",
-    "reference_counts_inliner_min",
     "reference_counts_vectors_inliner_0",
     // Enums are currently unsupported in comptime code
     "regression_7323",


### PR DESCRIPTION
## Problem Resolved

No issue.

## Summary of Changes

In a comptime context having `is_unconstrained` return `true` or `false` doesn't matter, or maybe the function itself doesn't make sense (we could consider "comptime" to be unconstrained, in a way). However, now that we have `nargo test --coverage` it's probably better to have this built-in behave the same way it works in the other runtimes. That way if a function body has two branches depending on `is_unconstrained` we can check that both branches have been covered by having two tests for this (one constrained, one unconstrained). Otherwise at least in the stdlib there will always be uncovered portions.

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
