### PR TITLE
fix(coverage): avoid duplicate impl method names

### DIFF
--- a/examples/coverage/lcov.info
+++ b/examples/coverage/lcov.info
@@ -9,6 +9,8 @@ FN:52,<u64 as Quadruple>::quadrupled
 FN:52,Quadruple::quadrupled
 FN:58,<u32 as Quadruple>::doubled
 FN:64,<u64 as Quadruple>::doubled
+FN:76,First::new
+FN:86,Second::new
 FNDA:0,double
 FNDA:0,add
 FNDA:0,moo::triple
@@ -18,7 +20,9 @@ FNDA:0,<u64 as Quadruple>::quadrupled
 FNDA:0,Quadruple::quadrupled
 FNDA:0,<u32 as Quadruple>::doubled
 FNDA:0,<u64 as Quadruple>::doubled
-FNF:9
+FNDA:0,First::new
+FNDA:0,Second::new
+FNF:11
 FNH:0
 DA:1,0
 DA:2,0
@@ -44,7 +48,11 @@ DA:58,0
 DA:59,0
 DA:64,0
 DA:65,0
-LF:24
+DA:76,0
+DA:77,0
+DA:86,0
+DA:87,0
+LF:28
 LH:0
 end_of_record
 TN:test_add
@@ -68,6 +76,21 @@ DA:1,1
 DA:2,3
 LF:2
 LH:2
+end_of_record
+TN:test_inherent_news
+SF:src/lib.nr
+FN:76,First::new
+FN:86,Second::new
+FNDA:1,First::new
+FNDA:1,Second::new
+FNF:2
+FNH:2
+DA:76,1
+DA:77,2
+DA:86,1
+DA:87,2
+LF:4
+LH:4
 end_of_record
 TN:test_quadrupled
 SF:src/lib.nr

--- a/examples/coverage/src/lib.nr
+++ b/examples/coverage/src/lib.nr
@@ -66,6 +66,34 @@ impl Quadruple for u64 {
     }
 }
 
+// Two inherent impls of `new` on different structs. Their entries should be qualified by
+// the receiver type so they don't collide on the bare name `new`.
+pub struct First {
+    value: u32,
+}
+
+impl First {
+    pub fn new(value: u32) -> Self {
+        Self { value }
+    }
+}
+
+pub struct Second {
+    value: u32,
+}
+
+impl Second {
+    pub fn new(value: u32) -> Self {
+        Self { value }
+    }
+}
+
+#[test]
+fn test_inherent_news() {
+    let _ = First::new(1);
+    let _ = Second::new(2);
+}
+
 #[test]
 fn test_double() {
     assert_eq(double(3), 6);

--- a/tooling/nargo_cli/src/cli/test_cmd/coverage.rs
+++ b/tooling/nargo_cli/src/cli/test_cmd/coverage.rs
@@ -240,9 +240,12 @@ fn sanitize_test_name(test_name: &str) -> String {
 
 /// Returns a fully-qualified name for `func_id` to use in the coverage report.
 ///
-/// Methods inside a trait impl get a `<Type as Trait>::method` qualification so distinct
-/// impls of the same trait method don't collapse onto a single display name (which would
-/// cause duplicate `FN`/`FNDA` entries to merge into one in `lcov.info`).
+/// Impl methods get an explicit type qualification so distinct impls of the same method
+/// name don't collapse onto a single display name (which would cause duplicate `FN`/`FNDA`
+/// entries to merge into one in `lcov.info`):
+///
+/// - A trait impl method becomes `<Type as Trait>::method`.
+/// - An inherent impl method becomes `Type::method`.
 ///
 /// Trait functions defined inside `trait { ... }` need no extra label work: the trait
 /// itself is a module, so the module path already qualifies them as `<module>::<Trait>::<fn>`.
@@ -263,6 +266,13 @@ fn fully_qualified_function_name(context: &Context, meta: &FuncMeta, func_id: &F
         let trait_impl = trait_impl.borrow();
         let trait_def = interner.get_trait(trait_impl.trait_id);
         format!("<{} as {}>::{}", trait_impl.typ, trait_def.name, name)
+    } else if meta.trait_id.is_some() {
+        // Trait function (inside `trait { ... }`): `self_type` here is `Self`, an
+        // unbound type variable that would render as `_`. Skip the type prefix — the
+        // module path already includes the trait name.
+        name.to_string()
+    } else if let Some(self_type) = &meta.self_type {
+        format!("{self_type}::{name}")
     } else {
         name.to_string()
     };


### PR DESCRIPTION
## Problem Resolved

No issue.

## Summary of Changes

While continuing to test the stdlib I found out that two impl methods with the same name, but for different types, ended up with the same name in the coverage file, which then produces errors on some tools (lcov and genthml). This PR fixes that.

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
