### PR TITLE
fix(frontend): snapshot+restore call expr bindings around trait-item monomorphization

### DIFF
--- a/compiler/noirc_frontend/src/monomorphization/mod.rs
+++ b/compiler/noirc_frontend/src/monomorphization/mod.rs
@@ -2027,6 +2027,18 @@ impl<'interner> Monomorphizer<'interner> {
         trait_item_id: TraitItemId,
         use_current_runtime: bool,
     ) -> Result<ast::Expression, MonomorphizationError> {
+        // `resolve_trait_item_impl` extends the call expression's stored
+        // instantiation bindings with the resolved impl's bindings (so the
+        // ensuing `queue_function` call sees them) and writes the result back
+        // to the interner. The same call expression can be visited again
+        // under a different monomorphization context when its receiver type
+        // is generic and gets resolved to different concrete types across
+        // monomorphization contexts; on the second visit the freshly-extended
+        // bindings would otherwise inherit impl-specific entries from the
+        // first visit. Snapshot and restore here so each visit starts from
+        // the elaboration-time bindings.
+        let saved_bindings = self.interner.try_get_instantiation_bindings(expr_id).cloned();
+
         let item = resolve_trait_item(self.interner, trait_item_id, expr_id)
             .map_err(MonomorphizationError::InterpreterError)?;
 
@@ -2040,11 +2052,17 @@ impl<'interner> Monomorphizer<'interner> {
         };
 
         // Functions are represented as (constrained, unconstrained) pairs
-        self.monomorphize_constrained_and_unconstrained(
+        let result = self.monomorphize_constrained_and_unconstrained(
             use_current_runtime,
             self.force_unconstrained,
             |this| this.resolve_trait_method_expr(func_id, expr_id, function_type, trait_item_id),
-        )
+        );
+
+        if let Some(saved) = saved_bindings {
+            self.interner.store_instantiation_bindings(expr_id, saved);
+        }
+
+        result
     }
 
     /// Look up the definition of a function (enqueue it for monomorphization if this is the first time),

--- a/test_programs/execution_success/regression_12572/Nargo.toml
+++ b/test_programs/execution_success/regression_12572/Nargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "regression_12572"
+type = "bin"
+authors = [""]
+
+[dependencies]

--- a/test_programs/execution_success/regression_12572/Prover.toml
+++ b/test_programs/execution_success/regression_12572/Prover.toml
@@ -1,0 +1,2 @@
+input = "5"
+return = "5"

--- a/test_programs/execution_success/regression_12572/src/main.nr
+++ b/test_programs/execution_success/regression_12572/src/main.nr
@@ -1,0 +1,23 @@
+use std::default::Default;
+
+#[derive(Default)]
+struct Log<let N: u32> {
+    fields: [Field; N],
+}
+
+#[derive(Default)]
+struct Wrapper {
+    log: Log<2>,
+}
+
+#[derive(Default)]
+struct Bundle {
+    small: [Log<1>; 1],
+    wrapped: [Wrapper; 1],
+}
+
+fn main(input: Field) -> pub Field {
+    let mut b: Bundle = Default::default();
+    b.wrapped[0].log.fields[0] = input;
+    b.wrapped[0].log.fields[0] + b.wrapped[0].log.fields[1] + b.small[0].fields[0]
+}

--- a/tooling/nargo_cli/tests/snapshots/execution_success/regression_12572/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/regression_12572/execute__tests__expanded.snap
@@ -1,0 +1,46 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: expanded_code
+---
+use std::default::Default;
+
+struct Log<let N: u32> {
+    fields: [Field; N],
+}
+
+impl<let N: u32> Default for Log<N> {
+    fn default() -> Self {
+        Self { fields: <[Field; N] as Default>::default() }
+    }
+}
+
+struct Wrapper {
+    log: Log<2>,
+}
+
+impl Default for Wrapper {
+    fn default() -> Self {
+        Self { log: <Log<2> as Default>::default() }
+    }
+}
+
+struct Bundle {
+    small: [Log<1>; 1],
+    wrapped: [Wrapper; 1],
+}
+
+impl Default for Bundle {
+    fn default() -> Self {
+        Self {
+            small: <[Log<1>; 1] as Default>::default(),
+            wrapped: <[Wrapper; 1] as Default>::default(),
+        }
+    }
+}
+
+fn main(input: Field) -> pub Field {
+    let mut b: Bundle = <Bundle as Default>::default();
+    b.wrapped[0_u32].log.fields[0_u32] = input;
+    (b.wrapped[0_u32].log.fields[0_u32] + b.wrapped[0_u32].log.fields[1_u32])
+        + b.small[0_u32].fields[0_u32]
+}

--- a/tooling/nargo_cli/tests/snapshots/execution_success/regression_12572/execute__tests__stdout.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/regression_12572/execute__tests__stdout.snap
@@ -1,0 +1,5 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: stdout
+---
+[regression_12572] Circuit output: 0x05


### PR DESCRIPTION
## Summary

Fixes #12572. The bug manifested as an SSA validation error (`Function call to f5 expected return type [Field; 2], but got [Field; 1]`) on programs that derive a trait via a comptime macro on a generic struct used at two or more concrete sizes.

`resolve_trait_item_impl` (in `monomorphization/mod.rs`) persists the call expression's instantiation bindings (extended with the resolved impl's bindings) on the interner so the immediately-following `queue_function` call sees them. The same call expression can be visited again in a different monomorphization context when its receiver type is generic and gets resolved to different concrete types — e.g. `T::method(...)` inside a generic impl's body with `T` set to two different concrete types across two monomorphization contexts. On the second visit the freshly-extended bindings would otherwise inherit impl-specific entries from the first visit.

For derive-emitted impls this is fatal: the impl's generic and the struct's generic share the same `TypeVariable` (because `s.generics()` returns `Type::NamedGeneric` values that carry the struct's `TypeVariable`, and `resolve_generic` at `generics.rs:148` reuses that `TypeVariable` when handling the `IdentOrQuotedType::Quoted` case). The leaked binding then pollutes the shared `TypeVariable` during the second visit's monomorphization job, and `convert_type` substitutes the wrong numeric value into the struct's fields, producing invalid SSA.

The fix snapshots the call expression's stored instantiation bindings in `resolve_trait_item_expr`, lets `resolve_trait_item_impl` mutate them for the queueing, and restores the snapshot afterwards so each visit starts from the elaboration-time bindings.

## Test plan

- [x] `cargo nextest run -p noirc_frontend` passes (1726 tests).
- [x] `cargo nextest run -p nargo_cli --test execute test_regression_12572` passes (16 variants).
- [x] Regression test in `test_programs/execution_success/regression_12572/` reproduces the bug on master and passes with the fix.