### PR TITLE
fix: patch cyclic type aliases before global elaboration

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/mod.rs
+++ b/compiler/noirc_frontend/src/elaborator/mod.rs
@@ -561,6 +561,10 @@ impl<'context> Elaborator<'context> {
         // lazily during the drain.
         self.drain_unresolved_function_metas();
 
+        // Break cyclic type aliases (replacing them with `Type::Error`) here because
+        // global elaboration might hit path lookup which might hit cyclic aliases.
+        self.interner.break_cyclic_type_aliases();
+
         // We must wait to resolve non-literal globals until after we resolve structs since struct
         // globals will need to reference the struct type they're initialized to ensure they are valid.
         self.elaborate_remaining_globals();

--- a/compiler/noirc_frontend/src/node_interner/dependency.rs
+++ b/compiler/noirc_frontend/src/node_interner/dependency.rs
@@ -82,6 +82,20 @@ impl NodeInterner {
         index
     }
 
+    /// Replace the body of every type alias caught in a dependency cycle with `Type::Error`.
+    pub(crate) fn break_cyclic_type_aliases(&self) {
+        for scc in tarjan_scc(&self.dependency_graph) {
+            if scc.len() <= 1 {
+                continue;
+            }
+            for node_index in &scc {
+                if let DependencyId::Alias(alias_id) = self.dependency_graph[*node_index] {
+                    self.get_type_alias(alias_id).borrow_mut().typ = Type::Error;
+                }
+            }
+        }
+    }
+
     pub(crate) fn check_for_dependency_cycles(&self) -> Vec<CompilationError> {
         let mut errors = Vec::new();
 

--- a/compiler/noirc_frontend/src/tests/aliases.rs
+++ b/compiler/noirc_frontend/src/tests/aliases.rs
@@ -1174,3 +1174,26 @@ fn unused_expression_result_correct_span() {
     "#;
     check_errors(src);
 }
+
+#[test]
+fn does_not_crash_if_alias_cycle_is_detected_in_global_initialization() {
+    let src = r#"
+    type A = B;
+    type B = A;
+         ^ Dependency cycle found
+         ~ 'B' recursively depends on itself: B -> A -> B
+
+    global G: u32 = f();
+           ^ unused global G
+           ~ unused global
+
+    fn f() -> u32 {
+        let _ = A::foo();
+                ^ Could not resolve 'A' in path
+        1
+    }
+
+    fn main() { }
+    "#;
+    check_errors(src);
+}


### PR DESCRIPTION
## Problem Resolved

Resolves https://app.audithub.dev/app/organizations/161/projects/599/project-viewer?version=1406&issueId=886

## Summary of Changes



## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
