### PR TITLE
feat: preserve global identifiers in #[abi] contract artifact output

### DIFF
--- a/compiler/noirc_driver/src/lib.rs
+++ b/compiler/noirc_driver/src/lib.rs
@@ -12,7 +12,7 @@ use acvm::acir::circuit::{ErrorSelector, Program, display_program};
 use clap::Args;
 use fm::{FileId, FileManager};
 use iter_extended::vecmap;
-use noirc_abi::{AbiErrorType, AbiParameter, AbiType, AbiValue};
+use noirc_abi::{AbiErrorType, AbiNamedValue, AbiParameter, AbiType};
 use noirc_artifacts::contract::{CompiledContract, CompiledContractOutputs, ContractFunction};
 use noirc_artifacts::debug::{DebugFile, DebugInfo, FunctionLocation};
 use noirc_artifacts::program::CompiledProgram;
@@ -848,14 +848,17 @@ fn compile_contract_inner(
             .globals
             .iter()
             .map(|(tag, globals)| {
-                let globals: Vec<AbiValue> = globals
+                let globals: Vec<AbiNamedValue> = globals
                     .iter()
                     .map(|global_id| {
+                        let global_info = context.def_interner.get_global(*global_id);
+                        let name = global_info.ident.to_string();
                         let let_statement =
                             context.def_interner.get_global_let_statement(*global_id).unwrap();
                         let hir_expression =
                             context.def_interner.expression(&let_statement.expression);
-                        value_from_hir_expression(context, hir_expression)
+                        let value = value_from_hir_expression(context, hir_expression);
+                        AbiNamedValue { name, value }
                     })
                     .collect();
                 (tag.clone(), globals)

--- a/compiler/noirc_driver/tests/contracts.rs
+++ b/compiler/noirc_driver/tests/contracts.rs
@@ -97,7 +97,8 @@ contract Foo {
     // Check global output
     let foo_globals = contract.outputs.globals.get("foo").expect("expected 'foo' tag in globals");
     assert_eq!(foo_globals.len(), 1);
-    match &foo_globals[0] {
+    assert_eq!(foo_globals[0].name, "my_global");
+    match &foo_globals[0].value {
         AbiValue::Integer { value, sign } => {
             assert!(!sign, "expected positive integer");
             assert_eq!(value, "000000000000000000000000000000000000000000000000000000000000002a");
@@ -150,4 +151,52 @@ contract Foo {
 
     assert!(found_a, "struct A not found in 'things' tag");
     assert!(found_b, "struct B not found in 'things' tag");
+}
+
+#[test]
+fn abi_tag_preserves_global_names_under_same_tag() {
+    let source = "
+contract Foo {
+    #[abi(constants)]
+    pub global PURPOSE_AUTHORIZE: str<27> = \"Authorize Aztec Transaction\";
+
+    #[abi(constants)]
+    pub global FEE_AMOUNT: Field = 100;
+
+    #[abi(error_codes)]
+    pub global ERR_NOT_FOUND: Field = 1;
+
+    #[abi(error_codes)]
+    pub global ERR_FORBIDDEN: Field = 2;
+}";
+
+    let contract = compile_contract_source(source);
+
+    let constants =
+        contract.outputs.globals.get("constants").expect("expected 'constants' tag in globals");
+    assert_eq!(constants.len(), 2);
+
+    let purpose = constants
+        .iter()
+        .find(|g| g.name == "PURPOSE_AUTHORIZE")
+        .expect("PURPOSE_AUTHORIZE not found");
+    match &purpose.value {
+        AbiValue::String { value } => assert_eq!(value, "Authorize Aztec Transaction"),
+        other => panic!("expected AbiValue::String for PURPOSE_AUTHORIZE, got: {other:?}"),
+    }
+
+    let fee = constants.iter().find(|g| g.name == "FEE_AMOUNT").expect("FEE_AMOUNT not found");
+    match &fee.value {
+        AbiValue::Integer { value, sign } => {
+            assert!(!sign);
+            assert_eq!(value, "0000000000000000000000000000000000000000000000000000000000000064");
+        }
+        other => panic!("expected AbiValue::Integer for FEE_AMOUNT, got: {other:?}"),
+    }
+
+    let error_codes =
+        contract.outputs.globals.get("error_codes").expect("expected 'error_codes' tag in globals");
+    assert_eq!(error_codes.len(), 2);
+    assert!(error_codes.iter().any(|g| g.name == "ERR_NOT_FOUND"));
+    assert!(error_codes.iter().any(|g| g.name == "ERR_FORBIDDEN"));
 }

--- a/tooling/noirc_abi/src/lib.rs
+++ b/tooling/noirc_abi/src/lib.rs
@@ -456,6 +456,12 @@ pub enum AbiValue {
     },
 }
 
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AbiNamedValue {
+    pub name: String,
+    pub value: AbiValue,
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Hash)]
 #[serde(tag = "error_kind", rename_all = "lowercase")]
 pub enum AbiErrorType {

--- a/tooling/noirc_artifacts/src/contract.rs
+++ b/tooling/noirc_artifacts/src/contract.rs
@@ -1,5 +1,5 @@
 use acvm::{FieldElement, acir::circuit::Program};
-use noirc_abi::{Abi, AbiType, AbiValue};
+use noirc_abi::{Abi, AbiNamedValue, AbiType};
 use serde::{Deserialize, Serialize};
 
 use std::collections::{BTreeMap, HashMap};
@@ -17,7 +17,7 @@ use super::{deserialize_hash, serialize_hash};
 #[derive(Clone, Serialize, Deserialize, Debug)]
 pub struct ContractOutputsArtifact {
     pub structs: HashMap<String, Vec<AbiType>>,
-    pub globals: HashMap<String, Vec<AbiValue>>,
+    pub globals: HashMap<String, Vec<AbiNamedValue>>,
 }
 
 impl From<CompiledContractOutputs> for ContractOutputsArtifact {
@@ -127,7 +127,7 @@ impl From<ContractFunction> for ContractFunctionArtifact {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct CompiledContractOutputs {
     pub structs: HashMap<String, Vec<AbiType>>,
-    pub globals: HashMap<String, Vec<AbiValue>>,
+    pub globals: HashMap<String, Vec<AbiNamedValue>>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]


### PR DESCRIPTION
## Problem Resolved

Resolves https://github.com/noir-lang/noir/issues/12620

## Summary of Changes



## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
