### PR TITLE
fix(lsp): don't delete from id_to_location

### DIFF
--- a/compiler/noirc_frontend/src/locations.rs
+++ b/compiler/noirc_frontend/src/locations.rs
@@ -437,13 +437,14 @@ impl NodeInterner {
     }
 
     /// Clears all location data associated with a given file.
-    /// Note that this only clears locations in `id_to_location` and `location_indices`.
+    /// Note that this only clears locations in `location_indices`.
+    /// This doesn't delete from `id_to_location` because IDs cannot be deleted from the interner,
+    /// so existing IDs should be able to be resolved to their location.
     /// For example, items that exist in the given `file` will still be present after
     /// this call.
     /// This is only used by LSP when a single file is changed, when just that file
     /// is type-checked again.
     pub(crate) fn clear_file_locations(&mut self, file: FileId) {
-        self.id_to_location.retain(|_index, location| location.file != file);
         self.location_indices.map_file_to_range.remove(&file);
     }
 }


### PR DESCRIPTION
## Problem Resolved

No issue.

## Summary of Changes

When editing `noir_stdlib/src/hash/mod.nr` LSP was crashing for me. The reason is that it couldn't find the location of an `ExprId`. These are stored in `id_to_location`. Before this PR we would clear from that HashMap, but that's not quite right: code in files other than the one being edited might still hold and reference `ExprId` that happen in that file. `ExprId`s can't be removed because they are in an Arena, and so we should not remove from `id_to_location` because getting from it with an `ExprId` that still exists should always work.

This shouldn't have any consequences except preventing LSP from crashing here.

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
