### PR TITLE
fix: drop noirc_span dep from acir to unblock publish

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,7 +13,6 @@ dependencies = [
  "criterion",
  "flate2",
  "insta",
- "noirc_span",
  "num-bigint",
  "num-traits",
  "num_enum",

--- a/acvm-repo/acir/Cargo.toml
+++ b/acvm-repo/acir/Cargo.toml
@@ -18,7 +18,6 @@ workspace = true
 [dependencies]
 acir_field.workspace = true
 brillig.workspace = true
-noirc_span.workspace = true
 
 serde.workspace = true
 thiserror.workspace = true

--- a/acvm-repo/acir/src/parser/lexer.rs
+++ b/acvm-repo/acir/src/parser/lexer.rs
@@ -2,7 +2,7 @@ use std::str::{CharIndices, FromStr};
 
 use acir_field::{AcirField, FieldElement};
 
-use noirc_span::{Position, Span};
+use super::span::{Position, Span};
 use num_bigint::BigInt;
 use num_traits::One;
 use thiserror::Error;

--- a/acvm-repo/acir/src/parser/mod.rs
+++ b/acvm-repo/acir/src/parser/mod.rs
@@ -3,7 +3,7 @@ use std::{collections::BTreeSet, str::FromStr};
 use acir_field::{AcirField, FieldElement};
 
 use lexer::{Lexer, LexerError};
-use noirc_span::Span;
+use span::Span;
 use thiserror::Error;
 use token::{Keyword, SpannedToken, Token};
 
@@ -18,6 +18,7 @@ use crate::{
 };
 
 mod lexer;
+mod span;
 #[cfg(test)]
 mod tests;
 mod token;

--- a/acvm-repo/acir/src/parser/span.rs
+++ b/acvm-repo/acir/src/parser/span.rs
@@ -1,0 +1,54 @@
+//! Minimal span types used by the ACIR text parser.
+//!
+//! These mirror a small slice of the public API of `noirc_span` (`Span`, `Position`,
+//! `Spanned`). We intentionally do not depend on `noirc_span` because `acir` is published
+//! to crates.io as part of the ACVM release set, while `noirc_span` is a compiler crate
+//! that is not. Pulling it in would either block the `acir` release or force every
+//! transitive compiler crate onto crates.io. Since these types are only used internally
+//! by the parser, an inline copy of just what the parser needs is the cheaper option.
+
+pub(super) type Position = u32;
+
+#[derive(PartialEq, Eq, Debug, Copy, Clone, Default)]
+pub(crate) struct Span {
+    start: u32,
+    end: u32,
+}
+
+impl Span {
+    pub(super) fn inclusive(start: u32, end: u32) -> Span {
+        Span { start, end: end + 1 }
+    }
+
+    pub(super) fn single_char(position: u32) -> Span {
+        Span::inclusive(position, position)
+    }
+
+    pub(crate) fn start(&self) -> u32 {
+        self.start
+    }
+
+    pub(crate) fn end(&self) -> u32 {
+        self.end
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(super) struct Spanned<T> {
+    pub(super) contents: T,
+    span: Span,
+}
+
+impl<T> Spanned<T> {
+    pub(super) fn from_position(start: Position, end: Position, contents: T) -> Spanned<T> {
+        Spanned { span: Span::inclusive(start, end), contents }
+    }
+
+    pub(super) fn from(t_span: Span, contents: T) -> Spanned<T> {
+        Spanned { span: t_span, contents }
+    }
+
+    pub(super) fn span(&self) -> Span {
+        self.span
+    }
+}

--- a/acvm-repo/acir/src/parser/token.rs
+++ b/acvm-repo/acir/src/parser/token.rs
@@ -1,5 +1,5 @@
+use super::span::{Position, Span, Spanned};
 use acir_field::FieldElement;
-use noirc_span::{Position, Span, Spanned};
 
 #[derive(Debug)]
 pub(crate) struct SpannedToken(Spanned<Token>);


### PR DESCRIPTION
## Summary

Publishing `acir` to crates.io currently fails with:

```
error: all dependencies must have a version specified when publishing.
dependency `noirc_span` does not specify a version
```

`acir` started depending on `noirc_span` in #9827 to share `Span` / `Position` / `Spanned` in its text parser. But `noirc_span` is a compiler crate that isn't in the ACVM publish set (`publish-acvm.yml`), so the dep can't be resolved on crates.io.

These types are only used by `acir`'s parser internally (no `pub` API surface escapes the parser module), so this PR inlines a minimal copy into a private `acir::parser::span` submodule and drops the `noirc_span` dependency from `acir`. Verified with `cargo publish --package acir --dry-run`.

## Test plan

- [x] `cargo build -p acir` clean
- [x] `cargo nextest run -p acir` — 114 passed
- [x] `cargo publish --package acir --dry-run --allow-dirty` succeeds