### PR TITLE
fix: handle quoted values in desugar_generic_trait_bounds

### DIFF
--- a/compiler/noirc_frontend/src/ast/traits.rs
+++ b/compiler/noirc_frontend/src/ast/traits.rs
@@ -329,21 +329,29 @@ fn desugar_generic_trait_bounds(
     where_clause: &mut Vec<UnresolvedTraitConstraint>,
 ) {
     for generic in generics {
-        let UnresolvedGeneric::Variable(IdentOrQuotedType::Ident(ident), trait_bounds) = generic
-        else {
-            continue;
-        };
+        match generic {
+            UnresolvedGeneric::Variable(ident_or_quoted_type, trait_bounds) => {
+                if trait_bounds.is_empty() {
+                    continue;
+                }
 
-        if trait_bounds.is_empty() {
-            continue;
-        }
+                let mut make_type = || match ident_or_quoted_type {
+                    IdentOrQuotedType::Ident(ident) => {
+                        let path = Path::from_ident(ident.clone());
+                        let typ = UnresolvedTypeData::Named(path, GenericTypeArgs::default(), true);
+                        UnresolvedType { typ, location: ident.location() }
+                    }
+                    IdentOrQuotedType::Quoted(quoted_type_id, location) => UnresolvedType {
+                        typ: UnresolvedTypeData::Resolved(*quoted_type_id),
+                        location: *location,
+                    },
+                };
 
-        for trait_bound in std::mem::take(trait_bounds) {
-            let path = Path::from_ident(ident.clone());
-            let typ = UnresolvedTypeData::Named(path, GenericTypeArgs::default(), true);
-            let typ = UnresolvedType { typ, location: ident.location() };
-            let trait_constraint = UnresolvedTraitConstraint { typ, trait_bound };
-            where_clause.push(trait_constraint);
+                for trait_bound in std::mem::take(trait_bounds) {
+                    where_clause.push(UnresolvedTraitConstraint { typ: make_type(), trait_bound });
+                }
+            }
+            UnresolvedGeneric::Numeric { .. } => (),
         }
     }
 }

--- a/compiler/noirc_frontend/src/tests/metaprogramming.rs
+++ b/compiler/noirc_frontend/src/tests/metaprogramming.rs
@@ -1744,3 +1744,40 @@ fn trait_impl_generated_with_constraint_does_not_drop_constraint() {
     "#;
     check_errors(src);
 }
+
+#[test]
+fn inline_bound_on_quoted_generic_is_preserved() {
+    let stdlib = r#"
+        pub enum Option<T> { None, Some(T) }
+        impl TypeDefinition {
+            #[builtin(type_def_generics)]
+            pub comptime fn generics(self) -> [(Type, Option<Type>)] {}
+        }
+    "#;
+    let src = r#"
+    pub trait Constraint {}
+    pub trait Target { fn run(self); }
+    pub struct Wrapper<T> { inner: T }
+    impl Constraint for i32 {}
+
+    #[generate_impl]
+    pub struct Marker<T> {}
+
+    comptime fn generate_impl(s: TypeDefinition) -> Quoted {
+        let t = s.generics()[0].0;
+        quote {
+            impl<$t: Constraint> Target for Wrapper<$t> {
+                fn run(_self: Self) { }
+            }
+        }
+    }
+
+    fn main() {
+        let w = Wrapper { inner: false };
+        w.run();
+        ^^^^^ No matching impl found for `bool: Constraint`
+        ~~~~~ No impl for `bool: Constraint`
+    }
+    "#;
+    check_errors_with_stdlib(src, [stdlib]);
+}


### PR DESCRIPTION
## Problem Resolved

Resolves https://github.com/noir-lang/noir-claude/issues/1061

## Summary of Changes



## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
