### PR TITLE
fix: elaborate op-assign RHS before LHS

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/statements.rs
+++ b/compiler/noirc_frontend/src/elaborator/statements.rs
@@ -277,7 +277,7 @@ impl Elaborator<'_> {
         // HIR lvalue we get back is safe to convert into a read expression without re-evaluating
         // any side effects.
         //
-        // When the lvalue could have side effects, we also extract a side-effectful
+        // When the lvalue is more than a plain variable, we also extract a side-effectful
         // right-hand side into a fresh let-binding emitted before the lvalue is evaluated. This
         // ensures the RHS is evaluated before the lvalue is read or written. For example, in
         // `arr[i] += { i = 1; 5 }` we want `i = 1` to be observed by the lvalue, so the final
@@ -291,7 +291,7 @@ impl Elaborator<'_> {
         let (hir_lvalue, lvalue_type, mutable, mut new_statements) =
             self.elaborate_lvalue(assign_op.lvalue, true);
 
-        if self.lvalue_could_have_side_effects(&hir_lvalue)
+        if !matches!(&hir_lvalue, HirLValue::Ident(..))
             && let Some((rhs_let, rhs_ident)) = self.fresh_definition_for_side_effect_extraction(
                 rhs_expr,
                 rhs_type.clone(),
@@ -949,19 +949,6 @@ impl Elaborator<'_> {
             | HirExpression::Unsafe(..)
             | HirExpression::Block(..)
             | HirExpression::Error => true,
-        }
-    }
-
-    fn lvalue_could_have_side_effects(&self, lvalue: &HirLValue) -> bool {
-        match lvalue {
-            HirLValue::Ident(..) => false,
-            HirLValue::MemberAccess { object, .. } => self.lvalue_could_have_side_effects(object),
-            HirLValue::Index { array, index, .. } => {
-                self.lvalue_could_have_side_effects(array)
-                    || self.expression_could_have_side_effects(*index)
-            }
-            HirLValue::Dereference { lvalue, .. } => self.lvalue_could_have_side_effects(lvalue),
-            HirLValue::Error { .. } => false,
         }
     }
 

--- a/compiler/noirc_frontend/src/elaborator/statements.rs
+++ b/compiler/noirc_frontend/src/elaborator/statements.rs
@@ -277,10 +277,9 @@ impl Elaborator<'_> {
         // HIR lvalue we get back is safe to convert into a read expression without re-evaluating
         // any side effects.
         //
-        // When the lvalue is more than a plain variable, we also extract a side-effectful
-        // right-hand side into a fresh let-binding emitted before the lvalue is evaluated. This
-        // ensures the RHS is evaluated before the lvalue is read or written. For example, in
-        // `arr[i] += { i = 1; 5 }` we want `i = 1` to be observed by the lvalue, so the final
+        // We also extract a side-effectful right-hand side into a fresh let-binding emitted before
+        // the lvalue is evaluated. This ensures the RHS is evaluated before the lvalue is read or written.
+        // For example, in `arr[i] += { i = 1; 5 }` we want `i = 1` to be observed by the lvalue, so the final
         // lowering reads/writes `arr[1]`. For a plain-variable lvalue the place doesn't depend
         // on any sub-expression the RHS could change, so we leave the RHS inline.
         let expression_location = assign_op.expression.location;
@@ -291,14 +290,12 @@ impl Elaborator<'_> {
         let (hir_lvalue, lvalue_type, mutable, mut new_statements) =
             self.elaborate_lvalue(assign_op.lvalue, true);
 
-        if !matches!(&hir_lvalue, HirLValue::Ident(..))
-            && let Some((rhs_let, rhs_ident)) = self.fresh_definition_for_side_effect_extraction(
-                rhs_expr,
-                rhs_type.clone(),
-                expression_location,
-                "op_rhs",
-            )
-        {
+        if let Some((rhs_let, rhs_ident)) = self.fresh_definition_for_side_effect_extraction(
+            rhs_expr,
+            rhs_type.clone(),
+            expression_location,
+            "op_rhs",
+        ) {
             new_statements.insert(0, rhs_let);
             rhs_expr = rhs_ident;
         }

--- a/compiler/noirc_frontend/src/elaborator/statements.rs
+++ b/compiler/noirc_frontend/src/elaborator/statements.rs
@@ -277,7 +277,7 @@ impl Elaborator<'_> {
         // HIR lvalue we get back is safe to convert into a read expression without re-evaluating
         // any side effects.
         //
-        // When the lvalue is more than a plain variable, we also extract a side-effectful
+        // When the lvalue could have side effects, we also extract a side-effectful
         // right-hand side into a fresh let-binding emitted before the lvalue is evaluated. This
         // ensures the RHS is evaluated before the lvalue is read or written. For example, in
         // `arr[i] += { i = 1; 5 }` we want `i = 1` to be observed by the lvalue, so the final
@@ -291,7 +291,7 @@ impl Elaborator<'_> {
         let (hir_lvalue, lvalue_type, mutable, mut new_statements) =
             self.elaborate_lvalue(assign_op.lvalue, true);
 
-        if !matches!(&hir_lvalue, HirLValue::Ident(..))
+        if self.lvalue_could_have_side_effects(&hir_lvalue)
             && let Some((rhs_let, rhs_ident)) = self.fresh_definition_for_side_effect_extraction(
                 rhs_expr,
                 rhs_type.clone(),
@@ -949,6 +949,19 @@ impl Elaborator<'_> {
             | HirExpression::Unsafe(..)
             | HirExpression::Block(..)
             | HirExpression::Error => true,
+        }
+    }
+
+    fn lvalue_could_have_side_effects(&self, lvalue: &HirLValue) -> bool {
+        match lvalue {
+            HirLValue::Ident(..) => false,
+            HirLValue::MemberAccess { object, .. } => self.lvalue_could_have_side_effects(object),
+            HirLValue::Index { array, index, .. } => {
+                self.lvalue_could_have_side_effects(array)
+                    || self.expression_could_have_side_effects(*index)
+            }
+            HirLValue::Dereference { lvalue, .. } => self.lvalue_could_have_side_effects(lvalue),
+            HirLValue::Error { .. } => false,
         }
     }
 

--- a/compiler/noirc_frontend/src/elaborator/statements.rs
+++ b/compiler/noirc_frontend/src/elaborator/statements.rs
@@ -911,12 +911,22 @@ impl Elaborator<'_> {
                 HirLiteral::Array(..) | HirLiteral::Vector(..) | HirLiteral::FmtStr(..) => true,
             },
             HirExpression::Prefix(hir_prefix_expression) => {
-                hir_prefix_expression.trait_method_id.is_some()
-                    || self.expression_could_have_side_effects(hir_prefix_expression.rhs)
+                // Something like `-x` can't have side effects if `x` is numeric
+                if hir_prefix_expression.trait_method_id.is_some()
+                    && !self.interner.id_type(hir_prefix_expression.rhs).is_numeric_value()
+                {
+                    return true;
+                }
+                self.expression_could_have_side_effects(hir_prefix_expression.rhs)
             }
             HirExpression::Infix(hir_infix_expression) => {
-                hir_infix_expression.trait_method_id.is_some()
-                    || self.expression_could_have_side_effects(hir_infix_expression.lhs)
+                // Something like `x + y` can't have side effects if `x` is numeric
+                if hir_infix_expression.trait_method_id.is_some()
+                    && !self.interner.id_type(hir_infix_expression.lhs).is_numeric_value()
+                {
+                    return true;
+                }
+                self.expression_could_have_side_effects(hir_infix_expression.lhs)
                     || self.expression_could_have_side_effects(hir_infix_expression.rhs)
             }
             HirExpression::Index(hir_index_expression) => {

--- a/compiler/noirc_frontend/src/elaborator/statements.rs
+++ b/compiler/noirc_frontend/src/elaborator/statements.rs
@@ -276,18 +276,37 @@ impl Elaborator<'_> {
         // let bindings (new_statements) and replaces them with simple ident references, so the
         // HIR lvalue we get back is safe to convert into a read expression without re-evaluating
         // any side effects.
+        //
+        // When the lvalue is more than a plain variable, we also extract a side-effectful
+        // right-hand side into a fresh let-binding emitted before the lvalue is evaluated. This
+        // ensures the RHS is evaluated before the lvalue is read or written. For example, in
+        // `arr[i] += { i = 1; 5 }` we want `i = 1` to be observed by the lvalue, so the final
+        // lowering reads/writes `arr[1]`. For a plain-variable lvalue the place doesn't depend
+        // on any sub-expression the RHS could change, so we leave the RHS inline.
         let expression_location = assign_op.expression.location;
 
-        let (hir_lvalue, lvalue_type, mutable, new_statements) =
+        // Elaborate the right-hand side of the operator first.
+        let (mut rhs_expr, rhs_type) = self.elaborate_expression(assign_op.expression);
+
+        let (hir_lvalue, lvalue_type, mutable, mut new_statements) =
             self.elaborate_lvalue(assign_op.lvalue, true);
+
+        if !matches!(&hir_lvalue, HirLValue::Ident(..))
+            && let Some((rhs_let, rhs_ident)) = self.fresh_definition_for_side_effect_extraction(
+                rhs_expr,
+                rhs_type.clone(),
+                expression_location,
+                "op_rhs",
+            )
+        {
+            new_statements.insert(0, rhs_let);
+            rhs_expr = rhs_ident;
+        }
 
         // Convert the HIR lvalue into a read expression, reusing the same ident ExprIds
         // that were already bound by the index let-statements in new_statements.
         let lhs_expr = self.hir_lvalue_as_expr(&hir_lvalue);
         let lhs_type = lvalue_type.clone();
-
-        // Elaborate the right-hand side of the operator.
-        let (rhs_expr, rhs_type) = self.elaborate_expression(assign_op.expression);
 
         let op_kind = assign_op.op.contents.to_binary_op_kind();
         let operator = HirBinaryOp { kind: op_kind, location: assign_op.op.location() };
@@ -724,8 +743,13 @@ impl Elaborator<'_> {
                 // afterward with a let binding. Note that since we recur first then push to the
                 // end of the list we're evaluating side-effects such that in `a[i][j]`, `i` will
                 // be evaluated first, followed by `j`.
-                if let Some((index_definition, new_index)) =
-                    self.fresh_definition_for_lvalue_index(index, index_type, expr_location)
+                if let Some((index_definition, new_index)) = self
+                    .fresh_definition_for_side_effect_extraction(
+                        index,
+                        index_type,
+                        expr_location,
+                        "i",
+                    )
                 {
                     index = new_index;
                     statements.push(index_definition);
@@ -844,22 +868,23 @@ impl Elaborator<'_> {
     }
 
     #[tracing::instrument(level = "trace", skip_all)]
-    fn fresh_definition_for_lvalue_index(
+    fn fresh_definition_for_side_effect_extraction(
         &mut self,
         expr: ExprId,
         typ: Type,
         location: Location,
+        name_prefix: &str,
     ) -> Option<(StmtId, ExprId)> {
         // If the original expression trivially cannot have side-effects, don't bother cluttering
         // the output with a let binding. Note that array literals can have side-effects but these
         // would produce type errors anyway.
-        if !self.index_could_have_side_effects(expr) {
+        if !self.expression_could_have_side_effects(expr) {
             return None;
         }
 
-        let lvalue_index_counter = self.next_lvalue_index_counter();
+        let counter = self.next_lvalue_index_counter();
         let id = self.interner.push_definition(
-            format!("i_{lvalue_index_counter}"),
+            format!("{name_prefix}_{counter}"),
             false,
             false,
             DefinitionKind::Local(None),
@@ -876,9 +901,9 @@ impl Elaborator<'_> {
         Some((let_, ident_id))
     }
 
-    /// Returns `true` if the given index expression could potentially have side-effects.
+    /// Returns `true` if the given expression could potentially have side-effects.
     /// Returns `false` if the expression is guaranteed to not have side-effects.
-    fn index_could_have_side_effects(&self, expr: ExprId) -> bool {
+    fn expression_could_have_side_effects(&self, expr: ExprId) -> bool {
         match self.interner.expression_ref(&expr) {
             HirExpression::Ident(..) => false,
             HirExpression::Literal(hir_literal) => match hir_literal {
@@ -890,16 +915,16 @@ impl Elaborator<'_> {
             },
             HirExpression::Prefix(hir_prefix_expression) => {
                 hir_prefix_expression.trait_method_id.is_some()
-                    || self.index_could_have_side_effects(hir_prefix_expression.rhs)
+                    || self.expression_could_have_side_effects(hir_prefix_expression.rhs)
             }
             HirExpression::Infix(hir_infix_expression) => {
                 hir_infix_expression.trait_method_id.is_some()
-                    || self.index_could_have_side_effects(hir_infix_expression.lhs)
-                    || self.index_could_have_side_effects(hir_infix_expression.rhs)
+                    || self.expression_could_have_side_effects(hir_infix_expression.lhs)
+                    || self.expression_could_have_side_effects(hir_infix_expression.rhs)
             }
             HirExpression::Index(hir_index_expression) => {
-                self.index_could_have_side_effects(hir_index_expression.collection)
-                    || self.index_could_have_side_effects(hir_index_expression.index)
+                self.expression_could_have_side_effects(hir_index_expression.collection)
+                    || self.expression_could_have_side_effects(hir_index_expression.index)
             }
             HirExpression::Constructor(hir_constructor_expression) => {
                 !hir_constructor_expression.fields.is_empty()
@@ -908,12 +933,12 @@ impl Elaborator<'_> {
                 !hir_enum_constructor_expression.arguments.is_empty()
             }
             HirExpression::MemberAccess(hir_member_access) => {
-                self.index_could_have_side_effects(hir_member_access.lhs)
+                self.expression_could_have_side_effects(hir_member_access.lhs)
             }
             HirExpression::Call(..) => true,
             HirExpression::Constrain(..) => true,
             HirExpression::Cast(hir_cast_expression) => {
-                self.index_could_have_side_effects(hir_cast_expression.lhs)
+                self.expression_could_have_side_effects(hir_cast_expression.lhs)
             }
             HirExpression::If(..)
             | HirExpression::Match(..)

--- a/test_programs/execution_success/op_assign_desugaring/src/main.nr
+++ b/test_programs/execution_success/op_assign_desugaring/src/main.nr
@@ -30,4 +30,14 @@ fn main() {
     };
 
     assert_eq(arr, [10, 25]);
+
+    // And another one: here this should be equivalent to `i = 10; i += 1;`
+    let mut i = 0;
+
+    i += {
+        i = 10;
+        1
+    };
+
+    assert_eq(i, 11);
 }

--- a/test_programs/execution_success/op_assign_desugaring/src/main.nr
+++ b/test_programs/execution_success/op_assign_desugaring/src/main.nr
@@ -17,4 +17,17 @@ fn main() {
     p.x += 5;
     assert_eq(p.x, 15);
     assert_eq(p.y, 20);
+
+    // Another regression: here the RHS expression must be evaluated
+    // first, so i ends up being 1, then the entire op-assign expression
+    // ends up being `arr[i] += 5`.
+    let mut arr = [10_i32, 20];
+    let mut i = 0;
+
+    arr[i] += {
+        i = 1;
+        5
+    };
+
+    assert_eq(arr, [10, 25]);
 }

--- a/tooling/nargo_cli/tests/snapshots/compile_success_empty/regression_bignum/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_empty/regression_bignum/execute__tests__expanded.snap
@@ -52,10 +52,7 @@ unconstrained fn shl(shift: u32) -> [u64; 6] {
     let mut result: [u64; 6] = [0_u64; 6];
     result[num_shifted_limbs] = 1_u64 << limb_shift;
     for i in 1_u32..6_u32 - num_shifted_limbs {
-        {
-            let i_0: u32 = i + num_shifted_limbs;
-            result[i_0] = 0_u64;
-        }
+        result[i + num_shifted_limbs] = 0_u64;
     }
     result
 }

--- a/tooling/nargo_cli/tests/snapshots/compile_success_empty/trait_impl_with_where_clause/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_empty/trait_impl_with_where_clause/execute__tests__expanded.snap
@@ -20,7 +20,10 @@ where
     fn my_eq(self, other: Self) -> bool {
         let mut ret: bool = true;
         for i in 0_u32..self.len() {
-            ret = ret & self[i].my_eq(other[i]);
+            {
+                let op_rhs_0: bool = self[i].my_eq(other[i]);
+                ret = ret & op_rhs_0;
+            }
         }
         ret
     }

--- a/tooling/nargo_cli/tests/snapshots/compile_success_no_bug/ram_blowup_regression/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_no_bug/ram_blowup_regression/execute__tests__expanded.snap
@@ -28,10 +28,7 @@ fn main(tx_effects_hash_input: [Field; 256]) -> pub Field {
     for offset in 0_u32..TX_EFFECTS_HASH_INPUT_FIELDS {
         let input_as_bytes: [u8; 32] = tx_effects_hash_input[offset].to_be_bytes();
         for byte_index in 0_u32..32_u32 {
-            {
-                let i_0: u32 = (offset * 32_u32) + byte_index;
-                hash_input_flattened[i_0] = input_as_bytes[byte_index];
-            }
+            hash_input_flattened[(offset * 32_u32) + byte_index] = input_as_bytes[byte_index];
         }
     }
     let blake2s_digest: Field = blake2s_to_field(hash_input_flattened);

--- a/tooling/nargo_cli/tests/snapshots/execution_success/aes128_encrypt/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/aes128_encrypt/execute__tests__expanded.snap
@@ -17,10 +17,7 @@ unconstrained fn decode_hex<let N: u32, let M: u32>(s: str<N>) -> [u8; M] {
     let as_bytes: [u8; N] = s.as_bytes();
     for i in 0_u32..N {
         if (i % 2_u32) != 0_u32 { continue; };
-        {
-            let i_0: u32 = i / 2_u32;
-            result[i_0] = (decode_ascii(as_bytes[i]) * 16_u8) + decode_ascii(as_bytes[i + 1_u32]);
-        }
+        result[i / 2_u32] = (decode_ascii(as_bytes[i]) * 16_u8) + decode_ascii(as_bytes[i + 1_u32]);
     }
     result
 }

--- a/tooling/nargo_cli/tests/snapshots/execution_success/array_dedup_regression/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/array_dedup_regression/execute__tests__expanded.snap
@@ -6,10 +6,7 @@ unconstrained fn main(x: u32) {
     let a1: [Field; 5] = [1_Field, 2_Field, 3_Field, 4_Field, 5_Field];
     for i in 0_u32..5_u32 {
         let mut a2: [Field; 5] = [1_Field, 2_Field, 3_Field, 4_Field, 5_Field];
-        {
-            let i_0: u32 = x + i;
-            a2[i_0] = 128_Field;
-        };
+        a2[x + i] = 128_Field;
         println(a2);
         if i != 0_u32 {
             assert(a2[(x + i) - 1_u32] != 128_Field);

--- a/tooling/nargo_cli/tests/snapshots/execution_success/array_dynamic_blackbox_input/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/array_dynamic_blackbox_input/execute__tests__expanded.snap
@@ -16,14 +16,8 @@ fn compute_root(leaf: [u8; 32], path: [u8; 64], _index: u32, root: [u8; 32]) {
         let a: u32 = if is_right { 32_u32 } else { 0_u32 };
         let b: u32 = if is_right { 0_u32 } else { 32_u32 };
         for j in 0_u32..32_u32 {
-            {
-                let i_0: u32 = j + a;
-                hash_input[i_0] = current[j];
-            };
-            {
-                let i_1: u32 = j + b;
-                hash_input[i_1] = path[offset + j];
-            }
+            hash_input[j + a] = current[j];
+            hash_input[j + b] = path[offset + j];
         }
         current = std::hash::blake3(hash_input);
         index = index >> 1_u32;

--- a/tooling/nargo_cli/tests/snapshots/execution_success/array_dynamic_nested_blackbox_input/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/array_dynamic_nested_blackbox_input/execute__tests__expanded.snap
@@ -13,15 +13,9 @@ struct Foo {
 }
 
 fn main(mut x: [Foo; 3], y: pub u32, hash_result: pub [u8; 32]) {
-    {
-        let i_0: u32 = y - 1_u32;
-        x[i_0].bar.inner = [106_u8, 107_u8, 10_u8];
-    };
+    x[y - 1_u32].bar.inner = [106_u8, 107_u8, 10_u8];
     let mut hash_input: [u8; 3] = x[y - 1_u32].bar.inner;
-    {
-        let i_1: u32 = y - 1_u32;
-        hash_input[i_1] = 0_u8;
-    };
+    hash_input[y - 1_u32] = 0_u8;
     let hash: [u8; 32] = std::hash::blake3(hash_input);
     assert(hash == hash_result);
 }

--- a/tooling/nargo_cli/tests/snapshots/execution_success/brillig_cow/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/brillig_cow/execute__tests__expanded.snap
@@ -21,10 +21,7 @@ fn modify_in_inlined_constrained(original: [Field; 5], index: u32) -> ExecutionR
     let mut modified: [Field; 5] = original;
     modified[index] = 27_Field;
     let modified_once: [Field; 5] = modified;
-    {
-        let i_0: u32 = index + 1_u32;
-        modified[i_0] = 27_Field;
-    };
+    modified[index + 1_u32] = 27_Field;
     ExecutionResult { original: original, modified_once: modified_once, modified_twice: modified }
 }
 
@@ -32,10 +29,7 @@ unconstrained fn modify_in_unconstrained(original: [Field; 5], index: u32) -> Ex
     let mut modified: [Field; 5] = original;
     modified[index] = 27_Field;
     let modified_once: [Field; 5] = modified;
-    {
-        let i_0: u32 = index + 1_u32;
-        modified[i_0] = 27_Field;
-    };
+    modified[index + 1_u32] = 27_Field;
     ExecutionResult { original: original, modified_once: modified_once, modified_twice: modified }
 }
 

--- a/tooling/nargo_cli/tests/snapshots/execution_success/brillig_cow_regression/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/brillig_cow_regression/execute__tests__expanded.snap
@@ -154,35 +154,21 @@ unconstrained fn main(kernel_data: DataToHash) -> pub [Field; 2] {
     let unencryptedLogsHash: [Field; 2] = kernel_data.unencrypted_logs_hash;
     let mut offset: u32 = 0_u32;
     for j in 0_u32..MAX_NOTE_HASHES_PER_TX {
-        {
-            let i_0: u32 = offset + j;
-            tx_effects_hash_inputs[i_0] = new_note_hashes[j];
-        }
+        tx_effects_hash_inputs[offset + j] = new_note_hashes[j];
     }
     offset = offset + MAX_NOTE_HASHES_PER_TX;
     for j in 0_u32..MAX_NULLIFIERS_PER_TX {
-        {
-            let i_1: u32 = offset + j;
-            tx_effects_hash_inputs[i_1] = new_nullifiers[j];
-        }
+        tx_effects_hash_inputs[offset + j] = new_nullifiers[j];
     }
     offset = offset + MAX_NULLIFIERS_PER_TX;
     for j in 0_u32..MAX_PUBLIC_DATA_UPDATE_REQUESTS_PER_TX {
-        {
-            let i_2: u32 = offset + (j * 2_u32);
-            tx_effects_hash_inputs[i_2] = public_data_update_requests[j].leaf_slot;
-        };
-        {
-            let i_3: u32 = (offset + (j * 2_u32)) + 1_u32;
-            tx_effects_hash_inputs[i_3] = public_data_update_requests[j].new_value;
-        }
+        tx_effects_hash_inputs[offset + (j * 2_u32)] = public_data_update_requests[j].leaf_slot;
+        tx_effects_hash_inputs[(offset + (j * 2_u32)) + 1_u32] =
+            public_data_update_requests[j].new_value;
     }
     offset = offset + (MAX_PUBLIC_DATA_UPDATE_REQUESTS_PER_TX * 2_u32);
     for j in 0_u32..MAX_L2_TO_L1_MSGS_PER_TX {
-        {
-            let i_4: u32 = offset + j;
-            tx_effects_hash_inputs[i_4] = l2ToL1Msgs[j];
-        }
+        tx_effects_hash_inputs[offset + j] = l2ToL1Msgs[j];
     }
     offset = offset + MAX_L2_TO_L1_MSGS_PER_TX;
     let contract_leaf: NewContractData = kernel_data.new_contracts[0_u32];
@@ -190,23 +176,14 @@ unconstrained fn main(kernel_data: DataToHash) -> pub [Field; 2] {
     offset = offset + MAX_NEW_CONTRACTS_PER_TX;
     let new_contracts: [NewContractData; 1] = kernel_data.new_contracts;
     tx_effects_hash_inputs[offset] = new_contracts[0_u32].contract_address;
-    {
-        let i_5: u32 = offset + 1_u32;
-        tx_effects_hash_inputs[i_5] = new_contracts[0_u32].portal_contract_address;
-    };
+    tx_effects_hash_inputs[offset + 1_u32] = new_contracts[0_u32].portal_contract_address;
     offset = offset + (MAX_NEW_CONTRACTS_PER_TX * 2_u32);
     for j in 0_u32..NUM_FIELDS_PER_SHA256 {
-        {
-            let i_6: u32 = offset + j;
-            tx_effects_hash_inputs[i_6] = encryptedLogsHash[j];
-        }
+        tx_effects_hash_inputs[offset + j] = encryptedLogsHash[j];
     }
     offset = offset + (NUM_ENCRYPTED_LOGS_HASHES_PER_TX * NUM_FIELDS_PER_SHA256);
     for j in 0_u32..NUM_FIELDS_PER_SHA256 {
-        {
-            let i_7: u32 = offset + j;
-            tx_effects_hash_inputs[i_7] = unencryptedLogsHash[j];
-        }
+        tx_effects_hash_inputs[offset + j] = unencryptedLogsHash[j];
     }
     offset = offset + (NUM_UNENCRYPTED_LOGS_HASHES_PER_TX * NUM_FIELDS_PER_SHA256);
     assert(offset == TX_EFFECT_HASH_INPUT_SIZE);
@@ -214,21 +191,17 @@ unconstrained fn main(kernel_data: DataToHash) -> pub [Field; 2] {
     for offset in 0_u32..TX_EFFECT_HASH_FULL_FIELDS {
         let input_as_bytes: [u8; 32] = tx_effects_hash_inputs[offset].to_be_bytes();
         for byte_index in 0_u32..32_u32 {
-            {
-                let i_8: u32 = (offset * 32_u32) + byte_index;
-                hash_input_flattened[i_8] = input_as_bytes[byte_index];
-            }
+            hash_input_flattened[(offset * 32_u32) + byte_index] = input_as_bytes[byte_index];
         }
     }
     for log_field_index in 0_u32..TX_EFFECT_HASH_LOG_FIELDS {
         let input_as_bytes: [u8; 16] =
             tx_effects_hash_inputs[TX_EFFECT_HASH_FULL_FIELDS + log_field_index].to_be_bytes();
         for byte_index in 0_u32..16_u32 {
-            {
-                let i_9: u32 = ((TX_EFFECT_HASH_FULL_FIELDS * 32_u32) + (log_field_index * 16_u32))
-                    + byte_index;
-                hash_input_flattened[i_9] = input_as_bytes[byte_index];
-            }
+            hash_input_flattened[(
+                (TX_EFFECT_HASH_FULL_FIELDS * 32_u32) + (log_field_index * 16_u32)
+            )
+                + byte_index] = input_as_bytes[byte_index];
         }
     }
     let blake2_digest: [u8; 32] = std::hash::blake2s(hash_input_flattened);

--- a/tooling/nargo_cli/tests/snapshots/execution_success/conditional_1/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/conditional_1/execute__tests__expanded.snap
@@ -26,10 +26,7 @@ fn main(a: u32, mut c: [u32; 4], x: [u8; 5], result: pub [u8; 32]) {
         let i_u32: u32 = i as u32;
         if i_u32 == a {
             for j in 0_u32..4_u32 {
-                {
-                    let i_0: u32 = i + j;
-                    data[i_0] = c[(4_u32 - 1_u32) - j];
-                };
+                data[i + j] = c[(4_u32 - 1_u32) - j];
                 for k in 0_u32..4_u32 {
                     ba = ba + data[k];
                 }

--- a/tooling/nargo_cli/tests/snapshots/execution_success/ecdsa_secp256r1_high_s/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/ecdsa_secp256r1_high_s/execute__tests__expanded.snap
@@ -40,16 +40,10 @@ fn normalize_ecdsa_signature(signature: [u8; 64]) -> [u8; 64] {
             let a: u32 = order[i] as u32;
             let b: u32 = (signature[32_u32 + i] as u32) + borrow;
             if a >= b {
-                {
-                    let i_0: u32 = 32_u32 + i;
-                    result[i_0] = (a - b) as u8;
-                };
+                result[32_u32 + i] = (a - b) as u8;
                 borrow = 0_u32;
             } else {
-                {
-                    let i_1: u32 = 32_u32 + i;
-                    result[i_1] = ((256_u32 + a) - b) as u8;
-                };
+                result[32_u32 + i] = ((256_u32 + a) - b) as u8;
                 borrow = 1_u32;
             }
         }

--- a/tooling/nargo_cli/tests/snapshots/execution_success/encrypted_log_regression/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/encrypted_log_regression/execute__tests__expanded.snap
@@ -38,27 +38,18 @@ fn compute_encrypted_log<let M: u32>(
     let mut offset: u32 = 0_u32;
     if flag {
         for i in 0_u32..EPH_PK_SIZE {
-            {
-                let i_0: u32 = offset + i;
-                encrypted_bytes[i_0] = eph_pk_bytes[i];
-            }
+            encrypted_bytes[offset + i] = eph_pk_bytes[i];
         }
         offset = offset + EPH_PK_SIZE;
         for i in 0_u32..HEADER_SIZE {
-            {
-                let i_1: u32 = offset + i;
-                encrypted_bytes[i_1] = incoming_header_ciphertext[i];
-            }
+            encrypted_bytes[offset + i] = incoming_header_ciphertext[i];
         }
         offset = offset + HEADER_SIZE;
         offset = offset + OVERHEAD_PADDING;
         let size: u32 = M - offset;
         assert(size == incoming_body_ciphertext.len(), "ciphertext length mismatch");
         for i in 0_u32..size {
-            {
-                let i_2: u32 = offset + i;
-                encrypted_bytes[i_2] = incoming_body_ciphertext[i];
-            }
+            encrypted_bytes[offset + i] = incoming_body_ciphertext[i];
         }
     };
     encrypted_bytes

--- a/tooling/nargo_cli/tests/snapshots/execution_success/nested_array_dynamic/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/nested_array_dynamic/execute__tests__expanded.snap
@@ -34,15 +34,9 @@ fn main(mut x: [Foo; 4], y: pub u32) {
     };
     assert(x[3_u32].a == 50_Field);
     if y == 2_u32 {
-        {
-            let i_0: u32 = y - 1_u32;
-            x[i_0].b = [50_Field, 51_Field, 52_Field];
-        }
+        x[y - 1_u32].b = [50_Field, 51_Field, 52_Field];
     } else {
-        {
-            let i_1: u32 = y - 1_u32;
-            x[i_1].b = [100_Field, 101_Field, 102_Field];
-        }
+        x[y - 1_u32].b = [100_Field, 101_Field, 102_Field];
     };
     assert(x[2_u32].b == [100_Field, 101_Field, 102_Field]);
     assert(x[y - 3_u32].bar.inner == [100_Field, 101_Field, 102_Field]);
@@ -59,40 +53,18 @@ fn main(mut x: [Foo; 4], y: pub u32) {
     assert(foo_parents[y - 3_u32].foos[y].a == 50_Field);
     assert(foo_parents[1_u32].foos[1_u32].b == [5_Field, 6_Field, 21_Field]);
     if y == 2_u32 {
-        {
-            let i_2: u32 = y - 2_u32;
-            let i_3: u32 = y - 2_u32;
-            foo_parents[i_2].foos[i_3].b = [10_Field, 9_Field, 8_Field];
-        }
+        foo_parents[y - 2_u32].foos[y - 2_u32].b = [10_Field, 9_Field, 8_Field];
     } else {
-        {
-            let i_4: u32 = y - 2_u32;
-            let i_5: u32 = y - 2_u32;
-            foo_parents[i_4].foos[i_5].b = [20_Field, 19_Field, 18_Field];
-        }
+        foo_parents[y - 2_u32].foos[y - 2_u32].b = [20_Field, 19_Field, 18_Field];
     };
     assert(foo_parents[1_u32].foos[1_u32].b == [20_Field, 19_Field, 18_Field]);
     assert(foo_parents[1_u32].foos[1_u32].b[2_u32] == 18_Field);
     if y == 3_u32 {
-        {
-            let i_6: u32 = y - 2_u32;
-            let i_7: u32 = y - 2_u32;
-            let i_8: u32 = y - 1_u32;
-            foo_parents[i_6].foos[i_7].b[i_8] = 5000_Field;
-        }
+        foo_parents[y - 2_u32].foos[y - 2_u32].b[y - 1_u32] = 5000_Field;
     } else {
-        {
-            let i_9: u32 = y - 2_u32;
-            let i_10: u32 = y - 2_u32;
-            let i_11: u32 = y - 1_u32;
-            foo_parents[i_9].foos[i_10].b[i_11] = 1000_Field;
-        }
+        foo_parents[y - 2_u32].foos[y - 2_u32].b[y - 1_u32] = 1000_Field;
     };
     assert(foo_parents[1_u32].foos[1_u32].b[2_u32] == 5000_Field);
-    {
-        let i_12: u32 = y - 2_u32;
-        let i_13: u32 = y - 3_u32;
-        foo_parents[i_12].foos[i_13].b = foo_parents[y - 2_u32].foos[y - 2_u32].b;
-    };
+    foo_parents[y - 2_u32].foos[y - 3_u32].b = foo_parents[y - 2_u32].foos[y - 2_u32].b;
     assert(foo_parents[1_u32].foos[0_u32].b == [20_Field, 19_Field, 5000_Field]);
 }

--- a/tooling/nargo_cli/tests/snapshots/execution_success/nested_array_in_vector/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/nested_array_in_vector/execute__tests__expanded.snap
@@ -47,27 +47,15 @@ fn main(y: u32) {
     assert(x[y].b == [11_Field, 12_Field, 23_Field]);
     assert(x[y].bar.inner == [109_Field, 110_Field, 111_Field]);
     if y != 2_u32 {
-        {
-            let i_0: u32 = y - 2_u32;
-            x[i_0].a = 50_Field;
-        }
+        x[y - 2_u32].a = 50_Field;
     } else {
-        {
-            let i_1: u32 = y - 2_u32;
-            x[i_1].a = 100_Field;
-        }
+        x[y - 2_u32].a = 100_Field;
     };
     assert(x[y - 2_u32].a == 50_Field);
     if y == 2_u32 {
-        {
-            let i_2: u32 = y - 1_u32;
-            x[i_2].b = [50_Field, 51_Field, 52_Field];
-        }
+        x[y - 1_u32].b = [50_Field, 51_Field, 52_Field];
     } else {
-        {
-            let i_3: u32 = y - 1_u32;
-            x[i_3].b = [100_Field, 101_Field, 102_Field];
-        }
+        x[y - 1_u32].b = [100_Field, 101_Field, 102_Field];
     };
     assert(x[2_u32].b == [100_Field, 101_Field, 102_Field]);
     assert(x[y - 3_u32].bar.inner == [100_Field, 101_Field, 102_Field]);

--- a/tooling/nargo_cli/tests/snapshots/execution_success/op_assign_desugaring/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/op_assign_desugaring/execute__tests__expanded.snap
@@ -21,4 +21,14 @@ fn main() {
     p.x = p.x + 5_Field;
     assert(p.x == 15_Field);
     assert(p.y == 20_Field);
+    let mut arr: [i32; 2] = [10_i32, 20_i32];
+    let mut i: u32 = 0_u32;
+    {
+        let op_rhs_1: i32 = {
+            i = 1_u32;
+            5_i32
+        };
+        arr[i] = arr[i] + op_rhs_1;
+    };
+    assert(arr == [10_i32, 25_i32]);
 }

--- a/tooling/nargo_cli/tests/snapshots/execution_success/op_assign_desugaring/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/op_assign_desugaring/execute__tests__expanded.snap
@@ -31,4 +31,13 @@ fn main() {
         arr[i] = arr[i] + op_rhs_1;
     };
     assert(arr == [10_i32, 25_i32]);
+    let mut i: Field = 0_Field;
+    {
+        let op_rhs_2: Field = {
+            i = 10_Field;
+            1_Field
+        };
+        i = i + op_rhs_2;
+    };
+    assert(i == 11_Field);
 }

--- a/tooling/nargo_cli/tests/snapshots/execution_success/regression_1144_1169_2399_6609/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/regression_1144_1169_2399_6609/execute__tests__expanded.snap
@@ -35,28 +35,16 @@ fn compact_decode<let N: u32>(input: [u8; N], length: Field) -> ([U4; 16], Field
         for i in 1_u32..input.len() {
             if (i as u32) < (length as u32) {
                 let x: u8 = input[i];
-                {
-                    let i_0: u32 = (2_u32 * i) - 1_u32;
-                    nibble[i_0] = U4::from_u8(x >> 4_u8);
-                };
-                {
-                    let i_1: u32 = 2_u32 * i;
-                    nibble[i_1] = U4::from_u8(x & 15_u8);
-                }
+                nibble[(2_u32 * i) - 1_u32] = U4::from_u8(x >> 4_u8);
+                nibble[2_u32 * i] = U4::from_u8(x & 15_u8);
             }
         }
     } else {
         for i in 0_u32..2_u32 {
             if (i as u32) < ((length as u32) - 1_u32) {
                 let x: u8 = input[i + 1_u32];
-                {
-                    let i_2: u32 = 2_u32 * i;
-                    nibble[i_2] = U4::from_u8(x >> 4_u8);
-                };
-                {
-                    let i_3: u32 = (2_u32 * i) + 1_u32;
-                    nibble[i_3] = U4::from_u8(x & 15_u8);
-                }
+                nibble[2_u32 * i] = U4::from_u8(x >> 4_u8);
+                nibble[(2_u32 * i) + 1_u32] = U4::from_u8(x & 15_u8);
             }
         }
     };

--- a/tooling/nargo_cli/tests/snapshots/execution_success/regression_11659/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/regression_11659/execute__tests__expanded.snap
@@ -1,6 +1,5 @@
 ---
 source: tooling/nargo_cli/tests/execute.rs
-assertion_line: 381
 expression: expanded_code
 ---
 pub struct Poseidon2Sponge {

--- a/tooling/nargo_cli/tests/snapshots/execution_success/regression_capacity_tracker/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/regression_capacity_tracker/execute__tests__expanded.snap
@@ -7,10 +7,7 @@ fn main(expected: pub Field, first: Field, input: [Field; 20]) {
     hasher_vector = hasher_vector.push_front(first);
     assert(hasher_vector[0_u32] == expected);
     if (expected as u32) > 10_u32 {
-        {
-            let i_0: u32 = (expected - 10_Field) as u32;
-            hasher_vector[i_0] = 100_Field;
-        }
+        hasher_vector[(expected - 10_Field) as u32] = 100_Field;
     } else {
         hasher_vector[expected as u32] = 100_Field;
     };

--- a/tooling/nargo_cli/tests/snapshots/execution_success/vector_dynamic_index/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/vector_dynamic_index/execute__tests__expanded.snap
@@ -35,10 +35,7 @@ fn dynamic_vector_index_set_if(mut vector: [Field], x: u32, y: u32) {
     if (x as u32) < 10_u32 {
         assert(vector[x] == 4_Field);
         vector[x] = vector[x] - 2_Field;
-        {
-            let i_0: u32 = x - 1_u32;
-            vector[i_0] = vector[x];
-        }
+        vector[x - 1_u32] = vector[x];
     } else {
         vector[x] = 0_Field;
     };
@@ -55,10 +52,7 @@ fn dynamic_vector_index_set_else(mut vector: [Field], x: u32, y: u32) {
     if (x as u32) > 10_u32 {
         assert(vector[x] == 4_Field);
         vector[x] = vector[x] - 2_Field;
-        {
-            let i_0: u32 = x - 1_u32;
-            vector[i_0] = vector[x];
-        }
+        vector[x - 1_u32] = vector[x];
     } else {
         vector[x] = 0_Field;
     };

--- a/tooling/nargo_cli/tests/snapshots/execution_success/vector_dynamic_insert/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/vector_dynamic_insert/execute__tests__expanded.snap
@@ -20,10 +20,7 @@ fn insert(x: u32, array: [Field; 5]) {
 
 fn insert_dynamic_array(x: u32, array: [Field; 5]) {
     let mut value_to_insert: [Field; 5] = array;
-    {
-        let i_0: u32 = x - 1_u32;
-        value_to_insert[i_0] = 10_Field;
-    };
+    value_to_insert[x - 1_u32] = 10_Field;
     let mut vector: [[Field; 5]] = [array, array, array].as_vector();
     vector = vector.insert(x - 3_u32, value_to_insert);
     assert(vector.len() == 4_u32);


### PR DESCRIPTION
## Problem Resolved

Resolves https://github.com/noir-lang/noir-claude/issues/1089

## Summary of Changes

I noticed that in the failing program monomorphization ended up like this:

```
    arr$l0[i$l1] = (arr$l0[i$l1] + {
        i$l1 = 1;
        5
    });
```

However, the correct program should have the block that has `i$l1 = 1;` be executed before everything else, and that's what's done in this PR. You can take a look at the updated nargo expand snapshot to see this.

Note: I don't fully understand yet why Brillig bytecode and executed ops changed. The differences I'm seeing in monomorphization are exactly the one I described above. For example, before we had:

```
state$l22[0] = (state$l22[0] + input$l18[(i$l23 * RATE$g1)]);
```

now we have:

```
{
    let op_rhs_0$l24 = input$l18[(i$l23 * RATE$g1)];
    state$l22[0] = (state$l22[0] + op_rhs_0$l24)
};
```

The only difference I see is that now we execute the RHS before the LHS. Maybe that leads to a difference somehow?

In any case:
- I think executing the RHS before the LHS is more correct
- there are some medium-sized regressions in brillig bytecode size
- there are some tiny regressions in brillig opcodes executed
- there are some good improvements in brillig opcodes executed

So maybe this is a good change?

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
