### PR TITLE
fix(ssa): Accept `&mut T` as `&T` in SSA validation in more places

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/ir/function.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/function.rs
@@ -372,12 +372,11 @@ pub(crate) struct Signature {
 impl Signature {
     /// Construct a [Signature] whose parameter and return types have all
     /// reference mutability canonicalized away. This makes `&T` and `&mut T`
-    /// compare equal when a [Signature] is used as a map key, matching the
-    /// validator's `types_equal_ignoring_reference_mutability` leniency and
-    /// the frontend's `&mut T → &T` coercion.
+    /// compare equal when a [Signature] is used as a map key, matching
+    /// [Type::canonical_eq] leniency and the frontend's `&mut T → &T` coercion.
     pub(crate) fn new(mut params: Vec<Type>, mut returns: Vec<Type>) -> Self {
         for typ in params.iter_mut().chain(returns.iter_mut()) {
-            typ.canonicalize_reference_mutability();
+            typ.canonicalize();
         }
         Self { params, returns }
     }

--- a/compiler/noirc_evaluator/src/ssa/ir/types.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/types.rs
@@ -357,27 +357,56 @@ impl Type {
 
     /// Recursively rewrite every [Type::Reference] inside `self` to be immutable.
     ///
-    /// The SSA validator (`types_equal_ignoring_reference_mutability`) and the
-    /// Noir frontend both accept passing `&mut T` where `&T` is expected. To
-    /// make types in those positions compare equal under that same leniency,
-    /// callers that need a canonical form (e.g., map keys in defunctionalize)
-    /// can collapse reference mutability here.
-    pub(crate) fn canonicalize_reference_mutability(&mut self) {
+    /// The SSA validator ([Type::canonical_eq]) and the Noir frontend both
+    /// accept passing `&mut T` where `&T` is expected. To make types in those
+    /// positions compare equal under that same leniency, callers that need a
+    /// canonical form (e.g., map keys in defunctionalize) can collapse
+    /// reference mutability here.
+    pub(crate) fn canonicalize(&mut self) {
         match self {
             Type::Reference(element, mutable) => {
                 *mutable = false;
                 let mut new_element = (**element).clone();
-                new_element.canonicalize_reference_mutability();
+                new_element.canonicalize();
                 *element = Arc::new(new_element);
             }
             Type::Array(elements, _) | Type::Vector(elements) => {
                 let mut new_elements = (**elements).clone();
                 for inner in &mut new_elements {
-                    inner.canonicalize_reference_mutability();
+                    inner.canonicalize();
                 }
                 *elements = Arc::new(new_elements);
             }
             Type::Numeric(_) | Type::Function => (),
+        }
+    }
+
+    /// Owned counterpart to [Type::canonicalize] — returns a clone with all
+    /// reference mutability stripped.
+    pub(crate) fn canonicalized(&self) -> Self {
+        let mut clone = self.clone();
+        clone.canonicalize();
+        clone
+    }
+
+    /// Compares two types, treating mutable and immutable references as equivalent.
+    ///
+    /// Equivalent to `self.canonicalized() == other.canonicalized()` but walks
+    /// both types in lockstep instead of allocating cloned trees — the SSA
+    /// validator calls this for every block-terminator argument and every call
+    /// site, so the no-alloc path matters in debug builds.
+    pub(crate) fn canonical_eq(&self, other: &Type) -> bool {
+        let all_eq = |a: &[Type], b: &[Type]| {
+            a.len() == b.len() && a.iter().zip(b).all(|(a, b)| a.canonical_eq(b))
+        };
+
+        match (self, other) {
+            (Type::Reference(a_elem, _), Type::Reference(b_elem, _)) => a_elem.canonical_eq(b_elem),
+            (Type::Array(a_elems, a_len), Type::Array(b_elems, b_len)) => {
+                a_len == b_len && all_eq(a_elems, b_elems)
+            }
+            (Type::Vector(a_elems), Type::Vector(b_elems)) => all_eq(a_elems, b_elems),
+            _ => self == other,
         }
     }
 }

--- a/compiler/noirc_evaluator/src/ssa/ir/types.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/types.rs
@@ -395,6 +395,10 @@ impl Type {
     /// both types in lockstep instead of allocating cloned trees — the SSA
     /// validator calls this for every block-terminator argument and every call
     /// site, so the no-alloc path matters in debug builds.
+    ///
+    /// This is a validation aid, not a soundness check: the frontend rejects
+    /// trying to use `&T` where `&mut T` is expected, but once compiled to
+    /// SSA, we can treat them as equivalents.
     pub(crate) fn canonical_eq(&self, other: &Type) -> bool {
         let all_eq = |a: &[Type], b: &[Type]| {
             a.len() == b.len() && a.iter().zip(b).all(|(a, b)| a.canonical_eq(b))

--- a/compiler/noirc_evaluator/src/ssa/opt/alias_analysis.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/alias_analysis.rs
@@ -115,30 +115,13 @@ use crate::ssa::{
         function::{Function, FunctionId},
         instruction::{Instruction, Intrinsic, TerminatorInstruction},
         post_order::PostOrder,
-        types::{CompositeType, Type},
+        types::Type,
         union_find::UnionFind,
         value::{Value, ValueId},
     },
     opt::unrolling::{LoopOrder, Loops},
     ssa_gen::Ssa,
 };
-
-/// Canonicalize a type so that `&T` and `&mut T` are treated as the same type
-/// for aliasing. Every `Reference(_, _)` is rewritten to have `mutable = false`.
-fn canonicalize_type(typ: &Type) -> Type {
-    match typ {
-        Type::Reference(inner, _) => Type::Reference(Arc::new(canonicalize_type(inner)), false),
-        Type::Array(composite, size) => {
-            let slots: CompositeType = composite.iter().map(canonicalize_type).collect();
-            Type::Array(Arc::new(slots), *size)
-        }
-        Type::Vector(composite) => {
-            let slots: CompositeType = composite.iter().map(canonicalize_type).collect();
-            Type::Vector(Arc::new(slots))
-        }
-        Type::Numeric(_) | Type::Function => typ.clone(),
-    }
-}
 
 /// Scope of the analysis
 enum Scope<'a> {
@@ -230,14 +213,14 @@ impl AliasAnalysis {
         }
 
         // Field-insensitivity may alias values with distinct types, but such values cannot alias.
-        // Types are canonicalized first so `&T` and `&mut T` compare equal
+        // Types are compared with [Type::canonical_eq] so `&T` and `&mut T` count as equal.
         // Note that this check is done only when both `a` and `b` match the given `function`.
         // This is purely for convenience, because the type filter would need access to the SSA
         // to look up types in other functions, which it doesn't currently.
         if function.id() == a.0 && a.0 == b.0 {
-            let type_a = canonicalize_type(&function.dfg.type_of_value(a.1));
-            let type_b = canonicalize_type(&function.dfg.type_of_value(b.1));
-            if type_a != type_b {
+            let type_a = function.dfg.type_of_value(a.1);
+            let type_b = function.dfg.type_of_value(b.1);
+            if !type_a.canonical_eq(&type_b) {
                 return false;
             }
         }
@@ -998,7 +981,7 @@ impl AliasAnalysisContext {
                     return None;
                 }
                 // Canonicalize so `&T` and `&mut T` have the cache entries
-                let typ = canonicalize_type(&typ);
+                let typ = typ.canonicalized();
                 let refs = self.get_ref_types(&typ);
                 Some((v, typ, refs))
             })

--- a/compiler/noirc_evaluator/src/ssa/validation/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/validation/mod.rs
@@ -301,7 +301,7 @@ impl<'f> Validator<'f> {
                 for (index, element) in elements.iter().enumerate() {
                     let element_type = dfg.type_of_value(*element);
                     let expected_type = &composite_type[index % composite_type_len];
-                    if &*element_type != expected_type {
+                    if !element_type.canonical_eq(expected_type) {
                         panic!(
                             "MakeArray has incorrect element type at index {index}: expected {expected_type}, got {element_type}"
                         );

--- a/compiler/noirc_evaluator/src/ssa/validation/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/validation/mod.rs
@@ -400,7 +400,7 @@ impl<'f> Validator<'f> {
                     {
                         let return_type = called_function.dfg.type_of_value(*return_value);
                         let instruction_result_type = dfg.type_of_value(*instruction_result);
-                        if return_type != instruction_result_type {
+                        if !return_type.canonical_eq(&instruction_result_type) {
                             panic!(
                                 "Function call to {} expected return type {}, but got {} (at position {})",
                                 func_id,

--- a/compiler/noirc_evaluator/src/ssa/validation/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/validation/mod.rs
@@ -375,9 +375,7 @@ impl<'f> Validator<'f> {
                     arguments.iter().zip_eq(parameter_types).enumerate()
                 {
                     let argument_type = dfg.type_of_value(*argument);
-                    if *argument_type != parameter_type
-                        && !is_mut_ref_to_immutable_ref(&argument_type, &parameter_type)
-                    {
+                    if !argument_type.canonical_eq(&parameter_type) {
                         panic!(
                             "Argument #{} to {func_id} has type {parameter_type}, but {argument_type} was given",
                             index + 1,
@@ -1260,15 +1258,6 @@ pub(crate) fn validate_no_acir_memory_ops(ssa: &Ssa) {
             }
         }
     }
-}
-
-/// Returns true if `arg` is `&mut T` and `param` is `&T` with the same element type.
-/// A mutable reference is compatible with an immutable reference parameter.
-fn is_mut_ref_to_immutable_ref(arg: &Type, param: &Type) -> bool {
-    matches!(
-        (arg, param),
-        (Type::Reference(a, true), Type::Reference(b, false)) if a == b
-    )
 }
 
 fn assert_arguments_length(arguments: &[ValueId], expected: usize, object: &str) {

--- a/compiler/noirc_evaluator/src/ssa/validation/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/validation/mod.rs
@@ -1797,6 +1797,158 @@ mod tests {
     }
 
     #[test]
+    fn call_allows_argument_reference_mutability_mismatch() {
+        // Reference mutability is a frontend concern with no meaning at the SSA
+        // level, so a `&mut Field` argument is accepted by a `&Field` parameter
+        // (and vice versa).
+        let src = "
+        acir(inline) fn main f0 {
+          b0():
+            v0 = allocate -> &mut Field
+            call f1(v0)
+            return
+        }
+        acir(inline) fn foo f1 {
+          b0(v0: &Field):
+            return
+        }
+        ";
+        let _ = Ssa::from_str(src).unwrap();
+
+        let src = "
+        acir(inline) fn main f0 {
+          b0():
+            v0 = allocate -> &Field
+            call f1(v0)
+            return
+        }
+        acir(inline) fn foo f1 {
+          b0(v0: &mut Field):
+            return
+        }
+        ";
+        let _ = Ssa::from_str(src).unwrap();
+    }
+
+    #[test]
+    fn call_allows_argument_reference_mutability_mismatch_nested_in_array() {
+        // The mutability-equivalence rule must look through composite types:
+        // a `[&mut Field; 1]` argument is accepted by a `[&Field; 1]` parameter.
+        let src = "
+        acir(inline) fn main f0 {
+          b0():
+            v0 = allocate -> &mut Field
+            v1 = make_array [v0] : [&mut Field; 1]
+            call f1(v1)
+            return
+        }
+        acir(inline) fn foo f1 {
+          b0(v0: [&Field; 1]):
+            return
+        }
+        ";
+        let _ = Ssa::from_str(src).unwrap();
+    }
+
+    #[test]
+    fn call_allows_argument_reference_mutability_mismatch_nested_in_reference() {
+        // The mutability-equivalence rule must recurse through nested references:
+        // a `&mut &mut Field` argument is accepted by a `&mut &Field` parameter.
+        let src = "
+        acir(inline) fn main f0 {
+          b0():
+            v0 = allocate -> &mut Field
+            v1 = allocate -> &mut &mut Field
+            store v0 at v1
+            call f1(v1)
+            return
+        }
+        acir(inline) fn foo f1 {
+          b0(v0: &mut &Field):
+            return
+        }
+        ";
+        let _ = Ssa::from_str(src).unwrap();
+    }
+
+    #[test]
+    fn call_allows_return_reference_mutability_mismatch() {
+        // Reference mutability is a frontend concern with no meaning at the SSA
+        // level, so a callee returning `&mut Field` satisfies a call instruction
+        // declaring `&Field` (and vice versa).
+        let src = "
+        acir(inline) fn main f0 {
+          b0():
+            v0 = call f1() -> &Field
+            return
+        }
+        acir(inline) fn foo f1 {
+          b0():
+            v0 = allocate -> &mut Field
+            return v0
+        }
+        ";
+        let _ = Ssa::from_str(src).unwrap();
+
+        let src = "
+        acir(inline) fn main f0 {
+          b0():
+            v0 = call f1() -> &mut Field
+            return
+        }
+        acir(inline) fn foo f1 {
+          b0():
+            v0 = allocate -> &Field
+            return v0
+        }
+        ";
+        let _ = Ssa::from_str(src).unwrap();
+    }
+
+    #[test]
+    fn call_allows_return_reference_mutability_mismatch_nested_in_array() {
+        // The mutability-equivalence rule must look through composite types:
+        // a callee returning `[&mut Field; 1]` satisfies a call declaring
+        // `[&Field; 1]`.
+        let src = "
+        acir(inline) fn main f0 {
+          b0():
+            v0 = call f1() -> [&Field; 1]
+            return
+        }
+        acir(inline) fn foo f1 {
+          b0():
+            v0 = allocate -> &mut Field
+            v1 = make_array [v0] : [&mut Field; 1]
+            return v1
+        }
+        ";
+        let _ = Ssa::from_str(src).unwrap();
+    }
+
+    #[test]
+    fn call_allows_return_reference_mutability_mismatch_nested_in_reference() {
+        // The mutability-equivalence rule must recurse through nested references:
+        // a callee returning `&mut &mut Field` satisfies a call declaring
+        // `&mut &Field`.
+        let src = "
+        acir(inline) fn main f0 {
+          b0():
+            v0 = call f1() -> &mut &Field
+            return
+        }
+        acir(inline) fn foo f1 {
+          b0():
+            v0 = allocate -> &mut Field
+            v1 = allocate -> &mut &mut Field
+            store v0 at v1
+            return v1
+        }
+        ";
+        let _ = Ssa::from_str(src).unwrap();
+    }
+
+    #[test]
     #[should_panic(expected = "Function f1 has multiple return blocks")]
     fn multiple_return_blocks() {
         let src = "
@@ -1885,6 +2037,67 @@ mod tests {
           b0():
             v0 = make_array [u8 1, Field 2, u8 3, u8 4] : [(u8, u8); 2]
             return v0
+        }
+        ";
+        let _ = Ssa::from_str(src).unwrap();
+    }
+
+    #[test]
+    fn make_array_allows_reference_mutability_mismatch() {
+        // Reference mutability is a frontend concern with no meaning at the SSA
+        // level, so a `&mut Field` element is accepted in a `&Field` composite
+        // slot (and vice versa).
+        let src = "
+        acir(inline) fn main f0 {
+          b0():
+            v0 = allocate -> &mut Field
+            v1 = make_array [v0] : [&Field; 1]
+            return
+        }
+        ";
+        let _ = Ssa::from_str(src).unwrap();
+
+        let src = "
+        acir(inline) fn main f0 {
+          b0():
+            v0 = allocate -> &Field
+            v1 = make_array [v0] : [&mut Field; 1]
+            return
+        }
+        ";
+        let _ = Ssa::from_str(src).unwrap();
+    }
+
+    #[test]
+    fn make_array_allows_reference_mutability_mismatch_nested_in_array() {
+        // The mutability-equivalence rule must look through composite types:
+        // a `[&mut Field; 1]` element is accepted in a `[&Field; 1]` composite
+        // slot.
+        let src = "
+        acir(inline) fn main f0 {
+          b0():
+            v0 = allocate -> &mut Field
+            v1 = make_array [v0] : [&mut Field; 1]
+            v2 = make_array [v1] : [[&Field; 1]; 1]
+            return
+        }
+        ";
+        let _ = Ssa::from_str(src).unwrap();
+    }
+
+    #[test]
+    fn make_array_allows_reference_mutability_mismatch_nested_in_reference() {
+        // The mutability-equivalence rule must recurse through nested references:
+        // a `&mut &mut Field` element is accepted in a `&mut &Field` composite
+        // slot.
+        let src = "
+        acir(inline) fn main f0 {
+          b0():
+            v0 = allocate -> &mut Field
+            v1 = allocate -> &mut &mut Field
+            store v0 at v1
+            v2 = make_array [v1] : [&mut &Field; 1]
+            return
         }
         ";
         let _ = Ssa::from_str(src).unwrap();

--- a/compiler/noirc_evaluator/src/ssa/validation/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/validation/mod.rs
@@ -1162,7 +1162,7 @@ impl<'f> Validator<'f> {
             let argument_type = self.function.dfg.type_of_value(*argument);
             let parameter_type = self.function.dfg.type_of_value(*parameter);
             assert!(
-                types_equal_ignoring_reference_mutability(&argument_type, &parameter_type),
+                argument_type.canonical_eq(&parameter_type),
                 "Argument type in {kind} must match block parameter type\n  left: {argument_type}\n right: {parameter_type}"
             );
         }
@@ -1269,25 +1269,6 @@ fn is_mut_ref_to_immutable_ref(arg: &Type, param: &Type) -> bool {
         (arg, param),
         (Type::Reference(a, true), Type::Reference(b, false)) if a == b
     )
-}
-
-/// Compares two types, treating mutable and immutable references as equivalent.
-fn types_equal_ignoring_reference_mutability(a: &Type, b: &Type) -> bool {
-    let all_eq = |a: &[Type], b: &[Type]| {
-        a.len() == b.len()
-            && a.iter().zip(b).all(|(a, b)| types_equal_ignoring_reference_mutability(a, b))
-    };
-
-    match (a, b) {
-        (Type::Reference(a_elem, _), Type::Reference(b_elem, _)) => {
-            types_equal_ignoring_reference_mutability(a_elem, b_elem)
-        }
-        (Type::Array(a_elems, a_len), Type::Array(b_elems, b_len)) => {
-            a_len == b_len && all_eq(a_elems, b_elems)
-        }
-        (Type::Vector(a_elems), Type::Vector(b_elems)) => all_eq(a_elems, b_elems),
-        _ => a == b,
-    }
 }
 
 fn assert_arguments_length(arguments: &[ValueId], expected: usize, object: &str) {

--- a/cspell.json
+++ b/cspell.json
@@ -117,6 +117,7 @@
         "eddsa",
         "effectful",
         "elab",
+        "elems",
         "Elligator",
         "endianness",
         "envrc",

--- a/test_programs/compile_success_no_bug/regression_12733/Nargo.toml
+++ b/test_programs/compile_success_no_bug/regression_12733/Nargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "regression_12733"
+type = "bin"
+authors = [""]
+
+[dependencies]

--- a/test_programs/compile_success_no_bug/regression_12733/src/main.nr
+++ b/test_programs/compile_success_no_bug/regression_12733/src/main.nr
@@ -1,8 +1,33 @@
 fn main(mut a: bool) {
+    // MakeArray composite slot type `&bool` vs element value `&mut bool`.
     let _: [&bool; 1] = [(&a); 1];
+
+    // Call return: callee returns `&mut bool`, declared `&bool`.
     let _ = foo(a);
+
+    // Allocate/Store/Load where the slot's element type contains a reference
+    // with different mutability than the stored value carries.
+    let _ref: &bool = &a;
+
+    // `let`-binding of a reference value — Allocate + Store + Load round-trip
+    // of a reference-typed value, exercising the Load/Store paths against an
+    // Allocate whose element type itself contains a reference.
+    let r: &bool = &a;
+    let _r2 = r;
+
+    // Call argument: nested mutability mismatch passed through an array.
+    let arr: [&bool; 1] = [(&a); 1];
+    bar(arr);
+
+    // Call argument: top-level `&mut → &` (already handled by
+    // is_mut_ref_to_immutable_ref).
+    baz(&a);
 }
 
 fn foo(mut a: bool) -> &bool {
     &a
 }
+
+fn bar(_arr: [&bool; 1]) {}
+
+fn baz(_r: &bool) {}

--- a/test_programs/compile_success_no_bug/regression_12733/src/main.nr
+++ b/test_programs/compile_success_no_bug/regression_12733/src/main.nr
@@ -1,0 +1,8 @@
+fn main(mut a: bool) {
+    let _: [&bool; 1] = [(&a); 1];
+    let _ = foo(a);
+}
+
+fn foo(mut a: bool) -> &bool {
+    &a
+}

--- a/tooling/nargo_cli/tests/snapshots/compile_success_no_bug/regression_12733/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_no_bug/regression_12733/execute__tests__expanded.snap
@@ -5,8 +5,18 @@ expression: expanded_code
 fn main(mut a: bool) {
     let _: [&bool; 1] = [&a; 1];
     let _: &bool = foo(a);
+    let _ref: &bool = &a;
+    let r: &bool = &a;
+    let _r2: &bool = r;
+    let arr: [&bool; 1] = [&a; 1];
+    bar(arr);
+    baz(&a);
 }
 
 fn foo(mut a: bool) -> &bool {
     &a
 }
+
+fn bar(_arr: [&bool; 1]) {}
+
+fn baz(_r: &bool) {}

--- a/tooling/nargo_cli/tests/snapshots/compile_success_no_bug/regression_12733/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_no_bug/regression_12733/execute__tests__expanded.snap
@@ -1,0 +1,12 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: expanded_code
+---
+fn main(mut a: bool) {
+    let _: [&bool; 1] = [&a; 1];
+    let _: &bool = foo(a);
+}
+
+fn foo(mut a: bool) -> &bool {
+    &a
+}


### PR DESCRIPTION
## Problem Resolved

Resolves #12733 

## Summary of Changes

* Two more places in SSA validation where `&mut T` should be treated as `&T`: `MakeArray` and function return values.
* Consolidates the 4 different places where special handling was implemented into 3 methods:
  * `Type::canonicalize` mutates in-place
  * `Type::canonicalized` returns a clone 
  * `Type::canonic_eq` walks with early return
* Replaced the existing special handlers in `validation`, `alias_analysis` and `defunctionalization` to use the new ones.
* Unit tests to show the SSA we are accepting

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
