### PR TITLE
chore(docs): Add quickstart with AI on docs home page

### DIFF
--- a/docs/docs/index.mdx
+++ b/docs/docs/index.mdx
@@ -89,5 +89,3 @@ Noir can be used both in complex cloud-based backends and in user's smartphones,
 Noir is meant to be easy to extend by simply importing Noir libraries just like in Rust. 
 The [awesome-noir repo](https://github.com/noir-lang/awesome-noir#libraries) is a collection of libraries developed by the Noir community.
 Writing a new library is easy and makes code be composable and easy to reuse. See the section on [dependencies](noir/modules_packages_crates/dependencies.md) for more information.
-
-

--- a/docs/docs/index.mdx
+++ b/docs/docs/index.mdx
@@ -37,6 +37,14 @@ Noir is an open-source Domain-Specific Language for safe and seamless constructi
 
 ZK programs are programs that can generate short proofs of statements without revealing all inputs to the statements. You can read more about Zero-Knowledge Proofs [here](https://dev.to/spalladino/a-beginners-intro-to-coding-zero-knowledge-proofs-c56).
 
+### Quickstart with AI
+
+Paste this into your agent to start a new Noir project:
+
+```
+Read https://noir-lang.org/docs/getting_started/quick_start and create a Noir project
+```
+
 ## What's new about Noir?
 
 Noir works differently from most ZK languages by taking a two-pronged path. First, it compiles the program to an adaptable intermediate language known as ACIR. From there, depending on a given project's needs, ACIR can be further compiled into an arithmetic circuit for integration with the proving backend.
@@ -81,3 +89,5 @@ Noir can be used both in complex cloud-based backends and in user's smartphones,
 Noir is meant to be easy to extend by simply importing Noir libraries just like in Rust. 
 The [awesome-noir repo](https://github.com/noir-lang/awesome-noir#libraries) is a collection of libraries developed by the Noir community.
 Writing a new library is easy and makes code be composable and easy to reuse. See the section on [dependencies](noir/modules_packages_crates/dependencies.md) for more information.
+
+


### PR DESCRIPTION
## Problem Resolved

Resolves https://github.com/noir-lang/noir/issues/12645.

## Summary of Changes

Add a simple one-line quickstart on the home page.

Other advanced documentations on using Noir with AI is considered out of scope and shall be addressed separately.

## User Documentation

Check one:
- [ ] No user documentation needed.
- [x] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
