### PR TITLE
fix: use fresh type vars when unifying type turbofish against impl ge…

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/variable.rs
+++ b/compiler/noirc_frontend/src/elaborator/variable.rs
@@ -193,14 +193,20 @@ impl Elaborator<'_> {
                 let func_meta = self.interner.function_meta(func_id);
                 let impl_generic_count =
                     func_meta.all_generics.len() - func_meta.direct_generics.len();
-                let impl_generics = &func_meta.all_generics[..impl_generic_count];
+                let impl_generics: Vec<TypeVariable> = func_meta.all_generics[..impl_generic_count]
+                    .iter()
+                    .map(|g| g.type_var.clone())
+                    .collect();
+                let self_type = func_meta.self_type.clone();
 
                 // For partially concrete impls (e.g. `impl<B> S<u32, B>`), the number of
                 // impl generics differs from the number of struct generics. The turbofish
                 // `S::<u32, bool>` provides type_generics aligned with the struct's params
-                // [A, B], not the impl's generics [B]. Use the impl's self_type to find
-                // the correct positional mapping from struct params to impl generics.
-                if let Some(Type::DataType(_, self_type_args)) = &func_meta.self_type {
+                // [A, B], not the impl's generics [B]. Replace each impl generic in
+                // `self_type`'s args with a fresh type variable and unify those with the
+                // turbofish-provided type generics. The fresh type variables get bound by
+                // unification, and we record those bindings for the impl generics.
+                if let Some(Type::DataType(_, self_type_args)) = self_type {
                     assert_eq!(
                         type_generics.len(),
                         self_type_args.len(),
@@ -208,41 +214,29 @@ impl Elaborator<'_> {
                         type_generics.len(),
                         self_type_args.len(),
                     );
-                    let mut concrete_mismatches = Vec::new();
+                    let impl_replacements: TypeBindings = impl_generics
+                        .iter()
+                        .map(|type_var| {
+                            let kind = type_var.kind();
+                            let fresh = self.interner.next_type_variable_with_kind(kind.clone());
+                            (type_var.id(), (type_var.clone(), kind, fresh))
+                        })
+                        .collect();
                     for (type_generic, self_type_arg) in
                         type_generics.into_iter().zip_eq(self_type_args)
                     {
-                        let type_var = match self_type_arg {
-                            Type::NamedGeneric(named) => Some(&named.type_var),
-                            Type::TypeVariable(tv) => Some(tv),
-                            _ => None,
-                        };
-                        if let Some(type_var) = type_var {
-                            if impl_generics.iter().any(|g| g.type_var.id() == type_var.id()) {
-                                bindings.insert(
-                                    type_var.id(),
-                                    (type_var.clone(), type_var.kind(), type_generic),
-                                );
-                            }
-                        } else {
-                            // Concrete position: collect for verification after releasing borrow
-                            concrete_mismatches.push((type_generic, self_type_arg.clone()));
-                        }
+                        let substituted = self_type_arg.substitute(&impl_replacements);
+                        self.unify_or_type_mismatch(&type_generic, &substituted, location);
                     }
-                    // Verify turbofish types match the impl's concrete types
-                    for (turbofish_type, concrete_type) in concrete_mismatches {
-                        self.unify_or_type_mismatch(&turbofish_type, &concrete_type, location);
-                    }
+                    bindings.extend(impl_replacements);
                 } else if type_generics.len() <= impl_generics.len() {
                     // For trait function paths, impl_generics may include Self and associated
                     // type generics after the trait's declared generics. The turbofish only
                     // provides types for the declared generics, which are always the first
                     // elements. Slice to match.
                     let impl_generics = &impl_generics[..type_generics.len()];
-                    for (type_generic, func_generic) in
-                        type_generics.into_iter().zip_eq(impl_generics)
+                    for (type_generic, type_var) in type_generics.into_iter().zip_eq(impl_generics)
                     {
-                        let type_var = &func_generic.type_var;
                         bindings.insert(
                             type_var.id(),
                             (type_var.clone(), type_var.kind(), type_generic),

--- a/compiler/noirc_frontend/src/elaborator/variable.rs
+++ b/compiler/noirc_frontend/src/elaborator/variable.rs
@@ -193,10 +193,7 @@ impl Elaborator<'_> {
                 let func_meta = self.interner.function_meta(func_id);
                 let impl_generic_count =
                     func_meta.all_generics.len() - func_meta.direct_generics.len();
-                let impl_generics: Vec<TypeVariable> = func_meta.all_generics[..impl_generic_count]
-                    .iter()
-                    .map(|g| g.type_var.clone())
-                    .collect();
+                let impl_generics = vecmap(&func_meta.all_generics[..impl_generic_count], |g| g.type_var.clone());
                 let self_type = func_meta.self_type.clone();
 
                 // For partially concrete impls (e.g. `impl<B> S<u32, B>`), the number of

--- a/compiler/noirc_frontend/src/elaborator/variable.rs
+++ b/compiler/noirc_frontend/src/elaborator/variable.rs
@@ -193,7 +193,8 @@ impl Elaborator<'_> {
                 let func_meta = self.interner.function_meta(func_id);
                 let impl_generic_count =
                     func_meta.all_generics.len() - func_meta.direct_generics.len();
-                let impl_generics = vecmap(&func_meta.all_generics[..impl_generic_count], |g| g.type_var.clone());
+                let impl_generics =
+                    vecmap(&func_meta.all_generics[..impl_generic_count], |g| g.type_var.clone());
                 let self_type = func_meta.self_type.clone();
 
                 // For partially concrete impls (e.g. `impl<B> S<u32, B>`), the number of

--- a/compiler/noirc_frontend/src/tests/turbofish.rs
+++ b/compiler/noirc_frontend/src/tests/turbofish.rs
@@ -1022,3 +1022,53 @@ fn struct_turbofish_mixed_generics_visibility_error() {
     "#;
     check_errors(src);
 }
+
+#[test]
+fn struct_turbofish_matching_identity_type_alias() {
+    let src = r#"
+    type Id<T> = T;
+
+    struct S<A> {
+        x: A,
+    }
+
+    impl<T> S<Id<T>> {
+        fn foo(x: T) -> T {
+            x
+        }
+    }
+
+    fn main() {
+        let x = 10u64;
+        let _y: u64 = S::<Id<u64>>::foo(x);
+        let _y: u64 = S::<u64>::foo(x);
+    }
+    "#;
+    assert_no_errors(src);
+}
+
+#[test]
+fn struct_turbofish_matching_struct_type_alias() {
+    let src = r#"
+    struct Foo<T> {}
+
+    type Id<T> = Foo<T>;
+
+    struct S<A> {
+        x: A,
+    }
+
+    impl<T> S<Id<T>> {
+        fn foo(x: T) -> T {
+            x
+        }
+    }
+
+    fn main() {
+        let x = 10u64;
+        let _y: u64 = S::<Id<u64>>::foo(x);
+        let _y: u64 = S::<Foo<u64>>::foo(x);
+    }
+    "#;
+    assert_no_errors(src);
+}


### PR DESCRIPTION
…nerics

## Problem Resolved

Resolves https://app.audithub.dev/app/organizations/161/projects/599/project-viewer?version=1406&issueId=947

## Summary of Changes

Previously if we had `impl<T> S<T>` and a call `S::<u64>`, the `T` in `S<T>` is a NamedGeneric, that's why we extracted its type variable for unification. However, I think that wasn't completely right as we shouldn't change that type var. Plus it didn't work in cases where `T` was nested inside other types. So here we substitute all these named generics with fresh type variables, then unification should succeed, and those bindings are then recorded.

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
