### PR TITLE
fix: Change error exprs to return SkippedDueToEarlierErrors

### DIFF
--- a/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
@@ -721,8 +721,8 @@ impl<'local, 'interner> Interpreter<'local, 'interner> {
                 Err(InterpreterError::UnquoteFoundDuringEvaluation { location })
             }
             HirExpression::Error => {
-                let location = self.elaborator.interner.expr_location(&id);
-                Err(InterpreterError::ErrorNodeEncountered { location })
+                self.elaborator.comptime_evaluation_halted = true;
+                Err(InterpreterError::SkippedDueToEarlierErrors)
             }
         };
         self.evaluation_depth -= 1;
@@ -1372,7 +1372,11 @@ impl<'local, 'interner> Interpreter<'local, 'interner> {
                 self.evaluate(expression)?;
                 Ok(Value::Unit)
             }
-            HirStatement::Error | HirStatement::TraitAssociatedConstant => {
+            HirStatement::Error => {
+                self.elaborator.comptime_evaluation_halted = true;
+                Err(InterpreterError::SkippedDueToEarlierErrors)
+            }
+            HirStatement::TraitAssociatedConstant => {
                 let location = self.elaborator.interner.id_location(statement);
                 Err(InterpreterError::ErrorNodeEncountered { location })
             }

--- a/compiler/noirc_frontend/src/tests/metaprogramming/skip_interpreter_on_fail.rs
+++ b/compiler/noirc_frontend/src/tests/metaprogramming/skip_interpreter_on_fail.rs
@@ -1,6 +1,10 @@
 //! Tests for skipping the comptime interpreter when there are elaboration errors for
 //! comptime blocks, functions, or let statements.
 
+use crate::hir::comptime::InterpreterError;
+use crate::hir::def_collector::dc_crate::CompilationError;
+use crate::parser::ParserErrorReason;
+use crate::test_utils::{GetProgramOptions, get_program_with_options};
 use crate::tests::check_errors;
 
 #[test]
@@ -1039,4 +1043,57 @@ fn mismatched_struct_pattern_assignment() {
     }
     ";
     check_errors(src);
+}
+
+// Regression for https://github.com/noir-lang/noir/issues/12678
+//
+// `comptime { return; }` should report only the parser-level "Early 'return' is
+// unsupported" error, not the additional "Internal Compiler Error: Error node
+// encountered" ICE that asks users to file a bug.
+#[test]
+fn early_return_in_comptime_block_does_not_ice() {
+    let src = "fn main() { comptime { return; } }";
+    let errors = get_program_with_options(
+        src,
+        GetProgramOptions { allow_parser_errors: true, ..Default::default() },
+    )
+    .2;
+
+    let has_early_return = errors.iter().any(|e| {
+        matches!(
+            e,
+            CompilationError::ParseError(err)
+                if matches!(err.reason(), Some(ParserErrorReason::EarlyReturn))
+        )
+    });
+    assert!(has_early_return, "expected EarlyReturn parser error, got: {errors:?}");
+
+    let has_ice = errors.iter().any(|e| {
+        matches!(e, CompilationError::InterpreterError(InterpreterError::ErrorNodeEncountered { .. }))
+    });
+    assert!(!has_ice, "should not emit ErrorNodeEncountered ICE, got: {errors:?}");
+}
+
+// Companion regression: the same defensive skip should also apply to HirExpression::Error.
+// An unresolved path inside a comptime block is one way to produce an Error expression
+// after the elaborator has already reported a name-resolution error.
+#[test]
+fn unresolved_path_in_comptime_block_does_not_ice() {
+    let src = "
+    fn main() {
+        comptime {
+            let _ = nonexistent::path;
+        }
+    }
+    ";
+    let errors = get_program_with_options(
+        src,
+        GetProgramOptions { allow_elaborator_errors: true, ..Default::default() },
+    )
+    .2;
+
+    let has_ice = errors.iter().any(|e| {
+        matches!(e, CompilationError::InterpreterError(InterpreterError::ErrorNodeEncountered { .. }))
+    });
+    assert!(!has_ice, "should not emit ErrorNodeEncountered ICE, got: {errors:?}");
 }

--- a/compiler/noirc_frontend/src/tests/metaprogramming/skip_interpreter_on_fail.rs
+++ b/compiler/noirc_frontend/src/tests/metaprogramming/skip_interpreter_on_fail.rs
@@ -1069,7 +1069,10 @@ fn early_return_in_comptime_block_does_not_ice() {
     assert!(has_early_return, "expected EarlyReturn parser error, got: {errors:?}");
 
     let has_ice = errors.iter().any(|e| {
-        matches!(e, CompilationError::InterpreterError(InterpreterError::ErrorNodeEncountered { .. }))
+        matches!(
+            e,
+            CompilationError::InterpreterError(InterpreterError::ErrorNodeEncountered { .. })
+        )
     });
     assert!(!has_ice, "should not emit ErrorNodeEncountered ICE, got: {errors:?}");
 }
@@ -1093,7 +1096,10 @@ fn unresolved_path_in_comptime_block_does_not_ice() {
     .2;
 
     let has_ice = errors.iter().any(|e| {
-        matches!(e, CompilationError::InterpreterError(InterpreterError::ErrorNodeEncountered { .. }))
+        matches!(
+            e,
+            CompilationError::InterpreterError(InterpreterError::ErrorNodeEncountered { .. })
+        )
     });
     assert!(!has_ice, "should not emit ErrorNodeEncountered ICE, got: {errors:?}");
 }

--- a/tooling/nargo_cli/tests/snapshots/compile_failure/comptime_stack_overflow_deeply_nested/execute__tests__stderr.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_failure/comptime_stack_overflow_deeply_nested/execute__tests__stderr.snap
@@ -25,13 +25,6 @@ error: expected type u32, found type ()
     │ ╰─────' () returned here
     │  
 
-error: Internal Compiler Error: Error node encountered
-    ┌─ src/main.nr:307:6
-    │
-307 │     )
-    │      - This is a bug, please report this if found!
-    │
-
 error: Maximum recursion depth exceeded while parsing expression
     ┌─ src/main.nr:101:404
     │
@@ -39,4 +32,4 @@ error: Maximum recursion depth exceeded while parsing expression
     │                                                                                                                                                                                                                                                                                                                                                                                                                    ---------
     │
 
-Aborting due to 3 previous errors
+Aborting due to 2 previous errors


### PR DESCRIPTION
## Problem Resolved

Resolves https://github.com/noir-lang/noir/issues/12678

## Summary of Changes

Any error exprs in the interpreter should have been emitted by the elaborator since it is the only component that emits Hir. So these nodes should be from earlier errors and we shouldn't report new ones.

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
