### PR TITLE
fix: avoid panic on zero-limb field byte decomposition

### DIFF
--- a/acvm-repo/brillig_vm/src/black_box.rs
+++ b/acvm-repo/brillig_vm/src/black_box.rs
@@ -344,11 +344,6 @@ fn to_be_radix<F: AcirField>(
     );
 
     assert!(
-        num_limbs >= 1 || input.is_zero(),
-        "Input value {input} is not zero but number of limbs is zero."
-    );
-
-    assert!(
         !output_bits || radix == 2u32,
         "Radix {radix} is not equal to 2 and bit mode is activated."
     );
@@ -434,5 +429,18 @@ mod to_be_radix_tests {
             .map(|byte| byte.expect_u8().unwrap())
             .collect();
         assert_eq!(limbs, expected_limbs);
+    }
+
+    #[test]
+    fn rejects_non_zero_field_with_zero_limbs() {
+        let value = FieldElement::from(1u128);
+
+        let error = to_be_radix(value, 256, 0, false).unwrap_err();
+        assert_eq!(
+            error,
+            acvm_blackbox_solver::BlackBoxResolutionError::AssertFailed(
+                "Field failed to decompose into specified 0 limbs".to_string()
+            )
+        );
     }
 }

--- a/noir_stdlib/src/field/mod.nr
+++ b/noir_stdlib/src/field/mod.nr
@@ -527,6 +527,16 @@ mod tests {
         let _: [u8; 16] = 0x100000000000000000000000000000000.to_le_bytes();
     }
 
+    #[test(should_fail_with = "Field failed to decompose into specified 0 limbs")]
+    unconstrained fn non_zero_field_to_le_bytes_zero_limbs() {
+        let _: [u8; 0] = 5.to_le_bytes();
+    }
+
+    #[test(should_fail_with = "Field failed to decompose into specified 0 limbs")]
+    unconstrained fn non_zero_field_to_be_bytes_zero_limbs() {
+        let _: [u8; 0] = 5.to_be_bytes();
+    }
+
     #[test]
     unconstrained fn test_field_less_than() {
         assert(field_less_than(0, 1));


### PR DESCRIPTION
## Summary

Fixes #12736.

This removes a Brillig VM panic when a nonzero field is decomposed into zero radix limbs. The existing decomposition failure path now reports the error normally:

`Field failed to decompose into specified 0 limbs`

Regression tests cover both little-endian and big-endian zero-length byte decomposition in unconstrained code.

## Tests

- `cargo test -p brillig_vm rejects_non_zero_field_with_zero_limbs`
- `cargo test -p brillig_vm`