### PR TITLE
feat(fmt): format quote blocks

### DIFF
--- a/compiler/noirc_frontend/src/parser/mod.rs
+++ b/compiler/noirc_frontend/src/parser/mod.rs
@@ -22,8 +22,9 @@ pub use errors::ParserError;
 pub use errors::ParserErrorReason;
 use noirc_errors::Location;
 pub use parser::{
-    Parser, StatementOrExpressionOrLValue, block_comment_has_all_leading_stars, parse_program,
-    parse_program_with_dummy_file,
+    Parser, StatementOrExpressionOrLValue, block_comment_has_all_leading_stars,
+    parse_expression_in_quote_body, parse_program, parse_program_in_quote_body,
+    parse_program_with_dummy_file, parse_statement_in_quote_body,
 };
 
 #[derive(Clone, Default)]

--- a/compiler/noirc_frontend/src/parser/parser.rs
+++ b/compiler/noirc_frontend/src/parser/parser.rs
@@ -79,15 +79,23 @@ pub fn parse_program_in_quote_body(source: &str) -> Result<ParsedModule, Vec<Par
 /// A trailing `;` is folded into the parsed statement (turning a plain expression
 /// statement into `StatementKind::Semi`) so callers like the formatter can preserve
 /// the semicolon when round-tripping.
+///
+/// We also reject the parse when the body starts with `#[...]` but the resulting
+/// statement kind doesn't carry attributes (only `Let` and `Comptime` do). Otherwise
+/// the parser would silently drop the attribute tokens and the formatter would lose
+/// sync with the source.
 pub fn parse_statement_in_quote_body(
     source: &str,
 ) -> Result<crate::ast::Statement, Vec<ParserError>> {
     use crate::ast::{Statement, StatementKind};
     use crate::parser::labels::ParsingRuleLabel;
+    use crate::token::Token;
     let mut parser = Parser::for_str_with_dummy_file(source);
     parser.parsing_quote_body = true;
     parser
         .parse_result(|parser| {
+            let started_with_attribute =
+                matches!(parser.token.token(), Token::AttributeStart { .. });
             let Some((statement, (semicolon, location))) = parser.parse_statement() else {
                 parser.expected_label(ParsingRuleLabel::Statement);
                 return Statement {
@@ -95,6 +103,12 @@ pub fn parse_statement_in_quote_body(
                     location: parser.location_at_previous_token_end(),
                 };
             };
+            if started_with_attribute
+                && !matches!(statement.kind, StatementKind::Let(_) | StatementKind::Comptime(_))
+            {
+                parser.expected_label(ParsingRuleLabel::Statement);
+                return Statement { kind: StatementKind::Error, location };
+            }
             statement.add_semicolon(
                 semicolon,
                 location,

--- a/compiler/noirc_frontend/src/parser/parser.rs
+++ b/compiler/noirc_frontend/src/parser/parser.rs
@@ -62,6 +62,59 @@ pub fn parse_program_with_dummy_file(source_program: &str) -> (ParsedModule, Vec
     parse_program(source_program, FileId::dummy())
 }
 
+/// Like `parse_program_with_dummy_file`, but enables a relaxed mode that accepts
+/// macro placeholders (e.g. `$name`, `$T`) in identifier-accepting positions.
+/// Intended for tooling that needs to inspect or reformat the body of a
+/// `quote { ... }` expression, where placeholders are legal. Returns `Err` if the
+/// input doesn't parse cleanly.
+pub fn parse_program_in_quote_body(source: &str) -> Result<ParsedModule, Vec<ParserError>> {
+    let mut parser = Parser::for_str_with_dummy_file(source);
+    parser.parsing_quote_body = true;
+    parser.parse_result(|parser| parser.parse_program()).map(|(program, _warnings)| program)
+}
+
+/// Parses the input as a single statement using the quote-body relaxation. Returns
+/// `Err` if the input doesn't parse cleanly or there is leftover input.
+///
+/// A trailing `;` is folded into the parsed statement (turning a plain expression
+/// statement into `StatementKind::Semi`) so callers like the formatter can preserve
+/// the semicolon when round-tripping.
+pub fn parse_statement_in_quote_body(
+    source: &str,
+) -> Result<crate::ast::Statement, Vec<ParserError>> {
+    use crate::ast::{Statement, StatementKind};
+    use crate::parser::labels::ParsingRuleLabel;
+    let mut parser = Parser::for_str_with_dummy_file(source);
+    parser.parsing_quote_body = true;
+    parser
+        .parse_result(|parser| {
+            let Some((statement, (semicolon, location))) = parser.parse_statement() else {
+                parser.expected_label(ParsingRuleLabel::Statement);
+                return Statement {
+                    kind: StatementKind::Error,
+                    location: parser.location_at_previous_token_end(),
+                };
+            };
+            statement.add_semicolon(
+                semicolon,
+                location,
+                true, // last_statement_in_block — permits a missing trailing `;`
+                &mut |error| parser.errors.push(error),
+            )
+        })
+        .map(|(stmt, _warnings)| stmt)
+}
+
+/// Parses the input as a single expression using the quote-body relaxation. Returns
+/// `Err` if the input doesn't parse cleanly or there is leftover input.
+pub fn parse_expression_in_quote_body(
+    source: &str,
+) -> Result<crate::ast::Expression, Vec<ParserError>> {
+    let mut parser = Parser::for_str_with_dummy_file(source);
+    parser.parsing_quote_body = true;
+    parser.parse_result(|parser| parser.parse_expression_or_error()).map(|(expr, _warnings)| expr)
+}
+
 enum TokenStream<'a> {
     Lexer(Lexer<'a>),
     Tokens(Tokens),
@@ -118,6 +171,12 @@ pub struct Parser<'a> {
     /// Set to true when recovering from a recursion depth overflow.
     /// Used to suppress cascading errors during stack unwinding.
     recovering_from_depth_overflow: bool,
+
+    /// When set, the parser permits `$ident` (and chained `$ident::...` paths) in
+    /// identifier-accepting positions, treating the two tokens as a single synthetic
+    /// identifier whose name literally begins with `$`. This lets the formatter parse
+    /// the body of a `quote { ... }` block even when it contains macro placeholders.
+    pub(crate) parsing_quote_body: bool,
 }
 
 impl<'a> Parser<'a> {
@@ -151,6 +210,7 @@ impl<'a> Parser<'a> {
             statement_comments: None,
             recursion_depth: 0,
             recovering_from_depth_overflow: false,
+            parsing_quote_body: false,
         };
         parser.read_two_first_tokens();
         parser
@@ -285,13 +345,45 @@ impl<'a> Parser<'a> {
 
     fn eat_ident(&mut self) -> Option<Ident> {
         if let Some(token) = self.eat_kind(TokenKind::Ident) {
-            match token.into_token() {
+            return match token.into_token() {
                 Token::Ident(ident) => Some(Ident::new(ident, self.previous_token_location)),
                 _ => unreachable!(),
-            }
-        } else {
-            None
+            };
         }
+        if self.at_quote_placeholder() {
+            let start_location = self.current_token_location;
+            self.bump(); // consume `$`
+            let Token::Ident(ident) = self.bump().into_token() else {
+                unreachable!("at_quote_placeholder guarantees the next token is Ident");
+            };
+            let location = start_location.merge(self.previous_token_location);
+            return Some(Ident::new(format!("${ident}"), location));
+        }
+        None
+    }
+
+    /// Returns true when looking at something `eat_ident` would consume — either a
+    /// regular identifier, or a `$ident` placeholder while parsing a quote body.
+    fn at_ident_token(&self) -> bool {
+        self.token.kind() == TokenKind::Ident || self.at_quote_placeholder()
+    }
+
+    /// Used in path parsing to decide whether to commit to consuming a `::`: if the
+    /// token after the `::` is plausibly the start of the next path segment.
+    /// We only have one token of lookahead, so in `parsing_quote_body` mode we accept
+    /// a `$` as the start of a placeholder identifier even though we can't verify the
+    /// following token here.
+    fn next_starts_path_segment(&self) -> bool {
+        matches!(self.next_token.token(), Token::Ident(..))
+            || (self.parsing_quote_body && self.next_token.token() == &Token::DollarSign)
+    }
+
+    /// True only when `parsing_quote_body` and the next two tokens are `$` followed
+    /// by an identifier — a synthetic identifier that we accept inside quote bodies.
+    fn at_quote_placeholder(&self) -> bool {
+        self.parsing_quote_body
+            && self.token.token() == &Token::DollarSign
+            && matches!(self.next_token.token(), Token::Ident(_))
     }
 
     fn eat_self(&mut self) -> bool {

--- a/compiler/noirc_frontend/src/parser/parser/path.rs
+++ b/compiler/noirc_frontend/src/parser/parser/path.rs
@@ -5,7 +5,7 @@ use crate::token::{Keyword, Token};
 
 use noirc_errors::Location;
 
-use crate::{parser::labels::ParsingRuleLabel, token::TokenKind};
+use crate::parser::labels::ParsingRuleLabel;
 
 use super::Parser;
 
@@ -112,9 +112,16 @@ impl Parser<'_> {
     ) -> Path {
         let mut segments = Vec::new();
 
-        if self.token.kind() == TokenKind::Ident {
+        if self.at_ident_token() {
             loop {
-                let ident = self.eat_ident().unwrap();
+                // In `parsing_quote_body` mode we may enter this iteration after
+                // optimistically committing to a `::` whose follow token is `$` (we
+                // only have one token of lookahead). If it turns out to be `$(...)`
+                // instead of `$ident`, `eat_ident` returns None and we bail out
+                // here rather than panicking.
+                let Some(ident) = self.eat_ident() else {
+                    break;
+                };
                 let location = ident.location();
 
                 let generics = if allow_turbofish
@@ -133,9 +140,7 @@ impl Parser<'_> {
                     location: self.location_since(location),
                 });
 
-                if self.at(Token::DoubleColon)
-                    && matches!(self.next_token.token(), Token::Ident(..))
-                {
+                if self.at(Token::DoubleColon) && self.next_starts_path_segment() {
                     // Skip the double colons
                     self.bump();
                 } else {

--- a/noir_stdlib/src/convert.nr
+++ b/noir_stdlib/src/convert.nr
@@ -253,12 +253,12 @@ comptime fn generate_as_primitive_impls(_: FunctionDefinition) -> Quoted {
 
             impls = impls.push_back(
                 quote {
-                impl AsPrimitive<$type1> for $type2 {
-                    fn as_(self) -> $type1 {
-                        $body
+                    impl AsPrimitive<$type1> for $type2 {
+                        fn as_(self) -> $type1 {
+                            $body
+                        }
                     }
-                }
-            },
+                },
             );
         }
     }

--- a/noir_stdlib/src/meta/expr.nr
+++ b/noir_stdlib/src/meta/expr.nr
@@ -504,7 +504,7 @@ comptime fn modify_expressions<Env>(exprs: [Expr], f: fn[Env](Expr) -> Option<Ex
 
 comptime fn new_array(exprs: [Expr]) -> Expr {
     let exprs = join_expressions(exprs, quote { , });
-    quote { [$exprs]}.as_expr().unwrap()
+    quote { [$exprs] }.as_expr().unwrap()
 }
 
 comptime fn new_assert(predicate: Expr, msg: Option<Expr>) -> Expr {
@@ -536,7 +536,7 @@ comptime fn new_binary_op(lhs: Expr, op: BinaryOp, rhs: Expr) -> Expr {
 
 comptime fn new_block(exprs: [Expr]) -> Expr {
     let exprs = join_expressions(exprs, quote { ; });
-    quote { { $exprs }}.as_expr().unwrap()
+    quote { { $exprs } }.as_expr().unwrap()
 }
 
 comptime fn new_cast(expr: Expr, typ: UnresolvedType) -> Expr {
@@ -545,7 +545,7 @@ comptime fn new_cast(expr: Expr, typ: UnresolvedType) -> Expr {
 
 comptime fn new_comptime(exprs: [Expr]) -> Expr {
     let exprs = join_expressions(exprs, quote { ; });
-    quote { comptime { $exprs }}.as_expr().unwrap()
+    quote { comptime { $exprs } }.as_expr().unwrap()
 }
 
 comptime fn new_constructor(typ: UnresolvedType, fields: [(Quoted, Expr)]) -> Expr {
@@ -612,7 +612,7 @@ comptime fn new_lambda(
 comptime fn new_let(pattern: Expr, typ: Option<UnresolvedType>, expr: Expr) -> Expr {
     if typ.is_some() {
         let typ = typ.unwrap();
-        quote { let $pattern : $typ = $expr; }.as_expr().unwrap()
+        quote { let $pattern: $typ = $expr; }.as_expr().unwrap()
     } else {
         quote { let $pattern = $expr; }.as_expr().unwrap()
     }

--- a/noir_stdlib/src/meta/expr.nr
+++ b/noir_stdlib/src/meta/expr.nr
@@ -556,14 +556,28 @@ comptime fn new_constructor(typ: UnresolvedType, fields: [(Quoted, Expr)]) -> Ex
 comptime fn new_if(condition: Expr, consequence: Expr, alternative: Option<Expr>) -> Expr {
     if alternative.is_some() {
         let alternative = alternative.unwrap();
-        quote { if $condition { $consequence } else { $alternative }}.as_expr().unwrap()
+        quote {
+            if $condition {
+                $consequence
+            } else {
+                $alternative
+            }
+        }
+            .as_expr()
+            .unwrap()
     } else {
         quote { if $condition { $consequence } }.as_expr().unwrap()
     }
 }
 
 comptime fn new_for(identifier: Quoted, array: Expr, body: Expr) -> Expr {
-    quote { for $identifier in $array { $body } }.as_expr().unwrap()
+    quote {
+        for $identifier in $array {
+            $body
+        }
+    }
+        .as_expr()
+        .unwrap()
 }
 
 comptime fn new_for_range(

--- a/noir_stdlib/src/meta/mod.nr
+++ b/noir_stdlib/src/meta/mod.nr
@@ -289,8 +289,8 @@ mod tests {
     #[test]
     fn concatenate_test() {
         comptime {
-            let result = concatenate(quote {foo}, quote {bar});
-            assert_eq(result, quote {foobar});
+            let result = concatenate(quote { foo }, quote { bar });
+            assert_eq(result, quote { foobar });
 
             let result = double_spaced(quote {foo bar 3}).as_quoted_str!();
             assert_eq(result, "foo  bar  3");

--- a/test_programs/compile_success_contract/contract_with_comptime_attributes/src/main.nr
+++ b/test_programs/compile_success_contract/contract_with_comptime_attributes/src/main.nr
@@ -13,7 +13,6 @@ comptime fn add_utility(_: FunctionDefinition) -> Quoted {
 
     quote {
         #[$utility]
-        fn fn2() {
-        }
+        fn fn2() {}
     }
 }

--- a/test_programs/compile_success_empty/attribute_sees_result_of_previous_attribute/src/main.nr
+++ b/test_programs/compile_success_empty/attribute_sees_result_of_previous_attribute/src/main.nr
@@ -5,7 +5,7 @@ pub struct Foo {}
 fn main() {}
 
 comptime fn check_eq_derived_for_foo(_f: FunctionDefinition) {
-    let foo = quote {Foo}.as_type();
-    let eq = quote {Eq}.as_trait_constraint();
+    let foo = quote { Foo }.as_type();
+    let eq = quote { Eq }.as_trait_constraint();
     assert(foo.implements(eq));
 }

--- a/test_programs/compile_success_empty/comptime_function_definition/src/main.nr
+++ b/test_programs/compile_success_empty/comptime_function_definition/src/main.nr
@@ -90,7 +90,7 @@ mod test_as_typed_expr_1 {
     comptime fn foo(module: Module) -> Quoted {
         let method = module.functions().filter(|f| f.name() == quote { method })[0];
         let func = method.as_typed_expr();
-        quote { 
+        quote {
             pub fn bar() -> i32 {
                 $func(1)
             }
@@ -114,10 +114,12 @@ mod test_as_typed_expr_2 {
     comptime fn foo(module: Module) -> Quoted {
         let method = module.functions().filter(|f| f.name() == quote { method })[0];
         let func = method.as_typed_expr();
-        quote { 
+        quote {
             pub fn bar() -> u32 {
                 // Safety: test program
-                unsafe { $func([1, 2, 3, 0]) }
+                unsafe {
+                    $func([1, 2, 3, 0])
+                }
             }
         }
     }
@@ -140,10 +142,12 @@ mod test_as_typed_expr_3 {
     comptime fn foo(module: Module) -> Quoted {
         let method = module.functions().filter(|f| f.name() == quote { method })[0];
         let func = method.as_typed_expr();
-        quote { 
+        quote {
             pub fn bar() -> u32 {
                 // Safety: test program
-                comptime { $func(([1, 2, 3, 0], "a")) }
+                comptime {
+                    $func(([1, 2, 3, 0], "a"))
+                }
             }
         }
     }
@@ -158,8 +162,8 @@ mod test_as_typed_expr_3 {
 mod test_as_typed_expr_4 {
     comptime fn foo(f: TypedExpr) -> Quoted {
         quote {
-        $f()
-    }
+            $f()
+        }
     }
 
     fn bar() -> Field {
@@ -169,8 +173,8 @@ mod test_as_typed_expr_4 {
     fn baz() -> Field {
         let x: Field = comptime {
             let bar_q = quote {
-            bar
-        };
+                bar
+            };
             foo!(bar_q.as_expr().unwrap().resolve(Option::none()))
         };
         x

--- a/test_programs/compile_success_empty/comptime_module/src/main.nr
+++ b/test_programs/compile_success_empty/comptime_module/src/main.nr
@@ -119,11 +119,11 @@ mod module1 {
 #[test]
 fn parent_test() {
     comptime {
-        let my_module2 = quote [module1::module2].as_module().unwrap();
-        assert_eq(my_module2.name(), quote [module2]);
+        let my_module2 = quote [ module1::module2 ].as_module().unwrap();
+        assert_eq(my_module2.name(), quote [ module2 ]);
 
         let my_module1 = my_module2.parent().unwrap();
-        assert_eq(my_module1.name(), quote [module1]);
+        assert_eq(my_module1.name(), quote [ module1 ]);
 
         // The top-level module in each crate has no name
         let top_level_module = my_module1.parent().unwrap();
@@ -144,11 +144,11 @@ mod my_module {
 #[test]
 fn child_modules_test() {
     comptime {
-        let my_module = quote [my_module].as_module().unwrap();
+        let my_module = quote [ my_module ].as_module().unwrap();
         let children = my_module.child_modules().map(Module::name);
 
         // The order children are returned in is left unspecified.
-        assert_eq(children, [quote [child1], quote [child2], quote [child3]].as_vector());
+        assert_eq(children, [quote [ child1 ], quote [ child2 ], quote [ child3 ]].as_vector());
     }
 }
 // docs:end:child_modules_example
@@ -160,18 +160,18 @@ fn child_modules_test() {
 #[test]
 fn child_modules_test2() {
     comptime {
-        let top = quote [my_module].as_module().unwrap().parent().unwrap();
+        let top = quote [ my_module ].as_module().unwrap().parent().unwrap();
         let children = top.child_modules().map(Module::name);
 
         let expected = [
-            quote [separate_module],
-            quote [foo],
-            quote [bar],
-            quote [another_module],
-            quote [yet_another_module],
-            quote [baz],
-            quote [module1],
-            quote [my_module],
+            quote [ separate_module ],
+            quote [ foo ],
+            quote [ bar ],
+            quote [ another_module ],
+            quote [ yet_another_module ],
+            quote [ baz ],
+            quote [ module1 ],
+            quote [ my_module ],
         ]
             .as_vector();
         assert_eq(children, expected);
@@ -182,7 +182,7 @@ fn child_modules_test2() {
 #[test]
 fn top_level_module_name_is_empty() {
     comptime {
-        let top = quote [my_module].as_module().unwrap().parent().unwrap();
+        let top = quote [ my_module ].as_module().unwrap().parent().unwrap();
         assert_eq(top.name(), quote []);
     }
 }

--- a/test_programs/compile_success_empty/comptime_parse_statement_as_expression/src/main.nr
+++ b/test_programs/compile_success_empty/comptime_parse_statement_as_expression/src/main.nr
@@ -1,26 +1,28 @@
 fn main() {
     comptime {
-        let block = quote {{
-            1;
-            2;
-            3
-        }};
+        let block = quote {
+            {
+                1;
+                2;
+                3
+            }
+        };
         let statements = block.as_expr().unwrap().as_block().unwrap();
         let last = statements.pop_back().1;
 
         // `3` should  fit in an expression position even though it is
         // originally a StatementKind::Expression
-        let regression1 = quote {{
-            let _ = $last;
-        }};
+        let regression1 = quote {
+            { let _ = $last; }
+        };
         assert(regression1.as_expr().is_some());
 
         // `1;` should  fit in an expression position even though it is
         // originally a StatementKind::Semi
         let first = statements.pop_front().0;
-        let regression2 = quote {{
-            let _ = $first;
-        }};
+        let regression2 = quote {
+            { let _ = $first; }
+        };
         assert(regression2.as_expr().is_some());
     }
 }

--- a/test_programs/compile_success_empty/comptime_quoted/src/main.nr
+++ b/test_programs/compile_success_empty/comptime_quoted/src/main.nr
@@ -1,7 +1,7 @@
 fn main() {
     comptime {
         let array = quote { [1, 2, 3] }.as_expr().unwrap();
-        let expr1 = quote { [1, 2, 3]};
+        let expr1 = quote { [1, 2, 3] };
         let expr2 = quote { $array };
         assert_eq(expr1, expr2);
     }

--- a/test_programs/compile_success_empty/comptime_struct_definition/src/main.nr
+++ b/test_programs/compile_success_empty/comptime_struct_definition/src/main.nr
@@ -58,7 +58,7 @@ fn main() {
         assert_eq(visibility2, quote {});
 
         // Test TypeDefinition::as_type_with_generics
-        let i32_type = quote [i32].as_type();
+        let i32_type = quote [ i32 ].as_type();
 
         let applied = struct_def.as_type_with_generics([i32_type, i32_type, i32_type].as_vector());
         let invalid = struct_def.as_type_with_generics([i32_type, i32_type].as_vector()); // invalid generic count

--- a/test_programs/compile_success_empty/macros_in_comptime/src/main.nr
+++ b/test_programs/compile_success_empty/macros_in_comptime/src/main.nr
@@ -33,7 +33,11 @@ comptime fn foo<let N: Field>(x: Field) {
         break;
     }
 
-    let loop_ = quote { for _ in 0..0 { break; } };
+    let loop_ = quote {
+        for _ in 0..0 {
+            break;
+        }
+    };
     unquote!(loop_);
 }
 

--- a/test_programs/compile_success_empty/resolved_type_in_constructor/src/main.nr
+++ b/test_programs/compile_success_empty/resolved_type_in_constructor/src/main.nr
@@ -4,7 +4,7 @@ fn main() {
 
 comptime fn my_macro() -> Quoted {
     let typ = quote { Foo }.as_type();
-    quote [$typ {}]
+    quote [ $typ {} ]
 }
 
 struct Foo {}

--- a/test_programs/compile_success_empty/unquote_in_numeric_generic/src/main.nr
+++ b/test_programs/compile_success_empty/unquote_in_numeric_generic/src/main.nr
@@ -11,7 +11,7 @@ fn main() {
 comptime fn foo_impl(t: TypeDefinition) -> Quoted {
     let g = t.generics();
 
-    let g_names = g.map(|(name, _)| quote [$name]).join(quote [,]);
+    let g_names = g.map(|(name, _)| quote [ $name ]).join(quote [,]);
 
     let g_intros = g
         .map(|(name, typ)| {
@@ -22,7 +22,9 @@ comptime fn foo_impl(t: TypeDefinition) -> Quoted {
 
     quote {
         impl<$g_intros> Foo<$g_names> {
-            fn foo(self) { let _ = self; }
+            fn foo(self) {
+                let _ = self;
+            }
         }
     }
 }

--- a/test_programs/compile_success_no_bug/regression_10748/src/main.nr
+++ b/test_programs/compile_success_no_bug/regression_10748/src/main.nr
@@ -22,7 +22,7 @@ pub comptime fn storage(s: TypeDefinition) -> Quoted {
     );
 
     quote {
-        impl Storage<$context> { }
+        impl Storage<$context> {}
     }
 }
 

--- a/test_programs/noir_test_success/comptime_expr/src/main.nr
+++ b/test_programs/noir_test_success/comptime_expr/src/main.nr
@@ -120,7 +120,15 @@ mod tests {
     #[test]
     fn test_expr_as_block() {
         comptime {
-            let expr = quote { { 1; 4; 23 } }.as_expr().unwrap();
+            let expr = quote {
+                {
+                    1;
+                    4;
+                    23
+                }
+            }
+                .as_expr()
+                .unwrap();
             let exprs = expr.as_block().unwrap();
             assert_eq(exprs.len(), 3);
             assert_eq(exprs[0].as_integer().unwrap(), 1);
@@ -136,7 +144,15 @@ mod tests {
     #[test]
     fn test_expr_modify_for_block() {
         comptime {
-            let expr = quote { { 1; 4; 23 } }.as_expr().unwrap();
+            let expr = quote {
+                {
+                    1;
+                    4;
+                    23
+                }
+            }
+                .as_expr()
+                .unwrap();
             let expr = expr.modify(times_two);
             let exprs = expr.as_block().unwrap();
             assert_eq(exprs.len(), 3);
@@ -280,7 +296,15 @@ mod tests {
     #[test]
     fn test_expr_as_comptime() {
         comptime {
-            let expr = quote { comptime { 1; 4; 23 } }.as_expr().unwrap();
+            let expr = quote {
+                comptime {
+                    1;
+                    4;
+                    23
+                }
+            }
+                .as_expr()
+                .unwrap();
             let exprs = expr.as_comptime().unwrap();
             assert_eq(exprs.len(), 3);
         }
@@ -289,7 +313,15 @@ mod tests {
     #[test]
     fn test_expr_modify_for_comptime() {
         comptime {
-            let expr = quote { comptime { 1; 4; 23 } }.as_expr().unwrap();
+            let expr = quote {
+                comptime {
+                    1;
+                    4;
+                    23
+                }
+            }
+                .as_expr()
+                .unwrap();
             let expr = expr.modify(times_two);
             let exprs = expr.as_comptime().unwrap();
             assert_eq(exprs.len(), 3);
@@ -300,7 +332,17 @@ mod tests {
     #[test]
     fn test_expr_as_comptime_as_statement() {
         comptime {
-            let expr = quote { { comptime { 1; 4; 23 } } }.as_expr().unwrap();
+            let expr = quote {
+                {
+                    comptime {
+                        1;
+                        4;
+                        23
+                    }
+                }
+            }
+                .as_expr()
+                .unwrap();
             let exprs = expr.as_block().unwrap();
             assert_eq(exprs.len(), 1);
 
@@ -687,7 +729,13 @@ mod tests {
     #[test]
     fn test_expr_as_for_statement() {
         comptime {
-            let expr = quote { for x in 2 { 3 } }.as_expr().unwrap();
+            let expr = quote {
+                for x in 2 {
+                    3
+                }
+            }
+                .as_expr()
+                .unwrap();
             let (index, array, body) = expr.as_for().unwrap();
             assert_eq(index, quote { x });
             assert_eq(array.as_integer().unwrap(), 2);
@@ -698,7 +746,13 @@ mod tests {
     #[test]
     fn test_expr_modify_for_statement() {
         comptime {
-            let expr = quote { for x in 2 { 3 } }.as_expr().unwrap();
+            let expr = quote {
+                for x in 2 {
+                    3
+                }
+            }
+                .as_expr()
+                .unwrap();
             let expr = expr.modify(times_two);
             let (index, array, body) = expr.as_for().unwrap();
             assert_eq(index, quote { x });
@@ -710,7 +764,13 @@ mod tests {
     #[test]
     fn test_expr_as_for_range_statement() {
         comptime {
-            let expr = quote { for x in 2..3 { 4 } }.as_expr().unwrap();
+            let expr = quote {
+                for x in 2..3 {
+                    4
+                }
+            }
+                .as_expr()
+                .unwrap();
             let (index, from, to, inclusive, body) = expr.as_for_range().unwrap();
             assert_eq(index, quote { x });
             assert_eq(from.as_integer().unwrap(), 2);
@@ -718,7 +778,13 @@ mod tests {
             assert(!inclusive);
             assert_eq(body.as_block().unwrap()[0].as_integer().unwrap(), 4);
 
-            let expr = quote { for x in 2..=3 { 4 } }.as_expr().unwrap();
+            let expr = quote {
+                for x in 2..=3 {
+                    4
+                }
+            }
+                .as_expr()
+                .unwrap();
             let (index, from, to, inclusive, body) = expr.as_for_range().unwrap();
             assert_eq(index, quote { x });
             assert_eq(from.as_integer().unwrap(), 2);
@@ -731,7 +797,13 @@ mod tests {
     #[test]
     fn test_expr_modify_for_range_statement() {
         comptime {
-            let expr = quote { for x in 2..3 { 4 } }.as_expr().unwrap();
+            let expr = quote {
+                for x in 2..3 {
+                    4
+                }
+            }
+                .as_expr()
+                .unwrap();
             let expr = expr.modify(times_two);
             let (index, from, to, inclusive, body) = expr.as_for_range().unwrap();
             assert_eq(index, quote { x });

--- a/test_programs/noir_test_success/comptime_expr/src/main.nr
+++ b/test_programs/noir_test_success/comptime_expr/src/main.nr
@@ -559,10 +559,14 @@ mod tests {
     #[test]
     fn test_expr_as_unsafe() {
         comptime {
-            let expr = quote {  
+            let expr = quote {
                 // Safety: test
-                unsafe { 1; 4; 23 } 
+                unsafe {
+                    1;
+                    4;
+                    23
                 }
+            }
                 .as_expr()
                 .unwrap();
             let exprs = expr.as_unsafe().unwrap();
@@ -573,9 +577,13 @@ mod tests {
     #[test]
     fn test_expr_modify_for_unsafe() {
         comptime {
-            let expr = quote { 
+            let expr = quote {
                 // Safety: test
-                unsafe { 1; 4; 23 } 
+                unsafe {
+                    1;
+                    4;
+                    23
+                }
             }
                 .as_expr()
                 .unwrap();
@@ -657,7 +665,7 @@ mod tests {
     #[test]
     fn test_expr_modify_for_let() {
         comptime {
-            let expr = quote { let x : Field = 1; }.as_expr().unwrap();
+            let expr = quote { let x: Field = 1; }.as_expr().unwrap();
             let expr = expr.modify(times_two);
             let (_pattern, typ, expr) = expr.as_let().unwrap();
             assert_eq(unresolved_type_to_string!(typ.unwrap()), "Field");

--- a/tooling/nargo_cli/tests/snapshots/compile_success_contract/contract_with_comptime_attributes/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_contract/contract_with_comptime_attributes/execute__tests__expanded.snap
@@ -15,8 +15,7 @@ comptime fn utility(f: FunctionDefinition) {
 comptime fn add_utility(_: FunctionDefinition) -> Quoted {
     let utility: fn(FunctionDefinition) = utility;
     quote {
-        #[$utility]fn fn2() {
-            
-        }
+        #[$utility]
+        fn fn2() {}
     }
 }

--- a/tooling/nargo_cli/tests/snapshots/compile_success_empty/comptime_attribute/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_empty/comptime_attribute/execute__tests__expanded.snap
@@ -6,9 +6,7 @@ mod moo {
     pub comptime fn add_fn(f: FunctionDefinition, name: Quoted) -> Quoted {
         assert(f.has_named_attribute("add_fn"));
         quote {
-            pub fn $name() {
-                
-            }
+            pub fn $name() {}
         }
     }
 

--- a/tooling/nargo_cli/tests/snapshots/compile_success_empty/comptime_function_definition/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_empty/comptime_function_definition/execute__tests__expanded.snap
@@ -35,10 +35,8 @@ comptime fn function_attr(f: FunctionDefinition) {
     assert(
         parameters[2_u32].0
             == quote {
-        Foo {
-            x, field: some_field
-        }
-    },
+                Foo { x, field: some_field }
+            },
     );
     assert(parameters[3_u32].0 == quote { mut a });
     assert(parameters[4_u32].0 == quote { (b, c) });

--- a/tooling/nargo_cli/tests/snapshots/compile_success_empty/comptime_module/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_empty/comptime_module/execute__tests__expanded.snap
@@ -38,9 +38,7 @@ comptime fn outer_attribute_func(m: Module) -> Quoted {
     assert(m.name() == quote { yet_another_module });
     increment_counter();
     quote {
-        pub fn generated_outer_function() {
-            
-        }
+        pub fn generated_outer_function() {}
     }
 }
 
@@ -48,9 +46,7 @@ comptime fn inner_attribute_func(m: Module) -> Quoted {
     assert(m.name() == quote { yet_another_module });
     increment_counter();
     quote {
-        pub fn generated_inner_function() {
-            
-        }
+        pub fn generated_inner_function() {}
     }
 }
 

--- a/tooling/nargo_cli/tests/snapshots/compile_success_empty/field_or_integer_static_trait_method/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_empty/field_or_integer_static_trait_method/execute__tests__expanded.snap
@@ -30,9 +30,7 @@ pub fn foo() {}
 
 comptime fn attr(_: FunctionDefinition) -> Quoted {
     quote {
-        pub fn hello() {
-            
-        }
+        pub fn hello() {}
     }
 }
 

--- a/tooling/nargo_cli/tests/snapshots/compile_success_empty/function_attribute/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_empty/function_attribute/execute__tests__expanded.snap
@@ -16,9 +16,7 @@ comptime fn function_attr(_f: FunctionDefinition) -> Quoted {
     quote {
         impl Default for Foo {
             fn default() -> Foo {
-                Foo {
-                    
-                }
+                Foo {}
             }
         }
     }

--- a/tooling/nargo_cli/tests/snapshots/compile_success_empty/regression_10445/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_empty/regression_10445/execute__tests__expanded.snap
@@ -5,12 +5,12 @@ expression: expanded_code
 comptime fn foo(_: FunctionDefinition) -> Quoted {
     let t: Type = quote { [i32; 3] }.as_type();
     quote {
-        struct Bar < T >  {
-            x: T, 
+        struct Bar<T> {
+            x: T,
         }
         struct Foo {
             // See https://github.com/noir-lang/noir/pull/11410/changes#r2747886398
-            x: Bar < $t > , 
+            x: Bar<$t>,
         }
     }
 }

--- a/tooling/nargo_cli/tests/snapshots/compile_success_empty/regression_10874/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_empty/regression_10874/execute__tests__expanded.snap
@@ -14,9 +14,7 @@ comptime fn foo(_: FunctionDefinition) -> Quoted {
     let q: Quoted = quote { Trait < Assoc = i32 >  };
     let trait_constraint: TraitConstraint = q.as_trait_constraint();
     quote {
-        impl $trait_constraint for Field {
-            
-        }
+        impl $trait_constraint for Field {}
     }
 }
 

--- a/tooling/nargo_cli/tests/snapshots/compile_success_empty/resolved_type_in_constructor/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_empty/resolved_type_in_constructor/execute__tests__expanded.snap
@@ -9,9 +9,7 @@ fn main() {
 comptime fn my_macro() -> Quoted {
     let typ: Type = quote { Foo }.as_type();
     quote {
-        $typ {
-            
-        }
+        $typ {}
     }
 }
 

--- a/tooling/nargo_cli/tests/snapshots/compile_success_empty/unquote_function/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_empty/unquote_function/execute__tests__expanded.snap
@@ -10,9 +10,7 @@ pub fn foo() {}
 
 comptime fn output_function(_f: FunctionDefinition) -> Quoted {
     quote {
-        fn bar() {
-            
-        }
+        fn bar() {}
     }
 }
 

--- a/tooling/nargo_cli/tests/snapshots/compile_success_empty/unquote_in_numeric_generic/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_empty/unquote_in_numeric_generic/execute__tests__expanded.snap
@@ -28,7 +28,7 @@ comptime fn foo_impl(t: TypeDefinition) -> Quoted {
         })
         .join(quote { ,  });
     quote {
-        impl < $g_intros > Foo < $g_names >  {
+        impl<$g_intros> Foo<$g_names> {
             fn foo(self) {
                 let _ = self;
             }

--- a/tooling/nargo_cli/tests/snapshots/compile_success_no_bug/regression_10748/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_no_bug/regression_10748/execute__tests__expanded.snap
@@ -24,9 +24,7 @@ pub comptime fn storage(s: TypeDefinition) -> Quoted {
         f"Type {typ} was placed in Storage struct but does not implement the StateVariable trait",
     );
     quote {
-        impl Storage < $context >  {
-            
-        }
+        impl Storage<$context> {}
     }
 }
 

--- a/tooling/nargo_cli/tests/snapshots/execution_success/derive/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/derive/execute__tests__expanded.snap
@@ -23,7 +23,7 @@ comptime fn derive_do_nothing(s: TypeDefinition) -> Quoted {
     let generics: Quoted =
         s.generics().map(|g: (Type, Option<Type>)| -> Quoted quote { $g }).join(quote { ,  });
     quote {
-        impl < $generics > DoNothing for $typ {
+        impl<$generics> DoNothing for $typ {
             fn do_nothing(_self: Self) {
                 // Traits can't tell us what to do
                 println("something");

--- a/tooling/nargo_fmt/src/formatter.rs
+++ b/tooling/nargo_fmt/src/formatter.rs
@@ -1,13 +1,14 @@
 use buffer::Buffer;
 use noirc_frontend::{
     ParsedModule,
-    ast::Ident,
+    ast::{Expression, Ident, Statement},
     hir::resolution::errors::Span,
     lexer::Lexer,
     token::{Keyword, SpannedToken, Token},
 };
 
 use crate::Config;
+use crate::chunks::ChunkGroup;
 
 mod alias;
 mod attribute;
@@ -123,8 +124,44 @@ impl<'a> Formatter<'a> {
         self.write_line();
     }
 
+    pub(crate) fn format_single_statement(&mut self, statement: Statement) {
+        self.skip_whitespace();
+        self.skip_comments_and_whitespace_impl(
+            true, // write lines
+            true, // at beginning
+        );
+
+        let ignore_next = self.ignore_next;
+        let mut group = ChunkGroup::new();
+        self.chunk_formatter().format_statement(statement, &mut group, ignore_next);
+        self.format_chunk_group(group);
+
+        self.buffer.trim_multiple_newlines();
+    }
+
+    pub(crate) fn format_single_expression(&mut self, expression: Expression) {
+        self.skip_whitespace();
+        self.skip_comments_and_whitespace_impl(
+            true, // write lines
+            true, // at beginning
+        );
+
+        let mut group = ChunkGroup::new();
+        self.chunk_formatter().format_expression(expression, &mut group);
+        self.format_chunk_group(group);
+
+        self.buffer.trim_multiple_newlines();
+    }
+
     pub(crate) fn write_identifier(&mut self, ident: Ident) {
         self.skip_comments_and_whitespace();
+
+        if ident.as_str().starts_with('$') && self.token == Token::DollarSign {
+            // The AST identifier was synthesized from `$` + a real identifier in a
+            // `quote { }` body. Consume both tokens.
+            self.bump();
+            self.skip_comments_and_whitespace();
+        }
 
         let Token::Ident(..) = self.token else {
             panic!("Expected identifier, got {:?}", self.token);
@@ -135,6 +172,11 @@ impl<'a> Formatter<'a> {
 
     pub(crate) fn write_identifier_or_integer(&mut self, ident: Ident) {
         self.skip_comments_and_whitespace();
+
+        if ident.as_str().starts_with('$') && self.token == Token::DollarSign {
+            self.bump();
+            self.skip_comments_and_whitespace();
+        }
 
         if !matches!(self.token, Token::Ident(..) | Token::Int(..)) {
             panic!("Expected identifier or integer, got {:?}", self.token);

--- a/tooling/nargo_fmt/src/formatter/expression.rs
+++ b/tooling/nargo_fmt/src/formatter/expression.rs
@@ -2501,6 +2501,23 @@ let     x   =    1   +    2 ;
     }
 
     #[test]
+    fn format_quote_with_attribute_on_unquote_does_not_panic() {
+        // The body has a leading `#[foo]` attribute followed by `$bar`. The statement
+        // parser would silently consume the attribute and leave the formatter's lexer
+        // pointing at `#[`, which used to make the formatter panic when writing the
+        // unquote. We must fall back to verbatim instead.
+        let src = "fn main() {
+    quote {
+        #[foo]
+        $bar
+    }
+}
+";
+        let expected = src;
+        assert_format(src, expected);
+    }
+
+    #[test]
     fn format_quote_falls_back_when_unparseable() {
         // The body `foo bar` isn't a valid Noir item sequence so the formatter must
         // leave it verbatim.

--- a/tooling/nargo_fmt/src/formatter/expression.rs
+++ b/tooling/nargo_fmt/src/formatter/expression.rs
@@ -1456,12 +1456,6 @@ fn format_quote_body(body_source: &str, config: &crate::Config) -> Option<String
     if trimmed.is_empty() || !quote_body_tokens_match(body_source, trimmed) {
         return None;
     }
-    // Don't rewrite a single-line `quote { ... }` into a multi-line block. Authors who
-    // wrote it on one line generally want it kept on one line, and forcing a wrap can
-    // make the surrounding call chain look much worse.
-    if !body_source.contains('\n') && trimmed.contains('\n') {
-        return None;
-    }
     Some(trimmed.to_string())
 }
 
@@ -2550,6 +2544,26 @@ let     x   =    1   +    2 ;
     fn format_quote_with_statement_body() {
         let src = "global x = quote { let  y   =    1 ;  };\n";
         let expected = "global x = quote { let y = 1; };\n";
+        assert_format(src, expected);
+    }
+
+    #[test]
+    fn format_quote_wraps_single_line_body_when_formatted_form_is_multi_line() {
+        // If the formatted body can't fit on one line we lay the quote out across
+        // multiple lines even if the author wrote it on a single line — the result
+        // is more readable than packing a multi-statement block back onto one line.
+        let src = "comptime fn outside() -> Quoted {
+    quote { fn foo() {   1     } }
+}
+";
+        let expected = "comptime fn outside() -> Quoted {
+    quote {
+        fn foo() {
+            1
+        }
+    }
+}
+";
         assert_format(src, expected);
     }
 

--- a/tooling/nargo_fmt/src/formatter/expression.rs
+++ b/tooling/nargo_fmt/src/formatter/expression.rs
@@ -88,8 +88,11 @@ impl ChunkFormatter<'_, '_> {
             ExpressionKind::Quote(..) => {
                 group.group(self.format_quote());
             }
-            ExpressionKind::Unquote(..) => {
-                unreachable!("Should not be present in the AST")
+            ExpressionKind::Unquote(inner) => {
+                group.text(self.chunk(|formatter| {
+                    formatter.write_token(Token::DollarSign);
+                }));
+                self.format_expression(*inner, group);
             }
             ExpressionKind::Comptime(block_expression, _span) => {
                 group.group(self.format_comptime_expression(
@@ -353,6 +356,10 @@ impl ChunkFormatter<'_, '_> {
             _ => panic!("Unexpected delimiter: {delimiter_start}"),
         };
 
+        // Everything between the delimiters is the quote body.
+        let body_source = &quote_source_code[1..quote_source_code.len() - 1];
+        let formatted_body = format_quote_body(body_source, self.config);
+
         // We use the current token rather than the Tokens we got from `Token::Quote` because
         // the current token has whitespace and comments in it, while the one we got from
         // the parser doesn't.
@@ -361,15 +368,61 @@ impl ChunkFormatter<'_, '_> {
         };
 
         let mut group = ChunkGroup::new();
-        group.verbatim(self.chunk(|formatter| {
-            formatter.write("quote");
-            formatter.write_space();
-            formatter.write(&delimiter_start.to_string());
-            for token in tokens.0 {
-                formatter.write_source_span(token.span());
+        if let Some(formatted_body) = formatted_body {
+            let single_line_body = !formatted_body.contains('\n');
+            group.force_multiple_lines = !single_line_body;
+            group.text(self.chunk(|formatter| {
+                formatter.write("quote");
+                formatter.write_space();
+                formatter.write(&delimiter_start.to_string());
+            }));
+            group.increase_indentation();
+            if single_line_body {
+                // Allow `quote { use $t; }` to stay on a single line when it fits.
+                group.space_or_line();
+                group.text(TextChunk::new(formatted_body));
+            } else {
+                group.line();
+                // Emit each line of the formatted body as its own text chunk, with `line`
+                // chunks between them. This way the chunk renderer takes care of writing
+                // the outer indentation at every line break while the body's own
+                // internal indentation is preserved in each chunk's text. Blank lines
+                // in the body become double `line` chunks so they survive the round-trip.
+                let mut lines = formatted_body.lines();
+                if let Some(first_line) = lines.next() {
+                    group.text(TextChunk::new(first_line.to_string()));
+                }
+                let mut pending_blank = false;
+                for line in lines {
+                    if line.trim().is_empty() {
+                        pending_blank = true;
+                        continue;
+                    }
+                    group.lines(pending_blank);
+                    pending_blank = false;
+                    group.text(TextChunk::new(line.to_string()));
+                }
             }
-            formatter.write(&delimiter_end.to_string());
-        }));
+            group.decrease_indentation();
+            if single_line_body {
+                group.space_or_line();
+            } else {
+                group.line();
+            }
+            group.text(self.chunk(|formatter| {
+                formatter.write(&delimiter_end.to_string());
+            }));
+        } else {
+            group.verbatim(self.chunk(|formatter| {
+                formatter.write("quote");
+                formatter.write_space();
+                formatter.write(&delimiter_start.to_string());
+                for token in tokens.0 {
+                    formatter.write_source_span(token.span());
+                }
+                formatter.write(&delimiter_end.to_string());
+            }));
+        }
         group
     }
 
@@ -1364,6 +1417,75 @@ fn force_if_chunks_to_multiple_lines(group: &mut ChunkGroup, group_tag: GroupTag
     }
 }
 
+/// Tries to parse the body of a `quote { ... }` as Noir and, if successful, formats it.
+/// We try three grammars and return the first that parses cleanly:
+///
+/// 1. a sequence of items (for bodies that generate top-level declarations),
+/// 2. a single expression (this catches block expressions like `{ $exprs }` before
+///    the statement parser does, where they would otherwise be forced multi-line),
+/// 3. a single statement (for things like `let x = 1;` that aren't expressions).
+///
+/// Returns `None` if none apply, so the caller can fall back to verbatim emission.
+///
+/// As a safety net we also reject any formatting that would change the body's token
+/// stream — the regular formatter performs token-level rewrites (e.g. collapsing a
+/// single-statement lambda body `|x| { e }` to `|x| e`) that are safe in normal code
+/// but can break semantics under macro substitution.
+fn format_quote_body(body_source: &str, config: &crate::Config) -> Option<String> {
+    use noirc_frontend::parser;
+
+    let candidate = if let Ok(module) = parser::parse_program_in_quote_body(body_source)
+        && !module.items.is_empty()
+    {
+        Some(crate::format(body_source, module, config))
+    } else if let Ok(expression) = parser::parse_expression_in_quote_body(body_source) {
+        Some(crate::format_expression(body_source, expression, config))
+    } else if let Ok(statement) = parser::parse_statement_in_quote_body(body_source) {
+        Some(crate::format_statement(body_source, statement, config))
+    } else {
+        None
+    };
+
+    let formatted = candidate?;
+    let trimmed = formatted.trim();
+    if trimmed.is_empty() || !quote_body_tokens_match(body_source, trimmed) {
+        return None;
+    }
+    // Don't rewrite a single-line `quote { ... }` into a multi-line block. Authors who
+    // wrote it on one line generally want it kept on one line, and forcing a wrap can
+    // make the surrounding call chain look much worse.
+    if !body_source.contains('\n') && trimmed.contains('\n') {
+        return None;
+    }
+    Some(trimmed.to_string())
+}
+
+/// Compares two snippets by their non-trivia token streams. Used to ensure the
+/// formatter didn't change anything other than whitespace/comments when rewriting a
+/// quote body.
+fn quote_body_tokens_match(a: &str, b: &str) -> bool {
+    use noirc_frontend::lexer::Lexer;
+    use noirc_frontend::token::Token;
+
+    fn collect(source: &str) -> Option<Vec<Token>> {
+        let mut tokens = Vec::new();
+        for result in Lexer::new_with_dummy_file(source) {
+            let located = result.ok()?;
+            let token = located.into_token();
+            if matches!(token, Token::EOF) {
+                break;
+            }
+            tokens.push(token);
+        }
+        Some(tokens)
+    }
+
+    match (collect(a), collect(b)) {
+        (Some(a), Some(b)) => a == b,
+        _ => false,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::{Config, assert_format, assert_format_with_config, assert_format_with_max_width};
@@ -2282,6 +2404,24 @@ global y = 1;
     }
 
     #[test]
+    fn format_unquote_in_regular_expression() {
+        // `$foo` and `$(expr)` parse as `ExpressionKind::Unquote` even outside of a
+        // `quote { }` block. The program may not type-check, but it's syntactically
+        // valid Noir, so the formatter must not panic.
+        let src = "fn main ( )  {
+    let x  =  $foo ;
+    let y  =  $( bar + 1 ) ;
+}
+";
+        let expected = "fn main() {
+    let x = $foo;
+    let y = $(bar + 1);
+}
+";
+        assert_format(src, expected);
+    }
+
+    #[test]
     fn format_quote_with_newlines() {
         let src = "fn foo() {
     quote {
@@ -2301,6 +2441,172 @@ global y = 1;
     fn format_quote_with_bracket_delimiter() {
         let src = "global x = quote [ 1  2  3 $four $(five) ];";
         let expected = "global x = quote [ 1  2  3 $four $(five) ];\n";
+        assert_format(src, expected);
+    }
+
+    #[test]
+    fn format_quote_with_parseable_function_body() {
+        let src = "pub comptime fn outside() -> Quoted {
+    quote {
+        fn body() -> Field {
+let     x   =    1   +    2 ;
+            x
+        }
+    }
+}
+";
+        let expected = "pub comptime fn outside() -> Quoted {
+    quote {
+        fn body() -> Field {
+            let x = 1 + 2;
+            x
+        }
+    }
+}
+";
+        assert_format(src, expected);
+    }
+
+    #[test]
+    fn format_quote_with_multiple_parseable_items() {
+        let src = "pub comptime fn outside() -> Quoted {
+    quote {
+        fn foo (   ) ->Field{1}
+        fn bar(   )->Field{2}
+    }
+}
+";
+        let expected = "pub comptime fn outside() -> Quoted {
+    quote {
+        fn foo() -> Field {
+            1
+        }
+        fn bar() -> Field {
+            2
+        }
+    }
+}
+";
+        assert_format(src, expected);
+    }
+
+    #[test]
+    fn format_quote_with_dollar_paren_in_path_does_not_panic() {
+        // After consuming `::` the path parser only has one token of lookahead, so in
+        // quote-body mode it optimistically commits when the next token is `$`. If
+        // what follows is `$(...)` (not a `$ident` placeholder) the path parser must
+        // bail out gracefully instead of panicking.
+        let src = "global x = quote { foo::$(bar) };\n";
+        let expected = src;
+        assert_format(src, expected);
+    }
+
+    #[test]
+    fn format_quote_falls_back_when_unparseable() {
+        // The body `foo bar` isn't a valid Noir item sequence so the formatter must
+        // leave it verbatim.
+        let src = "global x = quote { foo  bar };\n";
+        let expected = src;
+        assert_format(src, expected);
+    }
+
+    #[test]
+    fn format_quote_with_dollar_placeholder_in_identifier_position() {
+        // `$name` appears where a function name is expected. The formatter's parser
+        // accepts `$ident` as an identifier when reading a quote body so we can still
+        // format it.
+        let src = "pub comptime fn outside() -> Quoted {
+    quote {
+        fn $name() ->Field{
+            $value
+        }
+    }
+}
+";
+        let expected = "pub comptime fn outside() -> Quoted {
+    quote {
+        fn $name() -> Field {
+            $value
+        }
+    }
+}
+";
+        assert_format(src, expected);
+    }
+
+    #[test]
+    fn format_quote_with_expression_body() {
+        let src = "global x = quote { foo   +   bar };\n";
+        let expected = "global x = quote { foo + bar };\n";
+        assert_format(src, expected);
+    }
+
+    #[test]
+    fn format_quote_with_statement_body() {
+        let src = "global x = quote { let  y   =    1 ;  };\n";
+        let expected = "global x = quote { let y = 1; };\n";
+        assert_format(src, expected);
+    }
+
+    #[test]
+    fn format_quote_keeps_short_parseable_body_on_one_line() {
+        // A short body that fits on a single line should not be split across multiple
+        // lines just because the formatter understands it.
+        let src = "comptime fn foo() -> Quoted {
+    quote { use $t; }
+}
+";
+        let expected = src;
+        assert_format(src, expected);
+    }
+
+    #[test]
+    fn format_quote_with_dollar_placeholder_in_struct() {
+        let src = "pub comptime fn outside() -> Quoted {
+    quote {
+        struct Foo<$t>{
+            x : $t ,
+        }
+    }
+}
+";
+        let expected = "pub comptime fn outside() -> Quoted {
+    quote {
+        struct Foo<$t> {
+            x: $t,
+        }
+    }
+}
+";
+        assert_format(src, expected);
+    }
+
+    #[test]
+    fn format_quote_preserves_blank_lines_between_items() {
+        let src = "pub comptime fn outside() -> Quoted {
+    quote {
+        fn foo() {}
+
+        fn bar() {}
+    }
+}
+";
+        let expected = src;
+        assert_format(src, expected);
+    }
+
+    #[test]
+    fn format_quote_with_inner_comment() {
+        let src = "pub comptime fn outside() -> Quoted {
+    quote {
+        // a comment
+        fn body() -> Field {
+            1
+        }
+    }
+}
+";
+        let expected = src;
         assert_format(src, expected);
     }
 

--- a/tooling/nargo_fmt/src/formatter/expression.rs
+++ b/tooling/nargo_fmt/src/formatter/expression.rs
@@ -369,7 +369,12 @@ impl ChunkFormatter<'_, '_> {
 
         let mut group = ChunkGroup::new();
         if let Some(formatted_body) = formatted_body {
-            let single_line_body = !formatted_body.contains('\n');
+            // Stay on one line only if the author wrote it on one line *and* the
+            // formatted content fits on one line. If the source spans multiple lines
+            // we preserve that shape — `quote { fn foo() {} }` and the version
+            // written across three lines are both valid, and we shouldn't flip
+            // between them.
+            let single_line_body = !body_source.contains('\n') && !formatted_body.contains('\n');
             group.force_multiple_lines = !single_line_body;
             group.text(self.chunk(|formatter| {
                 formatter.write("quote");
@@ -2545,6 +2550,20 @@ let     x   =    1   +    2 ;
     fn format_quote_with_statement_body() {
         let src = "global x = quote { let  y   =    1 ;  };\n";
         let expected = "global x = quote { let y = 1; };\n";
+        assert_format(src, expected);
+    }
+
+    #[test]
+    fn format_quote_keeps_multi_line_body_multi_line() {
+        // The author wrote the body across multiple lines; even though the formatted
+        // content fits on a single line, we keep the multi-line shape.
+        let src = "comptime fn outside() -> Quoted {
+    quote {
+        fn foo() {}
+    }
+}
+";
+        let expected = src;
         assert_format(src, expected);
     }
 

--- a/tooling/nargo_fmt/src/lib.rs
+++ b/tooling/nargo_fmt/src/lib.rs
@@ -39,12 +39,27 @@ mod formatter;
 
 use formatter::Formatter;
 use noirc_frontend::ParsedModule;
+use noirc_frontend::ast::{Expression, Statement};
 
 pub use config::{Config, ImportsGranularity};
 
 pub fn format(source: &str, parsed_module: ParsedModule, config: &Config) -> String {
     let mut formatter = Formatter::new(source, config);
     formatter.format_program(parsed_module);
+    formatter.buffer.contents()
+}
+
+/// Formats a single Noir statement given its source and parsed form.
+pub fn format_statement(source: &str, statement: Statement, config: &Config) -> String {
+    let mut formatter = Formatter::new(source, config);
+    formatter.format_single_statement(statement);
+    formatter.buffer.contents()
+}
+
+/// Formats a single Noir expression given its source and parsed form.
+pub fn format_expression(source: &str, expression: Expression, config: &Config) -> String {
+    let mut formatter = Formatter::new(source, config);
+    formatter.format_single_expression(expression);
     formatter.buffer.contents()
 }
 


### PR DESCRIPTION
## Problem Resolved

Resolves #12617

## Summary of Changes

In addition to what was requested in #12617, I also wanted the formatter to be able to format quote blocks that have interpolations in them. For that, it occurred to me that we could try to parse the quote body in a "special" way: when an identifier is expected, if `$...` comes then we can treat that as an identifier. Then we simply format it as an identifier. And that worked!

Here some stdlib code is also reformatted because of this change.

Important notes:
- the formatter relies on how the user wrote a `quote` block. For example if they wrote it in a single line (`quote { foo }`), and it can be formatted in a single line, it will remain in a single line (if the formatted version needs multiple lines, it will be split into multiple lines). Similarly, if the user used multiple lines, the formatter won't change it to a single line if that's possible. This might be the only case so far where the formatter decides how to format something based on how the user wrote something, but here it might be fine because some `quote` blocks are intended to be small and it would be a bit harder to read if they were all turned into multiple lines.
- relatedly, now the formatter always insert spaces around the quote delimiters, so if you write `quote{foo}` it will be changed to `quote { foo }`. I guess here we could also try to honor what the user wrote, but on the other hand a unified style here might be better.

Let me know if you think we should change any of the above assumptions.

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
