### PR TITLE
chore: remove redundant registry in FileManager

### DIFF
--- a/compiler/fm/src/file_map.rs
+++ b/compiler/fm/src/file_map.rs
@@ -22,6 +22,10 @@ impl PathString {
         PathString(p)
     }
 
+    pub fn as_path_buf(&self) -> &PathBuf {
+        &self.0
+    }
+
     pub fn into_path_buf(self) -> PathBuf {
         self.0
     }
@@ -71,7 +75,9 @@ impl<'input> File<'input> {
 impl FileMap {
     pub fn add_file(&mut self, file_name: PathString, code: String) -> FileId {
         let file_id = FileId(self.files.add(file_name.clone(), code));
-        self.name_to_id.insert(file_name, file_id);
+        if self.name_to_id.insert(file_name, file_id).is_some() {
+            panic!("ice: the same file name was inserted into the file manager twice");
+        }
         file_id
     }
 
@@ -89,6 +95,10 @@ impl FileMap {
 
     pub fn all_file_ids(&self) -> impl Iterator<Item = &FileId> {
         self.name_to_id.values()
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = (&PathString, &FileId)> {
+        self.name_to_id.iter()
     }
 
     pub fn get_name(&self, file_id: FileId) -> Result<PathString, Error> {

--- a/compiler/fm/src/lib.rs
+++ b/compiler/fm/src/lib.rs
@@ -11,39 +11,18 @@ use itertools::Itertools;
 // Re-export for the lsp
 pub use codespan_reporting::files as codespan_files;
 
-use std::{
-    collections::HashMap,
-    path::{Component, Path, PathBuf},
-};
+use std::path::{Component, Path, PathBuf};
 
 pub const FILE_EXTENSION: &str = "nr";
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct FileManager {
     root: PathBuf,
     file_map: FileMap,
-    id_to_path: HashMap<FileId, PathBuf>,
-    path_to_id: HashMap<PathBuf, FileId>,
-}
-
-impl std::fmt::Debug for FileManager {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("FileManager")
-            .field("root", &self.root)
-            .field("file_map", &self.file_map)
-            .field("id_to_path", &self.id_to_path)
-            .field("path_to_id", &self.path_to_id)
-            .finish()
-    }
 }
 
 impl FileManager {
     pub fn new(root: &Path) -> Self {
-        Self {
-            root: root.normalize(),
-            file_map: Default::default(),
-            id_to_path: Default::default(),
-            path_to_id: Default::default(),
-        }
+        Self { root: root.normalize(), file_map: Default::default() }
     }
 
     pub fn as_file_map(&self) -> &FileMap {
@@ -68,14 +47,13 @@ impl FileManager {
     ) -> Option<FileId> {
         let file_name = file_name.normalize();
         // Check that the file name already exists in the file map, if it is, we return it.
-        if let Some(file_id) = self.path_to_id.get(&file_name) {
-            return Some(*file_id);
+        if let Some(file_id) = self.file_map.get_file_id(&PathString::from_path(file_name.clone()))
+        {
+            return Some(file_id);
         }
-        let file_name_path_buf = file_name;
 
         // Otherwise we add the file
-        let file_id = self.file_map.add_file(file_name_path_buf.clone().into(), source);
-        self.register_path(file_id, file_name_path_buf);
+        let file_id = self.file_map.add_file(file_name.into(), source);
         Some(file_id)
     }
 
@@ -84,25 +62,13 @@ impl FileManager {
         self.file_map.replace_file(file_id, source);
     }
 
-    fn register_path(&mut self, file_id: FileId, path: PathBuf) {
-        let old_value = self.id_to_path.insert(file_id, path.clone());
-        assert!(
-            old_value.is_none(),
-            "ice: the same file id was inserted into the file manager twice"
-        );
-        let old_value = self.path_to_id.insert(path, file_id);
-        assert!(old_value.is_none(), "ice: the same path was inserted into the file manager twice");
-    }
-
     pub fn fetch_file(&self, file_id: FileId) -> Option<&str> {
         // Unwrap as we ensure that all file_id's map to a corresponding file in the file map
         self.file_map.get_file(file_id).map(|file| file.source())
     }
 
-    pub fn path(&self, file_id: FileId) -> Option<&Path> {
-        // Unwrap as we ensure that all file_ids are created by the file manager
-        // So all file_ids will points to a corresponding path
-        self.id_to_path.get(&file_id).map(|path| path.as_path())
+    pub fn path(&self, file_id: FileId) -> Option<PathString> {
+        self.file_map.get_name(file_id).ok()
     }
 
     pub fn has_file(&self, file_name: &Path) -> bool {
@@ -120,10 +86,14 @@ impl FileManager {
     pub fn find_by_path_suffix(&self, suffix: &str) -> Result<Option<FileId>, Vec<PathBuf>> {
         let suffix_path: Vec<_> = Path::new(suffix).components().rev().collect();
         let results: Vec<_> = self
-            .path_to_id
+            .file_map
             .iter()
             .filter(|(path, _id)| {
-                path.components().rev().zip_eq(suffix_path.iter()).all(|(x, y)| &x == y)
+                path.as_path_buf()
+                    .components()
+                    .rev()
+                    .zip_eq(suffix_path.iter())
+                    .all(|(x, y)| &x == y)
             })
             .collect();
         if results.is_empty() {
@@ -131,7 +101,7 @@ impl FileManager {
         } else if results.len() == 1 {
             Ok(Some(*results[0].1))
         } else {
-            Err(vecmap(results, |(path, _id)| path.clone()))
+            Err(vecmap(results, |(path, _id)| path.clone().into_path_buf()))
         }
     }
 }
@@ -229,7 +199,7 @@ mod tests {
 
         let file_id = add_file(&mut fm, &dir.join("foo.nr"));
 
-        assert!(fm.path(file_id).unwrap().ends_with("foo.nr"));
+        assert!(fm.path(file_id).unwrap().into_path_buf().ends_with("foo.nr"));
     }
 
     /// Tests that two identical files that have different paths are treated as the same file

--- a/compiler/noirc_driver/src/lib.rs
+++ b/compiler/noirc_driver/src/lib.rs
@@ -901,7 +901,7 @@ pub fn filter_relevant_files(
             file_id,
             DebugFile {
                 source: file_source.to_string(),
-                path: file_path.to_path_buf(),
+                path: file_path.into_path_buf(),
                 function_locations,
             },
         );

--- a/compiler/noirc_frontend/src/hir/def_collector/dc_mod.rs
+++ b/compiler/noirc_frontend/src/hir/def_collector/dc_mod.rs
@@ -1465,6 +1465,7 @@ fn find_module(
     let anchor_path = file_manager
         .path(anchor)
         .expect("File must exist in file manager in order for us to be resolving its imports.")
+        .into_path_buf()
         .with_extension("");
     let anchor_dir = anchor_path.parent().unwrap();
 

--- a/compiler/wasm/src/errors.rs
+++ b/compiler/wasm/src/errors.rs
@@ -126,7 +126,7 @@ impl CompileError {
                 let file_path = file_manager
                     .path(err.file)
                     .expect("File must exist to have caused diagnostics");
-                Diagnostic::new(err, file_path.to_str().unwrap().to_string())
+                Diagnostic::new(err, file_path.to_string())
             })
             .collect();
 

--- a/tooling/lsp/src/lib.rs
+++ b/tooling/lsp/src/lib.rs
@@ -246,7 +246,7 @@ fn get_package_tests_in_crate(
             let file_path = fm.path(file_id).expect("file must exist to contain tests");
             let range =
                 byte_span_to_range(files, file_id, location.span.into()).unwrap_or_default();
-            let file_uri = Url::from_file_path(file_path)
+            let file_uri = Url::from_file_path(file_path.as_path_buf())
                 .expect("Expected a valid file path that can be converted into a URI");
 
             NargoTest {
@@ -370,12 +370,14 @@ fn parse_diff(file_manager: &FileManager, state: &mut LspState) -> ParsedFiles {
             .par_bridge()
             .filter_map(|&file_id| {
                 let file_path = file_manager.path(file_id).expect("expected file to exist");
-                let file_extension =
-                    file_path.extension().expect("expected all file paths to have an extension");
+                let file_extension = file_path
+                    .as_path_buf()
+                    .extension()
+                    .expect("expected all file paths to have an extension");
                 if file_extension == "nr" {
                     Some((
                         file_id,
-                        file_path.to_path_buf(),
+                        file_path.into_path_buf(),
                         rustc_hash::FxBuildHasher
                             .hash_one(file_manager.fetch_file(file_id).expect("file must exist"))
                             as usize,

--- a/tooling/lsp/src/notifications/mod.rs
+++ b/tooling/lsp/src/notifications/mod.rs
@@ -525,7 +525,7 @@ fn publish_diagnostics(
     for custom_diagnostic in custom_diagnostics {
         let file = custom_diagnostic.file;
         let path = fm.path(file).expect("file must exist to have emitted diagnostic");
-        if let Some(uri) = uri_from_path(path)
+        if let Some(uri) = uri_from_path(path.as_path_buf())
             && let Some(diagnostic) =
                 custom_diagnostic_to_diagnostic(custom_diagnostic, files, fm, uri.clone())
         {
@@ -622,7 +622,7 @@ fn secondary_to_related_information(
 ) -> Option<DiagnosticRelatedInformation> {
     let secondary_file = secondary.location.file;
     let path = fm.path(secondary_file)?;
-    let uri = uri_from_path(path)?;
+    let uri = uri_from_path(path.as_path_buf())?;
     let range = byte_span_to_range(files, secondary_file, secondary.location.span.into())?;
     let message = secondary.message;
     Some(DiagnosticRelatedInformation { location: lsp_types::Location { uri, range }, message })
@@ -644,7 +644,7 @@ fn call_stack_frame_to_related_information(
     fm: &FileManager,
 ) -> Option<DiagnosticRelatedInformation> {
     let path = fm.path(frame.file)?;
-    let uri = uri_from_path(path)?;
+    let uri = uri_from_path(path.as_path_buf())?;
     let range = byte_span_to_range(files, frame.file, frame.span.into())?;
     Some(DiagnosticRelatedInformation {
         location: lsp_types::Location { uri, range },

--- a/tooling/lsp/src/requests/completion.rs
+++ b/tooling/lsp/src/requests/completion.rs
@@ -1167,7 +1167,8 @@ impl<'a> NodeFinder<'a> {
     /// Try to suggest the name of a module to declare based on which
     /// files exist in the filesystem, excluding modules that are already declared.
     fn complete_module_declaration(&mut self, module: &ModuleDeclaration) -> Option<()> {
-        let filename = self.files.get_absolute_name(self.file).ok()?.into_path_buf();
+        let filename = self.files.get_absolute_name(self.file).ok()?;
+        let filename = filename.as_path_buf();
 
         let is_main_lib_or_mod = filename.ends_with("main.nr")
             || filename.ends_with("lib.nr")

--- a/tooling/lsp/src/requests/workspace_symbol.rs
+++ b/tooling/lsp/src/requests/workspace_symbol.rs
@@ -70,7 +70,7 @@ pub(crate) fn on_workspace_symbol_request(
     // figure out the symbols and store them in the cache.
     let parsed_files = parse_all(&file_manager);
     for (file_id, (parsed_module, _)) in parsed_files {
-        let path = file_manager.path(file_id).unwrap().to_path_buf();
+        let path = file_manager.path(file_id).unwrap().into_path_buf();
         let mut gatherer = WorkspaceSymbolGatherer::new(file_manager.as_file_map());
         parsed_module.accept(&mut gatherer);
         cache.symbols_per_path.insert(path, gatherer.symbols);

--- a/tooling/nargo/src/lib.rs
+++ b/tooling/nargo/src/lib.rs
@@ -238,8 +238,10 @@ pub fn parse_all(file_manager: &FileManager) -> ParsedFiles {
         .all_file_ids()
         .filter(|&&file_id| {
             let file_path = file_manager.path(file_id).expect("expected file to exist");
-            let file_extension =
-                file_path.extension().expect("expected all file paths to have an extension");
+            let file_extension = file_path
+                .as_path_buf()
+                .extension()
+                .expect("expected all file paths to have an extension");
             file_extension == "nr"
         })
         .copied()

--- a/tooling/nargo/src/ops/debug.rs
+++ b/tooling/nargo/src/ops/debug.rs
@@ -178,7 +178,7 @@ fn instrument_package_files(
     for (file_id, parsed_file) in parsed_files.iter_mut() {
         let file_path =
             file_manager.path(*file_id).expect("Parsed file ID not found in file manager");
-        for ancestor in file_path.ancestors() {
+        for ancestor in file_path.as_path_buf().ancestors() {
             if ancestor == entry_path_parent {
                 // file is in package
                 debug_instrumenter.instrument_module(&mut parsed_file.0);

--- a/tooling/nargo_cli/src/cli/doc_cmd.rs
+++ b/tooling/nargo_cli/src/cli/doc_cmd.rs
@@ -168,7 +168,7 @@ fn package_crate(
     broken_links.extend(module_broken_links);
 
     let root_file = &context.crate_graph[crate_id].root_file_id;
-    let root_file = file_manager.path(*root_file).unwrap().display().to_string();
+    let root_file = file_manager.path(*root_file).unwrap().to_string();
 
     let name = package.name.to_string();
     let version = package.version.clone();
@@ -189,7 +189,7 @@ fn collect_dependencies(
         let crate_id = dependency.crate_id;
         let crate_data = &context.crate_graph[crate_id];
         let root_file = crate_data.root_file_id;
-        let root_file = file_manager.path(root_file).unwrap().display().to_string();
+        let root_file = file_manager.path(root_file).unwrap().to_string();
         if dependencies.contains_key(&root_file) {
             continue;
         }

--- a/tooling/nargo_cli/src/cli/test_cmd/coverage.rs
+++ b/tooling/nargo_cli/src/cli/test_cmd/coverage.rs
@@ -227,7 +227,7 @@ pub(super) fn tracker_to_report(
 }
 
 fn file_path(context: &Context, file_id: FileId) -> Option<PathBuf> {
-    context.file_manager.as_file_map().get_name(file_id).ok().map(|p| p.into_path_buf())
+    context.file_manager.path(file_id).map(|p| p.into_path_buf())
 }
 
 /// `lcov` rejects `:` in the `TN:` (test name) field — without sanitization it logs

--- a/tooling/noirc_artifacts/src/debug.rs
+++ b/tooling/noirc_artifacts/src/debug.rs
@@ -84,7 +84,7 @@ impl DebugArtifact {
                 file_id,
                 DebugFile {
                     source: file_source.to_string(),
-                    path: file_path.to_path_buf(),
+                    path: file_path.into_path_buf(),
                     function_locations,
                 },
             );


### PR DESCRIPTION
## Problem Resolved

No issue, just something I noticed.

## Summary of Changes

FileManager kept two mappings between FileId and Path, but the underlying FileMap kind of also did that, just with slightly different types. There was a bit of redundancy. In particular, the `FileManager::path` method didn't make paths relative, while the one in `FileMap` did. Now it's consistent as `FileManager` always relies on `FileMap`.

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
