### PR TITLE
chore: Separate out parent bounds

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/trait_impls.rs
+++ b/compiler/noirc_frontend/src/elaborator/trait_impls.rs
@@ -312,22 +312,22 @@ impl Elaborator<'_> {
 
             if overrides.is_empty() {
                 if let Some(default_impl) = &method.default_impl {
-                    // copy 'where' clause from unresolved trait impl
                     let mut default_impl_clone = default_impl.clone();
-                    default_impl_clone.def.where_clause.extend(trait_impl.where_clause.clone());
 
                     let func_id = self.interner.push_empty_fn();
                     let module = self.module_id();
                     let location = default_impl.def.location;
                     self.interner.push_function(func_id, &default_impl.def, module, location);
+                    let extras =
+                        vecmap(trait_impl_where_clause, |c| (c.clone(), c.trait_bound.location));
+
                     self.recover_generics(|this| {
                         let no_trait_id = None;
-                        let no_extra_trait_constraints = &[];
                         this.define_function_meta(
                             &mut default_impl_clone,
                             func_id,
                             no_trait_id,
-                            no_extra_trait_constraints,
+                            &extras,
                         );
                     });
                     func_ids_in_trait.insert(func_id);
@@ -627,17 +627,23 @@ impl Elaborator<'_> {
         let impl_trait = the_trait.name.to_string();
         let ordered_generics = self.interner.get_ordered_generics_for_impl(impl_id);
 
-        // Bind Self to the object type of the impl so that parent-trait bounds
-        // (which are stored in the trait's where clause as constraints on Self)
-        // get checked against the concrete impl type.
+        // Bind Self to the object type of the impl so that parent-trait bounds get
+        // checked against the concrete impl type.
         let self_var = the_trait.self_type_typevar.clone();
         let self_kind = self_var.kind();
         let mut bindings = TypeBindings::default();
-        bindings.insert(self_var.id(), (self_var, self_kind, object_type.clone()));
+        bindings.insert(self_var.id(), (self_var.clone(), self_kind, object_type.clone()));
         bind_ordered_generics(&the_trait.generics, ordered_generics, &mut bindings);
 
+        let self_type = Type::TypeVariable(self_var);
+        let parent_constraints = the_trait.parent_bounds.iter().map(|trait_bound| {
+            TraitConstraint { typ: self_type.clone(), trait_bound: trait_bound.clone() }
+        });
+        let constraints =
+            the_trait.where_clause.iter().cloned().chain(parent_constraints).collect();
+
         self.check_trait_bounds_are_satisfied(
-            the_trait.where_clause.clone(),
+            constraints,
             &impl_trait,
             &trait_impl.object_type.location,
             &mut bindings,

--- a/compiler/noirc_frontend/src/elaborator/traits.rs
+++ b/compiler/noirc_frontend/src/elaborator/traits.rs
@@ -292,18 +292,9 @@ impl Elaborator<'_> {
                 self.interner.add_trait_dependency(DependencyId::Trait(bound.trait_id), *trait_id);
             }
 
-            // Lower super-trait bounds (`trait Foo: Bar`) into where-clause constraints
-            // keyed on `Self`, so that parent bounds and explicit where-clause entries
-            // share a single representation on `Trait`.
-            let self_type =
-                self.self_type.clone().expect("Expected Self type to be set inside collect_traits");
-            let mut where_clause = where_clause;
-            for trait_bound in resolved_trait_bounds {
-                where_clause.push(TraitConstraint { typ: self_type.clone(), trait_bound });
-            }
-
             self.interner.update_trait(*trait_id, |trait_def| {
                 trait_def.set_where_clause(where_clause);
+                trait_def.set_parent_bounds(resolved_trait_bounds);
                 trait_def.set_visibility(unresolved_trait.trait_def.visibility);
                 trait_def.set_associated_type_bounds(associated_type_bounds);
                 trait_def.set_all_generics(self.generics.clone());

--- a/compiler/noirc_frontend/src/hir/printer/mod.rs
+++ b/compiler/noirc_frontend/src/hir/printer/mod.rs
@@ -388,25 +388,25 @@ impl<'context, 'string> ItemPrinter<'context, 'string> {
         self.push_str(&trait_.name.to_string());
         self.show_generics(&trait_.generics);
 
-        let parent_bounds: Vec<_> = trait_.parent_bounds().cloned().collect();
-        if !parent_bounds.is_empty() {
+        if !trait_.parent_bounds.is_empty() {
             self.push_str(": ");
-            self.show_trait_bounds(&parent_bounds);
+            self.show_trait_bounds(&trait_.parent_bounds);
         }
 
-        // Filter out the parent bounds we already printed with colon syntax.
-        let self_id = trait_.self_type_typevar.id();
-        let where_only: Vec<_> = trait_
-            .where_clause
-            .iter()
-            .filter(|c| !matches!(&c.typ, Type::TypeVariable(v) if v.id() == self_id))
-            .cloned()
-            .collect();
-        self.show_where_clause(&where_only);
+        self.show_where_clause(&trait_.where_clause);
         self.push_str(" {\n");
         self.increase_indent();
 
-        self.trait_constraints = trait_.where_clause.clone();
+        let self_type = Type::TypeVariable(trait_.self_type_typevar.clone());
+        self.trait_constraints = trait_
+            .where_clause
+            .iter()
+            .cloned()
+            .chain(trait_.parent_bounds.iter().map(|trait_bound| TraitConstraint {
+                typ: self_type.clone(),
+                trait_bound: trait_bound.clone(),
+            }))
+            .collect();
 
         let mut printed_type_or_function = false;
 

--- a/compiler/noirc_frontend/src/hir_def/traits.rs
+++ b/compiler/noirc_frontend/src/hir_def/traits.rs
@@ -81,11 +81,12 @@ pub struct Trait {
     /// the correct Self type is for that particular impl block.
     pub self_type_typevar: TypeVariable,
 
-    /// The trait's where clause. Super-trait bounds (`trait Foo: Bar`) are lowered into
-    /// this list as `TraitConstraint { typ: Self, trait_bound: Bar }` so that parent
-    /// bounds and where-clause constraints share a single representation. Use
-    /// [`Trait::parent_bounds`] to extract just the parent-trait bounds.
+    /// The user-written where clause on the trait, e.g. the `T: Eq` in
+    /// `trait Foo<T> where T: Eq`.
     pub where_clause: Vec<TraitConstraint>,
+
+    /// The trait's super-trait bounds: the `Bar` in `trait Foo: Bar`.
+    pub parent_bounds: Vec<ResolvedTraitBound>,
 
     pub all_generics: ResolvedGenerics,
 
@@ -221,16 +222,13 @@ impl Trait {
         self.where_clause = where_clause;
     }
 
+    pub fn set_parent_bounds(&mut self, parent_bounds: Vec<ResolvedTraitBound>) {
+        self.parent_bounds = parent_bounds;
+    }
+
     /// The parent-trait bounds of this trait (the `Bar` in `trait Foo: Bar`).
-    ///
-    /// Parent bounds are stored in `where_clause` as constraints whose `typ` is this
-    /// trait's `Self` type variable; this accessor filters them back out.
     pub fn parent_bounds(&self) -> impl Iterator<Item = &ResolvedTraitBound> {
-        let self_id = self.self_type_typevar.id();
-        self.where_clause.iter().filter_map(move |c| match &c.typ {
-            Type::TypeVariable(v) if v.id() == self_id => Some(&c.trait_bound),
-            _ => None,
-        })
+        self.parent_bounds.iter()
     }
 
     pub fn set_visibility(&mut self, visibility: ItemVisibility) {

--- a/compiler/noirc_frontend/src/node_interner/mod.rs
+++ b/compiler/noirc_frontend/src/node_interner/mod.rs
@@ -599,6 +599,7 @@ impl NodeInterner {
             associated_types,
             associated_type_bounds: HashMap::default(),
             where_clause: Vec::new(),
+            parent_bounds: Vec::new(),
             all_generics: Vec::new(),
             associated_constant_ids,
         };
@@ -1297,6 +1298,7 @@ impl NodeInterner {
             visibility: ItemVisibility::Public,
             self_type_typevar: TypeVariable::unbound(self_type_typevar, Kind::Normal),
             where_clause: vec![],
+            parent_bounds: vec![],
             all_generics: vec![],
             associated_constant_ids: Default::default(),
         };


### PR DESCRIPTION
## Problem Resolved

Resolves <!-- Link to GitHub Issue -->

## Summary of Changes

Tried to simplify traits a bit by separating out the parent bounds from the rest of the trait constraints. Was it simpler? Net 3 lines removed so maybe not. 

## User Documentation

Check one:
- [ ] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
