### PR TITLE
chore(frontend): Handle all types in `type_complexity`

### DIFF
--- a/compiler/noirc_frontend/src/monomorphization/mod.rs
+++ b/compiler/noirc_frontend/src/monomorphization/mod.rs
@@ -1624,9 +1624,20 @@ impl<'interner> Monomorphizer<'interner> {
                 acc = Self::type_complexity_inner(elem_typ, acc);
                 Self::type_complexity_inner(len, acc)
             }
-            HirType::DataType(_def, generics) => {
+            HirType::DataType(def, generics) => {
                 for generic in generics {
                     acc = Self::type_complexity_inner(generic, acc);
+                }
+                if let Some(fields) = def.borrow().get_fields(generics) {
+                    for (_, field, _) in fields {
+                        acc = Self::type_complexity_inner(&field, acc);
+                    }
+                } else if let Some(variants) = def.borrow().get_variants(generics) {
+                    for (_, fields) in variants {
+                        for field in fields {
+                            acc = Self::type_complexity_inner(&field, acc);
+                        }
+                    }
                 }
                 acc
             }
@@ -1638,7 +1649,9 @@ impl<'interner> Monomorphizer<'interner> {
                 Self::type_complexity_inner(env, acc)
             }
             HirType::Reference(inner, _) => Self::type_complexity_inner(inner, acc),
-            HirType::Alias(_, generics) => {
+            HirType::Alias(alias, generics) => {
+                let typ = alias.borrow().get_type(generics);
+                acc = Self::type_complexity_inner(&typ, acc);
                 for generic in generics {
                     acc = Self::type_complexity_inner(generic, acc);
                 }

--- a/compiler/noirc_frontend/src/monomorphization/mod.rs
+++ b/compiler/noirc_frontend/src/monomorphization/mod.rs
@@ -1620,7 +1620,10 @@ impl<'interner> Monomorphizer<'interner> {
                 }
                 acc
             }
-            HirType::Array(elem_typ, _len) => Self::type_complexity_inner(elem_typ, acc),
+            HirType::Array(elem_typ, len) => {
+                acc = Self::type_complexity_inner(elem_typ, acc);
+                Self::type_complexity_inner(len, acc)
+            }
             HirType::DataType(_def, generics) => {
                 for generic in generics {
                     acc = Self::type_complexity_inner(generic, acc);

--- a/compiler/noirc_frontend/src/monomorphization/mod.rs
+++ b/compiler/noirc_frontend/src/monomorphization/mod.rs
@@ -1696,6 +1696,7 @@ impl<'interner> Monomorphizer<'interner> {
         typ: &HirType,
         location: Location,
     ) -> Result<ast::Type, MonomorphizationError> {
+        Self::error_on_complex_type(typ, &location)?;
         Self::convert_type_helper(typ, location, &mut HashSet::default())
     }
 
@@ -1713,8 +1714,6 @@ impl<'interner> Monomorphizer<'interner> {
         location: Location,
         seen_types: &mut HashSet<Type>,
     ) -> Result<ast::Type, MonomorphizationError> {
-        Self::error_on_complex_type(typ, &location)?;
-
         let typ = typ.follow_bindings_shallow();
         Ok(match typ.as_ref() {
             HirType::FieldElement => ast::Type::Field,

--- a/compiler/noirc_frontend/src/monomorphization/mod.rs
+++ b/compiler/noirc_frontend/src/monomorphization/mod.rs
@@ -52,6 +52,7 @@ use crate::ast::{FunctionKind, ItemVisibility, UnaryOp};
 use crate::hir::comptime::InterpreterError;
 use crate::hir::type_check::NoMatchingImplFoundError;
 use crate::node_interner::{ExprId, GlobalValue, ImplSearchErrorKind, TraitItemId};
+use crate::recursion::TypeRecursionContext;
 use crate::shared::{ForeignCall, Visibility};
 use crate::token::FunctionAttributeKind;
 use crate::{
@@ -1591,7 +1592,7 @@ impl<'interner> Monomorphizer<'interner> {
         typ: &HirType,
         location: &Location,
     ) -> Result<(), MonomorphizationError> {
-        let complexity = Self::type_complexity(typ, 0);
+        let complexity = Self::type_complexity(typ);
         if complexity > MAX_TYPE_COMPLEXITY {
             return Err(MonomorphizationError::ComplexType {
                 complexity,
@@ -1602,80 +1603,92 @@ impl<'interner> Monomorphizer<'interner> {
         Ok(())
     }
 
-    fn types_complexity<I, T>(types: I, acc: usize) -> usize
-    where
-        I: IntoIterator<Item = T>,
-        T: std::borrow::Borrow<HirType>,
-    {
-        types.into_iter().fold(acc, |acc, t| Self::type_complexity(t.borrow(), acc))
-    }
-
-    fn type_complexity(typ: &HirType, mut acc: usize) -> usize {
-        // Every type increases it by one, even if seen already.
-        acc += 1;
-
-        // Early return if acc complexity exceeds the limit,
-        // this avoids stack overflow due to the recursive nature of this computation
-        if acc > MAX_TYPE_COMPLEXITY {
-            return acc;
+    /// Estimate the complexity of a type by counting all the types in it (with repetition).
+    fn type_complexity(typ: &Type) -> usize {
+        fn go_fold<I, T>(types: I, acc: usize, ctx: TypeRecursionContext) -> usize
+        where
+            I: IntoIterator<Item = T>,
+            T: std::borrow::Borrow<HirType>,
+        {
+            types.into_iter().fold(acc, |acc, t| go(t.borrow(), acc, ctx.clone()))
         }
 
-        let typ = typ.follow_bindings_shallow();
-        match typ.as_ref() {
-            HirType::Tuple(fields) => Self::types_complexity(fields, acc),
-            HirType::Array(elem_typ, len) => {
-                Self::types_complexity([elem_typ.as_ref(), len.as_ref()], acc)
+        fn go(typ: &HirType, mut acc: usize, mut ctx: TypeRecursionContext) -> usize {
+            // Every type increases it by one, even if seen already.
+            acc += 1;
+
+            // Early return if acc complexity exceeds the limit,
+            // this avoids stack overflow due to the recursive nature of this computation
+            if acc > MAX_TYPE_COMPLEXITY {
+                return acc;
             }
-            HirType::Vector(elem_typ) => Self::type_complexity(elem_typ, acc),
-            HirType::DataType(def, generics) => {
-                if let Some(fields) = def.borrow().get_fields(generics) {
-                    let types = fields.iter().map(|(_, typ, _)| typ);
-                    acc = Self::types_complexity(types, acc);
-                } else if let Some(variants) = def.borrow().get_variants(generics) {
-                    let types = variants.iter().flat_map(|(_, fields)| fields);
-                    acc = Self::types_complexity(types, acc);
+
+            // This will prevent a stack overflow on overly deep and skinny types,
+            // where we might be well below the MAX_TYPE_COMPLEXITY.
+            ctx = ctx.recur();
+
+            let typ = typ.follow_bindings_shallow();
+            match typ.as_ref() {
+                HirType::Tuple(fields) => go_fold(fields, acc, ctx.recur()),
+                HirType::Array(elem_typ, len) => {
+                    go_fold([elem_typ.as_ref(), len.as_ref()], acc, ctx)
                 }
-                Self::types_complexity(generics, acc)
-            }
-            HirType::Function(args, ret, env, _) => {
-                let types = [ret.as_ref(), env.as_ref()].into_iter().chain(args);
-                Self::types_complexity(types, acc)
-            }
-            HirType::Reference(inner, _) => Self::type_complexity(inner, acc),
-            HirType::Alias(alias, generics) => {
-                let typ = alias.borrow().get_type(generics);
-                let types = std::iter::once(&typ).chain(generics);
-                Self::types_complexity(types, acc)
-            }
-            Type::String(len) => Self::type_complexity(len, acc),
-            Type::FmtString(len, args) => {
-                Self::types_complexity([len.as_ref(), args.as_ref()], acc)
-            }
+                HirType::Vector(elem_typ) => go(elem_typ, acc, ctx),
+                HirType::DataType(def, generics) => {
+                    // We count every type multiple times in the complexity, but if we are dealing
+                    // with a recursive type, we have more specific errors than the inevitable max
+                    // complexity we will hit.
+                    if !ctx.insert_data_type(def.borrow().id, generics.clone()) {
+                        return acc;
+                    }
+                    if let Some(fields) = def.borrow().get_fields(generics) {
+                        let types = fields.iter().map(|(_, typ, _)| typ);
+                        acc = go_fold(types, acc, ctx.clone());
+                    } else if let Some(variants) = def.borrow().get_variants(generics) {
+                        let types = variants.iter().flat_map(|(_, fields)| fields);
+                        acc = go_fold(types, acc, ctx.clone());
+                    }
+                    go_fold(generics, acc, ctx)
+                }
+                HirType::Function(args, ret, env, _) => {
+                    let types = [ret.as_ref(), env.as_ref()].into_iter().chain(args);
+                    go_fold(types, acc, ctx)
+                }
+                HirType::Reference(inner, _) => go(inner, acc, ctx),
+                HirType::Alias(alias, generics) => {
+                    if !ctx.insert_alias(alias.borrow().id, generics.clone()) {
+                        return acc;
+                    }
+                    let typ = alias.borrow().get_type(generics);
+                    let types = std::iter::once(&typ).chain(generics);
+                    go_fold(types, acc, ctx)
+                }
+                Type::String(len) => go(len, acc, ctx),
+                Type::FmtString(len, args) => go_fold([len.as_ref(), args.as_ref()], acc, ctx),
 
-            Type::TraitAsType(_, _, trait_generics) => {
-                let generics = trait_generics
-                    .ordered
-                    .iter()
-                    .chain(trait_generics.named.iter().map(|n| &n.typ));
-                Self::types_complexity(generics, acc)
+                Type::TraitAsType(_, _, trait_generics) => {
+                    let generics = trait_generics
+                        .ordered
+                        .iter()
+                        .chain(trait_generics.named.iter().map(|n| &n.typ));
+                    go_fold(generics, acc, ctx)
+                }
+                Type::CheckedCast { from, to } => go_fold([from.as_ref(), to.as_ref()], acc, ctx),
+                Type::Forall(_, typ) => go(typ, acc, ctx),
+                Type::InfixExpr(lhs, _, rhs, _) => go_fold([lhs.as_ref(), rhs.as_ref()], acc, ctx),
+                Type::Constant(..)
+                | Type::Quoted(..)
+                | Type::TypeVariable(..)
+                | Type::NamedGeneric(..)
+                | Type::Unit
+                | Type::FieldElement
+                | Type::Integer(..)
+                | Type::Bool
+                | Type::Error => acc,
             }
-            Type::CheckedCast { from, to } => {
-                Self::types_complexity([from.as_ref(), to.as_ref()], acc)
-            }
-            Type::Forall(_, typ) => Self::type_complexity(typ, acc),
-            Type::InfixExpr(lhs, _, rhs, _) => {
-                Self::types_complexity([lhs.as_ref(), rhs.as_ref()], acc)
-            }
-            Type::Constant(..)
-            | Type::Quoted(..)
-            | Type::TypeVariable(..)
-            | Type::NamedGeneric(..)
-            | Type::Unit
-            | Type::FieldElement
-            | Type::Integer(..)
-            | Type::Bool
-            | Type::Error => acc,
         }
+
+        go(typ, 0, TypeRecursionContext::default())
     }
 
     /// Convert a non-tuple/struct type to a monomorphized type

--- a/compiler/noirc_frontend/src/monomorphization/mod.rs
+++ b/compiler/noirc_frontend/src/monomorphization/mod.rs
@@ -1591,7 +1591,7 @@ impl<'interner> Monomorphizer<'interner> {
         typ: &HirType,
         location: &Location,
     ) -> Result<(), MonomorphizationError> {
-        let complexity = Self::type_complexity_inner(typ, 0);
+        let complexity = Self::type_complexity(typ, 0);
         if complexity > MAX_TYPE_COMPLEXITY {
             return Err(MonomorphizationError::ComplexType {
                 complexity,
@@ -1602,63 +1602,79 @@ impl<'interner> Monomorphizer<'interner> {
         Ok(())
     }
 
-    fn type_complexity_inner(typ: &HirType, mut acc: usize) -> usize {
-        // Early return if acc complexity exceeds the limit,
-        // this avoids stack overflow due to the recursive nature of this computation
-        if acc > MAX_TYPE_COMPLEXITY {
-            return acc + 1;
-        }
+    fn types_complexity<I, T>(types: I, acc: usize) -> usize
+    where
+        I: IntoIterator<Item = T>,
+        T: std::borrow::Borrow<HirType>,
+    {
+        types.into_iter().fold(acc, |acc, t| Self::type_complexity(t.borrow(), acc))
+    }
 
+    fn type_complexity(typ: &HirType, mut acc: usize) -> usize {
         // Every type increases it by one, even if seen already.
         acc += 1;
 
+        // Early return if acc complexity exceeds the limit,
+        // this avoids stack overflow due to the recursive nature of this computation
+        if acc > MAX_TYPE_COMPLEXITY {
+            return acc;
+        }
+
         let typ = typ.follow_bindings_shallow();
         match typ.as_ref() {
-            HirType::Tuple(fields) => {
-                for field in fields {
-                    acc = Self::type_complexity_inner(field, acc);
-                }
-                acc
-            }
+            HirType::Tuple(fields) => Self::types_complexity(fields, acc),
             HirType::Array(elem_typ, len) => {
-                acc = Self::type_complexity_inner(elem_typ, acc);
-                Self::type_complexity_inner(len, acc)
+                Self::types_complexity([elem_typ.as_ref(), len.as_ref()], acc)
             }
+            HirType::Vector(elem_typ) => Self::type_complexity(elem_typ, acc),
             HirType::DataType(def, generics) => {
-                for generic in generics {
-                    acc = Self::type_complexity_inner(generic, acc);
-                }
                 if let Some(fields) = def.borrow().get_fields(generics) {
-                    for (_, field, _) in fields {
-                        acc = Self::type_complexity_inner(&field, acc);
-                    }
+                    let types = fields.iter().map(|(_, typ, _)| typ);
+                    acc = Self::types_complexity(types, acc);
                 } else if let Some(variants) = def.borrow().get_variants(generics) {
-                    for (_, fields) in variants {
-                        for field in fields {
-                            acc = Self::type_complexity_inner(&field, acc);
-                        }
-                    }
+                    let types = variants.iter().flat_map(|(_, fields)| fields);
+                    acc = Self::types_complexity(types, acc);
                 }
-                acc
+                Self::types_complexity(generics, acc)
             }
             HirType::Function(args, ret, env, _) => {
-                for arg in args {
-                    acc = Self::type_complexity_inner(arg, acc);
-                }
-                acc = Self::type_complexity_inner(ret, acc);
-                Self::type_complexity_inner(env, acc)
+                let types = [ret.as_ref(), env.as_ref()].into_iter().chain(args);
+                Self::types_complexity(types, acc)
             }
-            HirType::Reference(inner, _) => Self::type_complexity_inner(inner, acc),
+            HirType::Reference(inner, _) => Self::type_complexity(inner, acc),
             HirType::Alias(alias, generics) => {
                 let typ = alias.borrow().get_type(generics);
-                acc = Self::type_complexity_inner(&typ, acc);
-                for generic in generics {
-                    acc = Self::type_complexity_inner(generic, acc);
-                }
-                acc
+                let types = std::iter::once(&typ).chain(generics);
+                Self::types_complexity(types, acc)
             }
-            // Simple types
-            _ => acc,
+            Type::String(len) => Self::type_complexity(len, acc),
+            Type::FmtString(len, args) => {
+                Self::types_complexity([len.as_ref(), args.as_ref()], acc)
+            }
+
+            Type::TraitAsType(_, _, trait_generics) => {
+                let generics = trait_generics
+                    .ordered
+                    .iter()
+                    .chain(trait_generics.named.iter().map(|n| &n.typ));
+                Self::types_complexity(generics, acc)
+            }
+            Type::CheckedCast { from, to } => {
+                Self::types_complexity([from.as_ref(), to.as_ref()], acc)
+            }
+            Type::Forall(_, typ) => Self::type_complexity(typ, acc),
+            Type::InfixExpr(lhs, _, rhs, _) => {
+                Self::types_complexity([lhs.as_ref(), rhs.as_ref()], acc)
+            }
+            Type::Constant(..)
+            | Type::Quoted(..)
+            | Type::TypeVariable(..)
+            | Type::NamedGeneric(..)
+            | Type::Unit
+            | Type::FieldElement
+            | Type::Integer(..)
+            | Type::Bool
+            | Type::Error => acc,
         }
     }
 

--- a/compiler/noirc_frontend/src/monomorphization/mod.rs
+++ b/compiler/noirc_frontend/src/monomorphization/mod.rs
@@ -1629,7 +1629,7 @@ impl<'interner> Monomorphizer<'interner> {
 
             let typ = typ.follow_bindings_shallow();
             match typ.as_ref() {
-                HirType::Tuple(fields) => go_fold(fields, acc, ctx.recur()),
+                HirType::Tuple(fields) => go_fold(fields, acc, ctx),
                 HirType::Array(elem_typ, len) => {
                     go_fold([elem_typ.as_ref(), len.as_ref()], acc, ctx)
                 }

--- a/compiler/noirc_frontend/src/monomorphization/mod.rs
+++ b/compiler/noirc_frontend/src/monomorphization/mod.rs
@@ -1586,7 +1586,7 @@ impl<'interner> Monomorphizer<'interner> {
     /// This is roughly the number of "nodes" in the type tree.
     ///
     /// To prevent stack overflow on deeply nested types, we stop recursion when
-    /// accumulated complexity exceeds MAX_TYPE_COMPLEXITY.
+    /// accumulated complexity exceeds [MAX_TYPE_COMPLEXITY].
     fn error_on_complex_type(
         typ: &HirType,
         location: &Location,
@@ -1602,50 +1602,47 @@ impl<'interner> Monomorphizer<'interner> {
         Ok(())
     }
 
-    fn type_complexity_inner(typ: &HirType, accumulated: usize) -> usize {
+    fn type_complexity_inner(typ: &HirType, mut accumulated: usize) -> usize {
         // Early return if accumulated complexity exceeds the limit,
         // this avoids stack overflow due to the recursive nature of this computation
         if accumulated > MAX_TYPE_COMPLEXITY {
             return accumulated + 1;
         }
 
+        // Every type increases it by one, even if seen already.
+        accumulated += 1;
+
         let typ = typ.follow_bindings_shallow();
         match typ.as_ref() {
             HirType::Tuple(fields) => {
-                let mut complexity = accumulated + 1;
                 for field in fields {
-                    complexity = Self::type_complexity_inner(field, complexity);
+                    accumulated = Self::type_complexity_inner(field, accumulated);
                 }
-                complexity
+                accumulated
             }
-            HirType::Array(elem_typ, _len) => {
-                Self::type_complexity_inner(elem_typ, accumulated + 1)
-            }
+            HirType::Array(elem_typ, _len) => Self::type_complexity_inner(elem_typ, accumulated),
             HirType::DataType(_def, generics) => {
-                let mut complexity = accumulated + 1;
                 for generic in generics {
-                    complexity = Self::type_complexity_inner(generic, complexity);
+                    accumulated = Self::type_complexity_inner(generic, accumulated);
                 }
-                complexity
+                accumulated
             }
             HirType::Function(args, ret, env, _) => {
-                let mut complexity = accumulated + 1;
                 for arg in args {
-                    complexity = Self::type_complexity_inner(arg, complexity);
+                    accumulated = Self::type_complexity_inner(arg, accumulated);
                 }
-                complexity = Self::type_complexity_inner(ret, complexity);
-                Self::type_complexity_inner(env, complexity)
+                accumulated = Self::type_complexity_inner(ret, accumulated);
+                Self::type_complexity_inner(env, accumulated)
             }
-            HirType::Reference(inner, _) => Self::type_complexity_inner(inner, accumulated + 1),
+            HirType::Reference(inner, _) => Self::type_complexity_inner(inner, accumulated),
             HirType::Alias(_, generics) => {
-                let mut complexity = accumulated + 1;
                 for generic in generics {
-                    complexity = Self::type_complexity_inner(generic, complexity);
+                    accumulated = Self::type_complexity_inner(generic, accumulated);
                 }
-                complexity
+                accumulated
             }
             // Simple types
-            _ => accumulated + 1,
+            _ => accumulated,
         }
     }
 

--- a/compiler/noirc_frontend/src/monomorphization/mod.rs
+++ b/compiler/noirc_frontend/src/monomorphization/mod.rs
@@ -1602,47 +1602,47 @@ impl<'interner> Monomorphizer<'interner> {
         Ok(())
     }
 
-    fn type_complexity_inner(typ: &HirType, mut accumulated: usize) -> usize {
-        // Early return if accumulated complexity exceeds the limit,
+    fn type_complexity_inner(typ: &HirType, mut acc: usize) -> usize {
+        // Early return if acc complexity exceeds the limit,
         // this avoids stack overflow due to the recursive nature of this computation
-        if accumulated > MAX_TYPE_COMPLEXITY {
-            return accumulated + 1;
+        if acc > MAX_TYPE_COMPLEXITY {
+            return acc + 1;
         }
 
         // Every type increases it by one, even if seen already.
-        accumulated += 1;
+        acc += 1;
 
         let typ = typ.follow_bindings_shallow();
         match typ.as_ref() {
             HirType::Tuple(fields) => {
                 for field in fields {
-                    accumulated = Self::type_complexity_inner(field, accumulated);
+                    acc = Self::type_complexity_inner(field, acc);
                 }
-                accumulated
+                acc
             }
-            HirType::Array(elem_typ, _len) => Self::type_complexity_inner(elem_typ, accumulated),
+            HirType::Array(elem_typ, _len) => Self::type_complexity_inner(elem_typ, acc),
             HirType::DataType(_def, generics) => {
                 for generic in generics {
-                    accumulated = Self::type_complexity_inner(generic, accumulated);
+                    acc = Self::type_complexity_inner(generic, acc);
                 }
-                accumulated
+                acc
             }
             HirType::Function(args, ret, env, _) => {
                 for arg in args {
-                    accumulated = Self::type_complexity_inner(arg, accumulated);
+                    acc = Self::type_complexity_inner(arg, acc);
                 }
-                accumulated = Self::type_complexity_inner(ret, accumulated);
-                Self::type_complexity_inner(env, accumulated)
+                acc = Self::type_complexity_inner(ret, acc);
+                Self::type_complexity_inner(env, acc)
             }
-            HirType::Reference(inner, _) => Self::type_complexity_inner(inner, accumulated),
+            HirType::Reference(inner, _) => Self::type_complexity_inner(inner, acc),
             HirType::Alias(_, generics) => {
                 for generic in generics {
-                    accumulated = Self::type_complexity_inner(generic, accumulated);
+                    acc = Self::type_complexity_inner(generic, acc);
                 }
-                accumulated
+                acc
             }
             // Simple types
-            _ => accumulated,
+            _ => acc,
         }
     }
 


### PR DESCRIPTION
## Problem Resolved

Resolves https://app.audithub.dev/app/organizations/161/projects/787/project-viewer?issueId=990&version=1681

## Summary of Changes

Changes `Monomorphizer::type_complexity` to handle more types:
* for example `HirType::Vector`, or the length type of `HirType::String`
* the fields and variants of `HirType::DataType` (analogous to how `HirType::Tuple` fields were accumulated)
* uses the `TypeRecursionContext` to handle infinitely recursive types

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
