### PR TITLE
fix: follow self_type bindings when matching turbofish on type

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/variable.rs
+++ b/compiler/noirc_frontend/src/elaborator/variable.rs
@@ -204,7 +204,8 @@ impl Elaborator<'_> {
                     func_meta.all_generics.len() - func_meta.direct_generics.len();
                 let impl_generics =
                     vecmap(&func_meta.all_generics[..impl_generic_count], |g| g.type_var.clone());
-                let self_type = func_meta.self_type.clone();
+                let self_type =
+                    func_meta.self_type.as_ref().map(|t| t.follow_bindings_shallow().into_owned());
 
                 // For partially concrete impls (e.g. `impl<B> S<u32, B>`), the number of
                 // impl generics differs from the number of struct generics. The turbofish

--- a/compiler/noirc_frontend/src/tests/turbofish.rs
+++ b/compiler/noirc_frontend/src/tests/turbofish.rs
@@ -1072,3 +1072,21 @@ fn struct_turbofish_matching_struct_type_alias() {
     "#;
     assert_no_errors(src);
 }
+
+#[test]
+fn no_turbofish_matching_on_type_alias_without_generics_with_underlaying_struct_with_generics() {
+    let src = r#"
+    struct S<A> {}
+
+    type Alias = S<u32>;
+
+    impl Alias {
+        fn foo() {}
+    }
+
+    fn main() {
+        Alias::foo();
+    }
+    "#;
+    assert_no_errors(src);
+}


### PR DESCRIPTION
## Problem Resolved

Resolves https://app.audithub.dev/app/organizations/161/projects/599/project-viewer?version=1406&issueId=947

## Summary of Changes


## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
