### PR TITLE
fix: Add side-effect check to is_oracle_wrapper

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/ssa_gen/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/ssa_gen/mod.rs
@@ -1698,7 +1698,7 @@ fn is_oracle_func(expr: &Expression) -> bool {
 
 /// Return whether the expression refers to a function whose body, after peeling block/semi
 /// wrapping, is exactly one [`Call`](ast::Call) whose target is either an oracle directly
-/// or another oracle wrapper.
+/// or another oracle wrapper, and whose arguments are structurally side-effect-free.
 ///
 /// Such "thin wrappers" inherit the input-preserving property of oracles: foreign calls
 /// only read their inputs (values are copied across the runtime boundary), so a wrapper
@@ -1724,6 +1724,9 @@ fn is_oracle_wrapper(expr: &Expression, program: &Program) -> bool {
         let Some(inner) = peel_to_single_call(&program[*func_id].body) else {
             return false;
         };
+        if !inner.arguments.iter().all(is_side_effect_free_arg) {
+            return false;
+        }
         is_oracle_func(&inner.func) || go(&inner.func, program, depth - 1)
     }
 
@@ -1738,5 +1741,39 @@ fn peel_to_single_call(expr: &Expression) -> Option<&ast::Call> {
         Expression::Semi(inner) => peel_to_single_call(inner),
         Expression::Block(stmts) if stmts.len() == 1 => peel_to_single_call(&stmts[0]),
         _ => None,
+    }
+}
+
+/// Conservatively check whether evaluating `expr` cannot mutate any caller-visible state.
+///
+/// Used by [`is_oracle_wrapper`] to confirm that the inner call's arguments do not run
+/// any side-effectful computation (such as an `Assign` against the wrapper's parameter)
+/// before the forwarded oracle call. Anything not on this whitelist — `Block`, `Semi`,
+/// `Assign`, `Let`, nested `Call`, control flow, etc. — is treated as potentially
+/// side-effectful and rejects the wrapper classification.
+fn is_side_effect_free_arg(expr: &Expression) -> bool {
+    match expr {
+        Expression::Ident(_) => true,
+        Expression::Literal(lit) => match lit {
+            ast::Literal::Array(arr) | ast::Literal::Vector(arr) => {
+                arr.contents.iter().all(is_side_effect_free_arg)
+            }
+            ast::Literal::Repeated { element, .. } => is_side_effect_free_arg(element),
+            ast::Literal::Integer(..)
+            | ast::Literal::Bool(_)
+            | ast::Literal::Unit
+            | ast::Literal::Str(_) => true,
+            ast::Literal::FmtStr(_, _, inner) => is_side_effect_free_arg(inner),
+        },
+        Expression::ExtractTupleField(inner, _) => is_side_effect_free_arg(inner),
+        Expression::Tuple(items) => items.iter().all(is_side_effect_free_arg),
+        Expression::Index(idx) => {
+            is_side_effect_free_arg(&idx.collection) && is_side_effect_free_arg(&idx.index)
+        }
+        Expression::Cast(cast) => is_side_effect_free_arg(&cast.lhs),
+        Expression::Unary(u) => is_side_effect_free_arg(&u.rhs),
+        Expression::Binary(b) => is_side_effect_free_arg(&b.lhs) && is_side_effect_free_arg(&b.rhs),
+        Expression::Clone(inner) => is_side_effect_free_arg(inner),
+        _ => false,
     }
 }

--- a/compiler/noirc_evaluator/src/ssa/ssa_gen/tests.rs
+++ b/compiler/noirc_evaluator/src/ssa/ssa_gen/tests.rs
@@ -338,6 +338,32 @@ fn oracle_wrapper_call_args_do_not_get_cloned() {
 }
 
 #[test]
+fn oracle_wrapper_with_mutating_arg_keeps_clone() {
+    let src = "
+    unconstrained fn main(seed: Field, idx: u32) -> pub Field {
+        let array: [Field; 3] = [seed, seed + 1, seed + 2];
+        mutating_print_wrapper(array);
+        array[idx]
+    }
+
+    unconstrained fn mutating_print_wrapper(mut array: [Field; 3]) {
+        println({
+            array[0] = 9;
+            array
+        });
+    }
+    ";
+
+    let program = get_monomorphized_with_stdlib(src, &[stdlib_src::PRINT]).unwrap();
+    let ssa = generate_ssa(program).unwrap();
+
+    let results = ssa
+        .interpret(vec![InterpreterValue::field(FieldElement::one()), InterpreterValue::u32(0)])
+        .unwrap();
+    assert_eq!(results, vec![InterpreterValue::field(FieldElement::one())]);
+}
+
+#[test]
 fn for_loop_exclusive() {
     let assert_src = "
     fn main() -> pub u32 {


### PR DESCRIPTION
## Problem Resolved

Resolves https://github.com/noir-lang/noir-claude/issues/1109

## Summary of Changes



## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
