### PR TITLE
feat!: allow UTF-8 in comments

### DIFF
--- a/compiler/noirc_frontend/src/lexer/errors.rs
+++ b/compiler/noirc_frontend/src/lexer/errors.rs
@@ -40,8 +40,6 @@ pub enum LexerErrorKind {
     InvalidEscape { escaped: char, location: Location },
     #[error("Invalid quote delimiter `{delimiter}`, valid delimiters are `{{`, `[`, and `(`")]
     InvalidQuoteDelimiter { delimiter: LocatedToken },
-    #[error("Non-ASCII characters are invalid in comments")]
-    NonAsciiComment { location: Location },
     #[error("Expected `{end_delim}` to close this {start_delim}")]
     UnclosedQuote { start_delim: LocatedToken, end_delim: Token },
     #[error("Unicode character '{}' looks like space, but is it not", char)]
@@ -81,7 +79,6 @@ impl LexerErrorKind {
             | LexerErrorKind::InvalidFormatString { location, .. }
             | LexerErrorKind::EmptyFormatStringInterpolation { location, .. }
             | LexerErrorKind::InvalidEscape { location, .. }
-            | LexerErrorKind::NonAsciiComment { location, .. }
             | LexerErrorKind::MalformedMustUseAttribute { location }
             | LexerErrorKind::UnicodeCharacterLooksLikeSpaceButIsItNot { location, .. } => {
                 *location
@@ -177,9 +174,6 @@ impl LexerErrorKind {
             LexerErrorKind::InvalidQuoteDelimiter { delimiter } => {
                 (format!("Invalid quote delimiter `{delimiter}`"), "Valid delimiters are `{`, `[`, and `(`".to_string(), delimiter.location())
             },
-            LexerErrorKind::NonAsciiComment { location } => {
-                ("Non-ASCII character in comment".to_string(), "Invalid comment character: only ASCII is currently supported.".to_string(), *location)
-            }
             LexerErrorKind::UnclosedQuote { start_delim, end_delim } => {
                 ("Unclosed `quote` expression".to_string(), format!("Expected a `{end_delim}` to close this `{start_delim}`"), start_delim.location())
             }

--- a/compiler/noirc_frontend/src/lexer/errors.rs
+++ b/compiler/noirc_frontend/src/lexer/errors.rs
@@ -44,6 +44,8 @@ pub enum LexerErrorKind {
     UnclosedQuote { start_delim: LocatedToken, end_delim: Token },
     #[error("Unicode character '{}' looks like space, but is it not", char)]
     UnicodeCharacterLooksLikeSpaceButIsItNot { char: char, location: Location },
+    #[error("Unicode bidirectional control character '\\u{{{:x}}}' is not allowed", *char as u32)]
+    BidiControlCharacter { char: char, location: Location },
     #[error(
         "Invalid form of the `must_use` attribute. Valid forms are `#[must_use]` and `#[must_use = \"message\"]`"
     )]
@@ -80,9 +82,8 @@ impl LexerErrorKind {
             | LexerErrorKind::EmptyFormatStringInterpolation { location, .. }
             | LexerErrorKind::InvalidEscape { location, .. }
             | LexerErrorKind::MalformedMustUseAttribute { location }
-            | LexerErrorKind::UnicodeCharacterLooksLikeSpaceButIsItNot { location, .. } => {
-                *location
-            }
+            | LexerErrorKind::UnicodeCharacterLooksLikeSpaceButIsItNot { location, .. }
+            | LexerErrorKind::BidiControlCharacter { location, .. } => *location,
             LexerErrorKind::InvalidQuoteDelimiter { delimiter } => delimiter.location(),
             LexerErrorKind::UnclosedQuote { start_delim, .. } => start_delim.location(),
         }
@@ -220,6 +221,28 @@ impl LexerErrorKind {
             LexerErrorKind::MalformedMustUseAttribute { location } => {
                 ("Invalid syntax for `must_use` attribute".to_string(), "Valid syntaxes are: `#[must_use]` and `#[must_use = \"message\"]`".to_string(), *location)
             },
+            LexerErrorKind::BidiControlCharacter { char, location } => {
+                let char_name = match char {
+                    '\u{202A}' => "Left-to-Right Embedding",
+                    '\u{202B}' => "Right-to-Left Embedding",
+                    '\u{202C}' => "Pop Directional Formatting",
+                    '\u{202D}' => "Left-to-Right Override",
+                    '\u{202E}' => "Right-to-Left Override",
+                    '\u{2066}' => "Left-to-Right Isolate",
+                    '\u{2067}' => "Right-to-Left Isolate",
+                    '\u{2068}' => "First Strong Isolate",
+                    '\u{2069}' => "Pop Directional Isolate",
+                    _ => "Unicode bidirectional control character",
+                };
+                let primary = format!(
+                    "Unicode bidirectional control character not allowed: \\u{{{:x}}}",
+                    (*char as u32)
+                );
+                let secondary = format!(
+                    "{char_name} can visually reorder source text and is rejected to prevent \"Trojan Source\" attacks"
+                );
+                (primary, secondary, *location)
+            }
         }
     }
 }

--- a/compiler/noirc_frontend/src/lexer/errors.rs
+++ b/compiler/noirc_frontend/src/lexer/errors.rs
@@ -46,6 +46,8 @@ pub enum LexerErrorKind {
     UnicodeCharacterLooksLikeSpaceButIsItNot { char: char, location: Location },
     #[error("Unicode bidirectional control character '\\u{{{:x}}}' is not allowed", *char as u32)]
     BidiControlCharacter { char: char, location: Location },
+    #[error("Unicode tag character '\\u{{{:x}}}' is not allowed", *char as u32)]
+    TagCharacter { char: char, location: Location },
     #[error(
         "Invalid form of the `must_use` attribute. Valid forms are `#[must_use]` and `#[must_use = \"message\"]`"
     )]
@@ -83,7 +85,8 @@ impl LexerErrorKind {
             | LexerErrorKind::InvalidEscape { location, .. }
             | LexerErrorKind::MalformedMustUseAttribute { location }
             | LexerErrorKind::UnicodeCharacterLooksLikeSpaceButIsItNot { location, .. }
-            | LexerErrorKind::BidiControlCharacter { location, .. } => *location,
+            | LexerErrorKind::BidiControlCharacter { location, .. }
+            | LexerErrorKind::TagCharacter { location, .. } => *location,
             LexerErrorKind::InvalidQuoteDelimiter { delimiter } => delimiter.location(),
             LexerErrorKind::UnclosedQuote { start_delim, .. } => start_delim.location(),
         }
@@ -221,6 +224,15 @@ impl LexerErrorKind {
             LexerErrorKind::MalformedMustUseAttribute { location } => {
                 ("Invalid syntax for `must_use` attribute".to_string(), "Valid syntaxes are: `#[must_use]` and `#[must_use = \"message\"]`".to_string(), *location)
             },
+            LexerErrorKind::TagCharacter { char, location } => {
+                let primary = format!(
+                    "Unicode tag character not allowed: \\u{{{:x}}}",
+                    (*char as u32)
+                );
+                let secondary = "Unicode tag characters (U+E0000\u{2013}U+E007F) are invisible in source but real bytes to text processors, and have been used to smuggle hidden instructions into LLM-assisted reviews"
+                    .to_string();
+                (primary, secondary, *location)
+            }
             LexerErrorKind::BidiControlCharacter { char, location } => {
                 let char_name = match char {
                     '\u{202A}' => "Left-to-Right Embedding",

--- a/compiler/noirc_frontend/src/lexer/lexer.rs
+++ b/compiler/noirc_frontend/src/lexer/lexer.rs
@@ -182,18 +182,7 @@ impl<'a> Lexer<'a> {
             Some('r') => self.eat_raw_string_or_alpha_numeric(),
             Some('q') => self.eat_quote_or_alpha_numeric(),
             Some('#') => self.eat_attribute_start(),
-            // cSpell:disable
-            Some(ch)
-                if ch.is_whitespace()
-                    // These aren't unicode whitespace but look like '' so they are also misleading
-                    || ch == '\u{180E}'
-                    || ch == '\u{200B}'
-                    || ch == '\u{200C}'
-                    || ch == '\u{200D}'
-                    || ch == '\u{2060}'
-                    || ch == '\u{FEFF}' =>
-            {
-                // cSpell:enable
+            Some(ch) if Self::is_misleading_whitespace(ch) => {
                 let span = Span::from(self.position..self.position + 1);
                 let location = Location::new(span, self.file_id);
                 self.next_char();
@@ -842,11 +831,20 @@ impl<'a> Lexer<'a> {
             }
             _ => None,
         };
-        let comment = self.eat_while(None, |ch| ch != '\n');
 
-        if !comment.is_ascii() {
-            let span = Span::from(start..self.position);
-            return Err(LexerErrorKind::NonAsciiComment { location: self.location(span) });
+        let mut comment = String::new();
+        while let Some(ch) = self.peek_char() {
+            if ch == '\n' {
+                break;
+            }
+            self.next_char();
+            if Self::is_misleading_whitespace(ch) {
+                return Err(LexerErrorKind::UnicodeCharacterLooksLikeSpaceButIsItNot {
+                    char: ch,
+                    location: self.location(Span::single_char(self.position)),
+                });
+            }
+            comment.push(ch);
         }
 
         Ok(Token::LineComment(comment, doc_style).into_span(start, self.position))
@@ -885,15 +883,16 @@ impl<'a> Lexer<'a> {
                         break;
                     }
                 }
+                ch if Self::is_misleading_whitespace(ch) => {
+                    return Err(LexerErrorKind::UnicodeCharacterLooksLikeSpaceButIsItNot {
+                        char: ch,
+                        location: self.location(Span::single_char(self.position)),
+                    });
+                }
                 ch => content.push(ch),
             }
         }
         if depth == 0 {
-            if !content.is_ascii() {
-                let span = Span::from(start..self.position);
-                return Err(LexerErrorKind::NonAsciiComment { location: self.location(span) });
-            }
-
             Ok(Token::BlockComment(content, doc_style).into_span(start, self.position))
         } else {
             let span = Span::inclusive(start, self.position);
@@ -904,6 +903,23 @@ impl<'a> Lexer<'a> {
     fn is_code_whitespace(c: char) -> bool {
         c == '\t' || c == '\n' || c == '\r' || c == ' '
     }
+
+    // cSpell:disable
+    /// Returns true for Unicode characters that visually resemble an ASCII space
+    /// but are not `is_code_whitespace`. Rejecting these keeps the lexer's
+    /// whitespace rules ASCII-only and prevents look-alike characters from
+    /// sneaking into source — including inside comments, where they are
+    /// invisible but could still mislead a reader.
+    fn is_misleading_whitespace(ch: char) -> bool {
+        (ch.is_whitespace() && !Self::is_code_whitespace(ch))
+            || ch == '\u{180E}'
+            || ch == '\u{200B}'
+            || ch == '\u{200C}'
+            || ch == '\u{200D}'
+            || ch == '\u{2060}'
+            || ch == '\u{FEFF}'
+    }
+    // cSpell:enable
 
     /// Skips white space. They are not significant in the source language
     fn eat_whitespace(&mut self, initial_char: char) -> SpannedToken {
@@ -1559,10 +1575,12 @@ mod tests {
 
                             Err(LexerErrorKind::InvalidIntegerLiteral { .. })
                             | Err(LexerErrorKind::UnexpectedCharacter { .. })
-                            | Err(LexerErrorKind::NonAsciiComment { .. })
                             | Err(LexerErrorKind::UnterminatedBlockComment { .. })
                             | Err(LexerErrorKind::UnterminatedStringLiteral { .. })
-                            | Err(LexerErrorKind::InvalidFormatString { .. }) => {
+                            | Err(LexerErrorKind::InvalidFormatString { .. })
+                            | Err(LexerErrorKind::UnicodeCharacterLooksLikeSpaceButIsItNot {
+                                ..
+                            }) => {
                                 expected_token_found = true;
                             }
                             Err(err) => {
@@ -1627,17 +1645,104 @@ mod tests {
     }
 
     #[test]
-    fn test_non_ascii_comments() {
+    fn test_utf8_in_line_comments() {
         // cSpell:disable-next-line
-        let cases = vec!["// 🙂", "// schön", "/* in the middle 🙂 of a comment */"];
+        let cases = vec![
+            ("// 🙂", Token::LineComment(" 🙂".to_string(), None)),
+            // cSpell:disable-next-line
+            ("// schön", Token::LineComment(" schön".to_string(), None)),
+            (
+                "/// 日本語 doc",
+                Token::LineComment(" 日本語 doc".to_string(), Some(DocStyle::Outer)),
+            ),
+            (
+                "//! 日本語 inner doc",
+                Token::LineComment(" 日本語 inner doc".to_string(), Some(DocStyle::Inner)),
+            ),
+        ];
 
-        for source in cases {
-            let mut lexer = Lexer::new_with_dummy_file(source);
-            assert!(
-                lexer.any(|token| matches!(token, Err(LexerErrorKind::NonAsciiComment { .. }))),
-                "Expected NonAsciiComment error"
-            );
+        for (source, expected_token) in cases {
+            let mut lexer = Lexer::new_with_dummy_file(source).skip_comments(false);
+            let token = lexer.next_token().expect("UTF-8 in a comment should lex").into_token();
+            assert_eq!(token, expected_token);
         }
+    }
+
+    #[test]
+    fn test_utf8_in_block_comments() {
+        // cSpell:disable-next-line
+        let cases = vec![
+            ("/* 🙂 */", Token::BlockComment(" 🙂 ".to_string(), None)),
+            // cSpell:disable-next-line
+            (
+                "/* in the middle 🙂 of a comment */",
+                Token::BlockComment(" in the middle 🙂 of a comment ".to_string(), None),
+            ),
+            (
+                "/** outer 日本語 */",
+                Token::BlockComment(" outer 日本語 ".to_string(), Some(DocStyle::Outer)),
+            ),
+            (
+                "/*! inner 日本語 */",
+                Token::BlockComment(" inner 日本語 ".to_string(), Some(DocStyle::Inner)),
+            ),
+        ];
+
+        for (source, expected_token) in cases {
+            let mut lexer = Lexer::new_with_dummy_file(source).skip_comments(false);
+            let token =
+                lexer.next_token().expect("UTF-8 in a block comment should lex").into_token();
+            assert_eq!(token, expected_token);
+        }
+    }
+
+    #[test]
+    fn test_utf8_in_comment_does_not_break_following_tokens() {
+        // The comment contains a multi-byte character; the following `let` keyword
+        // must still be recognized at the right span boundary.
+        // cSpell:disable-next-line
+        let input = "// schön\nlet x = 5;";
+        let mut lexer = Lexer::new_with_dummy_file(input);
+
+        let expected = vec![
+            Token::Keyword(Keyword::Let),
+            Token::Ident("x".to_string()),
+            Token::Assign,
+            Token::Int(5_i128.into(), None),
+            Token::Semicolon,
+        ];
+
+        for expected_token in expected {
+            let got = lexer.next_token().unwrap();
+            assert_eq!(got, expected_token);
+        }
+    }
+
+    #[test]
+    fn test_utf8_in_identifier_is_invalid_token() {
+        // A non-ASCII letter is not part of an identifier — the lexer emits a
+        // `Token::Invalid` for it (which the parser later turns into an error).
+        // cSpell:disable-next-line
+        let input = "let schön = 5;";
+        let mut lexer = Lexer::new_with_dummy_file(input);
+
+        // `let`
+        assert_eq!(lexer.next_token().unwrap().into_token(), Token::Keyword(Keyword::Let));
+        // `sch` is consumed as an identifier (only the ASCII prefix matches)
+        assert_eq!(lexer.next_token().unwrap().into_token(), Token::Ident("sch".to_string()));
+        // The next char is `ö` — it can't start any token, so it's `Invalid`.
+        match lexer.next_token().unwrap().into_token() {
+            Token::Invalid(ch) => assert_eq!(ch, 'ö'),
+            other => panic!("Expected Token::Invalid('ö'), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_utf8_in_string_literal_is_allowed() {
+        let input = "\"héllo 🙂\"";
+        let mut lexer = Lexer::new_with_dummy_file(input);
+        let token = lexer.next_token().unwrap().into_token();
+        assert_eq!(token, Token::Str("héllo 🙂".to_string()));
     }
 
     #[test]
@@ -1648,6 +1753,32 @@ mod tests {
             lexer.next_token(),
             Err(LexerErrorKind::UnicodeCharacterLooksLikeSpaceButIsItNot { .. })
         ));
+    }
+
+    #[test]
+    fn errors_on_misleading_whitespace_in_line_comment() {
+        // U+00A0 NO-BREAK SPACE looks like an ASCII space but isn't one.
+        let input = "// hello\u{00A0}world";
+        let mut lexer = Lexer::new_with_dummy_file(input);
+        match lexer.next_token() {
+            Err(LexerErrorKind::UnicodeCharacterLooksLikeSpaceButIsItNot { char, .. }) => {
+                assert_eq!(char, '\u{00A0}');
+            }
+            other => panic!("Expected UnicodeCharacterLooksLikeSpaceButIsItNot, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn errors_on_misleading_whitespace_in_block_comment() {
+        // U+00A0 NO-BREAK SPACE inside a block comment.
+        let input = "/* hello\u{00A0}world */";
+        let mut lexer = Lexer::new_with_dummy_file(input);
+        match lexer.next_token() {
+            Err(LexerErrorKind::UnicodeCharacterLooksLikeSpaceButIsItNot { char, .. }) => {
+                assert_eq!(char, '\u{00A0}');
+            }
+            other => panic!("Expected UnicodeCharacterLooksLikeSpaceButIsItNot, got {other:?}"),
+        }
     }
 
     #[test]

--- a/compiler/noirc_frontend/src/lexer/lexer.rs
+++ b/compiler/noirc_frontend/src/lexer/lexer.rs
@@ -512,6 +512,12 @@ impl<'a> Lexer<'a> {
                             location: self.location(Span::single_char(self.position)),
                         });
                     }
+                    other if Self::is_tag_character(other) => {
+                        return Err(LexerErrorKind::TagCharacter {
+                            char: other,
+                            location: self.location(Span::single_char(self.position)),
+                        });
+                    }
                     other => other,
                 };
 
@@ -592,6 +598,12 @@ impl<'a> Lexer<'a> {
                         }
                         other if Self::is_bidi_control(other) => {
                             return Err(LexerErrorKind::BidiControlCharacter {
+                                char: other,
+                                location: self.location(Span::single_char(self.position)),
+                            });
+                        }
+                        other if Self::is_tag_character(other) => {
+                            return Err(LexerErrorKind::TagCharacter {
                                 char: other,
                                 location: self.location(Span::single_char(self.position)),
                             });
@@ -748,6 +760,12 @@ impl<'a> Lexer<'a> {
                         location: self.location(Span::single_char(self.position)),
                     });
                 }
+                if Self::is_tag_character(ch) {
+                    return Err(LexerErrorKind::TagCharacter {
+                        char: ch,
+                        location: self.location(Span::single_char(self.position)),
+                    });
+                }
                 str_literal.push(ch);
             }
             if !self.peek_char_is('"') {
@@ -873,6 +891,12 @@ impl<'a> Lexer<'a> {
                     location: self.location(Span::single_char(self.position)),
                 });
             }
+            if Self::is_tag_character(ch) {
+                return Err(LexerErrorKind::TagCharacter {
+                    char: ch,
+                    location: self.location(Span::single_char(self.position)),
+                });
+            }
             comment.push(ch);
         }
 
@@ -924,6 +948,12 @@ impl<'a> Lexer<'a> {
                         location: self.location(Span::single_char(self.position)),
                     });
                 }
+                ch if Self::is_tag_character(ch) => {
+                    return Err(LexerErrorKind::TagCharacter {
+                        char: ch,
+                        location: self.location(Span::single_char(self.position)),
+                    });
+                }
                 ch => content.push(ch),
             }
         }
@@ -953,6 +983,16 @@ impl<'a> Lexer<'a> {
             || ch == '\u{200D}'
             || ch == '\u{2060}'
             || ch == '\u{FEFF}'
+    }
+
+    /// Returns true for Unicode tag characters (U+E0000\u{2013}U+E007F).
+    /// Codepoints U+E0020\u{2013}U+E007E mirror printable ASCII, so any
+    /// ASCII string can be re-encoded in this range. Virtually no renderer
+    /// displays them, but text processors (including LLM-based code review
+    /// tools) see the bytes — making them a vehicle for "ASCII smuggling"
+    /// of hidden instructions. They have no legitimate use in source code.
+    fn is_tag_character(ch: char) -> bool {
+        matches!(ch, '\u{E0000}'..='\u{E007F}')
     }
 
     /// Returns true for Unicode bidirectional control characters that can
@@ -1638,7 +1678,8 @@ mod tests {
                             | Err(LexerErrorKind::UnicodeCharacterLooksLikeSpaceButIsItNot {
                                 ..
                             })
-                            | Err(LexerErrorKind::BidiControlCharacter { .. }) => {
+                            | Err(LexerErrorKind::BidiControlCharacter { .. })
+                            | Err(LexerErrorKind::TagCharacter { .. }) => {
                                 expected_token_found = true;
                             }
                             Err(err) => {
@@ -1897,6 +1938,71 @@ mod tests {
                 assert_eq!(char, '\u{202E}');
             }
             other => panic!("Expected BidiControlCharacter, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn errors_on_tag_character_in_line_comment() {
+        // U+E0041 = "TAG LATIN CAPITAL LETTER A" — invisible to humans, but a real
+        // byte sequence that an LLM-based reviewer would tokenize.
+        let input = "// hello\u{E0041}world";
+        let mut lexer = Lexer::new_with_dummy_file(input);
+        match lexer.next_token() {
+            Err(LexerErrorKind::TagCharacter { char, .. }) => assert_eq!(char, '\u{E0041}'),
+            other => panic!("Expected TagCharacter, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn errors_on_tag_character_in_block_comment() {
+        let input = "/* hello\u{E0041}world */";
+        let mut lexer = Lexer::new_with_dummy_file(input);
+        match lexer.next_token() {
+            Err(LexerErrorKind::TagCharacter { char, .. }) => assert_eq!(char, '\u{E0041}'),
+            other => panic!("Expected TagCharacter, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn errors_on_tag_character_in_string_literal() {
+        let input = "\"hello\u{E0041}world\"";
+        let mut lexer = Lexer::new_with_dummy_file(input);
+        match lexer.next_token() {
+            Err(LexerErrorKind::TagCharacter { char, .. }) => assert_eq!(char, '\u{E0041}'),
+            other => panic!("Expected TagCharacter, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn errors_on_tag_character_in_raw_string_literal() {
+        let input = "r\"hello\u{E0041}world\"";
+        let mut lexer = Lexer::new_with_dummy_file(input);
+        match lexer.next_token() {
+            Err(LexerErrorKind::TagCharacter { char, .. }) => assert_eq!(char, '\u{E0041}'),
+            other => panic!("Expected TagCharacter, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn errors_on_tag_character_in_fmt_string_literal() {
+        let input = "f\"hello\u{E0041}world\"";
+        let mut lexer = Lexer::new_with_dummy_file(input);
+        match lexer.next_token() {
+            Err(LexerErrorKind::TagCharacter { char, .. }) => assert_eq!(char, '\u{E0041}'),
+            other => panic!("Expected TagCharacter, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn errors_on_tag_character_at_range_boundaries() {
+        // First and last codepoint of the tag block. Both must be rejected.
+        for ch in ['\u{E0000}', '\u{E007F}'] {
+            let input = format!("// x{ch}");
+            let mut lexer = Lexer::new_with_dummy_file(&input);
+            match lexer.next_token() {
+                Err(LexerErrorKind::TagCharacter { char, .. }) => assert_eq!(char, ch),
+                other => panic!("Expected TagCharacter for {:#x}, got {other:?}", ch as u32),
+            }
         }
     }
 

--- a/compiler/noirc_frontend/src/lexer/lexer.rs
+++ b/compiler/noirc_frontend/src/lexer/lexer.rs
@@ -506,6 +506,12 @@ impl<'a> Lexer<'a> {
                             });
                         }
                     },
+                    other if Self::is_bidi_control(other) => {
+                        return Err(LexerErrorKind::BidiControlCharacter {
+                            char: other,
+                            location: self.location(Span::single_char(self.position)),
+                        });
+                    }
                     other => other,
                 };
 
@@ -583,6 +589,12 @@ impl<'a> Lexer<'a> {
                         '{' => {
                             found_curly = true;
                             break;
+                        }
+                        other if Self::is_bidi_control(other) => {
+                            return Err(LexerErrorKind::BidiControlCharacter {
+                                char: other,
+                                location: self.location(Span::single_char(self.position)),
+                            });
                         }
                         other => other,
                     };
@@ -725,8 +737,19 @@ impl<'a> Lexer<'a> {
 
         let mut str_literal = String::new();
         loop {
-            let chars = self.eat_while(None, |ch| ch != '"');
-            str_literal.push_str(&chars[..]);
+            while let Some(ch) = self.peek_char() {
+                if ch == '"' {
+                    break;
+                }
+                self.next_char();
+                if Self::is_bidi_control(ch) {
+                    return Err(LexerErrorKind::BidiControlCharacter {
+                        char: ch,
+                        location: self.location(Span::single_char(self.position)),
+                    });
+                }
+                str_literal.push(ch);
+            }
             if !self.peek_char_is('"') {
                 return Err(LexerErrorKind::UnexpectedCharacter {
                     location: self.location(Span::single_char(self.position)),
@@ -844,6 +867,12 @@ impl<'a> Lexer<'a> {
                     location: self.location(Span::single_char(self.position)),
                 });
             }
+            if Self::is_bidi_control(ch) {
+                return Err(LexerErrorKind::BidiControlCharacter {
+                    char: ch,
+                    location: self.location(Span::single_char(self.position)),
+                });
+            }
             comment.push(ch);
         }
 
@@ -889,6 +918,12 @@ impl<'a> Lexer<'a> {
                         location: self.location(Span::single_char(self.position)),
                     });
                 }
+                ch if Self::is_bidi_control(ch) => {
+                    return Err(LexerErrorKind::BidiControlCharacter {
+                        char: ch,
+                        location: self.location(Span::single_char(self.position)),
+                    });
+                }
                 ch => content.push(ch),
             }
         }
@@ -918,6 +953,28 @@ impl<'a> Lexer<'a> {
             || ch == '\u{200D}'
             || ch == '\u{2060}'
             || ch == '\u{FEFF}'
+    }
+
+    /// Returns true for Unicode bidirectional control characters that can
+    /// visually reorder source text. Permitting these in source allows
+    /// "Trojan Source" attacks (CVE-2021-42574) where the rendered text
+    /// differs from the byte sequence the compiler sees. The set matches
+    /// Rust's `text_direction_codepoint_in_comment` /
+    /// `text_direction_codepoint_in_literal` lints; the plain LRM/RLM marks
+    /// (U+200E/F) don't reorder on their own and are not included.
+    fn is_bidi_control(ch: char) -> bool {
+        matches!(
+            ch,
+            '\u{202A}' // LEFT-TO-RIGHT EMBEDDING
+                | '\u{202B}' // RIGHT-TO-LEFT EMBEDDING
+                | '\u{202C}' // POP DIRECTIONAL FORMATTING
+                | '\u{202D}' // LEFT-TO-RIGHT OVERRIDE
+                | '\u{202E}' // RIGHT-TO-LEFT OVERRIDE
+                | '\u{2066}' // LEFT-TO-RIGHT ISOLATE
+                | '\u{2067}' // RIGHT-TO-LEFT ISOLATE
+                | '\u{2068}' // FIRST STRONG ISOLATE
+                | '\u{2069}' // POP DIRECTIONAL ISOLATE
+        )
     }
     // cSpell:enable
 
@@ -1580,7 +1637,8 @@ mod tests {
                             | Err(LexerErrorKind::InvalidFormatString { .. })
                             | Err(LexerErrorKind::UnicodeCharacterLooksLikeSpaceButIsItNot {
                                 ..
-                            }) => {
+                            })
+                            | Err(LexerErrorKind::BidiControlCharacter { .. }) => {
                                 expected_token_found = true;
                             }
                             Err(err) => {
@@ -1778,6 +1836,84 @@ mod tests {
                 assert_eq!(char, '\u{00A0}');
             }
             other => panic!("Expected UnicodeCharacterLooksLikeSpaceButIsItNot, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn errors_on_bidi_control_character_in_line_comment() {
+        // U+202E RIGHT-TO-LEFT OVERRIDE — the "Trojan Source" attack character.
+        let input = "// hello\u{202E}world";
+        let mut lexer = Lexer::new_with_dummy_file(input);
+        match lexer.next_token() {
+            Err(LexerErrorKind::BidiControlCharacter { char, .. }) => {
+                assert_eq!(char, '\u{202E}');
+            }
+            other => panic!("Expected BidiControlCharacter, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn errors_on_bidi_control_character_in_block_comment() {
+        let input = "/* hello\u{202E}world */";
+        let mut lexer = Lexer::new_with_dummy_file(input);
+        match lexer.next_token() {
+            Err(LexerErrorKind::BidiControlCharacter { char, .. }) => {
+                assert_eq!(char, '\u{202E}');
+            }
+            other => panic!("Expected BidiControlCharacter, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn errors_on_bidi_control_character_in_string_literal() {
+        let input = "\"hello\u{202E}world\"";
+        let mut lexer = Lexer::new_with_dummy_file(input);
+        match lexer.next_token() {
+            Err(LexerErrorKind::BidiControlCharacter { char, .. }) => {
+                assert_eq!(char, '\u{202E}');
+            }
+            other => panic!("Expected BidiControlCharacter, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn errors_on_bidi_control_character_in_raw_string_literal() {
+        let input = "r\"hello\u{202E}world\"";
+        let mut lexer = Lexer::new_with_dummy_file(input);
+        match lexer.next_token() {
+            Err(LexerErrorKind::BidiControlCharacter { char, .. }) => {
+                assert_eq!(char, '\u{202E}');
+            }
+            other => panic!("Expected BidiControlCharacter, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn errors_on_bidi_control_character_in_fmt_string_literal() {
+        let input = "f\"hello\u{202E}world\"";
+        let mut lexer = Lexer::new_with_dummy_file(input);
+        match lexer.next_token() {
+            Err(LexerErrorKind::BidiControlCharacter { char, .. }) => {
+                assert_eq!(char, '\u{202E}');
+            }
+            other => panic!("Expected BidiControlCharacter, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn errors_on_bidi_control_character_outside_comments_and_strings() {
+        // At the top level a BIDI control char falls into the `Token::Invalid` path
+        // (no token starts with it) — that's the parser's territory. This test pins
+        // that no BIDI control char ever becomes part of a valid token's text.
+        // We pick U+2066 (LRI) here to exercise a different codepoint than the others.
+        let input = "let \u{2066}x = 1;";
+        let mut lexer = Lexer::new_with_dummy_file(input);
+        // `let`
+        assert_eq!(lexer.next_token().unwrap().into_token(), Token::Keyword(Keyword::Let));
+        // The LRI char becomes a Token::Invalid (it's not whitespace, not an ident start).
+        match lexer.next_token().unwrap().into_token() {
+            Token::Invalid(ch) => assert_eq!(ch, '\u{2066}'),
+            other => panic!("Expected Token::Invalid('\\u{{2066}}'), got {other:?}"),
         }
     }
 

--- a/compiler/noirc_frontend/src/parser/parser/module.rs
+++ b/compiler/noirc_frontend/src/parser/parser/module.rs
@@ -97,4 +97,47 @@ mod tests {
         assert_eq!("foo", parsed_submodule.name.to_string());
         assert_eq!(parsed_submodule.contents.items.len(), 0);
     }
+
+    #[test]
+    fn parse_program_with_utf8_in_line_comment() {
+        // cSpell:disable-next-line
+        let src = "// schön — héllo 🙂\nmod foo;";
+        let (module, errors) = parse_program_with_dummy_file(src);
+        expect_no_errors(&errors);
+        assert_eq!(module.items.len(), 1);
+        let ItemKind::ModuleDecl(module) = &module.items[0].kind else {
+            panic!("Expected module declaration");
+        };
+        assert_eq!("foo", module.ident.to_string());
+    }
+
+    #[test]
+    fn parse_program_with_utf8_in_block_comment() {
+        let src = "/* 日本語 in a block comment */\nmod foo;";
+        let (module, errors) = parse_program_with_dummy_file(src);
+        expect_no_errors(&errors);
+        assert_eq!(module.items.len(), 1);
+        let ItemKind::ModuleDecl(module) = &module.items[0].kind else {
+            panic!("Expected module declaration");
+        };
+        assert_eq!("foo", module.ident.to_string());
+    }
+
+    #[test]
+    fn parse_program_with_utf8_in_doc_comment_on_item() {
+        let src = "/// 日本語 doc comment\nmod foo;";
+        let (module, errors) = parse_program_with_dummy_file(src);
+        expect_no_errors(&errors);
+        assert_eq!(module.items.len(), 1);
+        let item = &module.items[0];
+        assert!(!item.doc_comments.is_empty());
+    }
+
+    #[test]
+    fn parse_program_rejects_utf8_in_identifier() {
+        // cSpell:disable-next-line
+        let src = "fn schön() {}";
+        let (_module, errors) = parse_program_with_dummy_file(src);
+        assert!(!errors.is_empty(), "Expected parser errors for non-ASCII identifier");
+    }
 }

--- a/tooling/nargo_fmt/src/formatter/comments_and_whitespace.rs
+++ b/tooling/nargo_fmt/src/formatter/comments_and_whitespace.rs
@@ -1324,4 +1324,39 @@ impl Foo {
 ";
         assert_format_wrapping_comments(src, src, 120);
     }
+
+    #[test]
+    fn preserves_utf8_in_line_comment() {
+        // cSpell:disable-next-line
+        let src = "// schön — héllo 🙂
+fn main() {}
+";
+        assert_format(src, src);
+    }
+
+    #[test]
+    fn preserves_utf8_in_block_comment() {
+        let src = "/* 日本語 in a block comment */
+fn main() {}
+";
+        assert_format(src, src);
+    }
+
+    #[test]
+    fn preserves_utf8_in_doc_comment() {
+        let src = "/// 日本語 doc on a function
+fn main() {}
+";
+        assert_format(src, src);
+    }
+
+    #[test]
+    fn preserves_utf8_in_trailing_line_comment() {
+        // cSpell:disable-next-line
+        let src = "fn main() {
+    let x = 1; // héllo 🙂
+}
+";
+        assert_format(src, src);
+    }
 }


### PR DESCRIPTION
## Problem Resolved

Resolves #12697

## Summary of Changes

Also:
- disallows unicode characters that look like whitespace but aren't whitespace, in comments (we already do this in code)
- disallows bidi control characters (like in Rust) as they can be used for "Trojan Source" attacks. These are also now disallowed in strings, which is why I'm marking this is a breaking change (though it's very unlikely this will actually break existing code)
- unlike Rust, also disallows tag characters, which are invisible to humans but read by LLMs so they could tweak a bot's behavior when reviewing or auditing code

I chose to do the last point too because right now comments are very restrictive (only ASCII) and with this PR we'll already be allowing a huge new set of characters. We can always revisit allowing tags later on, though I'm not sure what use they could have in source code.

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
