### PR TITLE
chore(call_graph): panic in case of indirect calls

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/ir/call_graph.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/call_graph.rs
@@ -39,6 +39,8 @@ pub(crate) struct CallGraph {
 impl CallGraph {
     /// Construct a [CallGraph] from the [Ssa]
     /// The edges in this graph are unweighted. Thus, it is a pure dependency map.
+    /// Panics if the SSA contains indirect calls.
+    /// Use [`Self::from_ssa_partial`] from contexts that tolerate an incomplete graph.
     pub(crate) fn from_ssa(ssa: &Ssa) -> Self {
         let function_deps = ssa
             .functions
@@ -53,8 +55,26 @@ impl CallGraph {
 
     /// Construct a [CallGraph] from the [Ssa] with its edges weighted.
     /// An edges weight refers to the numbers of times a descendant node was called by its ancestor.
+    ///
+    /// Panics if the SSA contains indirect calls.
+    /// Use [`Self::from_ssa_weighted_partial`] from contexts that tolerate an incomplete graph.
     pub(crate) fn from_ssa_weighted(ssa: &Ssa) -> Self {
-        let dependencies = compute_callees(ssa);
+        let dependencies = compute_callees(ssa, false);
+        Self::from_deps_weighted(dependencies)
+    }
+
+    /// Like [`Self::from_ssa`], but silently skips indirect calls instead of panicking.
+    /// For consumers (e.g. inliner unit tests, purity analysis) that work on possibly
+    /// pre-defunctionalize SSA and tolerate an incomplete call graph.
+    pub(crate) fn from_ssa_partial(ssa: &Ssa) -> Self {
+        let function_deps =
+            ssa.functions.iter().map(|(id, func)| (*id, called_functions_partial(func))).collect();
+        Self::from_deps(function_deps)
+    }
+
+    /// Like [`Self::from_ssa_weighted`], but silently skips indirect calls instead of panicking.
+    pub(crate) fn from_ssa_weighted_partial(ssa: &Ssa) -> Self {
+        let dependencies = compute_callees(ssa, true);
         Self::from_deps_weighted(dependencies)
     }
 
@@ -345,7 +365,27 @@ impl CallGraph {
 /// Utility function to find out the direct calls of a function.
 ///
 /// Returns the function IDs from all `Call` instructions without deduplication.
+///
+/// # Panics
+/// Panics if any `Call` instruction targets a value that is not statically known
+/// (i.e. an indirect/higher-order call). The call graph is only complete after
+/// defunctionalize has lowered such calls; building it earlier would silently
+/// miss edges and yield wrong results for callers, callees, SCCs, etc.
+///
+/// Callers that are designed to tolerate indirect calls (e.g. the inliner and
+/// purity analysis, which work on direct call sites and conservatively handle
+/// the rest) should use [`called_functions_vec_partial`] instead.
 pub(crate) fn called_functions_vec(func: &Function) -> Vec<FunctionId> {
+    collect_called_functions(func, /* allow_indirect = */ false)
+}
+
+/// Like [`called_functions_vec`], but silently skips indirect calls instead of
+/// panicking. Use only from contexts that explicitly tolerate an incomplete graph.
+pub(crate) fn called_functions_vec_partial(func: &Function) -> Vec<FunctionId> {
+    collect_called_functions(func, /* allow_indirect = */ true)
+}
+
+fn collect_called_functions(func: &Function, allow_indirect: bool) -> Vec<FunctionId> {
     let mut called_function_ids = Vec::new();
     for block_id in func.reachable_blocks() {
         for instruction_id in func.dfg[block_id].instructions() {
@@ -353,8 +393,15 @@ pub(crate) fn called_functions_vec(func: &Function) -> Vec<FunctionId> {
                 continue;
             };
 
-            if let Value::Function(function_id) = func.dfg[*called_value_id] {
-                called_function_ids.push(function_id);
+            match func.dfg[*called_value_id] {
+                Value::Function(function_id) => called_function_ids.push(function_id),
+                Value::Intrinsic(_) | Value::ForeignFunction(_) => {}
+                _ if allow_indirect => {}
+                _ => panic!(
+                    "called_functions_vec: indirect call detected in {} — \
+                     CallGraph must be built post-defunctionalize",
+                    func.id()
+                ),
             }
         }
     }
@@ -367,12 +414,20 @@ pub(crate) fn called_functions(func: &Function) -> BTreeSet<FunctionId> {
     called_functions_vec(func).into_iter().collect()
 }
 
+/// Partial counterpart to [`called_functions`] — see [`called_functions_vec_partial`].
+pub(crate) fn called_functions_partial(func: &Function) -> BTreeSet<FunctionId> {
+    called_functions_vec_partial(func).into_iter().collect()
+}
+
 /// Compute for each function the set of functions called by it, and how many times it does so.
-fn compute_callees(ssa: &Ssa) -> BTreeMap<FunctionId, BTreeMap<FunctionId, usize>> {
+fn compute_callees(
+    ssa: &Ssa,
+    allow_indirect: bool,
+) -> BTreeMap<FunctionId, BTreeMap<FunctionId, usize>> {
     ssa.functions
         .iter()
         .flat_map(|(caller_id, function)| {
-            let called_functions = called_functions_vec(function);
+            let called_functions = collect_called_functions(function, allow_indirect);
             called_functions.into_iter().map(|callee_id| (*caller_id, callee_id))
         })
         .fold(

--- a/compiler/noirc_evaluator/src/ssa/opt/inlining.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/inlining.rs
@@ -88,7 +88,9 @@ impl Ssa {
         loop {
             let num_functions_before = self.functions.len();
 
-            let call_graph = CallGraph::from_ssa_weighted(&self);
+            // The inliner works on direct call sites and is robust to indirect calls
+            // (which it cannot inline anyway).
+            let call_graph = CallGraph::from_ssa_weighted_partial(&self);
 
             let inline_infos = compute_inline_infos(
                 &self,

--- a/compiler/noirc_evaluator/src/ssa/opt/inlining/inline_info.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/inlining/inline_info.rs
@@ -6,7 +6,7 @@ use rustc_hash::FxHashSet as HashSet;
 
 use crate::ssa::{
     ir::{
-        call_graph::{CallGraph, called_functions},
+        call_graph::{CallGraph, called_functions_partial},
         dfg::DataFlowGraph,
         function::FunctionId,
         instruction::{Instruction, Intrinsic},
@@ -117,7 +117,7 @@ pub(crate) fn compute_inline_infos(
         }
 
         // Any Brillig function called from ACIR is an entry into the Brillig VM.
-        for called_func_id in called_functions(function) {
+        for called_func_id in called_functions_partial(function) {
             if ssa.functions[&called_func_id].runtime().is_brillig() {
                 inline_infos.entry(called_func_id).or_default().is_brillig_entry_point = true;
             }

--- a/compiler/noirc_evaluator/src/ssa/opt/pure.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/pure.rs
@@ -30,7 +30,10 @@ impl Ssa {
     /// This is purely an analysis pass on its own but can help future optimizations.
     #[tracing::instrument(level = "trace", skip(self))]
     pub(crate) fn purity_analysis(mut self) -> Ssa {
-        let call_graph = CallGraph::from_ssa(&self);
+        // Purity falls back to `Impure` for any call whose callee cannot be statically
+        // resolved, so an incomplete call graph is fine — use the partial constructor
+        // to allow running on pre-defunctionalize SSA in unit tests.
+        let call_graph = CallGraph::from_ssa_partial(&self);
 
         let (sccs, recursive_functions) = call_graph.sccs();
 


### PR DESCRIPTION
## Problem Resolved

Resolves cantina issue: CallGraph::from_ssa is a potential footgun
https://cantina.xyz/code/5387827b-5629-4d61-beda-76d82161d335/findings/6

## Summary of Changes
Panic if indirect calls are present during call graph construction, which ensures a valid call-graph.
This is safe because the call-graph is constructed after defunctionalisation.
Because Inlining and Pure passes can work with incomplete call-graph, I added the possibility to request an incomplete call-graph, and this is used in the Inlining and Pure passes (so they are not required to run after defunctionalisation).


## User Documentation

Check one:
- [X] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
