### PR TITLE
fix: run mem2reg while it keeps making progress

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/opt/mem2reg.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/mem2reg.rs
@@ -54,6 +54,11 @@ impl Ssa {
 
 impl Function {
     pub(crate) fn mem2reg(&mut self) {
+        let cfg = ControlFlowGraph::with_function(self);
+        let post_order = PostOrder::with_cfg(&cfg);
+        let mut dom_tree = DominatorTree::with_cfg_and_post_order(&cfg, &post_order);
+        let blocks = post_order.into_vec_reverse();
+
         // Run mem2reg while we successfully removed at least one allocate instruction and there
         // are at least one more that couldn't be removed. In an SSA like this one:
         //
@@ -69,12 +74,7 @@ impl Function {
         // - now running it again will lead to optimizing out v0, etc.
         let mut keep_running = true;
         while keep_running {
-            let cfg = ControlFlowGraph::with_function(self);
-            let post_order = PostOrder::with_cfg(&cfg);
-            let mut dom_tree = DominatorTree::with_cfg_and_post_order(&cfg, &post_order);
             let mut inserter = FunctionInserter::new(self);
-
-            let blocks = post_order.into_vec_reverse();
 
             // `variables` and `def_sites` are both keyed by the original ValueId of the `allocate`
             // instruction result. These are iterated on in key order when adding block
@@ -119,7 +119,7 @@ impl Function {
                 &block_states,
                 &cfg,
             );
-            commit(&mut inserter, &variables, blocks);
+            commit(&mut inserter, &variables, &blocks);
 
             keep_running = has_ineligible_variables;
         }
@@ -515,9 +515,9 @@ fn collect_eligible_variables_and_def_sites(
 fn commit(
     inserter: &mut FunctionInserter,
     variables: &BTreeMap<ValueId, BasicBlockId>,
-    blocks: Vec<BasicBlockId>,
+    blocks: &[BasicBlockId],
 ) {
-    for block in blocks {
+    for &block in blocks {
         let mut instructions = inserter.function.dfg[block].take_instructions();
 
         // Remove any allocate, load, or store instructions for variables which were optimized out

--- a/compiler/noirc_evaluator/src/ssa/opt/mem2reg.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/mem2reg.rs
@@ -57,6 +57,7 @@ impl Function {
         let cfg = ControlFlowGraph::with_function(self);
         let post_order = PostOrder::with_cfg(&cfg);
         let mut dom_tree = DominatorTree::with_cfg_and_post_order(&cfg, &post_order);
+        let mut dom_frontiers = None;
         let blocks = post_order.into_vec_reverse();
 
         // Run mem2reg while we successfully removed at least one allocate instruction and there
@@ -91,8 +92,12 @@ impl Function {
             // A variable only needs a block parameter at blocks where values from different
             // control-flow paths could merge (its IDF). For variables stored in a single block,
             // this is typically empty — no block parameters needed at all.
-            let dom_frontiers = dom_tree.compute_dominance_frontiers_with_back_edges(&cfg);
-            let param_locations = compute_param_locations(&variables, &def_sites, &dom_frontiers);
+            if dom_frontiers.is_none() {
+                dom_frontiers = Some(dom_tree.compute_dominance_frontiers_with_back_edges(&cfg));
+            }
+
+            let param_locations =
+                compute_param_locations(&variables, &def_sites, dom_frontiers.as_ref().unwrap());
 
             // Precompute which variables are visible at each block by walking the dominator tree.
             // A variable declared in block D is visible at block B iff D dominates B.

--- a/compiler/noirc_evaluator/src/ssa/opt/mem2reg.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/mem2reg.rs
@@ -54,57 +54,71 @@ impl Ssa {
 
 impl Function {
     pub(crate) fn mem2reg(&mut self) {
-        let cfg = ControlFlowGraph::with_function(self);
-        let post_order = PostOrder::with_cfg(&cfg);
-        let mut dom_tree = DominatorTree::with_cfg_and_post_order(&cfg, &post_order);
-        let mut inserter = FunctionInserter::new(self);
+        // Run mem2reg until we stop making progress. In an SSA like this one:
+        //
+        // ```
+        // v0 = allocate -> &mut u16
+        // store u16 1 at v0
+        // v2 = allocate -> &mut &mut u16
+        // store v0 at v2
+        // ```
+        //
+        // - v0 can't be optimized out because it's stored in v2
+        // - v2 can and will be optimized out
+        // - now running it again will lead to optimizing out v0, etc.
+        loop {
+            let cfg = ControlFlowGraph::with_function(self);
+            let post_order = PostOrder::with_cfg(&cfg);
+            let mut dom_tree = DominatorTree::with_cfg_and_post_order(&cfg, &post_order);
+            let mut inserter = FunctionInserter::new(self);
 
-        let blocks = post_order.into_vec_reverse();
+            let blocks = post_order.into_vec_reverse();
 
-        // `variables` and `def_sites` are both keyed by the original ValueId of the `allocate`
-        // instruction result. These are iterated on in key order when adding block
-        // parameters and terminator arguments, so the maps must have a deterministic ordering
-        // for arguments to line up with parameters.
-        let (variables, def_sites) =
-            collect_eligible_variables_and_def_sites(inserter.function, &blocks);
+            // `variables` and `def_sites` are both keyed by the original ValueId of the `allocate`
+            // instruction result. These are iterated on in key order when adding block
+            // parameters and terminator arguments, so the maps must have a deterministic ordering
+            // for arguments to line up with parameters.
+            let (variables, def_sites) =
+                collect_eligible_variables_and_def_sites(inserter.function, &blocks);
 
-        if variables.is_empty() {
-            return;
+            if variables.is_empty() {
+                break;
+            }
+
+            // Compute where block parameters are needed using iterated dominance frontiers.
+            // A variable only needs a block parameter at blocks where values from different
+            // control-flow paths could merge (its IDF). For variables stored in a single block,
+            // this is typically empty — no block parameters needed at all.
+            let dom_frontiers = dom_tree.compute_dominance_frontiers_with_back_edges(&cfg);
+            let param_locations = compute_param_locations(&variables, &def_sites, &dom_frontiers);
+
+            // Precompute which variables are visible at each block by walking the dominator tree.
+            // A variable declared in block D is visible at block B iff D dominates B.
+            // Instead of checking dominates() for each (variable, block) pair — O(blocks × variables) —
+            // we inherit the visible set from the immediate dominator: O(blocks) tree walk.
+            // This completes the Cytron-style SSA construction (the IDF placement above is phase 1;
+            // this visibility propagation replaces the per-variable dominance checks in phase 2).
+            let visible_vars = compute_visible_vars(&blocks, &variables, &dom_tree);
+
+            let mut block_states = BlockStates::default();
+            add_block_params_and_find_exit_states(
+                &blocks,
+                &visible_vars,
+                &param_locations,
+                &mut inserter,
+                &mut block_states,
+                &cfg,
+            );
+            add_terminator_arguments(
+                &blocks,
+                &variables,
+                &param_locations,
+                &mut inserter,
+                &block_states,
+                &cfg,
+            );
+            commit(&mut inserter, &variables, blocks);
         }
-
-        // Compute where block parameters are needed using iterated dominance frontiers.
-        // A variable only needs a block parameter at blocks where values from different
-        // control-flow paths could merge (its IDF). For variables stored in a single block,
-        // this is typically empty — no block parameters needed at all.
-        let dom_frontiers = dom_tree.compute_dominance_frontiers_with_back_edges(&cfg);
-        let param_locations = compute_param_locations(&variables, &def_sites, &dom_frontiers);
-
-        // Precompute which variables are visible at each block by walking the dominator tree.
-        // A variable declared in block D is visible at block B iff D dominates B.
-        // Instead of checking dominates() for each (variable, block) pair — O(blocks × variables) —
-        // we inherit the visible set from the immediate dominator: O(blocks) tree walk.
-        // This completes the Cytron-style SSA construction (the IDF placement above is phase 1;
-        // this visibility propagation replaces the per-variable dominance checks in phase 2).
-        let visible_vars = compute_visible_vars(&blocks, &variables, &dom_tree);
-
-        let mut block_states = BlockStates::default();
-        add_block_params_and_find_exit_states(
-            &blocks,
-            &visible_vars,
-            &param_locations,
-            &mut inserter,
-            &mut block_states,
-            &cfg,
-        );
-        add_terminator_arguments(
-            &blocks,
-            &variables,
-            &param_locations,
-            &mut inserter,
-            &block_states,
-            &cfg,
-        );
-        commit(&mut inserter, &variables, blocks);
     }
 }
 
@@ -1462,6 +1476,31 @@ brillig(inline) fn main f0 {
           b3(v1: Field, v2: Field):
             v8 = add v1, v2
             return v8
+        }
+        ");
+    }
+
+    #[test]
+    fn keeps_running_while_allocations_are_removed() {
+        let src = "
+        acir(inline) predicate_pure fn main f0 {
+          b0():
+            v0 = allocate -> &mut u16
+            store u16 1 at v0
+            v2 = allocate -> &mut &mut u16
+            store v0 at v2
+            constrain u1 0 == u1 1
+            unreachable
+        }
+        ";
+
+        let ssa = Ssa::from_str(src).unwrap();
+        let ssa = ssa.mem2reg();
+        assert_ssa_snapshot!(ssa, @r"
+        acir(inline) predicate_pure fn main f0 {
+          b0():
+            constrain u1 0 == u1 1
+            unreachable
         }
         ");
     }

--- a/compiler/noirc_evaluator/src/ssa/opt/mem2reg.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/mem2reg.rs
@@ -54,7 +54,8 @@ impl Ssa {
 
 impl Function {
     pub(crate) fn mem2reg(&mut self) {
-        // Run mem2reg until we stop making progress. In an SSA like this one:
+        // Run mem2reg while we successfully removed at least one allocate instruction and there
+        // are at least one more that couldn't be removed. In an SSA like this one:
         //
         // ```
         // v0 = allocate -> &mut u16
@@ -66,7 +67,8 @@ impl Function {
         // - v0 can't be optimized out because it's stored in v2
         // - v2 can and will be optimized out
         // - now running it again will lead to optimizing out v0, etc.
-        loop {
+        let mut keep_running = true;
+        while keep_running {
             let cfg = ControlFlowGraph::with_function(self);
             let post_order = PostOrder::with_cfg(&cfg);
             let mut dom_tree = DominatorTree::with_cfg_and_post_order(&cfg, &post_order);
@@ -78,7 +80,7 @@ impl Function {
             // instruction result. These are iterated on in key order when adding block
             // parameters and terminator arguments, so the maps must have a deterministic ordering
             // for arguments to line up with parameters.
-            let (variables, def_sites) =
+            let (variables, def_sites, has_ineligible_variables) =
                 collect_eligible_variables_and_def_sites(inserter.function, &blocks);
 
             if variables.is_empty() {
@@ -118,6 +120,8 @@ impl Function {
                 &cfg,
             );
             commit(&mut inserter, &variables, blocks);
+
+            keep_running = has_ineligible_variables;
         }
     }
 }
@@ -437,11 +441,13 @@ fn abstract_interpret_block(
 fn collect_eligible_variables_and_def_sites(
     function: &Function,
     blocks: &[BasicBlockId],
-) -> (BTreeMap<ValueId, BasicBlockId>, HashMap<ValueId, HashSet<BasicBlockId>>) {
+) -> (BTreeMap<ValueId, BasicBlockId>, HashMap<ValueId, HashSet<BasicBlockId>>, bool) {
     // Map each variable to the block it was declared in
     let mut variables = BTreeMap::default();
     // Map each variable to the set of blocks that contain stores to it
     let mut def_sites: HashMap<ValueId, HashSet<BasicBlockId>> = HashMap::default();
+    // Whether there's any allocate that can't be optimized out
+    let mut has_ineligible_variables = false;
 
     // Workaround for https://github.com/noir-lang/noir/issues/11482
     // If the declaration block of an allocate has no starting store then it isn't eligible for mem2reg.
@@ -459,7 +465,9 @@ fn collect_eligible_variables_and_def_sites(
                 Instruction::Load { .. } => (),
                 // Storing to an address is fine, but storing an address prevents optimizing it out.
                 Instruction::Store { address, value } => {
-                    variables.remove(value);
+                    if variables.remove(value).is_some() {
+                        has_ineligible_variables = true;
+                    }
 
                     if let Some(decl_block) = variables.get(address) {
                         let is_decl_block = *decl_block == block_id;
@@ -471,13 +479,17 @@ fn collect_eligible_variables_and_def_sites(
                 }
                 // Any other use of an address (in arrays, functions, etc) is also first-class and prevents optimization.
                 _ => instruction.for_each_value(|value| {
-                    variables.remove(&value);
+                    if variables.remove(&value).is_some() {
+                        has_ineligible_variables = true;
+                    }
                 }),
             }
         }
 
         block.unwrap_terminator().for_each_value(|value| {
-            variables.remove(&value);
+            if variables.remove(&value).is_some() {
+                has_ineligible_variables = true;
+            }
         });
     }
 
@@ -485,9 +497,16 @@ fn collect_eligible_variables_and_def_sites(
     // `variables`, so `variables` is the authoritative set of eligible addresses. Both retains
     // below prune any stale entries left by first-class uses that removed an address from
     // `variables` without clearing `def_sites`.
-    variables.retain(|address, _| variables_with_stores_in_decl_block.contains(address));
+    variables.retain(|address, _| {
+        if variables_with_stores_in_decl_block.contains(address) {
+            true
+        } else {
+            has_ineligible_variables = true;
+            false
+        }
+    });
     def_sites.retain(|address, _| variables.contains_key(address));
-    (variables, def_sites)
+    (variables, def_sites, has_ineligible_variables)
 }
 
 /// Commit to all changes made by the pass:

--- a/compiler/noirc_evaluator/src/ssa/opt/mem2reg.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/mem2reg.rs
@@ -73,8 +73,7 @@ impl Function {
         // - v0 can't be optimized out because it's stored in v2
         // - v2 can and will be optimized out
         // - now running it again will lead to optimizing out v0, etc.
-        let mut keep_running = true;
-        while keep_running {
+        loop {
             let mut inserter = FunctionInserter::new(self);
 
             // `variables` and `def_sites` are both keyed by the original ValueId of the `allocate`
@@ -126,7 +125,10 @@ impl Function {
             );
             commit(&mut inserter, &variables, &blocks);
 
-            keep_running = has_ineligible_variables;
+            if !has_ineligible_variables {
+                // mem2reg can no longer simplify the program.
+                break;
+            }
         }
     }
 }

--- a/test_programs/compile_success_with_bug/mem2reg_fixed_point/Nargo.toml
+++ b/test_programs/compile_success_with_bug/mem2reg_fixed_point/Nargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "mem2reg_fixed_point"
+type = "bin"
+authors = [""]
+
+[dependencies]

--- a/test_programs/compile_success_with_bug/mem2reg_fixed_point/src/main.nr
+++ b/test_programs/compile_success_with_bug/mem2reg_fixed_point/src/main.nr
@@ -1,0 +1,6 @@
+fn main() -> pub Field {
+    let mut _: &mut [&mut &mut u16; 1] = &mut [&mut &mut 1_u16];
+    let r: [Field] = @[];
+    let i: u32 = 1;
+    r[i]
+}

--- a/tooling/nargo_cli/tests/snapshots/compile_success_with_bug/mem2reg_fixed_point/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_with_bug/mem2reg_fixed_point/execute__tests__expanded.snap
@@ -1,0 +1,10 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: expanded_code
+---
+fn main() -> pub Field {
+    let mut _: &mut [&mut &mut u16; 1] = &mut [&mut &mut 1_u16];
+    let r: [Field] = @[];
+    let i: u32 = 1_u32;
+    r[i]
+}

--- a/tooling/nargo_cli/tests/snapshots/compile_success_with_bug/mem2reg_fixed_point/execute__tests__stderr.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_with_bug/mem2reg_fixed_point/execute__tests__stderr.snap
@@ -1,0 +1,13 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: stderr
+---
+bug: Assertion is always false: Index out of bounds
+  ┌─ src/main.nr:5:5
+  │
+5 │     r[i]
+  │     ---- As a result, the compiled circuit is ensured to fail. Other assertions may also fail during execution
+  │
+  = Call stack:
+    1: main
+            at src/main.nr:5:5


### PR DESCRIPTION
## Problem Resolved

Resolves #12662

## Summary of Changes

I noticed that in the failing program we ended up with this SSA:

```
acir(inline) predicate_pure fn main f0 {
  b0():
    v0 = allocate -> &mut u16
    store u16 1 at v0
    constrain u1 0 == u1 1, "Index out of bounds"
    unreachable
}
```

I wondered why mem2reg didn't remove v0 here. I thought maybe it didn't because there was no load from v0. I wrote a test, and the test showed it removed v0. So why it wasn't removed in the real program?

The SSA above is what the last mem2reg pass left. Before that, the SSA was:

```
acir(inline) predicate_pure fn main f0 {
  b0():
    v0 = allocate -> &mut u16
    store u16 1 at v0
    v2 = allocate -> &mut &mut u16
    store v0 at v2
    constrain u1 0 == u1 1, "Index out of bounds"
    unreachable
}
```

What happened is that mem2reg was able to optimize v2 out, but it couldn't do the same for v0. The reason is that v0 is used in `store v0 at v2` so it's not safe to optimize. However, once `v2` is removed, if we run mem2reg again, it removes v0.

Instead of running mem2reg again here, I decided to run it in a loop while it makes progress. I _think_ mem2reg is a very simple pass so it should be quick to run, but let's see what bench-show says...

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
