### PR TITLE
fix(ssa-gen): consider `&mut (*x)` to be `x` in codegen_reference

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/ssa_gen/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/ssa_gen/mod.rs
@@ -480,6 +480,19 @@ impl FunctionContext<'_> {
                 let tuple = self.codegen_reference(tuple)?;
                 Ok(Self::get_field(tuple, *index))
             }
+            // `&mut (*x)` is just `x`. Wrapping as `Value::Mutable` signals to
+            // the surrounding `UnaryOp::Reference` handler that these are already addresses,
+            // so it returns them directly instead of allocating a fresh temporary copy.
+            Expression::Unary(unary)
+                if matches!(unary.operator, UnaryOp::Dereference { .. }) && !unary.skip =>
+            {
+                let references = self.codegen_expression(&unary.rhs)?;
+                let element_types = Self::convert_type(&unary.result_type);
+                Ok(references.map_both(element_types, |value, element_type| {
+                    let reference = value.eval_reference();
+                    Tree::Leaf(value::Value::Mutable(reference, element_type))
+                }))
+            }
             other => self.codegen_expression(other),
         }
     }

--- a/test_programs/compile_success_empty/reborrow_through_deref/Nargo.toml
+++ b/test_programs/compile_success_empty/reborrow_through_deref/Nargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "reborrow_through_deref"
+type = "bin"
+authors = [""]
+
+[dependencies]

--- a/test_programs/compile_success_empty/reborrow_through_deref/src/main.nr
+++ b/test_programs/compile_success_empty/reborrow_through_deref/src/main.nr
@@ -1,0 +1,12 @@
+struct Pair {
+    a: Field,
+    b: Field,
+}
+
+fn main() {
+    let mut pair = Pair { a: 1, b: 2 };
+    let pair_ref = &mut pair;
+    let field_ref = &mut (*pair_ref).b;
+    *field_ref = 9;
+    assert(pair.b == 9);
+}

--- a/tooling/nargo_cli/tests/snapshots/compile_success_empty/reborrow_through_deref/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_empty/reborrow_through_deref/execute__tests__expanded.snap
@@ -1,0 +1,17 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+assertion_line: 432
+expression: expanded_code
+---
+struct Pair {
+    a: Field,
+    b: Field,
+}
+
+fn main() {
+    let mut pair: Pair = Pair { a: 1_Field, b: 2_Field };
+    let pair_ref: &mut Pair = &mut pair;
+    let field_ref: &mut Field = &mut (*pair_ref).b;
+    *field_ref = 9_Field;
+    assert(pair.b == 9_Field);
+}


### PR DESCRIPTION
## Problem Resolved

Resolves https://github.com/noir-lang/noir-claude/issues/1099

## Summary of Changes



## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
