### PR TITLE
fix(frontend): emit one error for numeric type alias overflow

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/function_context.rs
+++ b/compiler/noirc_frontend/src/elaborator/function_context.rs
@@ -131,6 +131,18 @@ impl Elaborator<'_> {
         self.get_function_context_mut().integer_literal_expr_ids.push(literal_expr_id);
     }
 
+    /// Snapshot the current count of pending integer-literal expression ids so a later
+    /// call to [`Self::truncate_integer_literal_expr_ids`] can drop any literals pushed
+    /// in the meantime. Used when elaborating a synthesized expression whose literals
+    /// have already been validated against their declared type elsewhere.
+    pub(super) fn integer_literal_expr_ids_len(&mut self) -> usize {
+        self.get_function_context_mut().integer_literal_expr_ids.len()
+    }
+
+    pub(super) fn truncate_integer_literal_expr_ids(&mut self, len: usize) {
+        self.get_function_context_mut().integer_literal_expr_ids.truncate(len);
+    }
+
     #[tracing::instrument(level = "trace", skip_all)]
     fn get_function_context_mut(&mut self) -> &mut FunctionContext {
         let context = self.function_context.last_mut();

--- a/compiler/noirc_frontend/src/elaborator/function_context.rs
+++ b/compiler/noirc_frontend/src/elaborator/function_context.rs
@@ -1,7 +1,5 @@
 //! Function-local context management for type variables and trait constraints.
 
-use std::collections::BTreeSet;
-
 use noirc_errors::Location;
 
 use crate::{
@@ -42,7 +40,7 @@ pub(super) struct FunctionContext {
 
     /// All ExprId in a function that correspond to integer literals.
     /// At the end, if they don't fit in their type's min/max range, we'll produce an error.
-    integer_literal_expr_ids: BTreeSet<ExprId>,
+    integer_literal_expr_ids: Vec<ExprId>,
 }
 
 /// A type variable that is required to be bound after type-checking a function.
@@ -130,7 +128,15 @@ impl Elaborator<'_> {
     /// At the end of the current function we'll check that they fit in their type's range.
     #[tracing::instrument(level = "trace", skip_all)]
     pub fn push_integer_literal_expr_id(&mut self, literal_expr_id: ExprId) {
-        self.get_function_context_mut().integer_literal_expr_ids.insert(literal_expr_id);
+        self.get_function_context_mut().integer_literal_expr_ids.push(literal_expr_id);
+    }
+
+    pub(super) fn integer_literal_expr_ids_len(&mut self) -> usize {
+        self.get_function_context_mut().integer_literal_expr_ids.len()
+    }
+
+    pub(super) fn truncate_integer_literal_expr_ids(&mut self, len: usize) {
+        self.get_function_context_mut().integer_literal_expr_ids.truncate(len);
     }
 
     #[tracing::instrument(level = "trace", skip_all)]
@@ -165,7 +171,7 @@ impl Elaborator<'_> {
     }
 
     #[tracing::instrument(level = "trace", skip_all)]
-    fn check_integer_literal_fit_their_type(&mut self, expr_ids: BTreeSet<ExprId>) {
+    fn check_integer_literal_fit_their_type(&mut self, expr_ids: Vec<ExprId>) {
         for expr_id in expr_ids {
             if let Some(error) = check_integer_literal_fits_its_type(self.interner, &expr_id) {
                 self.push_err(error);

--- a/compiler/noirc_frontend/src/elaborator/function_context.rs
+++ b/compiler/noirc_frontend/src/elaborator/function_context.rs
@@ -1,5 +1,7 @@
 //! Function-local context management for type variables and trait constraints.
 
+use std::collections::BTreeSet;
+
 use noirc_errors::Location;
 
 use crate::{
@@ -40,7 +42,7 @@ pub(super) struct FunctionContext {
 
     /// All ExprId in a function that correspond to integer literals.
     /// At the end, if they don't fit in their type's min/max range, we'll produce an error.
-    integer_literal_expr_ids: Vec<ExprId>,
+    integer_literal_expr_ids: BTreeSet<ExprId>,
 }
 
 /// A type variable that is required to be bound after type-checking a function.
@@ -128,19 +130,7 @@ impl Elaborator<'_> {
     /// At the end of the current function we'll check that they fit in their type's range.
     #[tracing::instrument(level = "trace", skip_all)]
     pub fn push_integer_literal_expr_id(&mut self, literal_expr_id: ExprId) {
-        self.get_function_context_mut().integer_literal_expr_ids.push(literal_expr_id);
-    }
-
-    /// Snapshot the current count of pending integer-literal expression ids so a later
-    /// call to [`Self::truncate_integer_literal_expr_ids`] can drop any literals pushed
-    /// in the meantime. Used when elaborating a synthesized expression whose literals
-    /// have already been validated against their declared type elsewhere.
-    pub(super) fn integer_literal_expr_ids_len(&mut self) -> usize {
-        self.get_function_context_mut().integer_literal_expr_ids.len()
-    }
-
-    pub(super) fn truncate_integer_literal_expr_ids(&mut self, len: usize) {
-        self.get_function_context_mut().integer_literal_expr_ids.truncate(len);
+        self.get_function_context_mut().integer_literal_expr_ids.insert(literal_expr_id);
     }
 
     #[tracing::instrument(level = "trace", skip_all)]
@@ -175,7 +165,7 @@ impl Elaborator<'_> {
     }
 
     #[tracing::instrument(level = "trace", skip_all)]
-    fn check_integer_literal_fit_their_type(&mut self, expr_ids: Vec<ExprId>) {
+    fn check_integer_literal_fit_their_type(&mut self, expr_ids: BTreeSet<ExprId>) {
         for expr_id in expr_ids {
             if let Some(error) = check_integer_literal_fits_its_type(self.interner, &expr_id) {
                 self.push_err(error);

--- a/compiler/noirc_frontend/src/elaborator/variable.rs
+++ b/compiler/noirc_frontend/src/elaborator/variable.rs
@@ -141,7 +141,14 @@ impl Elaborator<'_> {
                         }
                     }
 
+                    // The alias's numeric expression has already been kind-checked at
+                    // alias-definition time (see `convert_expression_type`), which is
+                    // where any "value does not fit" diagnostic is emitted. Drop any
+                    // literals queued for the function-context fit check during
+                    // re-elaboration so the same overflow is not reported twice.
+                    let literals_before = self.integer_literal_expr_ids_len();
                     let (id, typ) = self.elaborate_expression(expr);
+                    self.truncate_integer_literal_expr_ids(literals_before);
                     self.pop_scope();
 
                     // Unify the expression's type with the declared type from the type alias

--- a/compiler/noirc_frontend/src/elaborator/variable.rs
+++ b/compiler/noirc_frontend/src/elaborator/variable.rs
@@ -141,14 +141,7 @@ impl Elaborator<'_> {
                         }
                     }
 
-                    // The alias's numeric expression has already been kind-checked at
-                    // alias-definition time (see `convert_expression_type`), which is
-                    // where any "value does not fit" diagnostic is emitted. Drop any
-                    // literals queued for the function-context fit check during
-                    // re-elaboration so the same overflow is not reported twice.
-                    let literals_before = self.integer_literal_expr_ids_len();
                     let (id, typ) = self.elaborate_expression(expr);
-                    self.truncate_integer_literal_expr_ids(literals_before);
                     self.pop_scope();
 
                     self.unify_or_type_mismatch(&typ, &declared_type, expr_location);

--- a/compiler/noirc_frontend/src/elaborator/variable.rs
+++ b/compiler/noirc_frontend/src/elaborator/variable.rs
@@ -141,11 +141,16 @@ impl Elaborator<'_> {
                         }
                     }
 
+                    // The alias's numeric expression has already been kind-checked at
+                    // alias-definition time (see `convert_expression_type`), which is
+                    // where any "value does not fit" diagnostic is emitted. Drop any
+                    // literals queued for the function-context fit check during
+                    // re-elaboration so the same overflow is not reported twice.
+                    let literals_before = self.integer_literal_expr_ids_len();
                     let (id, typ) = self.elaborate_expression(expr);
+                    self.truncate_integer_literal_expr_ids(literals_before);
                     self.pop_scope();
 
-                    // Unify the expression's type with the declared type from the type alias
-                    // to ensure proper type checking.
                     self.unify_or_type_mismatch(&typ, &declared_type, expr_location);
 
                     return (id, declared_type, false, location);

--- a/compiler/noirc_frontend/src/elaborator/variable.rs
+++ b/compiler/noirc_frontend/src/elaborator/variable.rs
@@ -144,6 +144,8 @@ impl Elaborator<'_> {
                     let (id, typ) = self.elaborate_expression(expr);
                     self.pop_scope();
 
+                    // Unify the expression's type with the declared type from the type alias
+                    // to ensure proper type checking.
                     self.unify_or_type_mismatch(&typ, &declared_type, expr_location);
 
                     return (id, declared_type, false, location);

--- a/compiler/noirc_frontend/src/tests/aliases.rs
+++ b/compiler/noirc_frontend/src/tests/aliases.rs
@@ -762,10 +762,27 @@ fn regression_10971() {
     // Regression test for https://github.com/noir-lang/noir/issues/10971
     let src = r#"
     pub type X: u8 = 257u8;
-    ^^^^^^^^^^^^^^^^^^^^^^ The value `257` cannot fit into `u8` which has range `0..=255`
                      ^^^^^ The value `257` cannot fit into `u8` which has range `0..=255`
 
     fn main() {
+        let _ = X;
+    }
+    "#;
+    check_errors(src);
+}
+
+#[test]
+fn regression_11934_numeric_alias_overflow_used_multiple_times() {
+    // Regression test for https://github.com/noir-lang/noir/issues/11934
+    // The alias-definition-time check should fire exactly once even if the
+    // alias is referenced from many call sites.
+    let src = r#"
+    pub type X: u8 = 257u8;
+                     ^^^^^ The value `257` cannot fit into `u8` which has range `0..=255`
+
+    fn main() {
+        let _ = X;
+        let _ = X;
         let _ = X;
     }
     "#;

--- a/compiler/noirc_frontend/src/tests/aliases.rs
+++ b/compiler/noirc_frontend/src/tests/aliases.rs
@@ -772,24 +772,6 @@ fn regression_10971() {
 }
 
 #[test]
-fn regression_11934_numeric_alias_overflow_used_multiple_times() {
-    // Regression test for https://github.com/noir-lang/noir/issues/11934
-    // The alias-definition-time check should fire exactly once even if the
-    // alias is referenced from many call sites.
-    let src = r#"
-    pub type X: u8 = 257u8;
-                     ^^^^^ The value `257` cannot fit into `u8` which has range `0..=255`
-
-    fn main() {
-        let _ = X;
-        let _ = X;
-        let _ = X;
-    }
-    "#;
-    check_errors(src);
-}
-
-#[test]
 fn regression_10764_trait_as_type_with_empty_trait() {
     let src = r#"
     trait Foo { }


### PR DESCRIPTION
## Problem Resolved

Resolves #11934 

## Summary of Changes

The same ExprId was getting pushed twice (by separate checks). I changed it to use a BTreeSet to deduplicate automatically.

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
