### PR TITLE
fix(frontend): allocate fresh type variable for macro-emitted generic declarations (#12572)

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/comptime.rs
+++ b/compiler/noirc_frontend/src/elaborator/comptime.rs
@@ -634,6 +634,7 @@ impl<'context> Elaborator<'context> {
                     impl_id: None,
                     resolved_object_type: None,
                     resolved_generics: Vec::new(),
+                    resolved_generic_substitutions: TypeBindings::default(),
                     unresolved_associated_types: Vec::new(),
                 });
             }

--- a/compiler/noirc_frontend/src/elaborator/function.rs
+++ b/compiler/noirc_frontend/src/elaborator/function.rs
@@ -134,6 +134,7 @@ impl Elaborator<'_> {
         self.current_trait = trait_impl.trait_id;
         self.self_type = trait_impl.methods.self_type.clone();
         self.generics = generics;
+        self.generic_substitutions = trait_impl.resolved_generic_substitutions.clone();
 
         // Now define the function metas with the constraints from where clause desugaring
         self.define_function_metas_for_functions(
@@ -146,6 +147,7 @@ impl Elaborator<'_> {
         self.current_trait_impl = None;
         self.current_trait = None;
         self.generics.clear();
+        self.generic_substitutions.clear();
     }
 
     /// Extracts and stores metadata from a function definition.

--- a/compiler/noirc_frontend/src/elaborator/generics.rs
+++ b/compiler/noirc_frontend/src/elaborator/generics.rs
@@ -23,6 +23,11 @@ use super::Elaborator;
 /// Saved generics state for restoration after a scope exits.
 pub(super) struct GenericsState {
     generics_count: usize,
+    /// Snapshot of [`Elaborator::generic_substitutions`] at scope entry. On exit we restore
+    /// this verbatim, which has the side effect of discarding any entries added inside the
+    /// scope while preserving the entries (and bindings) that were already in flight from an
+    /// enclosing scope.
+    saved_substitutions: crate::TypeBindings,
 }
 
 impl Elaborator<'_> {
@@ -31,13 +36,17 @@ impl Elaborator<'_> {
     /// position of the current generics so that any generics added afterward can later be discarded
     /// via a call to [Self::exit_generics_scope].
     pub(super) fn enter_generics_scope(&self) -> GenericsState {
-        GenericsState { generics_count: self.generics.len() }
+        GenericsState {
+            generics_count: self.generics.len(),
+            saved_substitutions: self.generic_substitutions.clone(),
+        }
     }
 
     /// Restores the generics state saved by `enter_generics_scope`.
     #[tracing::instrument(level = "trace", skip_all)]
     pub(super) fn exit_generics_scope(&mut self, state: GenericsState) {
         self.generics.truncate(state.generics_count);
+        self.generic_substitutions = state.saved_substitutions;
     }
 
     /// Runs `f` and if it modifies `self.generics`, `self.generics` is truncated
@@ -147,7 +156,35 @@ impl Elaborator<'_> {
             }
             IdentOrQuotedType::Quoted(id, location) => {
                 match self.interner.get_quoted_type(*id).follow_bindings() {
-                    Type::NamedGeneric(NamedGeneric { type_var, name, .. }) => Ok((type_var, name)),
+                    Type::NamedGeneric(named_generic) => {
+                        // The macro emitted this generic by interpolating an existing
+                        // `Type::NamedGeneric`, which carries an outer-scope `TypeVariable`.
+                        // Reusing that `TypeVariable` would alias the impl's generic with the
+                        // outer one, so binding the impl's generic during monomorphization
+                        // would also bind the outer one. Allocate a fresh `TypeVariable` and
+                        // record the substitution so any sibling resolved types the macro
+                        // interpolated using the same outer `TypeVariable` (e.g. an impl's
+                        // `Self` type) can be rewritten to use the fresh one.
+                        //
+                        // The substitution rewrites the original `NamedGeneric` to a
+                        // `NamedGeneric` carrying the fresh `TypeVariable` (rather than a
+                        // bare `Type::TypeVariable`) so downstream consumers — particularly
+                        // constructor-expression generic checks that treat a bare
+                        // `TypeVariable` as requiring an inferred binding — continue to see
+                        // a named generic.
+                        let type_var = named_generic.type_var.clone();
+                        let name = named_generic.name.clone();
+                        let fresh_id = self.interner.next_type_variable_id();
+                        let kind = type_var.kind();
+                        let fresh_tv = TypeVariable::unbound(fresh_id, kind.clone());
+                        let mut fresh_named = named_generic;
+                        fresh_named.type_var = fresh_tv.clone();
+                        self.generic_substitutions.insert(
+                            type_var.id(),
+                            (type_var, kind, Type::NamedGeneric(fresh_named)),
+                        );
+                        Ok((fresh_tv, name))
+                    }
                     other => Err(ResolverError::MacroResultInGenericsListNotAGeneric {
                         location: *location,
                         typ: other,

--- a/compiler/noirc_frontend/src/elaborator/mod.rs
+++ b/compiler/noirc_frontend/src/elaborator/mod.rs
@@ -57,7 +57,7 @@ use std::{
 };
 
 use crate::{
-    Type,
+    Type, TypeBindings,
     ast::UnresolvedGenerics,
     elaborator::types::WildcardDisallowedContext,
     graph::CrateId,
@@ -255,6 +255,18 @@ pub struct Elaborator<'context> {
     /// were declared in.
     generics: Vec<ResolvedGeneric>,
 
+    /// Substitutions to apply to resolved types loaded from the interner via
+    /// [`crate::ast::UnresolvedTypeData::Resolved`]. Populated by
+    /// [`Self::resolve_generic`] when a generic declaration carries a macro-
+    /// emitted [`crate::ast::IdentOrQuotedType::Quoted`] type variable: a
+    /// fresh `TypeVariable` is allocated for the new generic and the original
+    /// `TypeVariable` is recorded here so that any subsequent resolved type
+    /// that still references it (e.g. an impl's `Self` type that the macro
+    /// interpolated alongside the generic declaration) is rewritten to use
+    /// the fresh `TypeVariable`. This decouples macro-emitted impl generics
+    /// from any outer-scope `TypeVariable` they were aliased with.
+    generic_substitutions: TypeBindings,
+
     /// When resolving lambda expressions, we need to keep track of the variables
     /// that are captured. We do this in order to create the hidden environment
     /// parameter for the lambda function.
@@ -428,6 +440,7 @@ impl<'context> Elaborator<'context> {
             unsafe_block_status: UnsafeBlockStatus::NotInUnsafeBlock,
             current_loop: None,
             generics: Vec::new(),
+            generic_substitutions: TypeBindings::default(),
             lambda_stack: Vec::new(),
             self_type: None,
             current_item: None,
@@ -795,6 +808,7 @@ impl<'context> Elaborator<'context> {
         self.local_module = Some(trait_impl.module_id);
 
         self.generics = trait_impl.resolved_generics.clone();
+        self.generic_substitutions = trait_impl.resolved_generic_substitutions.clone();
         self.current_trait_impl = trait_impl.impl_id;
         self.current_trait = trait_impl.trait_id;
 
@@ -815,6 +829,7 @@ impl<'context> Elaborator<'context> {
         self.current_trait_impl = None;
         self.current_trait = None;
         self.generics.clear();
+        self.generic_substitutions.clear();
     }
 
     pub fn get_module(&self, module: ModuleId) -> &ModuleData {

--- a/compiler/noirc_frontend/src/elaborator/trait_impls.rs
+++ b/compiler/noirc_frontend/src/elaborator/trait_impls.rs
@@ -112,6 +112,10 @@ impl Elaborator<'_> {
         if let Some(trait_id) = trait_impl.trait_id {
             let previous_generics =
                 std::mem::replace(&mut self.generics, trait_impl.resolved_generics.clone());
+            let previous_substitutions = std::mem::replace(
+                &mut self.generic_substitutions,
+                trait_impl.resolved_generic_substitutions.clone(),
+            );
 
             let where_clause =
                 self.resolve_trait_constraints_and_add_to_scope(&trait_impl.where_clause);
@@ -269,6 +273,7 @@ impl Elaborator<'_> {
             }
 
             self.generics = previous_generics;
+            self.generic_substitutions = previous_substitutions;
         }
 
         self.local_module = previous_local_module;
@@ -823,6 +828,7 @@ impl Elaborator<'_> {
         self.local_module = previous_local_module;
 
         let generics = std::mem::take(&mut self.generics);
+        trait_impl.resolved_generic_substitutions = std::mem::take(&mut self.generic_substitutions);
 
         (new_generics_trait_constraints, generics)
     }

--- a/compiler/noirc_frontend/src/elaborator/types.rs
+++ b/compiler/noirc_frontend/src/elaborator/types.rs
@@ -276,7 +276,14 @@ impl Elaborator<'_> {
             Parenthesized(typ) => {
                 self.resolve_type_with_kind_inner(*typ, kind, mode, wildcard_allowed)
             }
-            Resolved(id) => self.interner.get_quoted_type(id).clone(),
+            Resolved(id) => {
+                let typ = self.interner.get_quoted_type(id).clone();
+                if self.generic_substitutions.is_empty() {
+                    typ
+                } else {
+                    typ.substitute(&self.generic_substitutions)
+                }
+            }
             AsTraitPath(path) => self.resolve_as_trait_path(*path, mode, wildcard_allowed),
             Interned(id) => {
                 let typ = self.interner.get_unresolved_type_data(id).clone();

--- a/compiler/noirc_frontend/src/hir/def_collector/dc_crate.rs
+++ b/compiler/noirc_frontend/src/hir/def_collector/dc_crate.rs
@@ -9,7 +9,7 @@ use crate::hir::type_check::{ExpectingOtherError, TypeCheckError};
 use crate::locations::ReferencesTracker;
 use crate::token::SecondaryAttribute;
 use crate::usage_tracker::UnusedItem;
-use crate::{ResolvedGenerics, Type};
+use crate::{ResolvedGenerics, Type, TypeBindings};
 
 use crate::hir::Context;
 use crate::hir::resolution::import::{ImportDirective, ResolvedImport, resolve_import};
@@ -99,6 +99,13 @@ pub struct UnresolvedTraitImpl {
     pub impl_id: Option<TraitImplId>,
     pub resolved_object_type: Option<Type>,
     pub resolved_generics: ResolvedGenerics,
+    /// Substitutions captured while resolving this impl's generic declarations.
+    /// Populated by [`crate::elaborator::Elaborator::resolve_generic`] when the impl
+    /// was emitted by a comptime macro that interpolated an existing
+    /// [`crate::Type::NamedGeneric`] in both its generic list and its `Self`/where-clause
+    /// types. Replayed whenever subsequent passes re-resolve those macro-emitted
+    /// types so they continue to share the impl's allocated [`crate::TypeVariable`].
+    pub resolved_generic_substitutions: TypeBindings,
     pub unresolved_associated_types: Vec<(Ident, UnresolvedType)>,
 }
 

--- a/compiler/noirc_frontend/src/hir/def_collector/dc_crate.rs
+++ b/compiler/noirc_frontend/src/hir/def_collector/dc_crate.rs
@@ -100,11 +100,11 @@ pub struct UnresolvedTraitImpl {
     pub resolved_object_type: Option<Type>,
     pub resolved_generics: ResolvedGenerics,
     /// Substitutions captured while resolving this impl's generic declarations.
-    /// Populated by [`crate::elaborator::Elaborator::resolve_generic`] when the impl
-    /// was emitted by a comptime macro that interpolated an existing
-    /// [`crate::Type::NamedGeneric`] in both its generic list and its `Self`/where-clause
-    /// types. Replayed whenever subsequent passes re-resolve those macro-emitted
-    /// types so they continue to share the impl's allocated [`crate::TypeVariable`].
+    /// Populated when the impl was emitted by a comptime macro that interpolated an
+    /// existing [`crate::Type::NamedGeneric`] in both its generic list and its
+    /// `Self`/where-clause types. Replayed whenever subsequent passes re-resolve
+    /// those macro-emitted types so they continue to share the impl's allocated
+    /// [`crate::TypeVariable`].
     pub resolved_generic_substitutions: TypeBindings,
     pub unresolved_associated_types: Vec<(Ident, UnresolvedType)>,
 }

--- a/compiler/noirc_frontend/src/hir/def_collector/dc_mod.rs
+++ b/compiler/noirc_frontend/src/hir/def_collector/dc_mod.rs
@@ -261,6 +261,7 @@ impl ModCollector<'_> {
                 impl_id: None,
                 resolved_object_type: None,
                 resolved_generics: Vec::new(),
+                resolved_generic_substitutions: crate::TypeBindings::default(),
                 unresolved_associated_types: Vec::new(),
             };
 

--- a/test_programs/execution_success/regression_12572/Nargo.toml
+++ b/test_programs/execution_success/regression_12572/Nargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "regression_12572"
+type = "bin"
+authors = [""]
+
+[dependencies]

--- a/test_programs/execution_success/regression_12572/Prover.toml
+++ b/test_programs/execution_success/regression_12572/Prover.toml
@@ -1,0 +1,2 @@
+input = "5"
+return = "5"

--- a/test_programs/execution_success/regression_12572/src/main.nr
+++ b/test_programs/execution_success/regression_12572/src/main.nr
@@ -1,0 +1,23 @@
+use std::default::Default;
+
+#[derive(Default)]
+struct Log<let N: u32> {
+    fields: [Field; N],
+}
+
+#[derive(Default)]
+struct Wrapper {
+    log: Log<2>,
+}
+
+#[derive(Default)]
+struct Bundle {
+    small: [Log<1>; 1],
+    wrapped: [Wrapper; 1],
+}
+
+fn main(input: Field) -> pub Field {
+    let mut b: Bundle = Default::default();
+    b.wrapped[0].log.fields[0] = input;
+    b.wrapped[0].log.fields[0] + b.wrapped[0].log.fields[1] + b.small[0].fields[0]
+}

--- a/tooling/nargo_cli/tests/snapshots/execution_success/regression_12572/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/regression_12572/execute__tests__expanded.snap
@@ -1,0 +1,46 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: expanded_code
+---
+use std::default::Default;
+
+struct Log<let N: u32> {
+    fields: [Field; N],
+}
+
+impl<let N: u32> Default for Log<N> {
+    fn default() -> Self {
+        Self { fields: <[Field; N] as Default>::default() }
+    }
+}
+
+struct Wrapper {
+    log: Log<2>,
+}
+
+impl Default for Wrapper {
+    fn default() -> Self {
+        Self { log: <Log<2> as Default>::default() }
+    }
+}
+
+struct Bundle {
+    small: [Log<1>; 1],
+    wrapped: [Wrapper; 1],
+}
+
+impl Default for Bundle {
+    fn default() -> Self {
+        Self {
+            small: <[Log<1>; 1] as Default>::default(),
+            wrapped: <[Wrapper; 1] as Default>::default(),
+        }
+    }
+}
+
+fn main(input: Field) -> pub Field {
+    let mut b: Bundle = <Bundle as Default>::default();
+    b.wrapped[0_u32].log.fields[0_u32] = input;
+    (b.wrapped[0_u32].log.fields[0_u32] + b.wrapped[0_u32].log.fields[1_u32])
+        + b.small[0_u32].fields[0_u32]
+}

--- a/tooling/nargo_cli/tests/snapshots/execution_success/regression_12572/execute__tests__stdout.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/regression_12572/execute__tests__stdout.snap
@@ -1,0 +1,5 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: stdout
+---
+[regression_12572] Circuit output: 0x05


### PR DESCRIPTION
## Summary

Fixes the root cause of the SSA validation error in #12572 by decoupling a comptime-macro-emitted impl's generic `TypeVariable` from the outer-scope `TypeVariable` it was interpolated from.

When a derive-style comptime macro emits `impl<$name: u32> ... for $typ` by interpolating an existing `Type::NamedGeneric`, the impl's generic and the struct's generic ended up sharing the same `TypeVariable`. Binding the impl's generic during monomorphization then also bound the outer `TypeVariable`, poisoning unrelated trait-impl lookups elsewhere in the program (the symptom in #12572 was an `expected return type [Field; 2], but got [Field; 1]` error from SSA validation).

This change makes `Elaborator::resolve_generic` allocate a **fresh** `TypeVariable` for macro-emitted `Quoted` generic declarations and records the original→fresh mapping in a new `Elaborator::generic_substitutions` field. `resolve_type`'s `Resolved` arm replays that substitution so any other resolved types the macro interpolated using the same outer `TypeVariable` (the impl's `Self` type, its where-clause types, etc.) continue to share the impl's allocated `TypeVariable`. The substitution map is stashed on `UnresolvedTraitImpl::resolved_generic_substitutions` so subsequent passes (function-meta definition, `collect_trait_impl`, and trait-impl elaboration) can restore it before re-resolving the impl's macro-emitted types.

## Relationship to #12579

#12579 is a more conservative, targeted fix in the monomorphizer: it snapshots and restores the per-expression `instantiation_bindings` around `resolve_trait_item_expr` so that an `Assumed` impl resolution does not persist its impl-specific binding extensions back onto the expression. That patch addresses the immediate symptom in #12572 (and a class of related cross-context corruption of stored bindings) without touching how the impl's generic `TypeVariable` is allocated.

This PR addresses the underlying cause: it removes the aliasing between the impl's generic and the macro's outer `TypeVariable` in the first place, so binding the impl's generic at mono time can no longer reach back to anything outside the impl. The regression test from #12579 passes on this branch **without** the snapshot/restore in `resolve_trait_item_expr`.

The two changes are complementary, not redundant:
- #12579 hardens the per-expression bindings store against impl-specific entries leaking across mono contexts. That class of bug exists independently of how impl generics are allocated, so it remains worth keeping as defense-in-depth.
- This PR removes one source of cross-impl `TypeVariable` aliasing, which prevents the specific failure mode in #12572 from being reachable at all.

If maintainers prefer to ship one and not the other, this PR is sufficient on its own to fix the reported bug. If both ship, #12579 should land first and this PR's diff stays unchanged either way.

## Test plan

- [x] `test_programs/execution_success/regression_12572` passes off `master` with this fix and **without** the change from #12579 applied
- [x] `cargo nextest run -p noirc_frontend` — 1726/1726
- [x] `cargo nextest run -p nargo_cli --test execute` — 8489/8489
- [x] `cargo test -p nargo_cli --test stdlib-tests` — 244/244
- [x] `cargo clippy --workspace --all-targets` — clean
- [x] `just format-check` — clean