### PR TITLE
feat(fmt): comments reflow

### DIFF
--- a/tooling/nargo_fmt/src/chunks.rs
+++ b/tooling/nargo_fmt/src/chunks.rs
@@ -1139,10 +1139,35 @@ impl<'a> Formatter<'a> {
                 if starts_with_space && !self.buffer.ends_with_space() {
                     self.write(" ");
                 }
-                self.write_comment_with_prefix(
-                    line.trim_start().strip_prefix("//").unwrap_or(line),
-                    "//",
-                );
+
+                // Collect the longest run of consecutive `//` lines (matching neither
+                // `///` nor `//!`, and not separated by blank lines) starting at `index`
+                // and reflow them as one paragraph-aware group.
+                let mut group_bodies: Vec<String> = Vec::new();
+                let mut peek = index;
+                while peek < lines.len() {
+                    let candidate = lines[peek];
+                    let trimmed = candidate.trim_start();
+                    let is_plain_line_comment = trimmed.starts_with("//")
+                        && !trimmed.starts_with("///")
+                        && !trimmed.starts_with("//!");
+                    if !is_plain_line_comment {
+                        break;
+                    }
+                    let body = trimmed.strip_prefix("//").unwrap_or(trimmed).to_string();
+                    group_bodies.push(body);
+                    peek += 1;
+                }
+
+                self.write_line_comment_group(&group_bodies, "//");
+
+                index = peek;
+                // Handle the run of blank lines that may follow the group.
+                while index < lines.len() && lines[index].is_empty() {
+                    self.write_multiple_lines_without_skipping_whitespace_and_comments();
+                    index += 1;
+                }
+                continue;
             } else if (is_block_comment || inside_block_comment) && self.config.wrap_comments {
                 // Only append a space if it's the start of a block comment (no leading spaces in following lines)
                 if starts_with_space && is_block_comment && !self.buffer.ends_with_space() {

--- a/tooling/nargo_fmt/src/chunks.rs
+++ b/tooling/nargo_fmt/src/chunks.rs
@@ -1168,16 +1168,63 @@ impl<'a> Formatter<'a> {
                     index += 1;
                 }
                 continue;
-            } else if (is_block_comment || inside_block_comment) && self.config.wrap_comments {
-                // Only append a space if it's the start of a block comment (no leading spaces in following lines)
-                if starts_with_space && is_block_comment && !self.buffer.ends_with_space() {
+            } else if is_block_comment && self.config.wrap_comments {
+                let trimmed = line.trim_start();
+                let opener = if trimmed.starts_with("/**") {
+                    "/**"
+                } else if trimmed.starts_with("/*!") {
+                    "/*!"
+                } else {
+                    "/*"
+                };
+
+                let mut block_end = index;
+                while block_end < lines.len() && !lines[block_end].trim_end().ends_with("*/") {
+                    block_end += 1;
+                }
+
+                if block_end < lines.len() {
+                    let first_after_open = trimmed.strip_prefix(opener).unwrap_or(trimmed);
+                    let last_line = lines[block_end];
+                    let last_before_close =
+                        last_line.trim_end().strip_suffix("*/").unwrap_or(last_line.trim_end());
+
+                    let body = if index == block_end {
+                        first_after_open.strip_suffix("*/").unwrap_or(first_after_open).to_string()
+                    } else {
+                        let mut parts = vec![first_after_open.to_string()];
+                        for inner_line in &lines[(index + 1)..block_end] {
+                            parts.push(inner_line.to_string());
+                        }
+                        parts.push(last_before_close.to_string());
+                        parts.join("\n")
+                    };
+
+                    if starts_with_space && !self.buffer.ends_with_space() {
+                        self.write(" ");
+                    }
+
+                    let saved_in_chunk = self.in_chunk;
+                    self.in_chunk = false;
+                    self.write_block_comment(&body, opener);
+                    self.in_chunk = saved_in_chunk;
+
+                    index = block_end + 1;
+                    while index < lines.len() && lines[index].is_empty() {
+                        self.write_multiple_lines_without_skipping_whitespace_and_comments();
+                        index += 1;
+                    }
+                    continue;
+                }
+
+                if starts_with_space && !self.buffer.ends_with_space() {
                     self.write(" ");
                 }
                 self.write_comment_with_prefix(line, "");
-                if inside_block_comment {
-                    self.start_new_line();
-                }
                 inside_block_comment = true;
+            } else if inside_block_comment && self.config.wrap_comments {
+                self.write_comment_with_prefix(line, "");
+                self.start_new_line();
             } else if index < lines.len() - 1 {
                 // Trim the end of all lines except the last one, to avoid trailing spaces
                 self.write(line.trim_end());

--- a/tooling/nargo_fmt/src/chunks.rs
+++ b/tooling/nargo_fmt/src/chunks.rs
@@ -1142,7 +1142,14 @@ impl<'a> Formatter<'a> {
 
                 // Collect the longest run of consecutive `//` lines (matching neither
                 // `///` nor `//!`, and not separated by blank lines) starting at `index`
-                // and reflow them as one paragraph-aware group.
+                // and reflow them as one paragraph-aware group. When the first line is
+                // attached to code on its own line, keep that first line isolated — a
+                // trailing inline comment must not be merged into the standalone comments
+                // that follow it. We detect this by comparing the current column against
+                // the formatter's structural indent: if we're past it, real code precedes
+                // this comment on the same rendered line.
+                let indent_col = (self.indentation.max(0) as usize) * self.config.tab_spaces;
+                let first_is_trailing_inline = index == 0 && self.current_line_width() > indent_col;
                 let mut group_bodies: Vec<String> = Vec::new();
                 let mut peek = index;
                 while peek < lines.len() {
@@ -1157,6 +1164,9 @@ impl<'a> Formatter<'a> {
                     let body = trimmed.strip_prefix("//").unwrap_or(trimmed).to_string();
                     group_bodies.push(body);
                     peek += 1;
+                    if first_is_trailing_inline && peek == index + 1 {
+                        break;
+                    }
                 }
 
                 self.write_line_comment_group(&group_bodies, "//");

--- a/tooling/nargo_fmt/src/chunks.rs
+++ b/tooling/nargo_fmt/src/chunks.rs
@@ -1179,6 +1179,24 @@ impl<'a> Formatter<'a> {
                 }
                 continue;
             } else if is_block_comment && self.config.wrap_comments {
+                // We've hit the opening `/*` / `/**` / `/*!` of a block comment inside
+                // a chunk's text. The chunks layer would otherwise process this line by
+                // line with the legacy per-line wrap, which has no awareness of fenced
+                // code blocks, paragraph reflow, etc. To get the same treatment as
+                // top-level block comments, we collect the full block from its opener
+                // down to the line ending in `*/`, reconstruct the body between the
+                // delimiters, and hand it to `write_block_comment` — temporarily
+                // clearing `in_chunk` so the parser-based wrap path actually runs (it's
+                // normally a no-op inside chunks; see the early return at the top of
+                // `write_block_comment`). On success we skip past the entire block and
+                // a single following blank-line separator.
+                //
+                // If we can't find the closing `*/` within this chunk (the block
+                // straddles the chunk boundary somehow — a rare shape that the legacy
+                // path was originally built for), we fall back to the old line-by-line
+                // emission: write this opener line via `write_comment_with_prefix` and
+                // let the `inside_block_comment` arm below pick up subsequent body
+                // lines on later iterations.
                 let trimmed = line.trim_start();
                 let opener = if trimmed.starts_with("/**") {
                     "/**"
@@ -1188,20 +1206,29 @@ impl<'a> Formatter<'a> {
                     "/*"
                 };
 
+                // Scan forward for the line that contains the closing `*/`. Note that
+                // for a single-line block comment (e.g. `/* foo */`) this loop exits
+                // immediately with `block_end == index`.
                 let mut block_end = index;
                 while block_end < lines.len() && !lines[block_end].trim_end().ends_with("*/") {
                     block_end += 1;
                 }
 
                 if block_end < lines.len() {
+                    // Strip the opening delimiter from the first line and the closing
+                    // `*/` from the last line, then reassemble the body in between.
                     let first_after_open = trimmed.strip_prefix(opener).unwrap_or(trimmed);
                     let last_line = lines[block_end];
                     let last_before_close =
                         last_line.trim_end().strip_suffix("*/").unwrap_or(last_line.trim_end());
 
                     let body = if index == block_end {
+                        // Single-line form: body is whatever lies between opener and `*/`.
                         first_after_open.strip_suffix("*/").unwrap_or(first_after_open).to_string()
                     } else {
+                        // Multi-line form: stitch together [first_after_open, middle
+                        // lines..., last_before_close] with `\n` separators so the body
+                        // matches what `write_block_comment` would see at the top level.
                         let mut parts = vec![first_after_open.to_string()];
                         for inner_line in &lines[(index + 1)..block_end] {
                             parts.push(inner_line.to_string());
@@ -1210,15 +1237,22 @@ impl<'a> Formatter<'a> {
                         parts.join("\n")
                     };
 
+                    // Preserve the leading space that separates the block comment from
+                    // whatever code precedes it (e.g. `let x = 1; /* ... */`).
                     if starts_with_space && !self.buffer.ends_with_space() {
                         self.write(" ");
                     }
 
+                    // Run `write_block_comment` as if at top level so the parser-based
+                    // wrap path executes (otherwise its `self.in_chunk` early return
+                    // would emit the body verbatim).
                     let saved_in_chunk = self.in_chunk;
                     self.in_chunk = false;
                     self.write_block_comment(&body, opener);
                     self.in_chunk = saved_in_chunk;
 
+                    // Jump past the whole block and any blank lines that follow,
+                    // collapsing the run to at most one blank-line separator.
                     index = block_end + 1;
                     while index < lines.len() && lines[index].is_empty() {
                         self.write_multiple_lines_without_skipping_whitespace_and_comments();
@@ -1227,6 +1261,9 @@ impl<'a> Formatter<'a> {
                     continue;
                 }
 
+                // Closing `*/` not found within this chunk: fall back to the legacy
+                // line-by-line wrap and let the `inside_block_comment` arm handle the
+                // subsequent body lines.
                 if starts_with_space && !self.buffer.ends_with_space() {
                     self.write(" ");
                 }

--- a/tooling/nargo_fmt/src/config.rs
+++ b/tooling/nargo_fmt/src/config.rs
@@ -55,7 +55,9 @@ config! {
     imports_granularity: ImportsGranularity, ImportsGranularity::Preserve, "How imports should be grouped into use statements.";
     reorder_imports: bool, true, "Reorder imports alphabetically";
     wrap_comments: bool, false, "Break comments to fit on the line";
-    comment_width: usize, 100, "Maximum length of comments. No effect unless `wrap_comments = true`"
+    comment_width: usize, 100, "Maximum length of comments. No effect unless `wrap_comments = true`";
+    reflow_comments: bool, false, "Merge consecutive comment lines into paragraphs and reflow to `comment_width`. No effect unless `wrap_comments = true`";
+    format_code_blocks: bool, false, "Recursively format Noir code inside markdown fenced code blocks in doc comments (untagged or tagged ```noir```). No effect unless `wrap_comments = true`"
 }
 
 impl Config {

--- a/tooling/nargo_fmt/src/config.rs
+++ b/tooling/nargo_fmt/src/config.rs
@@ -56,7 +56,8 @@ config! {
     reorder_imports: bool, true, "Reorder imports alphabetically";
     wrap_comments: bool, false, "Break comments to fit on the line";
     comment_width: usize, 100, "Maximum length of comments. No effect unless `wrap_comments = true`";
-    reflow_comments: bool, false, "Merge consecutive comment lines into paragraphs and reflow to `comment_width`. No effect unless `wrap_comments = true`";
+    reflow_doc_comments: bool, false, "Merge consecutive doc-comment lines (`///`, `//!`, `/**`, `/*!`) into paragraphs and reflow to `comment_width`. Doc comments follow markdown convention, so reflow rarely surprises. No effect unless `wrap_comments = true`";
+    reflow_non_doc_comments: bool, false, "Merge consecutive non-doc-comment lines (`//`, `/*`) into paragraphs and reflow to `comment_width`. Non-doc comments are free-form, so this can collapse intentionally separate lines like `// step 1` / `// step 2`. No effect unless `wrap_comments = true`";
     format_code_blocks: bool, false, "Recursively format Noir code inside markdown fenced code blocks in doc comments (untagged or tagged ```noir```). No effect unless `wrap_comments = true`"
 }
 

--- a/tooling/nargo_fmt/src/config.rs
+++ b/tooling/nargo_fmt/src/config.rs
@@ -6,6 +6,7 @@ use crate::errors::ConfigError;
 
 macro_rules! config {
     ($($field_name:ident: $field_ty:ty, $default_value:expr_2021, $description:expr_2021 );+ $(;)*) => (
+        #[derive(Clone)]
         pub struct Config {
             $(
                 #[doc = $description]

--- a/tooling/nargo_fmt/src/formatter.rs
+++ b/tooling/nargo_fmt/src/formatter.rs
@@ -13,6 +13,7 @@ use crate::chunks::ChunkGroup;
 mod alias;
 mod attribute;
 mod buffer;
+mod comment_reflow;
 mod comments_and_whitespace;
 mod doc_comments;
 mod enums;

--- a/tooling/nargo_fmt/src/formatter.rs
+++ b/tooling/nargo_fmt/src/formatter.rs
@@ -81,6 +81,11 @@ pub(crate) struct Formatter<'a> {
 
     /// Is the formatter inside a chunk?
     pub(crate) in_chunk: bool,
+
+    /// One-token lookahead buffer. When `Some`, the next `bump` consumes this
+    /// instead of advancing the lexer. Used by grouping logic that needs to look
+    /// past a whitespace to see what kind of token follows.
+    peeked: Option<SpannedToken>,
 }
 
 impl<'a> Formatter<'a> {
@@ -100,6 +105,7 @@ impl<'a> Formatter<'a> {
             max_width: config.max_width,
             buffer: Buffer::default(),
             in_chunk: false,
+            peeked: None,
         };
         formatter.bump();
         formatter
@@ -340,7 +346,8 @@ impl<'a> Formatter<'a> {
 
     /// Advances to the next token (the current token is not written).
     pub(crate) fn bump(&mut self) -> Token {
-        let next_token = self.read_token_internal();
+        let next_token =
+            if let Some(peeked) = self.peeked.take() { peeked } else { self.read_token_internal() };
 
         // Keep the ignore status as long as we keep finding comments or whitespace, otherwise reset it
         if !matches!(
@@ -364,5 +371,15 @@ impl<'a> Formatter<'a> {
         } else {
             SpannedToken::new(Token::EOF, Default::default())
         }
+    }
+
+    /// Returns the token that would become current after the next `bump`, without consuming it.
+    /// Used by grouping logic that needs to look past a whitespace to decide whether to extend
+    /// a comment group.
+    pub(crate) fn peek_next_token(&mut self) -> &Token {
+        if self.peeked.is_none() {
+            self.peeked = Some(self.read_token_internal());
+        }
+        self.peeked.as_ref().unwrap().token()
     }
 }

--- a/tooling/nargo_fmt/src/formatter/comment_reflow.rs
+++ b/tooling/nargo_fmt/src/formatter/comment_reflow.rs
@@ -19,7 +19,11 @@
 ///
 /// `first_budget` is the maximum characters allowed for content on the first
 /// output line. `cont_budget` is the maximum characters for subsequent lines.
-/// Budgets exclude the per-line prefix the caller will add.
+/// Budgets exclude the per-line prefix the caller will add. They differ when
+/// the comment starts trailing-inline after code (e.g. `let x = 1; // ...`):
+/// the first line shares column space with whatever is already on the rendered
+/// line, while continuations start fresh at the formatter's indent. When the
+/// comment opens on its own line, callers pass `first_budget == cont_budget`.
 ///
 /// Returns one String per output line. The caller adds the prefix and any
 /// indent to each line.
@@ -70,43 +74,70 @@ where
 #[derive(Debug, PartialEq, Eq)]
 #[allow(clippy::enum_variant_names)]
 enum Block {
-    Paragraph {
-        words: Vec<String>,
-    },
-    ListItem {
-        marker: String,
-        hanging_indent: usize,
-        words: Vec<String>,
-    },
-    BlockQuote {
-        words: Vec<String>,
-    },
-    Passthrough {
-        raw_lines: Vec<String>,
-    },
+    /// A plain prose paragraph. `words` is the flat list of whitespace-separated tokens
+    /// from one or more input lines (merged together when `reflow_paragraphs` is `true`),
+    /// to be greedy-wrapped on emit. Internal whitespace runs are normalized to single
+    /// spaces — callers that need to preserve verbatim spacing bypass the engine.
+    Paragraph { words: Vec<String> },
+    /// A markdown list item (bullet or ordered). `marker` is the literal marker text with
+    /// its trailing space (e.g. `"- "`, `"1. "`). `hanging_indent` is the column under
+    /// which continuation lines align — it includes both the leading indent of the marker
+    /// line and the marker's own width, so nested items stay nested. `words` are the
+    /// post-marker tokens, again merged across continuation lines when `reflow_paragraphs`
+    /// is `true`.
+    ListItem { marker: String, hanging_indent: usize, words: Vec<String> },
+    /// A markdown blockquote (`> ...`). `words` are the post-`>` tokens, optionally
+    /// merged across consecutive `>` lines when reflowing. On emit every output line is
+    /// re-prefixed with `> `.
+    BlockQuote { words: Vec<String> },
+    /// Lines that must be emitted verbatim, with no wrapping or merging. Used for
+    /// markdown headers (`# ...`), table rows (`| ... |`), URL-bearing lines,
+    /// Javadoc-style `@tag` lines that don't start a paragraph, and blank lines (where
+    /// `raw_lines` is `vec![String::new()]`). Multiple raw lines are emitted in order.
+    Passthrough { raw_lines: Vec<String> },
     /// A fenced code block. `lang` is the info string after the opening fence (empty for
     /// untagged fences). `fence_open` / `fence_close` are the raw delimiter lines as
     /// they appeared in the source so we can re-emit them verbatim. `inner_lines` is the
     /// fence body, which may be replaced by a code-formatter callback before emit.
-    CodeFence {
-        lang: String,
-        fence_open: String,
-        fence_close: String,
-        inner_lines: Vec<String>,
-    },
+    CodeFence { lang: String, fence_open: String, fence_close: String, inner_lines: Vec<String> },
 }
 
+/// Classification of a single input line, used by `parse_blocks` to decide which
+/// `Block` to open or extend. The classifier is intentionally heuristic — it doesn't
+/// run a full markdown parser, just enough pattern matching to recognize the line
+/// shapes that should *not* be reflowed as prose.
 #[derive(Debug, PartialEq, Eq)]
 enum LineKind<'a> {
+    /// Empty or whitespace-only line. Becomes a paragraph break in the emit.
     Blank,
+    /// Markdown ATX header, i.e. a line whose first non-whitespace char is `#`.
+    /// Emitted verbatim — never merged or wrapped.
     Header,
+    /// Javadoc-style tag like `@param`, `@return`, `@dev`. Starts a fresh paragraph
+    /// so it doesn't get glued to prose above it.
     JavadocTag,
+    /// Bullet list item (`* `, `- `, `+ `). `marker_len` is the byte length of the
+    /// marker + its trailing space, so the caller can split the line into marker
+    /// and content.
     BulletItem { marker_len: usize },
+    /// Ordered list item (`1. `, `99) `, etc.). `marker_len` covers digits + the
+    /// `. ` or `) ` suffix.
     OrderedItem { marker_len: usize },
+    /// Markdown blockquote line (`> ...`).
     BlockQuote,
+    /// Line containing a URL or a reference-style link definition. Kept on its own
+    /// line so we don't try to wrap inside a link.
     UrlLine,
+    /// Markdown table row — `| ... |` shape. Verbatim passthrough.
     TableLine,
+    /// Triple-backtick / triple-tilde line opening or closing a fenced code block.
+    /// `parse_blocks` uses this both to enter fence mode (capturing the lang tag from
+    /// the opener) and to detect the closer.
     FenceToggle,
+    /// Anything else — ordinary prose. `indent` is the line's leading whitespace
+    /// width in chars and `content` is the line with that leading whitespace
+    /// stripped. The indent is what lets list-item continuation logic detect
+    /// "this Plain line is indented under the open list item, fold it in."
     Plain { indent: usize, content: &'a str },
 }
 

--- a/tooling/nargo_fmt/src/formatter/comment_reflow.rs
+++ b/tooling/nargo_fmt/src/formatter/comment_reflow.rs
@@ -274,18 +274,21 @@ fn emit_blocks(blocks: &[Block], first_budget: usize, cont_budget: usize) -> Vec
             }
             Block::ListItem { marker, hanging_indent, words } => {
                 let fb = if output.is_empty() { first_budget } else { cont_budget };
-                let first_word_budget = fb.saturating_sub(marker.chars().count());
+                let first_word_budget = fb.saturating_sub(*hanging_indent);
                 let cont_word_budget = cont_budget.saturating_sub(*hanging_indent);
                 let wrapped = wrap_words(words, first_word_budget, cont_word_budget);
+                let marker_len = marker.chars().count();
+                let leading_indent = hanging_indent.saturating_sub(marker_len);
+                let leading_pad: String = " ".repeat(leading_indent);
                 let mut iter = wrapped.into_iter();
                 if let Some(first) = iter.next() {
-                    output.push(format!("{marker}{first}"));
+                    output.push(format!("{leading_pad}{marker}{first}"));
                 } else {
-                    output.push(marker.trim_end().to_string());
+                    output.push(format!("{leading_pad}{}", marker.trim_end()));
                 }
-                let pad: String = std::iter::repeat_n(' ', *hanging_indent).collect();
+                let cont_pad: String = " ".repeat(*hanging_indent);
                 for cont in iter {
-                    output.push(format!("{pad}{cont}"));
+                    output.push(format!("{cont_pad}{cont}"));
                 }
             }
             Block::BlockQuote { words } => {
@@ -420,6 +423,34 @@ mod tests {
     fn ordered_list_marker() {
         let out = reflow(&["1. first ordered item that wraps"], 18, 18);
         assert_eq!(out, vec!["1. first ordered".to_string(), "   item that wraps".to_string()]);
+    }
+
+    #[test]
+    fn nested_list_item_preserves_leading_indent() {
+        let out = reflow(&["- Parent", "  - Child"], 80, 80);
+        assert_eq!(out, vec!["- Parent".to_string(), "  - Child".to_string()]);
+    }
+
+    #[test]
+    fn nested_list_item_with_wrap() {
+        let out = reflow(&["- Parent", "  - Child item that is long enough to wrap"], 20, 20);
+        assert_eq!(
+            out,
+            vec![
+                "- Parent".to_string(),
+                "  - Child item that".to_string(),
+                "    is long enough".to_string(),
+                "    to wrap".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn idempotent_nested_list() {
+        let once = reflow(&["- Parent", "  - Child item that is long enough to wrap"], 20, 20);
+        let refs: Vec<&str> = once.iter().map(String::as_str).collect();
+        let twice = reflow(&refs, 20, 20);
+        assert_eq!(once, twice);
     }
 
     #[test]

--- a/tooling/nargo_fmt/src/formatter/comment_reflow.rs
+++ b/tooling/nargo_fmt/src/formatter/comment_reflow.rs
@@ -27,16 +27,22 @@
 /// It receives the joined fence body and the language tag (`None` for untagged fences).
 /// Returning `Some(formatted)` replaces the inner lines of the fence; returning `None`
 /// leaves the original content untouched.
+///
+/// When `reflow_paragraphs` is `false` the parser does not merge consecutive plain lines
+/// into a single paragraph, list-item continuations don't fold into their parent, and
+/// blockquotes don't span lines. Each input line is wrapped independently, preserving
+/// the pre-reflow per-line wrap behavior.
 pub(crate) fn reflow_comment_with_code_formatter<F>(
     lines: &[&str],
     first_budget: usize,
     cont_budget: usize,
+    reflow_paragraphs: bool,
     format_code: F,
 ) -> Vec<String>
 where
     F: Fn(&str, Option<&str>) -> Option<String>,
 {
-    let mut blocks = parse_blocks(lines);
+    let mut blocks = parse_blocks(lines, reflow_paragraphs);
     apply_code_formatter(&mut blocks, &format_code);
     emit_blocks(&blocks, first_budget, cont_budget)
 }
@@ -211,7 +217,7 @@ fn contains_url_or_reference(line: &str) -> bool {
     false
 }
 
-fn parse_blocks(lines: &[&str]) -> Vec<Block> {
+fn parse_blocks(lines: &[&str], reflow_paragraphs: bool) -> Vec<Block> {
     let mut blocks: Vec<Block> = Vec::new();
     let mut in_fence = false;
     let mut fence_open: String = String::new();
@@ -267,7 +273,9 @@ fn parse_blocks(lines: &[&str]) -> Vec<Block> {
                     .or_else(|| trimmed.strip_prefix('>'))
                     .unwrap_or(trimmed);
                 let words = collect_words(content);
-                if let Some(Block::BlockQuote { words: existing }) = blocks.last_mut() {
+                if reflow_paragraphs
+                    && let Some(Block::BlockQuote { words: existing }) = blocks.last_mut()
+                {
                     existing.extend(words);
                 } else {
                     blocks.push(Block::BlockQuote { words });
@@ -276,7 +284,7 @@ fn parse_blocks(lines: &[&str]) -> Vec<Block> {
             LineKind::Plain { indent, content } => {
                 let new_words = collect_words(content);
                 let mut merged = false;
-                if let Some(last) = blocks.last_mut() {
+                if reflow_paragraphs && let Some(last) = blocks.last_mut() {
                     match last {
                         Block::ListItem { hanging_indent, words, .. } => {
                             if indent >= *hanging_indent {
@@ -431,7 +439,11 @@ mod tests {
     use super::*;
 
     fn reflow(lines: &[&str], first: usize, cont: usize) -> Vec<String> {
-        reflow_comment_with_code_formatter(lines, first, cont, |_, _| None)
+        reflow_comment_with_code_formatter(lines, first, cont, true, |_, _| None)
+    }
+
+    fn reflow_no_merge(lines: &[&str], first: usize, cont: usize) -> Vec<String> {
+        reflow_comment_with_code_formatter(lines, first, cont, false, |_, _| None)
     }
 
     #[test]
@@ -528,6 +540,33 @@ mod tests {
                 "    to wrap".to_string(),
             ]
         );
+    }
+
+    #[test]
+    fn reflow_false_does_not_merge_consecutive_plain_lines() {
+        let out = reflow_no_merge(&["foo bar", "baz qux"], 80, 80);
+        assert_eq!(out, vec!["foo bar".to_string(), "baz qux".to_string()]);
+    }
+
+    #[test]
+    fn reflow_false_still_wraps_individual_long_lines() {
+        let out = reflow_no_merge(&["one two three four five six seven"], 12, 12);
+        assert_eq!(
+            out,
+            vec![
+                "one two".to_string(),
+                "three four".to_string(),
+                "five six".to_string(),
+                "seven".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn reflow_false_does_not_merge_list_item_continuations() {
+        let out = reflow_no_merge(&["- first item", "  continuation text"], 80, 80);
+        // The continuation does not fold into the list item; it becomes its own block.
+        assert_eq!(out, vec!["- first item".to_string(), "  continuation text".to_string()]);
     }
 
     #[test]

--- a/tooling/nargo_fmt/src/formatter/comment_reflow.rs
+++ b/tooling/nargo_fmt/src/formatter/comment_reflow.rs
@@ -385,13 +385,16 @@ fn emit_blocks(blocks: &[Block], first_budget: usize, cont_budget: usize) -> Vec
                 }
             }
             Block::Paragraph { words } => {
-                let fb = if output.is_empty() { first_budget } else { cont_budget };
-                let wrapped = wrap_words(words, fb, cont_budget);
+                // Only the engine's very first emitted line uses the original `first_budget`;
+                // once anything has been pushed, the rendered position has moved past the
+                // trailing-inline column and we're back on a fresh line at the indent.
+                let first_budget = if output.is_empty() { first_budget } else { cont_budget };
+                let wrapped = wrap_words(words, first_budget, cont_budget);
                 output.extend(wrapped);
             }
             Block::ListItem { marker, hanging_indent, words } => {
-                let fb = if output.is_empty() { first_budget } else { cont_budget };
-                let first_word_budget = fb.saturating_sub(*hanging_indent);
+                let first_budget = if output.is_empty() { first_budget } else { cont_budget };
+                let first_word_budget = first_budget.saturating_sub(*hanging_indent);
                 let cont_word_budget = cont_budget.saturating_sub(*hanging_indent);
                 let wrapped = wrap_words(words, first_word_budget, cont_word_budget);
                 let marker_len = marker.chars().count();
@@ -409,8 +412,8 @@ fn emit_blocks(blocks: &[Block], first_budget: usize, cont_budget: usize) -> Vec
                 }
             }
             Block::BlockQuote { words } => {
-                let fb = if output.is_empty() { first_budget } else { cont_budget };
-                let first_word_budget = fb.saturating_sub(2);
+                let first_budget = if output.is_empty() { first_budget } else { cont_budget };
+                let first_word_budget = first_budget.saturating_sub(2);
                 let cont_word_budget = cont_budget.saturating_sub(2);
                 let wrapped = wrap_words(words, first_word_budget, cont_word_budget);
                 for line in wrapped {

--- a/tooling/nargo_fmt/src/formatter/comment_reflow.rs
+++ b/tooling/nargo_fmt/src/formatter/comment_reflow.rs
@@ -1,0 +1,475 @@
+//! Paragraph-aware reflow for comments.
+//!
+//! Given a sequence of comment content lines (with the per-line prefix such as
+//! `//`, `///`, or ` * ` already stripped), this module merges adjacent "plain"
+//! lines into paragraphs, then greedily wraps each paragraph to the configured
+//! width. Certain line shapes (markdown headers, list items, blockquotes,
+//! fenced code, tables, URL lines, Javadoc-style `@tag` lines, blank lines)
+//! are recognized and never merged into prose.
+//!
+//! Output lines do not carry the prefix or any caller-side indentation; the
+//! caller is responsible for adding them. The engine is a pure function with
+//! no formatter state.
+
+/// Wrap a sequence of comment content lines into paragraph-aware reflowed output.
+///
+/// `lines` is the comment content split by physical source line, with each line's
+/// per-line prefix already stripped. Leading whitespace within each line is
+/// preserved so that markdown structure can be detected.
+///
+/// `first_budget` is the maximum characters allowed for content on the first
+/// output line. `cont_budget` is the maximum characters for subsequent lines.
+/// Budgets exclude the per-line prefix the caller will add.
+///
+/// Returns one String per output line. The caller adds the prefix and any
+/// indent to each line.
+pub(crate) fn reflow_comment(
+    lines: &[&str],
+    first_budget: usize,
+    cont_budget: usize,
+) -> Vec<String> {
+    let blocks = parse_blocks(lines);
+    emit_blocks(&blocks, first_budget, cont_budget)
+}
+
+#[derive(Debug, PartialEq, Eq)]
+#[allow(clippy::enum_variant_names)]
+enum Block {
+    Paragraph { words: Vec<String> },
+    ListItem { marker: String, hanging_indent: usize, words: Vec<String> },
+    BlockQuote { words: Vec<String> },
+    Passthrough { raw_lines: Vec<String> },
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum LineKind<'a> {
+    Blank,
+    Header,
+    JavadocTag,
+    BulletItem { marker_len: usize },
+    OrderedItem { marker_len: usize },
+    BlockQuote,
+    UrlLine,
+    TableLine,
+    FenceToggle,
+    Plain { indent: usize, content: &'a str },
+}
+
+fn classify<'a>(line: &'a str) -> LineKind<'a> {
+    let trimmed = line.trim_start();
+    if trimmed.is_empty() {
+        return LineKind::Blank;
+    }
+    if trimmed.starts_with("```") || trimmed.starts_with("~~~") {
+        return LineKind::FenceToggle;
+    }
+    if trimmed.starts_with('#') {
+        return LineKind::Header;
+    }
+    if is_javadoc_tag(trimmed) {
+        return LineKind::JavadocTag;
+    }
+    if let Some(len) = bullet_marker_len(trimmed) {
+        return LineKind::BulletItem { marker_len: len };
+    }
+    if let Some(len) = ordered_marker_len(trimmed) {
+        return LineKind::OrderedItem { marker_len: len };
+    }
+    if trimmed.starts_with("> ") || trimmed == ">" {
+        return LineKind::BlockQuote;
+    }
+    if is_table_line(trimmed) {
+        return LineKind::TableLine;
+    }
+    if contains_url_or_reference(line) {
+        return LineKind::UrlLine;
+    }
+    let indent = line.len() - trimmed.len();
+    LineKind::Plain { indent, content: trimmed }
+}
+
+fn is_javadoc_tag(trimmed: &str) -> bool {
+    let Some(rest) = trimmed.strip_prefix('@') else {
+        return false;
+    };
+    let mut chars = rest.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+    if !(first.is_ascii_alphabetic() || first == '_') {
+        return false;
+    }
+    chars.all(|c| c.is_ascii_alphanumeric() || c == '_')
+        || rest.split_once(|c: char| c.is_ascii_whitespace()).is_some_and(|(name, _)| {
+            !name.is_empty() && name.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
+        })
+}
+
+fn bullet_marker_len(trimmed: &str) -> Option<usize> {
+    for marker in ["* ", "- ", "+ "] {
+        if trimmed.starts_with(marker) {
+            return Some(marker.len());
+        }
+    }
+    None
+}
+
+fn ordered_marker_len(trimmed: &str) -> Option<usize> {
+    let mut chars = trimmed.char_indices();
+    let mut digits = 0;
+    let mut digit_end = 0;
+    while let Some((idx, c)) = chars.clone().next() {
+        if c.is_ascii_digit() {
+            digits += 1;
+            digit_end = idx + c.len_utf8();
+            chars.next();
+            if digits > 2 {
+                return None;
+            }
+        } else {
+            break;
+        }
+    }
+    if digits == 0 {
+        return None;
+    }
+    let rest = &trimmed[digit_end..];
+    if rest.starts_with(". ") || rest.starts_with(") ") { Some(digit_end + 2) } else { None }
+}
+
+fn is_table_line(trimmed: &str) -> bool {
+    if !trimmed.starts_with('|') {
+        return false;
+    }
+    trimmed[1..].contains('|')
+}
+
+fn contains_url_or_reference(line: &str) -> bool {
+    for scheme in ["https://", "http://", "ftp://", "file://"] {
+        if line.contains(scheme) {
+            return true;
+        }
+    }
+    let trimmed = line.trim_start();
+    if let Some(rest) = trimmed.strip_prefix('[')
+        && let Some(close_idx) = rest.find(']')
+    {
+        let after = &rest[close_idx + 1..];
+        if after.starts_with(':') {
+            return true;
+        }
+    }
+    false
+}
+
+fn parse_blocks(lines: &[&str]) -> Vec<Block> {
+    let mut blocks: Vec<Block> = Vec::new();
+    let mut in_fence = false;
+    let mut fence_lines: Vec<String> = Vec::new();
+
+    for &line in lines {
+        if in_fence {
+            fence_lines.push(line.to_string());
+            if matches!(classify(line), LineKind::FenceToggle) {
+                in_fence = false;
+                blocks.push(Block::Passthrough { raw_lines: std::mem::take(&mut fence_lines) });
+            }
+            continue;
+        }
+
+        let kind = classify(line);
+        match kind {
+            LineKind::FenceToggle => {
+                in_fence = true;
+                fence_lines.push(line.to_string());
+            }
+            LineKind::Blank => {
+                blocks.push(Block::Passthrough { raw_lines: vec![String::new()] });
+            }
+            LineKind::Header | LineKind::TableLine | LineKind::UrlLine => {
+                blocks.push(Block::Passthrough { raw_lines: vec![line.to_string()] });
+            }
+            LineKind::JavadocTag => {
+                let words = collect_words(line);
+                blocks.push(Block::Paragraph { words });
+            }
+            LineKind::BulletItem { marker_len } | LineKind::OrderedItem { marker_len } => {
+                let trimmed = line.trim_start();
+                let marker = trimmed[..marker_len].to_string();
+                let leading_indent = line.len() - trimmed.len();
+                let rest = &trimmed[marker_len..];
+                let words = collect_words(rest);
+                let hanging = leading_indent + marker_len;
+                blocks.push(Block::ListItem { marker, hanging_indent: hanging, words });
+            }
+            LineKind::BlockQuote => {
+                let trimmed = line.trim_start();
+                let content = trimmed
+                    .strip_prefix("> ")
+                    .or_else(|| trimmed.strip_prefix('>'))
+                    .unwrap_or(trimmed);
+                let words = collect_words(content);
+                if let Some(Block::BlockQuote { words: existing }) = blocks.last_mut() {
+                    existing.extend(words);
+                } else {
+                    blocks.push(Block::BlockQuote { words });
+                }
+            }
+            LineKind::Plain { indent, content } => {
+                let new_words = collect_words(content);
+                let mut merged = false;
+                if let Some(last) = blocks.last_mut() {
+                    match last {
+                        Block::ListItem { hanging_indent, words, .. } => {
+                            if indent >= *hanging_indent {
+                                words.extend(new_words.clone());
+                                merged = true;
+                            }
+                        }
+                        Block::Paragraph { words } => {
+                            if indent == 0 {
+                                words.extend(new_words.clone());
+                                merged = true;
+                            }
+                        }
+                        _ => {}
+                    }
+                }
+                if !merged {
+                    if indent == 0 {
+                        blocks.push(Block::Paragraph { words: new_words });
+                    } else {
+                        blocks.push(Block::Passthrough { raw_lines: vec![line.to_string()] });
+                    }
+                }
+            }
+        }
+    }
+
+    if in_fence && !fence_lines.is_empty() {
+        blocks.push(Block::Passthrough { raw_lines: fence_lines });
+    }
+
+    blocks
+}
+
+fn collect_words(content: &str) -> Vec<String> {
+    content.split_whitespace().map(|s| s.to_string()).collect()
+}
+
+fn emit_blocks(blocks: &[Block], first_budget: usize, cont_budget: usize) -> Vec<String> {
+    let mut output: Vec<String> = Vec::new();
+
+    for block in blocks {
+        match block {
+            Block::Passthrough { raw_lines } => {
+                for line in raw_lines {
+                    output.push(line.clone());
+                }
+            }
+            Block::Paragraph { words } => {
+                let fb = if output.is_empty() { first_budget } else { cont_budget };
+                let wrapped = wrap_words(words, fb, cont_budget);
+                output.extend(wrapped);
+            }
+            Block::ListItem { marker, hanging_indent, words } => {
+                let fb = if output.is_empty() { first_budget } else { cont_budget };
+                let first_word_budget = fb.saturating_sub(marker.chars().count());
+                let cont_word_budget = cont_budget.saturating_sub(*hanging_indent);
+                let wrapped = wrap_words(words, first_word_budget, cont_word_budget);
+                let mut iter = wrapped.into_iter();
+                if let Some(first) = iter.next() {
+                    output.push(format!("{marker}{first}"));
+                } else {
+                    output.push(marker.trim_end().to_string());
+                }
+                let pad: String = std::iter::repeat_n(' ', *hanging_indent).collect();
+                for cont in iter {
+                    output.push(format!("{pad}{cont}"));
+                }
+            }
+            Block::BlockQuote { words } => {
+                let fb = if output.is_empty() { first_budget } else { cont_budget };
+                let first_word_budget = fb.saturating_sub(2);
+                let cont_word_budget = cont_budget.saturating_sub(2);
+                let wrapped = wrap_words(words, first_word_budget, cont_word_budget);
+                for line in wrapped {
+                    output.push(format!("> {line}"));
+                }
+            }
+        }
+    }
+
+    output.into_iter().map(trim_trailing_spaces).collect()
+}
+
+fn trim_trailing_spaces(mut s: String) -> String {
+    let trimmed_len = s.trim_end_matches([' ', '\t']).len();
+    s.truncate(trimmed_len);
+    s
+}
+
+fn wrap_words(words: &[String], first_budget: usize, cont_budget: usize) -> Vec<String> {
+    if words.is_empty() {
+        return Vec::new();
+    }
+    let mut output: Vec<String> = Vec::new();
+    let mut current = String::new();
+    let mut on_first_line = true;
+    for word in words {
+        let budget = if on_first_line { first_budget } else { cont_budget };
+        if current.is_empty() {
+            current.push_str(word);
+        } else {
+            let needed = current.chars().count() + 1 + word.chars().count();
+            if needed <= budget {
+                current.push(' ');
+                current.push_str(word);
+            } else {
+                output.push(std::mem::take(&mut current));
+                on_first_line = false;
+                current.push_str(word);
+            }
+        }
+    }
+    if !current.is_empty() {
+        output.push(current);
+    }
+    output
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn reflow(lines: &[&str], first: usize, cont: usize) -> Vec<String> {
+        reflow_comment(lines, first, cont)
+    }
+
+    #[test]
+    fn single_short_paragraph_unchanged() {
+        let out = reflow(&["Hello world"], 80, 80);
+        assert_eq!(out, vec!["Hello world".to_string()]);
+    }
+
+    #[test]
+    fn merges_two_lines_then_rewraps() {
+        let out = reflow(&["Hello world, I just realized that this", "is a long comment"], 32, 32);
+        assert_eq!(
+            out,
+            vec![
+                "Hello world, I just realized".to_string(),
+                "that this is a long comment".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn user_example_reflow() {
+        let out = reflow(&["Hello world, I just realized that this", "is a long comment"], 22, 22);
+        // Words flow naturally across the boundary.
+        assert_eq!(
+            out,
+            vec![
+                "Hello world, I just".to_string(),
+                "realized that this is".to_string(),
+                "a long comment".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn blank_line_breaks_paragraph() {
+        let out = reflow(&["foo bar", "", "baz qux"], 80, 80);
+        assert_eq!(out, vec!["foo bar".to_string(), String::new(), "baz qux".to_string()]);
+    }
+
+    #[test]
+    fn markdown_header_passthrough() {
+        let out = reflow(&["# Title", "body text"], 5, 5);
+        assert_eq!(out, vec!["# Title".to_string(), "body".to_string(), "text".to_string()]);
+    }
+
+    #[test]
+    fn fenced_code_passthrough() {
+        let out = reflow(&["```rust", "fn  main()  {}", "```", "after"], 80, 80);
+        assert_eq!(
+            out,
+            vec![
+                "```rust".to_string(),
+                "fn  main()  {}".to_string(),
+                "```".to_string(),
+                "after".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn url_line_passthrough() {
+        let out = reflow(&["see https://example.com/some/very/long/path for more"], 10, 10);
+        assert_eq!(out, vec!["see https://example.com/some/very/long/path for more".to_string()]);
+    }
+
+    #[test]
+    fn bullet_item_with_hanging_indent() {
+        let out = reflow(&["- first item that wraps to next line"], 20, 20);
+        assert_eq!(out, vec!["- first item that".to_string(), "  wraps to next line".to_string(),]);
+    }
+
+    #[test]
+    fn ordered_list_marker() {
+        let out = reflow(&["1. first ordered item that wraps"], 18, 18);
+        assert_eq!(out, vec!["1. first ordered".to_string(), "   item that wraps".to_string()]);
+    }
+
+    #[test]
+    fn javadoc_tag_breaks_paragraph() {
+        let out = reflow(&["Build a Foo.", "@return a fresh Foo"], 80, 80);
+        assert_eq!(out, vec!["Build a Foo.".to_string(), "@return a fresh Foo".to_string()]);
+    }
+
+    #[test]
+    fn blockquote_reflows_with_prefix() {
+        let out = reflow(&["> a quoted line that should wrap"], 12, 12);
+        assert_eq!(
+            out,
+            vec![
+                "> a quoted".to_string(),
+                "> line that".to_string(),
+                "> should".to_string(),
+                "> wrap".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn word_longer_than_budget_emitted_alone() {
+        let out = reflow(&["short superduperlongword end"], 10, 10);
+        assert_eq!(
+            out,
+            vec!["short".to_string(), "superduperlongword".to_string(), "end".to_string(),]
+        );
+    }
+
+    #[test]
+    fn first_budget_can_differ_from_cont_budget() {
+        let out = reflow(&["alpha beta gamma delta"], 10, 20);
+        assert_eq!(out, vec!["alpha beta".to_string(), "gamma delta".to_string()]);
+    }
+
+    #[test]
+    fn idempotent_on_wrapped_paragraph() {
+        let once = reflow(&["Hello world, I just realized that this", "is a long comment"], 22, 22);
+        let refs: Vec<&str> = once.iter().map(String::as_str).collect();
+        let twice = reflow(&refs, 22, 22);
+        assert_eq!(once, twice);
+    }
+
+    #[test]
+    fn idempotent_on_list_item() {
+        let once = reflow(&["- first item that wraps to next line"], 20, 20);
+        let refs: Vec<&str> = once.iter().map(String::as_str).collect();
+        let twice = reflow(&refs, 20, 20);
+        assert_eq!(once, twice);
+    }
+}

--- a/tooling/nargo_fmt/src/formatter/comment_reflow.rs
+++ b/tooling/nargo_fmt/src/formatter/comment_reflow.rs
@@ -23,22 +23,71 @@
 ///
 /// Returns one String per output line. The caller adds the prefix and any
 /// indent to each line.
-pub(crate) fn reflow_comment(
+/// `format_code` is invoked for each fenced code block.
+/// It receives the joined fence body and the language tag (`None` for untagged fences).
+/// Returning `Some(formatted)` replaces the inner lines of the fence; returning `None`
+/// leaves the original content untouched.
+pub(crate) fn reflow_comment_with_code_formatter<F>(
     lines: &[&str],
     first_budget: usize,
     cont_budget: usize,
-) -> Vec<String> {
-    let blocks = parse_blocks(lines);
+    format_code: F,
+) -> Vec<String>
+where
+    F: Fn(&str, Option<&str>) -> Option<String>,
+{
+    let mut blocks = parse_blocks(lines);
+    apply_code_formatter(&mut blocks, &format_code);
     emit_blocks(&blocks, first_budget, cont_budget)
+}
+
+fn apply_code_formatter<F>(blocks: &mut [Block], format_code: &F)
+where
+    F: Fn(&str, Option<&str>) -> Option<String>,
+{
+    for block in blocks {
+        if let Block::CodeFence { lang, inner_lines, .. } = block {
+            let lang_opt = if lang.is_empty() { None } else { Some(lang.as_str()) };
+            let source = inner_lines.join("\n");
+            if let Some(formatted) = format_code(&source, lang_opt) {
+                *inner_lines = formatted
+                    .strip_suffix('\n')
+                    .unwrap_or(&formatted)
+                    .lines()
+                    .map(String::from)
+                    .collect();
+            }
+        }
+    }
 }
 
 #[derive(Debug, PartialEq, Eq)]
 #[allow(clippy::enum_variant_names)]
 enum Block {
-    Paragraph { words: Vec<String> },
-    ListItem { marker: String, hanging_indent: usize, words: Vec<String> },
-    BlockQuote { words: Vec<String> },
-    Passthrough { raw_lines: Vec<String> },
+    Paragraph {
+        words: Vec<String>,
+    },
+    ListItem {
+        marker: String,
+        hanging_indent: usize,
+        words: Vec<String>,
+    },
+    BlockQuote {
+        words: Vec<String>,
+    },
+    Passthrough {
+        raw_lines: Vec<String>,
+    },
+    /// A fenced code block. `lang` is the info string after the opening fence (empty for
+    /// untagged fences). `fence_open` / `fence_close` are the raw delimiter lines as
+    /// they appeared in the source so we can re-emit them verbatim. `inner_lines` is the
+    /// fence body, which may be replaced by a code-formatter callback before emit.
+    CodeFence {
+        lang: String,
+        fence_open: String,
+        fence_close: String,
+        inner_lines: Vec<String>,
+    },
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -165,14 +214,22 @@ fn contains_url_or_reference(line: &str) -> bool {
 fn parse_blocks(lines: &[&str]) -> Vec<Block> {
     let mut blocks: Vec<Block> = Vec::new();
     let mut in_fence = false;
+    let mut fence_open: String = String::new();
+    let mut fence_lang: String = String::new();
     let mut fence_lines: Vec<String> = Vec::new();
 
     for &line in lines {
         if in_fence {
-            fence_lines.push(line.to_string());
             if matches!(classify(line), LineKind::FenceToggle) {
                 in_fence = false;
-                blocks.push(Block::Passthrough { raw_lines: std::mem::take(&mut fence_lines) });
+                blocks.push(Block::CodeFence {
+                    lang: std::mem::take(&mut fence_lang),
+                    fence_open: std::mem::take(&mut fence_open),
+                    fence_close: line.to_string(),
+                    inner_lines: std::mem::take(&mut fence_lines),
+                });
+            } else {
+                fence_lines.push(line.to_string());
             }
             continue;
         }
@@ -181,7 +238,8 @@ fn parse_blocks(lines: &[&str]) -> Vec<Block> {
         match kind {
             LineKind::FenceToggle => {
                 in_fence = true;
-                fence_lines.push(line.to_string());
+                fence_open = line.to_string();
+                fence_lang = extract_fence_lang(line);
             }
             LineKind::Blank => {
                 blocks.push(Block::Passthrough { raw_lines: vec![String::new()] });
@@ -246,11 +304,31 @@ fn parse_blocks(lines: &[&str]) -> Vec<Block> {
         }
     }
 
-    if in_fence && !fence_lines.is_empty() {
-        blocks.push(Block::Passthrough { raw_lines: fence_lines });
+    if in_fence {
+        let mut raw_lines = Vec::new();
+        if !fence_open.is_empty() {
+            raw_lines.push(fence_open);
+        }
+        raw_lines.extend(fence_lines);
+        if !raw_lines.is_empty() {
+            blocks.push(Block::Passthrough { raw_lines });
+        }
     }
 
     blocks
+}
+
+/// Returns the language tag of a fence opener (the info string after the leading ` ``` `
+/// or `~~~`). Empty string for untagged fences.
+fn extract_fence_lang(line: &str) -> String {
+    let trimmed = line.trim_start();
+    let marker = if trimmed.starts_with("```") { "```" } else { "~~~" };
+    let after = trimmed.strip_prefix(marker).unwrap_or("");
+    let mut after = after;
+    while let Some(rest) = after.strip_prefix('`').or_else(|| after.strip_prefix('~')) {
+        after = rest;
+    }
+    after.trim().to_string()
 }
 
 fn collect_words(content: &str) -> Vec<String> {
@@ -300,6 +378,13 @@ fn emit_blocks(blocks: &[Block], first_budget: usize, cont_budget: usize) -> Vec
                     output.push(format!("> {line}"));
                 }
             }
+            Block::CodeFence { fence_open, fence_close, inner_lines, .. } => {
+                output.push(fence_open.clone());
+                for line in inner_lines {
+                    output.push(line.clone());
+                }
+                output.push(fence_close.clone());
+            }
         }
     }
 
@@ -346,7 +431,7 @@ mod tests {
     use super::*;
 
     fn reflow(lines: &[&str], first: usize, cont: usize) -> Vec<String> {
-        reflow_comment(lines, first, cont)
+        reflow_comment_with_code_formatter(lines, first, cont, |_, _| None)
     }
 
     #[test]

--- a/tooling/nargo_fmt/src/formatter/comments_and_whitespace.rs
+++ b/tooling/nargo_fmt/src/formatter/comments_and_whitespace.rs
@@ -180,15 +180,26 @@ impl Formatter<'_> {
                         self.write_space_without_skipping_whitespace_and_comments();
                     }
 
+                    // If this comment is trailing-inline (no newline came before it and we
+                    // aren't at the start of the file), keep it isolated. Subsequent
+                    // standalone `//` comments on the following lines belong to the next
+                    // "block" of comments, not to this one — they would arrive in a
+                    // separate `skip_comments_and_whitespace_impl` call in normal flow,
+                    // but here they'd get swallowed by the group loop. The buffer check
+                    // alone isn't enough because chunk construction runs us against a
+                    // fresh sub-buffer, so we rely on `number_of_newlines` instead.
+                    let first_is_trailing_inline = number_of_newlines == 0 && !at_beginning;
+
                     let mut group = vec![comment];
                     self.bump();
                     let mut group_count = 1;
 
                     // Extend the group with consecutive `//` line comments at the same
                     // indentation, so that reflow can treat them as one paragraph. We
-                    // never group across blank lines, ignore directives, or doc-style
-                    // changes (`///` and `//!` arrive as separate token variants).
-                    if self.config.wrap_comments && !self.ignore_next {
+                    // never group across blank lines, ignore directives, doc-style
+                    // changes (`///` and `//!` arrive as separate token variants), or
+                    // when the leading comment is attached to code on its own line.
+                    if self.config.wrap_comments && !self.ignore_next && !first_is_trailing_inline {
                         loop {
                             let Token::Whitespace(ws) = &self.token else { break };
                             let newlines = ws.chars().filter(|c| *c == '\n').count();
@@ -265,8 +276,13 @@ impl Formatter<'_> {
     /// group. The bodies arrive with the per-line `//` prefix already stripped (i.e. they
     /// are the lexer's comment body strings). The caller is responsible for having written
     /// any leading indentation for the first comment.
+    ///
+    /// While inside a chunk's sub-buffer we don't yet know the rendered position of the
+    /// emitted text, so we don't reflow here — we just emit each body verbatim. The
+    /// chunks layer (`write_chunk_lines`) does the actual reflow once we're back in the
+    /// main buffer and the budget is known.
     pub(crate) fn write_line_comment_group(&mut self, bodies: &[String], prefix: &str) {
-        if self.ignore_next || !self.config.wrap_comments {
+        if self.ignore_next || !self.config.wrap_comments || self.in_chunk {
             for (index, body) in bodies.iter().enumerate() {
                 if index > 0 {
                     self.start_new_line();
@@ -1258,6 +1274,16 @@ fn foo() {}
 }
 ";
         assert_format_wrapping_comments(src, expected, 30);
+    }
+
+    #[test]
+    fn trailing_inline_comment_not_merged_with_following_standalone_comment() {
+        let src = "fn foo() {
+    let x = 1; // Some comment
+    // This is something else
+}
+";
+        assert_format_wrapping_comments(src, src, 80);
     }
 
     #[test]

--- a/tooling/nargo_fmt/src/formatter/comments_and_whitespace.rs
+++ b/tooling/nargo_fmt/src/formatter/comments_and_whitespace.rs
@@ -24,6 +24,9 @@ fn format_noir_snippet(
     config: &Config,
     available_width: usize,
 ) -> Option<String> {
+    if !config.format_code_blocks {
+        return None;
+    }
     let lang_ok = match lang {
         None => true,
         Some(l) => l.eq_ignore_ascii_case("noir"),
@@ -293,6 +296,20 @@ impl Formatter<'_> {
             return;
         }
 
+        // With reflow disabled, take the pre-reflow per-line wrap path: each body wraps
+        // independently and internal whitespace (e.g. multiple spaces inside the
+        // comment) is preserved. The paragraph-aware engine normalizes runs of
+        // whitespace via `split_whitespace`, which we don't want here.
+        if !self.config.reflow_comments {
+            for (index, body) in bodies.iter().enumerate() {
+                if index > 0 {
+                    self.start_new_line();
+                }
+                self.write_comment_with_prefix(body.trim_end(), prefix);
+            }
+            return;
+        }
+
         let stripped: Vec<String> = bodies
             .iter()
             .map(|body| {
@@ -316,6 +333,7 @@ impl Formatter<'_> {
             &lines,
             first_budget,
             cont_budget,
+            self.config.reflow_comments,
             |source, lang| format_noir_snippet(source, lang, config, snippet_width),
         );
 
@@ -351,6 +369,45 @@ impl Formatter<'_> {
         }
     }
 
+    /// Pre-reflow body emit for `write_block_comment`. Each source line wraps
+    /// independently with the same word-by-word logic as `write_comment_with_prefix`,
+    /// preserving internal whitespace. The opening `/*`-style prefix has already been
+    /// written by the caller; we write the body and the closing `*/`.
+    fn write_block_comment_non_reflow(&mut self, comment: &str, all_stars: bool) {
+        if comment.trim_start_matches([' ', '\t']).starts_with('\n') {
+            self.start_new_line_no_indentation();
+        }
+
+        for (index, line) in comment.lines().enumerate() {
+            if index > 0 {
+                self.start_new_line_no_indentation();
+            }
+
+            for word in line.split_inclusive([' ', '\n', '\t']) {
+                if self.current_line_width() + word.trim().chars().count()
+                    > self.config.comment_width
+                {
+                    self.start_new_line();
+                    if all_stars {
+                        self.write(" * ");
+                    }
+                }
+
+                self.write(word);
+            }
+        }
+
+        if comment.ends_with('\n') {
+            self.start_new_line();
+        }
+
+        if self.current_line_width() + 2 > self.config.comment_width {
+            self.start_new_line();
+        }
+
+        self.write("*/");
+    }
+
     pub(crate) fn write_block_comment(&mut self, comment: &str, prefix: &str) {
         self.write(prefix);
 
@@ -363,6 +420,14 @@ impl Formatter<'_> {
         let all_stars = block_comment_has_all_leading_stars(comment);
         let indent_cols = (self.indentation.max(0) as usize) * self.config.tab_spaces;
         let comment_width = self.config.comment_width;
+
+        // With reflow disabled, take the pre-reflow per-line wrap path: each source
+        // line wraps independently and internal whitespace within each line is
+        // preserved (the paragraph-aware engine normalizes via `split_whitespace`).
+        if !self.config.reflow_comments {
+            self.write_block_comment_non_reflow(comment, all_stars);
+            return;
+        }
 
         // A block comment has two emit shapes. We pick based on whether the source
         // body opens with a newline; that decision is idempotent because the wrapped
@@ -427,6 +492,7 @@ impl Formatter<'_> {
                 &line_refs,
                 first_budget,
                 cont_budget,
+                self.config.reflow_comments,
                 |source, lang| format_noir_snippet(source, lang, config, snippet_width),
             );
 
@@ -458,6 +524,7 @@ impl Formatter<'_> {
             &line_refs,
             content_budget,
             content_budget,
+            self.config.reflow_comments,
             |source, lang| format_noir_snippet(source, lang, config, snippet_width),
         );
 
@@ -562,12 +629,24 @@ mod tests {
     use test_case::test_case;
 
     fn assert_format_wrapping_comments(src: &str, expected: &str, comment_width: usize) {
-        let config = Config { wrap_comments: true, comment_width, ..Config::default() };
+        let config = Config {
+            wrap_comments: true,
+            reflow_comments: true,
+            format_code_blocks: true,
+            comment_width,
+            ..Config::default()
+        };
         assert_format_with_config(src, expected, config);
     }
 
     fn assert_formatter_changes_wrapping_comments(src: &str, comment_width: usize) {
-        let config = Config { wrap_comments: true, comment_width, ..Config::default() };
+        let config = Config {
+            wrap_comments: true,
+            reflow_comments: true,
+            format_code_blocks: true,
+            comment_width,
+            ..Config::default()
+        };
         assert_formatter_changes_with_config(src, config);
     }
 
@@ -1274,6 +1353,81 @@ fn foo() {}
 }
 ";
         assert_format_wrapping_comments(src, expected, 30);
+    }
+
+    #[test]
+    fn reflow_comments_off_preserves_per_line_wrap() {
+        // Two consecutive `//` lines at narrow width: with reflow off they must not
+        // merge into a paragraph. Each line wraps independently.
+        let src = "fn foo() {
+    // Hello world, I just realized that this
+    // is a long comment
+    let x = 1;
+}
+";
+        let expected = "fn foo() {
+    // Hello world, I just realized
+    // that this
+    // is a long comment
+    let x = 1;
+}
+";
+        let config = Config {
+            wrap_comments: true,
+            reflow_comments: false,
+            comment_width: 35,
+            ..Config::default()
+        };
+        assert_format_with_config(src, expected, config);
+    }
+
+    #[test]
+    fn reflow_comments_off_preserves_internal_whitespace_in_line_comment() {
+        // Multiple consecutive spaces inside a `//` comment stay verbatim when reflow
+        // is off. Under reflow=true the engine would collapse them via
+        // `split_whitespace`.
+        let src = "// foo  bar    baz
+fn main() {}
+";
+        let config = Config {
+            wrap_comments: true,
+            reflow_comments: false,
+            comment_width: 80,
+            ..Config::default()
+        };
+        assert_format_with_config(src, src, config);
+    }
+
+    #[test]
+    fn reflow_comments_off_preserves_internal_whitespace_in_block_comment() {
+        let src = "/* foo  bar    baz */
+fn main() {}
+";
+        let config = Config {
+            wrap_comments: true,
+            reflow_comments: false,
+            comment_width: 80,
+            ..Config::default()
+        };
+        assert_format_with_config(src, src, config);
+    }
+
+    #[test]
+    fn format_code_blocks_off_leaves_fence_untouched() {
+        let src = "/// ```
+/// fn   foo()   {  1  }
+/// ```
+fn bar() {}
+";
+        let config = Config {
+            wrap_comments: true,
+            reflow_comments: true,
+            format_code_blocks: false,
+            comment_width: 80,
+            ..Config::default()
+        };
+        // The fence opener, body, and closer are emitted verbatim.
+        assert_format_with_config(src, src, config);
     }
 
     #[test]

--- a/tooling/nargo_fmt/src/formatter/comments_and_whitespace.rs
+++ b/tooling/nargo_fmt/src/formatter/comments_and_whitespace.rs
@@ -2,11 +2,30 @@ use noirc_frontend::{parser::block_comment_has_all_leading_stars, token::Token};
 
 use super::Formatter;
 use super::comment_reflow;
+use crate::Config;
 
 #[cfg(windows)]
 const NEWLINE: &str = "\r\n";
 #[cfg(not(windows))]
 const NEWLINE: &str = "\n";
+
+/// Recursively formats a Noir code snippet pulled from a doc-comment fenced block.
+/// Returns `None` when the snippet should be left alone — either the fence has a
+/// non-Noir language tag, the body is empty, or the snippet fails to parse cleanly.
+fn format_noir_snippet(source: &str, lang: Option<&str>, config: &Config) -> Option<String> {
+    let lang_ok = match lang {
+        None => true,
+        Some(l) => l.eq_ignore_ascii_case("noir"),
+    };
+    if !lang_ok || source.trim().is_empty() {
+        return None;
+    }
+    let (parsed, errors) = noirc_frontend::parse_program_with_dummy_file(source);
+    if errors.into_iter().any(|e| !e.is_warning()) {
+        return None;
+    }
+    Some(crate::format(source, parsed, config))
+}
 
 impl Formatter<'_> {
     /// Writes a single space, skipping any whitespace and comments.
@@ -251,7 +270,13 @@ impl Formatter<'_> {
             comment_width.saturating_sub(self.current_line_width()).saturating_sub(prefix_cols);
         let cont_budget = comment_width.saturating_sub(indent_cols).saturating_sub(prefix_cols);
 
-        let outputs = comment_reflow::reflow_comment(&lines, first_budget, cont_budget);
+        let config = self.config;
+        let outputs = comment_reflow::reflow_comment_with_code_formatter(
+            &lines,
+            first_budget,
+            cont_budget,
+            |source, lang| format_noir_snippet(source, lang, config),
+        );
 
         for (index, content) in outputs.iter().enumerate() {
             if index > 0 {
@@ -355,7 +380,13 @@ impl Formatter<'_> {
             let first_budget = comment_width.saturating_sub(first_used);
             let cont_budget = comment_width.saturating_sub(cont_used);
 
-            let outputs = comment_reflow::reflow_comment(&line_refs, first_budget, cont_budget);
+            let config = self.config;
+            let outputs = comment_reflow::reflow_comment_with_code_formatter(
+                &line_refs,
+                first_budget,
+                cont_budget,
+                |source, lang| format_noir_snippet(source, lang, config),
+            );
 
             if has_leading_space {
                 self.write(" ");
@@ -379,7 +410,13 @@ impl Formatter<'_> {
 
         let prefix_used = if all_stars { 3 } else { 0 };
         let content_budget = comment_width.saturating_sub(indent_cols + prefix_used);
-        let outputs = comment_reflow::reflow_comment(&line_refs, content_budget, content_budget);
+        let config = self.config;
+        let outputs = comment_reflow::reflow_comment_with_code_formatter(
+            &line_refs,
+            content_budget,
+            content_budget,
+            |source, lang| format_noir_snippet(source, lang, config),
+        );
 
         self.start_new_line_no_indentation();
         for content in &outputs {
@@ -1203,7 +1240,9 @@ fn foo() {}
     Example:
 
     ```
-    fn inner() { x + y + z + a + b + c + d + e + f }
+    fn inner() {
+        x + y + z + a + b + c + d + e + f
+    }
     ```
 
     After the fence.
@@ -1220,7 +1259,9 @@ fn foo() {}
     // Example:
     //
     // ```
-    // fn inner() { x + y + z + a + b + c + d + e + f }
+    // fn inner() {
+    //     x + y + z + a + b + c + d + e + f
+    // }
     // ```
     //
     // After the fence.

--- a/tooling/nargo_fmt/src/formatter/comments_and_whitespace.rs
+++ b/tooling/nargo_fmt/src/formatter/comments_and_whitespace.rs
@@ -344,14 +344,19 @@ impl Formatter<'_> {
         let line_refs: Vec<&str> = content_lines.iter().map(String::as_str).collect();
 
         if !body_opens_with_newline {
-            let first_used = self.current_line_width() + 1;
+            let has_leading_space = comment.starts_with(' ') || comment.starts_with('\t');
+            let has_trailing_space = comment.ends_with(' ') || comment.ends_with('\t');
+
+            let first_used = self.current_line_width() + if has_leading_space { 1 } else { 0 };
             let cont_used = indent_cols + 3;
             let first_budget = comment_width.saturating_sub(first_used);
             let cont_budget = comment_width.saturating_sub(cont_used);
 
             let outputs = comment_reflow::reflow_comment(&line_refs, first_budget, cont_budget);
 
-            self.write(" ");
+            if has_leading_space {
+                self.write(" ");
+            }
             if let Some((first, rest)) = outputs.split_first() {
                 self.write(first);
                 for line in rest {
@@ -362,7 +367,10 @@ impl Formatter<'_> {
                     self.write(line);
                 }
             }
-            self.write(" */");
+            if has_trailing_space {
+                self.write(" ");
+            }
+            self.write("*/");
             return;
         }
 
@@ -1098,6 +1106,33 @@ global x = 1;
 global x = 1;
 ";
         assert_format(src, expected);
+    }
+
+    #[test]
+    fn tight_block_comment_preserves_no_spaces() {
+        let src = "fn foo(/*static=*/ x: Field) {}\n";
+        assert_format_wrapping_comments(src, src, 80);
+    }
+
+    #[test]
+    fn block_comment_with_only_leading_space_preserved() {
+        let src = "fn foo(/* leading_only*/ x: Field) {}\n";
+        assert_format_wrapping_comments(src, src, 80);
+    }
+
+    #[test]
+    fn block_comment_with_only_trailing_space_preserved() {
+        let src = "fn foo(/*trailing_only */ x: Field) {}\n";
+        assert_format_wrapping_comments(src, src, 80);
+    }
+
+    #[test]
+    fn nested_list_in_outer_doc_comment() {
+        let src = "/// - Parent
+///   - Child
+fn foo() {}
+";
+        assert_format_wrapping_comments(src, src, 80);
     }
 
     #[test]

--- a/tooling/nargo_fmt/src/formatter/comments_and_whitespace.rs
+++ b/tooling/nargo_fmt/src/formatter/comments_and_whitespace.rs
@@ -216,15 +216,6 @@ impl Formatter<'_> {
         self.ignore_next = ignore_next;
     }
 
-    pub(crate) fn write_line_comment(&mut self, comment: &str, prefix: &str) {
-        if self.ignore_next || !self.config.wrap_comments || self.in_chunk {
-            self.write(prefix);
-            self.write(comment.trim_end());
-            return;
-        }
-        self.write_line_comment_group(&[comment.to_string()], prefix);
-    }
-
     /// Reflow a sequence of consecutive line-comment bodies as a single paragraph-aware
     /// group. The bodies arrive with the per-line `//` prefix already stripped (i.e. they
     /// are the lexer's comment body strings). The caller is responsible for having written
@@ -381,6 +372,10 @@ impl Formatter<'_> {
 
         self.start_new_line_no_indentation();
         for content in &outputs {
+            if content.is_empty() && !all_stars {
+                self.write(NEWLINE);
+                continue;
+            }
             self.write_indentation();
             if all_stars {
                 if content.is_empty() {
@@ -1164,6 +1159,40 @@ global x = 1;
     }
 
     #[test]
+    fn does_not_wrap_fenced_code_block_in_chunks_path_block_comment() {
+        let src = "fn foo() {
+    /*
+    Example:
+
+    ```
+    fn inner() { x + y + z + a + b + c + d + e + f }
+    ```
+
+    After the fence.
+    */
+    let x = 1;
+}
+";
+        assert_format_wrapping_comments(src, src, 30);
+    }
+
+    #[test]
+    fn does_not_wrap_fenced_code_block_in_chunks_path_line_comments() {
+        let src = "fn foo() {
+    // Example:
+    //
+    // ```
+    // fn inner() { x + y + z + a + b + c + d + e + f }
+    // ```
+    //
+    // After the fence.
+    let x = 1;
+}
+";
+        assert_format_wrapping_comments(src, src, 30);
+    }
+
+    #[test]
     fn reflow_url_line_passthrough() {
         let src = "fn foo() {
     // See https://example.com/some/very/long/path/that/exceeds for details
@@ -1408,8 +1437,8 @@ global x: Field = 1;
         ";
         let expected = "fn foo() {
     /* This is a long comment
-    that's going to be
-    wrapped. */
+     * that's going to be
+     * wrapped. */
     let x = 1;
 }
 ";
@@ -1419,9 +1448,9 @@ global x: Field = 1;
     #[test]
     fn wraps_mixed_comments_in_statement() {
         let src = "fn foo() {
-        /* 
-        This is a long comment that's going to be wrapped. 
-        This is a long comment that's going to be wrapped. 
+        /*
+        This is a long comment that's going to be wrapped.
+        This is a long comment that's going to be wrapped.
         */
         // This is a long comment that's going to be wrapped.
         /* This is a long comment that's going to be wrapped. */
@@ -1429,19 +1458,19 @@ global x: Field = 1;
     }
         ";
         let expected = "fn foo() {
-    /* This is a long comment
-    that's going to be
-    wrapped.
+    /*
     This is a long comment
     that's going to be
-    wrapped.
+    wrapped. This is a long
+    comment that's going to
+    be wrapped.
     */
     // This is a long comment
     // that's going to be
     // wrapped.
     /* This is a long comment
-    that's going to be
-    wrapped. */
+     * that's going to be
+     * wrapped. */
     let x = 1;
 }
 ";

--- a/tooling/nargo_fmt/src/formatter/comments_and_whitespace.rs
+++ b/tooling/nargo_fmt/src/formatter/comments_and_whitespace.rs
@@ -12,7 +12,18 @@ const NEWLINE: &str = "\n";
 /// Recursively formats a Noir code snippet pulled from a doc-comment fenced block.
 /// Returns `None` when the snippet should be left alone — either the fence has a
 /// non-Noir language tag, the body is empty, or the snippet fails to parse cleanly.
-fn format_noir_snippet(source: &str, lang: Option<&str>, config: &Config) -> Option<String> {
+///
+/// `available_width` is how many columns the rendered fence body actually gets — the
+/// parent's `max_width` minus the comment-line prefix (e.g. `/// `) and any outer
+/// indentation. The inner formatter's `max_width` and related single-line thresholds
+/// are tightened to this so output that lands inside the prefix still respects the
+/// configured maximum.
+fn format_noir_snippet(
+    source: &str,
+    lang: Option<&str>,
+    config: &Config,
+    available_width: usize,
+) -> Option<String> {
     let lang_ok = match lang {
         None => true,
         Some(l) => l.eq_ignore_ascii_case("noir"),
@@ -24,7 +35,19 @@ fn format_noir_snippet(source: &str, lang: Option<&str>, config: &Config) -> Opt
     if errors.into_iter().any(|e| !e.is_warning()) {
         return None;
     }
-    Some(crate::format(source, parsed, config))
+
+    // Floor at 20 so deeply-indented or very tight comment positions still produce
+    // legible output rather than degenerate one-token-per-line wrapping.
+    let inner_width = available_width.max(20);
+    let mut snippet_config = config.clone();
+    snippet_config.max_width = inner_width;
+    snippet_config.fn_call_width = config.fn_call_width.min(inner_width);
+    snippet_config.array_width = config.array_width.min(inner_width);
+    snippet_config.single_line_if_else_max_width =
+        config.single_line_if_else_max_width.min(inner_width);
+    snippet_config.comment_width = config.comment_width.min(inner_width);
+
+    Some(crate::format(source, parsed, &snippet_config))
 }
 
 impl Formatter<'_> {
@@ -271,11 +294,13 @@ impl Formatter<'_> {
         let cont_budget = comment_width.saturating_sub(indent_cols).saturating_sub(prefix_cols);
 
         let config = self.config;
+        let snippet_width =
+            self.config.max_width.saturating_sub(indent_cols).saturating_sub(prefix_cols);
         let outputs = comment_reflow::reflow_comment_with_code_formatter(
             &lines,
             first_budget,
             cont_budget,
-            |source, lang| format_noir_snippet(source, lang, config),
+            |source, lang| format_noir_snippet(source, lang, config, snippet_width),
         );
 
         for (index, content) in outputs.iter().enumerate() {
@@ -381,11 +406,12 @@ impl Formatter<'_> {
             let cont_budget = comment_width.saturating_sub(cont_used);
 
             let config = self.config;
+            let snippet_width = self.config.max_width.saturating_sub(cont_used);
             let outputs = comment_reflow::reflow_comment_with_code_formatter(
                 &line_refs,
                 first_budget,
                 cont_budget,
-                |source, lang| format_noir_snippet(source, lang, config),
+                |source, lang| format_noir_snippet(source, lang, config, snippet_width),
             );
 
             if has_leading_space {
@@ -411,11 +437,12 @@ impl Formatter<'_> {
         let prefix_used = if all_stars { 3 } else { 0 };
         let content_budget = comment_width.saturating_sub(indent_cols + prefix_used);
         let config = self.config;
+        let snippet_width = self.config.max_width.saturating_sub(indent_cols + prefix_used);
         let outputs = comment_reflow::reflow_comment_with_code_formatter(
             &line_refs,
             content_budget,
             content_budget,
-            |source, lang| format_noir_snippet(source, lang, config),
+            |source, lang| format_noir_snippet(source, lang, config, snippet_width),
         );
 
         self.start_new_line_no_indentation();

--- a/tooling/nargo_fmt/src/formatter/comments_and_whitespace.rs
+++ b/tooling/nargo_fmt/src/formatter/comments_and_whitespace.rs
@@ -252,11 +252,13 @@ impl Formatter<'_> {
             return;
         }
 
+        let reflow_enabled = reflow_enabled_for_prefix(self.config, prefix);
+
         // With reflow disabled, take the pre-reflow per-line wrap path: each body wraps
         // independently and internal whitespace (e.g. multiple spaces inside the
         // comment) is preserved. The paragraph-aware engine normalizes runs of
         // whitespace via `split_whitespace`, which we don't want here.
-        if !self.config.reflow_comments {
+        if !reflow_enabled {
             for (index, body) in bodies.iter().enumerate() {
                 if index > 0 {
                     self.start_new_line();
@@ -289,7 +291,7 @@ impl Formatter<'_> {
             &lines,
             first_budget,
             cont_budget,
-            self.config.reflow_comments,
+            reflow_enabled,
             |source, lang| format_noir_snippet(source, lang, config, snippet_width),
         );
 
@@ -375,10 +377,12 @@ impl Formatter<'_> {
         let indent_cols = (self.indentation.max(0) as usize) * self.config.tab_spaces;
         let comment_width = self.config.comment_width;
 
+        let reflow_enabled = reflow_enabled_for_prefix(self.config, prefix);
+
         // With reflow disabled, take the pre-reflow per-line wrap path: each source
         // line wraps independently and internal whitespace within each line is
         // preserved (the paragraph-aware engine normalizes via `split_whitespace`).
-        if !self.config.reflow_comments {
+        if !reflow_enabled {
             self.write_block_comment_non_reflow(comment, all_stars);
             return;
         }
@@ -446,7 +450,7 @@ impl Formatter<'_> {
                 &line_refs,
                 first_budget,
                 cont_budget,
-                self.config.reflow_comments,
+                reflow_enabled,
                 |source, lang| format_noir_snippet(source, lang, config, snippet_width),
             );
 
@@ -478,7 +482,7 @@ impl Formatter<'_> {
             &line_refs,
             content_budget,
             content_budget,
-            self.config.reflow_comments,
+            reflow_enabled,
             |source, lang| format_noir_snippet(source, lang, config, snippet_width),
         );
 
@@ -574,6 +578,16 @@ impl Formatter<'_> {
     }
 }
 
+/// Returns whether paragraph reflow is enabled for the comment kind identified by its
+/// per-line prefix. Plain `//` and `/*` opt in via `reflow_non_doc_comments`; doc-style
+/// `///`, `//!`, `/**`, and `/*!` opt in via `reflow_doc_comments`.
+fn reflow_enabled_for_prefix(config: &Config, prefix: &str) -> bool {
+    match prefix {
+        "//" | "/*" => config.reflow_non_doc_comments,
+        _ => config.reflow_doc_comments,
+    }
+}
+
 /// Recursively formats a Noir code snippet pulled from a doc-comment fenced block.
 /// Returns `None` when the snippet should be left alone — either the fence has a
 /// non-Noir language tag, the body is empty, or the snippet fails to parse cleanly.
@@ -629,7 +643,8 @@ mod tests {
     fn assert_format_wrapping_comments(src: &str, expected: &str, comment_width: usize) {
         let config = Config {
             wrap_comments: true,
-            reflow_comments: true,
+            reflow_doc_comments: true,
+            reflow_non_doc_comments: true,
             format_code_blocks: true,
             comment_width,
             ..Config::default()
@@ -640,7 +655,8 @@ mod tests {
     fn assert_formatter_changes_wrapping_comments(src: &str, comment_width: usize) {
         let config = Config {
             wrap_comments: true,
-            reflow_comments: true,
+            reflow_doc_comments: true,
+            reflow_non_doc_comments: true,
             format_code_blocks: true,
             comment_width,
             ..Config::default()
@@ -1372,7 +1388,8 @@ fn foo() {}
 ";
         let config = Config {
             wrap_comments: true,
-            reflow_comments: false,
+            reflow_doc_comments: false,
+            reflow_non_doc_comments: false,
             comment_width: 35,
             ..Config::default()
         };
@@ -1389,7 +1406,8 @@ fn main() {}
 ";
         let config = Config {
             wrap_comments: true,
-            reflow_comments: false,
+            reflow_doc_comments: false,
+            reflow_non_doc_comments: false,
             comment_width: 80,
             ..Config::default()
         };
@@ -1403,11 +1421,74 @@ fn main() {}
 ";
         let config = Config {
             wrap_comments: true,
-            reflow_comments: false,
+            reflow_doc_comments: false,
+            reflow_non_doc_comments: false,
             comment_width: 80,
             ..Config::default()
         };
         assert_format_with_config(src, src, config);
+    }
+
+    #[test]
+    fn reflow_doc_comments_only_does_not_merge_plain_comments() {
+        // With `reflow_doc_comments=true` and `reflow_non_doc_comments=false`,
+        // doc-style comments merge but plain `//` comments preserve their line breaks.
+        let src = "/// Hello world, I just realized that this
+/// is a long doc comment
+fn one() {}
+
+// Hello world, I just realized that this
+// is a long plain comment
+fn two() {}
+";
+        let expected = "/// Hello world, I just realized
+/// that this is a long doc comment
+fn one() {}
+
+// Hello world, I just realized
+// that this
+// is a long plain comment
+fn two() {}
+";
+        let config = Config {
+            wrap_comments: true,
+            reflow_doc_comments: true,
+            reflow_non_doc_comments: false,
+            comment_width: 35,
+            ..Config::default()
+        };
+        assert_format_with_config(src, expected, config);
+    }
+
+    #[test]
+    fn reflow_non_doc_comments_only_does_not_merge_doc_comments() {
+        // Mirror image: only plain `//` comments merge.
+        let src = "/// Hello world, I just realized that this
+/// is a long doc comment
+fn one() {}
+
+// Hello world, I just realized that this
+// is a long plain comment
+fn two() {}
+";
+        let expected = "/// Hello world, I just realized
+/// that this
+/// is a long doc comment
+fn one() {}
+
+// Hello world, I just realized
+// that this is a long plain
+// comment
+fn two() {}
+";
+        let config = Config {
+            wrap_comments: true,
+            reflow_doc_comments: false,
+            reflow_non_doc_comments: true,
+            comment_width: 35,
+            ..Config::default()
+        };
+        assert_format_with_config(src, expected, config);
     }
 
     #[test]
@@ -1419,7 +1500,8 @@ fn bar() {}
 ";
         let config = Config {
             wrap_comments: true,
-            reflow_comments: true,
+            reflow_doc_comments: true,
+            reflow_non_doc_comments: true,
             format_code_blocks: false,
             comment_width: 80,
             ..Config::default()

--- a/tooling/nargo_fmt/src/formatter/comments_and_whitespace.rs
+++ b/tooling/nargo_fmt/src/formatter/comments_and_whitespace.rs
@@ -153,18 +153,21 @@ impl Formatter<'_> {
                             if newlines != 1 {
                                 break;
                             }
-                            self.bump();
-                            if let Token::LineComment(next_body, None) = &self.token {
-                                let next_body = next_body.clone();
-                                if next_body.trim() == "noir-fmt:ignore" {
-                                    break;
+                            let extends = match self.peek_next_token() {
+                                Token::LineComment(next_body, None) => {
+                                    next_body.trim() != "noir-fmt:ignore"
                                 }
-                                group.push(next_body);
-                                self.bump();
-                                group_count += 1;
-                            } else {
+                                _ => false,
+                            };
+                            if !extends {
                                 break;
                             }
+                            self.bump();
+                            let Token::LineComment(next_body, None) = self.bump() else {
+                                unreachable!("peek confirmed a plain line comment")
+                            };
+                            group.push(next_body);
+                            group_count += 1;
                         }
                     }
 

--- a/tooling/nargo_fmt/src/formatter/comments_and_whitespace.rs
+++ b/tooling/nargo_fmt/src/formatter/comments_and_whitespace.rs
@@ -297,10 +297,8 @@ impl Formatter<'_> {
             if index > 0 {
                 self.start_new_line();
             }
-            if content.is_empty() {
-                self.write(prefix);
-            } else {
-                self.write(prefix);
+            self.write(prefix);
+            if !content.is_empty() {
                 self.write(" ");
                 self.write(content);
             }

--- a/tooling/nargo_fmt/src/formatter/comments_and_whitespace.rs
+++ b/tooling/nargo_fmt/src/formatter/comments_and_whitespace.rs
@@ -9,50 +9,6 @@ const NEWLINE: &str = "\r\n";
 #[cfg(not(windows))]
 const NEWLINE: &str = "\n";
 
-/// Recursively formats a Noir code snippet pulled from a doc-comment fenced block.
-/// Returns `None` when the snippet should be left alone — either the fence has a
-/// non-Noir language tag, the body is empty, or the snippet fails to parse cleanly.
-///
-/// `available_width` is how many columns the rendered fence body actually gets — the
-/// parent's `max_width` minus the comment-line prefix (e.g. `/// `) and any outer
-/// indentation. The inner formatter's `max_width` and related single-line thresholds
-/// are tightened to this so output that lands inside the prefix still respects the
-/// configured maximum.
-fn format_noir_snippet(
-    source: &str,
-    lang: Option<&str>,
-    config: &Config,
-    available_width: usize,
-) -> Option<String> {
-    if !config.format_code_blocks {
-        return None;
-    }
-    let lang_ok = match lang {
-        None => true,
-        Some(l) => l.eq_ignore_ascii_case("noir"),
-    };
-    if !lang_ok || source.trim().is_empty() {
-        return None;
-    }
-    let (parsed, errors) = noirc_frontend::parse_program_with_dummy_file(source);
-    if errors.into_iter().any(|e| !e.is_warning()) {
-        return None;
-    }
-
-    // Floor at 20 so deeply-indented or very tight comment positions still produce
-    // legible output rather than degenerate one-token-per-line wrapping.
-    let inner_width = available_width.max(20);
-    let mut snippet_config = config.clone();
-    snippet_config.max_width = inner_width;
-    snippet_config.fn_call_width = config.fn_call_width.min(inner_width);
-    snippet_config.array_width = config.array_width.min(inner_width);
-    snippet_config.single_line_if_else_max_width =
-        config.single_line_if_else_max_width.min(inner_width);
-    snippet_config.comment_width = config.comment_width.min(inner_width);
-
-    Some(crate::format(source, parsed, &snippet_config))
-}
-
 impl Formatter<'_> {
     /// Writes a single space, skipping any whitespace and comments.
     /// That is, suppose the next token is a big whitespace, possibly with multiple lines.
@@ -618,6 +574,50 @@ impl Formatter<'_> {
     pub(crate) fn trim_comma(&mut self) -> bool {
         self.buffer.trim_comma()
     }
+}
+
+/// Recursively formats a Noir code snippet pulled from a doc-comment fenced block.
+/// Returns `None` when the snippet should be left alone — either the fence has a
+/// non-Noir language tag, the body is empty, or the snippet fails to parse cleanly.
+///
+/// `available_width` is how many columns the rendered fence body actually gets — the
+/// parent's `max_width` minus the comment-line prefix (e.g. `/// `) and any outer
+/// indentation. The inner formatter's `max_width` and related single-line thresholds
+/// are tightened to this so output that lands inside the prefix still respects the
+/// configured maximum.
+fn format_noir_snippet(
+    source: &str,
+    lang: Option<&str>,
+    config: &Config,
+    available_width: usize,
+) -> Option<String> {
+    if !config.format_code_blocks {
+        return None;
+    }
+    let lang_ok = match lang {
+        None => true,
+        Some(l) => l.eq_ignore_ascii_case("noir"),
+    };
+    if !lang_ok || source.trim().is_empty() {
+        return None;
+    }
+    let (parsed, errors) = noirc_frontend::parse_program_with_dummy_file(source);
+    if errors.into_iter().any(|e| !e.is_warning()) {
+        return None;
+    }
+
+    // Floor at 20 so deeply-indented or very tight comment positions still produce
+    // legible output rather than degenerate one-token-per-line wrapping.
+    let inner_width = available_width.max(20);
+    let mut snippet_config = config.clone();
+    snippet_config.max_width = inner_width;
+    snippet_config.fn_call_width = config.fn_call_width.min(inner_width);
+    snippet_config.array_width = config.array_width.min(inner_width);
+    snippet_config.single_line_if_else_max_width =
+        config.single_line_if_else_max_width.min(inner_width);
+    snippet_config.comment_width = config.comment_width.min(inner_width);
+
+    Some(crate::format(source, parsed, &snippet_config))
 }
 
 #[cfg(test)]

--- a/tooling/nargo_fmt/src/formatter/comments_and_whitespace.rs
+++ b/tooling/nargo_fmt/src/formatter/comments_and_whitespace.rs
@@ -1,6 +1,7 @@
 use noirc_frontend::{parser::block_comment_has_all_leading_stars, token::Token};
 
 use super::Formatter;
+use super::comment_reflow;
 
 #[cfg(windows)]
 const NEWLINE: &str = "\r\n";
@@ -137,13 +138,42 @@ impl Formatter<'_> {
                         self.write_space_without_skipping_whitespace_and_comments();
                     }
 
-                    self.write_line_comment(&comment, "//");
+                    let mut group = vec![comment];
+                    self.bump();
+                    let mut group_count = 1;
+
+                    // Extend the group with consecutive `//` line comments at the same
+                    // indentation, so that reflow can treat them as one paragraph. We
+                    // never group across blank lines, ignore directives, or doc-style
+                    // changes (`///` and `//!` arrive as separate token variants).
+                    if self.config.wrap_comments && !self.ignore_next {
+                        loop {
+                            let Token::Whitespace(ws) = &self.token else { break };
+                            let newlines = ws.chars().filter(|c| *c == '\n').count();
+                            if newlines != 1 {
+                                break;
+                            }
+                            self.bump();
+                            if let Token::LineComment(next_body, None) = &self.token {
+                                let next_body = next_body.clone();
+                                if next_body.trim() == "noir-fmt:ignore" {
+                                    break;
+                                }
+                                group.push(next_body);
+                                self.bump();
+                                group_count += 1;
+                            } else {
+                                break;
+                            }
+                        }
+                    }
+
+                    self.write_line_comment_group(&group, "//");
                     self.write_line_without_skipping_whitespace_and_comments();
                     number_of_newlines = 1;
-                    self.bump();
                     passed_whitespace = false;
                     last_was_block_comment = false;
-                    self.written_comments_count += 1;
+                    self.written_comments_count += group_count;
                 }
                 Token::BlockComment(comment, None) => {
                     let comment = comment.clone();
@@ -187,23 +217,65 @@ impl Formatter<'_> {
     }
 
     pub(crate) fn write_line_comment(&mut self, comment: &str, prefix: &str) {
-        // We don't wrap lines that start with '#' because these might be
-        // markdown headers and wrapping those would actually break them.
-        if self.ignore_next
-            || !self.config.wrap_comments
-            || self.in_chunk
-            || comment.trim_start().starts_with('#')
-            || self.current_line_width() + comment.chars().count() + prefix.len()
-                < self.config.comment_width
-        {
+        if self.ignore_next || !self.config.wrap_comments || self.in_chunk {
             self.write(prefix);
             self.write(comment.trim_end());
             return;
         }
-
-        self.write_comment_with_prefix(comment, prefix);
+        self.write_line_comment_group(&[comment.to_string()], prefix);
     }
 
+    /// Reflow a sequence of consecutive line-comment bodies as a single paragraph-aware
+    /// group. The bodies arrive with the per-line `//` prefix already stripped (i.e. they
+    /// are the lexer's comment body strings). The caller is responsible for having written
+    /// any leading indentation for the first comment.
+    pub(crate) fn write_line_comment_group(&mut self, bodies: &[String], prefix: &str) {
+        if self.ignore_next || !self.config.wrap_comments {
+            for (index, body) in bodies.iter().enumerate() {
+                if index > 0 {
+                    self.start_new_line();
+                }
+                self.write(prefix);
+                self.write(body.trim_end());
+            }
+            return;
+        }
+
+        let stripped: Vec<String> = bodies
+            .iter()
+            .map(|body| {
+                let trimmed = body.trim_end();
+                trimmed.strip_prefix(' ').unwrap_or(trimmed).to_string()
+            })
+            .collect();
+        let lines: Vec<&str> = stripped.iter().map(String::as_str).collect();
+
+        let prefix_cols = prefix.chars().count() + 1;
+        let indent_cols = (self.indentation.max(0) as usize) * self.config.tab_spaces;
+        let comment_width = self.config.comment_width;
+        let first_budget =
+            comment_width.saturating_sub(self.current_line_width()).saturating_sub(prefix_cols);
+        let cont_budget = comment_width.saturating_sub(indent_cols).saturating_sub(prefix_cols);
+
+        let outputs = comment_reflow::reflow_comment(&lines, first_budget, cont_budget);
+
+        for (index, content) in outputs.iter().enumerate() {
+            if index > 0 {
+                self.start_new_line();
+            }
+            if content.is_empty() {
+                self.write(prefix);
+            } else {
+                self.write(prefix);
+                self.write(" ");
+                self.write(content);
+            }
+        }
+    }
+
+    /// Wraps a single comment body word-by-word with the given prefix. Kept for the
+    /// in-chunk path which performs line-by-line wrapping over already-grouped chunk
+    /// strings; the standalone-comment path uses `write_line_comment_group` instead.
     pub(crate) fn write_comment_with_prefix(&mut self, comment: &str, prefix: &str) {
         self.write(prefix);
         for word in comment.split_inclusive([' ', '\n', '\t']) {
@@ -229,43 +301,103 @@ impl Formatter<'_> {
         }
 
         let all_stars = block_comment_has_all_leading_stars(comment);
+        let indent_cols = (self.indentation.max(0) as usize) * self.config.tab_spaces;
+        let comment_width = self.config.comment_width;
 
-        if comment.trim_start_matches([' ', '\t']).starts_with('\n') {
-            self.start_new_line_no_indentation();
+        // A block comment has two emit shapes. We pick based on whether the source
+        // body opens with a newline; that decision is idempotent because the wrapped
+        // form preserves the opening shape.
+        //
+        // Single-line shape (no leading newline):
+        //     /* first wrap
+        //      * second wrap */
+        //
+        // Multi-line shape (leading newline):
+        //     /*
+        //     content
+        //     */
+        let body_opens_with_newline = comment.trim_start_matches([' ', '\t']).starts_with('\n');
+
+        let source_lines: Vec<&str> = comment.lines().collect();
+        let mut content_lines: Vec<String> = source_lines
+            .iter()
+            .map(|line| {
+                let after_ws = line.trim_start();
+                if all_stars {
+                    if let Some(rest) = after_ws.strip_prefix("* ") {
+                        rest.to_string()
+                    } else if let Some(rest) = after_ws.strip_prefix('*') {
+                        rest.strip_prefix(' ').unwrap_or(rest).to_string()
+                    } else {
+                        after_ws.to_string()
+                    }
+                } else {
+                    after_ws.to_string()
+                }
+            })
+            .collect();
+
+        while content_lines.first().is_some_and(|s| s.trim().is_empty()) {
+            content_lines.remove(0);
+        }
+        while content_lines.last().is_some_and(|s| s.trim().is_empty()) {
+            content_lines.pop();
         }
 
-        for (index, line) in comment.lines().enumerate() {
-            // When moving to the next source line, only emit a newline. The line itself
-            // carries the leading whitespace from the source, so re-emitting the
-            // structural indent here would double it up.
-            if index > 0 {
-                self.start_new_line_no_indentation();
-            }
+        if content_lines.is_empty() {
+            self.write(comment);
+            self.write("*/");
+            return;
+        }
 
-            for word in line.split_inclusive([' ', '\n', '\t']) {
-                if self.current_line_width() + word.trim().chars().count()
-                    > self.config.comment_width
-                {
-                    // Wrapping introduces a new line that has no source whitespace, so
-                    // we re-emit the structural indent and the canonical `*` prefix.
+        let line_refs: Vec<&str> = content_lines.iter().map(String::as_str).collect();
+
+        if !body_opens_with_newline {
+            let first_used = self.current_line_width() + 1;
+            let cont_used = indent_cols + 3;
+            let first_budget = comment_width.saturating_sub(first_used);
+            let cont_budget = comment_width.saturating_sub(cont_used);
+
+            let outputs = comment_reflow::reflow_comment(&line_refs, first_budget, cont_budget);
+
+            self.write(" ");
+            if let Some((first, rest)) = outputs.split_first() {
+                self.write(first);
+                for line in rest {
                     self.start_new_line();
                     if all_stars {
                         self.write(" * ");
                     }
+                    self.write(line);
                 }
-
-                self.write(word);
             }
+            self.write(" */");
+            return;
         }
 
-        if comment.ends_with('\n') {
-            self.start_new_line();
-        }
+        let prefix_used = if all_stars { 3 } else { 0 };
+        let content_budget = comment_width.saturating_sub(indent_cols + prefix_used);
+        let outputs = comment_reflow::reflow_comment(&line_refs, content_budget, content_budget);
 
-        if self.current_line_width() + 2 > self.config.comment_width {
-            self.start_new_line();
+        self.start_new_line_no_indentation();
+        for content in &outputs {
+            self.write_indentation();
+            if all_stars {
+                if content.is_empty() {
+                    self.write(" *");
+                } else {
+                    self.write(" * ");
+                    self.write(content);
+                }
+            } else {
+                self.write(content);
+            }
+            self.start_new_line_no_indentation();
         }
-
+        self.write_indentation();
+        if all_stars {
+            self.write(" ");
+        }
         self.write("*/");
     }
 
@@ -974,6 +1106,109 @@ global x = 1;
     }
 
     #[test]
+    fn reflow_respects_blank_line_paragraph_break() {
+        let src = "fn foo() {
+    // First paragraph that is long enough to wrap.
+    //
+    // Second paragraph that also goes on for quite a while.
+    let x = 1;
+}
+";
+        let expected = "fn foo() {
+    // First paragraph that is
+    // long enough to wrap.
+    //
+    // Second paragraph that
+    // also goes on for quite
+    // a while.
+    let x = 1;
+}
+";
+        assert_format_wrapping_comments(src, expected, 30);
+    }
+
+    #[test]
+    fn reflow_passes_through_markdown_header() {
+        let src = "fn foo() {
+    // # Title that should not wrap regardless of length whatsoever
+    // body text body text body text body text body text
+    let x = 1;
+}
+";
+        let expected = "fn foo() {
+    // # Title that should not wrap regardless of length whatsoever
+    // body text body text
+    // body text body text
+    // body text
+    let x = 1;
+}
+";
+        assert_format_wrapping_comments(src, expected, 30);
+    }
+
+    #[test]
+    fn reflow_list_item_with_hanging_indent() {
+        let src = "fn foo() {
+    // - first item that is long enough to wrap to the next line
+    let x = 1;
+}
+";
+        let expected = "fn foo() {
+    // - first item that is
+    //   long enough to wrap
+    //   to the next line
+    let x = 1;
+}
+";
+        assert_format_wrapping_comments(src, expected, 30);
+    }
+
+    #[test]
+    fn reflow_url_line_passthrough() {
+        let src = "fn foo() {
+    // See https://example.com/some/very/long/path/that/exceeds for details
+    let x = 1;
+}
+";
+        let expected = "fn foo() {
+    // See https://example.com/some/very/long/path/that/exceeds for details
+    let x = 1;
+}
+";
+        assert_format_wrapping_comments(src, expected, 30);
+    }
+
+    #[test]
+    fn reflow_javadoc_tag_breaks_paragraph_in_doc_comment() {
+        let src = "/// Build a Foo.
+/// @return a fresh Foo
+fn build() {}
+";
+        let expected = "/// Build a Foo.
+/// @return a fresh Foo
+fn build() {}
+";
+        assert_format_wrapping_comments(src, expected, 80);
+    }
+
+    #[test]
+    fn reflows_two_line_paragraph_into_natural_wrap() {
+        let src = "fn foo() {
+    // Hello world, I just realized that this
+    // is a long comment
+    let x = 1;
+}
+";
+        let expected = "fn foo() {
+    // Hello world, I just realized
+    // that this is a long comment
+    let x = 1;
+}
+";
+        assert_format_wrapping_comments(src, expected, 35);
+    }
+
+    #[test]
     fn wraps_line_comments() {
         let src = "
         // This is a long comment that's going to be wrapped.
@@ -1128,7 +1363,7 @@ global x: Field = 1;
     #[test]
     fn wraps_block_comments_multiple_lines() {
         let src = "
-/*  
+/*
 This is a long comment that's wrapped.
 This is a long comment that's wrapped.
 */
@@ -1136,9 +1371,8 @@ global x: Field = 1;
         ";
         let expected = "/*
 This is a long comment that's
-wrapped.
-This is a long comment that's
-wrapped.
+wrapped. This is a long
+comment that's wrapped.
 */
 global x: Field = 1;
 ";
@@ -1148,7 +1382,7 @@ global x: Field = 1;
     #[test]
     fn wraps_block_comments_multiple_lines_with_all_stars() {
         let src = "
-/*  
+/*
  * This is a long comment that's wrapped.
  * This is a long comment that's wrapped.
  */
@@ -1156,9 +1390,9 @@ global x: Field = 1;
         ";
         let expected = "/*
  * This is a long comment
- * that's wrapped.
- * This is a long comment
- * that's wrapped.
+ * that's wrapped. This is a
+ * long comment that's
+ * wrapped.
  */
 global x: Field = 1;
 ";
@@ -1316,9 +1550,9 @@ impl Foo {
 
 impl Foo {
     /**
-       Build a Foo.
-       @return a fresh Foo
-     */
+    Build a Foo.
+    @return a fresh Foo
+    */
     fn build() {}
 }
 ";

--- a/tooling/nargo_fmt/src/formatter/doc_comments.rs
+++ b/tooling/nargo_fmt/src/formatter/doc_comments.rs
@@ -375,6 +375,37 @@ fn bar() {}
     }
 
     #[test]
+    fn fence_snippet_respects_narrower_width_inside_doc_comment() {
+        let src = "/// ```
+/// fn foo() { call(aaa, bbb, ccc, ddd, eee, fff, ggg, hhh) }
+/// ```
+fn bar() {}
+";
+        // At max_width=50 the inner call would fit on a single line if the inner
+        // formatter saw the full 50-column budget. With the fix it sees
+        // max_width = 50 - 4 (for `/// `), forcing the call to wrap so the rendered
+        // doc-comment lines all stay within the configured 50 columns.
+        let expected = "/// ```
+/// fn foo() {
+///     call(
+///         aaa,
+///         bbb,
+///         ccc,
+///         ddd,
+///         eee,
+///         fff,
+///         ggg,
+///         hhh,
+///     )
+/// }
+/// ```
+fn bar() {}
+";
+        let config = Config { wrap_comments: true, max_width: 50, ..Config::default() };
+        assert_format_with_config(src, expected, config);
+    }
+
+    #[test]
     fn formats_noir_code_in_block_doc_comment_fence() {
         let src = "/**
  * ```

--- a/tooling/nargo_fmt/src/formatter/doc_comments.rs
+++ b/tooling/nargo_fmt/src/formatter/doc_comments.rs
@@ -13,8 +13,9 @@ impl Formatter<'_> {
 
             match self.bump() {
                 Token::LineComment(comment, Some(DocStyle::Inner)) => {
+                    let bodies = self.collect_doc_line_comment_group(comment, DocStyle::Inner);
                     self.write_indentation();
-                    self.write_line_comment(&comment, "//!");
+                    self.write_line_comment_group(&bodies, "//!");
                     self.write_line();
                 }
                 Token::BlockComment(comment, Some(DocStyle::Inner)) => {
@@ -37,9 +38,9 @@ impl Formatter<'_> {
 
             match self.bump() {
                 Token::LineComment(comment, Some(DocStyle::Outer)) => {
-                    let comment = comment.clone();
+                    let bodies = self.collect_doc_line_comment_group(comment, DocStyle::Outer);
                     self.write_indentation();
-                    self.write_line_comment(&comment, "///");
+                    self.write_line_comment_group(&bodies, "///");
                     self.write_line();
                 }
                 Token::BlockComment(comment, Some(DocStyle::Outer)) => {
@@ -51,6 +52,36 @@ impl Formatter<'_> {
                 _ => unreachable!("Expected an outer doc comment"),
             }
         }
+    }
+
+    /// Greedily collects the consecutive run of line-style doc comments at the same
+    /// `style` (separated by a single newline) starting from a body that was already
+    /// consumed via `bump`. The returned bodies are the lexer comment strings (with the
+    /// leading `///` or `//!` already stripped); the caller passes them to
+    /// `write_line_comment_group` so the reflow engine can recognize fenced code blocks
+    /// and other paragraph-spanning markdown across multiple source lines.
+    fn collect_doc_line_comment_group(&mut self, first: String, style: DocStyle) -> Vec<String> {
+        let mut bodies = vec![first];
+        if !self.config.wrap_comments || self.ignore_next {
+            return bodies;
+        }
+        loop {
+            let Token::Whitespace(ws) = &self.token else { break };
+            let newlines = ws.chars().filter(|c| *c == '\n').count();
+            if newlines != 1 {
+                break;
+            }
+            self.bump();
+            if let Token::LineComment(next_body, Some(next_style)) = &self.token
+                && *next_style == style
+            {
+                bodies.push(next_body.clone());
+                self.bump();
+            } else {
+                break;
+            }
+        }
+        bodies
     }
 
     /// Formats outer doc comments, turning them into regular comments if they start with "Safety:"
@@ -201,6 +232,68 @@ global x: Field = 1;
 global x: Field = 1;
 ";
         assert_format(src, expected);
+    }
+
+    #[test]
+    fn does_not_wrap_fenced_code_block_in_outer_doc_comment() {
+        let src = "/// ```
+/// fn foo() { x + y + z + a + b + c + d + e + f }
+/// ```
+fn bar() {}
+";
+        assert_format_wrapping_comments(src, src, 30);
+    }
+
+    #[test]
+    fn does_not_wrap_fenced_code_block_in_middle_of_outer_doc_comment() {
+        let src = "/// Example below.
+///
+/// ```
+/// fn foo() { x + y + z + a + b + c + d + e + f }
+/// ```
+///
+/// After the fence.
+fn bar() {}
+";
+        assert_format_wrapping_comments(src, src, 30);
+    }
+
+    #[test]
+    fn does_not_wrap_fenced_code_block_in_top_level_block_comment() {
+        let src = "/**
+ * Example below.
+ *
+ * ```
+ * fn foo() { x + y + z + a + b + c + d + e + f }
+ * ```
+ *
+ * After the fence.
+ */
+fn bar() {}
+";
+        assert_format_wrapping_comments(src, src, 30);
+    }
+
+    #[test]
+    fn does_not_wrap_fenced_code_block_in_inner_doc_comment() {
+        let src = "//! ```
+//! fn foo() { x + y + z + a + b + c + d + e + f }
+//! ```
+";
+        assert_format_wrapping_comments(src, src, 30);
+    }
+
+    #[test]
+    fn reflows_doc_comment_paragraph_outside_fence() {
+        let src = "/// Hello world, I just realized that this
+/// is a long comment
+fn bar() {}
+";
+        let expected = "/// Hello world, I just realized
+/// that this is a long comment
+fn bar() {}
+";
+        assert_format_wrapping_comments(src, expected, 35);
     }
 
     #[test]

--- a/tooling/nargo_fmt/src/formatter/doc_comments.rs
+++ b/tooling/nargo_fmt/src/formatter/doc_comments.rs
@@ -71,15 +71,18 @@ impl Formatter<'_> {
             if newlines != 1 {
                 break;
             }
-            self.bump();
-            if let Token::LineComment(next_body, Some(next_style)) = &self.token
-                && *next_style == style
-            {
-                bodies.push(next_body.clone());
-                self.bump();
-            } else {
+            let extends = matches!(
+                self.peek_next_token(),
+                Token::LineComment(_, Some(next_style)) if *next_style == style
+            );
+            if !extends {
                 break;
             }
+            self.bump();
+            let Token::LineComment(next_body, Some(_)) = self.bump() else {
+                unreachable!("peek confirmed a matching doc line comment")
+            };
+            bodies.push(next_body);
         }
         bodies
     }
@@ -218,6 +221,32 @@ global x: Field = 1;
 global x: Field = 1;
 ";
         assert_format_wrapping_comments(src, expected, 29);
+    }
+
+    #[test]
+    fn outer_doc_comment_not_merged_with_following_plain_comment() {
+        let src = "/// Hello
+// world
+fn foo() {}
+";
+        assert_format_wrapping_comments(src, src, 80);
+    }
+
+    #[test]
+    fn inner_doc_comment_not_merged_with_following_plain_comment() {
+        let src = "//! Hello
+// world
+";
+        assert_format_wrapping_comments(src, src, 80);
+    }
+
+    #[test]
+    fn plain_comment_not_merged_with_following_outer_doc_comment() {
+        let src = "// plain
+/// outer doc
+fn foo() {}
+";
+        assert_format_wrapping_comments(src, src, 80);
     }
 
     #[test]

--- a/tooling/nargo_fmt/src/formatter/doc_comments.rs
+++ b/tooling/nargo_fmt/src/formatter/doc_comments.rs
@@ -135,7 +135,13 @@ mod tests {
     use crate::{Config, assert_format, assert_format_with_config};
 
     fn assert_format_wrapping_comments(src: &str, expected: &str, comment_width: usize) {
-        let config = Config { wrap_comments: true, comment_width, ..Config::default() };
+        let config = Config {
+            wrap_comments: true,
+            reflow_comments: true,
+            format_code_blocks: true,
+            comment_width,
+            ..Config::default()
+        };
         assert_format_with_config(src, expected, config);
     }
 
@@ -401,7 +407,13 @@ fn bar() {}
 /// ```
 fn bar() {}
 ";
-        let config = Config { wrap_comments: true, max_width: 50, ..Config::default() };
+        let config = Config {
+            wrap_comments: true,
+            reflow_comments: true,
+            format_code_blocks: true,
+            max_width: 50,
+            ..Config::default()
+        };
         assert_format_with_config(src, expected, config);
     }
 

--- a/tooling/nargo_fmt/src/formatter/doc_comments.rs
+++ b/tooling/nargo_fmt/src/formatter/doc_comments.rs
@@ -137,7 +137,8 @@ mod tests {
     fn assert_format_wrapping_comments(src: &str, expected: &str, comment_width: usize) {
         let config = Config {
             wrap_comments: true,
-            reflow_comments: true,
+            reflow_doc_comments: true,
+            reflow_non_doc_comments: true,
             format_code_blocks: true,
             comment_width,
             ..Config::default()
@@ -409,7 +410,8 @@ fn bar() {}
 ";
         let config = Config {
             wrap_comments: true,
-            reflow_comments: true,
+            reflow_doc_comments: true,
+            reflow_non_doc_comments: true,
             format_code_blocks: true,
             max_width: 50,
             ..Config::default()

--- a/tooling/nargo_fmt/src/formatter/doc_comments.rs
+++ b/tooling/nargo_fmt/src/formatter/doc_comments.rs
@@ -266,7 +266,9 @@ global x: Field = 1;
     #[test]
     fn does_not_wrap_fenced_code_block_in_outer_doc_comment() {
         let src = "/// ```
-/// fn foo() { x + y + z + a + b + c + d + e + f }
+/// fn foo() {
+///     x + y + z + a + b + c + d + e + f
+/// }
 /// ```
 fn bar() {}
 ";
@@ -278,7 +280,9 @@ fn bar() {}
         let src = "/// Example below.
 ///
 /// ```
-/// fn foo() { x + y + z + a + b + c + d + e + f }
+/// fn foo() {
+///     x + y + z + a + b + c + d + e + f
+/// }
 /// ```
 ///
 /// After the fence.
@@ -293,7 +297,9 @@ fn bar() {}
  * Example below.
  *
  * ```
- * fn foo() { x + y + z + a + b + c + d + e + f }
+ * fn foo() {
+ *     x + y + z + a + b + c + d + e + f
+ * }
  * ```
  *
  * After the fence.
@@ -306,10 +312,87 @@ fn bar() {}
     #[test]
     fn does_not_wrap_fenced_code_block_in_inner_doc_comment() {
         let src = "//! ```
-//! fn foo() { x + y + z + a + b + c + d + e + f }
+//! fn foo() {
+//!     x + y + z + a + b + c + d + e + f
+//! }
 //! ```
 ";
         assert_format_wrapping_comments(src, src, 30);
+    }
+
+    #[test]
+    fn formats_noir_code_in_untagged_fence() {
+        let src = "/// ```
+/// fn   foo()   {  1  }
+/// ```
+fn bar() {}
+";
+        let expected = "/// ```
+/// fn foo() {
+///     1
+/// }
+/// ```
+fn bar() {}
+";
+        assert_format_wrapping_comments(src, expected, 80);
+    }
+
+    #[test]
+    fn formats_noir_code_in_noir_tagged_fence() {
+        let src = "/// ```noir
+/// fn   foo()   {  1  }
+/// ```
+fn bar() {}
+";
+        let expected = "/// ```noir
+/// fn foo() {
+///     1
+/// }
+/// ```
+fn bar() {}
+";
+        assert_format_wrapping_comments(src, expected, 80);
+    }
+
+    #[test]
+    fn does_not_format_code_in_non_noir_tagged_fence() {
+        let src = "/// ```rust
+/// fn   foo()   {  1  }
+/// ```
+fn bar() {}
+";
+        assert_format_wrapping_comments(src, src, 80);
+    }
+
+    #[test]
+    fn leaves_unparseable_fence_content_verbatim() {
+        let src = "/// ```
+/// this is not valid Noir at all -- !!! ???
+/// ```
+fn bar() {}
+";
+        assert_format_wrapping_comments(src, src, 80);
+    }
+
+    #[test]
+    fn formats_noir_code_in_block_doc_comment_fence() {
+        let src = "/**
+ * ```
+ * fn   foo()   {  1  }
+ * ```
+ */
+fn bar() {}
+";
+        let expected = "/**
+ * ```
+ * fn foo() {
+ *     1
+ * }
+ * ```
+ */
+fn bar() {}
+";
+        assert_format_wrapping_comments(src, expected, 80);
     }
 
     #[test]

--- a/tooling/nargo_fmt/tests/expected/comment_reflow.nr
+++ b/tooling/nargo_fmt/tests/expected/comment_reflow.nr
@@ -1,5 +1,6 @@
 // @wrap_comments = true
-// @reflow_comments = true
+// @reflow_doc_comments = true
+// @reflow_non_doc_comments = true
 // @format_code_blocks = true
 // @comment_width = 35
 

--- a/tooling/nargo_fmt/tests/expected/comment_reflow.nr
+++ b/tooling/nargo_fmt/tests/expected/comment_reflow.nr
@@ -1,0 +1,30 @@
+// @wrap_comments = true
+// @comment_width = 35
+
+// Hello world, I just realized
+// that this is a long comment
+fn one() {}
+
+// First paragraph here that wraps
+// nicely.
+//
+// Second paragraph after a blank
+// line break.
+fn two() {}
+
+// # Markdown header that is intentionally past the configured width and must not wrap
+// body text body text body text
+// body text body text
+fn three() {}
+
+// - first list item that is long
+//   enough to wrap
+// - second item
+//
+// See https://example.com/some/very/long/path/that/exceeds for details.
+fn four() {}
+
+/// Build a Foo.
+/// @return a fresh Foo with all
+/// the goodies inside of it
+fn build() {}

--- a/tooling/nargo_fmt/tests/expected/comment_reflow.nr
+++ b/tooling/nargo_fmt/tests/expected/comment_reflow.nr
@@ -1,4 +1,6 @@
 // @wrap_comments = true
+// @reflow_comments = true
+// @format_code_blocks = true
 // @comment_width = 35
 
 // Hello world, I just realized

--- a/tooling/nargo_fmt/tests/input/comment_reflow.nr
+++ b/tooling/nargo_fmt/tests/input/comment_reflow.nr
@@ -1,5 +1,6 @@
 //@wrap_comments = true
-//@reflow_comments = true
+//@reflow_doc_comments = true
+//@reflow_non_doc_comments = true
 //@format_code_blocks = true
 //@comment_width = 35
 

--- a/tooling/nargo_fmt/tests/input/comment_reflow.nr
+++ b/tooling/nargo_fmt/tests/input/comment_reflow.nr
@@ -1,0 +1,25 @@
+//@wrap_comments = true
+//@comment_width = 35
+
+// Hello world, I just realized that this
+// is a long comment
+fn one() {}
+
+// First paragraph here that wraps nicely.
+//
+// Second paragraph after a blank line break.
+fn two() {}
+
+// # Markdown header that is intentionally past the configured width and must not wrap
+// body text body text body text body text body text
+fn three() {}
+
+// - first list item that is long enough to wrap
+// - second item
+//
+// See https://example.com/some/very/long/path/that/exceeds for details.
+fn four() {}
+
+/// Build a Foo.
+/// @return a fresh Foo with all the goodies inside of it
+fn build() {}

--- a/tooling/nargo_fmt/tests/input/comment_reflow.nr
+++ b/tooling/nargo_fmt/tests/input/comment_reflow.nr
@@ -1,4 +1,6 @@
 //@wrap_comments = true
+//@reflow_comments = true
+//@format_code_blocks = true
 //@comment_width = 35
 
 // Hello world, I just realized that this


### PR DESCRIPTION
## Problem Resolved

Resolves https://github.com/noir-lang/noir/issues/12827 (and more)

## Summary of Changes

Yesterday night I let Claude working on this, giving it a specification of how I think wrapping comments should work. I mentioned "reflow", gave it some examples, and it managed to do it. Then I had to further refine the behavior with bugs I found, etc. This is similar to how it works in rustfmt except that reflow also moves words backwards when you delete from a previous line (see some examples below).

Overall changes:
- Added a new config to enable reflowing in doc comments (it's off by default)
- Added a new config to enable reflowing in non-doc comments (it's off by default)
- Added a new config to enable formatting code blocks (it's off by default)
- "Reflow" means that we take a look at each paragraph and try to wrap its lines, so if you add more text to the first line we parse that entire paragraph and re-wrap it. Same if you delete words from the first line or intermediate lines
- There are some cases that are not reflowed (similar to what rustfmt does). For example a line that's followed by a markdown header shouldn't be merged with it. Other special cases include tables, block quotes and list items

I decided to split it into doc comments and non-doc comments because non-doc comments aren't required to be markdown and they are usually more free-form, so automatically joining consecutive lines might not always be the best thing to do. It might make sense to only have this for doc comments, but the non-doc comments is still available.

Here's reflowing in action:

<img width="845" height="444" alt="nargo-fmt-reflow" src="https://github.com/user-attachments/assets/78cc3cc6-01a8-4dbb-ad99-4004da4b1f8e" />

Here's what happens with special markdown items:

<img width="845" height="444" alt="nargo-fmt-reflow-special" src="https://github.com/user-attachments/assets/218dafe0-1dcd-45df-8193-9fc8b69e4a69" />

With this behavior it might seem that all words are going to end up one after another, but double newlines keep things separate:

<img width="845" height="444" alt="nargo-fmt-reflow-paragraphs" src="https://github.com/user-attachments/assets/60b0b88b-5c2b-4cee-874d-17171de8cc83" />

I think reflowing is actually nice because if you write a code comment like this:

```noir
/// This does something.
/// Note that this is deprecated.
```

then you might think that it will show up in two lines in the generated docs, but it's actually going to show up in a single line, and nargo fmt will combine them. So keeping them separated by a newline, if you really want them to look like that, is the solution in both cases.

And here's code block formatting:

<img width="845" height="444" alt="nargo-fmt-code-blocks" src="https://github.com/user-attachments/assets/5be01f02-9121-4eeb-942c-445f7d03f78c" />

I considered pushing code block formatting to a separate PR but it wasn't that much more code, and it's kind of related (the code has to wrap, but it also wouldn't be nice if it wrapped without any code formatting, and code formatting just takes care of both things).

I reviewed the code and it looks okay. I also:
- Made sure that aztec-nr has no formatting changes when this is turned off
- Made sure that aztec-nr looks fine when this is turned on (there's some reflowing happening, and some things "break", for example there's a header that looks like "-- Note --" that gets merged into a next line, but I think in that case a markdown header should be used... then there's one or two ASCII drawings that break but, again, putting those in code fences should easily solve the issue)

I wanted to implement this because I heard from the team that reformatting comments so they wrap nicely (having to manually reflow things) was time consuming, so this would save them some time.

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
