### PR TITLE
fix(fmt): don't indent twice when wrapping block comments

### DIFF
--- a/tooling/nargo_fmt/src/formatter/comments_and_whitespace.rs
+++ b/tooling/nargo_fmt/src/formatter/comments_and_whitespace.rs
@@ -231,18 +231,23 @@ impl Formatter<'_> {
         let all_stars = block_comment_has_all_leading_stars(comment);
 
         if comment.trim_start_matches([' ', '\t']).starts_with('\n') {
-            self.start_new_line();
+            self.start_new_line_no_indentation();
         }
 
         for (index, line) in comment.lines().enumerate() {
+            // When moving to the next source line, only emit a newline. The line itself
+            // carries the leading whitespace from the source, so re-emitting the
+            // structural indent here would double it up.
             if index > 0 {
-                self.start_new_line();
+                self.start_new_line_no_indentation();
             }
 
             for word in line.split_inclusive([' ', '\n', '\t']) {
                 if self.current_line_width() + word.trim().chars().count()
                     > self.config.comment_width
                 {
+                    // Wrapping introduces a new line that has no source whitespace, so
+                    // we re-emit the structural indent and the canonical `*` prefix.
                     self.start_new_line();
                     if all_stars {
                         self.write(" * ");
@@ -310,9 +315,13 @@ impl Formatter<'_> {
     }
 
     pub(crate) fn start_new_line(&mut self) {
+        self.start_new_line_no_indentation();
+        self.write_indentation();
+    }
+
+    pub(crate) fn start_new_line_no_indentation(&mut self) {
         self.trim_spaces();
         self.write_line_without_skipping_whitespace_and_comments();
-        self.write_indentation();
     }
 
     /// Trim spaces from the end of the buffer.
@@ -1284,5 +1293,35 @@ global x: Field = 1;
         assert_formatter_changes_wrapping_comments(&comment, 29);
         let ignored_comment = format!("// noir-fmt:ignore\n{comment}");
         assert_format_wrapping_comments(&ignored_comment, &ignored_comment, 29);
+    }
+
+    #[test]
+    fn does_not_over_indent_block_comment_when_wrapping_is_enabled_all_stars() {
+        let src = "pub struct Foo {}
+
+impl Foo {
+    /**
+     * Build a Foo.
+     * @return a fresh Foo
+     */
+    fn build() {}
+}
+";
+        assert_format_wrapping_comments(src, src, 120);
+    }
+
+    #[test]
+    fn does_not_over_indent_block_comment_when_wrapping_is_enabled_not_all_stars() {
+        let src = "pub struct Foo {}
+
+impl Foo {
+    /**
+       Build a Foo.
+       @return a fresh Foo
+     */
+    fn build() {}
+}
+";
+        assert_format_wrapping_comments(src, src, 120);
     }
 }


### PR DESCRIPTION
## Problem Resolved

Resolves #12552

## Summary of Changes



## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
