### PR TITLE
feat(diagnostics): Improve missing ':' error

### DIFF
--- a/compiler/noirc_frontend/src/parser/errors.rs
+++ b/compiler/noirc_frontend/src/parser/errors.rs
@@ -51,6 +51,10 @@ pub enum ParserErrorReason {
 
     #[error("Missing type for function parameter")]
     MissingTypeForFunctionParameter,
+    #[error("Expected a `:` between the parameter name and its type")]
+    MissingColonInFunctionParameter,
+    #[error("Expected a `:` between the variable name and its type")]
+    MissingColonInLetStatement,
     #[error("Missing type for numeric generic")]
     MissingTypeForNumericGeneric,
     #[error("Expected a function body (`{{ ... }}`), not `;`")]

--- a/compiler/noirc_frontend/src/parser/parser/function.rs
+++ b/compiler/noirc_frontend/src/parser/parser/function.rs
@@ -233,15 +233,23 @@ impl Parser<'_> {
 
     fn pattern_param(&mut self, pattern: Pattern, start_location: Location) -> Param {
         let (visibility, visibility_location, typ) = if !self.eat_colon() {
-            self.push_error(
-                ParserErrorReason::MissingTypeForFunctionParameter,
-                pattern.location().merge(self.current_token_location),
-            );
+            if let Some(typ) = self.parse_type_allowing_generics(true) {
+                self.push_error(
+                    ParserErrorReason::MissingColonInFunctionParameter,
+                    pattern.location().merge(typ.location),
+                );
+                (Visibility::Private, typ.location, typ)
+            } else {
+                self.push_error(
+                    ParserErrorReason::MissingTypeForFunctionParameter,
+                    pattern.location().merge(self.current_token_location),
+                );
 
-            let visibility = Visibility::Private;
-            let location = self.location_at_previous_token_end();
-            let typ = UnresolvedType { typ: UnresolvedTypeData::Error, location };
-            (visibility, location, typ)
+                let visibility = Visibility::Private;
+                let location = self.location_at_previous_token_end();
+                let typ = UnresolvedType { typ: UnresolvedTypeData::Error, location };
+                (visibility, location, typ)
+            }
         } else {
             let (visibility, location) = self.parse_visibility();
             (
@@ -546,6 +554,27 @@ mod tests {
 
         let error = get_single_error(&errors, span);
         assert!(error.to_string().contains("Missing type for function parameter"));
+    }
+
+    #[test]
+    fn recovers_on_missing_colon_before_parameter_type() {
+        let src = "
+        fn foo(x u64, y: i32) {}
+               ^^^^^
+        ";
+        let (src, span) = get_source_with_error_span(src);
+        let (mut module, errors) = parse_program_with_dummy_file(&src);
+        assert_eq!(module.items.len(), 1);
+        let ItemKind::Function(noir_function) = module.items.remove(0).kind else {
+            panic!("Expected function");
+        };
+        let params = noir_function.parameters();
+        assert_eq!(params.len(), 2);
+        assert_eq!(params[0].typ.typ.to_string(), "u64");
+        assert_eq!(params[1].typ.typ.to_string(), "i32");
+
+        let reason = get_single_error_reason(&errors, span);
+        assert!(matches!(reason, ParserErrorReason::MissingColonInFunctionParameter));
     }
 
     #[test]

--- a/compiler/noirc_frontend/src/parser/parser/statement.rs
+++ b/compiler/noirc_frontend/src/parser/parser/statement.rs
@@ -438,6 +438,23 @@ impl Parser<'_> {
         let attributes = self.validate_secondary_attributes(attributes);
         let pattern = self.parse_pattern_or_error();
         let r#type = self.parse_optional_type_annotation();
+        let r#type = if r#type.is_none()
+            && !self.at(Token::Assign)
+            && !self.at(Token::Semicolon)
+            && !self.at_eof()
+        {
+            if let Some(typ) = self.parse_type_allowing_generics(true) {
+                self.push_error(
+                    ParserErrorReason::MissingColonInLetStatement,
+                    pattern.location().merge(typ.location),
+                );
+                Some(typ)
+            } else {
+                None
+            }
+        } else {
+            r#type
+        };
         let expression = if self.eat_assign() {
             self.parse_expression_or_error()
         } else {
@@ -576,6 +593,26 @@ mod tests {
 
         let reason = get_single_error_reason(&parser.errors, span);
         assert!(matches!(reason, ParserErrorReason::MutOnABindingCannotBeRepeated));
+    }
+
+    #[test]
+    fn recovers_on_missing_colon_in_let_binding() {
+        let src = "
+        let x u64 = 2;
+            ^^^^^
+        ";
+        let (src, span) = get_source_with_error_span(src);
+        let mut parser = Parser::for_str_with_dummy_file(&src);
+        let statement = parser.parse_statement().unwrap().0;
+        let StatementKind::Let(let_statement) = statement.kind else {
+            panic!("Expected let statement");
+        };
+        assert_eq!(let_statement.pattern.to_string(), "x");
+        assert_eq!(let_statement.r#type.unwrap().to_string(), "u64");
+        assert_eq!(let_statement.expression.to_string(), "2");
+
+        let reason = get_single_error_reason(&parser.errors, span);
+        assert!(matches!(reason, ParserErrorReason::MissingColonInLetStatement));
     }
 
     #[test]


### PR DESCRIPTION
## Problem Resolved

Resolves https://github.com/noir-lang/noir/issues/12726

## Summary of Changes

Improves the missing semicolon error with a dedicated error message

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
