### PR TITLE
chore: Remove `Clone` from args of calls to oracle wrappers during SSA generation

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/ssa_gen/context.rs
+++ b/compiler/noirc_evaluator/src/ssa/ssa_gen/context.rs
@@ -42,7 +42,7 @@ pub(super) struct FunctionContext<'a> {
     pub(super) redefinitions_allowed: bool,
 
     pub(super) builder: FunctionBuilder,
-    shared_context: &'a SharedContext,
+    pub(super) shared_context: &'a SharedContext,
 
     /// Contains any loops we're currently in the middle of translating.
     /// These are ordered such that an inner loop is at the end of the vector and

--- a/compiler/noirc_evaluator/src/ssa/ssa_gen/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/ssa_gen/mod.rs
@@ -1285,7 +1285,7 @@ impl FunctionContext<'_> {
         let program = &self.shared_context.program;
         let can_modify_args = !is_pure_builtin_func(&call.func)
             && !is_oracle_func(&call.func)
-            && !is_oracle_wrapper(&call.func, program, ORACLE_WRAPPER_MAX_DEPTH);
+            && !is_oracle_wrapper(&call.func, program);
 
         for argument in &call.arguments {
             // The ownership pass inserts `Clone` around call arguments, however if we know that
@@ -1683,11 +1683,6 @@ fn is_oracle_func(expr: &Expression) -> bool {
     matches!(expr, Expression::Ident(ast::Ident { definition: ast::Definition::Oracle { .. }, .. }))
 }
 
-/// Maximum recursion depth for [`is_oracle_wrapper`]. Real wrapper chains are 2–3 deep
-/// (e.g. `println` -> `print_unconstrained` -> `print` oracle); the bound only exists to
-/// keep pathological inputs from blowing the stack.
-const ORACLE_WRAPPER_MAX_DEPTH: u32 = 8;
-
 /// Return whether the expression refers to a function whose body, after peeling block/semi
 /// wrapping, is exactly one [`Call`](ast::Call) whose target is either an oracle directly
 /// or another oracle wrapper.
@@ -1696,22 +1691,30 @@ const ORACLE_WRAPPER_MAX_DEPTH: u32 = 8;
 /// only read their inputs (values are copied across the runtime boundary), so a wrapper
 /// that forwards to one cannot modify its array arguments either. This lets us drop the
 /// `Clone` that the ownership pass conservatively inserts around array arguments.
-///
-/// `depth` is the maximum remaining recursion depth; reaching zero bails out conservatively.
-fn is_oracle_wrapper(expr: &Expression, program: &Program, depth: u32) -> bool {
-    if depth == 0 {
-        return false;
+fn is_oracle_wrapper(expr: &Expression, program: &Program) -> bool {
+    /// Maximum recursion depth for [`is_oracle_wrapper`]. Real wrapper chains are 2–3 deep
+    /// (e.g. `println` -> `print_unconstrained` -> `print` oracle); the bound only exists to
+    /// keep pathological inputs from blowing the stack.
+    const ORACLE_WRAPPER_MAX_DEPTH: u32 = 5;
+
+    /// `depth` is the maximum remaining recursion depth; reaching zero bails out conservatively.
+    fn go(expr: &Expression, program: &Program, depth: u32) -> bool {
+        if depth == 0 {
+            return false;
+        }
+        let Expression::Ident(ident) = expr else {
+            return false;
+        };
+        let ast::Definition::Function(func_id) = &ident.definition else {
+            return false;
+        };
+        let Some(inner) = peel_to_single_call(&program[*func_id].body) else {
+            return false;
+        };
+        is_oracle_func(&inner.func) || go(&inner.func, program, depth - 1)
     }
-    let Expression::Ident(ident) = expr else {
-        return false;
-    };
-    let ast::Definition::Function(func_id) = &ident.definition else {
-        return false;
-    };
-    let Some(inner) = peel_to_single_call(&program[*func_id].body) else {
-        return false;
-    };
-    is_oracle_func(&inner.func) || is_oracle_wrapper(&inner.func, program, depth - 1)
+
+    go(expr, program, ORACLE_WRAPPER_MAX_DEPTH)
 }
 
 /// If `expr` is a block or `Semi` wrapping that ultimately reduces to a single

--- a/compiler/noirc_evaluator/src/ssa/ssa_gen/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/ssa_gen/mod.rs
@@ -1279,8 +1279,13 @@ impl FunctionContext<'_> {
         let function = self.codegen_non_tuple_expression(&call.func)?;
         let mut arguments = Vec::with_capacity(call.arguments.len());
 
-        // Do we know that the callee won't modify its arguments? Foreign calls only read their inputs.
-        let can_modify_args = !is_pure_builtin_func(&call.func) && !is_oracle_func(&call.func);
+        // Do we know that the callee won't modify its arguments? Foreign calls only read their
+        // inputs, and the same property propagates through thin wrappers that only forward to
+        // a foreign call (e.g. `println` -> `print_unconstrained` -> `print` oracle).
+        let program = &self.shared_context.program;
+        let can_modify_args = !is_pure_builtin_func(&call.func)
+            && !is_oracle_func(&call.func)
+            && !is_oracle_wrapper(&call.func, program, ORACLE_WRAPPER_MAX_DEPTH);
 
         for argument in &call.arguments {
             // The ownership pass inserts `Clone` around call arguments, however if we know that
@@ -1676,4 +1681,46 @@ fn is_pure_builtin_func(expr: &Expression) -> bool {
 /// Return whether the expression refers to a foreign function.
 fn is_oracle_func(expr: &Expression) -> bool {
     matches!(expr, Expression::Ident(ast::Ident { definition: ast::Definition::Oracle { .. }, .. }))
+}
+
+/// Maximum recursion depth for [`is_oracle_wrapper`]. Real wrapper chains are 2–3 deep
+/// (e.g. `println` -> `print_unconstrained` -> `print` oracle); the bound only exists to
+/// keep pathological inputs from blowing the stack.
+const ORACLE_WRAPPER_MAX_DEPTH: u32 = 8;
+
+/// Return whether the expression refers to a function whose body, after peeling block/semi
+/// wrapping, is exactly one [`Call`](ast::Call) whose target is either an oracle directly
+/// or another oracle wrapper.
+///
+/// Such "thin wrappers" inherit the input-preserving property of oracles: foreign calls
+/// only read their inputs (values are copied across the runtime boundary), so a wrapper
+/// that forwards to one cannot modify its array arguments either. This lets us drop the
+/// `Clone` that the ownership pass conservatively inserts around array arguments.
+///
+/// `depth` is the maximum remaining recursion depth; reaching zero bails out conservatively.
+fn is_oracle_wrapper(expr: &Expression, program: &Program, depth: u32) -> bool {
+    if depth == 0 {
+        return false;
+    }
+    let Expression::Ident(ident) = expr else {
+        return false;
+    };
+    let ast::Definition::Function(func_id) = &ident.definition else {
+        return false;
+    };
+    let Some(inner) = peel_to_single_call(&program[*func_id].body) else {
+        return false;
+    };
+    is_oracle_func(&inner.func) || is_oracle_wrapper(&inner.func, program, depth - 1)
+}
+
+/// If `expr` is a block or `Semi` wrapping that ultimately reduces to a single
+/// [`Call`](ast::Call), return that call. Otherwise return `None`.
+fn peel_to_single_call(expr: &Expression) -> Option<&ast::Call> {
+    match expr {
+        Expression::Call(call) => Some(call),
+        Expression::Semi(inner) => peel_to_single_call(inner),
+        Expression::Block(stmts) if stmts.len() == 1 => peel_to_single_call(&stmts[0]),
+        _ => None,
+    }
 }

--- a/compiler/noirc_evaluator/src/ssa/ssa_gen/tests.rs
+++ b/compiler/noirc_evaluator/src/ssa/ssa_gen/tests.rs
@@ -307,7 +307,9 @@ fn oracle_wrapper_call_args_do_not_get_cloned() {
 
     let ssa = generate_ssa(program).unwrap();
 
-    // The `inc_rc v0` in `foo` is the SSA lowering of the unnecessary `.clone()`.
+    // `foo` does not emit `inc_rc v0` before the call to `println` even though the
+    // monomorphized AST contains `a.clone()`: the SSA-gen call lowering recognizes
+    // `println` as a thin wrapper around the `print` oracle and skips the clone.
     assert_ssa_snapshot!(ssa, @r#"
     brillig(inline) fn main f0 {
       b0():
@@ -317,7 +319,6 @@ fn oracle_wrapper_call_args_do_not_get_cloned() {
     }
     brillig(inline) fn foo f1 {
       b0(v0: [u64; 1]):
-        inc_rc v0
         call f2(v0)
         v3 = array_get v0, index u32 0 -> u64
         return v3

--- a/compiler/noirc_evaluator/src/ssa/ssa_gen/tests.rs
+++ b/compiler/noirc_evaluator/src/ssa/ssa_gen/tests.rs
@@ -273,6 +273,70 @@ fn foreign_call_args_do_not_get_cloned() {
 }
 
 #[test]
+fn oracle_wrapper_call_args_do_not_get_cloned() {
+    let src = "
+    unconstrained fn main() -> pub u64 {
+        foo([1])
+    }
+    unconstrained fn foo(a: [u64; 1]) -> u64 {
+        println(a);
+        a[0]
+    }
+    ";
+
+    let program = get_monomorphized_with_stdlib(src, &[stdlib_src::PRINT]).unwrap();
+
+    // The ownership pass wraps `a` in `.clone()` in `foo` because `a` is used again
+    // after the `println` call. The clone is unnecessary: the wrapper chain only
+    // forwards the argument to the `print` oracle, which cannot modify the array.
+    insta::assert_snapshot!(program.to_string(), @r##"
+    unconstrained fn main$f0() -> pub u64 {
+        foo$f1([1])
+    }
+    unconstrained fn foo$f1(a$l0: [u64; 1]) -> u64 {
+        println$f2(a$l0.clone());;
+        a$l0[0]
+    }
+    unconstrained fn println$f2(input$l1: [u64; 1]) -> () {
+        print_unconstrained$f3(true, input$l1);
+    }
+    unconstrained fn print_unconstrained$f3(with_newline$l2: bool, input$l3: [u64; 1]) -> () {
+        print_oracle$print(with_newline$l2, input$l3, r#"{"kind":"array","length":1,"type":{"kind":"unsignedinteger","width":64}}"#, false);
+    }
+    "##);
+
+    let ssa = generate_ssa(program).unwrap();
+
+    // The `inc_rc v0` in `foo` is the SSA lowering of the unnecessary `.clone()`.
+    assert_ssa_snapshot!(ssa, @r#"
+    brillig(inline) fn main f0 {
+      b0():
+        v1 = make_array [u64 1] : [u64; 1]
+        v3 = call f1(v1) -> u64
+        return v3
+    }
+    brillig(inline) fn foo f1 {
+      b0(v0: [u64; 1]):
+        inc_rc v0
+        call f2(v0)
+        v3 = array_get v0, index u32 0 -> u64
+        return v3
+    }
+    brillig(inline) fn println f2 {
+      b0(v0: [u64; 1]):
+        call f3(u1 1, v0)
+        return
+    }
+    brillig(inline) fn print_unconstrained f3 {
+      b0(v0: u1, v1: [u64; 1]):
+        v26 = make_array b"{\"kind\":\"array\",\"length\":1,\"type\":{\"kind\":\"unsignedinteger\",\"width\":64}}"
+        call print(v0, v1, v26, u1 0)
+        return
+    }
+    "#);
+}
+
+#[test]
 fn for_loop_exclusive() {
     let assert_src = "
     fn main() -> pub u32 {

--- a/compiler/noirc_frontend/src/test_utils.rs
+++ b/compiler/noirc_frontend/src/test_utils.rs
@@ -285,5 +285,13 @@ pub mod stdlib_src {
     pub const PRINT: &str = "
         #[oracle(print)]
         unconstrained fn print_oracle<T>(with_newline: bool, input: T) {}
+
+        unconstrained fn println<T>(input: T) {
+            print_unconstrained(true, input);
+        }
+
+        unconstrained fn print_unconstrained<T>(with_newline: bool, input: T) {
+            print_oracle(with_newline, input);
+        }
     ";
 }


### PR DESCRIPTION
## Problem Resolved

During `ssa_gen`, the `codegen_call` method inspects the callee and if it's a pure builtin, or an oracle, then it strips any `Clone` from around the arguments: since these callees don't modify their arguments, we don't need to clone array inputs. However, so far we only checked direct oracle calls, and thus if the call to the oracle went through a proxy, then the `Clone` stayed in place.

One example of such proxies is the `println` function: the AST fuzzer does not wrap prints into wrappers, but rather calls the print oracle directly, which is allowed in unconstrained code. In constrained code, the fuzzer wraps them since https://github.com/noir-lang/noir/pull/12147 The `proxies.rs` pass automatically wraps direct oracle calls from ACIR runtimes as well. 

Not wrapping the `println` in unconstrained code was what allowed the fuzzer to discover https://github.com/noir-lang/noir/pull/12665, but it makes it unnecessarily hard to replicate the issue with a fresh Noir code, because prints always come with proxies in the normal pipeline, unlike other oracles (which would trigger the same bug, but are harder to wire into an ad-hoc Noir program). 

Even though oracle proxies are not needed since https://github.com/noir-lang/noir/pull/10827 `aztec-packages` still contains a mix of direct and [indirect](https://github.com/AztecProtocol/aztec-packages/blob/67d868d9480f21fa114008962e4531376ca95c74/noir-projects/aztec-nr/aztec/src/oracle/tx_phase.nr#L16-L17) calls to oracles. By considering proxies as "indirectly calling an oracle" we might be able to get rid of some extra clones.

## Summary of Changes

Add an `is_oracle_wrapper` function to tell if a function is directly calling an oracle (the existing `is_oracle_call`), or it's a function with a single `Call` instruction, calling an oracle or an oracle wrapper.

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
