### PR TITLE
fix: validate entry point types at the end

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/function.rs
+++ b/compiler/noirc_frontend/src/elaborator/function.rs
@@ -39,7 +39,23 @@ use crate::{
 
 use super::Elaborator;
 
-type ResolvedParametersInfo = (Vec<(HirPattern, Type, Visibility)>, Vec<Type>, Vec<HirIdent>);
+type ResolvedParametersInfo =
+    (Vec<(HirPattern, Type, Visibility)>, Vec<Type>, Vec<HirIdent>, Vec<Location>);
+
+/// Validation of entry-point parameter and return types is deferred until after
+/// all trait impls and globals are elaborated. This struct captures everything
+/// needed to run the check later: the function id (so we can fetch the resolved
+/// parameter and return types out of the interner), the source locations to
+/// attribute any errors to, and the flags that determine whether the entry-point
+/// or `#[fold]`/`#[no_predicates]` checks apply.
+pub(super) struct PendingEntryPointCheck {
+    pub(super) func_id: FuncId,
+    pub(super) parameter_locations: Vec<Location>,
+    pub(super) return_type_location: Location,
+    pub(super) is_entry_point: bool,
+    pub(super) has_inline_attribute: bool,
+    pub(super) check_return_type: bool,
+}
 
 impl Elaborator<'_> {
     /// Defines function metadata for all functions, impl methods, and trait impl methods.
@@ -197,7 +213,7 @@ impl Elaborator<'_> {
         extra_trait_constraints.extend(associated_generics_trait_constraints);
 
         // Resolve parameters
-        let (parameters, parameter_types, parameter_idents) =
+        let (parameters, parameter_types, parameter_idents, parameter_locations) =
             self.resolve_function_parameters(func, &mut generics, &mut trait_constraints);
 
         // Resolve return type
@@ -206,18 +222,25 @@ impl Elaborator<'_> {
 
         let is_crate_root = self.is_at_crate_root();
         let is_entry_point = func.is_entry_point(self.is_function_in_contract(), is_crate_root);
-        // Temporary allow vectors for contract functions, until contracts are re-factored.
-        if !func.attributes().has_contract_library_method() {
-            let output = true;
-            if let Err(err) = Self::check_if_type_is_valid_for_program(
-                &return_type,
-                is_entry_point || func.is_test_or_fuzz(),
-                func.has_inline_attribute(),
-                output,
-                func.return_type().location,
-            ) {
-                self.push_err(err);
-            }
+        let is_entry_point_check = is_entry_point || func.is_test_or_fuzz();
+        let has_inline_attribute = func.has_inline_attribute();
+        // Defer entry-point validity checks until the end of elaboration so that
+        // types that depend on trait-associated constants or globals (which may not
+        // yet be bound at this point) have a chance to fully resolve. The check is
+        // a no-op unless one of these flags is set, so we only enqueue then.
+        if is_entry_point_check || has_inline_attribute {
+            // Vectors are temporarily allowed in contract library methods' return
+            // types, so we skip the return-type check for them.
+            let check_return_type = !func.attributes().has_contract_library_method();
+            let return_type_location = func.return_type().location;
+            self.pending_entry_point_checks.push(PendingEntryPointCheck {
+                func_id,
+                parameter_locations,
+                return_type_location,
+                check_return_type,
+                is_entry_point: is_entry_point_check,
+                has_inline_attribute,
+            });
         }
 
         // Build function type
@@ -357,12 +380,12 @@ impl Elaborator<'_> {
         let is_entry_point = func.is_entry_point(self.is_function_in_contract(), is_crate_root);
         let is_test_or_fuzz = func.is_test_or_fuzz();
 
-        let has_inline_attribute = func.has_inline_attribute();
         let is_pub_allowed = self.pub_allowed(func, self.is_function_in_contract(), is_crate_root);
 
         let mut parameters = Vec::new();
         let mut parameter_types = Vec::new();
         let mut parameter_idents = Vec::new();
+        let mut parameter_locations = Vec::new();
         let mut parameter_names_in_list = rustc_hash::FxHashMap::default();
         let wildcard_allowed = WildcardAllowed::No(WildcardDisallowedContext::FunctionParameter);
 
@@ -407,16 +430,7 @@ impl Elaborator<'_> {
                 _ => self.resolve_type_with_kind(typ, &Kind::Normal, wildcard_allowed),
             };
 
-            let output = false;
-            if let Err(err) = Self::check_if_type_is_valid_for_program(
-                &typ,
-                is_entry_point || is_test_or_fuzz,
-                has_inline_attribute,
-                output,
-                type_location,
-            ) {
-                self.push_err(err);
-            }
+            parameter_locations.push(type_location);
 
             if is_entry_point || is_test_or_fuzz {
                 self.mark_type_as_used(&typ);
@@ -436,7 +450,48 @@ impl Elaborator<'_> {
             parameter_types.push(typ);
         }
 
-        (parameters, parameter_types, parameter_idents)
+        (parameters, parameter_types, parameter_idents, parameter_locations)
+    }
+
+    /// Runs the validity checks queued during `define_function_meta` for entry points,
+    /// tests, fuzz targets, and `#[fold]`/`#[no_predicates]` functions. This must be
+    /// called after trait impls and globals have been elaborated so that array and
+    /// string lengths involving trait-associated constants or globals can evaluate.
+    pub(super) fn run_pending_entry_point_checks(&mut self) {
+        let pending = std::mem::take(&mut self.pending_entry_point_checks);
+        for check in pending {
+            let (parameter_types, return_type) = {
+                let func_meta = self.interner.function_meta(&check.func_id);
+                let parameter_types: Vec<Type> =
+                    func_meta.parameters.iter().map(|p| p.1.clone()).collect();
+                let return_type = func_meta.return_type().clone();
+                (parameter_types, return_type)
+            };
+
+            for (typ, location) in parameter_types.iter().zip(check.parameter_locations.iter()) {
+                if let Err(err) = Self::check_if_type_is_valid_for_program(
+                    typ,
+                    check.is_entry_point,
+                    check.has_inline_attribute,
+                    false, // output
+                    *location,
+                ) {
+                    self.push_err(err);
+                }
+            }
+
+            if check.check_return_type
+                && let Err(err) = Self::check_if_type_is_valid_for_program(
+                    &return_type,
+                    check.is_entry_point,
+                    check.has_inline_attribute,
+                    true, // output
+                    check.return_type_location,
+                )
+            {
+                self.push_err(err);
+            }
+        }
     }
 
     /// Only sized types are valid to be used as main's parameters or the parameters to a contract

--- a/compiler/noirc_frontend/src/elaborator/mod.rs
+++ b/compiler/noirc_frontend/src/elaborator/mod.rs
@@ -374,6 +374,11 @@ pub struct Elaborator<'context> {
     /// lookup fails and the name is in this set, we can report a more specific error
     /// about runtime variables not being available in comptime code.
     parent_runtime_variables: rustc_hash::FxHashSet<String>,
+
+    /// Entry-point validity checks deferred until after all trait impls and globals
+    /// have been elaborated, so that types using trait-associated constants or globals
+    /// can fully evaluate their array/string lengths before being validated.
+    pending_entry_point_checks: Vec<function::PendingEntryPointCheck>,
 }
 
 #[derive(Copy, Clone)]
@@ -450,6 +455,7 @@ impl<'context> Elaborator<'context> {
             recursion_depth: 0,
             impl_trait_is_disallowed: None,
             parent_runtime_variables: rustc_hash::FxHashSet::default(),
+            pending_entry_point_checks: Vec::new(),
         }
     }
 
@@ -572,6 +578,12 @@ impl<'context> Elaborator<'context> {
         for trait_impl in items.trait_impls {
             self.elaborate_trait_impl(trait_impl);
         }
+
+        // Now that trait impls and globals have been elaborated, run the
+        // entry-point validity checks queued during function-meta definition.
+        // Deferring lets array/string lengths involving trait-associated
+        // constants or globals evaluate before being validated.
+        self.run_pending_entry_point_checks();
     }
 
     #[tracing::instrument(level = "trace", skip_all)]

--- a/compiler/noirc_frontend/src/tests/functions.rs
+++ b/compiler/noirc_frontend/src/tests/functions.rs
@@ -464,3 +464,21 @@ fn errors_if_using_comptime_enum_in_fn() {
     "#;
     check_errors(src);
 }
+
+#[test]
+fn can_use_trait_associated_constant_in_main_signature() {
+    let src = r#"
+    pub trait Deserialize {
+        let N: u32;
+    }
+
+    impl Deserialize for Field {
+        let N: u32 = 1;
+    }
+
+    unconstrained fn main(fields: [Field; <Field as Deserialize>::N]) -> pub Field {
+        fields[0]
+    }
+    "#;
+    check_errors(src);
+}

--- a/tooling/nargo_cli/tests/snapshots/compile_failure/empty_composite_array_get/execute__tests__stderr.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_failure/empty_composite_array_get/execute__tests__stderr.snap
@@ -2,14 +2,6 @@
 source: tooling/nargo_cli/tests/execute.rs
 expression: stderr
 ---
-error: Invalid type found in the entry point to a program
-  ┌─ src/main.nr:1:22
-  │
-1 │ fn main(empty_input: [(Field, Field); 0]) {
-  │                      ------------------- Invalid entry point type: [(Field, Field); 0]
-  │
-  = Note: vectors, references, empty arrays, empty strings, or any type containing them may not be used in main, contract functions, test functions, fuzz functions or foldable functions.
-
 error: Index 0 is out of bounds for this array of length 0
   ┌─ src/main.nr:3:25
   │
@@ -23,5 +15,13 @@ error: Index 0 is out of bounds for this array of length 0
 4 │     let _ = empty_array[0];
   │                         -
   │
+
+error: Invalid type found in the entry point to a program
+  ┌─ src/main.nr:1:22
+  │
+1 │ fn main(empty_input: [(Field, Field); 0]) {
+  │                      ------------------- Invalid entry point type: [(Field, Field); 0]
+  │
+  = Note: vectors, references, empty arrays, empty strings, or any type containing them may not be used in main, contract functions, test functions, fuzz functions or foldable functions.
 
 Aborting due to 3 previous errors


### PR DESCRIPTION
## Problem Resolved

Partially solves https://github.com/noir-lang/noir/issues/12574

## Summary of Changes

The idea I had here is to defer the entry-point types check until elaboration end (then I had Claude write the code because it was relatively straight-forward). That works for the first snippet but not for the second.

The second case is trickier, and is actually [an audit bug](https://app.audithub.dev/app/organizations/161/projects/787/project-viewer?version=1681&issueId=1000) which can be reproduced like this:

```noir
global LENGTH: u32 = init();

fn another(array: [Field; LENGTH]) {}

fn init() -> u32 {
    10
}
```

Here there's no entry point at all, but the compiler still crashes. The reason is that we delay elaboration of "complex" globals until the end of elaboration, or resolve them lazily if needed. The problem is that we'll first try to type-check `another`, find `LENGTH`, try to lazily solve that but `init` wasn't type-checked yet so we get:

```
The application panicked (crashed).
Message:  ice: all function ids should have metadata
Location: compiler/noirc_frontend/src/node_interner/function.rs:176
```

Both I and Jake thought of how to solve this but couldn't think of an easy fix. So maybe this issue should be separate from #12574 (or, put another way: once we fix that second issue, combined with this PR, it should start working).

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
