### PR TITLE
fix(elaborator): simplify re-borrowing expressions

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/ssa_gen/tests.rs
+++ b/compiler/noirc_evaluator/src/ssa/ssa_gen/tests.rs
@@ -892,6 +892,61 @@ fn mut_local_struct_field_assign_only_stores_needed_field() {
     ");
 }
 
+/// `&mut *p` is a re-borrow and must alias the same memory location as `p`.
+#[test]
+fn mut_reborrow_aliases_original_location() {
+    let src = "
+    fn main() {
+        let mut f: u64 = 10;
+        let p = &mut f;
+        let p1 = &mut *p;
+        *p1 = 15;
+        assert(f == 15);
+    }
+    ";
+    let ssa = get_initial_ssa(src).unwrap();
+    // Exactly one `allocate` for f. The store from `*p1 = 15` writes directly to v0,
+    // and the subsequent `f == 15` load observes the updated value.
+    assert_ssa_snapshot!(ssa, @r"
+    acir(inline) fn main f0 {
+      b0():
+        v0 = allocate -> &mut u64
+        store u64 10 at v0
+        store u64 15 at v0
+        v3 = load v0 -> u64
+        v4 = eq v3, u64 15
+        constrain v3 == u64 15
+        return
+    }
+    ");
+}
+
+/// Shows that `&mut (*&f)` is Ok in Noir, contrary to Rust.
+#[test]
+fn can_reborrow_through_immutable_ref() {
+    let src = "
+    fn main() {
+        let mut f: u64 = 10;
+        let p = &mut (*&f);
+        *p = 15;
+        assert(f == 15);
+    }
+    ";
+    let ssa = get_initial_ssa(src).unwrap();
+    assert_ssa_snapshot!(ssa, @r"
+    acir(inline) fn main f0 {
+      b0():
+        v0 = allocate -> &mut u64
+        store u64 10 at v0
+        store u64 15 at v0
+        v3 = load v0 -> u64
+        v4 = eq v3, u64 15
+        constrain v3 == u64 15
+        return
+    }
+    ");
+}
+
 /// Reassigning a mutable tuple using its own fields (`b = (false, b.0)`) must load
 /// the old values before any stores. Regression test for a lazy `codegen_ident` bug
 /// where stores were interleaved with lazy loads, causing stale reads.

--- a/compiler/noirc_frontend/src/elaborator/expressions.rs
+++ b/compiler/noirc_frontend/src/elaborator/expressions.rs
@@ -543,6 +543,16 @@ impl Elaborator<'_> {
             return (rhs, typ);
         }
 
+        // Simplify `&*x` and `&mut *x` to just `x`
+        if let UnaryOp::Reference { .. } = prefix.operator
+            && let ExpressionKind::Prefix(ref inner) = prefix.rhs.kind
+            && let UnaryOp::Dereference { .. } = inner.operator
+        {
+            let ExpressionKind::Prefix(inner) = prefix.rhs.kind else { unreachable!() };
+            let (rhs, typ) = self.elaborate_expression(inner.rhs);
+            return (rhs, typ);
+        }
+
         let rhs_location = prefix.rhs.location;
         let operator = prefix.operator;
 


### PR DESCRIPTION
## Problem Resolved

Follow up on AuditHub issue: Missing `*&` no-op folding in prefix elaboration
https://app.audithub.dev/app/organizations/161/projects/599/project-viewer?issueId=921&version=1406

## Summary of Changes
Simplifies also `&*`


## User Documentation

Check one:
- [X] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
