### PR TITLE
chore(scripts): Flip `eddsa` and `noir_base64` into non-critical libraries

### DIFF
--- a/EXTERNAL_NOIR_LIBRARIES.yml
+++ b/EXTERNAL_NOIR_LIBRARIES.yml
@@ -7,7 +7,7 @@ libraries:
   eddsa:
     repo: noir-lang/eddsa
     timeout: 5
-    critical: true
+    critical: false
   mimc:
     repo: noir-lang/mimc
     timeout: 2
@@ -35,7 +35,7 @@ libraries:
   noir_base64:
     repo: noir-lang/noir_base64
     timeout: 15
-    critical: true
+    critical: false
   noir_string_search:
     repo: noir-lang/noir_string_search
     timeout: 2


### PR DESCRIPTION
## Problem

Until https://github.com/noir-lang/eddsa/issues/18 and https://github.com/noir-lang/noir_base64/issues/57 are addressed, running [`check-critical-libraries.sh`](https://github.com/noir-lang/noir/blob/aaca1e0b853cc8e7556dc51ea3cf6a33a7e5db2f/scripts/check-critical-libraries.sh) always fails.

## Summary of Changes

Change _eddsa_'s and _noir\_base64_'s criticality for testing to false.

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
