### PR TITLE
fix: only produce one error when non-ASCII is used in identifier

### DIFF
--- a/compiler/noirc_frontend/src/lexer/errors.rs
+++ b/compiler/noirc_frontend/src/lexer/errors.rs
@@ -48,6 +48,8 @@ pub enum LexerErrorKind {
     BidiControlCharacter { char: char, location: Location },
     #[error("Unicode tag character '\\u{{{:x}}}' is not allowed", *char as u32)]
     TagCharacter { char: char, location: Location },
+    #[error("Identifier '{found}' contains non-ASCII characters")]
+    NonAsciiIdentifier { found: String, location: Location },
     #[error(
         "Invalid form of the `must_use` attribute. Valid forms are `#[must_use]` and `#[must_use = \"message\"]`"
     )]
@@ -86,7 +88,8 @@ impl LexerErrorKind {
             | LexerErrorKind::MalformedMustUseAttribute { location }
             | LexerErrorKind::UnicodeCharacterLooksLikeSpaceButIsItNot { location, .. }
             | LexerErrorKind::BidiControlCharacter { location, .. }
-            | LexerErrorKind::TagCharacter { location, .. } => *location,
+            | LexerErrorKind::TagCharacter { location, .. }
+            | LexerErrorKind::NonAsciiIdentifier { location, .. } => *location,
             LexerErrorKind::InvalidQuoteDelimiter { delimiter } => delimiter.location(),
             LexerErrorKind::UnclosedQuote { start_delim, .. } => start_delim.location(),
         }
@@ -224,6 +227,13 @@ impl LexerErrorKind {
             LexerErrorKind::MalformedMustUseAttribute { location } => {
                 ("Invalid syntax for `must_use` attribute".to_string(), "Valid syntaxes are: `#[must_use]` and `#[must_use = \"message\"]`".to_string(), *location)
             },
+            LexerErrorKind::NonAsciiIdentifier { found, location } => {
+                let primary = format!("Identifier '{found}' contains non-ASCII characters");
+                let secondary =
+                    "Identifiers are restricted to ASCII letters, digits, and underscore"
+                        .to_string();
+                (primary, secondary, *location)
+            }
             LexerErrorKind::TagCharacter { char, location } => {
                 let primary = format!(
                     "Unicode tag character not allowed: \\u{{{:x}}}",

--- a/compiler/noirc_frontend/src/lexer/lexer.rs
+++ b/compiler/noirc_frontend/src/lexer/lexer.rs
@@ -188,7 +188,19 @@ impl<'a> Lexer<'a> {
                 self.next_char();
                 Err(LexerErrorKind::UnicodeCharacterLooksLikeSpaceButIsItNot { char: ch, location })
             }
-            Some(ch) if ch.is_ascii_alphanumeric() || ch == '_' => self.eat_alpha_numeric(ch),
+            Some(ch) if Self::is_bidi_control(ch) => Err(LexerErrorKind::BidiControlCharacter {
+                char: ch,
+                location: self.location(Span::single_char(self.position)),
+            }),
+            Some(ch) if Self::is_tag_character(ch) => Err(LexerErrorKind::TagCharacter {
+                char: ch,
+                location: self.location(Span::single_char(self.position)),
+            }),
+            Some(ch)
+                if ch.is_alphanumeric() || ch == '_' || (!ch.is_ascii() && !ch.is_whitespace()) =>
+            {
+                self.eat_alpha_numeric(ch)
+            }
             Some(ch) => {
                 // We don't report invalid tokens in the source as errors until parsing to
                 // avoid reporting the error twice. See the note on Token::Invalid's documentation for details.
@@ -329,14 +341,22 @@ impl<'a> Lexer<'a> {
     }
 
     fn eat_alpha_numeric(&mut self, initial_char: char) -> SpannedTokenResult {
-        match initial_char {
-            'A'..='Z' | 'a'..='z' | '_' => Ok(self.eat_word(initial_char)?),
-            '0'..='9' => self.eat_digits(Some(initial_char), false),
-            _ => Err(LexerErrorKind::UnexpectedCharacter {
+        if initial_char.is_ascii_digit() {
+            self.eat_digits(Some(initial_char), false)
+        } else if initial_char.is_alphabetic()
+            || initial_char == '_'
+            || (!initial_char.is_ascii() && !initial_char.is_whitespace())
+        {
+            // Non-ASCII non-whitespace chars (emoji, Unicode symbols) are accepted as
+            // identifier starts here purely so `eat_word` can consume the whole token
+            // and emit one `NonAsciiIdentifier` error instead of fragmenting it.
+            self.eat_word(initial_char)
+        } else {
+            Err(LexerErrorKind::UnexpectedCharacter {
                 location: self.location(Span::single_char(self.position)),
                 found: initial_char.into(),
                 expected: "an alpha numeric character".to_owned(),
-            }),
+            })
         }
     }
 
@@ -373,14 +393,25 @@ impl<'a> Lexer<'a> {
     // https://doc.rust-lang.org/stable/std/primitive.str.html#method.rsplit
     fn eat_word(&mut self, initial_char: char) -> SpannedTokenResult {
         let (start, word, end) = self.lex_word(initial_char);
+        if !word.is_ascii() {
+            return Err(LexerErrorKind::NonAsciiIdentifier {
+                found: word,
+                location: self.location(Span::from(start..end)),
+            });
+        }
         self.lookup_word_token(word, start, end)
     }
 
-    /// Lex the next word in the input stream. Returns (start position, word, end position)
+    /// Lex the next word in the input stream. Returns (start position, word, end position).
+    /// The continuation predicate is intentionally broad: ASCII alphanumerics and `_`,
+    /// plus any non-ASCII character that isn't whitespace. This lets us consume the
+    /// whole "bad" identifier as a single unit — including emoji and Unicode symbols
+    /// that aren't alphanumeric — so `eat_word` can produce one clean error instead
+    /// of fragmenting it into a token cascade.
     fn lex_word(&mut self, initial_char: char) -> (Position, String, Position) {
         let start = self.position;
         let word = self.eat_while(Some(initial_char), |ch| {
-            ch.is_ascii_alphabetic() || ch.is_numeric() || ch == '_'
+            ch.is_alphanumeric() || ch == '_' || (!ch.is_ascii() && !ch.is_whitespace())
         });
         (start, word, self.position)
     }
@@ -1679,7 +1710,8 @@ mod tests {
                                 ..
                             })
                             | Err(LexerErrorKind::BidiControlCharacter { .. })
-                            | Err(LexerErrorKind::TagCharacter { .. }) => {
+                            | Err(LexerErrorKind::TagCharacter { .. })
+                            | Err(LexerErrorKind::NonAsciiIdentifier { .. }) => {
                                 expected_token_found = true;
                             }
                             Err(err) => {
@@ -1818,22 +1850,78 @@ mod tests {
     }
 
     #[test]
-    fn test_utf8_in_identifier_is_invalid_token() {
-        // A non-ASCII letter is not part of an identifier — the lexer emits a
-        // `Token::Invalid` for it (which the parser later turns into an error).
+    fn test_non_ascii_identifier_is_single_lexer_error() {
+        // A non-ASCII letter does not split the identifier any more: the whole word is
+        // lexed as one unit and a single `NonAsciiIdentifier` error is reported.
+        // Recovery is clean — the next real token is the `=`, with no token cascade.
         // cSpell:disable-next-line
         let input = "let schön = 5;";
         let mut lexer = Lexer::new_with_dummy_file(input);
 
-        // `let`
         assert_eq!(lexer.next_token().unwrap().into_token(), Token::Keyword(Keyword::Let));
-        // `sch` is consumed as an identifier (only the ASCII prefix matches)
-        assert_eq!(lexer.next_token().unwrap().into_token(), Token::Ident("sch".to_string()));
-        // The next char is `ö` — it can't start any token, so it's `Invalid`.
-        match lexer.next_token().unwrap().into_token() {
-            Token::Invalid(ch) => assert_eq!(ch, 'ö'),
-            other => panic!("Expected Token::Invalid('ö'), got {other:?}"),
+        match lexer.next_token() {
+            Err(LexerErrorKind::NonAsciiIdentifier { found, .. }) => {
+                assert_eq!(found, "schön");
+            }
+            other => panic!("Expected NonAsciiIdentifier, got {other:?}"),
         }
+        assert_eq!(lexer.next_token().unwrap().into_token(), Token::Assign);
+    }
+
+    #[test]
+    fn test_non_ascii_identifier_starting_with_non_ascii() {
+        // The identifier starts with a non-ASCII letter.
+        let input = "日本語_var";
+        let mut lexer = Lexer::new_with_dummy_file(input);
+        match lexer.next_token() {
+            Err(LexerErrorKind::NonAsciiIdentifier { found, .. }) => {
+                assert_eq!(found, "日本語_var");
+            }
+            other => panic!("Expected NonAsciiIdentifier, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_emoji_inside_identifier_is_consumed_as_one_unit() {
+        // Emoji aren't is_alphanumeric, but to give a single clean error we want
+        // them consumed as part of the identifier rather than fragmenting it.
+        let input = "let x🙂y = 5;";
+        let mut lexer = Lexer::new_with_dummy_file(input);
+        assert_eq!(lexer.next_token().unwrap().into_token(), Token::Keyword(Keyword::Let));
+        match lexer.next_token() {
+            Err(LexerErrorKind::NonAsciiIdentifier { found, .. }) => {
+                assert_eq!(found, "x🙂y");
+            }
+            other => panic!("Expected NonAsciiIdentifier, got {other:?}"),
+        }
+        assert_eq!(lexer.next_token().unwrap().into_token(), Token::Assign);
+    }
+
+    #[test]
+    fn test_emoji_at_start_of_identifier_is_non_ascii_identifier() {
+        // A leading emoji is now treated as the start of a (bad) identifier and the
+        // whole word is reported as one NonAsciiIdentifier error — matching the
+        // mid-identifier case.
+        let input = "🙂x = 5;";
+        let mut lexer = Lexer::new_with_dummy_file(input);
+        match lexer.next_token() {
+            Err(LexerErrorKind::NonAsciiIdentifier { found, .. }) => {
+                assert_eq!(found, "🙂x");
+            }
+            other => panic!("Expected NonAsciiIdentifier, got {other:?}"),
+        }
+        assert_eq!(lexer.next_token().unwrap().into_token(), Token::Assign);
+    }
+
+    #[test]
+    fn test_ascii_identifier_still_lexes_normally() {
+        let input = "let foo_bar_42 = 1;";
+        let mut lexer = Lexer::new_with_dummy_file(input);
+        assert_eq!(lexer.next_token().unwrap().into_token(), Token::Keyword(Keyword::Let));
+        assert_eq!(
+            lexer.next_token().unwrap().into_token(),
+            Token::Ident("foo_bar_42".to_string()),
+        );
     }
 
     #[test]
@@ -2008,18 +2096,18 @@ mod tests {
 
     #[test]
     fn errors_on_bidi_control_character_outside_comments_and_strings() {
-        // At the top level a BIDI control char falls into the `Token::Invalid` path
-        // (no token starts with it) — that's the parser's territory. This test pins
-        // that no BIDI control char ever becomes part of a valid token's text.
-        // We pick U+2066 (LRI) here to exercise a different codepoint than the others.
+        // A BIDI control char at the top level produces the specific BIDI error
+        // (rather than getting absorbed into a NonAsciiIdentifier), so the user
+        // sees the precise reason — "Trojan Source" — instead of a generic
+        // non-ASCII identifier message.
         let input = "let \u{2066}x = 1;";
         let mut lexer = Lexer::new_with_dummy_file(input);
-        // `let`
         assert_eq!(lexer.next_token().unwrap().into_token(), Token::Keyword(Keyword::Let));
-        // The LRI char becomes a Token::Invalid (it's not whitespace, not an ident start).
-        match lexer.next_token().unwrap().into_token() {
-            Token::Invalid(ch) => assert_eq!(ch, '\u{2066}'),
-            other => panic!("Expected Token::Invalid('\\u{{2066}}'), got {other:?}"),
+        match lexer.next_token() {
+            Err(LexerErrorKind::BidiControlCharacter { char, .. }) => {
+                assert_eq!(char, '\u{2066}');
+            }
+            other => panic!("Expected BidiControlCharacter, got {other:?}"),
         }
     }
 

--- a/compiler/noirc_frontend/src/lexer/lexer.rs
+++ b/compiler/noirc_frontend/src/lexer/lexer.rs
@@ -396,24 +396,21 @@ impl<'a> Lexer<'a> {
         if !word.is_ascii() {
             return Err(LexerErrorKind::NonAsciiIdentifier {
                 found: word,
-                location: self.location(Span::from(start..end)),
+                location: self.location(Span::inclusive(start, end)),
             });
         }
         self.lookup_word_token(word, start, end)
     }
 
     /// Lex the next word in the input stream. Returns (start position, word, end position).
-    /// The continuation predicate is intentionally broad: ASCII alphanumerics and `_`,
-    /// plus any non-ASCII character that isn't whitespace. This lets us consume the
-    /// whole "bad" identifier as a single unit — including emoji and Unicode symbols
-    /// that aren't alphanumeric — so `eat_word` can produce one clean error instead
-    /// of fragmenting it into a token cascade.
     fn lex_word(&mut self, initial_char: char) -> (Position, String, Position) {
         let start = self.position;
         let word = self.eat_while(Some(initial_char), |ch| {
             ch.is_alphanumeric() || ch == '_' || (!ch.is_ascii() && !ch.is_whitespace())
         });
-        (start, word, self.position)
+        let last_char_len = word.chars().next_back().map_or(1, |c| c.len_utf8() as u32);
+        let end = self.position + last_char_len - 1;
+        (start, word, end)
     }
 
     fn lookup_word_token(
@@ -1876,6 +1873,29 @@ mod tests {
         match lexer.next_token() {
             Err(LexerErrorKind::NonAsciiIdentifier { found, .. }) => {
                 assert_eq!(found, "日本語_var");
+            }
+            other => panic!("Expected NonAsciiIdentifier, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_non_ascii_identifier_span_includes_full_last_char() {
+        // The span end is the offset of the byte JUST PAST the last char so that
+        // the byte range covers the whole identifier. LSP byte→UTF-16 conversion
+        // requires the offset to land on a char boundary; if the span ended in
+        // the middle of a multi-byte char, conversions for tools like inlay hints
+        // would silently fail.
+        let input = "let xé = 1;";
+        let mut lexer = Lexer::new_with_dummy_file(input);
+        let _ = lexer.next_token(); // `let`
+        match lexer.next_token() {
+            Err(LexerErrorKind::NonAsciiIdentifier { found, location }) => {
+                assert_eq!(found, "xé");
+                // 'x' is at byte 4, 'é' is 2 bytes starting at 5, so the span
+                // should be 4..7 (exclusive end past the 'é').
+                assert_eq!(location.span.start(), 4);
+                assert_eq!(location.span.end(), 7);
+                assert!(input.is_char_boundary(location.span.end() as usize));
             }
             other => panic!("Expected NonAsciiIdentifier, got {other:?}"),
         }

--- a/compiler/noirc_frontend/src/parser/parser.rs
+++ b/compiler/noirc_frontend/src/parser/parser.rs
@@ -320,6 +320,14 @@ impl<'a> Parser<'a> {
                     let token = LocatedToken::new(Token::Int(FieldElement::zero(), None), location);
                     return (token, last_comments);
                 }
+                // A non-ASCII identifier is lexed as a single error so the parser can see the
+                // whole word at once. Push the error and substitute the original identifier back
+                // into the token stream so name resolution see a consistent program.
+                Some(Err(LexerErrorKind::NonAsciiIdentifier { found, location })) => {
+                    let ident_token = Token::Ident(found.clone());
+                    self.errors.push(LexerErrorKind::NonAsciiIdentifier { found, location }.into());
+                    return (LocatedToken::new(ident_token, location), last_comments);
+                }
                 Some(Err(lexer_error)) => self.errors.push(lexer_error.into()),
                 None => {
                     let end_span = Span::single_char(self.current_token_location.span.end());

--- a/compiler/noirc_frontend/src/parser/parser/module.rs
+++ b/compiler/noirc_frontend/src/parser/parser/module.rs
@@ -135,9 +135,34 @@ mod tests {
 
     #[test]
     fn parse_program_rejects_utf8_in_identifier() {
+        use crate::lexer::errors::LexerErrorKind;
+        use crate::parser::ParserErrorReason;
+
         // cSpell:disable-next-line
         let src = "fn schön() {}";
-        let (_module, errors) = parse_program_with_dummy_file(src);
-        assert!(!errors.is_empty(), "Expected parser errors for non-ASCII identifier");
+        let (module, errors) = parse_program_with_dummy_file(src);
+
+        let non_warning_errors: Vec<_> =
+            errors.iter().filter(|error| !error.is_warning()).collect();
+        assert_eq!(
+            non_warning_errors.len(),
+            1,
+            "Expected exactly one error, got: {non_warning_errors:?}",
+        );
+        match non_warning_errors[0].reason() {
+            Some(ParserErrorReason::Lexer(LexerErrorKind::NonAsciiIdentifier {
+                found, ..
+            })) => {
+                assert_eq!(found, "schön");
+            }
+            other => panic!("Expected NonAsciiIdentifier, got {other:?}"),
+        }
+
+        // The parser still recognised the function declaration, with the original name.
+        assert_eq!(module.items.len(), 1);
+        let ItemKind::Function(func) = &module.items[0].kind else {
+            panic!("Expected function declaration");
+        };
+        assert_eq!(func.def.name.to_string(), "schön");
     }
 }

--- a/tooling/lsp/src/requests/inlay_hint.rs
+++ b/tooling/lsp/src/requests/inlay_hint.rs
@@ -1125,4 +1125,25 @@ mod inlay_hints_tests {
         let label = parts.iter().map(|part| part.value.clone()).collect::<Vec<_>>().join("");
         assert_eq!(label, " bool");
     }
+
+    #[test]
+    async fn test_type_inlay_hint_for_identifier_ending_in_multi_byte_char() {
+        // Regression: when the identifier's last char was multi-byte the lexer's
+        // span end used to land in the middle of the UTF-8 sequence, breaking the
+        // byte→UTF-16 conversion and silently dropping the inlay hint.
+        // Source: `    let xé = 1;` on line 146 → `xé` ends at UTF-16 character 10.
+        let inlay_hints = get_inlay_hints(145, 147, type_hints()).await;
+        assert_eq!(inlay_hints.len(), 1);
+
+        let inlay_hint = &inlay_hints[0];
+        assert_eq!(inlay_hint.position, Position { line: 146, character: 10 });
+
+        if let InlayHintLabel::LabelParts(parts) = &inlay_hint.label {
+            assert_eq!(parts.len(), 2);
+            assert_eq!(parts[0].value, ": ");
+            assert_eq!(parts[1].value, "Field");
+        } else {
+            panic!("Expected InlayHintLabel::LabelParts, got {:?}", inlay_hint.label);
+        }
+    }
 }

--- a/tooling/lsp/test_programs/inlay_hints/src/main.nr
+++ b/tooling/lsp/test_programs/inlay_hints/src/main.nr
@@ -142,3 +142,7 @@ fn test_missing_args() {
     // This is here to prove that inlay hints don't break when arguments are missing
     yet_another_function()
 }
+
+fn test_unicode_identifier() {
+    let xé = 1;
+}


### PR DESCRIPTION
## Problem Resolved

Resolves https://github.com/noir-lang/noir/issues/12702

The second commit is because I noticed inlay hints were off when identifiers ended with unicode.

## Summary of Changes



## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
