### PR TITLE
chore(fuzz): Assign values to `&mut` using `Dereference`

### DIFF
--- a/compiler/noirc_frontend/src/monomorphization/printer.rs
+++ b/compiler/noirc_frontend/src/monomorphization/printer.rs
@@ -781,9 +781,8 @@ mod tests {
 
     impl Display for PrintAssign {
         fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
-            let mut printer = AstPrinter::default();
-            printer.show_id = false;
-            printer.show_clone_and_drop = false;
+            let mut printer =
+                AstPrinter { show_id: false, show_clone_and_drop: false, ..Default::default() };
             let assign = Expression::Assign(Assign {
                 lvalue: self.0.clone(),
                 expression: Box::new(Expression::Literal(Literal::Bool(true))),

--- a/compiler/noirc_frontend/src/monomorphization/printer.rs
+++ b/compiler/noirc_frontend/src/monomorphization/printer.rs
@@ -673,11 +673,24 @@ impl AstPrinter {
         Ok(true)
     }
 
+    /// Whether an lvalue's printed form starts with a `*` and therefore needs to be
+    /// parenthesized when it appears as the array of an `Index` or object of a `MemberAccess`.
+    ///
+    /// The ownership pass can wrap an lvalue in `LValue::Clone`. When `show_clone_and_drop`
+    /// is false, that wrapper is invisible in the output, so we have to peek through it.
+    fn prints_as_dereference(&self, lvalue: &LValue) -> bool {
+        match lvalue {
+            LValue::Dereference { .. } => true,
+            LValue::Clone(inner) if !self.show_clone_and_drop => self.prints_as_dereference(inner),
+            _ => false,
+        }
+    }
+
     fn print_lvalue(&mut self, lvalue: &LValue, f: &mut Formatter) -> std::fmt::Result {
         match lvalue {
             LValue::Ident(ident) => write!(f, "{}", self.fmt_ident(&ident.name, &ident.definition)),
             LValue::Index { array, index, .. } => {
-                let array_is_dereference = matches!(array.as_ref(), LValue::Dereference { .. });
+                let array_is_dereference = self.prints_as_dereference(array);
                 if array_is_dereference {
                     write!(f, "(")?;
                 }
@@ -690,7 +703,7 @@ impl AstPrinter {
                 write!(f, "]")
             }
             LValue::MemberAccess { object, field_index } => {
-                let object_is_dereference = matches!(object.as_ref(), LValue::Dereference { .. });
+                let object_is_dereference = self.prints_as_dereference(object);
                 if object_is_dereference {
                     write!(f, "(")?;
                 }
@@ -732,5 +745,106 @@ impl Display for Definition {
             Definition::LowLevel(name) => write!(f, "{name}"),
             Definition::Oracle { name, .. } => write!(f, "{name}"),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::rc::Rc;
+
+    use super::super::ast::{Assign, Expression, IdentId, Literal, LocalId};
+    use super::*;
+    use crate::ast::IntegerBitSize;
+    use crate::shared::Signedness;
+    use noirc_errors::Location;
+
+    fn local_ident(name: &str, id: u32, typ: Type) -> Ident {
+        Ident {
+            location: None,
+            definition: Definition::Local(LocalId(id)),
+            mutable: true,
+            name: name.to_string(),
+            typ: Rc::new(typ),
+            id: IdentId(id),
+        }
+    }
+
+    fn u32_literal(v: u32) -> Expression {
+        Expression::Literal(Literal::Integer(
+            v.into(),
+            Type::Integer(Signedness::Unsigned, IntegerBitSize::ThirtyTwo),
+            Location::dummy(),
+        ))
+    }
+
+    struct PrintAssign(LValue);
+
+    impl Display for PrintAssign {
+        fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
+            let mut printer = AstPrinter::default();
+            printer.show_id = false;
+            printer.show_clone_and_drop = false;
+            let assign = Expression::Assign(Assign {
+                lvalue: self.0.clone(),
+                expression: Box::new(Expression::Literal(Literal::Bool(true))),
+            });
+            printer.print_expr(&assign, f)
+        }
+    }
+
+    fn print(lvalue: LValue) -> String {
+        format!("{}", PrintAssign(lvalue))
+    }
+
+    /// Regression: the ownership pass wraps a `Dereference` in `LValue::Clone` when
+    /// `contains_index(array)` is true. With `show_clone_and_drop = false` the `Clone`
+    /// becomes invisible in the output, so the outer `Index` must still treat its array
+    /// as a dereference for parenthesis purposes.
+    #[test]
+    fn index_of_clone_wrapping_dereference_is_parenthesized() {
+        let bool_t = Type::Bool;
+        let array_bool = Type::Array(3, Rc::new(bool_t.clone()));
+        let ref_array_bool = Type::Reference(Rc::new(array_bool.clone()), true);
+        let outer_array = Type::Array(3, Rc::new(ref_array_bool.clone()));
+
+        // `Index(Clone(Dereference(Index(Ident(d), idx_e))), idx_f)`
+        let inner_index = LValue::Index {
+            array: Box::new(LValue::Ident(local_ident("d", 0, outer_array))),
+            index: Box::new(u32_literal(0)),
+            element_type: ref_array_bool,
+            location: Location::dummy(),
+        };
+        let deref =
+            LValue::Dereference { reference: Box::new(inner_index), element_type: array_bool };
+        let clone = LValue::Clone(Box::new(deref));
+        let outer_index = LValue::Index {
+            array: Box::new(clone),
+            index: Box::new(u32_literal(1)),
+            element_type: bool_t,
+            location: Location::dummy(),
+        };
+
+        assert_eq!(print(outer_index), "(*d[0])[1] = true");
+    }
+
+    /// Without the `Clone` wrapper the same parens are still produced.
+    #[test]
+    fn index_of_dereference_is_parenthesized() {
+        let bool_t = Type::Bool;
+        let array_bool = Type::Array(3, Rc::new(bool_t.clone()));
+        let ref_array_bool = Type::Reference(Rc::new(array_bool.clone()), true);
+
+        let deref = LValue::Dereference {
+            reference: Box::new(LValue::Ident(local_ident("d", 0, ref_array_bool))),
+            element_type: array_bool,
+        };
+        let outer_index = LValue::Index {
+            array: Box::new(deref),
+            index: Box::new(u32_literal(1)),
+            element_type: bool_t,
+            location: Location::dummy(),
+        };
+
+        assert_eq!(print(outer_index), "(*d)[1] = true");
     }
 }

--- a/tooling/ast_fuzzer/src/program/func.rs
+++ b/tooling/ast_fuzzer/src/program/func.rs
@@ -1313,8 +1313,9 @@ impl<'a> FunctionContext<'a> {
             .filter(|(_, (mutable, _, typ))| {
                 // We banned reassigning variables which contain mutable references in ACIR (#8790)
                 *mutable && (self.unconstrained() || !types::contains_reference(typ))
-                // We can always assign to mutable references via deref.
-                    || matches!(typ, Type::Reference(_, true))
+                // We can always assign to &mut references via deref,
+                // even if they are not themselves mutable.
+                || matches!(typ, Type::Reference(_, true))
             })
             .filter(|(id, (_, _, typ))| {
                 // Preserve the non-dynamic state of references.
@@ -1333,7 +1334,7 @@ impl<'a> FunctionContext<'a> {
 
         // References may have aliases, so we don't want to change their dynamic nature,
         // because the change would not be reflected on the alias. If the value is already
-        // dynamic, we'll keep it as dynamic, even never change it to non-dynamic.
+        // dynamic, we'll keep it as dynamic, and refrain from change it to non-dynamic as well.
         let preserve_non_dynamic = types::is_reference(&typ);
         let no_dynamic = self.in_no_dynamic || preserve_non_dynamic && !self.is_dynamic(&id);
         let was_in_no_dynamic = std::mem::replace(&mut self.in_no_dynamic, no_dynamic);
@@ -1432,7 +1433,8 @@ impl<'a> FunctionContext<'a> {
             }
             Type::Reference(typ, true) if !can_rebind || bool::arbitrary(u)? => {
                 // If the reference itself is not mutable, we cannot rebind it, but we can deref-assign to it.
-                // e.g. `let mut r = &mut 1;` can be re-bound: `r = &mut 2;`, or assigned a value: `*r = 3;`.
+                // eg. `let mut r = &mut 1;` can be re-bound: `r = &mut 2;`, or assigned a value: `*r = 3;`,
+                // but `let r = &mut 1;` can only be assigned to as `*r = 2;`.
                 let typ = typ.as_ref().clone();
                 let deref =
                     LValue::Dereference { reference: Box::new(lvalue), element_type: typ.clone() };

--- a/tooling/ast_fuzzer/src/program/func.rs
+++ b/tooling/ast_fuzzer/src/program/func.rs
@@ -1313,28 +1313,46 @@ impl<'a> FunctionContext<'a> {
             .filter(|(_, (mutable, _, typ))| {
                 // We banned reassigning variables which contain mutable references in ACIR (#8790)
                 *mutable && (self.unconstrained() || !types::contains_reference(typ))
+                // We can always assign to mutable references via deref.
+                    || matches!(typ, Type::Reference(_, true))
             })
-            .map(|(id, _)| id)
+            .filter(|(id, (_, _, typ))| {
+                // Preserve the non-dynamic state of references.
+                !(types::is_reference(typ) && !self.is_dynamic(id) && self.in_dynamic)
+            })
+            .map(|(id, (mutable, _, _))| (*id, *mutable))
             .collect::<Vec<_>>();
 
         if opts.is_empty() {
             return Ok(None);
         }
 
-        let id = *u.choose_iter(opts)?;
+        let (id, mutable) = u.choose_iter(opts)?;
         let ident = LValue::Ident(self.local_ident(id));
         let typ = self.local_type(id).clone();
-        let lvalue = self.gen_lvalue(u, ident, typ)?;
 
+        // References may have aliases, so we don't want to change their dynamic nature,
+        // because the change would not be reflected on the alias. If the value is already
+        // dynamic, we'll keep it as dynamic, even never change it to non-dynamic.
+        let preserve_non_dynamic = types::is_reference(&typ);
+        let no_dynamic = self.in_no_dynamic || preserve_non_dynamic && !self.is_dynamic(&id);
+        let was_in_no_dynamic = std::mem::replace(&mut self.in_no_dynamic, no_dynamic);
+
+        // Generate the part fo the ident we assign to.
+        let lvalue = self.gen_lvalue(u, ident, typ, mutable)?;
         // Generate the assigned value.
         let (expr, expr_dyn) = self.gen_expr(u, &lvalue.typ, self.max_depth(), Flags::TOP)?;
 
-        if lvalue.is_dyn || expr_dyn || self.in_dynamic {
-            self.set_dynamic(id, true);
-        } else if !lvalue.is_dyn && !expr_dyn && !lvalue.is_compound {
-            // This value is no longer considered dynamic, unless we assigned to a member of an array or tuple,
-            // in which case we don't know if other members have dynamic properties.
-            self.set_dynamic(id, false);
+        self.in_no_dynamic = was_in_no_dynamic;
+
+        if !preserve_non_dynamic {
+            if lvalue.is_dyn || expr_dyn || self.in_dynamic {
+                self.set_dynamic(id, true);
+            } else if !lvalue.is_dyn && !expr_dyn && !lvalue.is_compound {
+                // This value is no longer considered dynamic, unless we assigned to a member of an array or tuple,
+                // in which case we don't know if other members have dynamic properties.
+                self.set_dynamic(id, false);
+            }
         }
 
         let assign =
@@ -1356,6 +1374,7 @@ impl<'a> FunctionContext<'a> {
         u: &mut Unstructured,
         lvalue: LValue,
         typ: Type,
+        can_rebind: bool,
     ) -> arbitrary::Result<LValueWithMeta> {
         /// Accumulate statements for sub-indexes of multi-dimensional arrays.
         /// For example `a[1+2][3+4] = 5;` becomes `let i = 1+2; let j = 3+4; a[i][j] = 5;`
@@ -1397,7 +1416,7 @@ impl<'a> FunctionContext<'a> {
                     location: Location::dummy(),
                 };
 
-                let mut lvalue = self.gen_lvalue(u, index, typ)?;
+                let mut lvalue = self.gen_lvalue(u, index, typ, can_rebind)?;
                 lvalue.is_compound = true;
                 lvalue.is_dyn |= idx_dyn;
                 lvalue.statements = merge_statements(statements, lvalue.statements);
@@ -1407,9 +1426,17 @@ impl<'a> FunctionContext<'a> {
                 let idx = u.choose_index(items.len())?;
                 let typ = items[idx].clone();
                 let member = LValue::MemberAccess { object: Box::new(lvalue), field_index: idx };
-                let mut lvalue = self.gen_lvalue(u, member, typ)?;
+                let mut lvalue = self.gen_lvalue(u, member, typ, can_rebind)?;
                 lvalue.is_compound = true;
                 lvalue
+            }
+            Type::Reference(typ, true) if !can_rebind || bool::arbitrary(u)? => {
+                // If the reference itself is not mutable, we cannot rebind it, but we can deref-assign to it.
+                // e.g. `let mut r = &mut 1;` can be re-bound: `r = &mut 2;`, or assigned a value: `*r = 3;`.
+                let typ = typ.as_ref().clone();
+                let deref =
+                    LValue::Dereference { reference: Box::new(lvalue), element_type: typ.clone() };
+                self.gen_lvalue(u, deref, typ, can_rebind)?
             }
             typ => {
                 LValueWithMeta { lvalue, typ, is_dyn: false, is_compound: false, statements: None }


### PR DESCRIPTION
## Problem Resolved

I noticed during https://github.com/noir-lang/noir/pull/12735 that we only assign _to_ `&mut` variables like this:
```
let mut a = &mut 1;
a = &mut 2;
```
but never _through_ them like this:
```
let mut a = 1;
let b = &mut a;
*b = 2;
```

## Summary of Changes

* Changes `gen_assign` to allow picking non-mutable `&mut` variables.
* Changes `gen_lvalue` to either assign to the `&mut` variable, or `Dereference` it and assign a value to where it points.
* Fixes the AST printer to render dereferencing combined with cloning using parentheses

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
