### PR TITLE
fix(brillig): guard JmpIf then-arg spill stores with the branch condi…

### DIFF
--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_block.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_block.rs
@@ -518,7 +518,7 @@ impl<'block, Registers: RegisterAllocator> BrilligBlock<'block, Registers> {
     }
 
     fn jmp(&mut self, dfg: &DataFlowGraph, destination: BasicBlockId, arguments: &[ValueId]) {
-        let moves = self.jmp_setup(dfg, destination, arguments);
+        let moves = self.jmp_setup(dfg, destination, arguments, None);
         for (src, dst) in &moves {
             self.brillig_context.mov_instruction(*dst, *src);
         }
@@ -527,11 +527,20 @@ impl<'block, Registers: RegisterAllocator> BrilligBlock<'block, Registers> {
             .jump_instruction(self.create_block_label_for_current_function(destination));
     }
 
+    /// Lower a jmp/jmpif's parameter passing into Brillig instructions.
+    ///
+    /// Spill-slot stores for params with eagerly-spilled destinations are emitted
+    /// directly here. Register-to-register moves are *returned* (not emitted) so
+    /// the caller can wrap them with a conditional move when lowering a JmpIf
+    /// then-branch. When `condition` is `Some(_)`, the spill-slot stores are also
+    /// guarded by the condition; this prevents a JmpIf else-branch from leaving a
+    /// then-arg in the then-destination param's spill slot.
     fn jmp_setup(
         &mut self,
         dfg: &DataFlowGraph,
         destination: BasicBlockId,
         arguments: &[ValueId],
+        condition: Option<MemoryAddress>,
     ) -> Vec<(MemoryAddress, MemoryAddress)> {
         // Permanently spill non-param live-ins BEFORE the arg/param parallel moves.
         // The parallel moves may overwrite registers that hold values
@@ -559,7 +568,12 @@ impl<'block, Registers: RegisterAllocator> BrilligBlock<'block, Registers> {
 
             if let Some(offset) = spill_offset {
                 // Param was spilled — write arg directly to param's spill slot.
-                self.codegen_spill_store(offset, arg_reg);
+                // Guard the store with `condition` for JmpIf then-args so an
+                // else-taken branch leaves the slot intact.
+                match condition {
+                    Some(c) => self.codegen_conditional_spill_store(offset, arg_reg, c),
+                    None => self.codegen_spill_store(offset, arg_reg),
+                }
             } else {
                 let param_reg =
                     self.variables.get_allocation(self.function_context, *param).extract_register();
@@ -609,7 +623,9 @@ impl<'block, Registers: RegisterAllocator> BrilligBlock<'block, Registers> {
     /// ```
     /// Because we don't want to overwrite the parameters of the then-block if we don't end up
     /// taking that branch, the then arguments must be only conditionally moved while the else
-    /// arguments can be moved unconditionally.
+    /// arguments can be moved unconditionally. The same applies to spill-slot writes for
+    /// then-arguments whose destination param was eagerly spilled — those writes are guarded
+    /// by `condition` inside [Self::jmp_setup].
     fn jmpif_to_then_block(
         &mut self,
         dfg: &DataFlowGraph,
@@ -617,7 +633,7 @@ impl<'block, Registers: RegisterAllocator> BrilligBlock<'block, Registers> {
         then_destination: BasicBlockId,
         then_arguments: &[ValueId],
     ) {
-        let moves = self.jmp_setup(dfg, then_destination, then_arguments);
+        let moves = self.jmp_setup(dfg, then_destination, then_arguments, Some(condition.address));
         for (src, dst) in &moves {
             // The else_address is the same as the destination here to avoid modification if the
             // condition is false.
@@ -628,6 +644,28 @@ impl<'block, Registers: RegisterAllocator> BrilligBlock<'block, Registers> {
             condition.address,
             self.create_block_label_for_current_function(then_destination),
         );
+    }
+
+    /// Emit a conditional store of `src` into the spill slot at `offset`.
+    ///
+    /// Brillig has no conditional store opcode, so this is implemented as
+    /// `load slot → tmp; cmov(condition, src, tmp, tmp); store slot ← tmp`.
+    /// When the condition is false the slot's existing value is written back
+    /// unchanged; when true `src` is written.
+    ///
+    /// `tmp` is a reserved scratch slot rather than an allocated register, so
+    /// this never has to evict a value from the stack frame mid-terminator
+    /// (which would leak a transient spill across the block boundary).
+    fn codegen_conditional_spill_store(
+        &mut self,
+        offset: usize,
+        src: MemoryAddress,
+        condition: MemoryAddress,
+    ) {
+        let tmp = ReservedRegisters::spill_conditional_value();
+        self.codegen_spill_load(offset, tmp);
+        self.brillig_context.conditional_move_instruction(condition, src, tmp, tmp);
+        self.codegen_spill_store(offset, tmp);
     }
 
     /// Allocates the block parameters that the given block is defining.

--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/tests/spill.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/tests/spill.rs
@@ -393,3 +393,41 @@ fn brillig_spill_jmpif_condition_register_reuse() {
     );
     assert_eq!(result, vec![FieldElement::from(42u32)]);
 }
+
+/// Regression: a `JmpIf` whose then-arguments must be written into eagerly
+/// spilled successor-block param slots used to emit those spill-slot writes
+/// unconditionally. When the else branch was taken at runtime, the spill slot
+/// for the then-destination param was already overwritten with the then-arg,
+/// and any later reload from that slot returned the wrong value.
+///
+/// Here `b1` loops back to itself via a JmpIf whose then-arg is `v4 = v2 + 1`
+/// and whose else-edge falls through to `b2`. After the loop exits with v2 = 5,
+/// `b2` reloads `v2` from its spill slot. The buggy code wrote v4 = 6 into
+/// v2's spill slot before testing the condition, so the final reload produced
+/// 6 instead of 5 and the program returned 16 instead of 15.
+#[test]
+fn brillig_spill_jmpif_then_arg_does_not_overwrite_param_slot() {
+    let src = "
+    brillig(inline) fn main f0 {
+      b0(v0: u32, v1: u32):
+        jmp b1(v0)
+      b1(v2: u32):
+        v3 = lt v2, u32 5
+        v4 = unchecked_add v2, u32 1
+        jmpif v3 then: b1(v4), else: b2()
+      b2():
+        v5 = unchecked_add v2, v1
+        return v5
+    }
+    ";
+
+    let layout = LayoutConfig::new(7, 16, MAX_SCRATCH_SPACE);
+    let options = BrilligOptions { layout, ..Default::default() };
+    let result = execute_brillig_from_ssa_with_options(
+        src,
+        vec![FieldElement::from(0u32), FieldElement::from(10u32)],
+        &options,
+    );
+
+    assert_eq!(result, vec![FieldElement::from(15u32)]);
+}

--- a/compiler/noirc_evaluator/src/brillig/brillig_ir.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_ir.rs
@@ -96,6 +96,14 @@ impl ReservedRegisters {
         let start = ScratchSpace::start();
         (MemoryAddress::direct(assert_u32(start)), MemoryAddress::direct(assert_u32(start + 1)))
     }
+
+    /// A third scratch address (`@5`) used by [crate::brillig::brillig_gen::brillig_block::BrilligBlock::codegen_conditional_spill_store]
+    /// to hold a value across the load → cmov → store sequence. Disjoint from
+    /// [Self::spill_scratch] so the address-materialization scratch registers
+    /// can be reused by the inner load/store without clobbering the value.
+    pub(crate) fn spill_conditional_value() -> MemoryAddress {
+        MemoryAddress::direct(assert_u32(ScratchSpace::start() + 2))
+    }
 }
 
 /// Brillig context object that is used while constructing the


### PR DESCRIPTION
…tion

## Problem Resolved

Resolves https://github.com/AztecProtocol/noir-claude/issues/962

## Summary of Changes

I had Claude fix this one. I also asked it to ELI5 what the problem was and what's the fix, because AztecBot explains things in a complex way.

I think the fix makes sense.

Here's what Claude said:

### The bug

In Noir's Brillig codegen, when a block parameter has been "permanently spilled" (its real home is a memory slot, not a register), the predecessor block writes the parameter's value directly into that memory slot.

For an unconditional jump (jmp b1(v)), that's fine — execution always goes to b1.

For a conditional jump (jmpif cond then: b1(v_then), else: b2()), only the then-branch should write v_then into b1's slot. But the old code wrote it unconditionally, before even testing the condition:

```
store v_then into b1's_param_slot      ← happens always (BUG)
jumpif cond, b1
... fall through to b2 ...
```

So if cond was false and we fell through to b2, the slot for b1's parameter had already been clobbered with the then-arg. If anything later (e.g. b2) read from that slot, it got the wrong value.

The audit's repro: a loop where b1 jumps to itself with v + 1 until v == 5. On the last iteration, the buggy code stored 6 into v's slot before testing the condition, then fell through to b2. b2 read 6 instead of 5 and the program returned 16 instead of 15.

### The fix

Make the spill-slot store conditional when it's part of a jmpif's then-branch. Brillig has no conditional-store opcode, so it's emitted as three instructions:

```
load slot → tmp
cmov cond, then_arg, tmp, tmp     ← tmp = cond ? then_arg : (slot's old value)
store tmp → slot
```

When cond is false, we just write back what was already there — no change. When true, we write the then-arg. Concretely:

jmp_setup now takes an optional condition. If present, the spill stores it emits are conditional; otherwise unchanged.
jmpif_to_then_block passes the condition through.
A new reserved scratch slot (`@5`) holds the tmp value, so we don't have to evict a register from the stack frame mid-terminator.
Plus a regression test that runs the audit's program and checks it returns 15.

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
