### PR TITLE
chore: Validate brillig stack frame & scratch space flags

### DIFF
--- a/compiler/noirc_driver/src/lib.rs
+++ b/compiler/noirc_driver/src/lib.rs
@@ -20,7 +20,8 @@ use noirc_artifacts::ssa::{InternalBug, InternalWarning, SsaReport};
 use noirc_errors::CustomDiagnostic;
 use noirc_evaluator::brillig::BrilligOptions;
 use noirc_evaluator::brillig::brillig_ir::{
-    LayoutConfig, MAX_SCRATCH_SPACE, MAX_STACK_FRAME_SIZE, NUM_STACK_FRAMES,
+    LayoutConfig, MAX_SCRATCH_SPACE, MAX_STACK_FRAME_SIZE, MIN_SCRATCH_SPACE, MIN_STACK_FRAME_SIZE,
+    NUM_STACK_FRAMES,
 };
 use noirc_evaluator::create_program;
 use noirc_evaluator::errors::RuntimeError;
@@ -65,6 +66,32 @@ pub const NOIRC_VERSION: &str = env!("CARGO_PKG_VERSION");
 /// Note: You can't directly use the value of a constant produced with env! inside a concat! macro.
 pub const NOIR_ARTIFACT_VERSION_STRING: &str =
     concat!(env!("CARGO_PKG_VERSION"), "+", env!("GIT_COMMIT"));
+
+fn parse_num_stack_frames(s: &str) -> Result<usize, String> {
+    let n: usize = s.parse().map_err(|e| format!("'{s}' is not a valid unsigned integer: {e}"))?;
+    if n == 0 {
+        return Err("--num-stack-frames must be at least 1".to_string());
+    }
+    Ok(n)
+}
+
+fn parse_max_stack_frame_size(s: &str) -> Result<usize, String> {
+    let n: usize = s.parse().map_err(|e| format!("'{s}' is not a valid unsigned integer: {e}"))?;
+    if n < MIN_STACK_FRAME_SIZE {
+        return Err(format!(
+            "--max-stack-frame-size must be at least {MIN_STACK_FRAME_SIZE} (got {n})"
+        ));
+    }
+    Ok(n)
+}
+
+fn parse_max_scratch_space(s: &str) -> Result<usize, String> {
+    let n: usize = s.parse().map_err(|e| format!("'{s}' is not a valid unsigned integer: {e}"))?;
+    if n < MIN_SCRATCH_SPACE {
+        return Err(format!("--max-scratch-space must be at least {MIN_SCRATCH_SPACE} (got {n})"));
+    }
+    Ok(n)
+}
 
 #[derive(Args, Clone, Debug)]
 pub struct CompileOptions {
@@ -234,15 +261,15 @@ pub struct CompileOptions {
     pub max_specializations_per_fn: usize,
 
     /// Maximum size of a single Brillig stack frame.
-    #[arg(long, hide = true, default_value_t = MAX_STACK_FRAME_SIZE)]
+    #[arg(long, hide = true, default_value_t = MAX_STACK_FRAME_SIZE, value_parser = parse_max_stack_frame_size)]
     pub max_stack_frame_size: usize,
 
     /// Number of Brillig stack frames / call depth limit.
-    #[arg(long, hide = true, default_value_t = NUM_STACK_FRAMES)]
+    #[arg(long, hide = true, default_value_t = NUM_STACK_FRAMES, value_parser = parse_num_stack_frames)]
     pub num_stack_frames: usize,
 
     /// Maximum Brillig scratch space size.
-    #[arg(long, hide = true, default_value_t = MAX_SCRATCH_SPACE)]
+    #[arg(long, hide = true, default_value_t = MAX_SCRATCH_SPACE, value_parser = parse_max_scratch_space)]
     pub max_scratch_space: usize,
 
     /// Skip reading files/folders from the root directory and instead accept the

--- a/compiler/noirc_evaluator/src/brillig/brillig_ir.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_ir.rs
@@ -35,7 +35,10 @@ use registers::{RegisterAllocator, ScratchSpace};
 use crate::brillig::assert_u32;
 
 pub use self::registers::LayoutConfig;
-pub use self::registers::{MAX_SCRATCH_SPACE, MAX_STACK_FRAME_SIZE, NUM_STACK_FRAMES};
+pub use self::registers::{
+    MAX_SCRATCH_SPACE, MAX_STACK_FRAME_SIZE, MIN_SCRATCH_SPACE, MIN_STACK_FRAME_SIZE,
+    NUM_STACK_FRAMES,
+};
 use self::{artifact::BrilligArtifact, debug_show::DebugToString, registers::Stack};
 use acvm::{
     AcirField,

--- a/compiler/noirc_evaluator/src/brillig/brillig_ir/registers.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_ir/registers.rs
@@ -109,7 +109,15 @@ impl LayoutConfig {
 
 // These constants represent expert chosen defaults that are appropriate for the majority of programs
 pub const NUM_STACK_FRAMES: usize = 16;
+
+/// Smallest `max_stack_frame_size` value that reliably fits the per-frame prologue plus
+/// enough user-addressable slots to compile minimal programs.
+pub const MIN_STACK_FRAME_SIZE: usize = 8;
 pub const MAX_STACK_FRAME_SIZE: usize = 2048;
+
+/// Smallest `max_scratch_space` value that reliably fits the scratch slots used by the
+/// procedures emitted for minimal programs (e.g. `CheckMaxStackDepth`).
+pub const MIN_SCRATCH_SPACE: usize = 2;
 pub const MAX_SCRATCH_SPACE: usize = 64;
 
 impl Default for LayoutConfig {


### PR DESCRIPTION
## Problem Resolved

Resolves https://github.com/noir-lang/noir/issues/12575

## Summary of Changes



## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
