### PR TITLE
fix(coverage): include impl trait generics in name

### DIFF
--- a/examples/coverage/lcov.info
+++ b/examples/coverage/lcov.info
@@ -11,6 +11,10 @@ FN:58,<u32 as Quadruple>::doubled
 FN:64,<u64 as Quadruple>::doubled
 FN:76,First::new
 FN:86,Second::new
+FN:96,<u8 as Convert<u8>>::convert
+FN:102,<u8 as Convert<u16>>::convert
+FN:108,<u16 as Convert<u8>>::convert
+FN:114,<u16 as Convert<u16>>::convert
 FNDA:0,double
 FNDA:0,add
 FNDA:0,moo::triple
@@ -22,7 +26,11 @@ FNDA:0,<u32 as Quadruple>::doubled
 FNDA:0,<u64 as Quadruple>::doubled
 FNDA:0,First::new
 FNDA:0,Second::new
-FNF:11
+FNDA:0,<u8 as Convert<u8>>::convert
+FNDA:0,<u8 as Convert<u16>>::convert
+FNDA:0,<u16 as Convert<u8>>::convert
+FNDA:0,<u16 as Convert<u16>>::convert
+FNF:15
 FNH:0
 DA:1,0
 DA:2,0
@@ -52,8 +60,39 @@ DA:76,0
 DA:77,0
 DA:86,0
 DA:87,0
-LF:28
+DA:96,0
+DA:97,0
+DA:102,0
+DA:103,0
+DA:108,0
+DA:109,0
+DA:114,0
+DA:115,0
+LF:36
 LH:0
+end_of_record
+TN:test
+SF:src/lib.nr
+FN:96,<u8 as Convert<u8>>::convert
+FN:102,<u8 as Convert<u16>>::convert
+FN:108,<u16 as Convert<u8>>::convert
+FN:114,<u16 as Convert<u16>>::convert
+FNDA:1,<u8 as Convert<u8>>::convert
+FNDA:1,<u8 as Convert<u16>>::convert
+FNDA:1,<u16 as Convert<u8>>::convert
+FNDA:1,<u16 as Convert<u16>>::convert
+FNF:4
+FNH:4
+DA:96,1
+DA:97,1
+DA:102,1
+DA:103,1
+DA:108,1
+DA:109,1
+DA:114,1
+DA:115,1
+LF:8
+LH:8
 end_of_record
 TN:test_add
 SF:src/lib.nr
@@ -65,6 +104,29 @@ DA:5,1
 DA:6,3
 LF:2
 LH:2
+end_of_record
+TN:test_convert
+SF:src/lib.nr
+FN:96,<u8 as Convert<u8>>::convert
+FN:102,<u8 as Convert<u16>>::convert
+FN:108,<u16 as Convert<u8>>::convert
+FN:114,<u16 as Convert<u16>>::convert
+FNDA:1,<u8 as Convert<u8>>::convert
+FNDA:1,<u8 as Convert<u16>>::convert
+FNDA:1,<u16 as Convert<u8>>::convert
+FNDA:1,<u16 as Convert<u16>>::convert
+FNF:4
+FNH:4
+DA:96,1
+DA:97,1
+DA:102,1
+DA:103,1
+DA:108,1
+DA:109,1
+DA:114,1
+DA:115,1
+LF:8
+LH:8
 end_of_record
 TN:test_double
 SF:src/lib.nr

--- a/examples/coverage/src/lib.nr
+++ b/examples/coverage/src/lib.nr
@@ -88,6 +88,42 @@ impl Second {
     }
 }
 
+trait Convert<T> {
+    fn convert(self) -> T;
+}
+
+impl Convert<u8> for u8 {
+    fn convert(self) -> u8 {
+        0
+    }
+}
+
+impl Convert<u16> for u8 {
+    fn convert(self) -> u16 {
+        0
+    }
+}
+
+impl Convert<u8> for u16 {
+    fn convert(self) -> u8 {
+        0
+    }
+}
+
+impl Convert<u16> for u16 {
+    fn convert(self) -> u16 {
+        0
+    }
+}
+
+#[test]
+fn test() {
+    let _: u8 = 0_u8.convert();
+    let _: u16 = 0_u8.convert();
+    let _: u8 = 0_u16.convert();
+    let _: u16 = 0_u16.convert();
+}
+
 #[test]
 fn test_inherent_news() {
     let _ = First::new(1);
@@ -108,4 +144,12 @@ fn test_add() {
 fn test_quadrupled() {
     assert_eq(3u32.quadrupled(), 12);
     assert_eq(3u64.quadrupled(), 12);
+}
+
+#[test]
+fn test_convert() {
+    assert_eq(0_u8.convert(), 0_u8);
+    assert_eq(0_u8.convert(), 0_u16);
+    assert_eq(0_u16.convert(), 0_u8);
+    assert_eq(0_u16.convert(), 0_u16);
 }

--- a/tooling/nargo_cli/src/cli/test_cmd/coverage.rs
+++ b/tooling/nargo_cli/src/cli/test_cmd/coverage.rs
@@ -265,7 +265,8 @@ fn fully_qualified_function_name(context: &Context, meta: &FuncMeta, func_id: &F
         let trait_impl = interner.get_trait_implementation(trait_impl_id);
         let trait_impl = trait_impl.borrow();
         let trait_def = interner.get_trait(trait_impl.trait_id);
-        format!("<{} as {}>::{}", trait_impl.typ, trait_def.name, name)
+        let trait_generics = interner.get_trait_generics_for_impl(trait_impl_id);
+        format!("<{} as {}{}>::{}", trait_impl.typ, trait_def.name, trait_generics, name)
     } else if meta.trait_id.is_some() {
         // Trait function (inside `trait { ... }`): `self_type` here is `Self`, an
         // unbound type variable that would render as `_`. Skip the type prefix — the


### PR DESCRIPTION
## Problem Resolved

No issue.

## Summary of Changes

Yet another source of duplicate names. Without this two impls would get the same `<u8 as Convert>::convert` name.

I _think_ this is the last one.

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
