### PR TITLE
fix(ssa): array_gets are not side-effectual in brillig

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/interpreter/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/interpreter/mod.rs
@@ -1151,8 +1151,16 @@ impl<'ssa, W: Write> Interpreter<'ssa, W> {
         let array = self.lookup_array_or_vector(array, "array get")?;
         let length = array.elements.borrow().len() as u32;
 
+        // Per `Instruction::requires_acir_gen_predicate`, in Brillig an
+        // `array_get` is pure-in-isolation: the OOB check is inserted as a
+        // separate constraint, not part of the access itself. Match that here
+        // so the interpreter agrees with the Brillig VM on dead/unused gets.
+        let oob_is_pure = self.current_function().runtime().is_brillig();
+
         let index = match self.lookup_array_index(index, "array get index", length) {
-            Err(InterpreterError::IndexOutOfBounds { .. }) if !side_effects_enabled => {
+            Err(InterpreterError::IndexOutOfBounds { .. })
+                if !side_effects_enabled || oob_is_pure =>
+            {
                 return uninitialized(self);
             }
             other => other?,
@@ -1164,11 +1172,15 @@ impl<'ssa, W: Write> Interpreter<'ssa, W> {
             // the branch is not-taken during acir-gen and
             // a zeroed type is used in case of array get
             // So we can simply replace it with uninitialized value
-            if side_effects_enabled {
+            if side_effects_enabled && !oob_is_pure {
                 return Err(InterpreterError::IndexOutOfBounds { index: index.into(), length });
             } else {
                 return uninitialized(self);
             }
+        }
+
+        if oob_is_pure && index >= length {
+            return uninitialized(self);
         }
 
         let element = {

--- a/compiler/noirc_evaluator/src/ssa/interpreter/tests/instructions.rs
+++ b/compiler/noirc_evaluator/src/ssa/interpreter/tests/instructions.rs
@@ -20,7 +20,7 @@ use crate::ssa::{
     },
 };
 
-use super::{executes_with_no_errors, expect_error};
+use super::{Ssa, executes_with_no_errors, expect_error};
 
 fn make_unfit(value: impl Into<FieldElement>, typ: NumericType) -> Value {
     Value::unfit(value.into(), typ).unwrap()
@@ -901,6 +901,51 @@ fn array_get_disabled_by_enable_side_effects_if_index_is_not_known_to_be_safe() 
     );
     // If enable_side_effects is false, array get will retrieve the value at the first compatible index
     assert_eq!(value, from_constant(1_u32.into(), NumericType::NativeField));
+}
+
+#[test]
+fn brillig_oob_array_get_does_not_error() {
+    let src = "
+    brillig(inline) fn main f0 {
+      b0(v0: u32):
+        v4 = make_array [Field 1, Field 2, Field 3] : [Field; 3]
+        v5 = array_get v4, index v0 -> Field
+        return
+    }
+    ";
+    let ssa = Ssa::from_str(src).unwrap();
+    let result = ssa.interpret(vec![from_constant(10_u32.into(), NumericType::unsigned(32))]);
+    assert!(result.is_ok(), "expected success, got {result:?}");
+}
+
+#[test]
+fn brillig_oob_array_get_zero_length_does_not_error() {
+    let src = "
+    brillig(inline) fn main f0 {
+      b0(v0: u32):
+        v4 = make_array [] : [Field; 0]
+        v5 = array_get v4, index v0 -> Field
+        return
+    }
+    ";
+    let ssa = Ssa::from_str(src).unwrap();
+    let result = ssa.interpret(vec![from_constant(0_u32.into(), NumericType::unsigned(32))]);
+    assert!(result.is_ok(), "expected success, got {result:?}");
+}
+
+#[test]
+fn acir_oob_array_get_still_errors() {
+    let src = "
+    acir(inline) fn main f0 {
+      b0(v0: u32):
+        v4 = make_array [Field 1, Field 2, Field 3] : [Field; 3]
+        v5 = array_get v4, index v0 -> Field
+        return v5
+    }
+    ";
+    let ssa = Ssa::from_str(src).unwrap();
+    let result = ssa.interpret(vec![from_constant(10_u32.into(), NumericType::unsigned(32))]);
+    assert!(matches!(result, Err(InterpreterError::IndexOutOfBounds { .. })));
 }
 
 #[test]


### PR DESCRIPTION
## Problem Resolved

Resolves #9391 

## Summary of Changes

In Brillig, an `array_get` with an unsafe index is pure-in-isolation (per `Instruction::requires_acir_gen_predicate`): the OOB check is a separate constraint, not part of the access. The compiled Brillig VM therefore lets dead/unused OOB gets execute without aborting.

The SSA interpreter disagreed: `side_effects_enabled` hardcodes `true` for Brillig, so the OOB-suppression path in `interpret_array_get` never fired. This made the interpreter (used in `fold_constants_with_brillig`) abort on programs the real Brillig VM accepts.

Drive OOB suppression off the runtime as well, mirroring the comment in `requires_acir_gen_predicate`. `interpret_array_set` is unchanged -- `ArraySet` always has true side effects regardless of runtime.

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
