### PR TITLE
chore: C++ codegen for `MsgpackTagged`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,6 +49,7 @@ dependencies = [
  "num-bigint",
  "proptest",
  "serde",
+ "serde_bytes",
 ]
 
 [[package]]
@@ -5478,6 +5479,16 @@ dependencies = [
  "serde_json",
  "thiserror 1.0.69",
  "typeid",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
+dependencies = [
+ "serde",
+ "serde_core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -202,6 +202,7 @@ dirs = "^6.0.0"
 env_logger = "0.11.6"
 log = "0.4"
 serde = { version = "1.0.136", features = ["derive", "rc"] }
+serde_bytes = "0.11"
 serde_json = "1.0"
 smol_str = { version = "0.3.2", features = ["serde"] }
 thiserror = "2.0.18"

--- a/acvm-repo/acir/codegen/acir.cpp
+++ b/acvm-repo/acir/codegen/acir.cpp
@@ -2,6 +2,7 @@
 
 #include "serde.hpp"
 #include "barretenberg/serialize/msgpack_impl.hpp"
+#include "bincode.hpp"
 
 namespace Acir {
     struct Helpers {
@@ -158,55 +159,132 @@ namespace Acir {
 
         struct Add {
             friend bool operator==(const Add&, const Add&);
+            std::vector<uint8_t> bincodeSerialize() const;
+            static Add bincodeDeserialize(std::vector<uint8_t>);
 
+            void msgpack_pack(auto& packer) const {}
             void msgpack_unpack(msgpack::object const& o) {}
         };
 
         struct Sub {
             friend bool operator==(const Sub&, const Sub&);
+            std::vector<uint8_t> bincodeSerialize() const;
+            static Sub bincodeDeserialize(std::vector<uint8_t>);
 
+            void msgpack_pack(auto& packer) const {}
             void msgpack_unpack(msgpack::object const& o) {}
         };
 
         struct Mul {
             friend bool operator==(const Mul&, const Mul&);
+            std::vector<uint8_t> bincodeSerialize() const;
+            static Mul bincodeDeserialize(std::vector<uint8_t>);
 
+            void msgpack_pack(auto& packer) const {}
             void msgpack_unpack(msgpack::object const& o) {}
         };
 
         struct Div {
             friend bool operator==(const Div&, const Div&);
+            std::vector<uint8_t> bincodeSerialize() const;
+            static Div bincodeDeserialize(std::vector<uint8_t>);
 
+            void msgpack_pack(auto& packer) const {}
             void msgpack_unpack(msgpack::object const& o) {}
         };
 
         struct IntegerDiv {
             friend bool operator==(const IntegerDiv&, const IntegerDiv&);
+            std::vector<uint8_t> bincodeSerialize() const;
+            static IntegerDiv bincodeDeserialize(std::vector<uint8_t>);
 
+            void msgpack_pack(auto& packer) const {}
             void msgpack_unpack(msgpack::object const& o) {}
         };
 
         struct Equals {
             friend bool operator==(const Equals&, const Equals&);
+            std::vector<uint8_t> bincodeSerialize() const;
+            static Equals bincodeDeserialize(std::vector<uint8_t>);
 
+            void msgpack_pack(auto& packer) const {}
             void msgpack_unpack(msgpack::object const& o) {}
         };
 
         struct LessThan {
             friend bool operator==(const LessThan&, const LessThan&);
+            std::vector<uint8_t> bincodeSerialize() const;
+            static LessThan bincodeDeserialize(std::vector<uint8_t>);
 
+            void msgpack_pack(auto& packer) const {}
             void msgpack_unpack(msgpack::object const& o) {}
         };
 
         struct LessThanEquals {
             friend bool operator==(const LessThanEquals&, const LessThanEquals&);
+            std::vector<uint8_t> bincodeSerialize() const;
+            static LessThanEquals bincodeDeserialize(std::vector<uint8_t>);
 
+            void msgpack_pack(auto& packer) const {}
             void msgpack_unpack(msgpack::object const& o) {}
         };
 
         std::variant<Add, Sub, Mul, Div, IntegerDiv, Equals, LessThan, LessThanEquals> value;
 
         friend bool operator==(const BinaryFieldOp&, const BinaryFieldOp&);
+        std::vector<uint8_t> bincodeSerialize() const;
+        static BinaryFieldOp bincodeDeserialize(std::vector<uint8_t>);
+
+        void msgpack_pack(auto& packer) const {
+            std::string tag;
+            bool is_unit;
+            switch (value.index()) {
+                
+                case 0:
+                    tag = "Add";
+                    is_unit = true;
+                    break;
+                case 1:
+                    tag = "Sub";
+                    is_unit = true;
+                    break;
+                case 2:
+                    tag = "Mul";
+                    is_unit = true;
+                    break;
+                case 3:
+                    tag = "Div";
+                    is_unit = true;
+                    break;
+                case 4:
+                    tag = "IntegerDiv";
+                    is_unit = true;
+                    break;
+                case 5:
+                    tag = "Equals";
+                    is_unit = true;
+                    break;
+                case 6:
+                    tag = "LessThan";
+                    is_unit = true;
+                    break;
+                case 7:
+                    tag = "LessThanEquals";
+                    is_unit = true;
+                    break;
+                default:
+                    throw_or_abort("unknown enum 'BinaryFieldOp' variant index: " + std::to_string(value.index()));
+            }
+            if (is_unit) {
+                packer.pack(tag);
+            } else {
+                std::visit([&packer, tag](const auto& arg) {
+                    packer.pack_map(1);
+                    packer.pack(tag);
+                    packer.pack(arg);
+                }, value);
+            }
+        }
 
         void msgpack_unpack(msgpack::object const& o) {
 
@@ -329,79 +407,184 @@ namespace Acir {
 
         struct Add {
             friend bool operator==(const Add&, const Add&);
+            std::vector<uint8_t> bincodeSerialize() const;
+            static Add bincodeDeserialize(std::vector<uint8_t>);
 
+            void msgpack_pack(auto& packer) const {}
             void msgpack_unpack(msgpack::object const& o) {}
         };
 
         struct Sub {
             friend bool operator==(const Sub&, const Sub&);
+            std::vector<uint8_t> bincodeSerialize() const;
+            static Sub bincodeDeserialize(std::vector<uint8_t>);
 
+            void msgpack_pack(auto& packer) const {}
             void msgpack_unpack(msgpack::object const& o) {}
         };
 
         struct Mul {
             friend bool operator==(const Mul&, const Mul&);
+            std::vector<uint8_t> bincodeSerialize() const;
+            static Mul bincodeDeserialize(std::vector<uint8_t>);
 
+            void msgpack_pack(auto& packer) const {}
             void msgpack_unpack(msgpack::object const& o) {}
         };
 
         struct Div {
             friend bool operator==(const Div&, const Div&);
+            std::vector<uint8_t> bincodeSerialize() const;
+            static Div bincodeDeserialize(std::vector<uint8_t>);
 
+            void msgpack_pack(auto& packer) const {}
             void msgpack_unpack(msgpack::object const& o) {}
         };
 
         struct Equals {
             friend bool operator==(const Equals&, const Equals&);
+            std::vector<uint8_t> bincodeSerialize() const;
+            static Equals bincodeDeserialize(std::vector<uint8_t>);
 
+            void msgpack_pack(auto& packer) const {}
             void msgpack_unpack(msgpack::object const& o) {}
         };
 
         struct LessThan {
             friend bool operator==(const LessThan&, const LessThan&);
+            std::vector<uint8_t> bincodeSerialize() const;
+            static LessThan bincodeDeserialize(std::vector<uint8_t>);
 
+            void msgpack_pack(auto& packer) const {}
             void msgpack_unpack(msgpack::object const& o) {}
         };
 
         struct LessThanEquals {
             friend bool operator==(const LessThanEquals&, const LessThanEquals&);
+            std::vector<uint8_t> bincodeSerialize() const;
+            static LessThanEquals bincodeDeserialize(std::vector<uint8_t>);
 
+            void msgpack_pack(auto& packer) const {}
             void msgpack_unpack(msgpack::object const& o) {}
         };
 
         struct And {
             friend bool operator==(const And&, const And&);
+            std::vector<uint8_t> bincodeSerialize() const;
+            static And bincodeDeserialize(std::vector<uint8_t>);
 
+            void msgpack_pack(auto& packer) const {}
             void msgpack_unpack(msgpack::object const& o) {}
         };
 
         struct Or {
             friend bool operator==(const Or&, const Or&);
+            std::vector<uint8_t> bincodeSerialize() const;
+            static Or bincodeDeserialize(std::vector<uint8_t>);
 
+            void msgpack_pack(auto& packer) const {}
             void msgpack_unpack(msgpack::object const& o) {}
         };
 
         struct Xor {
             friend bool operator==(const Xor&, const Xor&);
+            std::vector<uint8_t> bincodeSerialize() const;
+            static Xor bincodeDeserialize(std::vector<uint8_t>);
 
+            void msgpack_pack(auto& packer) const {}
             void msgpack_unpack(msgpack::object const& o) {}
         };
 
         struct Shl {
             friend bool operator==(const Shl&, const Shl&);
+            std::vector<uint8_t> bincodeSerialize() const;
+            static Shl bincodeDeserialize(std::vector<uint8_t>);
 
+            void msgpack_pack(auto& packer) const {}
             void msgpack_unpack(msgpack::object const& o) {}
         };
 
         struct Shr {
             friend bool operator==(const Shr&, const Shr&);
+            std::vector<uint8_t> bincodeSerialize() const;
+            static Shr bincodeDeserialize(std::vector<uint8_t>);
 
+            void msgpack_pack(auto& packer) const {}
             void msgpack_unpack(msgpack::object const& o) {}
         };
 
         std::variant<Add, Sub, Mul, Div, Equals, LessThan, LessThanEquals, And, Or, Xor, Shl, Shr> value;
 
         friend bool operator==(const BinaryIntOp&, const BinaryIntOp&);
+        std::vector<uint8_t> bincodeSerialize() const;
+        static BinaryIntOp bincodeDeserialize(std::vector<uint8_t>);
+
+        void msgpack_pack(auto& packer) const {
+            std::string tag;
+            bool is_unit;
+            switch (value.index()) {
+                
+                case 0:
+                    tag = "Add";
+                    is_unit = true;
+                    break;
+                case 1:
+                    tag = "Sub";
+                    is_unit = true;
+                    break;
+                case 2:
+                    tag = "Mul";
+                    is_unit = true;
+                    break;
+                case 3:
+                    tag = "Div";
+                    is_unit = true;
+                    break;
+                case 4:
+                    tag = "Equals";
+                    is_unit = true;
+                    break;
+                case 5:
+                    tag = "LessThan";
+                    is_unit = true;
+                    break;
+                case 6:
+                    tag = "LessThanEquals";
+                    is_unit = true;
+                    break;
+                case 7:
+                    tag = "And";
+                    is_unit = true;
+                    break;
+                case 8:
+                    tag = "Or";
+                    is_unit = true;
+                    break;
+                case 9:
+                    tag = "Xor";
+                    is_unit = true;
+                    break;
+                case 10:
+                    tag = "Shl";
+                    is_unit = true;
+                    break;
+                case 11:
+                    tag = "Shr";
+                    is_unit = true;
+                    break;
+                default:
+                    throw_or_abort("unknown enum 'BinaryIntOp' variant index: " + std::to_string(value.index()));
+            }
+            if (is_unit) {
+                packer.pack(tag);
+            } else {
+                std::visit([&packer, tag](const auto& arg) {
+                    packer.pack_map(1);
+                    packer.pack(tag);
+                    packer.pack(arg);
+                }, value);
+            }
+        }
 
         void msgpack_unpack(msgpack::object const& o) {
 
@@ -560,43 +743,106 @@ namespace Acir {
 
         struct U1 {
             friend bool operator==(const U1&, const U1&);
+            std::vector<uint8_t> bincodeSerialize() const;
+            static U1 bincodeDeserialize(std::vector<uint8_t>);
 
+            void msgpack_pack(auto& packer) const {}
             void msgpack_unpack(msgpack::object const& o) {}
         };
 
         struct U8 {
             friend bool operator==(const U8&, const U8&);
+            std::vector<uint8_t> bincodeSerialize() const;
+            static U8 bincodeDeserialize(std::vector<uint8_t>);
 
+            void msgpack_pack(auto& packer) const {}
             void msgpack_unpack(msgpack::object const& o) {}
         };
 
         struct U16 {
             friend bool operator==(const U16&, const U16&);
+            std::vector<uint8_t> bincodeSerialize() const;
+            static U16 bincodeDeserialize(std::vector<uint8_t>);
 
+            void msgpack_pack(auto& packer) const {}
             void msgpack_unpack(msgpack::object const& o) {}
         };
 
         struct U32 {
             friend bool operator==(const U32&, const U32&);
+            std::vector<uint8_t> bincodeSerialize() const;
+            static U32 bincodeDeserialize(std::vector<uint8_t>);
 
+            void msgpack_pack(auto& packer) const {}
             void msgpack_unpack(msgpack::object const& o) {}
         };
 
         struct U64 {
             friend bool operator==(const U64&, const U64&);
+            std::vector<uint8_t> bincodeSerialize() const;
+            static U64 bincodeDeserialize(std::vector<uint8_t>);
 
+            void msgpack_pack(auto& packer) const {}
             void msgpack_unpack(msgpack::object const& o) {}
         };
 
         struct U128 {
             friend bool operator==(const U128&, const U128&);
+            std::vector<uint8_t> bincodeSerialize() const;
+            static U128 bincodeDeserialize(std::vector<uint8_t>);
 
+            void msgpack_pack(auto& packer) const {}
             void msgpack_unpack(msgpack::object const& o) {}
         };
 
         std::variant<U1, U8, U16, U32, U64, U128> value;
 
         friend bool operator==(const IntegerBitSize&, const IntegerBitSize&);
+        std::vector<uint8_t> bincodeSerialize() const;
+        static IntegerBitSize bincodeDeserialize(std::vector<uint8_t>);
+
+        void msgpack_pack(auto& packer) const {
+            std::string tag;
+            bool is_unit;
+            switch (value.index()) {
+                
+                case 0:
+                    tag = "U1";
+                    is_unit = true;
+                    break;
+                case 1:
+                    tag = "U8";
+                    is_unit = true;
+                    break;
+                case 2:
+                    tag = "U16";
+                    is_unit = true;
+                    break;
+                case 3:
+                    tag = "U32";
+                    is_unit = true;
+                    break;
+                case 4:
+                    tag = "U64";
+                    is_unit = true;
+                    break;
+                case 5:
+                    tag = "U128";
+                    is_unit = true;
+                    break;
+                default:
+                    throw_or_abort("unknown enum 'IntegerBitSize' variant index: " + std::to_string(value.index()));
+            }
+            if (is_unit) {
+                packer.pack(tag);
+            } else {
+                std::visit([&packer, tag](const auto& arg) {
+                    packer.pack_map(1);
+                    packer.pack(tag);
+                    packer.pack(arg);
+                }, value);
+            }
+        }
 
         void msgpack_unpack(msgpack::object const& o) {
 
@@ -701,7 +947,10 @@ namespace Acir {
 
         struct Field {
             friend bool operator==(const Field&, const Field&);
+            std::vector<uint8_t> bincodeSerialize() const;
+            static Field bincodeDeserialize(std::vector<uint8_t>);
 
+            void msgpack_pack(auto& packer) const {}
             void msgpack_unpack(msgpack::object const& o) {}
         };
 
@@ -709,6 +958,10 @@ namespace Acir {
             Acir::IntegerBitSize value;
 
             friend bool operator==(const Integer&, const Integer&);
+            std::vector<uint8_t> bincodeSerialize() const;
+            static Integer bincodeDeserialize(std::vector<uint8_t>);
+
+            void msgpack_pack(auto& packer) const { packer.pack(value); }
 
             void msgpack_unpack(msgpack::object const& o) {
                 try {
@@ -723,6 +976,35 @@ namespace Acir {
         std::variant<Field, Integer> value;
 
         friend bool operator==(const BitSize&, const BitSize&);
+        std::vector<uint8_t> bincodeSerialize() const;
+        static BitSize bincodeDeserialize(std::vector<uint8_t>);
+
+        void msgpack_pack(auto& packer) const {
+            std::string tag;
+            bool is_unit;
+            switch (value.index()) {
+                
+                case 0:
+                    tag = "Field";
+                    is_unit = true;
+                    break;
+                case 1:
+                    tag = "Integer";
+                    is_unit = false;
+                    break;
+                default:
+                    throw_or_abort("unknown enum 'BitSize' variant index: " + std::to_string(value.index()));
+            }
+            if (is_unit) {
+                packer.pack(tag);
+            } else {
+                std::visit([&packer, tag](const auto& arg) {
+                    packer.pack_map(1);
+                    packer.pack(tag);
+                    packer.pack(arg);
+                }, value);
+            }
+        }
 
         void msgpack_unpack(msgpack::object const& o) {
 
@@ -806,6 +1088,10 @@ namespace Acir {
             uint32_t value;
 
             friend bool operator==(const Direct&, const Direct&);
+            std::vector<uint8_t> bincodeSerialize() const;
+            static Direct bincodeDeserialize(std::vector<uint8_t>);
+
+            void msgpack_pack(auto& packer) const { packer.pack(value); }
 
             void msgpack_unpack(msgpack::object const& o) {
                 try {
@@ -821,6 +1107,10 @@ namespace Acir {
             uint32_t value;
 
             friend bool operator==(const Relative&, const Relative&);
+            std::vector<uint8_t> bincodeSerialize() const;
+            static Relative bincodeDeserialize(std::vector<uint8_t>);
+
+            void msgpack_pack(auto& packer) const { packer.pack(value); }
 
             void msgpack_unpack(msgpack::object const& o) {
                 try {
@@ -835,6 +1125,35 @@ namespace Acir {
         std::variant<Direct, Relative> value;
 
         friend bool operator==(const MemoryAddress&, const MemoryAddress&);
+        std::vector<uint8_t> bincodeSerialize() const;
+        static MemoryAddress bincodeDeserialize(std::vector<uint8_t>);
+
+        void msgpack_pack(auto& packer) const {
+            std::string tag;
+            bool is_unit;
+            switch (value.index()) {
+                
+                case 0:
+                    tag = "Direct";
+                    is_unit = false;
+                    break;
+                case 1:
+                    tag = "Relative";
+                    is_unit = false;
+                    break;
+                default:
+                    throw_or_abort("unknown enum 'MemoryAddress' variant index: " + std::to_string(value.index()));
+            }
+            if (is_unit) {
+                packer.pack(tag);
+            } else {
+                std::visit([&packer, tag](const auto& arg) {
+                    packer.pack_map(1);
+                    packer.pack(tag);
+                    packer.pack(arg);
+                }, value);
+            }
+        }
 
         void msgpack_unpack(msgpack::object const& o) {
 
@@ -929,6 +1248,10 @@ namespace Acir {
         uint32_t value;
 
         friend bool operator==(const SemiFlattenedLength&, const SemiFlattenedLength&);
+        std::vector<uint8_t> bincodeSerialize() const;
+        static SemiFlattenedLength bincodeDeserialize(std::vector<uint8_t>);
+
+        void msgpack_pack(auto& packer) const { packer.pack(value); }
 
         void msgpack_unpack(msgpack::object const& o) {
             try {
@@ -945,6 +1268,14 @@ namespace Acir {
         Acir::SemiFlattenedLength size;
 
         friend bool operator==(const HeapArray&, const HeapArray&);
+        std::vector<uint8_t> bincodeSerialize() const;
+        static HeapArray bincodeDeserialize(std::vector<uint8_t>);
+
+        void msgpack_pack(auto& packer) const {
+            packer.pack_map(2);
+            packer.pack(std::make_pair("pointer", pointer));
+            packer.pack(std::make_pair("size", size));
+        }
 
         void msgpack_unpack(msgpack::object const& o) {
             std::string name = "HeapArray";
@@ -989,6 +1320,16 @@ namespace Acir {
             Acir::HeapArray outputs;
 
             friend bool operator==(const AES128Encrypt&, const AES128Encrypt&);
+            std::vector<uint8_t> bincodeSerialize() const;
+            static AES128Encrypt bincodeDeserialize(std::vector<uint8_t>);
+
+            void msgpack_pack(auto& packer) const {
+                packer.pack_map(4);
+                packer.pack(std::make_pair("inputs", inputs));
+                packer.pack(std::make_pair("iv", iv));
+                packer.pack(std::make_pair("key", key));
+                packer.pack(std::make_pair("outputs", outputs));
+            }
 
             void msgpack_unpack(msgpack::object const& o) {
                 std::string name = "AES128Encrypt";
@@ -1039,6 +1380,14 @@ namespace Acir {
             Acir::HeapArray output;
 
             friend bool operator==(const Blake2s&, const Blake2s&);
+            std::vector<uint8_t> bincodeSerialize() const;
+            static Blake2s bincodeDeserialize(std::vector<uint8_t>);
+
+            void msgpack_pack(auto& packer) const {
+                packer.pack_map(2);
+                packer.pack(std::make_pair("message", message));
+                packer.pack(std::make_pair("output", output));
+            }
 
             void msgpack_unpack(msgpack::object const& o) {
                 std::string name = "Blake2s";
@@ -1079,6 +1428,14 @@ namespace Acir {
             Acir::HeapArray output;
 
             friend bool operator==(const Blake3&, const Blake3&);
+            std::vector<uint8_t> bincodeSerialize() const;
+            static Blake3 bincodeDeserialize(std::vector<uint8_t>);
+
+            void msgpack_pack(auto& packer) const {
+                packer.pack_map(2);
+                packer.pack(std::make_pair("message", message));
+                packer.pack(std::make_pair("output", output));
+            }
 
             void msgpack_unpack(msgpack::object const& o) {
                 std::string name = "Blake3";
@@ -1119,6 +1476,14 @@ namespace Acir {
             Acir::HeapArray output;
 
             friend bool operator==(const Keccakf1600&, const Keccakf1600&);
+            std::vector<uint8_t> bincodeSerialize() const;
+            static Keccakf1600 bincodeDeserialize(std::vector<uint8_t>);
+
+            void msgpack_pack(auto& packer) const {
+                packer.pack_map(2);
+                packer.pack(std::make_pair("input", input));
+                packer.pack(std::make_pair("output", output));
+            }
 
             void msgpack_unpack(msgpack::object const& o) {
                 std::string name = "Keccakf1600";
@@ -1162,6 +1527,17 @@ namespace Acir {
             Acir::MemoryAddress result;
 
             friend bool operator==(const EcdsaSecp256k1&, const EcdsaSecp256k1&);
+            std::vector<uint8_t> bincodeSerialize() const;
+            static EcdsaSecp256k1 bincodeDeserialize(std::vector<uint8_t>);
+
+            void msgpack_pack(auto& packer) const {
+                packer.pack_map(5);
+                packer.pack(std::make_pair("hashed_msg", hashed_msg));
+                packer.pack(std::make_pair("public_key_x", public_key_x));
+                packer.pack(std::make_pair("public_key_y", public_key_y));
+                packer.pack(std::make_pair("signature", signature));
+                packer.pack(std::make_pair("result", result));
+            }
 
             void msgpack_unpack(msgpack::object const& o) {
                 std::string name = "EcdsaSecp256k1";
@@ -1220,6 +1596,17 @@ namespace Acir {
             Acir::MemoryAddress result;
 
             friend bool operator==(const EcdsaSecp256r1&, const EcdsaSecp256r1&);
+            std::vector<uint8_t> bincodeSerialize() const;
+            static EcdsaSecp256r1 bincodeDeserialize(std::vector<uint8_t>);
+
+            void msgpack_pack(auto& packer) const {
+                packer.pack_map(5);
+                packer.pack(std::make_pair("hashed_msg", hashed_msg));
+                packer.pack(std::make_pair("public_key_x", public_key_x));
+                packer.pack(std::make_pair("public_key_y", public_key_y));
+                packer.pack(std::make_pair("signature", signature));
+                packer.pack(std::make_pair("result", result));
+            }
 
             void msgpack_unpack(msgpack::object const& o) {
                 std::string name = "EcdsaSecp256r1";
@@ -1276,6 +1663,15 @@ namespace Acir {
             Acir::HeapArray outputs;
 
             friend bool operator==(const MultiScalarMul&, const MultiScalarMul&);
+            std::vector<uint8_t> bincodeSerialize() const;
+            static MultiScalarMul bincodeDeserialize(std::vector<uint8_t>);
+
+            void msgpack_pack(auto& packer) const {
+                packer.pack_map(3);
+                packer.pack(std::make_pair("points", points));
+                packer.pack(std::make_pair("scalars", scalars));
+                packer.pack(std::make_pair("outputs", outputs));
+            }
 
             void msgpack_unpack(msgpack::object const& o) {
                 std::string name = "MultiScalarMul";
@@ -1326,6 +1722,19 @@ namespace Acir {
             Acir::HeapArray result;
 
             friend bool operator==(const EmbeddedCurveAdd&, const EmbeddedCurveAdd&);
+            std::vector<uint8_t> bincodeSerialize() const;
+            static EmbeddedCurveAdd bincodeDeserialize(std::vector<uint8_t>);
+
+            void msgpack_pack(auto& packer) const {
+                packer.pack_map(7);
+                packer.pack(std::make_pair("input1_x", input1_x));
+                packer.pack(std::make_pair("input1_y", input1_y));
+                packer.pack(std::make_pair("input1_infinite", input1_infinite));
+                packer.pack(std::make_pair("input2_x", input2_x));
+                packer.pack(std::make_pair("input2_y", input2_y));
+                packer.pack(std::make_pair("input2_infinite", input2_infinite));
+                packer.pack(std::make_pair("result", result));
+            }
 
             void msgpack_unpack(msgpack::object const& o) {
                 std::string name = "EmbeddedCurveAdd";
@@ -1391,6 +1800,14 @@ namespace Acir {
             Acir::HeapArray output;
 
             friend bool operator==(const Poseidon2Permutation&, const Poseidon2Permutation&);
+            std::vector<uint8_t> bincodeSerialize() const;
+            static Poseidon2Permutation bincodeDeserialize(std::vector<uint8_t>);
+
+            void msgpack_pack(auto& packer) const {
+                packer.pack_map(2);
+                packer.pack(std::make_pair("message", message));
+                packer.pack(std::make_pair("output", output));
+            }
 
             void msgpack_unpack(msgpack::object const& o) {
                 std::string name = "Poseidon2Permutation";
@@ -1432,6 +1849,15 @@ namespace Acir {
             Acir::HeapArray output;
 
             friend bool operator==(const Sha256Compression&, const Sha256Compression&);
+            std::vector<uint8_t> bincodeSerialize() const;
+            static Sha256Compression bincodeDeserialize(std::vector<uint8_t>);
+
+            void msgpack_pack(auto& packer) const {
+                packer.pack_map(3);
+                packer.pack(std::make_pair("input", input));
+                packer.pack(std::make_pair("hash_values", hash_values));
+                packer.pack(std::make_pair("output", output));
+            }
 
             void msgpack_unpack(msgpack::object const& o) {
                 std::string name = "Sha256Compression";
@@ -1480,6 +1906,17 @@ namespace Acir {
             Acir::MemoryAddress output_bits;
 
             friend bool operator==(const ToRadix&, const ToRadix&);
+            std::vector<uint8_t> bincodeSerialize() const;
+            static ToRadix bincodeDeserialize(std::vector<uint8_t>);
+
+            void msgpack_pack(auto& packer) const {
+                packer.pack_map(5);
+                packer.pack(std::make_pair("input", input));
+                packer.pack(std::make_pair("radix", radix));
+                packer.pack(std::make_pair("output_pointer", output_pointer));
+                packer.pack(std::make_pair("num_limbs", num_limbs));
+                packer.pack(std::make_pair("output_bits", output_bits));
+            }
 
             void msgpack_unpack(msgpack::object const& o) {
                 std::string name = "ToRadix";
@@ -1533,6 +1970,71 @@ namespace Acir {
         std::variant<AES128Encrypt, Blake2s, Blake3, Keccakf1600, EcdsaSecp256k1, EcdsaSecp256r1, MultiScalarMul, EmbeddedCurveAdd, Poseidon2Permutation, Sha256Compression, ToRadix> value;
 
         friend bool operator==(const BlackBoxOp&, const BlackBoxOp&);
+        std::vector<uint8_t> bincodeSerialize() const;
+        static BlackBoxOp bincodeDeserialize(std::vector<uint8_t>);
+
+        void msgpack_pack(auto& packer) const {
+            std::string tag;
+            bool is_unit;
+            switch (value.index()) {
+                
+                case 0:
+                    tag = "AES128Encrypt";
+                    is_unit = false;
+                    break;
+                case 1:
+                    tag = "Blake2s";
+                    is_unit = false;
+                    break;
+                case 2:
+                    tag = "Blake3";
+                    is_unit = false;
+                    break;
+                case 3:
+                    tag = "Keccakf1600";
+                    is_unit = false;
+                    break;
+                case 4:
+                    tag = "EcdsaSecp256k1";
+                    is_unit = false;
+                    break;
+                case 5:
+                    tag = "EcdsaSecp256r1";
+                    is_unit = false;
+                    break;
+                case 6:
+                    tag = "MultiScalarMul";
+                    is_unit = false;
+                    break;
+                case 7:
+                    tag = "EmbeddedCurveAdd";
+                    is_unit = false;
+                    break;
+                case 8:
+                    tag = "Poseidon2Permutation";
+                    is_unit = false;
+                    break;
+                case 9:
+                    tag = "Sha256Compression";
+                    is_unit = false;
+                    break;
+                case 10:
+                    tag = "ToRadix";
+                    is_unit = false;
+                    break;
+                default:
+                    throw_or_abort("unknown enum 'BlackBoxOp' variant index: " + std::to_string(value.index()));
+            }
+            if (is_unit) {
+                packer.pack(tag);
+            } else {
+                std::visit([&packer, tag](const auto& arg) {
+                    packer.pack_map(1);
+                    packer.pack(tag);
+                    packer.pack(arg);
+                }, value);
+            }
+        }
 
         void msgpack_unpack(msgpack::object const& o) {
 
@@ -1825,6 +2327,10 @@ namespace Acir {
         uint32_t value;
 
         friend bool operator==(const SemanticLength&, const SemanticLength&);
+        std::vector<uint8_t> bincodeSerialize() const;
+        static SemanticLength bincodeDeserialize(std::vector<uint8_t>);
+
+        void msgpack_pack(auto& packer) const { packer.pack(value); }
 
         void msgpack_unpack(msgpack::object const& o) {
             try {
@@ -1844,6 +2350,10 @@ namespace Acir {
             Acir::BitSize value;
 
             friend bool operator==(const Simple&, const Simple&);
+            std::vector<uint8_t> bincodeSerialize() const;
+            static Simple bincodeDeserialize(std::vector<uint8_t>);
+
+            void msgpack_pack(auto& packer) const { packer.pack(value); }
 
             void msgpack_unpack(msgpack::object const& o) {
                 try {
@@ -1860,6 +2370,14 @@ namespace Acir {
             Acir::SemanticLength size;
 
             friend bool operator==(const Array&, const Array&);
+            std::vector<uint8_t> bincodeSerialize() const;
+            static Array bincodeDeserialize(std::vector<uint8_t>);
+
+            void msgpack_pack(auto& packer) const {
+                packer.pack_map(2);
+                packer.pack(std::make_pair("value_types", value_types));
+                packer.pack(std::make_pair("size", size));
+            }
 
             void msgpack_unpack(msgpack::object const& o) {
                 std::string name = "Array";
@@ -1899,6 +2417,13 @@ namespace Acir {
             std::vector<Acir::HeapValueType> value_types;
 
             friend bool operator==(const Vector&, const Vector&);
+            std::vector<uint8_t> bincodeSerialize() const;
+            static Vector bincodeDeserialize(std::vector<uint8_t>);
+
+            void msgpack_pack(auto& packer) const {
+                packer.pack_map(1);
+                packer.pack(std::make_pair("value_types", value_types));
+            }
 
             void msgpack_unpack(msgpack::object const& o) {
                 std::string name = "Vector";
@@ -1932,6 +2457,39 @@ namespace Acir {
         std::variant<Simple, Array, Vector> value;
 
         friend bool operator==(const HeapValueType&, const HeapValueType&);
+        std::vector<uint8_t> bincodeSerialize() const;
+        static HeapValueType bincodeDeserialize(std::vector<uint8_t>);
+
+        void msgpack_pack(auto& packer) const {
+            std::string tag;
+            bool is_unit;
+            switch (value.index()) {
+                
+                case 0:
+                    tag = "Simple";
+                    is_unit = false;
+                    break;
+                case 1:
+                    tag = "Array";
+                    is_unit = false;
+                    break;
+                case 2:
+                    tag = "Vector";
+                    is_unit = false;
+                    break;
+                default:
+                    throw_or_abort("unknown enum 'HeapValueType' variant index: " + std::to_string(value.index()));
+            }
+            if (is_unit) {
+                packer.pack(tag);
+            } else {
+                std::visit([&packer, tag](const auto& arg) {
+                    packer.pack_map(1);
+                    packer.pack(tag);
+                    packer.pack(arg);
+                }, value);
+            }
+        }
 
         void msgpack_unpack(msgpack::object const& o) {
 
@@ -2049,6 +2607,14 @@ namespace Acir {
         Acir::MemoryAddress size;
 
         friend bool operator==(const HeapVector&, const HeapVector&);
+        std::vector<uint8_t> bincodeSerialize() const;
+        static HeapVector bincodeDeserialize(std::vector<uint8_t>);
+
+        void msgpack_pack(auto& packer) const {
+            packer.pack_map(2);
+            packer.pack(std::make_pair("pointer", pointer));
+            packer.pack(std::make_pair("size", size));
+        }
 
         void msgpack_unpack(msgpack::object const& o) {
             std::string name = "HeapVector";
@@ -2090,6 +2656,10 @@ namespace Acir {
             Acir::MemoryAddress value;
 
             friend bool operator==(const MemoryAddress&, const MemoryAddress&);
+            std::vector<uint8_t> bincodeSerialize() const;
+            static MemoryAddress bincodeDeserialize(std::vector<uint8_t>);
+
+            void msgpack_pack(auto& packer) const { packer.pack(value); }
 
             void msgpack_unpack(msgpack::object const& o) {
                 try {
@@ -2105,6 +2675,10 @@ namespace Acir {
             Acir::HeapArray value;
 
             friend bool operator==(const HeapArray&, const HeapArray&);
+            std::vector<uint8_t> bincodeSerialize() const;
+            static HeapArray bincodeDeserialize(std::vector<uint8_t>);
+
+            void msgpack_pack(auto& packer) const { packer.pack(value); }
 
             void msgpack_unpack(msgpack::object const& o) {
                 try {
@@ -2120,6 +2694,10 @@ namespace Acir {
             Acir::HeapVector value;
 
             friend bool operator==(const HeapVector&, const HeapVector&);
+            std::vector<uint8_t> bincodeSerialize() const;
+            static HeapVector bincodeDeserialize(std::vector<uint8_t>);
+
+            void msgpack_pack(auto& packer) const { packer.pack(value); }
 
             void msgpack_unpack(msgpack::object const& o) {
                 try {
@@ -2134,6 +2712,39 @@ namespace Acir {
         std::variant<MemoryAddress, HeapArray, HeapVector> value;
 
         friend bool operator==(const ValueOrArray&, const ValueOrArray&);
+        std::vector<uint8_t> bincodeSerialize() const;
+        static ValueOrArray bincodeDeserialize(std::vector<uint8_t>);
+
+        void msgpack_pack(auto& packer) const {
+            std::string tag;
+            bool is_unit;
+            switch (value.index()) {
+                
+                case 0:
+                    tag = "MemoryAddress";
+                    is_unit = false;
+                    break;
+                case 1:
+                    tag = "HeapArray";
+                    is_unit = false;
+                    break;
+                case 2:
+                    tag = "HeapVector";
+                    is_unit = false;
+                    break;
+                default:
+                    throw_or_abort("unknown enum 'ValueOrArray' variant index: " + std::to_string(value.index()));
+            }
+            if (is_unit) {
+                packer.pack(tag);
+            } else {
+                std::visit([&packer, tag](const auto& arg) {
+                    packer.pack_map(1);
+                    packer.pack(tag);
+                    packer.pack(arg);
+                }, value);
+            }
+        }
 
         void msgpack_unpack(msgpack::object const& o) {
 
@@ -2255,6 +2866,16 @@ namespace Acir {
             Acir::MemoryAddress rhs;
 
             friend bool operator==(const BinaryFieldOp&, const BinaryFieldOp&);
+            std::vector<uint8_t> bincodeSerialize() const;
+            static BinaryFieldOp bincodeDeserialize(std::vector<uint8_t>);
+
+            void msgpack_pack(auto& packer) const {
+                packer.pack_map(4);
+                packer.pack(std::make_pair("destination", destination));
+                packer.pack(std::make_pair("op", op));
+                packer.pack(std::make_pair("lhs", lhs));
+                packer.pack(std::make_pair("rhs", rhs));
+            }
 
             void msgpack_unpack(msgpack::object const& o) {
                 std::string name = "BinaryFieldOp";
@@ -2308,6 +2929,17 @@ namespace Acir {
             Acir::MemoryAddress rhs;
 
             friend bool operator==(const BinaryIntOp&, const BinaryIntOp&);
+            std::vector<uint8_t> bincodeSerialize() const;
+            static BinaryIntOp bincodeDeserialize(std::vector<uint8_t>);
+
+            void msgpack_pack(auto& packer) const {
+                packer.pack_map(5);
+                packer.pack(std::make_pair("destination", destination));
+                packer.pack(std::make_pair("op", op));
+                packer.pack(std::make_pair("bit_size", bit_size));
+                packer.pack(std::make_pair("lhs", lhs));
+                packer.pack(std::make_pair("rhs", rhs));
+            }
 
             void msgpack_unpack(msgpack::object const& o) {
                 std::string name = "BinaryIntOp";
@@ -2364,6 +2996,15 @@ namespace Acir {
             Acir::IntegerBitSize bit_size;
 
             friend bool operator==(const Not&, const Not&);
+            std::vector<uint8_t> bincodeSerialize() const;
+            static Not bincodeDeserialize(std::vector<uint8_t>);
+
+            void msgpack_pack(auto& packer) const {
+                packer.pack_map(3);
+                packer.pack(std::make_pair("destination", destination));
+                packer.pack(std::make_pair("source", source));
+                packer.pack(std::make_pair("bit_size", bit_size));
+            }
 
             void msgpack_unpack(msgpack::object const& o) {
                 std::string name = "Not";
@@ -2410,6 +3051,15 @@ namespace Acir {
             Acir::BitSize bit_size;
 
             friend bool operator==(const Cast&, const Cast&);
+            std::vector<uint8_t> bincodeSerialize() const;
+            static Cast bincodeDeserialize(std::vector<uint8_t>);
+
+            void msgpack_pack(auto& packer) const {
+                packer.pack_map(3);
+                packer.pack(std::make_pair("destination", destination));
+                packer.pack(std::make_pair("source", source));
+                packer.pack(std::make_pair("bit_size", bit_size));
+            }
 
             void msgpack_unpack(msgpack::object const& o) {
                 std::string name = "Cast";
@@ -2455,6 +3105,14 @@ namespace Acir {
             uint64_t location;
 
             friend bool operator==(const JumpIf&, const JumpIf&);
+            std::vector<uint8_t> bincodeSerialize() const;
+            static JumpIf bincodeDeserialize(std::vector<uint8_t>);
+
+            void msgpack_pack(auto& packer) const {
+                packer.pack_map(2);
+                packer.pack(std::make_pair("condition", condition));
+                packer.pack(std::make_pair("location", location));
+            }
 
             void msgpack_unpack(msgpack::object const& o) {
                 std::string name = "JumpIf";
@@ -2494,6 +3152,13 @@ namespace Acir {
             uint64_t location;
 
             friend bool operator==(const Jump&, const Jump&);
+            std::vector<uint8_t> bincodeSerialize() const;
+            static Jump bincodeDeserialize(std::vector<uint8_t>);
+
+            void msgpack_pack(auto& packer) const {
+                packer.pack_map(1);
+                packer.pack(std::make_pair("location", location));
+            }
 
             void msgpack_unpack(msgpack::object const& o) {
                 std::string name = "Jump";
@@ -2530,6 +3195,15 @@ namespace Acir {
             Acir::MemoryAddress offset_address;
 
             friend bool operator==(const CalldataCopy&, const CalldataCopy&);
+            std::vector<uint8_t> bincodeSerialize() const;
+            static CalldataCopy bincodeDeserialize(std::vector<uint8_t>);
+
+            void msgpack_pack(auto& packer) const {
+                packer.pack_map(3);
+                packer.pack(std::make_pair("destination_address", destination_address));
+                packer.pack(std::make_pair("size_address", size_address));
+                packer.pack(std::make_pair("offset_address", offset_address));
+            }
 
             void msgpack_unpack(msgpack::object const& o) {
                 std::string name = "CalldataCopy";
@@ -2574,6 +3248,13 @@ namespace Acir {
             uint64_t location;
 
             friend bool operator==(const Call&, const Call&);
+            std::vector<uint8_t> bincodeSerialize() const;
+            static Call bincodeDeserialize(std::vector<uint8_t>);
+
+            void msgpack_pack(auto& packer) const {
+                packer.pack_map(1);
+                packer.pack(std::make_pair("location", location));
+            }
 
             void msgpack_unpack(msgpack::object const& o) {
                 std::string name = "Call";
@@ -2610,6 +3291,15 @@ namespace Acir {
             std::vector<uint8_t> value;
 
             friend bool operator==(const Const&, const Const&);
+            std::vector<uint8_t> bincodeSerialize() const;
+            static Const bincodeDeserialize(std::vector<uint8_t>);
+
+            void msgpack_pack(auto& packer) const {
+                packer.pack_map(3);
+                packer.pack(std::make_pair("destination", destination));
+                packer.pack(std::make_pair("bit_size", bit_size));
+                packer.pack(std::make_pair("value", value));
+            }
 
             void msgpack_unpack(msgpack::object const& o) {
                 std::string name = "Const";
@@ -2656,6 +3346,15 @@ namespace Acir {
             std::vector<uint8_t> value;
 
             friend bool operator==(const IndirectConst&, const IndirectConst&);
+            std::vector<uint8_t> bincodeSerialize() const;
+            static IndirectConst bincodeDeserialize(std::vector<uint8_t>);
+
+            void msgpack_pack(auto& packer) const {
+                packer.pack_map(3);
+                packer.pack(std::make_pair("destination_pointer", destination_pointer));
+                packer.pack(std::make_pair("bit_size", bit_size));
+                packer.pack(std::make_pair("value", value));
+            }
 
             void msgpack_unpack(msgpack::object const& o) {
                 std::string name = "IndirectConst";
@@ -2698,7 +3397,10 @@ namespace Acir {
 
         struct Return {
             friend bool operator==(const Return&, const Return&);
+            std::vector<uint8_t> bincodeSerialize() const;
+            static Return bincodeDeserialize(std::vector<uint8_t>);
 
+            void msgpack_pack(auto& packer) const {}
             void msgpack_unpack(msgpack::object const& o) {}
         };
 
@@ -2710,6 +3412,17 @@ namespace Acir {
             std::vector<Acir::HeapValueType> input_value_types;
 
             friend bool operator==(const ForeignCall&, const ForeignCall&);
+            std::vector<uint8_t> bincodeSerialize() const;
+            static ForeignCall bincodeDeserialize(std::vector<uint8_t>);
+
+            void msgpack_pack(auto& packer) const {
+                packer.pack_map(5);
+                packer.pack(std::make_pair("function", function));
+                packer.pack(std::make_pair("destinations", destinations));
+                packer.pack(std::make_pair("destination_value_types", destination_value_types));
+                packer.pack(std::make_pair("inputs", inputs));
+                packer.pack(std::make_pair("input_value_types", input_value_types));
+            }
 
             void msgpack_unpack(msgpack::object const& o) {
                 std::string name = "ForeignCall";
@@ -2765,6 +3478,14 @@ namespace Acir {
             Acir::MemoryAddress source;
 
             friend bool operator==(const Mov&, const Mov&);
+            std::vector<uint8_t> bincodeSerialize() const;
+            static Mov bincodeDeserialize(std::vector<uint8_t>);
+
+            void msgpack_pack(auto& packer) const {
+                packer.pack_map(2);
+                packer.pack(std::make_pair("destination", destination));
+                packer.pack(std::make_pair("source", source));
+            }
 
             void msgpack_unpack(msgpack::object const& o) {
                 std::string name = "Mov";
@@ -2807,6 +3528,16 @@ namespace Acir {
             Acir::MemoryAddress condition;
 
             friend bool operator==(const ConditionalMov&, const ConditionalMov&);
+            std::vector<uint8_t> bincodeSerialize() const;
+            static ConditionalMov bincodeDeserialize(std::vector<uint8_t>);
+
+            void msgpack_pack(auto& packer) const {
+                packer.pack_map(4);
+                packer.pack(std::make_pair("destination", destination));
+                packer.pack(std::make_pair("source_a", source_a));
+                packer.pack(std::make_pair("source_b", source_b));
+                packer.pack(std::make_pair("condition", condition));
+            }
 
             void msgpack_unpack(msgpack::object const& o) {
                 std::string name = "ConditionalMov";
@@ -2857,6 +3588,14 @@ namespace Acir {
             Acir::MemoryAddress source_pointer;
 
             friend bool operator==(const Load&, const Load&);
+            std::vector<uint8_t> bincodeSerialize() const;
+            static Load bincodeDeserialize(std::vector<uint8_t>);
+
+            void msgpack_pack(auto& packer) const {
+                packer.pack_map(2);
+                packer.pack(std::make_pair("destination", destination));
+                packer.pack(std::make_pair("source_pointer", source_pointer));
+            }
 
             void msgpack_unpack(msgpack::object const& o) {
                 std::string name = "Load";
@@ -2897,6 +3636,14 @@ namespace Acir {
             Acir::MemoryAddress source;
 
             friend bool operator==(const Store&, const Store&);
+            std::vector<uint8_t> bincodeSerialize() const;
+            static Store bincodeDeserialize(std::vector<uint8_t>);
+
+            void msgpack_pack(auto& packer) const {
+                packer.pack_map(2);
+                packer.pack(std::make_pair("destination_pointer", destination_pointer));
+                packer.pack(std::make_pair("source", source));
+            }
 
             void msgpack_unpack(msgpack::object const& o) {
                 std::string name = "Store";
@@ -2936,6 +3683,10 @@ namespace Acir {
             Acir::BlackBoxOp value;
 
             friend bool operator==(const BlackBox&, const BlackBox&);
+            std::vector<uint8_t> bincodeSerialize() const;
+            static BlackBox bincodeDeserialize(std::vector<uint8_t>);
+
+            void msgpack_pack(auto& packer) const { packer.pack(value); }
 
             void msgpack_unpack(msgpack::object const& o) {
                 try {
@@ -2951,6 +3702,13 @@ namespace Acir {
             Acir::HeapVector revert_data;
 
             friend bool operator==(const Trap&, const Trap&);
+            std::vector<uint8_t> bincodeSerialize() const;
+            static Trap bincodeDeserialize(std::vector<uint8_t>);
+
+            void msgpack_pack(auto& packer) const {
+                packer.pack_map(1);
+                packer.pack(std::make_pair("revert_data", revert_data));
+            }
 
             void msgpack_unpack(msgpack::object const& o) {
                 std::string name = "Trap";
@@ -2985,6 +3743,13 @@ namespace Acir {
             Acir::HeapVector return_data;
 
             friend bool operator==(const Stop&, const Stop&);
+            std::vector<uint8_t> bincodeSerialize() const;
+            static Stop bincodeDeserialize(std::vector<uint8_t>);
+
+            void msgpack_pack(auto& packer) const {
+                packer.pack_map(1);
+                packer.pack(std::make_pair("return_data", return_data));
+            }
 
             void msgpack_unpack(msgpack::object const& o) {
                 std::string name = "Stop";
@@ -3018,6 +3783,103 @@ namespace Acir {
         std::variant<BinaryFieldOp, BinaryIntOp, Not, Cast, JumpIf, Jump, CalldataCopy, Call, Const, IndirectConst, Return, ForeignCall, Mov, ConditionalMov, Load, Store, BlackBox, Trap, Stop> value;
 
         friend bool operator==(const BrilligOpcode&, const BrilligOpcode&);
+        std::vector<uint8_t> bincodeSerialize() const;
+        static BrilligOpcode bincodeDeserialize(std::vector<uint8_t>);
+
+        void msgpack_pack(auto& packer) const {
+            std::string tag;
+            bool is_unit;
+            switch (value.index()) {
+                
+                case 0:
+                    tag = "BinaryFieldOp";
+                    is_unit = false;
+                    break;
+                case 1:
+                    tag = "BinaryIntOp";
+                    is_unit = false;
+                    break;
+                case 2:
+                    tag = "Not";
+                    is_unit = false;
+                    break;
+                case 3:
+                    tag = "Cast";
+                    is_unit = false;
+                    break;
+                case 4:
+                    tag = "JumpIf";
+                    is_unit = false;
+                    break;
+                case 5:
+                    tag = "Jump";
+                    is_unit = false;
+                    break;
+                case 6:
+                    tag = "CalldataCopy";
+                    is_unit = false;
+                    break;
+                case 7:
+                    tag = "Call";
+                    is_unit = false;
+                    break;
+                case 8:
+                    tag = "Const";
+                    is_unit = false;
+                    break;
+                case 9:
+                    tag = "IndirectConst";
+                    is_unit = false;
+                    break;
+                case 10:
+                    tag = "Return";
+                    is_unit = true;
+                    break;
+                case 11:
+                    tag = "ForeignCall";
+                    is_unit = false;
+                    break;
+                case 12:
+                    tag = "Mov";
+                    is_unit = false;
+                    break;
+                case 13:
+                    tag = "ConditionalMov";
+                    is_unit = false;
+                    break;
+                case 14:
+                    tag = "Load";
+                    is_unit = false;
+                    break;
+                case 15:
+                    tag = "Store";
+                    is_unit = false;
+                    break;
+                case 16:
+                    tag = "BlackBox";
+                    is_unit = false;
+                    break;
+                case 17:
+                    tag = "Trap";
+                    is_unit = false;
+                    break;
+                case 18:
+                    tag = "Stop";
+                    is_unit = false;
+                    break;
+                default:
+                    throw_or_abort("unknown enum 'BrilligOpcode' variant index: " + std::to_string(value.index()));
+            }
+            if (is_unit) {
+                packer.pack(tag);
+            } else {
+                std::visit([&packer, tag](const auto& arg) {
+                    packer.pack_map(1);
+                    packer.pack(tag);
+                    packer.pack(arg);
+                }, value);
+            }
+        }
 
         void msgpack_unpack(msgpack::object const& o) {
 
@@ -3473,6 +4335,10 @@ namespace Acir {
         uint32_t value;
 
         friend bool operator==(const Witness&, const Witness&);
+        std::vector<uint8_t> bincodeSerialize() const;
+        static Witness bincodeDeserialize(std::vector<uint8_t>);
+
+        void msgpack_pack(auto& packer) const { packer.pack(value); }
 
         void msgpack_unpack(msgpack::object const& o) {
             try {
@@ -3490,6 +4356,10 @@ namespace Acir {
             std::vector<uint8_t> value;
 
             friend bool operator==(const Constant&, const Constant&);
+            std::vector<uint8_t> bincodeSerialize() const;
+            static Constant bincodeDeserialize(std::vector<uint8_t>);
+
+            void msgpack_pack(auto& packer) const { packer.pack(value); }
 
             void msgpack_unpack(msgpack::object const& o) {
                 try {
@@ -3505,6 +4375,10 @@ namespace Acir {
             Acir::Witness value;
 
             friend bool operator==(const Witness&, const Witness&);
+            std::vector<uint8_t> bincodeSerialize() const;
+            static Witness bincodeDeserialize(std::vector<uint8_t>);
+
+            void msgpack_pack(auto& packer) const { packer.pack(value); }
 
             void msgpack_unpack(msgpack::object const& o) {
                 try {
@@ -3519,6 +4393,35 @@ namespace Acir {
         std::variant<Constant, Witness> value;
 
         friend bool operator==(const FunctionInput&, const FunctionInput&);
+        std::vector<uint8_t> bincodeSerialize() const;
+        static FunctionInput bincodeDeserialize(std::vector<uint8_t>);
+
+        void msgpack_pack(auto& packer) const {
+            std::string tag;
+            bool is_unit;
+            switch (value.index()) {
+                
+                case 0:
+                    tag = "Constant";
+                    is_unit = false;
+                    break;
+                case 1:
+                    tag = "Witness";
+                    is_unit = false;
+                    break;
+                default:
+                    throw_or_abort("unknown enum 'FunctionInput' variant index: " + std::to_string(value.index()));
+            }
+            if (is_unit) {
+                packer.pack(tag);
+            } else {
+                std::visit([&packer, tag](const auto& arg) {
+                    packer.pack_map(1);
+                    packer.pack(tag);
+                    packer.pack(arg);
+                }, value);
+            }
+        }
 
         void msgpack_unpack(msgpack::object const& o) {
 
@@ -3618,6 +4521,16 @@ namespace Acir {
             std::vector<Acir::Witness> outputs;
 
             friend bool operator==(const AES128Encrypt&, const AES128Encrypt&);
+            std::vector<uint8_t> bincodeSerialize() const;
+            static AES128Encrypt bincodeDeserialize(std::vector<uint8_t>);
+
+            void msgpack_pack(auto& packer) const {
+                packer.pack_map(4);
+                packer.pack(std::make_pair("inputs", inputs));
+                packer.pack(std::make_pair("iv", iv));
+                packer.pack(std::make_pair("key", key));
+                packer.pack(std::make_pair("outputs", outputs));
+            }
 
             void msgpack_unpack(msgpack::object const& o) {
                 std::string name = "AES128Encrypt";
@@ -3670,6 +4583,16 @@ namespace Acir {
             Acir::Witness output;
 
             friend bool operator==(const AND&, const AND&);
+            std::vector<uint8_t> bincodeSerialize() const;
+            static AND bincodeDeserialize(std::vector<uint8_t>);
+
+            void msgpack_pack(auto& packer) const {
+                packer.pack_map(4);
+                packer.pack(std::make_pair("lhs", lhs));
+                packer.pack(std::make_pair("rhs", rhs));
+                packer.pack(std::make_pair("num_bits", num_bits));
+                packer.pack(std::make_pair("output", output));
+            }
 
             void msgpack_unpack(msgpack::object const& o) {
                 std::string name = "AND";
@@ -3722,6 +4645,16 @@ namespace Acir {
             Acir::Witness output;
 
             friend bool operator==(const XOR&, const XOR&);
+            std::vector<uint8_t> bincodeSerialize() const;
+            static XOR bincodeDeserialize(std::vector<uint8_t>);
+
+            void msgpack_pack(auto& packer) const {
+                packer.pack_map(4);
+                packer.pack(std::make_pair("lhs", lhs));
+                packer.pack(std::make_pair("rhs", rhs));
+                packer.pack(std::make_pair("num_bits", num_bits));
+                packer.pack(std::make_pair("output", output));
+            }
 
             void msgpack_unpack(msgpack::object const& o) {
                 std::string name = "XOR";
@@ -3772,6 +4705,14 @@ namespace Acir {
             uint32_t num_bits;
 
             friend bool operator==(const RANGE&, const RANGE&);
+            std::vector<uint8_t> bincodeSerialize() const;
+            static RANGE bincodeDeserialize(std::vector<uint8_t>);
+
+            void msgpack_pack(auto& packer) const {
+                packer.pack_map(2);
+                packer.pack(std::make_pair("input", input));
+                packer.pack(std::make_pair("num_bits", num_bits));
+            }
 
             void msgpack_unpack(msgpack::object const& o) {
                 std::string name = "RANGE";
@@ -3812,6 +4753,14 @@ namespace Acir {
             std::shared_ptr<std::array<Acir::Witness, 32>> outputs;
 
             friend bool operator==(const Blake2s&, const Blake2s&);
+            std::vector<uint8_t> bincodeSerialize() const;
+            static Blake2s bincodeDeserialize(std::vector<uint8_t>);
+
+            void msgpack_pack(auto& packer) const {
+                packer.pack_map(2);
+                packer.pack(std::make_pair("inputs", inputs));
+                packer.pack(std::make_pair("outputs", outputs));
+            }
 
             void msgpack_unpack(msgpack::object const& o) {
                 std::string name = "Blake2s";
@@ -3852,6 +4801,14 @@ namespace Acir {
             std::shared_ptr<std::array<Acir::Witness, 32>> outputs;
 
             friend bool operator==(const Blake3&, const Blake3&);
+            std::vector<uint8_t> bincodeSerialize() const;
+            static Blake3 bincodeDeserialize(std::vector<uint8_t>);
+
+            void msgpack_pack(auto& packer) const {
+                packer.pack_map(2);
+                packer.pack(std::make_pair("inputs", inputs));
+                packer.pack(std::make_pair("outputs", outputs));
+            }
 
             void msgpack_unpack(msgpack::object const& o) {
                 std::string name = "Blake3";
@@ -3896,6 +4853,18 @@ namespace Acir {
             Acir::Witness output;
 
             friend bool operator==(const EcdsaSecp256k1&, const EcdsaSecp256k1&);
+            std::vector<uint8_t> bincodeSerialize() const;
+            static EcdsaSecp256k1 bincodeDeserialize(std::vector<uint8_t>);
+
+            void msgpack_pack(auto& packer) const {
+                packer.pack_map(6);
+                packer.pack(std::make_pair("public_key_x", public_key_x));
+                packer.pack(std::make_pair("public_key_y", public_key_y));
+                packer.pack(std::make_pair("signature", signature));
+                packer.pack(std::make_pair("hashed_message", hashed_message));
+                packer.pack(std::make_pair("predicate", predicate));
+                packer.pack(std::make_pair("output", output));
+            }
 
             void msgpack_unpack(msgpack::object const& o) {
                 std::string name = "EcdsaSecp256k1";
@@ -3960,6 +4929,18 @@ namespace Acir {
             Acir::Witness output;
 
             friend bool operator==(const EcdsaSecp256r1&, const EcdsaSecp256r1&);
+            std::vector<uint8_t> bincodeSerialize() const;
+            static EcdsaSecp256r1 bincodeDeserialize(std::vector<uint8_t>);
+
+            void msgpack_pack(auto& packer) const {
+                packer.pack_map(6);
+                packer.pack(std::make_pair("public_key_x", public_key_x));
+                packer.pack(std::make_pair("public_key_y", public_key_y));
+                packer.pack(std::make_pair("signature", signature));
+                packer.pack(std::make_pair("hashed_message", hashed_message));
+                packer.pack(std::make_pair("predicate", predicate));
+                packer.pack(std::make_pair("output", output));
+            }
 
             void msgpack_unpack(msgpack::object const& o) {
                 std::string name = "EcdsaSecp256r1";
@@ -4022,6 +5003,16 @@ namespace Acir {
             std::shared_ptr<std::array<Acir::Witness, 3>> outputs;
 
             friend bool operator==(const MultiScalarMul&, const MultiScalarMul&);
+            std::vector<uint8_t> bincodeSerialize() const;
+            static MultiScalarMul bincodeDeserialize(std::vector<uint8_t>);
+
+            void msgpack_pack(auto& packer) const {
+                packer.pack_map(4);
+                packer.pack(std::make_pair("points", points));
+                packer.pack(std::make_pair("scalars", scalars));
+                packer.pack(std::make_pair("predicate", predicate));
+                packer.pack(std::make_pair("outputs", outputs));
+            }
 
             void msgpack_unpack(msgpack::object const& o) {
                 std::string name = "MultiScalarMul";
@@ -4074,6 +5065,16 @@ namespace Acir {
             std::shared_ptr<std::array<Acir::Witness, 3>> outputs;
 
             friend bool operator==(const EmbeddedCurveAdd&, const EmbeddedCurveAdd&);
+            std::vector<uint8_t> bincodeSerialize() const;
+            static EmbeddedCurveAdd bincodeDeserialize(std::vector<uint8_t>);
+
+            void msgpack_pack(auto& packer) const {
+                packer.pack_map(4);
+                packer.pack(std::make_pair("input1", input1));
+                packer.pack(std::make_pair("input2", input2));
+                packer.pack(std::make_pair("predicate", predicate));
+                packer.pack(std::make_pair("outputs", outputs));
+            }
 
             void msgpack_unpack(msgpack::object const& o) {
                 std::string name = "EmbeddedCurveAdd";
@@ -4124,6 +5125,14 @@ namespace Acir {
             std::shared_ptr<std::array<Acir::Witness, 25>> outputs;
 
             friend bool operator==(const Keccakf1600&, const Keccakf1600&);
+            std::vector<uint8_t> bincodeSerialize() const;
+            static Keccakf1600 bincodeDeserialize(std::vector<uint8_t>);
+
+            void msgpack_pack(auto& packer) const {
+                packer.pack_map(2);
+                packer.pack(std::make_pair("inputs", inputs));
+                packer.pack(std::make_pair("outputs", outputs));
+            }
 
             void msgpack_unpack(msgpack::object const& o) {
                 std::string name = "Keccakf1600";
@@ -4168,6 +5177,18 @@ namespace Acir {
             Acir::FunctionInput predicate;
 
             friend bool operator==(const RecursiveAggregation&, const RecursiveAggregation&);
+            std::vector<uint8_t> bincodeSerialize() const;
+            static RecursiveAggregation bincodeDeserialize(std::vector<uint8_t>);
+
+            void msgpack_pack(auto& packer) const {
+                packer.pack_map(6);
+                packer.pack(std::make_pair("verification_key", verification_key));
+                packer.pack(std::make_pair("proof", proof));
+                packer.pack(std::make_pair("public_inputs", public_inputs));
+                packer.pack(std::make_pair("key_hash", key_hash));
+                packer.pack(std::make_pair("proof_type", proof_type));
+                packer.pack(std::make_pair("predicate", predicate));
+            }
 
             void msgpack_unpack(msgpack::object const& o) {
                 std::string name = "RecursiveAggregation";
@@ -4228,6 +5249,14 @@ namespace Acir {
             std::vector<Acir::Witness> outputs;
 
             friend bool operator==(const Poseidon2Permutation&, const Poseidon2Permutation&);
+            std::vector<uint8_t> bincodeSerialize() const;
+            static Poseidon2Permutation bincodeDeserialize(std::vector<uint8_t>);
+
+            void msgpack_pack(auto& packer) const {
+                packer.pack_map(2);
+                packer.pack(std::make_pair("inputs", inputs));
+                packer.pack(std::make_pair("outputs", outputs));
+            }
 
             void msgpack_unpack(msgpack::object const& o) {
                 std::string name = "Poseidon2Permutation";
@@ -4269,6 +5298,15 @@ namespace Acir {
             std::shared_ptr<std::array<Acir::Witness, 8>> outputs;
 
             friend bool operator==(const Sha256Compression&, const Sha256Compression&);
+            std::vector<uint8_t> bincodeSerialize() const;
+            static Sha256Compression bincodeDeserialize(std::vector<uint8_t>);
+
+            void msgpack_pack(auto& packer) const {
+                packer.pack_map(3);
+                packer.pack(std::make_pair("inputs", inputs));
+                packer.pack(std::make_pair("hash_values", hash_values));
+                packer.pack(std::make_pair("outputs", outputs));
+            }
 
             void msgpack_unpack(msgpack::object const& o) {
                 std::string name = "Sha256Compression";
@@ -4312,6 +5350,83 @@ namespace Acir {
         std::variant<AES128Encrypt, AND, XOR, RANGE, Blake2s, Blake3, EcdsaSecp256k1, EcdsaSecp256r1, MultiScalarMul, EmbeddedCurveAdd, Keccakf1600, RecursiveAggregation, Poseidon2Permutation, Sha256Compression> value;
 
         friend bool operator==(const BlackBoxFuncCall&, const BlackBoxFuncCall&);
+        std::vector<uint8_t> bincodeSerialize() const;
+        static BlackBoxFuncCall bincodeDeserialize(std::vector<uint8_t>);
+
+        void msgpack_pack(auto& packer) const {
+            std::string tag;
+            bool is_unit;
+            switch (value.index()) {
+                
+                case 0:
+                    tag = "AES128Encrypt";
+                    is_unit = false;
+                    break;
+                case 1:
+                    tag = "AND";
+                    is_unit = false;
+                    break;
+                case 2:
+                    tag = "XOR";
+                    is_unit = false;
+                    break;
+                case 3:
+                    tag = "RANGE";
+                    is_unit = false;
+                    break;
+                case 4:
+                    tag = "Blake2s";
+                    is_unit = false;
+                    break;
+                case 5:
+                    tag = "Blake3";
+                    is_unit = false;
+                    break;
+                case 6:
+                    tag = "EcdsaSecp256k1";
+                    is_unit = false;
+                    break;
+                case 7:
+                    tag = "EcdsaSecp256r1";
+                    is_unit = false;
+                    break;
+                case 8:
+                    tag = "MultiScalarMul";
+                    is_unit = false;
+                    break;
+                case 9:
+                    tag = "EmbeddedCurveAdd";
+                    is_unit = false;
+                    break;
+                case 10:
+                    tag = "Keccakf1600";
+                    is_unit = false;
+                    break;
+                case 11:
+                    tag = "RecursiveAggregation";
+                    is_unit = false;
+                    break;
+                case 12:
+                    tag = "Poseidon2Permutation";
+                    is_unit = false;
+                    break;
+                case 13:
+                    tag = "Sha256Compression";
+                    is_unit = false;
+                    break;
+                default:
+                    throw_or_abort("unknown enum 'BlackBoxFuncCall' variant index: " + std::to_string(value.index()));
+            }
+            if (is_unit) {
+                packer.pack(tag);
+            } else {
+                std::visit([&packer, tag](const auto& arg) {
+                    packer.pack_map(1);
+                    packer.pack(tag);
+                    packer.pack(arg);
+                }, value);
+            }
+        }
 
         void msgpack_unpack(msgpack::object const& o) {
 
@@ -4670,6 +5785,10 @@ namespace Acir {
         uint32_t value;
 
         friend bool operator==(const BlockId&, const BlockId&);
+        std::vector<uint8_t> bincodeSerialize() const;
+        static BlockId bincodeDeserialize(std::vector<uint8_t>);
+
+        void msgpack_pack(auto& packer) const { packer.pack(value); }
 
         void msgpack_unpack(msgpack::object const& o) {
             try {
@@ -4685,7 +5804,10 @@ namespace Acir {
 
         struct Memory {
             friend bool operator==(const Memory&, const Memory&);
+            std::vector<uint8_t> bincodeSerialize() const;
+            static Memory bincodeDeserialize(std::vector<uint8_t>);
 
+            void msgpack_pack(auto& packer) const {}
             void msgpack_unpack(msgpack::object const& o) {}
         };
 
@@ -4693,6 +5815,10 @@ namespace Acir {
             uint32_t value;
 
             friend bool operator==(const CallData&, const CallData&);
+            std::vector<uint8_t> bincodeSerialize() const;
+            static CallData bincodeDeserialize(std::vector<uint8_t>);
+
+            void msgpack_pack(auto& packer) const { packer.pack(value); }
 
             void msgpack_unpack(msgpack::object const& o) {
                 try {
@@ -4706,13 +5832,49 @@ namespace Acir {
 
         struct ReturnData {
             friend bool operator==(const ReturnData&, const ReturnData&);
+            std::vector<uint8_t> bincodeSerialize() const;
+            static ReturnData bincodeDeserialize(std::vector<uint8_t>);
 
+            void msgpack_pack(auto& packer) const {}
             void msgpack_unpack(msgpack::object const& o) {}
         };
 
         std::variant<Memory, CallData, ReturnData> value;
 
         friend bool operator==(const BlockType&, const BlockType&);
+        std::vector<uint8_t> bincodeSerialize() const;
+        static BlockType bincodeDeserialize(std::vector<uint8_t>);
+
+        void msgpack_pack(auto& packer) const {
+            std::string tag;
+            bool is_unit;
+            switch (value.index()) {
+                
+                case 0:
+                    tag = "Memory";
+                    is_unit = true;
+                    break;
+                case 1:
+                    tag = "CallData";
+                    is_unit = false;
+                    break;
+                case 2:
+                    tag = "ReturnData";
+                    is_unit = true;
+                    break;
+                default:
+                    throw_or_abort("unknown enum 'BlockType' variant index: " + std::to_string(value.index()));
+            }
+            if (is_unit) {
+                packer.pack(tag);
+            } else {
+                std::visit([&packer, tag](const auto& arg) {
+                    packer.pack_map(1);
+                    packer.pack(tag);
+                    packer.pack(arg);
+                }, value);
+            }
+        }
 
         void msgpack_unpack(msgpack::object const& o) {
 
@@ -4805,6 +5967,15 @@ namespace Acir {
         std::vector<uint8_t> q_c;
 
         friend bool operator==(const Expression&, const Expression&);
+        std::vector<uint8_t> bincodeSerialize() const;
+        static Expression bincodeDeserialize(std::vector<uint8_t>);
+
+        void msgpack_pack(auto& packer) const {
+            packer.pack_map(3);
+            packer.pack(std::make_pair("mul_terms", mul_terms));
+            packer.pack(std::make_pair("linear_combinations", linear_combinations));
+            packer.pack(std::make_pair("q_c", q_c));
+        }
 
         void msgpack_unpack(msgpack::object const& o) {
             std::string name = "Expression";
@@ -4851,6 +6022,10 @@ namespace Acir {
             Acir::Expression value;
 
             friend bool operator==(const Single&, const Single&);
+            std::vector<uint8_t> bincodeSerialize() const;
+            static Single bincodeDeserialize(std::vector<uint8_t>);
+
+            void msgpack_pack(auto& packer) const { packer.pack(value); }
 
             void msgpack_unpack(msgpack::object const& o) {
                 try {
@@ -4866,6 +6041,10 @@ namespace Acir {
             std::vector<Acir::Expression> value;
 
             friend bool operator==(const Array&, const Array&);
+            std::vector<uint8_t> bincodeSerialize() const;
+            static Array bincodeDeserialize(std::vector<uint8_t>);
+
+            void msgpack_pack(auto& packer) const { packer.pack(value); }
 
             void msgpack_unpack(msgpack::object const& o) {
                 try {
@@ -4881,6 +6060,10 @@ namespace Acir {
             Acir::BlockId value;
 
             friend bool operator==(const MemoryArray&, const MemoryArray&);
+            std::vector<uint8_t> bincodeSerialize() const;
+            static MemoryArray bincodeDeserialize(std::vector<uint8_t>);
+
+            void msgpack_pack(auto& packer) const { packer.pack(value); }
 
             void msgpack_unpack(msgpack::object const& o) {
                 try {
@@ -4895,6 +6078,39 @@ namespace Acir {
         std::variant<Single, Array, MemoryArray> value;
 
         friend bool operator==(const BrilligInputs&, const BrilligInputs&);
+        std::vector<uint8_t> bincodeSerialize() const;
+        static BrilligInputs bincodeDeserialize(std::vector<uint8_t>);
+
+        void msgpack_pack(auto& packer) const {
+            std::string tag;
+            bool is_unit;
+            switch (value.index()) {
+                
+                case 0:
+                    tag = "Single";
+                    is_unit = false;
+                    break;
+                case 1:
+                    tag = "Array";
+                    is_unit = false;
+                    break;
+                case 2:
+                    tag = "MemoryArray";
+                    is_unit = false;
+                    break;
+                default:
+                    throw_or_abort("unknown enum 'BrilligInputs' variant index: " + std::to_string(value.index()));
+            }
+            if (is_unit) {
+                packer.pack(tag);
+            } else {
+                std::visit([&packer, tag](const auto& arg) {
+                    packer.pack_map(1);
+                    packer.pack(tag);
+                    packer.pack(arg);
+                }, value);
+            }
+        }
 
         void msgpack_unpack(msgpack::object const& o) {
 
@@ -5013,6 +6229,10 @@ namespace Acir {
             Acir::Witness value;
 
             friend bool operator==(const Simple&, const Simple&);
+            std::vector<uint8_t> bincodeSerialize() const;
+            static Simple bincodeDeserialize(std::vector<uint8_t>);
+
+            void msgpack_pack(auto& packer) const { packer.pack(value); }
 
             void msgpack_unpack(msgpack::object const& o) {
                 try {
@@ -5028,6 +6248,10 @@ namespace Acir {
             std::vector<Acir::Witness> value;
 
             friend bool operator==(const Array&, const Array&);
+            std::vector<uint8_t> bincodeSerialize() const;
+            static Array bincodeDeserialize(std::vector<uint8_t>);
+
+            void msgpack_pack(auto& packer) const { packer.pack(value); }
 
             void msgpack_unpack(msgpack::object const& o) {
                 try {
@@ -5042,6 +6266,35 @@ namespace Acir {
         std::variant<Simple, Array> value;
 
         friend bool operator==(const BrilligOutputs&, const BrilligOutputs&);
+        std::vector<uint8_t> bincodeSerialize() const;
+        static BrilligOutputs bincodeDeserialize(std::vector<uint8_t>);
+
+        void msgpack_pack(auto& packer) const {
+            std::string tag;
+            bool is_unit;
+            switch (value.index()) {
+                
+                case 0:
+                    tag = "Simple";
+                    is_unit = false;
+                    break;
+                case 1:
+                    tag = "Array";
+                    is_unit = false;
+                    break;
+                default:
+                    throw_or_abort("unknown enum 'BrilligOutputs' variant index: " + std::to_string(value.index()));
+            }
+            if (is_unit) {
+                packer.pack(tag);
+            } else {
+                std::visit([&packer, tag](const auto& arg) {
+                    packer.pack_map(1);
+                    packer.pack(tag);
+                    packer.pack(arg);
+                }, value);
+            }
+        }
 
         void msgpack_unpack(msgpack::object const& o) {
 
@@ -5138,6 +6391,15 @@ namespace Acir {
         Acir::Expression value;
 
         friend bool operator==(const MemOp&, const MemOp&);
+        std::vector<uint8_t> bincodeSerialize() const;
+        static MemOp bincodeDeserialize(std::vector<uint8_t>);
+
+        void msgpack_pack(auto& packer) const {
+            packer.pack_map(3);
+            packer.pack(std::make_pair("operation", operation));
+            packer.pack(std::make_pair("index", index));
+            packer.pack(std::make_pair("value", value));
+        }
 
         void msgpack_unpack(msgpack::object const& o) {
             std::string name = "MemOp";
@@ -5184,6 +6446,10 @@ namespace Acir {
             Acir::Expression value;
 
             friend bool operator==(const AssertZero&, const AssertZero&);
+            std::vector<uint8_t> bincodeSerialize() const;
+            static AssertZero bincodeDeserialize(std::vector<uint8_t>);
+
+            void msgpack_pack(auto& packer) const { packer.pack(value); }
 
             void msgpack_unpack(msgpack::object const& o) {
                 try {
@@ -5199,6 +6465,10 @@ namespace Acir {
             Acir::BlackBoxFuncCall value;
 
             friend bool operator==(const BlackBoxFuncCall&, const BlackBoxFuncCall&);
+            std::vector<uint8_t> bincodeSerialize() const;
+            static BlackBoxFuncCall bincodeDeserialize(std::vector<uint8_t>);
+
+            void msgpack_pack(auto& packer) const { packer.pack(value); }
 
             void msgpack_unpack(msgpack::object const& o) {
                 try {
@@ -5215,6 +6485,14 @@ namespace Acir {
             Acir::MemOp op;
 
             friend bool operator==(const MemoryOp&, const MemoryOp&);
+            std::vector<uint8_t> bincodeSerialize() const;
+            static MemoryOp bincodeDeserialize(std::vector<uint8_t>);
+
+            void msgpack_pack(auto& packer) const {
+                packer.pack_map(2);
+                packer.pack(std::make_pair("block_id", block_id));
+                packer.pack(std::make_pair("op", op));
+            }
 
             void msgpack_unpack(msgpack::object const& o) {
                 std::string name = "MemoryOp";
@@ -5256,6 +6534,15 @@ namespace Acir {
             Acir::BlockType block_type;
 
             friend bool operator==(const MemoryInit&, const MemoryInit&);
+            std::vector<uint8_t> bincodeSerialize() const;
+            static MemoryInit bincodeDeserialize(std::vector<uint8_t>);
+
+            void msgpack_pack(auto& packer) const {
+                packer.pack_map(3);
+                packer.pack(std::make_pair("block_id", block_id));
+                packer.pack(std::make_pair("init", init));
+                packer.pack(std::make_pair("block_type", block_type));
+            }
 
             void msgpack_unpack(msgpack::object const& o) {
                 std::string name = "MemoryInit";
@@ -5303,6 +6590,16 @@ namespace Acir {
             Acir::Expression predicate;
 
             friend bool operator==(const BrilligCall&, const BrilligCall&);
+            std::vector<uint8_t> bincodeSerialize() const;
+            static BrilligCall bincodeDeserialize(std::vector<uint8_t>);
+
+            void msgpack_pack(auto& packer) const {
+                packer.pack_map(4);
+                packer.pack(std::make_pair("id", id));
+                packer.pack(std::make_pair("inputs", inputs));
+                packer.pack(std::make_pair("outputs", outputs));
+                packer.pack(std::make_pair("predicate", predicate));
+            }
 
             void msgpack_unpack(msgpack::object const& o) {
                 std::string name = "BrilligCall";
@@ -5355,6 +6652,16 @@ namespace Acir {
             Acir::Expression predicate;
 
             friend bool operator==(const Call&, const Call&);
+            std::vector<uint8_t> bincodeSerialize() const;
+            static Call bincodeDeserialize(std::vector<uint8_t>);
+
+            void msgpack_pack(auto& packer) const {
+                packer.pack_map(4);
+                packer.pack(std::make_pair("id", id));
+                packer.pack(std::make_pair("inputs", inputs));
+                packer.pack(std::make_pair("outputs", outputs));
+                packer.pack(std::make_pair("predicate", predicate));
+            }
 
             void msgpack_unpack(msgpack::object const& o) {
                 std::string name = "Call";
@@ -5403,6 +6710,51 @@ namespace Acir {
         std::variant<AssertZero, BlackBoxFuncCall, MemoryOp, MemoryInit, BrilligCall, Call> value;
 
         friend bool operator==(const Opcode&, const Opcode&);
+        std::vector<uint8_t> bincodeSerialize() const;
+        static Opcode bincodeDeserialize(std::vector<uint8_t>);
+
+        void msgpack_pack(auto& packer) const {
+            std::string tag;
+            bool is_unit;
+            switch (value.index()) {
+                
+                case 0:
+                    tag = "AssertZero";
+                    is_unit = false;
+                    break;
+                case 1:
+                    tag = "BlackBoxFuncCall";
+                    is_unit = false;
+                    break;
+                case 2:
+                    tag = "MemoryOp";
+                    is_unit = false;
+                    break;
+                case 3:
+                    tag = "MemoryInit";
+                    is_unit = false;
+                    break;
+                case 4:
+                    tag = "BrilligCall";
+                    is_unit = false;
+                    break;
+                case 5:
+                    tag = "Call";
+                    is_unit = false;
+                    break;
+                default:
+                    throw_or_abort("unknown enum 'Opcode' variant index: " + std::to_string(value.index()));
+            }
+            if (is_unit) {
+                packer.pack(tag);
+            } else {
+                std::visit([&packer, tag](const auto& arg) {
+                    packer.pack_map(1);
+                    packer.pack(tag);
+                    packer.pack(arg);
+                }, value);
+            }
+        }
 
         void msgpack_unpack(msgpack::object const& o) {
 
@@ -5587,6 +6939,10 @@ namespace Acir {
             Acir::Expression value;
 
             friend bool operator==(const Expression&, const Expression&);
+            std::vector<uint8_t> bincodeSerialize() const;
+            static Expression bincodeDeserialize(std::vector<uint8_t>);
+
+            void msgpack_pack(auto& packer) const { packer.pack(value); }
 
             void msgpack_unpack(msgpack::object const& o) {
                 try {
@@ -5602,6 +6958,10 @@ namespace Acir {
             Acir::BlockId value;
 
             friend bool operator==(const Memory&, const Memory&);
+            std::vector<uint8_t> bincodeSerialize() const;
+            static Memory bincodeDeserialize(std::vector<uint8_t>);
+
+            void msgpack_pack(auto& packer) const { packer.pack(value); }
 
             void msgpack_unpack(msgpack::object const& o) {
                 try {
@@ -5616,6 +6976,35 @@ namespace Acir {
         std::variant<Expression, Memory> value;
 
         friend bool operator==(const ExpressionOrMemory&, const ExpressionOrMemory&);
+        std::vector<uint8_t> bincodeSerialize() const;
+        static ExpressionOrMemory bincodeDeserialize(std::vector<uint8_t>);
+
+        void msgpack_pack(auto& packer) const {
+            std::string tag;
+            bool is_unit;
+            switch (value.index()) {
+                
+                case 0:
+                    tag = "Expression";
+                    is_unit = false;
+                    break;
+                case 1:
+                    tag = "Memory";
+                    is_unit = false;
+                    break;
+                default:
+                    throw_or_abort("unknown enum 'ExpressionOrMemory' variant index: " + std::to_string(value.index()));
+            }
+            if (is_unit) {
+                packer.pack(tag);
+            } else {
+                std::visit([&packer, tag](const auto& arg) {
+                    packer.pack_map(1);
+                    packer.pack(tag);
+                    packer.pack(arg);
+                }, value);
+            }
+        }
 
         void msgpack_unpack(msgpack::object const& o) {
 
@@ -5711,6 +7100,14 @@ namespace Acir {
         std::vector<Acir::ExpressionOrMemory> payload;
 
         friend bool operator==(const AssertionPayload&, const AssertionPayload&);
+        std::vector<uint8_t> bincodeSerialize() const;
+        static AssertionPayload bincodeDeserialize(std::vector<uint8_t>);
+
+        void msgpack_pack(auto& packer) const {
+            packer.pack_map(2);
+            packer.pack(std::make_pair("error_selector", error_selector));
+            packer.pack(std::make_pair("payload", payload));
+        }
 
         void msgpack_unpack(msgpack::object const& o) {
             std::string name = "AssertionPayload";
@@ -5752,6 +7149,10 @@ namespace Acir {
             uint64_t value;
 
             friend bool operator==(const Acir&, const Acir&);
+            std::vector<uint8_t> bincodeSerialize() const;
+            static Acir bincodeDeserialize(std::vector<uint8_t>);
+
+            void msgpack_pack(auto& packer) const { packer.pack(value); }
 
             void msgpack_unpack(msgpack::object const& o) {
                 try {
@@ -5768,6 +7169,14 @@ namespace Acir {
             uint64_t brillig_index;
 
             friend bool operator==(const Brillig&, const Brillig&);
+            std::vector<uint8_t> bincodeSerialize() const;
+            static Brillig bincodeDeserialize(std::vector<uint8_t>);
+
+            void msgpack_pack(auto& packer) const {
+                packer.pack_map(2);
+                packer.pack(std::make_pair("acir_index", acir_index));
+                packer.pack(std::make_pair("brillig_index", brillig_index));
+            }
 
             void msgpack_unpack(msgpack::object const& o) {
                 std::string name = "Brillig";
@@ -5806,6 +7215,35 @@ namespace Acir {
         std::variant<Acir, Brillig> value;
 
         friend bool operator==(const OpcodeLocation&, const OpcodeLocation&);
+        std::vector<uint8_t> bincodeSerialize() const;
+        static OpcodeLocation bincodeDeserialize(std::vector<uint8_t>);
+
+        void msgpack_pack(auto& packer) const {
+            std::string tag;
+            bool is_unit;
+            switch (value.index()) {
+                
+                case 0:
+                    tag = "Acir";
+                    is_unit = false;
+                    break;
+                case 1:
+                    tag = "Brillig";
+                    is_unit = false;
+                    break;
+                default:
+                    throw_or_abort("unknown enum 'OpcodeLocation' variant index: " + std::to_string(value.index()));
+            }
+            if (is_unit) {
+                packer.pack(tag);
+            } else {
+                std::visit([&packer, tag](const auto& arg) {
+                    packer.pack_map(1);
+                    packer.pack(tag);
+                    packer.pack(arg);
+                }, value);
+            }
+        }
 
         void msgpack_unpack(msgpack::object const& o) {
 
@@ -5900,6 +7338,10 @@ namespace Acir {
         std::vector<Acir::Witness> value;
 
         friend bool operator==(const PublicInputs&, const PublicInputs&);
+        std::vector<uint8_t> bincodeSerialize() const;
+        static PublicInputs bincodeDeserialize(std::vector<uint8_t>);
+
+        void msgpack_pack(auto& packer) const { packer.pack(value); }
 
         void msgpack_unpack(msgpack::object const& o) {
             try {
@@ -5921,6 +7363,19 @@ namespace Acir {
         std::vector<std::tuple<Acir::OpcodeLocation, Acir::AssertionPayload>> assert_messages;
 
         friend bool operator==(const Circuit&, const Circuit&);
+        std::vector<uint8_t> bincodeSerialize() const;
+        static Circuit bincodeDeserialize(std::vector<uint8_t>);
+
+        void msgpack_pack(auto& packer) const {
+            packer.pack_map(7);
+            packer.pack(std::make_pair("function_name", function_name));
+            packer.pack(std::make_pair("current_witness_index", current_witness_index));
+            packer.pack(std::make_pair("opcodes", opcodes));
+            packer.pack(std::make_pair("private_parameters", private_parameters));
+            packer.pack(std::make_pair("public_parameters", public_parameters));
+            packer.pack(std::make_pair("return_values", return_values));
+            packer.pack(std::make_pair("assert_messages", assert_messages));
+        }
 
         void msgpack_unpack(msgpack::object const& o) {
             std::string name = "Circuit";
@@ -5985,6 +7440,14 @@ namespace Acir {
         std::vector<Acir::BrilligOpcode> bytecode;
 
         friend bool operator==(const BrilligBytecode&, const BrilligBytecode&);
+        std::vector<uint8_t> bincodeSerialize() const;
+        static BrilligBytecode bincodeDeserialize(std::vector<uint8_t>);
+
+        void msgpack_pack(auto& packer) const {
+            packer.pack_map(2);
+            packer.pack(std::make_pair("function_name", function_name));
+            packer.pack(std::make_pair("bytecode", bytecode));
+        }
 
         void msgpack_unpack(msgpack::object const& o) {
             std::string name = "BrilligBytecode";
@@ -6024,6 +7487,14 @@ namespace Acir {
         std::vector<Acir::BrilligBytecode> unconstrained_functions;
 
         friend bool operator==(const Program&, const Program&);
+        std::vector<uint8_t> bincodeSerialize() const;
+        static Program bincodeDeserialize(std::vector<uint8_t>);
+
+        void msgpack_pack(auto& packer) const {
+            packer.pack_map(2);
+            packer.pack(std::make_pair("functions", functions));
+            packer.pack(std::make_pair("unconstrained_functions", unconstrained_functions));
+        }
 
         void msgpack_unpack(msgpack::object const& o) {
             std::string name = "Program";
@@ -6063,6 +7534,13 @@ namespace Acir {
         std::monostate unconstrained_functions;
 
         friend bool operator==(const ProgramWithoutBrillig&, const ProgramWithoutBrillig&);
+        std::vector<uint8_t> bincodeSerialize() const;
+        static ProgramWithoutBrillig bincodeDeserialize(std::vector<uint8_t>);
+
+        void msgpack_pack(auto& packer) const {
+            packer.pack_map(1);
+            packer.pack(std::make_pair("functions", functions));
+        }
 
         void msgpack_unpack(msgpack::object const& o) {
             std::string name = "ProgramWithoutBrillig";
@@ -6107,6 +7585,21 @@ namespace Acir {
         return true;
     }
 
+    inline std::vector<uint8_t> AssertionPayload::bincodeSerialize() const {
+        auto serializer = serde::BincodeSerializer();
+        serde::Serializable<AssertionPayload>::serialize(*this, serializer);
+        return std::move(serializer).bytes();
+    }
+
+    inline AssertionPayload AssertionPayload::bincodeDeserialize(std::vector<uint8_t> input) {
+        auto deserializer = serde::BincodeDeserializer(input);
+        auto value = serde::Deserializable<AssertionPayload>::deserialize(deserializer);
+        if (deserializer.get_buffer_offset() < input.size()) {
+            throw_or_abort("Some input bytes were not read");
+        }
+        return value;
+    }
+
 } // end of namespace Acir
 
 template <>
@@ -6136,6 +7629,21 @@ namespace Acir {
         return true;
     }
 
+    inline std::vector<uint8_t> BinaryFieldOp::bincodeSerialize() const {
+        auto serializer = serde::BincodeSerializer();
+        serde::Serializable<BinaryFieldOp>::serialize(*this, serializer);
+        return std::move(serializer).bytes();
+    }
+
+    inline BinaryFieldOp BinaryFieldOp::bincodeDeserialize(std::vector<uint8_t> input) {
+        auto deserializer = serde::BincodeDeserializer(input);
+        auto value = serde::Deserializable<BinaryFieldOp>::deserialize(deserializer);
+        if (deserializer.get_buffer_offset() < input.size()) {
+            throw_or_abort("Some input bytes were not read");
+        }
+        return value;
+    }
+
 } // end of namespace Acir
 
 template <>
@@ -6162,6 +7670,21 @@ namespace Acir {
         return true;
     }
 
+    inline std::vector<uint8_t> BinaryFieldOp::Add::bincodeSerialize() const {
+        auto serializer = serde::BincodeSerializer();
+        serde::Serializable<BinaryFieldOp::Add>::serialize(*this, serializer);
+        return std::move(serializer).bytes();
+    }
+
+    inline BinaryFieldOp::Add BinaryFieldOp::Add::bincodeDeserialize(std::vector<uint8_t> input) {
+        auto deserializer = serde::BincodeDeserializer(input);
+        auto value = serde::Deserializable<BinaryFieldOp::Add>::deserialize(deserializer);
+        if (deserializer.get_buffer_offset() < input.size()) {
+            throw_or_abort("Some input bytes were not read");
+        }
+        return value;
+    }
+
 } // end of namespace Acir
 
 template <>
@@ -6180,6 +7703,21 @@ namespace Acir {
 
     inline bool operator==(const BinaryFieldOp::Sub &lhs, const BinaryFieldOp::Sub &rhs) {
         return true;
+    }
+
+    inline std::vector<uint8_t> BinaryFieldOp::Sub::bincodeSerialize() const {
+        auto serializer = serde::BincodeSerializer();
+        serde::Serializable<BinaryFieldOp::Sub>::serialize(*this, serializer);
+        return std::move(serializer).bytes();
+    }
+
+    inline BinaryFieldOp::Sub BinaryFieldOp::Sub::bincodeDeserialize(std::vector<uint8_t> input) {
+        auto deserializer = serde::BincodeDeserializer(input);
+        auto value = serde::Deserializable<BinaryFieldOp::Sub>::deserialize(deserializer);
+        if (deserializer.get_buffer_offset() < input.size()) {
+            throw_or_abort("Some input bytes were not read");
+        }
+        return value;
     }
 
 } // end of namespace Acir
@@ -6202,6 +7740,21 @@ namespace Acir {
         return true;
     }
 
+    inline std::vector<uint8_t> BinaryFieldOp::Mul::bincodeSerialize() const {
+        auto serializer = serde::BincodeSerializer();
+        serde::Serializable<BinaryFieldOp::Mul>::serialize(*this, serializer);
+        return std::move(serializer).bytes();
+    }
+
+    inline BinaryFieldOp::Mul BinaryFieldOp::Mul::bincodeDeserialize(std::vector<uint8_t> input) {
+        auto deserializer = serde::BincodeDeserializer(input);
+        auto value = serde::Deserializable<BinaryFieldOp::Mul>::deserialize(deserializer);
+        if (deserializer.get_buffer_offset() < input.size()) {
+            throw_or_abort("Some input bytes were not read");
+        }
+        return value;
+    }
+
 } // end of namespace Acir
 
 template <>
@@ -6220,6 +7773,21 @@ namespace Acir {
 
     inline bool operator==(const BinaryFieldOp::Div &lhs, const BinaryFieldOp::Div &rhs) {
         return true;
+    }
+
+    inline std::vector<uint8_t> BinaryFieldOp::Div::bincodeSerialize() const {
+        auto serializer = serde::BincodeSerializer();
+        serde::Serializable<BinaryFieldOp::Div>::serialize(*this, serializer);
+        return std::move(serializer).bytes();
+    }
+
+    inline BinaryFieldOp::Div BinaryFieldOp::Div::bincodeDeserialize(std::vector<uint8_t> input) {
+        auto deserializer = serde::BincodeDeserializer(input);
+        auto value = serde::Deserializable<BinaryFieldOp::Div>::deserialize(deserializer);
+        if (deserializer.get_buffer_offset() < input.size()) {
+            throw_or_abort("Some input bytes were not read");
+        }
+        return value;
     }
 
 } // end of namespace Acir
@@ -6242,6 +7810,21 @@ namespace Acir {
         return true;
     }
 
+    inline std::vector<uint8_t> BinaryFieldOp::IntegerDiv::bincodeSerialize() const {
+        auto serializer = serde::BincodeSerializer();
+        serde::Serializable<BinaryFieldOp::IntegerDiv>::serialize(*this, serializer);
+        return std::move(serializer).bytes();
+    }
+
+    inline BinaryFieldOp::IntegerDiv BinaryFieldOp::IntegerDiv::bincodeDeserialize(std::vector<uint8_t> input) {
+        auto deserializer = serde::BincodeDeserializer(input);
+        auto value = serde::Deserializable<BinaryFieldOp::IntegerDiv>::deserialize(deserializer);
+        if (deserializer.get_buffer_offset() < input.size()) {
+            throw_or_abort("Some input bytes were not read");
+        }
+        return value;
+    }
+
 } // end of namespace Acir
 
 template <>
@@ -6260,6 +7843,21 @@ namespace Acir {
 
     inline bool operator==(const BinaryFieldOp::Equals &lhs, const BinaryFieldOp::Equals &rhs) {
         return true;
+    }
+
+    inline std::vector<uint8_t> BinaryFieldOp::Equals::bincodeSerialize() const {
+        auto serializer = serde::BincodeSerializer();
+        serde::Serializable<BinaryFieldOp::Equals>::serialize(*this, serializer);
+        return std::move(serializer).bytes();
+    }
+
+    inline BinaryFieldOp::Equals BinaryFieldOp::Equals::bincodeDeserialize(std::vector<uint8_t> input) {
+        auto deserializer = serde::BincodeDeserializer(input);
+        auto value = serde::Deserializable<BinaryFieldOp::Equals>::deserialize(deserializer);
+        if (deserializer.get_buffer_offset() < input.size()) {
+            throw_or_abort("Some input bytes were not read");
+        }
+        return value;
     }
 
 } // end of namespace Acir
@@ -6282,6 +7880,21 @@ namespace Acir {
         return true;
     }
 
+    inline std::vector<uint8_t> BinaryFieldOp::LessThan::bincodeSerialize() const {
+        auto serializer = serde::BincodeSerializer();
+        serde::Serializable<BinaryFieldOp::LessThan>::serialize(*this, serializer);
+        return std::move(serializer).bytes();
+    }
+
+    inline BinaryFieldOp::LessThan BinaryFieldOp::LessThan::bincodeDeserialize(std::vector<uint8_t> input) {
+        auto deserializer = serde::BincodeDeserializer(input);
+        auto value = serde::Deserializable<BinaryFieldOp::LessThan>::deserialize(deserializer);
+        if (deserializer.get_buffer_offset() < input.size()) {
+            throw_or_abort("Some input bytes were not read");
+        }
+        return value;
+    }
+
 } // end of namespace Acir
 
 template <>
@@ -6300,6 +7913,21 @@ namespace Acir {
 
     inline bool operator==(const BinaryFieldOp::LessThanEquals &lhs, const BinaryFieldOp::LessThanEquals &rhs) {
         return true;
+    }
+
+    inline std::vector<uint8_t> BinaryFieldOp::LessThanEquals::bincodeSerialize() const {
+        auto serializer = serde::BincodeSerializer();
+        serde::Serializable<BinaryFieldOp::LessThanEquals>::serialize(*this, serializer);
+        return std::move(serializer).bytes();
+    }
+
+    inline BinaryFieldOp::LessThanEquals BinaryFieldOp::LessThanEquals::bincodeDeserialize(std::vector<uint8_t> input) {
+        auto deserializer = serde::BincodeDeserializer(input);
+        auto value = serde::Deserializable<BinaryFieldOp::LessThanEquals>::deserialize(deserializer);
+        if (deserializer.get_buffer_offset() < input.size()) {
+            throw_or_abort("Some input bytes were not read");
+        }
+        return value;
     }
 
 } // end of namespace Acir
@@ -6321,6 +7949,21 @@ namespace Acir {
     inline bool operator==(const BinaryIntOp &lhs, const BinaryIntOp &rhs) {
         if (!(lhs.value == rhs.value)) { return false; }
         return true;
+    }
+
+    inline std::vector<uint8_t> BinaryIntOp::bincodeSerialize() const {
+        auto serializer = serde::BincodeSerializer();
+        serde::Serializable<BinaryIntOp>::serialize(*this, serializer);
+        return std::move(serializer).bytes();
+    }
+
+    inline BinaryIntOp BinaryIntOp::bincodeDeserialize(std::vector<uint8_t> input) {
+        auto deserializer = serde::BincodeDeserializer(input);
+        auto value = serde::Deserializable<BinaryIntOp>::deserialize(deserializer);
+        if (deserializer.get_buffer_offset() < input.size()) {
+            throw_or_abort("Some input bytes were not read");
+        }
+        return value;
     }
 
 } // end of namespace Acir
@@ -6349,6 +7992,21 @@ namespace Acir {
         return true;
     }
 
+    inline std::vector<uint8_t> BinaryIntOp::Add::bincodeSerialize() const {
+        auto serializer = serde::BincodeSerializer();
+        serde::Serializable<BinaryIntOp::Add>::serialize(*this, serializer);
+        return std::move(serializer).bytes();
+    }
+
+    inline BinaryIntOp::Add BinaryIntOp::Add::bincodeDeserialize(std::vector<uint8_t> input) {
+        auto deserializer = serde::BincodeDeserializer(input);
+        auto value = serde::Deserializable<BinaryIntOp::Add>::deserialize(deserializer);
+        if (deserializer.get_buffer_offset() < input.size()) {
+            throw_or_abort("Some input bytes were not read");
+        }
+        return value;
+    }
+
 } // end of namespace Acir
 
 template <>
@@ -6367,6 +8025,21 @@ namespace Acir {
 
     inline bool operator==(const BinaryIntOp::Sub &lhs, const BinaryIntOp::Sub &rhs) {
         return true;
+    }
+
+    inline std::vector<uint8_t> BinaryIntOp::Sub::bincodeSerialize() const {
+        auto serializer = serde::BincodeSerializer();
+        serde::Serializable<BinaryIntOp::Sub>::serialize(*this, serializer);
+        return std::move(serializer).bytes();
+    }
+
+    inline BinaryIntOp::Sub BinaryIntOp::Sub::bincodeDeserialize(std::vector<uint8_t> input) {
+        auto deserializer = serde::BincodeDeserializer(input);
+        auto value = serde::Deserializable<BinaryIntOp::Sub>::deserialize(deserializer);
+        if (deserializer.get_buffer_offset() < input.size()) {
+            throw_or_abort("Some input bytes were not read");
+        }
+        return value;
     }
 
 } // end of namespace Acir
@@ -6389,6 +8062,21 @@ namespace Acir {
         return true;
     }
 
+    inline std::vector<uint8_t> BinaryIntOp::Mul::bincodeSerialize() const {
+        auto serializer = serde::BincodeSerializer();
+        serde::Serializable<BinaryIntOp::Mul>::serialize(*this, serializer);
+        return std::move(serializer).bytes();
+    }
+
+    inline BinaryIntOp::Mul BinaryIntOp::Mul::bincodeDeserialize(std::vector<uint8_t> input) {
+        auto deserializer = serde::BincodeDeserializer(input);
+        auto value = serde::Deserializable<BinaryIntOp::Mul>::deserialize(deserializer);
+        if (deserializer.get_buffer_offset() < input.size()) {
+            throw_or_abort("Some input bytes were not read");
+        }
+        return value;
+    }
+
 } // end of namespace Acir
 
 template <>
@@ -6407,6 +8095,21 @@ namespace Acir {
 
     inline bool operator==(const BinaryIntOp::Div &lhs, const BinaryIntOp::Div &rhs) {
         return true;
+    }
+
+    inline std::vector<uint8_t> BinaryIntOp::Div::bincodeSerialize() const {
+        auto serializer = serde::BincodeSerializer();
+        serde::Serializable<BinaryIntOp::Div>::serialize(*this, serializer);
+        return std::move(serializer).bytes();
+    }
+
+    inline BinaryIntOp::Div BinaryIntOp::Div::bincodeDeserialize(std::vector<uint8_t> input) {
+        auto deserializer = serde::BincodeDeserializer(input);
+        auto value = serde::Deserializable<BinaryIntOp::Div>::deserialize(deserializer);
+        if (deserializer.get_buffer_offset() < input.size()) {
+            throw_or_abort("Some input bytes were not read");
+        }
+        return value;
     }
 
 } // end of namespace Acir
@@ -6429,6 +8132,21 @@ namespace Acir {
         return true;
     }
 
+    inline std::vector<uint8_t> BinaryIntOp::Equals::bincodeSerialize() const {
+        auto serializer = serde::BincodeSerializer();
+        serde::Serializable<BinaryIntOp::Equals>::serialize(*this, serializer);
+        return std::move(serializer).bytes();
+    }
+
+    inline BinaryIntOp::Equals BinaryIntOp::Equals::bincodeDeserialize(std::vector<uint8_t> input) {
+        auto deserializer = serde::BincodeDeserializer(input);
+        auto value = serde::Deserializable<BinaryIntOp::Equals>::deserialize(deserializer);
+        if (deserializer.get_buffer_offset() < input.size()) {
+            throw_or_abort("Some input bytes were not read");
+        }
+        return value;
+    }
+
 } // end of namespace Acir
 
 template <>
@@ -6447,6 +8165,21 @@ namespace Acir {
 
     inline bool operator==(const BinaryIntOp::LessThan &lhs, const BinaryIntOp::LessThan &rhs) {
         return true;
+    }
+
+    inline std::vector<uint8_t> BinaryIntOp::LessThan::bincodeSerialize() const {
+        auto serializer = serde::BincodeSerializer();
+        serde::Serializable<BinaryIntOp::LessThan>::serialize(*this, serializer);
+        return std::move(serializer).bytes();
+    }
+
+    inline BinaryIntOp::LessThan BinaryIntOp::LessThan::bincodeDeserialize(std::vector<uint8_t> input) {
+        auto deserializer = serde::BincodeDeserializer(input);
+        auto value = serde::Deserializable<BinaryIntOp::LessThan>::deserialize(deserializer);
+        if (deserializer.get_buffer_offset() < input.size()) {
+            throw_or_abort("Some input bytes were not read");
+        }
+        return value;
     }
 
 } // end of namespace Acir
@@ -6469,6 +8202,21 @@ namespace Acir {
         return true;
     }
 
+    inline std::vector<uint8_t> BinaryIntOp::LessThanEquals::bincodeSerialize() const {
+        auto serializer = serde::BincodeSerializer();
+        serde::Serializable<BinaryIntOp::LessThanEquals>::serialize(*this, serializer);
+        return std::move(serializer).bytes();
+    }
+
+    inline BinaryIntOp::LessThanEquals BinaryIntOp::LessThanEquals::bincodeDeserialize(std::vector<uint8_t> input) {
+        auto deserializer = serde::BincodeDeserializer(input);
+        auto value = serde::Deserializable<BinaryIntOp::LessThanEquals>::deserialize(deserializer);
+        if (deserializer.get_buffer_offset() < input.size()) {
+            throw_or_abort("Some input bytes were not read");
+        }
+        return value;
+    }
+
 } // end of namespace Acir
 
 template <>
@@ -6487,6 +8235,21 @@ namespace Acir {
 
     inline bool operator==(const BinaryIntOp::And &lhs, const BinaryIntOp::And &rhs) {
         return true;
+    }
+
+    inline std::vector<uint8_t> BinaryIntOp::And::bincodeSerialize() const {
+        auto serializer = serde::BincodeSerializer();
+        serde::Serializable<BinaryIntOp::And>::serialize(*this, serializer);
+        return std::move(serializer).bytes();
+    }
+
+    inline BinaryIntOp::And BinaryIntOp::And::bincodeDeserialize(std::vector<uint8_t> input) {
+        auto deserializer = serde::BincodeDeserializer(input);
+        auto value = serde::Deserializable<BinaryIntOp::And>::deserialize(deserializer);
+        if (deserializer.get_buffer_offset() < input.size()) {
+            throw_or_abort("Some input bytes were not read");
+        }
+        return value;
     }
 
 } // end of namespace Acir
@@ -6509,6 +8272,21 @@ namespace Acir {
         return true;
     }
 
+    inline std::vector<uint8_t> BinaryIntOp::Or::bincodeSerialize() const {
+        auto serializer = serde::BincodeSerializer();
+        serde::Serializable<BinaryIntOp::Or>::serialize(*this, serializer);
+        return std::move(serializer).bytes();
+    }
+
+    inline BinaryIntOp::Or BinaryIntOp::Or::bincodeDeserialize(std::vector<uint8_t> input) {
+        auto deserializer = serde::BincodeDeserializer(input);
+        auto value = serde::Deserializable<BinaryIntOp::Or>::deserialize(deserializer);
+        if (deserializer.get_buffer_offset() < input.size()) {
+            throw_or_abort("Some input bytes were not read");
+        }
+        return value;
+    }
+
 } // end of namespace Acir
 
 template <>
@@ -6527,6 +8305,21 @@ namespace Acir {
 
     inline bool operator==(const BinaryIntOp::Xor &lhs, const BinaryIntOp::Xor &rhs) {
         return true;
+    }
+
+    inline std::vector<uint8_t> BinaryIntOp::Xor::bincodeSerialize() const {
+        auto serializer = serde::BincodeSerializer();
+        serde::Serializable<BinaryIntOp::Xor>::serialize(*this, serializer);
+        return std::move(serializer).bytes();
+    }
+
+    inline BinaryIntOp::Xor BinaryIntOp::Xor::bincodeDeserialize(std::vector<uint8_t> input) {
+        auto deserializer = serde::BincodeDeserializer(input);
+        auto value = serde::Deserializable<BinaryIntOp::Xor>::deserialize(deserializer);
+        if (deserializer.get_buffer_offset() < input.size()) {
+            throw_or_abort("Some input bytes were not read");
+        }
+        return value;
     }
 
 } // end of namespace Acir
@@ -6549,6 +8342,21 @@ namespace Acir {
         return true;
     }
 
+    inline std::vector<uint8_t> BinaryIntOp::Shl::bincodeSerialize() const {
+        auto serializer = serde::BincodeSerializer();
+        serde::Serializable<BinaryIntOp::Shl>::serialize(*this, serializer);
+        return std::move(serializer).bytes();
+    }
+
+    inline BinaryIntOp::Shl BinaryIntOp::Shl::bincodeDeserialize(std::vector<uint8_t> input) {
+        auto deserializer = serde::BincodeDeserializer(input);
+        auto value = serde::Deserializable<BinaryIntOp::Shl>::deserialize(deserializer);
+        if (deserializer.get_buffer_offset() < input.size()) {
+            throw_or_abort("Some input bytes were not read");
+        }
+        return value;
+    }
+
 } // end of namespace Acir
 
 template <>
@@ -6567,6 +8375,21 @@ namespace Acir {
 
     inline bool operator==(const BinaryIntOp::Shr &lhs, const BinaryIntOp::Shr &rhs) {
         return true;
+    }
+
+    inline std::vector<uint8_t> BinaryIntOp::Shr::bincodeSerialize() const {
+        auto serializer = serde::BincodeSerializer();
+        serde::Serializable<BinaryIntOp::Shr>::serialize(*this, serializer);
+        return std::move(serializer).bytes();
+    }
+
+    inline BinaryIntOp::Shr BinaryIntOp::Shr::bincodeDeserialize(std::vector<uint8_t> input) {
+        auto deserializer = serde::BincodeDeserializer(input);
+        auto value = serde::Deserializable<BinaryIntOp::Shr>::deserialize(deserializer);
+        if (deserializer.get_buffer_offset() < input.size()) {
+            throw_or_abort("Some input bytes were not read");
+        }
+        return value;
     }
 
 } // end of namespace Acir
@@ -6588,6 +8411,21 @@ namespace Acir {
     inline bool operator==(const BitSize &lhs, const BitSize &rhs) {
         if (!(lhs.value == rhs.value)) { return false; }
         return true;
+    }
+
+    inline std::vector<uint8_t> BitSize::bincodeSerialize() const {
+        auto serializer = serde::BincodeSerializer();
+        serde::Serializable<BitSize>::serialize(*this, serializer);
+        return std::move(serializer).bytes();
+    }
+
+    inline BitSize BitSize::bincodeDeserialize(std::vector<uint8_t> input) {
+        auto deserializer = serde::BincodeDeserializer(input);
+        auto value = serde::Deserializable<BitSize>::deserialize(deserializer);
+        if (deserializer.get_buffer_offset() < input.size()) {
+            throw_or_abort("Some input bytes were not read");
+        }
+        return value;
     }
 
 } // end of namespace Acir
@@ -6616,6 +8454,21 @@ namespace Acir {
         return true;
     }
 
+    inline std::vector<uint8_t> BitSize::Field::bincodeSerialize() const {
+        auto serializer = serde::BincodeSerializer();
+        serde::Serializable<BitSize::Field>::serialize(*this, serializer);
+        return std::move(serializer).bytes();
+    }
+
+    inline BitSize::Field BitSize::Field::bincodeDeserialize(std::vector<uint8_t> input) {
+        auto deserializer = serde::BincodeDeserializer(input);
+        auto value = serde::Deserializable<BitSize::Field>::deserialize(deserializer);
+        if (deserializer.get_buffer_offset() < input.size()) {
+            throw_or_abort("Some input bytes were not read");
+        }
+        return value;
+    }
+
 } // end of namespace Acir
 
 template <>
@@ -6635,6 +8488,21 @@ namespace Acir {
     inline bool operator==(const BitSize::Integer &lhs, const BitSize::Integer &rhs) {
         if (!(lhs.value == rhs.value)) { return false; }
         return true;
+    }
+
+    inline std::vector<uint8_t> BitSize::Integer::bincodeSerialize() const {
+        auto serializer = serde::BincodeSerializer();
+        serde::Serializable<BitSize::Integer>::serialize(*this, serializer);
+        return std::move(serializer).bytes();
+    }
+
+    inline BitSize::Integer BitSize::Integer::bincodeDeserialize(std::vector<uint8_t> input) {
+        auto deserializer = serde::BincodeDeserializer(input);
+        auto value = serde::Deserializable<BitSize::Integer>::deserialize(deserializer);
+        if (deserializer.get_buffer_offset() < input.size()) {
+            throw_or_abort("Some input bytes were not read");
+        }
+        return value;
     }
 
 } // end of namespace Acir
@@ -6658,6 +8526,21 @@ namespace Acir {
     inline bool operator==(const BlackBoxFuncCall &lhs, const BlackBoxFuncCall &rhs) {
         if (!(lhs.value == rhs.value)) { return false; }
         return true;
+    }
+
+    inline std::vector<uint8_t> BlackBoxFuncCall::bincodeSerialize() const {
+        auto serializer = serde::BincodeSerializer();
+        serde::Serializable<BlackBoxFuncCall>::serialize(*this, serializer);
+        return std::move(serializer).bytes();
+    }
+
+    inline BlackBoxFuncCall BlackBoxFuncCall::bincodeDeserialize(std::vector<uint8_t> input) {
+        auto deserializer = serde::BincodeDeserializer(input);
+        auto value = serde::Deserializable<BlackBoxFuncCall>::deserialize(deserializer);
+        if (deserializer.get_buffer_offset() < input.size()) {
+            throw_or_abort("Some input bytes were not read");
+        }
+        return value;
     }
 
 } // end of namespace Acir
@@ -6688,6 +8571,21 @@ namespace Acir {
         if (!(lhs.key == rhs.key)) { return false; }
         if (!(lhs.outputs == rhs.outputs)) { return false; }
         return true;
+    }
+
+    inline std::vector<uint8_t> BlackBoxFuncCall::AES128Encrypt::bincodeSerialize() const {
+        auto serializer = serde::BincodeSerializer();
+        serde::Serializable<BlackBoxFuncCall::AES128Encrypt>::serialize(*this, serializer);
+        return std::move(serializer).bytes();
+    }
+
+    inline BlackBoxFuncCall::AES128Encrypt BlackBoxFuncCall::AES128Encrypt::bincodeDeserialize(std::vector<uint8_t> input) {
+        auto deserializer = serde::BincodeDeserializer(input);
+        auto value = serde::Deserializable<BlackBoxFuncCall::AES128Encrypt>::deserialize(deserializer);
+        if (deserializer.get_buffer_offset() < input.size()) {
+            throw_or_abort("Some input bytes were not read");
+        }
+        return value;
     }
 
 } // end of namespace Acir
@@ -6722,6 +8620,21 @@ namespace Acir {
         return true;
     }
 
+    inline std::vector<uint8_t> BlackBoxFuncCall::AND::bincodeSerialize() const {
+        auto serializer = serde::BincodeSerializer();
+        serde::Serializable<BlackBoxFuncCall::AND>::serialize(*this, serializer);
+        return std::move(serializer).bytes();
+    }
+
+    inline BlackBoxFuncCall::AND BlackBoxFuncCall::AND::bincodeDeserialize(std::vector<uint8_t> input) {
+        auto deserializer = serde::BincodeDeserializer(input);
+        auto value = serde::Deserializable<BlackBoxFuncCall::AND>::deserialize(deserializer);
+        if (deserializer.get_buffer_offset() < input.size()) {
+            throw_or_abort("Some input bytes were not read");
+        }
+        return value;
+    }
+
 } // end of namespace Acir
 
 template <>
@@ -6754,6 +8667,21 @@ namespace Acir {
         return true;
     }
 
+    inline std::vector<uint8_t> BlackBoxFuncCall::XOR::bincodeSerialize() const {
+        auto serializer = serde::BincodeSerializer();
+        serde::Serializable<BlackBoxFuncCall::XOR>::serialize(*this, serializer);
+        return std::move(serializer).bytes();
+    }
+
+    inline BlackBoxFuncCall::XOR BlackBoxFuncCall::XOR::bincodeDeserialize(std::vector<uint8_t> input) {
+        auto deserializer = serde::BincodeDeserializer(input);
+        auto value = serde::Deserializable<BlackBoxFuncCall::XOR>::deserialize(deserializer);
+        if (deserializer.get_buffer_offset() < input.size()) {
+            throw_or_abort("Some input bytes were not read");
+        }
+        return value;
+    }
+
 } // end of namespace Acir
 
 template <>
@@ -6784,6 +8712,21 @@ namespace Acir {
         return true;
     }
 
+    inline std::vector<uint8_t> BlackBoxFuncCall::RANGE::bincodeSerialize() const {
+        auto serializer = serde::BincodeSerializer();
+        serde::Serializable<BlackBoxFuncCall::RANGE>::serialize(*this, serializer);
+        return std::move(serializer).bytes();
+    }
+
+    inline BlackBoxFuncCall::RANGE BlackBoxFuncCall::RANGE::bincodeDeserialize(std::vector<uint8_t> input) {
+        auto deserializer = serde::BincodeDeserializer(input);
+        auto value = serde::Deserializable<BlackBoxFuncCall::RANGE>::deserialize(deserializer);
+        if (deserializer.get_buffer_offset() < input.size()) {
+            throw_or_abort("Some input bytes were not read");
+        }
+        return value;
+    }
+
 } // end of namespace Acir
 
 template <>
@@ -6810,6 +8753,21 @@ namespace Acir {
         return true;
     }
 
+    inline std::vector<uint8_t> BlackBoxFuncCall::Blake2s::bincodeSerialize() const {
+        auto serializer = serde::BincodeSerializer();
+        serde::Serializable<BlackBoxFuncCall::Blake2s>::serialize(*this, serializer);
+        return std::move(serializer).bytes();
+    }
+
+    inline BlackBoxFuncCall::Blake2s BlackBoxFuncCall::Blake2s::bincodeDeserialize(std::vector<uint8_t> input) {
+        auto deserializer = serde::BincodeDeserializer(input);
+        auto value = serde::Deserializable<BlackBoxFuncCall::Blake2s>::deserialize(deserializer);
+        if (deserializer.get_buffer_offset() < input.size()) {
+            throw_or_abort("Some input bytes were not read");
+        }
+        return value;
+    }
+
 } // end of namespace Acir
 
 template <>
@@ -6834,6 +8792,21 @@ namespace Acir {
         if (!(lhs.inputs == rhs.inputs)) { return false; }
         if (!(lhs.outputs == rhs.outputs)) { return false; }
         return true;
+    }
+
+    inline std::vector<uint8_t> BlackBoxFuncCall::Blake3::bincodeSerialize() const {
+        auto serializer = serde::BincodeSerializer();
+        serde::Serializable<BlackBoxFuncCall::Blake3>::serialize(*this, serializer);
+        return std::move(serializer).bytes();
+    }
+
+    inline BlackBoxFuncCall::Blake3 BlackBoxFuncCall::Blake3::bincodeDeserialize(std::vector<uint8_t> input) {
+        auto deserializer = serde::BincodeDeserializer(input);
+        auto value = serde::Deserializable<BlackBoxFuncCall::Blake3>::deserialize(deserializer);
+        if (deserializer.get_buffer_offset() < input.size()) {
+            throw_or_abort("Some input bytes were not read");
+        }
+        return value;
     }
 
 } // end of namespace Acir
@@ -6864,6 +8837,21 @@ namespace Acir {
         if (!(lhs.predicate == rhs.predicate)) { return false; }
         if (!(lhs.output == rhs.output)) { return false; }
         return true;
+    }
+
+    inline std::vector<uint8_t> BlackBoxFuncCall::EcdsaSecp256k1::bincodeSerialize() const {
+        auto serializer = serde::BincodeSerializer();
+        serde::Serializable<BlackBoxFuncCall::EcdsaSecp256k1>::serialize(*this, serializer);
+        return std::move(serializer).bytes();
+    }
+
+    inline BlackBoxFuncCall::EcdsaSecp256k1 BlackBoxFuncCall::EcdsaSecp256k1::bincodeDeserialize(std::vector<uint8_t> input) {
+        auto deserializer = serde::BincodeDeserializer(input);
+        auto value = serde::Deserializable<BlackBoxFuncCall::EcdsaSecp256k1>::deserialize(deserializer);
+        if (deserializer.get_buffer_offset() < input.size()) {
+            throw_or_abort("Some input bytes were not read");
+        }
+        return value;
     }
 
 } // end of namespace Acir
@@ -6904,6 +8892,21 @@ namespace Acir {
         return true;
     }
 
+    inline std::vector<uint8_t> BlackBoxFuncCall::EcdsaSecp256r1::bincodeSerialize() const {
+        auto serializer = serde::BincodeSerializer();
+        serde::Serializable<BlackBoxFuncCall::EcdsaSecp256r1>::serialize(*this, serializer);
+        return std::move(serializer).bytes();
+    }
+
+    inline BlackBoxFuncCall::EcdsaSecp256r1 BlackBoxFuncCall::EcdsaSecp256r1::bincodeDeserialize(std::vector<uint8_t> input) {
+        auto deserializer = serde::BincodeDeserializer(input);
+        auto value = serde::Deserializable<BlackBoxFuncCall::EcdsaSecp256r1>::deserialize(deserializer);
+        if (deserializer.get_buffer_offset() < input.size()) {
+            throw_or_abort("Some input bytes were not read");
+        }
+        return value;
+    }
+
 } // end of namespace Acir
 
 template <>
@@ -6940,6 +8943,21 @@ namespace Acir {
         return true;
     }
 
+    inline std::vector<uint8_t> BlackBoxFuncCall::MultiScalarMul::bincodeSerialize() const {
+        auto serializer = serde::BincodeSerializer();
+        serde::Serializable<BlackBoxFuncCall::MultiScalarMul>::serialize(*this, serializer);
+        return std::move(serializer).bytes();
+    }
+
+    inline BlackBoxFuncCall::MultiScalarMul BlackBoxFuncCall::MultiScalarMul::bincodeDeserialize(std::vector<uint8_t> input) {
+        auto deserializer = serde::BincodeDeserializer(input);
+        auto value = serde::Deserializable<BlackBoxFuncCall::MultiScalarMul>::deserialize(deserializer);
+        if (deserializer.get_buffer_offset() < input.size()) {
+            throw_or_abort("Some input bytes were not read");
+        }
+        return value;
+    }
+
 } // end of namespace Acir
 
 template <>
@@ -6972,6 +8990,21 @@ namespace Acir {
         return true;
     }
 
+    inline std::vector<uint8_t> BlackBoxFuncCall::EmbeddedCurveAdd::bincodeSerialize() const {
+        auto serializer = serde::BincodeSerializer();
+        serde::Serializable<BlackBoxFuncCall::EmbeddedCurveAdd>::serialize(*this, serializer);
+        return std::move(serializer).bytes();
+    }
+
+    inline BlackBoxFuncCall::EmbeddedCurveAdd BlackBoxFuncCall::EmbeddedCurveAdd::bincodeDeserialize(std::vector<uint8_t> input) {
+        auto deserializer = serde::BincodeDeserializer(input);
+        auto value = serde::Deserializable<BlackBoxFuncCall::EmbeddedCurveAdd>::deserialize(deserializer);
+        if (deserializer.get_buffer_offset() < input.size()) {
+            throw_or_abort("Some input bytes were not read");
+        }
+        return value;
+    }
+
 } // end of namespace Acir
 
 template <>
@@ -7002,6 +9035,21 @@ namespace Acir {
         return true;
     }
 
+    inline std::vector<uint8_t> BlackBoxFuncCall::Keccakf1600::bincodeSerialize() const {
+        auto serializer = serde::BincodeSerializer();
+        serde::Serializable<BlackBoxFuncCall::Keccakf1600>::serialize(*this, serializer);
+        return std::move(serializer).bytes();
+    }
+
+    inline BlackBoxFuncCall::Keccakf1600 BlackBoxFuncCall::Keccakf1600::bincodeDeserialize(std::vector<uint8_t> input) {
+        auto deserializer = serde::BincodeDeserializer(input);
+        auto value = serde::Deserializable<BlackBoxFuncCall::Keccakf1600>::deserialize(deserializer);
+        if (deserializer.get_buffer_offset() < input.size()) {
+            throw_or_abort("Some input bytes were not read");
+        }
+        return value;
+    }
+
 } // end of namespace Acir
 
 template <>
@@ -7030,6 +9078,21 @@ namespace Acir {
         if (!(lhs.proof_type == rhs.proof_type)) { return false; }
         if (!(lhs.predicate == rhs.predicate)) { return false; }
         return true;
+    }
+
+    inline std::vector<uint8_t> BlackBoxFuncCall::RecursiveAggregation::bincodeSerialize() const {
+        auto serializer = serde::BincodeSerializer();
+        serde::Serializable<BlackBoxFuncCall::RecursiveAggregation>::serialize(*this, serializer);
+        return std::move(serializer).bytes();
+    }
+
+    inline BlackBoxFuncCall::RecursiveAggregation BlackBoxFuncCall::RecursiveAggregation::bincodeDeserialize(std::vector<uint8_t> input) {
+        auto deserializer = serde::BincodeDeserializer(input);
+        auto value = serde::Deserializable<BlackBoxFuncCall::RecursiveAggregation>::deserialize(deserializer);
+        if (deserializer.get_buffer_offset() < input.size()) {
+            throw_or_abort("Some input bytes were not read");
+        }
+        return value;
     }
 
 } // end of namespace Acir
@@ -7066,6 +9129,21 @@ namespace Acir {
         return true;
     }
 
+    inline std::vector<uint8_t> BlackBoxFuncCall::Poseidon2Permutation::bincodeSerialize() const {
+        auto serializer = serde::BincodeSerializer();
+        serde::Serializable<BlackBoxFuncCall::Poseidon2Permutation>::serialize(*this, serializer);
+        return std::move(serializer).bytes();
+    }
+
+    inline BlackBoxFuncCall::Poseidon2Permutation BlackBoxFuncCall::Poseidon2Permutation::bincodeDeserialize(std::vector<uint8_t> input) {
+        auto deserializer = serde::BincodeDeserializer(input);
+        auto value = serde::Deserializable<BlackBoxFuncCall::Poseidon2Permutation>::deserialize(deserializer);
+        if (deserializer.get_buffer_offset() < input.size()) {
+            throw_or_abort("Some input bytes were not read");
+        }
+        return value;
+    }
+
 } // end of namespace Acir
 
 template <>
@@ -7093,6 +9171,21 @@ namespace Acir {
         return true;
     }
 
+    inline std::vector<uint8_t> BlackBoxFuncCall::Sha256Compression::bincodeSerialize() const {
+        auto serializer = serde::BincodeSerializer();
+        serde::Serializable<BlackBoxFuncCall::Sha256Compression>::serialize(*this, serializer);
+        return std::move(serializer).bytes();
+    }
+
+    inline BlackBoxFuncCall::Sha256Compression BlackBoxFuncCall::Sha256Compression::bincodeDeserialize(std::vector<uint8_t> input) {
+        auto deserializer = serde::BincodeDeserializer(input);
+        auto value = serde::Deserializable<BlackBoxFuncCall::Sha256Compression>::deserialize(deserializer);
+        if (deserializer.get_buffer_offset() < input.size()) {
+            throw_or_abort("Some input bytes were not read");
+        }
+        return value;
+    }
+
 } // end of namespace Acir
 
 template <>
@@ -7118,6 +9211,21 @@ namespace Acir {
     inline bool operator==(const BlackBoxOp &lhs, const BlackBoxOp &rhs) {
         if (!(lhs.value == rhs.value)) { return false; }
         return true;
+    }
+
+    inline std::vector<uint8_t> BlackBoxOp::bincodeSerialize() const {
+        auto serializer = serde::BincodeSerializer();
+        serde::Serializable<BlackBoxOp>::serialize(*this, serializer);
+        return std::move(serializer).bytes();
+    }
+
+    inline BlackBoxOp BlackBoxOp::bincodeDeserialize(std::vector<uint8_t> input) {
+        auto deserializer = serde::BincodeDeserializer(input);
+        auto value = serde::Deserializable<BlackBoxOp>::deserialize(deserializer);
+        if (deserializer.get_buffer_offset() < input.size()) {
+            throw_or_abort("Some input bytes were not read");
+        }
+        return value;
     }
 
 } // end of namespace Acir
@@ -7150,6 +9258,21 @@ namespace Acir {
         return true;
     }
 
+    inline std::vector<uint8_t> BlackBoxOp::AES128Encrypt::bincodeSerialize() const {
+        auto serializer = serde::BincodeSerializer();
+        serde::Serializable<BlackBoxOp::AES128Encrypt>::serialize(*this, serializer);
+        return std::move(serializer).bytes();
+    }
+
+    inline BlackBoxOp::AES128Encrypt BlackBoxOp::AES128Encrypt::bincodeDeserialize(std::vector<uint8_t> input) {
+        auto deserializer = serde::BincodeDeserializer(input);
+        auto value = serde::Deserializable<BlackBoxOp::AES128Encrypt>::deserialize(deserializer);
+        if (deserializer.get_buffer_offset() < input.size()) {
+            throw_or_abort("Some input bytes were not read");
+        }
+        return value;
+    }
+
 } // end of namespace Acir
 
 template <>
@@ -7180,6 +9303,21 @@ namespace Acir {
         return true;
     }
 
+    inline std::vector<uint8_t> BlackBoxOp::Blake2s::bincodeSerialize() const {
+        auto serializer = serde::BincodeSerializer();
+        serde::Serializable<BlackBoxOp::Blake2s>::serialize(*this, serializer);
+        return std::move(serializer).bytes();
+    }
+
+    inline BlackBoxOp::Blake2s BlackBoxOp::Blake2s::bincodeDeserialize(std::vector<uint8_t> input) {
+        auto deserializer = serde::BincodeDeserializer(input);
+        auto value = serde::Deserializable<BlackBoxOp::Blake2s>::deserialize(deserializer);
+        if (deserializer.get_buffer_offset() < input.size()) {
+            throw_or_abort("Some input bytes were not read");
+        }
+        return value;
+    }
+
 } // end of namespace Acir
 
 template <>
@@ -7206,6 +9344,21 @@ namespace Acir {
         return true;
     }
 
+    inline std::vector<uint8_t> BlackBoxOp::Blake3::bincodeSerialize() const {
+        auto serializer = serde::BincodeSerializer();
+        serde::Serializable<BlackBoxOp::Blake3>::serialize(*this, serializer);
+        return std::move(serializer).bytes();
+    }
+
+    inline BlackBoxOp::Blake3 BlackBoxOp::Blake3::bincodeDeserialize(std::vector<uint8_t> input) {
+        auto deserializer = serde::BincodeDeserializer(input);
+        auto value = serde::Deserializable<BlackBoxOp::Blake3>::deserialize(deserializer);
+        if (deserializer.get_buffer_offset() < input.size()) {
+            throw_or_abort("Some input bytes were not read");
+        }
+        return value;
+    }
+
 } // end of namespace Acir
 
 template <>
@@ -7230,6 +9383,21 @@ namespace Acir {
         if (!(lhs.input == rhs.input)) { return false; }
         if (!(lhs.output == rhs.output)) { return false; }
         return true;
+    }
+
+    inline std::vector<uint8_t> BlackBoxOp::Keccakf1600::bincodeSerialize() const {
+        auto serializer = serde::BincodeSerializer();
+        serde::Serializable<BlackBoxOp::Keccakf1600>::serialize(*this, serializer);
+        return std::move(serializer).bytes();
+    }
+
+    inline BlackBoxOp::Keccakf1600 BlackBoxOp::Keccakf1600::bincodeDeserialize(std::vector<uint8_t> input) {
+        auto deserializer = serde::BincodeDeserializer(input);
+        auto value = serde::Deserializable<BlackBoxOp::Keccakf1600>::deserialize(deserializer);
+        if (deserializer.get_buffer_offset() < input.size()) {
+            throw_or_abort("Some input bytes were not read");
+        }
+        return value;
     }
 
 } // end of namespace Acir
@@ -7259,6 +9427,21 @@ namespace Acir {
         if (!(lhs.signature == rhs.signature)) { return false; }
         if (!(lhs.result == rhs.result)) { return false; }
         return true;
+    }
+
+    inline std::vector<uint8_t> BlackBoxOp::EcdsaSecp256k1::bincodeSerialize() const {
+        auto serializer = serde::BincodeSerializer();
+        serde::Serializable<BlackBoxOp::EcdsaSecp256k1>::serialize(*this, serializer);
+        return std::move(serializer).bytes();
+    }
+
+    inline BlackBoxOp::EcdsaSecp256k1 BlackBoxOp::EcdsaSecp256k1::bincodeDeserialize(std::vector<uint8_t> input) {
+        auto deserializer = serde::BincodeDeserializer(input);
+        auto value = serde::Deserializable<BlackBoxOp::EcdsaSecp256k1>::deserialize(deserializer);
+        if (deserializer.get_buffer_offset() < input.size()) {
+            throw_or_abort("Some input bytes were not read");
+        }
+        return value;
     }
 
 } // end of namespace Acir
@@ -7296,6 +9479,21 @@ namespace Acir {
         return true;
     }
 
+    inline std::vector<uint8_t> BlackBoxOp::EcdsaSecp256r1::bincodeSerialize() const {
+        auto serializer = serde::BincodeSerializer();
+        serde::Serializable<BlackBoxOp::EcdsaSecp256r1>::serialize(*this, serializer);
+        return std::move(serializer).bytes();
+    }
+
+    inline BlackBoxOp::EcdsaSecp256r1 BlackBoxOp::EcdsaSecp256r1::bincodeDeserialize(std::vector<uint8_t> input) {
+        auto deserializer = serde::BincodeDeserializer(input);
+        auto value = serde::Deserializable<BlackBoxOp::EcdsaSecp256r1>::deserialize(deserializer);
+        if (deserializer.get_buffer_offset() < input.size()) {
+            throw_or_abort("Some input bytes were not read");
+        }
+        return value;
+    }
+
 } // end of namespace Acir
 
 template <>
@@ -7329,6 +9527,21 @@ namespace Acir {
         return true;
     }
 
+    inline std::vector<uint8_t> BlackBoxOp::MultiScalarMul::bincodeSerialize() const {
+        auto serializer = serde::BincodeSerializer();
+        serde::Serializable<BlackBoxOp::MultiScalarMul>::serialize(*this, serializer);
+        return std::move(serializer).bytes();
+    }
+
+    inline BlackBoxOp::MultiScalarMul BlackBoxOp::MultiScalarMul::bincodeDeserialize(std::vector<uint8_t> input) {
+        auto deserializer = serde::BincodeDeserializer(input);
+        auto value = serde::Deserializable<BlackBoxOp::MultiScalarMul>::deserialize(deserializer);
+        if (deserializer.get_buffer_offset() < input.size()) {
+            throw_or_abort("Some input bytes were not read");
+        }
+        return value;
+    }
+
 } // end of namespace Acir
 
 template <>
@@ -7360,6 +9573,21 @@ namespace Acir {
         if (!(lhs.input2_infinite == rhs.input2_infinite)) { return false; }
         if (!(lhs.result == rhs.result)) { return false; }
         return true;
+    }
+
+    inline std::vector<uint8_t> BlackBoxOp::EmbeddedCurveAdd::bincodeSerialize() const {
+        auto serializer = serde::BincodeSerializer();
+        serde::Serializable<BlackBoxOp::EmbeddedCurveAdd>::serialize(*this, serializer);
+        return std::move(serializer).bytes();
+    }
+
+    inline BlackBoxOp::EmbeddedCurveAdd BlackBoxOp::EmbeddedCurveAdd::bincodeDeserialize(std::vector<uint8_t> input) {
+        auto deserializer = serde::BincodeDeserializer(input);
+        auto value = serde::Deserializable<BlackBoxOp::EmbeddedCurveAdd>::deserialize(deserializer);
+        if (deserializer.get_buffer_offset() < input.size()) {
+            throw_or_abort("Some input bytes were not read");
+        }
+        return value;
     }
 
 } // end of namespace Acir
@@ -7398,6 +9626,21 @@ namespace Acir {
         return true;
     }
 
+    inline std::vector<uint8_t> BlackBoxOp::Poseidon2Permutation::bincodeSerialize() const {
+        auto serializer = serde::BincodeSerializer();
+        serde::Serializable<BlackBoxOp::Poseidon2Permutation>::serialize(*this, serializer);
+        return std::move(serializer).bytes();
+    }
+
+    inline BlackBoxOp::Poseidon2Permutation BlackBoxOp::Poseidon2Permutation::bincodeDeserialize(std::vector<uint8_t> input) {
+        auto deserializer = serde::BincodeDeserializer(input);
+        auto value = serde::Deserializable<BlackBoxOp::Poseidon2Permutation>::deserialize(deserializer);
+        if (deserializer.get_buffer_offset() < input.size()) {
+            throw_or_abort("Some input bytes were not read");
+        }
+        return value;
+    }
+
 } // end of namespace Acir
 
 template <>
@@ -7423,6 +9666,21 @@ namespace Acir {
         if (!(lhs.hash_values == rhs.hash_values)) { return false; }
         if (!(lhs.output == rhs.output)) { return false; }
         return true;
+    }
+
+    inline std::vector<uint8_t> BlackBoxOp::Sha256Compression::bincodeSerialize() const {
+        auto serializer = serde::BincodeSerializer();
+        serde::Serializable<BlackBoxOp::Sha256Compression>::serialize(*this, serializer);
+        return std::move(serializer).bytes();
+    }
+
+    inline BlackBoxOp::Sha256Compression BlackBoxOp::Sha256Compression::bincodeDeserialize(std::vector<uint8_t> input) {
+        auto deserializer = serde::BincodeDeserializer(input);
+        auto value = serde::Deserializable<BlackBoxOp::Sha256Compression>::deserialize(deserializer);
+        if (deserializer.get_buffer_offset() < input.size()) {
+            throw_or_abort("Some input bytes were not read");
+        }
+        return value;
     }
 
 } // end of namespace Acir
@@ -7456,6 +9714,21 @@ namespace Acir {
         return true;
     }
 
+    inline std::vector<uint8_t> BlackBoxOp::ToRadix::bincodeSerialize() const {
+        auto serializer = serde::BincodeSerializer();
+        serde::Serializable<BlackBoxOp::ToRadix>::serialize(*this, serializer);
+        return std::move(serializer).bytes();
+    }
+
+    inline BlackBoxOp::ToRadix BlackBoxOp::ToRadix::bincodeDeserialize(std::vector<uint8_t> input) {
+        auto deserializer = serde::BincodeDeserializer(input);
+        auto value = serde::Deserializable<BlackBoxOp::ToRadix>::deserialize(deserializer);
+        if (deserializer.get_buffer_offset() < input.size()) {
+            throw_or_abort("Some input bytes were not read");
+        }
+        return value;
+    }
+
 } // end of namespace Acir
 
 template <>
@@ -7487,6 +9760,21 @@ namespace Acir {
         return true;
     }
 
+    inline std::vector<uint8_t> BlockId::bincodeSerialize() const {
+        auto serializer = serde::BincodeSerializer();
+        serde::Serializable<BlockId>::serialize(*this, serializer);
+        return std::move(serializer).bytes();
+    }
+
+    inline BlockId BlockId::bincodeDeserialize(std::vector<uint8_t> input) {
+        auto deserializer = serde::BincodeDeserializer(input);
+        auto value = serde::Deserializable<BlockId>::deserialize(deserializer);
+        if (deserializer.get_buffer_offset() < input.size()) {
+            throw_or_abort("Some input bytes were not read");
+        }
+        return value;
+    }
+
 } // end of namespace Acir
 
 template <>
@@ -7512,6 +9800,21 @@ namespace Acir {
     inline bool operator==(const BlockType &lhs, const BlockType &rhs) {
         if (!(lhs.value == rhs.value)) { return false; }
         return true;
+    }
+
+    inline std::vector<uint8_t> BlockType::bincodeSerialize() const {
+        auto serializer = serde::BincodeSerializer();
+        serde::Serializable<BlockType>::serialize(*this, serializer);
+        return std::move(serializer).bytes();
+    }
+
+    inline BlockType BlockType::bincodeDeserialize(std::vector<uint8_t> input) {
+        auto deserializer = serde::BincodeDeserializer(input);
+        auto value = serde::Deserializable<BlockType>::deserialize(deserializer);
+        if (deserializer.get_buffer_offset() < input.size()) {
+            throw_or_abort("Some input bytes were not read");
+        }
+        return value;
     }
 
 } // end of namespace Acir
@@ -7540,6 +9843,21 @@ namespace Acir {
         return true;
     }
 
+    inline std::vector<uint8_t> BlockType::Memory::bincodeSerialize() const {
+        auto serializer = serde::BincodeSerializer();
+        serde::Serializable<BlockType::Memory>::serialize(*this, serializer);
+        return std::move(serializer).bytes();
+    }
+
+    inline BlockType::Memory BlockType::Memory::bincodeDeserialize(std::vector<uint8_t> input) {
+        auto deserializer = serde::BincodeDeserializer(input);
+        auto value = serde::Deserializable<BlockType::Memory>::deserialize(deserializer);
+        if (deserializer.get_buffer_offset() < input.size()) {
+            throw_or_abort("Some input bytes were not read");
+        }
+        return value;
+    }
+
 } // end of namespace Acir
 
 template <>
@@ -7559,6 +9877,21 @@ namespace Acir {
     inline bool operator==(const BlockType::CallData &lhs, const BlockType::CallData &rhs) {
         if (!(lhs.value == rhs.value)) { return false; }
         return true;
+    }
+
+    inline std::vector<uint8_t> BlockType::CallData::bincodeSerialize() const {
+        auto serializer = serde::BincodeSerializer();
+        serde::Serializable<BlockType::CallData>::serialize(*this, serializer);
+        return std::move(serializer).bytes();
+    }
+
+    inline BlockType::CallData BlockType::CallData::bincodeDeserialize(std::vector<uint8_t> input) {
+        auto deserializer = serde::BincodeDeserializer(input);
+        auto value = serde::Deserializable<BlockType::CallData>::deserialize(deserializer);
+        if (deserializer.get_buffer_offset() < input.size()) {
+            throw_or_abort("Some input bytes were not read");
+        }
+        return value;
     }
 
 } // end of namespace Acir
@@ -7583,6 +9916,21 @@ namespace Acir {
         return true;
     }
 
+    inline std::vector<uint8_t> BlockType::ReturnData::bincodeSerialize() const {
+        auto serializer = serde::BincodeSerializer();
+        serde::Serializable<BlockType::ReturnData>::serialize(*this, serializer);
+        return std::move(serializer).bytes();
+    }
+
+    inline BlockType::ReturnData BlockType::ReturnData::bincodeDeserialize(std::vector<uint8_t> input) {
+        auto deserializer = serde::BincodeDeserializer(input);
+        auto value = serde::Deserializable<BlockType::ReturnData>::deserialize(deserializer);
+        if (deserializer.get_buffer_offset() < input.size()) {
+            throw_or_abort("Some input bytes were not read");
+        }
+        return value;
+    }
+
 } // end of namespace Acir
 
 template <>
@@ -7603,6 +9951,21 @@ namespace Acir {
         if (!(lhs.function_name == rhs.function_name)) { return false; }
         if (!(lhs.bytecode == rhs.bytecode)) { return false; }
         return true;
+    }
+
+    inline std::vector<uint8_t> BrilligBytecode::bincodeSerialize() const {
+        auto serializer = serde::BincodeSerializer();
+        serde::Serializable<BrilligBytecode>::serialize(*this, serializer);
+        return std::move(serializer).bytes();
+    }
+
+    inline BrilligBytecode BrilligBytecode::bincodeDeserialize(std::vector<uint8_t> input) {
+        auto deserializer = serde::BincodeDeserializer(input);
+        auto value = serde::Deserializable<BrilligBytecode>::deserialize(deserializer);
+        if (deserializer.get_buffer_offset() < input.size()) {
+            throw_or_abort("Some input bytes were not read");
+        }
+        return value;
     }
 
 } // end of namespace Acir
@@ -7634,6 +9997,21 @@ namespace Acir {
         return true;
     }
 
+    inline std::vector<uint8_t> BrilligInputs::bincodeSerialize() const {
+        auto serializer = serde::BincodeSerializer();
+        serde::Serializable<BrilligInputs>::serialize(*this, serializer);
+        return std::move(serializer).bytes();
+    }
+
+    inline BrilligInputs BrilligInputs::bincodeDeserialize(std::vector<uint8_t> input) {
+        auto deserializer = serde::BincodeDeserializer(input);
+        auto value = serde::Deserializable<BrilligInputs>::deserialize(deserializer);
+        if (deserializer.get_buffer_offset() < input.size()) {
+            throw_or_abort("Some input bytes were not read");
+        }
+        return value;
+    }
+
 } // end of namespace Acir
 
 template <>
@@ -7661,6 +10039,21 @@ namespace Acir {
         return true;
     }
 
+    inline std::vector<uint8_t> BrilligInputs::Single::bincodeSerialize() const {
+        auto serializer = serde::BincodeSerializer();
+        serde::Serializable<BrilligInputs::Single>::serialize(*this, serializer);
+        return std::move(serializer).bytes();
+    }
+
+    inline BrilligInputs::Single BrilligInputs::Single::bincodeDeserialize(std::vector<uint8_t> input) {
+        auto deserializer = serde::BincodeDeserializer(input);
+        auto value = serde::Deserializable<BrilligInputs::Single>::deserialize(deserializer);
+        if (deserializer.get_buffer_offset() < input.size()) {
+            throw_or_abort("Some input bytes were not read");
+        }
+        return value;
+    }
+
 } // end of namespace Acir
 
 template <>
@@ -7682,6 +10075,21 @@ namespace Acir {
     inline bool operator==(const BrilligInputs::Array &lhs, const BrilligInputs::Array &rhs) {
         if (!(lhs.value == rhs.value)) { return false; }
         return true;
+    }
+
+    inline std::vector<uint8_t> BrilligInputs::Array::bincodeSerialize() const {
+        auto serializer = serde::BincodeSerializer();
+        serde::Serializable<BrilligInputs::Array>::serialize(*this, serializer);
+        return std::move(serializer).bytes();
+    }
+
+    inline BrilligInputs::Array BrilligInputs::Array::bincodeDeserialize(std::vector<uint8_t> input) {
+        auto deserializer = serde::BincodeDeserializer(input);
+        auto value = serde::Deserializable<BrilligInputs::Array>::deserialize(deserializer);
+        if (deserializer.get_buffer_offset() < input.size()) {
+            throw_or_abort("Some input bytes were not read");
+        }
+        return value;
     }
 
 } // end of namespace Acir
@@ -7707,6 +10115,21 @@ namespace Acir {
         return true;
     }
 
+    inline std::vector<uint8_t> BrilligInputs::MemoryArray::bincodeSerialize() const {
+        auto serializer = serde::BincodeSerializer();
+        serde::Serializable<BrilligInputs::MemoryArray>::serialize(*this, serializer);
+        return std::move(serializer).bytes();
+    }
+
+    inline BrilligInputs::MemoryArray BrilligInputs::MemoryArray::bincodeDeserialize(std::vector<uint8_t> input) {
+        auto deserializer = serde::BincodeDeserializer(input);
+        auto value = serde::Deserializable<BrilligInputs::MemoryArray>::deserialize(deserializer);
+        if (deserializer.get_buffer_offset() < input.size()) {
+            throw_or_abort("Some input bytes were not read");
+        }
+        return value;
+    }
+
 } // end of namespace Acir
 
 template <>
@@ -7728,6 +10151,21 @@ namespace Acir {
     inline bool operator==(const BrilligOpcode &lhs, const BrilligOpcode &rhs) {
         if (!(lhs.value == rhs.value)) { return false; }
         return true;
+    }
+
+    inline std::vector<uint8_t> BrilligOpcode::bincodeSerialize() const {
+        auto serializer = serde::BincodeSerializer();
+        serde::Serializable<BrilligOpcode>::serialize(*this, serializer);
+        return std::move(serializer).bytes();
+    }
+
+    inline BrilligOpcode BrilligOpcode::bincodeDeserialize(std::vector<uint8_t> input) {
+        auto deserializer = serde::BincodeDeserializer(input);
+        auto value = serde::Deserializable<BrilligOpcode>::deserialize(deserializer);
+        if (deserializer.get_buffer_offset() < input.size()) {
+            throw_or_abort("Some input bytes were not read");
+        }
+        return value;
     }
 
 } // end of namespace Acir
@@ -7758,6 +10196,21 @@ namespace Acir {
         if (!(lhs.lhs == rhs.lhs)) { return false; }
         if (!(lhs.rhs == rhs.rhs)) { return false; }
         return true;
+    }
+
+    inline std::vector<uint8_t> BrilligOpcode::BinaryFieldOp::bincodeSerialize() const {
+        auto serializer = serde::BincodeSerializer();
+        serde::Serializable<BrilligOpcode::BinaryFieldOp>::serialize(*this, serializer);
+        return std::move(serializer).bytes();
+    }
+
+    inline BrilligOpcode::BinaryFieldOp BrilligOpcode::BinaryFieldOp::bincodeDeserialize(std::vector<uint8_t> input) {
+        auto deserializer = serde::BincodeDeserializer(input);
+        auto value = serde::Deserializable<BrilligOpcode::BinaryFieldOp>::deserialize(deserializer);
+        if (deserializer.get_buffer_offset() < input.size()) {
+            throw_or_abort("Some input bytes were not read");
+        }
+        return value;
     }
 
 } // end of namespace Acir
@@ -7793,6 +10246,21 @@ namespace Acir {
         return true;
     }
 
+    inline std::vector<uint8_t> BrilligOpcode::BinaryIntOp::bincodeSerialize() const {
+        auto serializer = serde::BincodeSerializer();
+        serde::Serializable<BrilligOpcode::BinaryIntOp>::serialize(*this, serializer);
+        return std::move(serializer).bytes();
+    }
+
+    inline BrilligOpcode::BinaryIntOp BrilligOpcode::BinaryIntOp::bincodeDeserialize(std::vector<uint8_t> input) {
+        auto deserializer = serde::BincodeDeserializer(input);
+        auto value = serde::Deserializable<BrilligOpcode::BinaryIntOp>::deserialize(deserializer);
+        if (deserializer.get_buffer_offset() < input.size()) {
+            throw_or_abort("Some input bytes were not read");
+        }
+        return value;
+    }
+
 } // end of namespace Acir
 
 template <>
@@ -7826,6 +10294,21 @@ namespace Acir {
         return true;
     }
 
+    inline std::vector<uint8_t> BrilligOpcode::Not::bincodeSerialize() const {
+        auto serializer = serde::BincodeSerializer();
+        serde::Serializable<BrilligOpcode::Not>::serialize(*this, serializer);
+        return std::move(serializer).bytes();
+    }
+
+    inline BrilligOpcode::Not BrilligOpcode::Not::bincodeDeserialize(std::vector<uint8_t> input) {
+        auto deserializer = serde::BincodeDeserializer(input);
+        auto value = serde::Deserializable<BrilligOpcode::Not>::deserialize(deserializer);
+        if (deserializer.get_buffer_offset() < input.size()) {
+            throw_or_abort("Some input bytes were not read");
+        }
+        return value;
+    }
+
 } // end of namespace Acir
 
 template <>
@@ -7853,6 +10336,21 @@ namespace Acir {
         if (!(lhs.source == rhs.source)) { return false; }
         if (!(lhs.bit_size == rhs.bit_size)) { return false; }
         return true;
+    }
+
+    inline std::vector<uint8_t> BrilligOpcode::Cast::bincodeSerialize() const {
+        auto serializer = serde::BincodeSerializer();
+        serde::Serializable<BrilligOpcode::Cast>::serialize(*this, serializer);
+        return std::move(serializer).bytes();
+    }
+
+    inline BrilligOpcode::Cast BrilligOpcode::Cast::bincodeDeserialize(std::vector<uint8_t> input) {
+        auto deserializer = serde::BincodeDeserializer(input);
+        auto value = serde::Deserializable<BrilligOpcode::Cast>::deserialize(deserializer);
+        if (deserializer.get_buffer_offset() < input.size()) {
+            throw_or_abort("Some input bytes were not read");
+        }
+        return value;
     }
 
 } // end of namespace Acir
@@ -7883,6 +10381,21 @@ namespace Acir {
         return true;
     }
 
+    inline std::vector<uint8_t> BrilligOpcode::JumpIf::bincodeSerialize() const {
+        auto serializer = serde::BincodeSerializer();
+        serde::Serializable<BrilligOpcode::JumpIf>::serialize(*this, serializer);
+        return std::move(serializer).bytes();
+    }
+
+    inline BrilligOpcode::JumpIf BrilligOpcode::JumpIf::bincodeDeserialize(std::vector<uint8_t> input) {
+        auto deserializer = serde::BincodeDeserializer(input);
+        auto value = serde::Deserializable<BrilligOpcode::JumpIf>::deserialize(deserializer);
+        if (deserializer.get_buffer_offset() < input.size()) {
+            throw_or_abort("Some input bytes were not read");
+        }
+        return value;
+    }
+
 } // end of namespace Acir
 
 template <>
@@ -7908,6 +10421,21 @@ namespace Acir {
         return true;
     }
 
+    inline std::vector<uint8_t> BrilligOpcode::Jump::bincodeSerialize() const {
+        auto serializer = serde::BincodeSerializer();
+        serde::Serializable<BrilligOpcode::Jump>::serialize(*this, serializer);
+        return std::move(serializer).bytes();
+    }
+
+    inline BrilligOpcode::Jump BrilligOpcode::Jump::bincodeDeserialize(std::vector<uint8_t> input) {
+        auto deserializer = serde::BincodeDeserializer(input);
+        auto value = serde::Deserializable<BrilligOpcode::Jump>::deserialize(deserializer);
+        if (deserializer.get_buffer_offset() < input.size()) {
+            throw_or_abort("Some input bytes were not read");
+        }
+        return value;
+    }
+
 } // end of namespace Acir
 
 template <>
@@ -7931,6 +10459,21 @@ namespace Acir {
         if (!(lhs.size_address == rhs.size_address)) { return false; }
         if (!(lhs.offset_address == rhs.offset_address)) { return false; }
         return true;
+    }
+
+    inline std::vector<uint8_t> BrilligOpcode::CalldataCopy::bincodeSerialize() const {
+        auto serializer = serde::BincodeSerializer();
+        serde::Serializable<BrilligOpcode::CalldataCopy>::serialize(*this, serializer);
+        return std::move(serializer).bytes();
+    }
+
+    inline BrilligOpcode::CalldataCopy BrilligOpcode::CalldataCopy::bincodeDeserialize(std::vector<uint8_t> input) {
+        auto deserializer = serde::BincodeDeserializer(input);
+        auto value = serde::Deserializable<BrilligOpcode::CalldataCopy>::deserialize(deserializer);
+        if (deserializer.get_buffer_offset() < input.size()) {
+            throw_or_abort("Some input bytes were not read");
+        }
+        return value;
     }
 
 } // end of namespace Acir
@@ -7960,6 +10503,21 @@ namespace Acir {
         return true;
     }
 
+    inline std::vector<uint8_t> BrilligOpcode::Call::bincodeSerialize() const {
+        auto serializer = serde::BincodeSerializer();
+        serde::Serializable<BrilligOpcode::Call>::serialize(*this, serializer);
+        return std::move(serializer).bytes();
+    }
+
+    inline BrilligOpcode::Call BrilligOpcode::Call::bincodeDeserialize(std::vector<uint8_t> input) {
+        auto deserializer = serde::BincodeDeserializer(input);
+        auto value = serde::Deserializable<BrilligOpcode::Call>::deserialize(deserializer);
+        if (deserializer.get_buffer_offset() < input.size()) {
+            throw_or_abort("Some input bytes were not read");
+        }
+        return value;
+    }
+
 } // end of namespace Acir
 
 template <>
@@ -7983,6 +10541,21 @@ namespace Acir {
         if (!(lhs.bit_size == rhs.bit_size)) { return false; }
         if (!(lhs.value == rhs.value)) { return false; }
         return true;
+    }
+
+    inline std::vector<uint8_t> BrilligOpcode::Const::bincodeSerialize() const {
+        auto serializer = serde::BincodeSerializer();
+        serde::Serializable<BrilligOpcode::Const>::serialize(*this, serializer);
+        return std::move(serializer).bytes();
+    }
+
+    inline BrilligOpcode::Const BrilligOpcode::Const::bincodeDeserialize(std::vector<uint8_t> input) {
+        auto deserializer = serde::BincodeDeserializer(input);
+        auto value = serde::Deserializable<BrilligOpcode::Const>::deserialize(deserializer);
+        if (deserializer.get_buffer_offset() < input.size()) {
+            throw_or_abort("Some input bytes were not read");
+        }
+        return value;
     }
 
 } // end of namespace Acir
@@ -8014,6 +10587,21 @@ namespace Acir {
         return true;
     }
 
+    inline std::vector<uint8_t> BrilligOpcode::IndirectConst::bincodeSerialize() const {
+        auto serializer = serde::BincodeSerializer();
+        serde::Serializable<BrilligOpcode::IndirectConst>::serialize(*this, serializer);
+        return std::move(serializer).bytes();
+    }
+
+    inline BrilligOpcode::IndirectConst BrilligOpcode::IndirectConst::bincodeDeserialize(std::vector<uint8_t> input) {
+        auto deserializer = serde::BincodeDeserializer(input);
+        auto value = serde::Deserializable<BrilligOpcode::IndirectConst>::deserialize(deserializer);
+        if (deserializer.get_buffer_offset() < input.size()) {
+            throw_or_abort("Some input bytes were not read");
+        }
+        return value;
+    }
+
 } // end of namespace Acir
 
 template <>
@@ -8040,6 +10628,21 @@ namespace Acir {
         return true;
     }
 
+    inline std::vector<uint8_t> BrilligOpcode::Return::bincodeSerialize() const {
+        auto serializer = serde::BincodeSerializer();
+        serde::Serializable<BrilligOpcode::Return>::serialize(*this, serializer);
+        return std::move(serializer).bytes();
+    }
+
+    inline BrilligOpcode::Return BrilligOpcode::Return::bincodeDeserialize(std::vector<uint8_t> input) {
+        auto deserializer = serde::BincodeDeserializer(input);
+        auto value = serde::Deserializable<BrilligOpcode::Return>::deserialize(deserializer);
+        if (deserializer.get_buffer_offset() < input.size()) {
+            throw_or_abort("Some input bytes were not read");
+        }
+        return value;
+    }
+
 } // end of namespace Acir
 
 template <>
@@ -8063,6 +10666,21 @@ namespace Acir {
         if (!(lhs.inputs == rhs.inputs)) { return false; }
         if (!(lhs.input_value_types == rhs.input_value_types)) { return false; }
         return true;
+    }
+
+    inline std::vector<uint8_t> BrilligOpcode::ForeignCall::bincodeSerialize() const {
+        auto serializer = serde::BincodeSerializer();
+        serde::Serializable<BrilligOpcode::ForeignCall>::serialize(*this, serializer);
+        return std::move(serializer).bytes();
+    }
+
+    inline BrilligOpcode::ForeignCall BrilligOpcode::ForeignCall::bincodeDeserialize(std::vector<uint8_t> input) {
+        auto deserializer = serde::BincodeDeserializer(input);
+        auto value = serde::Deserializable<BrilligOpcode::ForeignCall>::deserialize(deserializer);
+        if (deserializer.get_buffer_offset() < input.size()) {
+            throw_or_abort("Some input bytes were not read");
+        }
+        return value;
     }
 
 } // end of namespace Acir
@@ -8097,6 +10715,21 @@ namespace Acir {
         return true;
     }
 
+    inline std::vector<uint8_t> BrilligOpcode::Mov::bincodeSerialize() const {
+        auto serializer = serde::BincodeSerializer();
+        serde::Serializable<BrilligOpcode::Mov>::serialize(*this, serializer);
+        return std::move(serializer).bytes();
+    }
+
+    inline BrilligOpcode::Mov BrilligOpcode::Mov::bincodeDeserialize(std::vector<uint8_t> input) {
+        auto deserializer = serde::BincodeDeserializer(input);
+        auto value = serde::Deserializable<BrilligOpcode::Mov>::deserialize(deserializer);
+        if (deserializer.get_buffer_offset() < input.size()) {
+            throw_or_abort("Some input bytes were not read");
+        }
+        return value;
+    }
+
 } // end of namespace Acir
 
 template <>
@@ -8123,6 +10756,21 @@ namespace Acir {
         if (!(lhs.source_b == rhs.source_b)) { return false; }
         if (!(lhs.condition == rhs.condition)) { return false; }
         return true;
+    }
+
+    inline std::vector<uint8_t> BrilligOpcode::ConditionalMov::bincodeSerialize() const {
+        auto serializer = serde::BincodeSerializer();
+        serde::Serializable<BrilligOpcode::ConditionalMov>::serialize(*this, serializer);
+        return std::move(serializer).bytes();
+    }
+
+    inline BrilligOpcode::ConditionalMov BrilligOpcode::ConditionalMov::bincodeDeserialize(std::vector<uint8_t> input) {
+        auto deserializer = serde::BincodeDeserializer(input);
+        auto value = serde::Deserializable<BrilligOpcode::ConditionalMov>::deserialize(deserializer);
+        if (deserializer.get_buffer_offset() < input.size()) {
+            throw_or_abort("Some input bytes were not read");
+        }
+        return value;
     }
 
 } // end of namespace Acir
@@ -8155,6 +10803,21 @@ namespace Acir {
         return true;
     }
 
+    inline std::vector<uint8_t> BrilligOpcode::Load::bincodeSerialize() const {
+        auto serializer = serde::BincodeSerializer();
+        serde::Serializable<BrilligOpcode::Load>::serialize(*this, serializer);
+        return std::move(serializer).bytes();
+    }
+
+    inline BrilligOpcode::Load BrilligOpcode::Load::bincodeDeserialize(std::vector<uint8_t> input) {
+        auto deserializer = serde::BincodeDeserializer(input);
+        auto value = serde::Deserializable<BrilligOpcode::Load>::deserialize(deserializer);
+        if (deserializer.get_buffer_offset() < input.size()) {
+            throw_or_abort("Some input bytes were not read");
+        }
+        return value;
+    }
+
 } // end of namespace Acir
 
 template <>
@@ -8179,6 +10842,21 @@ namespace Acir {
         if (!(lhs.destination_pointer == rhs.destination_pointer)) { return false; }
         if (!(lhs.source == rhs.source)) { return false; }
         return true;
+    }
+
+    inline std::vector<uint8_t> BrilligOpcode::Store::bincodeSerialize() const {
+        auto serializer = serde::BincodeSerializer();
+        serde::Serializable<BrilligOpcode::Store>::serialize(*this, serializer);
+        return std::move(serializer).bytes();
+    }
+
+    inline BrilligOpcode::Store BrilligOpcode::Store::bincodeDeserialize(std::vector<uint8_t> input) {
+        auto deserializer = serde::BincodeDeserializer(input);
+        auto value = serde::Deserializable<BrilligOpcode::Store>::deserialize(deserializer);
+        if (deserializer.get_buffer_offset() < input.size()) {
+            throw_or_abort("Some input bytes were not read");
+        }
+        return value;
     }
 
 } // end of namespace Acir
@@ -8206,6 +10884,21 @@ namespace Acir {
         return true;
     }
 
+    inline std::vector<uint8_t> BrilligOpcode::BlackBox::bincodeSerialize() const {
+        auto serializer = serde::BincodeSerializer();
+        serde::Serializable<BrilligOpcode::BlackBox>::serialize(*this, serializer);
+        return std::move(serializer).bytes();
+    }
+
+    inline BrilligOpcode::BlackBox BrilligOpcode::BlackBox::bincodeDeserialize(std::vector<uint8_t> input) {
+        auto deserializer = serde::BincodeDeserializer(input);
+        auto value = serde::Deserializable<BrilligOpcode::BlackBox>::deserialize(deserializer);
+        if (deserializer.get_buffer_offset() < input.size()) {
+            throw_or_abort("Some input bytes were not read");
+        }
+        return value;
+    }
+
 } // end of namespace Acir
 
 template <>
@@ -8227,6 +10920,21 @@ namespace Acir {
     inline bool operator==(const BrilligOpcode::Trap &lhs, const BrilligOpcode::Trap &rhs) {
         if (!(lhs.revert_data == rhs.revert_data)) { return false; }
         return true;
+    }
+
+    inline std::vector<uint8_t> BrilligOpcode::Trap::bincodeSerialize() const {
+        auto serializer = serde::BincodeSerializer();
+        serde::Serializable<BrilligOpcode::Trap>::serialize(*this, serializer);
+        return std::move(serializer).bytes();
+    }
+
+    inline BrilligOpcode::Trap BrilligOpcode::Trap::bincodeDeserialize(std::vector<uint8_t> input) {
+        auto deserializer = serde::BincodeDeserializer(input);
+        auto value = serde::Deserializable<BrilligOpcode::Trap>::deserialize(deserializer);
+        if (deserializer.get_buffer_offset() < input.size()) {
+            throw_or_abort("Some input bytes were not read");
+        }
+        return value;
     }
 
 } // end of namespace Acir
@@ -8252,6 +10960,21 @@ namespace Acir {
         return true;
     }
 
+    inline std::vector<uint8_t> BrilligOpcode::Stop::bincodeSerialize() const {
+        auto serializer = serde::BincodeSerializer();
+        serde::Serializable<BrilligOpcode::Stop>::serialize(*this, serializer);
+        return std::move(serializer).bytes();
+    }
+
+    inline BrilligOpcode::Stop BrilligOpcode::Stop::bincodeDeserialize(std::vector<uint8_t> input) {
+        auto deserializer = serde::BincodeDeserializer(input);
+        auto value = serde::Deserializable<BrilligOpcode::Stop>::deserialize(deserializer);
+        if (deserializer.get_buffer_offset() < input.size()) {
+            throw_or_abort("Some input bytes were not read");
+        }
+        return value;
+    }
+
 } // end of namespace Acir
 
 template <>
@@ -8273,6 +10996,21 @@ namespace Acir {
     inline bool operator==(const BrilligOutputs &lhs, const BrilligOutputs &rhs) {
         if (!(lhs.value == rhs.value)) { return false; }
         return true;
+    }
+
+    inline std::vector<uint8_t> BrilligOutputs::bincodeSerialize() const {
+        auto serializer = serde::BincodeSerializer();
+        serde::Serializable<BrilligOutputs>::serialize(*this, serializer);
+        return std::move(serializer).bytes();
+    }
+
+    inline BrilligOutputs BrilligOutputs::bincodeDeserialize(std::vector<uint8_t> input) {
+        auto deserializer = serde::BincodeDeserializer(input);
+        auto value = serde::Deserializable<BrilligOutputs>::deserialize(deserializer);
+        if (deserializer.get_buffer_offset() < input.size()) {
+            throw_or_abort("Some input bytes were not read");
+        }
+        return value;
     }
 
 } // end of namespace Acir
@@ -8302,6 +11040,21 @@ namespace Acir {
         return true;
     }
 
+    inline std::vector<uint8_t> BrilligOutputs::Simple::bincodeSerialize() const {
+        auto serializer = serde::BincodeSerializer();
+        serde::Serializable<BrilligOutputs::Simple>::serialize(*this, serializer);
+        return std::move(serializer).bytes();
+    }
+
+    inline BrilligOutputs::Simple BrilligOutputs::Simple::bincodeDeserialize(std::vector<uint8_t> input) {
+        auto deserializer = serde::BincodeDeserializer(input);
+        auto value = serde::Deserializable<BrilligOutputs::Simple>::deserialize(deserializer);
+        if (deserializer.get_buffer_offset() < input.size()) {
+            throw_or_abort("Some input bytes were not read");
+        }
+        return value;
+    }
+
 } // end of namespace Acir
 
 template <>
@@ -8323,6 +11076,21 @@ namespace Acir {
     inline bool operator==(const BrilligOutputs::Array &lhs, const BrilligOutputs::Array &rhs) {
         if (!(lhs.value == rhs.value)) { return false; }
         return true;
+    }
+
+    inline std::vector<uint8_t> BrilligOutputs::Array::bincodeSerialize() const {
+        auto serializer = serde::BincodeSerializer();
+        serde::Serializable<BrilligOutputs::Array>::serialize(*this, serializer);
+        return std::move(serializer).bytes();
+    }
+
+    inline BrilligOutputs::Array BrilligOutputs::Array::bincodeDeserialize(std::vector<uint8_t> input) {
+        auto deserializer = serde::BincodeDeserializer(input);
+        auto value = serde::Deserializable<BrilligOutputs::Array>::deserialize(deserializer);
+        if (deserializer.get_buffer_offset() < input.size()) {
+            throw_or_abort("Some input bytes were not read");
+        }
+        return value;
     }
 
 } // end of namespace Acir
@@ -8352,6 +11120,21 @@ namespace Acir {
         if (!(lhs.return_values == rhs.return_values)) { return false; }
         if (!(lhs.assert_messages == rhs.assert_messages)) { return false; }
         return true;
+    }
+
+    inline std::vector<uint8_t> Circuit::bincodeSerialize() const {
+        auto serializer = serde::BincodeSerializer();
+        serde::Serializable<Circuit>::serialize(*this, serializer);
+        return std::move(serializer).bytes();
+    }
+
+    inline Circuit Circuit::bincodeDeserialize(std::vector<uint8_t> input) {
+        auto deserializer = serde::BincodeDeserializer(input);
+        auto value = serde::Deserializable<Circuit>::deserialize(deserializer);
+        if (deserializer.get_buffer_offset() < input.size()) {
+            throw_or_abort("Some input bytes were not read");
+        }
+        return value;
     }
 
 } // end of namespace Acir
@@ -8395,6 +11178,21 @@ namespace Acir {
         return true;
     }
 
+    inline std::vector<uint8_t> Expression::bincodeSerialize() const {
+        auto serializer = serde::BincodeSerializer();
+        serde::Serializable<Expression>::serialize(*this, serializer);
+        return std::move(serializer).bytes();
+    }
+
+    inline Expression Expression::bincodeDeserialize(std::vector<uint8_t> input) {
+        auto deserializer = serde::BincodeDeserializer(input);
+        auto value = serde::Deserializable<Expression>::deserialize(deserializer);
+        if (deserializer.get_buffer_offset() < input.size()) {
+            throw_or_abort("Some input bytes were not read");
+        }
+        return value;
+    }
+
 } // end of namespace Acir
 
 template <>
@@ -8426,6 +11224,21 @@ namespace Acir {
         return true;
     }
 
+    inline std::vector<uint8_t> ExpressionOrMemory::bincodeSerialize() const {
+        auto serializer = serde::BincodeSerializer();
+        serde::Serializable<ExpressionOrMemory>::serialize(*this, serializer);
+        return std::move(serializer).bytes();
+    }
+
+    inline ExpressionOrMemory ExpressionOrMemory::bincodeDeserialize(std::vector<uint8_t> input) {
+        auto deserializer = serde::BincodeDeserializer(input);
+        auto value = serde::Deserializable<ExpressionOrMemory>::deserialize(deserializer);
+        if (deserializer.get_buffer_offset() < input.size()) {
+            throw_or_abort("Some input bytes were not read");
+        }
+        return value;
+    }
+
 } // end of namespace Acir
 
 template <>
@@ -8453,6 +11266,21 @@ namespace Acir {
         return true;
     }
 
+    inline std::vector<uint8_t> ExpressionOrMemory::Expression::bincodeSerialize() const {
+        auto serializer = serde::BincodeSerializer();
+        serde::Serializable<ExpressionOrMemory::Expression>::serialize(*this, serializer);
+        return std::move(serializer).bytes();
+    }
+
+    inline ExpressionOrMemory::Expression ExpressionOrMemory::Expression::bincodeDeserialize(std::vector<uint8_t> input) {
+        auto deserializer = serde::BincodeDeserializer(input);
+        auto value = serde::Deserializable<ExpressionOrMemory::Expression>::deserialize(deserializer);
+        if (deserializer.get_buffer_offset() < input.size()) {
+            throw_or_abort("Some input bytes were not read");
+        }
+        return value;
+    }
+
 } // end of namespace Acir
 
 template <>
@@ -8476,6 +11304,21 @@ namespace Acir {
         return true;
     }
 
+    inline std::vector<uint8_t> ExpressionOrMemory::Memory::bincodeSerialize() const {
+        auto serializer = serde::BincodeSerializer();
+        serde::Serializable<ExpressionOrMemory::Memory>::serialize(*this, serializer);
+        return std::move(serializer).bytes();
+    }
+
+    inline ExpressionOrMemory::Memory ExpressionOrMemory::Memory::bincodeDeserialize(std::vector<uint8_t> input) {
+        auto deserializer = serde::BincodeDeserializer(input);
+        auto value = serde::Deserializable<ExpressionOrMemory::Memory>::deserialize(deserializer);
+        if (deserializer.get_buffer_offset() < input.size()) {
+            throw_or_abort("Some input bytes were not read");
+        }
+        return value;
+    }
+
 } // end of namespace Acir
 
 template <>
@@ -8497,6 +11340,21 @@ namespace Acir {
     inline bool operator==(const FunctionInput &lhs, const FunctionInput &rhs) {
         if (!(lhs.value == rhs.value)) { return false; }
         return true;
+    }
+
+    inline std::vector<uint8_t> FunctionInput::bincodeSerialize() const {
+        auto serializer = serde::BincodeSerializer();
+        serde::Serializable<FunctionInput>::serialize(*this, serializer);
+        return std::move(serializer).bytes();
+    }
+
+    inline FunctionInput FunctionInput::bincodeDeserialize(std::vector<uint8_t> input) {
+        auto deserializer = serde::BincodeDeserializer(input);
+        auto value = serde::Deserializable<FunctionInput>::deserialize(deserializer);
+        if (deserializer.get_buffer_offset() < input.size()) {
+            throw_or_abort("Some input bytes were not read");
+        }
+        return value;
     }
 
 } // end of namespace Acir
@@ -8526,6 +11384,21 @@ namespace Acir {
         return true;
     }
 
+    inline std::vector<uint8_t> FunctionInput::Constant::bincodeSerialize() const {
+        auto serializer = serde::BincodeSerializer();
+        serde::Serializable<FunctionInput::Constant>::serialize(*this, serializer);
+        return std::move(serializer).bytes();
+    }
+
+    inline FunctionInput::Constant FunctionInput::Constant::bincodeDeserialize(std::vector<uint8_t> input) {
+        auto deserializer = serde::BincodeDeserializer(input);
+        auto value = serde::Deserializable<FunctionInput::Constant>::deserialize(deserializer);
+        if (deserializer.get_buffer_offset() < input.size()) {
+            throw_or_abort("Some input bytes were not read");
+        }
+        return value;
+    }
+
 } // end of namespace Acir
 
 template <>
@@ -8547,6 +11420,21 @@ namespace Acir {
     inline bool operator==(const FunctionInput::Witness &lhs, const FunctionInput::Witness &rhs) {
         if (!(lhs.value == rhs.value)) { return false; }
         return true;
+    }
+
+    inline std::vector<uint8_t> FunctionInput::Witness::bincodeSerialize() const {
+        auto serializer = serde::BincodeSerializer();
+        serde::Serializable<FunctionInput::Witness>::serialize(*this, serializer);
+        return std::move(serializer).bytes();
+    }
+
+    inline FunctionInput::Witness FunctionInput::Witness::bincodeDeserialize(std::vector<uint8_t> input) {
+        auto deserializer = serde::BincodeDeserializer(input);
+        auto value = serde::Deserializable<FunctionInput::Witness>::deserialize(deserializer);
+        if (deserializer.get_buffer_offset() < input.size()) {
+            throw_or_abort("Some input bytes were not read");
+        }
+        return value;
     }
 
 } // end of namespace Acir
@@ -8571,6 +11459,21 @@ namespace Acir {
         if (!(lhs.pointer == rhs.pointer)) { return false; }
         if (!(lhs.size == rhs.size)) { return false; }
         return true;
+    }
+
+    inline std::vector<uint8_t> HeapArray::bincodeSerialize() const {
+        auto serializer = serde::BincodeSerializer();
+        serde::Serializable<HeapArray>::serialize(*this, serializer);
+        return std::move(serializer).bytes();
+    }
+
+    inline HeapArray HeapArray::bincodeDeserialize(std::vector<uint8_t> input) {
+        auto deserializer = serde::BincodeDeserializer(input);
+        auto value = serde::Deserializable<HeapArray>::deserialize(deserializer);
+        if (deserializer.get_buffer_offset() < input.size()) {
+            throw_or_abort("Some input bytes were not read");
+        }
+        return value;
     }
 
 } // end of namespace Acir
@@ -8602,6 +11505,21 @@ namespace Acir {
         return true;
     }
 
+    inline std::vector<uint8_t> HeapValueType::bincodeSerialize() const {
+        auto serializer = serde::BincodeSerializer();
+        serde::Serializable<HeapValueType>::serialize(*this, serializer);
+        return std::move(serializer).bytes();
+    }
+
+    inline HeapValueType HeapValueType::bincodeDeserialize(std::vector<uint8_t> input) {
+        auto deserializer = serde::BincodeDeserializer(input);
+        auto value = serde::Deserializable<HeapValueType>::deserialize(deserializer);
+        if (deserializer.get_buffer_offset() < input.size()) {
+            throw_or_abort("Some input bytes were not read");
+        }
+        return value;
+    }
+
 } // end of namespace Acir
 
 template <>
@@ -8629,6 +11547,21 @@ namespace Acir {
         return true;
     }
 
+    inline std::vector<uint8_t> HeapValueType::Simple::bincodeSerialize() const {
+        auto serializer = serde::BincodeSerializer();
+        serde::Serializable<HeapValueType::Simple>::serialize(*this, serializer);
+        return std::move(serializer).bytes();
+    }
+
+    inline HeapValueType::Simple HeapValueType::Simple::bincodeDeserialize(std::vector<uint8_t> input) {
+        auto deserializer = serde::BincodeDeserializer(input);
+        auto value = serde::Deserializable<HeapValueType::Simple>::deserialize(deserializer);
+        if (deserializer.get_buffer_offset() < input.size()) {
+            throw_or_abort("Some input bytes were not read");
+        }
+        return value;
+    }
+
 } // end of namespace Acir
 
 template <>
@@ -8651,6 +11584,21 @@ namespace Acir {
         if (!(lhs.value_types == rhs.value_types)) { return false; }
         if (!(lhs.size == rhs.size)) { return false; }
         return true;
+    }
+
+    inline std::vector<uint8_t> HeapValueType::Array::bincodeSerialize() const {
+        auto serializer = serde::BincodeSerializer();
+        serde::Serializable<HeapValueType::Array>::serialize(*this, serializer);
+        return std::move(serializer).bytes();
+    }
+
+    inline HeapValueType::Array HeapValueType::Array::bincodeDeserialize(std::vector<uint8_t> input) {
+        auto deserializer = serde::BincodeDeserializer(input);
+        auto value = serde::Deserializable<HeapValueType::Array>::deserialize(deserializer);
+        if (deserializer.get_buffer_offset() < input.size()) {
+            throw_or_abort("Some input bytes were not read");
+        }
+        return value;
     }
 
 } // end of namespace Acir
@@ -8678,6 +11626,21 @@ namespace Acir {
         return true;
     }
 
+    inline std::vector<uint8_t> HeapValueType::Vector::bincodeSerialize() const {
+        auto serializer = serde::BincodeSerializer();
+        serde::Serializable<HeapValueType::Vector>::serialize(*this, serializer);
+        return std::move(serializer).bytes();
+    }
+
+    inline HeapValueType::Vector HeapValueType::Vector::bincodeDeserialize(std::vector<uint8_t> input) {
+        auto deserializer = serde::BincodeDeserializer(input);
+        auto value = serde::Deserializable<HeapValueType::Vector>::deserialize(deserializer);
+        if (deserializer.get_buffer_offset() < input.size()) {
+            throw_or_abort("Some input bytes were not read");
+        }
+        return value;
+    }
+
 } // end of namespace Acir
 
 template <>
@@ -8700,6 +11663,21 @@ namespace Acir {
         if (!(lhs.pointer == rhs.pointer)) { return false; }
         if (!(lhs.size == rhs.size)) { return false; }
         return true;
+    }
+
+    inline std::vector<uint8_t> HeapVector::bincodeSerialize() const {
+        auto serializer = serde::BincodeSerializer();
+        serde::Serializable<HeapVector>::serialize(*this, serializer);
+        return std::move(serializer).bytes();
+    }
+
+    inline HeapVector HeapVector::bincodeDeserialize(std::vector<uint8_t> input) {
+        auto deserializer = serde::BincodeDeserializer(input);
+        auto value = serde::Deserializable<HeapVector>::deserialize(deserializer);
+        if (deserializer.get_buffer_offset() < input.size()) {
+            throw_or_abort("Some input bytes were not read");
+        }
+        return value;
     }
 
 } // end of namespace Acir
@@ -8731,6 +11709,21 @@ namespace Acir {
         return true;
     }
 
+    inline std::vector<uint8_t> IntegerBitSize::bincodeSerialize() const {
+        auto serializer = serde::BincodeSerializer();
+        serde::Serializable<IntegerBitSize>::serialize(*this, serializer);
+        return std::move(serializer).bytes();
+    }
+
+    inline IntegerBitSize IntegerBitSize::bincodeDeserialize(std::vector<uint8_t> input) {
+        auto deserializer = serde::BincodeDeserializer(input);
+        auto value = serde::Deserializable<IntegerBitSize>::deserialize(deserializer);
+        if (deserializer.get_buffer_offset() < input.size()) {
+            throw_or_abort("Some input bytes were not read");
+        }
+        return value;
+    }
+
 } // end of namespace Acir
 
 template <>
@@ -8757,6 +11750,21 @@ namespace Acir {
         return true;
     }
 
+    inline std::vector<uint8_t> IntegerBitSize::U1::bincodeSerialize() const {
+        auto serializer = serde::BincodeSerializer();
+        serde::Serializable<IntegerBitSize::U1>::serialize(*this, serializer);
+        return std::move(serializer).bytes();
+    }
+
+    inline IntegerBitSize::U1 IntegerBitSize::U1::bincodeDeserialize(std::vector<uint8_t> input) {
+        auto deserializer = serde::BincodeDeserializer(input);
+        auto value = serde::Deserializable<IntegerBitSize::U1>::deserialize(deserializer);
+        if (deserializer.get_buffer_offset() < input.size()) {
+            throw_or_abort("Some input bytes were not read");
+        }
+        return value;
+    }
+
 } // end of namespace Acir
 
 template <>
@@ -8775,6 +11783,21 @@ namespace Acir {
 
     inline bool operator==(const IntegerBitSize::U8 &lhs, const IntegerBitSize::U8 &rhs) {
         return true;
+    }
+
+    inline std::vector<uint8_t> IntegerBitSize::U8::bincodeSerialize() const {
+        auto serializer = serde::BincodeSerializer();
+        serde::Serializable<IntegerBitSize::U8>::serialize(*this, serializer);
+        return std::move(serializer).bytes();
+    }
+
+    inline IntegerBitSize::U8 IntegerBitSize::U8::bincodeDeserialize(std::vector<uint8_t> input) {
+        auto deserializer = serde::BincodeDeserializer(input);
+        auto value = serde::Deserializable<IntegerBitSize::U8>::deserialize(deserializer);
+        if (deserializer.get_buffer_offset() < input.size()) {
+            throw_or_abort("Some input bytes were not read");
+        }
+        return value;
     }
 
 } // end of namespace Acir
@@ -8797,6 +11820,21 @@ namespace Acir {
         return true;
     }
 
+    inline std::vector<uint8_t> IntegerBitSize::U16::bincodeSerialize() const {
+        auto serializer = serde::BincodeSerializer();
+        serde::Serializable<IntegerBitSize::U16>::serialize(*this, serializer);
+        return std::move(serializer).bytes();
+    }
+
+    inline IntegerBitSize::U16 IntegerBitSize::U16::bincodeDeserialize(std::vector<uint8_t> input) {
+        auto deserializer = serde::BincodeDeserializer(input);
+        auto value = serde::Deserializable<IntegerBitSize::U16>::deserialize(deserializer);
+        if (deserializer.get_buffer_offset() < input.size()) {
+            throw_or_abort("Some input bytes were not read");
+        }
+        return value;
+    }
+
 } // end of namespace Acir
 
 template <>
@@ -8815,6 +11853,21 @@ namespace Acir {
 
     inline bool operator==(const IntegerBitSize::U32 &lhs, const IntegerBitSize::U32 &rhs) {
         return true;
+    }
+
+    inline std::vector<uint8_t> IntegerBitSize::U32::bincodeSerialize() const {
+        auto serializer = serde::BincodeSerializer();
+        serde::Serializable<IntegerBitSize::U32>::serialize(*this, serializer);
+        return std::move(serializer).bytes();
+    }
+
+    inline IntegerBitSize::U32 IntegerBitSize::U32::bincodeDeserialize(std::vector<uint8_t> input) {
+        auto deserializer = serde::BincodeDeserializer(input);
+        auto value = serde::Deserializable<IntegerBitSize::U32>::deserialize(deserializer);
+        if (deserializer.get_buffer_offset() < input.size()) {
+            throw_or_abort("Some input bytes were not read");
+        }
+        return value;
     }
 
 } // end of namespace Acir
@@ -8837,6 +11890,21 @@ namespace Acir {
         return true;
     }
 
+    inline std::vector<uint8_t> IntegerBitSize::U64::bincodeSerialize() const {
+        auto serializer = serde::BincodeSerializer();
+        serde::Serializable<IntegerBitSize::U64>::serialize(*this, serializer);
+        return std::move(serializer).bytes();
+    }
+
+    inline IntegerBitSize::U64 IntegerBitSize::U64::bincodeDeserialize(std::vector<uint8_t> input) {
+        auto deserializer = serde::BincodeDeserializer(input);
+        auto value = serde::Deserializable<IntegerBitSize::U64>::deserialize(deserializer);
+        if (deserializer.get_buffer_offset() < input.size()) {
+            throw_or_abort("Some input bytes were not read");
+        }
+        return value;
+    }
+
 } // end of namespace Acir
 
 template <>
@@ -8855,6 +11923,21 @@ namespace Acir {
 
     inline bool operator==(const IntegerBitSize::U128 &lhs, const IntegerBitSize::U128 &rhs) {
         return true;
+    }
+
+    inline std::vector<uint8_t> IntegerBitSize::U128::bincodeSerialize() const {
+        auto serializer = serde::BincodeSerializer();
+        serde::Serializable<IntegerBitSize::U128>::serialize(*this, serializer);
+        return std::move(serializer).bytes();
+    }
+
+    inline IntegerBitSize::U128 IntegerBitSize::U128::bincodeDeserialize(std::vector<uint8_t> input) {
+        auto deserializer = serde::BincodeDeserializer(input);
+        auto value = serde::Deserializable<IntegerBitSize::U128>::deserialize(deserializer);
+        if (deserializer.get_buffer_offset() < input.size()) {
+            throw_or_abort("Some input bytes were not read");
+        }
+        return value;
     }
 
 } // end of namespace Acir
@@ -8878,6 +11961,21 @@ namespace Acir {
         if (!(lhs.index == rhs.index)) { return false; }
         if (!(lhs.value == rhs.value)) { return false; }
         return true;
+    }
+
+    inline std::vector<uint8_t> MemOp::bincodeSerialize() const {
+        auto serializer = serde::BincodeSerializer();
+        serde::Serializable<MemOp>::serialize(*this, serializer);
+        return std::move(serializer).bytes();
+    }
+
+    inline MemOp MemOp::bincodeDeserialize(std::vector<uint8_t> input) {
+        auto deserializer = serde::BincodeDeserializer(input);
+        auto value = serde::Deserializable<MemOp>::deserialize(deserializer);
+        if (deserializer.get_buffer_offset() < input.size()) {
+            throw_or_abort("Some input bytes were not read");
+        }
+        return value;
     }
 
 } // end of namespace Acir
@@ -8911,6 +12009,21 @@ namespace Acir {
         return true;
     }
 
+    inline std::vector<uint8_t> MemoryAddress::bincodeSerialize() const {
+        auto serializer = serde::BincodeSerializer();
+        serde::Serializable<MemoryAddress>::serialize(*this, serializer);
+        return std::move(serializer).bytes();
+    }
+
+    inline MemoryAddress MemoryAddress::bincodeDeserialize(std::vector<uint8_t> input) {
+        auto deserializer = serde::BincodeDeserializer(input);
+        auto value = serde::Deserializable<MemoryAddress>::deserialize(deserializer);
+        if (deserializer.get_buffer_offset() < input.size()) {
+            throw_or_abort("Some input bytes were not read");
+        }
+        return value;
+    }
+
 } // end of namespace Acir
 
 template <>
@@ -8938,6 +12051,21 @@ namespace Acir {
         return true;
     }
 
+    inline std::vector<uint8_t> MemoryAddress::Direct::bincodeSerialize() const {
+        auto serializer = serde::BincodeSerializer();
+        serde::Serializable<MemoryAddress::Direct>::serialize(*this, serializer);
+        return std::move(serializer).bytes();
+    }
+
+    inline MemoryAddress::Direct MemoryAddress::Direct::bincodeDeserialize(std::vector<uint8_t> input) {
+        auto deserializer = serde::BincodeDeserializer(input);
+        auto value = serde::Deserializable<MemoryAddress::Direct>::deserialize(deserializer);
+        if (deserializer.get_buffer_offset() < input.size()) {
+            throw_or_abort("Some input bytes were not read");
+        }
+        return value;
+    }
+
 } // end of namespace Acir
 
 template <>
@@ -8961,6 +12089,21 @@ namespace Acir {
         return true;
     }
 
+    inline std::vector<uint8_t> MemoryAddress::Relative::bincodeSerialize() const {
+        auto serializer = serde::BincodeSerializer();
+        serde::Serializable<MemoryAddress::Relative>::serialize(*this, serializer);
+        return std::move(serializer).bytes();
+    }
+
+    inline MemoryAddress::Relative MemoryAddress::Relative::bincodeDeserialize(std::vector<uint8_t> input) {
+        auto deserializer = serde::BincodeDeserializer(input);
+        auto value = serde::Deserializable<MemoryAddress::Relative>::deserialize(deserializer);
+        if (deserializer.get_buffer_offset() < input.size()) {
+            throw_or_abort("Some input bytes were not read");
+        }
+        return value;
+    }
+
 } // end of namespace Acir
 
 template <>
@@ -8982,6 +12125,21 @@ namespace Acir {
     inline bool operator==(const Opcode &lhs, const Opcode &rhs) {
         if (!(lhs.value == rhs.value)) { return false; }
         return true;
+    }
+
+    inline std::vector<uint8_t> Opcode::bincodeSerialize() const {
+        auto serializer = serde::BincodeSerializer();
+        serde::Serializable<Opcode>::serialize(*this, serializer);
+        return std::move(serializer).bytes();
+    }
+
+    inline Opcode Opcode::bincodeDeserialize(std::vector<uint8_t> input) {
+        auto deserializer = serde::BincodeDeserializer(input);
+        auto value = serde::Deserializable<Opcode>::deserialize(deserializer);
+        if (deserializer.get_buffer_offset() < input.size()) {
+            throw_or_abort("Some input bytes were not read");
+        }
+        return value;
     }
 
 } // end of namespace Acir
@@ -9011,6 +12169,21 @@ namespace Acir {
         return true;
     }
 
+    inline std::vector<uint8_t> Opcode::AssertZero::bincodeSerialize() const {
+        auto serializer = serde::BincodeSerializer();
+        serde::Serializable<Opcode::AssertZero>::serialize(*this, serializer);
+        return std::move(serializer).bytes();
+    }
+
+    inline Opcode::AssertZero Opcode::AssertZero::bincodeDeserialize(std::vector<uint8_t> input) {
+        auto deserializer = serde::BincodeDeserializer(input);
+        auto value = serde::Deserializable<Opcode::AssertZero>::deserialize(deserializer);
+        if (deserializer.get_buffer_offset() < input.size()) {
+            throw_or_abort("Some input bytes were not read");
+        }
+        return value;
+    }
+
 } // end of namespace Acir
 
 template <>
@@ -9032,6 +12205,21 @@ namespace Acir {
     inline bool operator==(const Opcode::BlackBoxFuncCall &lhs, const Opcode::BlackBoxFuncCall &rhs) {
         if (!(lhs.value == rhs.value)) { return false; }
         return true;
+    }
+
+    inline std::vector<uint8_t> Opcode::BlackBoxFuncCall::bincodeSerialize() const {
+        auto serializer = serde::BincodeSerializer();
+        serde::Serializable<Opcode::BlackBoxFuncCall>::serialize(*this, serializer);
+        return std::move(serializer).bytes();
+    }
+
+    inline Opcode::BlackBoxFuncCall Opcode::BlackBoxFuncCall::bincodeDeserialize(std::vector<uint8_t> input) {
+        auto deserializer = serde::BincodeDeserializer(input);
+        auto value = serde::Deserializable<Opcode::BlackBoxFuncCall>::deserialize(deserializer);
+        if (deserializer.get_buffer_offset() < input.size()) {
+            throw_or_abort("Some input bytes were not read");
+        }
+        return value;
     }
 
 } // end of namespace Acir
@@ -9056,6 +12244,21 @@ namespace Acir {
         if (!(lhs.block_id == rhs.block_id)) { return false; }
         if (!(lhs.op == rhs.op)) { return false; }
         return true;
+    }
+
+    inline std::vector<uint8_t> Opcode::MemoryOp::bincodeSerialize() const {
+        auto serializer = serde::BincodeSerializer();
+        serde::Serializable<Opcode::MemoryOp>::serialize(*this, serializer);
+        return std::move(serializer).bytes();
+    }
+
+    inline Opcode::MemoryOp Opcode::MemoryOp::bincodeDeserialize(std::vector<uint8_t> input) {
+        auto deserializer = serde::BincodeDeserializer(input);
+        auto value = serde::Deserializable<Opcode::MemoryOp>::deserialize(deserializer);
+        if (deserializer.get_buffer_offset() < input.size()) {
+            throw_or_abort("Some input bytes were not read");
+        }
+        return value;
     }
 
 } // end of namespace Acir
@@ -9083,6 +12286,21 @@ namespace Acir {
         if (!(lhs.init == rhs.init)) { return false; }
         if (!(lhs.block_type == rhs.block_type)) { return false; }
         return true;
+    }
+
+    inline std::vector<uint8_t> Opcode::MemoryInit::bincodeSerialize() const {
+        auto serializer = serde::BincodeSerializer();
+        serde::Serializable<Opcode::MemoryInit>::serialize(*this, serializer);
+        return std::move(serializer).bytes();
+    }
+
+    inline Opcode::MemoryInit Opcode::MemoryInit::bincodeDeserialize(std::vector<uint8_t> input) {
+        auto deserializer = serde::BincodeDeserializer(input);
+        auto value = serde::Deserializable<Opcode::MemoryInit>::deserialize(deserializer);
+        if (deserializer.get_buffer_offset() < input.size()) {
+            throw_or_abort("Some input bytes were not read");
+        }
+        return value;
     }
 
 } // end of namespace Acir
@@ -9113,6 +12331,21 @@ namespace Acir {
         if (!(lhs.outputs == rhs.outputs)) { return false; }
         if (!(lhs.predicate == rhs.predicate)) { return false; }
         return true;
+    }
+
+    inline std::vector<uint8_t> Opcode::BrilligCall::bincodeSerialize() const {
+        auto serializer = serde::BincodeSerializer();
+        serde::Serializable<Opcode::BrilligCall>::serialize(*this, serializer);
+        return std::move(serializer).bytes();
+    }
+
+    inline Opcode::BrilligCall Opcode::BrilligCall::bincodeDeserialize(std::vector<uint8_t> input) {
+        auto deserializer = serde::BincodeDeserializer(input);
+        auto value = serde::Deserializable<Opcode::BrilligCall>::deserialize(deserializer);
+        if (deserializer.get_buffer_offset() < input.size()) {
+            throw_or_abort("Some input bytes were not read");
+        }
+        return value;
     }
 
 } // end of namespace Acir
@@ -9147,6 +12380,21 @@ namespace Acir {
         return true;
     }
 
+    inline std::vector<uint8_t> Opcode::Call::bincodeSerialize() const {
+        auto serializer = serde::BincodeSerializer();
+        serde::Serializable<Opcode::Call>::serialize(*this, serializer);
+        return std::move(serializer).bytes();
+    }
+
+    inline Opcode::Call Opcode::Call::bincodeDeserialize(std::vector<uint8_t> input) {
+        auto deserializer = serde::BincodeDeserializer(input);
+        auto value = serde::Deserializable<Opcode::Call>::deserialize(deserializer);
+        if (deserializer.get_buffer_offset() < input.size()) {
+            throw_or_abort("Some input bytes were not read");
+        }
+        return value;
+    }
+
 } // end of namespace Acir
 
 template <>
@@ -9176,6 +12424,21 @@ namespace Acir {
         return true;
     }
 
+    inline std::vector<uint8_t> OpcodeLocation::bincodeSerialize() const {
+        auto serializer = serde::BincodeSerializer();
+        serde::Serializable<OpcodeLocation>::serialize(*this, serializer);
+        return std::move(serializer).bytes();
+    }
+
+    inline OpcodeLocation OpcodeLocation::bincodeDeserialize(std::vector<uint8_t> input) {
+        auto deserializer = serde::BincodeDeserializer(input);
+        auto value = serde::Deserializable<OpcodeLocation>::deserialize(deserializer);
+        if (deserializer.get_buffer_offset() < input.size()) {
+            throw_or_abort("Some input bytes were not read");
+        }
+        return value;
+    }
+
 } // end of namespace Acir
 
 template <>
@@ -9203,6 +12466,21 @@ namespace Acir {
         return true;
     }
 
+    inline std::vector<uint8_t> OpcodeLocation::Acir::bincodeSerialize() const {
+        auto serializer = serde::BincodeSerializer();
+        serde::Serializable<OpcodeLocation::Acir>::serialize(*this, serializer);
+        return std::move(serializer).bytes();
+    }
+
+    inline OpcodeLocation::Acir OpcodeLocation::Acir::bincodeDeserialize(std::vector<uint8_t> input) {
+        auto deserializer = serde::BincodeDeserializer(input);
+        auto value = serde::Deserializable<OpcodeLocation::Acir>::deserialize(deserializer);
+        if (deserializer.get_buffer_offset() < input.size()) {
+            throw_or_abort("Some input bytes were not read");
+        }
+        return value;
+    }
+
 } // end of namespace Acir
 
 template <>
@@ -9225,6 +12503,21 @@ namespace Acir {
         if (!(lhs.acir_index == rhs.acir_index)) { return false; }
         if (!(lhs.brillig_index == rhs.brillig_index)) { return false; }
         return true;
+    }
+
+    inline std::vector<uint8_t> OpcodeLocation::Brillig::bincodeSerialize() const {
+        auto serializer = serde::BincodeSerializer();
+        serde::Serializable<OpcodeLocation::Brillig>::serialize(*this, serializer);
+        return std::move(serializer).bytes();
+    }
+
+    inline OpcodeLocation::Brillig OpcodeLocation::Brillig::bincodeDeserialize(std::vector<uint8_t> input) {
+        auto deserializer = serde::BincodeDeserializer(input);
+        auto value = serde::Deserializable<OpcodeLocation::Brillig>::deserialize(deserializer);
+        if (deserializer.get_buffer_offset() < input.size()) {
+            throw_or_abort("Some input bytes were not read");
+        }
+        return value;
     }
 
 } // end of namespace Acir
@@ -9251,6 +12544,21 @@ namespace Acir {
         if (!(lhs.functions == rhs.functions)) { return false; }
         if (!(lhs.unconstrained_functions == rhs.unconstrained_functions)) { return false; }
         return true;
+    }
+
+    inline std::vector<uint8_t> Program::bincodeSerialize() const {
+        auto serializer = serde::BincodeSerializer();
+        serde::Serializable<Program>::serialize(*this, serializer);
+        return std::move(serializer).bytes();
+    }
+
+    inline Program Program::bincodeDeserialize(std::vector<uint8_t> input) {
+        auto deserializer = serde::BincodeDeserializer(input);
+        auto value = serde::Deserializable<Program>::deserialize(deserializer);
+        if (deserializer.get_buffer_offset() < input.size()) {
+            throw_or_abort("Some input bytes were not read");
+        }
+        return value;
     }
 
 } // end of namespace Acir
@@ -9283,6 +12591,21 @@ namespace Acir {
         return true;
     }
 
+    inline std::vector<uint8_t> ProgramWithoutBrillig::bincodeSerialize() const {
+        auto serializer = serde::BincodeSerializer();
+        serde::Serializable<ProgramWithoutBrillig>::serialize(*this, serializer);
+        return std::move(serializer).bytes();
+    }
+
+    inline ProgramWithoutBrillig ProgramWithoutBrillig::bincodeDeserialize(std::vector<uint8_t> input) {
+        auto deserializer = serde::BincodeDeserializer(input);
+        auto value = serde::Deserializable<ProgramWithoutBrillig>::deserialize(deserializer);
+        if (deserializer.get_buffer_offset() < input.size()) {
+            throw_or_abort("Some input bytes were not read");
+        }
+        return value;
+    }
+
 } // end of namespace Acir
 
 template <>
@@ -9312,6 +12635,21 @@ namespace Acir {
         return true;
     }
 
+    inline std::vector<uint8_t> PublicInputs::bincodeSerialize() const {
+        auto serializer = serde::BincodeSerializer();
+        serde::Serializable<PublicInputs>::serialize(*this, serializer);
+        return std::move(serializer).bytes();
+    }
+
+    inline PublicInputs PublicInputs::bincodeDeserialize(std::vector<uint8_t> input) {
+        auto deserializer = serde::BincodeDeserializer(input);
+        auto value = serde::Deserializable<PublicInputs>::deserialize(deserializer);
+        if (deserializer.get_buffer_offset() < input.size()) {
+            throw_or_abort("Some input bytes were not read");
+        }
+        return value;
+    }
+
 } // end of namespace Acir
 
 template <>
@@ -9337,6 +12675,21 @@ namespace Acir {
     inline bool operator==(const SemanticLength &lhs, const SemanticLength &rhs) {
         if (!(lhs.value == rhs.value)) { return false; }
         return true;
+    }
+
+    inline std::vector<uint8_t> SemanticLength::bincodeSerialize() const {
+        auto serializer = serde::BincodeSerializer();
+        serde::Serializable<SemanticLength>::serialize(*this, serializer);
+        return std::move(serializer).bytes();
+    }
+
+    inline SemanticLength SemanticLength::bincodeDeserialize(std::vector<uint8_t> input) {
+        auto deserializer = serde::BincodeDeserializer(input);
+        auto value = serde::Deserializable<SemanticLength>::deserialize(deserializer);
+        if (deserializer.get_buffer_offset() < input.size()) {
+            throw_or_abort("Some input bytes were not read");
+        }
+        return value;
     }
 
 } // end of namespace Acir
@@ -9366,6 +12719,21 @@ namespace Acir {
         return true;
     }
 
+    inline std::vector<uint8_t> SemiFlattenedLength::bincodeSerialize() const {
+        auto serializer = serde::BincodeSerializer();
+        serde::Serializable<SemiFlattenedLength>::serialize(*this, serializer);
+        return std::move(serializer).bytes();
+    }
+
+    inline SemiFlattenedLength SemiFlattenedLength::bincodeDeserialize(std::vector<uint8_t> input) {
+        auto deserializer = serde::BincodeDeserializer(input);
+        auto value = serde::Deserializable<SemiFlattenedLength>::deserialize(deserializer);
+        if (deserializer.get_buffer_offset() < input.size()) {
+            throw_or_abort("Some input bytes were not read");
+        }
+        return value;
+    }
+
 } // end of namespace Acir
 
 template <>
@@ -9391,6 +12759,21 @@ namespace Acir {
     inline bool operator==(const ValueOrArray &lhs, const ValueOrArray &rhs) {
         if (!(lhs.value == rhs.value)) { return false; }
         return true;
+    }
+
+    inline std::vector<uint8_t> ValueOrArray::bincodeSerialize() const {
+        auto serializer = serde::BincodeSerializer();
+        serde::Serializable<ValueOrArray>::serialize(*this, serializer);
+        return std::move(serializer).bytes();
+    }
+
+    inline ValueOrArray ValueOrArray::bincodeDeserialize(std::vector<uint8_t> input) {
+        auto deserializer = serde::BincodeDeserializer(input);
+        auto value = serde::Deserializable<ValueOrArray>::deserialize(deserializer);
+        if (deserializer.get_buffer_offset() < input.size()) {
+            throw_or_abort("Some input bytes were not read");
+        }
+        return value;
     }
 
 } // end of namespace Acir
@@ -9420,6 +12803,21 @@ namespace Acir {
         return true;
     }
 
+    inline std::vector<uint8_t> ValueOrArray::MemoryAddress::bincodeSerialize() const {
+        auto serializer = serde::BincodeSerializer();
+        serde::Serializable<ValueOrArray::MemoryAddress>::serialize(*this, serializer);
+        return std::move(serializer).bytes();
+    }
+
+    inline ValueOrArray::MemoryAddress ValueOrArray::MemoryAddress::bincodeDeserialize(std::vector<uint8_t> input) {
+        auto deserializer = serde::BincodeDeserializer(input);
+        auto value = serde::Deserializable<ValueOrArray::MemoryAddress>::deserialize(deserializer);
+        if (deserializer.get_buffer_offset() < input.size()) {
+            throw_or_abort("Some input bytes were not read");
+        }
+        return value;
+    }
+
 } // end of namespace Acir
 
 template <>
@@ -9441,6 +12839,21 @@ namespace Acir {
     inline bool operator==(const ValueOrArray::HeapArray &lhs, const ValueOrArray::HeapArray &rhs) {
         if (!(lhs.value == rhs.value)) { return false; }
         return true;
+    }
+
+    inline std::vector<uint8_t> ValueOrArray::HeapArray::bincodeSerialize() const {
+        auto serializer = serde::BincodeSerializer();
+        serde::Serializable<ValueOrArray::HeapArray>::serialize(*this, serializer);
+        return std::move(serializer).bytes();
+    }
+
+    inline ValueOrArray::HeapArray ValueOrArray::HeapArray::bincodeDeserialize(std::vector<uint8_t> input) {
+        auto deserializer = serde::BincodeDeserializer(input);
+        auto value = serde::Deserializable<ValueOrArray::HeapArray>::deserialize(deserializer);
+        if (deserializer.get_buffer_offset() < input.size()) {
+            throw_or_abort("Some input bytes were not read");
+        }
+        return value;
     }
 
 } // end of namespace Acir
@@ -9466,6 +12879,21 @@ namespace Acir {
         return true;
     }
 
+    inline std::vector<uint8_t> ValueOrArray::HeapVector::bincodeSerialize() const {
+        auto serializer = serde::BincodeSerializer();
+        serde::Serializable<ValueOrArray::HeapVector>::serialize(*this, serializer);
+        return std::move(serializer).bytes();
+    }
+
+    inline ValueOrArray::HeapVector ValueOrArray::HeapVector::bincodeDeserialize(std::vector<uint8_t> input) {
+        auto deserializer = serde::BincodeDeserializer(input);
+        auto value = serde::Deserializable<ValueOrArray::HeapVector>::deserialize(deserializer);
+        if (deserializer.get_buffer_offset() < input.size()) {
+            throw_or_abort("Some input bytes were not read");
+        }
+        return value;
+    }
+
 } // end of namespace Acir
 
 template <>
@@ -9487,6 +12915,21 @@ namespace Acir {
     inline bool operator==(const Witness &lhs, const Witness &rhs) {
         if (!(lhs.value == rhs.value)) { return false; }
         return true;
+    }
+
+    inline std::vector<uint8_t> Witness::bincodeSerialize() const {
+        auto serializer = serde::BincodeSerializer();
+        serde::Serializable<Witness>::serialize(*this, serializer);
+        return std::move(serializer).bytes();
+    }
+
+    inline Witness Witness::bincodeDeserialize(std::vector<uint8_t> input) {
+        auto deserializer = serde::BincodeDeserializer(input);
+        auto value = serde::Deserializable<Witness>::deserialize(deserializer);
+        if (deserializer.get_buffer_offset() < input.size()) {
+            throw_or_abort("Some input bytes were not read");
+        }
+        return value;
     }
 
 } // end of namespace Acir

--- a/acvm-repo/acir/codegen/acir.cpp
+++ b/acvm-repo/acir/codegen/acir.cpp
@@ -2,7 +2,6 @@
 
 #include "serde.hpp"
 #include "barretenberg/serialize/msgpack_impl.hpp"
-#include "bincode.hpp"
 
 namespace Acir {
     struct Helpers {
@@ -162,8 +161,6 @@ namespace Acir {
 
         struct Add {
             friend bool operator==(const Add&, const Add&);
-            std::vector<uint8_t> bincodeSerialize() const;
-            static Add bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const {}
             void msgpack_unpack(msgpack::object const& o) {}
@@ -171,8 +168,6 @@ namespace Acir {
 
         struct Sub {
             friend bool operator==(const Sub&, const Sub&);
-            std::vector<uint8_t> bincodeSerialize() const;
-            static Sub bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const {}
             void msgpack_unpack(msgpack::object const& o) {}
@@ -180,8 +175,6 @@ namespace Acir {
 
         struct Mul {
             friend bool operator==(const Mul&, const Mul&);
-            std::vector<uint8_t> bincodeSerialize() const;
-            static Mul bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const {}
             void msgpack_unpack(msgpack::object const& o) {}
@@ -189,8 +182,6 @@ namespace Acir {
 
         struct Div {
             friend bool operator==(const Div&, const Div&);
-            std::vector<uint8_t> bincodeSerialize() const;
-            static Div bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const {}
             void msgpack_unpack(msgpack::object const& o) {}
@@ -198,8 +189,6 @@ namespace Acir {
 
         struct IntegerDiv {
             friend bool operator==(const IntegerDiv&, const IntegerDiv&);
-            std::vector<uint8_t> bincodeSerialize() const;
-            static IntegerDiv bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const {}
             void msgpack_unpack(msgpack::object const& o) {}
@@ -207,8 +196,6 @@ namespace Acir {
 
         struct Equals {
             friend bool operator==(const Equals&, const Equals&);
-            std::vector<uint8_t> bincodeSerialize() const;
-            static Equals bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const {}
             void msgpack_unpack(msgpack::object const& o) {}
@@ -216,8 +203,6 @@ namespace Acir {
 
         struct LessThan {
             friend bool operator==(const LessThan&, const LessThan&);
-            std::vector<uint8_t> bincodeSerialize() const;
-            static LessThan bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const {}
             void msgpack_unpack(msgpack::object const& o) {}
@@ -225,8 +210,6 @@ namespace Acir {
 
         struct LessThanEquals {
             friend bool operator==(const LessThanEquals&, const LessThanEquals&);
-            std::vector<uint8_t> bincodeSerialize() const;
-            static LessThanEquals bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const {}
             void msgpack_unpack(msgpack::object const& o) {}
@@ -235,8 +218,6 @@ namespace Acir {
         std::variant<Add, Sub, Mul, Div, IntegerDiv, Equals, LessThan, LessThanEquals> value;
 
         friend bool operator==(const BinaryFieldOp&, const BinaryFieldOp&);
-        std::vector<uint8_t> bincodeSerialize() const;
-        static BinaryFieldOp bincodeDeserialize(std::vector<uint8_t>);
 
         void msgpack_pack(auto& packer) const {
             std::string tag;
@@ -410,8 +391,6 @@ namespace Acir {
 
         struct Add {
             friend bool operator==(const Add&, const Add&);
-            std::vector<uint8_t> bincodeSerialize() const;
-            static Add bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const {}
             void msgpack_unpack(msgpack::object const& o) {}
@@ -419,8 +398,6 @@ namespace Acir {
 
         struct Sub {
             friend bool operator==(const Sub&, const Sub&);
-            std::vector<uint8_t> bincodeSerialize() const;
-            static Sub bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const {}
             void msgpack_unpack(msgpack::object const& o) {}
@@ -428,8 +405,6 @@ namespace Acir {
 
         struct Mul {
             friend bool operator==(const Mul&, const Mul&);
-            std::vector<uint8_t> bincodeSerialize() const;
-            static Mul bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const {}
             void msgpack_unpack(msgpack::object const& o) {}
@@ -437,8 +412,6 @@ namespace Acir {
 
         struct Div {
             friend bool operator==(const Div&, const Div&);
-            std::vector<uint8_t> bincodeSerialize() const;
-            static Div bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const {}
             void msgpack_unpack(msgpack::object const& o) {}
@@ -446,8 +419,6 @@ namespace Acir {
 
         struct Equals {
             friend bool operator==(const Equals&, const Equals&);
-            std::vector<uint8_t> bincodeSerialize() const;
-            static Equals bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const {}
             void msgpack_unpack(msgpack::object const& o) {}
@@ -455,8 +426,6 @@ namespace Acir {
 
         struct LessThan {
             friend bool operator==(const LessThan&, const LessThan&);
-            std::vector<uint8_t> bincodeSerialize() const;
-            static LessThan bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const {}
             void msgpack_unpack(msgpack::object const& o) {}
@@ -464,8 +433,6 @@ namespace Acir {
 
         struct LessThanEquals {
             friend bool operator==(const LessThanEquals&, const LessThanEquals&);
-            std::vector<uint8_t> bincodeSerialize() const;
-            static LessThanEquals bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const {}
             void msgpack_unpack(msgpack::object const& o) {}
@@ -473,8 +440,6 @@ namespace Acir {
 
         struct And {
             friend bool operator==(const And&, const And&);
-            std::vector<uint8_t> bincodeSerialize() const;
-            static And bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const {}
             void msgpack_unpack(msgpack::object const& o) {}
@@ -482,8 +447,6 @@ namespace Acir {
 
         struct Or {
             friend bool operator==(const Or&, const Or&);
-            std::vector<uint8_t> bincodeSerialize() const;
-            static Or bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const {}
             void msgpack_unpack(msgpack::object const& o) {}
@@ -491,8 +454,6 @@ namespace Acir {
 
         struct Xor {
             friend bool operator==(const Xor&, const Xor&);
-            std::vector<uint8_t> bincodeSerialize() const;
-            static Xor bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const {}
             void msgpack_unpack(msgpack::object const& o) {}
@@ -500,8 +461,6 @@ namespace Acir {
 
         struct Shl {
             friend bool operator==(const Shl&, const Shl&);
-            std::vector<uint8_t> bincodeSerialize() const;
-            static Shl bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const {}
             void msgpack_unpack(msgpack::object const& o) {}
@@ -509,8 +468,6 @@ namespace Acir {
 
         struct Shr {
             friend bool operator==(const Shr&, const Shr&);
-            std::vector<uint8_t> bincodeSerialize() const;
-            static Shr bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const {}
             void msgpack_unpack(msgpack::object const& o) {}
@@ -519,8 +476,6 @@ namespace Acir {
         std::variant<Add, Sub, Mul, Div, Equals, LessThan, LessThanEquals, And, Or, Xor, Shl, Shr> value;
 
         friend bool operator==(const BinaryIntOp&, const BinaryIntOp&);
-        std::vector<uint8_t> bincodeSerialize() const;
-        static BinaryIntOp bincodeDeserialize(std::vector<uint8_t>);
 
         void msgpack_pack(auto& packer) const {
             std::string tag;
@@ -746,8 +701,6 @@ namespace Acir {
 
         struct U1 {
             friend bool operator==(const U1&, const U1&);
-            std::vector<uint8_t> bincodeSerialize() const;
-            static U1 bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const {}
             void msgpack_unpack(msgpack::object const& o) {}
@@ -755,8 +708,6 @@ namespace Acir {
 
         struct U8 {
             friend bool operator==(const U8&, const U8&);
-            std::vector<uint8_t> bincodeSerialize() const;
-            static U8 bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const {}
             void msgpack_unpack(msgpack::object const& o) {}
@@ -764,8 +715,6 @@ namespace Acir {
 
         struct U16 {
             friend bool operator==(const U16&, const U16&);
-            std::vector<uint8_t> bincodeSerialize() const;
-            static U16 bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const {}
             void msgpack_unpack(msgpack::object const& o) {}
@@ -773,8 +722,6 @@ namespace Acir {
 
         struct U32 {
             friend bool operator==(const U32&, const U32&);
-            std::vector<uint8_t> bincodeSerialize() const;
-            static U32 bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const {}
             void msgpack_unpack(msgpack::object const& o) {}
@@ -782,8 +729,6 @@ namespace Acir {
 
         struct U64 {
             friend bool operator==(const U64&, const U64&);
-            std::vector<uint8_t> bincodeSerialize() const;
-            static U64 bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const {}
             void msgpack_unpack(msgpack::object const& o) {}
@@ -791,8 +736,6 @@ namespace Acir {
 
         struct U128 {
             friend bool operator==(const U128&, const U128&);
-            std::vector<uint8_t> bincodeSerialize() const;
-            static U128 bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const {}
             void msgpack_unpack(msgpack::object const& o) {}
@@ -801,8 +744,6 @@ namespace Acir {
         std::variant<U1, U8, U16, U32, U64, U128> value;
 
         friend bool operator==(const IntegerBitSize&, const IntegerBitSize&);
-        std::vector<uint8_t> bincodeSerialize() const;
-        static IntegerBitSize bincodeDeserialize(std::vector<uint8_t>);
 
         void msgpack_pack(auto& packer) const {
             std::string tag;
@@ -950,8 +891,6 @@ namespace Acir {
 
         struct Field {
             friend bool operator==(const Field&, const Field&);
-            std::vector<uint8_t> bincodeSerialize() const;
-            static Field bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const {}
             void msgpack_unpack(msgpack::object const& o) {}
@@ -961,8 +900,6 @@ namespace Acir {
             Acir::IntegerBitSize value;
 
             friend bool operator==(const Integer&, const Integer&);
-            std::vector<uint8_t> bincodeSerialize() const;
-            static Integer bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const { packer.pack(value); }
 
@@ -979,8 +916,6 @@ namespace Acir {
         std::variant<Field, Integer> value;
 
         friend bool operator==(const BitSize&, const BitSize&);
-        std::vector<uint8_t> bincodeSerialize() const;
-        static BitSize bincodeDeserialize(std::vector<uint8_t>);
 
         void msgpack_pack(auto& packer) const {
             std::string tag;
@@ -1091,8 +1026,6 @@ namespace Acir {
             uint32_t value;
 
             friend bool operator==(const Direct&, const Direct&);
-            std::vector<uint8_t> bincodeSerialize() const;
-            static Direct bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const { packer.pack(value); }
 
@@ -1110,8 +1043,6 @@ namespace Acir {
             uint32_t value;
 
             friend bool operator==(const Relative&, const Relative&);
-            std::vector<uint8_t> bincodeSerialize() const;
-            static Relative bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const { packer.pack(value); }
 
@@ -1128,8 +1059,6 @@ namespace Acir {
         std::variant<Direct, Relative> value;
 
         friend bool operator==(const MemoryAddress&, const MemoryAddress&);
-        std::vector<uint8_t> bincodeSerialize() const;
-        static MemoryAddress bincodeDeserialize(std::vector<uint8_t>);
 
         void msgpack_pack(auto& packer) const {
             std::string tag;
@@ -1251,8 +1180,6 @@ namespace Acir {
         uint32_t value;
 
         friend bool operator==(const SemiFlattenedLength&, const SemiFlattenedLength&);
-        std::vector<uint8_t> bincodeSerialize() const;
-        static SemiFlattenedLength bincodeDeserialize(std::vector<uint8_t>);
 
         void msgpack_pack(auto& packer) const { packer.pack(value); }
 
@@ -1271,8 +1198,6 @@ namespace Acir {
         Acir::SemiFlattenedLength size;
 
         friend bool operator==(const HeapArray&, const HeapArray&);
-        std::vector<uint8_t> bincodeSerialize() const;
-        static HeapArray bincodeDeserialize(std::vector<uint8_t>);
 
         void msgpack_pack(auto& packer) const {
             packer.pack_array(2);
@@ -1323,8 +1248,6 @@ namespace Acir {
             Acir::HeapArray outputs;
 
             friend bool operator==(const AES128Encrypt&, const AES128Encrypt&);
-            std::vector<uint8_t> bincodeSerialize() const;
-            static AES128Encrypt bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const {
                 packer.pack_array(4);
@@ -1383,8 +1306,6 @@ namespace Acir {
             Acir::HeapArray output;
 
             friend bool operator==(const Blake2s&, const Blake2s&);
-            std::vector<uint8_t> bincodeSerialize() const;
-            static Blake2s bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const {
                 packer.pack_array(2);
@@ -1431,8 +1352,6 @@ namespace Acir {
             Acir::HeapArray output;
 
             friend bool operator==(const Blake3&, const Blake3&);
-            std::vector<uint8_t> bincodeSerialize() const;
-            static Blake3 bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const {
                 packer.pack_array(2);
@@ -1479,8 +1398,6 @@ namespace Acir {
             Acir::HeapArray output;
 
             friend bool operator==(const Keccakf1600&, const Keccakf1600&);
-            std::vector<uint8_t> bincodeSerialize() const;
-            static Keccakf1600 bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const {
                 packer.pack_array(2);
@@ -1530,8 +1447,6 @@ namespace Acir {
             Acir::MemoryAddress result;
 
             friend bool operator==(const EcdsaSecp256k1&, const EcdsaSecp256k1&);
-            std::vector<uint8_t> bincodeSerialize() const;
-            static EcdsaSecp256k1 bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const {
                 packer.pack_array(5);
@@ -1599,8 +1514,6 @@ namespace Acir {
             Acir::MemoryAddress result;
 
             friend bool operator==(const EcdsaSecp256r1&, const EcdsaSecp256r1&);
-            std::vector<uint8_t> bincodeSerialize() const;
-            static EcdsaSecp256r1 bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const {
                 packer.pack_array(5);
@@ -1666,8 +1579,6 @@ namespace Acir {
             Acir::HeapArray outputs;
 
             friend bool operator==(const MultiScalarMul&, const MultiScalarMul&);
-            std::vector<uint8_t> bincodeSerialize() const;
-            static MultiScalarMul bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const {
                 packer.pack_array(3);
@@ -1725,8 +1636,6 @@ namespace Acir {
             Acir::HeapArray result;
 
             friend bool operator==(const EmbeddedCurveAdd&, const EmbeddedCurveAdd&);
-            std::vector<uint8_t> bincodeSerialize() const;
-            static EmbeddedCurveAdd bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const {
                 packer.pack_array(7);
@@ -1803,8 +1712,6 @@ namespace Acir {
             Acir::HeapArray output;
 
             friend bool operator==(const Poseidon2Permutation&, const Poseidon2Permutation&);
-            std::vector<uint8_t> bincodeSerialize() const;
-            static Poseidon2Permutation bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const {
                 packer.pack_array(2);
@@ -1852,8 +1759,6 @@ namespace Acir {
             Acir::HeapArray output;
 
             friend bool operator==(const Sha256Compression&, const Sha256Compression&);
-            std::vector<uint8_t> bincodeSerialize() const;
-            static Sha256Compression bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const {
                 packer.pack_array(3);
@@ -1909,8 +1814,6 @@ namespace Acir {
             Acir::MemoryAddress output_bits;
 
             friend bool operator==(const ToRadix&, const ToRadix&);
-            std::vector<uint8_t> bincodeSerialize() const;
-            static ToRadix bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const {
                 packer.pack_array(5);
@@ -1973,8 +1876,6 @@ namespace Acir {
         std::variant<AES128Encrypt, Blake2s, Blake3, Keccakf1600, EcdsaSecp256k1, EcdsaSecp256r1, MultiScalarMul, EmbeddedCurveAdd, Poseidon2Permutation, Sha256Compression, ToRadix> value;
 
         friend bool operator==(const BlackBoxOp&, const BlackBoxOp&);
-        std::vector<uint8_t> bincodeSerialize() const;
-        static BlackBoxOp bincodeDeserialize(std::vector<uint8_t>);
 
         void msgpack_pack(auto& packer) const {
             std::string tag;
@@ -2330,8 +2231,6 @@ namespace Acir {
         uint32_t value;
 
         friend bool operator==(const SemanticLength&, const SemanticLength&);
-        std::vector<uint8_t> bincodeSerialize() const;
-        static SemanticLength bincodeDeserialize(std::vector<uint8_t>);
 
         void msgpack_pack(auto& packer) const { packer.pack(value); }
 
@@ -2353,8 +2252,6 @@ namespace Acir {
             Acir::BitSize value;
 
             friend bool operator==(const Simple&, const Simple&);
-            std::vector<uint8_t> bincodeSerialize() const;
-            static Simple bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const { packer.pack(value); }
 
@@ -2373,8 +2270,6 @@ namespace Acir {
             Acir::SemanticLength size;
 
             friend bool operator==(const Array&, const Array&);
-            std::vector<uint8_t> bincodeSerialize() const;
-            static Array bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const {
                 packer.pack_array(2);
@@ -2420,8 +2315,6 @@ namespace Acir {
             std::vector<Acir::HeapValueType> value_types;
 
             friend bool operator==(const Vector&, const Vector&);
-            std::vector<uint8_t> bincodeSerialize() const;
-            static Vector bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const {
                 packer.pack_array(1);
@@ -2460,8 +2353,6 @@ namespace Acir {
         std::variant<Simple, Array, Vector> value;
 
         friend bool operator==(const HeapValueType&, const HeapValueType&);
-        std::vector<uint8_t> bincodeSerialize() const;
-        static HeapValueType bincodeDeserialize(std::vector<uint8_t>);
 
         void msgpack_pack(auto& packer) const {
             std::string tag;
@@ -2610,8 +2501,6 @@ namespace Acir {
         Acir::MemoryAddress size;
 
         friend bool operator==(const HeapVector&, const HeapVector&);
-        std::vector<uint8_t> bincodeSerialize() const;
-        static HeapVector bincodeDeserialize(std::vector<uint8_t>);
 
         void msgpack_pack(auto& packer) const {
             packer.pack_array(2);
@@ -2659,8 +2548,6 @@ namespace Acir {
             Acir::MemoryAddress value;
 
             friend bool operator==(const MemoryAddress&, const MemoryAddress&);
-            std::vector<uint8_t> bincodeSerialize() const;
-            static MemoryAddress bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const { packer.pack(value); }
 
@@ -2678,8 +2565,6 @@ namespace Acir {
             Acir::HeapArray value;
 
             friend bool operator==(const HeapArray&, const HeapArray&);
-            std::vector<uint8_t> bincodeSerialize() const;
-            static HeapArray bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const { packer.pack(value); }
 
@@ -2697,8 +2582,6 @@ namespace Acir {
             Acir::HeapVector value;
 
             friend bool operator==(const HeapVector&, const HeapVector&);
-            std::vector<uint8_t> bincodeSerialize() const;
-            static HeapVector bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const { packer.pack(value); }
 
@@ -2715,8 +2598,6 @@ namespace Acir {
         std::variant<MemoryAddress, HeapArray, HeapVector> value;
 
         friend bool operator==(const ValueOrArray&, const ValueOrArray&);
-        std::vector<uint8_t> bincodeSerialize() const;
-        static ValueOrArray bincodeDeserialize(std::vector<uint8_t>);
 
         void msgpack_pack(auto& packer) const {
             std::string tag;
@@ -2869,8 +2750,6 @@ namespace Acir {
             Acir::MemoryAddress rhs;
 
             friend bool operator==(const BinaryFieldOp&, const BinaryFieldOp&);
-            std::vector<uint8_t> bincodeSerialize() const;
-            static BinaryFieldOp bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const {
                 packer.pack_array(4);
@@ -2932,8 +2811,6 @@ namespace Acir {
             Acir::MemoryAddress rhs;
 
             friend bool operator==(const BinaryIntOp&, const BinaryIntOp&);
-            std::vector<uint8_t> bincodeSerialize() const;
-            static BinaryIntOp bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const {
                 packer.pack_array(5);
@@ -2999,8 +2876,6 @@ namespace Acir {
             Acir::IntegerBitSize bit_size;
 
             friend bool operator==(const Not&, const Not&);
-            std::vector<uint8_t> bincodeSerialize() const;
-            static Not bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const {
                 packer.pack_array(3);
@@ -3054,8 +2929,6 @@ namespace Acir {
             Acir::BitSize bit_size;
 
             friend bool operator==(const Cast&, const Cast&);
-            std::vector<uint8_t> bincodeSerialize() const;
-            static Cast bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const {
                 packer.pack_array(3);
@@ -3108,8 +2981,6 @@ namespace Acir {
             uint64_t location;
 
             friend bool operator==(const JumpIf&, const JumpIf&);
-            std::vector<uint8_t> bincodeSerialize() const;
-            static JumpIf bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const {
                 packer.pack_array(2);
@@ -3155,8 +3026,6 @@ namespace Acir {
             uint64_t location;
 
             friend bool operator==(const Jump&, const Jump&);
-            std::vector<uint8_t> bincodeSerialize() const;
-            static Jump bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const {
                 packer.pack_array(1);
@@ -3198,8 +3067,6 @@ namespace Acir {
             Acir::MemoryAddress offset_address;
 
             friend bool operator==(const CalldataCopy&, const CalldataCopy&);
-            std::vector<uint8_t> bincodeSerialize() const;
-            static CalldataCopy bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const {
                 packer.pack_array(3);
@@ -3251,8 +3118,6 @@ namespace Acir {
             uint64_t location;
 
             friend bool operator==(const Call&, const Call&);
-            std::vector<uint8_t> bincodeSerialize() const;
-            static Call bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const {
                 packer.pack_array(1);
@@ -3294,8 +3159,6 @@ namespace Acir {
             std::vector<uint8_t> value;
 
             friend bool operator==(const Const&, const Const&);
-            std::vector<uint8_t> bincodeSerialize() const;
-            static Const bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const {
                 packer.pack_array(3);
@@ -3349,8 +3212,6 @@ namespace Acir {
             std::vector<uint8_t> value;
 
             friend bool operator==(const IndirectConst&, const IndirectConst&);
-            std::vector<uint8_t> bincodeSerialize() const;
-            static IndirectConst bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const {
                 packer.pack_array(3);
@@ -3400,8 +3261,6 @@ namespace Acir {
 
         struct Return {
             friend bool operator==(const Return&, const Return&);
-            std::vector<uint8_t> bincodeSerialize() const;
-            static Return bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const {}
             void msgpack_unpack(msgpack::object const& o) {}
@@ -3415,8 +3274,6 @@ namespace Acir {
             std::vector<Acir::HeapValueType> input_value_types;
 
             friend bool operator==(const ForeignCall&, const ForeignCall&);
-            std::vector<uint8_t> bincodeSerialize() const;
-            static ForeignCall bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const {
                 packer.pack_array(5);
@@ -3481,8 +3338,6 @@ namespace Acir {
             Acir::MemoryAddress source;
 
             friend bool operator==(const Mov&, const Mov&);
-            std::vector<uint8_t> bincodeSerialize() const;
-            static Mov bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const {
                 packer.pack_array(2);
@@ -3531,8 +3386,6 @@ namespace Acir {
             Acir::MemoryAddress condition;
 
             friend bool operator==(const ConditionalMov&, const ConditionalMov&);
-            std::vector<uint8_t> bincodeSerialize() const;
-            static ConditionalMov bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const {
                 packer.pack_array(4);
@@ -3591,8 +3444,6 @@ namespace Acir {
             Acir::MemoryAddress source_pointer;
 
             friend bool operator==(const Load&, const Load&);
-            std::vector<uint8_t> bincodeSerialize() const;
-            static Load bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const {
                 packer.pack_array(2);
@@ -3639,8 +3490,6 @@ namespace Acir {
             Acir::MemoryAddress source;
 
             friend bool operator==(const Store&, const Store&);
-            std::vector<uint8_t> bincodeSerialize() const;
-            static Store bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const {
                 packer.pack_array(2);
@@ -3686,8 +3535,6 @@ namespace Acir {
             Acir::BlackBoxOp value;
 
             friend bool operator==(const BlackBox&, const BlackBox&);
-            std::vector<uint8_t> bincodeSerialize() const;
-            static BlackBox bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const { packer.pack(value); }
 
@@ -3705,8 +3552,6 @@ namespace Acir {
             Acir::HeapVector revert_data;
 
             friend bool operator==(const Trap&, const Trap&);
-            std::vector<uint8_t> bincodeSerialize() const;
-            static Trap bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const {
                 packer.pack_array(1);
@@ -3746,8 +3591,6 @@ namespace Acir {
             Acir::HeapVector return_data;
 
             friend bool operator==(const Stop&, const Stop&);
-            std::vector<uint8_t> bincodeSerialize() const;
-            static Stop bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const {
                 packer.pack_array(1);
@@ -3786,8 +3629,6 @@ namespace Acir {
         std::variant<BinaryFieldOp, BinaryIntOp, Not, Cast, JumpIf, Jump, CalldataCopy, Call, Const, IndirectConst, Return, ForeignCall, Mov, ConditionalMov, Load, Store, BlackBox, Trap, Stop> value;
 
         friend bool operator==(const BrilligOpcode&, const BrilligOpcode&);
-        std::vector<uint8_t> bincodeSerialize() const;
-        static BrilligOpcode bincodeDeserialize(std::vector<uint8_t>);
 
         void msgpack_pack(auto& packer) const {
             std::string tag;
@@ -4338,8 +4179,6 @@ namespace Acir {
         uint32_t value;
 
         friend bool operator==(const Witness&, const Witness&);
-        std::vector<uint8_t> bincodeSerialize() const;
-        static Witness bincodeDeserialize(std::vector<uint8_t>);
 
         void msgpack_pack(auto& packer) const { packer.pack(value); }
 
@@ -4359,8 +4198,6 @@ namespace Acir {
             std::vector<uint8_t> value;
 
             friend bool operator==(const Constant&, const Constant&);
-            std::vector<uint8_t> bincodeSerialize() const;
-            static Constant bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const { packer.pack(value); }
 
@@ -4378,8 +4215,6 @@ namespace Acir {
             Acir::Witness value;
 
             friend bool operator==(const Witness&, const Witness&);
-            std::vector<uint8_t> bincodeSerialize() const;
-            static Witness bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const { packer.pack(value); }
 
@@ -4396,8 +4231,6 @@ namespace Acir {
         std::variant<Constant, Witness> value;
 
         friend bool operator==(const FunctionInput&, const FunctionInput&);
-        std::vector<uint8_t> bincodeSerialize() const;
-        static FunctionInput bincodeDeserialize(std::vector<uint8_t>);
 
         void msgpack_pack(auto& packer) const {
             std::string tag;
@@ -4524,8 +4357,6 @@ namespace Acir {
             std::vector<Acir::Witness> outputs;
 
             friend bool operator==(const AES128Encrypt&, const AES128Encrypt&);
-            std::vector<uint8_t> bincodeSerialize() const;
-            static AES128Encrypt bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const {
                 packer.pack_array(4);
@@ -4586,8 +4417,6 @@ namespace Acir {
             Acir::Witness output;
 
             friend bool operator==(const AND&, const AND&);
-            std::vector<uint8_t> bincodeSerialize() const;
-            static AND bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const {
                 packer.pack_array(4);
@@ -4648,8 +4477,6 @@ namespace Acir {
             Acir::Witness output;
 
             friend bool operator==(const XOR&, const XOR&);
-            std::vector<uint8_t> bincodeSerialize() const;
-            static XOR bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const {
                 packer.pack_array(4);
@@ -4708,8 +4535,6 @@ namespace Acir {
             uint32_t num_bits;
 
             friend bool operator==(const RANGE&, const RANGE&);
-            std::vector<uint8_t> bincodeSerialize() const;
-            static RANGE bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const {
                 packer.pack_array(2);
@@ -4756,8 +4581,6 @@ namespace Acir {
             std::shared_ptr<std::array<Acir::Witness, 32>> outputs;
 
             friend bool operator==(const Blake2s&, const Blake2s&);
-            std::vector<uint8_t> bincodeSerialize() const;
-            static Blake2s bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const {
                 packer.pack_array(2);
@@ -4804,8 +4627,6 @@ namespace Acir {
             std::shared_ptr<std::array<Acir::Witness, 32>> outputs;
 
             friend bool operator==(const Blake3&, const Blake3&);
-            std::vector<uint8_t> bincodeSerialize() const;
-            static Blake3 bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const {
                 packer.pack_array(2);
@@ -4856,8 +4677,6 @@ namespace Acir {
             Acir::Witness output;
 
             friend bool operator==(const EcdsaSecp256k1&, const EcdsaSecp256k1&);
-            std::vector<uint8_t> bincodeSerialize() const;
-            static EcdsaSecp256k1 bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const {
                 packer.pack_array(6);
@@ -4932,8 +4751,6 @@ namespace Acir {
             Acir::Witness output;
 
             friend bool operator==(const EcdsaSecp256r1&, const EcdsaSecp256r1&);
-            std::vector<uint8_t> bincodeSerialize() const;
-            static EcdsaSecp256r1 bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const {
                 packer.pack_array(6);
@@ -5006,8 +4823,6 @@ namespace Acir {
             std::shared_ptr<std::array<Acir::Witness, 3>> outputs;
 
             friend bool operator==(const MultiScalarMul&, const MultiScalarMul&);
-            std::vector<uint8_t> bincodeSerialize() const;
-            static MultiScalarMul bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const {
                 packer.pack_array(4);
@@ -5068,8 +4883,6 @@ namespace Acir {
             std::shared_ptr<std::array<Acir::Witness, 3>> outputs;
 
             friend bool operator==(const EmbeddedCurveAdd&, const EmbeddedCurveAdd&);
-            std::vector<uint8_t> bincodeSerialize() const;
-            static EmbeddedCurveAdd bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const {
                 packer.pack_array(4);
@@ -5128,8 +4941,6 @@ namespace Acir {
             std::shared_ptr<std::array<Acir::Witness, 25>> outputs;
 
             friend bool operator==(const Keccakf1600&, const Keccakf1600&);
-            std::vector<uint8_t> bincodeSerialize() const;
-            static Keccakf1600 bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const {
                 packer.pack_array(2);
@@ -5180,8 +4991,6 @@ namespace Acir {
             Acir::FunctionInput predicate;
 
             friend bool operator==(const RecursiveAggregation&, const RecursiveAggregation&);
-            std::vector<uint8_t> bincodeSerialize() const;
-            static RecursiveAggregation bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const {
                 packer.pack_array(6);
@@ -5252,8 +5061,6 @@ namespace Acir {
             std::vector<Acir::Witness> outputs;
 
             friend bool operator==(const Poseidon2Permutation&, const Poseidon2Permutation&);
-            std::vector<uint8_t> bincodeSerialize() const;
-            static Poseidon2Permutation bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const {
                 packer.pack_array(2);
@@ -5301,8 +5108,6 @@ namespace Acir {
             std::shared_ptr<std::array<Acir::Witness, 8>> outputs;
 
             friend bool operator==(const Sha256Compression&, const Sha256Compression&);
-            std::vector<uint8_t> bincodeSerialize() const;
-            static Sha256Compression bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const {
                 packer.pack_array(3);
@@ -5353,8 +5158,6 @@ namespace Acir {
         std::variant<AES128Encrypt, AND, XOR, RANGE, Blake2s, Blake3, EcdsaSecp256k1, EcdsaSecp256r1, MultiScalarMul, EmbeddedCurveAdd, Keccakf1600, RecursiveAggregation, Poseidon2Permutation, Sha256Compression> value;
 
         friend bool operator==(const BlackBoxFuncCall&, const BlackBoxFuncCall&);
-        std::vector<uint8_t> bincodeSerialize() const;
-        static BlackBoxFuncCall bincodeDeserialize(std::vector<uint8_t>);
 
         void msgpack_pack(auto& packer) const {
             std::string tag;
@@ -5788,8 +5591,6 @@ namespace Acir {
         uint32_t value;
 
         friend bool operator==(const BlockId&, const BlockId&);
-        std::vector<uint8_t> bincodeSerialize() const;
-        static BlockId bincodeDeserialize(std::vector<uint8_t>);
 
         void msgpack_pack(auto& packer) const { packer.pack(value); }
 
@@ -5807,8 +5608,6 @@ namespace Acir {
 
         struct Memory {
             friend bool operator==(const Memory&, const Memory&);
-            std::vector<uint8_t> bincodeSerialize() const;
-            static Memory bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const {}
             void msgpack_unpack(msgpack::object const& o) {}
@@ -5818,8 +5617,6 @@ namespace Acir {
             uint32_t value;
 
             friend bool operator==(const CallData&, const CallData&);
-            std::vector<uint8_t> bincodeSerialize() const;
-            static CallData bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const { packer.pack(value); }
 
@@ -5835,8 +5632,6 @@ namespace Acir {
 
         struct ReturnData {
             friend bool operator==(const ReturnData&, const ReturnData&);
-            std::vector<uint8_t> bincodeSerialize() const;
-            static ReturnData bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const {}
             void msgpack_unpack(msgpack::object const& o) {}
@@ -5845,8 +5640,6 @@ namespace Acir {
         std::variant<Memory, CallData, ReturnData> value;
 
         friend bool operator==(const BlockType&, const BlockType&);
-        std::vector<uint8_t> bincodeSerialize() const;
-        static BlockType bincodeDeserialize(std::vector<uint8_t>);
 
         void msgpack_pack(auto& packer) const {
             std::string tag;
@@ -5970,8 +5763,6 @@ namespace Acir {
         std::vector<uint8_t> q_c;
 
         friend bool operator==(const Expression&, const Expression&);
-        std::vector<uint8_t> bincodeSerialize() const;
-        static Expression bincodeDeserialize(std::vector<uint8_t>);
 
         void msgpack_pack(auto& packer) const {
             packer.pack_array(3);
@@ -6025,8 +5816,6 @@ namespace Acir {
             Acir::Expression value;
 
             friend bool operator==(const Single&, const Single&);
-            std::vector<uint8_t> bincodeSerialize() const;
-            static Single bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const { packer.pack(value); }
 
@@ -6044,8 +5833,6 @@ namespace Acir {
             std::vector<Acir::Expression> value;
 
             friend bool operator==(const Array&, const Array&);
-            std::vector<uint8_t> bincodeSerialize() const;
-            static Array bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const { packer.pack(value); }
 
@@ -6063,8 +5850,6 @@ namespace Acir {
             Acir::BlockId value;
 
             friend bool operator==(const MemoryArray&, const MemoryArray&);
-            std::vector<uint8_t> bincodeSerialize() const;
-            static MemoryArray bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const { packer.pack(value); }
 
@@ -6081,8 +5866,6 @@ namespace Acir {
         std::variant<Single, Array, MemoryArray> value;
 
         friend bool operator==(const BrilligInputs&, const BrilligInputs&);
-        std::vector<uint8_t> bincodeSerialize() const;
-        static BrilligInputs bincodeDeserialize(std::vector<uint8_t>);
 
         void msgpack_pack(auto& packer) const {
             std::string tag;
@@ -6232,8 +6015,6 @@ namespace Acir {
             Acir::Witness value;
 
             friend bool operator==(const Simple&, const Simple&);
-            std::vector<uint8_t> bincodeSerialize() const;
-            static Simple bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const { packer.pack(value); }
 
@@ -6251,8 +6032,6 @@ namespace Acir {
             std::vector<Acir::Witness> value;
 
             friend bool operator==(const Array&, const Array&);
-            std::vector<uint8_t> bincodeSerialize() const;
-            static Array bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const { packer.pack(value); }
 
@@ -6269,8 +6048,6 @@ namespace Acir {
         std::variant<Simple, Array> value;
 
         friend bool operator==(const BrilligOutputs&, const BrilligOutputs&);
-        std::vector<uint8_t> bincodeSerialize() const;
-        static BrilligOutputs bincodeDeserialize(std::vector<uint8_t>);
 
         void msgpack_pack(auto& packer) const {
             std::string tag;
@@ -6394,8 +6171,6 @@ namespace Acir {
         Acir::Expression value;
 
         friend bool operator==(const MemOp&, const MemOp&);
-        std::vector<uint8_t> bincodeSerialize() const;
-        static MemOp bincodeDeserialize(std::vector<uint8_t>);
 
         void msgpack_pack(auto& packer) const {
             packer.pack_array(3);
@@ -6449,8 +6224,6 @@ namespace Acir {
             Acir::Expression value;
 
             friend bool operator==(const AssertZero&, const AssertZero&);
-            std::vector<uint8_t> bincodeSerialize() const;
-            static AssertZero bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const { packer.pack(value); }
 
@@ -6468,8 +6241,6 @@ namespace Acir {
             Acir::BlackBoxFuncCall value;
 
             friend bool operator==(const BlackBoxFuncCall&, const BlackBoxFuncCall&);
-            std::vector<uint8_t> bincodeSerialize() const;
-            static BlackBoxFuncCall bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const { packer.pack(value); }
 
@@ -6488,8 +6259,6 @@ namespace Acir {
             Acir::MemOp op;
 
             friend bool operator==(const MemoryOp&, const MemoryOp&);
-            std::vector<uint8_t> bincodeSerialize() const;
-            static MemoryOp bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const {
                 packer.pack_array(2);
@@ -6537,8 +6306,6 @@ namespace Acir {
             Acir::BlockType block_type;
 
             friend bool operator==(const MemoryInit&, const MemoryInit&);
-            std::vector<uint8_t> bincodeSerialize() const;
-            static MemoryInit bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const {
                 packer.pack_array(3);
@@ -6593,8 +6360,6 @@ namespace Acir {
             Acir::Expression predicate;
 
             friend bool operator==(const BrilligCall&, const BrilligCall&);
-            std::vector<uint8_t> bincodeSerialize() const;
-            static BrilligCall bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const {
                 packer.pack_array(4);
@@ -6655,8 +6420,6 @@ namespace Acir {
             Acir::Expression predicate;
 
             friend bool operator==(const Call&, const Call&);
-            std::vector<uint8_t> bincodeSerialize() const;
-            static Call bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const {
                 packer.pack_array(4);
@@ -6713,8 +6476,6 @@ namespace Acir {
         std::variant<AssertZero, BlackBoxFuncCall, MemoryOp, MemoryInit, BrilligCall, Call> value;
 
         friend bool operator==(const Opcode&, const Opcode&);
-        std::vector<uint8_t> bincodeSerialize() const;
-        static Opcode bincodeDeserialize(std::vector<uint8_t>);
 
         void msgpack_pack(auto& packer) const {
             std::string tag;
@@ -6942,8 +6703,6 @@ namespace Acir {
             Acir::Expression value;
 
             friend bool operator==(const Expression&, const Expression&);
-            std::vector<uint8_t> bincodeSerialize() const;
-            static Expression bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const { packer.pack(value); }
 
@@ -6961,8 +6720,6 @@ namespace Acir {
             Acir::BlockId value;
 
             friend bool operator==(const Memory&, const Memory&);
-            std::vector<uint8_t> bincodeSerialize() const;
-            static Memory bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const { packer.pack(value); }
 
@@ -6979,8 +6736,6 @@ namespace Acir {
         std::variant<Expression, Memory> value;
 
         friend bool operator==(const ExpressionOrMemory&, const ExpressionOrMemory&);
-        std::vector<uint8_t> bincodeSerialize() const;
-        static ExpressionOrMemory bincodeDeserialize(std::vector<uint8_t>);
 
         void msgpack_pack(auto& packer) const {
             std::string tag;
@@ -7103,8 +6858,6 @@ namespace Acir {
         std::vector<Acir::ExpressionOrMemory> payload;
 
         friend bool operator==(const AssertionPayload&, const AssertionPayload&);
-        std::vector<uint8_t> bincodeSerialize() const;
-        static AssertionPayload bincodeDeserialize(std::vector<uint8_t>);
 
         void msgpack_pack(auto& packer) const {
             packer.pack_array(2);
@@ -7152,8 +6905,6 @@ namespace Acir {
             uint64_t value;
 
             friend bool operator==(const Acir&, const Acir&);
-            std::vector<uint8_t> bincodeSerialize() const;
-            static Acir bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const { packer.pack(value); }
 
@@ -7172,8 +6923,6 @@ namespace Acir {
             uint64_t brillig_index;
 
             friend bool operator==(const Brillig&, const Brillig&);
-            std::vector<uint8_t> bincodeSerialize() const;
-            static Brillig bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const {
                 packer.pack_array(2);
@@ -7218,8 +6967,6 @@ namespace Acir {
         std::variant<Acir, Brillig> value;
 
         friend bool operator==(const OpcodeLocation&, const OpcodeLocation&);
-        std::vector<uint8_t> bincodeSerialize() const;
-        static OpcodeLocation bincodeDeserialize(std::vector<uint8_t>);
 
         void msgpack_pack(auto& packer) const {
             std::string tag;
@@ -7341,8 +7088,6 @@ namespace Acir {
         std::vector<Acir::Witness> value;
 
         friend bool operator==(const PublicInputs&, const PublicInputs&);
-        std::vector<uint8_t> bincodeSerialize() const;
-        static PublicInputs bincodeDeserialize(std::vector<uint8_t>);
 
         void msgpack_pack(auto& packer) const { packer.pack(value); }
 
@@ -7366,8 +7111,6 @@ namespace Acir {
         std::vector<std::tuple<Acir::OpcodeLocation, Acir::AssertionPayload>> assert_messages;
 
         friend bool operator==(const Circuit&, const Circuit&);
-        std::vector<uint8_t> bincodeSerialize() const;
-        static Circuit bincodeDeserialize(std::vector<uint8_t>);
 
         void msgpack_pack(auto& packer) const {
             packer.pack_array(7);
@@ -7443,8 +7186,6 @@ namespace Acir {
         std::vector<Acir::BrilligOpcode> bytecode;
 
         friend bool operator==(const BrilligBytecode&, const BrilligBytecode&);
-        std::vector<uint8_t> bincodeSerialize() const;
-        static BrilligBytecode bincodeDeserialize(std::vector<uint8_t>);
 
         void msgpack_pack(auto& packer) const {
             packer.pack_array(2);
@@ -7490,8 +7231,6 @@ namespace Acir {
         std::vector<Acir::BrilligBytecode> unconstrained_functions;
 
         friend bool operator==(const Program&, const Program&);
-        std::vector<uint8_t> bincodeSerialize() const;
-        static Program bincodeDeserialize(std::vector<uint8_t>);
 
         void msgpack_pack(auto& packer) const {
             packer.pack_array(2);
@@ -7537,8 +7276,6 @@ namespace Acir {
         std::monostate unconstrained_functions;
 
         friend bool operator==(const ProgramWithoutBrillig&, const ProgramWithoutBrillig&);
-        std::vector<uint8_t> bincodeSerialize() const;
-        static ProgramWithoutBrillig bincodeDeserialize(std::vector<uint8_t>);
 
         void msgpack_pack(auto& packer) const {
             packer.pack_array(2);
@@ -7589,21 +7326,6 @@ namespace Acir {
         return true;
     }
 
-    inline std::vector<uint8_t> AssertionPayload::bincodeSerialize() const {
-        auto serializer = serde::BincodeSerializer();
-        serde::Serializable<AssertionPayload>::serialize(*this, serializer);
-        return std::move(serializer).bytes();
-    }
-
-    inline AssertionPayload AssertionPayload::bincodeDeserialize(std::vector<uint8_t> input) {
-        auto deserializer = serde::BincodeDeserializer(input);
-        auto value = serde::Deserializable<AssertionPayload>::deserialize(deserializer);
-        if (deserializer.get_buffer_offset() < input.size()) {
-            throw_or_abort("Some input bytes were not read");
-        }
-        return value;
-    }
-
 } // end of namespace Acir
 
 template <>
@@ -7633,21 +7355,6 @@ namespace Acir {
         return true;
     }
 
-    inline std::vector<uint8_t> BinaryFieldOp::bincodeSerialize() const {
-        auto serializer = serde::BincodeSerializer();
-        serde::Serializable<BinaryFieldOp>::serialize(*this, serializer);
-        return std::move(serializer).bytes();
-    }
-
-    inline BinaryFieldOp BinaryFieldOp::bincodeDeserialize(std::vector<uint8_t> input) {
-        auto deserializer = serde::BincodeDeserializer(input);
-        auto value = serde::Deserializable<BinaryFieldOp>::deserialize(deserializer);
-        if (deserializer.get_buffer_offset() < input.size()) {
-            throw_or_abort("Some input bytes were not read");
-        }
-        return value;
-    }
-
 } // end of namespace Acir
 
 template <>
@@ -7674,21 +7381,6 @@ namespace Acir {
         return true;
     }
 
-    inline std::vector<uint8_t> BinaryFieldOp::Add::bincodeSerialize() const {
-        auto serializer = serde::BincodeSerializer();
-        serde::Serializable<BinaryFieldOp::Add>::serialize(*this, serializer);
-        return std::move(serializer).bytes();
-    }
-
-    inline BinaryFieldOp::Add BinaryFieldOp::Add::bincodeDeserialize(std::vector<uint8_t> input) {
-        auto deserializer = serde::BincodeDeserializer(input);
-        auto value = serde::Deserializable<BinaryFieldOp::Add>::deserialize(deserializer);
-        if (deserializer.get_buffer_offset() < input.size()) {
-            throw_or_abort("Some input bytes were not read");
-        }
-        return value;
-    }
-
 } // end of namespace Acir
 
 template <>
@@ -7707,21 +7399,6 @@ namespace Acir {
 
     inline bool operator==(const BinaryFieldOp::Sub &lhs, const BinaryFieldOp::Sub &rhs) {
         return true;
-    }
-
-    inline std::vector<uint8_t> BinaryFieldOp::Sub::bincodeSerialize() const {
-        auto serializer = serde::BincodeSerializer();
-        serde::Serializable<BinaryFieldOp::Sub>::serialize(*this, serializer);
-        return std::move(serializer).bytes();
-    }
-
-    inline BinaryFieldOp::Sub BinaryFieldOp::Sub::bincodeDeserialize(std::vector<uint8_t> input) {
-        auto deserializer = serde::BincodeDeserializer(input);
-        auto value = serde::Deserializable<BinaryFieldOp::Sub>::deserialize(deserializer);
-        if (deserializer.get_buffer_offset() < input.size()) {
-            throw_or_abort("Some input bytes were not read");
-        }
-        return value;
     }
 
 } // end of namespace Acir
@@ -7744,21 +7421,6 @@ namespace Acir {
         return true;
     }
 
-    inline std::vector<uint8_t> BinaryFieldOp::Mul::bincodeSerialize() const {
-        auto serializer = serde::BincodeSerializer();
-        serde::Serializable<BinaryFieldOp::Mul>::serialize(*this, serializer);
-        return std::move(serializer).bytes();
-    }
-
-    inline BinaryFieldOp::Mul BinaryFieldOp::Mul::bincodeDeserialize(std::vector<uint8_t> input) {
-        auto deserializer = serde::BincodeDeserializer(input);
-        auto value = serde::Deserializable<BinaryFieldOp::Mul>::deserialize(deserializer);
-        if (deserializer.get_buffer_offset() < input.size()) {
-            throw_or_abort("Some input bytes were not read");
-        }
-        return value;
-    }
-
 } // end of namespace Acir
 
 template <>
@@ -7777,21 +7439,6 @@ namespace Acir {
 
     inline bool operator==(const BinaryFieldOp::Div &lhs, const BinaryFieldOp::Div &rhs) {
         return true;
-    }
-
-    inline std::vector<uint8_t> BinaryFieldOp::Div::bincodeSerialize() const {
-        auto serializer = serde::BincodeSerializer();
-        serde::Serializable<BinaryFieldOp::Div>::serialize(*this, serializer);
-        return std::move(serializer).bytes();
-    }
-
-    inline BinaryFieldOp::Div BinaryFieldOp::Div::bincodeDeserialize(std::vector<uint8_t> input) {
-        auto deserializer = serde::BincodeDeserializer(input);
-        auto value = serde::Deserializable<BinaryFieldOp::Div>::deserialize(deserializer);
-        if (deserializer.get_buffer_offset() < input.size()) {
-            throw_or_abort("Some input bytes were not read");
-        }
-        return value;
     }
 
 } // end of namespace Acir
@@ -7814,21 +7461,6 @@ namespace Acir {
         return true;
     }
 
-    inline std::vector<uint8_t> BinaryFieldOp::IntegerDiv::bincodeSerialize() const {
-        auto serializer = serde::BincodeSerializer();
-        serde::Serializable<BinaryFieldOp::IntegerDiv>::serialize(*this, serializer);
-        return std::move(serializer).bytes();
-    }
-
-    inline BinaryFieldOp::IntegerDiv BinaryFieldOp::IntegerDiv::bincodeDeserialize(std::vector<uint8_t> input) {
-        auto deserializer = serde::BincodeDeserializer(input);
-        auto value = serde::Deserializable<BinaryFieldOp::IntegerDiv>::deserialize(deserializer);
-        if (deserializer.get_buffer_offset() < input.size()) {
-            throw_or_abort("Some input bytes were not read");
-        }
-        return value;
-    }
-
 } // end of namespace Acir
 
 template <>
@@ -7847,21 +7479,6 @@ namespace Acir {
 
     inline bool operator==(const BinaryFieldOp::Equals &lhs, const BinaryFieldOp::Equals &rhs) {
         return true;
-    }
-
-    inline std::vector<uint8_t> BinaryFieldOp::Equals::bincodeSerialize() const {
-        auto serializer = serde::BincodeSerializer();
-        serde::Serializable<BinaryFieldOp::Equals>::serialize(*this, serializer);
-        return std::move(serializer).bytes();
-    }
-
-    inline BinaryFieldOp::Equals BinaryFieldOp::Equals::bincodeDeserialize(std::vector<uint8_t> input) {
-        auto deserializer = serde::BincodeDeserializer(input);
-        auto value = serde::Deserializable<BinaryFieldOp::Equals>::deserialize(deserializer);
-        if (deserializer.get_buffer_offset() < input.size()) {
-            throw_or_abort("Some input bytes were not read");
-        }
-        return value;
     }
 
 } // end of namespace Acir
@@ -7884,21 +7501,6 @@ namespace Acir {
         return true;
     }
 
-    inline std::vector<uint8_t> BinaryFieldOp::LessThan::bincodeSerialize() const {
-        auto serializer = serde::BincodeSerializer();
-        serde::Serializable<BinaryFieldOp::LessThan>::serialize(*this, serializer);
-        return std::move(serializer).bytes();
-    }
-
-    inline BinaryFieldOp::LessThan BinaryFieldOp::LessThan::bincodeDeserialize(std::vector<uint8_t> input) {
-        auto deserializer = serde::BincodeDeserializer(input);
-        auto value = serde::Deserializable<BinaryFieldOp::LessThan>::deserialize(deserializer);
-        if (deserializer.get_buffer_offset() < input.size()) {
-            throw_or_abort("Some input bytes were not read");
-        }
-        return value;
-    }
-
 } // end of namespace Acir
 
 template <>
@@ -7917,21 +7519,6 @@ namespace Acir {
 
     inline bool operator==(const BinaryFieldOp::LessThanEquals &lhs, const BinaryFieldOp::LessThanEquals &rhs) {
         return true;
-    }
-
-    inline std::vector<uint8_t> BinaryFieldOp::LessThanEquals::bincodeSerialize() const {
-        auto serializer = serde::BincodeSerializer();
-        serde::Serializable<BinaryFieldOp::LessThanEquals>::serialize(*this, serializer);
-        return std::move(serializer).bytes();
-    }
-
-    inline BinaryFieldOp::LessThanEquals BinaryFieldOp::LessThanEquals::bincodeDeserialize(std::vector<uint8_t> input) {
-        auto deserializer = serde::BincodeDeserializer(input);
-        auto value = serde::Deserializable<BinaryFieldOp::LessThanEquals>::deserialize(deserializer);
-        if (deserializer.get_buffer_offset() < input.size()) {
-            throw_or_abort("Some input bytes were not read");
-        }
-        return value;
     }
 
 } // end of namespace Acir
@@ -7953,21 +7540,6 @@ namespace Acir {
     inline bool operator==(const BinaryIntOp &lhs, const BinaryIntOp &rhs) {
         if (!(lhs.value == rhs.value)) { return false; }
         return true;
-    }
-
-    inline std::vector<uint8_t> BinaryIntOp::bincodeSerialize() const {
-        auto serializer = serde::BincodeSerializer();
-        serde::Serializable<BinaryIntOp>::serialize(*this, serializer);
-        return std::move(serializer).bytes();
-    }
-
-    inline BinaryIntOp BinaryIntOp::bincodeDeserialize(std::vector<uint8_t> input) {
-        auto deserializer = serde::BincodeDeserializer(input);
-        auto value = serde::Deserializable<BinaryIntOp>::deserialize(deserializer);
-        if (deserializer.get_buffer_offset() < input.size()) {
-            throw_or_abort("Some input bytes were not read");
-        }
-        return value;
     }
 
 } // end of namespace Acir
@@ -7996,21 +7568,6 @@ namespace Acir {
         return true;
     }
 
-    inline std::vector<uint8_t> BinaryIntOp::Add::bincodeSerialize() const {
-        auto serializer = serde::BincodeSerializer();
-        serde::Serializable<BinaryIntOp::Add>::serialize(*this, serializer);
-        return std::move(serializer).bytes();
-    }
-
-    inline BinaryIntOp::Add BinaryIntOp::Add::bincodeDeserialize(std::vector<uint8_t> input) {
-        auto deserializer = serde::BincodeDeserializer(input);
-        auto value = serde::Deserializable<BinaryIntOp::Add>::deserialize(deserializer);
-        if (deserializer.get_buffer_offset() < input.size()) {
-            throw_or_abort("Some input bytes were not read");
-        }
-        return value;
-    }
-
 } // end of namespace Acir
 
 template <>
@@ -8029,21 +7586,6 @@ namespace Acir {
 
     inline bool operator==(const BinaryIntOp::Sub &lhs, const BinaryIntOp::Sub &rhs) {
         return true;
-    }
-
-    inline std::vector<uint8_t> BinaryIntOp::Sub::bincodeSerialize() const {
-        auto serializer = serde::BincodeSerializer();
-        serde::Serializable<BinaryIntOp::Sub>::serialize(*this, serializer);
-        return std::move(serializer).bytes();
-    }
-
-    inline BinaryIntOp::Sub BinaryIntOp::Sub::bincodeDeserialize(std::vector<uint8_t> input) {
-        auto deserializer = serde::BincodeDeserializer(input);
-        auto value = serde::Deserializable<BinaryIntOp::Sub>::deserialize(deserializer);
-        if (deserializer.get_buffer_offset() < input.size()) {
-            throw_or_abort("Some input bytes were not read");
-        }
-        return value;
     }
 
 } // end of namespace Acir
@@ -8066,21 +7608,6 @@ namespace Acir {
         return true;
     }
 
-    inline std::vector<uint8_t> BinaryIntOp::Mul::bincodeSerialize() const {
-        auto serializer = serde::BincodeSerializer();
-        serde::Serializable<BinaryIntOp::Mul>::serialize(*this, serializer);
-        return std::move(serializer).bytes();
-    }
-
-    inline BinaryIntOp::Mul BinaryIntOp::Mul::bincodeDeserialize(std::vector<uint8_t> input) {
-        auto deserializer = serde::BincodeDeserializer(input);
-        auto value = serde::Deserializable<BinaryIntOp::Mul>::deserialize(deserializer);
-        if (deserializer.get_buffer_offset() < input.size()) {
-            throw_or_abort("Some input bytes were not read");
-        }
-        return value;
-    }
-
 } // end of namespace Acir
 
 template <>
@@ -8099,21 +7626,6 @@ namespace Acir {
 
     inline bool operator==(const BinaryIntOp::Div &lhs, const BinaryIntOp::Div &rhs) {
         return true;
-    }
-
-    inline std::vector<uint8_t> BinaryIntOp::Div::bincodeSerialize() const {
-        auto serializer = serde::BincodeSerializer();
-        serde::Serializable<BinaryIntOp::Div>::serialize(*this, serializer);
-        return std::move(serializer).bytes();
-    }
-
-    inline BinaryIntOp::Div BinaryIntOp::Div::bincodeDeserialize(std::vector<uint8_t> input) {
-        auto deserializer = serde::BincodeDeserializer(input);
-        auto value = serde::Deserializable<BinaryIntOp::Div>::deserialize(deserializer);
-        if (deserializer.get_buffer_offset() < input.size()) {
-            throw_or_abort("Some input bytes were not read");
-        }
-        return value;
     }
 
 } // end of namespace Acir
@@ -8136,21 +7648,6 @@ namespace Acir {
         return true;
     }
 
-    inline std::vector<uint8_t> BinaryIntOp::Equals::bincodeSerialize() const {
-        auto serializer = serde::BincodeSerializer();
-        serde::Serializable<BinaryIntOp::Equals>::serialize(*this, serializer);
-        return std::move(serializer).bytes();
-    }
-
-    inline BinaryIntOp::Equals BinaryIntOp::Equals::bincodeDeserialize(std::vector<uint8_t> input) {
-        auto deserializer = serde::BincodeDeserializer(input);
-        auto value = serde::Deserializable<BinaryIntOp::Equals>::deserialize(deserializer);
-        if (deserializer.get_buffer_offset() < input.size()) {
-            throw_or_abort("Some input bytes were not read");
-        }
-        return value;
-    }
-
 } // end of namespace Acir
 
 template <>
@@ -8169,21 +7666,6 @@ namespace Acir {
 
     inline bool operator==(const BinaryIntOp::LessThan &lhs, const BinaryIntOp::LessThan &rhs) {
         return true;
-    }
-
-    inline std::vector<uint8_t> BinaryIntOp::LessThan::bincodeSerialize() const {
-        auto serializer = serde::BincodeSerializer();
-        serde::Serializable<BinaryIntOp::LessThan>::serialize(*this, serializer);
-        return std::move(serializer).bytes();
-    }
-
-    inline BinaryIntOp::LessThan BinaryIntOp::LessThan::bincodeDeserialize(std::vector<uint8_t> input) {
-        auto deserializer = serde::BincodeDeserializer(input);
-        auto value = serde::Deserializable<BinaryIntOp::LessThan>::deserialize(deserializer);
-        if (deserializer.get_buffer_offset() < input.size()) {
-            throw_or_abort("Some input bytes were not read");
-        }
-        return value;
     }
 
 } // end of namespace Acir
@@ -8206,21 +7688,6 @@ namespace Acir {
         return true;
     }
 
-    inline std::vector<uint8_t> BinaryIntOp::LessThanEquals::bincodeSerialize() const {
-        auto serializer = serde::BincodeSerializer();
-        serde::Serializable<BinaryIntOp::LessThanEquals>::serialize(*this, serializer);
-        return std::move(serializer).bytes();
-    }
-
-    inline BinaryIntOp::LessThanEquals BinaryIntOp::LessThanEquals::bincodeDeserialize(std::vector<uint8_t> input) {
-        auto deserializer = serde::BincodeDeserializer(input);
-        auto value = serde::Deserializable<BinaryIntOp::LessThanEquals>::deserialize(deserializer);
-        if (deserializer.get_buffer_offset() < input.size()) {
-            throw_or_abort("Some input bytes were not read");
-        }
-        return value;
-    }
-
 } // end of namespace Acir
 
 template <>
@@ -8239,21 +7706,6 @@ namespace Acir {
 
     inline bool operator==(const BinaryIntOp::And &lhs, const BinaryIntOp::And &rhs) {
         return true;
-    }
-
-    inline std::vector<uint8_t> BinaryIntOp::And::bincodeSerialize() const {
-        auto serializer = serde::BincodeSerializer();
-        serde::Serializable<BinaryIntOp::And>::serialize(*this, serializer);
-        return std::move(serializer).bytes();
-    }
-
-    inline BinaryIntOp::And BinaryIntOp::And::bincodeDeserialize(std::vector<uint8_t> input) {
-        auto deserializer = serde::BincodeDeserializer(input);
-        auto value = serde::Deserializable<BinaryIntOp::And>::deserialize(deserializer);
-        if (deserializer.get_buffer_offset() < input.size()) {
-            throw_or_abort("Some input bytes were not read");
-        }
-        return value;
     }
 
 } // end of namespace Acir
@@ -8276,21 +7728,6 @@ namespace Acir {
         return true;
     }
 
-    inline std::vector<uint8_t> BinaryIntOp::Or::bincodeSerialize() const {
-        auto serializer = serde::BincodeSerializer();
-        serde::Serializable<BinaryIntOp::Or>::serialize(*this, serializer);
-        return std::move(serializer).bytes();
-    }
-
-    inline BinaryIntOp::Or BinaryIntOp::Or::bincodeDeserialize(std::vector<uint8_t> input) {
-        auto deserializer = serde::BincodeDeserializer(input);
-        auto value = serde::Deserializable<BinaryIntOp::Or>::deserialize(deserializer);
-        if (deserializer.get_buffer_offset() < input.size()) {
-            throw_or_abort("Some input bytes were not read");
-        }
-        return value;
-    }
-
 } // end of namespace Acir
 
 template <>
@@ -8309,21 +7746,6 @@ namespace Acir {
 
     inline bool operator==(const BinaryIntOp::Xor &lhs, const BinaryIntOp::Xor &rhs) {
         return true;
-    }
-
-    inline std::vector<uint8_t> BinaryIntOp::Xor::bincodeSerialize() const {
-        auto serializer = serde::BincodeSerializer();
-        serde::Serializable<BinaryIntOp::Xor>::serialize(*this, serializer);
-        return std::move(serializer).bytes();
-    }
-
-    inline BinaryIntOp::Xor BinaryIntOp::Xor::bincodeDeserialize(std::vector<uint8_t> input) {
-        auto deserializer = serde::BincodeDeserializer(input);
-        auto value = serde::Deserializable<BinaryIntOp::Xor>::deserialize(deserializer);
-        if (deserializer.get_buffer_offset() < input.size()) {
-            throw_or_abort("Some input bytes were not read");
-        }
-        return value;
     }
 
 } // end of namespace Acir
@@ -8346,21 +7768,6 @@ namespace Acir {
         return true;
     }
 
-    inline std::vector<uint8_t> BinaryIntOp::Shl::bincodeSerialize() const {
-        auto serializer = serde::BincodeSerializer();
-        serde::Serializable<BinaryIntOp::Shl>::serialize(*this, serializer);
-        return std::move(serializer).bytes();
-    }
-
-    inline BinaryIntOp::Shl BinaryIntOp::Shl::bincodeDeserialize(std::vector<uint8_t> input) {
-        auto deserializer = serde::BincodeDeserializer(input);
-        auto value = serde::Deserializable<BinaryIntOp::Shl>::deserialize(deserializer);
-        if (deserializer.get_buffer_offset() < input.size()) {
-            throw_or_abort("Some input bytes were not read");
-        }
-        return value;
-    }
-
 } // end of namespace Acir
 
 template <>
@@ -8379,21 +7786,6 @@ namespace Acir {
 
     inline bool operator==(const BinaryIntOp::Shr &lhs, const BinaryIntOp::Shr &rhs) {
         return true;
-    }
-
-    inline std::vector<uint8_t> BinaryIntOp::Shr::bincodeSerialize() const {
-        auto serializer = serde::BincodeSerializer();
-        serde::Serializable<BinaryIntOp::Shr>::serialize(*this, serializer);
-        return std::move(serializer).bytes();
-    }
-
-    inline BinaryIntOp::Shr BinaryIntOp::Shr::bincodeDeserialize(std::vector<uint8_t> input) {
-        auto deserializer = serde::BincodeDeserializer(input);
-        auto value = serde::Deserializable<BinaryIntOp::Shr>::deserialize(deserializer);
-        if (deserializer.get_buffer_offset() < input.size()) {
-            throw_or_abort("Some input bytes were not read");
-        }
-        return value;
     }
 
 } // end of namespace Acir
@@ -8415,21 +7807,6 @@ namespace Acir {
     inline bool operator==(const BitSize &lhs, const BitSize &rhs) {
         if (!(lhs.value == rhs.value)) { return false; }
         return true;
-    }
-
-    inline std::vector<uint8_t> BitSize::bincodeSerialize() const {
-        auto serializer = serde::BincodeSerializer();
-        serde::Serializable<BitSize>::serialize(*this, serializer);
-        return std::move(serializer).bytes();
-    }
-
-    inline BitSize BitSize::bincodeDeserialize(std::vector<uint8_t> input) {
-        auto deserializer = serde::BincodeDeserializer(input);
-        auto value = serde::Deserializable<BitSize>::deserialize(deserializer);
-        if (deserializer.get_buffer_offset() < input.size()) {
-            throw_or_abort("Some input bytes were not read");
-        }
-        return value;
     }
 
 } // end of namespace Acir
@@ -8458,21 +7835,6 @@ namespace Acir {
         return true;
     }
 
-    inline std::vector<uint8_t> BitSize::Field::bincodeSerialize() const {
-        auto serializer = serde::BincodeSerializer();
-        serde::Serializable<BitSize::Field>::serialize(*this, serializer);
-        return std::move(serializer).bytes();
-    }
-
-    inline BitSize::Field BitSize::Field::bincodeDeserialize(std::vector<uint8_t> input) {
-        auto deserializer = serde::BincodeDeserializer(input);
-        auto value = serde::Deserializable<BitSize::Field>::deserialize(deserializer);
-        if (deserializer.get_buffer_offset() < input.size()) {
-            throw_or_abort("Some input bytes were not read");
-        }
-        return value;
-    }
-
 } // end of namespace Acir
 
 template <>
@@ -8492,21 +7854,6 @@ namespace Acir {
     inline bool operator==(const BitSize::Integer &lhs, const BitSize::Integer &rhs) {
         if (!(lhs.value == rhs.value)) { return false; }
         return true;
-    }
-
-    inline std::vector<uint8_t> BitSize::Integer::bincodeSerialize() const {
-        auto serializer = serde::BincodeSerializer();
-        serde::Serializable<BitSize::Integer>::serialize(*this, serializer);
-        return std::move(serializer).bytes();
-    }
-
-    inline BitSize::Integer BitSize::Integer::bincodeDeserialize(std::vector<uint8_t> input) {
-        auto deserializer = serde::BincodeDeserializer(input);
-        auto value = serde::Deserializable<BitSize::Integer>::deserialize(deserializer);
-        if (deserializer.get_buffer_offset() < input.size()) {
-            throw_or_abort("Some input bytes were not read");
-        }
-        return value;
     }
 
 } // end of namespace Acir
@@ -8530,21 +7877,6 @@ namespace Acir {
     inline bool operator==(const BlackBoxFuncCall &lhs, const BlackBoxFuncCall &rhs) {
         if (!(lhs.value == rhs.value)) { return false; }
         return true;
-    }
-
-    inline std::vector<uint8_t> BlackBoxFuncCall::bincodeSerialize() const {
-        auto serializer = serde::BincodeSerializer();
-        serde::Serializable<BlackBoxFuncCall>::serialize(*this, serializer);
-        return std::move(serializer).bytes();
-    }
-
-    inline BlackBoxFuncCall BlackBoxFuncCall::bincodeDeserialize(std::vector<uint8_t> input) {
-        auto deserializer = serde::BincodeDeserializer(input);
-        auto value = serde::Deserializable<BlackBoxFuncCall>::deserialize(deserializer);
-        if (deserializer.get_buffer_offset() < input.size()) {
-            throw_or_abort("Some input bytes were not read");
-        }
-        return value;
     }
 
 } // end of namespace Acir
@@ -8575,21 +7907,6 @@ namespace Acir {
         if (!(lhs.key == rhs.key)) { return false; }
         if (!(lhs.outputs == rhs.outputs)) { return false; }
         return true;
-    }
-
-    inline std::vector<uint8_t> BlackBoxFuncCall::AES128Encrypt::bincodeSerialize() const {
-        auto serializer = serde::BincodeSerializer();
-        serde::Serializable<BlackBoxFuncCall::AES128Encrypt>::serialize(*this, serializer);
-        return std::move(serializer).bytes();
-    }
-
-    inline BlackBoxFuncCall::AES128Encrypt BlackBoxFuncCall::AES128Encrypt::bincodeDeserialize(std::vector<uint8_t> input) {
-        auto deserializer = serde::BincodeDeserializer(input);
-        auto value = serde::Deserializable<BlackBoxFuncCall::AES128Encrypt>::deserialize(deserializer);
-        if (deserializer.get_buffer_offset() < input.size()) {
-            throw_or_abort("Some input bytes were not read");
-        }
-        return value;
     }
 
 } // end of namespace Acir
@@ -8624,21 +7941,6 @@ namespace Acir {
         return true;
     }
 
-    inline std::vector<uint8_t> BlackBoxFuncCall::AND::bincodeSerialize() const {
-        auto serializer = serde::BincodeSerializer();
-        serde::Serializable<BlackBoxFuncCall::AND>::serialize(*this, serializer);
-        return std::move(serializer).bytes();
-    }
-
-    inline BlackBoxFuncCall::AND BlackBoxFuncCall::AND::bincodeDeserialize(std::vector<uint8_t> input) {
-        auto deserializer = serde::BincodeDeserializer(input);
-        auto value = serde::Deserializable<BlackBoxFuncCall::AND>::deserialize(deserializer);
-        if (deserializer.get_buffer_offset() < input.size()) {
-            throw_or_abort("Some input bytes were not read");
-        }
-        return value;
-    }
-
 } // end of namespace Acir
 
 template <>
@@ -8671,21 +7973,6 @@ namespace Acir {
         return true;
     }
 
-    inline std::vector<uint8_t> BlackBoxFuncCall::XOR::bincodeSerialize() const {
-        auto serializer = serde::BincodeSerializer();
-        serde::Serializable<BlackBoxFuncCall::XOR>::serialize(*this, serializer);
-        return std::move(serializer).bytes();
-    }
-
-    inline BlackBoxFuncCall::XOR BlackBoxFuncCall::XOR::bincodeDeserialize(std::vector<uint8_t> input) {
-        auto deserializer = serde::BincodeDeserializer(input);
-        auto value = serde::Deserializable<BlackBoxFuncCall::XOR>::deserialize(deserializer);
-        if (deserializer.get_buffer_offset() < input.size()) {
-            throw_or_abort("Some input bytes were not read");
-        }
-        return value;
-    }
-
 } // end of namespace Acir
 
 template <>
@@ -8716,21 +8003,6 @@ namespace Acir {
         return true;
     }
 
-    inline std::vector<uint8_t> BlackBoxFuncCall::RANGE::bincodeSerialize() const {
-        auto serializer = serde::BincodeSerializer();
-        serde::Serializable<BlackBoxFuncCall::RANGE>::serialize(*this, serializer);
-        return std::move(serializer).bytes();
-    }
-
-    inline BlackBoxFuncCall::RANGE BlackBoxFuncCall::RANGE::bincodeDeserialize(std::vector<uint8_t> input) {
-        auto deserializer = serde::BincodeDeserializer(input);
-        auto value = serde::Deserializable<BlackBoxFuncCall::RANGE>::deserialize(deserializer);
-        if (deserializer.get_buffer_offset() < input.size()) {
-            throw_or_abort("Some input bytes were not read");
-        }
-        return value;
-    }
-
 } // end of namespace Acir
 
 template <>
@@ -8757,21 +8029,6 @@ namespace Acir {
         return true;
     }
 
-    inline std::vector<uint8_t> BlackBoxFuncCall::Blake2s::bincodeSerialize() const {
-        auto serializer = serde::BincodeSerializer();
-        serde::Serializable<BlackBoxFuncCall::Blake2s>::serialize(*this, serializer);
-        return std::move(serializer).bytes();
-    }
-
-    inline BlackBoxFuncCall::Blake2s BlackBoxFuncCall::Blake2s::bincodeDeserialize(std::vector<uint8_t> input) {
-        auto deserializer = serde::BincodeDeserializer(input);
-        auto value = serde::Deserializable<BlackBoxFuncCall::Blake2s>::deserialize(deserializer);
-        if (deserializer.get_buffer_offset() < input.size()) {
-            throw_or_abort("Some input bytes were not read");
-        }
-        return value;
-    }
-
 } // end of namespace Acir
 
 template <>
@@ -8796,21 +8053,6 @@ namespace Acir {
         if (!(lhs.inputs == rhs.inputs)) { return false; }
         if (!(lhs.outputs == rhs.outputs)) { return false; }
         return true;
-    }
-
-    inline std::vector<uint8_t> BlackBoxFuncCall::Blake3::bincodeSerialize() const {
-        auto serializer = serde::BincodeSerializer();
-        serde::Serializable<BlackBoxFuncCall::Blake3>::serialize(*this, serializer);
-        return std::move(serializer).bytes();
-    }
-
-    inline BlackBoxFuncCall::Blake3 BlackBoxFuncCall::Blake3::bincodeDeserialize(std::vector<uint8_t> input) {
-        auto deserializer = serde::BincodeDeserializer(input);
-        auto value = serde::Deserializable<BlackBoxFuncCall::Blake3>::deserialize(deserializer);
-        if (deserializer.get_buffer_offset() < input.size()) {
-            throw_or_abort("Some input bytes were not read");
-        }
-        return value;
     }
 
 } // end of namespace Acir
@@ -8841,21 +8083,6 @@ namespace Acir {
         if (!(lhs.predicate == rhs.predicate)) { return false; }
         if (!(lhs.output == rhs.output)) { return false; }
         return true;
-    }
-
-    inline std::vector<uint8_t> BlackBoxFuncCall::EcdsaSecp256k1::bincodeSerialize() const {
-        auto serializer = serde::BincodeSerializer();
-        serde::Serializable<BlackBoxFuncCall::EcdsaSecp256k1>::serialize(*this, serializer);
-        return std::move(serializer).bytes();
-    }
-
-    inline BlackBoxFuncCall::EcdsaSecp256k1 BlackBoxFuncCall::EcdsaSecp256k1::bincodeDeserialize(std::vector<uint8_t> input) {
-        auto deserializer = serde::BincodeDeserializer(input);
-        auto value = serde::Deserializable<BlackBoxFuncCall::EcdsaSecp256k1>::deserialize(deserializer);
-        if (deserializer.get_buffer_offset() < input.size()) {
-            throw_or_abort("Some input bytes were not read");
-        }
-        return value;
     }
 
 } // end of namespace Acir
@@ -8896,21 +8123,6 @@ namespace Acir {
         return true;
     }
 
-    inline std::vector<uint8_t> BlackBoxFuncCall::EcdsaSecp256r1::bincodeSerialize() const {
-        auto serializer = serde::BincodeSerializer();
-        serde::Serializable<BlackBoxFuncCall::EcdsaSecp256r1>::serialize(*this, serializer);
-        return std::move(serializer).bytes();
-    }
-
-    inline BlackBoxFuncCall::EcdsaSecp256r1 BlackBoxFuncCall::EcdsaSecp256r1::bincodeDeserialize(std::vector<uint8_t> input) {
-        auto deserializer = serde::BincodeDeserializer(input);
-        auto value = serde::Deserializable<BlackBoxFuncCall::EcdsaSecp256r1>::deserialize(deserializer);
-        if (deserializer.get_buffer_offset() < input.size()) {
-            throw_or_abort("Some input bytes were not read");
-        }
-        return value;
-    }
-
 } // end of namespace Acir
 
 template <>
@@ -8947,21 +8159,6 @@ namespace Acir {
         return true;
     }
 
-    inline std::vector<uint8_t> BlackBoxFuncCall::MultiScalarMul::bincodeSerialize() const {
-        auto serializer = serde::BincodeSerializer();
-        serde::Serializable<BlackBoxFuncCall::MultiScalarMul>::serialize(*this, serializer);
-        return std::move(serializer).bytes();
-    }
-
-    inline BlackBoxFuncCall::MultiScalarMul BlackBoxFuncCall::MultiScalarMul::bincodeDeserialize(std::vector<uint8_t> input) {
-        auto deserializer = serde::BincodeDeserializer(input);
-        auto value = serde::Deserializable<BlackBoxFuncCall::MultiScalarMul>::deserialize(deserializer);
-        if (deserializer.get_buffer_offset() < input.size()) {
-            throw_or_abort("Some input bytes were not read");
-        }
-        return value;
-    }
-
 } // end of namespace Acir
 
 template <>
@@ -8994,21 +8191,6 @@ namespace Acir {
         return true;
     }
 
-    inline std::vector<uint8_t> BlackBoxFuncCall::EmbeddedCurveAdd::bincodeSerialize() const {
-        auto serializer = serde::BincodeSerializer();
-        serde::Serializable<BlackBoxFuncCall::EmbeddedCurveAdd>::serialize(*this, serializer);
-        return std::move(serializer).bytes();
-    }
-
-    inline BlackBoxFuncCall::EmbeddedCurveAdd BlackBoxFuncCall::EmbeddedCurveAdd::bincodeDeserialize(std::vector<uint8_t> input) {
-        auto deserializer = serde::BincodeDeserializer(input);
-        auto value = serde::Deserializable<BlackBoxFuncCall::EmbeddedCurveAdd>::deserialize(deserializer);
-        if (deserializer.get_buffer_offset() < input.size()) {
-            throw_or_abort("Some input bytes were not read");
-        }
-        return value;
-    }
-
 } // end of namespace Acir
 
 template <>
@@ -9039,21 +8221,6 @@ namespace Acir {
         return true;
     }
 
-    inline std::vector<uint8_t> BlackBoxFuncCall::Keccakf1600::bincodeSerialize() const {
-        auto serializer = serde::BincodeSerializer();
-        serde::Serializable<BlackBoxFuncCall::Keccakf1600>::serialize(*this, serializer);
-        return std::move(serializer).bytes();
-    }
-
-    inline BlackBoxFuncCall::Keccakf1600 BlackBoxFuncCall::Keccakf1600::bincodeDeserialize(std::vector<uint8_t> input) {
-        auto deserializer = serde::BincodeDeserializer(input);
-        auto value = serde::Deserializable<BlackBoxFuncCall::Keccakf1600>::deserialize(deserializer);
-        if (deserializer.get_buffer_offset() < input.size()) {
-            throw_or_abort("Some input bytes were not read");
-        }
-        return value;
-    }
-
 } // end of namespace Acir
 
 template <>
@@ -9082,21 +8249,6 @@ namespace Acir {
         if (!(lhs.proof_type == rhs.proof_type)) { return false; }
         if (!(lhs.predicate == rhs.predicate)) { return false; }
         return true;
-    }
-
-    inline std::vector<uint8_t> BlackBoxFuncCall::RecursiveAggregation::bincodeSerialize() const {
-        auto serializer = serde::BincodeSerializer();
-        serde::Serializable<BlackBoxFuncCall::RecursiveAggregation>::serialize(*this, serializer);
-        return std::move(serializer).bytes();
-    }
-
-    inline BlackBoxFuncCall::RecursiveAggregation BlackBoxFuncCall::RecursiveAggregation::bincodeDeserialize(std::vector<uint8_t> input) {
-        auto deserializer = serde::BincodeDeserializer(input);
-        auto value = serde::Deserializable<BlackBoxFuncCall::RecursiveAggregation>::deserialize(deserializer);
-        if (deserializer.get_buffer_offset() < input.size()) {
-            throw_or_abort("Some input bytes were not read");
-        }
-        return value;
     }
 
 } // end of namespace Acir
@@ -9133,21 +8285,6 @@ namespace Acir {
         return true;
     }
 
-    inline std::vector<uint8_t> BlackBoxFuncCall::Poseidon2Permutation::bincodeSerialize() const {
-        auto serializer = serde::BincodeSerializer();
-        serde::Serializable<BlackBoxFuncCall::Poseidon2Permutation>::serialize(*this, serializer);
-        return std::move(serializer).bytes();
-    }
-
-    inline BlackBoxFuncCall::Poseidon2Permutation BlackBoxFuncCall::Poseidon2Permutation::bincodeDeserialize(std::vector<uint8_t> input) {
-        auto deserializer = serde::BincodeDeserializer(input);
-        auto value = serde::Deserializable<BlackBoxFuncCall::Poseidon2Permutation>::deserialize(deserializer);
-        if (deserializer.get_buffer_offset() < input.size()) {
-            throw_or_abort("Some input bytes were not read");
-        }
-        return value;
-    }
-
 } // end of namespace Acir
 
 template <>
@@ -9175,21 +8312,6 @@ namespace Acir {
         return true;
     }
 
-    inline std::vector<uint8_t> BlackBoxFuncCall::Sha256Compression::bincodeSerialize() const {
-        auto serializer = serde::BincodeSerializer();
-        serde::Serializable<BlackBoxFuncCall::Sha256Compression>::serialize(*this, serializer);
-        return std::move(serializer).bytes();
-    }
-
-    inline BlackBoxFuncCall::Sha256Compression BlackBoxFuncCall::Sha256Compression::bincodeDeserialize(std::vector<uint8_t> input) {
-        auto deserializer = serde::BincodeDeserializer(input);
-        auto value = serde::Deserializable<BlackBoxFuncCall::Sha256Compression>::deserialize(deserializer);
-        if (deserializer.get_buffer_offset() < input.size()) {
-            throw_or_abort("Some input bytes were not read");
-        }
-        return value;
-    }
-
 } // end of namespace Acir
 
 template <>
@@ -9215,21 +8337,6 @@ namespace Acir {
     inline bool operator==(const BlackBoxOp &lhs, const BlackBoxOp &rhs) {
         if (!(lhs.value == rhs.value)) { return false; }
         return true;
-    }
-
-    inline std::vector<uint8_t> BlackBoxOp::bincodeSerialize() const {
-        auto serializer = serde::BincodeSerializer();
-        serde::Serializable<BlackBoxOp>::serialize(*this, serializer);
-        return std::move(serializer).bytes();
-    }
-
-    inline BlackBoxOp BlackBoxOp::bincodeDeserialize(std::vector<uint8_t> input) {
-        auto deserializer = serde::BincodeDeserializer(input);
-        auto value = serde::Deserializable<BlackBoxOp>::deserialize(deserializer);
-        if (deserializer.get_buffer_offset() < input.size()) {
-            throw_or_abort("Some input bytes were not read");
-        }
-        return value;
     }
 
 } // end of namespace Acir
@@ -9262,21 +8369,6 @@ namespace Acir {
         return true;
     }
 
-    inline std::vector<uint8_t> BlackBoxOp::AES128Encrypt::bincodeSerialize() const {
-        auto serializer = serde::BincodeSerializer();
-        serde::Serializable<BlackBoxOp::AES128Encrypt>::serialize(*this, serializer);
-        return std::move(serializer).bytes();
-    }
-
-    inline BlackBoxOp::AES128Encrypt BlackBoxOp::AES128Encrypt::bincodeDeserialize(std::vector<uint8_t> input) {
-        auto deserializer = serde::BincodeDeserializer(input);
-        auto value = serde::Deserializable<BlackBoxOp::AES128Encrypt>::deserialize(deserializer);
-        if (deserializer.get_buffer_offset() < input.size()) {
-            throw_or_abort("Some input bytes were not read");
-        }
-        return value;
-    }
-
 } // end of namespace Acir
 
 template <>
@@ -9307,21 +8399,6 @@ namespace Acir {
         return true;
     }
 
-    inline std::vector<uint8_t> BlackBoxOp::Blake2s::bincodeSerialize() const {
-        auto serializer = serde::BincodeSerializer();
-        serde::Serializable<BlackBoxOp::Blake2s>::serialize(*this, serializer);
-        return std::move(serializer).bytes();
-    }
-
-    inline BlackBoxOp::Blake2s BlackBoxOp::Blake2s::bincodeDeserialize(std::vector<uint8_t> input) {
-        auto deserializer = serde::BincodeDeserializer(input);
-        auto value = serde::Deserializable<BlackBoxOp::Blake2s>::deserialize(deserializer);
-        if (deserializer.get_buffer_offset() < input.size()) {
-            throw_or_abort("Some input bytes were not read");
-        }
-        return value;
-    }
-
 } // end of namespace Acir
 
 template <>
@@ -9348,21 +8425,6 @@ namespace Acir {
         return true;
     }
 
-    inline std::vector<uint8_t> BlackBoxOp::Blake3::bincodeSerialize() const {
-        auto serializer = serde::BincodeSerializer();
-        serde::Serializable<BlackBoxOp::Blake3>::serialize(*this, serializer);
-        return std::move(serializer).bytes();
-    }
-
-    inline BlackBoxOp::Blake3 BlackBoxOp::Blake3::bincodeDeserialize(std::vector<uint8_t> input) {
-        auto deserializer = serde::BincodeDeserializer(input);
-        auto value = serde::Deserializable<BlackBoxOp::Blake3>::deserialize(deserializer);
-        if (deserializer.get_buffer_offset() < input.size()) {
-            throw_or_abort("Some input bytes were not read");
-        }
-        return value;
-    }
-
 } // end of namespace Acir
 
 template <>
@@ -9387,21 +8449,6 @@ namespace Acir {
         if (!(lhs.input == rhs.input)) { return false; }
         if (!(lhs.output == rhs.output)) { return false; }
         return true;
-    }
-
-    inline std::vector<uint8_t> BlackBoxOp::Keccakf1600::bincodeSerialize() const {
-        auto serializer = serde::BincodeSerializer();
-        serde::Serializable<BlackBoxOp::Keccakf1600>::serialize(*this, serializer);
-        return std::move(serializer).bytes();
-    }
-
-    inline BlackBoxOp::Keccakf1600 BlackBoxOp::Keccakf1600::bincodeDeserialize(std::vector<uint8_t> input) {
-        auto deserializer = serde::BincodeDeserializer(input);
-        auto value = serde::Deserializable<BlackBoxOp::Keccakf1600>::deserialize(deserializer);
-        if (deserializer.get_buffer_offset() < input.size()) {
-            throw_or_abort("Some input bytes were not read");
-        }
-        return value;
     }
 
 } // end of namespace Acir
@@ -9431,21 +8478,6 @@ namespace Acir {
         if (!(lhs.signature == rhs.signature)) { return false; }
         if (!(lhs.result == rhs.result)) { return false; }
         return true;
-    }
-
-    inline std::vector<uint8_t> BlackBoxOp::EcdsaSecp256k1::bincodeSerialize() const {
-        auto serializer = serde::BincodeSerializer();
-        serde::Serializable<BlackBoxOp::EcdsaSecp256k1>::serialize(*this, serializer);
-        return std::move(serializer).bytes();
-    }
-
-    inline BlackBoxOp::EcdsaSecp256k1 BlackBoxOp::EcdsaSecp256k1::bincodeDeserialize(std::vector<uint8_t> input) {
-        auto deserializer = serde::BincodeDeserializer(input);
-        auto value = serde::Deserializable<BlackBoxOp::EcdsaSecp256k1>::deserialize(deserializer);
-        if (deserializer.get_buffer_offset() < input.size()) {
-            throw_or_abort("Some input bytes were not read");
-        }
-        return value;
     }
 
 } // end of namespace Acir
@@ -9483,21 +8515,6 @@ namespace Acir {
         return true;
     }
 
-    inline std::vector<uint8_t> BlackBoxOp::EcdsaSecp256r1::bincodeSerialize() const {
-        auto serializer = serde::BincodeSerializer();
-        serde::Serializable<BlackBoxOp::EcdsaSecp256r1>::serialize(*this, serializer);
-        return std::move(serializer).bytes();
-    }
-
-    inline BlackBoxOp::EcdsaSecp256r1 BlackBoxOp::EcdsaSecp256r1::bincodeDeserialize(std::vector<uint8_t> input) {
-        auto deserializer = serde::BincodeDeserializer(input);
-        auto value = serde::Deserializable<BlackBoxOp::EcdsaSecp256r1>::deserialize(deserializer);
-        if (deserializer.get_buffer_offset() < input.size()) {
-            throw_or_abort("Some input bytes were not read");
-        }
-        return value;
-    }
-
 } // end of namespace Acir
 
 template <>
@@ -9531,21 +8548,6 @@ namespace Acir {
         return true;
     }
 
-    inline std::vector<uint8_t> BlackBoxOp::MultiScalarMul::bincodeSerialize() const {
-        auto serializer = serde::BincodeSerializer();
-        serde::Serializable<BlackBoxOp::MultiScalarMul>::serialize(*this, serializer);
-        return std::move(serializer).bytes();
-    }
-
-    inline BlackBoxOp::MultiScalarMul BlackBoxOp::MultiScalarMul::bincodeDeserialize(std::vector<uint8_t> input) {
-        auto deserializer = serde::BincodeDeserializer(input);
-        auto value = serde::Deserializable<BlackBoxOp::MultiScalarMul>::deserialize(deserializer);
-        if (deserializer.get_buffer_offset() < input.size()) {
-            throw_or_abort("Some input bytes were not read");
-        }
-        return value;
-    }
-
 } // end of namespace Acir
 
 template <>
@@ -9577,21 +8579,6 @@ namespace Acir {
         if (!(lhs.input2_infinite == rhs.input2_infinite)) { return false; }
         if (!(lhs.result == rhs.result)) { return false; }
         return true;
-    }
-
-    inline std::vector<uint8_t> BlackBoxOp::EmbeddedCurveAdd::bincodeSerialize() const {
-        auto serializer = serde::BincodeSerializer();
-        serde::Serializable<BlackBoxOp::EmbeddedCurveAdd>::serialize(*this, serializer);
-        return std::move(serializer).bytes();
-    }
-
-    inline BlackBoxOp::EmbeddedCurveAdd BlackBoxOp::EmbeddedCurveAdd::bincodeDeserialize(std::vector<uint8_t> input) {
-        auto deserializer = serde::BincodeDeserializer(input);
-        auto value = serde::Deserializable<BlackBoxOp::EmbeddedCurveAdd>::deserialize(deserializer);
-        if (deserializer.get_buffer_offset() < input.size()) {
-            throw_or_abort("Some input bytes were not read");
-        }
-        return value;
     }
 
 } // end of namespace Acir
@@ -9630,21 +8617,6 @@ namespace Acir {
         return true;
     }
 
-    inline std::vector<uint8_t> BlackBoxOp::Poseidon2Permutation::bincodeSerialize() const {
-        auto serializer = serde::BincodeSerializer();
-        serde::Serializable<BlackBoxOp::Poseidon2Permutation>::serialize(*this, serializer);
-        return std::move(serializer).bytes();
-    }
-
-    inline BlackBoxOp::Poseidon2Permutation BlackBoxOp::Poseidon2Permutation::bincodeDeserialize(std::vector<uint8_t> input) {
-        auto deserializer = serde::BincodeDeserializer(input);
-        auto value = serde::Deserializable<BlackBoxOp::Poseidon2Permutation>::deserialize(deserializer);
-        if (deserializer.get_buffer_offset() < input.size()) {
-            throw_or_abort("Some input bytes were not read");
-        }
-        return value;
-    }
-
 } // end of namespace Acir
 
 template <>
@@ -9670,21 +8642,6 @@ namespace Acir {
         if (!(lhs.hash_values == rhs.hash_values)) { return false; }
         if (!(lhs.output == rhs.output)) { return false; }
         return true;
-    }
-
-    inline std::vector<uint8_t> BlackBoxOp::Sha256Compression::bincodeSerialize() const {
-        auto serializer = serde::BincodeSerializer();
-        serde::Serializable<BlackBoxOp::Sha256Compression>::serialize(*this, serializer);
-        return std::move(serializer).bytes();
-    }
-
-    inline BlackBoxOp::Sha256Compression BlackBoxOp::Sha256Compression::bincodeDeserialize(std::vector<uint8_t> input) {
-        auto deserializer = serde::BincodeDeserializer(input);
-        auto value = serde::Deserializable<BlackBoxOp::Sha256Compression>::deserialize(deserializer);
-        if (deserializer.get_buffer_offset() < input.size()) {
-            throw_or_abort("Some input bytes were not read");
-        }
-        return value;
     }
 
 } // end of namespace Acir
@@ -9718,21 +8675,6 @@ namespace Acir {
         return true;
     }
 
-    inline std::vector<uint8_t> BlackBoxOp::ToRadix::bincodeSerialize() const {
-        auto serializer = serde::BincodeSerializer();
-        serde::Serializable<BlackBoxOp::ToRadix>::serialize(*this, serializer);
-        return std::move(serializer).bytes();
-    }
-
-    inline BlackBoxOp::ToRadix BlackBoxOp::ToRadix::bincodeDeserialize(std::vector<uint8_t> input) {
-        auto deserializer = serde::BincodeDeserializer(input);
-        auto value = serde::Deserializable<BlackBoxOp::ToRadix>::deserialize(deserializer);
-        if (deserializer.get_buffer_offset() < input.size()) {
-            throw_or_abort("Some input bytes were not read");
-        }
-        return value;
-    }
-
 } // end of namespace Acir
 
 template <>
@@ -9764,21 +8706,6 @@ namespace Acir {
         return true;
     }
 
-    inline std::vector<uint8_t> BlockId::bincodeSerialize() const {
-        auto serializer = serde::BincodeSerializer();
-        serde::Serializable<BlockId>::serialize(*this, serializer);
-        return std::move(serializer).bytes();
-    }
-
-    inline BlockId BlockId::bincodeDeserialize(std::vector<uint8_t> input) {
-        auto deserializer = serde::BincodeDeserializer(input);
-        auto value = serde::Deserializable<BlockId>::deserialize(deserializer);
-        if (deserializer.get_buffer_offset() < input.size()) {
-            throw_or_abort("Some input bytes were not read");
-        }
-        return value;
-    }
-
 } // end of namespace Acir
 
 template <>
@@ -9804,21 +8731,6 @@ namespace Acir {
     inline bool operator==(const BlockType &lhs, const BlockType &rhs) {
         if (!(lhs.value == rhs.value)) { return false; }
         return true;
-    }
-
-    inline std::vector<uint8_t> BlockType::bincodeSerialize() const {
-        auto serializer = serde::BincodeSerializer();
-        serde::Serializable<BlockType>::serialize(*this, serializer);
-        return std::move(serializer).bytes();
-    }
-
-    inline BlockType BlockType::bincodeDeserialize(std::vector<uint8_t> input) {
-        auto deserializer = serde::BincodeDeserializer(input);
-        auto value = serde::Deserializable<BlockType>::deserialize(deserializer);
-        if (deserializer.get_buffer_offset() < input.size()) {
-            throw_or_abort("Some input bytes were not read");
-        }
-        return value;
     }
 
 } // end of namespace Acir
@@ -9847,21 +8759,6 @@ namespace Acir {
         return true;
     }
 
-    inline std::vector<uint8_t> BlockType::Memory::bincodeSerialize() const {
-        auto serializer = serde::BincodeSerializer();
-        serde::Serializable<BlockType::Memory>::serialize(*this, serializer);
-        return std::move(serializer).bytes();
-    }
-
-    inline BlockType::Memory BlockType::Memory::bincodeDeserialize(std::vector<uint8_t> input) {
-        auto deserializer = serde::BincodeDeserializer(input);
-        auto value = serde::Deserializable<BlockType::Memory>::deserialize(deserializer);
-        if (deserializer.get_buffer_offset() < input.size()) {
-            throw_or_abort("Some input bytes were not read");
-        }
-        return value;
-    }
-
 } // end of namespace Acir
 
 template <>
@@ -9881,21 +8778,6 @@ namespace Acir {
     inline bool operator==(const BlockType::CallData &lhs, const BlockType::CallData &rhs) {
         if (!(lhs.value == rhs.value)) { return false; }
         return true;
-    }
-
-    inline std::vector<uint8_t> BlockType::CallData::bincodeSerialize() const {
-        auto serializer = serde::BincodeSerializer();
-        serde::Serializable<BlockType::CallData>::serialize(*this, serializer);
-        return std::move(serializer).bytes();
-    }
-
-    inline BlockType::CallData BlockType::CallData::bincodeDeserialize(std::vector<uint8_t> input) {
-        auto deserializer = serde::BincodeDeserializer(input);
-        auto value = serde::Deserializable<BlockType::CallData>::deserialize(deserializer);
-        if (deserializer.get_buffer_offset() < input.size()) {
-            throw_or_abort("Some input bytes were not read");
-        }
-        return value;
     }
 
 } // end of namespace Acir
@@ -9920,21 +8802,6 @@ namespace Acir {
         return true;
     }
 
-    inline std::vector<uint8_t> BlockType::ReturnData::bincodeSerialize() const {
-        auto serializer = serde::BincodeSerializer();
-        serde::Serializable<BlockType::ReturnData>::serialize(*this, serializer);
-        return std::move(serializer).bytes();
-    }
-
-    inline BlockType::ReturnData BlockType::ReturnData::bincodeDeserialize(std::vector<uint8_t> input) {
-        auto deserializer = serde::BincodeDeserializer(input);
-        auto value = serde::Deserializable<BlockType::ReturnData>::deserialize(deserializer);
-        if (deserializer.get_buffer_offset() < input.size()) {
-            throw_or_abort("Some input bytes were not read");
-        }
-        return value;
-    }
-
 } // end of namespace Acir
 
 template <>
@@ -9955,21 +8822,6 @@ namespace Acir {
         if (!(lhs.function_name == rhs.function_name)) { return false; }
         if (!(lhs.bytecode == rhs.bytecode)) { return false; }
         return true;
-    }
-
-    inline std::vector<uint8_t> BrilligBytecode::bincodeSerialize() const {
-        auto serializer = serde::BincodeSerializer();
-        serde::Serializable<BrilligBytecode>::serialize(*this, serializer);
-        return std::move(serializer).bytes();
-    }
-
-    inline BrilligBytecode BrilligBytecode::bincodeDeserialize(std::vector<uint8_t> input) {
-        auto deserializer = serde::BincodeDeserializer(input);
-        auto value = serde::Deserializable<BrilligBytecode>::deserialize(deserializer);
-        if (deserializer.get_buffer_offset() < input.size()) {
-            throw_or_abort("Some input bytes were not read");
-        }
-        return value;
     }
 
 } // end of namespace Acir
@@ -10001,21 +8853,6 @@ namespace Acir {
         return true;
     }
 
-    inline std::vector<uint8_t> BrilligInputs::bincodeSerialize() const {
-        auto serializer = serde::BincodeSerializer();
-        serde::Serializable<BrilligInputs>::serialize(*this, serializer);
-        return std::move(serializer).bytes();
-    }
-
-    inline BrilligInputs BrilligInputs::bincodeDeserialize(std::vector<uint8_t> input) {
-        auto deserializer = serde::BincodeDeserializer(input);
-        auto value = serde::Deserializable<BrilligInputs>::deserialize(deserializer);
-        if (deserializer.get_buffer_offset() < input.size()) {
-            throw_or_abort("Some input bytes were not read");
-        }
-        return value;
-    }
-
 } // end of namespace Acir
 
 template <>
@@ -10043,21 +8880,6 @@ namespace Acir {
         return true;
     }
 
-    inline std::vector<uint8_t> BrilligInputs::Single::bincodeSerialize() const {
-        auto serializer = serde::BincodeSerializer();
-        serde::Serializable<BrilligInputs::Single>::serialize(*this, serializer);
-        return std::move(serializer).bytes();
-    }
-
-    inline BrilligInputs::Single BrilligInputs::Single::bincodeDeserialize(std::vector<uint8_t> input) {
-        auto deserializer = serde::BincodeDeserializer(input);
-        auto value = serde::Deserializable<BrilligInputs::Single>::deserialize(deserializer);
-        if (deserializer.get_buffer_offset() < input.size()) {
-            throw_or_abort("Some input bytes were not read");
-        }
-        return value;
-    }
-
 } // end of namespace Acir
 
 template <>
@@ -10079,21 +8901,6 @@ namespace Acir {
     inline bool operator==(const BrilligInputs::Array &lhs, const BrilligInputs::Array &rhs) {
         if (!(lhs.value == rhs.value)) { return false; }
         return true;
-    }
-
-    inline std::vector<uint8_t> BrilligInputs::Array::bincodeSerialize() const {
-        auto serializer = serde::BincodeSerializer();
-        serde::Serializable<BrilligInputs::Array>::serialize(*this, serializer);
-        return std::move(serializer).bytes();
-    }
-
-    inline BrilligInputs::Array BrilligInputs::Array::bincodeDeserialize(std::vector<uint8_t> input) {
-        auto deserializer = serde::BincodeDeserializer(input);
-        auto value = serde::Deserializable<BrilligInputs::Array>::deserialize(deserializer);
-        if (deserializer.get_buffer_offset() < input.size()) {
-            throw_or_abort("Some input bytes were not read");
-        }
-        return value;
     }
 
 } // end of namespace Acir
@@ -10119,21 +8926,6 @@ namespace Acir {
         return true;
     }
 
-    inline std::vector<uint8_t> BrilligInputs::MemoryArray::bincodeSerialize() const {
-        auto serializer = serde::BincodeSerializer();
-        serde::Serializable<BrilligInputs::MemoryArray>::serialize(*this, serializer);
-        return std::move(serializer).bytes();
-    }
-
-    inline BrilligInputs::MemoryArray BrilligInputs::MemoryArray::bincodeDeserialize(std::vector<uint8_t> input) {
-        auto deserializer = serde::BincodeDeserializer(input);
-        auto value = serde::Deserializable<BrilligInputs::MemoryArray>::deserialize(deserializer);
-        if (deserializer.get_buffer_offset() < input.size()) {
-            throw_or_abort("Some input bytes were not read");
-        }
-        return value;
-    }
-
 } // end of namespace Acir
 
 template <>
@@ -10155,21 +8947,6 @@ namespace Acir {
     inline bool operator==(const BrilligOpcode &lhs, const BrilligOpcode &rhs) {
         if (!(lhs.value == rhs.value)) { return false; }
         return true;
-    }
-
-    inline std::vector<uint8_t> BrilligOpcode::bincodeSerialize() const {
-        auto serializer = serde::BincodeSerializer();
-        serde::Serializable<BrilligOpcode>::serialize(*this, serializer);
-        return std::move(serializer).bytes();
-    }
-
-    inline BrilligOpcode BrilligOpcode::bincodeDeserialize(std::vector<uint8_t> input) {
-        auto deserializer = serde::BincodeDeserializer(input);
-        auto value = serde::Deserializable<BrilligOpcode>::deserialize(deserializer);
-        if (deserializer.get_buffer_offset() < input.size()) {
-            throw_or_abort("Some input bytes were not read");
-        }
-        return value;
     }
 
 } // end of namespace Acir
@@ -10200,21 +8977,6 @@ namespace Acir {
         if (!(lhs.lhs == rhs.lhs)) { return false; }
         if (!(lhs.rhs == rhs.rhs)) { return false; }
         return true;
-    }
-
-    inline std::vector<uint8_t> BrilligOpcode::BinaryFieldOp::bincodeSerialize() const {
-        auto serializer = serde::BincodeSerializer();
-        serde::Serializable<BrilligOpcode::BinaryFieldOp>::serialize(*this, serializer);
-        return std::move(serializer).bytes();
-    }
-
-    inline BrilligOpcode::BinaryFieldOp BrilligOpcode::BinaryFieldOp::bincodeDeserialize(std::vector<uint8_t> input) {
-        auto deserializer = serde::BincodeDeserializer(input);
-        auto value = serde::Deserializable<BrilligOpcode::BinaryFieldOp>::deserialize(deserializer);
-        if (deserializer.get_buffer_offset() < input.size()) {
-            throw_or_abort("Some input bytes were not read");
-        }
-        return value;
     }
 
 } // end of namespace Acir
@@ -10250,21 +9012,6 @@ namespace Acir {
         return true;
     }
 
-    inline std::vector<uint8_t> BrilligOpcode::BinaryIntOp::bincodeSerialize() const {
-        auto serializer = serde::BincodeSerializer();
-        serde::Serializable<BrilligOpcode::BinaryIntOp>::serialize(*this, serializer);
-        return std::move(serializer).bytes();
-    }
-
-    inline BrilligOpcode::BinaryIntOp BrilligOpcode::BinaryIntOp::bincodeDeserialize(std::vector<uint8_t> input) {
-        auto deserializer = serde::BincodeDeserializer(input);
-        auto value = serde::Deserializable<BrilligOpcode::BinaryIntOp>::deserialize(deserializer);
-        if (deserializer.get_buffer_offset() < input.size()) {
-            throw_or_abort("Some input bytes were not read");
-        }
-        return value;
-    }
-
 } // end of namespace Acir
 
 template <>
@@ -10298,21 +9045,6 @@ namespace Acir {
         return true;
     }
 
-    inline std::vector<uint8_t> BrilligOpcode::Not::bincodeSerialize() const {
-        auto serializer = serde::BincodeSerializer();
-        serde::Serializable<BrilligOpcode::Not>::serialize(*this, serializer);
-        return std::move(serializer).bytes();
-    }
-
-    inline BrilligOpcode::Not BrilligOpcode::Not::bincodeDeserialize(std::vector<uint8_t> input) {
-        auto deserializer = serde::BincodeDeserializer(input);
-        auto value = serde::Deserializable<BrilligOpcode::Not>::deserialize(deserializer);
-        if (deserializer.get_buffer_offset() < input.size()) {
-            throw_or_abort("Some input bytes were not read");
-        }
-        return value;
-    }
-
 } // end of namespace Acir
 
 template <>
@@ -10340,21 +9072,6 @@ namespace Acir {
         if (!(lhs.source == rhs.source)) { return false; }
         if (!(lhs.bit_size == rhs.bit_size)) { return false; }
         return true;
-    }
-
-    inline std::vector<uint8_t> BrilligOpcode::Cast::bincodeSerialize() const {
-        auto serializer = serde::BincodeSerializer();
-        serde::Serializable<BrilligOpcode::Cast>::serialize(*this, serializer);
-        return std::move(serializer).bytes();
-    }
-
-    inline BrilligOpcode::Cast BrilligOpcode::Cast::bincodeDeserialize(std::vector<uint8_t> input) {
-        auto deserializer = serde::BincodeDeserializer(input);
-        auto value = serde::Deserializable<BrilligOpcode::Cast>::deserialize(deserializer);
-        if (deserializer.get_buffer_offset() < input.size()) {
-            throw_or_abort("Some input bytes were not read");
-        }
-        return value;
     }
 
 } // end of namespace Acir
@@ -10385,21 +9102,6 @@ namespace Acir {
         return true;
     }
 
-    inline std::vector<uint8_t> BrilligOpcode::JumpIf::bincodeSerialize() const {
-        auto serializer = serde::BincodeSerializer();
-        serde::Serializable<BrilligOpcode::JumpIf>::serialize(*this, serializer);
-        return std::move(serializer).bytes();
-    }
-
-    inline BrilligOpcode::JumpIf BrilligOpcode::JumpIf::bincodeDeserialize(std::vector<uint8_t> input) {
-        auto deserializer = serde::BincodeDeserializer(input);
-        auto value = serde::Deserializable<BrilligOpcode::JumpIf>::deserialize(deserializer);
-        if (deserializer.get_buffer_offset() < input.size()) {
-            throw_or_abort("Some input bytes were not read");
-        }
-        return value;
-    }
-
 } // end of namespace Acir
 
 template <>
@@ -10425,21 +9127,6 @@ namespace Acir {
         return true;
     }
 
-    inline std::vector<uint8_t> BrilligOpcode::Jump::bincodeSerialize() const {
-        auto serializer = serde::BincodeSerializer();
-        serde::Serializable<BrilligOpcode::Jump>::serialize(*this, serializer);
-        return std::move(serializer).bytes();
-    }
-
-    inline BrilligOpcode::Jump BrilligOpcode::Jump::bincodeDeserialize(std::vector<uint8_t> input) {
-        auto deserializer = serde::BincodeDeserializer(input);
-        auto value = serde::Deserializable<BrilligOpcode::Jump>::deserialize(deserializer);
-        if (deserializer.get_buffer_offset() < input.size()) {
-            throw_or_abort("Some input bytes were not read");
-        }
-        return value;
-    }
-
 } // end of namespace Acir
 
 template <>
@@ -10463,21 +9150,6 @@ namespace Acir {
         if (!(lhs.size_address == rhs.size_address)) { return false; }
         if (!(lhs.offset_address == rhs.offset_address)) { return false; }
         return true;
-    }
-
-    inline std::vector<uint8_t> BrilligOpcode::CalldataCopy::bincodeSerialize() const {
-        auto serializer = serde::BincodeSerializer();
-        serde::Serializable<BrilligOpcode::CalldataCopy>::serialize(*this, serializer);
-        return std::move(serializer).bytes();
-    }
-
-    inline BrilligOpcode::CalldataCopy BrilligOpcode::CalldataCopy::bincodeDeserialize(std::vector<uint8_t> input) {
-        auto deserializer = serde::BincodeDeserializer(input);
-        auto value = serde::Deserializable<BrilligOpcode::CalldataCopy>::deserialize(deserializer);
-        if (deserializer.get_buffer_offset() < input.size()) {
-            throw_or_abort("Some input bytes were not read");
-        }
-        return value;
     }
 
 } // end of namespace Acir
@@ -10507,21 +9179,6 @@ namespace Acir {
         return true;
     }
 
-    inline std::vector<uint8_t> BrilligOpcode::Call::bincodeSerialize() const {
-        auto serializer = serde::BincodeSerializer();
-        serde::Serializable<BrilligOpcode::Call>::serialize(*this, serializer);
-        return std::move(serializer).bytes();
-    }
-
-    inline BrilligOpcode::Call BrilligOpcode::Call::bincodeDeserialize(std::vector<uint8_t> input) {
-        auto deserializer = serde::BincodeDeserializer(input);
-        auto value = serde::Deserializable<BrilligOpcode::Call>::deserialize(deserializer);
-        if (deserializer.get_buffer_offset() < input.size()) {
-            throw_or_abort("Some input bytes were not read");
-        }
-        return value;
-    }
-
 } // end of namespace Acir
 
 template <>
@@ -10545,21 +9202,6 @@ namespace Acir {
         if (!(lhs.bit_size == rhs.bit_size)) { return false; }
         if (!(lhs.value == rhs.value)) { return false; }
         return true;
-    }
-
-    inline std::vector<uint8_t> BrilligOpcode::Const::bincodeSerialize() const {
-        auto serializer = serde::BincodeSerializer();
-        serde::Serializable<BrilligOpcode::Const>::serialize(*this, serializer);
-        return std::move(serializer).bytes();
-    }
-
-    inline BrilligOpcode::Const BrilligOpcode::Const::bincodeDeserialize(std::vector<uint8_t> input) {
-        auto deserializer = serde::BincodeDeserializer(input);
-        auto value = serde::Deserializable<BrilligOpcode::Const>::deserialize(deserializer);
-        if (deserializer.get_buffer_offset() < input.size()) {
-            throw_or_abort("Some input bytes were not read");
-        }
-        return value;
     }
 
 } // end of namespace Acir
@@ -10591,21 +9233,6 @@ namespace Acir {
         return true;
     }
 
-    inline std::vector<uint8_t> BrilligOpcode::IndirectConst::bincodeSerialize() const {
-        auto serializer = serde::BincodeSerializer();
-        serde::Serializable<BrilligOpcode::IndirectConst>::serialize(*this, serializer);
-        return std::move(serializer).bytes();
-    }
-
-    inline BrilligOpcode::IndirectConst BrilligOpcode::IndirectConst::bincodeDeserialize(std::vector<uint8_t> input) {
-        auto deserializer = serde::BincodeDeserializer(input);
-        auto value = serde::Deserializable<BrilligOpcode::IndirectConst>::deserialize(deserializer);
-        if (deserializer.get_buffer_offset() < input.size()) {
-            throw_or_abort("Some input bytes were not read");
-        }
-        return value;
-    }
-
 } // end of namespace Acir
 
 template <>
@@ -10632,21 +9259,6 @@ namespace Acir {
         return true;
     }
 
-    inline std::vector<uint8_t> BrilligOpcode::Return::bincodeSerialize() const {
-        auto serializer = serde::BincodeSerializer();
-        serde::Serializable<BrilligOpcode::Return>::serialize(*this, serializer);
-        return std::move(serializer).bytes();
-    }
-
-    inline BrilligOpcode::Return BrilligOpcode::Return::bincodeDeserialize(std::vector<uint8_t> input) {
-        auto deserializer = serde::BincodeDeserializer(input);
-        auto value = serde::Deserializable<BrilligOpcode::Return>::deserialize(deserializer);
-        if (deserializer.get_buffer_offset() < input.size()) {
-            throw_or_abort("Some input bytes were not read");
-        }
-        return value;
-    }
-
 } // end of namespace Acir
 
 template <>
@@ -10670,21 +9282,6 @@ namespace Acir {
         if (!(lhs.inputs == rhs.inputs)) { return false; }
         if (!(lhs.input_value_types == rhs.input_value_types)) { return false; }
         return true;
-    }
-
-    inline std::vector<uint8_t> BrilligOpcode::ForeignCall::bincodeSerialize() const {
-        auto serializer = serde::BincodeSerializer();
-        serde::Serializable<BrilligOpcode::ForeignCall>::serialize(*this, serializer);
-        return std::move(serializer).bytes();
-    }
-
-    inline BrilligOpcode::ForeignCall BrilligOpcode::ForeignCall::bincodeDeserialize(std::vector<uint8_t> input) {
-        auto deserializer = serde::BincodeDeserializer(input);
-        auto value = serde::Deserializable<BrilligOpcode::ForeignCall>::deserialize(deserializer);
-        if (deserializer.get_buffer_offset() < input.size()) {
-            throw_or_abort("Some input bytes were not read");
-        }
-        return value;
     }
 
 } // end of namespace Acir
@@ -10719,21 +9316,6 @@ namespace Acir {
         return true;
     }
 
-    inline std::vector<uint8_t> BrilligOpcode::Mov::bincodeSerialize() const {
-        auto serializer = serde::BincodeSerializer();
-        serde::Serializable<BrilligOpcode::Mov>::serialize(*this, serializer);
-        return std::move(serializer).bytes();
-    }
-
-    inline BrilligOpcode::Mov BrilligOpcode::Mov::bincodeDeserialize(std::vector<uint8_t> input) {
-        auto deserializer = serde::BincodeDeserializer(input);
-        auto value = serde::Deserializable<BrilligOpcode::Mov>::deserialize(deserializer);
-        if (deserializer.get_buffer_offset() < input.size()) {
-            throw_or_abort("Some input bytes were not read");
-        }
-        return value;
-    }
-
 } // end of namespace Acir
 
 template <>
@@ -10760,21 +9342,6 @@ namespace Acir {
         if (!(lhs.source_b == rhs.source_b)) { return false; }
         if (!(lhs.condition == rhs.condition)) { return false; }
         return true;
-    }
-
-    inline std::vector<uint8_t> BrilligOpcode::ConditionalMov::bincodeSerialize() const {
-        auto serializer = serde::BincodeSerializer();
-        serde::Serializable<BrilligOpcode::ConditionalMov>::serialize(*this, serializer);
-        return std::move(serializer).bytes();
-    }
-
-    inline BrilligOpcode::ConditionalMov BrilligOpcode::ConditionalMov::bincodeDeserialize(std::vector<uint8_t> input) {
-        auto deserializer = serde::BincodeDeserializer(input);
-        auto value = serde::Deserializable<BrilligOpcode::ConditionalMov>::deserialize(deserializer);
-        if (deserializer.get_buffer_offset() < input.size()) {
-            throw_or_abort("Some input bytes were not read");
-        }
-        return value;
     }
 
 } // end of namespace Acir
@@ -10807,21 +9374,6 @@ namespace Acir {
         return true;
     }
 
-    inline std::vector<uint8_t> BrilligOpcode::Load::bincodeSerialize() const {
-        auto serializer = serde::BincodeSerializer();
-        serde::Serializable<BrilligOpcode::Load>::serialize(*this, serializer);
-        return std::move(serializer).bytes();
-    }
-
-    inline BrilligOpcode::Load BrilligOpcode::Load::bincodeDeserialize(std::vector<uint8_t> input) {
-        auto deserializer = serde::BincodeDeserializer(input);
-        auto value = serde::Deserializable<BrilligOpcode::Load>::deserialize(deserializer);
-        if (deserializer.get_buffer_offset() < input.size()) {
-            throw_or_abort("Some input bytes were not read");
-        }
-        return value;
-    }
-
 } // end of namespace Acir
 
 template <>
@@ -10846,21 +9398,6 @@ namespace Acir {
         if (!(lhs.destination_pointer == rhs.destination_pointer)) { return false; }
         if (!(lhs.source == rhs.source)) { return false; }
         return true;
-    }
-
-    inline std::vector<uint8_t> BrilligOpcode::Store::bincodeSerialize() const {
-        auto serializer = serde::BincodeSerializer();
-        serde::Serializable<BrilligOpcode::Store>::serialize(*this, serializer);
-        return std::move(serializer).bytes();
-    }
-
-    inline BrilligOpcode::Store BrilligOpcode::Store::bincodeDeserialize(std::vector<uint8_t> input) {
-        auto deserializer = serde::BincodeDeserializer(input);
-        auto value = serde::Deserializable<BrilligOpcode::Store>::deserialize(deserializer);
-        if (deserializer.get_buffer_offset() < input.size()) {
-            throw_or_abort("Some input bytes were not read");
-        }
-        return value;
     }
 
 } // end of namespace Acir
@@ -10888,21 +9425,6 @@ namespace Acir {
         return true;
     }
 
-    inline std::vector<uint8_t> BrilligOpcode::BlackBox::bincodeSerialize() const {
-        auto serializer = serde::BincodeSerializer();
-        serde::Serializable<BrilligOpcode::BlackBox>::serialize(*this, serializer);
-        return std::move(serializer).bytes();
-    }
-
-    inline BrilligOpcode::BlackBox BrilligOpcode::BlackBox::bincodeDeserialize(std::vector<uint8_t> input) {
-        auto deserializer = serde::BincodeDeserializer(input);
-        auto value = serde::Deserializable<BrilligOpcode::BlackBox>::deserialize(deserializer);
-        if (deserializer.get_buffer_offset() < input.size()) {
-            throw_or_abort("Some input bytes were not read");
-        }
-        return value;
-    }
-
 } // end of namespace Acir
 
 template <>
@@ -10924,21 +9446,6 @@ namespace Acir {
     inline bool operator==(const BrilligOpcode::Trap &lhs, const BrilligOpcode::Trap &rhs) {
         if (!(lhs.revert_data == rhs.revert_data)) { return false; }
         return true;
-    }
-
-    inline std::vector<uint8_t> BrilligOpcode::Trap::bincodeSerialize() const {
-        auto serializer = serde::BincodeSerializer();
-        serde::Serializable<BrilligOpcode::Trap>::serialize(*this, serializer);
-        return std::move(serializer).bytes();
-    }
-
-    inline BrilligOpcode::Trap BrilligOpcode::Trap::bincodeDeserialize(std::vector<uint8_t> input) {
-        auto deserializer = serde::BincodeDeserializer(input);
-        auto value = serde::Deserializable<BrilligOpcode::Trap>::deserialize(deserializer);
-        if (deserializer.get_buffer_offset() < input.size()) {
-            throw_or_abort("Some input bytes were not read");
-        }
-        return value;
     }
 
 } // end of namespace Acir
@@ -10964,21 +9471,6 @@ namespace Acir {
         return true;
     }
 
-    inline std::vector<uint8_t> BrilligOpcode::Stop::bincodeSerialize() const {
-        auto serializer = serde::BincodeSerializer();
-        serde::Serializable<BrilligOpcode::Stop>::serialize(*this, serializer);
-        return std::move(serializer).bytes();
-    }
-
-    inline BrilligOpcode::Stop BrilligOpcode::Stop::bincodeDeserialize(std::vector<uint8_t> input) {
-        auto deserializer = serde::BincodeDeserializer(input);
-        auto value = serde::Deserializable<BrilligOpcode::Stop>::deserialize(deserializer);
-        if (deserializer.get_buffer_offset() < input.size()) {
-            throw_or_abort("Some input bytes were not read");
-        }
-        return value;
-    }
-
 } // end of namespace Acir
 
 template <>
@@ -11000,21 +9492,6 @@ namespace Acir {
     inline bool operator==(const BrilligOutputs &lhs, const BrilligOutputs &rhs) {
         if (!(lhs.value == rhs.value)) { return false; }
         return true;
-    }
-
-    inline std::vector<uint8_t> BrilligOutputs::bincodeSerialize() const {
-        auto serializer = serde::BincodeSerializer();
-        serde::Serializable<BrilligOutputs>::serialize(*this, serializer);
-        return std::move(serializer).bytes();
-    }
-
-    inline BrilligOutputs BrilligOutputs::bincodeDeserialize(std::vector<uint8_t> input) {
-        auto deserializer = serde::BincodeDeserializer(input);
-        auto value = serde::Deserializable<BrilligOutputs>::deserialize(deserializer);
-        if (deserializer.get_buffer_offset() < input.size()) {
-            throw_or_abort("Some input bytes were not read");
-        }
-        return value;
     }
 
 } // end of namespace Acir
@@ -11044,21 +9521,6 @@ namespace Acir {
         return true;
     }
 
-    inline std::vector<uint8_t> BrilligOutputs::Simple::bincodeSerialize() const {
-        auto serializer = serde::BincodeSerializer();
-        serde::Serializable<BrilligOutputs::Simple>::serialize(*this, serializer);
-        return std::move(serializer).bytes();
-    }
-
-    inline BrilligOutputs::Simple BrilligOutputs::Simple::bincodeDeserialize(std::vector<uint8_t> input) {
-        auto deserializer = serde::BincodeDeserializer(input);
-        auto value = serde::Deserializable<BrilligOutputs::Simple>::deserialize(deserializer);
-        if (deserializer.get_buffer_offset() < input.size()) {
-            throw_or_abort("Some input bytes were not read");
-        }
-        return value;
-    }
-
 } // end of namespace Acir
 
 template <>
@@ -11080,21 +9542,6 @@ namespace Acir {
     inline bool operator==(const BrilligOutputs::Array &lhs, const BrilligOutputs::Array &rhs) {
         if (!(lhs.value == rhs.value)) { return false; }
         return true;
-    }
-
-    inline std::vector<uint8_t> BrilligOutputs::Array::bincodeSerialize() const {
-        auto serializer = serde::BincodeSerializer();
-        serde::Serializable<BrilligOutputs::Array>::serialize(*this, serializer);
-        return std::move(serializer).bytes();
-    }
-
-    inline BrilligOutputs::Array BrilligOutputs::Array::bincodeDeserialize(std::vector<uint8_t> input) {
-        auto deserializer = serde::BincodeDeserializer(input);
-        auto value = serde::Deserializable<BrilligOutputs::Array>::deserialize(deserializer);
-        if (deserializer.get_buffer_offset() < input.size()) {
-            throw_or_abort("Some input bytes were not read");
-        }
-        return value;
     }
 
 } // end of namespace Acir
@@ -11124,21 +9571,6 @@ namespace Acir {
         if (!(lhs.return_values == rhs.return_values)) { return false; }
         if (!(lhs.assert_messages == rhs.assert_messages)) { return false; }
         return true;
-    }
-
-    inline std::vector<uint8_t> Circuit::bincodeSerialize() const {
-        auto serializer = serde::BincodeSerializer();
-        serde::Serializable<Circuit>::serialize(*this, serializer);
-        return std::move(serializer).bytes();
-    }
-
-    inline Circuit Circuit::bincodeDeserialize(std::vector<uint8_t> input) {
-        auto deserializer = serde::BincodeDeserializer(input);
-        auto value = serde::Deserializable<Circuit>::deserialize(deserializer);
-        if (deserializer.get_buffer_offset() < input.size()) {
-            throw_or_abort("Some input bytes were not read");
-        }
-        return value;
     }
 
 } // end of namespace Acir
@@ -11182,21 +9614,6 @@ namespace Acir {
         return true;
     }
 
-    inline std::vector<uint8_t> Expression::bincodeSerialize() const {
-        auto serializer = serde::BincodeSerializer();
-        serde::Serializable<Expression>::serialize(*this, serializer);
-        return std::move(serializer).bytes();
-    }
-
-    inline Expression Expression::bincodeDeserialize(std::vector<uint8_t> input) {
-        auto deserializer = serde::BincodeDeserializer(input);
-        auto value = serde::Deserializable<Expression>::deserialize(deserializer);
-        if (deserializer.get_buffer_offset() < input.size()) {
-            throw_or_abort("Some input bytes were not read");
-        }
-        return value;
-    }
-
 } // end of namespace Acir
 
 template <>
@@ -11228,21 +9645,6 @@ namespace Acir {
         return true;
     }
 
-    inline std::vector<uint8_t> ExpressionOrMemory::bincodeSerialize() const {
-        auto serializer = serde::BincodeSerializer();
-        serde::Serializable<ExpressionOrMemory>::serialize(*this, serializer);
-        return std::move(serializer).bytes();
-    }
-
-    inline ExpressionOrMemory ExpressionOrMemory::bincodeDeserialize(std::vector<uint8_t> input) {
-        auto deserializer = serde::BincodeDeserializer(input);
-        auto value = serde::Deserializable<ExpressionOrMemory>::deserialize(deserializer);
-        if (deserializer.get_buffer_offset() < input.size()) {
-            throw_or_abort("Some input bytes were not read");
-        }
-        return value;
-    }
-
 } // end of namespace Acir
 
 template <>
@@ -11270,21 +9672,6 @@ namespace Acir {
         return true;
     }
 
-    inline std::vector<uint8_t> ExpressionOrMemory::Expression::bincodeSerialize() const {
-        auto serializer = serde::BincodeSerializer();
-        serde::Serializable<ExpressionOrMemory::Expression>::serialize(*this, serializer);
-        return std::move(serializer).bytes();
-    }
-
-    inline ExpressionOrMemory::Expression ExpressionOrMemory::Expression::bincodeDeserialize(std::vector<uint8_t> input) {
-        auto deserializer = serde::BincodeDeserializer(input);
-        auto value = serde::Deserializable<ExpressionOrMemory::Expression>::deserialize(deserializer);
-        if (deserializer.get_buffer_offset() < input.size()) {
-            throw_or_abort("Some input bytes were not read");
-        }
-        return value;
-    }
-
 } // end of namespace Acir
 
 template <>
@@ -11308,21 +9695,6 @@ namespace Acir {
         return true;
     }
 
-    inline std::vector<uint8_t> ExpressionOrMemory::Memory::bincodeSerialize() const {
-        auto serializer = serde::BincodeSerializer();
-        serde::Serializable<ExpressionOrMemory::Memory>::serialize(*this, serializer);
-        return std::move(serializer).bytes();
-    }
-
-    inline ExpressionOrMemory::Memory ExpressionOrMemory::Memory::bincodeDeserialize(std::vector<uint8_t> input) {
-        auto deserializer = serde::BincodeDeserializer(input);
-        auto value = serde::Deserializable<ExpressionOrMemory::Memory>::deserialize(deserializer);
-        if (deserializer.get_buffer_offset() < input.size()) {
-            throw_or_abort("Some input bytes were not read");
-        }
-        return value;
-    }
-
 } // end of namespace Acir
 
 template <>
@@ -11344,21 +9716,6 @@ namespace Acir {
     inline bool operator==(const FunctionInput &lhs, const FunctionInput &rhs) {
         if (!(lhs.value == rhs.value)) { return false; }
         return true;
-    }
-
-    inline std::vector<uint8_t> FunctionInput::bincodeSerialize() const {
-        auto serializer = serde::BincodeSerializer();
-        serde::Serializable<FunctionInput>::serialize(*this, serializer);
-        return std::move(serializer).bytes();
-    }
-
-    inline FunctionInput FunctionInput::bincodeDeserialize(std::vector<uint8_t> input) {
-        auto deserializer = serde::BincodeDeserializer(input);
-        auto value = serde::Deserializable<FunctionInput>::deserialize(deserializer);
-        if (deserializer.get_buffer_offset() < input.size()) {
-            throw_or_abort("Some input bytes were not read");
-        }
-        return value;
     }
 
 } // end of namespace Acir
@@ -11388,21 +9745,6 @@ namespace Acir {
         return true;
     }
 
-    inline std::vector<uint8_t> FunctionInput::Constant::bincodeSerialize() const {
-        auto serializer = serde::BincodeSerializer();
-        serde::Serializable<FunctionInput::Constant>::serialize(*this, serializer);
-        return std::move(serializer).bytes();
-    }
-
-    inline FunctionInput::Constant FunctionInput::Constant::bincodeDeserialize(std::vector<uint8_t> input) {
-        auto deserializer = serde::BincodeDeserializer(input);
-        auto value = serde::Deserializable<FunctionInput::Constant>::deserialize(deserializer);
-        if (deserializer.get_buffer_offset() < input.size()) {
-            throw_or_abort("Some input bytes were not read");
-        }
-        return value;
-    }
-
 } // end of namespace Acir
 
 template <>
@@ -11424,21 +9766,6 @@ namespace Acir {
     inline bool operator==(const FunctionInput::Witness &lhs, const FunctionInput::Witness &rhs) {
         if (!(lhs.value == rhs.value)) { return false; }
         return true;
-    }
-
-    inline std::vector<uint8_t> FunctionInput::Witness::bincodeSerialize() const {
-        auto serializer = serde::BincodeSerializer();
-        serde::Serializable<FunctionInput::Witness>::serialize(*this, serializer);
-        return std::move(serializer).bytes();
-    }
-
-    inline FunctionInput::Witness FunctionInput::Witness::bincodeDeserialize(std::vector<uint8_t> input) {
-        auto deserializer = serde::BincodeDeserializer(input);
-        auto value = serde::Deserializable<FunctionInput::Witness>::deserialize(deserializer);
-        if (deserializer.get_buffer_offset() < input.size()) {
-            throw_or_abort("Some input bytes were not read");
-        }
-        return value;
     }
 
 } // end of namespace Acir
@@ -11463,21 +9790,6 @@ namespace Acir {
         if (!(lhs.pointer == rhs.pointer)) { return false; }
         if (!(lhs.size == rhs.size)) { return false; }
         return true;
-    }
-
-    inline std::vector<uint8_t> HeapArray::bincodeSerialize() const {
-        auto serializer = serde::BincodeSerializer();
-        serde::Serializable<HeapArray>::serialize(*this, serializer);
-        return std::move(serializer).bytes();
-    }
-
-    inline HeapArray HeapArray::bincodeDeserialize(std::vector<uint8_t> input) {
-        auto deserializer = serde::BincodeDeserializer(input);
-        auto value = serde::Deserializable<HeapArray>::deserialize(deserializer);
-        if (deserializer.get_buffer_offset() < input.size()) {
-            throw_or_abort("Some input bytes were not read");
-        }
-        return value;
     }
 
 } // end of namespace Acir
@@ -11509,21 +9821,6 @@ namespace Acir {
         return true;
     }
 
-    inline std::vector<uint8_t> HeapValueType::bincodeSerialize() const {
-        auto serializer = serde::BincodeSerializer();
-        serde::Serializable<HeapValueType>::serialize(*this, serializer);
-        return std::move(serializer).bytes();
-    }
-
-    inline HeapValueType HeapValueType::bincodeDeserialize(std::vector<uint8_t> input) {
-        auto deserializer = serde::BincodeDeserializer(input);
-        auto value = serde::Deserializable<HeapValueType>::deserialize(deserializer);
-        if (deserializer.get_buffer_offset() < input.size()) {
-            throw_or_abort("Some input bytes were not read");
-        }
-        return value;
-    }
-
 } // end of namespace Acir
 
 template <>
@@ -11551,21 +9848,6 @@ namespace Acir {
         return true;
     }
 
-    inline std::vector<uint8_t> HeapValueType::Simple::bincodeSerialize() const {
-        auto serializer = serde::BincodeSerializer();
-        serde::Serializable<HeapValueType::Simple>::serialize(*this, serializer);
-        return std::move(serializer).bytes();
-    }
-
-    inline HeapValueType::Simple HeapValueType::Simple::bincodeDeserialize(std::vector<uint8_t> input) {
-        auto deserializer = serde::BincodeDeserializer(input);
-        auto value = serde::Deserializable<HeapValueType::Simple>::deserialize(deserializer);
-        if (deserializer.get_buffer_offset() < input.size()) {
-            throw_or_abort("Some input bytes were not read");
-        }
-        return value;
-    }
-
 } // end of namespace Acir
 
 template <>
@@ -11588,21 +9870,6 @@ namespace Acir {
         if (!(lhs.value_types == rhs.value_types)) { return false; }
         if (!(lhs.size == rhs.size)) { return false; }
         return true;
-    }
-
-    inline std::vector<uint8_t> HeapValueType::Array::bincodeSerialize() const {
-        auto serializer = serde::BincodeSerializer();
-        serde::Serializable<HeapValueType::Array>::serialize(*this, serializer);
-        return std::move(serializer).bytes();
-    }
-
-    inline HeapValueType::Array HeapValueType::Array::bincodeDeserialize(std::vector<uint8_t> input) {
-        auto deserializer = serde::BincodeDeserializer(input);
-        auto value = serde::Deserializable<HeapValueType::Array>::deserialize(deserializer);
-        if (deserializer.get_buffer_offset() < input.size()) {
-            throw_or_abort("Some input bytes were not read");
-        }
-        return value;
     }
 
 } // end of namespace Acir
@@ -11630,21 +9897,6 @@ namespace Acir {
         return true;
     }
 
-    inline std::vector<uint8_t> HeapValueType::Vector::bincodeSerialize() const {
-        auto serializer = serde::BincodeSerializer();
-        serde::Serializable<HeapValueType::Vector>::serialize(*this, serializer);
-        return std::move(serializer).bytes();
-    }
-
-    inline HeapValueType::Vector HeapValueType::Vector::bincodeDeserialize(std::vector<uint8_t> input) {
-        auto deserializer = serde::BincodeDeserializer(input);
-        auto value = serde::Deserializable<HeapValueType::Vector>::deserialize(deserializer);
-        if (deserializer.get_buffer_offset() < input.size()) {
-            throw_or_abort("Some input bytes were not read");
-        }
-        return value;
-    }
-
 } // end of namespace Acir
 
 template <>
@@ -11667,21 +9919,6 @@ namespace Acir {
         if (!(lhs.pointer == rhs.pointer)) { return false; }
         if (!(lhs.size == rhs.size)) { return false; }
         return true;
-    }
-
-    inline std::vector<uint8_t> HeapVector::bincodeSerialize() const {
-        auto serializer = serde::BincodeSerializer();
-        serde::Serializable<HeapVector>::serialize(*this, serializer);
-        return std::move(serializer).bytes();
-    }
-
-    inline HeapVector HeapVector::bincodeDeserialize(std::vector<uint8_t> input) {
-        auto deserializer = serde::BincodeDeserializer(input);
-        auto value = serde::Deserializable<HeapVector>::deserialize(deserializer);
-        if (deserializer.get_buffer_offset() < input.size()) {
-            throw_or_abort("Some input bytes were not read");
-        }
-        return value;
     }
 
 } // end of namespace Acir
@@ -11713,21 +9950,6 @@ namespace Acir {
         return true;
     }
 
-    inline std::vector<uint8_t> IntegerBitSize::bincodeSerialize() const {
-        auto serializer = serde::BincodeSerializer();
-        serde::Serializable<IntegerBitSize>::serialize(*this, serializer);
-        return std::move(serializer).bytes();
-    }
-
-    inline IntegerBitSize IntegerBitSize::bincodeDeserialize(std::vector<uint8_t> input) {
-        auto deserializer = serde::BincodeDeserializer(input);
-        auto value = serde::Deserializable<IntegerBitSize>::deserialize(deserializer);
-        if (deserializer.get_buffer_offset() < input.size()) {
-            throw_or_abort("Some input bytes were not read");
-        }
-        return value;
-    }
-
 } // end of namespace Acir
 
 template <>
@@ -11754,21 +9976,6 @@ namespace Acir {
         return true;
     }
 
-    inline std::vector<uint8_t> IntegerBitSize::U1::bincodeSerialize() const {
-        auto serializer = serde::BincodeSerializer();
-        serde::Serializable<IntegerBitSize::U1>::serialize(*this, serializer);
-        return std::move(serializer).bytes();
-    }
-
-    inline IntegerBitSize::U1 IntegerBitSize::U1::bincodeDeserialize(std::vector<uint8_t> input) {
-        auto deserializer = serde::BincodeDeserializer(input);
-        auto value = serde::Deserializable<IntegerBitSize::U1>::deserialize(deserializer);
-        if (deserializer.get_buffer_offset() < input.size()) {
-            throw_or_abort("Some input bytes were not read");
-        }
-        return value;
-    }
-
 } // end of namespace Acir
 
 template <>
@@ -11787,21 +9994,6 @@ namespace Acir {
 
     inline bool operator==(const IntegerBitSize::U8 &lhs, const IntegerBitSize::U8 &rhs) {
         return true;
-    }
-
-    inline std::vector<uint8_t> IntegerBitSize::U8::bincodeSerialize() const {
-        auto serializer = serde::BincodeSerializer();
-        serde::Serializable<IntegerBitSize::U8>::serialize(*this, serializer);
-        return std::move(serializer).bytes();
-    }
-
-    inline IntegerBitSize::U8 IntegerBitSize::U8::bincodeDeserialize(std::vector<uint8_t> input) {
-        auto deserializer = serde::BincodeDeserializer(input);
-        auto value = serde::Deserializable<IntegerBitSize::U8>::deserialize(deserializer);
-        if (deserializer.get_buffer_offset() < input.size()) {
-            throw_or_abort("Some input bytes were not read");
-        }
-        return value;
     }
 
 } // end of namespace Acir
@@ -11824,21 +10016,6 @@ namespace Acir {
         return true;
     }
 
-    inline std::vector<uint8_t> IntegerBitSize::U16::bincodeSerialize() const {
-        auto serializer = serde::BincodeSerializer();
-        serde::Serializable<IntegerBitSize::U16>::serialize(*this, serializer);
-        return std::move(serializer).bytes();
-    }
-
-    inline IntegerBitSize::U16 IntegerBitSize::U16::bincodeDeserialize(std::vector<uint8_t> input) {
-        auto deserializer = serde::BincodeDeserializer(input);
-        auto value = serde::Deserializable<IntegerBitSize::U16>::deserialize(deserializer);
-        if (deserializer.get_buffer_offset() < input.size()) {
-            throw_or_abort("Some input bytes were not read");
-        }
-        return value;
-    }
-
 } // end of namespace Acir
 
 template <>
@@ -11857,21 +10034,6 @@ namespace Acir {
 
     inline bool operator==(const IntegerBitSize::U32 &lhs, const IntegerBitSize::U32 &rhs) {
         return true;
-    }
-
-    inline std::vector<uint8_t> IntegerBitSize::U32::bincodeSerialize() const {
-        auto serializer = serde::BincodeSerializer();
-        serde::Serializable<IntegerBitSize::U32>::serialize(*this, serializer);
-        return std::move(serializer).bytes();
-    }
-
-    inline IntegerBitSize::U32 IntegerBitSize::U32::bincodeDeserialize(std::vector<uint8_t> input) {
-        auto deserializer = serde::BincodeDeserializer(input);
-        auto value = serde::Deserializable<IntegerBitSize::U32>::deserialize(deserializer);
-        if (deserializer.get_buffer_offset() < input.size()) {
-            throw_or_abort("Some input bytes were not read");
-        }
-        return value;
     }
 
 } // end of namespace Acir
@@ -11894,21 +10056,6 @@ namespace Acir {
         return true;
     }
 
-    inline std::vector<uint8_t> IntegerBitSize::U64::bincodeSerialize() const {
-        auto serializer = serde::BincodeSerializer();
-        serde::Serializable<IntegerBitSize::U64>::serialize(*this, serializer);
-        return std::move(serializer).bytes();
-    }
-
-    inline IntegerBitSize::U64 IntegerBitSize::U64::bincodeDeserialize(std::vector<uint8_t> input) {
-        auto deserializer = serde::BincodeDeserializer(input);
-        auto value = serde::Deserializable<IntegerBitSize::U64>::deserialize(deserializer);
-        if (deserializer.get_buffer_offset() < input.size()) {
-            throw_or_abort("Some input bytes were not read");
-        }
-        return value;
-    }
-
 } // end of namespace Acir
 
 template <>
@@ -11927,21 +10074,6 @@ namespace Acir {
 
     inline bool operator==(const IntegerBitSize::U128 &lhs, const IntegerBitSize::U128 &rhs) {
         return true;
-    }
-
-    inline std::vector<uint8_t> IntegerBitSize::U128::bincodeSerialize() const {
-        auto serializer = serde::BincodeSerializer();
-        serde::Serializable<IntegerBitSize::U128>::serialize(*this, serializer);
-        return std::move(serializer).bytes();
-    }
-
-    inline IntegerBitSize::U128 IntegerBitSize::U128::bincodeDeserialize(std::vector<uint8_t> input) {
-        auto deserializer = serde::BincodeDeserializer(input);
-        auto value = serde::Deserializable<IntegerBitSize::U128>::deserialize(deserializer);
-        if (deserializer.get_buffer_offset() < input.size()) {
-            throw_or_abort("Some input bytes were not read");
-        }
-        return value;
     }
 
 } // end of namespace Acir
@@ -11965,21 +10097,6 @@ namespace Acir {
         if (!(lhs.index == rhs.index)) { return false; }
         if (!(lhs.value == rhs.value)) { return false; }
         return true;
-    }
-
-    inline std::vector<uint8_t> MemOp::bincodeSerialize() const {
-        auto serializer = serde::BincodeSerializer();
-        serde::Serializable<MemOp>::serialize(*this, serializer);
-        return std::move(serializer).bytes();
-    }
-
-    inline MemOp MemOp::bincodeDeserialize(std::vector<uint8_t> input) {
-        auto deserializer = serde::BincodeDeserializer(input);
-        auto value = serde::Deserializable<MemOp>::deserialize(deserializer);
-        if (deserializer.get_buffer_offset() < input.size()) {
-            throw_or_abort("Some input bytes were not read");
-        }
-        return value;
     }
 
 } // end of namespace Acir
@@ -12013,21 +10130,6 @@ namespace Acir {
         return true;
     }
 
-    inline std::vector<uint8_t> MemoryAddress::bincodeSerialize() const {
-        auto serializer = serde::BincodeSerializer();
-        serde::Serializable<MemoryAddress>::serialize(*this, serializer);
-        return std::move(serializer).bytes();
-    }
-
-    inline MemoryAddress MemoryAddress::bincodeDeserialize(std::vector<uint8_t> input) {
-        auto deserializer = serde::BincodeDeserializer(input);
-        auto value = serde::Deserializable<MemoryAddress>::deserialize(deserializer);
-        if (deserializer.get_buffer_offset() < input.size()) {
-            throw_or_abort("Some input bytes were not read");
-        }
-        return value;
-    }
-
 } // end of namespace Acir
 
 template <>
@@ -12055,21 +10157,6 @@ namespace Acir {
         return true;
     }
 
-    inline std::vector<uint8_t> MemoryAddress::Direct::bincodeSerialize() const {
-        auto serializer = serde::BincodeSerializer();
-        serde::Serializable<MemoryAddress::Direct>::serialize(*this, serializer);
-        return std::move(serializer).bytes();
-    }
-
-    inline MemoryAddress::Direct MemoryAddress::Direct::bincodeDeserialize(std::vector<uint8_t> input) {
-        auto deserializer = serde::BincodeDeserializer(input);
-        auto value = serde::Deserializable<MemoryAddress::Direct>::deserialize(deserializer);
-        if (deserializer.get_buffer_offset() < input.size()) {
-            throw_or_abort("Some input bytes were not read");
-        }
-        return value;
-    }
-
 } // end of namespace Acir
 
 template <>
@@ -12093,21 +10180,6 @@ namespace Acir {
         return true;
     }
 
-    inline std::vector<uint8_t> MemoryAddress::Relative::bincodeSerialize() const {
-        auto serializer = serde::BincodeSerializer();
-        serde::Serializable<MemoryAddress::Relative>::serialize(*this, serializer);
-        return std::move(serializer).bytes();
-    }
-
-    inline MemoryAddress::Relative MemoryAddress::Relative::bincodeDeserialize(std::vector<uint8_t> input) {
-        auto deserializer = serde::BincodeDeserializer(input);
-        auto value = serde::Deserializable<MemoryAddress::Relative>::deserialize(deserializer);
-        if (deserializer.get_buffer_offset() < input.size()) {
-            throw_or_abort("Some input bytes were not read");
-        }
-        return value;
-    }
-
 } // end of namespace Acir
 
 template <>
@@ -12129,21 +10201,6 @@ namespace Acir {
     inline bool operator==(const Opcode &lhs, const Opcode &rhs) {
         if (!(lhs.value == rhs.value)) { return false; }
         return true;
-    }
-
-    inline std::vector<uint8_t> Opcode::bincodeSerialize() const {
-        auto serializer = serde::BincodeSerializer();
-        serde::Serializable<Opcode>::serialize(*this, serializer);
-        return std::move(serializer).bytes();
-    }
-
-    inline Opcode Opcode::bincodeDeserialize(std::vector<uint8_t> input) {
-        auto deserializer = serde::BincodeDeserializer(input);
-        auto value = serde::Deserializable<Opcode>::deserialize(deserializer);
-        if (deserializer.get_buffer_offset() < input.size()) {
-            throw_or_abort("Some input bytes were not read");
-        }
-        return value;
     }
 
 } // end of namespace Acir
@@ -12173,21 +10230,6 @@ namespace Acir {
         return true;
     }
 
-    inline std::vector<uint8_t> Opcode::AssertZero::bincodeSerialize() const {
-        auto serializer = serde::BincodeSerializer();
-        serde::Serializable<Opcode::AssertZero>::serialize(*this, serializer);
-        return std::move(serializer).bytes();
-    }
-
-    inline Opcode::AssertZero Opcode::AssertZero::bincodeDeserialize(std::vector<uint8_t> input) {
-        auto deserializer = serde::BincodeDeserializer(input);
-        auto value = serde::Deserializable<Opcode::AssertZero>::deserialize(deserializer);
-        if (deserializer.get_buffer_offset() < input.size()) {
-            throw_or_abort("Some input bytes were not read");
-        }
-        return value;
-    }
-
 } // end of namespace Acir
 
 template <>
@@ -12209,21 +10251,6 @@ namespace Acir {
     inline bool operator==(const Opcode::BlackBoxFuncCall &lhs, const Opcode::BlackBoxFuncCall &rhs) {
         if (!(lhs.value == rhs.value)) { return false; }
         return true;
-    }
-
-    inline std::vector<uint8_t> Opcode::BlackBoxFuncCall::bincodeSerialize() const {
-        auto serializer = serde::BincodeSerializer();
-        serde::Serializable<Opcode::BlackBoxFuncCall>::serialize(*this, serializer);
-        return std::move(serializer).bytes();
-    }
-
-    inline Opcode::BlackBoxFuncCall Opcode::BlackBoxFuncCall::bincodeDeserialize(std::vector<uint8_t> input) {
-        auto deserializer = serde::BincodeDeserializer(input);
-        auto value = serde::Deserializable<Opcode::BlackBoxFuncCall>::deserialize(deserializer);
-        if (deserializer.get_buffer_offset() < input.size()) {
-            throw_or_abort("Some input bytes were not read");
-        }
-        return value;
     }
 
 } // end of namespace Acir
@@ -12248,21 +10275,6 @@ namespace Acir {
         if (!(lhs.block_id == rhs.block_id)) { return false; }
         if (!(lhs.op == rhs.op)) { return false; }
         return true;
-    }
-
-    inline std::vector<uint8_t> Opcode::MemoryOp::bincodeSerialize() const {
-        auto serializer = serde::BincodeSerializer();
-        serde::Serializable<Opcode::MemoryOp>::serialize(*this, serializer);
-        return std::move(serializer).bytes();
-    }
-
-    inline Opcode::MemoryOp Opcode::MemoryOp::bincodeDeserialize(std::vector<uint8_t> input) {
-        auto deserializer = serde::BincodeDeserializer(input);
-        auto value = serde::Deserializable<Opcode::MemoryOp>::deserialize(deserializer);
-        if (deserializer.get_buffer_offset() < input.size()) {
-            throw_or_abort("Some input bytes were not read");
-        }
-        return value;
     }
 
 } // end of namespace Acir
@@ -12290,21 +10302,6 @@ namespace Acir {
         if (!(lhs.init == rhs.init)) { return false; }
         if (!(lhs.block_type == rhs.block_type)) { return false; }
         return true;
-    }
-
-    inline std::vector<uint8_t> Opcode::MemoryInit::bincodeSerialize() const {
-        auto serializer = serde::BincodeSerializer();
-        serde::Serializable<Opcode::MemoryInit>::serialize(*this, serializer);
-        return std::move(serializer).bytes();
-    }
-
-    inline Opcode::MemoryInit Opcode::MemoryInit::bincodeDeserialize(std::vector<uint8_t> input) {
-        auto deserializer = serde::BincodeDeserializer(input);
-        auto value = serde::Deserializable<Opcode::MemoryInit>::deserialize(deserializer);
-        if (deserializer.get_buffer_offset() < input.size()) {
-            throw_or_abort("Some input bytes were not read");
-        }
-        return value;
     }
 
 } // end of namespace Acir
@@ -12335,21 +10332,6 @@ namespace Acir {
         if (!(lhs.outputs == rhs.outputs)) { return false; }
         if (!(lhs.predicate == rhs.predicate)) { return false; }
         return true;
-    }
-
-    inline std::vector<uint8_t> Opcode::BrilligCall::bincodeSerialize() const {
-        auto serializer = serde::BincodeSerializer();
-        serde::Serializable<Opcode::BrilligCall>::serialize(*this, serializer);
-        return std::move(serializer).bytes();
-    }
-
-    inline Opcode::BrilligCall Opcode::BrilligCall::bincodeDeserialize(std::vector<uint8_t> input) {
-        auto deserializer = serde::BincodeDeserializer(input);
-        auto value = serde::Deserializable<Opcode::BrilligCall>::deserialize(deserializer);
-        if (deserializer.get_buffer_offset() < input.size()) {
-            throw_or_abort("Some input bytes were not read");
-        }
-        return value;
     }
 
 } // end of namespace Acir
@@ -12384,21 +10366,6 @@ namespace Acir {
         return true;
     }
 
-    inline std::vector<uint8_t> Opcode::Call::bincodeSerialize() const {
-        auto serializer = serde::BincodeSerializer();
-        serde::Serializable<Opcode::Call>::serialize(*this, serializer);
-        return std::move(serializer).bytes();
-    }
-
-    inline Opcode::Call Opcode::Call::bincodeDeserialize(std::vector<uint8_t> input) {
-        auto deserializer = serde::BincodeDeserializer(input);
-        auto value = serde::Deserializable<Opcode::Call>::deserialize(deserializer);
-        if (deserializer.get_buffer_offset() < input.size()) {
-            throw_or_abort("Some input bytes were not read");
-        }
-        return value;
-    }
-
 } // end of namespace Acir
 
 template <>
@@ -12428,21 +10395,6 @@ namespace Acir {
         return true;
     }
 
-    inline std::vector<uint8_t> OpcodeLocation::bincodeSerialize() const {
-        auto serializer = serde::BincodeSerializer();
-        serde::Serializable<OpcodeLocation>::serialize(*this, serializer);
-        return std::move(serializer).bytes();
-    }
-
-    inline OpcodeLocation OpcodeLocation::bincodeDeserialize(std::vector<uint8_t> input) {
-        auto deserializer = serde::BincodeDeserializer(input);
-        auto value = serde::Deserializable<OpcodeLocation>::deserialize(deserializer);
-        if (deserializer.get_buffer_offset() < input.size()) {
-            throw_or_abort("Some input bytes were not read");
-        }
-        return value;
-    }
-
 } // end of namespace Acir
 
 template <>
@@ -12470,21 +10422,6 @@ namespace Acir {
         return true;
     }
 
-    inline std::vector<uint8_t> OpcodeLocation::Acir::bincodeSerialize() const {
-        auto serializer = serde::BincodeSerializer();
-        serde::Serializable<OpcodeLocation::Acir>::serialize(*this, serializer);
-        return std::move(serializer).bytes();
-    }
-
-    inline OpcodeLocation::Acir OpcodeLocation::Acir::bincodeDeserialize(std::vector<uint8_t> input) {
-        auto deserializer = serde::BincodeDeserializer(input);
-        auto value = serde::Deserializable<OpcodeLocation::Acir>::deserialize(deserializer);
-        if (deserializer.get_buffer_offset() < input.size()) {
-            throw_or_abort("Some input bytes were not read");
-        }
-        return value;
-    }
-
 } // end of namespace Acir
 
 template <>
@@ -12507,21 +10444,6 @@ namespace Acir {
         if (!(lhs.acir_index == rhs.acir_index)) { return false; }
         if (!(lhs.brillig_index == rhs.brillig_index)) { return false; }
         return true;
-    }
-
-    inline std::vector<uint8_t> OpcodeLocation::Brillig::bincodeSerialize() const {
-        auto serializer = serde::BincodeSerializer();
-        serde::Serializable<OpcodeLocation::Brillig>::serialize(*this, serializer);
-        return std::move(serializer).bytes();
-    }
-
-    inline OpcodeLocation::Brillig OpcodeLocation::Brillig::bincodeDeserialize(std::vector<uint8_t> input) {
-        auto deserializer = serde::BincodeDeserializer(input);
-        auto value = serde::Deserializable<OpcodeLocation::Brillig>::deserialize(deserializer);
-        if (deserializer.get_buffer_offset() < input.size()) {
-            throw_or_abort("Some input bytes were not read");
-        }
-        return value;
     }
 
 } // end of namespace Acir
@@ -12548,21 +10470,6 @@ namespace Acir {
         if (!(lhs.functions == rhs.functions)) { return false; }
         if (!(lhs.unconstrained_functions == rhs.unconstrained_functions)) { return false; }
         return true;
-    }
-
-    inline std::vector<uint8_t> Program::bincodeSerialize() const {
-        auto serializer = serde::BincodeSerializer();
-        serde::Serializable<Program>::serialize(*this, serializer);
-        return std::move(serializer).bytes();
-    }
-
-    inline Program Program::bincodeDeserialize(std::vector<uint8_t> input) {
-        auto deserializer = serde::BincodeDeserializer(input);
-        auto value = serde::Deserializable<Program>::deserialize(deserializer);
-        if (deserializer.get_buffer_offset() < input.size()) {
-            throw_or_abort("Some input bytes were not read");
-        }
-        return value;
     }
 
 } // end of namespace Acir
@@ -12595,21 +10502,6 @@ namespace Acir {
         return true;
     }
 
-    inline std::vector<uint8_t> ProgramWithoutBrillig::bincodeSerialize() const {
-        auto serializer = serde::BincodeSerializer();
-        serde::Serializable<ProgramWithoutBrillig>::serialize(*this, serializer);
-        return std::move(serializer).bytes();
-    }
-
-    inline ProgramWithoutBrillig ProgramWithoutBrillig::bincodeDeserialize(std::vector<uint8_t> input) {
-        auto deserializer = serde::BincodeDeserializer(input);
-        auto value = serde::Deserializable<ProgramWithoutBrillig>::deserialize(deserializer);
-        if (deserializer.get_buffer_offset() < input.size()) {
-            throw_or_abort("Some input bytes were not read");
-        }
-        return value;
-    }
-
 } // end of namespace Acir
 
 template <>
@@ -12639,21 +10531,6 @@ namespace Acir {
         return true;
     }
 
-    inline std::vector<uint8_t> PublicInputs::bincodeSerialize() const {
-        auto serializer = serde::BincodeSerializer();
-        serde::Serializable<PublicInputs>::serialize(*this, serializer);
-        return std::move(serializer).bytes();
-    }
-
-    inline PublicInputs PublicInputs::bincodeDeserialize(std::vector<uint8_t> input) {
-        auto deserializer = serde::BincodeDeserializer(input);
-        auto value = serde::Deserializable<PublicInputs>::deserialize(deserializer);
-        if (deserializer.get_buffer_offset() < input.size()) {
-            throw_or_abort("Some input bytes were not read");
-        }
-        return value;
-    }
-
 } // end of namespace Acir
 
 template <>
@@ -12679,21 +10556,6 @@ namespace Acir {
     inline bool operator==(const SemanticLength &lhs, const SemanticLength &rhs) {
         if (!(lhs.value == rhs.value)) { return false; }
         return true;
-    }
-
-    inline std::vector<uint8_t> SemanticLength::bincodeSerialize() const {
-        auto serializer = serde::BincodeSerializer();
-        serde::Serializable<SemanticLength>::serialize(*this, serializer);
-        return std::move(serializer).bytes();
-    }
-
-    inline SemanticLength SemanticLength::bincodeDeserialize(std::vector<uint8_t> input) {
-        auto deserializer = serde::BincodeDeserializer(input);
-        auto value = serde::Deserializable<SemanticLength>::deserialize(deserializer);
-        if (deserializer.get_buffer_offset() < input.size()) {
-            throw_or_abort("Some input bytes were not read");
-        }
-        return value;
     }
 
 } // end of namespace Acir
@@ -12723,21 +10585,6 @@ namespace Acir {
         return true;
     }
 
-    inline std::vector<uint8_t> SemiFlattenedLength::bincodeSerialize() const {
-        auto serializer = serde::BincodeSerializer();
-        serde::Serializable<SemiFlattenedLength>::serialize(*this, serializer);
-        return std::move(serializer).bytes();
-    }
-
-    inline SemiFlattenedLength SemiFlattenedLength::bincodeDeserialize(std::vector<uint8_t> input) {
-        auto deserializer = serde::BincodeDeserializer(input);
-        auto value = serde::Deserializable<SemiFlattenedLength>::deserialize(deserializer);
-        if (deserializer.get_buffer_offset() < input.size()) {
-            throw_or_abort("Some input bytes were not read");
-        }
-        return value;
-    }
-
 } // end of namespace Acir
 
 template <>
@@ -12763,21 +10610,6 @@ namespace Acir {
     inline bool operator==(const ValueOrArray &lhs, const ValueOrArray &rhs) {
         if (!(lhs.value == rhs.value)) { return false; }
         return true;
-    }
-
-    inline std::vector<uint8_t> ValueOrArray::bincodeSerialize() const {
-        auto serializer = serde::BincodeSerializer();
-        serde::Serializable<ValueOrArray>::serialize(*this, serializer);
-        return std::move(serializer).bytes();
-    }
-
-    inline ValueOrArray ValueOrArray::bincodeDeserialize(std::vector<uint8_t> input) {
-        auto deserializer = serde::BincodeDeserializer(input);
-        auto value = serde::Deserializable<ValueOrArray>::deserialize(deserializer);
-        if (deserializer.get_buffer_offset() < input.size()) {
-            throw_or_abort("Some input bytes were not read");
-        }
-        return value;
     }
 
 } // end of namespace Acir
@@ -12807,21 +10639,6 @@ namespace Acir {
         return true;
     }
 
-    inline std::vector<uint8_t> ValueOrArray::MemoryAddress::bincodeSerialize() const {
-        auto serializer = serde::BincodeSerializer();
-        serde::Serializable<ValueOrArray::MemoryAddress>::serialize(*this, serializer);
-        return std::move(serializer).bytes();
-    }
-
-    inline ValueOrArray::MemoryAddress ValueOrArray::MemoryAddress::bincodeDeserialize(std::vector<uint8_t> input) {
-        auto deserializer = serde::BincodeDeserializer(input);
-        auto value = serde::Deserializable<ValueOrArray::MemoryAddress>::deserialize(deserializer);
-        if (deserializer.get_buffer_offset() < input.size()) {
-            throw_or_abort("Some input bytes were not read");
-        }
-        return value;
-    }
-
 } // end of namespace Acir
 
 template <>
@@ -12843,21 +10660,6 @@ namespace Acir {
     inline bool operator==(const ValueOrArray::HeapArray &lhs, const ValueOrArray::HeapArray &rhs) {
         if (!(lhs.value == rhs.value)) { return false; }
         return true;
-    }
-
-    inline std::vector<uint8_t> ValueOrArray::HeapArray::bincodeSerialize() const {
-        auto serializer = serde::BincodeSerializer();
-        serde::Serializable<ValueOrArray::HeapArray>::serialize(*this, serializer);
-        return std::move(serializer).bytes();
-    }
-
-    inline ValueOrArray::HeapArray ValueOrArray::HeapArray::bincodeDeserialize(std::vector<uint8_t> input) {
-        auto deserializer = serde::BincodeDeserializer(input);
-        auto value = serde::Deserializable<ValueOrArray::HeapArray>::deserialize(deserializer);
-        if (deserializer.get_buffer_offset() < input.size()) {
-            throw_or_abort("Some input bytes were not read");
-        }
-        return value;
     }
 
 } // end of namespace Acir
@@ -12883,21 +10685,6 @@ namespace Acir {
         return true;
     }
 
-    inline std::vector<uint8_t> ValueOrArray::HeapVector::bincodeSerialize() const {
-        auto serializer = serde::BincodeSerializer();
-        serde::Serializable<ValueOrArray::HeapVector>::serialize(*this, serializer);
-        return std::move(serializer).bytes();
-    }
-
-    inline ValueOrArray::HeapVector ValueOrArray::HeapVector::bincodeDeserialize(std::vector<uint8_t> input) {
-        auto deserializer = serde::BincodeDeserializer(input);
-        auto value = serde::Deserializable<ValueOrArray::HeapVector>::deserialize(deserializer);
-        if (deserializer.get_buffer_offset() < input.size()) {
-            throw_or_abort("Some input bytes were not read");
-        }
-        return value;
-    }
-
 } // end of namespace Acir
 
 template <>
@@ -12919,21 +10706,6 @@ namespace Acir {
     inline bool operator==(const Witness &lhs, const Witness &rhs) {
         if (!(lhs.value == rhs.value)) { return false; }
         return true;
-    }
-
-    inline std::vector<uint8_t> Witness::bincodeSerialize() const {
-        auto serializer = serde::BincodeSerializer();
-        serde::Serializable<Witness>::serialize(*this, serializer);
-        return std::move(serializer).bytes();
-    }
-
-    inline Witness Witness::bincodeDeserialize(std::vector<uint8_t> input) {
-        auto deserializer = serde::BincodeDeserializer(input);
-        auto value = serde::Deserializable<Witness>::deserialize(deserializer);
-        if (deserializer.get_buffer_offset() < input.size()) {
-            throw_or_abort("Some input bytes were not read");
-        }
-        return value;
     }
 
 } // end of namespace Acir

--- a/acvm-repo/acir/codegen/acir.cpp
+++ b/acvm-repo/acir/codegen/acir.cpp
@@ -226,7 +226,6 @@ namespace Acir {
                     std::cerr << o << std::endl;
                     throw_or_abort("expected u8 variant tag for enum 'BinaryFieldOp'");
                 }
-                msgpack::object const& val = o.via.map.ptr[0].val;
                 switch (tag) {
                     case 0: {
                         Add v;
@@ -422,7 +421,6 @@ namespace Acir {
                     std::cerr << o << std::endl;
                     throw_or_abort("expected u8 variant tag for enum 'BinaryIntOp'");
                 }
-                msgpack::object const& val = o.via.map.ptr[0].val;
                 switch (tag) {
                     case 0: {
                         Add v;
@@ -618,7 +616,6 @@ namespace Acir {
                     std::cerr << o << std::endl;
                     throw_or_abort("expected u8 variant tag for enum 'IntegerBitSize'");
                 }
-                msgpack::object const& val = o.via.map.ptr[0].val;
                 switch (tag) {
                     case 0: {
                         U1 v;
@@ -745,7 +742,6 @@ namespace Acir {
                     std::cerr << o << std::endl;
                     throw_or_abort("expected u8 variant tag for enum 'BitSize'");
                 }
-                msgpack::object const& val = o.via.map.ptr[0].val;
                 switch (tag) {
                     case 0: {
                         Field v;
@@ -755,9 +751,9 @@ namespace Acir {
                     case 1: {
                         Integer v;
                         try {
-                            val.convert(v);
+                            o.via.map.ptr[0].val.convert(v);
                         } catch (const msgpack::type_error&) {
-                            std::cerr << val << std::endl;
+                            std::cerr << o << std::endl;
                             throw_or_abort("error converting into enum variant 'BitSize::Integer'");
                         }
                         value = v;
@@ -858,14 +854,13 @@ namespace Acir {
                     std::cerr << o << std::endl;
                     throw_or_abort("expected u8 variant tag for enum 'MemoryAddress'");
                 }
-                msgpack::object const& val = o.via.map.ptr[0].val;
                 switch (tag) {
                     case 0: {
                         Direct v;
                         try {
-                            val.convert(v);
+                            o.via.map.ptr[0].val.convert(v);
                         } catch (const msgpack::type_error&) {
-                            std::cerr << val << std::endl;
+                            std::cerr << o << std::endl;
                             throw_or_abort("error converting into enum variant 'MemoryAddress::Direct'");
                         }
                         value = v;
@@ -874,9 +869,9 @@ namespace Acir {
                     case 1: {
                         Relative v;
                         try {
-                            val.convert(v);
+                            o.via.map.ptr[0].val.convert(v);
                         } catch (const msgpack::type_error&) {
-                            std::cerr << val << std::endl;
+                            std::cerr << o << std::endl;
                             throw_or_abort("error converting into enum variant 'MemoryAddress::Relative'");
                         }
                         value = v;
@@ -1557,14 +1552,13 @@ namespace Acir {
                     std::cerr << o << std::endl;
                     throw_or_abort("expected u8 variant tag for enum 'BlackBoxOp'");
                 }
-                msgpack::object const& val = o.via.map.ptr[0].val;
                 switch (tag) {
                     case 0: {
                         AES128Encrypt v;
                         try {
-                            val.convert(v);
+                            o.via.map.ptr[0].val.convert(v);
                         } catch (const msgpack::type_error&) {
-                            std::cerr << val << std::endl;
+                            std::cerr << o << std::endl;
                             throw_or_abort("error converting into enum variant 'BlackBoxOp::AES128Encrypt'");
                         }
                         value = v;
@@ -1573,9 +1567,9 @@ namespace Acir {
                     case 1: {
                         Blake2s v;
                         try {
-                            val.convert(v);
+                            o.via.map.ptr[0].val.convert(v);
                         } catch (const msgpack::type_error&) {
-                            std::cerr << val << std::endl;
+                            std::cerr << o << std::endl;
                             throw_or_abort("error converting into enum variant 'BlackBoxOp::Blake2s'");
                         }
                         value = v;
@@ -1584,9 +1578,9 @@ namespace Acir {
                     case 2: {
                         Blake3 v;
                         try {
-                            val.convert(v);
+                            o.via.map.ptr[0].val.convert(v);
                         } catch (const msgpack::type_error&) {
-                            std::cerr << val << std::endl;
+                            std::cerr << o << std::endl;
                             throw_or_abort("error converting into enum variant 'BlackBoxOp::Blake3'");
                         }
                         value = v;
@@ -1595,9 +1589,9 @@ namespace Acir {
                     case 3: {
                         Keccakf1600 v;
                         try {
-                            val.convert(v);
+                            o.via.map.ptr[0].val.convert(v);
                         } catch (const msgpack::type_error&) {
-                            std::cerr << val << std::endl;
+                            std::cerr << o << std::endl;
                             throw_or_abort("error converting into enum variant 'BlackBoxOp::Keccakf1600'");
                         }
                         value = v;
@@ -1606,9 +1600,9 @@ namespace Acir {
                     case 4: {
                         EcdsaSecp256k1 v;
                         try {
-                            val.convert(v);
+                            o.via.map.ptr[0].val.convert(v);
                         } catch (const msgpack::type_error&) {
-                            std::cerr << val << std::endl;
+                            std::cerr << o << std::endl;
                             throw_or_abort("error converting into enum variant 'BlackBoxOp::EcdsaSecp256k1'");
                         }
                         value = v;
@@ -1617,9 +1611,9 @@ namespace Acir {
                     case 5: {
                         EcdsaSecp256r1 v;
                         try {
-                            val.convert(v);
+                            o.via.map.ptr[0].val.convert(v);
                         } catch (const msgpack::type_error&) {
-                            std::cerr << val << std::endl;
+                            std::cerr << o << std::endl;
                             throw_or_abort("error converting into enum variant 'BlackBoxOp::EcdsaSecp256r1'");
                         }
                         value = v;
@@ -1628,9 +1622,9 @@ namespace Acir {
                     case 6: {
                         MultiScalarMul v;
                         try {
-                            val.convert(v);
+                            o.via.map.ptr[0].val.convert(v);
                         } catch (const msgpack::type_error&) {
-                            std::cerr << val << std::endl;
+                            std::cerr << o << std::endl;
                             throw_or_abort("error converting into enum variant 'BlackBoxOp::MultiScalarMul'");
                         }
                         value = v;
@@ -1639,9 +1633,9 @@ namespace Acir {
                     case 7: {
                         EmbeddedCurveAdd v;
                         try {
-                            val.convert(v);
+                            o.via.map.ptr[0].val.convert(v);
                         } catch (const msgpack::type_error&) {
-                            std::cerr << val << std::endl;
+                            std::cerr << o << std::endl;
                             throw_or_abort("error converting into enum variant 'BlackBoxOp::EmbeddedCurveAdd'");
                         }
                         value = v;
@@ -1650,9 +1644,9 @@ namespace Acir {
                     case 8: {
                         Poseidon2Permutation v;
                         try {
-                            val.convert(v);
+                            o.via.map.ptr[0].val.convert(v);
                         } catch (const msgpack::type_error&) {
-                            std::cerr << val << std::endl;
+                            std::cerr << o << std::endl;
                             throw_or_abort("error converting into enum variant 'BlackBoxOp::Poseidon2Permutation'");
                         }
                         value = v;
@@ -1661,9 +1655,9 @@ namespace Acir {
                     case 9: {
                         Sha256Compression v;
                         try {
-                            val.convert(v);
+                            o.via.map.ptr[0].val.convert(v);
                         } catch (const msgpack::type_error&) {
-                            std::cerr << val << std::endl;
+                            std::cerr << o << std::endl;
                             throw_or_abort("error converting into enum variant 'BlackBoxOp::Sha256Compression'");
                         }
                         value = v;
@@ -1672,9 +1666,9 @@ namespace Acir {
                     case 10: {
                         ToRadix v;
                         try {
-                            val.convert(v);
+                            o.via.map.ptr[0].val.convert(v);
                         } catch (const msgpack::type_error&) {
-                            std::cerr << val << std::endl;
+                            std::cerr << o << std::endl;
                             throw_or_abort("error converting into enum variant 'BlackBoxOp::ToRadix'");
                         }
                         value = v;
@@ -1957,14 +1951,13 @@ namespace Acir {
                     std::cerr << o << std::endl;
                     throw_or_abort("expected u8 variant tag for enum 'HeapValueType'");
                 }
-                msgpack::object const& val = o.via.map.ptr[0].val;
                 switch (tag) {
                     case 0: {
                         Simple v;
                         try {
-                            val.convert(v);
+                            o.via.map.ptr[0].val.convert(v);
                         } catch (const msgpack::type_error&) {
-                            std::cerr << val << std::endl;
+                            std::cerr << o << std::endl;
                             throw_or_abort("error converting into enum variant 'HeapValueType::Simple'");
                         }
                         value = v;
@@ -1973,9 +1966,9 @@ namespace Acir {
                     case 1: {
                         Array v;
                         try {
-                            val.convert(v);
+                            o.via.map.ptr[0].val.convert(v);
                         } catch (const msgpack::type_error&) {
-                            std::cerr << val << std::endl;
+                            std::cerr << o << std::endl;
                             throw_or_abort("error converting into enum variant 'HeapValueType::Array'");
                         }
                         value = v;
@@ -1984,9 +1977,9 @@ namespace Acir {
                     case 2: {
                         Vector v;
                         try {
-                            val.convert(v);
+                            o.via.map.ptr[0].val.convert(v);
                         } catch (const msgpack::type_error&) {
-                            std::cerr << val << std::endl;
+                            std::cerr << o << std::endl;
                             throw_or_abort("error converting into enum variant 'HeapValueType::Vector'");
                         }
                         value = v;
@@ -2160,14 +2153,13 @@ namespace Acir {
                     std::cerr << o << std::endl;
                     throw_or_abort("expected u8 variant tag for enum 'ValueOrArray'");
                 }
-                msgpack::object const& val = o.via.map.ptr[0].val;
                 switch (tag) {
                     case 0: {
                         MemoryAddress v;
                         try {
-                            val.convert(v);
+                            o.via.map.ptr[0].val.convert(v);
                         } catch (const msgpack::type_error&) {
-                            std::cerr << val << std::endl;
+                            std::cerr << o << std::endl;
                             throw_or_abort("error converting into enum variant 'ValueOrArray::MemoryAddress'");
                         }
                         value = v;
@@ -2176,9 +2168,9 @@ namespace Acir {
                     case 1: {
                         HeapArray v;
                         try {
-                            val.convert(v);
+                            o.via.map.ptr[0].val.convert(v);
                         } catch (const msgpack::type_error&) {
-                            std::cerr << val << std::endl;
+                            std::cerr << o << std::endl;
                             throw_or_abort("error converting into enum variant 'ValueOrArray::HeapArray'");
                         }
                         value = v;
@@ -2187,9 +2179,9 @@ namespace Acir {
                     case 2: {
                         HeapVector v;
                         try {
-                            val.convert(v);
+                            o.via.map.ptr[0].val.convert(v);
                         } catch (const msgpack::type_error&) {
-                            std::cerr << val << std::endl;
+                            std::cerr << o << std::endl;
                             throw_or_abort("error converting into enum variant 'ValueOrArray::HeapVector'");
                         }
                         value = v;
@@ -3045,14 +3037,13 @@ namespace Acir {
                     std::cerr << o << std::endl;
                     throw_or_abort("expected u8 variant tag for enum 'BrilligOpcode'");
                 }
-                msgpack::object const& val = o.via.map.ptr[0].val;
                 switch (tag) {
                     case 0: {
                         BinaryFieldOp v;
                         try {
-                            val.convert(v);
+                            o.via.map.ptr[0].val.convert(v);
                         } catch (const msgpack::type_error&) {
-                            std::cerr << val << std::endl;
+                            std::cerr << o << std::endl;
                             throw_or_abort("error converting into enum variant 'BrilligOpcode::BinaryFieldOp'");
                         }
                         value = v;
@@ -3061,9 +3052,9 @@ namespace Acir {
                     case 1: {
                         BinaryIntOp v;
                         try {
-                            val.convert(v);
+                            o.via.map.ptr[0].val.convert(v);
                         } catch (const msgpack::type_error&) {
-                            std::cerr << val << std::endl;
+                            std::cerr << o << std::endl;
                             throw_or_abort("error converting into enum variant 'BrilligOpcode::BinaryIntOp'");
                         }
                         value = v;
@@ -3072,9 +3063,9 @@ namespace Acir {
                     case 2: {
                         Not v;
                         try {
-                            val.convert(v);
+                            o.via.map.ptr[0].val.convert(v);
                         } catch (const msgpack::type_error&) {
-                            std::cerr << val << std::endl;
+                            std::cerr << o << std::endl;
                             throw_or_abort("error converting into enum variant 'BrilligOpcode::Not'");
                         }
                         value = v;
@@ -3083,9 +3074,9 @@ namespace Acir {
                     case 3: {
                         Cast v;
                         try {
-                            val.convert(v);
+                            o.via.map.ptr[0].val.convert(v);
                         } catch (const msgpack::type_error&) {
-                            std::cerr << val << std::endl;
+                            std::cerr << o << std::endl;
                             throw_or_abort("error converting into enum variant 'BrilligOpcode::Cast'");
                         }
                         value = v;
@@ -3094,9 +3085,9 @@ namespace Acir {
                     case 4: {
                         JumpIf v;
                         try {
-                            val.convert(v);
+                            o.via.map.ptr[0].val.convert(v);
                         } catch (const msgpack::type_error&) {
-                            std::cerr << val << std::endl;
+                            std::cerr << o << std::endl;
                             throw_or_abort("error converting into enum variant 'BrilligOpcode::JumpIf'");
                         }
                         value = v;
@@ -3105,9 +3096,9 @@ namespace Acir {
                     case 5: {
                         Jump v;
                         try {
-                            val.convert(v);
+                            o.via.map.ptr[0].val.convert(v);
                         } catch (const msgpack::type_error&) {
-                            std::cerr << val << std::endl;
+                            std::cerr << o << std::endl;
                             throw_or_abort("error converting into enum variant 'BrilligOpcode::Jump'");
                         }
                         value = v;
@@ -3116,9 +3107,9 @@ namespace Acir {
                     case 6: {
                         CalldataCopy v;
                         try {
-                            val.convert(v);
+                            o.via.map.ptr[0].val.convert(v);
                         } catch (const msgpack::type_error&) {
-                            std::cerr << val << std::endl;
+                            std::cerr << o << std::endl;
                             throw_or_abort("error converting into enum variant 'BrilligOpcode::CalldataCopy'");
                         }
                         value = v;
@@ -3127,9 +3118,9 @@ namespace Acir {
                     case 7: {
                         Call v;
                         try {
-                            val.convert(v);
+                            o.via.map.ptr[0].val.convert(v);
                         } catch (const msgpack::type_error&) {
-                            std::cerr << val << std::endl;
+                            std::cerr << o << std::endl;
                             throw_or_abort("error converting into enum variant 'BrilligOpcode::Call'");
                         }
                         value = v;
@@ -3138,9 +3129,9 @@ namespace Acir {
                     case 8: {
                         Const v;
                         try {
-                            val.convert(v);
+                            o.via.map.ptr[0].val.convert(v);
                         } catch (const msgpack::type_error&) {
-                            std::cerr << val << std::endl;
+                            std::cerr << o << std::endl;
                             throw_or_abort("error converting into enum variant 'BrilligOpcode::Const'");
                         }
                         value = v;
@@ -3149,9 +3140,9 @@ namespace Acir {
                     case 9: {
                         IndirectConst v;
                         try {
-                            val.convert(v);
+                            o.via.map.ptr[0].val.convert(v);
                         } catch (const msgpack::type_error&) {
-                            std::cerr << val << std::endl;
+                            std::cerr << o << std::endl;
                             throw_or_abort("error converting into enum variant 'BrilligOpcode::IndirectConst'");
                         }
                         value = v;
@@ -3165,9 +3156,9 @@ namespace Acir {
                     case 11: {
                         ForeignCall v;
                         try {
-                            val.convert(v);
+                            o.via.map.ptr[0].val.convert(v);
                         } catch (const msgpack::type_error&) {
-                            std::cerr << val << std::endl;
+                            std::cerr << o << std::endl;
                             throw_or_abort("error converting into enum variant 'BrilligOpcode::ForeignCall'");
                         }
                         value = v;
@@ -3176,9 +3167,9 @@ namespace Acir {
                     case 12: {
                         Mov v;
                         try {
-                            val.convert(v);
+                            o.via.map.ptr[0].val.convert(v);
                         } catch (const msgpack::type_error&) {
-                            std::cerr << val << std::endl;
+                            std::cerr << o << std::endl;
                             throw_or_abort("error converting into enum variant 'BrilligOpcode::Mov'");
                         }
                         value = v;
@@ -3187,9 +3178,9 @@ namespace Acir {
                     case 13: {
                         ConditionalMov v;
                         try {
-                            val.convert(v);
+                            o.via.map.ptr[0].val.convert(v);
                         } catch (const msgpack::type_error&) {
-                            std::cerr << val << std::endl;
+                            std::cerr << o << std::endl;
                             throw_or_abort("error converting into enum variant 'BrilligOpcode::ConditionalMov'");
                         }
                         value = v;
@@ -3198,9 +3189,9 @@ namespace Acir {
                     case 14: {
                         Load v;
                         try {
-                            val.convert(v);
+                            o.via.map.ptr[0].val.convert(v);
                         } catch (const msgpack::type_error&) {
-                            std::cerr << val << std::endl;
+                            std::cerr << o << std::endl;
                             throw_or_abort("error converting into enum variant 'BrilligOpcode::Load'");
                         }
                         value = v;
@@ -3209,9 +3200,9 @@ namespace Acir {
                     case 15: {
                         Store v;
                         try {
-                            val.convert(v);
+                            o.via.map.ptr[0].val.convert(v);
                         } catch (const msgpack::type_error&) {
-                            std::cerr << val << std::endl;
+                            std::cerr << o << std::endl;
                             throw_or_abort("error converting into enum variant 'BrilligOpcode::Store'");
                         }
                         value = v;
@@ -3220,9 +3211,9 @@ namespace Acir {
                     case 16: {
                         BlackBox v;
                         try {
-                            val.convert(v);
+                            o.via.map.ptr[0].val.convert(v);
                         } catch (const msgpack::type_error&) {
-                            std::cerr << val << std::endl;
+                            std::cerr << o << std::endl;
                             throw_or_abort("error converting into enum variant 'BrilligOpcode::BlackBox'");
                         }
                         value = v;
@@ -3231,9 +3222,9 @@ namespace Acir {
                     case 17: {
                         Trap v;
                         try {
-                            val.convert(v);
+                            o.via.map.ptr[0].val.convert(v);
                         } catch (const msgpack::type_error&) {
-                            std::cerr << val << std::endl;
+                            std::cerr << o << std::endl;
                             throw_or_abort("error converting into enum variant 'BrilligOpcode::Trap'");
                         }
                         value = v;
@@ -3242,9 +3233,9 @@ namespace Acir {
                     case 18: {
                         Stop v;
                         try {
-                            val.convert(v);
+                            o.via.map.ptr[0].val.convert(v);
                         } catch (const msgpack::type_error&) {
-                            std::cerr << val << std::endl;
+                            std::cerr << o << std::endl;
                             throw_or_abort("error converting into enum variant 'BrilligOpcode::Stop'");
                         }
                         value = v;
@@ -3547,14 +3538,13 @@ namespace Acir {
                     std::cerr << o << std::endl;
                     throw_or_abort("expected u8 variant tag for enum 'FunctionInput'");
                 }
-                msgpack::object const& val = o.via.map.ptr[0].val;
                 switch (tag) {
                     case 0: {
                         Constant v;
                         try {
-                            val.convert(v);
+                            o.via.map.ptr[0].val.convert(v);
                         } catch (const msgpack::type_error&) {
-                            std::cerr << val << std::endl;
+                            std::cerr << o << std::endl;
                             throw_or_abort("error converting into enum variant 'FunctionInput::Constant'");
                         }
                         value = v;
@@ -3563,9 +3553,9 @@ namespace Acir {
                     case 1: {
                         Witness v;
                         try {
-                            val.convert(v);
+                            o.via.map.ptr[0].val.convert(v);
                         } catch (const msgpack::type_error&) {
-                            std::cerr << val << std::endl;
+                            std::cerr << o << std::endl;
                             throw_or_abort("error converting into enum variant 'FunctionInput::Witness'");
                         }
                         value = v;
@@ -4341,14 +4331,13 @@ namespace Acir {
                     std::cerr << o << std::endl;
                     throw_or_abort("expected u8 variant tag for enum 'BlackBoxFuncCall'");
                 }
-                msgpack::object const& val = o.via.map.ptr[0].val;
                 switch (tag) {
                     case 0: {
                         AES128Encrypt v;
                         try {
-                            val.convert(v);
+                            o.via.map.ptr[0].val.convert(v);
                         } catch (const msgpack::type_error&) {
-                            std::cerr << val << std::endl;
+                            std::cerr << o << std::endl;
                             throw_or_abort("error converting into enum variant 'BlackBoxFuncCall::AES128Encrypt'");
                         }
                         value = v;
@@ -4357,9 +4346,9 @@ namespace Acir {
                     case 1: {
                         AND v;
                         try {
-                            val.convert(v);
+                            o.via.map.ptr[0].val.convert(v);
                         } catch (const msgpack::type_error&) {
-                            std::cerr << val << std::endl;
+                            std::cerr << o << std::endl;
                             throw_or_abort("error converting into enum variant 'BlackBoxFuncCall::AND'");
                         }
                         value = v;
@@ -4368,9 +4357,9 @@ namespace Acir {
                     case 2: {
                         XOR v;
                         try {
-                            val.convert(v);
+                            o.via.map.ptr[0].val.convert(v);
                         } catch (const msgpack::type_error&) {
-                            std::cerr << val << std::endl;
+                            std::cerr << o << std::endl;
                             throw_or_abort("error converting into enum variant 'BlackBoxFuncCall::XOR'");
                         }
                         value = v;
@@ -4379,9 +4368,9 @@ namespace Acir {
                     case 3: {
                         RANGE v;
                         try {
-                            val.convert(v);
+                            o.via.map.ptr[0].val.convert(v);
                         } catch (const msgpack::type_error&) {
-                            std::cerr << val << std::endl;
+                            std::cerr << o << std::endl;
                             throw_or_abort("error converting into enum variant 'BlackBoxFuncCall::RANGE'");
                         }
                         value = v;
@@ -4390,9 +4379,9 @@ namespace Acir {
                     case 4: {
                         Blake2s v;
                         try {
-                            val.convert(v);
+                            o.via.map.ptr[0].val.convert(v);
                         } catch (const msgpack::type_error&) {
-                            std::cerr << val << std::endl;
+                            std::cerr << o << std::endl;
                             throw_or_abort("error converting into enum variant 'BlackBoxFuncCall::Blake2s'");
                         }
                         value = v;
@@ -4401,9 +4390,9 @@ namespace Acir {
                     case 5: {
                         Blake3 v;
                         try {
-                            val.convert(v);
+                            o.via.map.ptr[0].val.convert(v);
                         } catch (const msgpack::type_error&) {
-                            std::cerr << val << std::endl;
+                            std::cerr << o << std::endl;
                             throw_or_abort("error converting into enum variant 'BlackBoxFuncCall::Blake3'");
                         }
                         value = v;
@@ -4412,9 +4401,9 @@ namespace Acir {
                     case 6: {
                         EcdsaSecp256k1 v;
                         try {
-                            val.convert(v);
+                            o.via.map.ptr[0].val.convert(v);
                         } catch (const msgpack::type_error&) {
-                            std::cerr << val << std::endl;
+                            std::cerr << o << std::endl;
                             throw_or_abort("error converting into enum variant 'BlackBoxFuncCall::EcdsaSecp256k1'");
                         }
                         value = v;
@@ -4423,9 +4412,9 @@ namespace Acir {
                     case 7: {
                         EcdsaSecp256r1 v;
                         try {
-                            val.convert(v);
+                            o.via.map.ptr[0].val.convert(v);
                         } catch (const msgpack::type_error&) {
-                            std::cerr << val << std::endl;
+                            std::cerr << o << std::endl;
                             throw_or_abort("error converting into enum variant 'BlackBoxFuncCall::EcdsaSecp256r1'");
                         }
                         value = v;
@@ -4434,9 +4423,9 @@ namespace Acir {
                     case 8: {
                         MultiScalarMul v;
                         try {
-                            val.convert(v);
+                            o.via.map.ptr[0].val.convert(v);
                         } catch (const msgpack::type_error&) {
-                            std::cerr << val << std::endl;
+                            std::cerr << o << std::endl;
                             throw_or_abort("error converting into enum variant 'BlackBoxFuncCall::MultiScalarMul'");
                         }
                         value = v;
@@ -4445,9 +4434,9 @@ namespace Acir {
                     case 9: {
                         EmbeddedCurveAdd v;
                         try {
-                            val.convert(v);
+                            o.via.map.ptr[0].val.convert(v);
                         } catch (const msgpack::type_error&) {
-                            std::cerr << val << std::endl;
+                            std::cerr << o << std::endl;
                             throw_or_abort("error converting into enum variant 'BlackBoxFuncCall::EmbeddedCurveAdd'");
                         }
                         value = v;
@@ -4456,9 +4445,9 @@ namespace Acir {
                     case 10: {
                         Keccakf1600 v;
                         try {
-                            val.convert(v);
+                            o.via.map.ptr[0].val.convert(v);
                         } catch (const msgpack::type_error&) {
-                            std::cerr << val << std::endl;
+                            std::cerr << o << std::endl;
                             throw_or_abort("error converting into enum variant 'BlackBoxFuncCall::Keccakf1600'");
                         }
                         value = v;
@@ -4467,9 +4456,9 @@ namespace Acir {
                     case 11: {
                         RecursiveAggregation v;
                         try {
-                            val.convert(v);
+                            o.via.map.ptr[0].val.convert(v);
                         } catch (const msgpack::type_error&) {
-                            std::cerr << val << std::endl;
+                            std::cerr << o << std::endl;
                             throw_or_abort("error converting into enum variant 'BlackBoxFuncCall::RecursiveAggregation'");
                         }
                         value = v;
@@ -4478,9 +4467,9 @@ namespace Acir {
                     case 12: {
                         Poseidon2Permutation v;
                         try {
-                            val.convert(v);
+                            o.via.map.ptr[0].val.convert(v);
                         } catch (const msgpack::type_error&) {
-                            std::cerr << val << std::endl;
+                            std::cerr << o << std::endl;
                             throw_or_abort("error converting into enum variant 'BlackBoxFuncCall::Poseidon2Permutation'");
                         }
                         value = v;
@@ -4489,9 +4478,9 @@ namespace Acir {
                     case 13: {
                         Sha256Compression v;
                         try {
-                            val.convert(v);
+                            o.via.map.ptr[0].val.convert(v);
                         } catch (const msgpack::type_error&) {
-                            std::cerr << val << std::endl;
+                            std::cerr << o << std::endl;
                             throw_or_abort("error converting into enum variant 'BlackBoxFuncCall::Sha256Compression'");
                         }
                         value = v;
@@ -4743,7 +4732,6 @@ namespace Acir {
                     std::cerr << o << std::endl;
                     throw_or_abort("expected u8 variant tag for enum 'BlockType'");
                 }
-                msgpack::object const& val = o.via.map.ptr[0].val;
                 switch (tag) {
                     case 0: {
                         Memory v;
@@ -4753,9 +4741,9 @@ namespace Acir {
                     case 1: {
                         CallData v;
                         try {
-                            val.convert(v);
+                            o.via.map.ptr[0].val.convert(v);
                         } catch (const msgpack::type_error&) {
-                            std::cerr << val << std::endl;
+                            std::cerr << o << std::endl;
                             throw_or_abort("error converting into enum variant 'BlockType::CallData'");
                         }
                         value = v;
@@ -4926,14 +4914,13 @@ namespace Acir {
                     std::cerr << o << std::endl;
                     throw_or_abort("expected u8 variant tag for enum 'BrilligInputs'");
                 }
-                msgpack::object const& val = o.via.map.ptr[0].val;
                 switch (tag) {
                     case 0: {
                         Single v;
                         try {
-                            val.convert(v);
+                            o.via.map.ptr[0].val.convert(v);
                         } catch (const msgpack::type_error&) {
-                            std::cerr << val << std::endl;
+                            std::cerr << o << std::endl;
                             throw_or_abort("error converting into enum variant 'BrilligInputs::Single'");
                         }
                         value = v;
@@ -4942,9 +4929,9 @@ namespace Acir {
                     case 1: {
                         Array v;
                         try {
-                            val.convert(v);
+                            o.via.map.ptr[0].val.convert(v);
                         } catch (const msgpack::type_error&) {
-                            std::cerr << val << std::endl;
+                            std::cerr << o << std::endl;
                             throw_or_abort("error converting into enum variant 'BrilligInputs::Array'");
                         }
                         value = v;
@@ -4953,9 +4940,9 @@ namespace Acir {
                     case 2: {
                         MemoryArray v;
                         try {
-                            val.convert(v);
+                            o.via.map.ptr[0].val.convert(v);
                         } catch (const msgpack::type_error&) {
-                            std::cerr << val << std::endl;
+                            std::cerr << o << std::endl;
                             throw_or_abort("error converting into enum variant 'BrilligInputs::MemoryArray'");
                         }
                         value = v;
@@ -5074,14 +5061,13 @@ namespace Acir {
                     std::cerr << o << std::endl;
                     throw_or_abort("expected u8 variant tag for enum 'BrilligOutputs'");
                 }
-                msgpack::object const& val = o.via.map.ptr[0].val;
                 switch (tag) {
                     case 0: {
                         Simple v;
                         try {
-                            val.convert(v);
+                            o.via.map.ptr[0].val.convert(v);
                         } catch (const msgpack::type_error&) {
-                            std::cerr << val << std::endl;
+                            std::cerr << o << std::endl;
                             throw_or_abort("error converting into enum variant 'BrilligOutputs::Simple'");
                         }
                         value = v;
@@ -5090,9 +5076,9 @@ namespace Acir {
                     case 1: {
                         Array v;
                         try {
-                            val.convert(v);
+                            o.via.map.ptr[0].val.convert(v);
                         } catch (const msgpack::type_error&) {
-                            std::cerr << val << std::endl;
+                            std::cerr << o << std::endl;
                             throw_or_abort("error converting into enum variant 'BrilligOutputs::Array'");
                         }
                         value = v;
@@ -5436,14 +5422,13 @@ namespace Acir {
                     std::cerr << o << std::endl;
                     throw_or_abort("expected u8 variant tag for enum 'Opcode'");
                 }
-                msgpack::object const& val = o.via.map.ptr[0].val;
                 switch (tag) {
                     case 0: {
                         AssertZero v;
                         try {
-                            val.convert(v);
+                            o.via.map.ptr[0].val.convert(v);
                         } catch (const msgpack::type_error&) {
-                            std::cerr << val << std::endl;
+                            std::cerr << o << std::endl;
                             throw_or_abort("error converting into enum variant 'Opcode::AssertZero'");
                         }
                         value = v;
@@ -5452,9 +5437,9 @@ namespace Acir {
                     case 1: {
                         BlackBoxFuncCall v;
                         try {
-                            val.convert(v);
+                            o.via.map.ptr[0].val.convert(v);
                         } catch (const msgpack::type_error&) {
-                            std::cerr << val << std::endl;
+                            std::cerr << o << std::endl;
                             throw_or_abort("error converting into enum variant 'Opcode::BlackBoxFuncCall'");
                         }
                         value = v;
@@ -5463,9 +5448,9 @@ namespace Acir {
                     case 2: {
                         MemoryOp v;
                         try {
-                            val.convert(v);
+                            o.via.map.ptr[0].val.convert(v);
                         } catch (const msgpack::type_error&) {
-                            std::cerr << val << std::endl;
+                            std::cerr << o << std::endl;
                             throw_or_abort("error converting into enum variant 'Opcode::MemoryOp'");
                         }
                         value = v;
@@ -5474,9 +5459,9 @@ namespace Acir {
                     case 3: {
                         MemoryInit v;
                         try {
-                            val.convert(v);
+                            o.via.map.ptr[0].val.convert(v);
                         } catch (const msgpack::type_error&) {
-                            std::cerr << val << std::endl;
+                            std::cerr << o << std::endl;
                             throw_or_abort("error converting into enum variant 'Opcode::MemoryInit'");
                         }
                         value = v;
@@ -5485,9 +5470,9 @@ namespace Acir {
                     case 4: {
                         BrilligCall v;
                         try {
-                            val.convert(v);
+                            o.via.map.ptr[0].val.convert(v);
                         } catch (const msgpack::type_error&) {
-                            std::cerr << val << std::endl;
+                            std::cerr << o << std::endl;
                             throw_or_abort("error converting into enum variant 'Opcode::BrilligCall'");
                         }
                         value = v;
@@ -5496,9 +5481,9 @@ namespace Acir {
                     case 5: {
                         Call v;
                         try {
-                            val.convert(v);
+                            o.via.map.ptr[0].val.convert(v);
                         } catch (const msgpack::type_error&) {
-                            std::cerr << val << std::endl;
+                            std::cerr << o << std::endl;
                             throw_or_abort("error converting into enum variant 'Opcode::Call'");
                         }
                         value = v;
@@ -5650,14 +5635,13 @@ namespace Acir {
                     std::cerr << o << std::endl;
                     throw_or_abort("expected u8 variant tag for enum 'ExpressionOrMemory'");
                 }
-                msgpack::object const& val = o.via.map.ptr[0].val;
                 switch (tag) {
                     case 0: {
                         Expression v;
                         try {
-                            val.convert(v);
+                            o.via.map.ptr[0].val.convert(v);
                         } catch (const msgpack::type_error&) {
-                            std::cerr << val << std::endl;
+                            std::cerr << o << std::endl;
                             throw_or_abort("error converting into enum variant 'ExpressionOrMemory::Expression'");
                         }
                         value = v;
@@ -5666,9 +5650,9 @@ namespace Acir {
                     case 1: {
                         Memory v;
                         try {
-                            val.convert(v);
+                            o.via.map.ptr[0].val.convert(v);
                         } catch (const msgpack::type_error&) {
-                            std::cerr << val << std::endl;
+                            std::cerr << o << std::endl;
                             throw_or_abort("error converting into enum variant 'ExpressionOrMemory::Memory'");
                         }
                         value = v;
@@ -5841,14 +5825,13 @@ namespace Acir {
                     std::cerr << o << std::endl;
                     throw_or_abort("expected u8 variant tag for enum 'OpcodeLocation'");
                 }
-                msgpack::object const& val = o.via.map.ptr[0].val;
                 switch (tag) {
                     case 0: {
                         Acir v;
                         try {
-                            val.convert(v);
+                            o.via.map.ptr[0].val.convert(v);
                         } catch (const msgpack::type_error&) {
-                            std::cerr << val << std::endl;
+                            std::cerr << o << std::endl;
                             throw_or_abort("error converting into enum variant 'OpcodeLocation::Acir'");
                         }
                         value = v;
@@ -5857,9 +5840,9 @@ namespace Acir {
                     case 1: {
                         Brillig v;
                         try {
-                            val.convert(v);
+                            o.via.map.ptr[0].val.convert(v);
                         } catch (const msgpack::type_error&) {
-                            std::cerr << val << std::endl;
+                            std::cerr << o << std::endl;
                             throw_or_abort("error converting into enum variant 'OpcodeLocation::Brillig'");
                         }
                         value = v;

--- a/acvm-repo/acir/codegen/acir.cpp
+++ b/acvm-repo/acir/codegen/acir.cpp
@@ -38,6 +38,9 @@ namespace Acir {
         ) {
             auto it = kvmap.find(field_name);
             if (it != kvmap.end()) {
+                if (!is_optional && it->second->type == msgpack::type::NIL) {
+                    throw_or_abort("nil value for required field: " + struct_name + "::" + field_name);
+                }
                 try {
                     it->second->convert(field);
                 } catch (const msgpack::type_error&) {

--- a/acvm-repo/acir/codegen/acir.cpp
+++ b/acvm-repo/acir/codegen/acir.cpp
@@ -122,51 +122,31 @@ namespace Acir {
             }
         }
 
-        /// Cap the positional-array length: under-length wires error
-        /// downstream in `conv_fld_from_array` (index out of bounds);
-        /// over-length wires up to `active + reserved` are tolerated as
-        /// retired trailing fields (Rust-side `#[tagged(reserved(...))]`);
-        /// anything longer is forward-compat drift that the producer
-        /// would only have emitted if newer fields were added, and is
-        /// the cue for a focused error message pointing at the opt-in.
-        static void check_array_size(
-            msgpack::object_array const& array,
+        /// Cap a `MAP` or `ARRAY` entry count against `active + reserved`.
+        /// Under-length wires are caught downstream (`conv_fld_from_array`
+        /// errors out of bounds; `conv_fld_from_kvmap` errors on missing
+        /// required keys), so we only need the upper bound here.
+        ///
+        /// * Up to `reserved` extra trailing entries are tolerated as
+        ///   retired fields (`#[tagged(reserved(...))]` on the Rust side).
+        /// * Anything beyond that is forward-compat drift that the
+        ///   producer only emits when newer fields were added. The
+        ///   Rust-side cue is `#[tagged(allow_unknown_tags)]`; the
+        ///   message points at it so a reviewer can see the opt-in.
+        static void check_size(
+            uint32_t actual,
             std::string const& name,
             uint32_t active,
             uint32_t reserved
         ) {
             uint32_t max_size = active + reserved;
-            if (array.size > max_size) {
+            if (actual > max_size) {
                 throw_or_abort(
-                    "array for " + name +
-                    " has " + std::to_string(array.size) +
-                    " elements but at most " + std::to_string(max_size) +
-                    " are expected (" + std::to_string(active) +
-                    " active + " + std::to_string(reserved) +
-                    " reserved); opt into `#[tagged(allow_unknown_tags)]` on the Rust type to accept trailing extras");
-            }
-        }
-
-        /// Cap a string-keyed map size. Parallel to `check_array_size`
-        /// for the legacy `Format::Msgpack` named-struct wire shape: the
-        /// string-keyed dispatch only looks up keys it recognizes, so
-        /// extras would otherwise pass silently. Same `active +
-        /// reserved` ceiling, same `allow_unknown_tags` opt-out.
-        static void check_map_size(
-            msgpack::object_map const& map,
-            std::string const& name,
-            uint32_t active,
-            uint32_t reserved
-        ) {
-            uint32_t max_size = active + reserved;
-            if (map.size > max_size) {
-                throw_or_abort(
-                    "map for " + name +
-                    " has " + std::to_string(map.size) +
+                    name + " has " + std::to_string(actual) +
                     " entries but at most " + std::to_string(max_size) +
                     " are expected (" + std::to_string(active) +
                     " active + " + std::to_string(reserved) +
-                    " reserved); opt into `#[tagged(allow_unknown_tags)]` on the Rust type to accept extra keys");
+                    " reserved); opt into `#[tagged(allow_unknown_tags)]` on the Rust type to accept extras");
             }
         }
     };
@@ -989,14 +969,14 @@ namespace Acir {
                         }
                     });
                 } else {
-                    Helpers::check_map_size(o.via.map, name, 2, 0);
+                    Helpers::check_size(o.via.map.size, name, 2, 0);
                     auto kvmap = Helpers::make_kvmap(o, name);
                     Helpers::conv_fld_from_kvmap(kvmap, name, "pointer", pointer, false);
                     Helpers::conv_fld_from_kvmap(kvmap, name, "size", size, false);
                 }
             } else if (o.type == msgpack::type::ARRAY) {
                 auto array = o.via.array;
-                Helpers::check_array_size(array, name, 2, 0);
+                Helpers::check_size(array.size, name, 2, 0);
                 Helpers::conv_fld_from_array(array, name, "pointer", pointer, 0);
                 Helpers::conv_fld_from_array(array, name, "size", size, 1);
             } else {
@@ -1039,7 +1019,7 @@ namespace Acir {
                             }
                         });
                     } else {
-                        Helpers::check_map_size(o.via.map, name, 4, 0);
+                        Helpers::check_size(o.via.map.size, name, 4, 0);
                         auto kvmap = Helpers::make_kvmap(o, name);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "inputs", inputs, false);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "iv", iv, false);
@@ -1048,7 +1028,7 @@ namespace Acir {
                     }
                 } else if (o.type == msgpack::type::ARRAY) {
                     auto array = o.via.array;
-                    Helpers::check_array_size(array, name, 4, 0);
+                    Helpers::check_size(array.size, name, 4, 0);
                     Helpers::conv_fld_from_array(array, name, "inputs", inputs, 0);
                     Helpers::conv_fld_from_array(array, name, "iv", iv, 1);
                     Helpers::conv_fld_from_array(array, name, "key", key, 2);
@@ -1083,14 +1063,14 @@ namespace Acir {
                             }
                         });
                     } else {
-                        Helpers::check_map_size(o.via.map, name, 2, 0);
+                        Helpers::check_size(o.via.map.size, name, 2, 0);
                         auto kvmap = Helpers::make_kvmap(o, name);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "message", message, false);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "output", output, false);
                     }
                 } else if (o.type == msgpack::type::ARRAY) {
                     auto array = o.via.array;
-                    Helpers::check_array_size(array, name, 2, 0);
+                    Helpers::check_size(array.size, name, 2, 0);
                     Helpers::conv_fld_from_array(array, name, "message", message, 0);
                     Helpers::conv_fld_from_array(array, name, "output", output, 1);
                 } else {
@@ -1123,14 +1103,14 @@ namespace Acir {
                             }
                         });
                     } else {
-                        Helpers::check_map_size(o.via.map, name, 2, 0);
+                        Helpers::check_size(o.via.map.size, name, 2, 0);
                         auto kvmap = Helpers::make_kvmap(o, name);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "message", message, false);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "output", output, false);
                     }
                 } else if (o.type == msgpack::type::ARRAY) {
                     auto array = o.via.array;
-                    Helpers::check_array_size(array, name, 2, 0);
+                    Helpers::check_size(array.size, name, 2, 0);
                     Helpers::conv_fld_from_array(array, name, "message", message, 0);
                     Helpers::conv_fld_from_array(array, name, "output", output, 1);
                 } else {
@@ -1163,14 +1143,14 @@ namespace Acir {
                             }
                         });
                     } else {
-                        Helpers::check_map_size(o.via.map, name, 2, 0);
+                        Helpers::check_size(o.via.map.size, name, 2, 0);
                         auto kvmap = Helpers::make_kvmap(o, name);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "input", input, false);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "output", output, false);
                     }
                 } else if (o.type == msgpack::type::ARRAY) {
                     auto array = o.via.array;
-                    Helpers::check_array_size(array, name, 2, 0);
+                    Helpers::check_size(array.size, name, 2, 0);
                     Helpers::conv_fld_from_array(array, name, "input", input, 0);
                     Helpers::conv_fld_from_array(array, name, "output", output, 1);
                 } else {
@@ -1215,7 +1195,7 @@ namespace Acir {
                             }
                         });
                     } else {
-                        Helpers::check_map_size(o.via.map, name, 5, 0);
+                        Helpers::check_size(o.via.map.size, name, 5, 0);
                         auto kvmap = Helpers::make_kvmap(o, name);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "hashed_msg", hashed_msg, false);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "public_key_x", public_key_x, false);
@@ -1225,7 +1205,7 @@ namespace Acir {
                     }
                 } else if (o.type == msgpack::type::ARRAY) {
                     auto array = o.via.array;
-                    Helpers::check_array_size(array, name, 5, 0);
+                    Helpers::check_size(array.size, name, 5, 0);
                     Helpers::conv_fld_from_array(array, name, "hashed_msg", hashed_msg, 0);
                     Helpers::conv_fld_from_array(array, name, "public_key_x", public_key_x, 1);
                     Helpers::conv_fld_from_array(array, name, "public_key_y", public_key_y, 2);
@@ -1273,7 +1253,7 @@ namespace Acir {
                             }
                         });
                     } else {
-                        Helpers::check_map_size(o.via.map, name, 5, 0);
+                        Helpers::check_size(o.via.map.size, name, 5, 0);
                         auto kvmap = Helpers::make_kvmap(o, name);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "hashed_msg", hashed_msg, false);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "public_key_x", public_key_x, false);
@@ -1283,7 +1263,7 @@ namespace Acir {
                     }
                 } else if (o.type == msgpack::type::ARRAY) {
                     auto array = o.via.array;
-                    Helpers::check_array_size(array, name, 5, 0);
+                    Helpers::check_size(array.size, name, 5, 0);
                     Helpers::conv_fld_from_array(array, name, "hashed_msg", hashed_msg, 0);
                     Helpers::conv_fld_from_array(array, name, "public_key_x", public_key_x, 1);
                     Helpers::conv_fld_from_array(array, name, "public_key_y", public_key_y, 2);
@@ -1323,7 +1303,7 @@ namespace Acir {
                             }
                         });
                     } else {
-                        Helpers::check_map_size(o.via.map, name, 3, 0);
+                        Helpers::check_size(o.via.map.size, name, 3, 0);
                         auto kvmap = Helpers::make_kvmap(o, name);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "points", points, false);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "scalars", scalars, false);
@@ -1331,7 +1311,7 @@ namespace Acir {
                     }
                 } else if (o.type == msgpack::type::ARRAY) {
                     auto array = o.via.array;
-                    Helpers::check_array_size(array, name, 3, 0);
+                    Helpers::check_size(array.size, name, 3, 0);
                     Helpers::conv_fld_from_array(array, name, "points", points, 0);
                     Helpers::conv_fld_from_array(array, name, "scalars", scalars, 1);
                     Helpers::conv_fld_from_array(array, name, "outputs", outputs, 2);
@@ -1385,7 +1365,7 @@ namespace Acir {
                             }
                         });
                     } else {
-                        Helpers::check_map_size(o.via.map, name, 7, 0);
+                        Helpers::check_size(o.via.map.size, name, 7, 0);
                         auto kvmap = Helpers::make_kvmap(o, name);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "input1_x", input1_x, false);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "input1_y", input1_y, false);
@@ -1397,7 +1377,7 @@ namespace Acir {
                     }
                 } else if (o.type == msgpack::type::ARRAY) {
                     auto array = o.via.array;
-                    Helpers::check_array_size(array, name, 7, 0);
+                    Helpers::check_size(array.size, name, 7, 0);
                     Helpers::conv_fld_from_array(array, name, "input1_x", input1_x, 0);
                     Helpers::conv_fld_from_array(array, name, "input1_y", input1_y, 1);
                     Helpers::conv_fld_from_array(array, name, "input1_infinite", input1_infinite, 2);
@@ -1435,14 +1415,14 @@ namespace Acir {
                             }
                         });
                     } else {
-                        Helpers::check_map_size(o.via.map, name, 2, 0);
+                        Helpers::check_size(o.via.map.size, name, 2, 0);
                         auto kvmap = Helpers::make_kvmap(o, name);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "message", message, false);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "output", output, false);
                     }
                 } else if (o.type == msgpack::type::ARRAY) {
                     auto array = o.via.array;
-                    Helpers::check_array_size(array, name, 2, 0);
+                    Helpers::check_size(array.size, name, 2, 0);
                     Helpers::conv_fld_from_array(array, name, "message", message, 0);
                     Helpers::conv_fld_from_array(array, name, "output", output, 1);
                 } else {
@@ -1479,7 +1459,7 @@ namespace Acir {
                             }
                         });
                     } else {
-                        Helpers::check_map_size(o.via.map, name, 3, 0);
+                        Helpers::check_size(o.via.map.size, name, 3, 0);
                         auto kvmap = Helpers::make_kvmap(o, name);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "input", input, false);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "hash_values", hash_values, false);
@@ -1487,7 +1467,7 @@ namespace Acir {
                     }
                 } else if (o.type == msgpack::type::ARRAY) {
                     auto array = o.via.array;
-                    Helpers::check_array_size(array, name, 3, 0);
+                    Helpers::check_size(array.size, name, 3, 0);
                     Helpers::conv_fld_from_array(array, name, "input", input, 0);
                     Helpers::conv_fld_from_array(array, name, "hash_values", hash_values, 1);
                     Helpers::conv_fld_from_array(array, name, "output", output, 2);
@@ -1533,7 +1513,7 @@ namespace Acir {
                             }
                         });
                     } else {
-                        Helpers::check_map_size(o.via.map, name, 5, 0);
+                        Helpers::check_size(o.via.map.size, name, 5, 0);
                         auto kvmap = Helpers::make_kvmap(o, name);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "input", input, false);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "radix", radix, false);
@@ -1543,7 +1523,7 @@ namespace Acir {
                     }
                 } else if (o.type == msgpack::type::ARRAY) {
                     auto array = o.via.array;
-                    Helpers::check_array_size(array, name, 5, 0);
+                    Helpers::check_size(array.size, name, 5, 0);
                     Helpers::conv_fld_from_array(array, name, "input", input, 0);
                     Helpers::conv_fld_from_array(array, name, "radix", radix, 1);
                     Helpers::conv_fld_from_array(array, name, "output_pointer", output_pointer, 2);
@@ -1905,14 +1885,14 @@ namespace Acir {
                             }
                         });
                     } else {
-                        Helpers::check_map_size(o.via.map, name, 2, 0);
+                        Helpers::check_size(o.via.map.size, name, 2, 0);
                         auto kvmap = Helpers::make_kvmap(o, name);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "value_types", value_types, false);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "size", size, false);
                     }
                 } else if (o.type == msgpack::type::ARRAY) {
                     auto array = o.via.array;
-                    Helpers::check_array_size(array, name, 2, 0);
+                    Helpers::check_size(array.size, name, 2, 0);
                     Helpers::conv_fld_from_array(array, name, "value_types", value_types, 0);
                     Helpers::conv_fld_from_array(array, name, "size", size, 1);
                 } else {
@@ -1941,13 +1921,13 @@ namespace Acir {
                             }
                         });
                     } else {
-                        Helpers::check_map_size(o.via.map, name, 1, 0);
+                        Helpers::check_size(o.via.map.size, name, 1, 0);
                         auto kvmap = Helpers::make_kvmap(o, name);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "value_types", value_types, false);
                     }
                 } else if (o.type == msgpack::type::ARRAY) {
                     auto array = o.via.array;
-                    Helpers::check_array_size(array, name, 1, 0);
+                    Helpers::check_size(array.size, name, 1, 0);
                     Helpers::conv_fld_from_array(array, name, "value_types", value_types, 0);
                 } else {
                     throw_or_abort("expected MAP or ARRAY for " + name);
@@ -2095,14 +2075,14 @@ namespace Acir {
                         }
                     });
                 } else {
-                    Helpers::check_map_size(o.via.map, name, 2, 0);
+                    Helpers::check_size(o.via.map.size, name, 2, 0);
                     auto kvmap = Helpers::make_kvmap(o, name);
                     Helpers::conv_fld_from_kvmap(kvmap, name, "pointer", pointer, false);
                     Helpers::conv_fld_from_kvmap(kvmap, name, "size", size, false);
                 }
             } else if (o.type == msgpack::type::ARRAY) {
                 auto array = o.via.array;
-                Helpers::check_array_size(array, name, 2, 0);
+                Helpers::check_size(array.size, name, 2, 0);
                 Helpers::conv_fld_from_array(array, name, "pointer", pointer, 0);
                 Helpers::conv_fld_from_array(array, name, "size", size, 1);
             } else {
@@ -2308,7 +2288,7 @@ namespace Acir {
                             }
                         });
                     } else {
-                        Helpers::check_map_size(o.via.map, name, 4, 0);
+                        Helpers::check_size(o.via.map.size, name, 4, 0);
                         auto kvmap = Helpers::make_kvmap(o, name);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "destination", destination, false);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "op", op, false);
@@ -2317,7 +2297,7 @@ namespace Acir {
                     }
                 } else if (o.type == msgpack::type::ARRAY) {
                     auto array = o.via.array;
-                    Helpers::check_array_size(array, name, 4, 0);
+                    Helpers::check_size(array.size, name, 4, 0);
                     Helpers::conv_fld_from_array(array, name, "destination", destination, 0);
                     Helpers::conv_fld_from_array(array, name, "op", op, 1);
                     Helpers::conv_fld_from_array(array, name, "lhs", lhs, 2);
@@ -2364,7 +2344,7 @@ namespace Acir {
                             }
                         });
                     } else {
-                        Helpers::check_map_size(o.via.map, name, 5, 0);
+                        Helpers::check_size(o.via.map.size, name, 5, 0);
                         auto kvmap = Helpers::make_kvmap(o, name);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "destination", destination, false);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "op", op, false);
@@ -2374,7 +2354,7 @@ namespace Acir {
                     }
                 } else if (o.type == msgpack::type::ARRAY) {
                     auto array = o.via.array;
-                    Helpers::check_array_size(array, name, 5, 0);
+                    Helpers::check_size(array.size, name, 5, 0);
                     Helpers::conv_fld_from_array(array, name, "destination", destination, 0);
                     Helpers::conv_fld_from_array(array, name, "op", op, 1);
                     Helpers::conv_fld_from_array(array, name, "bit_size", bit_size, 2);
@@ -2414,7 +2394,7 @@ namespace Acir {
                             }
                         });
                     } else {
-                        Helpers::check_map_size(o.via.map, name, 3, 0);
+                        Helpers::check_size(o.via.map.size, name, 3, 0);
                         auto kvmap = Helpers::make_kvmap(o, name);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "destination", destination, false);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "source", source, false);
@@ -2422,7 +2402,7 @@ namespace Acir {
                     }
                 } else if (o.type == msgpack::type::ARRAY) {
                     auto array = o.via.array;
-                    Helpers::check_array_size(array, name, 3, 0);
+                    Helpers::check_size(array.size, name, 3, 0);
                     Helpers::conv_fld_from_array(array, name, "destination", destination, 0);
                     Helpers::conv_fld_from_array(array, name, "source", source, 1);
                     Helpers::conv_fld_from_array(array, name, "bit_size", bit_size, 2);
@@ -2460,7 +2440,7 @@ namespace Acir {
                             }
                         });
                     } else {
-                        Helpers::check_map_size(o.via.map, name, 3, 0);
+                        Helpers::check_size(o.via.map.size, name, 3, 0);
                         auto kvmap = Helpers::make_kvmap(o, name);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "destination", destination, false);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "source", source, false);
@@ -2468,7 +2448,7 @@ namespace Acir {
                     }
                 } else if (o.type == msgpack::type::ARRAY) {
                     auto array = o.via.array;
-                    Helpers::check_array_size(array, name, 3, 0);
+                    Helpers::check_size(array.size, name, 3, 0);
                     Helpers::conv_fld_from_array(array, name, "destination", destination, 0);
                     Helpers::conv_fld_from_array(array, name, "source", source, 1);
                     Helpers::conv_fld_from_array(array, name, "bit_size", bit_size, 2);
@@ -2502,14 +2482,14 @@ namespace Acir {
                             }
                         });
                     } else {
-                        Helpers::check_map_size(o.via.map, name, 2, 0);
+                        Helpers::check_size(o.via.map.size, name, 2, 0);
                         auto kvmap = Helpers::make_kvmap(o, name);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "condition", condition, false);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "location", location, false);
                     }
                 } else if (o.type == msgpack::type::ARRAY) {
                     auto array = o.via.array;
-                    Helpers::check_array_size(array, name, 2, 0);
+                    Helpers::check_size(array.size, name, 2, 0);
                     Helpers::conv_fld_from_array(array, name, "condition", condition, 0);
                     Helpers::conv_fld_from_array(array, name, "location", location, 1);
                 } else {
@@ -2538,13 +2518,13 @@ namespace Acir {
                             }
                         });
                     } else {
-                        Helpers::check_map_size(o.via.map, name, 1, 0);
+                        Helpers::check_size(o.via.map.size, name, 1, 0);
                         auto kvmap = Helpers::make_kvmap(o, name);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "location", location, false);
                     }
                 } else if (o.type == msgpack::type::ARRAY) {
                     auto array = o.via.array;
-                    Helpers::check_array_size(array, name, 1, 0);
+                    Helpers::check_size(array.size, name, 1, 0);
                     Helpers::conv_fld_from_array(array, name, "location", location, 0);
                 } else {
                     throw_or_abort("expected MAP or ARRAY for " + name);
@@ -2580,7 +2560,7 @@ namespace Acir {
                             }
                         });
                     } else {
-                        Helpers::check_map_size(o.via.map, name, 3, 0);
+                        Helpers::check_size(o.via.map.size, name, 3, 0);
                         auto kvmap = Helpers::make_kvmap(o, name);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "destination_address", destination_address, false);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "size_address", size_address, false);
@@ -2588,7 +2568,7 @@ namespace Acir {
                     }
                 } else if (o.type == msgpack::type::ARRAY) {
                     auto array = o.via.array;
-                    Helpers::check_array_size(array, name, 3, 0);
+                    Helpers::check_size(array.size, name, 3, 0);
                     Helpers::conv_fld_from_array(array, name, "destination_address", destination_address, 0);
                     Helpers::conv_fld_from_array(array, name, "size_address", size_address, 1);
                     Helpers::conv_fld_from_array(array, name, "offset_address", offset_address, 2);
@@ -2618,13 +2598,13 @@ namespace Acir {
                             }
                         });
                     } else {
-                        Helpers::check_map_size(o.via.map, name, 1, 0);
+                        Helpers::check_size(o.via.map.size, name, 1, 0);
                         auto kvmap = Helpers::make_kvmap(o, name);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "location", location, false);
                     }
                 } else if (o.type == msgpack::type::ARRAY) {
                     auto array = o.via.array;
-                    Helpers::check_array_size(array, name, 1, 0);
+                    Helpers::check_size(array.size, name, 1, 0);
                     Helpers::conv_fld_from_array(array, name, "location", location, 0);
                 } else {
                     throw_or_abort("expected MAP or ARRAY for " + name);
@@ -2660,7 +2640,7 @@ namespace Acir {
                             }
                         });
                     } else {
-                        Helpers::check_map_size(o.via.map, name, 3, 0);
+                        Helpers::check_size(o.via.map.size, name, 3, 0);
                         auto kvmap = Helpers::make_kvmap(o, name);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "destination", destination, false);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "bit_size", bit_size, false);
@@ -2668,7 +2648,7 @@ namespace Acir {
                     }
                 } else if (o.type == msgpack::type::ARRAY) {
                     auto array = o.via.array;
-                    Helpers::check_array_size(array, name, 3, 0);
+                    Helpers::check_size(array.size, name, 3, 0);
                     Helpers::conv_fld_from_array(array, name, "destination", destination, 0);
                     Helpers::conv_fld_from_array(array, name, "bit_size", bit_size, 1);
                     Helpers::conv_fld_from_array(array, name, "value", value, 2);
@@ -2706,7 +2686,7 @@ namespace Acir {
                             }
                         });
                     } else {
-                        Helpers::check_map_size(o.via.map, name, 3, 0);
+                        Helpers::check_size(o.via.map.size, name, 3, 0);
                         auto kvmap = Helpers::make_kvmap(o, name);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "destination_pointer", destination_pointer, false);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "bit_size", bit_size, false);
@@ -2714,7 +2694,7 @@ namespace Acir {
                     }
                 } else if (o.type == msgpack::type::ARRAY) {
                     auto array = o.via.array;
-                    Helpers::check_array_size(array, name, 3, 0);
+                    Helpers::check_size(array.size, name, 3, 0);
                     Helpers::conv_fld_from_array(array, name, "destination_pointer", destination_pointer, 0);
                     Helpers::conv_fld_from_array(array, name, "bit_size", bit_size, 1);
                     Helpers::conv_fld_from_array(array, name, "value", value, 2);
@@ -2766,7 +2746,7 @@ namespace Acir {
                             }
                         });
                     } else {
-                        Helpers::check_map_size(o.via.map, name, 5, 0);
+                        Helpers::check_size(o.via.map.size, name, 5, 0);
                         auto kvmap = Helpers::make_kvmap(o, name);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "function", function, false);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "destinations", destinations, false);
@@ -2776,7 +2756,7 @@ namespace Acir {
                     }
                 } else if (o.type == msgpack::type::ARRAY) {
                     auto array = o.via.array;
-                    Helpers::check_array_size(array, name, 5, 0);
+                    Helpers::check_size(array.size, name, 5, 0);
                     Helpers::conv_fld_from_array(array, name, "function", function, 0);
                     Helpers::conv_fld_from_array(array, name, "destinations", destinations, 1);
                     Helpers::conv_fld_from_array(array, name, "destination_value_types", destination_value_types, 2);
@@ -2812,14 +2792,14 @@ namespace Acir {
                             }
                         });
                     } else {
-                        Helpers::check_map_size(o.via.map, name, 2, 0);
+                        Helpers::check_size(o.via.map.size, name, 2, 0);
                         auto kvmap = Helpers::make_kvmap(o, name);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "destination", destination, false);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "source", source, false);
                     }
                 } else if (o.type == msgpack::type::ARRAY) {
                     auto array = o.via.array;
-                    Helpers::check_array_size(array, name, 2, 0);
+                    Helpers::check_size(array.size, name, 2, 0);
                     Helpers::conv_fld_from_array(array, name, "destination", destination, 0);
                     Helpers::conv_fld_from_array(array, name, "source", source, 1);
                 } else {
@@ -2860,7 +2840,7 @@ namespace Acir {
                             }
                         });
                     } else {
-                        Helpers::check_map_size(o.via.map, name, 4, 0);
+                        Helpers::check_size(o.via.map.size, name, 4, 0);
                         auto kvmap = Helpers::make_kvmap(o, name);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "destination", destination, false);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "source_a", source_a, false);
@@ -2869,7 +2849,7 @@ namespace Acir {
                     }
                 } else if (o.type == msgpack::type::ARRAY) {
                     auto array = o.via.array;
-                    Helpers::check_array_size(array, name, 4, 0);
+                    Helpers::check_size(array.size, name, 4, 0);
                     Helpers::conv_fld_from_array(array, name, "destination", destination, 0);
                     Helpers::conv_fld_from_array(array, name, "source_a", source_a, 1);
                     Helpers::conv_fld_from_array(array, name, "source_b", source_b, 2);
@@ -2904,14 +2884,14 @@ namespace Acir {
                             }
                         });
                     } else {
-                        Helpers::check_map_size(o.via.map, name, 2, 0);
+                        Helpers::check_size(o.via.map.size, name, 2, 0);
                         auto kvmap = Helpers::make_kvmap(o, name);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "destination", destination, false);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "source_pointer", source_pointer, false);
                     }
                 } else if (o.type == msgpack::type::ARRAY) {
                     auto array = o.via.array;
-                    Helpers::check_array_size(array, name, 2, 0);
+                    Helpers::check_size(array.size, name, 2, 0);
                     Helpers::conv_fld_from_array(array, name, "destination", destination, 0);
                     Helpers::conv_fld_from_array(array, name, "source_pointer", source_pointer, 1);
                 } else {
@@ -2944,14 +2924,14 @@ namespace Acir {
                             }
                         });
                     } else {
-                        Helpers::check_map_size(o.via.map, name, 2, 0);
+                        Helpers::check_size(o.via.map.size, name, 2, 0);
                         auto kvmap = Helpers::make_kvmap(o, name);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "destination_pointer", destination_pointer, false);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "source", source, false);
                     }
                 } else if (o.type == msgpack::type::ARRAY) {
                     auto array = o.via.array;
-                    Helpers::check_array_size(array, name, 2, 0);
+                    Helpers::check_size(array.size, name, 2, 0);
                     Helpers::conv_fld_from_array(array, name, "destination_pointer", destination_pointer, 0);
                     Helpers::conv_fld_from_array(array, name, "source", source, 1);
                 } else {
@@ -2995,13 +2975,13 @@ namespace Acir {
                             }
                         });
                     } else {
-                        Helpers::check_map_size(o.via.map, name, 1, 0);
+                        Helpers::check_size(o.via.map.size, name, 1, 0);
                         auto kvmap = Helpers::make_kvmap(o, name);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "revert_data", revert_data, false);
                     }
                 } else if (o.type == msgpack::type::ARRAY) {
                     auto array = o.via.array;
-                    Helpers::check_array_size(array, name, 1, 0);
+                    Helpers::check_size(array.size, name, 1, 0);
                     Helpers::conv_fld_from_array(array, name, "revert_data", revert_data, 0);
                 } else {
                     throw_or_abort("expected MAP or ARRAY for " + name);
@@ -3029,13 +3009,13 @@ namespace Acir {
                             }
                         });
                     } else {
-                        Helpers::check_map_size(o.via.map, name, 1, 0);
+                        Helpers::check_size(o.via.map.size, name, 1, 0);
                         auto kvmap = Helpers::make_kvmap(o, name);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "return_data", return_data, false);
                     }
                 } else if (o.type == msgpack::type::ARRAY) {
                     auto array = o.via.array;
-                    Helpers::check_array_size(array, name, 1, 0);
+                    Helpers::check_size(array.size, name, 1, 0);
                     Helpers::conv_fld_from_array(array, name, "return_data", return_data, 0);
                 } else {
                     throw_or_abort("expected MAP or ARRAY for " + name);
@@ -3673,7 +3653,7 @@ namespace Acir {
                             }
                         });
                     } else {
-                        Helpers::check_map_size(o.via.map, name, 4, 0);
+                        Helpers::check_size(o.via.map.size, name, 4, 0);
                         auto kvmap = Helpers::make_kvmap(o, name);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "inputs", inputs, false);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "iv", iv, false);
@@ -3682,7 +3662,7 @@ namespace Acir {
                     }
                 } else if (o.type == msgpack::type::ARRAY) {
                     auto array = o.via.array;
-                    Helpers::check_array_size(array, name, 4, 0);
+                    Helpers::check_size(array.size, name, 4, 0);
                     Helpers::conv_fld_from_array(array, name, "inputs", inputs, 0);
                     Helpers::conv_fld_from_array(array, name, "iv", iv, 1);
                     Helpers::conv_fld_from_array(array, name, "key", key, 2);
@@ -3725,7 +3705,7 @@ namespace Acir {
                             }
                         });
                     } else {
-                        Helpers::check_map_size(o.via.map, name, 4, 0);
+                        Helpers::check_size(o.via.map.size, name, 4, 0);
                         auto kvmap = Helpers::make_kvmap(o, name);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "lhs", lhs, false);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "rhs", rhs, false);
@@ -3734,7 +3714,7 @@ namespace Acir {
                     }
                 } else if (o.type == msgpack::type::ARRAY) {
                     auto array = o.via.array;
-                    Helpers::check_array_size(array, name, 4, 0);
+                    Helpers::check_size(array.size, name, 4, 0);
                     Helpers::conv_fld_from_array(array, name, "lhs", lhs, 0);
                     Helpers::conv_fld_from_array(array, name, "rhs", rhs, 1);
                     Helpers::conv_fld_from_array(array, name, "num_bits", num_bits, 2);
@@ -3777,7 +3757,7 @@ namespace Acir {
                             }
                         });
                     } else {
-                        Helpers::check_map_size(o.via.map, name, 4, 0);
+                        Helpers::check_size(o.via.map.size, name, 4, 0);
                         auto kvmap = Helpers::make_kvmap(o, name);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "lhs", lhs, false);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "rhs", rhs, false);
@@ -3786,7 +3766,7 @@ namespace Acir {
                     }
                 } else if (o.type == msgpack::type::ARRAY) {
                     auto array = o.via.array;
-                    Helpers::check_array_size(array, name, 4, 0);
+                    Helpers::check_size(array.size, name, 4, 0);
                     Helpers::conv_fld_from_array(array, name, "lhs", lhs, 0);
                     Helpers::conv_fld_from_array(array, name, "rhs", rhs, 1);
                     Helpers::conv_fld_from_array(array, name, "num_bits", num_bits, 2);
@@ -3821,14 +3801,14 @@ namespace Acir {
                             }
                         });
                     } else {
-                        Helpers::check_map_size(o.via.map, name, 2, 0);
+                        Helpers::check_size(o.via.map.size, name, 2, 0);
                         auto kvmap = Helpers::make_kvmap(o, name);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "input", input, false);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "num_bits", num_bits, false);
                     }
                 } else if (o.type == msgpack::type::ARRAY) {
                     auto array = o.via.array;
-                    Helpers::check_array_size(array, name, 2, 0);
+                    Helpers::check_size(array.size, name, 2, 0);
                     Helpers::conv_fld_from_array(array, name, "input", input, 0);
                     Helpers::conv_fld_from_array(array, name, "num_bits", num_bits, 1);
                 } else {
@@ -3861,14 +3841,14 @@ namespace Acir {
                             }
                         });
                     } else {
-                        Helpers::check_map_size(o.via.map, name, 2, 0);
+                        Helpers::check_size(o.via.map.size, name, 2, 0);
                         auto kvmap = Helpers::make_kvmap(o, name);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "inputs", inputs, false);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "outputs", outputs, false);
                     }
                 } else if (o.type == msgpack::type::ARRAY) {
                     auto array = o.via.array;
-                    Helpers::check_array_size(array, name, 2, 0);
+                    Helpers::check_size(array.size, name, 2, 0);
                     Helpers::conv_fld_from_array(array, name, "inputs", inputs, 0);
                     Helpers::conv_fld_from_array(array, name, "outputs", outputs, 1);
                 } else {
@@ -3901,14 +3881,14 @@ namespace Acir {
                             }
                         });
                     } else {
-                        Helpers::check_map_size(o.via.map, name, 2, 0);
+                        Helpers::check_size(o.via.map.size, name, 2, 0);
                         auto kvmap = Helpers::make_kvmap(o, name);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "inputs", inputs, false);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "outputs", outputs, false);
                     }
                 } else if (o.type == msgpack::type::ARRAY) {
                     auto array = o.via.array;
-                    Helpers::check_array_size(array, name, 2, 0);
+                    Helpers::check_size(array.size, name, 2, 0);
                     Helpers::conv_fld_from_array(array, name, "inputs", inputs, 0);
                     Helpers::conv_fld_from_array(array, name, "outputs", outputs, 1);
                 } else {
@@ -3957,7 +3937,7 @@ namespace Acir {
                             }
                         });
                     } else {
-                        Helpers::check_map_size(o.via.map, name, 6, 0);
+                        Helpers::check_size(o.via.map.size, name, 6, 0);
                         auto kvmap = Helpers::make_kvmap(o, name);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "public_key_x", public_key_x, false);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "public_key_y", public_key_y, false);
@@ -3968,7 +3948,7 @@ namespace Acir {
                     }
                 } else if (o.type == msgpack::type::ARRAY) {
                     auto array = o.via.array;
-                    Helpers::check_array_size(array, name, 6, 0);
+                    Helpers::check_size(array.size, name, 6, 0);
                     Helpers::conv_fld_from_array(array, name, "public_key_x", public_key_x, 0);
                     Helpers::conv_fld_from_array(array, name, "public_key_y", public_key_y, 1);
                     Helpers::conv_fld_from_array(array, name, "signature", signature, 2);
@@ -4021,7 +4001,7 @@ namespace Acir {
                             }
                         });
                     } else {
-                        Helpers::check_map_size(o.via.map, name, 6, 0);
+                        Helpers::check_size(o.via.map.size, name, 6, 0);
                         auto kvmap = Helpers::make_kvmap(o, name);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "public_key_x", public_key_x, false);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "public_key_y", public_key_y, false);
@@ -4032,7 +4012,7 @@ namespace Acir {
                     }
                 } else if (o.type == msgpack::type::ARRAY) {
                     auto array = o.via.array;
-                    Helpers::check_array_size(array, name, 6, 0);
+                    Helpers::check_size(array.size, name, 6, 0);
                     Helpers::conv_fld_from_array(array, name, "public_key_x", public_key_x, 0);
                     Helpers::conv_fld_from_array(array, name, "public_key_y", public_key_y, 1);
                     Helpers::conv_fld_from_array(array, name, "signature", signature, 2);
@@ -4077,7 +4057,7 @@ namespace Acir {
                             }
                         });
                     } else {
-                        Helpers::check_map_size(o.via.map, name, 4, 0);
+                        Helpers::check_size(o.via.map.size, name, 4, 0);
                         auto kvmap = Helpers::make_kvmap(o, name);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "points", points, false);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "scalars", scalars, false);
@@ -4086,7 +4066,7 @@ namespace Acir {
                     }
                 } else if (o.type == msgpack::type::ARRAY) {
                     auto array = o.via.array;
-                    Helpers::check_array_size(array, name, 4, 0);
+                    Helpers::check_size(array.size, name, 4, 0);
                     Helpers::conv_fld_from_array(array, name, "points", points, 0);
                     Helpers::conv_fld_from_array(array, name, "scalars", scalars, 1);
                     Helpers::conv_fld_from_array(array, name, "predicate", predicate, 2);
@@ -4129,7 +4109,7 @@ namespace Acir {
                             }
                         });
                     } else {
-                        Helpers::check_map_size(o.via.map, name, 4, 0);
+                        Helpers::check_size(o.via.map.size, name, 4, 0);
                         auto kvmap = Helpers::make_kvmap(o, name);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "input1", input1, false);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "input2", input2, false);
@@ -4138,7 +4118,7 @@ namespace Acir {
                     }
                 } else if (o.type == msgpack::type::ARRAY) {
                     auto array = o.via.array;
-                    Helpers::check_array_size(array, name, 4, 0);
+                    Helpers::check_size(array.size, name, 4, 0);
                     Helpers::conv_fld_from_array(array, name, "input1", input1, 0);
                     Helpers::conv_fld_from_array(array, name, "input2", input2, 1);
                     Helpers::conv_fld_from_array(array, name, "predicate", predicate, 2);
@@ -4173,14 +4153,14 @@ namespace Acir {
                             }
                         });
                     } else {
-                        Helpers::check_map_size(o.via.map, name, 2, 0);
+                        Helpers::check_size(o.via.map.size, name, 2, 0);
                         auto kvmap = Helpers::make_kvmap(o, name);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "inputs", inputs, false);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "outputs", outputs, false);
                     }
                 } else if (o.type == msgpack::type::ARRAY) {
                     auto array = o.via.array;
-                    Helpers::check_array_size(array, name, 2, 0);
+                    Helpers::check_size(array.size, name, 2, 0);
                     Helpers::conv_fld_from_array(array, name, "inputs", inputs, 0);
                     Helpers::conv_fld_from_array(array, name, "outputs", outputs, 1);
                 } else {
@@ -4229,7 +4209,7 @@ namespace Acir {
                             }
                         });
                     } else {
-                        Helpers::check_map_size(o.via.map, name, 6, 0);
+                        Helpers::check_size(o.via.map.size, name, 6, 0);
                         auto kvmap = Helpers::make_kvmap(o, name);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "verification_key", verification_key, false);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "proof", proof, false);
@@ -4240,7 +4220,7 @@ namespace Acir {
                     }
                 } else if (o.type == msgpack::type::ARRAY) {
                     auto array = o.via.array;
-                    Helpers::check_array_size(array, name, 6, 0);
+                    Helpers::check_size(array.size, name, 6, 0);
                     Helpers::conv_fld_from_array(array, name, "verification_key", verification_key, 0);
                     Helpers::conv_fld_from_array(array, name, "proof", proof, 1);
                     Helpers::conv_fld_from_array(array, name, "public_inputs", public_inputs, 2);
@@ -4277,14 +4257,14 @@ namespace Acir {
                             }
                         });
                     } else {
-                        Helpers::check_map_size(o.via.map, name, 2, 0);
+                        Helpers::check_size(o.via.map.size, name, 2, 0);
                         auto kvmap = Helpers::make_kvmap(o, name);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "inputs", inputs, false);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "outputs", outputs, false);
                     }
                 } else if (o.type == msgpack::type::ARRAY) {
                     auto array = o.via.array;
-                    Helpers::check_array_size(array, name, 2, 0);
+                    Helpers::check_size(array.size, name, 2, 0);
                     Helpers::conv_fld_from_array(array, name, "inputs", inputs, 0);
                     Helpers::conv_fld_from_array(array, name, "outputs", outputs, 1);
                 } else {
@@ -4321,7 +4301,7 @@ namespace Acir {
                             }
                         });
                     } else {
-                        Helpers::check_map_size(o.via.map, name, 3, 0);
+                        Helpers::check_size(o.via.map.size, name, 3, 0);
                         auto kvmap = Helpers::make_kvmap(o, name);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "inputs", inputs, false);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "hash_values", hash_values, false);
@@ -4329,7 +4309,7 @@ namespace Acir {
                     }
                 } else if (o.type == msgpack::type::ARRAY) {
                     auto array = o.via.array;
-                    Helpers::check_array_size(array, name, 3, 0);
+                    Helpers::check_size(array.size, name, 3, 0);
                     Helpers::conv_fld_from_array(array, name, "inputs", inputs, 0);
                     Helpers::conv_fld_from_array(array, name, "hash_values", hash_values, 1);
                     Helpers::conv_fld_from_array(array, name, "outputs", outputs, 2);
@@ -4859,7 +4839,7 @@ namespace Acir {
                         }
                     });
                 } else {
-                    Helpers::check_map_size(o.via.map, name, 3, 0);
+                    Helpers::check_size(o.via.map.size, name, 3, 0);
                     auto kvmap = Helpers::make_kvmap(o, name);
                     Helpers::conv_fld_from_kvmap(kvmap, name, "mul_terms", mul_terms, false);
                     Helpers::conv_fld_from_kvmap(kvmap, name, "linear_combinations", linear_combinations, false);
@@ -4867,7 +4847,7 @@ namespace Acir {
                 }
             } else if (o.type == msgpack::type::ARRAY) {
                 auto array = o.via.array;
-                Helpers::check_array_size(array, name, 3, 0);
+                Helpers::check_size(array.size, name, 3, 0);
                 Helpers::conv_fld_from_array(array, name, "mul_terms", mul_terms, 0);
                 Helpers::conv_fld_from_array(array, name, "linear_combinations", linear_combinations, 1);
                 Helpers::conv_fld_from_array(array, name, "q_c", q_c, 2);
@@ -5194,7 +5174,7 @@ namespace Acir {
                         }
                     });
                 } else {
-                    Helpers::check_map_size(o.via.map, name, 3, 0);
+                    Helpers::check_size(o.via.map.size, name, 3, 0);
                     auto kvmap = Helpers::make_kvmap(o, name);
                     Helpers::conv_fld_from_kvmap(kvmap, name, "operation", operation, false);
                     Helpers::conv_fld_from_kvmap(kvmap, name, "index", index, false);
@@ -5202,7 +5182,7 @@ namespace Acir {
                 }
             } else if (o.type == msgpack::type::ARRAY) {
                 auto array = o.via.array;
-                Helpers::check_array_size(array, name, 3, 0);
+                Helpers::check_size(array.size, name, 3, 0);
                 Helpers::conv_fld_from_array(array, name, "operation", operation, 0);
                 Helpers::conv_fld_from_array(array, name, "index", index, 1);
                 Helpers::conv_fld_from_array(array, name, "value", value, 2);
@@ -5268,14 +5248,14 @@ namespace Acir {
                             }
                         });
                     } else {
-                        Helpers::check_map_size(o.via.map, name, 2, 0);
+                        Helpers::check_size(o.via.map.size, name, 2, 0);
                         auto kvmap = Helpers::make_kvmap(o, name);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "block_id", block_id, false);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "op", op, false);
                     }
                 } else if (o.type == msgpack::type::ARRAY) {
                     auto array = o.via.array;
-                    Helpers::check_array_size(array, name, 2, 0);
+                    Helpers::check_size(array.size, name, 2, 0);
                     Helpers::conv_fld_from_array(array, name, "block_id", block_id, 0);
                     Helpers::conv_fld_from_array(array, name, "op", op, 1);
                 } else {
@@ -5312,7 +5292,7 @@ namespace Acir {
                             }
                         });
                     } else {
-                        Helpers::check_map_size(o.via.map, name, 3, 0);
+                        Helpers::check_size(o.via.map.size, name, 3, 0);
                         auto kvmap = Helpers::make_kvmap(o, name);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "block_id", block_id, false);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "init", init, false);
@@ -5320,7 +5300,7 @@ namespace Acir {
                     }
                 } else if (o.type == msgpack::type::ARRAY) {
                     auto array = o.via.array;
-                    Helpers::check_array_size(array, name, 3, 0);
+                    Helpers::check_size(array.size, name, 3, 0);
                     Helpers::conv_fld_from_array(array, name, "block_id", block_id, 0);
                     Helpers::conv_fld_from_array(array, name, "init", init, 1);
                     Helpers::conv_fld_from_array(array, name, "block_type", block_type, 2);
@@ -5362,7 +5342,7 @@ namespace Acir {
                             }
                         });
                     } else {
-                        Helpers::check_map_size(o.via.map, name, 4, 0);
+                        Helpers::check_size(o.via.map.size, name, 4, 0);
                         auto kvmap = Helpers::make_kvmap(o, name);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "id", id, false);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "inputs", inputs, false);
@@ -5371,7 +5351,7 @@ namespace Acir {
                     }
                 } else if (o.type == msgpack::type::ARRAY) {
                     auto array = o.via.array;
-                    Helpers::check_array_size(array, name, 4, 0);
+                    Helpers::check_size(array.size, name, 4, 0);
                     Helpers::conv_fld_from_array(array, name, "id", id, 0);
                     Helpers::conv_fld_from_array(array, name, "inputs", inputs, 1);
                     Helpers::conv_fld_from_array(array, name, "outputs", outputs, 2);
@@ -5414,7 +5394,7 @@ namespace Acir {
                             }
                         });
                     } else {
-                        Helpers::check_map_size(o.via.map, name, 4, 0);
+                        Helpers::check_size(o.via.map.size, name, 4, 0);
                         auto kvmap = Helpers::make_kvmap(o, name);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "id", id, false);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "inputs", inputs, false);
@@ -5423,7 +5403,7 @@ namespace Acir {
                     }
                 } else if (o.type == msgpack::type::ARRAY) {
                     auto array = o.via.array;
-                    Helpers::check_array_size(array, name, 4, 0);
+                    Helpers::check_size(array.size, name, 4, 0);
                     Helpers::conv_fld_from_array(array, name, "id", id, 0);
                     Helpers::conv_fld_from_array(array, name, "inputs", inputs, 1);
                     Helpers::conv_fld_from_array(array, name, "outputs", outputs, 2);
@@ -5766,14 +5746,14 @@ namespace Acir {
                         }
                     });
                 } else {
-                    Helpers::check_map_size(o.via.map, name, 2, 0);
+                    Helpers::check_size(o.via.map.size, name, 2, 0);
                     auto kvmap = Helpers::make_kvmap(o, name);
                     Helpers::conv_fld_from_kvmap(kvmap, name, "error_selector", error_selector, false);
                     Helpers::conv_fld_from_kvmap(kvmap, name, "payload", payload, false);
                 }
             } else if (o.type == msgpack::type::ARRAY) {
                 auto array = o.via.array;
-                Helpers::check_array_size(array, name, 2, 0);
+                Helpers::check_size(array.size, name, 2, 0);
                 Helpers::conv_fld_from_array(array, name, "error_selector", error_selector, 0);
                 Helpers::conv_fld_from_array(array, name, "payload", payload, 1);
             } else {
@@ -5823,14 +5803,14 @@ namespace Acir {
                             }
                         });
                     } else {
-                        Helpers::check_map_size(o.via.map, name, 2, 0);
+                        Helpers::check_size(o.via.map.size, name, 2, 0);
                         auto kvmap = Helpers::make_kvmap(o, name);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "acir_index", acir_index, false);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "brillig_index", brillig_index, false);
                     }
                 } else if (o.type == msgpack::type::ARRAY) {
                     auto array = o.via.array;
-                    Helpers::check_array_size(array, name, 2, 0);
+                    Helpers::check_size(array.size, name, 2, 0);
                     Helpers::conv_fld_from_array(array, name, "acir_index", acir_index, 0);
                     Helpers::conv_fld_from_array(array, name, "brillig_index", brillig_index, 1);
                 } else {
@@ -6119,13 +6099,13 @@ namespace Acir {
                         }
                     });
                 } else {
-                    Helpers::check_map_size(o.via.map, name, 2, 0);
+                    Helpers::check_size(o.via.map.size, name, 2, 0);
                     auto kvmap = Helpers::make_kvmap(o, name);
                     Helpers::conv_fld_from_kvmap(kvmap, name, "functions", functions, false);
                 }
             } else if (o.type == msgpack::type::ARRAY) {
                 auto array = o.via.array;
-                Helpers::check_array_size(array, name, 2, 0);
+                Helpers::check_size(array.size, name, 2, 0);
                 Helpers::conv_fld_from_array(array, name, "functions", functions, 0);
             } else {
                 throw_or_abort("expected MAP or ARRAY for " + name);

--- a/acvm-repo/acir/codegen/acir.cpp
+++ b/acvm-repo/acir/codegen/acir.cpp
@@ -146,6 +146,29 @@ namespace Acir {
                     " reserved); opt into `#[tagged(allow_unknown_tags)]` on the Rust type to accept trailing extras");
             }
         }
+
+        /// Cap a string-keyed map size. Parallel to `check_array_size`
+        /// for the legacy `Format::Msgpack` named-struct wire shape: the
+        /// string-keyed dispatch only looks up keys it recognizes, so
+        /// extras would otherwise pass silently. Same `active +
+        /// reserved` ceiling, same `allow_unknown_tags` opt-out.
+        static void check_map_size(
+            msgpack::object_map const& map,
+            std::string const& name,
+            uint32_t active,
+            uint32_t reserved
+        ) {
+            uint32_t max_size = active + reserved;
+            if (map.size > max_size) {
+                throw_or_abort(
+                    "map for " + name +
+                    " has " + std::to_string(map.size) +
+                    " entries but at most " + std::to_string(max_size) +
+                    " are expected (" + std::to_string(active) +
+                    " active + " + std::to_string(reserved) +
+                    " reserved); opt into `#[tagged(allow_unknown_tags)]` on the Rust type to accept extra keys");
+            }
+        }
     };
     }
 
@@ -966,6 +989,7 @@ namespace Acir {
                         }
                     });
                 } else {
+                    Helpers::check_map_size(o.via.map, name, 2, 0);
                     auto kvmap = Helpers::make_kvmap(o, name);
                     Helpers::conv_fld_from_kvmap(kvmap, name, "pointer", pointer, false);
                     Helpers::conv_fld_from_kvmap(kvmap, name, "size", size, false);
@@ -1015,6 +1039,7 @@ namespace Acir {
                             }
                         });
                     } else {
+                        Helpers::check_map_size(o.via.map, name, 4, 0);
                         auto kvmap = Helpers::make_kvmap(o, name);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "inputs", inputs, false);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "iv", iv, false);
@@ -1058,6 +1083,7 @@ namespace Acir {
                             }
                         });
                     } else {
+                        Helpers::check_map_size(o.via.map, name, 2, 0);
                         auto kvmap = Helpers::make_kvmap(o, name);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "message", message, false);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "output", output, false);
@@ -1097,6 +1123,7 @@ namespace Acir {
                             }
                         });
                     } else {
+                        Helpers::check_map_size(o.via.map, name, 2, 0);
                         auto kvmap = Helpers::make_kvmap(o, name);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "message", message, false);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "output", output, false);
@@ -1136,6 +1163,7 @@ namespace Acir {
                             }
                         });
                     } else {
+                        Helpers::check_map_size(o.via.map, name, 2, 0);
                         auto kvmap = Helpers::make_kvmap(o, name);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "input", input, false);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "output", output, false);
@@ -1187,6 +1215,7 @@ namespace Acir {
                             }
                         });
                     } else {
+                        Helpers::check_map_size(o.via.map, name, 5, 0);
                         auto kvmap = Helpers::make_kvmap(o, name);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "hashed_msg", hashed_msg, false);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "public_key_x", public_key_x, false);
@@ -1244,6 +1273,7 @@ namespace Acir {
                             }
                         });
                     } else {
+                        Helpers::check_map_size(o.via.map, name, 5, 0);
                         auto kvmap = Helpers::make_kvmap(o, name);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "hashed_msg", hashed_msg, false);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "public_key_x", public_key_x, false);
@@ -1293,6 +1323,7 @@ namespace Acir {
                             }
                         });
                     } else {
+                        Helpers::check_map_size(o.via.map, name, 3, 0);
                         auto kvmap = Helpers::make_kvmap(o, name);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "points", points, false);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "scalars", scalars, false);
@@ -1354,6 +1385,7 @@ namespace Acir {
                             }
                         });
                     } else {
+                        Helpers::check_map_size(o.via.map, name, 7, 0);
                         auto kvmap = Helpers::make_kvmap(o, name);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "input1_x", input1_x, false);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "input1_y", input1_y, false);
@@ -1403,6 +1435,7 @@ namespace Acir {
                             }
                         });
                     } else {
+                        Helpers::check_map_size(o.via.map, name, 2, 0);
                         auto kvmap = Helpers::make_kvmap(o, name);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "message", message, false);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "output", output, false);
@@ -1446,6 +1479,7 @@ namespace Acir {
                             }
                         });
                     } else {
+                        Helpers::check_map_size(o.via.map, name, 3, 0);
                         auto kvmap = Helpers::make_kvmap(o, name);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "input", input, false);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "hash_values", hash_values, false);
@@ -1499,6 +1533,7 @@ namespace Acir {
                             }
                         });
                     } else {
+                        Helpers::check_map_size(o.via.map, name, 5, 0);
                         auto kvmap = Helpers::make_kvmap(o, name);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "input", input, false);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "radix", radix, false);
@@ -1870,6 +1905,7 @@ namespace Acir {
                             }
                         });
                     } else {
+                        Helpers::check_map_size(o.via.map, name, 2, 0);
                         auto kvmap = Helpers::make_kvmap(o, name);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "value_types", value_types, false);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "size", size, false);
@@ -1905,6 +1941,7 @@ namespace Acir {
                             }
                         });
                     } else {
+                        Helpers::check_map_size(o.via.map, name, 1, 0);
                         auto kvmap = Helpers::make_kvmap(o, name);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "value_types", value_types, false);
                     }
@@ -2058,6 +2095,7 @@ namespace Acir {
                         }
                     });
                 } else {
+                    Helpers::check_map_size(o.via.map, name, 2, 0);
                     auto kvmap = Helpers::make_kvmap(o, name);
                     Helpers::conv_fld_from_kvmap(kvmap, name, "pointer", pointer, false);
                     Helpers::conv_fld_from_kvmap(kvmap, name, "size", size, false);
@@ -2270,6 +2308,7 @@ namespace Acir {
                             }
                         });
                     } else {
+                        Helpers::check_map_size(o.via.map, name, 4, 0);
                         auto kvmap = Helpers::make_kvmap(o, name);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "destination", destination, false);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "op", op, false);
@@ -2325,6 +2364,7 @@ namespace Acir {
                             }
                         });
                     } else {
+                        Helpers::check_map_size(o.via.map, name, 5, 0);
                         auto kvmap = Helpers::make_kvmap(o, name);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "destination", destination, false);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "op", op, false);
@@ -2374,6 +2414,7 @@ namespace Acir {
                             }
                         });
                     } else {
+                        Helpers::check_map_size(o.via.map, name, 3, 0);
                         auto kvmap = Helpers::make_kvmap(o, name);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "destination", destination, false);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "source", source, false);
@@ -2419,6 +2460,7 @@ namespace Acir {
                             }
                         });
                     } else {
+                        Helpers::check_map_size(o.via.map, name, 3, 0);
                         auto kvmap = Helpers::make_kvmap(o, name);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "destination", destination, false);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "source", source, false);
@@ -2460,6 +2502,7 @@ namespace Acir {
                             }
                         });
                     } else {
+                        Helpers::check_map_size(o.via.map, name, 2, 0);
                         auto kvmap = Helpers::make_kvmap(o, name);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "condition", condition, false);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "location", location, false);
@@ -2495,6 +2538,7 @@ namespace Acir {
                             }
                         });
                     } else {
+                        Helpers::check_map_size(o.via.map, name, 1, 0);
                         auto kvmap = Helpers::make_kvmap(o, name);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "location", location, false);
                     }
@@ -2536,6 +2580,7 @@ namespace Acir {
                             }
                         });
                     } else {
+                        Helpers::check_map_size(o.via.map, name, 3, 0);
                         auto kvmap = Helpers::make_kvmap(o, name);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "destination_address", destination_address, false);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "size_address", size_address, false);
@@ -2573,6 +2618,7 @@ namespace Acir {
                             }
                         });
                     } else {
+                        Helpers::check_map_size(o.via.map, name, 1, 0);
                         auto kvmap = Helpers::make_kvmap(o, name);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "location", location, false);
                     }
@@ -2614,6 +2660,7 @@ namespace Acir {
                             }
                         });
                     } else {
+                        Helpers::check_map_size(o.via.map, name, 3, 0);
                         auto kvmap = Helpers::make_kvmap(o, name);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "destination", destination, false);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "bit_size", bit_size, false);
@@ -2659,6 +2706,7 @@ namespace Acir {
                             }
                         });
                     } else {
+                        Helpers::check_map_size(o.via.map, name, 3, 0);
                         auto kvmap = Helpers::make_kvmap(o, name);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "destination_pointer", destination_pointer, false);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "bit_size", bit_size, false);
@@ -2718,6 +2766,7 @@ namespace Acir {
                             }
                         });
                     } else {
+                        Helpers::check_map_size(o.via.map, name, 5, 0);
                         auto kvmap = Helpers::make_kvmap(o, name);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "function", function, false);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "destinations", destinations, false);
@@ -2763,6 +2812,7 @@ namespace Acir {
                             }
                         });
                     } else {
+                        Helpers::check_map_size(o.via.map, name, 2, 0);
                         auto kvmap = Helpers::make_kvmap(o, name);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "destination", destination, false);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "source", source, false);
@@ -2810,6 +2860,7 @@ namespace Acir {
                             }
                         });
                     } else {
+                        Helpers::check_map_size(o.via.map, name, 4, 0);
                         auto kvmap = Helpers::make_kvmap(o, name);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "destination", destination, false);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "source_a", source_a, false);
@@ -2853,6 +2904,7 @@ namespace Acir {
                             }
                         });
                     } else {
+                        Helpers::check_map_size(o.via.map, name, 2, 0);
                         auto kvmap = Helpers::make_kvmap(o, name);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "destination", destination, false);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "source_pointer", source_pointer, false);
@@ -2892,6 +2944,7 @@ namespace Acir {
                             }
                         });
                     } else {
+                        Helpers::check_map_size(o.via.map, name, 2, 0);
                         auto kvmap = Helpers::make_kvmap(o, name);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "destination_pointer", destination_pointer, false);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "source", source, false);
@@ -2942,6 +2995,7 @@ namespace Acir {
                             }
                         });
                     } else {
+                        Helpers::check_map_size(o.via.map, name, 1, 0);
                         auto kvmap = Helpers::make_kvmap(o, name);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "revert_data", revert_data, false);
                     }
@@ -2975,6 +3029,7 @@ namespace Acir {
                             }
                         });
                     } else {
+                        Helpers::check_map_size(o.via.map, name, 1, 0);
                         auto kvmap = Helpers::make_kvmap(o, name);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "return_data", return_data, false);
                     }
@@ -3618,6 +3673,7 @@ namespace Acir {
                             }
                         });
                     } else {
+                        Helpers::check_map_size(o.via.map, name, 4, 0);
                         auto kvmap = Helpers::make_kvmap(o, name);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "inputs", inputs, false);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "iv", iv, false);
@@ -3669,6 +3725,7 @@ namespace Acir {
                             }
                         });
                     } else {
+                        Helpers::check_map_size(o.via.map, name, 4, 0);
                         auto kvmap = Helpers::make_kvmap(o, name);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "lhs", lhs, false);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "rhs", rhs, false);
@@ -3720,6 +3777,7 @@ namespace Acir {
                             }
                         });
                     } else {
+                        Helpers::check_map_size(o.via.map, name, 4, 0);
                         auto kvmap = Helpers::make_kvmap(o, name);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "lhs", lhs, false);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "rhs", rhs, false);
@@ -3763,6 +3821,7 @@ namespace Acir {
                             }
                         });
                     } else {
+                        Helpers::check_map_size(o.via.map, name, 2, 0);
                         auto kvmap = Helpers::make_kvmap(o, name);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "input", input, false);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "num_bits", num_bits, false);
@@ -3802,6 +3861,7 @@ namespace Acir {
                             }
                         });
                     } else {
+                        Helpers::check_map_size(o.via.map, name, 2, 0);
                         auto kvmap = Helpers::make_kvmap(o, name);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "inputs", inputs, false);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "outputs", outputs, false);
@@ -3841,6 +3901,7 @@ namespace Acir {
                             }
                         });
                     } else {
+                        Helpers::check_map_size(o.via.map, name, 2, 0);
                         auto kvmap = Helpers::make_kvmap(o, name);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "inputs", inputs, false);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "outputs", outputs, false);
@@ -3896,6 +3957,7 @@ namespace Acir {
                             }
                         });
                     } else {
+                        Helpers::check_map_size(o.via.map, name, 6, 0);
                         auto kvmap = Helpers::make_kvmap(o, name);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "public_key_x", public_key_x, false);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "public_key_y", public_key_y, false);
@@ -3959,6 +4021,7 @@ namespace Acir {
                             }
                         });
                     } else {
+                        Helpers::check_map_size(o.via.map, name, 6, 0);
                         auto kvmap = Helpers::make_kvmap(o, name);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "public_key_x", public_key_x, false);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "public_key_y", public_key_y, false);
@@ -4014,6 +4077,7 @@ namespace Acir {
                             }
                         });
                     } else {
+                        Helpers::check_map_size(o.via.map, name, 4, 0);
                         auto kvmap = Helpers::make_kvmap(o, name);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "points", points, false);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "scalars", scalars, false);
@@ -4065,6 +4129,7 @@ namespace Acir {
                             }
                         });
                     } else {
+                        Helpers::check_map_size(o.via.map, name, 4, 0);
                         auto kvmap = Helpers::make_kvmap(o, name);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "input1", input1, false);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "input2", input2, false);
@@ -4108,6 +4173,7 @@ namespace Acir {
                             }
                         });
                     } else {
+                        Helpers::check_map_size(o.via.map, name, 2, 0);
                         auto kvmap = Helpers::make_kvmap(o, name);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "inputs", inputs, false);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "outputs", outputs, false);
@@ -4163,6 +4229,7 @@ namespace Acir {
                             }
                         });
                     } else {
+                        Helpers::check_map_size(o.via.map, name, 6, 0);
                         auto kvmap = Helpers::make_kvmap(o, name);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "verification_key", verification_key, false);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "proof", proof, false);
@@ -4210,6 +4277,7 @@ namespace Acir {
                             }
                         });
                     } else {
+                        Helpers::check_map_size(o.via.map, name, 2, 0);
                         auto kvmap = Helpers::make_kvmap(o, name);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "inputs", inputs, false);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "outputs", outputs, false);
@@ -4253,6 +4321,7 @@ namespace Acir {
                             }
                         });
                     } else {
+                        Helpers::check_map_size(o.via.map, name, 3, 0);
                         auto kvmap = Helpers::make_kvmap(o, name);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "inputs", inputs, false);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "hash_values", hash_values, false);
@@ -4790,6 +4859,7 @@ namespace Acir {
                         }
                     });
                 } else {
+                    Helpers::check_map_size(o.via.map, name, 3, 0);
                     auto kvmap = Helpers::make_kvmap(o, name);
                     Helpers::conv_fld_from_kvmap(kvmap, name, "mul_terms", mul_terms, false);
                     Helpers::conv_fld_from_kvmap(kvmap, name, "linear_combinations", linear_combinations, false);
@@ -5124,6 +5194,7 @@ namespace Acir {
                         }
                     });
                 } else {
+                    Helpers::check_map_size(o.via.map, name, 3, 0);
                     auto kvmap = Helpers::make_kvmap(o, name);
                     Helpers::conv_fld_from_kvmap(kvmap, name, "operation", operation, false);
                     Helpers::conv_fld_from_kvmap(kvmap, name, "index", index, false);
@@ -5197,6 +5268,7 @@ namespace Acir {
                             }
                         });
                     } else {
+                        Helpers::check_map_size(o.via.map, name, 2, 0);
                         auto kvmap = Helpers::make_kvmap(o, name);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "block_id", block_id, false);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "op", op, false);
@@ -5240,6 +5312,7 @@ namespace Acir {
                             }
                         });
                     } else {
+                        Helpers::check_map_size(o.via.map, name, 3, 0);
                         auto kvmap = Helpers::make_kvmap(o, name);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "block_id", block_id, false);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "init", init, false);
@@ -5289,6 +5362,7 @@ namespace Acir {
                             }
                         });
                     } else {
+                        Helpers::check_map_size(o.via.map, name, 4, 0);
                         auto kvmap = Helpers::make_kvmap(o, name);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "id", id, false);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "inputs", inputs, false);
@@ -5340,6 +5414,7 @@ namespace Acir {
                             }
                         });
                     } else {
+                        Helpers::check_map_size(o.via.map, name, 4, 0);
                         auto kvmap = Helpers::make_kvmap(o, name);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "id", id, false);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "inputs", inputs, false);
@@ -5691,6 +5766,7 @@ namespace Acir {
                         }
                     });
                 } else {
+                    Helpers::check_map_size(o.via.map, name, 2, 0);
                     auto kvmap = Helpers::make_kvmap(o, name);
                     Helpers::conv_fld_from_kvmap(kvmap, name, "error_selector", error_selector, false);
                     Helpers::conv_fld_from_kvmap(kvmap, name, "payload", payload, false);
@@ -5747,6 +5823,7 @@ namespace Acir {
                             }
                         });
                     } else {
+                        Helpers::check_map_size(o.via.map, name, 2, 0);
                         auto kvmap = Helpers::make_kvmap(o, name);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "acir_index", acir_index, false);
                         Helpers::conv_fld_from_kvmap(kvmap, name, "brillig_index", brillig_index, false);
@@ -6042,6 +6119,7 @@ namespace Acir {
                         }
                     });
                 } else {
+                    Helpers::check_map_size(o.via.map, name, 2, 0);
                     auto kvmap = Helpers::make_kvmap(o, name);
                     Helpers::conv_fld_from_kvmap(kvmap, name, "functions", functions, false);
                 }

--- a/acvm-repo/acir/codegen/acir.cpp
+++ b/acvm-repo/acir/codegen/acir.cpp
@@ -121,6 +121,31 @@ namespace Acir {
                 dispatch(tag, o.via.map.ptr[i].val);
             }
         }
+
+        /// Cap the positional-array length: under-length wires error
+        /// downstream in `conv_fld_from_array` (index out of bounds);
+        /// over-length wires up to `active + reserved` are tolerated as
+        /// retired trailing fields (Rust-side `#[tagged(reserved(...))]`);
+        /// anything longer is forward-compat drift that the producer
+        /// would only have emitted if newer fields were added, and is
+        /// the cue for a focused error message pointing at the opt-in.
+        static void check_array_size(
+            msgpack::object_array const& array,
+            std::string const& name,
+            uint32_t active,
+            uint32_t reserved
+        ) {
+            uint32_t max_size = active + reserved;
+            if (array.size > max_size) {
+                throw_or_abort(
+                    "array for " + name +
+                    " has " + std::to_string(array.size) +
+                    " elements but at most " + std::to_string(max_size) +
+                    " are expected (" + std::to_string(active) +
+                    " active + " + std::to_string(reserved) +
+                    " reserved); opt into `#[tagged(allow_unknown_tags)]` on the Rust type to accept trailing extras");
+            }
+        }
     };
     }
 
@@ -946,7 +971,8 @@ namespace Acir {
                     Helpers::conv_fld_from_kvmap(kvmap, name, "size", size, false);
                 }
             } else if (o.type == msgpack::type::ARRAY) {
-                auto array = o.via.array; 
+                auto array = o.via.array;
+                Helpers::check_array_size(array, name, 2, 0);
                 Helpers::conv_fld_from_array(array, name, "pointer", pointer, 0);
                 Helpers::conv_fld_from_array(array, name, "size", size, 1);
             } else {
@@ -996,7 +1022,8 @@ namespace Acir {
                         Helpers::conv_fld_from_kvmap(kvmap, name, "outputs", outputs, false);
                     }
                 } else if (o.type == msgpack::type::ARRAY) {
-                    auto array = o.via.array; 
+                    auto array = o.via.array;
+                    Helpers::check_array_size(array, name, 4, 0);
                     Helpers::conv_fld_from_array(array, name, "inputs", inputs, 0);
                     Helpers::conv_fld_from_array(array, name, "iv", iv, 1);
                     Helpers::conv_fld_from_array(array, name, "key", key, 2);
@@ -1036,7 +1063,8 @@ namespace Acir {
                         Helpers::conv_fld_from_kvmap(kvmap, name, "output", output, false);
                     }
                 } else if (o.type == msgpack::type::ARRAY) {
-                    auto array = o.via.array; 
+                    auto array = o.via.array;
+                    Helpers::check_array_size(array, name, 2, 0);
                     Helpers::conv_fld_from_array(array, name, "message", message, 0);
                     Helpers::conv_fld_from_array(array, name, "output", output, 1);
                 } else {
@@ -1074,7 +1102,8 @@ namespace Acir {
                         Helpers::conv_fld_from_kvmap(kvmap, name, "output", output, false);
                     }
                 } else if (o.type == msgpack::type::ARRAY) {
-                    auto array = o.via.array; 
+                    auto array = o.via.array;
+                    Helpers::check_array_size(array, name, 2, 0);
                     Helpers::conv_fld_from_array(array, name, "message", message, 0);
                     Helpers::conv_fld_from_array(array, name, "output", output, 1);
                 } else {
@@ -1112,7 +1141,8 @@ namespace Acir {
                         Helpers::conv_fld_from_kvmap(kvmap, name, "output", output, false);
                     }
                 } else if (o.type == msgpack::type::ARRAY) {
-                    auto array = o.via.array; 
+                    auto array = o.via.array;
+                    Helpers::check_array_size(array, name, 2, 0);
                     Helpers::conv_fld_from_array(array, name, "input", input, 0);
                     Helpers::conv_fld_from_array(array, name, "output", output, 1);
                 } else {
@@ -1165,7 +1195,8 @@ namespace Acir {
                         Helpers::conv_fld_from_kvmap(kvmap, name, "result", result, false);
                     }
                 } else if (o.type == msgpack::type::ARRAY) {
-                    auto array = o.via.array; 
+                    auto array = o.via.array;
+                    Helpers::check_array_size(array, name, 5, 0);
                     Helpers::conv_fld_from_array(array, name, "hashed_msg", hashed_msg, 0);
                     Helpers::conv_fld_from_array(array, name, "public_key_x", public_key_x, 1);
                     Helpers::conv_fld_from_array(array, name, "public_key_y", public_key_y, 2);
@@ -1221,7 +1252,8 @@ namespace Acir {
                         Helpers::conv_fld_from_kvmap(kvmap, name, "result", result, false);
                     }
                 } else if (o.type == msgpack::type::ARRAY) {
-                    auto array = o.via.array; 
+                    auto array = o.via.array;
+                    Helpers::check_array_size(array, name, 5, 0);
                     Helpers::conv_fld_from_array(array, name, "hashed_msg", hashed_msg, 0);
                     Helpers::conv_fld_from_array(array, name, "public_key_x", public_key_x, 1);
                     Helpers::conv_fld_from_array(array, name, "public_key_y", public_key_y, 2);
@@ -1267,7 +1299,8 @@ namespace Acir {
                         Helpers::conv_fld_from_kvmap(kvmap, name, "outputs", outputs, false);
                     }
                 } else if (o.type == msgpack::type::ARRAY) {
-                    auto array = o.via.array; 
+                    auto array = o.via.array;
+                    Helpers::check_array_size(array, name, 3, 0);
                     Helpers::conv_fld_from_array(array, name, "points", points, 0);
                     Helpers::conv_fld_from_array(array, name, "scalars", scalars, 1);
                     Helpers::conv_fld_from_array(array, name, "outputs", outputs, 2);
@@ -1331,7 +1364,8 @@ namespace Acir {
                         Helpers::conv_fld_from_kvmap(kvmap, name, "result", result, false);
                     }
                 } else if (o.type == msgpack::type::ARRAY) {
-                    auto array = o.via.array; 
+                    auto array = o.via.array;
+                    Helpers::check_array_size(array, name, 7, 0);
                     Helpers::conv_fld_from_array(array, name, "input1_x", input1_x, 0);
                     Helpers::conv_fld_from_array(array, name, "input1_y", input1_y, 1);
                     Helpers::conv_fld_from_array(array, name, "input1_infinite", input1_infinite, 2);
@@ -1374,7 +1408,8 @@ namespace Acir {
                         Helpers::conv_fld_from_kvmap(kvmap, name, "output", output, false);
                     }
                 } else if (o.type == msgpack::type::ARRAY) {
-                    auto array = o.via.array; 
+                    auto array = o.via.array;
+                    Helpers::check_array_size(array, name, 2, 0);
                     Helpers::conv_fld_from_array(array, name, "message", message, 0);
                     Helpers::conv_fld_from_array(array, name, "output", output, 1);
                 } else {
@@ -1417,7 +1452,8 @@ namespace Acir {
                         Helpers::conv_fld_from_kvmap(kvmap, name, "output", output, false);
                     }
                 } else if (o.type == msgpack::type::ARRAY) {
-                    auto array = o.via.array; 
+                    auto array = o.via.array;
+                    Helpers::check_array_size(array, name, 3, 0);
                     Helpers::conv_fld_from_array(array, name, "input", input, 0);
                     Helpers::conv_fld_from_array(array, name, "hash_values", hash_values, 1);
                     Helpers::conv_fld_from_array(array, name, "output", output, 2);
@@ -1471,7 +1507,8 @@ namespace Acir {
                         Helpers::conv_fld_from_kvmap(kvmap, name, "output_bits", output_bits, false);
                     }
                 } else if (o.type == msgpack::type::ARRAY) {
-                    auto array = o.via.array; 
+                    auto array = o.via.array;
+                    Helpers::check_array_size(array, name, 5, 0);
                     Helpers::conv_fld_from_array(array, name, "input", input, 0);
                     Helpers::conv_fld_from_array(array, name, "radix", radix, 1);
                     Helpers::conv_fld_from_array(array, name, "output_pointer", output_pointer, 2);
@@ -1838,7 +1875,8 @@ namespace Acir {
                         Helpers::conv_fld_from_kvmap(kvmap, name, "size", size, false);
                     }
                 } else if (o.type == msgpack::type::ARRAY) {
-                    auto array = o.via.array; 
+                    auto array = o.via.array;
+                    Helpers::check_array_size(array, name, 2, 0);
                     Helpers::conv_fld_from_array(array, name, "value_types", value_types, 0);
                     Helpers::conv_fld_from_array(array, name, "size", size, 1);
                 } else {
@@ -1871,7 +1909,8 @@ namespace Acir {
                         Helpers::conv_fld_from_kvmap(kvmap, name, "value_types", value_types, false);
                     }
                 } else if (o.type == msgpack::type::ARRAY) {
-                    auto array = o.via.array; 
+                    auto array = o.via.array;
+                    Helpers::check_array_size(array, name, 1, 0);
                     Helpers::conv_fld_from_array(array, name, "value_types", value_types, 0);
                 } else {
                     throw_or_abort("expected MAP or ARRAY for " + name);
@@ -2024,7 +2063,8 @@ namespace Acir {
                     Helpers::conv_fld_from_kvmap(kvmap, name, "size", size, false);
                 }
             } else if (o.type == msgpack::type::ARRAY) {
-                auto array = o.via.array; 
+                auto array = o.via.array;
+                Helpers::check_array_size(array, name, 2, 0);
                 Helpers::conv_fld_from_array(array, name, "pointer", pointer, 0);
                 Helpers::conv_fld_from_array(array, name, "size", size, 1);
             } else {
@@ -2237,7 +2277,8 @@ namespace Acir {
                         Helpers::conv_fld_from_kvmap(kvmap, name, "rhs", rhs, false);
                     }
                 } else if (o.type == msgpack::type::ARRAY) {
-                    auto array = o.via.array; 
+                    auto array = o.via.array;
+                    Helpers::check_array_size(array, name, 4, 0);
                     Helpers::conv_fld_from_array(array, name, "destination", destination, 0);
                     Helpers::conv_fld_from_array(array, name, "op", op, 1);
                     Helpers::conv_fld_from_array(array, name, "lhs", lhs, 2);
@@ -2292,7 +2333,8 @@ namespace Acir {
                         Helpers::conv_fld_from_kvmap(kvmap, name, "rhs", rhs, false);
                     }
                 } else if (o.type == msgpack::type::ARRAY) {
-                    auto array = o.via.array; 
+                    auto array = o.via.array;
+                    Helpers::check_array_size(array, name, 5, 0);
                     Helpers::conv_fld_from_array(array, name, "destination", destination, 0);
                     Helpers::conv_fld_from_array(array, name, "op", op, 1);
                     Helpers::conv_fld_from_array(array, name, "bit_size", bit_size, 2);
@@ -2338,7 +2380,8 @@ namespace Acir {
                         Helpers::conv_fld_from_kvmap(kvmap, name, "bit_size", bit_size, false);
                     }
                 } else if (o.type == msgpack::type::ARRAY) {
-                    auto array = o.via.array; 
+                    auto array = o.via.array;
+                    Helpers::check_array_size(array, name, 3, 0);
                     Helpers::conv_fld_from_array(array, name, "destination", destination, 0);
                     Helpers::conv_fld_from_array(array, name, "source", source, 1);
                     Helpers::conv_fld_from_array(array, name, "bit_size", bit_size, 2);
@@ -2382,7 +2425,8 @@ namespace Acir {
                         Helpers::conv_fld_from_kvmap(kvmap, name, "bit_size", bit_size, false);
                     }
                 } else if (o.type == msgpack::type::ARRAY) {
-                    auto array = o.via.array; 
+                    auto array = o.via.array;
+                    Helpers::check_array_size(array, name, 3, 0);
                     Helpers::conv_fld_from_array(array, name, "destination", destination, 0);
                     Helpers::conv_fld_from_array(array, name, "source", source, 1);
                     Helpers::conv_fld_from_array(array, name, "bit_size", bit_size, 2);
@@ -2421,7 +2465,8 @@ namespace Acir {
                         Helpers::conv_fld_from_kvmap(kvmap, name, "location", location, false);
                     }
                 } else if (o.type == msgpack::type::ARRAY) {
-                    auto array = o.via.array; 
+                    auto array = o.via.array;
+                    Helpers::check_array_size(array, name, 2, 0);
                     Helpers::conv_fld_from_array(array, name, "condition", condition, 0);
                     Helpers::conv_fld_from_array(array, name, "location", location, 1);
                 } else {
@@ -2454,7 +2499,8 @@ namespace Acir {
                         Helpers::conv_fld_from_kvmap(kvmap, name, "location", location, false);
                     }
                 } else if (o.type == msgpack::type::ARRAY) {
-                    auto array = o.via.array; 
+                    auto array = o.via.array;
+                    Helpers::check_array_size(array, name, 1, 0);
                     Helpers::conv_fld_from_array(array, name, "location", location, 0);
                 } else {
                     throw_or_abort("expected MAP or ARRAY for " + name);
@@ -2496,7 +2542,8 @@ namespace Acir {
                         Helpers::conv_fld_from_kvmap(kvmap, name, "offset_address", offset_address, false);
                     }
                 } else if (o.type == msgpack::type::ARRAY) {
-                    auto array = o.via.array; 
+                    auto array = o.via.array;
+                    Helpers::check_array_size(array, name, 3, 0);
                     Helpers::conv_fld_from_array(array, name, "destination_address", destination_address, 0);
                     Helpers::conv_fld_from_array(array, name, "size_address", size_address, 1);
                     Helpers::conv_fld_from_array(array, name, "offset_address", offset_address, 2);
@@ -2530,7 +2577,8 @@ namespace Acir {
                         Helpers::conv_fld_from_kvmap(kvmap, name, "location", location, false);
                     }
                 } else if (o.type == msgpack::type::ARRAY) {
-                    auto array = o.via.array; 
+                    auto array = o.via.array;
+                    Helpers::check_array_size(array, name, 1, 0);
                     Helpers::conv_fld_from_array(array, name, "location", location, 0);
                 } else {
                     throw_or_abort("expected MAP or ARRAY for " + name);
@@ -2572,7 +2620,8 @@ namespace Acir {
                         Helpers::conv_fld_from_kvmap(kvmap, name, "value", value, false);
                     }
                 } else if (o.type == msgpack::type::ARRAY) {
-                    auto array = o.via.array; 
+                    auto array = o.via.array;
+                    Helpers::check_array_size(array, name, 3, 0);
                     Helpers::conv_fld_from_array(array, name, "destination", destination, 0);
                     Helpers::conv_fld_from_array(array, name, "bit_size", bit_size, 1);
                     Helpers::conv_fld_from_array(array, name, "value", value, 2);
@@ -2616,7 +2665,8 @@ namespace Acir {
                         Helpers::conv_fld_from_kvmap(kvmap, name, "value", value, false);
                     }
                 } else if (o.type == msgpack::type::ARRAY) {
-                    auto array = o.via.array; 
+                    auto array = o.via.array;
+                    Helpers::check_array_size(array, name, 3, 0);
                     Helpers::conv_fld_from_array(array, name, "destination_pointer", destination_pointer, 0);
                     Helpers::conv_fld_from_array(array, name, "bit_size", bit_size, 1);
                     Helpers::conv_fld_from_array(array, name, "value", value, 2);
@@ -2676,7 +2726,8 @@ namespace Acir {
                         Helpers::conv_fld_from_kvmap(kvmap, name, "input_value_types", input_value_types, false);
                     }
                 } else if (o.type == msgpack::type::ARRAY) {
-                    auto array = o.via.array; 
+                    auto array = o.via.array;
+                    Helpers::check_array_size(array, name, 5, 0);
                     Helpers::conv_fld_from_array(array, name, "function", function, 0);
                     Helpers::conv_fld_from_array(array, name, "destinations", destinations, 1);
                     Helpers::conv_fld_from_array(array, name, "destination_value_types", destination_value_types, 2);
@@ -2717,7 +2768,8 @@ namespace Acir {
                         Helpers::conv_fld_from_kvmap(kvmap, name, "source", source, false);
                     }
                 } else if (o.type == msgpack::type::ARRAY) {
-                    auto array = o.via.array; 
+                    auto array = o.via.array;
+                    Helpers::check_array_size(array, name, 2, 0);
                     Helpers::conv_fld_from_array(array, name, "destination", destination, 0);
                     Helpers::conv_fld_from_array(array, name, "source", source, 1);
                 } else {
@@ -2765,7 +2817,8 @@ namespace Acir {
                         Helpers::conv_fld_from_kvmap(kvmap, name, "condition", condition, false);
                     }
                 } else if (o.type == msgpack::type::ARRAY) {
-                    auto array = o.via.array; 
+                    auto array = o.via.array;
+                    Helpers::check_array_size(array, name, 4, 0);
                     Helpers::conv_fld_from_array(array, name, "destination", destination, 0);
                     Helpers::conv_fld_from_array(array, name, "source_a", source_a, 1);
                     Helpers::conv_fld_from_array(array, name, "source_b", source_b, 2);
@@ -2805,7 +2858,8 @@ namespace Acir {
                         Helpers::conv_fld_from_kvmap(kvmap, name, "source_pointer", source_pointer, false);
                     }
                 } else if (o.type == msgpack::type::ARRAY) {
-                    auto array = o.via.array; 
+                    auto array = o.via.array;
+                    Helpers::check_array_size(array, name, 2, 0);
                     Helpers::conv_fld_from_array(array, name, "destination", destination, 0);
                     Helpers::conv_fld_from_array(array, name, "source_pointer", source_pointer, 1);
                 } else {
@@ -2843,7 +2897,8 @@ namespace Acir {
                         Helpers::conv_fld_from_kvmap(kvmap, name, "source", source, false);
                     }
                 } else if (o.type == msgpack::type::ARRAY) {
-                    auto array = o.via.array; 
+                    auto array = o.via.array;
+                    Helpers::check_array_size(array, name, 2, 0);
                     Helpers::conv_fld_from_array(array, name, "destination_pointer", destination_pointer, 0);
                     Helpers::conv_fld_from_array(array, name, "source", source, 1);
                 } else {
@@ -2891,7 +2946,8 @@ namespace Acir {
                         Helpers::conv_fld_from_kvmap(kvmap, name, "revert_data", revert_data, false);
                     }
                 } else if (o.type == msgpack::type::ARRAY) {
-                    auto array = o.via.array; 
+                    auto array = o.via.array;
+                    Helpers::check_array_size(array, name, 1, 0);
                     Helpers::conv_fld_from_array(array, name, "revert_data", revert_data, 0);
                 } else {
                     throw_or_abort("expected MAP or ARRAY for " + name);
@@ -2923,7 +2979,8 @@ namespace Acir {
                         Helpers::conv_fld_from_kvmap(kvmap, name, "return_data", return_data, false);
                     }
                 } else if (o.type == msgpack::type::ARRAY) {
-                    auto array = o.via.array; 
+                    auto array = o.via.array;
+                    Helpers::check_array_size(array, name, 1, 0);
                     Helpers::conv_fld_from_array(array, name, "return_data", return_data, 0);
                 } else {
                     throw_or_abort("expected MAP or ARRAY for " + name);
@@ -3568,7 +3625,8 @@ namespace Acir {
                         Helpers::conv_fld_from_kvmap(kvmap, name, "outputs", outputs, false);
                     }
                 } else if (o.type == msgpack::type::ARRAY) {
-                    auto array = o.via.array; 
+                    auto array = o.via.array;
+                    Helpers::check_array_size(array, name, 4, 0);
                     Helpers::conv_fld_from_array(array, name, "inputs", inputs, 0);
                     Helpers::conv_fld_from_array(array, name, "iv", iv, 1);
                     Helpers::conv_fld_from_array(array, name, "key", key, 2);
@@ -3618,7 +3676,8 @@ namespace Acir {
                         Helpers::conv_fld_from_kvmap(kvmap, name, "output", output, false);
                     }
                 } else if (o.type == msgpack::type::ARRAY) {
-                    auto array = o.via.array; 
+                    auto array = o.via.array;
+                    Helpers::check_array_size(array, name, 4, 0);
                     Helpers::conv_fld_from_array(array, name, "lhs", lhs, 0);
                     Helpers::conv_fld_from_array(array, name, "rhs", rhs, 1);
                     Helpers::conv_fld_from_array(array, name, "num_bits", num_bits, 2);
@@ -3668,7 +3727,8 @@ namespace Acir {
                         Helpers::conv_fld_from_kvmap(kvmap, name, "output", output, false);
                     }
                 } else if (o.type == msgpack::type::ARRAY) {
-                    auto array = o.via.array; 
+                    auto array = o.via.array;
+                    Helpers::check_array_size(array, name, 4, 0);
                     Helpers::conv_fld_from_array(array, name, "lhs", lhs, 0);
                     Helpers::conv_fld_from_array(array, name, "rhs", rhs, 1);
                     Helpers::conv_fld_from_array(array, name, "num_bits", num_bits, 2);
@@ -3708,7 +3768,8 @@ namespace Acir {
                         Helpers::conv_fld_from_kvmap(kvmap, name, "num_bits", num_bits, false);
                     }
                 } else if (o.type == msgpack::type::ARRAY) {
-                    auto array = o.via.array; 
+                    auto array = o.via.array;
+                    Helpers::check_array_size(array, name, 2, 0);
                     Helpers::conv_fld_from_array(array, name, "input", input, 0);
                     Helpers::conv_fld_from_array(array, name, "num_bits", num_bits, 1);
                 } else {
@@ -3746,7 +3807,8 @@ namespace Acir {
                         Helpers::conv_fld_from_kvmap(kvmap, name, "outputs", outputs, false);
                     }
                 } else if (o.type == msgpack::type::ARRAY) {
-                    auto array = o.via.array; 
+                    auto array = o.via.array;
+                    Helpers::check_array_size(array, name, 2, 0);
                     Helpers::conv_fld_from_array(array, name, "inputs", inputs, 0);
                     Helpers::conv_fld_from_array(array, name, "outputs", outputs, 1);
                 } else {
@@ -3784,7 +3846,8 @@ namespace Acir {
                         Helpers::conv_fld_from_kvmap(kvmap, name, "outputs", outputs, false);
                     }
                 } else if (o.type == msgpack::type::ARRAY) {
-                    auto array = o.via.array; 
+                    auto array = o.via.array;
+                    Helpers::check_array_size(array, name, 2, 0);
                     Helpers::conv_fld_from_array(array, name, "inputs", inputs, 0);
                     Helpers::conv_fld_from_array(array, name, "outputs", outputs, 1);
                 } else {
@@ -3842,7 +3905,8 @@ namespace Acir {
                         Helpers::conv_fld_from_kvmap(kvmap, name, "output", output, false);
                     }
                 } else if (o.type == msgpack::type::ARRAY) {
-                    auto array = o.via.array; 
+                    auto array = o.via.array;
+                    Helpers::check_array_size(array, name, 6, 0);
                     Helpers::conv_fld_from_array(array, name, "public_key_x", public_key_x, 0);
                     Helpers::conv_fld_from_array(array, name, "public_key_y", public_key_y, 1);
                     Helpers::conv_fld_from_array(array, name, "signature", signature, 2);
@@ -3904,7 +3968,8 @@ namespace Acir {
                         Helpers::conv_fld_from_kvmap(kvmap, name, "output", output, false);
                     }
                 } else if (o.type == msgpack::type::ARRAY) {
-                    auto array = o.via.array; 
+                    auto array = o.via.array;
+                    Helpers::check_array_size(array, name, 6, 0);
                     Helpers::conv_fld_from_array(array, name, "public_key_x", public_key_x, 0);
                     Helpers::conv_fld_from_array(array, name, "public_key_y", public_key_y, 1);
                     Helpers::conv_fld_from_array(array, name, "signature", signature, 2);
@@ -3956,7 +4021,8 @@ namespace Acir {
                         Helpers::conv_fld_from_kvmap(kvmap, name, "outputs", outputs, false);
                     }
                 } else if (o.type == msgpack::type::ARRAY) {
-                    auto array = o.via.array; 
+                    auto array = o.via.array;
+                    Helpers::check_array_size(array, name, 4, 0);
                     Helpers::conv_fld_from_array(array, name, "points", points, 0);
                     Helpers::conv_fld_from_array(array, name, "scalars", scalars, 1);
                     Helpers::conv_fld_from_array(array, name, "predicate", predicate, 2);
@@ -4006,7 +4072,8 @@ namespace Acir {
                         Helpers::conv_fld_from_kvmap(kvmap, name, "outputs", outputs, false);
                     }
                 } else if (o.type == msgpack::type::ARRAY) {
-                    auto array = o.via.array; 
+                    auto array = o.via.array;
+                    Helpers::check_array_size(array, name, 4, 0);
                     Helpers::conv_fld_from_array(array, name, "input1", input1, 0);
                     Helpers::conv_fld_from_array(array, name, "input2", input2, 1);
                     Helpers::conv_fld_from_array(array, name, "predicate", predicate, 2);
@@ -4046,7 +4113,8 @@ namespace Acir {
                         Helpers::conv_fld_from_kvmap(kvmap, name, "outputs", outputs, false);
                     }
                 } else if (o.type == msgpack::type::ARRAY) {
-                    auto array = o.via.array; 
+                    auto array = o.via.array;
+                    Helpers::check_array_size(array, name, 2, 0);
                     Helpers::conv_fld_from_array(array, name, "inputs", inputs, 0);
                     Helpers::conv_fld_from_array(array, name, "outputs", outputs, 1);
                 } else {
@@ -4104,7 +4172,8 @@ namespace Acir {
                         Helpers::conv_fld_from_kvmap(kvmap, name, "predicate", predicate, false);
                     }
                 } else if (o.type == msgpack::type::ARRAY) {
-                    auto array = o.via.array; 
+                    auto array = o.via.array;
+                    Helpers::check_array_size(array, name, 6, 0);
                     Helpers::conv_fld_from_array(array, name, "verification_key", verification_key, 0);
                     Helpers::conv_fld_from_array(array, name, "proof", proof, 1);
                     Helpers::conv_fld_from_array(array, name, "public_inputs", public_inputs, 2);
@@ -4146,7 +4215,8 @@ namespace Acir {
                         Helpers::conv_fld_from_kvmap(kvmap, name, "outputs", outputs, false);
                     }
                 } else if (o.type == msgpack::type::ARRAY) {
-                    auto array = o.via.array; 
+                    auto array = o.via.array;
+                    Helpers::check_array_size(array, name, 2, 0);
                     Helpers::conv_fld_from_array(array, name, "inputs", inputs, 0);
                     Helpers::conv_fld_from_array(array, name, "outputs", outputs, 1);
                 } else {
@@ -4189,7 +4259,8 @@ namespace Acir {
                         Helpers::conv_fld_from_kvmap(kvmap, name, "outputs", outputs, false);
                     }
                 } else if (o.type == msgpack::type::ARRAY) {
-                    auto array = o.via.array; 
+                    auto array = o.via.array;
+                    Helpers::check_array_size(array, name, 3, 0);
                     Helpers::conv_fld_from_array(array, name, "inputs", inputs, 0);
                     Helpers::conv_fld_from_array(array, name, "hash_values", hash_values, 1);
                     Helpers::conv_fld_from_array(array, name, "outputs", outputs, 2);
@@ -4725,7 +4796,8 @@ namespace Acir {
                     Helpers::conv_fld_from_kvmap(kvmap, name, "q_c", q_c, false);
                 }
             } else if (o.type == msgpack::type::ARRAY) {
-                auto array = o.via.array; 
+                auto array = o.via.array;
+                Helpers::check_array_size(array, name, 3, 0);
                 Helpers::conv_fld_from_array(array, name, "mul_terms", mul_terms, 0);
                 Helpers::conv_fld_from_array(array, name, "linear_combinations", linear_combinations, 1);
                 Helpers::conv_fld_from_array(array, name, "q_c", q_c, 2);
@@ -5058,7 +5130,8 @@ namespace Acir {
                     Helpers::conv_fld_from_kvmap(kvmap, name, "value", value, false);
                 }
             } else if (o.type == msgpack::type::ARRAY) {
-                auto array = o.via.array; 
+                auto array = o.via.array;
+                Helpers::check_array_size(array, name, 3, 0);
                 Helpers::conv_fld_from_array(array, name, "operation", operation, 0);
                 Helpers::conv_fld_from_array(array, name, "index", index, 1);
                 Helpers::conv_fld_from_array(array, name, "value", value, 2);
@@ -5129,7 +5202,8 @@ namespace Acir {
                         Helpers::conv_fld_from_kvmap(kvmap, name, "op", op, false);
                     }
                 } else if (o.type == msgpack::type::ARRAY) {
-                    auto array = o.via.array; 
+                    auto array = o.via.array;
+                    Helpers::check_array_size(array, name, 2, 0);
                     Helpers::conv_fld_from_array(array, name, "block_id", block_id, 0);
                     Helpers::conv_fld_from_array(array, name, "op", op, 1);
                 } else {
@@ -5172,7 +5246,8 @@ namespace Acir {
                         Helpers::conv_fld_from_kvmap(kvmap, name, "block_type", block_type, false);
                     }
                 } else if (o.type == msgpack::type::ARRAY) {
-                    auto array = o.via.array; 
+                    auto array = o.via.array;
+                    Helpers::check_array_size(array, name, 3, 0);
                     Helpers::conv_fld_from_array(array, name, "block_id", block_id, 0);
                     Helpers::conv_fld_from_array(array, name, "init", init, 1);
                     Helpers::conv_fld_from_array(array, name, "block_type", block_type, 2);
@@ -5221,7 +5296,8 @@ namespace Acir {
                         Helpers::conv_fld_from_kvmap(kvmap, name, "predicate", predicate, false);
                     }
                 } else if (o.type == msgpack::type::ARRAY) {
-                    auto array = o.via.array; 
+                    auto array = o.via.array;
+                    Helpers::check_array_size(array, name, 4, 0);
                     Helpers::conv_fld_from_array(array, name, "id", id, 0);
                     Helpers::conv_fld_from_array(array, name, "inputs", inputs, 1);
                     Helpers::conv_fld_from_array(array, name, "outputs", outputs, 2);
@@ -5271,7 +5347,8 @@ namespace Acir {
                         Helpers::conv_fld_from_kvmap(kvmap, name, "predicate", predicate, false);
                     }
                 } else if (o.type == msgpack::type::ARRAY) {
-                    auto array = o.via.array; 
+                    auto array = o.via.array;
+                    Helpers::check_array_size(array, name, 4, 0);
                     Helpers::conv_fld_from_array(array, name, "id", id, 0);
                     Helpers::conv_fld_from_array(array, name, "inputs", inputs, 1);
                     Helpers::conv_fld_from_array(array, name, "outputs", outputs, 2);
@@ -5619,7 +5696,8 @@ namespace Acir {
                     Helpers::conv_fld_from_kvmap(kvmap, name, "payload", payload, false);
                 }
             } else if (o.type == msgpack::type::ARRAY) {
-                auto array = o.via.array; 
+                auto array = o.via.array;
+                Helpers::check_array_size(array, name, 2, 0);
                 Helpers::conv_fld_from_array(array, name, "error_selector", error_selector, 0);
                 Helpers::conv_fld_from_array(array, name, "payload", payload, 1);
             } else {
@@ -5674,7 +5752,8 @@ namespace Acir {
                         Helpers::conv_fld_from_kvmap(kvmap, name, "brillig_index", brillig_index, false);
                     }
                 } else if (o.type == msgpack::type::ARRAY) {
-                    auto array = o.via.array; 
+                    auto array = o.via.array;
+                    Helpers::check_array_size(array, name, 2, 0);
                     Helpers::conv_fld_from_array(array, name, "acir_index", acir_index, 0);
                     Helpers::conv_fld_from_array(array, name, "brillig_index", brillig_index, 1);
                 } else {
@@ -5847,7 +5926,7 @@ namespace Acir {
                     Helpers::conv_fld_from_kvmap(kvmap, name, "assert_messages", assert_messages, false);
                 }
             } else if (o.type == msgpack::type::ARRAY) {
-                auto array = o.via.array; 
+                auto array = o.via.array;
                 Helpers::conv_fld_from_array(array, name, "function_name", function_name, 0);
                 Helpers::conv_fld_from_array(array, name, "current_witness_index", current_witness_index, 1);
                 Helpers::conv_fld_from_array(array, name, "opcodes", opcodes, 2);
@@ -5891,7 +5970,7 @@ namespace Acir {
                     Helpers::conv_fld_from_kvmap(kvmap, name, "bytecode", bytecode, false);
                 }
             } else if (o.type == msgpack::type::ARRAY) {
-                auto array = o.via.array; 
+                auto array = o.via.array;
                 Helpers::conv_fld_from_array(array, name, "function_name", function_name, 0);
                 Helpers::conv_fld_from_array(array, name, "bytecode", bytecode, 1);
             } else {
@@ -5930,7 +6009,7 @@ namespace Acir {
                     Helpers::conv_fld_from_kvmap(kvmap, name, "unconstrained_functions", unconstrained_functions, false);
                 }
             } else if (o.type == msgpack::type::ARRAY) {
-                auto array = o.via.array; 
+                auto array = o.via.array;
                 Helpers::conv_fld_from_array(array, name, "functions", functions, 0);
                 Helpers::conv_fld_from_array(array, name, "unconstrained_functions", unconstrained_functions, 1);
             } else {
@@ -5967,7 +6046,8 @@ namespace Acir {
                     Helpers::conv_fld_from_kvmap(kvmap, name, "functions", functions, false);
                 }
             } else if (o.type == msgpack::type::ARRAY) {
-                auto array = o.via.array; 
+                auto array = o.via.array;
+                Helpers::check_array_size(array, name, 2, 0);
                 Helpers::conv_fld_from_array(array, name, "functions", functions, 0);
             } else {
                 throw_or_abort("expected MAP or ARRAY for " + name);

--- a/acvm-repo/acir/codegen/acir.cpp
+++ b/acvm-repo/acir/codegen/acir.cpp
@@ -62,6 +62,9 @@ namespace Acir {
                 throw_or_abort("index out of bounds: " + struct_name + "::" + field_name + " at " + std::to_string(index));
             }
             auto element = array.ptr[index];
+            if (element.type == msgpack::type::NIL) {
+                throw_or_abort("nil value for required field: " + struct_name + "::" + field_name);
+            }
             try {
                 element.convert(field);
             } catch (const msgpack::type_error&) {
@@ -1272,9 +1275,9 @@ namespace Acir {
         static HeapArray bincodeDeserialize(std::vector<uint8_t>);
 
         void msgpack_pack(auto& packer) const {
-            packer.pack_map(2);
-            packer.pack(std::make_pair("pointer", pointer));
-            packer.pack(std::make_pair("size", size));
+            packer.pack_array(2);
+            packer.pack(pointer);
+            packer.pack(size);
         }
 
         void msgpack_unpack(msgpack::object const& o) {
@@ -1324,11 +1327,11 @@ namespace Acir {
             static AES128Encrypt bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const {
-                packer.pack_map(4);
-                packer.pack(std::make_pair("inputs", inputs));
-                packer.pack(std::make_pair("iv", iv));
-                packer.pack(std::make_pair("key", key));
-                packer.pack(std::make_pair("outputs", outputs));
+                packer.pack_array(4);
+                packer.pack(inputs);
+                packer.pack(iv);
+                packer.pack(key);
+                packer.pack(outputs);
             }
 
             void msgpack_unpack(msgpack::object const& o) {
@@ -1384,9 +1387,9 @@ namespace Acir {
             static Blake2s bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const {
-                packer.pack_map(2);
-                packer.pack(std::make_pair("message", message));
-                packer.pack(std::make_pair("output", output));
+                packer.pack_array(2);
+                packer.pack(message);
+                packer.pack(output);
             }
 
             void msgpack_unpack(msgpack::object const& o) {
@@ -1432,9 +1435,9 @@ namespace Acir {
             static Blake3 bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const {
-                packer.pack_map(2);
-                packer.pack(std::make_pair("message", message));
-                packer.pack(std::make_pair("output", output));
+                packer.pack_array(2);
+                packer.pack(message);
+                packer.pack(output);
             }
 
             void msgpack_unpack(msgpack::object const& o) {
@@ -1480,9 +1483,9 @@ namespace Acir {
             static Keccakf1600 bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const {
-                packer.pack_map(2);
-                packer.pack(std::make_pair("input", input));
-                packer.pack(std::make_pair("output", output));
+                packer.pack_array(2);
+                packer.pack(input);
+                packer.pack(output);
             }
 
             void msgpack_unpack(msgpack::object const& o) {
@@ -1531,12 +1534,12 @@ namespace Acir {
             static EcdsaSecp256k1 bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const {
-                packer.pack_map(5);
-                packer.pack(std::make_pair("hashed_msg", hashed_msg));
-                packer.pack(std::make_pair("public_key_x", public_key_x));
-                packer.pack(std::make_pair("public_key_y", public_key_y));
-                packer.pack(std::make_pair("signature", signature));
-                packer.pack(std::make_pair("result", result));
+                packer.pack_array(5);
+                packer.pack(hashed_msg);
+                packer.pack(public_key_x);
+                packer.pack(public_key_y);
+                packer.pack(signature);
+                packer.pack(result);
             }
 
             void msgpack_unpack(msgpack::object const& o) {
@@ -1600,12 +1603,12 @@ namespace Acir {
             static EcdsaSecp256r1 bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const {
-                packer.pack_map(5);
-                packer.pack(std::make_pair("hashed_msg", hashed_msg));
-                packer.pack(std::make_pair("public_key_x", public_key_x));
-                packer.pack(std::make_pair("public_key_y", public_key_y));
-                packer.pack(std::make_pair("signature", signature));
-                packer.pack(std::make_pair("result", result));
+                packer.pack_array(5);
+                packer.pack(hashed_msg);
+                packer.pack(public_key_x);
+                packer.pack(public_key_y);
+                packer.pack(signature);
+                packer.pack(result);
             }
 
             void msgpack_unpack(msgpack::object const& o) {
@@ -1667,10 +1670,10 @@ namespace Acir {
             static MultiScalarMul bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const {
-                packer.pack_map(3);
-                packer.pack(std::make_pair("points", points));
-                packer.pack(std::make_pair("scalars", scalars));
-                packer.pack(std::make_pair("outputs", outputs));
+                packer.pack_array(3);
+                packer.pack(points);
+                packer.pack(scalars);
+                packer.pack(outputs);
             }
 
             void msgpack_unpack(msgpack::object const& o) {
@@ -1726,14 +1729,14 @@ namespace Acir {
             static EmbeddedCurveAdd bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const {
-                packer.pack_map(7);
-                packer.pack(std::make_pair("input1_x", input1_x));
-                packer.pack(std::make_pair("input1_y", input1_y));
-                packer.pack(std::make_pair("input1_infinite", input1_infinite));
-                packer.pack(std::make_pair("input2_x", input2_x));
-                packer.pack(std::make_pair("input2_y", input2_y));
-                packer.pack(std::make_pair("input2_infinite", input2_infinite));
-                packer.pack(std::make_pair("result", result));
+                packer.pack_array(7);
+                packer.pack(input1_x);
+                packer.pack(input1_y);
+                packer.pack(input1_infinite);
+                packer.pack(input2_x);
+                packer.pack(input2_y);
+                packer.pack(input2_infinite);
+                packer.pack(result);
             }
 
             void msgpack_unpack(msgpack::object const& o) {
@@ -1804,9 +1807,9 @@ namespace Acir {
             static Poseidon2Permutation bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const {
-                packer.pack_map(2);
-                packer.pack(std::make_pair("message", message));
-                packer.pack(std::make_pair("output", output));
+                packer.pack_array(2);
+                packer.pack(message);
+                packer.pack(output);
             }
 
             void msgpack_unpack(msgpack::object const& o) {
@@ -1853,10 +1856,10 @@ namespace Acir {
             static Sha256Compression bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const {
-                packer.pack_map(3);
-                packer.pack(std::make_pair("input", input));
-                packer.pack(std::make_pair("hash_values", hash_values));
-                packer.pack(std::make_pair("output", output));
+                packer.pack_array(3);
+                packer.pack(input);
+                packer.pack(hash_values);
+                packer.pack(output);
             }
 
             void msgpack_unpack(msgpack::object const& o) {
@@ -1910,12 +1913,12 @@ namespace Acir {
             static ToRadix bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const {
-                packer.pack_map(5);
-                packer.pack(std::make_pair("input", input));
-                packer.pack(std::make_pair("radix", radix));
-                packer.pack(std::make_pair("output_pointer", output_pointer));
-                packer.pack(std::make_pair("num_limbs", num_limbs));
-                packer.pack(std::make_pair("output_bits", output_bits));
+                packer.pack_array(5);
+                packer.pack(input);
+                packer.pack(radix);
+                packer.pack(output_pointer);
+                packer.pack(num_limbs);
+                packer.pack(output_bits);
             }
 
             void msgpack_unpack(msgpack::object const& o) {
@@ -2374,9 +2377,9 @@ namespace Acir {
             static Array bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const {
-                packer.pack_map(2);
-                packer.pack(std::make_pair("value_types", value_types));
-                packer.pack(std::make_pair("size", size));
+                packer.pack_array(2);
+                packer.pack(value_types);
+                packer.pack(size);
             }
 
             void msgpack_unpack(msgpack::object const& o) {
@@ -2421,8 +2424,8 @@ namespace Acir {
             static Vector bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const {
-                packer.pack_map(1);
-                packer.pack(std::make_pair("value_types", value_types));
+                packer.pack_array(1);
+                packer.pack(value_types);
             }
 
             void msgpack_unpack(msgpack::object const& o) {
@@ -2611,9 +2614,9 @@ namespace Acir {
         static HeapVector bincodeDeserialize(std::vector<uint8_t>);
 
         void msgpack_pack(auto& packer) const {
-            packer.pack_map(2);
-            packer.pack(std::make_pair("pointer", pointer));
-            packer.pack(std::make_pair("size", size));
+            packer.pack_array(2);
+            packer.pack(pointer);
+            packer.pack(size);
         }
 
         void msgpack_unpack(msgpack::object const& o) {
@@ -2870,11 +2873,11 @@ namespace Acir {
             static BinaryFieldOp bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const {
-                packer.pack_map(4);
-                packer.pack(std::make_pair("destination", destination));
-                packer.pack(std::make_pair("op", op));
-                packer.pack(std::make_pair("lhs", lhs));
-                packer.pack(std::make_pair("rhs", rhs));
+                packer.pack_array(4);
+                packer.pack(destination);
+                packer.pack(op);
+                packer.pack(lhs);
+                packer.pack(rhs);
             }
 
             void msgpack_unpack(msgpack::object const& o) {
@@ -2933,12 +2936,12 @@ namespace Acir {
             static BinaryIntOp bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const {
-                packer.pack_map(5);
-                packer.pack(std::make_pair("destination", destination));
-                packer.pack(std::make_pair("op", op));
-                packer.pack(std::make_pair("bit_size", bit_size));
-                packer.pack(std::make_pair("lhs", lhs));
-                packer.pack(std::make_pair("rhs", rhs));
+                packer.pack_array(5);
+                packer.pack(destination);
+                packer.pack(op);
+                packer.pack(bit_size);
+                packer.pack(lhs);
+                packer.pack(rhs);
             }
 
             void msgpack_unpack(msgpack::object const& o) {
@@ -3000,10 +3003,10 @@ namespace Acir {
             static Not bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const {
-                packer.pack_map(3);
-                packer.pack(std::make_pair("destination", destination));
-                packer.pack(std::make_pair("source", source));
-                packer.pack(std::make_pair("bit_size", bit_size));
+                packer.pack_array(3);
+                packer.pack(destination);
+                packer.pack(source);
+                packer.pack(bit_size);
             }
 
             void msgpack_unpack(msgpack::object const& o) {
@@ -3055,10 +3058,10 @@ namespace Acir {
             static Cast bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const {
-                packer.pack_map(3);
-                packer.pack(std::make_pair("destination", destination));
-                packer.pack(std::make_pair("source", source));
-                packer.pack(std::make_pair("bit_size", bit_size));
+                packer.pack_array(3);
+                packer.pack(destination);
+                packer.pack(source);
+                packer.pack(bit_size);
             }
 
             void msgpack_unpack(msgpack::object const& o) {
@@ -3109,9 +3112,9 @@ namespace Acir {
             static JumpIf bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const {
-                packer.pack_map(2);
-                packer.pack(std::make_pair("condition", condition));
-                packer.pack(std::make_pair("location", location));
+                packer.pack_array(2);
+                packer.pack(condition);
+                packer.pack(location);
             }
 
             void msgpack_unpack(msgpack::object const& o) {
@@ -3156,8 +3159,8 @@ namespace Acir {
             static Jump bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const {
-                packer.pack_map(1);
-                packer.pack(std::make_pair("location", location));
+                packer.pack_array(1);
+                packer.pack(location);
             }
 
             void msgpack_unpack(msgpack::object const& o) {
@@ -3199,10 +3202,10 @@ namespace Acir {
             static CalldataCopy bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const {
-                packer.pack_map(3);
-                packer.pack(std::make_pair("destination_address", destination_address));
-                packer.pack(std::make_pair("size_address", size_address));
-                packer.pack(std::make_pair("offset_address", offset_address));
+                packer.pack_array(3);
+                packer.pack(destination_address);
+                packer.pack(size_address);
+                packer.pack(offset_address);
             }
 
             void msgpack_unpack(msgpack::object const& o) {
@@ -3252,8 +3255,8 @@ namespace Acir {
             static Call bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const {
-                packer.pack_map(1);
-                packer.pack(std::make_pair("location", location));
+                packer.pack_array(1);
+                packer.pack(location);
             }
 
             void msgpack_unpack(msgpack::object const& o) {
@@ -3295,10 +3298,10 @@ namespace Acir {
             static Const bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const {
-                packer.pack_map(3);
-                packer.pack(std::make_pair("destination", destination));
-                packer.pack(std::make_pair("bit_size", bit_size));
-                packer.pack(std::make_pair("value", value));
+                packer.pack_array(3);
+                packer.pack(destination);
+                packer.pack(bit_size);
+                packer.pack(value);
             }
 
             void msgpack_unpack(msgpack::object const& o) {
@@ -3350,10 +3353,10 @@ namespace Acir {
             static IndirectConst bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const {
-                packer.pack_map(3);
-                packer.pack(std::make_pair("destination_pointer", destination_pointer));
-                packer.pack(std::make_pair("bit_size", bit_size));
-                packer.pack(std::make_pair("value", value));
+                packer.pack_array(3);
+                packer.pack(destination_pointer);
+                packer.pack(bit_size);
+                packer.pack(value);
             }
 
             void msgpack_unpack(msgpack::object const& o) {
@@ -3416,12 +3419,12 @@ namespace Acir {
             static ForeignCall bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const {
-                packer.pack_map(5);
-                packer.pack(std::make_pair("function", function));
-                packer.pack(std::make_pair("destinations", destinations));
-                packer.pack(std::make_pair("destination_value_types", destination_value_types));
-                packer.pack(std::make_pair("inputs", inputs));
-                packer.pack(std::make_pair("input_value_types", input_value_types));
+                packer.pack_array(5);
+                packer.pack(function);
+                packer.pack(destinations);
+                packer.pack(destination_value_types);
+                packer.pack(inputs);
+                packer.pack(input_value_types);
             }
 
             void msgpack_unpack(msgpack::object const& o) {
@@ -3482,9 +3485,9 @@ namespace Acir {
             static Mov bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const {
-                packer.pack_map(2);
-                packer.pack(std::make_pair("destination", destination));
-                packer.pack(std::make_pair("source", source));
+                packer.pack_array(2);
+                packer.pack(destination);
+                packer.pack(source);
             }
 
             void msgpack_unpack(msgpack::object const& o) {
@@ -3532,11 +3535,11 @@ namespace Acir {
             static ConditionalMov bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const {
-                packer.pack_map(4);
-                packer.pack(std::make_pair("destination", destination));
-                packer.pack(std::make_pair("source_a", source_a));
-                packer.pack(std::make_pair("source_b", source_b));
-                packer.pack(std::make_pair("condition", condition));
+                packer.pack_array(4);
+                packer.pack(destination);
+                packer.pack(source_a);
+                packer.pack(source_b);
+                packer.pack(condition);
             }
 
             void msgpack_unpack(msgpack::object const& o) {
@@ -3592,9 +3595,9 @@ namespace Acir {
             static Load bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const {
-                packer.pack_map(2);
-                packer.pack(std::make_pair("destination", destination));
-                packer.pack(std::make_pair("source_pointer", source_pointer));
+                packer.pack_array(2);
+                packer.pack(destination);
+                packer.pack(source_pointer);
             }
 
             void msgpack_unpack(msgpack::object const& o) {
@@ -3640,9 +3643,9 @@ namespace Acir {
             static Store bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const {
-                packer.pack_map(2);
-                packer.pack(std::make_pair("destination_pointer", destination_pointer));
-                packer.pack(std::make_pair("source", source));
+                packer.pack_array(2);
+                packer.pack(destination_pointer);
+                packer.pack(source);
             }
 
             void msgpack_unpack(msgpack::object const& o) {
@@ -3706,8 +3709,8 @@ namespace Acir {
             static Trap bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const {
-                packer.pack_map(1);
-                packer.pack(std::make_pair("revert_data", revert_data));
+                packer.pack_array(1);
+                packer.pack(revert_data);
             }
 
             void msgpack_unpack(msgpack::object const& o) {
@@ -3747,8 +3750,8 @@ namespace Acir {
             static Stop bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const {
-                packer.pack_map(1);
-                packer.pack(std::make_pair("return_data", return_data));
+                packer.pack_array(1);
+                packer.pack(return_data);
             }
 
             void msgpack_unpack(msgpack::object const& o) {
@@ -4525,11 +4528,11 @@ namespace Acir {
             static AES128Encrypt bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const {
-                packer.pack_map(4);
-                packer.pack(std::make_pair("inputs", inputs));
-                packer.pack(std::make_pair("iv", iv));
-                packer.pack(std::make_pair("key", key));
-                packer.pack(std::make_pair("outputs", outputs));
+                packer.pack_array(4);
+                packer.pack(inputs);
+                packer.pack(iv);
+                packer.pack(key);
+                packer.pack(outputs);
             }
 
             void msgpack_unpack(msgpack::object const& o) {
@@ -4587,11 +4590,11 @@ namespace Acir {
             static AND bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const {
-                packer.pack_map(4);
-                packer.pack(std::make_pair("lhs", lhs));
-                packer.pack(std::make_pair("rhs", rhs));
-                packer.pack(std::make_pair("num_bits", num_bits));
-                packer.pack(std::make_pair("output", output));
+                packer.pack_array(4);
+                packer.pack(lhs);
+                packer.pack(rhs);
+                packer.pack(num_bits);
+                packer.pack(output);
             }
 
             void msgpack_unpack(msgpack::object const& o) {
@@ -4649,11 +4652,11 @@ namespace Acir {
             static XOR bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const {
-                packer.pack_map(4);
-                packer.pack(std::make_pair("lhs", lhs));
-                packer.pack(std::make_pair("rhs", rhs));
-                packer.pack(std::make_pair("num_bits", num_bits));
-                packer.pack(std::make_pair("output", output));
+                packer.pack_array(4);
+                packer.pack(lhs);
+                packer.pack(rhs);
+                packer.pack(num_bits);
+                packer.pack(output);
             }
 
             void msgpack_unpack(msgpack::object const& o) {
@@ -4709,9 +4712,9 @@ namespace Acir {
             static RANGE bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const {
-                packer.pack_map(2);
-                packer.pack(std::make_pair("input", input));
-                packer.pack(std::make_pair("num_bits", num_bits));
+                packer.pack_array(2);
+                packer.pack(input);
+                packer.pack(num_bits);
             }
 
             void msgpack_unpack(msgpack::object const& o) {
@@ -4757,9 +4760,9 @@ namespace Acir {
             static Blake2s bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const {
-                packer.pack_map(2);
-                packer.pack(std::make_pair("inputs", inputs));
-                packer.pack(std::make_pair("outputs", outputs));
+                packer.pack_array(2);
+                packer.pack(inputs);
+                packer.pack(outputs);
             }
 
             void msgpack_unpack(msgpack::object const& o) {
@@ -4805,9 +4808,9 @@ namespace Acir {
             static Blake3 bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const {
-                packer.pack_map(2);
-                packer.pack(std::make_pair("inputs", inputs));
-                packer.pack(std::make_pair("outputs", outputs));
+                packer.pack_array(2);
+                packer.pack(inputs);
+                packer.pack(outputs);
             }
 
             void msgpack_unpack(msgpack::object const& o) {
@@ -4857,13 +4860,13 @@ namespace Acir {
             static EcdsaSecp256k1 bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const {
-                packer.pack_map(6);
-                packer.pack(std::make_pair("public_key_x", public_key_x));
-                packer.pack(std::make_pair("public_key_y", public_key_y));
-                packer.pack(std::make_pair("signature", signature));
-                packer.pack(std::make_pair("hashed_message", hashed_message));
-                packer.pack(std::make_pair("predicate", predicate));
-                packer.pack(std::make_pair("output", output));
+                packer.pack_array(6);
+                packer.pack(public_key_x);
+                packer.pack(public_key_y);
+                packer.pack(signature);
+                packer.pack(hashed_message);
+                packer.pack(predicate);
+                packer.pack(output);
             }
 
             void msgpack_unpack(msgpack::object const& o) {
@@ -4933,13 +4936,13 @@ namespace Acir {
             static EcdsaSecp256r1 bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const {
-                packer.pack_map(6);
-                packer.pack(std::make_pair("public_key_x", public_key_x));
-                packer.pack(std::make_pair("public_key_y", public_key_y));
-                packer.pack(std::make_pair("signature", signature));
-                packer.pack(std::make_pair("hashed_message", hashed_message));
-                packer.pack(std::make_pair("predicate", predicate));
-                packer.pack(std::make_pair("output", output));
+                packer.pack_array(6);
+                packer.pack(public_key_x);
+                packer.pack(public_key_y);
+                packer.pack(signature);
+                packer.pack(hashed_message);
+                packer.pack(predicate);
+                packer.pack(output);
             }
 
             void msgpack_unpack(msgpack::object const& o) {
@@ -5007,11 +5010,11 @@ namespace Acir {
             static MultiScalarMul bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const {
-                packer.pack_map(4);
-                packer.pack(std::make_pair("points", points));
-                packer.pack(std::make_pair("scalars", scalars));
-                packer.pack(std::make_pair("predicate", predicate));
-                packer.pack(std::make_pair("outputs", outputs));
+                packer.pack_array(4);
+                packer.pack(points);
+                packer.pack(scalars);
+                packer.pack(predicate);
+                packer.pack(outputs);
             }
 
             void msgpack_unpack(msgpack::object const& o) {
@@ -5069,11 +5072,11 @@ namespace Acir {
             static EmbeddedCurveAdd bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const {
-                packer.pack_map(4);
-                packer.pack(std::make_pair("input1", input1));
-                packer.pack(std::make_pair("input2", input2));
-                packer.pack(std::make_pair("predicate", predicate));
-                packer.pack(std::make_pair("outputs", outputs));
+                packer.pack_array(4);
+                packer.pack(input1);
+                packer.pack(input2);
+                packer.pack(predicate);
+                packer.pack(outputs);
             }
 
             void msgpack_unpack(msgpack::object const& o) {
@@ -5129,9 +5132,9 @@ namespace Acir {
             static Keccakf1600 bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const {
-                packer.pack_map(2);
-                packer.pack(std::make_pair("inputs", inputs));
-                packer.pack(std::make_pair("outputs", outputs));
+                packer.pack_array(2);
+                packer.pack(inputs);
+                packer.pack(outputs);
             }
 
             void msgpack_unpack(msgpack::object const& o) {
@@ -5181,13 +5184,13 @@ namespace Acir {
             static RecursiveAggregation bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const {
-                packer.pack_map(6);
-                packer.pack(std::make_pair("verification_key", verification_key));
-                packer.pack(std::make_pair("proof", proof));
-                packer.pack(std::make_pair("public_inputs", public_inputs));
-                packer.pack(std::make_pair("key_hash", key_hash));
-                packer.pack(std::make_pair("proof_type", proof_type));
-                packer.pack(std::make_pair("predicate", predicate));
+                packer.pack_array(6);
+                packer.pack(verification_key);
+                packer.pack(proof);
+                packer.pack(public_inputs);
+                packer.pack(key_hash);
+                packer.pack(proof_type);
+                packer.pack(predicate);
             }
 
             void msgpack_unpack(msgpack::object const& o) {
@@ -5253,9 +5256,9 @@ namespace Acir {
             static Poseidon2Permutation bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const {
-                packer.pack_map(2);
-                packer.pack(std::make_pair("inputs", inputs));
-                packer.pack(std::make_pair("outputs", outputs));
+                packer.pack_array(2);
+                packer.pack(inputs);
+                packer.pack(outputs);
             }
 
             void msgpack_unpack(msgpack::object const& o) {
@@ -5302,10 +5305,10 @@ namespace Acir {
             static Sha256Compression bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const {
-                packer.pack_map(3);
-                packer.pack(std::make_pair("inputs", inputs));
-                packer.pack(std::make_pair("hash_values", hash_values));
-                packer.pack(std::make_pair("outputs", outputs));
+                packer.pack_array(3);
+                packer.pack(inputs);
+                packer.pack(hash_values);
+                packer.pack(outputs);
             }
 
             void msgpack_unpack(msgpack::object const& o) {
@@ -5971,10 +5974,10 @@ namespace Acir {
         static Expression bincodeDeserialize(std::vector<uint8_t>);
 
         void msgpack_pack(auto& packer) const {
-            packer.pack_map(3);
-            packer.pack(std::make_pair("mul_terms", mul_terms));
-            packer.pack(std::make_pair("linear_combinations", linear_combinations));
-            packer.pack(std::make_pair("q_c", q_c));
+            packer.pack_array(3);
+            packer.pack(mul_terms);
+            packer.pack(linear_combinations);
+            packer.pack(q_c);
         }
 
         void msgpack_unpack(msgpack::object const& o) {
@@ -6395,10 +6398,10 @@ namespace Acir {
         static MemOp bincodeDeserialize(std::vector<uint8_t>);
 
         void msgpack_pack(auto& packer) const {
-            packer.pack_map(3);
-            packer.pack(std::make_pair("operation", operation));
-            packer.pack(std::make_pair("index", index));
-            packer.pack(std::make_pair("value", value));
+            packer.pack_array(3);
+            packer.pack(operation);
+            packer.pack(index);
+            packer.pack(value);
         }
 
         void msgpack_unpack(msgpack::object const& o) {
@@ -6489,9 +6492,9 @@ namespace Acir {
             static MemoryOp bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const {
-                packer.pack_map(2);
-                packer.pack(std::make_pair("block_id", block_id));
-                packer.pack(std::make_pair("op", op));
+                packer.pack_array(2);
+                packer.pack(block_id);
+                packer.pack(op);
             }
 
             void msgpack_unpack(msgpack::object const& o) {
@@ -6538,10 +6541,10 @@ namespace Acir {
             static MemoryInit bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const {
-                packer.pack_map(3);
-                packer.pack(std::make_pair("block_id", block_id));
-                packer.pack(std::make_pair("init", init));
-                packer.pack(std::make_pair("block_type", block_type));
+                packer.pack_array(3);
+                packer.pack(block_id);
+                packer.pack(init);
+                packer.pack(block_type);
             }
 
             void msgpack_unpack(msgpack::object const& o) {
@@ -6594,11 +6597,11 @@ namespace Acir {
             static BrilligCall bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const {
-                packer.pack_map(4);
-                packer.pack(std::make_pair("id", id));
-                packer.pack(std::make_pair("inputs", inputs));
-                packer.pack(std::make_pair("outputs", outputs));
-                packer.pack(std::make_pair("predicate", predicate));
+                packer.pack_array(4);
+                packer.pack(id);
+                packer.pack(inputs);
+                packer.pack(outputs);
+                packer.pack(predicate);
             }
 
             void msgpack_unpack(msgpack::object const& o) {
@@ -6656,11 +6659,11 @@ namespace Acir {
             static Call bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const {
-                packer.pack_map(4);
-                packer.pack(std::make_pair("id", id));
-                packer.pack(std::make_pair("inputs", inputs));
-                packer.pack(std::make_pair("outputs", outputs));
-                packer.pack(std::make_pair("predicate", predicate));
+                packer.pack_array(4);
+                packer.pack(id);
+                packer.pack(inputs);
+                packer.pack(outputs);
+                packer.pack(predicate);
             }
 
             void msgpack_unpack(msgpack::object const& o) {
@@ -7104,9 +7107,9 @@ namespace Acir {
         static AssertionPayload bincodeDeserialize(std::vector<uint8_t>);
 
         void msgpack_pack(auto& packer) const {
-            packer.pack_map(2);
-            packer.pack(std::make_pair("error_selector", error_selector));
-            packer.pack(std::make_pair("payload", payload));
+            packer.pack_array(2);
+            packer.pack(error_selector);
+            packer.pack(payload);
         }
 
         void msgpack_unpack(msgpack::object const& o) {
@@ -7173,9 +7176,9 @@ namespace Acir {
             static Brillig bincodeDeserialize(std::vector<uint8_t>);
 
             void msgpack_pack(auto& packer) const {
-                packer.pack_map(2);
-                packer.pack(std::make_pair("acir_index", acir_index));
-                packer.pack(std::make_pair("brillig_index", brillig_index));
+                packer.pack_array(2);
+                packer.pack(acir_index);
+                packer.pack(brillig_index);
             }
 
             void msgpack_unpack(msgpack::object const& o) {
@@ -7367,14 +7370,14 @@ namespace Acir {
         static Circuit bincodeDeserialize(std::vector<uint8_t>);
 
         void msgpack_pack(auto& packer) const {
-            packer.pack_map(7);
-            packer.pack(std::make_pair("function_name", function_name));
-            packer.pack(std::make_pair("current_witness_index", current_witness_index));
-            packer.pack(std::make_pair("opcodes", opcodes));
-            packer.pack(std::make_pair("private_parameters", private_parameters));
-            packer.pack(std::make_pair("public_parameters", public_parameters));
-            packer.pack(std::make_pair("return_values", return_values));
-            packer.pack(std::make_pair("assert_messages", assert_messages));
+            packer.pack_array(7);
+            packer.pack(function_name);
+            packer.pack(current_witness_index);
+            packer.pack(opcodes);
+            packer.pack(private_parameters);
+            packer.pack(public_parameters);
+            packer.pack(return_values);
+            packer.pack(assert_messages);
         }
 
         void msgpack_unpack(msgpack::object const& o) {
@@ -7444,9 +7447,9 @@ namespace Acir {
         static BrilligBytecode bincodeDeserialize(std::vector<uint8_t>);
 
         void msgpack_pack(auto& packer) const {
-            packer.pack_map(2);
-            packer.pack(std::make_pair("function_name", function_name));
-            packer.pack(std::make_pair("bytecode", bytecode));
+            packer.pack_array(2);
+            packer.pack(function_name);
+            packer.pack(bytecode);
         }
 
         void msgpack_unpack(msgpack::object const& o) {
@@ -7491,9 +7494,9 @@ namespace Acir {
         static Program bincodeDeserialize(std::vector<uint8_t>);
 
         void msgpack_pack(auto& packer) const {
-            packer.pack_map(2);
-            packer.pack(std::make_pair("functions", functions));
-            packer.pack(std::make_pair("unconstrained_functions", unconstrained_functions));
+            packer.pack_array(2);
+            packer.pack(functions);
+            packer.pack(unconstrained_functions);
         }
 
         void msgpack_unpack(msgpack::object const& o) {
@@ -7538,8 +7541,9 @@ namespace Acir {
         static ProgramWithoutBrillig bincodeDeserialize(std::vector<uint8_t>);
 
         void msgpack_pack(auto& packer) const {
-            packer.pack_map(1);
-            packer.pack(std::make_pair("functions", functions));
+            packer.pack_array(2);
+            packer.pack(functions);
+            packer.pack(unconstrained_functions);
         }
 
         void msgpack_unpack(msgpack::object const& o) {

--- a/acvm-repo/acir/codegen/acir.cpp
+++ b/acvm-repo/acir/codegen/acir.cpp
@@ -936,9 +936,8 @@ namespace Acir {
                                 Helpers::convert_or_throw(val, name, "size", size);
                                 break;
                             default:
-                                // Unknown tag — skip silently (forward-compat /
-                                // retired tags drained — matches the Rust decoder).
-                                break;
+                                std::cerr << val << std::endl;
+                                throw_or_abort("unknown tag for HeapArray: " + std::to_string(tag));
                         }
                     });
                 } else {
@@ -985,9 +984,8 @@ namespace Acir {
                                     Helpers::convert_or_throw(val, name, "outputs", outputs);
                                     break;
                                 default:
-                                    // Unknown tag — skip silently (forward-compat /
-                                    // retired tags drained — matches the Rust decoder).
-                                    break;
+                                    std::cerr << val << std::endl;
+                                    throw_or_abort("unknown tag for AES128Encrypt: " + std::to_string(tag));
                             }
                         });
                     } else {
@@ -1028,9 +1026,8 @@ namespace Acir {
                                     Helpers::convert_or_throw(val, name, "output", output);
                                     break;
                                 default:
-                                    // Unknown tag — skip silently (forward-compat /
-                                    // retired tags drained — matches the Rust decoder).
-                                    break;
+                                    std::cerr << val << std::endl;
+                                    throw_or_abort("unknown tag for Blake2s: " + std::to_string(tag));
                             }
                         });
                     } else {
@@ -1067,9 +1064,8 @@ namespace Acir {
                                     Helpers::convert_or_throw(val, name, "output", output);
                                     break;
                                 default:
-                                    // Unknown tag — skip silently (forward-compat /
-                                    // retired tags drained — matches the Rust decoder).
-                                    break;
+                                    std::cerr << val << std::endl;
+                                    throw_or_abort("unknown tag for Blake3: " + std::to_string(tag));
                             }
                         });
                     } else {
@@ -1106,9 +1102,8 @@ namespace Acir {
                                     Helpers::convert_or_throw(val, name, "output", output);
                                     break;
                                 default:
-                                    // Unknown tag — skip silently (forward-compat /
-                                    // retired tags drained — matches the Rust decoder).
-                                    break;
+                                    std::cerr << val << std::endl;
+                                    throw_or_abort("unknown tag for Keccakf1600: " + std::to_string(tag));
                             }
                         });
                     } else {
@@ -1157,9 +1152,8 @@ namespace Acir {
                                     Helpers::convert_or_throw(val, name, "result", result);
                                     break;
                                 default:
-                                    // Unknown tag — skip silently (forward-compat /
-                                    // retired tags drained — matches the Rust decoder).
-                                    break;
+                                    std::cerr << val << std::endl;
+                                    throw_or_abort("unknown tag for EcdsaSecp256k1: " + std::to_string(tag));
                             }
                         });
                     } else {
@@ -1214,9 +1208,8 @@ namespace Acir {
                                     Helpers::convert_or_throw(val, name, "result", result);
                                     break;
                                 default:
-                                    // Unknown tag — skip silently (forward-compat /
-                                    // retired tags drained — matches the Rust decoder).
-                                    break;
+                                    std::cerr << val << std::endl;
+                                    throw_or_abort("unknown tag for EcdsaSecp256r1: " + std::to_string(tag));
                             }
                         });
                     } else {
@@ -1263,9 +1256,8 @@ namespace Acir {
                                     Helpers::convert_or_throw(val, name, "outputs", outputs);
                                     break;
                                 default:
-                                    // Unknown tag — skip silently (forward-compat /
-                                    // retired tags drained — matches the Rust decoder).
-                                    break;
+                                    std::cerr << val << std::endl;
+                                    throw_or_abort("unknown tag for MultiScalarMul: " + std::to_string(tag));
                             }
                         });
                     } else {
@@ -1324,9 +1316,8 @@ namespace Acir {
                                     Helpers::convert_or_throw(val, name, "result", result);
                                     break;
                                 default:
-                                    // Unknown tag — skip silently (forward-compat /
-                                    // retired tags drained — matches the Rust decoder).
-                                    break;
+                                    std::cerr << val << std::endl;
+                                    throw_or_abort("unknown tag for EmbeddedCurveAdd: " + std::to_string(tag));
                             }
                         });
                     } else {
@@ -1373,9 +1364,8 @@ namespace Acir {
                                     Helpers::convert_or_throw(val, name, "output", output);
                                     break;
                                 default:
-                                    // Unknown tag — skip silently (forward-compat /
-                                    // retired tags drained — matches the Rust decoder).
-                                    break;
+                                    std::cerr << val << std::endl;
+                                    throw_or_abort("unknown tag for Poseidon2Permutation: " + std::to_string(tag));
                             }
                         });
                     } else {
@@ -1416,9 +1406,8 @@ namespace Acir {
                                     Helpers::convert_or_throw(val, name, "output", output);
                                     break;
                                 default:
-                                    // Unknown tag — skip silently (forward-compat /
-                                    // retired tags drained — matches the Rust decoder).
-                                    break;
+                                    std::cerr << val << std::endl;
+                                    throw_or_abort("unknown tag for Sha256Compression: " + std::to_string(tag));
                             }
                         });
                     } else {
@@ -1469,9 +1458,8 @@ namespace Acir {
                                     Helpers::convert_or_throw(val, name, "output_bits", output_bits);
                                     break;
                                 default:
-                                    // Unknown tag — skip silently (forward-compat /
-                                    // retired tags drained — matches the Rust decoder).
-                                    break;
+                                    std::cerr << val << std::endl;
+                                    throw_or_abort("unknown tag for ToRadix: " + std::to_string(tag));
                             }
                         });
                     } else {
@@ -1840,9 +1828,8 @@ namespace Acir {
                                     Helpers::convert_or_throw(val, name, "size", size);
                                     break;
                                 default:
-                                    // Unknown tag — skip silently (forward-compat /
-                                    // retired tags drained — matches the Rust decoder).
-                                    break;
+                                    std::cerr << val << std::endl;
+                                    throw_or_abort("unknown tag for Array: " + std::to_string(tag));
                             }
                         });
                     } else {
@@ -1875,9 +1862,8 @@ namespace Acir {
                                     Helpers::convert_or_throw(val, name, "value_types", value_types);
                                     break;
                                 default:
-                                    // Unknown tag — skip silently (forward-compat /
-                                    // retired tags drained — matches the Rust decoder).
-                                    break;
+                                    std::cerr << val << std::endl;
+                                    throw_or_abort("unknown tag for Vector: " + std::to_string(tag));
                             }
                         });
                     } else {
@@ -2028,9 +2014,8 @@ namespace Acir {
                                 Helpers::convert_or_throw(val, name, "size", size);
                                 break;
                             default:
-                                // Unknown tag — skip silently (forward-compat /
-                                // retired tags drained — matches the Rust decoder).
-                                break;
+                                std::cerr << val << std::endl;
+                                throw_or_abort("unknown tag for HeapVector: " + std::to_string(tag));
                         }
                     });
                 } else {
@@ -2240,9 +2225,8 @@ namespace Acir {
                                     Helpers::convert_or_throw(val, name, "rhs", rhs);
                                     break;
                                 default:
-                                    // Unknown tag — skip silently (forward-compat /
-                                    // retired tags drained — matches the Rust decoder).
-                                    break;
+                                    std::cerr << val << std::endl;
+                                    throw_or_abort("unknown tag for BinaryFieldOp: " + std::to_string(tag));
                             }
                         });
                     } else {
@@ -2295,9 +2279,8 @@ namespace Acir {
                                     Helpers::convert_or_throw(val, name, "rhs", rhs);
                                     break;
                                 default:
-                                    // Unknown tag — skip silently (forward-compat /
-                                    // retired tags drained — matches the Rust decoder).
-                                    break;
+                                    std::cerr << val << std::endl;
+                                    throw_or_abort("unknown tag for BinaryIntOp: " + std::to_string(tag));
                             }
                         });
                     } else {
@@ -2344,9 +2327,8 @@ namespace Acir {
                                     Helpers::convert_or_throw(val, name, "bit_size", bit_size);
                                     break;
                                 default:
-                                    // Unknown tag — skip silently (forward-compat /
-                                    // retired tags drained — matches the Rust decoder).
-                                    break;
+                                    std::cerr << val << std::endl;
+                                    throw_or_abort("unknown tag for Not: " + std::to_string(tag));
                             }
                         });
                     } else {
@@ -2389,9 +2371,8 @@ namespace Acir {
                                     Helpers::convert_or_throw(val, name, "bit_size", bit_size);
                                     break;
                                 default:
-                                    // Unknown tag — skip silently (forward-compat /
-                                    // retired tags drained — matches the Rust decoder).
-                                    break;
+                                    std::cerr << val << std::endl;
+                                    throw_or_abort("unknown tag for Cast: " + std::to_string(tag));
                             }
                         });
                     } else {
@@ -2430,9 +2411,8 @@ namespace Acir {
                                     Helpers::convert_or_throw(val, name, "location", location);
                                     break;
                                 default:
-                                    // Unknown tag — skip silently (forward-compat /
-                                    // retired tags drained — matches the Rust decoder).
-                                    break;
+                                    std::cerr << val << std::endl;
+                                    throw_or_abort("unknown tag for JumpIf: " + std::to_string(tag));
                             }
                         });
                     } else {
@@ -2465,9 +2445,8 @@ namespace Acir {
                                     Helpers::convert_or_throw(val, name, "location", location);
                                     break;
                                 default:
-                                    // Unknown tag — skip silently (forward-compat /
-                                    // retired tags drained — matches the Rust decoder).
-                                    break;
+                                    std::cerr << val << std::endl;
+                                    throw_or_abort("unknown tag for Jump: " + std::to_string(tag));
                             }
                         });
                     } else {
@@ -2506,9 +2485,8 @@ namespace Acir {
                                     Helpers::convert_or_throw(val, name, "offset_address", offset_address);
                                     break;
                                 default:
-                                    // Unknown tag — skip silently (forward-compat /
-                                    // retired tags drained — matches the Rust decoder).
-                                    break;
+                                    std::cerr << val << std::endl;
+                                    throw_or_abort("unknown tag for CalldataCopy: " + std::to_string(tag));
                             }
                         });
                     } else {
@@ -2543,9 +2521,8 @@ namespace Acir {
                                     Helpers::convert_or_throw(val, name, "location", location);
                                     break;
                                 default:
-                                    // Unknown tag — skip silently (forward-compat /
-                                    // retired tags drained — matches the Rust decoder).
-                                    break;
+                                    std::cerr << val << std::endl;
+                                    throw_or_abort("unknown tag for Call: " + std::to_string(tag));
                             }
                         });
                     } else {
@@ -2584,9 +2561,8 @@ namespace Acir {
                                     Helpers::convert_or_throw(val, name, "value", value);
                                     break;
                                 default:
-                                    // Unknown tag — skip silently (forward-compat /
-                                    // retired tags drained — matches the Rust decoder).
-                                    break;
+                                    std::cerr << val << std::endl;
+                                    throw_or_abort("unknown tag for Const: " + std::to_string(tag));
                             }
                         });
                     } else {
@@ -2629,9 +2605,8 @@ namespace Acir {
                                     Helpers::convert_or_throw(val, name, "value", value);
                                     break;
                                 default:
-                                    // Unknown tag — skip silently (forward-compat /
-                                    // retired tags drained — matches the Rust decoder).
-                                    break;
+                                    std::cerr << val << std::endl;
+                                    throw_or_abort("unknown tag for IndirectConst: " + std::to_string(tag));
                             }
                         });
                     } else {
@@ -2688,9 +2663,8 @@ namespace Acir {
                                     Helpers::convert_or_throw(val, name, "input_value_types", input_value_types);
                                     break;
                                 default:
-                                    // Unknown tag — skip silently (forward-compat /
-                                    // retired tags drained — matches the Rust decoder).
-                                    break;
+                                    std::cerr << val << std::endl;
+                                    throw_or_abort("unknown tag for ForeignCall: " + std::to_string(tag));
                             }
                         });
                     } else {
@@ -2733,9 +2707,8 @@ namespace Acir {
                                     Helpers::convert_or_throw(val, name, "source", source);
                                     break;
                                 default:
-                                    // Unknown tag — skip silently (forward-compat /
-                                    // retired tags drained — matches the Rust decoder).
-                                    break;
+                                    std::cerr << val << std::endl;
+                                    throw_or_abort("unknown tag for Mov: " + std::to_string(tag));
                             }
                         });
                     } else {
@@ -2780,9 +2753,8 @@ namespace Acir {
                                     Helpers::convert_or_throw(val, name, "condition", condition);
                                     break;
                                 default:
-                                    // Unknown tag — skip silently (forward-compat /
-                                    // retired tags drained — matches the Rust decoder).
-                                    break;
+                                    std::cerr << val << std::endl;
+                                    throw_or_abort("unknown tag for ConditionalMov: " + std::to_string(tag));
                             }
                         });
                     } else {
@@ -2823,9 +2795,8 @@ namespace Acir {
                                     Helpers::convert_or_throw(val, name, "source_pointer", source_pointer);
                                     break;
                                 default:
-                                    // Unknown tag — skip silently (forward-compat /
-                                    // retired tags drained — matches the Rust decoder).
-                                    break;
+                                    std::cerr << val << std::endl;
+                                    throw_or_abort("unknown tag for Load: " + std::to_string(tag));
                             }
                         });
                     } else {
@@ -2862,9 +2833,8 @@ namespace Acir {
                                     Helpers::convert_or_throw(val, name, "source", source);
                                     break;
                                 default:
-                                    // Unknown tag — skip silently (forward-compat /
-                                    // retired tags drained — matches the Rust decoder).
-                                    break;
+                                    std::cerr << val << std::endl;
+                                    throw_or_abort("unknown tag for Store: " + std::to_string(tag));
                             }
                         });
                     } else {
@@ -2912,9 +2882,8 @@ namespace Acir {
                                     Helpers::convert_or_throw(val, name, "revert_data", revert_data);
                                     break;
                                 default:
-                                    // Unknown tag — skip silently (forward-compat /
-                                    // retired tags drained — matches the Rust decoder).
-                                    break;
+                                    std::cerr << val << std::endl;
+                                    throw_or_abort("unknown tag for Trap: " + std::to_string(tag));
                             }
                         });
                     } else {
@@ -2945,9 +2914,8 @@ namespace Acir {
                                     Helpers::convert_or_throw(val, name, "return_data", return_data);
                                     break;
                                 default:
-                                    // Unknown tag — skip silently (forward-compat /
-                                    // retired tags drained — matches the Rust decoder).
-                                    break;
+                                    std::cerr << val << std::endl;
+                                    throw_or_abort("unknown tag for Stop: " + std::to_string(tag));
                             }
                         });
                     } else {
@@ -3588,9 +3556,8 @@ namespace Acir {
                                     Helpers::convert_or_throw(val, name, "outputs", outputs);
                                     break;
                                 default:
-                                    // Unknown tag — skip silently (forward-compat /
-                                    // retired tags drained — matches the Rust decoder).
-                                    break;
+                                    std::cerr << val << std::endl;
+                                    throw_or_abort("unknown tag for AES128Encrypt: " + std::to_string(tag));
                             }
                         });
                     } else {
@@ -3639,9 +3606,8 @@ namespace Acir {
                                     Helpers::convert_or_throw(val, name, "output", output);
                                     break;
                                 default:
-                                    // Unknown tag — skip silently (forward-compat /
-                                    // retired tags drained — matches the Rust decoder).
-                                    break;
+                                    std::cerr << val << std::endl;
+                                    throw_or_abort("unknown tag for AND: " + std::to_string(tag));
                             }
                         });
                     } else {
@@ -3690,9 +3656,8 @@ namespace Acir {
                                     Helpers::convert_or_throw(val, name, "output", output);
                                     break;
                                 default:
-                                    // Unknown tag — skip silently (forward-compat /
-                                    // retired tags drained — matches the Rust decoder).
-                                    break;
+                                    std::cerr << val << std::endl;
+                                    throw_or_abort("unknown tag for XOR: " + std::to_string(tag));
                             }
                         });
                     } else {
@@ -3733,9 +3698,8 @@ namespace Acir {
                                     Helpers::convert_or_throw(val, name, "num_bits", num_bits);
                                     break;
                                 default:
-                                    // Unknown tag — skip silently (forward-compat /
-                                    // retired tags drained — matches the Rust decoder).
-                                    break;
+                                    std::cerr << val << std::endl;
+                                    throw_or_abort("unknown tag for RANGE: " + std::to_string(tag));
                             }
                         });
                     } else {
@@ -3772,9 +3736,8 @@ namespace Acir {
                                     Helpers::convert_or_throw(val, name, "outputs", outputs);
                                     break;
                                 default:
-                                    // Unknown tag — skip silently (forward-compat /
-                                    // retired tags drained — matches the Rust decoder).
-                                    break;
+                                    std::cerr << val << std::endl;
+                                    throw_or_abort("unknown tag for Blake2s: " + std::to_string(tag));
                             }
                         });
                     } else {
@@ -3811,9 +3774,8 @@ namespace Acir {
                                     Helpers::convert_or_throw(val, name, "outputs", outputs);
                                     break;
                                 default:
-                                    // Unknown tag — skip silently (forward-compat /
-                                    // retired tags drained — matches the Rust decoder).
-                                    break;
+                                    std::cerr << val << std::endl;
+                                    throw_or_abort("unknown tag for Blake3: " + std::to_string(tag));
                             }
                         });
                     } else {
@@ -3866,9 +3828,8 @@ namespace Acir {
                                     Helpers::convert_or_throw(val, name, "output", output);
                                     break;
                                 default:
-                                    // Unknown tag — skip silently (forward-compat /
-                                    // retired tags drained — matches the Rust decoder).
-                                    break;
+                                    std::cerr << val << std::endl;
+                                    throw_or_abort("unknown tag for EcdsaSecp256k1: " + std::to_string(tag));
                             }
                         });
                     } else {
@@ -3929,9 +3890,8 @@ namespace Acir {
                                     Helpers::convert_or_throw(val, name, "output", output);
                                     break;
                                 default:
-                                    // Unknown tag — skip silently (forward-compat /
-                                    // retired tags drained — matches the Rust decoder).
-                                    break;
+                                    std::cerr << val << std::endl;
+                                    throw_or_abort("unknown tag for EcdsaSecp256r1: " + std::to_string(tag));
                             }
                         });
                     } else {
@@ -3984,9 +3944,8 @@ namespace Acir {
                                     Helpers::convert_or_throw(val, name, "outputs", outputs);
                                     break;
                                 default:
-                                    // Unknown tag — skip silently (forward-compat /
-                                    // retired tags drained — matches the Rust decoder).
-                                    break;
+                                    std::cerr << val << std::endl;
+                                    throw_or_abort("unknown tag for MultiScalarMul: " + std::to_string(tag));
                             }
                         });
                     } else {
@@ -4035,9 +3994,8 @@ namespace Acir {
                                     Helpers::convert_or_throw(val, name, "outputs", outputs);
                                     break;
                                 default:
-                                    // Unknown tag — skip silently (forward-compat /
-                                    // retired tags drained — matches the Rust decoder).
-                                    break;
+                                    std::cerr << val << std::endl;
+                                    throw_or_abort("unknown tag for EmbeddedCurveAdd: " + std::to_string(tag));
                             }
                         });
                     } else {
@@ -4078,9 +4036,8 @@ namespace Acir {
                                     Helpers::convert_or_throw(val, name, "outputs", outputs);
                                     break;
                                 default:
-                                    // Unknown tag — skip silently (forward-compat /
-                                    // retired tags drained — matches the Rust decoder).
-                                    break;
+                                    std::cerr << val << std::endl;
+                                    throw_or_abort("unknown tag for Keccakf1600: " + std::to_string(tag));
                             }
                         });
                     } else {
@@ -4133,9 +4090,8 @@ namespace Acir {
                                     Helpers::convert_or_throw(val, name, "predicate", predicate);
                                     break;
                                 default:
-                                    // Unknown tag — skip silently (forward-compat /
-                                    // retired tags drained — matches the Rust decoder).
-                                    break;
+                                    std::cerr << val << std::endl;
+                                    throw_or_abort("unknown tag for RecursiveAggregation: " + std::to_string(tag));
                             }
                         });
                     } else {
@@ -4180,9 +4136,8 @@ namespace Acir {
                                     Helpers::convert_or_throw(val, name, "outputs", outputs);
                                     break;
                                 default:
-                                    // Unknown tag — skip silently (forward-compat /
-                                    // retired tags drained — matches the Rust decoder).
-                                    break;
+                                    std::cerr << val << std::endl;
+                                    throw_or_abort("unknown tag for Poseidon2Permutation: " + std::to_string(tag));
                             }
                         });
                     } else {
@@ -4223,9 +4178,8 @@ namespace Acir {
                                     Helpers::convert_or_throw(val, name, "outputs", outputs);
                                     break;
                                 default:
-                                    // Unknown tag — skip silently (forward-compat /
-                                    // retired tags drained — matches the Rust decoder).
-                                    break;
+                                    std::cerr << val << std::endl;
+                                    throw_or_abort("unknown tag for Sha256Compression: " + std::to_string(tag));
                             }
                         });
                     } else {
@@ -4760,9 +4714,8 @@ namespace Acir {
                                 Helpers::convert_or_throw(val, name, "q_c", q_c);
                                 break;
                             default:
-                                // Unknown tag — skip silently (forward-compat /
-                                // retired tags drained — matches the Rust decoder).
-                                break;
+                                std::cerr << val << std::endl;
+                                throw_or_abort("unknown tag for Expression: " + std::to_string(tag));
                         }
                     });
                 } else {
@@ -5094,9 +5047,8 @@ namespace Acir {
                                 Helpers::convert_or_throw(val, name, "value", value);
                                 break;
                             default:
-                                // Unknown tag — skip silently (forward-compat /
-                                // retired tags drained — matches the Rust decoder).
-                                break;
+                                std::cerr << val << std::endl;
+                                throw_or_abort("unknown tag for MemOp: " + std::to_string(tag));
                         }
                     });
                 } else {
@@ -5167,9 +5119,8 @@ namespace Acir {
                                     Helpers::convert_or_throw(val, name, "op", op);
                                     break;
                                 default:
-                                    // Unknown tag — skip silently (forward-compat /
-                                    // retired tags drained — matches the Rust decoder).
-                                    break;
+                                    std::cerr << val << std::endl;
+                                    throw_or_abort("unknown tag for MemoryOp: " + std::to_string(tag));
                             }
                         });
                     } else {
@@ -5210,9 +5161,8 @@ namespace Acir {
                                     Helpers::convert_or_throw(val, name, "block_type", block_type);
                                     break;
                                 default:
-                                    // Unknown tag — skip silently (forward-compat /
-                                    // retired tags drained — matches the Rust decoder).
-                                    break;
+                                    std::cerr << val << std::endl;
+                                    throw_or_abort("unknown tag for MemoryInit: " + std::to_string(tag));
                             }
                         });
                     } else {
@@ -5259,9 +5209,8 @@ namespace Acir {
                                     Helpers::convert_or_throw(val, name, "predicate", predicate);
                                     break;
                                 default:
-                                    // Unknown tag — skip silently (forward-compat /
-                                    // retired tags drained — matches the Rust decoder).
-                                    break;
+                                    std::cerr << val << std::endl;
+                                    throw_or_abort("unknown tag for BrilligCall: " + std::to_string(tag));
                             }
                         });
                     } else {
@@ -5310,9 +5259,8 @@ namespace Acir {
                                     Helpers::convert_or_throw(val, name, "predicate", predicate);
                                     break;
                                 default:
-                                    // Unknown tag — skip silently (forward-compat /
-                                    // retired tags drained — matches the Rust decoder).
-                                    break;
+                                    std::cerr << val << std::endl;
+                                    throw_or_abort("unknown tag for Call: " + std::to_string(tag));
                             }
                         });
                     } else {
@@ -5661,9 +5609,8 @@ namespace Acir {
                                 Helpers::convert_or_throw(val, name, "payload", payload);
                                 break;
                             default:
-                                // Unknown tag — skip silently (forward-compat /
-                                // retired tags drained — matches the Rust decoder).
-                                break;
+                                std::cerr << val << std::endl;
+                                throw_or_abort("unknown tag for AssertionPayload: " + std::to_string(tag));
                         }
                     });
                 } else {
@@ -5717,9 +5664,8 @@ namespace Acir {
                                     Helpers::convert_or_throw(val, name, "brillig_index", brillig_index);
                                     break;
                                 default:
-                                    // Unknown tag — skip silently (forward-compat /
-                                    // retired tags drained — matches the Rust decoder).
-                                    break;
+                                    std::cerr << val << std::endl;
+                                    throw_or_abort("unknown tag for Brillig: " + std::to_string(tag));
                             }
                         });
                     } else {
@@ -5885,8 +5831,8 @@ namespace Acir {
                                 Helpers::convert_or_throw(val, name, "assert_messages", assert_messages);
                                 break;
                             default:
-                                // Unknown tag — skip silently (forward-compat /
-                                // retired tags drained — matches the Rust decoder).
+                                // `#[tagged(allow_unknown_tags)]` on the Rust side:
+                                // silently skip any tag we don't recognize.
                                 break;
                         }
                     });
@@ -5934,8 +5880,8 @@ namespace Acir {
                                 Helpers::convert_or_throw(val, name, "bytecode", bytecode);
                                 break;
                             default:
-                                // Unknown tag — skip silently (forward-compat /
-                                // retired tags drained — matches the Rust decoder).
+                                // `#[tagged(allow_unknown_tags)]` on the Rust side:
+                                // silently skip any tag we don't recognize.
                                 break;
                         }
                     });
@@ -5973,8 +5919,8 @@ namespace Acir {
                                 Helpers::convert_or_throw(val, name, "unconstrained_functions", unconstrained_functions);
                                 break;
                             default:
-                                // Unknown tag — skip silently (forward-compat /
-                                // retired tags drained — matches the Rust decoder).
+                                // `#[tagged(allow_unknown_tags)]` on the Rust side:
+                                // silently skip any tag we don't recognize.
                                 break;
                         }
                     });
@@ -6008,10 +5954,12 @@ namespace Acir {
                             case 0:
                                 Helpers::convert_or_throw(val, name, "functions", functions);
                                 break;
-                            default:
-                                // Unknown tag — skip silently (forward-compat /
-                                // retired tags drained — matches the Rust decoder).
+                            case 1:
+                                // Field is `std::monostate` — wire entry intentionally discarded.
                                 break;
+                            default:
+                                std::cerr << val << std::endl;
+                                throw_or_abort("unknown tag for ProgramWithoutBrillig: " + std::to_string(tag));
                         }
                     });
                 } else {

--- a/acvm-repo/acir/codegen/acir.cpp
+++ b/acvm-repo/acir/codegen/acir.cpp
@@ -68,6 +68,59 @@ namespace Acir {
                 throw_or_abort("error converting into field " + struct_name + "::" + field_name);
             }
         }
+
+        /// Convert `val` into `field`, or throw a focused error mentioning
+        /// the struct + field name. Used by the int-keyed dispatch path
+        /// where each `switch` case populates one field directly.
+        template<typename T>
+        static void convert_or_throw(
+            msgpack::object const& val,
+            std::string const& struct_name,
+            std::string const& field_name,
+            T& field
+        ) {
+            try {
+                val.convert(field);
+            } catch (const msgpack::type_error&) {
+                std::cerr << val << std::endl;
+                throw_or_abort("error converting into field " + struct_name + "::" + field_name);
+            }
+        }
+
+        /// Whether `o` is a non-empty MAP whose first key is an integer.
+        /// This is the signature of `Format::MsgpackTagged`: int keys for
+        /// struct field tags and enum variant tags. Legacy `Format::Msgpack`
+        /// keys are always strings, so a positive-integer first key is a
+        /// reliable shape discriminator between the two.
+        static bool is_int_keyed_map(msgpack::object const& o) {
+            return o.type == msgpack::type::MAP
+                && o.via.map.size > 0
+                && o.via.map.ptr[0].key.type == msgpack::type::POSITIVE_INTEGER;
+        }
+
+        /// Iterate an int-keyed MAP and invoke `dispatch(tag, val)` for each
+        /// `(u8, msgpack::object)` entry. The per-tag `switch` inside the
+        /// caller's lambda decides which field (or variant) to populate;
+        /// unknown tags fall through to `default` and are silently skipped,
+        /// matching the `MsgpackTagged` decoder's forward-compat policy
+        /// (`allow_unknown_tags` / retired tags drained).
+        template<typename Dispatch>
+        static void int_map_dispatch(
+            msgpack::object const& o,
+            std::string const& name,
+            Dispatch&& dispatch
+        ) {
+            for (uint32_t i = 0; i < o.via.map.size; ++i) {
+                uint8_t tag;
+                try {
+                    o.via.map.ptr[i].key.convert(tag);
+                } catch (const msgpack::type_error&) {
+                    std::cerr << o.via.map.ptr[i].key << std::endl;
+                    throw_or_abort("expected u8 tag in int-keyed map for " + name);
+                }
+                dispatch(tag, o.via.map.ptr[i].val);
+            }
+        }
     };
     }
 
@@ -136,52 +189,111 @@ namespace Acir {
             if (o.type == msgpack::type::object_type::MAP && o.via.map.size != 1) {
                 throw_or_abort("expected 1 entry for enum 'BinaryFieldOp'; got " + std::to_string(o.via.map.size));
             }
-            std::string tag;
-            try {
-                if (o.type == msgpack::type::object_type::MAP) {
+            if (Helpers::is_int_keyed_map(o)) {
+                // `Format::MsgpackTagged` — int-keyed variant.
+                uint8_t tag;
+                try {
                     o.via.map.ptr[0].key.convert(tag);
-                } else {
-                    o.convert(tag);
+                } catch (const msgpack::type_error&) {
+                    std::cerr << o << std::endl;
+                    throw_or_abort("expected u8 variant tag for enum 'BinaryFieldOp'");
                 }
-            } catch(const msgpack::type_error&) {
-                std::cerr << o << std::endl;
-                throw_or_abort("error converting tag to string for enum 'BinaryFieldOp'");
-            }
-            if (tag == "Add") {
-                Add v;
-                value = v;
-            }
-            else if (tag == "Sub") {
-                Sub v;
-                value = v;
-            }
-            else if (tag == "Mul") {
-                Mul v;
-                value = v;
-            }
-            else if (tag == "Div") {
-                Div v;
-                value = v;
-            }
-            else if (tag == "IntegerDiv") {
-                IntegerDiv v;
-                value = v;
-            }
-            else if (tag == "Equals") {
-                Equals v;
-                value = v;
-            }
-            else if (tag == "LessThan") {
-                LessThan v;
-                value = v;
-            }
-            else if (tag == "LessThanEquals") {
-                LessThanEquals v;
-                value = v;
-            }
-            else {
-                std::cerr << o << std::endl;
-                throw_or_abort("unknown 'BinaryFieldOp' enum variant: " + tag);
+                msgpack::object const& val = o.via.map.ptr[0].val;
+                switch (tag) {
+                    case 0: {
+                        Add v;
+                        value = v;
+                        break;
+                    }
+                    case 1: {
+                        Sub v;
+                        value = v;
+                        break;
+                    }
+                    case 2: {
+                        Mul v;
+                        value = v;
+                        break;
+                    }
+                    case 3: {
+                        Div v;
+                        value = v;
+                        break;
+                    }
+                    case 4: {
+                        IntegerDiv v;
+                        value = v;
+                        break;
+                    }
+                    case 5: {
+                        Equals v;
+                        value = v;
+                        break;
+                    }
+                    case 6: {
+                        LessThan v;
+                        value = v;
+                        break;
+                    }
+                    case 7: {
+                        LessThanEquals v;
+                        value = v;
+                        break;
+                    }
+                    default:
+                        std::cerr << o << std::endl;
+                        throw_or_abort("unknown 'BinaryFieldOp' enum variant tag: " + std::to_string(tag));
+                }
+            } else {
+                // `Format::Msgpack` (MAP, string-keyed) or `Format::MsgpackCompact`
+                // unit variant (bare STR) — both dispatch on the variant name.
+                std::string tag;
+                try {
+                    if (o.type == msgpack::type::object_type::MAP) {
+                        o.via.map.ptr[0].key.convert(tag);
+                    } else {
+                        o.convert(tag);
+                    }
+                } catch(const msgpack::type_error&) {
+                    std::cerr << o << std::endl;
+                    throw_or_abort("error converting tag to string for enum 'BinaryFieldOp'");
+                }
+                if (tag == "Add") {
+                    Add v;
+                    value = v;
+                }
+                else if (tag == "Sub") {
+                    Sub v;
+                    value = v;
+                }
+                else if (tag == "Mul") {
+                    Mul v;
+                    value = v;
+                }
+                else if (tag == "Div") {
+                    Div v;
+                    value = v;
+                }
+                else if (tag == "IntegerDiv") {
+                    IntegerDiv v;
+                    value = v;
+                }
+                else if (tag == "Equals") {
+                    Equals v;
+                    value = v;
+                }
+                else if (tag == "LessThan") {
+                    LessThan v;
+                    value = v;
+                }
+                else if (tag == "LessThanEquals") {
+                    LessThanEquals v;
+                    value = v;
+                }
+                else {
+                    std::cerr << o << std::endl;
+                    throw_or_abort("unknown 'BinaryFieldOp' enum variant: " + tag);
+                }
             }
         }
     };
@@ -273,68 +385,147 @@ namespace Acir {
             if (o.type == msgpack::type::object_type::MAP && o.via.map.size != 1) {
                 throw_or_abort("expected 1 entry for enum 'BinaryIntOp'; got " + std::to_string(o.via.map.size));
             }
-            std::string tag;
-            try {
-                if (o.type == msgpack::type::object_type::MAP) {
+            if (Helpers::is_int_keyed_map(o)) {
+                // `Format::MsgpackTagged` — int-keyed variant.
+                uint8_t tag;
+                try {
                     o.via.map.ptr[0].key.convert(tag);
-                } else {
-                    o.convert(tag);
+                } catch (const msgpack::type_error&) {
+                    std::cerr << o << std::endl;
+                    throw_or_abort("expected u8 variant tag for enum 'BinaryIntOp'");
                 }
-            } catch(const msgpack::type_error&) {
-                std::cerr << o << std::endl;
-                throw_or_abort("error converting tag to string for enum 'BinaryIntOp'");
-            }
-            if (tag == "Add") {
-                Add v;
-                value = v;
-            }
-            else if (tag == "Sub") {
-                Sub v;
-                value = v;
-            }
-            else if (tag == "Mul") {
-                Mul v;
-                value = v;
-            }
-            else if (tag == "Div") {
-                Div v;
-                value = v;
-            }
-            else if (tag == "Equals") {
-                Equals v;
-                value = v;
-            }
-            else if (tag == "LessThan") {
-                LessThan v;
-                value = v;
-            }
-            else if (tag == "LessThanEquals") {
-                LessThanEquals v;
-                value = v;
-            }
-            else if (tag == "And") {
-                And v;
-                value = v;
-            }
-            else if (tag == "Or") {
-                Or v;
-                value = v;
-            }
-            else if (tag == "Xor") {
-                Xor v;
-                value = v;
-            }
-            else if (tag == "Shl") {
-                Shl v;
-                value = v;
-            }
-            else if (tag == "Shr") {
-                Shr v;
-                value = v;
-            }
-            else {
-                std::cerr << o << std::endl;
-                throw_or_abort("unknown 'BinaryIntOp' enum variant: " + tag);
+                msgpack::object const& val = o.via.map.ptr[0].val;
+                switch (tag) {
+                    case 0: {
+                        Add v;
+                        value = v;
+                        break;
+                    }
+                    case 1: {
+                        Sub v;
+                        value = v;
+                        break;
+                    }
+                    case 2: {
+                        Mul v;
+                        value = v;
+                        break;
+                    }
+                    case 3: {
+                        Div v;
+                        value = v;
+                        break;
+                    }
+                    case 4: {
+                        Equals v;
+                        value = v;
+                        break;
+                    }
+                    case 5: {
+                        LessThan v;
+                        value = v;
+                        break;
+                    }
+                    case 6: {
+                        LessThanEquals v;
+                        value = v;
+                        break;
+                    }
+                    case 7: {
+                        And v;
+                        value = v;
+                        break;
+                    }
+                    case 8: {
+                        Or v;
+                        value = v;
+                        break;
+                    }
+                    case 9: {
+                        Xor v;
+                        value = v;
+                        break;
+                    }
+                    case 10: {
+                        Shl v;
+                        value = v;
+                        break;
+                    }
+                    case 11: {
+                        Shr v;
+                        value = v;
+                        break;
+                    }
+                    default:
+                        std::cerr << o << std::endl;
+                        throw_or_abort("unknown 'BinaryIntOp' enum variant tag: " + std::to_string(tag));
+                }
+            } else {
+                // `Format::Msgpack` (MAP, string-keyed) or `Format::MsgpackCompact`
+                // unit variant (bare STR) — both dispatch on the variant name.
+                std::string tag;
+                try {
+                    if (o.type == msgpack::type::object_type::MAP) {
+                        o.via.map.ptr[0].key.convert(tag);
+                    } else {
+                        o.convert(tag);
+                    }
+                } catch(const msgpack::type_error&) {
+                    std::cerr << o << std::endl;
+                    throw_or_abort("error converting tag to string for enum 'BinaryIntOp'");
+                }
+                if (tag == "Add") {
+                    Add v;
+                    value = v;
+                }
+                else if (tag == "Sub") {
+                    Sub v;
+                    value = v;
+                }
+                else if (tag == "Mul") {
+                    Mul v;
+                    value = v;
+                }
+                else if (tag == "Div") {
+                    Div v;
+                    value = v;
+                }
+                else if (tag == "Equals") {
+                    Equals v;
+                    value = v;
+                }
+                else if (tag == "LessThan") {
+                    LessThan v;
+                    value = v;
+                }
+                else if (tag == "LessThanEquals") {
+                    LessThanEquals v;
+                    value = v;
+                }
+                else if (tag == "And") {
+                    And v;
+                    value = v;
+                }
+                else if (tag == "Or") {
+                    Or v;
+                    value = v;
+                }
+                else if (tag == "Xor") {
+                    Xor v;
+                    value = v;
+                }
+                else if (tag == "Shl") {
+                    Shl v;
+                    value = v;
+                }
+                else if (tag == "Shr") {
+                    Shr v;
+                    value = v;
+                }
+                else {
+                    std::cerr << o << std::endl;
+                    throw_or_abort("unknown 'BinaryIntOp' enum variant: " + tag);
+                }
             }
         }
     };
@@ -390,44 +581,93 @@ namespace Acir {
             if (o.type == msgpack::type::object_type::MAP && o.via.map.size != 1) {
                 throw_or_abort("expected 1 entry for enum 'IntegerBitSize'; got " + std::to_string(o.via.map.size));
             }
-            std::string tag;
-            try {
-                if (o.type == msgpack::type::object_type::MAP) {
+            if (Helpers::is_int_keyed_map(o)) {
+                // `Format::MsgpackTagged` — int-keyed variant.
+                uint8_t tag;
+                try {
                     o.via.map.ptr[0].key.convert(tag);
-                } else {
-                    o.convert(tag);
+                } catch (const msgpack::type_error&) {
+                    std::cerr << o << std::endl;
+                    throw_or_abort("expected u8 variant tag for enum 'IntegerBitSize'");
                 }
-            } catch(const msgpack::type_error&) {
-                std::cerr << o << std::endl;
-                throw_or_abort("error converting tag to string for enum 'IntegerBitSize'");
-            }
-            if (tag == "U1") {
-                U1 v;
-                value = v;
-            }
-            else if (tag == "U8") {
-                U8 v;
-                value = v;
-            }
-            else if (tag == "U16") {
-                U16 v;
-                value = v;
-            }
-            else if (tag == "U32") {
-                U32 v;
-                value = v;
-            }
-            else if (tag == "U64") {
-                U64 v;
-                value = v;
-            }
-            else if (tag == "U128") {
-                U128 v;
-                value = v;
-            }
-            else {
-                std::cerr << o << std::endl;
-                throw_or_abort("unknown 'IntegerBitSize' enum variant: " + tag);
+                msgpack::object const& val = o.via.map.ptr[0].val;
+                switch (tag) {
+                    case 0: {
+                        U1 v;
+                        value = v;
+                        break;
+                    }
+                    case 1: {
+                        U8 v;
+                        value = v;
+                        break;
+                    }
+                    case 2: {
+                        U16 v;
+                        value = v;
+                        break;
+                    }
+                    case 3: {
+                        U32 v;
+                        value = v;
+                        break;
+                    }
+                    case 4: {
+                        U64 v;
+                        value = v;
+                        break;
+                    }
+                    case 5: {
+                        U128 v;
+                        value = v;
+                        break;
+                    }
+                    default:
+                        std::cerr << o << std::endl;
+                        throw_or_abort("unknown 'IntegerBitSize' enum variant tag: " + std::to_string(tag));
+                }
+            } else {
+                // `Format::Msgpack` (MAP, string-keyed) or `Format::MsgpackCompact`
+                // unit variant (bare STR) — both dispatch on the variant name.
+                std::string tag;
+                try {
+                    if (o.type == msgpack::type::object_type::MAP) {
+                        o.via.map.ptr[0].key.convert(tag);
+                    } else {
+                        o.convert(tag);
+                    }
+                } catch(const msgpack::type_error&) {
+                    std::cerr << o << std::endl;
+                    throw_or_abort("error converting tag to string for enum 'IntegerBitSize'");
+                }
+                if (tag == "U1") {
+                    U1 v;
+                    value = v;
+                }
+                else if (tag == "U8") {
+                    U8 v;
+                    value = v;
+                }
+                else if (tag == "U16") {
+                    U16 v;
+                    value = v;
+                }
+                else if (tag == "U32") {
+                    U32 v;
+                    value = v;
+                }
+                else if (tag == "U64") {
+                    U64 v;
+                    value = v;
+                }
+                else if (tag == "U128") {
+                    U128 v;
+                    value = v;
+                }
+                else {
+                    std::cerr << o << std::endl;
+                    throw_or_abort("unknown 'IntegerBitSize' enum variant: " + tag);
+                }
             }
         }
     };
@@ -468,35 +708,70 @@ namespace Acir {
             if (o.type == msgpack::type::object_type::MAP && o.via.map.size != 1) {
                 throw_or_abort("expected 1 entry for enum 'BitSize'; got " + std::to_string(o.via.map.size));
             }
-            std::string tag;
-            try {
-                if (o.type == msgpack::type::object_type::MAP) {
-                    o.via.map.ptr[0].key.convert(tag);
-                } else {
-                    o.convert(tag);
-                }
-            } catch(const msgpack::type_error&) {
-                std::cerr << o << std::endl;
-                throw_or_abort("error converting tag to string for enum 'BitSize'");
-            }
-            if (tag == "Field") {
-                Field v;
-                value = v;
-            }
-            else if (tag == "Integer") {
-                Integer v;
+            if (Helpers::is_int_keyed_map(o)) {
+                // `Format::MsgpackTagged` — int-keyed variant.
+                uint8_t tag;
                 try {
-                    o.via.map.ptr[0].val.convert(v);
+                    o.via.map.ptr[0].key.convert(tag);
                 } catch (const msgpack::type_error&) {
                     std::cerr << o << std::endl;
-                    throw_or_abort("error converting into enum variant 'BitSize::Integer'");
+                    throw_or_abort("expected u8 variant tag for enum 'BitSize'");
                 }
-                
-                value = v;
-            }
-            else {
-                std::cerr << o << std::endl;
-                throw_or_abort("unknown 'BitSize' enum variant: " + tag);
+                msgpack::object const& val = o.via.map.ptr[0].val;
+                switch (tag) {
+                    case 0: {
+                        Field v;
+                        value = v;
+                        break;
+                    }
+                    case 1: {
+                        Integer v;
+                        try {
+                            val.convert(v);
+                        } catch (const msgpack::type_error&) {
+                            std::cerr << val << std::endl;
+                            throw_or_abort("error converting into enum variant 'BitSize::Integer'");
+                        }
+                        value = v;
+                        break;
+                    }
+                    default:
+                        std::cerr << o << std::endl;
+                        throw_or_abort("unknown 'BitSize' enum variant tag: " + std::to_string(tag));
+                }
+            } else {
+                // `Format::Msgpack` (MAP, string-keyed) or `Format::MsgpackCompact`
+                // unit variant (bare STR) — both dispatch on the variant name.
+                std::string tag;
+                try {
+                    if (o.type == msgpack::type::object_type::MAP) {
+                        o.via.map.ptr[0].key.convert(tag);
+                    } else {
+                        o.convert(tag);
+                    }
+                } catch(const msgpack::type_error&) {
+                    std::cerr << o << std::endl;
+                    throw_or_abort("error converting tag to string for enum 'BitSize'");
+                }
+                if (tag == "Field") {
+                    Field v;
+                    value = v;
+                }
+                else if (tag == "Integer") {
+                    Integer v;
+                    try {
+                        o.via.map.ptr[0].val.convert(v);
+                    } catch (const msgpack::type_error&) {
+                        std::cerr << o << std::endl;
+                        throw_or_abort("error converting into enum variant 'BitSize::Integer'");
+                    }
+                    
+                    value = v;
+                }
+                else {
+                    std::cerr << o << std::endl;
+                    throw_or_abort("unknown 'BitSize' enum variant: " + tag);
+                }
             }
         }
     };
@@ -546,42 +821,83 @@ namespace Acir {
             if (o.type == msgpack::type::object_type::MAP && o.via.map.size != 1) {
                 throw_or_abort("expected 1 entry for enum 'MemoryAddress'; got " + std::to_string(o.via.map.size));
             }
-            std::string tag;
-            try {
-                if (o.type == msgpack::type::object_type::MAP) {
+            if (Helpers::is_int_keyed_map(o)) {
+                // `Format::MsgpackTagged` — int-keyed variant.
+                uint8_t tag;
+                try {
                     o.via.map.ptr[0].key.convert(tag);
-                } else {
-                    o.convert(tag);
-                }
-            } catch(const msgpack::type_error&) {
-                std::cerr << o << std::endl;
-                throw_or_abort("error converting tag to string for enum 'MemoryAddress'");
-            }
-            if (tag == "Direct") {
-                Direct v;
-                try {
-                    o.via.map.ptr[0].val.convert(v);
                 } catch (const msgpack::type_error&) {
                     std::cerr << o << std::endl;
-                    throw_or_abort("error converting into enum variant 'MemoryAddress::Direct'");
+                    throw_or_abort("expected u8 variant tag for enum 'MemoryAddress'");
                 }
-                
-                value = v;
-            }
-            else if (tag == "Relative") {
-                Relative v;
+                msgpack::object const& val = o.via.map.ptr[0].val;
+                switch (tag) {
+                    case 0: {
+                        Direct v;
+                        try {
+                            val.convert(v);
+                        } catch (const msgpack::type_error&) {
+                            std::cerr << val << std::endl;
+                            throw_or_abort("error converting into enum variant 'MemoryAddress::Direct'");
+                        }
+                        value = v;
+                        break;
+                    }
+                    case 1: {
+                        Relative v;
+                        try {
+                            val.convert(v);
+                        } catch (const msgpack::type_error&) {
+                            std::cerr << val << std::endl;
+                            throw_or_abort("error converting into enum variant 'MemoryAddress::Relative'");
+                        }
+                        value = v;
+                        break;
+                    }
+                    default:
+                        std::cerr << o << std::endl;
+                        throw_or_abort("unknown 'MemoryAddress' enum variant tag: " + std::to_string(tag));
+                }
+            } else {
+                // `Format::Msgpack` (MAP, string-keyed) or `Format::MsgpackCompact`
+                // unit variant (bare STR) — both dispatch on the variant name.
+                std::string tag;
                 try {
-                    o.via.map.ptr[0].val.convert(v);
-                } catch (const msgpack::type_error&) {
+                    if (o.type == msgpack::type::object_type::MAP) {
+                        o.via.map.ptr[0].key.convert(tag);
+                    } else {
+                        o.convert(tag);
+                    }
+                } catch(const msgpack::type_error&) {
                     std::cerr << o << std::endl;
-                    throw_or_abort("error converting into enum variant 'MemoryAddress::Relative'");
+                    throw_or_abort("error converting tag to string for enum 'MemoryAddress'");
                 }
-                
-                value = v;
-            }
-            else {
-                std::cerr << o << std::endl;
-                throw_or_abort("unknown 'MemoryAddress' enum variant: " + tag);
+                if (tag == "Direct") {
+                    Direct v;
+                    try {
+                        o.via.map.ptr[0].val.convert(v);
+                    } catch (const msgpack::type_error&) {
+                        std::cerr << o << std::endl;
+                        throw_or_abort("error converting into enum variant 'MemoryAddress::Direct'");
+                    }
+                    
+                    value = v;
+                }
+                else if (tag == "Relative") {
+                    Relative v;
+                    try {
+                        o.via.map.ptr[0].val.convert(v);
+                    } catch (const msgpack::type_error&) {
+                        std::cerr << o << std::endl;
+                        throw_or_abort("error converting into enum variant 'MemoryAddress::Relative'");
+                    }
+                    
+                    value = v;
+                }
+                else {
+                    std::cerr << o << std::endl;
+                    throw_or_abort("unknown 'MemoryAddress' enum variant: " + tag);
+                }
             }
         }
     };
@@ -610,9 +926,26 @@ namespace Acir {
         void msgpack_unpack(msgpack::object const& o) {
             std::string name = "HeapArray";
             if (o.type == msgpack::type::MAP) {
-                auto kvmap = Helpers::make_kvmap(o, name);
-                Helpers::conv_fld_from_kvmap(kvmap, name, "pointer", pointer, false);
-                Helpers::conv_fld_from_kvmap(kvmap, name, "size", size, false);
+                if (Helpers::is_int_keyed_map(o)) {
+                    Helpers::int_map_dispatch(o, name, [&](uint8_t tag, msgpack::object const& val) {
+                        switch (tag) {
+                            case 0:
+                                Helpers::convert_or_throw(val, name, "pointer", pointer);
+                                break;
+                            case 1:
+                                Helpers::convert_or_throw(val, name, "size", size);
+                                break;
+                            default:
+                                // Unknown tag — skip silently (forward-compat /
+                                // retired tags drained — matches the Rust decoder).
+                                break;
+                        }
+                    });
+                } else {
+                    auto kvmap = Helpers::make_kvmap(o, name);
+                    Helpers::conv_fld_from_kvmap(kvmap, name, "pointer", pointer, false);
+                    Helpers::conv_fld_from_kvmap(kvmap, name, "size", size, false);
+                }
             } else if (o.type == msgpack::type::ARRAY) {
                 auto array = o.via.array; 
                 Helpers::conv_fld_from_array(array, name, "pointer", pointer, 0);
@@ -636,11 +969,34 @@ namespace Acir {
             void msgpack_unpack(msgpack::object const& o) {
                 std::string name = "AES128Encrypt";
                 if (o.type == msgpack::type::MAP) {
-                    auto kvmap = Helpers::make_kvmap(o, name);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "inputs", inputs, false);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "iv", iv, false);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "key", key, false);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "outputs", outputs, false);
+                    if (Helpers::is_int_keyed_map(o)) {
+                        Helpers::int_map_dispatch(o, name, [&](uint8_t tag, msgpack::object const& val) {
+                            switch (tag) {
+                                case 0:
+                                    Helpers::convert_or_throw(val, name, "inputs", inputs);
+                                    break;
+                                case 1:
+                                    Helpers::convert_or_throw(val, name, "iv", iv);
+                                    break;
+                                case 2:
+                                    Helpers::convert_or_throw(val, name, "key", key);
+                                    break;
+                                case 3:
+                                    Helpers::convert_or_throw(val, name, "outputs", outputs);
+                                    break;
+                                default:
+                                    // Unknown tag — skip silently (forward-compat /
+                                    // retired tags drained — matches the Rust decoder).
+                                    break;
+                            }
+                        });
+                    } else {
+                        auto kvmap = Helpers::make_kvmap(o, name);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "inputs", inputs, false);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "iv", iv, false);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "key", key, false);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "outputs", outputs, false);
+                    }
                 } else if (o.type == msgpack::type::ARRAY) {
                     auto array = o.via.array; 
                     Helpers::conv_fld_from_array(array, name, "inputs", inputs, 0);
@@ -662,9 +1018,26 @@ namespace Acir {
             void msgpack_unpack(msgpack::object const& o) {
                 std::string name = "Blake2s";
                 if (o.type == msgpack::type::MAP) {
-                    auto kvmap = Helpers::make_kvmap(o, name);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "message", message, false);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "output", output, false);
+                    if (Helpers::is_int_keyed_map(o)) {
+                        Helpers::int_map_dispatch(o, name, [&](uint8_t tag, msgpack::object const& val) {
+                            switch (tag) {
+                                case 0:
+                                    Helpers::convert_or_throw(val, name, "message", message);
+                                    break;
+                                case 1:
+                                    Helpers::convert_or_throw(val, name, "output", output);
+                                    break;
+                                default:
+                                    // Unknown tag — skip silently (forward-compat /
+                                    // retired tags drained — matches the Rust decoder).
+                                    break;
+                            }
+                        });
+                    } else {
+                        auto kvmap = Helpers::make_kvmap(o, name);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "message", message, false);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "output", output, false);
+                    }
                 } else if (o.type == msgpack::type::ARRAY) {
                     auto array = o.via.array; 
                     Helpers::conv_fld_from_array(array, name, "message", message, 0);
@@ -684,9 +1057,26 @@ namespace Acir {
             void msgpack_unpack(msgpack::object const& o) {
                 std::string name = "Blake3";
                 if (o.type == msgpack::type::MAP) {
-                    auto kvmap = Helpers::make_kvmap(o, name);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "message", message, false);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "output", output, false);
+                    if (Helpers::is_int_keyed_map(o)) {
+                        Helpers::int_map_dispatch(o, name, [&](uint8_t tag, msgpack::object const& val) {
+                            switch (tag) {
+                                case 0:
+                                    Helpers::convert_or_throw(val, name, "message", message);
+                                    break;
+                                case 1:
+                                    Helpers::convert_or_throw(val, name, "output", output);
+                                    break;
+                                default:
+                                    // Unknown tag — skip silently (forward-compat /
+                                    // retired tags drained — matches the Rust decoder).
+                                    break;
+                            }
+                        });
+                    } else {
+                        auto kvmap = Helpers::make_kvmap(o, name);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "message", message, false);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "output", output, false);
+                    }
                 } else if (o.type == msgpack::type::ARRAY) {
                     auto array = o.via.array; 
                     Helpers::conv_fld_from_array(array, name, "message", message, 0);
@@ -706,9 +1096,26 @@ namespace Acir {
             void msgpack_unpack(msgpack::object const& o) {
                 std::string name = "Keccakf1600";
                 if (o.type == msgpack::type::MAP) {
-                    auto kvmap = Helpers::make_kvmap(o, name);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "input", input, false);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "output", output, false);
+                    if (Helpers::is_int_keyed_map(o)) {
+                        Helpers::int_map_dispatch(o, name, [&](uint8_t tag, msgpack::object const& val) {
+                            switch (tag) {
+                                case 0:
+                                    Helpers::convert_or_throw(val, name, "input", input);
+                                    break;
+                                case 1:
+                                    Helpers::convert_or_throw(val, name, "output", output);
+                                    break;
+                                default:
+                                    // Unknown tag — skip silently (forward-compat /
+                                    // retired tags drained — matches the Rust decoder).
+                                    break;
+                            }
+                        });
+                    } else {
+                        auto kvmap = Helpers::make_kvmap(o, name);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "input", input, false);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "output", output, false);
+                    }
                 } else if (o.type == msgpack::type::ARRAY) {
                     auto array = o.via.array; 
                     Helpers::conv_fld_from_array(array, name, "input", input, 0);
@@ -731,12 +1138,38 @@ namespace Acir {
             void msgpack_unpack(msgpack::object const& o) {
                 std::string name = "EcdsaSecp256k1";
                 if (o.type == msgpack::type::MAP) {
-                    auto kvmap = Helpers::make_kvmap(o, name);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "hashed_msg", hashed_msg, false);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "public_key_x", public_key_x, false);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "public_key_y", public_key_y, false);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "signature", signature, false);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "result", result, false);
+                    if (Helpers::is_int_keyed_map(o)) {
+                        Helpers::int_map_dispatch(o, name, [&](uint8_t tag, msgpack::object const& val) {
+                            switch (tag) {
+                                case 0:
+                                    Helpers::convert_or_throw(val, name, "hashed_msg", hashed_msg);
+                                    break;
+                                case 1:
+                                    Helpers::convert_or_throw(val, name, "public_key_x", public_key_x);
+                                    break;
+                                case 2:
+                                    Helpers::convert_or_throw(val, name, "public_key_y", public_key_y);
+                                    break;
+                                case 3:
+                                    Helpers::convert_or_throw(val, name, "signature", signature);
+                                    break;
+                                case 4:
+                                    Helpers::convert_or_throw(val, name, "result", result);
+                                    break;
+                                default:
+                                    // Unknown tag — skip silently (forward-compat /
+                                    // retired tags drained — matches the Rust decoder).
+                                    break;
+                            }
+                        });
+                    } else {
+                        auto kvmap = Helpers::make_kvmap(o, name);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "hashed_msg", hashed_msg, false);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "public_key_x", public_key_x, false);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "public_key_y", public_key_y, false);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "signature", signature, false);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "result", result, false);
+                    }
                 } else if (o.type == msgpack::type::ARRAY) {
                     auto array = o.via.array; 
                     Helpers::conv_fld_from_array(array, name, "hashed_msg", hashed_msg, 0);
@@ -762,12 +1195,38 @@ namespace Acir {
             void msgpack_unpack(msgpack::object const& o) {
                 std::string name = "EcdsaSecp256r1";
                 if (o.type == msgpack::type::MAP) {
-                    auto kvmap = Helpers::make_kvmap(o, name);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "hashed_msg", hashed_msg, false);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "public_key_x", public_key_x, false);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "public_key_y", public_key_y, false);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "signature", signature, false);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "result", result, false);
+                    if (Helpers::is_int_keyed_map(o)) {
+                        Helpers::int_map_dispatch(o, name, [&](uint8_t tag, msgpack::object const& val) {
+                            switch (tag) {
+                                case 0:
+                                    Helpers::convert_or_throw(val, name, "hashed_msg", hashed_msg);
+                                    break;
+                                case 1:
+                                    Helpers::convert_or_throw(val, name, "public_key_x", public_key_x);
+                                    break;
+                                case 2:
+                                    Helpers::convert_or_throw(val, name, "public_key_y", public_key_y);
+                                    break;
+                                case 3:
+                                    Helpers::convert_or_throw(val, name, "signature", signature);
+                                    break;
+                                case 4:
+                                    Helpers::convert_or_throw(val, name, "result", result);
+                                    break;
+                                default:
+                                    // Unknown tag — skip silently (forward-compat /
+                                    // retired tags drained — matches the Rust decoder).
+                                    break;
+                            }
+                        });
+                    } else {
+                        auto kvmap = Helpers::make_kvmap(o, name);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "hashed_msg", hashed_msg, false);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "public_key_x", public_key_x, false);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "public_key_y", public_key_y, false);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "signature", signature, false);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "result", result, false);
+                    }
                 } else if (o.type == msgpack::type::ARRAY) {
                     auto array = o.via.array; 
                     Helpers::conv_fld_from_array(array, name, "hashed_msg", hashed_msg, 0);
@@ -791,10 +1250,30 @@ namespace Acir {
             void msgpack_unpack(msgpack::object const& o) {
                 std::string name = "MultiScalarMul";
                 if (o.type == msgpack::type::MAP) {
-                    auto kvmap = Helpers::make_kvmap(o, name);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "points", points, false);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "scalars", scalars, false);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "outputs", outputs, false);
+                    if (Helpers::is_int_keyed_map(o)) {
+                        Helpers::int_map_dispatch(o, name, [&](uint8_t tag, msgpack::object const& val) {
+                            switch (tag) {
+                                case 0:
+                                    Helpers::convert_or_throw(val, name, "points", points);
+                                    break;
+                                case 1:
+                                    Helpers::convert_or_throw(val, name, "scalars", scalars);
+                                    break;
+                                case 2:
+                                    Helpers::convert_or_throw(val, name, "outputs", outputs);
+                                    break;
+                                default:
+                                    // Unknown tag — skip silently (forward-compat /
+                                    // retired tags drained — matches the Rust decoder).
+                                    break;
+                            }
+                        });
+                    } else {
+                        auto kvmap = Helpers::make_kvmap(o, name);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "points", points, false);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "scalars", scalars, false);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "outputs", outputs, false);
+                    }
                 } else if (o.type == msgpack::type::ARRAY) {
                     auto array = o.via.array; 
                     Helpers::conv_fld_from_array(array, name, "points", points, 0);
@@ -820,14 +1299,46 @@ namespace Acir {
             void msgpack_unpack(msgpack::object const& o) {
                 std::string name = "EmbeddedCurveAdd";
                 if (o.type == msgpack::type::MAP) {
-                    auto kvmap = Helpers::make_kvmap(o, name);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "input1_x", input1_x, false);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "input1_y", input1_y, false);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "input1_infinite", input1_infinite, false);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "input2_x", input2_x, false);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "input2_y", input2_y, false);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "input2_infinite", input2_infinite, false);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "result", result, false);
+                    if (Helpers::is_int_keyed_map(o)) {
+                        Helpers::int_map_dispatch(o, name, [&](uint8_t tag, msgpack::object const& val) {
+                            switch (tag) {
+                                case 0:
+                                    Helpers::convert_or_throw(val, name, "input1_x", input1_x);
+                                    break;
+                                case 1:
+                                    Helpers::convert_or_throw(val, name, "input1_y", input1_y);
+                                    break;
+                                case 2:
+                                    Helpers::convert_or_throw(val, name, "input1_infinite", input1_infinite);
+                                    break;
+                                case 3:
+                                    Helpers::convert_or_throw(val, name, "input2_x", input2_x);
+                                    break;
+                                case 4:
+                                    Helpers::convert_or_throw(val, name, "input2_y", input2_y);
+                                    break;
+                                case 5:
+                                    Helpers::convert_or_throw(val, name, "input2_infinite", input2_infinite);
+                                    break;
+                                case 6:
+                                    Helpers::convert_or_throw(val, name, "result", result);
+                                    break;
+                                default:
+                                    // Unknown tag — skip silently (forward-compat /
+                                    // retired tags drained — matches the Rust decoder).
+                                    break;
+                            }
+                        });
+                    } else {
+                        auto kvmap = Helpers::make_kvmap(o, name);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "input1_x", input1_x, false);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "input1_y", input1_y, false);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "input1_infinite", input1_infinite, false);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "input2_x", input2_x, false);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "input2_y", input2_y, false);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "input2_infinite", input2_infinite, false);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "result", result, false);
+                    }
                 } else if (o.type == msgpack::type::ARRAY) {
                     auto array = o.via.array; 
                     Helpers::conv_fld_from_array(array, name, "input1_x", input1_x, 0);
@@ -852,9 +1363,26 @@ namespace Acir {
             void msgpack_unpack(msgpack::object const& o) {
                 std::string name = "Poseidon2Permutation";
                 if (o.type == msgpack::type::MAP) {
-                    auto kvmap = Helpers::make_kvmap(o, name);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "message", message, false);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "output", output, false);
+                    if (Helpers::is_int_keyed_map(o)) {
+                        Helpers::int_map_dispatch(o, name, [&](uint8_t tag, msgpack::object const& val) {
+                            switch (tag) {
+                                case 0:
+                                    Helpers::convert_or_throw(val, name, "message", message);
+                                    break;
+                                case 1:
+                                    Helpers::convert_or_throw(val, name, "output", output);
+                                    break;
+                                default:
+                                    // Unknown tag — skip silently (forward-compat /
+                                    // retired tags drained — matches the Rust decoder).
+                                    break;
+                            }
+                        });
+                    } else {
+                        auto kvmap = Helpers::make_kvmap(o, name);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "message", message, false);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "output", output, false);
+                    }
                 } else if (o.type == msgpack::type::ARRAY) {
                     auto array = o.via.array; 
                     Helpers::conv_fld_from_array(array, name, "message", message, 0);
@@ -875,10 +1403,30 @@ namespace Acir {
             void msgpack_unpack(msgpack::object const& o) {
                 std::string name = "Sha256Compression";
                 if (o.type == msgpack::type::MAP) {
-                    auto kvmap = Helpers::make_kvmap(o, name);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "input", input, false);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "hash_values", hash_values, false);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "output", output, false);
+                    if (Helpers::is_int_keyed_map(o)) {
+                        Helpers::int_map_dispatch(o, name, [&](uint8_t tag, msgpack::object const& val) {
+                            switch (tag) {
+                                case 0:
+                                    Helpers::convert_or_throw(val, name, "input", input);
+                                    break;
+                                case 1:
+                                    Helpers::convert_or_throw(val, name, "hash_values", hash_values);
+                                    break;
+                                case 2:
+                                    Helpers::convert_or_throw(val, name, "output", output);
+                                    break;
+                                default:
+                                    // Unknown tag — skip silently (forward-compat /
+                                    // retired tags drained — matches the Rust decoder).
+                                    break;
+                            }
+                        });
+                    } else {
+                        auto kvmap = Helpers::make_kvmap(o, name);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "input", input, false);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "hash_values", hash_values, false);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "output", output, false);
+                    }
                 } else if (o.type == msgpack::type::ARRAY) {
                     auto array = o.via.array; 
                     Helpers::conv_fld_from_array(array, name, "input", input, 0);
@@ -902,12 +1450,38 @@ namespace Acir {
             void msgpack_unpack(msgpack::object const& o) {
                 std::string name = "ToRadix";
                 if (o.type == msgpack::type::MAP) {
-                    auto kvmap = Helpers::make_kvmap(o, name);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "input", input, false);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "radix", radix, false);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "output_pointer", output_pointer, false);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "num_limbs", num_limbs, false);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "output_bits", output_bits, false);
+                    if (Helpers::is_int_keyed_map(o)) {
+                        Helpers::int_map_dispatch(o, name, [&](uint8_t tag, msgpack::object const& val) {
+                            switch (tag) {
+                                case 0:
+                                    Helpers::convert_or_throw(val, name, "input", input);
+                                    break;
+                                case 1:
+                                    Helpers::convert_or_throw(val, name, "radix", radix);
+                                    break;
+                                case 2:
+                                    Helpers::convert_or_throw(val, name, "output_pointer", output_pointer);
+                                    break;
+                                case 3:
+                                    Helpers::convert_or_throw(val, name, "num_limbs", num_limbs);
+                                    break;
+                                case 4:
+                                    Helpers::convert_or_throw(val, name, "output_bits", output_bits);
+                                    break;
+                                default:
+                                    // Unknown tag — skip silently (forward-compat /
+                                    // retired tags drained — matches the Rust decoder).
+                                    break;
+                            }
+                        });
+                    } else {
+                        auto kvmap = Helpers::make_kvmap(o, name);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "input", input, false);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "radix", radix, false);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "output_pointer", output_pointer, false);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "num_limbs", num_limbs, false);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "output_bits", output_bits, false);
+                    }
                 } else if (o.type == msgpack::type::ARRAY) {
                     auto array = o.via.array; 
                     Helpers::conv_fld_from_array(array, name, "input", input, 0);
@@ -934,141 +1508,281 @@ namespace Acir {
             if (o.type == msgpack::type::object_type::MAP && o.via.map.size != 1) {
                 throw_or_abort("expected 1 entry for enum 'BlackBoxOp'; got " + std::to_string(o.via.map.size));
             }
-            std::string tag;
-            try {
-                if (o.type == msgpack::type::object_type::MAP) {
+            if (Helpers::is_int_keyed_map(o)) {
+                // `Format::MsgpackTagged` — int-keyed variant.
+                uint8_t tag;
+                try {
                     o.via.map.ptr[0].key.convert(tag);
-                } else {
-                    o.convert(tag);
-                }
-            } catch(const msgpack::type_error&) {
-                std::cerr << o << std::endl;
-                throw_or_abort("error converting tag to string for enum 'BlackBoxOp'");
-            }
-            if (tag == "AES128Encrypt") {
-                AES128Encrypt v;
-                try {
-                    o.via.map.ptr[0].val.convert(v);
                 } catch (const msgpack::type_error&) {
                     std::cerr << o << std::endl;
-                    throw_or_abort("error converting into enum variant 'BlackBoxOp::AES128Encrypt'");
+                    throw_or_abort("expected u8 variant tag for enum 'BlackBoxOp'");
                 }
-                
-                value = v;
-            }
-            else if (tag == "Blake2s") {
-                Blake2s v;
+                msgpack::object const& val = o.via.map.ptr[0].val;
+                switch (tag) {
+                    case 0: {
+                        AES128Encrypt v;
+                        try {
+                            val.convert(v);
+                        } catch (const msgpack::type_error&) {
+                            std::cerr << val << std::endl;
+                            throw_or_abort("error converting into enum variant 'BlackBoxOp::AES128Encrypt'");
+                        }
+                        value = v;
+                        break;
+                    }
+                    case 1: {
+                        Blake2s v;
+                        try {
+                            val.convert(v);
+                        } catch (const msgpack::type_error&) {
+                            std::cerr << val << std::endl;
+                            throw_or_abort("error converting into enum variant 'BlackBoxOp::Blake2s'");
+                        }
+                        value = v;
+                        break;
+                    }
+                    case 2: {
+                        Blake3 v;
+                        try {
+                            val.convert(v);
+                        } catch (const msgpack::type_error&) {
+                            std::cerr << val << std::endl;
+                            throw_or_abort("error converting into enum variant 'BlackBoxOp::Blake3'");
+                        }
+                        value = v;
+                        break;
+                    }
+                    case 3: {
+                        Keccakf1600 v;
+                        try {
+                            val.convert(v);
+                        } catch (const msgpack::type_error&) {
+                            std::cerr << val << std::endl;
+                            throw_or_abort("error converting into enum variant 'BlackBoxOp::Keccakf1600'");
+                        }
+                        value = v;
+                        break;
+                    }
+                    case 4: {
+                        EcdsaSecp256k1 v;
+                        try {
+                            val.convert(v);
+                        } catch (const msgpack::type_error&) {
+                            std::cerr << val << std::endl;
+                            throw_or_abort("error converting into enum variant 'BlackBoxOp::EcdsaSecp256k1'");
+                        }
+                        value = v;
+                        break;
+                    }
+                    case 5: {
+                        EcdsaSecp256r1 v;
+                        try {
+                            val.convert(v);
+                        } catch (const msgpack::type_error&) {
+                            std::cerr << val << std::endl;
+                            throw_or_abort("error converting into enum variant 'BlackBoxOp::EcdsaSecp256r1'");
+                        }
+                        value = v;
+                        break;
+                    }
+                    case 6: {
+                        MultiScalarMul v;
+                        try {
+                            val.convert(v);
+                        } catch (const msgpack::type_error&) {
+                            std::cerr << val << std::endl;
+                            throw_or_abort("error converting into enum variant 'BlackBoxOp::MultiScalarMul'");
+                        }
+                        value = v;
+                        break;
+                    }
+                    case 7: {
+                        EmbeddedCurveAdd v;
+                        try {
+                            val.convert(v);
+                        } catch (const msgpack::type_error&) {
+                            std::cerr << val << std::endl;
+                            throw_or_abort("error converting into enum variant 'BlackBoxOp::EmbeddedCurveAdd'");
+                        }
+                        value = v;
+                        break;
+                    }
+                    case 8: {
+                        Poseidon2Permutation v;
+                        try {
+                            val.convert(v);
+                        } catch (const msgpack::type_error&) {
+                            std::cerr << val << std::endl;
+                            throw_or_abort("error converting into enum variant 'BlackBoxOp::Poseidon2Permutation'");
+                        }
+                        value = v;
+                        break;
+                    }
+                    case 9: {
+                        Sha256Compression v;
+                        try {
+                            val.convert(v);
+                        } catch (const msgpack::type_error&) {
+                            std::cerr << val << std::endl;
+                            throw_or_abort("error converting into enum variant 'BlackBoxOp::Sha256Compression'");
+                        }
+                        value = v;
+                        break;
+                    }
+                    case 10: {
+                        ToRadix v;
+                        try {
+                            val.convert(v);
+                        } catch (const msgpack::type_error&) {
+                            std::cerr << val << std::endl;
+                            throw_or_abort("error converting into enum variant 'BlackBoxOp::ToRadix'");
+                        }
+                        value = v;
+                        break;
+                    }
+                    default:
+                        std::cerr << o << std::endl;
+                        throw_or_abort("unknown 'BlackBoxOp' enum variant tag: " + std::to_string(tag));
+                }
+            } else {
+                // `Format::Msgpack` (MAP, string-keyed) or `Format::MsgpackCompact`
+                // unit variant (bare STR) — both dispatch on the variant name.
+                std::string tag;
                 try {
-                    o.via.map.ptr[0].val.convert(v);
-                } catch (const msgpack::type_error&) {
+                    if (o.type == msgpack::type::object_type::MAP) {
+                        o.via.map.ptr[0].key.convert(tag);
+                    } else {
+                        o.convert(tag);
+                    }
+                } catch(const msgpack::type_error&) {
                     std::cerr << o << std::endl;
-                    throw_or_abort("error converting into enum variant 'BlackBoxOp::Blake2s'");
+                    throw_or_abort("error converting tag to string for enum 'BlackBoxOp'");
                 }
-                
-                value = v;
-            }
-            else if (tag == "Blake3") {
-                Blake3 v;
-                try {
-                    o.via.map.ptr[0].val.convert(v);
-                } catch (const msgpack::type_error&) {
+                if (tag == "AES128Encrypt") {
+                    AES128Encrypt v;
+                    try {
+                        o.via.map.ptr[0].val.convert(v);
+                    } catch (const msgpack::type_error&) {
+                        std::cerr << o << std::endl;
+                        throw_or_abort("error converting into enum variant 'BlackBoxOp::AES128Encrypt'");
+                    }
+                    
+                    value = v;
+                }
+                else if (tag == "Blake2s") {
+                    Blake2s v;
+                    try {
+                        o.via.map.ptr[0].val.convert(v);
+                    } catch (const msgpack::type_error&) {
+                        std::cerr << o << std::endl;
+                        throw_or_abort("error converting into enum variant 'BlackBoxOp::Blake2s'");
+                    }
+                    
+                    value = v;
+                }
+                else if (tag == "Blake3") {
+                    Blake3 v;
+                    try {
+                        o.via.map.ptr[0].val.convert(v);
+                    } catch (const msgpack::type_error&) {
+                        std::cerr << o << std::endl;
+                        throw_or_abort("error converting into enum variant 'BlackBoxOp::Blake3'");
+                    }
+                    
+                    value = v;
+                }
+                else if (tag == "Keccakf1600") {
+                    Keccakf1600 v;
+                    try {
+                        o.via.map.ptr[0].val.convert(v);
+                    } catch (const msgpack::type_error&) {
+                        std::cerr << o << std::endl;
+                        throw_or_abort("error converting into enum variant 'BlackBoxOp::Keccakf1600'");
+                    }
+                    
+                    value = v;
+                }
+                else if (tag == "EcdsaSecp256k1") {
+                    EcdsaSecp256k1 v;
+                    try {
+                        o.via.map.ptr[0].val.convert(v);
+                    } catch (const msgpack::type_error&) {
+                        std::cerr << o << std::endl;
+                        throw_or_abort("error converting into enum variant 'BlackBoxOp::EcdsaSecp256k1'");
+                    }
+                    
+                    value = v;
+                }
+                else if (tag == "EcdsaSecp256r1") {
+                    EcdsaSecp256r1 v;
+                    try {
+                        o.via.map.ptr[0].val.convert(v);
+                    } catch (const msgpack::type_error&) {
+                        std::cerr << o << std::endl;
+                        throw_or_abort("error converting into enum variant 'BlackBoxOp::EcdsaSecp256r1'");
+                    }
+                    
+                    value = v;
+                }
+                else if (tag == "MultiScalarMul") {
+                    MultiScalarMul v;
+                    try {
+                        o.via.map.ptr[0].val.convert(v);
+                    } catch (const msgpack::type_error&) {
+                        std::cerr << o << std::endl;
+                        throw_or_abort("error converting into enum variant 'BlackBoxOp::MultiScalarMul'");
+                    }
+                    
+                    value = v;
+                }
+                else if (tag == "EmbeddedCurveAdd") {
+                    EmbeddedCurveAdd v;
+                    try {
+                        o.via.map.ptr[0].val.convert(v);
+                    } catch (const msgpack::type_error&) {
+                        std::cerr << o << std::endl;
+                        throw_or_abort("error converting into enum variant 'BlackBoxOp::EmbeddedCurveAdd'");
+                    }
+                    
+                    value = v;
+                }
+                else if (tag == "Poseidon2Permutation") {
+                    Poseidon2Permutation v;
+                    try {
+                        o.via.map.ptr[0].val.convert(v);
+                    } catch (const msgpack::type_error&) {
+                        std::cerr << o << std::endl;
+                        throw_or_abort("error converting into enum variant 'BlackBoxOp::Poseidon2Permutation'");
+                    }
+                    
+                    value = v;
+                }
+                else if (tag == "Sha256Compression") {
+                    Sha256Compression v;
+                    try {
+                        o.via.map.ptr[0].val.convert(v);
+                    } catch (const msgpack::type_error&) {
+                        std::cerr << o << std::endl;
+                        throw_or_abort("error converting into enum variant 'BlackBoxOp::Sha256Compression'");
+                    }
+                    
+                    value = v;
+                }
+                else if (tag == "ToRadix") {
+                    ToRadix v;
+                    try {
+                        o.via.map.ptr[0].val.convert(v);
+                    } catch (const msgpack::type_error&) {
+                        std::cerr << o << std::endl;
+                        throw_or_abort("error converting into enum variant 'BlackBoxOp::ToRadix'");
+                    }
+                    
+                    value = v;
+                }
+                else {
                     std::cerr << o << std::endl;
-                    throw_or_abort("error converting into enum variant 'BlackBoxOp::Blake3'");
+                    throw_or_abort("unknown 'BlackBoxOp' enum variant: " + tag);
                 }
-                
-                value = v;
-            }
-            else if (tag == "Keccakf1600") {
-                Keccakf1600 v;
-                try {
-                    o.via.map.ptr[0].val.convert(v);
-                } catch (const msgpack::type_error&) {
-                    std::cerr << o << std::endl;
-                    throw_or_abort("error converting into enum variant 'BlackBoxOp::Keccakf1600'");
-                }
-                
-                value = v;
-            }
-            else if (tag == "EcdsaSecp256k1") {
-                EcdsaSecp256k1 v;
-                try {
-                    o.via.map.ptr[0].val.convert(v);
-                } catch (const msgpack::type_error&) {
-                    std::cerr << o << std::endl;
-                    throw_or_abort("error converting into enum variant 'BlackBoxOp::EcdsaSecp256k1'");
-                }
-                
-                value = v;
-            }
-            else if (tag == "EcdsaSecp256r1") {
-                EcdsaSecp256r1 v;
-                try {
-                    o.via.map.ptr[0].val.convert(v);
-                } catch (const msgpack::type_error&) {
-                    std::cerr << o << std::endl;
-                    throw_or_abort("error converting into enum variant 'BlackBoxOp::EcdsaSecp256r1'");
-                }
-                
-                value = v;
-            }
-            else if (tag == "MultiScalarMul") {
-                MultiScalarMul v;
-                try {
-                    o.via.map.ptr[0].val.convert(v);
-                } catch (const msgpack::type_error&) {
-                    std::cerr << o << std::endl;
-                    throw_or_abort("error converting into enum variant 'BlackBoxOp::MultiScalarMul'");
-                }
-                
-                value = v;
-            }
-            else if (tag == "EmbeddedCurveAdd") {
-                EmbeddedCurveAdd v;
-                try {
-                    o.via.map.ptr[0].val.convert(v);
-                } catch (const msgpack::type_error&) {
-                    std::cerr << o << std::endl;
-                    throw_or_abort("error converting into enum variant 'BlackBoxOp::EmbeddedCurveAdd'");
-                }
-                
-                value = v;
-            }
-            else if (tag == "Poseidon2Permutation") {
-                Poseidon2Permutation v;
-                try {
-                    o.via.map.ptr[0].val.convert(v);
-                } catch (const msgpack::type_error&) {
-                    std::cerr << o << std::endl;
-                    throw_or_abort("error converting into enum variant 'BlackBoxOp::Poseidon2Permutation'");
-                }
-                
-                value = v;
-            }
-            else if (tag == "Sha256Compression") {
-                Sha256Compression v;
-                try {
-                    o.via.map.ptr[0].val.convert(v);
-                } catch (const msgpack::type_error&) {
-                    std::cerr << o << std::endl;
-                    throw_or_abort("error converting into enum variant 'BlackBoxOp::Sha256Compression'");
-                }
-                
-                value = v;
-            }
-            else if (tag == "ToRadix") {
-                ToRadix v;
-                try {
-                    o.via.map.ptr[0].val.convert(v);
-                } catch (const msgpack::type_error&) {
-                    std::cerr << o << std::endl;
-                    throw_or_abort("error converting into enum variant 'BlackBoxOp::ToRadix'");
-                }
-                
-                value = v;
-            }
-            else {
-                std::cerr << o << std::endl;
-                throw_or_abort("unknown 'BlackBoxOp' enum variant: " + tag);
             }
         }
     };
@@ -1116,9 +1830,26 @@ namespace Acir {
             void msgpack_unpack(msgpack::object const& o) {
                 std::string name = "Array";
                 if (o.type == msgpack::type::MAP) {
-                    auto kvmap = Helpers::make_kvmap(o, name);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "value_types", value_types, false);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "size", size, false);
+                    if (Helpers::is_int_keyed_map(o)) {
+                        Helpers::int_map_dispatch(o, name, [&](uint8_t tag, msgpack::object const& val) {
+                            switch (tag) {
+                                case 0:
+                                    Helpers::convert_or_throw(val, name, "value_types", value_types);
+                                    break;
+                                case 1:
+                                    Helpers::convert_or_throw(val, name, "size", size);
+                                    break;
+                                default:
+                                    // Unknown tag — skip silently (forward-compat /
+                                    // retired tags drained — matches the Rust decoder).
+                                    break;
+                            }
+                        });
+                    } else {
+                        auto kvmap = Helpers::make_kvmap(o, name);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "value_types", value_types, false);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "size", size, false);
+                    }
                 } else if (o.type == msgpack::type::ARRAY) {
                     auto array = o.via.array; 
                     Helpers::conv_fld_from_array(array, name, "value_types", value_types, 0);
@@ -1137,8 +1868,22 @@ namespace Acir {
             void msgpack_unpack(msgpack::object const& o) {
                 std::string name = "Vector";
                 if (o.type == msgpack::type::MAP) {
-                    auto kvmap = Helpers::make_kvmap(o, name);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "value_types", value_types, false);
+                    if (Helpers::is_int_keyed_map(o)) {
+                        Helpers::int_map_dispatch(o, name, [&](uint8_t tag, msgpack::object const& val) {
+                            switch (tag) {
+                                case 0:
+                                    Helpers::convert_or_throw(val, name, "value_types", value_types);
+                                    break;
+                                default:
+                                    // Unknown tag — skip silently (forward-compat /
+                                    // retired tags drained — matches the Rust decoder).
+                                    break;
+                            }
+                        });
+                    } else {
+                        auto kvmap = Helpers::make_kvmap(o, name);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "value_types", value_types, false);
+                    }
                 } else if (o.type == msgpack::type::ARRAY) {
                     auto array = o.via.array; 
                     Helpers::conv_fld_from_array(array, name, "value_types", value_types, 0);
@@ -1161,53 +1906,105 @@ namespace Acir {
             if (o.type == msgpack::type::object_type::MAP && o.via.map.size != 1) {
                 throw_or_abort("expected 1 entry for enum 'HeapValueType'; got " + std::to_string(o.via.map.size));
             }
-            std::string tag;
-            try {
-                if (o.type == msgpack::type::object_type::MAP) {
+            if (Helpers::is_int_keyed_map(o)) {
+                // `Format::MsgpackTagged` — int-keyed variant.
+                uint8_t tag;
+                try {
                     o.via.map.ptr[0].key.convert(tag);
-                } else {
-                    o.convert(tag);
-                }
-            } catch(const msgpack::type_error&) {
-                std::cerr << o << std::endl;
-                throw_or_abort("error converting tag to string for enum 'HeapValueType'");
-            }
-            if (tag == "Simple") {
-                Simple v;
-                try {
-                    o.via.map.ptr[0].val.convert(v);
                 } catch (const msgpack::type_error&) {
                     std::cerr << o << std::endl;
-                    throw_or_abort("error converting into enum variant 'HeapValueType::Simple'");
+                    throw_or_abort("expected u8 variant tag for enum 'HeapValueType'");
                 }
-                
-                value = v;
-            }
-            else if (tag == "Array") {
-                Array v;
+                msgpack::object const& val = o.via.map.ptr[0].val;
+                switch (tag) {
+                    case 0: {
+                        Simple v;
+                        try {
+                            val.convert(v);
+                        } catch (const msgpack::type_error&) {
+                            std::cerr << val << std::endl;
+                            throw_or_abort("error converting into enum variant 'HeapValueType::Simple'");
+                        }
+                        value = v;
+                        break;
+                    }
+                    case 1: {
+                        Array v;
+                        try {
+                            val.convert(v);
+                        } catch (const msgpack::type_error&) {
+                            std::cerr << val << std::endl;
+                            throw_or_abort("error converting into enum variant 'HeapValueType::Array'");
+                        }
+                        value = v;
+                        break;
+                    }
+                    case 2: {
+                        Vector v;
+                        try {
+                            val.convert(v);
+                        } catch (const msgpack::type_error&) {
+                            std::cerr << val << std::endl;
+                            throw_or_abort("error converting into enum variant 'HeapValueType::Vector'");
+                        }
+                        value = v;
+                        break;
+                    }
+                    default:
+                        std::cerr << o << std::endl;
+                        throw_or_abort("unknown 'HeapValueType' enum variant tag: " + std::to_string(tag));
+                }
+            } else {
+                // `Format::Msgpack` (MAP, string-keyed) or `Format::MsgpackCompact`
+                // unit variant (bare STR) — both dispatch on the variant name.
+                std::string tag;
                 try {
-                    o.via.map.ptr[0].val.convert(v);
-                } catch (const msgpack::type_error&) {
+                    if (o.type == msgpack::type::object_type::MAP) {
+                        o.via.map.ptr[0].key.convert(tag);
+                    } else {
+                        o.convert(tag);
+                    }
+                } catch(const msgpack::type_error&) {
                     std::cerr << o << std::endl;
-                    throw_or_abort("error converting into enum variant 'HeapValueType::Array'");
+                    throw_or_abort("error converting tag to string for enum 'HeapValueType'");
                 }
-                
-                value = v;
-            }
-            else if (tag == "Vector") {
-                Vector v;
-                try {
-                    o.via.map.ptr[0].val.convert(v);
-                } catch (const msgpack::type_error&) {
+                if (tag == "Simple") {
+                    Simple v;
+                    try {
+                        o.via.map.ptr[0].val.convert(v);
+                    } catch (const msgpack::type_error&) {
+                        std::cerr << o << std::endl;
+                        throw_or_abort("error converting into enum variant 'HeapValueType::Simple'");
+                    }
+                    
+                    value = v;
+                }
+                else if (tag == "Array") {
+                    Array v;
+                    try {
+                        o.via.map.ptr[0].val.convert(v);
+                    } catch (const msgpack::type_error&) {
+                        std::cerr << o << std::endl;
+                        throw_or_abort("error converting into enum variant 'HeapValueType::Array'");
+                    }
+                    
+                    value = v;
+                }
+                else if (tag == "Vector") {
+                    Vector v;
+                    try {
+                        o.via.map.ptr[0].val.convert(v);
+                    } catch (const msgpack::type_error&) {
+                        std::cerr << o << std::endl;
+                        throw_or_abort("error converting into enum variant 'HeapValueType::Vector'");
+                    }
+                    
+                    value = v;
+                }
+                else {
                     std::cerr << o << std::endl;
-                    throw_or_abort("error converting into enum variant 'HeapValueType::Vector'");
+                    throw_or_abort("unknown 'HeapValueType' enum variant: " + tag);
                 }
-                
-                value = v;
-            }
-            else {
-                std::cerr << o << std::endl;
-                throw_or_abort("unknown 'HeapValueType' enum variant: " + tag);
             }
         }
     };
@@ -1221,9 +2018,26 @@ namespace Acir {
         void msgpack_unpack(msgpack::object const& o) {
             std::string name = "HeapVector";
             if (o.type == msgpack::type::MAP) {
-                auto kvmap = Helpers::make_kvmap(o, name);
-                Helpers::conv_fld_from_kvmap(kvmap, name, "pointer", pointer, false);
-                Helpers::conv_fld_from_kvmap(kvmap, name, "size", size, false);
+                if (Helpers::is_int_keyed_map(o)) {
+                    Helpers::int_map_dispatch(o, name, [&](uint8_t tag, msgpack::object const& val) {
+                        switch (tag) {
+                            case 0:
+                                Helpers::convert_or_throw(val, name, "pointer", pointer);
+                                break;
+                            case 1:
+                                Helpers::convert_or_throw(val, name, "size", size);
+                                break;
+                            default:
+                                // Unknown tag — skip silently (forward-compat /
+                                // retired tags drained — matches the Rust decoder).
+                                break;
+                        }
+                    });
+                } else {
+                    auto kvmap = Helpers::make_kvmap(o, name);
+                    Helpers::conv_fld_from_kvmap(kvmap, name, "pointer", pointer, false);
+                    Helpers::conv_fld_from_kvmap(kvmap, name, "size", size, false);
+                }
             } else if (o.type == msgpack::type::ARRAY) {
                 auto array = o.via.array; 
                 Helpers::conv_fld_from_array(array, name, "pointer", pointer, 0);
@@ -1294,53 +2108,105 @@ namespace Acir {
             if (o.type == msgpack::type::object_type::MAP && o.via.map.size != 1) {
                 throw_or_abort("expected 1 entry for enum 'ValueOrArray'; got " + std::to_string(o.via.map.size));
             }
-            std::string tag;
-            try {
-                if (o.type == msgpack::type::object_type::MAP) {
+            if (Helpers::is_int_keyed_map(o)) {
+                // `Format::MsgpackTagged` — int-keyed variant.
+                uint8_t tag;
+                try {
                     o.via.map.ptr[0].key.convert(tag);
-                } else {
-                    o.convert(tag);
-                }
-            } catch(const msgpack::type_error&) {
-                std::cerr << o << std::endl;
-                throw_or_abort("error converting tag to string for enum 'ValueOrArray'");
-            }
-            if (tag == "MemoryAddress") {
-                MemoryAddress v;
-                try {
-                    o.via.map.ptr[0].val.convert(v);
                 } catch (const msgpack::type_error&) {
                     std::cerr << o << std::endl;
-                    throw_or_abort("error converting into enum variant 'ValueOrArray::MemoryAddress'");
+                    throw_or_abort("expected u8 variant tag for enum 'ValueOrArray'");
                 }
-                
-                value = v;
-            }
-            else if (tag == "HeapArray") {
-                HeapArray v;
+                msgpack::object const& val = o.via.map.ptr[0].val;
+                switch (tag) {
+                    case 0: {
+                        MemoryAddress v;
+                        try {
+                            val.convert(v);
+                        } catch (const msgpack::type_error&) {
+                            std::cerr << val << std::endl;
+                            throw_or_abort("error converting into enum variant 'ValueOrArray::MemoryAddress'");
+                        }
+                        value = v;
+                        break;
+                    }
+                    case 1: {
+                        HeapArray v;
+                        try {
+                            val.convert(v);
+                        } catch (const msgpack::type_error&) {
+                            std::cerr << val << std::endl;
+                            throw_or_abort("error converting into enum variant 'ValueOrArray::HeapArray'");
+                        }
+                        value = v;
+                        break;
+                    }
+                    case 2: {
+                        HeapVector v;
+                        try {
+                            val.convert(v);
+                        } catch (const msgpack::type_error&) {
+                            std::cerr << val << std::endl;
+                            throw_or_abort("error converting into enum variant 'ValueOrArray::HeapVector'");
+                        }
+                        value = v;
+                        break;
+                    }
+                    default:
+                        std::cerr << o << std::endl;
+                        throw_or_abort("unknown 'ValueOrArray' enum variant tag: " + std::to_string(tag));
+                }
+            } else {
+                // `Format::Msgpack` (MAP, string-keyed) or `Format::MsgpackCompact`
+                // unit variant (bare STR) — both dispatch on the variant name.
+                std::string tag;
                 try {
-                    o.via.map.ptr[0].val.convert(v);
-                } catch (const msgpack::type_error&) {
+                    if (o.type == msgpack::type::object_type::MAP) {
+                        o.via.map.ptr[0].key.convert(tag);
+                    } else {
+                        o.convert(tag);
+                    }
+                } catch(const msgpack::type_error&) {
                     std::cerr << o << std::endl;
-                    throw_or_abort("error converting into enum variant 'ValueOrArray::HeapArray'");
+                    throw_or_abort("error converting tag to string for enum 'ValueOrArray'");
                 }
-                
-                value = v;
-            }
-            else if (tag == "HeapVector") {
-                HeapVector v;
-                try {
-                    o.via.map.ptr[0].val.convert(v);
-                } catch (const msgpack::type_error&) {
+                if (tag == "MemoryAddress") {
+                    MemoryAddress v;
+                    try {
+                        o.via.map.ptr[0].val.convert(v);
+                    } catch (const msgpack::type_error&) {
+                        std::cerr << o << std::endl;
+                        throw_or_abort("error converting into enum variant 'ValueOrArray::MemoryAddress'");
+                    }
+                    
+                    value = v;
+                }
+                else if (tag == "HeapArray") {
+                    HeapArray v;
+                    try {
+                        o.via.map.ptr[0].val.convert(v);
+                    } catch (const msgpack::type_error&) {
+                        std::cerr << o << std::endl;
+                        throw_or_abort("error converting into enum variant 'ValueOrArray::HeapArray'");
+                    }
+                    
+                    value = v;
+                }
+                else if (tag == "HeapVector") {
+                    HeapVector v;
+                    try {
+                        o.via.map.ptr[0].val.convert(v);
+                    } catch (const msgpack::type_error&) {
+                        std::cerr << o << std::endl;
+                        throw_or_abort("error converting into enum variant 'ValueOrArray::HeapVector'");
+                    }
+                    
+                    value = v;
+                }
+                else {
                     std::cerr << o << std::endl;
-                    throw_or_abort("error converting into enum variant 'ValueOrArray::HeapVector'");
+                    throw_or_abort("unknown 'ValueOrArray' enum variant: " + tag);
                 }
-                
-                value = v;
-            }
-            else {
-                std::cerr << o << std::endl;
-                throw_or_abort("unknown 'ValueOrArray' enum variant: " + tag);
             }
         }
     };
@@ -1358,11 +2224,34 @@ namespace Acir {
             void msgpack_unpack(msgpack::object const& o) {
                 std::string name = "BinaryFieldOp";
                 if (o.type == msgpack::type::MAP) {
-                    auto kvmap = Helpers::make_kvmap(o, name);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "destination", destination, false);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "op", op, false);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "lhs", lhs, false);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "rhs", rhs, false);
+                    if (Helpers::is_int_keyed_map(o)) {
+                        Helpers::int_map_dispatch(o, name, [&](uint8_t tag, msgpack::object const& val) {
+                            switch (tag) {
+                                case 0:
+                                    Helpers::convert_or_throw(val, name, "destination", destination);
+                                    break;
+                                case 1:
+                                    Helpers::convert_or_throw(val, name, "op", op);
+                                    break;
+                                case 2:
+                                    Helpers::convert_or_throw(val, name, "lhs", lhs);
+                                    break;
+                                case 3:
+                                    Helpers::convert_or_throw(val, name, "rhs", rhs);
+                                    break;
+                                default:
+                                    // Unknown tag — skip silently (forward-compat /
+                                    // retired tags drained — matches the Rust decoder).
+                                    break;
+                            }
+                        });
+                    } else {
+                        auto kvmap = Helpers::make_kvmap(o, name);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "destination", destination, false);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "op", op, false);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "lhs", lhs, false);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "rhs", rhs, false);
+                    }
                 } else if (o.type == msgpack::type::ARRAY) {
                     auto array = o.via.array; 
                     Helpers::conv_fld_from_array(array, name, "destination", destination, 0);
@@ -1387,12 +2276,38 @@ namespace Acir {
             void msgpack_unpack(msgpack::object const& o) {
                 std::string name = "BinaryIntOp";
                 if (o.type == msgpack::type::MAP) {
-                    auto kvmap = Helpers::make_kvmap(o, name);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "destination", destination, false);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "op", op, false);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "bit_size", bit_size, false);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "lhs", lhs, false);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "rhs", rhs, false);
+                    if (Helpers::is_int_keyed_map(o)) {
+                        Helpers::int_map_dispatch(o, name, [&](uint8_t tag, msgpack::object const& val) {
+                            switch (tag) {
+                                case 0:
+                                    Helpers::convert_or_throw(val, name, "destination", destination);
+                                    break;
+                                case 1:
+                                    Helpers::convert_or_throw(val, name, "op", op);
+                                    break;
+                                case 2:
+                                    Helpers::convert_or_throw(val, name, "bit_size", bit_size);
+                                    break;
+                                case 3:
+                                    Helpers::convert_or_throw(val, name, "lhs", lhs);
+                                    break;
+                                case 4:
+                                    Helpers::convert_or_throw(val, name, "rhs", rhs);
+                                    break;
+                                default:
+                                    // Unknown tag — skip silently (forward-compat /
+                                    // retired tags drained — matches the Rust decoder).
+                                    break;
+                            }
+                        });
+                    } else {
+                        auto kvmap = Helpers::make_kvmap(o, name);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "destination", destination, false);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "op", op, false);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "bit_size", bit_size, false);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "lhs", lhs, false);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "rhs", rhs, false);
+                    }
                 } else if (o.type == msgpack::type::ARRAY) {
                     auto array = o.via.array; 
                     Helpers::conv_fld_from_array(array, name, "destination", destination, 0);
@@ -1416,10 +2331,30 @@ namespace Acir {
             void msgpack_unpack(msgpack::object const& o) {
                 std::string name = "Not";
                 if (o.type == msgpack::type::MAP) {
-                    auto kvmap = Helpers::make_kvmap(o, name);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "destination", destination, false);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "source", source, false);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "bit_size", bit_size, false);
+                    if (Helpers::is_int_keyed_map(o)) {
+                        Helpers::int_map_dispatch(o, name, [&](uint8_t tag, msgpack::object const& val) {
+                            switch (tag) {
+                                case 0:
+                                    Helpers::convert_or_throw(val, name, "destination", destination);
+                                    break;
+                                case 1:
+                                    Helpers::convert_or_throw(val, name, "source", source);
+                                    break;
+                                case 2:
+                                    Helpers::convert_or_throw(val, name, "bit_size", bit_size);
+                                    break;
+                                default:
+                                    // Unknown tag — skip silently (forward-compat /
+                                    // retired tags drained — matches the Rust decoder).
+                                    break;
+                            }
+                        });
+                    } else {
+                        auto kvmap = Helpers::make_kvmap(o, name);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "destination", destination, false);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "source", source, false);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "bit_size", bit_size, false);
+                    }
                 } else if (o.type == msgpack::type::ARRAY) {
                     auto array = o.via.array; 
                     Helpers::conv_fld_from_array(array, name, "destination", destination, 0);
@@ -1441,10 +2376,30 @@ namespace Acir {
             void msgpack_unpack(msgpack::object const& o) {
                 std::string name = "Cast";
                 if (o.type == msgpack::type::MAP) {
-                    auto kvmap = Helpers::make_kvmap(o, name);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "destination", destination, false);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "source", source, false);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "bit_size", bit_size, false);
+                    if (Helpers::is_int_keyed_map(o)) {
+                        Helpers::int_map_dispatch(o, name, [&](uint8_t tag, msgpack::object const& val) {
+                            switch (tag) {
+                                case 0:
+                                    Helpers::convert_or_throw(val, name, "destination", destination);
+                                    break;
+                                case 1:
+                                    Helpers::convert_or_throw(val, name, "source", source);
+                                    break;
+                                case 2:
+                                    Helpers::convert_or_throw(val, name, "bit_size", bit_size);
+                                    break;
+                                default:
+                                    // Unknown tag — skip silently (forward-compat /
+                                    // retired tags drained — matches the Rust decoder).
+                                    break;
+                            }
+                        });
+                    } else {
+                        auto kvmap = Helpers::make_kvmap(o, name);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "destination", destination, false);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "source", source, false);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "bit_size", bit_size, false);
+                    }
                 } else if (o.type == msgpack::type::ARRAY) {
                     auto array = o.via.array; 
                     Helpers::conv_fld_from_array(array, name, "destination", destination, 0);
@@ -1465,9 +2420,26 @@ namespace Acir {
             void msgpack_unpack(msgpack::object const& o) {
                 std::string name = "JumpIf";
                 if (o.type == msgpack::type::MAP) {
-                    auto kvmap = Helpers::make_kvmap(o, name);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "condition", condition, false);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "location", location, false);
+                    if (Helpers::is_int_keyed_map(o)) {
+                        Helpers::int_map_dispatch(o, name, [&](uint8_t tag, msgpack::object const& val) {
+                            switch (tag) {
+                                case 0:
+                                    Helpers::convert_or_throw(val, name, "condition", condition);
+                                    break;
+                                case 1:
+                                    Helpers::convert_or_throw(val, name, "location", location);
+                                    break;
+                                default:
+                                    // Unknown tag — skip silently (forward-compat /
+                                    // retired tags drained — matches the Rust decoder).
+                                    break;
+                            }
+                        });
+                    } else {
+                        auto kvmap = Helpers::make_kvmap(o, name);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "condition", condition, false);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "location", location, false);
+                    }
                 } else if (o.type == msgpack::type::ARRAY) {
                     auto array = o.via.array; 
                     Helpers::conv_fld_from_array(array, name, "condition", condition, 0);
@@ -1486,8 +2458,22 @@ namespace Acir {
             void msgpack_unpack(msgpack::object const& o) {
                 std::string name = "Jump";
                 if (o.type == msgpack::type::MAP) {
-                    auto kvmap = Helpers::make_kvmap(o, name);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "location", location, false);
+                    if (Helpers::is_int_keyed_map(o)) {
+                        Helpers::int_map_dispatch(o, name, [&](uint8_t tag, msgpack::object const& val) {
+                            switch (tag) {
+                                case 0:
+                                    Helpers::convert_or_throw(val, name, "location", location);
+                                    break;
+                                default:
+                                    // Unknown tag — skip silently (forward-compat /
+                                    // retired tags drained — matches the Rust decoder).
+                                    break;
+                            }
+                        });
+                    } else {
+                        auto kvmap = Helpers::make_kvmap(o, name);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "location", location, false);
+                    }
                 } else if (o.type == msgpack::type::ARRAY) {
                     auto array = o.via.array; 
                     Helpers::conv_fld_from_array(array, name, "location", location, 0);
@@ -1507,10 +2493,30 @@ namespace Acir {
             void msgpack_unpack(msgpack::object const& o) {
                 std::string name = "CalldataCopy";
                 if (o.type == msgpack::type::MAP) {
-                    auto kvmap = Helpers::make_kvmap(o, name);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "destination_address", destination_address, false);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "size_address", size_address, false);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "offset_address", offset_address, false);
+                    if (Helpers::is_int_keyed_map(o)) {
+                        Helpers::int_map_dispatch(o, name, [&](uint8_t tag, msgpack::object const& val) {
+                            switch (tag) {
+                                case 0:
+                                    Helpers::convert_or_throw(val, name, "destination_address", destination_address);
+                                    break;
+                                case 1:
+                                    Helpers::convert_or_throw(val, name, "size_address", size_address);
+                                    break;
+                                case 2:
+                                    Helpers::convert_or_throw(val, name, "offset_address", offset_address);
+                                    break;
+                                default:
+                                    // Unknown tag — skip silently (forward-compat /
+                                    // retired tags drained — matches the Rust decoder).
+                                    break;
+                            }
+                        });
+                    } else {
+                        auto kvmap = Helpers::make_kvmap(o, name);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "destination_address", destination_address, false);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "size_address", size_address, false);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "offset_address", offset_address, false);
+                    }
                 } else if (o.type == msgpack::type::ARRAY) {
                     auto array = o.via.array; 
                     Helpers::conv_fld_from_array(array, name, "destination_address", destination_address, 0);
@@ -1530,8 +2536,22 @@ namespace Acir {
             void msgpack_unpack(msgpack::object const& o) {
                 std::string name = "Call";
                 if (o.type == msgpack::type::MAP) {
-                    auto kvmap = Helpers::make_kvmap(o, name);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "location", location, false);
+                    if (Helpers::is_int_keyed_map(o)) {
+                        Helpers::int_map_dispatch(o, name, [&](uint8_t tag, msgpack::object const& val) {
+                            switch (tag) {
+                                case 0:
+                                    Helpers::convert_or_throw(val, name, "location", location);
+                                    break;
+                                default:
+                                    // Unknown tag — skip silently (forward-compat /
+                                    // retired tags drained — matches the Rust decoder).
+                                    break;
+                            }
+                        });
+                    } else {
+                        auto kvmap = Helpers::make_kvmap(o, name);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "location", location, false);
+                    }
                 } else if (o.type == msgpack::type::ARRAY) {
                     auto array = o.via.array; 
                     Helpers::conv_fld_from_array(array, name, "location", location, 0);
@@ -1551,10 +2571,30 @@ namespace Acir {
             void msgpack_unpack(msgpack::object const& o) {
                 std::string name = "Const";
                 if (o.type == msgpack::type::MAP) {
-                    auto kvmap = Helpers::make_kvmap(o, name);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "destination", destination, false);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "bit_size", bit_size, false);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "value", value, false);
+                    if (Helpers::is_int_keyed_map(o)) {
+                        Helpers::int_map_dispatch(o, name, [&](uint8_t tag, msgpack::object const& val) {
+                            switch (tag) {
+                                case 0:
+                                    Helpers::convert_or_throw(val, name, "destination", destination);
+                                    break;
+                                case 1:
+                                    Helpers::convert_or_throw(val, name, "bit_size", bit_size);
+                                    break;
+                                case 2:
+                                    Helpers::convert_or_throw(val, name, "value", value);
+                                    break;
+                                default:
+                                    // Unknown tag — skip silently (forward-compat /
+                                    // retired tags drained — matches the Rust decoder).
+                                    break;
+                            }
+                        });
+                    } else {
+                        auto kvmap = Helpers::make_kvmap(o, name);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "destination", destination, false);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "bit_size", bit_size, false);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "value", value, false);
+                    }
                 } else if (o.type == msgpack::type::ARRAY) {
                     auto array = o.via.array; 
                     Helpers::conv_fld_from_array(array, name, "destination", destination, 0);
@@ -1576,10 +2616,30 @@ namespace Acir {
             void msgpack_unpack(msgpack::object const& o) {
                 std::string name = "IndirectConst";
                 if (o.type == msgpack::type::MAP) {
-                    auto kvmap = Helpers::make_kvmap(o, name);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "destination_pointer", destination_pointer, false);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "bit_size", bit_size, false);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "value", value, false);
+                    if (Helpers::is_int_keyed_map(o)) {
+                        Helpers::int_map_dispatch(o, name, [&](uint8_t tag, msgpack::object const& val) {
+                            switch (tag) {
+                                case 0:
+                                    Helpers::convert_or_throw(val, name, "destination_pointer", destination_pointer);
+                                    break;
+                                case 1:
+                                    Helpers::convert_or_throw(val, name, "bit_size", bit_size);
+                                    break;
+                                case 2:
+                                    Helpers::convert_or_throw(val, name, "value", value);
+                                    break;
+                                default:
+                                    // Unknown tag — skip silently (forward-compat /
+                                    // retired tags drained — matches the Rust decoder).
+                                    break;
+                            }
+                        });
+                    } else {
+                        auto kvmap = Helpers::make_kvmap(o, name);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "destination_pointer", destination_pointer, false);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "bit_size", bit_size, false);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "value", value, false);
+                    }
                 } else if (o.type == msgpack::type::ARRAY) {
                     auto array = o.via.array; 
                     Helpers::conv_fld_from_array(array, name, "destination_pointer", destination_pointer, 0);
@@ -1609,12 +2669,38 @@ namespace Acir {
             void msgpack_unpack(msgpack::object const& o) {
                 std::string name = "ForeignCall";
                 if (o.type == msgpack::type::MAP) {
-                    auto kvmap = Helpers::make_kvmap(o, name);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "function", function, false);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "destinations", destinations, false);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "destination_value_types", destination_value_types, false);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "inputs", inputs, false);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "input_value_types", input_value_types, false);
+                    if (Helpers::is_int_keyed_map(o)) {
+                        Helpers::int_map_dispatch(o, name, [&](uint8_t tag, msgpack::object const& val) {
+                            switch (tag) {
+                                case 0:
+                                    Helpers::convert_or_throw(val, name, "function", function);
+                                    break;
+                                case 1:
+                                    Helpers::convert_or_throw(val, name, "destinations", destinations);
+                                    break;
+                                case 2:
+                                    Helpers::convert_or_throw(val, name, "destination_value_types", destination_value_types);
+                                    break;
+                                case 3:
+                                    Helpers::convert_or_throw(val, name, "inputs", inputs);
+                                    break;
+                                case 4:
+                                    Helpers::convert_or_throw(val, name, "input_value_types", input_value_types);
+                                    break;
+                                default:
+                                    // Unknown tag — skip silently (forward-compat /
+                                    // retired tags drained — matches the Rust decoder).
+                                    break;
+                            }
+                        });
+                    } else {
+                        auto kvmap = Helpers::make_kvmap(o, name);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "function", function, false);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "destinations", destinations, false);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "destination_value_types", destination_value_types, false);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "inputs", inputs, false);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "input_value_types", input_value_types, false);
+                    }
                 } else if (o.type == msgpack::type::ARRAY) {
                     auto array = o.via.array; 
                     Helpers::conv_fld_from_array(array, name, "function", function, 0);
@@ -1637,9 +2723,26 @@ namespace Acir {
             void msgpack_unpack(msgpack::object const& o) {
                 std::string name = "Mov";
                 if (o.type == msgpack::type::MAP) {
-                    auto kvmap = Helpers::make_kvmap(o, name);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "destination", destination, false);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "source", source, false);
+                    if (Helpers::is_int_keyed_map(o)) {
+                        Helpers::int_map_dispatch(o, name, [&](uint8_t tag, msgpack::object const& val) {
+                            switch (tag) {
+                                case 0:
+                                    Helpers::convert_or_throw(val, name, "destination", destination);
+                                    break;
+                                case 1:
+                                    Helpers::convert_or_throw(val, name, "source", source);
+                                    break;
+                                default:
+                                    // Unknown tag — skip silently (forward-compat /
+                                    // retired tags drained — matches the Rust decoder).
+                                    break;
+                            }
+                        });
+                    } else {
+                        auto kvmap = Helpers::make_kvmap(o, name);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "destination", destination, false);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "source", source, false);
+                    }
                 } else if (o.type == msgpack::type::ARRAY) {
                     auto array = o.via.array; 
                     Helpers::conv_fld_from_array(array, name, "destination", destination, 0);
@@ -1661,11 +2764,34 @@ namespace Acir {
             void msgpack_unpack(msgpack::object const& o) {
                 std::string name = "ConditionalMov";
                 if (o.type == msgpack::type::MAP) {
-                    auto kvmap = Helpers::make_kvmap(o, name);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "destination", destination, false);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "source_a", source_a, false);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "source_b", source_b, false);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "condition", condition, false);
+                    if (Helpers::is_int_keyed_map(o)) {
+                        Helpers::int_map_dispatch(o, name, [&](uint8_t tag, msgpack::object const& val) {
+                            switch (tag) {
+                                case 0:
+                                    Helpers::convert_or_throw(val, name, "destination", destination);
+                                    break;
+                                case 1:
+                                    Helpers::convert_or_throw(val, name, "source_a", source_a);
+                                    break;
+                                case 2:
+                                    Helpers::convert_or_throw(val, name, "source_b", source_b);
+                                    break;
+                                case 3:
+                                    Helpers::convert_or_throw(val, name, "condition", condition);
+                                    break;
+                                default:
+                                    // Unknown tag — skip silently (forward-compat /
+                                    // retired tags drained — matches the Rust decoder).
+                                    break;
+                            }
+                        });
+                    } else {
+                        auto kvmap = Helpers::make_kvmap(o, name);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "destination", destination, false);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "source_a", source_a, false);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "source_b", source_b, false);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "condition", condition, false);
+                    }
                 } else if (o.type == msgpack::type::ARRAY) {
                     auto array = o.via.array; 
                     Helpers::conv_fld_from_array(array, name, "destination", destination, 0);
@@ -1687,9 +2813,26 @@ namespace Acir {
             void msgpack_unpack(msgpack::object const& o) {
                 std::string name = "Load";
                 if (o.type == msgpack::type::MAP) {
-                    auto kvmap = Helpers::make_kvmap(o, name);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "destination", destination, false);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "source_pointer", source_pointer, false);
+                    if (Helpers::is_int_keyed_map(o)) {
+                        Helpers::int_map_dispatch(o, name, [&](uint8_t tag, msgpack::object const& val) {
+                            switch (tag) {
+                                case 0:
+                                    Helpers::convert_or_throw(val, name, "destination", destination);
+                                    break;
+                                case 1:
+                                    Helpers::convert_or_throw(val, name, "source_pointer", source_pointer);
+                                    break;
+                                default:
+                                    // Unknown tag — skip silently (forward-compat /
+                                    // retired tags drained — matches the Rust decoder).
+                                    break;
+                            }
+                        });
+                    } else {
+                        auto kvmap = Helpers::make_kvmap(o, name);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "destination", destination, false);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "source_pointer", source_pointer, false);
+                    }
                 } else if (o.type == msgpack::type::ARRAY) {
                     auto array = o.via.array; 
                     Helpers::conv_fld_from_array(array, name, "destination", destination, 0);
@@ -1709,9 +2852,26 @@ namespace Acir {
             void msgpack_unpack(msgpack::object const& o) {
                 std::string name = "Store";
                 if (o.type == msgpack::type::MAP) {
-                    auto kvmap = Helpers::make_kvmap(o, name);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "destination_pointer", destination_pointer, false);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "source", source, false);
+                    if (Helpers::is_int_keyed_map(o)) {
+                        Helpers::int_map_dispatch(o, name, [&](uint8_t tag, msgpack::object const& val) {
+                            switch (tag) {
+                                case 0:
+                                    Helpers::convert_or_throw(val, name, "destination_pointer", destination_pointer);
+                                    break;
+                                case 1:
+                                    Helpers::convert_or_throw(val, name, "source", source);
+                                    break;
+                                default:
+                                    // Unknown tag — skip silently (forward-compat /
+                                    // retired tags drained — matches the Rust decoder).
+                                    break;
+                            }
+                        });
+                    } else {
+                        auto kvmap = Helpers::make_kvmap(o, name);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "destination_pointer", destination_pointer, false);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "source", source, false);
+                    }
                 } else if (o.type == msgpack::type::ARRAY) {
                     auto array = o.via.array; 
                     Helpers::conv_fld_from_array(array, name, "destination_pointer", destination_pointer, 0);
@@ -1745,8 +2905,22 @@ namespace Acir {
             void msgpack_unpack(msgpack::object const& o) {
                 std::string name = "Trap";
                 if (o.type == msgpack::type::MAP) {
-                    auto kvmap = Helpers::make_kvmap(o, name);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "revert_data", revert_data, false);
+                    if (Helpers::is_int_keyed_map(o)) {
+                        Helpers::int_map_dispatch(o, name, [&](uint8_t tag, msgpack::object const& val) {
+                            switch (tag) {
+                                case 0:
+                                    Helpers::convert_or_throw(val, name, "revert_data", revert_data);
+                                    break;
+                                default:
+                                    // Unknown tag — skip silently (forward-compat /
+                                    // retired tags drained — matches the Rust decoder).
+                                    break;
+                            }
+                        });
+                    } else {
+                        auto kvmap = Helpers::make_kvmap(o, name);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "revert_data", revert_data, false);
+                    }
                 } else if (o.type == msgpack::type::ARRAY) {
                     auto array = o.via.array; 
                     Helpers::conv_fld_from_array(array, name, "revert_data", revert_data, 0);
@@ -1764,8 +2938,22 @@ namespace Acir {
             void msgpack_unpack(msgpack::object const& o) {
                 std::string name = "Stop";
                 if (o.type == msgpack::type::MAP) {
-                    auto kvmap = Helpers::make_kvmap(o, name);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "return_data", return_data, false);
+                    if (Helpers::is_int_keyed_map(o)) {
+                        Helpers::int_map_dispatch(o, name, [&](uint8_t tag, msgpack::object const& val) {
+                            switch (tag) {
+                                case 0:
+                                    Helpers::convert_or_throw(val, name, "return_data", return_data);
+                                    break;
+                                default:
+                                    // Unknown tag — skip silently (forward-compat /
+                                    // retired tags drained — matches the Rust decoder).
+                                    break;
+                            }
+                        });
+                    } else {
+                        auto kvmap = Helpers::make_kvmap(o, name);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "return_data", return_data, false);
+                    }
                 } else if (o.type == msgpack::type::ARRAY) {
                     auto array = o.via.array; 
                     Helpers::conv_fld_from_array(array, name, "return_data", return_data, 0);
@@ -1788,222 +2976,444 @@ namespace Acir {
             if (o.type == msgpack::type::object_type::MAP && o.via.map.size != 1) {
                 throw_or_abort("expected 1 entry for enum 'BrilligOpcode'; got " + std::to_string(o.via.map.size));
             }
-            std::string tag;
-            try {
-                if (o.type == msgpack::type::object_type::MAP) {
+            if (Helpers::is_int_keyed_map(o)) {
+                // `Format::MsgpackTagged` — int-keyed variant.
+                uint8_t tag;
+                try {
                     o.via.map.ptr[0].key.convert(tag);
-                } else {
-                    o.convert(tag);
-                }
-            } catch(const msgpack::type_error&) {
-                std::cerr << o << std::endl;
-                throw_or_abort("error converting tag to string for enum 'BrilligOpcode'");
-            }
-            if (tag == "BinaryFieldOp") {
-                BinaryFieldOp v;
-                try {
-                    o.via.map.ptr[0].val.convert(v);
                 } catch (const msgpack::type_error&) {
                     std::cerr << o << std::endl;
-                    throw_or_abort("error converting into enum variant 'BrilligOpcode::BinaryFieldOp'");
+                    throw_or_abort("expected u8 variant tag for enum 'BrilligOpcode'");
                 }
-                
-                value = v;
-            }
-            else if (tag == "BinaryIntOp") {
-                BinaryIntOp v;
+                msgpack::object const& val = o.via.map.ptr[0].val;
+                switch (tag) {
+                    case 0: {
+                        BinaryFieldOp v;
+                        try {
+                            val.convert(v);
+                        } catch (const msgpack::type_error&) {
+                            std::cerr << val << std::endl;
+                            throw_or_abort("error converting into enum variant 'BrilligOpcode::BinaryFieldOp'");
+                        }
+                        value = v;
+                        break;
+                    }
+                    case 1: {
+                        BinaryIntOp v;
+                        try {
+                            val.convert(v);
+                        } catch (const msgpack::type_error&) {
+                            std::cerr << val << std::endl;
+                            throw_or_abort("error converting into enum variant 'BrilligOpcode::BinaryIntOp'");
+                        }
+                        value = v;
+                        break;
+                    }
+                    case 2: {
+                        Not v;
+                        try {
+                            val.convert(v);
+                        } catch (const msgpack::type_error&) {
+                            std::cerr << val << std::endl;
+                            throw_or_abort("error converting into enum variant 'BrilligOpcode::Not'");
+                        }
+                        value = v;
+                        break;
+                    }
+                    case 3: {
+                        Cast v;
+                        try {
+                            val.convert(v);
+                        } catch (const msgpack::type_error&) {
+                            std::cerr << val << std::endl;
+                            throw_or_abort("error converting into enum variant 'BrilligOpcode::Cast'");
+                        }
+                        value = v;
+                        break;
+                    }
+                    case 4: {
+                        JumpIf v;
+                        try {
+                            val.convert(v);
+                        } catch (const msgpack::type_error&) {
+                            std::cerr << val << std::endl;
+                            throw_or_abort("error converting into enum variant 'BrilligOpcode::JumpIf'");
+                        }
+                        value = v;
+                        break;
+                    }
+                    case 5: {
+                        Jump v;
+                        try {
+                            val.convert(v);
+                        } catch (const msgpack::type_error&) {
+                            std::cerr << val << std::endl;
+                            throw_or_abort("error converting into enum variant 'BrilligOpcode::Jump'");
+                        }
+                        value = v;
+                        break;
+                    }
+                    case 6: {
+                        CalldataCopy v;
+                        try {
+                            val.convert(v);
+                        } catch (const msgpack::type_error&) {
+                            std::cerr << val << std::endl;
+                            throw_or_abort("error converting into enum variant 'BrilligOpcode::CalldataCopy'");
+                        }
+                        value = v;
+                        break;
+                    }
+                    case 7: {
+                        Call v;
+                        try {
+                            val.convert(v);
+                        } catch (const msgpack::type_error&) {
+                            std::cerr << val << std::endl;
+                            throw_or_abort("error converting into enum variant 'BrilligOpcode::Call'");
+                        }
+                        value = v;
+                        break;
+                    }
+                    case 8: {
+                        Const v;
+                        try {
+                            val.convert(v);
+                        } catch (const msgpack::type_error&) {
+                            std::cerr << val << std::endl;
+                            throw_or_abort("error converting into enum variant 'BrilligOpcode::Const'");
+                        }
+                        value = v;
+                        break;
+                    }
+                    case 9: {
+                        IndirectConst v;
+                        try {
+                            val.convert(v);
+                        } catch (const msgpack::type_error&) {
+                            std::cerr << val << std::endl;
+                            throw_or_abort("error converting into enum variant 'BrilligOpcode::IndirectConst'");
+                        }
+                        value = v;
+                        break;
+                    }
+                    case 10: {
+                        Return v;
+                        value = v;
+                        break;
+                    }
+                    case 11: {
+                        ForeignCall v;
+                        try {
+                            val.convert(v);
+                        } catch (const msgpack::type_error&) {
+                            std::cerr << val << std::endl;
+                            throw_or_abort("error converting into enum variant 'BrilligOpcode::ForeignCall'");
+                        }
+                        value = v;
+                        break;
+                    }
+                    case 12: {
+                        Mov v;
+                        try {
+                            val.convert(v);
+                        } catch (const msgpack::type_error&) {
+                            std::cerr << val << std::endl;
+                            throw_or_abort("error converting into enum variant 'BrilligOpcode::Mov'");
+                        }
+                        value = v;
+                        break;
+                    }
+                    case 13: {
+                        ConditionalMov v;
+                        try {
+                            val.convert(v);
+                        } catch (const msgpack::type_error&) {
+                            std::cerr << val << std::endl;
+                            throw_or_abort("error converting into enum variant 'BrilligOpcode::ConditionalMov'");
+                        }
+                        value = v;
+                        break;
+                    }
+                    case 14: {
+                        Load v;
+                        try {
+                            val.convert(v);
+                        } catch (const msgpack::type_error&) {
+                            std::cerr << val << std::endl;
+                            throw_or_abort("error converting into enum variant 'BrilligOpcode::Load'");
+                        }
+                        value = v;
+                        break;
+                    }
+                    case 15: {
+                        Store v;
+                        try {
+                            val.convert(v);
+                        } catch (const msgpack::type_error&) {
+                            std::cerr << val << std::endl;
+                            throw_or_abort("error converting into enum variant 'BrilligOpcode::Store'");
+                        }
+                        value = v;
+                        break;
+                    }
+                    case 16: {
+                        BlackBox v;
+                        try {
+                            val.convert(v);
+                        } catch (const msgpack::type_error&) {
+                            std::cerr << val << std::endl;
+                            throw_or_abort("error converting into enum variant 'BrilligOpcode::BlackBox'");
+                        }
+                        value = v;
+                        break;
+                    }
+                    case 17: {
+                        Trap v;
+                        try {
+                            val.convert(v);
+                        } catch (const msgpack::type_error&) {
+                            std::cerr << val << std::endl;
+                            throw_or_abort("error converting into enum variant 'BrilligOpcode::Trap'");
+                        }
+                        value = v;
+                        break;
+                    }
+                    case 18: {
+                        Stop v;
+                        try {
+                            val.convert(v);
+                        } catch (const msgpack::type_error&) {
+                            std::cerr << val << std::endl;
+                            throw_or_abort("error converting into enum variant 'BrilligOpcode::Stop'");
+                        }
+                        value = v;
+                        break;
+                    }
+                    default:
+                        std::cerr << o << std::endl;
+                        throw_or_abort("unknown 'BrilligOpcode' enum variant tag: " + std::to_string(tag));
+                }
+            } else {
+                // `Format::Msgpack` (MAP, string-keyed) or `Format::MsgpackCompact`
+                // unit variant (bare STR) — both dispatch on the variant name.
+                std::string tag;
                 try {
-                    o.via.map.ptr[0].val.convert(v);
-                } catch (const msgpack::type_error&) {
+                    if (o.type == msgpack::type::object_type::MAP) {
+                        o.via.map.ptr[0].key.convert(tag);
+                    } else {
+                        o.convert(tag);
+                    }
+                } catch(const msgpack::type_error&) {
                     std::cerr << o << std::endl;
-                    throw_or_abort("error converting into enum variant 'BrilligOpcode::BinaryIntOp'");
+                    throw_or_abort("error converting tag to string for enum 'BrilligOpcode'");
                 }
-                
-                value = v;
-            }
-            else if (tag == "Not") {
-                Not v;
-                try {
-                    o.via.map.ptr[0].val.convert(v);
-                } catch (const msgpack::type_error&) {
+                if (tag == "BinaryFieldOp") {
+                    BinaryFieldOp v;
+                    try {
+                        o.via.map.ptr[0].val.convert(v);
+                    } catch (const msgpack::type_error&) {
+                        std::cerr << o << std::endl;
+                        throw_or_abort("error converting into enum variant 'BrilligOpcode::BinaryFieldOp'");
+                    }
+                    
+                    value = v;
+                }
+                else if (tag == "BinaryIntOp") {
+                    BinaryIntOp v;
+                    try {
+                        o.via.map.ptr[0].val.convert(v);
+                    } catch (const msgpack::type_error&) {
+                        std::cerr << o << std::endl;
+                        throw_or_abort("error converting into enum variant 'BrilligOpcode::BinaryIntOp'");
+                    }
+                    
+                    value = v;
+                }
+                else if (tag == "Not") {
+                    Not v;
+                    try {
+                        o.via.map.ptr[0].val.convert(v);
+                    } catch (const msgpack::type_error&) {
+                        std::cerr << o << std::endl;
+                        throw_or_abort("error converting into enum variant 'BrilligOpcode::Not'");
+                    }
+                    
+                    value = v;
+                }
+                else if (tag == "Cast") {
+                    Cast v;
+                    try {
+                        o.via.map.ptr[0].val.convert(v);
+                    } catch (const msgpack::type_error&) {
+                        std::cerr << o << std::endl;
+                        throw_or_abort("error converting into enum variant 'BrilligOpcode::Cast'");
+                    }
+                    
+                    value = v;
+                }
+                else if (tag == "JumpIf") {
+                    JumpIf v;
+                    try {
+                        o.via.map.ptr[0].val.convert(v);
+                    } catch (const msgpack::type_error&) {
+                        std::cerr << o << std::endl;
+                        throw_or_abort("error converting into enum variant 'BrilligOpcode::JumpIf'");
+                    }
+                    
+                    value = v;
+                }
+                else if (tag == "Jump") {
+                    Jump v;
+                    try {
+                        o.via.map.ptr[0].val.convert(v);
+                    } catch (const msgpack::type_error&) {
+                        std::cerr << o << std::endl;
+                        throw_or_abort("error converting into enum variant 'BrilligOpcode::Jump'");
+                    }
+                    
+                    value = v;
+                }
+                else if (tag == "CalldataCopy") {
+                    CalldataCopy v;
+                    try {
+                        o.via.map.ptr[0].val.convert(v);
+                    } catch (const msgpack::type_error&) {
+                        std::cerr << o << std::endl;
+                        throw_or_abort("error converting into enum variant 'BrilligOpcode::CalldataCopy'");
+                    }
+                    
+                    value = v;
+                }
+                else if (tag == "Call") {
+                    Call v;
+                    try {
+                        o.via.map.ptr[0].val.convert(v);
+                    } catch (const msgpack::type_error&) {
+                        std::cerr << o << std::endl;
+                        throw_or_abort("error converting into enum variant 'BrilligOpcode::Call'");
+                    }
+                    
+                    value = v;
+                }
+                else if (tag == "Const") {
+                    Const v;
+                    try {
+                        o.via.map.ptr[0].val.convert(v);
+                    } catch (const msgpack::type_error&) {
+                        std::cerr << o << std::endl;
+                        throw_or_abort("error converting into enum variant 'BrilligOpcode::Const'");
+                    }
+                    
+                    value = v;
+                }
+                else if (tag == "IndirectConst") {
+                    IndirectConst v;
+                    try {
+                        o.via.map.ptr[0].val.convert(v);
+                    } catch (const msgpack::type_error&) {
+                        std::cerr << o << std::endl;
+                        throw_or_abort("error converting into enum variant 'BrilligOpcode::IndirectConst'");
+                    }
+                    
+                    value = v;
+                }
+                else if (tag == "Return") {
+                    Return v;
+                    value = v;
+                }
+                else if (tag == "ForeignCall") {
+                    ForeignCall v;
+                    try {
+                        o.via.map.ptr[0].val.convert(v);
+                    } catch (const msgpack::type_error&) {
+                        std::cerr << o << std::endl;
+                        throw_or_abort("error converting into enum variant 'BrilligOpcode::ForeignCall'");
+                    }
+                    
+                    value = v;
+                }
+                else if (tag == "Mov") {
+                    Mov v;
+                    try {
+                        o.via.map.ptr[0].val.convert(v);
+                    } catch (const msgpack::type_error&) {
+                        std::cerr << o << std::endl;
+                        throw_or_abort("error converting into enum variant 'BrilligOpcode::Mov'");
+                    }
+                    
+                    value = v;
+                }
+                else if (tag == "ConditionalMov") {
+                    ConditionalMov v;
+                    try {
+                        o.via.map.ptr[0].val.convert(v);
+                    } catch (const msgpack::type_error&) {
+                        std::cerr << o << std::endl;
+                        throw_or_abort("error converting into enum variant 'BrilligOpcode::ConditionalMov'");
+                    }
+                    
+                    value = v;
+                }
+                else if (tag == "Load") {
+                    Load v;
+                    try {
+                        o.via.map.ptr[0].val.convert(v);
+                    } catch (const msgpack::type_error&) {
+                        std::cerr << o << std::endl;
+                        throw_or_abort("error converting into enum variant 'BrilligOpcode::Load'");
+                    }
+                    
+                    value = v;
+                }
+                else if (tag == "Store") {
+                    Store v;
+                    try {
+                        o.via.map.ptr[0].val.convert(v);
+                    } catch (const msgpack::type_error&) {
+                        std::cerr << o << std::endl;
+                        throw_or_abort("error converting into enum variant 'BrilligOpcode::Store'");
+                    }
+                    
+                    value = v;
+                }
+                else if (tag == "BlackBox") {
+                    BlackBox v;
+                    try {
+                        o.via.map.ptr[0].val.convert(v);
+                    } catch (const msgpack::type_error&) {
+                        std::cerr << o << std::endl;
+                        throw_or_abort("error converting into enum variant 'BrilligOpcode::BlackBox'");
+                    }
+                    
+                    value = v;
+                }
+                else if (tag == "Trap") {
+                    Trap v;
+                    try {
+                        o.via.map.ptr[0].val.convert(v);
+                    } catch (const msgpack::type_error&) {
+                        std::cerr << o << std::endl;
+                        throw_or_abort("error converting into enum variant 'BrilligOpcode::Trap'");
+                    }
+                    
+                    value = v;
+                }
+                else if (tag == "Stop") {
+                    Stop v;
+                    try {
+                        o.via.map.ptr[0].val.convert(v);
+                    } catch (const msgpack::type_error&) {
+                        std::cerr << o << std::endl;
+                        throw_or_abort("error converting into enum variant 'BrilligOpcode::Stop'");
+                    }
+                    
+                    value = v;
+                }
+                else {
                     std::cerr << o << std::endl;
-                    throw_or_abort("error converting into enum variant 'BrilligOpcode::Not'");
+                    throw_or_abort("unknown 'BrilligOpcode' enum variant: " + tag);
                 }
-                
-                value = v;
-            }
-            else if (tag == "Cast") {
-                Cast v;
-                try {
-                    o.via.map.ptr[0].val.convert(v);
-                } catch (const msgpack::type_error&) {
-                    std::cerr << o << std::endl;
-                    throw_or_abort("error converting into enum variant 'BrilligOpcode::Cast'");
-                }
-                
-                value = v;
-            }
-            else if (tag == "JumpIf") {
-                JumpIf v;
-                try {
-                    o.via.map.ptr[0].val.convert(v);
-                } catch (const msgpack::type_error&) {
-                    std::cerr << o << std::endl;
-                    throw_or_abort("error converting into enum variant 'BrilligOpcode::JumpIf'");
-                }
-                
-                value = v;
-            }
-            else if (tag == "Jump") {
-                Jump v;
-                try {
-                    o.via.map.ptr[0].val.convert(v);
-                } catch (const msgpack::type_error&) {
-                    std::cerr << o << std::endl;
-                    throw_or_abort("error converting into enum variant 'BrilligOpcode::Jump'");
-                }
-                
-                value = v;
-            }
-            else if (tag == "CalldataCopy") {
-                CalldataCopy v;
-                try {
-                    o.via.map.ptr[0].val.convert(v);
-                } catch (const msgpack::type_error&) {
-                    std::cerr << o << std::endl;
-                    throw_or_abort("error converting into enum variant 'BrilligOpcode::CalldataCopy'");
-                }
-                
-                value = v;
-            }
-            else if (tag == "Call") {
-                Call v;
-                try {
-                    o.via.map.ptr[0].val.convert(v);
-                } catch (const msgpack::type_error&) {
-                    std::cerr << o << std::endl;
-                    throw_or_abort("error converting into enum variant 'BrilligOpcode::Call'");
-                }
-                
-                value = v;
-            }
-            else if (tag == "Const") {
-                Const v;
-                try {
-                    o.via.map.ptr[0].val.convert(v);
-                } catch (const msgpack::type_error&) {
-                    std::cerr << o << std::endl;
-                    throw_or_abort("error converting into enum variant 'BrilligOpcode::Const'");
-                }
-                
-                value = v;
-            }
-            else if (tag == "IndirectConst") {
-                IndirectConst v;
-                try {
-                    o.via.map.ptr[0].val.convert(v);
-                } catch (const msgpack::type_error&) {
-                    std::cerr << o << std::endl;
-                    throw_or_abort("error converting into enum variant 'BrilligOpcode::IndirectConst'");
-                }
-                
-                value = v;
-            }
-            else if (tag == "Return") {
-                Return v;
-                value = v;
-            }
-            else if (tag == "ForeignCall") {
-                ForeignCall v;
-                try {
-                    o.via.map.ptr[0].val.convert(v);
-                } catch (const msgpack::type_error&) {
-                    std::cerr << o << std::endl;
-                    throw_or_abort("error converting into enum variant 'BrilligOpcode::ForeignCall'");
-                }
-                
-                value = v;
-            }
-            else if (tag == "Mov") {
-                Mov v;
-                try {
-                    o.via.map.ptr[0].val.convert(v);
-                } catch (const msgpack::type_error&) {
-                    std::cerr << o << std::endl;
-                    throw_or_abort("error converting into enum variant 'BrilligOpcode::Mov'");
-                }
-                
-                value = v;
-            }
-            else if (tag == "ConditionalMov") {
-                ConditionalMov v;
-                try {
-                    o.via.map.ptr[0].val.convert(v);
-                } catch (const msgpack::type_error&) {
-                    std::cerr << o << std::endl;
-                    throw_or_abort("error converting into enum variant 'BrilligOpcode::ConditionalMov'");
-                }
-                
-                value = v;
-            }
-            else if (tag == "Load") {
-                Load v;
-                try {
-                    o.via.map.ptr[0].val.convert(v);
-                } catch (const msgpack::type_error&) {
-                    std::cerr << o << std::endl;
-                    throw_or_abort("error converting into enum variant 'BrilligOpcode::Load'");
-                }
-                
-                value = v;
-            }
-            else if (tag == "Store") {
-                Store v;
-                try {
-                    o.via.map.ptr[0].val.convert(v);
-                } catch (const msgpack::type_error&) {
-                    std::cerr << o << std::endl;
-                    throw_or_abort("error converting into enum variant 'BrilligOpcode::Store'");
-                }
-                
-                value = v;
-            }
-            else if (tag == "BlackBox") {
-                BlackBox v;
-                try {
-                    o.via.map.ptr[0].val.convert(v);
-                } catch (const msgpack::type_error&) {
-                    std::cerr << o << std::endl;
-                    throw_or_abort("error converting into enum variant 'BrilligOpcode::BlackBox'");
-                }
-                
-                value = v;
-            }
-            else if (tag == "Trap") {
-                Trap v;
-                try {
-                    o.via.map.ptr[0].val.convert(v);
-                } catch (const msgpack::type_error&) {
-                    std::cerr << o << std::endl;
-                    throw_or_abort("error converting into enum variant 'BrilligOpcode::Trap'");
-                }
-                
-                value = v;
-            }
-            else if (tag == "Stop") {
-                Stop v;
-                try {
-                    o.via.map.ptr[0].val.convert(v);
-                } catch (const msgpack::type_error&) {
-                    std::cerr << o << std::endl;
-                    throw_or_abort("error converting into enum variant 'BrilligOpcode::Stop'");
-                }
-                
-                value = v;
-            }
-            else {
-                std::cerr << o << std::endl;
-                throw_or_abort("unknown 'BrilligOpcode' enum variant: " + tag);
             }
         }
     };
@@ -2068,42 +3478,83 @@ namespace Acir {
             if (o.type == msgpack::type::object_type::MAP && o.via.map.size != 1) {
                 throw_or_abort("expected 1 entry for enum 'FunctionInput'; got " + std::to_string(o.via.map.size));
             }
-            std::string tag;
-            try {
-                if (o.type == msgpack::type::object_type::MAP) {
+            if (Helpers::is_int_keyed_map(o)) {
+                // `Format::MsgpackTagged` — int-keyed variant.
+                uint8_t tag;
+                try {
                     o.via.map.ptr[0].key.convert(tag);
-                } else {
-                    o.convert(tag);
-                }
-            } catch(const msgpack::type_error&) {
-                std::cerr << o << std::endl;
-                throw_or_abort("error converting tag to string for enum 'FunctionInput'");
-            }
-            if (tag == "Constant") {
-                Constant v;
-                try {
-                    o.via.map.ptr[0].val.convert(v);
                 } catch (const msgpack::type_error&) {
                     std::cerr << o << std::endl;
-                    throw_or_abort("error converting into enum variant 'FunctionInput::Constant'");
+                    throw_or_abort("expected u8 variant tag for enum 'FunctionInput'");
                 }
-                
-                value = v;
-            }
-            else if (tag == "Witness") {
-                Witness v;
+                msgpack::object const& val = o.via.map.ptr[0].val;
+                switch (tag) {
+                    case 0: {
+                        Constant v;
+                        try {
+                            val.convert(v);
+                        } catch (const msgpack::type_error&) {
+                            std::cerr << val << std::endl;
+                            throw_or_abort("error converting into enum variant 'FunctionInput::Constant'");
+                        }
+                        value = v;
+                        break;
+                    }
+                    case 1: {
+                        Witness v;
+                        try {
+                            val.convert(v);
+                        } catch (const msgpack::type_error&) {
+                            std::cerr << val << std::endl;
+                            throw_or_abort("error converting into enum variant 'FunctionInput::Witness'");
+                        }
+                        value = v;
+                        break;
+                    }
+                    default:
+                        std::cerr << o << std::endl;
+                        throw_or_abort("unknown 'FunctionInput' enum variant tag: " + std::to_string(tag));
+                }
+            } else {
+                // `Format::Msgpack` (MAP, string-keyed) or `Format::MsgpackCompact`
+                // unit variant (bare STR) — both dispatch on the variant name.
+                std::string tag;
                 try {
-                    o.via.map.ptr[0].val.convert(v);
-                } catch (const msgpack::type_error&) {
+                    if (o.type == msgpack::type::object_type::MAP) {
+                        o.via.map.ptr[0].key.convert(tag);
+                    } else {
+                        o.convert(tag);
+                    }
+                } catch(const msgpack::type_error&) {
                     std::cerr << o << std::endl;
-                    throw_or_abort("error converting into enum variant 'FunctionInput::Witness'");
+                    throw_or_abort("error converting tag to string for enum 'FunctionInput'");
                 }
-                
-                value = v;
-            }
-            else {
-                std::cerr << o << std::endl;
-                throw_or_abort("unknown 'FunctionInput' enum variant: " + tag);
+                if (tag == "Constant") {
+                    Constant v;
+                    try {
+                        o.via.map.ptr[0].val.convert(v);
+                    } catch (const msgpack::type_error&) {
+                        std::cerr << o << std::endl;
+                        throw_or_abort("error converting into enum variant 'FunctionInput::Constant'");
+                    }
+                    
+                    value = v;
+                }
+                else if (tag == "Witness") {
+                    Witness v;
+                    try {
+                        o.via.map.ptr[0].val.convert(v);
+                    } catch (const msgpack::type_error&) {
+                        std::cerr << o << std::endl;
+                        throw_or_abort("error converting into enum variant 'FunctionInput::Witness'");
+                    }
+                    
+                    value = v;
+                }
+                else {
+                    std::cerr << o << std::endl;
+                    throw_or_abort("unknown 'FunctionInput' enum variant: " + tag);
+                }
             }
         }
     };
@@ -2121,11 +3572,34 @@ namespace Acir {
             void msgpack_unpack(msgpack::object const& o) {
                 std::string name = "AES128Encrypt";
                 if (o.type == msgpack::type::MAP) {
-                    auto kvmap = Helpers::make_kvmap(o, name);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "inputs", inputs, false);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "iv", iv, false);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "key", key, false);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "outputs", outputs, false);
+                    if (Helpers::is_int_keyed_map(o)) {
+                        Helpers::int_map_dispatch(o, name, [&](uint8_t tag, msgpack::object const& val) {
+                            switch (tag) {
+                                case 0:
+                                    Helpers::convert_or_throw(val, name, "inputs", inputs);
+                                    break;
+                                case 1:
+                                    Helpers::convert_or_throw(val, name, "iv", iv);
+                                    break;
+                                case 2:
+                                    Helpers::convert_or_throw(val, name, "key", key);
+                                    break;
+                                case 3:
+                                    Helpers::convert_or_throw(val, name, "outputs", outputs);
+                                    break;
+                                default:
+                                    // Unknown tag — skip silently (forward-compat /
+                                    // retired tags drained — matches the Rust decoder).
+                                    break;
+                            }
+                        });
+                    } else {
+                        auto kvmap = Helpers::make_kvmap(o, name);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "inputs", inputs, false);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "iv", iv, false);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "key", key, false);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "outputs", outputs, false);
+                    }
                 } else if (o.type == msgpack::type::ARRAY) {
                     auto array = o.via.array; 
                     Helpers::conv_fld_from_array(array, name, "inputs", inputs, 0);
@@ -2149,11 +3623,34 @@ namespace Acir {
             void msgpack_unpack(msgpack::object const& o) {
                 std::string name = "AND";
                 if (o.type == msgpack::type::MAP) {
-                    auto kvmap = Helpers::make_kvmap(o, name);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "lhs", lhs, false);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "rhs", rhs, false);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "num_bits", num_bits, false);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "output", output, false);
+                    if (Helpers::is_int_keyed_map(o)) {
+                        Helpers::int_map_dispatch(o, name, [&](uint8_t tag, msgpack::object const& val) {
+                            switch (tag) {
+                                case 0:
+                                    Helpers::convert_or_throw(val, name, "lhs", lhs);
+                                    break;
+                                case 1:
+                                    Helpers::convert_or_throw(val, name, "rhs", rhs);
+                                    break;
+                                case 2:
+                                    Helpers::convert_or_throw(val, name, "num_bits", num_bits);
+                                    break;
+                                case 3:
+                                    Helpers::convert_or_throw(val, name, "output", output);
+                                    break;
+                                default:
+                                    // Unknown tag — skip silently (forward-compat /
+                                    // retired tags drained — matches the Rust decoder).
+                                    break;
+                            }
+                        });
+                    } else {
+                        auto kvmap = Helpers::make_kvmap(o, name);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "lhs", lhs, false);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "rhs", rhs, false);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "num_bits", num_bits, false);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "output", output, false);
+                    }
                 } else if (o.type == msgpack::type::ARRAY) {
                     auto array = o.via.array; 
                     Helpers::conv_fld_from_array(array, name, "lhs", lhs, 0);
@@ -2177,11 +3674,34 @@ namespace Acir {
             void msgpack_unpack(msgpack::object const& o) {
                 std::string name = "XOR";
                 if (o.type == msgpack::type::MAP) {
-                    auto kvmap = Helpers::make_kvmap(o, name);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "lhs", lhs, false);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "rhs", rhs, false);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "num_bits", num_bits, false);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "output", output, false);
+                    if (Helpers::is_int_keyed_map(o)) {
+                        Helpers::int_map_dispatch(o, name, [&](uint8_t tag, msgpack::object const& val) {
+                            switch (tag) {
+                                case 0:
+                                    Helpers::convert_or_throw(val, name, "lhs", lhs);
+                                    break;
+                                case 1:
+                                    Helpers::convert_or_throw(val, name, "rhs", rhs);
+                                    break;
+                                case 2:
+                                    Helpers::convert_or_throw(val, name, "num_bits", num_bits);
+                                    break;
+                                case 3:
+                                    Helpers::convert_or_throw(val, name, "output", output);
+                                    break;
+                                default:
+                                    // Unknown tag — skip silently (forward-compat /
+                                    // retired tags drained — matches the Rust decoder).
+                                    break;
+                            }
+                        });
+                    } else {
+                        auto kvmap = Helpers::make_kvmap(o, name);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "lhs", lhs, false);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "rhs", rhs, false);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "num_bits", num_bits, false);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "output", output, false);
+                    }
                 } else if (o.type == msgpack::type::ARRAY) {
                     auto array = o.via.array; 
                     Helpers::conv_fld_from_array(array, name, "lhs", lhs, 0);
@@ -2203,9 +3723,26 @@ namespace Acir {
             void msgpack_unpack(msgpack::object const& o) {
                 std::string name = "RANGE";
                 if (o.type == msgpack::type::MAP) {
-                    auto kvmap = Helpers::make_kvmap(o, name);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "input", input, false);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "num_bits", num_bits, false);
+                    if (Helpers::is_int_keyed_map(o)) {
+                        Helpers::int_map_dispatch(o, name, [&](uint8_t tag, msgpack::object const& val) {
+                            switch (tag) {
+                                case 0:
+                                    Helpers::convert_or_throw(val, name, "input", input);
+                                    break;
+                                case 1:
+                                    Helpers::convert_or_throw(val, name, "num_bits", num_bits);
+                                    break;
+                                default:
+                                    // Unknown tag — skip silently (forward-compat /
+                                    // retired tags drained — matches the Rust decoder).
+                                    break;
+                            }
+                        });
+                    } else {
+                        auto kvmap = Helpers::make_kvmap(o, name);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "input", input, false);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "num_bits", num_bits, false);
+                    }
                 } else if (o.type == msgpack::type::ARRAY) {
                     auto array = o.via.array; 
                     Helpers::conv_fld_from_array(array, name, "input", input, 0);
@@ -2225,9 +3762,26 @@ namespace Acir {
             void msgpack_unpack(msgpack::object const& o) {
                 std::string name = "Blake2s";
                 if (o.type == msgpack::type::MAP) {
-                    auto kvmap = Helpers::make_kvmap(o, name);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "inputs", inputs, false);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "outputs", outputs, false);
+                    if (Helpers::is_int_keyed_map(o)) {
+                        Helpers::int_map_dispatch(o, name, [&](uint8_t tag, msgpack::object const& val) {
+                            switch (tag) {
+                                case 0:
+                                    Helpers::convert_or_throw(val, name, "inputs", inputs);
+                                    break;
+                                case 1:
+                                    Helpers::convert_or_throw(val, name, "outputs", outputs);
+                                    break;
+                                default:
+                                    // Unknown tag — skip silently (forward-compat /
+                                    // retired tags drained — matches the Rust decoder).
+                                    break;
+                            }
+                        });
+                    } else {
+                        auto kvmap = Helpers::make_kvmap(o, name);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "inputs", inputs, false);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "outputs", outputs, false);
+                    }
                 } else if (o.type == msgpack::type::ARRAY) {
                     auto array = o.via.array; 
                     Helpers::conv_fld_from_array(array, name, "inputs", inputs, 0);
@@ -2247,9 +3801,26 @@ namespace Acir {
             void msgpack_unpack(msgpack::object const& o) {
                 std::string name = "Blake3";
                 if (o.type == msgpack::type::MAP) {
-                    auto kvmap = Helpers::make_kvmap(o, name);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "inputs", inputs, false);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "outputs", outputs, false);
+                    if (Helpers::is_int_keyed_map(o)) {
+                        Helpers::int_map_dispatch(o, name, [&](uint8_t tag, msgpack::object const& val) {
+                            switch (tag) {
+                                case 0:
+                                    Helpers::convert_or_throw(val, name, "inputs", inputs);
+                                    break;
+                                case 1:
+                                    Helpers::convert_or_throw(val, name, "outputs", outputs);
+                                    break;
+                                default:
+                                    // Unknown tag — skip silently (forward-compat /
+                                    // retired tags drained — matches the Rust decoder).
+                                    break;
+                            }
+                        });
+                    } else {
+                        auto kvmap = Helpers::make_kvmap(o, name);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "inputs", inputs, false);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "outputs", outputs, false);
+                    }
                 } else if (o.type == msgpack::type::ARRAY) {
                     auto array = o.via.array; 
                     Helpers::conv_fld_from_array(array, name, "inputs", inputs, 0);
@@ -2273,13 +3844,42 @@ namespace Acir {
             void msgpack_unpack(msgpack::object const& o) {
                 std::string name = "EcdsaSecp256k1";
                 if (o.type == msgpack::type::MAP) {
-                    auto kvmap = Helpers::make_kvmap(o, name);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "public_key_x", public_key_x, false);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "public_key_y", public_key_y, false);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "signature", signature, false);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "hashed_message", hashed_message, false);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "predicate", predicate, false);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "output", output, false);
+                    if (Helpers::is_int_keyed_map(o)) {
+                        Helpers::int_map_dispatch(o, name, [&](uint8_t tag, msgpack::object const& val) {
+                            switch (tag) {
+                                case 0:
+                                    Helpers::convert_or_throw(val, name, "public_key_x", public_key_x);
+                                    break;
+                                case 1:
+                                    Helpers::convert_or_throw(val, name, "public_key_y", public_key_y);
+                                    break;
+                                case 2:
+                                    Helpers::convert_or_throw(val, name, "signature", signature);
+                                    break;
+                                case 3:
+                                    Helpers::convert_or_throw(val, name, "hashed_message", hashed_message);
+                                    break;
+                                case 4:
+                                    Helpers::convert_or_throw(val, name, "predicate", predicate);
+                                    break;
+                                case 5:
+                                    Helpers::convert_or_throw(val, name, "output", output);
+                                    break;
+                                default:
+                                    // Unknown tag — skip silently (forward-compat /
+                                    // retired tags drained — matches the Rust decoder).
+                                    break;
+                            }
+                        });
+                    } else {
+                        auto kvmap = Helpers::make_kvmap(o, name);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "public_key_x", public_key_x, false);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "public_key_y", public_key_y, false);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "signature", signature, false);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "hashed_message", hashed_message, false);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "predicate", predicate, false);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "output", output, false);
+                    }
                 } else if (o.type == msgpack::type::ARRAY) {
                     auto array = o.via.array; 
                     Helpers::conv_fld_from_array(array, name, "public_key_x", public_key_x, 0);
@@ -2307,13 +3907,42 @@ namespace Acir {
             void msgpack_unpack(msgpack::object const& o) {
                 std::string name = "EcdsaSecp256r1";
                 if (o.type == msgpack::type::MAP) {
-                    auto kvmap = Helpers::make_kvmap(o, name);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "public_key_x", public_key_x, false);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "public_key_y", public_key_y, false);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "signature", signature, false);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "hashed_message", hashed_message, false);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "predicate", predicate, false);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "output", output, false);
+                    if (Helpers::is_int_keyed_map(o)) {
+                        Helpers::int_map_dispatch(o, name, [&](uint8_t tag, msgpack::object const& val) {
+                            switch (tag) {
+                                case 0:
+                                    Helpers::convert_or_throw(val, name, "public_key_x", public_key_x);
+                                    break;
+                                case 1:
+                                    Helpers::convert_or_throw(val, name, "public_key_y", public_key_y);
+                                    break;
+                                case 2:
+                                    Helpers::convert_or_throw(val, name, "signature", signature);
+                                    break;
+                                case 3:
+                                    Helpers::convert_or_throw(val, name, "hashed_message", hashed_message);
+                                    break;
+                                case 4:
+                                    Helpers::convert_or_throw(val, name, "predicate", predicate);
+                                    break;
+                                case 5:
+                                    Helpers::convert_or_throw(val, name, "output", output);
+                                    break;
+                                default:
+                                    // Unknown tag — skip silently (forward-compat /
+                                    // retired tags drained — matches the Rust decoder).
+                                    break;
+                            }
+                        });
+                    } else {
+                        auto kvmap = Helpers::make_kvmap(o, name);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "public_key_x", public_key_x, false);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "public_key_y", public_key_y, false);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "signature", signature, false);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "hashed_message", hashed_message, false);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "predicate", predicate, false);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "output", output, false);
+                    }
                 } else if (o.type == msgpack::type::ARRAY) {
                     auto array = o.via.array; 
                     Helpers::conv_fld_from_array(array, name, "public_key_x", public_key_x, 0);
@@ -2339,11 +3968,34 @@ namespace Acir {
             void msgpack_unpack(msgpack::object const& o) {
                 std::string name = "MultiScalarMul";
                 if (o.type == msgpack::type::MAP) {
-                    auto kvmap = Helpers::make_kvmap(o, name);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "points", points, false);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "scalars", scalars, false);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "predicate", predicate, false);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "outputs", outputs, false);
+                    if (Helpers::is_int_keyed_map(o)) {
+                        Helpers::int_map_dispatch(o, name, [&](uint8_t tag, msgpack::object const& val) {
+                            switch (tag) {
+                                case 0:
+                                    Helpers::convert_or_throw(val, name, "points", points);
+                                    break;
+                                case 1:
+                                    Helpers::convert_or_throw(val, name, "scalars", scalars);
+                                    break;
+                                case 2:
+                                    Helpers::convert_or_throw(val, name, "predicate", predicate);
+                                    break;
+                                case 3:
+                                    Helpers::convert_or_throw(val, name, "outputs", outputs);
+                                    break;
+                                default:
+                                    // Unknown tag — skip silently (forward-compat /
+                                    // retired tags drained — matches the Rust decoder).
+                                    break;
+                            }
+                        });
+                    } else {
+                        auto kvmap = Helpers::make_kvmap(o, name);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "points", points, false);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "scalars", scalars, false);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "predicate", predicate, false);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "outputs", outputs, false);
+                    }
                 } else if (o.type == msgpack::type::ARRAY) {
                     auto array = o.via.array; 
                     Helpers::conv_fld_from_array(array, name, "points", points, 0);
@@ -2367,11 +4019,34 @@ namespace Acir {
             void msgpack_unpack(msgpack::object const& o) {
                 std::string name = "EmbeddedCurveAdd";
                 if (o.type == msgpack::type::MAP) {
-                    auto kvmap = Helpers::make_kvmap(o, name);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "input1", input1, false);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "input2", input2, false);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "predicate", predicate, false);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "outputs", outputs, false);
+                    if (Helpers::is_int_keyed_map(o)) {
+                        Helpers::int_map_dispatch(o, name, [&](uint8_t tag, msgpack::object const& val) {
+                            switch (tag) {
+                                case 0:
+                                    Helpers::convert_or_throw(val, name, "input1", input1);
+                                    break;
+                                case 1:
+                                    Helpers::convert_or_throw(val, name, "input2", input2);
+                                    break;
+                                case 2:
+                                    Helpers::convert_or_throw(val, name, "predicate", predicate);
+                                    break;
+                                case 3:
+                                    Helpers::convert_or_throw(val, name, "outputs", outputs);
+                                    break;
+                                default:
+                                    // Unknown tag — skip silently (forward-compat /
+                                    // retired tags drained — matches the Rust decoder).
+                                    break;
+                            }
+                        });
+                    } else {
+                        auto kvmap = Helpers::make_kvmap(o, name);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "input1", input1, false);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "input2", input2, false);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "predicate", predicate, false);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "outputs", outputs, false);
+                    }
                 } else if (o.type == msgpack::type::ARRAY) {
                     auto array = o.via.array; 
                     Helpers::conv_fld_from_array(array, name, "input1", input1, 0);
@@ -2393,9 +4068,26 @@ namespace Acir {
             void msgpack_unpack(msgpack::object const& o) {
                 std::string name = "Keccakf1600";
                 if (o.type == msgpack::type::MAP) {
-                    auto kvmap = Helpers::make_kvmap(o, name);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "inputs", inputs, false);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "outputs", outputs, false);
+                    if (Helpers::is_int_keyed_map(o)) {
+                        Helpers::int_map_dispatch(o, name, [&](uint8_t tag, msgpack::object const& val) {
+                            switch (tag) {
+                                case 0:
+                                    Helpers::convert_or_throw(val, name, "inputs", inputs);
+                                    break;
+                                case 1:
+                                    Helpers::convert_or_throw(val, name, "outputs", outputs);
+                                    break;
+                                default:
+                                    // Unknown tag — skip silently (forward-compat /
+                                    // retired tags drained — matches the Rust decoder).
+                                    break;
+                            }
+                        });
+                    } else {
+                        auto kvmap = Helpers::make_kvmap(o, name);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "inputs", inputs, false);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "outputs", outputs, false);
+                    }
                 } else if (o.type == msgpack::type::ARRAY) {
                     auto array = o.via.array; 
                     Helpers::conv_fld_from_array(array, name, "inputs", inputs, 0);
@@ -2419,13 +4111,42 @@ namespace Acir {
             void msgpack_unpack(msgpack::object const& o) {
                 std::string name = "RecursiveAggregation";
                 if (o.type == msgpack::type::MAP) {
-                    auto kvmap = Helpers::make_kvmap(o, name);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "verification_key", verification_key, false);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "proof", proof, false);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "public_inputs", public_inputs, false);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "key_hash", key_hash, false);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "proof_type", proof_type, false);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "predicate", predicate, false);
+                    if (Helpers::is_int_keyed_map(o)) {
+                        Helpers::int_map_dispatch(o, name, [&](uint8_t tag, msgpack::object const& val) {
+                            switch (tag) {
+                                case 0:
+                                    Helpers::convert_or_throw(val, name, "verification_key", verification_key);
+                                    break;
+                                case 1:
+                                    Helpers::convert_or_throw(val, name, "proof", proof);
+                                    break;
+                                case 2:
+                                    Helpers::convert_or_throw(val, name, "public_inputs", public_inputs);
+                                    break;
+                                case 3:
+                                    Helpers::convert_or_throw(val, name, "key_hash", key_hash);
+                                    break;
+                                case 4:
+                                    Helpers::convert_or_throw(val, name, "proof_type", proof_type);
+                                    break;
+                                case 5:
+                                    Helpers::convert_or_throw(val, name, "predicate", predicate);
+                                    break;
+                                default:
+                                    // Unknown tag — skip silently (forward-compat /
+                                    // retired tags drained — matches the Rust decoder).
+                                    break;
+                            }
+                        });
+                    } else {
+                        auto kvmap = Helpers::make_kvmap(o, name);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "verification_key", verification_key, false);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "proof", proof, false);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "public_inputs", public_inputs, false);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "key_hash", key_hash, false);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "proof_type", proof_type, false);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "predicate", predicate, false);
+                    }
                 } else if (o.type == msgpack::type::ARRAY) {
                     auto array = o.via.array; 
                     Helpers::conv_fld_from_array(array, name, "verification_key", verification_key, 0);
@@ -2449,9 +4170,26 @@ namespace Acir {
             void msgpack_unpack(msgpack::object const& o) {
                 std::string name = "Poseidon2Permutation";
                 if (o.type == msgpack::type::MAP) {
-                    auto kvmap = Helpers::make_kvmap(o, name);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "inputs", inputs, false);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "outputs", outputs, false);
+                    if (Helpers::is_int_keyed_map(o)) {
+                        Helpers::int_map_dispatch(o, name, [&](uint8_t tag, msgpack::object const& val) {
+                            switch (tag) {
+                                case 0:
+                                    Helpers::convert_or_throw(val, name, "inputs", inputs);
+                                    break;
+                                case 1:
+                                    Helpers::convert_or_throw(val, name, "outputs", outputs);
+                                    break;
+                                default:
+                                    // Unknown tag — skip silently (forward-compat /
+                                    // retired tags drained — matches the Rust decoder).
+                                    break;
+                            }
+                        });
+                    } else {
+                        auto kvmap = Helpers::make_kvmap(o, name);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "inputs", inputs, false);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "outputs", outputs, false);
+                    }
                 } else if (o.type == msgpack::type::ARRAY) {
                     auto array = o.via.array; 
                     Helpers::conv_fld_from_array(array, name, "inputs", inputs, 0);
@@ -2472,10 +4210,30 @@ namespace Acir {
             void msgpack_unpack(msgpack::object const& o) {
                 std::string name = "Sha256Compression";
                 if (o.type == msgpack::type::MAP) {
-                    auto kvmap = Helpers::make_kvmap(o, name);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "inputs", inputs, false);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "hash_values", hash_values, false);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "outputs", outputs, false);
+                    if (Helpers::is_int_keyed_map(o)) {
+                        Helpers::int_map_dispatch(o, name, [&](uint8_t tag, msgpack::object const& val) {
+                            switch (tag) {
+                                case 0:
+                                    Helpers::convert_or_throw(val, name, "inputs", inputs);
+                                    break;
+                                case 1:
+                                    Helpers::convert_or_throw(val, name, "hash_values", hash_values);
+                                    break;
+                                case 2:
+                                    Helpers::convert_or_throw(val, name, "outputs", outputs);
+                                    break;
+                                default:
+                                    // Unknown tag — skip silently (forward-compat /
+                                    // retired tags drained — matches the Rust decoder).
+                                    break;
+                            }
+                        });
+                    } else {
+                        auto kvmap = Helpers::make_kvmap(o, name);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "inputs", inputs, false);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "hash_values", hash_values, false);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "outputs", outputs, false);
+                    }
                 } else if (o.type == msgpack::type::ARRAY) {
                     auto array = o.via.array; 
                     Helpers::conv_fld_from_array(array, name, "inputs", inputs, 0);
@@ -2500,174 +4258,347 @@ namespace Acir {
             if (o.type == msgpack::type::object_type::MAP && o.via.map.size != 1) {
                 throw_or_abort("expected 1 entry for enum 'BlackBoxFuncCall'; got " + std::to_string(o.via.map.size));
             }
-            std::string tag;
-            try {
-                if (o.type == msgpack::type::object_type::MAP) {
+            if (Helpers::is_int_keyed_map(o)) {
+                // `Format::MsgpackTagged` — int-keyed variant.
+                uint8_t tag;
+                try {
                     o.via.map.ptr[0].key.convert(tag);
-                } else {
-                    o.convert(tag);
-                }
-            } catch(const msgpack::type_error&) {
-                std::cerr << o << std::endl;
-                throw_or_abort("error converting tag to string for enum 'BlackBoxFuncCall'");
-            }
-            if (tag == "AES128Encrypt") {
-                AES128Encrypt v;
-                try {
-                    o.via.map.ptr[0].val.convert(v);
                 } catch (const msgpack::type_error&) {
                     std::cerr << o << std::endl;
-                    throw_or_abort("error converting into enum variant 'BlackBoxFuncCall::AES128Encrypt'");
+                    throw_or_abort("expected u8 variant tag for enum 'BlackBoxFuncCall'");
                 }
-                
-                value = v;
-            }
-            else if (tag == "AND") {
-                AND v;
+                msgpack::object const& val = o.via.map.ptr[0].val;
+                switch (tag) {
+                    case 0: {
+                        AES128Encrypt v;
+                        try {
+                            val.convert(v);
+                        } catch (const msgpack::type_error&) {
+                            std::cerr << val << std::endl;
+                            throw_or_abort("error converting into enum variant 'BlackBoxFuncCall::AES128Encrypt'");
+                        }
+                        value = v;
+                        break;
+                    }
+                    case 1: {
+                        AND v;
+                        try {
+                            val.convert(v);
+                        } catch (const msgpack::type_error&) {
+                            std::cerr << val << std::endl;
+                            throw_or_abort("error converting into enum variant 'BlackBoxFuncCall::AND'");
+                        }
+                        value = v;
+                        break;
+                    }
+                    case 2: {
+                        XOR v;
+                        try {
+                            val.convert(v);
+                        } catch (const msgpack::type_error&) {
+                            std::cerr << val << std::endl;
+                            throw_or_abort("error converting into enum variant 'BlackBoxFuncCall::XOR'");
+                        }
+                        value = v;
+                        break;
+                    }
+                    case 3: {
+                        RANGE v;
+                        try {
+                            val.convert(v);
+                        } catch (const msgpack::type_error&) {
+                            std::cerr << val << std::endl;
+                            throw_or_abort("error converting into enum variant 'BlackBoxFuncCall::RANGE'");
+                        }
+                        value = v;
+                        break;
+                    }
+                    case 4: {
+                        Blake2s v;
+                        try {
+                            val.convert(v);
+                        } catch (const msgpack::type_error&) {
+                            std::cerr << val << std::endl;
+                            throw_or_abort("error converting into enum variant 'BlackBoxFuncCall::Blake2s'");
+                        }
+                        value = v;
+                        break;
+                    }
+                    case 5: {
+                        Blake3 v;
+                        try {
+                            val.convert(v);
+                        } catch (const msgpack::type_error&) {
+                            std::cerr << val << std::endl;
+                            throw_or_abort("error converting into enum variant 'BlackBoxFuncCall::Blake3'");
+                        }
+                        value = v;
+                        break;
+                    }
+                    case 6: {
+                        EcdsaSecp256k1 v;
+                        try {
+                            val.convert(v);
+                        } catch (const msgpack::type_error&) {
+                            std::cerr << val << std::endl;
+                            throw_or_abort("error converting into enum variant 'BlackBoxFuncCall::EcdsaSecp256k1'");
+                        }
+                        value = v;
+                        break;
+                    }
+                    case 7: {
+                        EcdsaSecp256r1 v;
+                        try {
+                            val.convert(v);
+                        } catch (const msgpack::type_error&) {
+                            std::cerr << val << std::endl;
+                            throw_or_abort("error converting into enum variant 'BlackBoxFuncCall::EcdsaSecp256r1'");
+                        }
+                        value = v;
+                        break;
+                    }
+                    case 8: {
+                        MultiScalarMul v;
+                        try {
+                            val.convert(v);
+                        } catch (const msgpack::type_error&) {
+                            std::cerr << val << std::endl;
+                            throw_or_abort("error converting into enum variant 'BlackBoxFuncCall::MultiScalarMul'");
+                        }
+                        value = v;
+                        break;
+                    }
+                    case 9: {
+                        EmbeddedCurveAdd v;
+                        try {
+                            val.convert(v);
+                        } catch (const msgpack::type_error&) {
+                            std::cerr << val << std::endl;
+                            throw_or_abort("error converting into enum variant 'BlackBoxFuncCall::EmbeddedCurveAdd'");
+                        }
+                        value = v;
+                        break;
+                    }
+                    case 10: {
+                        Keccakf1600 v;
+                        try {
+                            val.convert(v);
+                        } catch (const msgpack::type_error&) {
+                            std::cerr << val << std::endl;
+                            throw_or_abort("error converting into enum variant 'BlackBoxFuncCall::Keccakf1600'");
+                        }
+                        value = v;
+                        break;
+                    }
+                    case 11: {
+                        RecursiveAggregation v;
+                        try {
+                            val.convert(v);
+                        } catch (const msgpack::type_error&) {
+                            std::cerr << val << std::endl;
+                            throw_or_abort("error converting into enum variant 'BlackBoxFuncCall::RecursiveAggregation'");
+                        }
+                        value = v;
+                        break;
+                    }
+                    case 12: {
+                        Poseidon2Permutation v;
+                        try {
+                            val.convert(v);
+                        } catch (const msgpack::type_error&) {
+                            std::cerr << val << std::endl;
+                            throw_or_abort("error converting into enum variant 'BlackBoxFuncCall::Poseidon2Permutation'");
+                        }
+                        value = v;
+                        break;
+                    }
+                    case 13: {
+                        Sha256Compression v;
+                        try {
+                            val.convert(v);
+                        } catch (const msgpack::type_error&) {
+                            std::cerr << val << std::endl;
+                            throw_or_abort("error converting into enum variant 'BlackBoxFuncCall::Sha256Compression'");
+                        }
+                        value = v;
+                        break;
+                    }
+                    default:
+                        std::cerr << o << std::endl;
+                        throw_or_abort("unknown 'BlackBoxFuncCall' enum variant tag: " + std::to_string(tag));
+                }
+            } else {
+                // `Format::Msgpack` (MAP, string-keyed) or `Format::MsgpackCompact`
+                // unit variant (bare STR) — both dispatch on the variant name.
+                std::string tag;
                 try {
-                    o.via.map.ptr[0].val.convert(v);
-                } catch (const msgpack::type_error&) {
+                    if (o.type == msgpack::type::object_type::MAP) {
+                        o.via.map.ptr[0].key.convert(tag);
+                    } else {
+                        o.convert(tag);
+                    }
+                } catch(const msgpack::type_error&) {
                     std::cerr << o << std::endl;
-                    throw_or_abort("error converting into enum variant 'BlackBoxFuncCall::AND'");
+                    throw_or_abort("error converting tag to string for enum 'BlackBoxFuncCall'");
                 }
-                
-                value = v;
-            }
-            else if (tag == "XOR") {
-                XOR v;
-                try {
-                    o.via.map.ptr[0].val.convert(v);
-                } catch (const msgpack::type_error&) {
+                if (tag == "AES128Encrypt") {
+                    AES128Encrypt v;
+                    try {
+                        o.via.map.ptr[0].val.convert(v);
+                    } catch (const msgpack::type_error&) {
+                        std::cerr << o << std::endl;
+                        throw_or_abort("error converting into enum variant 'BlackBoxFuncCall::AES128Encrypt'");
+                    }
+                    
+                    value = v;
+                }
+                else if (tag == "AND") {
+                    AND v;
+                    try {
+                        o.via.map.ptr[0].val.convert(v);
+                    } catch (const msgpack::type_error&) {
+                        std::cerr << o << std::endl;
+                        throw_or_abort("error converting into enum variant 'BlackBoxFuncCall::AND'");
+                    }
+                    
+                    value = v;
+                }
+                else if (tag == "XOR") {
+                    XOR v;
+                    try {
+                        o.via.map.ptr[0].val.convert(v);
+                    } catch (const msgpack::type_error&) {
+                        std::cerr << o << std::endl;
+                        throw_or_abort("error converting into enum variant 'BlackBoxFuncCall::XOR'");
+                    }
+                    
+                    value = v;
+                }
+                else if (tag == "RANGE") {
+                    RANGE v;
+                    try {
+                        o.via.map.ptr[0].val.convert(v);
+                    } catch (const msgpack::type_error&) {
+                        std::cerr << o << std::endl;
+                        throw_or_abort("error converting into enum variant 'BlackBoxFuncCall::RANGE'");
+                    }
+                    
+                    value = v;
+                }
+                else if (tag == "Blake2s") {
+                    Blake2s v;
+                    try {
+                        o.via.map.ptr[0].val.convert(v);
+                    } catch (const msgpack::type_error&) {
+                        std::cerr << o << std::endl;
+                        throw_or_abort("error converting into enum variant 'BlackBoxFuncCall::Blake2s'");
+                    }
+                    
+                    value = v;
+                }
+                else if (tag == "Blake3") {
+                    Blake3 v;
+                    try {
+                        o.via.map.ptr[0].val.convert(v);
+                    } catch (const msgpack::type_error&) {
+                        std::cerr << o << std::endl;
+                        throw_or_abort("error converting into enum variant 'BlackBoxFuncCall::Blake3'");
+                    }
+                    
+                    value = v;
+                }
+                else if (tag == "EcdsaSecp256k1") {
+                    EcdsaSecp256k1 v;
+                    try {
+                        o.via.map.ptr[0].val.convert(v);
+                    } catch (const msgpack::type_error&) {
+                        std::cerr << o << std::endl;
+                        throw_or_abort("error converting into enum variant 'BlackBoxFuncCall::EcdsaSecp256k1'");
+                    }
+                    
+                    value = v;
+                }
+                else if (tag == "EcdsaSecp256r1") {
+                    EcdsaSecp256r1 v;
+                    try {
+                        o.via.map.ptr[0].val.convert(v);
+                    } catch (const msgpack::type_error&) {
+                        std::cerr << o << std::endl;
+                        throw_or_abort("error converting into enum variant 'BlackBoxFuncCall::EcdsaSecp256r1'");
+                    }
+                    
+                    value = v;
+                }
+                else if (tag == "MultiScalarMul") {
+                    MultiScalarMul v;
+                    try {
+                        o.via.map.ptr[0].val.convert(v);
+                    } catch (const msgpack::type_error&) {
+                        std::cerr << o << std::endl;
+                        throw_or_abort("error converting into enum variant 'BlackBoxFuncCall::MultiScalarMul'");
+                    }
+                    
+                    value = v;
+                }
+                else if (tag == "EmbeddedCurveAdd") {
+                    EmbeddedCurveAdd v;
+                    try {
+                        o.via.map.ptr[0].val.convert(v);
+                    } catch (const msgpack::type_error&) {
+                        std::cerr << o << std::endl;
+                        throw_or_abort("error converting into enum variant 'BlackBoxFuncCall::EmbeddedCurveAdd'");
+                    }
+                    
+                    value = v;
+                }
+                else if (tag == "Keccakf1600") {
+                    Keccakf1600 v;
+                    try {
+                        o.via.map.ptr[0].val.convert(v);
+                    } catch (const msgpack::type_error&) {
+                        std::cerr << o << std::endl;
+                        throw_or_abort("error converting into enum variant 'BlackBoxFuncCall::Keccakf1600'");
+                    }
+                    
+                    value = v;
+                }
+                else if (tag == "RecursiveAggregation") {
+                    RecursiveAggregation v;
+                    try {
+                        o.via.map.ptr[0].val.convert(v);
+                    } catch (const msgpack::type_error&) {
+                        std::cerr << o << std::endl;
+                        throw_or_abort("error converting into enum variant 'BlackBoxFuncCall::RecursiveAggregation'");
+                    }
+                    
+                    value = v;
+                }
+                else if (tag == "Poseidon2Permutation") {
+                    Poseidon2Permutation v;
+                    try {
+                        o.via.map.ptr[0].val.convert(v);
+                    } catch (const msgpack::type_error&) {
+                        std::cerr << o << std::endl;
+                        throw_or_abort("error converting into enum variant 'BlackBoxFuncCall::Poseidon2Permutation'");
+                    }
+                    
+                    value = v;
+                }
+                else if (tag == "Sha256Compression") {
+                    Sha256Compression v;
+                    try {
+                        o.via.map.ptr[0].val.convert(v);
+                    } catch (const msgpack::type_error&) {
+                        std::cerr << o << std::endl;
+                        throw_or_abort("error converting into enum variant 'BlackBoxFuncCall::Sha256Compression'");
+                    }
+                    
+                    value = v;
+                }
+                else {
                     std::cerr << o << std::endl;
-                    throw_or_abort("error converting into enum variant 'BlackBoxFuncCall::XOR'");
+                    throw_or_abort("unknown 'BlackBoxFuncCall' enum variant: " + tag);
                 }
-                
-                value = v;
-            }
-            else if (tag == "RANGE") {
-                RANGE v;
-                try {
-                    o.via.map.ptr[0].val.convert(v);
-                } catch (const msgpack::type_error&) {
-                    std::cerr << o << std::endl;
-                    throw_or_abort("error converting into enum variant 'BlackBoxFuncCall::RANGE'");
-                }
-                
-                value = v;
-            }
-            else if (tag == "Blake2s") {
-                Blake2s v;
-                try {
-                    o.via.map.ptr[0].val.convert(v);
-                } catch (const msgpack::type_error&) {
-                    std::cerr << o << std::endl;
-                    throw_or_abort("error converting into enum variant 'BlackBoxFuncCall::Blake2s'");
-                }
-                
-                value = v;
-            }
-            else if (tag == "Blake3") {
-                Blake3 v;
-                try {
-                    o.via.map.ptr[0].val.convert(v);
-                } catch (const msgpack::type_error&) {
-                    std::cerr << o << std::endl;
-                    throw_or_abort("error converting into enum variant 'BlackBoxFuncCall::Blake3'");
-                }
-                
-                value = v;
-            }
-            else if (tag == "EcdsaSecp256k1") {
-                EcdsaSecp256k1 v;
-                try {
-                    o.via.map.ptr[0].val.convert(v);
-                } catch (const msgpack::type_error&) {
-                    std::cerr << o << std::endl;
-                    throw_or_abort("error converting into enum variant 'BlackBoxFuncCall::EcdsaSecp256k1'");
-                }
-                
-                value = v;
-            }
-            else if (tag == "EcdsaSecp256r1") {
-                EcdsaSecp256r1 v;
-                try {
-                    o.via.map.ptr[0].val.convert(v);
-                } catch (const msgpack::type_error&) {
-                    std::cerr << o << std::endl;
-                    throw_or_abort("error converting into enum variant 'BlackBoxFuncCall::EcdsaSecp256r1'");
-                }
-                
-                value = v;
-            }
-            else if (tag == "MultiScalarMul") {
-                MultiScalarMul v;
-                try {
-                    o.via.map.ptr[0].val.convert(v);
-                } catch (const msgpack::type_error&) {
-                    std::cerr << o << std::endl;
-                    throw_or_abort("error converting into enum variant 'BlackBoxFuncCall::MultiScalarMul'");
-                }
-                
-                value = v;
-            }
-            else if (tag == "EmbeddedCurveAdd") {
-                EmbeddedCurveAdd v;
-                try {
-                    o.via.map.ptr[0].val.convert(v);
-                } catch (const msgpack::type_error&) {
-                    std::cerr << o << std::endl;
-                    throw_or_abort("error converting into enum variant 'BlackBoxFuncCall::EmbeddedCurveAdd'");
-                }
-                
-                value = v;
-            }
-            else if (tag == "Keccakf1600") {
-                Keccakf1600 v;
-                try {
-                    o.via.map.ptr[0].val.convert(v);
-                } catch (const msgpack::type_error&) {
-                    std::cerr << o << std::endl;
-                    throw_or_abort("error converting into enum variant 'BlackBoxFuncCall::Keccakf1600'");
-                }
-                
-                value = v;
-            }
-            else if (tag == "RecursiveAggregation") {
-                RecursiveAggregation v;
-                try {
-                    o.via.map.ptr[0].val.convert(v);
-                } catch (const msgpack::type_error&) {
-                    std::cerr << o << std::endl;
-                    throw_or_abort("error converting into enum variant 'BlackBoxFuncCall::RecursiveAggregation'");
-                }
-                
-                value = v;
-            }
-            else if (tag == "Poseidon2Permutation") {
-                Poseidon2Permutation v;
-                try {
-                    o.via.map.ptr[0].val.convert(v);
-                } catch (const msgpack::type_error&) {
-                    std::cerr << o << std::endl;
-                    throw_or_abort("error converting into enum variant 'BlackBoxFuncCall::Poseidon2Permutation'");
-                }
-                
-                value = v;
-            }
-            else if (tag == "Sha256Compression") {
-                Sha256Compression v;
-                try {
-                    o.via.map.ptr[0].val.convert(v);
-                } catch (const msgpack::type_error&) {
-                    std::cerr << o << std::endl;
-                    throw_or_abort("error converting into enum variant 'BlackBoxFuncCall::Sha256Compression'");
-                }
-                
-                value = v;
-            }
-            else {
-                std::cerr << o << std::endl;
-                throw_or_abort("unknown 'BlackBoxFuncCall' enum variant: " + tag);
             }
         }
     };
@@ -2729,39 +4660,79 @@ namespace Acir {
             if (o.type == msgpack::type::object_type::MAP && o.via.map.size != 1) {
                 throw_or_abort("expected 1 entry for enum 'BlockType'; got " + std::to_string(o.via.map.size));
             }
-            std::string tag;
-            try {
-                if (o.type == msgpack::type::object_type::MAP) {
-                    o.via.map.ptr[0].key.convert(tag);
-                } else {
-                    o.convert(tag);
-                }
-            } catch(const msgpack::type_error&) {
-                std::cerr << o << std::endl;
-                throw_or_abort("error converting tag to string for enum 'BlockType'");
-            }
-            if (tag == "Memory") {
-                Memory v;
-                value = v;
-            }
-            else if (tag == "CallData") {
-                CallData v;
+            if (Helpers::is_int_keyed_map(o)) {
+                // `Format::MsgpackTagged` — int-keyed variant.
+                uint8_t tag;
                 try {
-                    o.via.map.ptr[0].val.convert(v);
+                    o.via.map.ptr[0].key.convert(tag);
                 } catch (const msgpack::type_error&) {
                     std::cerr << o << std::endl;
-                    throw_or_abort("error converting into enum variant 'BlockType::CallData'");
+                    throw_or_abort("expected u8 variant tag for enum 'BlockType'");
                 }
-                
-                value = v;
-            }
-            else if (tag == "ReturnData") {
-                ReturnData v;
-                value = v;
-            }
-            else {
-                std::cerr << o << std::endl;
-                throw_or_abort("unknown 'BlockType' enum variant: " + tag);
+                msgpack::object const& val = o.via.map.ptr[0].val;
+                switch (tag) {
+                    case 0: {
+                        Memory v;
+                        value = v;
+                        break;
+                    }
+                    case 1: {
+                        CallData v;
+                        try {
+                            val.convert(v);
+                        } catch (const msgpack::type_error&) {
+                            std::cerr << val << std::endl;
+                            throw_or_abort("error converting into enum variant 'BlockType::CallData'");
+                        }
+                        value = v;
+                        break;
+                    }
+                    case 2: {
+                        ReturnData v;
+                        value = v;
+                        break;
+                    }
+                    default:
+                        std::cerr << o << std::endl;
+                        throw_or_abort("unknown 'BlockType' enum variant tag: " + std::to_string(tag));
+                }
+            } else {
+                // `Format::Msgpack` (MAP, string-keyed) or `Format::MsgpackCompact`
+                // unit variant (bare STR) — both dispatch on the variant name.
+                std::string tag;
+                try {
+                    if (o.type == msgpack::type::object_type::MAP) {
+                        o.via.map.ptr[0].key.convert(tag);
+                    } else {
+                        o.convert(tag);
+                    }
+                } catch(const msgpack::type_error&) {
+                    std::cerr << o << std::endl;
+                    throw_or_abort("error converting tag to string for enum 'BlockType'");
+                }
+                if (tag == "Memory") {
+                    Memory v;
+                    value = v;
+                }
+                else if (tag == "CallData") {
+                    CallData v;
+                    try {
+                        o.via.map.ptr[0].val.convert(v);
+                    } catch (const msgpack::type_error&) {
+                        std::cerr << o << std::endl;
+                        throw_or_abort("error converting into enum variant 'BlockType::CallData'");
+                    }
+                    
+                    value = v;
+                }
+                else if (tag == "ReturnData") {
+                    ReturnData v;
+                    value = v;
+                }
+                else {
+                    std::cerr << o << std::endl;
+                    throw_or_abort("unknown 'BlockType' enum variant: " + tag);
+                }
             }
         }
     };
@@ -2776,10 +4747,30 @@ namespace Acir {
         void msgpack_unpack(msgpack::object const& o) {
             std::string name = "Expression";
             if (o.type == msgpack::type::MAP) {
-                auto kvmap = Helpers::make_kvmap(o, name);
-                Helpers::conv_fld_from_kvmap(kvmap, name, "mul_terms", mul_terms, false);
-                Helpers::conv_fld_from_kvmap(kvmap, name, "linear_combinations", linear_combinations, false);
-                Helpers::conv_fld_from_kvmap(kvmap, name, "q_c", q_c, false);
+                if (Helpers::is_int_keyed_map(o)) {
+                    Helpers::int_map_dispatch(o, name, [&](uint8_t tag, msgpack::object const& val) {
+                        switch (tag) {
+                            case 0:
+                                Helpers::convert_or_throw(val, name, "mul_terms", mul_terms);
+                                break;
+                            case 1:
+                                Helpers::convert_or_throw(val, name, "linear_combinations", linear_combinations);
+                                break;
+                            case 2:
+                                Helpers::convert_or_throw(val, name, "q_c", q_c);
+                                break;
+                            default:
+                                // Unknown tag — skip silently (forward-compat /
+                                // retired tags drained — matches the Rust decoder).
+                                break;
+                        }
+                    });
+                } else {
+                    auto kvmap = Helpers::make_kvmap(o, name);
+                    Helpers::conv_fld_from_kvmap(kvmap, name, "mul_terms", mul_terms, false);
+                    Helpers::conv_fld_from_kvmap(kvmap, name, "linear_combinations", linear_combinations, false);
+                    Helpers::conv_fld_from_kvmap(kvmap, name, "q_c", q_c, false);
+                }
             } else if (o.type == msgpack::type::ARRAY) {
                 auto array = o.via.array; 
                 Helpers::conv_fld_from_array(array, name, "mul_terms", mul_terms, 0);
@@ -2851,53 +4842,105 @@ namespace Acir {
             if (o.type == msgpack::type::object_type::MAP && o.via.map.size != 1) {
                 throw_or_abort("expected 1 entry for enum 'BrilligInputs'; got " + std::to_string(o.via.map.size));
             }
-            std::string tag;
-            try {
-                if (o.type == msgpack::type::object_type::MAP) {
+            if (Helpers::is_int_keyed_map(o)) {
+                // `Format::MsgpackTagged` — int-keyed variant.
+                uint8_t tag;
+                try {
                     o.via.map.ptr[0].key.convert(tag);
-                } else {
-                    o.convert(tag);
-                }
-            } catch(const msgpack::type_error&) {
-                std::cerr << o << std::endl;
-                throw_or_abort("error converting tag to string for enum 'BrilligInputs'");
-            }
-            if (tag == "Single") {
-                Single v;
-                try {
-                    o.via.map.ptr[0].val.convert(v);
                 } catch (const msgpack::type_error&) {
                     std::cerr << o << std::endl;
-                    throw_or_abort("error converting into enum variant 'BrilligInputs::Single'");
+                    throw_or_abort("expected u8 variant tag for enum 'BrilligInputs'");
                 }
-                
-                value = v;
-            }
-            else if (tag == "Array") {
-                Array v;
+                msgpack::object const& val = o.via.map.ptr[0].val;
+                switch (tag) {
+                    case 0: {
+                        Single v;
+                        try {
+                            val.convert(v);
+                        } catch (const msgpack::type_error&) {
+                            std::cerr << val << std::endl;
+                            throw_or_abort("error converting into enum variant 'BrilligInputs::Single'");
+                        }
+                        value = v;
+                        break;
+                    }
+                    case 1: {
+                        Array v;
+                        try {
+                            val.convert(v);
+                        } catch (const msgpack::type_error&) {
+                            std::cerr << val << std::endl;
+                            throw_or_abort("error converting into enum variant 'BrilligInputs::Array'");
+                        }
+                        value = v;
+                        break;
+                    }
+                    case 2: {
+                        MemoryArray v;
+                        try {
+                            val.convert(v);
+                        } catch (const msgpack::type_error&) {
+                            std::cerr << val << std::endl;
+                            throw_or_abort("error converting into enum variant 'BrilligInputs::MemoryArray'");
+                        }
+                        value = v;
+                        break;
+                    }
+                    default:
+                        std::cerr << o << std::endl;
+                        throw_or_abort("unknown 'BrilligInputs' enum variant tag: " + std::to_string(tag));
+                }
+            } else {
+                // `Format::Msgpack` (MAP, string-keyed) or `Format::MsgpackCompact`
+                // unit variant (bare STR) — both dispatch on the variant name.
+                std::string tag;
                 try {
-                    o.via.map.ptr[0].val.convert(v);
-                } catch (const msgpack::type_error&) {
+                    if (o.type == msgpack::type::object_type::MAP) {
+                        o.via.map.ptr[0].key.convert(tag);
+                    } else {
+                        o.convert(tag);
+                    }
+                } catch(const msgpack::type_error&) {
                     std::cerr << o << std::endl;
-                    throw_or_abort("error converting into enum variant 'BrilligInputs::Array'");
+                    throw_or_abort("error converting tag to string for enum 'BrilligInputs'");
                 }
-                
-                value = v;
-            }
-            else if (tag == "MemoryArray") {
-                MemoryArray v;
-                try {
-                    o.via.map.ptr[0].val.convert(v);
-                } catch (const msgpack::type_error&) {
+                if (tag == "Single") {
+                    Single v;
+                    try {
+                        o.via.map.ptr[0].val.convert(v);
+                    } catch (const msgpack::type_error&) {
+                        std::cerr << o << std::endl;
+                        throw_or_abort("error converting into enum variant 'BrilligInputs::Single'");
+                    }
+                    
+                    value = v;
+                }
+                else if (tag == "Array") {
+                    Array v;
+                    try {
+                        o.via.map.ptr[0].val.convert(v);
+                    } catch (const msgpack::type_error&) {
+                        std::cerr << o << std::endl;
+                        throw_or_abort("error converting into enum variant 'BrilligInputs::Array'");
+                    }
+                    
+                    value = v;
+                }
+                else if (tag == "MemoryArray") {
+                    MemoryArray v;
+                    try {
+                        o.via.map.ptr[0].val.convert(v);
+                    } catch (const msgpack::type_error&) {
+                        std::cerr << o << std::endl;
+                        throw_or_abort("error converting into enum variant 'BrilligInputs::MemoryArray'");
+                    }
+                    
+                    value = v;
+                }
+                else {
                     std::cerr << o << std::endl;
-                    throw_or_abort("error converting into enum variant 'BrilligInputs::MemoryArray'");
+                    throw_or_abort("unknown 'BrilligInputs' enum variant: " + tag);
                 }
-                
-                value = v;
-            }
-            else {
-                std::cerr << o << std::endl;
-                throw_or_abort("unknown 'BrilligInputs' enum variant: " + tag);
             }
         }
     };
@@ -2947,42 +4990,83 @@ namespace Acir {
             if (o.type == msgpack::type::object_type::MAP && o.via.map.size != 1) {
                 throw_or_abort("expected 1 entry for enum 'BrilligOutputs'; got " + std::to_string(o.via.map.size));
             }
-            std::string tag;
-            try {
-                if (o.type == msgpack::type::object_type::MAP) {
+            if (Helpers::is_int_keyed_map(o)) {
+                // `Format::MsgpackTagged` — int-keyed variant.
+                uint8_t tag;
+                try {
                     o.via.map.ptr[0].key.convert(tag);
-                } else {
-                    o.convert(tag);
-                }
-            } catch(const msgpack::type_error&) {
-                std::cerr << o << std::endl;
-                throw_or_abort("error converting tag to string for enum 'BrilligOutputs'");
-            }
-            if (tag == "Simple") {
-                Simple v;
-                try {
-                    o.via.map.ptr[0].val.convert(v);
                 } catch (const msgpack::type_error&) {
                     std::cerr << o << std::endl;
-                    throw_or_abort("error converting into enum variant 'BrilligOutputs::Simple'");
+                    throw_or_abort("expected u8 variant tag for enum 'BrilligOutputs'");
                 }
-                
-                value = v;
-            }
-            else if (tag == "Array") {
-                Array v;
+                msgpack::object const& val = o.via.map.ptr[0].val;
+                switch (tag) {
+                    case 0: {
+                        Simple v;
+                        try {
+                            val.convert(v);
+                        } catch (const msgpack::type_error&) {
+                            std::cerr << val << std::endl;
+                            throw_or_abort("error converting into enum variant 'BrilligOutputs::Simple'");
+                        }
+                        value = v;
+                        break;
+                    }
+                    case 1: {
+                        Array v;
+                        try {
+                            val.convert(v);
+                        } catch (const msgpack::type_error&) {
+                            std::cerr << val << std::endl;
+                            throw_or_abort("error converting into enum variant 'BrilligOutputs::Array'");
+                        }
+                        value = v;
+                        break;
+                    }
+                    default:
+                        std::cerr << o << std::endl;
+                        throw_or_abort("unknown 'BrilligOutputs' enum variant tag: " + std::to_string(tag));
+                }
+            } else {
+                // `Format::Msgpack` (MAP, string-keyed) or `Format::MsgpackCompact`
+                // unit variant (bare STR) — both dispatch on the variant name.
+                std::string tag;
                 try {
-                    o.via.map.ptr[0].val.convert(v);
-                } catch (const msgpack::type_error&) {
+                    if (o.type == msgpack::type::object_type::MAP) {
+                        o.via.map.ptr[0].key.convert(tag);
+                    } else {
+                        o.convert(tag);
+                    }
+                } catch(const msgpack::type_error&) {
                     std::cerr << o << std::endl;
-                    throw_or_abort("error converting into enum variant 'BrilligOutputs::Array'");
+                    throw_or_abort("error converting tag to string for enum 'BrilligOutputs'");
                 }
-                
-                value = v;
-            }
-            else {
-                std::cerr << o << std::endl;
-                throw_or_abort("unknown 'BrilligOutputs' enum variant: " + tag);
+                if (tag == "Simple") {
+                    Simple v;
+                    try {
+                        o.via.map.ptr[0].val.convert(v);
+                    } catch (const msgpack::type_error&) {
+                        std::cerr << o << std::endl;
+                        throw_or_abort("error converting into enum variant 'BrilligOutputs::Simple'");
+                    }
+                    
+                    value = v;
+                }
+                else if (tag == "Array") {
+                    Array v;
+                    try {
+                        o.via.map.ptr[0].val.convert(v);
+                    } catch (const msgpack::type_error&) {
+                        std::cerr << o << std::endl;
+                        throw_or_abort("error converting into enum variant 'BrilligOutputs::Array'");
+                    }
+                    
+                    value = v;
+                }
+                else {
+                    std::cerr << o << std::endl;
+                    throw_or_abort("unknown 'BrilligOutputs' enum variant: " + tag);
+                }
             }
         }
     };
@@ -2997,10 +5081,30 @@ namespace Acir {
         void msgpack_unpack(msgpack::object const& o) {
             std::string name = "MemOp";
             if (o.type == msgpack::type::MAP) {
-                auto kvmap = Helpers::make_kvmap(o, name);
-                Helpers::conv_fld_from_kvmap(kvmap, name, "operation", operation, false);
-                Helpers::conv_fld_from_kvmap(kvmap, name, "index", index, false);
-                Helpers::conv_fld_from_kvmap(kvmap, name, "value", value, false);
+                if (Helpers::is_int_keyed_map(o)) {
+                    Helpers::int_map_dispatch(o, name, [&](uint8_t tag, msgpack::object const& val) {
+                        switch (tag) {
+                            case 0:
+                                Helpers::convert_or_throw(val, name, "operation", operation);
+                                break;
+                            case 1:
+                                Helpers::convert_or_throw(val, name, "index", index);
+                                break;
+                            case 2:
+                                Helpers::convert_or_throw(val, name, "value", value);
+                                break;
+                            default:
+                                // Unknown tag — skip silently (forward-compat /
+                                // retired tags drained — matches the Rust decoder).
+                                break;
+                        }
+                    });
+                } else {
+                    auto kvmap = Helpers::make_kvmap(o, name);
+                    Helpers::conv_fld_from_kvmap(kvmap, name, "operation", operation, false);
+                    Helpers::conv_fld_from_kvmap(kvmap, name, "index", index, false);
+                    Helpers::conv_fld_from_kvmap(kvmap, name, "value", value, false);
+                }
             } else if (o.type == msgpack::type::ARRAY) {
                 auto array = o.via.array; 
                 Helpers::conv_fld_from_array(array, name, "operation", operation, 0);
@@ -3053,9 +5157,26 @@ namespace Acir {
             void msgpack_unpack(msgpack::object const& o) {
                 std::string name = "MemoryOp";
                 if (o.type == msgpack::type::MAP) {
-                    auto kvmap = Helpers::make_kvmap(o, name);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "block_id", block_id, false);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "op", op, false);
+                    if (Helpers::is_int_keyed_map(o)) {
+                        Helpers::int_map_dispatch(o, name, [&](uint8_t tag, msgpack::object const& val) {
+                            switch (tag) {
+                                case 0:
+                                    Helpers::convert_or_throw(val, name, "block_id", block_id);
+                                    break;
+                                case 1:
+                                    Helpers::convert_or_throw(val, name, "op", op);
+                                    break;
+                                default:
+                                    // Unknown tag — skip silently (forward-compat /
+                                    // retired tags drained — matches the Rust decoder).
+                                    break;
+                            }
+                        });
+                    } else {
+                        auto kvmap = Helpers::make_kvmap(o, name);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "block_id", block_id, false);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "op", op, false);
+                    }
                 } else if (o.type == msgpack::type::ARRAY) {
                     auto array = o.via.array; 
                     Helpers::conv_fld_from_array(array, name, "block_id", block_id, 0);
@@ -3076,10 +5197,30 @@ namespace Acir {
             void msgpack_unpack(msgpack::object const& o) {
                 std::string name = "MemoryInit";
                 if (o.type == msgpack::type::MAP) {
-                    auto kvmap = Helpers::make_kvmap(o, name);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "block_id", block_id, false);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "init", init, false);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "block_type", block_type, false);
+                    if (Helpers::is_int_keyed_map(o)) {
+                        Helpers::int_map_dispatch(o, name, [&](uint8_t tag, msgpack::object const& val) {
+                            switch (tag) {
+                                case 0:
+                                    Helpers::convert_or_throw(val, name, "block_id", block_id);
+                                    break;
+                                case 1:
+                                    Helpers::convert_or_throw(val, name, "init", init);
+                                    break;
+                                case 2:
+                                    Helpers::convert_or_throw(val, name, "block_type", block_type);
+                                    break;
+                                default:
+                                    // Unknown tag — skip silently (forward-compat /
+                                    // retired tags drained — matches the Rust decoder).
+                                    break;
+                            }
+                        });
+                    } else {
+                        auto kvmap = Helpers::make_kvmap(o, name);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "block_id", block_id, false);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "init", init, false);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "block_type", block_type, false);
+                    }
                 } else if (o.type == msgpack::type::ARRAY) {
                     auto array = o.via.array; 
                     Helpers::conv_fld_from_array(array, name, "block_id", block_id, 0);
@@ -3102,11 +5243,34 @@ namespace Acir {
             void msgpack_unpack(msgpack::object const& o) {
                 std::string name = "BrilligCall";
                 if (o.type == msgpack::type::MAP) {
-                    auto kvmap = Helpers::make_kvmap(o, name);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "id", id, false);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "inputs", inputs, false);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "outputs", outputs, false);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "predicate", predicate, false);
+                    if (Helpers::is_int_keyed_map(o)) {
+                        Helpers::int_map_dispatch(o, name, [&](uint8_t tag, msgpack::object const& val) {
+                            switch (tag) {
+                                case 0:
+                                    Helpers::convert_or_throw(val, name, "id", id);
+                                    break;
+                                case 1:
+                                    Helpers::convert_or_throw(val, name, "inputs", inputs);
+                                    break;
+                                case 2:
+                                    Helpers::convert_or_throw(val, name, "outputs", outputs);
+                                    break;
+                                case 3:
+                                    Helpers::convert_or_throw(val, name, "predicate", predicate);
+                                    break;
+                                default:
+                                    // Unknown tag — skip silently (forward-compat /
+                                    // retired tags drained — matches the Rust decoder).
+                                    break;
+                            }
+                        });
+                    } else {
+                        auto kvmap = Helpers::make_kvmap(o, name);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "id", id, false);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "inputs", inputs, false);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "outputs", outputs, false);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "predicate", predicate, false);
+                    }
                 } else if (o.type == msgpack::type::ARRAY) {
                     auto array = o.via.array; 
                     Helpers::conv_fld_from_array(array, name, "id", id, 0);
@@ -3130,11 +5294,34 @@ namespace Acir {
             void msgpack_unpack(msgpack::object const& o) {
                 std::string name = "Call";
                 if (o.type == msgpack::type::MAP) {
-                    auto kvmap = Helpers::make_kvmap(o, name);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "id", id, false);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "inputs", inputs, false);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "outputs", outputs, false);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "predicate", predicate, false);
+                    if (Helpers::is_int_keyed_map(o)) {
+                        Helpers::int_map_dispatch(o, name, [&](uint8_t tag, msgpack::object const& val) {
+                            switch (tag) {
+                                case 0:
+                                    Helpers::convert_or_throw(val, name, "id", id);
+                                    break;
+                                case 1:
+                                    Helpers::convert_or_throw(val, name, "inputs", inputs);
+                                    break;
+                                case 2:
+                                    Helpers::convert_or_throw(val, name, "outputs", outputs);
+                                    break;
+                                case 3:
+                                    Helpers::convert_or_throw(val, name, "predicate", predicate);
+                                    break;
+                                default:
+                                    // Unknown tag — skip silently (forward-compat /
+                                    // retired tags drained — matches the Rust decoder).
+                                    break;
+                            }
+                        });
+                    } else {
+                        auto kvmap = Helpers::make_kvmap(o, name);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "id", id, false);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "inputs", inputs, false);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "outputs", outputs, false);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "predicate", predicate, false);
+                    }
                 } else if (o.type == msgpack::type::ARRAY) {
                     auto array = o.via.array; 
                     Helpers::conv_fld_from_array(array, name, "id", id, 0);
@@ -3160,86 +5347,171 @@ namespace Acir {
             if (o.type == msgpack::type::object_type::MAP && o.via.map.size != 1) {
                 throw_or_abort("expected 1 entry for enum 'Opcode'; got " + std::to_string(o.via.map.size));
             }
-            std::string tag;
-            try {
-                if (o.type == msgpack::type::object_type::MAP) {
+            if (Helpers::is_int_keyed_map(o)) {
+                // `Format::MsgpackTagged` — int-keyed variant.
+                uint8_t tag;
+                try {
                     o.via.map.ptr[0].key.convert(tag);
-                } else {
-                    o.convert(tag);
-                }
-            } catch(const msgpack::type_error&) {
-                std::cerr << o << std::endl;
-                throw_or_abort("error converting tag to string for enum 'Opcode'");
-            }
-            if (tag == "AssertZero") {
-                AssertZero v;
-                try {
-                    o.via.map.ptr[0].val.convert(v);
                 } catch (const msgpack::type_error&) {
                     std::cerr << o << std::endl;
-                    throw_or_abort("error converting into enum variant 'Opcode::AssertZero'");
+                    throw_or_abort("expected u8 variant tag for enum 'Opcode'");
                 }
-                
-                value = v;
-            }
-            else if (tag == "BlackBoxFuncCall") {
-                BlackBoxFuncCall v;
+                msgpack::object const& val = o.via.map.ptr[0].val;
+                switch (tag) {
+                    case 0: {
+                        AssertZero v;
+                        try {
+                            val.convert(v);
+                        } catch (const msgpack::type_error&) {
+                            std::cerr << val << std::endl;
+                            throw_or_abort("error converting into enum variant 'Opcode::AssertZero'");
+                        }
+                        value = v;
+                        break;
+                    }
+                    case 1: {
+                        BlackBoxFuncCall v;
+                        try {
+                            val.convert(v);
+                        } catch (const msgpack::type_error&) {
+                            std::cerr << val << std::endl;
+                            throw_or_abort("error converting into enum variant 'Opcode::BlackBoxFuncCall'");
+                        }
+                        value = v;
+                        break;
+                    }
+                    case 2: {
+                        MemoryOp v;
+                        try {
+                            val.convert(v);
+                        } catch (const msgpack::type_error&) {
+                            std::cerr << val << std::endl;
+                            throw_or_abort("error converting into enum variant 'Opcode::MemoryOp'");
+                        }
+                        value = v;
+                        break;
+                    }
+                    case 3: {
+                        MemoryInit v;
+                        try {
+                            val.convert(v);
+                        } catch (const msgpack::type_error&) {
+                            std::cerr << val << std::endl;
+                            throw_or_abort("error converting into enum variant 'Opcode::MemoryInit'");
+                        }
+                        value = v;
+                        break;
+                    }
+                    case 4: {
+                        BrilligCall v;
+                        try {
+                            val.convert(v);
+                        } catch (const msgpack::type_error&) {
+                            std::cerr << val << std::endl;
+                            throw_or_abort("error converting into enum variant 'Opcode::BrilligCall'");
+                        }
+                        value = v;
+                        break;
+                    }
+                    case 5: {
+                        Call v;
+                        try {
+                            val.convert(v);
+                        } catch (const msgpack::type_error&) {
+                            std::cerr << val << std::endl;
+                            throw_or_abort("error converting into enum variant 'Opcode::Call'");
+                        }
+                        value = v;
+                        break;
+                    }
+                    default:
+                        std::cerr << o << std::endl;
+                        throw_or_abort("unknown 'Opcode' enum variant tag: " + std::to_string(tag));
+                }
+            } else {
+                // `Format::Msgpack` (MAP, string-keyed) or `Format::MsgpackCompact`
+                // unit variant (bare STR) — both dispatch on the variant name.
+                std::string tag;
                 try {
-                    o.via.map.ptr[0].val.convert(v);
-                } catch (const msgpack::type_error&) {
+                    if (o.type == msgpack::type::object_type::MAP) {
+                        o.via.map.ptr[0].key.convert(tag);
+                    } else {
+                        o.convert(tag);
+                    }
+                } catch(const msgpack::type_error&) {
                     std::cerr << o << std::endl;
-                    throw_or_abort("error converting into enum variant 'Opcode::BlackBoxFuncCall'");
+                    throw_or_abort("error converting tag to string for enum 'Opcode'");
                 }
-                
-                value = v;
-            }
-            else if (tag == "MemoryOp") {
-                MemoryOp v;
-                try {
-                    o.via.map.ptr[0].val.convert(v);
-                } catch (const msgpack::type_error&) {
+                if (tag == "AssertZero") {
+                    AssertZero v;
+                    try {
+                        o.via.map.ptr[0].val.convert(v);
+                    } catch (const msgpack::type_error&) {
+                        std::cerr << o << std::endl;
+                        throw_or_abort("error converting into enum variant 'Opcode::AssertZero'");
+                    }
+                    
+                    value = v;
+                }
+                else if (tag == "BlackBoxFuncCall") {
+                    BlackBoxFuncCall v;
+                    try {
+                        o.via.map.ptr[0].val.convert(v);
+                    } catch (const msgpack::type_error&) {
+                        std::cerr << o << std::endl;
+                        throw_or_abort("error converting into enum variant 'Opcode::BlackBoxFuncCall'");
+                    }
+                    
+                    value = v;
+                }
+                else if (tag == "MemoryOp") {
+                    MemoryOp v;
+                    try {
+                        o.via.map.ptr[0].val.convert(v);
+                    } catch (const msgpack::type_error&) {
+                        std::cerr << o << std::endl;
+                        throw_or_abort("error converting into enum variant 'Opcode::MemoryOp'");
+                    }
+                    
+                    value = v;
+                }
+                else if (tag == "MemoryInit") {
+                    MemoryInit v;
+                    try {
+                        o.via.map.ptr[0].val.convert(v);
+                    } catch (const msgpack::type_error&) {
+                        std::cerr << o << std::endl;
+                        throw_or_abort("error converting into enum variant 'Opcode::MemoryInit'");
+                    }
+                    
+                    value = v;
+                }
+                else if (tag == "BrilligCall") {
+                    BrilligCall v;
+                    try {
+                        o.via.map.ptr[0].val.convert(v);
+                    } catch (const msgpack::type_error&) {
+                        std::cerr << o << std::endl;
+                        throw_or_abort("error converting into enum variant 'Opcode::BrilligCall'");
+                    }
+                    
+                    value = v;
+                }
+                else if (tag == "Call") {
+                    Call v;
+                    try {
+                        o.via.map.ptr[0].val.convert(v);
+                    } catch (const msgpack::type_error&) {
+                        std::cerr << o << std::endl;
+                        throw_or_abort("error converting into enum variant 'Opcode::Call'");
+                    }
+                    
+                    value = v;
+                }
+                else {
                     std::cerr << o << std::endl;
-                    throw_or_abort("error converting into enum variant 'Opcode::MemoryOp'");
+                    throw_or_abort("unknown 'Opcode' enum variant: " + tag);
                 }
-                
-                value = v;
-            }
-            else if (tag == "MemoryInit") {
-                MemoryInit v;
-                try {
-                    o.via.map.ptr[0].val.convert(v);
-                } catch (const msgpack::type_error&) {
-                    std::cerr << o << std::endl;
-                    throw_or_abort("error converting into enum variant 'Opcode::MemoryInit'");
-                }
-                
-                value = v;
-            }
-            else if (tag == "BrilligCall") {
-                BrilligCall v;
-                try {
-                    o.via.map.ptr[0].val.convert(v);
-                } catch (const msgpack::type_error&) {
-                    std::cerr << o << std::endl;
-                    throw_or_abort("error converting into enum variant 'Opcode::BrilligCall'");
-                }
-                
-                value = v;
-            }
-            else if (tag == "Call") {
-                Call v;
-                try {
-                    o.via.map.ptr[0].val.convert(v);
-                } catch (const msgpack::type_error&) {
-                    std::cerr << o << std::endl;
-                    throw_or_abort("error converting into enum variant 'Opcode::Call'");
-                }
-                
-                value = v;
-            }
-            else {
-                std::cerr << o << std::endl;
-                throw_or_abort("unknown 'Opcode' enum variant: " + tag);
             }
         }
     };
@@ -3289,42 +5561,83 @@ namespace Acir {
             if (o.type == msgpack::type::object_type::MAP && o.via.map.size != 1) {
                 throw_or_abort("expected 1 entry for enum 'ExpressionOrMemory'; got " + std::to_string(o.via.map.size));
             }
-            std::string tag;
-            try {
-                if (o.type == msgpack::type::object_type::MAP) {
+            if (Helpers::is_int_keyed_map(o)) {
+                // `Format::MsgpackTagged` — int-keyed variant.
+                uint8_t tag;
+                try {
                     o.via.map.ptr[0].key.convert(tag);
-                } else {
-                    o.convert(tag);
-                }
-            } catch(const msgpack::type_error&) {
-                std::cerr << o << std::endl;
-                throw_or_abort("error converting tag to string for enum 'ExpressionOrMemory'");
-            }
-            if (tag == "Expression") {
-                Expression v;
-                try {
-                    o.via.map.ptr[0].val.convert(v);
                 } catch (const msgpack::type_error&) {
                     std::cerr << o << std::endl;
-                    throw_or_abort("error converting into enum variant 'ExpressionOrMemory::Expression'");
+                    throw_or_abort("expected u8 variant tag for enum 'ExpressionOrMemory'");
                 }
-                
-                value = v;
-            }
-            else if (tag == "Memory") {
-                Memory v;
+                msgpack::object const& val = o.via.map.ptr[0].val;
+                switch (tag) {
+                    case 0: {
+                        Expression v;
+                        try {
+                            val.convert(v);
+                        } catch (const msgpack::type_error&) {
+                            std::cerr << val << std::endl;
+                            throw_or_abort("error converting into enum variant 'ExpressionOrMemory::Expression'");
+                        }
+                        value = v;
+                        break;
+                    }
+                    case 1: {
+                        Memory v;
+                        try {
+                            val.convert(v);
+                        } catch (const msgpack::type_error&) {
+                            std::cerr << val << std::endl;
+                            throw_or_abort("error converting into enum variant 'ExpressionOrMemory::Memory'");
+                        }
+                        value = v;
+                        break;
+                    }
+                    default:
+                        std::cerr << o << std::endl;
+                        throw_or_abort("unknown 'ExpressionOrMemory' enum variant tag: " + std::to_string(tag));
+                }
+            } else {
+                // `Format::Msgpack` (MAP, string-keyed) or `Format::MsgpackCompact`
+                // unit variant (bare STR) — both dispatch on the variant name.
+                std::string tag;
                 try {
-                    o.via.map.ptr[0].val.convert(v);
-                } catch (const msgpack::type_error&) {
+                    if (o.type == msgpack::type::object_type::MAP) {
+                        o.via.map.ptr[0].key.convert(tag);
+                    } else {
+                        o.convert(tag);
+                    }
+                } catch(const msgpack::type_error&) {
                     std::cerr << o << std::endl;
-                    throw_or_abort("error converting into enum variant 'ExpressionOrMemory::Memory'");
+                    throw_or_abort("error converting tag to string for enum 'ExpressionOrMemory'");
                 }
-                
-                value = v;
-            }
-            else {
-                std::cerr << o << std::endl;
-                throw_or_abort("unknown 'ExpressionOrMemory' enum variant: " + tag);
+                if (tag == "Expression") {
+                    Expression v;
+                    try {
+                        o.via.map.ptr[0].val.convert(v);
+                    } catch (const msgpack::type_error&) {
+                        std::cerr << o << std::endl;
+                        throw_or_abort("error converting into enum variant 'ExpressionOrMemory::Expression'");
+                    }
+                    
+                    value = v;
+                }
+                else if (tag == "Memory") {
+                    Memory v;
+                    try {
+                        o.via.map.ptr[0].val.convert(v);
+                    } catch (const msgpack::type_error&) {
+                        std::cerr << o << std::endl;
+                        throw_or_abort("error converting into enum variant 'ExpressionOrMemory::Memory'");
+                    }
+                    
+                    value = v;
+                }
+                else {
+                    std::cerr << o << std::endl;
+                    throw_or_abort("unknown 'ExpressionOrMemory' enum variant: " + tag);
+                }
             }
         }
     };
@@ -3338,9 +5651,26 @@ namespace Acir {
         void msgpack_unpack(msgpack::object const& o) {
             std::string name = "AssertionPayload";
             if (o.type == msgpack::type::MAP) {
-                auto kvmap = Helpers::make_kvmap(o, name);
-                Helpers::conv_fld_from_kvmap(kvmap, name, "error_selector", error_selector, false);
-                Helpers::conv_fld_from_kvmap(kvmap, name, "payload", payload, false);
+                if (Helpers::is_int_keyed_map(o)) {
+                    Helpers::int_map_dispatch(o, name, [&](uint8_t tag, msgpack::object const& val) {
+                        switch (tag) {
+                            case 0:
+                                Helpers::convert_or_throw(val, name, "error_selector", error_selector);
+                                break;
+                            case 1:
+                                Helpers::convert_or_throw(val, name, "payload", payload);
+                                break;
+                            default:
+                                // Unknown tag — skip silently (forward-compat /
+                                // retired tags drained — matches the Rust decoder).
+                                break;
+                        }
+                    });
+                } else {
+                    auto kvmap = Helpers::make_kvmap(o, name);
+                    Helpers::conv_fld_from_kvmap(kvmap, name, "error_selector", error_selector, false);
+                    Helpers::conv_fld_from_kvmap(kvmap, name, "payload", payload, false);
+                }
             } else if (o.type == msgpack::type::ARRAY) {
                 auto array = o.via.array; 
                 Helpers::conv_fld_from_array(array, name, "error_selector", error_selector, 0);
@@ -3377,9 +5707,26 @@ namespace Acir {
             void msgpack_unpack(msgpack::object const& o) {
                 std::string name = "Brillig";
                 if (o.type == msgpack::type::MAP) {
-                    auto kvmap = Helpers::make_kvmap(o, name);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "acir_index", acir_index, false);
-                    Helpers::conv_fld_from_kvmap(kvmap, name, "brillig_index", brillig_index, false);
+                    if (Helpers::is_int_keyed_map(o)) {
+                        Helpers::int_map_dispatch(o, name, [&](uint8_t tag, msgpack::object const& val) {
+                            switch (tag) {
+                                case 0:
+                                    Helpers::convert_or_throw(val, name, "acir_index", acir_index);
+                                    break;
+                                case 1:
+                                    Helpers::convert_or_throw(val, name, "brillig_index", brillig_index);
+                                    break;
+                                default:
+                                    // Unknown tag — skip silently (forward-compat /
+                                    // retired tags drained — matches the Rust decoder).
+                                    break;
+                            }
+                        });
+                    } else {
+                        auto kvmap = Helpers::make_kvmap(o, name);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "acir_index", acir_index, false);
+                        Helpers::conv_fld_from_kvmap(kvmap, name, "brillig_index", brillig_index, false);
+                    }
                 } else if (o.type == msgpack::type::ARRAY) {
                     auto array = o.via.array; 
                     Helpers::conv_fld_from_array(array, name, "acir_index", acir_index, 0);
@@ -3403,42 +5750,83 @@ namespace Acir {
             if (o.type == msgpack::type::object_type::MAP && o.via.map.size != 1) {
                 throw_or_abort("expected 1 entry for enum 'OpcodeLocation'; got " + std::to_string(o.via.map.size));
             }
-            std::string tag;
-            try {
-                if (o.type == msgpack::type::object_type::MAP) {
+            if (Helpers::is_int_keyed_map(o)) {
+                // `Format::MsgpackTagged` — int-keyed variant.
+                uint8_t tag;
+                try {
                     o.via.map.ptr[0].key.convert(tag);
-                } else {
-                    o.convert(tag);
-                }
-            } catch(const msgpack::type_error&) {
-                std::cerr << o << std::endl;
-                throw_or_abort("error converting tag to string for enum 'OpcodeLocation'");
-            }
-            if (tag == "Acir") {
-                Acir v;
-                try {
-                    o.via.map.ptr[0].val.convert(v);
                 } catch (const msgpack::type_error&) {
                     std::cerr << o << std::endl;
-                    throw_or_abort("error converting into enum variant 'OpcodeLocation::Acir'");
+                    throw_or_abort("expected u8 variant tag for enum 'OpcodeLocation'");
                 }
-                
-                value = v;
-            }
-            else if (tag == "Brillig") {
-                Brillig v;
+                msgpack::object const& val = o.via.map.ptr[0].val;
+                switch (tag) {
+                    case 0: {
+                        Acir v;
+                        try {
+                            val.convert(v);
+                        } catch (const msgpack::type_error&) {
+                            std::cerr << val << std::endl;
+                            throw_or_abort("error converting into enum variant 'OpcodeLocation::Acir'");
+                        }
+                        value = v;
+                        break;
+                    }
+                    case 1: {
+                        Brillig v;
+                        try {
+                            val.convert(v);
+                        } catch (const msgpack::type_error&) {
+                            std::cerr << val << std::endl;
+                            throw_or_abort("error converting into enum variant 'OpcodeLocation::Brillig'");
+                        }
+                        value = v;
+                        break;
+                    }
+                    default:
+                        std::cerr << o << std::endl;
+                        throw_or_abort("unknown 'OpcodeLocation' enum variant tag: " + std::to_string(tag));
+                }
+            } else {
+                // `Format::Msgpack` (MAP, string-keyed) or `Format::MsgpackCompact`
+                // unit variant (bare STR) — both dispatch on the variant name.
+                std::string tag;
                 try {
-                    o.via.map.ptr[0].val.convert(v);
-                } catch (const msgpack::type_error&) {
+                    if (o.type == msgpack::type::object_type::MAP) {
+                        o.via.map.ptr[0].key.convert(tag);
+                    } else {
+                        o.convert(tag);
+                    }
+                } catch(const msgpack::type_error&) {
                     std::cerr << o << std::endl;
-                    throw_or_abort("error converting into enum variant 'OpcodeLocation::Brillig'");
+                    throw_or_abort("error converting tag to string for enum 'OpcodeLocation'");
                 }
-                
-                value = v;
-            }
-            else {
-                std::cerr << o << std::endl;
-                throw_or_abort("unknown 'OpcodeLocation' enum variant: " + tag);
+                if (tag == "Acir") {
+                    Acir v;
+                    try {
+                        o.via.map.ptr[0].val.convert(v);
+                    } catch (const msgpack::type_error&) {
+                        std::cerr << o << std::endl;
+                        throw_or_abort("error converting into enum variant 'OpcodeLocation::Acir'");
+                    }
+                    
+                    value = v;
+                }
+                else if (tag == "Brillig") {
+                    Brillig v;
+                    try {
+                        o.via.map.ptr[0].val.convert(v);
+                    } catch (const msgpack::type_error&) {
+                        std::cerr << o << std::endl;
+                        throw_or_abort("error converting into enum variant 'OpcodeLocation::Brillig'");
+                    }
+                    
+                    value = v;
+                }
+                else {
+                    std::cerr << o << std::endl;
+                    throw_or_abort("unknown 'OpcodeLocation' enum variant: " + tag);
+                }
             }
         }
     };
@@ -3472,14 +5860,46 @@ namespace Acir {
         void msgpack_unpack(msgpack::object const& o) {
             std::string name = "Circuit";
             if (o.type == msgpack::type::MAP) {
-                auto kvmap = Helpers::make_kvmap(o, name);
-                Helpers::conv_fld_from_kvmap(kvmap, name, "function_name", function_name, false);
-                Helpers::conv_fld_from_kvmap(kvmap, name, "current_witness_index", current_witness_index, false);
-                Helpers::conv_fld_from_kvmap(kvmap, name, "opcodes", opcodes, false);
-                Helpers::conv_fld_from_kvmap(kvmap, name, "private_parameters", private_parameters, false);
-                Helpers::conv_fld_from_kvmap(kvmap, name, "public_parameters", public_parameters, false);
-                Helpers::conv_fld_from_kvmap(kvmap, name, "return_values", return_values, false);
-                Helpers::conv_fld_from_kvmap(kvmap, name, "assert_messages", assert_messages, false);
+                if (Helpers::is_int_keyed_map(o)) {
+                    Helpers::int_map_dispatch(o, name, [&](uint8_t tag, msgpack::object const& val) {
+                        switch (tag) {
+                            case 0:
+                                Helpers::convert_or_throw(val, name, "function_name", function_name);
+                                break;
+                            case 1:
+                                Helpers::convert_or_throw(val, name, "current_witness_index", current_witness_index);
+                                break;
+                            case 2:
+                                Helpers::convert_or_throw(val, name, "opcodes", opcodes);
+                                break;
+                            case 3:
+                                Helpers::convert_or_throw(val, name, "private_parameters", private_parameters);
+                                break;
+                            case 4:
+                                Helpers::convert_or_throw(val, name, "public_parameters", public_parameters);
+                                break;
+                            case 5:
+                                Helpers::convert_or_throw(val, name, "return_values", return_values);
+                                break;
+                            case 6:
+                                Helpers::convert_or_throw(val, name, "assert_messages", assert_messages);
+                                break;
+                            default:
+                                // Unknown tag — skip silently (forward-compat /
+                                // retired tags drained — matches the Rust decoder).
+                                break;
+                        }
+                    });
+                } else {
+                    auto kvmap = Helpers::make_kvmap(o, name);
+                    Helpers::conv_fld_from_kvmap(kvmap, name, "function_name", function_name, false);
+                    Helpers::conv_fld_from_kvmap(kvmap, name, "current_witness_index", current_witness_index, false);
+                    Helpers::conv_fld_from_kvmap(kvmap, name, "opcodes", opcodes, false);
+                    Helpers::conv_fld_from_kvmap(kvmap, name, "private_parameters", private_parameters, false);
+                    Helpers::conv_fld_from_kvmap(kvmap, name, "public_parameters", public_parameters, false);
+                    Helpers::conv_fld_from_kvmap(kvmap, name, "return_values", return_values, false);
+                    Helpers::conv_fld_from_kvmap(kvmap, name, "assert_messages", assert_messages, false);
+                }
             } else if (o.type == msgpack::type::ARRAY) {
                 auto array = o.via.array; 
                 Helpers::conv_fld_from_array(array, name, "function_name", function_name, 0);
@@ -3504,9 +5924,26 @@ namespace Acir {
         void msgpack_unpack(msgpack::object const& o) {
             std::string name = "BrilligBytecode";
             if (o.type == msgpack::type::MAP) {
-                auto kvmap = Helpers::make_kvmap(o, name);
-                Helpers::conv_fld_from_kvmap(kvmap, name, "function_name", function_name, false);
-                Helpers::conv_fld_from_kvmap(kvmap, name, "bytecode", bytecode, false);
+                if (Helpers::is_int_keyed_map(o)) {
+                    Helpers::int_map_dispatch(o, name, [&](uint8_t tag, msgpack::object const& val) {
+                        switch (tag) {
+                            case 0:
+                                Helpers::convert_or_throw(val, name, "function_name", function_name);
+                                break;
+                            case 1:
+                                Helpers::convert_or_throw(val, name, "bytecode", bytecode);
+                                break;
+                            default:
+                                // Unknown tag — skip silently (forward-compat /
+                                // retired tags drained — matches the Rust decoder).
+                                break;
+                        }
+                    });
+                } else {
+                    auto kvmap = Helpers::make_kvmap(o, name);
+                    Helpers::conv_fld_from_kvmap(kvmap, name, "function_name", function_name, false);
+                    Helpers::conv_fld_from_kvmap(kvmap, name, "bytecode", bytecode, false);
+                }
             } else if (o.type == msgpack::type::ARRAY) {
                 auto array = o.via.array; 
                 Helpers::conv_fld_from_array(array, name, "function_name", function_name, 0);
@@ -3526,9 +5963,26 @@ namespace Acir {
         void msgpack_unpack(msgpack::object const& o) {
             std::string name = "Program";
             if (o.type == msgpack::type::MAP) {
-                auto kvmap = Helpers::make_kvmap(o, name);
-                Helpers::conv_fld_from_kvmap(kvmap, name, "functions", functions, false);
-                Helpers::conv_fld_from_kvmap(kvmap, name, "unconstrained_functions", unconstrained_functions, false);
+                if (Helpers::is_int_keyed_map(o)) {
+                    Helpers::int_map_dispatch(o, name, [&](uint8_t tag, msgpack::object const& val) {
+                        switch (tag) {
+                            case 0:
+                                Helpers::convert_or_throw(val, name, "functions", functions);
+                                break;
+                            case 1:
+                                Helpers::convert_or_throw(val, name, "unconstrained_functions", unconstrained_functions);
+                                break;
+                            default:
+                                // Unknown tag — skip silently (forward-compat /
+                                // retired tags drained — matches the Rust decoder).
+                                break;
+                        }
+                    });
+                } else {
+                    auto kvmap = Helpers::make_kvmap(o, name);
+                    Helpers::conv_fld_from_kvmap(kvmap, name, "functions", functions, false);
+                    Helpers::conv_fld_from_kvmap(kvmap, name, "unconstrained_functions", unconstrained_functions, false);
+                }
             } else if (o.type == msgpack::type::ARRAY) {
                 auto array = o.via.array; 
                 Helpers::conv_fld_from_array(array, name, "functions", functions, 0);
@@ -3548,8 +6002,22 @@ namespace Acir {
         void msgpack_unpack(msgpack::object const& o) {
             std::string name = "ProgramWithoutBrillig";
             if (o.type == msgpack::type::MAP) {
-                auto kvmap = Helpers::make_kvmap(o, name);
-                Helpers::conv_fld_from_kvmap(kvmap, name, "functions", functions, false);
+                if (Helpers::is_int_keyed_map(o)) {
+                    Helpers::int_map_dispatch(o, name, [&](uint8_t tag, msgpack::object const& val) {
+                        switch (tag) {
+                            case 0:
+                                Helpers::convert_or_throw(val, name, "functions", functions);
+                                break;
+                            default:
+                                // Unknown tag — skip silently (forward-compat /
+                                // retired tags drained — matches the Rust decoder).
+                                break;
+                        }
+                    });
+                } else {
+                    auto kvmap = Helpers::make_kvmap(o, name);
+                    Helpers::conv_fld_from_kvmap(kvmap, name, "functions", functions, false);
+                }
             } else if (o.type == msgpack::type::ARRAY) {
                 auto array = o.via.array; 
                 Helpers::conv_fld_from_array(array, name, "functions", functions, 0);

--- a/acvm-repo/acir/codegen/witness.cpp
+++ b/acvm-repo/acir/codegen/witness.cpp
@@ -2,6 +2,7 @@
 
 #include "serde.hpp"
 #include "barretenberg/serialize/msgpack_impl.hpp"
+#include "bincode.hpp"
 
 namespace Witnesses {
     struct Helpers {
@@ -158,8 +159,11 @@ namespace Witnesses {
         uint32_t value;
 
         friend bool operator==(const Witness&, const Witness&);
+        std::vector<uint8_t> bincodeSerialize() const;
+        static Witness bincodeDeserialize(std::vector<uint8_t>);
 
-        bool operator<(Witness const& rhs) const { return value < rhs.value; }
+        bool operator<(Witness const& rhs) const { return value < rhs.value; }void msgpack_pack(auto& packer) const { packer.pack(value); }
+
         void msgpack_unpack(msgpack::object const& o) {
             try {
                 o.convert(value);
@@ -174,6 +178,10 @@ namespace Witnesses {
         std::map<Witnesses::Witness, std::vector<uint8_t>> value;
 
         friend bool operator==(const WitnessMap&, const WitnessMap&);
+        std::vector<uint8_t> bincodeSerialize() const;
+        static WitnessMap bincodeDeserialize(std::vector<uint8_t>);
+
+        void msgpack_pack(auto& packer) const { packer.pack(value); }
 
         void msgpack_unpack(msgpack::object const& o) {
             try {
@@ -190,6 +198,14 @@ namespace Witnesses {
         Witnesses::WitnessMap witness;
 
         friend bool operator==(const StackItem&, const StackItem&);
+        std::vector<uint8_t> bincodeSerialize() const;
+        static StackItem bincodeDeserialize(std::vector<uint8_t>);
+
+        void msgpack_pack(auto& packer) const {
+            packer.pack_map(2);
+            packer.pack(std::make_pair("index", index));
+            packer.pack(std::make_pair("witness", witness));
+        }
 
         void msgpack_unpack(msgpack::object const& o) {
             std::string name = "StackItem";
@@ -229,6 +245,13 @@ namespace Witnesses {
         std::vector<Witnesses::StackItem> stack;
 
         friend bool operator==(const WitnessStack&, const WitnessStack&);
+        std::vector<uint8_t> bincodeSerialize() const;
+        static WitnessStack bincodeDeserialize(std::vector<uint8_t>);
+
+        void msgpack_pack(auto& packer) const {
+            packer.pack_map(1);
+            packer.pack(std::make_pair("stack", stack));
+        }
 
         void msgpack_unpack(msgpack::object const& o) {
             std::string name = "WitnessStack";
@@ -270,6 +293,21 @@ namespace Witnesses {
         return true;
     }
 
+    inline std::vector<uint8_t> StackItem::bincodeSerialize() const {
+        auto serializer = serde::BincodeSerializer();
+        serde::Serializable<StackItem>::serialize(*this, serializer);
+        return std::move(serializer).bytes();
+    }
+
+    inline StackItem StackItem::bincodeDeserialize(std::vector<uint8_t> input) {
+        auto deserializer = serde::BincodeDeserializer(input);
+        auto value = serde::Deserializable<StackItem>::deserialize(deserializer);
+        if (deserializer.get_buffer_offset() < input.size()) {
+            throw_or_abort("Some input bytes were not read");
+        }
+        return value;
+    }
+
 } // end of namespace Witnesses
 
 template <>
@@ -299,6 +337,21 @@ namespace Witnesses {
         return true;
     }
 
+    inline std::vector<uint8_t> Witness::bincodeSerialize() const {
+        auto serializer = serde::BincodeSerializer();
+        serde::Serializable<Witness>::serialize(*this, serializer);
+        return std::move(serializer).bytes();
+    }
+
+    inline Witness Witness::bincodeDeserialize(std::vector<uint8_t> input) {
+        auto deserializer = serde::BincodeDeserializer(input);
+        auto value = serde::Deserializable<Witness>::deserialize(deserializer);
+        if (deserializer.get_buffer_offset() < input.size()) {
+            throw_or_abort("Some input bytes were not read");
+        }
+        return value;
+    }
+
 } // end of namespace Witnesses
 
 template <>
@@ -326,6 +379,21 @@ namespace Witnesses {
         return true;
     }
 
+    inline std::vector<uint8_t> WitnessMap::bincodeSerialize() const {
+        auto serializer = serde::BincodeSerializer();
+        serde::Serializable<WitnessMap>::serialize(*this, serializer);
+        return std::move(serializer).bytes();
+    }
+
+    inline WitnessMap WitnessMap::bincodeDeserialize(std::vector<uint8_t> input) {
+        auto deserializer = serde::BincodeDeserializer(input);
+        auto value = serde::Deserializable<WitnessMap>::deserialize(deserializer);
+        if (deserializer.get_buffer_offset() < input.size()) {
+            throw_or_abort("Some input bytes were not read");
+        }
+        return value;
+    }
+
 } // end of namespace Witnesses
 
 template <>
@@ -351,6 +419,21 @@ namespace Witnesses {
     inline bool operator==(const WitnessStack &lhs, const WitnessStack &rhs) {
         if (!(lhs.stack == rhs.stack)) { return false; }
         return true;
+    }
+
+    inline std::vector<uint8_t> WitnessStack::bincodeSerialize() const {
+        auto serializer = serde::BincodeSerializer();
+        serde::Serializable<WitnessStack>::serialize(*this, serializer);
+        return std::move(serializer).bytes();
+    }
+
+    inline WitnessStack WitnessStack::bincodeDeserialize(std::vector<uint8_t> input) {
+        auto deserializer = serde::BincodeDeserializer(input);
+        auto value = serde::Deserializable<WitnessStack>::deserialize(deserializer);
+        if (deserializer.get_buffer_offset() < input.size()) {
+            throw_or_abort("Some input bytes were not read");
+        }
+        return value;
     }
 
 } // end of namespace Witnesses

--- a/acvm-repo/acir/codegen/witness.cpp
+++ b/acvm-repo/acir/codegen/witness.cpp
@@ -68,6 +68,59 @@ namespace Witnesses {
                 throw_or_abort("error converting into field " + struct_name + "::" + field_name);
             }
         }
+
+        /// Convert `val` into `field`, or throw a focused error mentioning
+        /// the struct + field name. Used by the int-keyed dispatch path
+        /// where each `switch` case populates one field directly.
+        template<typename T>
+        static void convert_or_throw(
+            msgpack::object const& val,
+            std::string const& struct_name,
+            std::string const& field_name,
+            T& field
+        ) {
+            try {
+                val.convert(field);
+            } catch (const msgpack::type_error&) {
+                std::cerr << val << std::endl;
+                throw_or_abort("error converting into field " + struct_name + "::" + field_name);
+            }
+        }
+
+        /// Whether `o` is a non-empty MAP whose first key is an integer.
+        /// This is the signature of `Format::MsgpackTagged`: int keys for
+        /// struct field tags and enum variant tags. Legacy `Format::Msgpack`
+        /// keys are always strings, so a positive-integer first key is a
+        /// reliable shape discriminator between the two.
+        static bool is_int_keyed_map(msgpack::object const& o) {
+            return o.type == msgpack::type::MAP
+                && o.via.map.size > 0
+                && o.via.map.ptr[0].key.type == msgpack::type::POSITIVE_INTEGER;
+        }
+
+        /// Iterate an int-keyed MAP and invoke `dispatch(tag, val)` for each
+        /// `(u8, msgpack::object)` entry. The per-tag `switch` inside the
+        /// caller's lambda decides which field (or variant) to populate;
+        /// unknown tags fall through to `default` and are silently skipped,
+        /// matching the `MsgpackTagged` decoder's forward-compat policy
+        /// (`allow_unknown_tags` / retired tags drained).
+        template<typename Dispatch>
+        static void int_map_dispatch(
+            msgpack::object const& o,
+            std::string const& name,
+            Dispatch&& dispatch
+        ) {
+            for (uint32_t i = 0; i < o.via.map.size; ++i) {
+                uint8_t tag;
+                try {
+                    o.via.map.ptr[i].key.convert(tag);
+                } catch (const msgpack::type_error&) {
+                    std::cerr << o.via.map.ptr[i].key << std::endl;
+                    throw_or_abort("expected u8 tag in int-keyed map for " + name);
+                }
+                dispatch(tag, o.via.map.ptr[i].val);
+            }
+        }
     };
     }
 
@@ -113,9 +166,26 @@ namespace Witnesses {
         void msgpack_unpack(msgpack::object const& o) {
             std::string name = "StackItem";
             if (o.type == msgpack::type::MAP) {
-                auto kvmap = Helpers::make_kvmap(o, name);
-                Helpers::conv_fld_from_kvmap(kvmap, name, "index", index, false);
-                Helpers::conv_fld_from_kvmap(kvmap, name, "witness", witness, false);
+                if (Helpers::is_int_keyed_map(o)) {
+                    Helpers::int_map_dispatch(o, name, [&](uint8_t tag, msgpack::object const& val) {
+                        switch (tag) {
+                            case 0:
+                                Helpers::convert_or_throw(val, name, "index", index);
+                                break;
+                            case 1:
+                                Helpers::convert_or_throw(val, name, "witness", witness);
+                                break;
+                            default:
+                                // Unknown tag — skip silently (forward-compat /
+                                // retired tags drained — matches the Rust decoder).
+                                break;
+                        }
+                    });
+                } else {
+                    auto kvmap = Helpers::make_kvmap(o, name);
+                    Helpers::conv_fld_from_kvmap(kvmap, name, "index", index, false);
+                    Helpers::conv_fld_from_kvmap(kvmap, name, "witness", witness, false);
+                }
             } else if (o.type == msgpack::type::ARRAY) {
                 auto array = o.via.array; 
                 Helpers::conv_fld_from_array(array, name, "index", index, 0);
@@ -134,8 +204,22 @@ namespace Witnesses {
         void msgpack_unpack(msgpack::object const& o) {
             std::string name = "WitnessStack";
             if (o.type == msgpack::type::MAP) {
-                auto kvmap = Helpers::make_kvmap(o, name);
-                Helpers::conv_fld_from_kvmap(kvmap, name, "stack", stack, false);
+                if (Helpers::is_int_keyed_map(o)) {
+                    Helpers::int_map_dispatch(o, name, [&](uint8_t tag, msgpack::object const& val) {
+                        switch (tag) {
+                            case 0:
+                                Helpers::convert_or_throw(val, name, "stack", stack);
+                                break;
+                            default:
+                                // Unknown tag — skip silently (forward-compat /
+                                // retired tags drained — matches the Rust decoder).
+                                break;
+                        }
+                    });
+                } else {
+                    auto kvmap = Helpers::make_kvmap(o, name);
+                    Helpers::conv_fld_from_kvmap(kvmap, name, "stack", stack, false);
+                }
             } else if (o.type == msgpack::type::ARRAY) {
                 auto array = o.via.array; 
                 Helpers::conv_fld_from_array(array, name, "stack", stack, 0);

--- a/acvm-repo/acir/codegen/witness.cpp
+++ b/acvm-repo/acir/codegen/witness.cpp
@@ -121,6 +121,31 @@ namespace Witnesses {
                 dispatch(tag, o.via.map.ptr[i].val);
             }
         }
+
+        /// Cap the positional-array length: under-length wires error
+        /// downstream in `conv_fld_from_array` (index out of bounds);
+        /// over-length wires up to `active + reserved` are tolerated as
+        /// retired trailing fields (Rust-side `#[tagged(reserved(...))]`);
+        /// anything longer is forward-compat drift that the producer
+        /// would only have emitted if newer fields were added, and is
+        /// the cue for a focused error message pointing at the opt-in.
+        static void check_array_size(
+            msgpack::object_array const& array,
+            std::string const& name,
+            uint32_t active,
+            uint32_t reserved
+        ) {
+            uint32_t max_size = active + reserved;
+            if (array.size > max_size) {
+                throw_or_abort(
+                    "array for " + name +
+                    " has " + std::to_string(array.size) +
+                    " elements but at most " + std::to_string(max_size) +
+                    " are expected (" + std::to_string(active) +
+                    " active + " + std::to_string(reserved) +
+                    " reserved); opt into `#[tagged(allow_unknown_tags)]` on the Rust type to accept trailing extras");
+            }
+        }
     };
     }
 
@@ -186,7 +211,8 @@ namespace Witnesses {
                     Helpers::conv_fld_from_kvmap(kvmap, name, "witness", witness, false);
                 }
             } else if (o.type == msgpack::type::ARRAY) {
-                auto array = o.via.array; 
+                auto array = o.via.array;
+                Helpers::check_array_size(array, name, 2, 0);
                 Helpers::conv_fld_from_array(array, name, "index", index, 0);
                 Helpers::conv_fld_from_array(array, name, "witness", witness, 1);
             } else {
@@ -219,7 +245,8 @@ namespace Witnesses {
                     Helpers::conv_fld_from_kvmap(kvmap, name, "stack", stack, false);
                 }
             } else if (o.type == msgpack::type::ARRAY) {
-                auto array = o.via.array; 
+                auto array = o.via.array;
+                Helpers::check_array_size(array, name, 1, 0);
                 Helpers::conv_fld_from_array(array, name, "stack", stack, 0);
             } else {
                 throw_or_abort("expected MAP or ARRAY for " + name);

--- a/acvm-repo/acir/codegen/witness.cpp
+++ b/acvm-repo/acir/codegen/witness.cpp
@@ -38,6 +38,9 @@ namespace Witnesses {
         ) {
             auto it = kvmap.find(field_name);
             if (it != kvmap.end()) {
+                if (!is_optional && it->second->type == msgpack::type::NIL) {
+                    throw_or_abort("nil value for required field: " + struct_name + "::" + field_name);
+                }
                 try {
                     it->second->convert(field);
                 } catch (const msgpack::type_error&) {

--- a/acvm-repo/acir/codegen/witness.cpp
+++ b/acvm-repo/acir/codegen/witness.cpp
@@ -62,6 +62,9 @@ namespace Witnesses {
                 throw_or_abort("index out of bounds: " + struct_name + "::" + field_name + " at " + std::to_string(index));
             }
             auto element = array.ptr[index];
+            if (element.type == msgpack::type::NIL) {
+                throw_or_abort("nil value for required field: " + struct_name + "::" + field_name);
+            }
             try {
                 element.convert(field);
             } catch (const msgpack::type_error&) {
@@ -202,9 +205,9 @@ namespace Witnesses {
         static StackItem bincodeDeserialize(std::vector<uint8_t>);
 
         void msgpack_pack(auto& packer) const {
-            packer.pack_map(2);
-            packer.pack(std::make_pair("index", index));
-            packer.pack(std::make_pair("witness", witness));
+            packer.pack_array(2);
+            packer.pack(index);
+            packer.pack(witness);
         }
 
         void msgpack_unpack(msgpack::object const& o) {
@@ -249,8 +252,8 @@ namespace Witnesses {
         static WitnessStack bincodeDeserialize(std::vector<uint8_t>);
 
         void msgpack_pack(auto& packer) const {
-            packer.pack_map(1);
-            packer.pack(std::make_pair("stack", stack));
+            packer.pack_array(1);
+            packer.pack(stack);
         }
 
         void msgpack_unpack(msgpack::object const& o) {

--- a/acvm-repo/acir/codegen/witness.cpp
+++ b/acvm-repo/acir/codegen/witness.cpp
@@ -122,51 +122,31 @@ namespace Witnesses {
             }
         }
 
-        /// Cap the positional-array length: under-length wires error
-        /// downstream in `conv_fld_from_array` (index out of bounds);
-        /// over-length wires up to `active + reserved` are tolerated as
-        /// retired trailing fields (Rust-side `#[tagged(reserved(...))]`);
-        /// anything longer is forward-compat drift that the producer
-        /// would only have emitted if newer fields were added, and is
-        /// the cue for a focused error message pointing at the opt-in.
-        static void check_array_size(
-            msgpack::object_array const& array,
+        /// Cap a `MAP` or `ARRAY` entry count against `active + reserved`.
+        /// Under-length wires are caught downstream (`conv_fld_from_array`
+        /// errors out of bounds; `conv_fld_from_kvmap` errors on missing
+        /// required keys), so we only need the upper bound here.
+        ///
+        /// * Up to `reserved` extra trailing entries are tolerated as
+        ///   retired fields (`#[tagged(reserved(...))]` on the Rust side).
+        /// * Anything beyond that is forward-compat drift that the
+        ///   producer only emits when newer fields were added. The
+        ///   Rust-side cue is `#[tagged(allow_unknown_tags)]`; the
+        ///   message points at it so a reviewer can see the opt-in.
+        static void check_size(
+            uint32_t actual,
             std::string const& name,
             uint32_t active,
             uint32_t reserved
         ) {
             uint32_t max_size = active + reserved;
-            if (array.size > max_size) {
+            if (actual > max_size) {
                 throw_or_abort(
-                    "array for " + name +
-                    " has " + std::to_string(array.size) +
-                    " elements but at most " + std::to_string(max_size) +
-                    " are expected (" + std::to_string(active) +
-                    " active + " + std::to_string(reserved) +
-                    " reserved); opt into `#[tagged(allow_unknown_tags)]` on the Rust type to accept trailing extras");
-            }
-        }
-
-        /// Cap a string-keyed map size. Parallel to `check_array_size`
-        /// for the legacy `Format::Msgpack` named-struct wire shape: the
-        /// string-keyed dispatch only looks up keys it recognizes, so
-        /// extras would otherwise pass silently. Same `active +
-        /// reserved` ceiling, same `allow_unknown_tags` opt-out.
-        static void check_map_size(
-            msgpack::object_map const& map,
-            std::string const& name,
-            uint32_t active,
-            uint32_t reserved
-        ) {
-            uint32_t max_size = active + reserved;
-            if (map.size > max_size) {
-                throw_or_abort(
-                    "map for " + name +
-                    " has " + std::to_string(map.size) +
+                    name + " has " + std::to_string(actual) +
                     " entries but at most " + std::to_string(max_size) +
                     " are expected (" + std::to_string(active) +
                     " active + " + std::to_string(reserved) +
-                    " reserved); opt into `#[tagged(allow_unknown_tags)]` on the Rust type to accept extra keys");
+                    " reserved); opt into `#[tagged(allow_unknown_tags)]` on the Rust type to accept extras");
             }
         }
     };
@@ -229,14 +209,14 @@ namespace Witnesses {
                         }
                     });
                 } else {
-                    Helpers::check_map_size(o.via.map, name, 2, 0);
+                    Helpers::check_size(o.via.map.size, name, 2, 0);
                     auto kvmap = Helpers::make_kvmap(o, name);
                     Helpers::conv_fld_from_kvmap(kvmap, name, "index", index, false);
                     Helpers::conv_fld_from_kvmap(kvmap, name, "witness", witness, false);
                 }
             } else if (o.type == msgpack::type::ARRAY) {
                 auto array = o.via.array;
-                Helpers::check_array_size(array, name, 2, 0);
+                Helpers::check_size(array.size, name, 2, 0);
                 Helpers::conv_fld_from_array(array, name, "index", index, 0);
                 Helpers::conv_fld_from_array(array, name, "witness", witness, 1);
             } else {
@@ -265,13 +245,13 @@ namespace Witnesses {
                         }
                     });
                 } else {
-                    Helpers::check_map_size(o.via.map, name, 1, 0);
+                    Helpers::check_size(o.via.map.size, name, 1, 0);
                     auto kvmap = Helpers::make_kvmap(o, name);
                     Helpers::conv_fld_from_kvmap(kvmap, name, "stack", stack, false);
                 }
             } else if (o.type == msgpack::type::ARRAY) {
                 auto array = o.via.array;
-                Helpers::check_array_size(array, name, 1, 0);
+                Helpers::check_size(array.size, name, 1, 0);
                 Helpers::conv_fld_from_array(array, name, "stack", stack, 0);
             } else {
                 throw_or_abort("expected MAP or ARRAY for " + name);

--- a/acvm-repo/acir/codegen/witness.cpp
+++ b/acvm-repo/acir/codegen/witness.cpp
@@ -2,7 +2,6 @@
 
 #include "serde.hpp"
 #include "barretenberg/serialize/msgpack_impl.hpp"
-#include "bincode.hpp"
 
 namespace Witnesses {
     struct Helpers {
@@ -162,8 +161,6 @@ namespace Witnesses {
         uint32_t value;
 
         friend bool operator==(const Witness&, const Witness&);
-        std::vector<uint8_t> bincodeSerialize() const;
-        static Witness bincodeDeserialize(std::vector<uint8_t>);
 
         bool operator<(Witness const& rhs) const { return value < rhs.value; }void msgpack_pack(auto& packer) const { packer.pack(value); }
 
@@ -181,8 +178,6 @@ namespace Witnesses {
         std::map<Witnesses::Witness, std::vector<uint8_t>> value;
 
         friend bool operator==(const WitnessMap&, const WitnessMap&);
-        std::vector<uint8_t> bincodeSerialize() const;
-        static WitnessMap bincodeDeserialize(std::vector<uint8_t>);
 
         void msgpack_pack(auto& packer) const { packer.pack(value); }
 
@@ -201,8 +196,6 @@ namespace Witnesses {
         Witnesses::WitnessMap witness;
 
         friend bool operator==(const StackItem&, const StackItem&);
-        std::vector<uint8_t> bincodeSerialize() const;
-        static StackItem bincodeDeserialize(std::vector<uint8_t>);
 
         void msgpack_pack(auto& packer) const {
             packer.pack_array(2);
@@ -248,8 +241,6 @@ namespace Witnesses {
         std::vector<Witnesses::StackItem> stack;
 
         friend bool operator==(const WitnessStack&, const WitnessStack&);
-        std::vector<uint8_t> bincodeSerialize() const;
-        static WitnessStack bincodeDeserialize(std::vector<uint8_t>);
 
         void msgpack_pack(auto& packer) const {
             packer.pack_array(1);
@@ -296,21 +287,6 @@ namespace Witnesses {
         return true;
     }
 
-    inline std::vector<uint8_t> StackItem::bincodeSerialize() const {
-        auto serializer = serde::BincodeSerializer();
-        serde::Serializable<StackItem>::serialize(*this, serializer);
-        return std::move(serializer).bytes();
-    }
-
-    inline StackItem StackItem::bincodeDeserialize(std::vector<uint8_t> input) {
-        auto deserializer = serde::BincodeDeserializer(input);
-        auto value = serde::Deserializable<StackItem>::deserialize(deserializer);
-        if (deserializer.get_buffer_offset() < input.size()) {
-            throw_or_abort("Some input bytes were not read");
-        }
-        return value;
-    }
-
 } // end of namespace Witnesses
 
 template <>
@@ -340,21 +316,6 @@ namespace Witnesses {
         return true;
     }
 
-    inline std::vector<uint8_t> Witness::bincodeSerialize() const {
-        auto serializer = serde::BincodeSerializer();
-        serde::Serializable<Witness>::serialize(*this, serializer);
-        return std::move(serializer).bytes();
-    }
-
-    inline Witness Witness::bincodeDeserialize(std::vector<uint8_t> input) {
-        auto deserializer = serde::BincodeDeserializer(input);
-        auto value = serde::Deserializable<Witness>::deserialize(deserializer);
-        if (deserializer.get_buffer_offset() < input.size()) {
-            throw_or_abort("Some input bytes were not read");
-        }
-        return value;
-    }
-
 } // end of namespace Witnesses
 
 template <>
@@ -382,21 +343,6 @@ namespace Witnesses {
         return true;
     }
 
-    inline std::vector<uint8_t> WitnessMap::bincodeSerialize() const {
-        auto serializer = serde::BincodeSerializer();
-        serde::Serializable<WitnessMap>::serialize(*this, serializer);
-        return std::move(serializer).bytes();
-    }
-
-    inline WitnessMap WitnessMap::bincodeDeserialize(std::vector<uint8_t> input) {
-        auto deserializer = serde::BincodeDeserializer(input);
-        auto value = serde::Deserializable<WitnessMap>::deserialize(deserializer);
-        if (deserializer.get_buffer_offset() < input.size()) {
-            throw_or_abort("Some input bytes were not read");
-        }
-        return value;
-    }
-
 } // end of namespace Witnesses
 
 template <>
@@ -422,21 +368,6 @@ namespace Witnesses {
     inline bool operator==(const WitnessStack &lhs, const WitnessStack &rhs) {
         if (!(lhs.stack == rhs.stack)) { return false; }
         return true;
-    }
-
-    inline std::vector<uint8_t> WitnessStack::bincodeSerialize() const {
-        auto serializer = serde::BincodeSerializer();
-        serde::Serializable<WitnessStack>::serialize(*this, serializer);
-        return std::move(serializer).bytes();
-    }
-
-    inline WitnessStack WitnessStack::bincodeDeserialize(std::vector<uint8_t> input) {
-        auto deserializer = serde::BincodeDeserializer(input);
-        auto value = serde::Deserializable<WitnessStack>::deserialize(deserializer);
-        if (deserializer.get_buffer_offset() < input.size()) {
-            throw_or_abort("Some input bytes were not read");
-        }
-        return value;
     }
 
 } // end of namespace Witnesses

--- a/acvm-repo/acir/codegen/witness.cpp
+++ b/acvm-repo/acir/codegen/witness.cpp
@@ -176,9 +176,8 @@ namespace Witnesses {
                                 Helpers::convert_or_throw(val, name, "witness", witness);
                                 break;
                             default:
-                                // Unknown tag — skip silently (forward-compat /
-                                // retired tags drained — matches the Rust decoder).
-                                break;
+                                std::cerr << val << std::endl;
+                                throw_or_abort("unknown tag for StackItem: " + std::to_string(tag));
                         }
                     });
                 } else {
@@ -211,9 +210,8 @@ namespace Witnesses {
                                 Helpers::convert_or_throw(val, name, "stack", stack);
                                 break;
                             default:
-                                // Unknown tag — skip silently (forward-compat /
-                                // retired tags drained — matches the Rust decoder).
-                                break;
+                                std::cerr << val << std::endl;
+                                throw_or_abort("unknown tag for WitnessStack: " + std::to_string(tag));
                         }
                     });
                 } else {

--- a/acvm-repo/acir/codegen/witness.cpp
+++ b/acvm-repo/acir/codegen/witness.cpp
@@ -146,6 +146,29 @@ namespace Witnesses {
                     " reserved); opt into `#[tagged(allow_unknown_tags)]` on the Rust type to accept trailing extras");
             }
         }
+
+        /// Cap a string-keyed map size. Parallel to `check_array_size`
+        /// for the legacy `Format::Msgpack` named-struct wire shape: the
+        /// string-keyed dispatch only looks up keys it recognizes, so
+        /// extras would otherwise pass silently. Same `active +
+        /// reserved` ceiling, same `allow_unknown_tags` opt-out.
+        static void check_map_size(
+            msgpack::object_map const& map,
+            std::string const& name,
+            uint32_t active,
+            uint32_t reserved
+        ) {
+            uint32_t max_size = active + reserved;
+            if (map.size > max_size) {
+                throw_or_abort(
+                    "map for " + name +
+                    " has " + std::to_string(map.size) +
+                    " entries but at most " + std::to_string(max_size) +
+                    " are expected (" + std::to_string(active) +
+                    " active + " + std::to_string(reserved) +
+                    " reserved); opt into `#[tagged(allow_unknown_tags)]` on the Rust type to accept extra keys");
+            }
+        }
     };
     }
 
@@ -206,6 +229,7 @@ namespace Witnesses {
                         }
                     });
                 } else {
+                    Helpers::check_map_size(o.via.map, name, 2, 0);
                     auto kvmap = Helpers::make_kvmap(o, name);
                     Helpers::conv_fld_from_kvmap(kvmap, name, "index", index, false);
                     Helpers::conv_fld_from_kvmap(kvmap, name, "witness", witness, false);
@@ -241,6 +265,7 @@ namespace Witnesses {
                         }
                     });
                 } else {
+                    Helpers::check_map_size(o.via.map, name, 1, 0);
                     auto kvmap = Helpers::make_kvmap(o, name);
                     Helpers::conv_fld_from_kvmap(kvmap, name, "stack", stack, false);
                 }

--- a/acvm-repo/acir/src/lib.rs
+++ b/acvm-repo/acir/src/lib.rs
@@ -537,6 +537,29 @@ mod reflection {
                     " reserved); opt into `#[tagged(allow_unknown_tags)]` on the Rust type to accept trailing extras");
             }
         }
+
+        /// Cap a string-keyed map size. Parallel to `check_array_size`
+        /// for the legacy `Format::Msgpack` named-struct wire shape: the
+        /// string-keyed dispatch only looks up keys it recognizes, so
+        /// extras would otherwise pass silently. Same `active +
+        /// reserved` ceiling, same `allow_unknown_tags` opt-out.
+        static void check_map_size(
+            msgpack::object_map const& map,
+            std::string const& name,
+            uint32_t active,
+            uint32_t reserved
+        ) {
+            uint32_t max_size = active + reserved;
+            if (map.size > max_size) {
+                throw_or_abort(
+                    "map for " + name +
+                    " has " + std::to_string(map.size) +
+                    " entries but at most " + std::to_string(max_size) +
+                    " are expected (" + std::to_string(active) +
+                    " active + " + std::to_string(reserved) +
+                    " reserved); opt into `#[tagged(allow_unknown_tags)]` on the Rust type to accept extra keys");
+            }
+        }
     };
     "#;
             // cSpell:enable
@@ -798,7 +821,25 @@ mod reflection {
                     r#"
                 }
             });
-        } else {
+        } else {"#,
+                );
+                // cSpell:enable
+                // String-keyed map branch (`Format::Msgpack`): the
+                // lookup is by field name, so extra wire keys would
+                // otherwise pass unnoticed. Same `active + reserved`
+                // ceiling and same `allow_unknown_tags` opt-out as the
+                // ARRAY branch.
+                if !product.allow_unknown_tags {
+                    body.push_str(&format!(
+                        r#"
+            Helpers::check_map_size(o.via.map, name, {active}, {reserved});"#,
+                        active = fields.len(),
+                        reserved = product.reserved.len(),
+                    ));
+                }
+                // cSpell:disable
+                body.push_str(
+                    r#"
             auto kvmap = Helpers::make_kvmap(o, name);"#,
                 );
                 // cSpell:enable

--- a/acvm-repo/acir/src/lib.rs
+++ b/acvm-repo/acir/src/lib.rs
@@ -296,8 +296,7 @@ mod reflection {
         fn from_env() -> Self {
             Self {
                 // We agreed on the default format to be compact, so it makes sense for Barretenberg to use it for serialization.
-                // But in the latest version they seem to be using MAP format again.
-                pack_compact: env_flag("NOIR_CODEGEN_PACK_COMPACT", false),
+                pack_compact: env_flag("NOIR_CODEGEN_PACK_COMPACT", true),
                 // Barretenberg didn't use serialization outside tests, so they decided they don't want to have this code at all.
                 // But in the latest code they seem to have kept it again.
                 no_pack: env_flag("NOIR_CODEGEN_NO_PACK", false),
@@ -455,6 +454,9 @@ mod reflection {
                 throw_or_abort("index out of bounds: " + struct_name + "::" + field_name + " at " + std::to_string(index));
             }
             auto element = array.ptr[index];
+            if (element.type == msgpack::type::NIL) {
+                throw_or_abort("nil value for required field: " + struct_name + "::" + field_name);
+            }
             try {
                 element.convert(field);
             } catch (const msgpack::type_error&) {

--- a/acvm-repo/acir/src/lib.rs
+++ b/acvm-repo/acir/src/lib.rs
@@ -695,9 +695,6 @@ mod reflection {
                 );
                 // cSpell:enable
                 for field in fields {
-                    if is_unit(field) {
-                        continue;
-                    }
                     let field_name = &field.name;
                     let tag = product.tag_for(field_name).unwrap_or_else(|| {
                         panic!(
@@ -706,6 +703,21 @@ mod reflection {
                              on which fields are on the wire",
                         )
                     });
+                    if is_unit(field) {
+                        // Field is `()` in Rust / `std::monostate` in C++.
+                        // The wire still carries a value at this tag; we
+                        // consume it without binding to any C++ member,
+                        // mirroring `deserialize_unit`'s skip-any semantics.
+                        // cSpell:disable
+                        body.push_str(&format!(
+                            r#"
+                    case {tag}:
+                        // Field is `std::monostate` — wire entry intentionally discarded.
+                        break;"#
+                        ));
+                        // cSpell:enable
+                        continue;
+                    }
                     // cSpell:disable
                     body.push_str(&format!(
                         r#"
@@ -715,13 +727,47 @@ mod reflection {
                     ));
                     // cSpell:enable
                 }
+                // Reserved tags: retired in the Rust type via
+                // `#[tagged(reserved(...))]`. The Rust decoder skips
+                // them silently regardless of `allow_unknown_tags`; do
+                // the same here, with an explicit case so the strict
+                // default below can distinguish "retired" from "never
+                // declared".
+                for &reserved_tag in product.reserved {
+                    // cSpell:disable
+                    body.push_str(&format!(
+                        r#"
+                    case {reserved_tag}:
+                        // Reserved tag (retired field) — skip silently.
+                        break;"#
+                    ));
+                    // cSpell:enable
+                }
+                // Default branch: strict by default (reject unknown tags
+                // so a C++ reviewer can see the type-level intent). Opt
+                // into silent forward-compat with `#[tagged(allow_unknown_tags)]`
+                // on the Rust struct.
+                if product.allow_unknown_tags {
+                    body.push_str(
+                        r#"
+                    default:
+                        // `#[tagged(allow_unknown_tags)]` on the Rust side:
+                        // silently skip any tag we don't recognize.
+                        break;"#,
+                    );
+                } else {
+                    // cSpell:disable
+                    body.push_str(&format!(
+                        r#"
+                    default:
+                        std::cerr << val << std::endl;
+                        throw_or_abort("unknown tag for {name}: " + std::to_string(tag));"#
+                    ));
+                    // cSpell:enable
+                }
                 // cSpell:disable
                 body.push_str(
                     r#"
-                    default:
-                        // Unknown tag — skip silently (forward-compat /
-                        // retired tags drained — matches the Rust decoder).
-                        break;
                 }
             });
         } else {
@@ -949,14 +995,93 @@ mod reflection {
                         // cSpell:enable
                     }
                 }
-                // cSpell:disable
-                body.push_str(&format!(
-                    r#"
+
+                // Reserved variant tags: retired variants on the Rust side
+                // (`#[tagged(reserved(...))]` on the enum). If the enum
+                // marks a unit variant with `#[tagged(on_reserved)]`,
+                // legacy wires carrying a retired tag route to that
+                // fallback; otherwise we throw with a "retired" message
+                // that's distinguishable from the "unknown" case below.
+                let lookup_unit_variant = |fallback_tag: u8| -> &str {
+                    sum.variants.iter().find(|v| v.tag == fallback_tag).map_or_else(
+                        || {
+                            panic!(
+                                "MsgpackTagged Sum for enum {name:?} declares a fallback \
+                                 tag {fallback_tag} that doesn't match any registered variant",
+                            )
+                        },
+                        |v| v.name,
+                    )
+                };
+                for &reserved_tag in sum.reserved {
+                    if let Some(fallback_tag) = sum.on_reserved_tag {
+                        let fallback_name = lookup_unit_variant(fallback_tag);
+                        // cSpell:disable
+                        body.push_str(&format!(
+                            r#"
+            case {reserved_tag}: {{
+                // `#[tagged(on_reserved)]` fallback: retired tag routes to
+                // the designated unit variant (payload discarded).
+                {fallback_name} v;
+                value = v;
+                break;
+            }}"#
+                        ));
+                        // cSpell:enable
+                    } else {
+                        // cSpell:disable
+                        body.push_str(&format!(
+                            r#"
+            case {reserved_tag}:
+                std::cerr << o << std::endl;
+                throw_or_abort("retired variant tag {reserved_tag} for enum '{name}' (declare `#[tagged(on_reserved)]` on a unit variant to route legacy data here)");"#
+                        ));
+                        // cSpell:enable
+                    }
+                }
+
+                // Default branch for unknown variant tags (not active,
+                // not reserved). Routes to `#[tagged(on_unknown)]` if
+                // set — the forward-compat opt-in for newer producers
+                // introducing variants this code doesn't know about.
+                if let Some(fallback_tag) = sum.on_unknown_tag {
+                    let fallback_name = lookup_unit_variant(fallback_tag);
+                    // cSpell:disable
+                    body.push_str(&format!(
+                        r#"
+            default: {{
+                // `#[tagged(on_unknown)]` fallback: any tag we don't recognize
+                // (and isn't reserved) routes here.
+                {fallback_name} v;
+                value = v;
+                break;
+            }}"#
+                    ));
+                    // cSpell:enable
+                } else {
+                    // cSpell:disable
+                    body.push_str(&format!(
+                        r#"
             default:
                 std::cerr << o << std::endl;
-                throw_or_abort("unknown '{name}' enum variant tag: " + std::to_string(tag));
-        }}
-    }} else {{
+                throw_or_abort("unknown '{name}' enum variant tag: " + std::to_string(tag));"#
+                    ));
+                    // cSpell:enable
+                }
+                // cSpell:disable
+                body.push_str(
+                    r#"
+        }
+    } else {"#,
+                );
+                // cSpell:enable
+                // Reuse the existing format-string body for the legacy
+                // string-keyed dispatch path. The `format!(name = ...)`
+                // substitution from the previous body is preserved in the
+                // already-appended text; the section below is plain C++
+                // with no further interpolation.
+                body.push_str(&format!(
+                    r#"
         // `Format::Msgpack` (MAP, string-keyed) or `Format::MsgpackCompact`
         // unit variant (bare STR) — both dispatch on the variant name.
         std::string tag;

--- a/acvm-repo/acir/src/lib.rs
+++ b/acvm-repo/acir/src/lib.rs
@@ -430,6 +430,9 @@ mod reflection {
         ) {
             auto it = kvmap.find(field_name);
             if (it != kvmap.end()) {
+                if (!is_optional && it->second->type == msgpack::type::NIL) {
+                    throw_or_abort("nil value for required field: " + struct_name + "::" + field_name);
+                }
                 try {
                     it->second->convert(field);
                 } catch (const msgpack::type_error&) {

--- a/acvm-repo/acir/src/lib.rs
+++ b/acvm-repo/acir/src/lib.rs
@@ -214,10 +214,9 @@ mod reflection {
         // Create C++ class definitions.
         let mut source = Vec::new();
         // We use `serde_generate` to take advantage of its integration with `serde_reflection` but only use our
-        // custom msgpack code generation. We don't support the legacy Bincode format any more, but it seems to
-        // be in use in Barretenberg for testing.
+        // custom msgpack code generation.
         let config = serde_generate::CodeGeneratorConfig::new(namespace.to_string())
-            .with_encodings(vec![serde_generate::Encoding::Bincode])
+            .with_encodings(vec![])
             .with_custom_code(msgpack_code);
         let generator = serde_generate::cpp::CodeGenerator::new(&config);
         generator.output(&mut source, registry).expect("failed to generate C++ code");

--- a/acvm-repo/acir/src/lib.rs
+++ b/acvm-repo/acir/src/lib.rs
@@ -1016,7 +1016,6 @@ mod reflection {
             std::cerr << o << std::endl;
             throw_or_abort("expected u8 variant tag for enum '{name}'");
         }}
-        msgpack::object const& val = o.via.map.ptr[0].val;
         switch (tag) {{"#
                 );
                 // cSpell:enable
@@ -1033,9 +1032,12 @@ mod reflection {
                         |reg_v| reg_v.tag,
                     );
                     if matches!(v.value, VariantFormat::Unit) {
-                        // Unit variants carry a `nil` payload; the variant's
-                        // empty `msgpack_unpack` accepts any object, so we
-                        // can call `val.convert(v)` uniformly.
+                        // Unit variants carry a `nil` payload that the
+                        // variant's empty `msgpack_unpack` would accept,
+                        // but constructing the value and assigning is
+                        // simpler and avoids reading `o.via.map.ptr[0].val`
+                        // (which Barretenberg's `-Werror=unused-variable`
+                        // flags when all variants of an enum are unit).
                         body.push_str(&format!(
                             r#"
             case {tag}: {{
@@ -1051,9 +1053,9 @@ mod reflection {
             case {tag}: {{
                 {variant} v;
                 try {{
-                    val.convert(v);
+                    o.via.map.ptr[0].val.convert(v);
                 }} catch (const msgpack::type_error&) {{
-                    std::cerr << val << std::endl;
+                    std::cerr << o << std::endl;
                     throw_or_abort("error converting into enum variant '{name}::{variant}'");
                 }}
                 value = v;

--- a/acvm-repo/acir/src/lib.rs
+++ b/acvm-repo/acir/src/lib.rs
@@ -214,9 +214,10 @@ mod reflection {
         // Create C++ class definitions.
         let mut source = Vec::new();
         // We use `serde_generate` to take advantage of its integration with `serde_reflection` but only use our
-        // custom msgpack code generation.
+        // custom msgpack code generation. We don't support the legacy Bincode format any more, but it seems to
+        // be in use in Barretenberg for testing.
         let config = serde_generate::CodeGeneratorConfig::new(namespace.to_string())
-            .with_encodings(vec![])
+            .with_encodings(vec![serde_generate::Encoding::Bincode])
             .with_custom_code(msgpack_code);
         let generator = serde_generate::cpp::CodeGenerator::new(&config);
         generator.output(&mut source, registry).expect("failed to generate C++ code");
@@ -295,9 +296,11 @@ mod reflection {
         fn from_env() -> Self {
             Self {
                 // We agreed on the default format to be compact, so it makes sense for Barretenberg to use it for serialization.
-                pack_compact: env_flag("NOIR_CODEGEN_PACK_COMPACT", true),
+                // But in the latest version they seem to be using MAP format again.
+                pack_compact: env_flag("NOIR_CODEGEN_PACK_COMPACT", false),
                 // Barretenberg didn't use serialization outside tests, so they decided they don't want to have this code at all.
-                no_pack: env_flag("NOIR_CODEGEN_NO_PACK", true),
+                // But in the latest code they seem to have kept it again.
+                no_pack: env_flag("NOIR_CODEGEN_NO_PACK", false),
             }
         }
     }

--- a/acvm-repo/acir/src/lib.rs
+++ b/acvm-repo/acir/src/lib.rs
@@ -513,51 +513,31 @@ mod reflection {
             }
         }
 
-        /// Cap the positional-array length: under-length wires error
-        /// downstream in `conv_fld_from_array` (index out of bounds);
-        /// over-length wires up to `active + reserved` are tolerated as
-        /// retired trailing fields (Rust-side `#[tagged(reserved(...))]`);
-        /// anything longer is forward-compat drift that the producer
-        /// would only have emitted if newer fields were added, and is
-        /// the cue for a focused error message pointing at the opt-in.
-        static void check_array_size(
-            msgpack::object_array const& array,
+        /// Cap a `MAP` or `ARRAY` entry count against `active + reserved`.
+        /// Under-length wires are caught downstream (`conv_fld_from_array`
+        /// errors out of bounds; `conv_fld_from_kvmap` errors on missing
+        /// required keys), so we only need the upper bound here.
+        ///
+        /// * Up to `reserved` extra trailing entries are tolerated as
+        ///   retired fields (`#[tagged(reserved(...))]` on the Rust side).
+        /// * Anything beyond that is forward-compat drift that the
+        ///   producer only emits when newer fields were added. The
+        ///   Rust-side cue is `#[tagged(allow_unknown_tags)]`; the
+        ///   message points at it so a reviewer can see the opt-in.
+        static void check_size(
+            uint32_t actual,
             std::string const& name,
             uint32_t active,
             uint32_t reserved
         ) {
             uint32_t max_size = active + reserved;
-            if (array.size > max_size) {
+            if (actual > max_size) {
                 throw_or_abort(
-                    "array for " + name +
-                    " has " + std::to_string(array.size) +
-                    " elements but at most " + std::to_string(max_size) +
-                    " are expected (" + std::to_string(active) +
-                    " active + " + std::to_string(reserved) +
-                    " reserved); opt into `#[tagged(allow_unknown_tags)]` on the Rust type to accept trailing extras");
-            }
-        }
-
-        /// Cap a string-keyed map size. Parallel to `check_array_size`
-        /// for the legacy `Format::Msgpack` named-struct wire shape: the
-        /// string-keyed dispatch only looks up keys it recognizes, so
-        /// extras would otherwise pass silently. Same `active +
-        /// reserved` ceiling, same `allow_unknown_tags` opt-out.
-        static void check_map_size(
-            msgpack::object_map const& map,
-            std::string const& name,
-            uint32_t active,
-            uint32_t reserved
-        ) {
-            uint32_t max_size = active + reserved;
-            if (map.size > max_size) {
-                throw_or_abort(
-                    "map for " + name +
-                    " has " + std::to_string(map.size) +
+                    name + " has " + std::to_string(actual) +
                     " entries but at most " + std::to_string(max_size) +
                     " are expected (" + std::to_string(active) +
                     " active + " + std::to_string(reserved) +
-                    " reserved); opt into `#[tagged(allow_unknown_tags)]` on the Rust type to accept extra keys");
+                    " reserved); opt into `#[tagged(allow_unknown_tags)]` on the Rust type to accept extras");
             }
         }
     };
@@ -832,7 +812,7 @@ mod reflection {
                 if !product.allow_unknown_tags {
                     body.push_str(&format!(
                         r#"
-            Helpers::check_map_size(o.via.map, name, {active}, {reserved});"#,
+            Helpers::check_size(o.via.map.size, name, {active}, {reserved});"#,
                         active = fields.len(),
                         reserved = product.reserved.len(),
                     ));
@@ -876,7 +856,7 @@ mod reflection {
                 if !product.allow_unknown_tags {
                     body.push_str(&format!(
                         r#"
-        Helpers::check_array_size(array, name, {active}, {reserved});"#,
+        Helpers::check_size(array.size, name, {active}, {reserved});"#,
                         active = fields.len(),
                         reserved = product.reserved.len(),
                     ));

--- a/acvm-repo/acir/src/lib.rs
+++ b/acvm-repo/acir/src/lib.rs
@@ -512,6 +512,31 @@ mod reflection {
                 dispatch(tag, o.via.map.ptr[i].val);
             }
         }
+
+        /// Cap the positional-array length: under-length wires error
+        /// downstream in `conv_fld_from_array` (index out of bounds);
+        /// over-length wires up to `active + reserved` are tolerated as
+        /// retired trailing fields (Rust-side `#[tagged(reserved(...))]`);
+        /// anything longer is forward-compat drift that the producer
+        /// would only have emitted if newer fields were added, and is
+        /// the cue for a focused error message pointing at the opt-in.
+        static void check_array_size(
+            msgpack::object_array const& array,
+            std::string const& name,
+            uint32_t active,
+            uint32_t reserved
+        ) {
+            uint32_t max_size = active + reserved;
+            if (array.size > max_size) {
+                throw_or_abort(
+                    "array for " + name +
+                    " has " + std::to_string(array.size) +
+                    " elements but at most " + std::to_string(max_size) +
+                    " are expected (" + std::to_string(active) +
+                    " active + " + std::to_string(reserved) +
+                    " reserved); opt into `#[tagged(allow_unknown_tags)]` on the Rust type to accept trailing extras");
+            }
+        }
     };
     "#;
             // cSpell:enable
@@ -794,8 +819,27 @@ mod reflection {
                     "
         }
     } else if (o.type == msgpack::type::ARRAY) {
-        auto array = o.via.array; ",
+        auto array = o.via.array;",
                 );
+                // Cap the array length: an older reader of a newer wire
+                // (forward-compat) should reject extra trailing items
+                // unless the type opts into `#[tagged(allow_unknown_tags)]`;
+                // a newer reader of an older wire that retired trailing
+                // fields (backward-compat) gets `reserved.len()` extra
+                // trailing positions tolerated either way.
+                //
+                // Under-length wires are caught downstream by
+                // `Helpers::conv_fld_from_array` (it errors when its
+                // index is past `array.size`), so we only need the
+                // upper bound here.
+                if !product.allow_unknown_tags {
+                    body.push_str(&format!(
+                        r#"
+        Helpers::check_array_size(array, name, {active}, {reserved});"#,
+                        active = fields.len(),
+                        reserved = product.reserved.len(),
+                    ));
+                }
                 for (index, field) in fields.iter().enumerate() {
                     if is_unit(field) {
                         continue;

--- a/acvm-repo/acir/src/lib.rs
+++ b/acvm-repo/acir/src/lib.rs
@@ -46,7 +46,7 @@ mod reflection {
         BinaryFieldOp, BinaryIntOp, BitSize, BlackBoxOp, HeapValueType, IntegerBitSize,
         MemoryAddress, Opcode as BrilligOpcode, ValueOrArray,
     };
-    use msgpack_tagged::MsgpackTagged;
+    use msgpack_tagged::{MsgpackTagged, Product, Sum, TagRegistry};
     use regex::Regex;
     use serde::{Deserialize, Serialize};
     use serde_generate::CustomCode;
@@ -130,10 +130,26 @@ mod reflection {
         tracer.trace_simple_type::<IntegerBitSize>().unwrap();
         tracer.trace_simple_type::<MemoryAddress>().unwrap();
 
+        // The `msgpack_tagged` tag registry mirrors the type graph that
+        // serde-reflection traced above, but additionally carries the
+        // integer tag → field-name (and variant) mapping the C++ codegen
+        // needs for the new int-keyed dispatch branch. We register the
+        // same top-level types as the tracer: `Program<F>` covers the
+        // bulk of the graph via its transitive walk, and
+        // `ProgramWithoutBrillig<F>` is a sibling type that needs its own
+        // entry (its serde name `"ProgramWithoutBrillig"` is distinct
+        // from `"Program"`, and its `unconstrained_functions: ()` field
+        // doesn't introduce any types that Program's walk didn't already
+        // reach).
+        let mut tag_registry = TagRegistry::new();
+        <Program<FieldElement> as MsgpackTagged>::register_into(&mut tag_registry);
+        <ProgramWithoutBrillig<FieldElement> as MsgpackTagged>::register_into(&mut tag_registry);
+
         serde_cpp_codegen(
             "Acir",
             PathBuf::from("./codegen/acir.cpp").as_path(),
             &tracer.registry().unwrap(),
+            &tag_registry,
             CustomCode::default(),
         );
     }
@@ -144,6 +160,11 @@ mod reflection {
         tracer.trace_simple_type::<Witness>().unwrap();
         tracer.trace_simple_type::<WitnessMap<FieldElement>>().unwrap();
         tracer.trace_simple_type::<WitnessStack<FieldElement>>().unwrap();
+
+        let mut tag_registry = TagRegistry::new();
+        <Witness as MsgpackTagged>::register_into(&mut tag_registry);
+        <WitnessMap<FieldElement> as MsgpackTagged>::register_into(&mut tag_registry);
+        <WitnessStack<FieldElement> as MsgpackTagged>::register_into(&mut tag_registry);
 
         let namespace = "Witnesses";
         let mut code = CustomCode::default();
@@ -158,6 +179,7 @@ mod reflection {
             namespace,
             PathBuf::from("./codegen/witness.cpp").as_path(),
             &tracer.registry().unwrap(),
+            &tag_registry,
             code,
         );
     }
@@ -167,7 +189,13 @@ mod reflection {
     ///
     /// If `should_overwrite()` returns `false` then just check if the old file hash is the
     /// same as the new one, to guard against unintended changes in the serialization format.
-    fn serde_cpp_codegen(namespace: &str, path: &Path, registry: &Registry, code: CustomCode) {
+    fn serde_cpp_codegen(
+        namespace: &str,
+        path: &Path,
+        registry: &Registry,
+        tag_registry: &TagRegistry,
+        code: CustomCode,
+    ) {
         let old_hash = if path.is_file() {
             let old_source = std::fs::read(path).expect("failed to read existing code");
             let old_source = String::from_utf8(old_source).expect("old source not UTF-8");
@@ -178,6 +206,7 @@ mod reflection {
         let msgpack_code = MsgPackCodeGenerator::generate(
             namespace,
             registry,
+            tag_registry,
             code,
             MsgPackCodeConfig::from_env(),
         );
@@ -273,15 +302,83 @@ mod reflection {
         }
     }
 
+    /// Assert that every product / sum container in the serde-reflection
+    /// `registry` is also present in the `MsgpackTagged` `tag_registry`,
+    /// and that every product is in *canonical* (tag-ascending) source
+    /// order. Panics with a focused message on the first miss.
+    ///
+    /// **Why the coverage check.** The int-keyed dispatch branch in the
+    /// generated C++ needs each field's u8 tag (for structs) and each
+    /// variant's u8 tag (for enums). That metadata only exists on the
+    /// `MsgpackTagged` side. A type in `registry` but not in
+    /// `tag_registry` means somebody added a wire type without deriving
+    /// `MsgpackTagged` — fail loudly at codegen time, not silently at
+    /// runtime.
+    ///
+    /// **Why the order check.** Under `Format::MsgpackCompact` a struct
+    /// is emitted as a fixarray in *source* order; under
+    /// `Format::MsgpackTagged` with the `Array` strategy it's a fixarray
+    /// in *tag-ascending* order. Both shapes look identical to the C++
+    /// decoder (just `msgpack::type::ARRAY`), so byte-different wires
+    /// for the same logical value would silently land on the wrong
+    /// fields if the two orders ever diverge. Forcing
+    /// `tag_order_matches_source` keeps them lockstep — both formats
+    /// produce byte-identical arrays, and the codegen reads positionally
+    /// in tag-ascending order.
+    fn assert_tag_registry_covers(registry: &Registry, tag_registry: &TagRegistry) {
+        use serde_reflection::ContainerFormat;
+        for (name, container) in registry {
+            // Only named-struct and enum containers need an entry in the
+            // `MsgpackTagged` registry: their int-keyed dispatch branch
+            // depends on per-field / per-variant tag metadata. Unit
+            // structs, newtypes, and (currently `unimplemented!`) tuple
+            // structs pass through to their inner type (or are no-ops)
+            // and don't register themselves in `TagRegistry`.
+            let needs_tags =
+                matches!(container, ContainerFormat::Struct(_) | ContainerFormat::Enum(_),);
+            if !needs_tags {
+                continue;
+            }
+            let Some(entry) = tag_registry.get(name) else {
+                panic!(
+                    "MsgpackTagged tag registry is missing {name:?} — the type is on \
+                     the wire (serde-reflection traced it as a struct/enum) but \
+                     doesn't derive `MsgpackTagged`. Add `#[derive(MsgpackTagged)]` \
+                     to the type, and a `register_into` call at the codegen test \
+                     site if the type isn't reachable from a type that's already \
+                     registered.",
+                );
+            };
+            if let Some(p) = entry.tagged().as_product()
+                && !p.tag_order_matches_source
+            {
+                panic!(
+                    "MsgpackTagged product {name:?} declares its fields in an order \
+                     that doesn't match tag-ascending. The C++ codegen can't tell \
+                     `MsgpackCompact` (source-order array) from \
+                     `MsgpackTagged::Array` (tag-ascending array) on the wire — \
+                     reorder the Rust fields so `#[tag(N)]` values are increasing \
+                     in source order, or drop the type from the C++ wire types.",
+                );
+            }
+        }
+    }
+
     /// Generate custom code for the msgpack machinery in Barretenberg.
     /// See https://github.com/AztecProtocol/aztec-packages/blob/master/barretenberg/cpp/src/barretenberg/serialize/msgpack.hpp
-    struct MsgPackCodeGenerator {
+    struct MsgPackCodeGenerator<'a> {
         config: MsgPackCodeConfig,
         namespace: Vec<String>,
         code: CustomCode,
+        /// Carries the integer-tag metadata produced by `MsgpackTagged`
+        /// derives. The serde-reflection `Registry` only knows field/variant
+        /// *names*; consulting this registry lets us pair each name with its
+        /// stable u8 tag so the generated C++ can dispatch on int-keyed
+        /// `MsgpackTagged` wires the same way the Rust decoder does.
+        tag_registry: &'a TagRegistry,
     }
 
-    impl MsgPackCodeGenerator {
+    impl<'a> MsgPackCodeGenerator<'a> {
         /// Add the import of the Barretenberg C++ header for msgpack.
         pub(crate) fn add_preamble(source: &mut String) {
             let inc = r#"#include "serde.hpp""#;
@@ -362,6 +459,59 @@ mod reflection {
                 throw_or_abort("error converting into field " + struct_name + "::" + field_name);
             }
         }
+
+        /// Convert `val` into `field`, or throw a focused error mentioning
+        /// the struct + field name. Used by the int-keyed dispatch path
+        /// where each `switch` case populates one field directly.
+        template<typename T>
+        static void convert_or_throw(
+            msgpack::object const& val,
+            std::string const& struct_name,
+            std::string const& field_name,
+            T& field
+        ) {
+            try {
+                val.convert(field);
+            } catch (const msgpack::type_error&) {
+                std::cerr << val << std::endl;
+                throw_or_abort("error converting into field " + struct_name + "::" + field_name);
+            }
+        }
+
+        /// Whether `o` is a non-empty MAP whose first key is an integer.
+        /// This is the signature of `Format::MsgpackTagged`: int keys for
+        /// struct field tags and enum variant tags. Legacy `Format::Msgpack`
+        /// keys are always strings, so a positive-integer first key is a
+        /// reliable shape discriminator between the two.
+        static bool is_int_keyed_map(msgpack::object const& o) {
+            return o.type == msgpack::type::MAP
+                && o.via.map.size > 0
+                && o.via.map.ptr[0].key.type == msgpack::type::POSITIVE_INTEGER;
+        }
+
+        /// Iterate an int-keyed MAP and invoke `dispatch(tag, val)` for each
+        /// `(u8, msgpack::object)` entry. The per-tag `switch` inside the
+        /// caller's lambda decides which field (or variant) to populate;
+        /// unknown tags fall through to `default` and are silently skipped,
+        /// matching the `MsgpackTagged` decoder's forward-compat policy
+        /// (`allow_unknown_tags` / retired tags drained).
+        template<typename Dispatch>
+        static void int_map_dispatch(
+            msgpack::object const& o,
+            std::string const& name,
+            Dispatch&& dispatch
+        ) {
+            for (uint32_t i = 0; i < o.via.map.size; ++i) {
+                uint8_t tag;
+                try {
+                    o.via.map.ptr[i].key.convert(tag);
+                } catch (const msgpack::type_error&) {
+                    std::cerr << o.via.map.ptr[i].key << std::endl;
+                    throw_or_abort("expected u8 tag in int-keyed map for " + name);
+                }
+                dispatch(tag, o.via.map.ptr[i].val);
+            }
+        }
     };
     "#;
             // cSpell:enable
@@ -382,13 +532,25 @@ mod reflection {
         }
 
         /// Add custom code for msgpack serialization and deserialization.
+        ///
+        /// Walks the serde-reflection `registry` and asserts that every
+        /// product/sum container is also present in the `MsgpackTagged`
+        /// `tag_registry` — every wire type must derive `MsgpackTagged`
+        /// for the int-keyed dispatch to have tag metadata available.
+        /// Products additionally have to be in *canonical* (tag-ascending)
+        /// source order — otherwise `MsgpackCompact` (source-order array)
+        /// and `MsgpackTagged::Array` (tag-ascending array) would produce
+        /// indistinguishable but byte-different wires on the same input,
+        /// and the C++ side can't tell which to expect.
         pub(crate) fn generate(
             namespace: &str,
             registry: &Registry,
+            tag_registry: &'a TagRegistry,
             code: CustomCode,
             config: MsgPackCodeConfig,
         ) -> CustomCode {
-            let mut g = Self { namespace: vec![namespace.to_string()], code, config };
+            assert_tag_registry_covers(registry, tag_registry);
+            let mut g = Self { namespace: vec![namespace.to_string()], code, config, tag_registry };
             for (name, container) in registry {
                 g.generate_container(name, container);
             }
@@ -420,7 +582,17 @@ mod reflection {
                     self.generate_tuple(name, formats);
                 }
                 Struct(fields) => {
-                    self.generate_struct(name, fields);
+                    // Top-level struct — look up its Product in the
+                    // tag registry. `assert_tag_registry_covers` has
+                    // already validated coverage.
+                    let product: Product = self
+                        .tag_registry
+                        .get(name)
+                        .expect("assert_tag_registry_covers should have caught this")
+                        .tagged()
+                        .as_product()
+                        .expect("struct name should map to a Product");
+                    self.generate_struct(name, fields, product);
                 }
                 Enum(variants) => {
                     self.generate_enum(name, variants);
@@ -437,8 +609,12 @@ mod reflection {
             self.msgpack_unpack(name, "");
         }
 
-        /// Regular structs pack into a map.
-        fn generate_struct(&mut self, name: &str, fields: &[Named<Format>]) {
+        /// Regular structs pack into a map. `product` is the
+        /// `MsgpackTagged` metadata for this shape: either the top-level
+        /// type's entry (for ordinary structs) or the variant's payload
+        /// (when recursing into a struct-variant). It carries the
+        /// per-field u8 tag the int-keyed dispatch branch needs.
+        fn generate_struct(&mut self, name: &str, fields: &[Named<Format>], product: Product) {
             // We could use the `MSGPACK_FIELDS` macro with the following:
             // self.msgpack_fields(name, fields.iter().map(|f| f.name.clone()));
             // Unfortunately it doesn't seem to deal with missing optional fields,
@@ -498,14 +674,58 @@ mod reflection {
             });
 
             self.msgpack_unpack(name, &{
-                // Turn the MAP into a `std::map<string, msgpack::object>`,
-                // then look up each field, returning error if one isn't found.
+                // Dispatch on wire shape:
+                //   * MAP with INT first key → `Format::MsgpackTagged`
+                //     (int-keyed: dispatch by u8 tag).
+                //   * MAP with STR keys → legacy `Format::Msgpack`
+                //     (string-keyed: look up by field name).
+                //   * ARRAY → legacy `Format::MsgpackCompact` and also
+                //     `Format::MsgpackTagged::Array` (both emit fields in
+                //     tag-ascending order under the codegen invariant
+                //     `tag_order_matches_source`, so positional indexing
+                //     decodes both correctly).
                 // cSpell:disable
                 let mut body = format!(
                     r#"
     std::string name = "{name}";
     if (o.type == msgpack::type::MAP) {{
-        auto kvmap = Helpers::make_kvmap(o, name);"#
+        if (Helpers::is_int_keyed_map(o)) {{
+            Helpers::int_map_dispatch(o, name, [&](uint8_t tag, msgpack::object const& val) {{
+                switch (tag) {{"#
+                );
+                // cSpell:enable
+                for field in fields {
+                    if is_unit(field) {
+                        continue;
+                    }
+                    let field_name = &field.name;
+                    let tag = product.tag_for(field_name).unwrap_or_else(|| {
+                        panic!(
+                            "field {field_name:?} of {name:?} is not in the MsgpackTagged \
+                             Product — serde-reflection and #[derive(MsgpackTagged)] disagree \
+                             on which fields are on the wire",
+                        )
+                    });
+                    // cSpell:disable
+                    body.push_str(&format!(
+                        r#"
+                    case {tag}:
+                        Helpers::convert_or_throw(val, name, "{field_name}", {field_name});
+                        break;"#
+                    ));
+                    // cSpell:enable
+                }
+                // cSpell:disable
+                body.push_str(
+                    r#"
+                    default:
+                        // Unknown tag — skip silently (forward-compat /
+                        // retired tags drained — matches the Rust decoder).
+                        break;
+                }
+            });
+        } else {
+            auto kvmap = Helpers::make_kvmap(o, name);"#,
                 );
                 // cSpell:enable
                 for field in fields {
@@ -517,12 +737,13 @@ mod reflection {
                     // cSpell:disable
                     body.push_str(&format!(
                         r#"
-        Helpers::conv_fld_from_kvmap(kvmap, name, "{field_name}", {field_name}, {is_optional});"#
+            Helpers::conv_fld_from_kvmap(kvmap, name, "{field_name}", {field_name}, {is_optional});"#
                     ));
                     // cSpell:enable
                 }
                 body.push_str(
                     "
+        }
     } else if (o.type == msgpack::type::ARRAY) {
         auto array = o.via.array; ",
                 );
@@ -576,10 +797,39 @@ mod reflection {
 
         /// Enums serialize as a single element map keyed by the variant type name.
         fn generate_enum(&mut self, name: &str, variants: &BTreeMap<u32, Named<VariantFormat>>) {
+            // Look up the `Sum` upfront — both the per-variant recursion
+            // (each variant's payload Product comes from here) and the
+            // int-keyed `msgpack_unpack` body below need it. Coverage is
+            // already enforced by `assert_tag_registry_covers`.
+            let sum: Sum = self
+                .tag_registry
+                .get(name)
+                .expect("assert_tag_registry_covers should have caught this")
+                .tagged()
+                .as_sum()
+                .expect("enum name should map to a Sum");
+
+            // Resolve a variant's payload Product by its serde name. The
+            // `MsgpackTagged` macro and serde-derive agree on names, so
+            // a miss here is an internal bug.
+            let payload_for = |variant_name: &str| -> Product {
+                sum.variants.iter().find(|v| v.name == variant_name).map_or_else(
+                    || {
+                        panic!(
+                            "variant {variant_name:?} of enum {name:?} is not in the \
+                             MsgpackTagged Sum — serde-reflection and \
+                             #[derive(MsgpackTagged)] disagree on variants",
+                        )
+                    },
+                    |v| v.payload,
+                )
+            };
+
             // Recurse into the variants
             self.namespace.push(name.to_string());
             for variant in variants.values() {
-                self.generate_variant(&variant.name, &variant.value);
+                let payload = payload_for(&variant.name);
+                self.generate_variant(&variant.name, &variant.value, payload);
             }
             self.namespace.pop();
 
@@ -622,9 +872,15 @@ mod reflection {
                 )
             });
 
-            // Unpack the enum into a map, inspect the key, then unpack the entry value.
-            // See https://c.msgpack.org/cpp/structmsgpack_1_1object.html#a8c7c484d2a6979a833bdb69412ad382c
-            // for how to access the object's content without parsing it.
+            // Unpack the enum:
+            //   * MAP with INT key → `Format::MsgpackTagged` variant
+            //     (int-keyed dispatch on the u8 tag).
+            //   * MAP with STR key → legacy `Format::Msgpack` variant
+            //     (string-keyed dispatch on variant name).
+            //   * STR top-level → legacy `Format::MsgpackCompact` unit
+            //     variant (bare variant-name string).
+            // The 1-entry-size invariant of the MAP cases is enforced
+            // upfront.
             self.msgpack_unpack(name, &{
                 // cSpell:disable
                 let mut body = format!(
@@ -637,26 +893,92 @@ mod reflection {
     if (o.type == msgpack::type::object_type::MAP && o.via.map.size != 1) {{
         throw_or_abort("expected 1 entry for enum '{name}'; got " + std::to_string(o.via.map.size));
     }}
-    std::string tag;
-    try {{
-        if (o.type == msgpack::type::object_type::MAP) {{
+    if (Helpers::is_int_keyed_map(o)) {{
+        // `Format::MsgpackTagged` — int-keyed variant.
+        uint8_t tag;
+        try {{
             o.via.map.ptr[0].key.convert(tag);
-        }} else {{
-            o.convert(tag);
+        }} catch (const msgpack::type_error&) {{
+            std::cerr << o << std::endl;
+            throw_or_abort("expected u8 variant tag for enum '{name}'");
         }}
-    }} catch(const msgpack::type_error&) {{
-        std::cerr << o << std::endl;
-        throw_or_abort("error converting tag to string for enum '{name}'");
-    }}"#
+        msgpack::object const& val = o.via.map.ptr[0].val;
+        switch (tag) {{"#
                 );
+                // cSpell:enable
+
+                for v in variants.values() {
+                    let variant = &v.name;
+                    let tag = sum.variants.iter().find(|reg_v| reg_v.name == variant).map_or_else(
+                        || {
+                            panic!(
+                                "variant {variant:?} of enum {name:?} is not in the MsgpackTagged \
+                                 Sum — serde-reflection and #[derive(MsgpackTagged)] disagree",
+                            )
+                        },
+                        |reg_v| reg_v.tag,
+                    );
+                    if matches!(v.value, VariantFormat::Unit) {
+                        // Unit variants carry a `nil` payload; the variant's
+                        // empty `msgpack_unpack` accepts any object, so we
+                        // can call `val.convert(v)` uniformly.
+                        body.push_str(&format!(
+                            r#"
+            case {tag}: {{
+                {variant} v;
+                value = v;
+                break;
+            }}"#
+                        ));
+                    } else {
+                        // cSpell:disable
+                        body.push_str(&format!(
+                            r#"
+            case {tag}: {{
+                {variant} v;
+                try {{
+                    val.convert(v);
+                }} catch (const msgpack::type_error&) {{
+                    std::cerr << val << std::endl;
+                    throw_or_abort("error converting into enum variant '{name}::{variant}'");
+                }}
+                value = v;
+                break;
+            }}"#
+                        ));
+                        // cSpell:enable
+                    }
+                }
+                // cSpell:disable
+                body.push_str(&format!(
+                    r#"
+            default:
+                std::cerr << o << std::endl;
+                throw_or_abort("unknown '{name}' enum variant tag: " + std::to_string(tag));
+        }}
+    }} else {{
+        // `Format::Msgpack` (MAP, string-keyed) or `Format::MsgpackCompact`
+        // unit variant (bare STR) — both dispatch on the variant name.
+        std::string tag;
+        try {{
+            if (o.type == msgpack::type::object_type::MAP) {{
+                o.via.map.ptr[0].key.convert(tag);
+            }} else {{
+                o.convert(tag);
+            }}
+        }} catch(const msgpack::type_error&) {{
+            std::cerr << o << std::endl;
+            throw_or_abort("error converting tag to string for enum '{name}'");
+        }}"#
+                ));
                 // cSpell:enable
 
                 for (i, v) in variants {
                     let variant = &v.name;
                     body.push_str(&format!(
                         r#"
-    {}if (tag == "{variant}") {{
-        {variant} v;"#,
+        {}if (tag == "{variant}") {{
+            {variant} v;"#,
                         if *i == 0 { "" } else { "else " }
                     ));
 
@@ -664,29 +986,30 @@ mod reflection {
                         // cSpell:disable
                         body.push_str(&format!(
                             r#"
-        try {{
-            o.via.map.ptr[0].val.convert(v);
-        }} catch (const msgpack::type_error&) {{
-            std::cerr << o << std::endl;
-            throw_or_abort("error converting into enum variant '{name}::{variant}'");
-        }}
-        "#
+            try {{
+                o.via.map.ptr[0].val.convert(v);
+            }} catch (const msgpack::type_error&) {{
+                std::cerr << o << std::endl;
+                throw_or_abort("error converting into enum variant '{name}::{variant}'");
+            }}
+            "#
                         ));
                         // cSpell:enable
                     }
                     // Closing brace of if statement
                     body.push_str(
                         r#"
-        value = v;
-    }"#,
+            value = v;
+        }"#,
                     );
                 }
                 // cSpell:disable
                 body.push_str(&format!(
                     r#"
-    else {{
-        std::cerr << o << std::endl;
-        throw_or_abort("unknown '{name}' enum variant: " + tag);
+        else {{
+            std::cerr << o << std::endl;
+            throw_or_abort("unknown '{name}' enum variant: " + tag);
+        }}
     }}"#
                 ));
                 // cSpell:enable
@@ -695,8 +1018,13 @@ mod reflection {
             });
         }
 
-        /// Generate msgpack code for nested enum variants.
-        fn generate_variant(&mut self, name: &str, variant: &VariantFormat) {
+        /// Generate msgpack code for nested enum variants. `payload` is
+        /// the variant's `MsgpackTagged` `Product`, looked up from the
+        /// parent enum's `Sum`. Only the `Struct` variant case consults
+        /// it (it carries the int-keyed dispatch metadata for that
+        /// variant's named fields); the other cases are tag-irrelevant
+        /// (unit / passthrough newtype / unimplemented tuple).
+        fn generate_variant(&mut self, name: &str, variant: &VariantFormat, payload: Product) {
             match variant {
                 VariantFormat::Variable(_) => {
                     unreachable!("internal construct")
@@ -704,7 +1032,7 @@ mod reflection {
                 VariantFormat::Unit => self.generate_unit_struct(name),
                 VariantFormat::NewType(_format) => self.generate_newtype(name),
                 VariantFormat::Tuple(formats) => self.generate_tuple(name, formats),
-                VariantFormat::Struct(fields) => self.generate_struct(name, fields),
+                VariantFormat::Struct(fields) => self.generate_struct(name, fields, payload),
             }
         }
 

--- a/acvm-repo/acir/src/lib.rs
+++ b/acvm-repo/acir/src/lib.rs
@@ -733,15 +733,18 @@ mod reflection {
                 // the same here, with an explicit case so the strict
                 // default below can distinguish "retired" from "never
                 // declared".
-                for &reserved_tag in product.reserved {
-                    // cSpell:disable
-                    body.push_str(&format!(
+                if !product.reserved.is_empty() {
+                    for &reserved_tag in product.reserved {
+                        body.push_str(&format!(
+                            "
+                    case {reserved_tag}:"
+                        ));
+                    }
+                    body.push_str(
                         r#"
-                    case {reserved_tag}:
                         // Reserved tag (retired field) — skip silently.
-                        break;"#
-                    ));
-                    // cSpell:enable
+                        break;"#,
+                    );
                 }
                 // Default branch: strict by default (reject unknown tags
                 // so a C++ reviewer can see the type-level intent). Opt
@@ -1013,13 +1016,18 @@ mod reflection {
                         |v| v.name,
                     )
                 };
-                for &reserved_tag in sum.reserved {
+                if !sum.reserved.is_empty() {
+                    for &reserved_tag in sum.reserved {
+                        body.push_str(&format!(
+                            "
+            case {reserved_tag}:"
+                        ));
+                    }
                     if let Some(fallback_tag) = sum.on_reserved_tag {
                         let fallback_name = lookup_unit_variant(fallback_tag);
                         // cSpell:disable
                         body.push_str(&format!(
-                            r#"
-            case {reserved_tag}: {{
+                            r#" {{
                 // `#[tagged(on_reserved)]` fallback: retired tag routes to
                 // the designated unit variant (payload discarded).
                 {fallback_name} v;
@@ -1032,9 +1040,8 @@ mod reflection {
                         // cSpell:disable
                         body.push_str(&format!(
                             r#"
-            case {reserved_tag}:
                 std::cerr << o << std::endl;
-                throw_or_abort("retired variant tag {reserved_tag} for enum '{name}' (declare `#[tagged(on_reserved)]` on a unit variant to route legacy data here)");"#
+                throw_or_abort("retired variant tag for enum '{name}' (declare `#[tagged(on_reserved)]` on a unit variant to route legacy data here): " + std::to_string(tag));"#
                         ));
                         // cSpell:enable
                     }

--- a/acvm-repo/acir/src/serialization.rs
+++ b/acvm-repo/acir/src/serialization.rs
@@ -353,6 +353,82 @@ mod tests {
         assert!(matches!(msg, Value::Integer(_)));
     }
 
+    /// `FieldElement` serializes via `serializer.serialize_bytes`, which
+    /// in msgpack-land is the `bin8` / `bin16` / `bin32` family — NOT a
+    /// `fixarray` of `fixint`s. The C++ codegen's
+    /// `std::vector<uint8_t>` adapter only accepts the `bin` shape, and
+    /// our `MsgpackTagged` wrapper relies on this hook to bypass the
+    /// `collect_seq` interception that would otherwise emit a fixarray.
+    /// These tests lock the wire shape under all three formats so a
+    /// regression here surfaces in `cargo test`, not as an obscure
+    /// runtime `type_error` on the Barretenberg side.
+    mod msgpack_repr_field_element {
+        use super::super::{Format, deserialize_any_format, serialize_with_format};
+        use acir_field::{AcirField, FieldElement};
+        use rmpv::Value;
+
+        /// Helper: encode `value` with a given `Format` and pop the
+        /// 1-byte `Format` prefix so the returned bytes can be fed to
+        /// `rmpv::decode::read_value` directly.
+        fn encoded_msgpack<F: Into<Format>>(value: &FieldElement, format: F) -> Vec<u8> {
+            let mut bz = serialize_with_format(value, format.into()).unwrap();
+            bz.remove(0);
+            bz
+        }
+
+        /// Decode and assert the top-level msgpack value is a `Binary`
+        /// blob, returning the decoded byte vector for further checks.
+        fn assert_bin(bz: &[u8]) -> Vec<u8> {
+            let msg = rmpv::decode::read_value::<&[u8]>(&mut &bz[..]).unwrap();
+            match msg {
+                Value::Binary(v) => v,
+                other => panic!("expected msgpack Binary for FieldElement; got {other:?}"),
+            }
+        }
+
+        #[test]
+        fn msgpack_tagged_emits_bin() {
+            let v = FieldElement::from(1u128);
+            let bytes = assert_bin(&encoded_msgpack(&v, Format::MsgpackTagged));
+            assert_eq!(bytes.len(), v.to_be_bytes().len());
+            assert_eq!(bytes, v.to_be_bytes());
+        }
+
+        #[test]
+        fn msgpack_compact_emits_bin() {
+            // The legacy `Format::MsgpackCompact` path used by the C++
+            // side has historically emitted `bin` via
+            // `BytesMode::ForceIterables` on the rmp_serde serializer.
+            // After the `FieldElement::serialize` change it still does,
+            // because `serialize_bytes` writes `write_bin` regardless of
+            // `BytesMode`. This test guards the legacy shape so the
+            // change can't accidentally regress what Barretenberg
+            // already consumes.
+            let v = FieldElement::from(42u128);
+            let bytes = assert_bin(&encoded_msgpack(&v, Format::MsgpackCompact));
+            assert_eq!(bytes, v.to_be_bytes());
+        }
+
+        #[test]
+        fn msgpack_named_emits_bin() {
+            // Same guarantee for the named-struct legacy format.
+            let v = FieldElement::from(99u128);
+            let bytes = assert_bin(&encoded_msgpack(&v, Format::Msgpack));
+            assert_eq!(bytes, v.to_be_bytes());
+        }
+
+        /// Sanity: round-trip through each format yields the same value.
+        #[test]
+        fn round_trips_under_all_formats() {
+            for &format in &[Format::Msgpack, Format::MsgpackCompact, Format::MsgpackTagged] {
+                let v = FieldElement::from(7u128);
+                let bytes = serialize_with_format(&v, format).unwrap();
+                let decoded: FieldElement = deserialize_any_format(&bytes).unwrap();
+                assert_eq!(decoded, v, "round-trip failed under {format:?}");
+            }
+        }
+    }
+
     #[test]
     fn format_from_str() {
         assert_eq!(Format::from_str("msgpack-compact").unwrap(), Format::MsgpackCompact);

--- a/acvm-repo/acir_field/Cargo.toml
+++ b/acvm-repo/acir_field/Cargo.toml
@@ -19,6 +19,7 @@ workspace = true
 hex.workspace = true
 num-bigint.workspace = true
 serde.workspace = true
+serde_bytes.workspace = true
 msgpack_tagged.workspace = true
 
 ark-bn254.workspace = true

--- a/acvm-repo/acir_field/src/field_element.rs
+++ b/acvm-repo/acir_field/src/field_element.rs
@@ -149,44 +149,17 @@ impl<'de, T: PrimeField> Deserialize<'de> for FieldElement<T> {
     where
         D: serde::Deserializer<'de>,
     {
-        // Mirror of `Serialize`: explicitly route through
-        // `deserialize_bytes` so the read side is symmetric with the
-        // write side and works against the msgpack `bin` shape emitted
-        // by `FieldElement::serialize`. The default
-        // `Cow<'_, [u8]>::deserialize` would forward to
-        // `Vec<u8>::deserialize` → `deserialize_seq`, which expects a
-        // msgpack `fixarray` and rejects `bin` under our
+        // Mirror of `Serialize`: route explicitly through the bytes
+        // hook (`deserialize_byte_buf` under the covers) so the read
+        // side is symmetric with the write side and matches the
+        // msgpack `bin` shape `FieldElement::serialize` emits.
+        // `serde_bytes::ByteBuf` is serde-ecosystem's standard wrapper
+        // for "deserialize as bytes, give me an owned `Vec<u8>`",
+        // wrapping the same visitor boilerplate a hand-rolled one
+        // would. The default `Vec<u8>::deserialize` would instead
+        // route to `deserialize_seq` and reject `bin` under our
         // `MsgpackTagged` wrapper.
-        //
-        // The visitor accepts both byte-shaped (`bin`) and sequence
-        // (`fixarray`) wire forms, just in case.
-        struct FieldBytesVisitor;
-        impl<'de> serde::de::Visitor<'de> for FieldBytesVisitor {
-            type Value = Vec<u8>;
-            fn expecting(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-                f.write_str("a byte string or sequence of u8 (field-element big-endian bytes)")
-            }
-            fn visit_bytes<E: serde::de::Error>(self, v: &[u8]) -> Result<Vec<u8>, E> {
-                Ok(v.to_vec())
-            }
-            fn visit_byte_buf<E: serde::de::Error>(self, v: Vec<u8>) -> Result<Vec<u8>, E> {
-                Ok(v)
-            }
-            fn visit_borrowed_bytes<E: serde::de::Error>(self, v: &'de [u8]) -> Result<Vec<u8>, E> {
-                Ok(v.to_vec())
-            }
-            fn visit_seq<A: serde::de::SeqAccess<'de>>(
-                self,
-                mut seq: A,
-            ) -> Result<Vec<u8>, A::Error> {
-                let mut bytes = Vec::with_capacity(seq.size_hint().unwrap_or(0));
-                while let Some(b) = seq.next_element::<u8>()? {
-                    bytes.push(b);
-                }
-                Ok(bytes)
-            }
-        }
-        let bytes = deserializer.deserialize_bytes(FieldBytesVisitor)?;
+        let bytes = serde_bytes::ByteBuf::deserialize(deserializer)?;
         Ok(Self::from_be_bytes_reduce(&bytes))
     }
 }

--- a/acvm-repo/acir_field/src/field_element.rs
+++ b/acvm-repo/acir_field/src/field_element.rs
@@ -3,7 +3,6 @@ use ark_ff::Zero;
 use msgpack_tagged::MsgpackTagged;
 use num_bigint::BigUint;
 use serde::{Deserialize, Serialize};
-use std::borrow::Cow;
 use std::ops::{Add, AddAssign, Div, Mul, Neg, Sub, SubAssign};
 
 use crate::AcirField;
@@ -119,7 +118,29 @@ impl<T: PrimeField> Serialize for FieldElement<T> {
     where
         S: serde::Serializer,
     {
-        self.to_be_bytes().serialize(serializer)
+        // Call `serialize_bytes` rather than `self.to_be_bytes().serialize(...)`
+        // (which would forward to `Vec<u8>::serialize` and then
+        // `serializer.collect_seq(...)`). A field element is
+        // semantically a fixed-width byte blob, not a sequence of u8
+        // elements, and going through `serialize_bytes` keeps the wire
+        // shape consistent across serializers:
+        //
+        // * `rmp_serde`'s `serialize_bytes` is unconditional
+        //   `write_bin` — independent of `BytesMode` — so all three
+        //   `Format::Msgpack*` variants emit the same `bin` blob the
+        //   C++ codegen's `std::vector<uint8_t>` adapter expects.
+        // * Without this, our `MsgpackTagged` wrapper would have to intercept
+        //   the `collect_seq` call and emit a `fixarray` of `fixint`s
+        //   instead (per its tagged-recursion contract for sequences),
+        //   which msgpack-c's `std::vector<uint8_t>` adapter refuses
+        //   with `type_error` mid-decode — a confusing failure mode
+        //   that's much easier to land in than to debug. The other two
+        //   `Msgpack*` formats would have to remember to create a
+        //   `RmpSerializer::with_bytes(BytesMode::ForceAll)`.
+        //
+        // The corresponding `Deserialize` (see below) calls
+        // `deserialize_bytes` via a visitor — the symmetric read hook.
+        serializer.serialize_bytes(&self.to_be_bytes())
     }
 }
 
@@ -128,8 +149,45 @@ impl<'de, T: PrimeField> Deserialize<'de> for FieldElement<T> {
     where
         D: serde::Deserializer<'de>,
     {
-        let s: Cow<'de, [u8]> = Deserialize::deserialize(deserializer)?;
-        Ok(Self::from_be_bytes_reduce(&s))
+        // Mirror of `Serialize`: explicitly route through
+        // `deserialize_bytes` so the read side is symmetric with the
+        // write side and works against the msgpack `bin` shape emitted
+        // by `FieldElement::serialize`. The default
+        // `Cow<'_, [u8]>::deserialize` would forward to
+        // `Vec<u8>::deserialize` → `deserialize_seq`, which expects a
+        // msgpack `fixarray` and rejects `bin` under our
+        // `MsgpackTagged` wrapper.
+        //
+        // The visitor accepts both byte-shaped (`bin`) and sequence
+        // (`fixarray`) wire forms, just in case.
+        struct FieldBytesVisitor;
+        impl<'de> serde::de::Visitor<'de> for FieldBytesVisitor {
+            type Value = Vec<u8>;
+            fn expecting(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+                f.write_str("a byte string or sequence of u8 (field-element big-endian bytes)")
+            }
+            fn visit_bytes<E: serde::de::Error>(self, v: &[u8]) -> Result<Vec<u8>, E> {
+                Ok(v.to_vec())
+            }
+            fn visit_byte_buf<E: serde::de::Error>(self, v: Vec<u8>) -> Result<Vec<u8>, E> {
+                Ok(v)
+            }
+            fn visit_borrowed_bytes<E: serde::de::Error>(self, v: &'de [u8]) -> Result<Vec<u8>, E> {
+                Ok(v.to_vec())
+            }
+            fn visit_seq<A: serde::de::SeqAccess<'de>>(
+                self,
+                mut seq: A,
+            ) -> Result<Vec<u8>, A::Error> {
+                let mut bytes = Vec::with_capacity(seq.size_hint().unwrap_or(0));
+                while let Some(b) = seq.next_element::<u8>()? {
+                    bytes.push(b);
+                }
+                Ok(bytes)
+            }
+        }
+        let bytes = deserializer.deserialize_bytes(FieldBytesVisitor)?;
+        Ok(Self::from_be_bytes_reduce(&bytes))
     }
 }
 

--- a/acvm-repo/msgpack_tagged/README.md
+++ b/acvm-repo/msgpack_tagged/README.md
@@ -398,3 +398,88 @@ buffer for correctness on reordered types — it's not optional there —
 but `Tagged` types pay it only for the byte-determinism guarantee, so
 if you've got a Tagged type where cross-implementation byte-equivalence
 isn't load-bearing, keeping the source ordered avoids the cost.
+
+## Consuming from C++
+
+The ACIR crate generates C++ `msgpack_unpack` methods for every wire
+type, used by Barretenberg to deserialize ACIR / Witness payloads. The
+generator (`acvm-repo/acir/src/lib.rs`, `serde_acir_cpp_codegen` /
+`serde_witness_map_cpp_codegen`) emits a four-way dispatch per
+struct:
+
+| `o.type` / first key | format(s) that produce it |
+|---|---|
+| `MAP`, first key is `POSITIVE_INTEGER` | `MsgpackTagged` (Tagged variant header; Tagged-strategy struct) |
+| `MAP`, first key is `STR` | legacy `Msgpack` (string-keyed structs and enum variants) |
+| `STR` (top-level) | legacy `MsgpackCompact` unit variant (bare variant name) |
+| `ARRAY` | legacy `MsgpackCompact` struct **and** `MsgpackTagged::Array` struct |
+
+The last row is the one to watch.
+
+### The `ARRAY` ambiguity
+
+Both `Format::MsgpackCompact` and `Format::MsgpackTagged` with the
+`Array` strategy produce a bare `fixarray` of field values on the
+wire — identical shapes, no per-element metadata. They differ only in
+**order**:
+
+* `MsgpackCompact` emits fields in *source-declaration* order
+  (`rmp_serde::with_struct_tuple()` behavior).
+* `MsgpackTagged::Array` emits fields in *tag-ascending* order
+  (`Serializer::with_default_strategy(Array)`).
+
+The Rust side knows which format is being decoded because the outer
+`Format` byte is consumed before dispatch lands in `msgpack_unpack`. The
+C++ side **doesn't** — `msgpack_unpack(msgpack::object const& o)`
+receives the parsed inner object with no surviving reference to the
+format byte. Both shapes look like `msgpack::type::ARRAY` to it.
+
+### The fix: source order must equal tag order
+
+The generated C++ assumes `ARRAY` means *tag-ascending* — that's the
+only positional decode the codegen emits. For this to also be correct
+under `MsgpackCompact`, the producing Rust type's
+**source-declaration order must be tag-ascending** as well. The two
+orders then agree, both wires are byte-identical, and the C++ decoder
+parses them with the same logic.
+
+The codegen enforces this at test time: `serde_acir_cpp_codegen` panics
+if any type reachable from `Program` / `Circuit` / `WitnessMap` /
+`WitnessStack` has `tag_order_matches_source == false`. Reorder the
+Rust fields so `#[tag(N)]` values increase in source order, or drop the
+type from the C++ wire types.
+
+### Workaround: reorder in the model via shadow DTO
+
+If the Rust-side type really needs a different field order than the
+wire — typically for ergonomics, accessor placement, or aligning with
+unrelated traits — wrap the wire identity in a shadow DTO. The public
+type's source layout is yours to choose; the DTO carries the canonical
+tag-ascending order, and `#[tagged(via(WireType))]` redirects the
+serialization path through it:
+
+```rust
+#[derive(Serialize, Deserialize, MsgpackTagged)]
+#[tagged(via(FooWire))]
+pub struct Foo {
+    // Order whatever way reads best for callers.
+    pub b: bool,
+    pub a: u32,
+}
+
+#[derive(Serialize, Deserialize, MsgpackTagged)]
+#[serde(rename = "Foo")]
+struct FooWire {
+    // Stays tag-ascending: matches `MsgpackCompact`'s source-order
+    // output and the C++ codegen's positional-array assumption.
+    #[tag(0)] a: u32,
+    #[tag(1)] b: bool,
+}
+```
+
+The codegen-time order check sees `FooWire` (registered under the same
+serde name `"Foo"` thanks to `#[serde(rename)]`), so the invariant
+holds and C++ generation succeeds — even though `Foo`'s source layout
+isn't tag-ascending. See the
+[Shadow-DTO via `#[tagged(via(WireType))]`](#shadow-dto-via-taggedviawiretype)
+section above for the pattern's general form and trade-offs.

--- a/acvm-repo/msgpack_tagged/src/deserializer.rs
+++ b/acvm-repo/msgpack_tagged/src/deserializer.rs
@@ -204,7 +204,7 @@ impl<'a, 'de> de::Deserializer<'de> for &mut Deserializer<'a, 'de> {
         // `R: Clone` is the cost of admission for that restore. For the
         // `&[u8]`-shaped readers that the public entry function constructs
         // it's a trivial slice-handle copy.
-        let reader_state_before: &'de [u8] = self.inner.get_mut();
+        let reader_state_before: &'de [u8] = self.inner.get_ref();
         let marker = rmp::decode::read_marker(self.inner.get_mut())
             .map_err(|e| RmpError::custom(format!("failed to read msgpack marker: {e:?}")))?;
         if matches!(marker, Marker::Null) {

--- a/acvm-repo/msgpack_tagged/src/deserializer.rs
+++ b/acvm-repo/msgpack_tagged/src/deserializer.rs
@@ -278,8 +278,7 @@ impl<'a, 'de> de::Deserializer<'de> for &mut Deserializer<'a, 'de> {
         visitor.visit_newtype_struct(&mut *self)
     }
 
-    // -------- collection / aggregate shapes: forwarded for now; subsequent
-    //          commits intercept these.
+    // -------- collection / aggregate shapes
 
     fn deserialize_seq<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
         // Read the msgpack array header (length-prefixed; `read_array_len`
@@ -289,6 +288,12 @@ impl<'a, 'de> de::Deserializer<'de> for &mut Deserializer<'a, 'de> {
         // The adapter then yields each element via `&mut *self.parent`
         // so any tagged element inside the sequence recurses through
         // this wrapper.
+        //
+        // Byte-shaped values (`Vec<u8>`-equivalents like `FieldElement`)
+        // arrive via `deserialize_bytes`, not `deserialize_seq` — see
+        // the comment on `FieldElement::serialize` for why the encode
+        // side uses `serialize_bytes` directly. So `deserialize_seq`
+        // doesn't need to peek for `bin` markers here.
         let len = self.read_array_len()?;
         visitor.visit_seq(TaggedAccessViaParent { parent: self, remaining: len })
     }

--- a/acvm-repo/msgpack_tagged/src/serializer.rs
+++ b/acvm-repo/msgpack_tagged/src/serializer.rs
@@ -611,7 +611,7 @@ impl<'a, W: Write> Serializer<'a, W> {
 /// a `Vec`. Hard to debug, easy to land in.
 ///
 /// Instead we keep the wrapper simple and require the load-bearing
-/// case ([`acir_field::FieldElement`]'s `Serialize` impl) to call
+/// case (`FieldElement`'s `Serialize` impl) to call
 /// `serializer.serialize_bytes(...)` directly — bypassing
 /// `collect_seq` entirely. `serialize_bytes` is `rmp_serde`'s
 /// unconditional `write_bin` (independent of `BytesMode`), and our

--- a/acvm-repo/msgpack_tagged/src/serializer.rs
+++ b/acvm-repo/msgpack_tagged/src/serializer.rs
@@ -98,16 +98,16 @@ impl<'a, W: Write> Serializer<'a, W> {
     /// the top-level type being serialized — the registration walk seeds
     /// every nested tagged type.
     pub fn new(writer: W, registry: &'a TagRegistry) -> Self {
-        // We intentionally use rmp_serde's default config (no
-        // `with_struct_map`): every tagged type's `serialize_struct` /
-        // variant call routes through our interception layer below, which
-        // emits int-keyed maps directly. The handful of `Serializer` methods
-        // we still forward to inner won't be reached by tagged types under
-        // the registry's bound chain — primitives and containers don't go
-        // through `serialize_struct`, and any type that does is expected to
-        // be in the registry.
+        // Tagged types' `serialize_struct` / variant calls route
+        // through our interception layer below; the inner
+        // `RmpSerializer` only gets the structurally-irrelevant calls
+        // (primitives, `serialize_bytes`, etc.). See
+        // [`make_inner_rmp_serializer`] for why no `BytesMode`
+        // override is applied (and the rule for new bytes-shaped
+        // types: call `serialize_bytes` directly in their
+        // `Serialize` impl).
         Self {
-            inner: RmpSerializer::new(writer),
+            inner: make_inner_rmp_serializer(writer),
             registry,
             default_strategy: EncodingStrategy::Tagged,
             overrides: HashMap::new(),
@@ -493,7 +493,7 @@ impl<'a, W: Write> Serializer<'a, W> {
         writer: &'sub mut Vec<u8>,
     ) -> Serializer<'a, &'sub mut Vec<u8>> {
         Serializer {
-            inner: RmpSerializer::new(writer),
+            inner: make_inner_rmp_serializer(writer),
             registry: self.registry,
             default_strategy: self.default_strategy,
             overrides: self.overrides.clone(),
@@ -580,6 +580,52 @@ impl<'a, W: Write> Serializer<'a, W> {
         ser::Serializer::serialize_u8(&mut *self, v.tag)?;
         Ok(v)
     }
+}
+
+/// Build the inner `rmp_serde::Serializer` for primitive / forwarded
+/// calls. Single construction point so every spawn site
+/// ([`Serializer::new`], [`Serializer::sub_serializer_into`]) stays in
+/// lockstep.
+///
+/// **Why we don't apply `BytesMode::ForceIterables` here** (despite
+/// the legacy `acir::serialization::msgpack_serialize` doing so):
+///
+/// `ForceIterables` makes `rmp_serde::Serializer::collect_seq` detect
+/// byte-shaped iterators and emit msgpack `bin` instead of a
+/// `fixarray` of `fixint`s — the wire shape the C++ codegen's
+/// `std::vector<uint8_t>` adapter expects. But for that detection to
+/// apply, the call has to *reach* the inner's `collect_seq`. Our
+/// wrapper intercepts `Vec<T>::serialize` via the default
+/// `collect_seq` → `Self::serialize_seq` path: `serialize_seq` writes
+/// a `fixarray` header directly and routes each element through this
+/// wrapper, so the inner's `ForceIterables` is never consulted.
+///
+/// We could override `collect_seq` to forward byte-shaped iterators
+/// to `inner.collect_seq` — but rmp_serde's detection heuristic is
+/// purely size-based: any iterator over pointer-sized items (`&u8`,
+/// `Box<T>`, `Rc<T>`, `&T`, …) matches. For items that *aren't*
+/// actually `u8`, rmp_serde's `OnlyBytes` probe rejects, and rmp_serde
+/// falls back to its **own** `serialize_seq` — which doesn't route
+/// through our wrapper. That would silently bypass `MsgpackTagged`
+/// interception for any tagged type wrapped in `Box`/`&`/etc. inside
+/// a `Vec`. Hard to debug, easy to land in.
+///
+/// Instead we keep the wrapper simple and require the load-bearing
+/// case ([`acir_field::FieldElement`]'s `Serialize` impl) to call
+/// `serializer.serialize_bytes(...)` directly — bypassing
+/// `collect_seq` entirely. `serialize_bytes` is `rmp_serde`'s
+/// unconditional `write_bin` (independent of `BytesMode`), and our
+/// own `serialize_bytes` forwards it untouched, so the wire is
+/// reliably `bin` for that field.
+///
+/// **If a future model adds another byte-shaped value type**, prefer
+/// hooking it up via `serialize_bytes` for the same reason. Only if a
+/// generic byte-iter intercept becomes truly necessary should we
+/// override `collect_seq` here — and at that point we'd need to
+/// **also replicate rmp_serde's `OnlyBytes` probe** so the
+/// reference-bypass risk above is closed.
+fn make_inner_rmp_serializer<W: Write>(writer: W) -> RmpSerializer<W> {
+    RmpSerializer::new(writer)
 }
 
 /// Write a msgpack array header (`fixarray` / `array16` / `array32` depending


### PR DESCRIPTION
## Problem Resolved

The C++ codegen task in #12554 

The code generated in this PR was ported to Barretenberg in https://github.com/AztecProtocol/aztec-packages/pull/23247

## Summary of Changes

* Generates C++ code to handle `Format::MsgpackTagged` in `msgpack_unpack` methods. 
* Re-enables the generation `msgpack_pack` methods using the `ARRAY` format for now, which is still the default. (They are used in tests in Barretenberg). 
* Adds extra validation to the existing cases in C++: `MAP` and `ARRAY` with more elements than the number of active and `reserved` fields are rejected, unless `#[allow_unknown_tags]` was added to the type.
* Tested it it similarly to https://github.com/AztecProtocol/aztec-packages/pull/12841 with the updates to Barretenberg in https://github.com/AztecProtocol/aztec-packages/pull/23247 
* Changes `FieldElement` serialization to be as `bytes` rather than `Vec<u8>`, so we don't have to force `rmp` (or in our case, replicate that logic) to detect byte sequences and serialise them different than others.

### Limitations

The `MsgpackCompact` format, as well as `MsgpackTagged` with the `EncodingStrategy::Array` generate `ARRAY`s in `msgpack` for structs. In Rust we can tell which format we are dealing with based on the format byte at the beginning, and pick the right deserialiser, but in C++ the `msgpack_unpack` of the given type has to infer the format based on what the data looks like. In this case it cannot tell the difference. 

This means that it can only deal with cases where the two are identical, which is only true if the tag-order and the source-order are identical. For this reason if we encounter a structure during C++ codegen where this doesn't hold, the generator panics. We can work around this by introducing a "shadow DTO", keeping the original order. 

Seemingly this means that the promise of `MsgpackTagged` to be resilient in the face of reorder was false, but this is because in today's C++ decoding strategy we cannot tell the difference between two overlapping `Msgpack*` formats; for clients which only handle `MsgpackTagged`, the promise still holds.  

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
