### PR TITLE
chore(fuzz): Run arbitrary two passes in `pass_vs_prev`

### DIFF
--- a/tooling/ast_fuzzer/fuzz/src/targets/pass_vs_prev.rs
+++ b/tooling/ast_fuzzer/fuzz/src/targets/pass_vs_prev.rs
@@ -1,5 +1,19 @@
-//! Compare the execution of an SSA pass to the one preceding it
-//! using the SSA interpreter.
+//! Compare the execution of an SSA at two arbitrary points in the
+//! optimization pipeline using the SSA interpreter.
+//!
+//! The two points are chosen independently per seed and may be any
+//! distance apart — including adjacent (the original behavior) and
+//! all the way from the initial SSA to the fully-optimized form. If
+//! their interpretation results differ, semantic preservation has been
+//! broken by some pass between them; the offending pass can then be
+//! pinpointed with `nargo interpret` (or the `bisect-ssa-pass` skill).
+//!
+//! Comparing arbitrary-distance pairs (rather than only adjacent ones)
+//! roughly multiplies the per-seed odds of catching a bug whose
+//! "toggling" pass is at a fixed pipeline position: adjacent-only
+//! comparison catches the bug with probability `1/N` for `N` passes,
+//! while arbitrary-distance comparison catches it whenever the two
+//! sampled steps straddle the toggling pass.
 //!
 //! By using the SSA interpreter we can execute any pass in the pipeline,
 //! as opposed to the Brillig runtime, which requires a minimum number
@@ -20,30 +34,30 @@ pub fn fuzz(u: &mut Unstructured) -> eyre::Result<()> {
         let ssa_options = options.onto(default_ssa_options());
         let ssa_passes = primary_passes(&ssa_options);
 
-        // Choose the number of passes we run on top of the initial SSA.
+        // Step 0 = the initial SSA (no passes run yet); step N = the SSA
+        // after running the first N passes in `ssa_passes`. We pick two
+        // distinct steps `step_a < step_b` from the closed interval
+        // `[0, max_passes]` and compare them.
         let max_passes = ssa_passes.len();
-        let run_passes = u.int_in_range(1..=max_passes)?;
+        let step_a = u.int_in_range(0..=max_passes - 1)?;
+        let step_b = u.int_in_range(step_a + 1..=max_passes)?;
 
         // Generate the initial SSA, which is considered to be step 0.
         let ssa = ssa_gen::generate_ssa(program).expect("failed to generate initial SSA");
 
-        // Compare two consecutive passes.
-        let last_pass = &ssa_passes[run_passes - 1];
-        let ssa1 = if run_passes == 1 {
-            ComparePass { step: 0, msg: "Initial SSA".to_string(), ssa }
-        } else {
-            let prev_step = run_passes - 1;
-            let prev_idx = prev_step - 1;
-            ComparePass {
-                step: prev_step,
-                msg: ssa_passes[prev_idx].msg().to_string(),
-                ssa: ssa_passes[..=prev_idx].iter().fold(ssa, run_pass_or_die),
-            }
+        // Run passes up to (and not including) step_a to get the state
+        // at step_a. The remaining passes [step_a..step_b) are then
+        // applied on a clone of that state to get step_b.
+        let ssa_at_a = ssa_passes[..step_a].iter().fold(ssa, run_pass_or_die);
+        let ssa1 = ComparePass {
+            step: step_a,
+            msg: step_msg(&ssa_passes, step_a),
+            ssa: clone_ssa(&ssa_at_a),
         };
         let ssa2 = ComparePass {
-            step: run_passes,
-            msg: last_pass.msg().to_string(),
-            ssa: run_pass_or_die(clone_ssa(&ssa1.ssa), last_pass),
+            step: step_b,
+            msg: step_msg(&ssa_passes, step_b),
+            ssa: ssa_passes[step_a..step_b].iter().fold(ssa_at_a, run_pass_or_die),
         };
 
         Ok((options, ssa1, ssa2))
@@ -52,6 +66,14 @@ pub fn fuzz(u: &mut Unstructured) -> eyre::Result<()> {
     let result = inputs.exec()?;
 
     compare_results_interpreted(&inputs, &result)
+}
+
+/// Human-readable label for a given pipeline step:
+/// - step 0 is the initial SSA, before any pass has run;
+/// - step N (1 ≤ N ≤ passes.len()) is the SSA after running
+///   `passes[N - 1]`.
+fn step_msg(passes: &[SsaPass<'_>], step: usize) -> String {
+    if step == 0 { "Initial SSA".to_string() } else { passes[step - 1].msg().to_string() }
 }
 
 fn run_pass_or_die(ssa: Ssa, pass: &SsaPass) -> Ssa {


### PR DESCRIPTION
## Problem Resolved

In theory the `pass_vs_prev` fuzz target could have discovered https://github.com/noir-lang/noir/issues/12713 already. I think one reason it didn't might be that it only compares steps `N` to step `N-1`, so it has to land _exactly_ on a pass which has a bug. Nice for reporting the culprit, but the chance of finding the buggy pass is `1/N`, which in a pipeline of 70+ steps is a "fat chance".

## Summary of Changes

Changes `pass_vs_prev` to choose two passes at an arbitrary distance, to allow us to cover more of the pipeline, which should increase our probability of including an arbitrary bug to ~50%. 

The pass does not attempt to bisect the problem down to a single pass, because we already have tools to help with that, e.g. the `nargo interpret` command highlights exactly where the output changes. Running all the passes between them was also rejected, as most programs are not expected to be buggy, so we don't want to spend all that time in the interpreter. 

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
