### PR TITLE
chore: Model prop tests and benchmark

### DIFF
--- a/acvm-repo/acir/src/circuit/mod.rs
+++ b/acvm-repo/acir/src/circuit/mod.rs
@@ -313,7 +313,7 @@ impl<F: AcirField> Circuit<F> {
     }
 }
 
-impl<F: Serialize + AcirField> Program<F> {
+impl<F: Serialize + AcirField + MsgpackTagged> Program<F> {
     /// Compress a serialized [Program].
     fn compress(buf: Vec<u8>) -> std::io::Result<Vec<u8>> {
         let mut compressed: Vec<u8> = Vec::new();
@@ -348,7 +348,7 @@ impl<F: Serialize + AcirField> Program<F> {
     }
 }
 
-impl<F: AcirField + for<'a> Deserialize<'a>> Program<F> {
+impl<F: AcirField + for<'a> Deserialize<'a> + MsgpackTagged> Program<F> {
     /// Decompress and deserialize bytes into a [Program].
     fn read<R: Read>(reader: R) -> std::io::Result<Self> {
         let mut gz_decoder = flate2::read::GzDecoder::new(reader);
@@ -503,6 +503,7 @@ mod tests {
     use super::{Circuit, Compression};
     use crate::circuit::Program;
     use acir_field::{AcirField, FieldElement};
+    use msgpack_tagged::MsgpackTagged;
     use serde::{Deserialize, Serialize};
 
     #[test]
@@ -517,7 +518,7 @@ mod tests {
         let circuit = Circuit::from_str(src).unwrap();
         let program = Program { functions: vec![circuit], unconstrained_functions: Vec::new() };
 
-        fn read_write<F: Serialize + for<'a> Deserialize<'a> + AcirField>(
+        fn read_write<F: Serialize + for<'a> Deserialize<'a> + AcirField + MsgpackTagged>(
             program: Program<F>,
         ) -> (Program<F>, Program<F>) {
             let bytes = Program::serialize_program(&program);
@@ -604,13 +605,14 @@ mod tests {
     /// choosing a particular `F`.
     #[test]
     fn ensure_program_is_msgpack_tagged() {
-        fn assert_impl<T: msgpack_tagged::MsgpackTagged>() {}
+        fn assert_impl<T: MsgpackTagged>() {}
         assert_impl::<Program<FieldElement>>();
     }
 
     /// Property based testing for serialization
     mod props {
         use acir_field::FieldElement;
+        use msgpack_tagged::MsgpackTagged;
         use proptest::prelude::*;
         use proptest::test_runner::{TestCaseResult, TestRunner};
 
@@ -640,6 +642,11 @@ mod tests {
             fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
                 any::<u128>().prop_map(|v| Self(FieldElement::from(v))).boxed()
             }
+        }
+
+        impl MsgpackTagged for TestField {
+            const TAGGED: msgpack_tagged::Tagged = msgpack_tagged::Tagged::empty_product();
+            fn register_into(_reg: &mut msgpack_tagged::TagRegistry) {}
         }
 
         /// Override the maximum size of collections created by `proptest`.

--- a/acvm-repo/acir/src/circuit/mod.rs
+++ b/acvm-repo/acir/src/circuit/mod.rs
@@ -675,11 +675,15 @@ mod tests {
             result.unwrap();
         }
 
+        /// Round-trip a `Program` through each `Format` variant chosen
+        /// arbitrarily. Uses `serialize_with_format` + `deserialize_any_format`
+        /// so the framing-byte dispatch is exercised too — picks the right
+        /// encoder/decoder pair per format under one test name.
         #[test]
-        fn prop_program_msgpack_roundtrip() {
-            run_with_max_size_range(100, |(program, compact): (Program<TestField>, bool)| {
-                let bz = msgpack_serialize(&program, compact)?;
-                let de = msgpack_deserialize(&bz)?;
+        fn prop_program_arb_roundtrip() {
+            run_with_max_size_range(100, |(program, format): (Program<TestField>, Format)| {
+                let bz = serialize_with_format(&program, format)?;
+                let de = deserialize_any_format(&bz)?;
                 prop_assert_eq!(program, de);
                 Ok(())
             });
@@ -696,10 +700,10 @@ mod tests {
         }
 
         #[test]
-        fn prop_witness_stack_msgpack_roundtrip() {
-            run_with_max_size_range(10, |(witness, compact): (WitnessStack<TestField>, bool)| {
-                let bz = msgpack_serialize(&witness, compact)?;
-                let de = msgpack_deserialize(&bz)?;
+        fn prop_witness_stack_arb_roundtrip() {
+            run_with_max_size_range(10, |(witness, format): (WitnessStack<TestField>, Format)| {
+                let bz = serialize_with_format(&witness, format)?;
+                let de = deserialize_any_format(&bz)?;
                 prop_assert_eq!(witness, de);
                 Ok(())
             });
@@ -716,10 +720,10 @@ mod tests {
         }
 
         #[test]
-        fn prop_witness_map_msgpack_roundtrip() {
-            run_with_max_size_range(10, |(witness, compact): (WitnessMap<TestField>, bool)| {
-                let bz = msgpack_serialize(&witness, compact)?;
-                let de = msgpack_deserialize(&bz)?;
+        fn prop_witness_map_arb_roundtrip() {
+            run_with_max_size_range(10, |(witness, format): (WitnessMap<TestField>, Format)| {
+                let bz = serialize_with_format(&witness, format)?;
+                let de = deserialize_any_format(&bz)?;
                 prop_assert_eq!(witness, de);
                 Ok(())
             });

--- a/acvm-repo/acir/src/native_types/witness_map.rs
+++ b/acvm-repo/acir/src/native_types/witness_map.rs
@@ -93,7 +93,7 @@ impl<F> From<BTreeMap<Witness, F>> for WitnessMap<F> {
     }
 }
 
-impl<F: AcirField + Serialize> WitnessMap<F> {
+impl<F: AcirField + Serialize + MsgpackTagged> WitnessMap<F> {
     /// Serialize and compress.
     pub fn serialize(&self) -> Result<Vec<u8>, WitnessMapError> {
         let format = SerializationFormat::from_env()
@@ -119,7 +119,7 @@ impl<F: AcirField + Serialize> WitnessMap<F> {
     }
 }
 
-impl<F: AcirField + for<'a> Deserialize<'a>> WitnessMap<F> {
+impl<F: AcirField + for<'a> Deserialize<'a> + MsgpackTagged> WitnessMap<F> {
     /// Decompress and deserialize.
     pub fn deserialize(buf: &[u8]) -> Result<Self, WitnessMapError> {
         let mut deflater = GzDecoder::new(buf);

--- a/acvm-repo/acir/src/native_types/witness_stack.rs
+++ b/acvm-repo/acir/src/native_types/witness_stack.rs
@@ -76,7 +76,7 @@ impl<F> WitnessStack<F> {
     }
 }
 
-impl<F: AcirField + Serialize> WitnessStack<F> {
+impl<F: AcirField + Serialize + MsgpackTagged> WitnessStack<F> {
     /// Serialize and compress.
     pub fn serialize(&self) -> Result<Vec<u8>, WitnessStackError> {
         let format = SerializationFormat::from_env()
@@ -102,7 +102,7 @@ impl<F: AcirField + Serialize> WitnessStack<F> {
     }
 }
 
-impl<F: AcirField + for<'a> Deserialize<'a>> WitnessStack<F> {
+impl<F: AcirField + for<'a> Deserialize<'a> + MsgpackTagged> WitnessStack<F> {
     /// Decompress and deserialize.
     pub fn deserialize(buf: &[u8]) -> Result<Self, WitnessStackError> {
         let mut deflater = GzDecoder::new(buf);

--- a/acvm-repo/acir/src/serialization.rs
+++ b/acvm-repo/acir/src/serialization.rs
@@ -10,6 +10,7 @@ const FORMAT_ENV_VAR: &str = "NOIR_SERIALIZATION_FORMAT";
 
 /// A marker byte for the serialization format.
 #[derive(Debug, Default, Clone, Copy, IntoPrimitive, TryFromPrimitive, EnumString, PartialEq, Eq)]
+#[cfg_attr(feature = "arb", derive(proptest_derive::Arbitrary))]
 #[strum(serialize_all = "kebab-case")]
 #[repr(u8)]
 pub enum Format {

--- a/acvm-repo/acir/src/serialization.rs
+++ b/acvm-repo/acir/src/serialization.rs
@@ -1,5 +1,6 @@
 //! Serialization formats we consider using for the bytecode and the witness stack.
 
+use msgpack_tagged::{MsgpackTagged, msgpack_tagged_deserialize, msgpack_tagged_serialize};
 use num_enum::{IntoPrimitive, TryFromPrimitive};
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
@@ -17,6 +18,11 @@ pub enum Format {
     /// Msgpack with tuple structs.
     #[default]
     MsgpackCompact = 3,
+    /// Msgpack with int-keyed tag maps via the `msgpack_tagged` wrapper —
+    /// compact (single-byte field/variant tags) and schema-evolution-friendly
+    /// (retiring a field/variant + `#[tagged(reserved(...))]` keeps old data
+    /// decodable). Requires `T: MsgpackTagged`.
+    MsgpackTagged = 4,
 }
 
 impl Format {
@@ -79,7 +85,7 @@ pub(crate) fn msgpack_deserialize<T: for<'a> Deserialize<'a>>(buf: &[u8]) -> std
 /// Deserialize any of the supported formats.
 pub(crate) fn deserialize_any_format<T>(buf: &[u8]) -> std::io::Result<T>
 where
-    T: for<'a> Deserialize<'a>,
+    T: for<'a> Deserialize<'a> + MsgpackTagged,
 {
     let Some(format_byte) = buf.first() else {
         return Err(std::io::Error::new(std::io::ErrorKind::InvalidInput, "empty buffer"));
@@ -87,18 +93,20 @@ where
 
     match Format::try_from(*format_byte) {
         Ok(Format::Msgpack) | Ok(Format::MsgpackCompact) => msgpack_deserialize(&buf[1..]),
+        Ok(Format::MsgpackTagged) => msgpack_tagged_deserialize(&buf[1..]),
         Err(msg) => Err(std::io::Error::new(std::io::ErrorKind::InvalidInput, msg.to_string())),
     }
 }
 
 pub(crate) fn serialize_with_format<T>(value: &T, format: Format) -> std::io::Result<Vec<u8>>
 where
-    T: Serialize,
+    T: Serialize + MsgpackTagged,
 {
     // It would be more efficient to skip having to create a vector here, and use a std::io::Writer instead.
     let mut buf = match format {
         Format::Msgpack => msgpack_serialize(value, false)?,
         Format::MsgpackCompact => msgpack_serialize(value, true)?,
+        Format::MsgpackTagged => msgpack_tagged_serialize(value)?,
     };
     let mut res = vec![format.into()];
     res.append(&mut buf);
@@ -311,5 +319,30 @@ mod tests {
     #[test]
     fn format_from_str() {
         assert_eq!(Format::from_str("msgpack-compact").unwrap(), Format::MsgpackCompact);
+        assert_eq!(Format::from_str("msgpack-tagged").unwrap(), Format::MsgpackTagged);
+    }
+
+    /// `Format::MsgpackTagged` round-trips a value through `msgpack_tagged`'s
+    /// int-keyed-map encoder/decoder, with the `Format` byte prepended so
+    /// `deserialize_any_format` can route to the right decoder. The fixture
+    /// type derives `MsgpackTagged` so the bound on the dispatch functions
+    /// is satisfied.
+    #[test]
+    fn msgpack_tagged_format_roundtrip() {
+        use msgpack_tagged::MsgpackTagged;
+
+        #[derive(serde::Serialize, serde::Deserialize, MsgpackTagged, PartialEq, Eq, Debug)]
+        struct Foo {
+            #[tag(0)]
+            a: u32,
+            #[tag(1)]
+            b: bool,
+        }
+
+        let value = Foo { a: 7, b: true };
+        let bytes = super::serialize_with_format(&value, Format::MsgpackTagged).unwrap();
+        assert_eq!(bytes[0], Format::MsgpackTagged as u8);
+        let decoded: Foo = super::deserialize_any_format(&bytes).unwrap();
+        assert_eq!(decoded, value);
     }
 }

--- a/scripts/bytecode-sizes/README.md
+++ b/scripts/bytecode-sizes/README.md
@@ -55,4 +55,16 @@ Once the contracts are recompiled, run the following commands to record the new 
     ./scripts/bytecode-sizes/$BASELINE-vs-$ALTERNATIVE.jsonl
 ```
 
-You can look at the impact in `./scripts/bytecode-sizes/$BASELINE-vs-$ALTERNATIVE.png`.
+Two scatter plots are produced:
+
+* `./scripts/bytecode-sizes/$BASELINE-vs-$ALTERNATIVE-compressed.png` —
+  ratio of the gzipped + base64-encoded bytecode that actually ships in
+  the artifact (what end users see).
+* `./scripts/bytecode-sizes/$BASELINE-vs-$ALTERNATIVE-uncompressed.png` —
+  ratio of the pre-gzip msgpack bytes. Isolates wire-format cost from
+  gzip's compression ratio.
+
+The two can diverge: a denser pre-gzip encoding may compress slightly
+worse than a more verbose one (gzip rewards repetition), so a small
+post-compression regression on a particular program doesn't necessarily
+mean the wire format itself grew.

--- a/scripts/bytecode-sizes/README.md
+++ b/scripts/bytecode-sizes/README.md
@@ -2,31 +2,49 @@
 
 These scripts can be used to compare the bytecode size of circuits in `aztec-packages` between two different versions of `nargo`.
 
+## Build `nargo`
+
+```shell
+cargo build -p nargo_cli --release
+```
+
+## Baseline format
+
+Pick one of the existing serialization formats, for example:
+
+```shell
+BASELINE=msgpack-compact
+export NOIR_SERIALIZATION_FORMAT=$BASELINE
+```
+
 ## Compiling contracts
 
 Run these commands to compile Noir protocol circuits and contracts in `aztec-packages` after rebuilding `nargo`:
 
 ```shell
-cargo build -p nargo_cli --release
-./target/release/nargo --program-dir ../aztec-packages/noir-projects/noir-protocol-circuits compile --force --silence-warnings --skip-underconstrained-check
-./target/release/nargo --program-dir ../aztec-packages/noir-projects/noir-contracts compile --force --silence-warnings --skip-underconstrained-check
+./target/release/nargo --program-dir ../aztec-packages/noir-projects/noir-protocol-circuits compile --force --silence-warnings --skip-underconstrained-check --skip-brillig-constraints-check
+./target/release/nargo --program-dir ../aztec-packages/noir-projects/noir-contracts compile --force --silence-warnings --skip-underconstrained-check --skip-brillig-constraints-check
 ```
 
-## Baseline
+## Baseline measurement
 
 Record the baseline bytecode size with before switching to other implementations:
 ```shell
-./scripts/bytecode-sizes/print-bytecode-size.sh ../aztec-packages > ./scripts/bytecode-sizes/baseline.jsonl
+./scripts/bytecode-sizes/print-bytecode-size.sh ../aztec-packages > ./scripts/bytecode-sizes/$BASELINE.jsonl
 ```
 
 ## Alternative
 
-After making some changes to `nargo`, compile the contracts again with the commands above, then run the following
-commands to record a new measurement, and compare it against the baseline recorded earlier.
+After making some changes to `nargo`, or setting an alternative format, compile the contracts again with the commands above. For example here we just set a different format as an alternative, before running the commands again:
 
 ```shell
-BASELINE=baseline
-ALTERNATIVE=alternative
+ALTERNATIVE=msgpack-tagged
+export NOIR_SERIALIZATION_FORMAT=$ALTERNATIVE
+```
+
+Once the contracts are recompiled, run the following commands to record the new measurement, then compare it against the baseline recorded earlier:
+
+```shell
 ./scripts/bytecode-sizes/print-bytecode-size.sh ../aztec-packages \
     > ./scripts/bytecode-sizes/$ALTERNATIVE.jsonl
 ./scripts/bytecode-sizes/compare-bytecode-size.sh \

--- a/scripts/bytecode-sizes/bytecode-size-scatter.plt
+++ b/scripts/bytecode-sizes/bytecode-size-scatter.plt
@@ -6,4 +6,4 @@ set logscale x;
 set xlabel "Base Bytecode Size (Log)";
 set ylabel "Alt Bytecode Ratio";
 
-plot FILEIN using 2:4 with points;
+plot FILEIN using X_COL:RATIO_COL with points;

--- a/scripts/bytecode-sizes/compare-bytecode-size.sh
+++ b/scripts/bytecode-sizes/compare-bytecode-size.sh
@@ -4,16 +4,23 @@ set -eu
 IN1=$1
 IN2=$2
 
+# Join records from the two input files by program name and emit two ratios:
+# `compressed_ratio` and `uncompressed_ratio`. The latter isolates the
+# wire-format cost from gzip's contribution — handy for diagnosing cases
+# where the compressed ratio regresses despite the format being denser.
 jq --slurp -c '
 . as $top |
 ($top[] | select(.encoding == "base") | .data[]) as $base |
 ($top[] | select(.encoding == "alt")  | .data[] | select(.name == $base.name)) as $alt |
 {
     name: $base.name,
-    base_size: $base.bytecode_size,
-    alt_size: $alt.bytecode_size,
-    ratio: ($alt.bytecode_size / $base.bytecode_size)
+    compressed_base: $base.compressed_size,
+    compressed_alt: $alt.compressed_size,
+    compressed_ratio: ($alt.compressed_size / $base.compressed_size),
+    uncompressed_base: $base.uncompressed_size,
+    uncompressed_alt: $alt.uncompressed_size,
+    uncompressed_ratio: ($alt.uncompressed_size / $base.uncompressed_size)
 }
 ' \
     <(cat $IN1 | jq --slurp '{encoding: "base", data: .}') \
-    <(cat $IN2 | jq --slurp '{encoding: "alt", data: .}') \
+    <(cat $IN2 | jq --slurp '{encoding: "alt", data: .}')

--- a/scripts/bytecode-sizes/plot-bytecode-size.sh
+++ b/scripts/bytecode-sizes/plot-bytecode-size.sh
@@ -4,15 +4,34 @@ set -eu
 IN=$1
 NAME=$(basename $IN .jsonl)
 DAT=$(dirname $IN)/$NAME.dat
-PNG=$(dirname $IN)/$NAME.png
 PLT=$(dirname $0)/bytecode-size-scatter.plt
 
-cat $IN | jq -r '[.name, .base_size, .alt_size, .ratio] | @tsv' > $DAT
+# TSV columns:
+#   1: name
+#   2: compressed_base   3: compressed_alt   4: compressed_ratio
+#   5: uncompressed_base 6: uncompressed_alt 7: uncompressed_ratio
+cat $IN | jq -r '[
+    .name,
+    .compressed_base, .compressed_alt, .compressed_ratio,
+    .uncompressed_base, .uncompressed_alt, .uncompressed_ratio
+] | @tsv' > $DAT
 
-gnuplot \
-  -e "NAME='$(echo $NAME | tr _ - )'" \
-  -e "FILEIN='$DAT'" \
-  -e "FILEOUT='$PNG'" \
-  $PLT
+# Plot compressed (the wire size that ships) and uncompressed (pre-gzip
+# raw format size) separately. The two ratios can diverge because gzip
+# rewards redundancy that a denser pre-gzip encoding has already removed.
+for kind in compressed uncompressed; do
+    case $kind in
+        compressed)   x_col=2; ratio_col=4 ;;
+        uncompressed) x_col=5; ratio_col=7 ;;
+    esac
+    PNG=$(dirname $IN)/$NAME-$kind.png
+    gnuplot \
+        -e "NAME='$(echo $NAME | tr _ - ) ($kind)'" \
+        -e "FILEIN='$DAT'" \
+        -e "FILEOUT='$PNG'" \
+        -e "X_COL=$x_col" \
+        -e "RATIO_COL=$ratio_col" \
+        $PLT
+done
 
 rm $DAT

--- a/scripts/bytecode-sizes/print-bytecode-size.sh
+++ b/scripts/bytecode-sizes/print-bytecode-size.sh
@@ -3,16 +3,47 @@ set -eu
 
 AZTEC_PACKAGES_DIR=$1
 
-for file in $AZTEC_PACKAGES_DIR/noir-projects/noir-protocol-circuits/target/*.json; do
-    PROGRAM=$(basename $file .json)
-    cat $file \
-        | jq --arg PROGRAM $PROGRAM \
-            -c '{name: $PROGRAM, bytecode_size: .bytecode | @base64d | length}'
+# The `bytecode` field in nargo's compiled artifact is `base64(gzip(format_byte
+# + msgpack_bytes))`. We emit both:
+#
+# * `compressed_size`   — length of the base64-decoded blob (the gzipped
+#                         payload that ships on the wire). Matches what the
+#                         prior version of this script reported.
+# * `uncompressed_size` — length after un-gzipping. The "raw" size, useful
+#                         for separating wire-format cost from gzip's
+#                         compression ratio.
+#
+# Writes a base64-decoded copy of the bytecode to a temp file once per
+# program so we can `wc -c` it directly and pipe it through `gzip -d`
+# without re-decoding.
+emit_sizes() {
+    local name="$1"
+    local b64="$2"
+    local tmp
+    tmp=$(mktemp)
+    printf '%s' "$b64" | base64 -d > "$tmp"
+    local compressed uncompressed
+    compressed=$(wc -c < "$tmp" | tr -d '[:space:]')
+    uncompressed=$(gzip -dc "$tmp" | wc -c | tr -d '[:space:]')
+    rm -f "$tmp"
+    jq -nc \
+        --arg name "$name" \
+        --argjson compressed_size "$compressed" \
+        --argjson uncompressed_size "$uncompressed" \
+        '{name: $name, compressed_size: $compressed_size, uncompressed_size: $uncompressed_size}'
+}
+
+for file in "$AZTEC_PACKAGES_DIR/noir-projects/noir-protocol-circuits/target/"*.json; do
+    program=$(basename "$file" .json)
+    b64=$(jq -r '.bytecode' "$file")
+    emit_sizes "$program" "$b64"
 done
 
-for file in $AZTEC_PACKAGES_DIR/noir-projects/noir-contracts/target/*.json; do
-    CONTRACT=$(basename $file .json)
-    cat $file \
-        | jq --arg CONTRACT $CONTRACT \
-            -c '.functions | sort_by(.name) | .[] | {name: ($CONTRACT + "::" + .name), "bytecode_size": .bytecode | @base64d | length}'
+for file in "$AZTEC_PACKAGES_DIR/noir-projects/noir-contracts/target/"*.json; do
+    contract=$(basename "$file" .json)
+    # Each contract file has multiple functions, each with its own bytecode.
+    # `@tsv` puts the function name and its base64 bytecode on one line each.
+    while IFS=$'\t' read -r fname b64; do
+        emit_sizes "${contract}::${fname}" "$b64"
+    done < <(jq -r '.functions | sort_by(.name) | .[] | [.name, .bytecode] | @tsv' "$file")
 done


### PR DESCRIPTION
## Problem Resolved

Resolves some of the tasks in #12554 

Benchmarks the new serialization format relative to the current default. The models have already been decorated in https://github.com/noir-lang/noir/pull/12596

## Summary of Changes

* Adds a new `Format::MsgpackTagged` variant
* Changes the property based serialization tests to pick an arbitrary `Format`, to test the tagged serialization with all the models we put it onto in https://github.com/noir-lang/noir/pull/12596

I ran the byte size comparison vs the `msgpack-tagged` format (with a [fix](4cced1097ee143b5def5c6571d35bff1571f66c0) for the measurements back ported from https://github.com/noir-lang/noir/pull/12635), see below:
* The tagged format can up to ~25% better on small programs, after compression. On larger programs the compression takes care of the repeated string discriminators of enums, so the effect isn't that significant, less than 5%. 
* In some cases the `msgpack-compact` format is better, which is why I want to follow up this work with the _per-type strategy_ feature: if the bytecode has mostly structs, which are currently represented by `ARRAY`s in msgpack, then changing those to int-keyed `MAP`s are still going to be worse, which is why the design document planned for a _default strategy_ to be `Array` for most types, allowing us to _opt into_ `Tagged` for schema evolution, as and when we need it.

<img width="1200" height="800" alt="image" src="https://github.com/user-attachments/assets/fb4761f5-1706-46aa-9ad5-d56dd6a41cbc" />



## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
