### PR TITLE
fix: let `nargo interpret` validate inputs and output

### DIFF
--- a/tooling/ast_fuzzer/src/compare/interpreted.rs
+++ b/tooling/ast_fuzzer/src/compare/interpreted.rs
@@ -8,7 +8,7 @@ use arbitrary::Unstructured;
 use color_eyre::eyre;
 use iter_extended::vecmap;
 use itertools::Itertools;
-use noirc_abi::{Abi, AbiType, InputMap, Sign, input_parser::InputValue};
+use noirc_abi::{Abi, AbiType, InputMap, Sign, errors::AbiError, input_parser::InputValue};
 use noirc_evaluator::ssa::{
     self,
     interpreter::{InterpreterOptions, value::Value},
@@ -252,8 +252,24 @@ impl Comparable for Value {
     }
 }
 
+pub fn encode_to_ssa(
+    abi: &Abi,
+    input_map: &InputMap,
+    return_value: Option<InputValue>,
+) -> Result<(Vec<Value>, Option<Vec<Value>>), AbiError> {
+    abi.encode(input_map, return_value.clone())?;
+    let ssa_args = input_values_to_ssa(abi, input_map);
+    let ssa_return =
+        if let (Some(return_value), Some(return_type)) = (return_value, abi.return_type.as_ref()) {
+            Some(input_value_to_ssa(&return_type.abi_type, &return_value))
+        } else {
+            None
+        };
+    Ok((ssa_args, ssa_return))
+}
+
 /// Convert the ABI encoded inputs to what the SSA interpreter expects.
-pub fn input_values_to_ssa(abi: &Abi, input_map: &InputMap) -> Vec<Value> {
+fn input_values_to_ssa(abi: &Abi, input_map: &InputMap) -> Vec<Value> {
     let mut inputs = Vec::new();
     for param in &abi.parameters {
         let input = &input_map
@@ -268,7 +284,7 @@ pub fn input_values_to_ssa(abi: &Abi, input_map: &InputMap) -> Vec<Value> {
 /// Convert one ABI encoded input to what the SSA interpreter expects.
 ///
 /// Tuple types and structs are flattened.
-pub fn input_value_to_ssa(typ: &AbiType, input: &InputValue) -> Vec<Value> {
+fn input_value_to_ssa(typ: &AbiType, input: &InputValue) -> Vec<Value> {
     let mut values = Vec::new();
     append_input_value_to_ssa(typ, input, &mut values);
     values

--- a/tooling/ast_fuzzer/src/compare/mod.rs
+++ b/tooling/ast_fuzzer/src/compare/mod.rs
@@ -17,10 +17,7 @@ pub use compiled::{
     CompareArtifact, CompareCompiled, CompareCompiledResult, CompareMorph, ComparePipelines,
 };
 pub use comptime::CompareComptime;
-pub use interpreted::{
-    CompareInterpreted, CompareInterpretedResult, ComparePass, input_value_to_ssa,
-    input_values_to_ssa,
-};
+pub use interpreted::{CompareInterpreted, CompareInterpretedResult, ComparePass, encode_to_ssa};
 
 /// Help iterate over the program(s) in the comparable artifact.
 pub trait HasPrograms {

--- a/tooling/ast_fuzzer/src/lib.rs
+++ b/tooling/ast_fuzzer/src/lib.rs
@@ -9,7 +9,7 @@ mod input;
 mod program;
 
 pub use abi::program_abi;
-pub use compare::{input_value_to_ssa, input_values_to_ssa};
+pub use compare::encode_to_ssa;
 pub use input::arb_inputs;
 use program::freq::Freqs;
 pub use program::{

--- a/tooling/nargo_cli/src/cli/interpret_cmd.rs
+++ b/tooling/nargo_cli/src/cli/interpret_cmd.rs
@@ -106,6 +106,10 @@ pub(crate) fn run(args: InterpretCommand, workspace: Workspace) -> Result<(), Cl
         let (prover_input, return_value) =
             noir_artifact_cli::fs::inputs::read_inputs_from_file(&prover_file, &abi)?;
 
+        // Validate the inputs against the ABI the same way `nargo execute` does, so that
+        // mismatches surface as clean errors instead of panicking inside the SSA conversion.
+        abi.encode(&prover_input, return_value.clone())?;
+
         // We need to give a fresh copy of arrays each time, because the shared structures are modified.
         let ssa_args = noir_ast_fuzzer::input_values_to_ssa(&abi, &prover_input);
 

--- a/tooling/nargo_cli/src/cli/interpret_cmd.rs
+++ b/tooling/nargo_cli/src/cli/interpret_cmd.rs
@@ -106,19 +106,8 @@ pub(crate) fn run(args: InterpretCommand, workspace: Workspace) -> Result<(), Cl
         let (prover_input, return_value) =
             noir_artifact_cli::fs::inputs::read_inputs_from_file(&prover_file, &abi)?;
 
-        // Validate the inputs against the ABI the same way `nargo execute` does, so that
-        // mismatches surface as clean errors instead of panicking inside the SSA conversion.
-        abi.encode(&prover_input, return_value.clone())?;
-
-        // We need to give a fresh copy of arrays each time, because the shared structures are modified.
-        let ssa_args = noir_ast_fuzzer::input_values_to_ssa(&abi, &prover_input);
-
-        let ssa_return =
-            if let (Some(return_type), Some(return_value)) = (&abi.return_type, return_value) {
-                Some(noir_ast_fuzzer::input_value_to_ssa(&return_type.abi_type, &return_value))
-            } else {
-                None
-            };
+        let (ssa_args, ssa_return) =
+            noir_ast_fuzzer::encode_to_ssa(&abi, &prover_input, return_value)?;
 
         // Generate the initial SSA.
         let mut ssa = generate_ssa(program)

--- a/tooling/nargo_cli/tests/interpret.rs
+++ b/tooling/nargo_cli/tests/interpret.rs
@@ -1,0 +1,43 @@
+//! Integration tests for `nargo interpret`.
+
+use assert_cmd::prelude::*;
+use predicates::prelude::*;
+use std::process::Command;
+
+use assert_fs::prelude::{FileWriteStr, PathChild, PathCreateDir};
+
+/// A `Prover.toml` whose array length disagrees with the declared parameter type
+/// should surface a clean error, the same way `nargo execute` does, instead of
+/// panicking inside the SSA input conversion.
+#[test]
+fn interpret_with_array_length_mismatch_reports_clean_error() {
+    let project_dir = assert_fs::TempDir::new().unwrap();
+    project_dir.child("src").create_dir_all().unwrap();
+    project_dir
+        .child("Nargo.toml")
+        .write_str(
+            r#"[package]
+name = "interpret_length_mismatch"
+type = "bin"
+authors = []
+compiler_version = ">=0.0.0"
+
+[dependencies]
+"#,
+        )
+        .unwrap();
+    project_dir
+        .child("src/main.nr")
+        .write_str("fn main(a: pub [u32; 3]) -> pub u32 { a[0] }\n")
+        .unwrap();
+    project_dir.child("Prover.toml").write_str("a = [\"1\"]\n").unwrap();
+
+    #[allow(deprecated)]
+    let mut cmd = Command::cargo_bin("nargo").unwrap();
+    cmd.arg("--program-dir").arg(project_dir.path()).arg("interpret");
+    cmd.assert().failure().stderr(
+        predicate::str::contains("does not match the specified type")
+            .and(predicate::str::contains("array length != input length").not())
+            .and(predicate::str::contains("application panicked").not()),
+    );
+}

--- a/tooling/ssa_cli/src/cli/interpret_cmd.rs
+++ b/tooling/ssa_cli/src/cli/interpret_cmd.rs
@@ -58,18 +58,7 @@ pub(super) fn run(args: InterpretCommand, ssa: Ssa) -> eyre::Result<()> {
 
     let (input_map, return_value) = read_inputs_and_return(&abi, &args)?;
 
-    // Validate the inputs against the ABI the same way `nargo execute` does, so that
-    // mismatches surface as clean errors instead of panicking inside the SSA conversion.
-    abi.encode(&input_map, return_value.clone())?;
-
-    let ssa_args = noir_ast_fuzzer::input_values_to_ssa(&abi, &input_map);
-
-    let ssa_return =
-        if let (Some(return_type), Some(return_value)) = (&abi.return_type, return_value) {
-            Some(noir_ast_fuzzer::input_value_to_ssa(&return_type.abi_type, &return_value))
-        } else {
-            None
-        };
+    let (ssa_args, ssa_return) = noir_ast_fuzzer::encode_to_ssa(&abi, &input_map, return_value)?;
 
     let result = ssa.interpret_with_options(ssa_args, options, std::io::stdout());
 

--- a/tooling/ssa_cli/src/cli/interpret_cmd.rs
+++ b/tooling/ssa_cli/src/cli/interpret_cmd.rs
@@ -57,6 +57,11 @@ pub(super) fn run(args: InterpretCommand, ssa: Ssa) -> eyre::Result<()> {
         InterpreterOptions { trace: args.trace, step_limit: args.step_limit, ..Default::default() };
 
     let (input_map, return_value) = read_inputs_and_return(&abi, &args)?;
+
+    // Validate the inputs against the ABI the same way `nargo execute` does, so that
+    // mismatches surface as clean errors instead of panicking inside the SSA conversion.
+    abi.encode(&input_map, return_value.clone())?;
+
     let ssa_args = noir_ast_fuzzer::input_values_to_ssa(&abi, &input_map);
 
     let ssa_return =


### PR DESCRIPTION
## Problem Resolved

Resolves #12734
Resolves #12731

## Summary of Changes

Calls `encode` before turning the inputs into SSA values, so that any errors are reported beforehand. Matches what `nargo execute` does. The result is discarded, but I think this is fine here to avoid adding specific code to validate this.

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
