### PR TITLE
chore: additional test program for vector_pop_front ref count

### DIFF
--- a/test_programs/execution_success/vector_pop_front_aliased_source/Nargo.toml
+++ b/test_programs/execution_success/vector_pop_front_aliased_source/Nargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "vector_pop_front_aliased_source"
+type = "bin"
+authors = [""]
+
+[dependencies]

--- a/test_programs/execution_success/vector_pop_front_aliased_source/src/main.nr
+++ b/test_programs/execution_success/vector_pop_front_aliased_source/src/main.nr
@@ -1,0 +1,21 @@
+// 'Regression' for fuzzer issue in https://github.com/noir-lang/noir/issues/11440
+// The issue is that the fuzzer generated some SSA with a missing RC increment.
+// A minimal repro is:
+// brillig(inline) impure fn main f0 {
+//   b0():
+//     v0 = make_array [Field 42, Field 43, Field 44] : [Field]
+//     v1, v2, v3 = call vector_pop_front(u32 3, v0) -> (Field, u32, [Field])
+//     v4 = make_array b"{\"kind\":\"vector\",\"type\":{\"kind\":\"field\"}}"
+//     call print(u1 1, u32 3, v0, v4, u1 0)
+//     return
+// }
+// This test ensures that the RC is properly added by the frontend
+// when a vector is kept alive after a discarded `vector_pop_front`.
+unconstrained fn main() {
+    foo(@[42, 43, 44]);
+}
+
+unconstrained fn foo(mut v: [Field]) {
+    let _ = v.pop_front();
+    println(v);
+}

--- a/tooling/nargo_cli/tests/snapshots/execution_success/vector_pop_front_aliased_source/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/vector_pop_front_aliased_source/execute__tests__expanded.snap
@@ -1,0 +1,12 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: expanded_code
+---
+unconstrained fn main() {
+    foo(@[42_Field, 43_Field, 44_Field]);
+}
+
+unconstrained fn foo(mut v: [Field]) {
+    let _: (Field, [Field]) = v.pop_front();
+    println(v);
+}

--- a/tooling/nargo_cli/tests/snapshots/execution_success/vector_pop_front_aliased_source/execute__tests__stdout.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/vector_pop_front_aliased_source/execute__tests__stdout.snap
@@ -1,0 +1,5 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: stdout
+---
+@[0x2a, 0x2b, 0x2c]


### PR DESCRIPTION
## Problem Resolved

Related to #11440 

## Summary of Changes
The fuzzer issue is a program that makes a 'discarded' vector pop but use the input vector in a later 'print()'.
Without a proper ref count, the vector is modified and print cannot print all the former elements.
The original issue was fixed some time ago, so I simply add a test to ensure this case is properly handled.


## User Documentation

Check one:
- [X] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
