### PR TITLE
fix: lazily define function metas

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/function.rs
+++ b/compiler/noirc_frontend/src/elaborator/function.rs
@@ -39,7 +39,23 @@ use crate::{
 
 use super::Elaborator;
 
-type ResolvedParametersInfo = (Vec<(HirPattern, Type, Visibility)>, Vec<Type>, Vec<HirIdent>);
+type ResolvedParametersInfo =
+    (Vec<(HirPattern, Type, Visibility)>, Vec<Type>, Vec<HirIdent>, Vec<Location>);
+
+/// Validation of entry-point parameter and return types is deferred until after
+/// all trait impls and globals are elaborated. This struct captures everything
+/// needed to run the check later: the function id (so we can fetch the resolved
+/// parameter and return types out of the interner), the source locations to
+/// attribute any errors to, and the flags that determine whether the entry-point
+/// or `#[fold]`/`#[no_predicates]` checks apply.
+pub(super) struct PendingEntryPointCheck {
+    pub(super) func_id: FuncId,
+    pub(super) parameter_locations: Vec<Location>,
+    pub(super) return_type_location: Location,
+    pub(super) is_entry_point: bool,
+    pub(super) has_inline_attribute: bool,
+    pub(super) check_return_type: bool,
+}
 
 impl Elaborator<'_> {
     /// Defines function metadata for all functions, impl methods, and trait impl methods.
@@ -197,7 +213,7 @@ impl Elaborator<'_> {
         extra_trait_constraints.extend(associated_generics_trait_constraints);
 
         // Resolve parameters
-        let (parameters, parameter_types, parameter_idents) =
+        let (parameters, parameter_types, parameter_idents, parameter_locations) =
             self.resolve_function_parameters(func, &mut generics, &mut trait_constraints);
 
         // Resolve return type
@@ -206,18 +222,25 @@ impl Elaborator<'_> {
 
         let is_crate_root = self.is_at_crate_root();
         let is_entry_point = func.is_entry_point(self.is_function_in_contract(), is_crate_root);
-        // Temporary allow vectors for contract functions, until contracts are re-factored.
-        if !func.attributes().has_contract_library_method() {
-            let output = true;
-            if let Err(err) = Self::check_if_type_is_valid_for_program(
-                &return_type,
-                is_entry_point || func.is_test_or_fuzz(),
-                func.has_inline_attribute(),
-                output,
-                func.return_type().location,
-            ) {
-                self.push_err(err);
-            }
+        let is_entry_point_check = is_entry_point || func.is_test_or_fuzz();
+        let has_inline_attribute = func.has_inline_attribute();
+        // Defer entry-point validity checks until the end of elaboration so that
+        // types that depend on trait-associated constants or globals (which may not
+        // yet be bound at this point) have a chance to fully resolve. The check is
+        // a no-op unless one of these flags is set, so we only enqueue then.
+        if is_entry_point_check || has_inline_attribute {
+            // Vectors are temporarily allowed in contract library methods' return
+            // types, so we skip the return-type check for them.
+            let check_return_type = !func.attributes().has_contract_library_method();
+            let return_type_location = func.return_type().location;
+            self.pending_entry_point_checks.push(PendingEntryPointCheck {
+                func_id,
+                parameter_locations,
+                return_type_location,
+                check_return_type,
+                is_entry_point: is_entry_point_check,
+                has_inline_attribute,
+            });
         }
 
         // Build function type
@@ -357,12 +380,12 @@ impl Elaborator<'_> {
         let is_entry_point = func.is_entry_point(self.is_function_in_contract(), is_crate_root);
         let is_test_or_fuzz = func.is_test_or_fuzz();
 
-        let has_inline_attribute = func.has_inline_attribute();
         let is_pub_allowed = self.pub_allowed(func, self.is_function_in_contract(), is_crate_root);
 
         let mut parameters = Vec::new();
         let mut parameter_types = Vec::new();
         let mut parameter_idents = Vec::new();
+        let mut parameter_locations = Vec::new();
         let mut parameter_names_in_list = rustc_hash::FxHashMap::default();
         let wildcard_allowed = WildcardAllowed::No(WildcardDisallowedContext::FunctionParameter);
 
@@ -407,16 +430,7 @@ impl Elaborator<'_> {
                 _ => self.resolve_type_with_kind(typ, &Kind::Normal, wildcard_allowed),
             };
 
-            let output = false;
-            if let Err(err) = Self::check_if_type_is_valid_for_program(
-                &typ,
-                is_entry_point || is_test_or_fuzz,
-                has_inline_attribute,
-                output,
-                type_location,
-            ) {
-                self.push_err(err);
-            }
+            parameter_locations.push(type_location);
 
             if is_entry_point || is_test_or_fuzz {
                 self.mark_type_as_used(&typ);
@@ -436,7 +450,48 @@ impl Elaborator<'_> {
             parameter_types.push(typ);
         }
 
-        (parameters, parameter_types, parameter_idents)
+        (parameters, parameter_types, parameter_idents, parameter_locations)
+    }
+
+    /// Runs the validity checks queued during `define_function_meta` for entry points,
+    /// tests, fuzz targets, and `#[fold]`/`#[no_predicates]` functions. This must be
+    /// called after trait impls and globals have been elaborated so that array and
+    /// string lengths involving trait-associated constants or globals can evaluate.
+    pub(super) fn run_pending_entry_point_checks(&mut self) {
+        let pending = std::mem::take(&mut self.pending_entry_point_checks);
+        for check in pending {
+            let (parameter_types, return_type) = {
+                let func_meta = self.interner.function_meta(&check.func_id);
+                let parameter_types: Vec<Type> =
+                    func_meta.parameters.iter().map(|p| p.1.clone()).collect();
+                let return_type = func_meta.return_type().clone();
+                (parameter_types, return_type)
+            };
+
+            for (typ, location) in parameter_types.iter().zip(check.parameter_locations.iter()) {
+                if let Err(err) = Self::check_if_type_is_valid_for_program(
+                    typ,
+                    check.is_entry_point,
+                    check.has_inline_attribute,
+                    false, // output
+                    *location,
+                ) {
+                    self.push_err(err);
+                }
+            }
+
+            if check.check_return_type
+                && let Err(err) = Self::check_if_type_is_valid_for_program(
+                    &return_type,
+                    check.is_entry_point,
+                    check.has_inline_attribute,
+                    true, // output
+                    check.return_type_location,
+                )
+            {
+                self.push_err(err);
+            }
+        }
     }
 
     /// Only sized types are valid to be used as main's parameters or the parameters to a contract

--- a/compiler/noirc_frontend/src/elaborator/function.rs
+++ b/compiler/noirc_frontend/src/elaborator/function.rs
@@ -24,6 +24,7 @@ use crate::{
     },
     hir::{
         def_collector::dc_crate::{ImplMap, UnresolvedFunctions, UnresolvedTraitImpl},
+        def_map::LocalModuleId,
         resolution::errors::ResolverError,
         type_check::TypeCheckError,
     },
@@ -33,36 +34,47 @@ use crate::{
         stmt::HirPattern,
         traits::TraitConstraint,
     },
-    node_interner::{DefinitionKind, DependencyId, FuncId, FunctionModifiers, TraitId},
+    node_interner::{
+        DefinitionKind, DependencyId, FuncId, FunctionModifiers, TraitId, TraitImplId,
+    },
     shared::Visibility,
 };
 
 use super::Elaborator;
 
-type ResolvedParametersInfo =
-    (Vec<(HirPattern, Type, Visibility)>, Vec<Type>, Vec<HirIdent>, Vec<Location>);
+type ResolvedParametersInfo = (Vec<(HirPattern, Type, Visibility)>, Vec<Type>, Vec<HirIdent>);
 
-/// Validation of entry-point parameter and return types is deferred until after
-/// all trait impls and globals are elaborated. This struct captures everything
-/// needed to run the check later: the function id (so we can fetch the resolved
-/// parameter and return types out of the interner), the source locations to
-/// attribute any errors to, and the flags that determine whether the entry-point
-/// or `#[fold]`/`#[no_predicates]` checks apply.
-pub(super) struct PendingEntryPointCheck {
-    pub(super) func_id: FuncId,
-    pub(super) parameter_locations: Vec<Location>,
-    pub(super) return_type_location: Location,
-    pub(super) is_entry_point: bool,
-    pub(super) has_inline_attribute: bool,
-    pub(super) check_return_type: bool,
+/// Captures everything needed to lazily resolve a function's metadata.
+///
+/// Function metas are registered with this elaborator-side context up-front, then
+/// resolved lazily when a meta is first read (or eagerly drained at the end of
+/// elaboration). This lets meta resolution happen *after* trait impls are bound
+/// and globals can elaborate, and lets forward references between metas, globals,
+/// and other functions resolve in any order.
+pub(super) struct UnresolvedFunctionMeta {
+    pub(super) func: NoirFunction,
+    pub(super) local_module: LocalModuleId,
+    pub(super) self_type: Option<Type>,
+    /// Generics in scope from an enclosing `impl<...>` or trait impl, already
+    /// resolved. The function's own generics are added during meta resolution.
+    pub(super) outer_generics: Vec<ResolvedGeneric>,
+    pub(super) current_trait: Option<TraitId>,
+    pub(super) current_trait_impl: Option<TraitImplId>,
+    pub(super) extra_trait_constraints: Vec<(TraitConstraint, Location)>,
 }
 
 impl Elaborator<'_> {
-    /// Defines function metadata for all functions, impl methods, and trait impl methods.
-    /// This is the first pass of function elaboration that extracts type signatures and
-    /// resolves generics before the function bodies are elaborated.
+    /// Registers all functions, impl methods, and trait impl methods for *lazy*
+    /// metadata resolution. Each entry captures the elaborator context (self_type,
+    /// outer generics, trait/impl ids) needed to resolve the meta later. Trait
+    /// impls are also prepared here so that `<Object as Trait>::Type` references
+    /// inside any signature can be looked up during meta resolution.
+    ///
+    /// The metas are not actually resolved here — they are resolved on demand
+    /// (the first time something reads the meta) or drained at the end of
+    /// elaboration via [Self::drain_unresolved_function_metas].
     #[tracing::instrument(level = "trace", skip_all)]
-    pub(super) fn define_function_metas(
+    pub(super) fn register_function_metas(
         &mut self,
         functions: &mut [UnresolvedFunctions],
         impls: &mut ImplMap,
@@ -73,95 +85,184 @@ impl Elaborator<'_> {
             self.prepare_trait_impl_for_function_meta_definition(trait_impl)
         });
 
-        // Define metas for regular functions
+        // Register metas for regular functions
         for function_set in functions {
-            self.define_function_metas_for_functions(function_set, &[]);
+            self.register_function_metas_for_functions(function_set, &[]);
         }
 
-        // Define metas for impl functions
+        // Register metas for impl functions
         for ((self_type, local_module), function_sets) in impls {
-            self.define_function_metas_for_impl(self_type, *local_module, function_sets);
+            self.register_function_metas_for_impl(self_type, *local_module, function_sets);
         }
 
-        // Define metas for trait impl functions
+        // Register metas for trait impl functions
         for (trait_impl, (trait_constraints, generics)) in
             trait_impls.iter_mut().zip_eq(trait_constraints_and_generics)
         {
-            self.define_function_metas_for_trait_impl(trait_impl, trait_constraints, generics);
+            self.register_function_metas_for_trait_impl(trait_impl, trait_constraints, generics);
         }
     }
 
-    /// Defines function metadata for a set of functions with optional extra trait constraints.
-    /// This is used for both standalone functions and methods within impls/trait impls.
+    /// Registers each function in the set as an unresolved meta. The functions are
+    /// not iterated by `define_function_meta` here — they are resolved lazily.
     #[tracing::instrument(level = "trace", skip_all)]
-    fn define_function_metas_for_functions(
+    fn register_function_metas_for_functions(
         &mut self,
-        function_set: &mut UnresolvedFunctions,
+        function_set: &UnresolvedFunctions,
         extra_constraints: &[(TraitConstraint, Location)],
     ) {
-        for (local_module, id, func) in &mut function_set.functions {
-            self.local_module = Some(*local_module);
-            self.recover_generics(|this| {
-                this.define_function_meta(func, *id, None, extra_constraints);
-            });
+        for (local_module, id, func) in &function_set.functions {
+            self.unresolved_function_metas.insert(
+                *id,
+                UnresolvedFunctionMeta {
+                    func: func.clone(),
+                    local_module: *local_module,
+                    self_type: None,
+                    outer_generics: Vec::new(),
+                    current_trait: None,
+                    current_trait_impl: None,
+                    extra_trait_constraints: extra_constraints.to_vec(),
+                },
+            );
         }
     }
 
-    /// Defines function metadata for all methods within an impl block.
-    /// Resolves the self type and adds it to scope for method resolution.
+    /// Registers each impl method as an unresolved meta, resolving the impl's
+    /// self type and generics so that they're captured for later meta resolution.
     #[tracing::instrument(level = "trace", skip_all)]
-    fn define_function_metas_for_impl(
+    fn register_function_metas_for_impl(
         &mut self,
         self_type: &UnresolvedType,
-        local_module: crate::hir::def_map::LocalModuleId,
+        local_module: LocalModuleId,
         function_sets: &mut Vec<(UnresolvedGenerics, Location, UnresolvedFunctions)>,
     ) {
         self.local_module = Some(local_module);
 
         for (generics, _, function_set) in function_sets {
-            // Prepare the impl
-            // Adds the impl generics to the generics state and resolve the impl's self type
+            // Prepare the impl: adds the impl generics to scope so the self type can
+            // reference them, then resolve the self type.
             self.add_generics(generics);
 
             let wildcard_allowed = WildcardAllowed::No(WildcardDisallowedContext::ImplType);
             let self_type = self.resolve_type(self_type.clone(), wildcard_allowed);
             function_set.self_type = Some(self_type.clone());
-            self.self_type = Some(self_type);
 
-            self.define_function_metas_for_functions(function_set, &[]);
+            let outer_generics = self.generics.clone();
+            for (method_module, id, func) in &function_set.functions {
+                self.unresolved_function_metas.insert(
+                    *id,
+                    UnresolvedFunctionMeta {
+                        func: func.clone(),
+                        local_module: *method_module,
+                        self_type: Some(self_type.clone()),
+                        outer_generics: outer_generics.clone(),
+                        current_trait: None,
+                        current_trait_impl: None,
+                        extra_trait_constraints: Vec::new(),
+                    },
+                );
+            }
 
-            // Cleanup
-            self.self_type = None;
             self.generics.clear();
         }
     }
 
-    /// Defines function metadata for all methods within a trait impl.
-    /// This handles trait resolution, generics, associated types, and constraint checking.
+    /// Registers each trait impl method as an unresolved meta, capturing the trait
+    /// impl's self type, generics, and trait/impl ids for later resolution.
     #[tracing::instrument(level = "trace", skip_all)]
-    fn define_function_metas_for_trait_impl(
+    fn register_function_metas_for_trait_impl(
         &mut self,
-        trait_impl: &mut UnresolvedTraitImpl,
+        trait_impl: &UnresolvedTraitImpl,
         new_generics_trait_constraints: Vec<(TraitConstraint, Location)>,
         generics: Vec<ResolvedGeneric>,
     ) {
-        // Set up trait impl state
-        self.current_trait_impl = trait_impl.impl_id;
-        self.current_trait = trait_impl.trait_id;
-        self.self_type = trait_impl.methods.self_type.clone();
-        self.generics = generics;
+        let self_type = trait_impl.methods.self_type.clone();
+        for (method_module, id, func) in &trait_impl.methods.functions {
+            self.unresolved_function_metas.insert(
+                *id,
+                UnresolvedFunctionMeta {
+                    func: func.clone(),
+                    local_module: *method_module,
+                    self_type: self_type.clone(),
+                    outer_generics: generics.clone(),
+                    current_trait: trait_impl.trait_id,
+                    current_trait_impl: trait_impl.impl_id,
+                    extra_trait_constraints: new_generics_trait_constraints.clone(),
+                },
+            );
+        }
+    }
 
-        // Now define the function metas with the constraints from where clause desugaring
-        self.define_function_metas_for_functions(
-            &mut trait_impl.methods,
-            &new_generics_trait_constraints,
-        );
+    /// Returns whether `func_id` is a method on a trait impl, looking through both
+    /// resolved and yet-to-be-resolved metas. Useful when callers only need to
+    /// distinguish trait-impl methods without forcing full meta resolution (which
+    /// may not be possible if other borrows are live).
+    pub(crate) fn function_is_trait_impl_method(&self, func_id: FuncId) -> bool {
+        if let Some(info) = self.unresolved_function_metas.get(&func_id) {
+            return info.current_trait_impl.is_some();
+        }
+        self.interner.try_function_meta(&func_id).is_some_and(|meta| meta.trait_impl.is_some())
+    }
 
-        // Cleanup
-        self.self_type = None;
-        self.current_trait_impl = None;
-        self.current_trait = None;
-        self.generics.clear();
+    /// If `func_id` was registered but its meta hasn't been resolved yet, resolve
+    /// it now under the registered context. This is the lazy entry point used by
+    /// callers that need a function's meta before the end-of-elaboration drain.
+    ///
+    /// A no-op for: functions already resolved, functions that aren't in the side
+    /// map (e.g. trait method definitions and default impl methods, which are
+    /// resolved eagerly elsewhere), and re-entrant calls for a function currently
+    /// being resolved (the `remove` returns `None`, breaking cycles — the cycle
+    /// will surface as an error from later phases like dependency-cycle detection).
+    pub(crate) fn define_function_meta_if_undefined(&mut self, func_id: FuncId) {
+        let Some(info) = self.unresolved_function_metas.remove(&func_id) else {
+            return;
+        };
+        self.resolve_unresolved_function_meta(func_id, info);
+    }
+
+    /// Drains every remaining unresolved meta. Called at the end of elaboration so
+    /// that any functions not pulled in by a forward reference still get resolved.
+    #[tracing::instrument(level = "trace", skip_all)]
+    pub(super) fn drain_unresolved_function_metas(&mut self) {
+        while let Some((func_id, info)) = self.unresolved_function_metas.pop_first() {
+            self.resolve_unresolved_function_meta(func_id, info);
+        }
+    }
+
+    /// Sets up the elaborator context that was captured at registration time, then
+    /// runs `define_function_meta`. Restores the prior context on the way out so
+    /// callers (which may themselves be mid-resolution) aren't disturbed.
+    fn resolve_unresolved_function_meta(&mut self, func_id: FuncId, info: UnresolvedFunctionMeta) {
+        let UnresolvedFunctionMeta {
+            mut func,
+            local_module,
+            self_type,
+            outer_generics,
+            current_trait,
+            current_trait_impl,
+            extra_trait_constraints,
+        } = info;
+
+        let prev_local_module = self.local_module;
+        let prev_self_type = self.self_type.take();
+        let prev_generics = std::mem::replace(&mut self.generics, outer_generics);
+        let prev_current_trait = self.current_trait.take();
+        let prev_current_trait_impl = self.current_trait_impl.take();
+
+        self.local_module = Some(local_module);
+        self.self_type = self_type;
+        self.current_trait = current_trait;
+        self.current_trait_impl = current_trait_impl;
+
+        self.recover_generics(|this| {
+            this.define_function_meta(&mut func, func_id, None, &extra_trait_constraints);
+        });
+
+        self.local_module = prev_local_module;
+        self.self_type = prev_self_type;
+        self.generics = prev_generics;
+        self.current_trait = prev_current_trait;
+        self.current_trait_impl = prev_current_trait_impl;
     }
 
     /// Extracts and stores metadata from a function definition.
@@ -213,7 +314,7 @@ impl Elaborator<'_> {
         extra_trait_constraints.extend(associated_generics_trait_constraints);
 
         // Resolve parameters
-        let (parameters, parameter_types, parameter_idents, parameter_locations) =
+        let (parameters, parameter_types, parameter_idents) =
             self.resolve_function_parameters(func, &mut generics, &mut trait_constraints);
 
         // Resolve return type
@@ -222,25 +323,18 @@ impl Elaborator<'_> {
 
         let is_crate_root = self.is_at_crate_root();
         let is_entry_point = func.is_entry_point(self.is_function_in_contract(), is_crate_root);
-        let is_entry_point_check = is_entry_point || func.is_test_or_fuzz();
-        let has_inline_attribute = func.has_inline_attribute();
-        // Defer entry-point validity checks until the end of elaboration so that
-        // types that depend on trait-associated constants or globals (which may not
-        // yet be bound at this point) have a chance to fully resolve. The check is
-        // a no-op unless one of these flags is set, so we only enqueue then.
-        if is_entry_point_check || has_inline_attribute {
-            // Vectors are temporarily allowed in contract library methods' return
-            // types, so we skip the return-type check for them.
-            let check_return_type = !func.attributes().has_contract_library_method();
-            let return_type_location = func.return_type().location;
-            self.pending_entry_point_checks.push(PendingEntryPointCheck {
-                func_id,
-                parameter_locations,
-                return_type_location,
-                check_return_type,
-                is_entry_point: is_entry_point_check,
-                has_inline_attribute,
-            });
+        // Temporary allow vectors for contract functions, until contracts are re-factored.
+        if !func.attributes().has_contract_library_method() {
+            let output = true;
+            if let Err(err) = Self::check_if_type_is_valid_for_program(
+                &return_type,
+                is_entry_point || func.is_test_or_fuzz(),
+                func.has_inline_attribute(),
+                output,
+                func.return_type().location,
+            ) {
+                self.push_err(err);
+            }
         }
 
         // Build function type
@@ -380,12 +474,12 @@ impl Elaborator<'_> {
         let is_entry_point = func.is_entry_point(self.is_function_in_contract(), is_crate_root);
         let is_test_or_fuzz = func.is_test_or_fuzz();
 
+        let has_inline_attribute = func.has_inline_attribute();
         let is_pub_allowed = self.pub_allowed(func, self.is_function_in_contract(), is_crate_root);
 
         let mut parameters = Vec::new();
         let mut parameter_types = Vec::new();
         let mut parameter_idents = Vec::new();
-        let mut parameter_locations = Vec::new();
         let mut parameter_names_in_list = rustc_hash::FxHashMap::default();
         let wildcard_allowed = WildcardAllowed::No(WildcardDisallowedContext::FunctionParameter);
 
@@ -430,7 +524,16 @@ impl Elaborator<'_> {
                 _ => self.resolve_type_with_kind(typ, &Kind::Normal, wildcard_allowed),
             };
 
-            parameter_locations.push(type_location);
+            let output = false;
+            if let Err(err) = Self::check_if_type_is_valid_for_program(
+                &typ,
+                is_entry_point || is_test_or_fuzz,
+                has_inline_attribute,
+                output,
+                type_location,
+            ) {
+                self.push_err(err);
+            }
 
             if is_entry_point || is_test_or_fuzz {
                 self.mark_type_as_used(&typ);
@@ -450,48 +553,7 @@ impl Elaborator<'_> {
             parameter_types.push(typ);
         }
 
-        (parameters, parameter_types, parameter_idents, parameter_locations)
-    }
-
-    /// Runs the validity checks queued during `define_function_meta` for entry points,
-    /// tests, fuzz targets, and `#[fold]`/`#[no_predicates]` functions. This must be
-    /// called after trait impls and globals have been elaborated so that array and
-    /// string lengths involving trait-associated constants or globals can evaluate.
-    pub(super) fn run_pending_entry_point_checks(&mut self) {
-        let pending = std::mem::take(&mut self.pending_entry_point_checks);
-        for check in pending {
-            let (parameter_types, return_type) = {
-                let func_meta = self.interner.function_meta(&check.func_id);
-                let parameter_types: Vec<Type> =
-                    func_meta.parameters.iter().map(|p| p.1.clone()).collect();
-                let return_type = func_meta.return_type().clone();
-                (parameter_types, return_type)
-            };
-
-            for (typ, location) in parameter_types.iter().zip(check.parameter_locations.iter()) {
-                if let Err(err) = Self::check_if_type_is_valid_for_program(
-                    typ,
-                    check.is_entry_point,
-                    check.has_inline_attribute,
-                    false, // output
-                    *location,
-                ) {
-                    self.push_err(err);
-                }
-            }
-
-            if check.check_return_type
-                && let Err(err) = Self::check_if_type_is_valid_for_program(
-                    &return_type,
-                    check.is_entry_point,
-                    check.has_inline_attribute,
-                    true, // output
-                    check.return_type_location,
-                )
-            {
-                self.push_err(err);
-            }
-        }
+        (parameters, parameter_types, parameter_idents)
     }
 
     /// Only sized types are valid to be used as main's parameters or the parameters to a contract

--- a/compiler/noirc_frontend/src/elaborator/impls.rs
+++ b/compiler/noirc_frontend/src/elaborator/impls.rs
@@ -255,12 +255,6 @@ impl Elaborator<'_> {
     /// ```
     #[tracing::instrument(level = "trace", skip_all)]
     fn declare_methods(&mut self, self_type: &Type, function_ids: &[FuncId]) {
-        // `add_method` reads `function_meta(method_id).typ` for overlap detection
-        // and `function_meta(method_id).name.location` for diagnostics, so the meta
-        // for each candidate must be resolved before we register it.
-        for method_id in function_ids {
-            self.define_function_meta_if_undefined(*method_id);
-        }
         for method_id in function_ids {
             let method_name = self.interner.function_name(method_id).to_owned();
 

--- a/compiler/noirc_frontend/src/elaborator/impls.rs
+++ b/compiler/noirc_frontend/src/elaborator/impls.rs
@@ -104,7 +104,7 @@ impl Elaborator<'_> {
     ///
     /// # Panics
     /// If the self_type is not already resolved in each impl's function set.
-    /// The self type should be resolved by [Self::define_function_metas] before this method is called.
+    /// The self type should be resolved by [Self::register_function_metas] before this method is called.
     #[tracing::instrument(level = "trace", skip_all)]
     pub(super) fn collect_impls(
         &mut self,
@@ -141,7 +141,7 @@ impl Elaborator<'_> {
     ///
     /// # Panics
     /// If the self_type is not already resolved in each impl's function set.
-    /// The self type should be resolved by [Self::define_function_metas] before this method is called.
+    /// The self type should be resolved by [Self::register_function_metas] before this method is called.
     #[tracing::instrument(level = "trace", skip_all)]
     pub(super) fn declare_methods_on_data_type(
         &mut self,

--- a/compiler/noirc_frontend/src/elaborator/impls.rs
+++ b/compiler/noirc_frontend/src/elaborator/impls.rs
@@ -165,36 +165,43 @@ impl Elaborator<'_> {
                 return;
             }
 
-            // Grab the module defined by the data type. Note that impls are a case
-            // where the module the methods are added to is not the same as the module
-            // they are resolved in.
-            let module = Self::get_module_mut(self.def_maps, data_ref.id.module_id());
+            let module_id = data_ref.id.module_id();
 
-            // Declare each method in the data type's module for qualified access (TypeName::method)
-            for (_, method_id, method) in &functions.functions {
-                let name = method.name_ident().clone();
-                let result = if let Some(trait_id) = trait_id {
-                    module.declare_trait_function(name, *method_id, trait_id)
-                } else {
-                    module.declare_function(name, method.def.visibility, *method_id)
-                };
+            // Declare each method in the data type's module for qualified access (TypeName::method).
+            // Conflicts are resolved in two steps so we don't hold a `&mut def_maps` borrow when
+            // we ask the elaborator whether the existing method is a trait-impl method.
+            let mut conflicts = Vec::new();
+            {
+                let module = Self::get_module_mut(self.def_maps, module_id);
+                for (_, method_id, method) in &functions.functions {
+                    let name = method.name_ident().clone();
+                    let result = if let Some(trait_id) = trait_id {
+                        module.declare_trait_function(name, *method_id, trait_id)
+                    } else {
+                        module.declare_function(name, method.def.visibility, *method_id)
+                    };
 
-                // Handle method shadowing when a duplicate method name is found
-                if result.is_err()
-                    && let Some(existing) = module.find_func_with_name(method.name_ident())
-                {
-                    // Inherent impls take precedence over trait impls for qualified calls.
-                    // If the existing method is from a trait impl, remove it from module scope
-                    // so that `TypeName::method` resolves to the inherent impl version.
-                    //
-                    // For trait-impl vs trait-impl duplicates, we also remove the existing
-                    // method to prevent qualified access. This allows specialization (e.g.,
-                    // `impl Trait<A> for Foo` and `impl Trait<B> for Foo` can coexist).
-                    // Checking whether the object types in each method overlap (which will be rejected)
-                    // happens later during trait resolution.
-                    if self.interner.function_meta(&existing).trait_impl.is_some() {
-                        module.remove_function(method.name_ident());
+                    if result.is_err()
+                        && let Some(existing) = module.find_func_with_name(method.name_ident())
+                    {
+                        conflicts.push((existing, method.name_ident().clone()));
                     }
+                }
+            }
+
+            for (existing, name) in conflicts {
+                // Inherent impls take precedence over trait impls for qualified calls.
+                // If the existing method is from a trait impl, remove it from module scope
+                // so that `TypeName::method` resolves to the inherent impl version.
+                //
+                // For trait-impl vs trait-impl duplicates, we also remove the existing
+                // method to prevent qualified access. This allows specialization (e.g.,
+                // `impl Trait<A> for Foo` and `impl Trait<B> for Foo` can coexist).
+                // Checking whether the object types in each method overlap (which will be rejected)
+                // happens later during trait resolution.
+                if self.function_is_trait_impl_method(existing) {
+                    let module = Self::get_module_mut(self.def_maps, module_id);
+                    module.remove_function(&name);
                 }
             }
 
@@ -248,6 +255,12 @@ impl Elaborator<'_> {
     /// ```
     #[tracing::instrument(level = "trace", skip_all)]
     fn declare_methods(&mut self, self_type: &Type, function_ids: &[FuncId]) {
+        // `add_method` reads `function_meta(method_id).typ` for overlap detection
+        // and `function_meta(method_id).name.location` for diagnostics, so the meta
+        // for each candidate must be resolved before we register it.
+        for method_id in function_ids {
+            self.define_function_meta_if_undefined(*method_id);
+        }
         for method_id in function_ids {
             let method_name = self.interner.function_name(method_id).to_owned();
 

--- a/compiler/noirc_frontend/src/elaborator/mod.rs
+++ b/compiler/noirc_frontend/src/elaborator/mod.rs
@@ -81,7 +81,7 @@ use crate::{
         types::{Kind, ResolvedGeneric},
     },
     node_interner::{
-        DependencyId, GlobalId, NodeInterner, TraitId, TraitImplId, TypeAliasId, TypeId,
+        DependencyId, FuncId, GlobalId, NodeInterner, TraitId, TraitImplId, TypeAliasId, TypeId,
     },
     parser::{ParserError, ParserErrorReason},
     recursion::TypeRecursionContext,
@@ -375,10 +375,12 @@ pub struct Elaborator<'context> {
     /// about runtime variables not being available in comptime code.
     parent_runtime_variables: rustc_hash::FxHashSet<String>,
 
-    /// Entry-point validity checks deferred until after all trait impls and globals
-    /// have been elaborated, so that types using trait-associated constants or globals
-    /// can fully evaluate their array/string lengths before being validated.
-    pending_entry_point_checks: Vec<function::PendingEntryPointCheck>,
+    /// Function metadata that has been *registered* but not yet *resolved*. We register
+    /// up-front (capturing the impl/trait-impl context) and resolve lazily on first read,
+    /// so that forward references between functions, globals, and trait associated
+    /// constants don't depend on source order. Any entries left after lazy resolution
+    /// has played out are drained at the end of [Self::elaborate_items].
+    unresolved_function_metas: BTreeMap<FuncId, function::UnresolvedFunctionMeta>,
 }
 
 #[derive(Copy, Clone)]
@@ -455,7 +457,7 @@ impl<'context> Elaborator<'context> {
             recursion_depth: 0,
             impl_trait_is_disallowed: None,
             parent_runtime_variables: rustc_hash::FxHashSet::default(),
-            pending_entry_point_checks: Vec::new(),
+            unresolved_function_metas: BTreeMap::default(),
         }
     }
 
@@ -529,7 +531,11 @@ impl<'context> Elaborator<'context> {
         self.collect_enum_definitions(&items.enums);
         self.collect_traits(&mut items.traits);
 
-        self.define_function_metas(&mut items.functions, &mut items.impls, &mut items.trait_impls);
+        self.register_function_metas(
+            &mut items.functions,
+            &mut items.impls,
+            &mut items.trait_impls,
+        );
 
         // Before we resolve any function symbols we must go through our impls and
         // re-collect the methods within into their proper module. This cannot be
@@ -546,6 +552,14 @@ impl<'context> Elaborator<'context> {
         for trait_impl in &mut items.trait_impls {
             self.collect_trait_impl(trait_impl);
         }
+
+        // Resolve any function metas that weren't pulled in by a forward reference
+        // during the collect-* phases above. Doing this before global elaboration
+        // means a global's RHS can call user-defined functions, while doing it after
+        // `collect_trait_impl` means meta resolution sees fully-bound trait
+        // associated constants. Globals referenced from a meta still elaborate
+        // lazily during the drain.
+        self.drain_unresolved_function_metas();
 
         // We must wait to resolve non-literal globals until after we resolve structs since struct
         // globals will need to reference the struct type they're initialized to ensure they are valid.
@@ -578,12 +592,6 @@ impl<'context> Elaborator<'context> {
         for trait_impl in items.trait_impls {
             self.elaborate_trait_impl(trait_impl);
         }
-
-        // Now that trait impls and globals have been elaborated, run the
-        // entry-point validity checks queued during function-meta definition.
-        // Deferring lets array/string lengths involving trait-associated
-        // constants or globals evaluate before being validated.
-        self.run_pending_entry_point_checks();
     }
 
     #[tracing::instrument(level = "trace", skip_all)]

--- a/compiler/noirc_frontend/src/elaborator/mod.rs
+++ b/compiler/noirc_frontend/src/elaborator/mod.rs
@@ -374,6 +374,11 @@ pub struct Elaborator<'context> {
     /// lookup fails and the name is in this set, we can report a more specific error
     /// about runtime variables not being available in comptime code.
     parent_runtime_variables: rustc_hash::FxHashSet<String>,
+
+    /// Entry-point validity checks deferred until after all trait impls and globals
+    /// have been elaborated, so that types using trait-associated constants or globals
+    /// can fully evaluate their array/string lengths before being validated.
+    pending_entry_point_checks: Vec<function::PendingEntryPointCheck>,
 }
 
 #[derive(Copy, Clone)]
@@ -450,6 +455,7 @@ impl<'context> Elaborator<'context> {
             recursion_depth: 0,
             impl_trait_is_disallowed: None,
             parent_runtime_variables: rustc_hash::FxHashSet::default(),
+            pending_entry_point_checks: Vec::new(),
         }
     }
 
@@ -572,6 +578,12 @@ impl<'context> Elaborator<'context> {
         for trait_impl in items.trait_impls {
             self.elaborate_trait_impl(trait_impl);
         }
+
+        // Now that trait impls and globals have been elaborated, run the
+        // entry-point validity checks queued during function-meta definition.
+        // Deferring lets array/string lengths involving trait-associated
+        // constants or globals evaluate before being validated.
+        self.run_pending_entry_point_checks();
     }
 
     #[tracing::instrument(level = "trace", skip_all)]

--- a/compiler/noirc_frontend/src/elaborator/trait_impls.rs
+++ b/compiler/noirc_frontend/src/elaborator/trait_impls.rs
@@ -426,6 +426,10 @@ impl Elaborator<'_> {
         let mut bindings =
             self.interner.trait_to_impl_bindings(trait_id, impl_id, trait_impl_generics, self_type);
 
+        // The override method's meta may not have been resolved yet — function metas are
+        // resolved lazily so they can see fully-bound trait impls and globals. Resolve it
+        // now before we read it.
+        self.define_function_meta_if_undefined(*func_id);
         let override_meta = self.interner.remove_function_meta(func_id);
 
         // Substitute each generic on the trait function with the corresponding generic on the impl function

--- a/compiler/noirc_frontend/src/elaborator/types.rs
+++ b/compiler/noirc_frontend/src/elaborator/types.rs
@@ -3051,8 +3051,14 @@ impl Elaborator<'_> {
         expr: ExprId,
         location: Location,
     ) -> Result<bool, CompilationError> {
-        if let Some(func_id) = self.interner.lookup_function_from_expr(&expr, location)? {
-            let meta = self.interner.function_meta(&func_id);
+        // `try_function_meta` rather than `function_meta`: the call may happen while
+        // the callee's meta is still mid-resolution (e.g. a function whose signature
+        // transitively calls itself through a global). A dependency-cycle error has
+        // already been pushed in that case; treat the call as constrained to avoid a
+        // panic.
+        if let Some(func_id) = self.interner.lookup_function_from_expr(&expr, location)?
+            && let Some(meta) = self.interner.try_function_meta(&func_id)
+        {
             Ok(meta.is_unconstrained())
         } else {
             Ok(false)

--- a/compiler/noirc_frontend/src/elaborator/variable.rs
+++ b/compiler/noirc_frontend/src/elaborator/variable.rs
@@ -811,6 +811,13 @@ impl Elaborator<'_> {
             return Type::Error;
         }
 
+        // If the variable is a function whose meta hasn't been resolved yet, resolve
+        // it now. This handles forward references — a global's RHS may name a
+        // function whose meta would otherwise only be drained at end-of-elaboration.
+        if let DefinitionKind::Function(func_id) = definition.kind {
+            self.define_function_meta_if_undefined(func_id);
+        }
+
         // An identifiers type may be forall-quantified in the case of generic functions.
         // E.g. `fn foo<T>(t: T, field: Field) -> T` has type `forall T. fn(T, Field) -> T`.
         // We must instantiate identifiers at every call site to replace this T with a new type

--- a/compiler/noirc_frontend/src/elaborator/variable.rs
+++ b/compiler/noirc_frontend/src/elaborator/variable.rs
@@ -815,7 +815,20 @@ impl Elaborator<'_> {
         // it now. This handles forward references — a global's RHS may name a
         // function whose meta would otherwise only be drained at end-of-elaboration.
         if let DefinitionKind::Function(func_id) = definition.kind {
+            let item_name = definition.name.clone();
             self.define_function_meta_if_undefined(func_id);
+
+            // If lazy resolution leaves the meta still unset, the function is currently
+            // mid-resolution and we have a dependency cycle (e.g. `global F = f();`
+            // combined with `fn f(_: [u8; F]) {}`).
+            if self.interner.try_function_meta(&func_id).is_none() {
+                self.push_err(ResolverError::DependencyCycle {
+                    location: ident.location,
+                    item: item_name,
+                    cycle: "the function signature hasn't been resolved yet".to_string(),
+                });
+                return Type::Error;
+            }
         }
 
         // An identifiers type may be forall-quantified in the case of generic functions.

--- a/compiler/noirc_frontend/src/node_interner/function.rs
+++ b/compiler/noirc_frontend/src/node_interner/function.rs
@@ -190,9 +190,8 @@ impl NodeInterner {
     }
 
     pub fn function_ident(&self, func_id: &FuncId) -> crate::ast::Ident {
-        let name = self.function_name(func_id).to_owned();
-        let location = self.function_meta(func_id).name.location;
-        crate::ast::Ident::new(name, location)
+        let modifiers = &self.function_modifiers[func_id];
+        crate::ast::Ident::new(modifiers.name.clone(), modifiers.name_location)
     }
 
     pub fn function_name(&self, func_id: &FuncId) -> &str {

--- a/compiler/noirc_frontend/src/node_interner/ids.rs
+++ b/compiler/noirc_frontend/src/node_interner/ids.rs
@@ -41,7 +41,7 @@ pub struct StmtId(pub(super) Index);
 #[derive(Debug, Eq, PartialEq, Hash, Copy, Clone, PartialOrd, Ord)]
 pub struct ExprId(pub(super) Index);
 
-#[derive(Debug, Eq, PartialEq, Hash, Copy, Clone)]
+#[derive(Debug, Eq, PartialEq, Hash, Copy, Clone, PartialOrd, Ord)]
 pub struct FuncId(pub(super) Index);
 
 impl fmt::Display for FuncId {

--- a/compiler/noirc_frontend/src/tests/functions.rs
+++ b/compiler/noirc_frontend/src/tests/functions.rs
@@ -480,5 +480,25 @@ fn can_use_trait_associated_constant_in_main_signature() {
         fields[0]
     }
     "#;
-    check_errors(src);
+    assert_no_errors(src);
+}
+
+#[test]
+fn can_use_trait_associated_constant_via_global_in_main_signature() {
+    let src = r#"
+    pub trait Deserialize {
+        let N: u32;
+    }
+
+    impl Deserialize for Field {
+        let N: u32 = 1;
+    }
+
+    global FIELD_N: u32 = <Field as Deserialize>::N;
+
+    unconstrained fn main(fields: [Field; FIELD_N]) -> pub Field {
+        fields[0]
+    }
+    "#;
+    assert_no_errors(src);
 }

--- a/compiler/noirc_frontend/src/tests/functions.rs
+++ b/compiler/noirc_frontend/src/tests/functions.rs
@@ -464,3 +464,21 @@ fn errors_if_using_comptime_enum_in_fn() {
     "#;
     check_errors(src);
 }
+
+#[test]
+fn can_use_trait_associated_constant_in_main_signature() {
+    let src = r#"
+    pub trait Deserialize {
+        let N: u32;
+    }
+
+    impl Deserialize for Field {
+        let N: u32 = 1;
+    }
+
+    unconstrained fn main(fields: [Field; <Field as Deserialize>::N]) -> pub Field {
+        fields[0]
+    }
+    "#;
+    check_errors(src);
+}

--- a/compiler/noirc_frontend/src/tests/globals.rs
+++ b/compiler/noirc_frontend/src/tests/globals.rs
@@ -412,3 +412,21 @@ fn can_refer_to_complex_global_in_method_signature() {
     "#;
     assert_no_errors(src);
 }
+
+#[test]
+fn errors_if_global_is_needed_in_initialize_and_function_signature() {
+    let src = r#"
+    global FOO: u32 = init([0; 10]);
+           ^^^ Dependency cycle found
+           ~~~ 'FOO' recursively depends on itself: FOO -> init -> FOO
+                      ^^^^ Dependency cycle found
+                      ~~~~ 'init' recursively depends on itself: the function signature hasn't been resolved yet
+                      ^^^^^^^^^^^^^ Global failed to evaluate
+
+    fn init(_array: [Field; FOO]) {}
+                            ^^^ expected type, found global `FOO`
+
+    fn main() {}
+    "#;
+    check_errors(src);
+}

--- a/compiler/noirc_frontend/src/tests/globals.rs
+++ b/compiler/noirc_frontend/src/tests/globals.rs
@@ -380,3 +380,35 @@ fn regression_5626_global_annotation_flows_into_block() {
     "#;
     assert_no_errors(src);
 }
+
+#[test]
+fn can_refer_to_complex_global_in_function_signature() {
+    let src = r#"
+    global LENGTH: u32 = init();
+
+    pub fn another(_array: [Field; LENGTH]) {}
+
+    fn init() -> u32 {
+        10
+    }
+    "#;
+    assert_no_errors(src);
+}
+
+#[test]
+fn can_refer_to_complex_global_in_method_signature() {
+    let src = r#"
+    global LENGTH: u32 = init();
+
+    pub struct Foo {}
+
+    impl Foo {
+        pub fn another(_array: [Field; LENGTH]) {}
+    }
+
+    fn init() -> u32 {
+        10
+    }
+    "#;
+    assert_no_errors(src);
+}

--- a/tooling/nargo_cli/tests/snapshots/compile_failure/empty_composite_array_get/execute__tests__stderr.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_failure/empty_composite_array_get/execute__tests__stderr.snap
@@ -2,6 +2,14 @@
 source: tooling/nargo_cli/tests/execute.rs
 expression: stderr
 ---
+error: Invalid type found in the entry point to a program
+  ┌─ src/main.nr:1:22
+  │
+1 │ fn main(empty_input: [(Field, Field); 0]) {
+  │                      ------------------- Invalid entry point type: [(Field, Field); 0]
+  │
+  = Note: vectors, references, empty arrays, empty strings, or any type containing them may not be used in main, contract functions, test functions, fuzz functions or foldable functions.
+
 error: Index 0 is out of bounds for this array of length 0
   ┌─ src/main.nr:3:25
   │
@@ -15,13 +23,5 @@ error: Index 0 is out of bounds for this array of length 0
 4 │     let _ = empty_array[0];
   │                         -
   │
-
-error: Invalid type found in the entry point to a program
-  ┌─ src/main.nr:1:22
-  │
-1 │ fn main(empty_input: [(Field, Field); 0]) {
-  │                      ------------------- Invalid entry point type: [(Field, Field); 0]
-  │
-  = Note: vectors, references, empty arrays, empty strings, or any type containing them may not be used in main, contract functions, test functions, fuzz functions or foldable functions.
 
 Aborting due to 3 previous errors

--- a/tooling/nargo_cli/tests/snapshots/compile_failure/empty_composite_array_get/execute__tests__stderr.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_failure/empty_composite_array_get/execute__tests__stderr.snap
@@ -2,14 +2,6 @@
 source: tooling/nargo_cli/tests/execute.rs
 expression: stderr
 ---
-error: Invalid type found in the entry point to a program
-  ┌─ src/main.nr:1:22
-  │
-1 │ fn main(empty_input: [(Field, Field); 0]) {
-  │                      ------------------- Invalid entry point type: [(Field, Field); 0]
-  │
-  = Note: vectors, references, empty arrays, empty strings, or any type containing them may not be used in main, contract functions, test functions, fuzz functions or foldable functions.
-
 error: Index 0 is out of bounds for this array of length 0
   ┌─ src/main.nr:3:25
   │
@@ -23,5 +15,13 @@ error: Index 0 is out of bounds for this array of length 0
 4 │     let _ = empty_array[0];
   │                         -
   │
+
+error: Invalid type found in the entry point to a program
+  ┌─ src/main.nr:1:22
+  │
+1 │ fn main(empty_input: [(Field, Field); 0]) {
+  │                      ------------------- Invalid entry point type: [(Field, Field); 0]
+  │
+  = Note: vectors, references, empty arrays, empty strings, or any type containing them may not be used in main, contract functions, test functions, fuzz functions or foldable functions.
 
 Aborting due to 3 previous errors

--- a/tooling/nargo_cli/tests/snapshots/compile_failure/wildcards_in_wrong_places/execute__tests__stderr.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_failure/wildcards_in_wrong_places/execute__tests__stderr.snap
@@ -38,41 +38,6 @@ error: The placeholder `_` is not allowed in trait bounds
    │
 
 error: The placeholder `_` is not allowed in function parameter types
-  ┌─ src/main.nr:1:16
-  │
-1 │ pub fn foo(_: [_; _]) -> [_; _] {
-  │                -
-  │
-
-error: The placeholder `_` is not allowed in function parameter types
-  ┌─ src/main.nr:1:19
-  │
-1 │ pub fn foo(_: [_; _]) -> [_; _] {
-  │                   -
-  │
-
-error: The placeholder `_` is not allowed in function return types
-  ┌─ src/main.nr:1:27
-  │
-1 │ pub fn foo(_: [_; _]) -> [_; _] {
-  │                           -
-  │
-
-error: The placeholder `_` is not allowed in function return types
-  ┌─ src/main.nr:1:30
-  │
-1 │ pub fn foo(_: [_; _]) -> [_; _] {
-  │                              -
-  │
-
-error: The placeholder `_` is not allowed in trait constraints
-   ┌─ src/main.nr:24:9
-   │
-24 │     Gen<_>: Trait2<T>,
-   │         -
-   │
-
-error: The placeholder `_` is not allowed in function parameter types
    ┌─ src/main.nr:10:20
    │
 10 │     pub fn foo(_: [_; _]) -> [_; _] {
@@ -140,6 +105,41 @@ error: The placeholder `_` is not allowed in trait bounds
    │
 29 │     Gen<_>: Trait2<_>,
    │                    -
+   │
+
+error: The placeholder `_` is not allowed in function parameter types
+  ┌─ src/main.nr:1:16
+  │
+1 │ pub fn foo(_: [_; _]) -> [_; _] {
+  │                -
+  │
+
+error: The placeholder `_` is not allowed in function parameter types
+  ┌─ src/main.nr:1:19
+  │
+1 │ pub fn foo(_: [_; _]) -> [_; _] {
+  │                   -
+  │
+
+error: The placeholder `_` is not allowed in function return types
+  ┌─ src/main.nr:1:27
+  │
+1 │ pub fn foo(_: [_; _]) -> [_; _] {
+  │                           -
+  │
+
+error: The placeholder `_` is not allowed in function return types
+  ┌─ src/main.nr:1:30
+  │
+1 │ pub fn foo(_: [_; _]) -> [_; _] {
+  │                              -
+  │
+
+error: The placeholder `_` is not allowed in trait constraints
+   ┌─ src/main.nr:24:9
+   │
+24 │     Gen<_>: Trait2<T>,
+   │         -
    │
 
 Aborting due to 19 previous errors

--- a/tooling/nargo_cli/tests/snapshots/compile_failure/wildcards_in_wrong_places/execute__tests__stderr.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_failure/wildcards_in_wrong_places/execute__tests__stderr.snap
@@ -38,34 +38,6 @@ error: The placeholder `_` is not allowed in trait bounds
    │
 
 error: The placeholder `_` is not allowed in function parameter types
-   ┌─ src/main.nr:10:20
-   │
-10 │     pub fn foo(_: [_; _]) -> [_; _] {
-   │                    -
-   │
-
-error: The placeholder `_` is not allowed in function parameter types
-   ┌─ src/main.nr:10:23
-   │
-10 │     pub fn foo(_: [_; _]) -> [_; _] {
-   │                       -
-   │
-
-error: The placeholder `_` is not allowed in function return types
-   ┌─ src/main.nr:10:31
-   │
-10 │     pub fn foo(_: [_; _]) -> [_; _] {
-   │                               -
-   │
-
-error: The placeholder `_` is not allowed in function return types
-   ┌─ src/main.nr:10:34
-   │
-10 │     pub fn foo(_: [_; _]) -> [_; _] {
-   │                                  -
-   │
-
-error: The placeholder `_` is not allowed in function parameter types
    ┌─ src/main.nr:16:25
    │
 16 │     fn trait_method(_: [_; _]) -> [_; _];
@@ -140,6 +112,34 @@ error: The placeholder `_` is not allowed in trait constraints
    │
 24 │     Gen<_>: Trait2<T>,
    │         -
+   │
+
+error: The placeholder `_` is not allowed in function parameter types
+   ┌─ src/main.nr:10:20
+   │
+10 │     pub fn foo(_: [_; _]) -> [_; _] {
+   │                    -
+   │
+
+error: The placeholder `_` is not allowed in function parameter types
+   ┌─ src/main.nr:10:23
+   │
+10 │     pub fn foo(_: [_; _]) -> [_; _] {
+   │                       -
+   │
+
+error: The placeholder `_` is not allowed in function return types
+   ┌─ src/main.nr:10:31
+   │
+10 │     pub fn foo(_: [_; _]) -> [_; _] {
+   │                               -
+   │
+
+error: The placeholder `_` is not allowed in function return types
+   ┌─ src/main.nr:10:34
+   │
+10 │     pub fn foo(_: [_; _]) -> [_; _] {
+   │                                  -
    │
 
 Aborting due to 19 previous errors


### PR DESCRIPTION
## Problem Resolved

Resolves #12574
Resolves https://app.audithub.dev/app/organizations/161/projects/787/project-viewer?version=1681&issueId=1000
Closes https://github.com/noir-lang/noir/pull/12580
Closes #12577

## Summary of Changes

Built on top of #12580 but actually first reverts the code from that PR as it's no longer needed, so we could decide to merge this directly into master.

One solution to the dependency cycle between globals and types in function signatures is lazily type-checking function signatures. At least it's one idea I had, and checking with Claude it's also one of the ideas it had. I also asked Claude how Rust solves this and it said that they also lazily solve things (though I haven't checked this).

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
