### PR TITLE
chore: check_errors for parser tests

### DIFF
--- a/compiler/noirc_frontend/src/parser/parser/enums.rs
+++ b/compiler/noirc_frontend/src/parser/parser/enums.rs
@@ -131,14 +131,12 @@ impl Parser<'_> {
 
 #[cfg(test)]
 mod tests {
-    use insta::assert_snapshot;
-
     use crate::{
         ast::{NoirEnumeration, UnresolvedGeneric},
         parse_program_with_dummy_file,
         parser::{
-            ItemKind, ParserErrorReason,
-            parser::tests::{expect_no_errors, get_source_with_error_span},
+            ItemKind,
+            parser::tests::{check_errors, expect_no_errors},
         },
     };
 
@@ -249,22 +247,18 @@ mod tests {
     fn parse_error_no_function_attributes_allowed_on_enum() {
         let src = "
         #[test] enum Foo {}
-        ^^^^^^^
+        ^^^^^^^ A function attribute cannot be placed on a struct or enum
         ";
-        let (src, _) = get_source_with_error_span(src);
-        let (_, errors) = parse_program_with_dummy_file(&src);
-        let reason = errors[0].reason().unwrap();
-        assert!(matches!(reason, ParserErrorReason::NoFunctionAttributesAllowedOnType));
+        check_errors(src, |parser| parser.parse_program());
     }
 
     #[test]
     fn recovers_on_non_field() {
         let src = "
         enum Foo { 42 X(i32) }
-                   ^^
+                   ^^ Expected an identifier but found '42'
         ";
-        let (src, _) = get_source_with_error_span(src);
-        let (module, errors) = parse_program_with_dummy_file(&src);
+        let module = check_errors(src, |parser| parser.parse_program());
 
         assert_eq!(module.items.len(), 1);
         let item = &module.items[0];
@@ -273,9 +267,5 @@ mod tests {
         };
         assert_eq!("Foo", noir_enum.name.to_string());
         assert_eq!(noir_enum.variants.len(), 1);
-
-        assert_eq!(errors.len(), 1);
-        let error = &errors[0];
-        assert_snapshot!(error.to_string(), @"Expected an identifier but found '42'");
     }
 }

--- a/compiler/noirc_frontend/src/parser/parser/expression.rs
+++ b/compiler/noirc_frontend/src/parser/parser/expression.rs
@@ -1145,7 +1145,6 @@ impl Parser<'_> {
 
 #[cfg(test)]
 mod tests {
-    use insta::assert_snapshot;
     use strum::IntoEnumIterator;
 
     use crate::{
@@ -1153,16 +1152,11 @@ mod tests {
             ArrayLiteral, BinaryOpKind, ConstrainKind, Expression, ExpressionKind, Literal,
             StatementKind, UnaryOp,
         },
-        lexer::errors::LexerErrorKind,
         parse_program_with_dummy_file,
         parser::{
-            Parser, ParserErrorReason,
-            parser::tests::{
-                expect_no_errors, get_single_error, get_single_error_reason,
-                get_source_with_error_span,
-            },
+            Parser,
+            parser::tests::{check_errors, expect_no_errors},
         },
-        token::Token,
     };
     use acvm::FieldElement;
 
@@ -1331,21 +1325,12 @@ mod tests {
         let src = "
         {
             1
+            ^ Expected a ; separating these two statements
             2
+            ^ Expected a ; separating these two statements
             3
         }";
-        let mut parser = Parser::for_str_with_dummy_file(src);
-        let expr = parser.parse_expression_or_error();
-        assert_eq!(expr.location.span.end() as usize, src.len());
-        assert_eq!(parser.errors.len(), 2);
-        assert!(matches!(
-            parser.errors[0].reason(),
-            Some(ParserErrorReason::MissingSeparatingSemi)
-        ));
-        assert!(matches!(
-            parser.errors[1].reason(),
-            Some(ParserErrorReason::MissingSeparatingSemi)
-        ));
+        let expr = check_errors(src, |parser| parser.parse_expression_or_error());
         let ExpressionKind::Block(block) = expr.kind else {
             panic!("Expected block expression");
         };
@@ -1374,15 +1359,9 @@ mod tests {
     fn parses_block_expression_with_a_single_let() {
         let src = "
         { let x = 1 }
-                  ^
+                  ^ Expected a ; after `let` statement
         ";
-        let (src, span) = get_source_with_error_span(src);
-        let mut parser = Parser::for_str_with_dummy_file(&src);
-        parser.parse_expression();
-        let reason = get_single_error_reason(&parser.errors, span);
-        let ParserErrorReason::MissingSemicolonAfterLet = reason else {
-            panic!("Expected a different error");
-        };
+        check_errors(src, |parser| parser.parse_expression());
     }
 
     #[test]
@@ -1417,30 +1396,18 @@ mod tests {
     fn parses_unclosed_parentheses() {
         let src = "
         (
-        ^
+        ^ Expected an expression but found end of input
         ";
-        let (src, span) = get_source_with_error_span(src);
-        let mut parser = Parser::for_str_with_dummy_file(&src);
-        parser.parse_expression();
-        let error = get_single_error(&parser.errors, span);
-        assert_snapshot!(error.to_string(), @"Expected an expression but found end of input");
+        check_errors(src, |parser| parser.parse_expression());
     }
 
     #[test]
     fn parses_missing_comma_in_tuple() {
         let src = "
         (1 2)
-           ^
+           ^ Expected a `,` separating these two expressions
         ";
-        let (src, span) = get_source_with_error_span(src);
-        let mut parser = Parser::for_str_with_dummy_file(&src);
-        parser.parse_expression();
-        let reason = get_single_error_reason(&parser.errors, span);
-        let ParserErrorReason::ExpectedTokenSeparatingTwoItems { token, items } = reason else {
-            panic!("Expected a different error");
-        };
-        assert_eq!(token, &Token::Comma);
-        assert_eq!(*items, "expressions");
+        check_errors(src, |parser| parser.parse_expression());
     }
 
     #[test]
@@ -1483,19 +1450,9 @@ mod tests {
     fn parses_array_expression_with_two_elements_missing_comma() {
         let src = "
         [1 3]
-           ^
+           ^ Expected a `,` separating these two expressions
         ";
-        let (src, span) = get_source_with_error_span(src);
-        let mut parser = Parser::for_str_with_dummy_file(&src);
-        let expr = parser.parse_expression_or_error();
-        assert_eq!(expr.location.span.end() as usize, src.len());
-
-        let reason = get_single_error_reason(&parser.errors, span);
-        let ParserErrorReason::ExpectedTokenSeparatingTwoItems { token, items } = reason else {
-            panic!("Expected a different error");
-        };
-        assert_eq!(token, &Token::Comma);
-        assert_eq!(*items, "expressions");
+        let expr = check_errors(src, |parser| parser.parse_expression_or_error());
 
         let ExpressionKind::Literal(Literal::Array(ArrayLiteral::Standard(exprs))) = expr.kind
         else {
@@ -1733,18 +1690,9 @@ mod tests {
     fn parses_call_missing_comma() {
         let src = "
         foo(1 2)
-              ^
+              ^ Expected a `,` separating these two arguments
         ";
-        let (src, span) = get_source_with_error_span(src);
-        let mut parser = Parser::for_str_with_dummy_file(&src);
-        let expr = parser.parse_expression_or_error();
-        assert_eq!(expr.location.span.end() as usize, src.len());
-        let reason = get_single_error_reason(&parser.errors, span);
-        let ParserErrorReason::ExpectedTokenSeparatingTwoItems { token, items } = reason else {
-            panic!("Expected a different error");
-        };
-        assert_eq!(token, &Token::Comma);
-        assert_eq!(*items, "arguments");
+        let expr = check_errors(src, |parser| parser.parse_expression_or_error());
 
         let ExpressionKind::Call(call) = expr.kind else {
             panic!("Expected call expression");
@@ -1877,14 +1825,9 @@ mod tests {
     fn parses_constructor_with_fields_recovers_if_assign_instead_of_colon() {
         let src = "
         Foo { x = 1, y }
-                ^
+                ^ Expected a ':' but found '='
         ";
-        let (src, span) = get_source_with_error_span(src);
-        let mut parser = Parser::for_str_with_dummy_file(&src);
-        let expr = parser.parse_expression_or_error();
-
-        let error = get_single_error(&parser.errors, span);
-        assert_snapshot!(error.to_string(), @"Expected a ':' but found '='");
+        let expr = check_errors(src, |parser| parser.parse_expression_or_error());
 
         let ExpressionKind::Constructor(mut constructor) = expr.kind else {
             panic!("Expected constructor");
@@ -1905,14 +1848,9 @@ mod tests {
     fn parses_constructor_recovers_if_double_colon_instead_of_colon() {
         let src = "
         Foo { x: 1, y:: z }
-                     ^^
+                     ^^ Expected a ':' but found '::'
         ";
-        let (src, span) = get_source_with_error_span(src);
-        let mut parser = Parser::for_str_with_dummy_file(&src);
-        let expr = parser.parse_expression_or_error();
-
-        let error = get_single_error(&parser.errors, span);
-        assert_snapshot!(error.to_string(), @"Expected a ':' but found '::'");
+        let expr = check_errors(src, |parser| parser.parse_expression_or_error());
 
         let ExpressionKind::Constructor(mut constructor) = expr.kind else {
             panic!("Expected constructor");
@@ -1933,11 +1871,9 @@ mod tests {
     fn parses_constructor_with_fields_recovers_if_not_an_identifier_1() {
         let src = "
         Foo { x: 1, 2 }
-                    ^
+                    ^ Expected an identifier but found '2'
         ";
-        let (src, span) = get_source_with_error_span(src);
-        let mut parser = Parser::for_str_with_dummy_file(&src);
-        let expr = parser.parse_expression_or_error();
+        let expr = check_errors(src, |parser| parser.parse_expression_or_error());
 
         let ExpressionKind::Constructor(mut constructor) = expr.kind else {
             panic!("Expected constructor");
@@ -1948,20 +1884,15 @@ mod tests {
         let (name, expr) = constructor.fields.remove(0);
         assert_eq!(name.to_string(), "x");
         assert_eq!(expr.to_string(), "1");
-
-        let error = get_single_error(&parser.errors, span);
-        assert_snapshot!(error.to_string(), @"Expected an identifier but found '2'");
     }
 
     #[test]
     fn parses_constructor_with_fields_recovers_if_not_an_identifier_2() {
         let src = "
         Foo { x: 1, 2, y: 2 }
-                    ^
+                    ^ Expected an identifier but found '2'
         ";
-        let (src, span) = get_source_with_error_span(src);
-        let mut parser = Parser::for_str_with_dummy_file(&src);
-        let expr = parser.parse_expression_or_error();
+        let expr = check_errors(src, |parser| parser.parse_expression_or_error());
 
         let ExpressionKind::Constructor(mut constructor) = expr.kind else {
             panic!("Expected constructor");
@@ -1976,9 +1907,6 @@ mod tests {
         let (name, expr) = constructor.fields.remove(0);
         assert_eq!(name.to_string(), "y");
         assert_eq!(expr.to_string(), "2");
-
-        let error = get_single_error(&parser.errors, span);
-        assert_snapshot!(error.to_string(), @"Expected an identifier but found '2'");
     }
 
     #[test]
@@ -2085,13 +2013,9 @@ mod tests {
     fn parses_cast_missing_type() {
         let src = "
         1 as
-           ^
+           ^ Expected a type but found end of input
         ";
-        let (src, span) = get_source_with_error_span(src);
-        let mut parser = Parser::for_str_with_dummy_file(&src);
-        parser.parse_expression();
-        let error = get_single_error(&parser.errors, span);
-        assert_snapshot!(error.to_string(), @"Expected a type but found end of input");
+        check_errors(src, |parser| parser.parse_expression());
     }
 
     #[test]
@@ -2193,15 +2117,10 @@ mod tests {
     fn errors_on_logical_and() {
         let src = "
         1 && 2
-          ^^
+          ^^ Noir has no logical-and (&&) operator since short-circuiting is much less efficient when compiling to circuits
         ";
-        let (src, span) = get_source_with_error_span(src);
-        let mut parser = Parser::for_str_with_dummy_file(&src);
-        let expression = parser.parse_expression_or_error();
+        let expression = check_errors(src, |parser| parser.parse_expression_or_error());
         assert_eq!(expression.to_string(), "(1 & 2)");
-
-        let reason = get_single_error_reason(&parser.errors, span);
-        assert!(matches!(reason, ParserErrorReason::LogicalAnd));
     }
 
     #[test]
@@ -2297,11 +2216,9 @@ mod tests {
     fn parses_type_path_with_empty_tuple_missing_angle_brackets() {
         let src = "
           ()::foo
-          ^^
+          ^^ Missing angle brackets surrounding type in associated item path
           ";
-        let (src, span) = get_source_with_error_span(src);
-        let mut parser = Parser::for_str_with_dummy_file(&src);
-        let expr = parser.parse_expression_or_error();
+        let expr = check_errors(src, |parser| parser.parse_expression_or_error());
 
         let ExpressionKind::TypePath(type_path) = expr.kind else {
             panic!("Expected type_path");
@@ -2309,41 +2226,26 @@ mod tests {
         assert_eq!(type_path.typ.to_string(), "()");
         assert_eq!(type_path.item.to_string(), "foo");
         assert!(type_path.turbofish.is_none());
-
-        let reason = get_single_error_reason(&parser.errors, span);
-        assert!(matches!(reason, ParserErrorReason::MissingAngleBrackets));
     }
 
     #[test]
     fn parses_type_path_with_non_empty_tuple_missing_angle_brackets() {
         let src = "
           (Field, i32)::foo
-          ^^^^^^^^^^^^
+          ^^^^^^^^^^^^ Missing angle brackets surrounding type in associated item path
           ";
-        let (src, span) = get_source_with_error_span(src);
-        let mut parser = Parser::for_str_with_dummy_file(&src);
-        let expr = parser.parse_expression_or_error();
-
+        let expr = check_errors(src, |parser| parser.parse_expression_or_error());
         assert!(matches!(expr.kind, ExpressionKind::Error));
-
-        let reason = get_single_error_reason(&parser.errors, span);
-        assert!(matches!(reason, ParserErrorReason::MissingAngleBrackets));
     }
 
     #[test]
     fn parses_type_path_with_array_missing_angle_brackets() {
         let src = "
           [Field; 3]::foo
-          ^^^^^^^^^^
+          ^^^^^^^^^^ Missing angle brackets surrounding type in associated item path
           ";
-        let (src, span) = get_source_with_error_span(src);
-        let mut parser = Parser::for_str_with_dummy_file(&src);
-        let expr = parser.parse_expression_or_error();
-
+        let expr = check_errors(src, |parser| parser.parse_expression_or_error());
         assert!(matches!(expr.kind, ExpressionKind::Error));
-
-        let reason = get_single_error_reason(&parser.errors, span);
-        assert!(matches!(reason, ParserErrorReason::MissingAngleBrackets));
     }
 
     #[test]
@@ -2395,19 +2297,14 @@ mod tests {
     fn parses_constrain() {
         let src = "
         constrain 1
-        ^^^^^^^^^
+        ^^^^^^^^^ Use of deprecated keyword 'constrain'
         ";
-        let (src, span) = get_source_with_error_span(src);
-        let mut parser = Parser::for_str_with_dummy_file(&src);
-        let expression = parser.parse_expression_or_error();
+        let expression = check_errors(src, |parser| parser.parse_expression_or_error());
         let ExpressionKind::Constrain(constrain) = expression.kind else {
             panic!("Expected constrain expression");
         };
         assert_eq!(constrain.kind, ConstrainKind::Constrain);
         assert_eq!(constrain.arguments.len(), 1);
-
-        let reason = get_single_error_reason(&parser.errors, span);
-        assert!(matches!(reason, ParserErrorReason::ConstrainDeprecated));
     }
 
     #[test]
@@ -2429,43 +2326,28 @@ mod tests {
     fn parses_if_missing_condition() {
         let src = "
         if { 1 }
-        ^^
+        ^^ missing condition for `if` expression
         ";
-        let (src, span) = get_source_with_error_span(src);
-        let mut parser = Parser::for_str_with_dummy_file(&src);
-        let expression = parser.parse_expression_or_error();
+        let expression = check_errors(src, |parser| parser.parse_expression_or_error());
         assert!(matches!(expression.kind, ExpressionKind::If(..)));
-
-        let reason = get_single_error_reason(&parser.errors, span);
-        assert!(matches!(reason, ParserErrorReason::MissingIfCondition));
     }
 
     #[test]
     fn errors_on_struct_literal_used_in_if_condition() {
-        let src = "if MyStruct { field: true }.field {}";
-        let mut parser = Parser::for_str_with_dummy_file(src);
-        let expression = parser.parse_expression_or_error();
-        assert_eq!(expression.location.span.end() as usize, src.len());
-
-        assert_eq!(parser.errors.len(), 1);
-        assert!(matches!(
-            parser.errors[0].reason(),
-            Some(ParserErrorReason::StructLiteralInIfCondition)
-        ));
+        let src = "
+        if MyStruct { field: true }.field {}
+           ^^^^^^^^^^^^^^^^^^^^^^^^ Struct literals are not allowed in `if` conditions
+        ";
+        check_errors(src, |parser| parser.parse_expression_or_error());
     }
 
     #[test]
     fn errors_on_struct_literal_used_in_if_condition_with_block_argument() {
-        let src = "if MyStruct { field: true }.foo({ 1 }) {}";
-        let mut parser = Parser::for_str_with_dummy_file(src);
-        let expression = parser.parse_expression_or_error();
-        assert_eq!(expression.location.span.end() as usize, src.len());
-
-        assert_eq!(parser.errors.len(), 1);
-        assert!(matches!(
-            parser.errors[0].reason(),
-            Some(ParserErrorReason::StructLiteralInIfCondition)
-        ));
+        let src = "
+        if MyStruct { field: true }.foo({ 1 }) {}
+           ^^^^^^^^^^^^^^^^^^^^^^^^ Struct literals are not allowed in `if` conditions
+        ";
+        check_errors(src, |parser| parser.parse_expression_or_error());
     }
 
     /// When an integer is too large, the lexer will issue an error instead of an integer token.
@@ -2475,18 +2357,10 @@ mod tests {
         // The fifth integer here should overflow bn254
         let src = "
             @[0, 1, 23, 3444, 21888242871839275222246405745257275088548364400416034343698204186575808495617, 43, 2, 32, 4]
-                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Integer literal is too large
         ";
-        let (src, span) = get_source_with_error_span(src);
-        let mut parser = Parser::for_str_with_dummy_file(&src);
-        let expression = parser.parse_expression_or_error();
+        let expression = check_errors(src, |parser| parser.parse_expression_or_error());
         assert!(matches!(expression.kind, ExpressionKind::Literal(Literal::Vector(_))));
-
-        let reason = get_single_error_reason(&parser.errors, span);
-        assert!(matches!(
-            reason,
-            ParserErrorReason::Lexer(LexerErrorKind::IntegerLiteralTooLarge { .. })
-        ));
     }
 
     #[test]

--- a/compiler/noirc_frontend/src/parser/parser/function.rs
+++ b/compiler/noirc_frontend/src/parser/parser/function.rs
@@ -376,17 +376,12 @@ fn empty_body() -> BlockExpression {
 
 #[cfg(test)]
 mod tests {
-    use insta::assert_snapshot;
-
     use crate::{
         ast::{ExpressionKind, ItemVisibility, NoirFunction, StatementKind},
         parse_program_with_dummy_file,
         parser::{
-            ItemKind, Parser, ParserErrorReason,
-            parser::tests::{
-                expect_no_errors, get_single_error, get_single_error_reason,
-                get_source_with_error_span,
-            },
+            ItemKind,
+            parser::tests::{check_errors, expect_no_errors},
         },
         shared::Visibility,
     };
@@ -500,70 +495,55 @@ mod tests {
     fn parse_error_multiple_function_attributes_found() {
         let src = "
         #[foreign(foo)] #[oracle(bar)] fn foo() {}
-                        ^^^^^^^^^^^^^^
+                        ^^^^^^^^^^^^^^ Multiple primary attributes found. Only one function attribute is allowed per function
         ";
-        let (src, span) = get_source_with_error_span(src);
-        let (_, errors) = parse_program_with_dummy_file(&src);
-        let reason = get_single_error_reason(&errors, span);
-        assert!(matches!(reason, ParserErrorReason::MultipleFunctionAttributesFound));
+        check_errors(src, |parser| parser.parse_program());
     }
 
     #[test]
     fn parse_function_found_semicolon_instead_of_braces() {
         let src = "
         fn foo();
-                ^
+                ^ Expected a function body (`{ ... }`), not `;`
         ";
-        let (src, span) = get_source_with_error_span(src);
-        let (_, errors) = parse_program_with_dummy_file(&src);
-        let reason = get_single_error_reason(&errors, span);
-        assert!(matches!(reason, ParserErrorReason::ExpectedFunctionBody));
+        check_errors(src, |parser| parser.parse_program());
     }
 
     #[test]
     fn recovers_on_wrong_parameter_name() {
         let src = "
         fn foo(1 x: i32) {}
-               ^
+               ^ Expected a pattern but found '1'
         ";
-        let (src, span) = get_source_with_error_span(src);
-        let (module, errors) = parse_program_with_dummy_file(&src);
+        let module = check_errors(src, |parser| parser.parse_program());
         assert_eq!(module.items.len(), 1);
         let ItemKind::Function(noir_function) = &module.items[0].kind else {
             panic!("Expected function");
         };
         assert_eq!(noir_function.parameters().len(), 1);
-
-        let error = get_single_error(&errors, span);
-        assert_snapshot!(error.to_string(), @"Expected a pattern but found '1'");
     }
 
     #[test]
     fn recovers_on_missing_colon_after_parameter_name() {
         let src = "
         fn foo(x, y: i32) {}
-               ^^
+               ^^ Missing type for function parameter
         ";
-        let (src, span) = get_source_with_error_span(src);
-        let (module, errors) = parse_program_with_dummy_file(&src);
+        let module = check_errors(src, |parser| parser.parse_program());
         assert_eq!(module.items.len(), 1);
         let ItemKind::Function(noir_function) = &module.items[0].kind else {
             panic!("Expected function");
         };
         assert_eq!(noir_function.parameters().len(), 2);
-
-        let error = get_single_error(&errors, span);
-        assert!(error.to_string().contains("Missing type for function parameter"));
     }
 
     #[test]
     fn recovers_on_missing_colon_before_parameter_type() {
         let src = "
         fn foo(x u64, y: i32) {}
-               ^^^^^
+               ^^^^^ Expected a `:` between the parameter name and its type
         ";
-        let (src, span) = get_source_with_error_span(src);
-        let (mut module, errors) = parse_program_with_dummy_file(&src);
+        let mut module = check_errors(src, |parser| parser.parse_program());
         assert_eq!(module.items.len(), 1);
         let ItemKind::Function(noir_function) = module.items.remove(0).kind else {
             panic!("Expected function");
@@ -572,27 +552,20 @@ mod tests {
         assert_eq!(params.len(), 2);
         assert_eq!(params[0].typ.typ.to_string(), "u64");
         assert_eq!(params[1].typ.typ.to_string(), "i32");
-
-        let reason = get_single_error_reason(&errors, span);
-        assert!(matches!(reason, ParserErrorReason::MissingColonInFunctionParameter));
     }
 
     #[test]
     fn recovers_on_missing_type_after_parameter_colon() {
         let src = "
         fn foo(x: , y: i32) {}
-                  ^
+                  ^ Expected a type but found ','
         ";
-        let (src, span) = get_source_with_error_span(src);
-        let (module, errors) = parse_program_with_dummy_file(&src);
+        let module = check_errors(src, |parser| parser.parse_program());
         assert_eq!(module.items.len(), 1);
         let ItemKind::Function(noir_function) = &module.items[0].kind else {
             panic!("Expected function");
         };
         assert_eq!(noir_function.parameters().len(), 2);
-
-        let error = get_single_error(&errors, span);
-        assert_snapshot!(error.to_string(), @"Expected a type but found ','");
     }
 
     #[test]
@@ -608,24 +581,18 @@ mod tests {
     fn parse_function_without_parentheses() {
         let src = "
         fn foo {}
-           ^^^
+           ^^^ Missing parameters for function definition
         ";
-        let (src, span) = get_source_with_error_span(src);
-        let (_, errors) = parse_program_with_dummy_file(&src);
-        let reason = get_single_error_reason(&errors, span);
-        assert!(matches!(reason, ParserErrorReason::MissingParametersForFunctionDefinition));
+        check_errors(src, |parser| parser.parse_program());
     }
 
     #[test]
     fn parse_function_with_keyword_before_type() {
         let src = "
         fn foo(x: mut i32, y: i64) {}
-                  ^^^
+                  ^^^ Expected a type but found 'mut'
         ";
-        let (src, span) = get_source_with_error_span(src);
-        let (mut module, errors) = parse_program_with_dummy_file(&src);
-        let error = get_single_error(&errors, span);
-        assert_snapshot!(error.to_string(), @"Expected a type but found 'mut'");
+        let mut module = check_errors(src, |parser| parser.parse_program());
 
         assert_eq!(module.items.len(), 1);
         let item = module.items.remove(0);
@@ -683,69 +650,46 @@ mod tests {
         let src = "
         fn foo(
             /// Doc comment
+            ^^^^^^^^^^^^^^^ Documentation comments cannot be applied to function parameters
             x: Field,
         ) {}
         ";
-        let (_module, errors) = parse_program_with_dummy_file(src);
-        assert_eq!(errors.len(), 1);
-
-        let reason = errors[0].reason().unwrap();
-        assert_eq!(reason, &ParserErrorReason::DocCommentCannotBeAppliedToFunctionParameters);
+        check_errors(src, |parser| parser.parse_program());
     }
 
     #[test]
     fn errors_on_missing_function_braces_1() {
         let src = "
           fn foo() struct Foo {}
-                   ^^^^^^
+                   ^^^^^^ Unexpected 'struct', expected one of 'where', '{', '->'
           ";
-        let (src, span) = get_source_with_error_span(src);
-        let mut parser = Parser::for_str_with_dummy_file(&src);
-        let _ = parser.parse_program();
-
-        let error = get_single_error(&parser.errors, span);
-        assert_snapshot!(error.to_string(), @"Unexpected 'struct', expected one of 'where', '{', '->'");
+        check_errors(src, |parser| parser.parse_program());
     }
 
     #[test]
     fn errors_on_missing_function_braces_2() {
         let src = "
           fn foo() -> Field struct Foo {}
-                            ^^^^^^
+                            ^^^^^^ Unexpected 'struct', expected one of 'where', '{'
           ";
-        let (src, span) = get_source_with_error_span(src);
-        let mut parser = Parser::for_str_with_dummy_file(&src);
-        let _ = parser.parse_program();
-
-        let error = get_single_error(&parser.errors, span);
-        assert_snapshot!(error.to_string(), @"Unexpected 'struct', expected one of 'where', '{'");
+        check_errors(src, |parser| parser.parse_program());
     }
 
     #[test]
     fn errors_on_missing_function_braces_3() {
         let src = "
           fn foo<T>() -> Field where T: Trait struct Foo {}
-                                              ^^^^^^
+                                              ^^^^^^ Expected a '{' but found 'struct'
           ";
-        let (src, span) = get_source_with_error_span(src);
-        let mut parser = Parser::for_str_with_dummy_file(&src);
-        let _ = parser.parse_program();
-
-        let error = get_single_error(&parser.errors, span);
-        assert_snapshot!(error.to_string(), @"Expected a '{' but found 'struct'");
+        check_errors(src, |parser| parser.parse_program());
     }
 
     #[test]
     fn errors_on_missing_function_name() {
         let src = "
           fn () {}
-             ^
+             ^ Expected an identifier but found '('
           ";
-        let (src, span) = get_source_with_error_span(src);
-        let mut parser = Parser::for_str_with_dummy_file(&src);
-        let _ = parser.parse_program();
-
-        let error = get_single_error(&parser.errors, span);
-        assert_snapshot!(error.to_string(), @"Expected an identifier but found '('");
+        check_errors(src, |parser| parser.parse_program());
     }
 }

--- a/compiler/noirc_frontend/src/parser/parser/generics.rs
+++ b/compiler/noirc_frontend/src/parser/parser/generics.rs
@@ -200,10 +200,8 @@ mod tests {
     use crate::{
         ast::{GenericTypeArgs, UnresolvedGeneric},
         parser::{
-            Parser, ParserErrorReason,
-            parser::tests::{
-                expect_no_errors, get_single_error_reason, get_source_with_error_span,
-            },
+            Parser,
+            parser::tests::{check_errors, expect_no_errors},
         },
     };
 
@@ -317,12 +315,8 @@ mod tests {
     fn parse_generic_trait_bound_not_allowed() {
         let src = "
         N: Trait
-         ^
+         ^ Trait bounds are not allowed here
         ";
-        let (src, span) = get_source_with_error_span(src);
-        let mut parser = Parser::for_str_with_dummy_file(&src);
-        parser.parse_generic(false);
-        let reason = get_single_error_reason(&parser.errors, span);
-        assert!(matches!(reason, ParserErrorReason::TraitBoundsNotAllowedHere));
+        check_errors(src, |parser| parser.parse_generic(false));
     }
 }

--- a/compiler/noirc_frontend/src/parser/parser/global.rs
+++ b/compiler/noirc_frontend/src/parser/parser/global.rs
@@ -69,17 +69,13 @@ fn ident_to_pattern(ident: Ident, mutable: bool) -> Pattern {
 #[cfg(test)]
 mod tests {
     use acvm::FieldElement;
-    use insta::assert_snapshot;
 
     use crate::{
         ast::{ExpressionKind, ItemVisibility, LetStatement, Literal, Pattern},
         parse_program_with_dummy_file,
         parser::{
-            ItemKind, ParserErrorReason,
-            parser::tests::{
-                expect_no_errors, get_single_error, get_single_error_reason,
-                get_source_with_error_span,
-            },
+            ItemKind,
+            parser::tests::{check_errors, expect_no_errors},
         },
     };
 
@@ -146,46 +142,36 @@ mod tests {
     fn parse_global_no_value() {
         let src = "
         global foo;
-               ^^^
+               ^^^ Expected the global to have a value
         ";
-        let (src, span) = get_source_with_error_span(src);
-        let (_, errors) = parse_program_with_dummy_file(&src);
-        let reason = get_single_error_reason(&errors, span);
-        assert!(matches!(reason, ParserErrorReason::GlobalWithoutValue));
+        check_errors(src, |parser| parser.parse_program());
     }
 
     #[test]
     fn parse_global_no_semicolon() {
         let src = "
-        global foo = 1 
-                      ^ 
+        global foo = 1
+                     ^ Expected a ';' but found end of input
         ";
-        let (src, span) = get_source_with_error_span(src);
-        let (_, errors) = parse_program_with_dummy_file(&src);
-        let error = get_single_error(&errors, span);
-        assert_snapshot!(error.to_string(), @"Expected a ';' but found end of input");
+        check_errors(src, |parser| parser.parse_program());
     }
 
     #[test]
     fn parse_global_missing_identifier() {
         let src = "
         global : u32 = 100;
-               ^
+               ^ Expected an identifier but found ':'
         ";
-        let (src, span) = get_source_with_error_span(src);
-        let (_, errors) = parse_program_with_dummy_file(&src);
-        let error = get_single_error(&errors, span);
-        assert_snapshot!(error.to_string(), @"Expected an identifier but found ':'");
+        check_errors(src, |parser| parser.parse_program());
     }
 
     #[test]
     fn parse_global_invalid_syntax_after_ident() {
-        let src = "global N<let X: u32>: u32 = 100;";
-        let (_, errors) = parse_program_with_dummy_file(src);
-        // The parser should recover by skipping to `;` rather than producing cascading errors
-        assert_eq!(errors.len(), 1, "Expected 1 error, got: {errors:?}");
-        let reason = errors[0].reason().unwrap();
-        assert!(matches!(reason, ParserErrorReason::GlobalWithoutValue));
+        let src = "
+        global N<let X: u32>: u32 = 100;
+               ^ Expected the global to have a value
+        ";
+        check_errors(src, |parser| parser.parse_program());
     }
 
     #[test]

--- a/compiler/noirc_frontend/src/parser/parser/impls.rs
+++ b/compiler/noirc_frontend/src/parser/parser/impls.rs
@@ -235,8 +235,6 @@ impl Parser<'_> {
 
 #[cfg(test)]
 mod tests {
-    use insta::assert_snapshot;
-
     use crate::{
         ast::{
             ItemVisibility, NoirTraitImpl, Pattern, TraitImplItemKind, TypeImpl, UnresolvedTypeData,
@@ -244,7 +242,7 @@ mod tests {
         parse_program_with_dummy_file,
         parser::{
             ItemKind,
-            parser::tests::{expect_no_errors, get_single_error, get_source_with_error_span},
+            parser::tests::{check_errors, expect_no_errors},
         },
     };
 
@@ -545,10 +543,9 @@ mod tests {
     fn recovers_on_unknown_impl_item() {
         let src = "
         impl Foo { hello fn foo() {} }
-                   ^^^^^
+                   ^^^^^ Expected a function but found 'hello'
         ";
-        let (src, span) = get_source_with_error_span(src);
-        let (module, errors) = parse_program_with_dummy_file(&src);
+        let module = check_errors(src, |parser| parser.parse_program());
 
         assert_eq!(module.items.len(), 1);
         let item = &module.items[0];
@@ -556,19 +553,15 @@ mod tests {
             panic!("Expected impl");
         };
         assert_eq!(type_impl.methods.len(), 1);
-
-        let error = get_single_error(&errors, span);
-        assert_snapshot!(error.to_string(), @"Expected a function but found 'hello'");
     }
 
     #[test]
     fn recovers_on_unknown_trait_impl_item() {
         let src = "
         impl Foo for i32 { hello fn foo() {} }
-                           ^^^^^
+                           ^^^^^ Expected a trait impl item but found 'hello'
         ";
-        let (src, span) = get_source_with_error_span(src);
-        let (module, errors) = parse_program_with_dummy_file(&src);
+        let module = check_errors(src, |parser| parser.parse_program());
 
         assert_eq!(module.items.len(), 1);
         let item = &module.items[0];
@@ -576,9 +569,6 @@ mod tests {
             panic!("Expected trait impl");
         };
         assert_eq!(trait_imp.items.len(), 1);
-
-        let error = get_single_error(&errors, span);
-        assert_snapshot!(error.to_string(), @"Expected a trait impl item but found 'hello'");
     }
 
     #[test]

--- a/compiler/noirc_frontend/src/parser/parser/item.rs
+++ b/compiler/noirc_frontend/src/parser/parser/item.rs
@@ -278,40 +278,29 @@ impl<'a> Parser<'a> {
 
 #[cfg(test)]
 mod tests {
-    use insta::assert_snapshot;
-
     use crate::{
         parse_program_with_dummy_file,
-        parser::{
-            ItemKind, Parser, ParserErrorReason,
-            parser::tests::{get_single_error, get_source_with_error_span},
-        },
+        parser::{ItemKind, parser::tests::check_errors},
     };
 
     #[test]
     fn recovers_on_unknown_item() {
         let src = "
         fn foo() {} hello fn bar() {}
-                    ^^^^^
+                    ^^^^^ Expected an item but found 'hello'
         ";
-        let (src, span) = get_source_with_error_span(src);
-        let (module, errors) = parse_program_with_dummy_file(&src);
+        let module = check_errors(src, |parser| parser.parse_program());
         assert_eq!(module.items.len(), 2);
-        let error = get_single_error(&errors, span);
-        assert_snapshot!(error.to_string(), @"Expected an item but found 'hello'");
     }
 
     #[test]
     fn errors_on_eof_in_nested_mod() {
         let src = "
         mod foo { fn foo() {}
-                            ^
+                            ^ Expected a '}' but found end of input
         ";
-        let (src, span) = get_source_with_error_span(src);
-        let (module, errors) = parse_program_with_dummy_file(&src);
+        let module = check_errors(src, |parser| parser.parse_program());
         assert_eq!(module.items.len(), 1);
-        let error = get_single_error(&errors, span);
-        assert_snapshot!(error.to_string(), @"Expected a '}' but found end of input");
     }
 
     #[test]
@@ -319,13 +308,10 @@ mod tests {
         let src = "
         fn foo() {}
         /// doc comment
-        ^^^^^^^^^^^^^^^
+        ^^^^^^^^^^^^^^^ This doc comment doesn't document anything
         ";
-        let (src, span) = get_source_with_error_span(src);
-        let (module, errors) = parse_program_with_dummy_file(&src);
+        let module = check_errors(src, |parser| parser.parse_program());
         assert_eq!(module.items.len(), 1);
-        let error = get_single_error(&errors, span);
-        assert!(error.to_string().contains("This doc comment doesn't document anything"));
     }
 
     #[test]
@@ -361,131 +347,87 @@ mod tests {
     fn error_recovery_for_missing_fn_between_visibility_and_name() {
         let src = "
         pub foo() { }
-            ^^^
+            ^^^ Expected a 'fn' but found 'foo'
         ";
-        let (src, span) = get_source_with_error_span(src);
-        let mut parser = Parser::for_str_with_dummy_file(&src);
-        let module = parser.parse_program();
+        let module = check_errors(src, |parser| parser.parse_program());
         assert_eq!(module.items.len(), 1);
         let ItemKind::Function(noir_function) = &module.items[0].kind else {
             panic!("Expected function");
         };
         assert_eq!(noir_function.name(), "foo");
-
-        let reason = get_single_error(&parser.errors, span);
-        assert_eq!(reason.to_string(), "Expected a 'fn' but found 'foo'");
     }
 
     #[test]
     fn error_recovery_for_missing_fn_between_unconstrained_and_name() {
         let src = "
         unconstrained foo() { }
-                      ^^^
+                      ^^^ Expected a 'fn' but found 'foo'
         ";
-        let (src, span) = get_source_with_error_span(src);
-        let mut parser = Parser::for_str_with_dummy_file(&src);
-        let module = parser.parse_program();
+        let module = check_errors(src, |parser| parser.parse_program());
         assert_eq!(module.items.len(), 1);
         let ItemKind::Function(noir_function) = &module.items[0].kind else {
             panic!("Expected function");
         };
         assert_eq!(noir_function.name(), "foo");
-
-        let reason = get_single_error(&parser.errors, span);
-        assert_eq!(reason.to_string(), "Expected a 'fn' but found 'foo'");
     }
 
     #[test]
     fn errors_on_missing_mod_identifier() {
         let src = "
         mod ; fn foo() {}
-            ^
+            ^ Expected an identifier but found ';'
         ";
-        let (src, span) = get_source_with_error_span(src);
-        let (module, errors) = parse_program_with_dummy_file(&src);
+        let module = check_errors(src, |parser| parser.parse_program());
         assert_eq!(module.items.len(), 1);
-        let error = get_single_error(&errors, span);
-        assert_snapshot!(error.to_string(), @"Expected an identifier but found ';'");
     }
 
     #[test]
     fn errors_on_mod_named_underscore() {
         let src = "
         mod _ {}
-            ^
+            ^ expected an identifier, found reserved identifier `_`
         ";
-        let (src, span) = get_source_with_error_span(src);
-        let (module, errors) = parse_program_with_dummy_file(&src);
+        let module = check_errors(src, |parser| parser.parse_program());
         assert_eq!(module.items.len(), 1);
-        let error = get_single_error(&errors, span);
-        assert!(matches!(error.reason(), Some(ParserErrorReason::ExpectedIdentifierGotUnderscore)));
     }
 
     #[test]
     fn errors_on_lonely_pub() {
         let src = "
         pub
-        ^^^
+        ^^^ Visibility `pub` is not followed by an item
         ";
-        let (src, span) = get_source_with_error_span(src);
-        let (module, errors) = parse_program_with_dummy_file(&src);
+        let module = check_errors(src, |parser| parser.parse_program());
         assert!(module.items.is_empty());
-        let error = get_single_error(&errors, span);
-        assert_snapshot!(error.to_string(), @r"
-        Unexpected end of input in input
-        reason: Visibility `pub` is not followed by an item
-        secondary:
-        ");
     }
 
     #[test]
     fn errors_on_lonely_unconstrained() {
         let src = "
         unconstrained
-        ^^^^^^^^^^^^^
+        ^^^^^^^^^^^^^ `unconstrained` is not followed by an item
         ";
-        let (src, span) = get_source_with_error_span(src);
-        let (module, errors) = parse_program_with_dummy_file(&src);
+        let module = check_errors(src, |parser| parser.parse_program());
         assert!(module.items.is_empty());
-        let error = get_single_error(&errors, span);
-        assert_snapshot!(error.to_string(), @r"
-        Unexpected end of input in input
-        reason: `unconstrained` is not followed by an item
-        secondary:
-        ");
     }
 
     #[test]
     fn errors_on_lonely_comptime() {
         let src = "
         comptime
-        ^^^^^^^^
+        ^^^^^^^^ `comptime` is not followed by an item
         ";
-        let (src, span) = get_source_with_error_span(src);
-        let (module, errors) = parse_program_with_dummy_file(&src);
+        let module = check_errors(src, |parser| parser.parse_program());
         assert!(module.items.is_empty());
-        let error = get_single_error(&errors, span);
-        assert_snapshot!(error.to_string(), @r"
-        Unexpected end of input in input
-        reason: `comptime` is not followed by an item
-        secondary:
-        ");
     }
 
     #[test]
     fn errors_on_lonely_mut() {
         let src = "
-        mut 
-        ^^^
+        mut
+        ^^^ `mut` is not followed by an item
         ";
-        let (src, span) = get_source_with_error_span(src);
-        let (module, errors) = parse_program_with_dummy_file(&src);
+        let module = check_errors(src, |parser| parser.parse_program());
         assert!(module.items.is_empty());
-        let error = get_single_error(&errors, span);
-        assert_snapshot!(error.to_string(), @r"
-        Unexpected end of input in input
-        reason: `mut` is not followed by an item
-        secondary:
-        ");
     }
 }

--- a/compiler/noirc_frontend/src/parser/parser/item_visibility.rs
+++ b/compiler/noirc_frontend/src/parser/parser/item_visibility.rs
@@ -36,13 +36,11 @@ impl Parser<'_> {
 
 #[cfg(test)]
 mod tests {
-    use insta::assert_snapshot;
-
     use crate::{
         ast::ItemVisibility,
         parser::{
             Parser,
-            parser::tests::{expect_no_errors, get_single_error, get_source_with_error_span},
+            parser::tests::{check_errors, expect_no_errors},
         },
     };
 
@@ -67,42 +65,30 @@ mod tests {
     #[test]
     fn parses_public_visibility_unclosed_parentheses() {
         let src = "
-        pub( 
-            ^
+        pub(
+           ^ Expected a 'crate' but found end of input
         ";
-        let (src, span) = get_source_with_error_span(src);
-        let mut parser = Parser::for_str_with_dummy_file(&src);
-        let visibility = parser.parse_item_visibility();
+        let visibility = check_errors(src, |parser| parser.parse_item_visibility());
         assert_eq!(visibility, ItemVisibility::Public);
-        let error = get_single_error(&parser.errors, span);
-        assert_snapshot!(error.to_string(), @"Expected a 'crate' but found end of input");
     }
 
     #[test]
     fn parses_public_visibility_no_crate_after_pub() {
         let src = "
         pub(hello
-            ^^^^^
+            ^^^^^ Expected a 'crate' but found 'hello'
         ";
-        let (src, span) = get_source_with_error_span(src);
-        let mut parser = Parser::for_str_with_dummy_file(&src);
-        let visibility = parser.parse_item_visibility();
+        let visibility = check_errors(src, |parser| parser.parse_item_visibility());
         assert_eq!(visibility, ItemVisibility::Public);
-        let error = get_single_error(&parser.errors, span);
-        assert_snapshot!(error.to_string(), @"Expected a 'crate' but found 'hello'");
     }
     #[test]
     fn parses_public_visibility_missing_paren_after_pub_crate() {
         let src = "
-        pub(crate 
-                 ^
+        pub(crate
+                ^ Expected a ')' but found end of input
         ";
-        let (src, span) = get_source_with_error_span(src);
-        let mut parser = Parser::for_str_with_dummy_file(&src);
-        let visibility = parser.parse_item_visibility();
+        let visibility = check_errors(src, |parser| parser.parse_item_visibility());
         assert_eq!(visibility, ItemVisibility::PublicCrate);
-        let error = get_single_error(&parser.errors, span);
-        assert_snapshot!(error.to_string(), @"Expected a ')' but found end of input");
     }
 
     #[test]

--- a/compiler/noirc_frontend/src/parser/parser/path.rs
+++ b/compiler/noirc_frontend/src/parser/parser/path.rs
@@ -257,13 +257,11 @@ impl Parser<'_> {
 #[cfg(test)]
 mod tests {
 
-    use insta::assert_snapshot;
-
     use crate::{
         ast::{Path, PathKind},
         parser::{
             Parser,
-            parser::tests::{expect_no_errors, get_single_error, get_source_with_error_span},
+            parser::tests::{check_errors, expect_no_errors},
         },
     };
 
@@ -383,15 +381,10 @@ mod tests {
     #[test]
     fn errors_on_crate_double_colons() {
         let src = "
-        crate:: 
-               ^
+        crate::
+              ^ Expected an identifier but found end of input
         ";
-        let (src, span) = get_source_with_error_span(src);
-        let mut parser = Parser::for_str_with_dummy_file(&src);
-        let path = parser.parse_path();
+        let path = check_errors(src, |parser| parser.parse_path());
         assert!(path.is_none());
-
-        let error = get_single_error(&parser.errors, span);
-        assert_snapshot!(error.to_string(), @"Expected an identifier but found end of input");
     }
 }

--- a/compiler/noirc_frontend/src/parser/parser/pattern.rs
+++ b/compiler/noirc_frontend/src/parser/parser/pattern.rs
@@ -237,13 +237,11 @@ impl Parser<'_> {
 #[cfg(test)]
 mod tests {
 
-    use insta::assert_snapshot;
-
     use crate::{
         ast::Pattern,
         parser::{
             Parser,
-            parser::tests::{expect_no_errors, get_single_error, get_source_with_error_span},
+            parser::tests::{check_errors, expect_no_errors},
         },
     };
 
@@ -358,14 +356,9 @@ mod tests {
     fn parses_struct_pattern_recovers_if_assign_instead_of_colon() {
         let src = "
         foo::Bar { x = one, y }
-                     ^
+                     ^ Expected a ':' but found '='
         ";
-        let (src, span) = get_source_with_error_span(src);
-        let mut parser = Parser::for_str_with_dummy_file(&src);
-        let pattern = parser.parse_pattern_or_error();
-
-        let error = get_single_error(&parser.errors, span);
-        assert_snapshot!(error.to_string(), @"Expected a ':' but found '='");
+        let pattern = check_errors(src, |parser| parser.parse_pattern_or_error());
 
         let Pattern::Struct(path, mut patterns, _) = pattern else {
             panic!("Expected a struct pattern")

--- a/compiler/noirc_frontend/src/parser/parser/statement.rs
+++ b/compiler/noirc_frontend/src/parser/parser/statement.rs
@@ -475,16 +475,11 @@ impl Parser<'_> {
 
 #[cfg(test)]
 mod tests {
-    use insta::assert_snapshot;
-
     use crate::{
         ast::{ExpressionKind, ForRange, LValue, LoopStatement, Statement, StatementKind},
         parser::{
-            Parser, ParserErrorReason,
-            parser::tests::{
-                expect_no_errors, get_single_error, get_single_error_reason,
-                get_source_with_error_span,
-            },
+            Parser,
+            parser::tests::{check_errors, expect_no_errors},
         },
     };
 
@@ -578,11 +573,9 @@ mod tests {
     fn parses_let_statement_with_two_mut() {
         let src = "
         let mut mut x = 1;
-                ^^^
+                ^^^ `mut` on a binding cannot be repeated
         ";
-        let (src, span) = get_source_with_error_span(src);
-        let mut parser = Parser::for_str_with_dummy_file(&src);
-        let statement = parser.parse_statement().unwrap().0;
+        let (statement, _) = check_errors(src, |parser| parser.parse_statement()).unwrap();
         let StatementKind::Let(let_statement) = statement.kind else {
             panic!("Expected let statement");
         };
@@ -590,29 +583,21 @@ mod tests {
         assert!(let_statement.r#type.is_none());
         assert_eq!(let_statement.expression.to_string(), "1");
         assert!(!let_statement.comptime);
-
-        let reason = get_single_error_reason(&parser.errors, span);
-        assert!(matches!(reason, ParserErrorReason::MutOnABindingCannotBeRepeated));
     }
 
     #[test]
     fn recovers_on_missing_colon_in_let_binding() {
         let src = "
         let x u64 = 2;
-            ^^^^^
+            ^^^^^ Expected a `:` between the variable name and its type
         ";
-        let (src, span) = get_source_with_error_span(src);
-        let mut parser = Parser::for_str_with_dummy_file(&src);
-        let statement = parser.parse_statement().unwrap().0;
+        let (statement, _) = check_errors(src, |parser| parser.parse_statement()).unwrap();
         let StatementKind::Let(let_statement) = statement.kind else {
             panic!("Expected let statement");
         };
         assert_eq!(let_statement.pattern.to_string(), "x");
         assert_eq!(let_statement.r#type.unwrap().to_string(), "u64");
         assert_eq!(let_statement.expression.to_string(), "2");
-
-        let reason = get_single_error_reason(&parser.errors, span);
-        assert!(matches!(reason, ParserErrorReason::MissingColonInLetStatement));
     }
 
     #[test]
@@ -817,28 +802,20 @@ mod tests {
         // This shouldn't be parsed as a call
         let src = "
         return 1
-        ^^^^^^^^
+        ^^^^^^^^ Early 'return' is unsupported
         ";
-        let (src, span) = get_source_with_error_span(src);
-        let mut parser = Parser::for_str_with_dummy_file(&src);
-        let statement = parser.parse_statement_or_error();
+        let statement = check_errors(src, |parser| parser.parse_statement_or_error());
         assert!(matches!(statement.kind, StatementKind::Error));
-        let reason = get_single_error_reason(&parser.errors, span);
-        assert!(matches!(reason, ParserErrorReason::EarlyReturn));
     }
 
     #[test]
     fn recovers_on_unknown_statement_followed_by_actual_statement() {
         let src = "
         ] let x = 1;
-        ^
+        ^ Expected a statement but found ']'
         ";
-        let (src, span) = get_source_with_error_span(src);
-        let mut parser = Parser::for_str_with_dummy_file(&src);
-        let statement = parser.parse_statement_or_error();
+        let statement = check_errors(src, |parser| parser.parse_statement_or_error());
         assert!(matches!(statement.kind, StatementKind::Let(..)));
-        let error = get_single_error(&parser.errors, span);
-        assert_snapshot!(error.to_string(), @"Expected a statement but found ']'");
     }
 
     #[test]

--- a/compiler/noirc_frontend/src/parser/parser/structs.rs
+++ b/compiler/noirc_frontend/src/parser/parser/structs.rs
@@ -147,17 +147,12 @@ impl Parser<'_> {
 
 #[cfg(test)]
 mod tests {
-    use insta::assert_snapshot;
-
     use crate::{
         ast::{NoirStruct, UnresolvedGeneric},
         parse_program_with_dummy_file,
         parser::{
-            ItemKind, ParserErrorReason,
-            parser::tests::{
-                expect_no_errors, get_single_error, get_single_error_reason,
-                get_source_with_error_span,
-            },
+            ItemKind,
+            parser::tests::{check_errors, expect_no_errors},
         },
     };
 
@@ -268,22 +263,18 @@ mod tests {
     fn parse_error_no_function_attributes_allowed_on_struct() {
         let src = "
         #[test] struct Foo {}
-        ^^^^^^^
+        ^^^^^^^ A function attribute cannot be placed on a struct or enum
         ";
-        let (src, span) = get_source_with_error_span(src);
-        let (_, errors) = parse_program_with_dummy_file(&src);
-        let reason = get_single_error_reason(&errors, span);
-        assert!(matches!(reason, ParserErrorReason::NoFunctionAttributesAllowedOnType));
+        check_errors(src, |parser| parser.parse_program());
     }
 
     #[test]
     fn recovers_on_non_field() {
         let src = "
         struct Foo { 42 x: i32 }
-                     ^^
+                     ^^ Expected an identifier but found '42'
         ";
-        let (src, span) = get_source_with_error_span(src);
-        let (module, errors) = parse_program_with_dummy_file(&src);
+        let module = check_errors(src, |parser| parser.parse_program());
 
         assert_eq!(module.items.len(), 1);
         let item = &module.items[0];
@@ -292,8 +283,5 @@ mod tests {
         };
         assert_eq!("Foo", noir_struct.name.to_string());
         assert_eq!(noir_struct.fields.len(), 1);
-
-        let error = get_single_error(&errors, span);
-        assert_snapshot!(error.to_string(), @"Expected an identifier but found '42'");
     }
 }

--- a/compiler/noirc_frontend/src/parser/parser/tests.rs
+++ b/compiler/noirc_frontend/src/parser/parser/tests.rs
@@ -1,46 +1,103 @@
 #![cfg(test)]
 
-use noirc_errors::Span;
+use noirc_errors::{CustomDiagnostic, Span};
 
-use crate::parser::{ParserError, ParserErrorReason};
+use crate::parser::{Parser, ParserError};
 
-pub(super) fn get_source_with_error_span(src: &str) -> (String, Span) {
-    let mut lines: Vec<&str> = src.trim_end().lines().collect();
-    let squiggles_line = lines.pop().expect("Expected at least two lines in src (the last one should have squiggles for the error location)");
-    let squiggle_index = squiggles_line
-        .chars()
-        .position(|char| char == '^')
-        .expect("Expected at least one `^` character in the last line of the src");
-    let squiggle_length = squiggles_line.len() - squiggle_index;
-    let last_line = lines.last().expect("Expected at least two lines in src");
-    let src = lines.join("\n");
-    let span_start = src.len() - last_line.len() + squiggle_index;
-    let span_end = span_start + squiggle_length;
-    let span = Span::from(span_start as u32..span_end as u32);
-    (src, span)
-}
+/// Run `parse` on `src` (which may contain inline `^^^ message` annotations) and verify
+/// that the parser produces exactly those errors at those locations. Returns the value
+/// returned by `parse` so the test can make further assertions on the parsed AST.
+///
+/// An annotation line directly follows the line it refers to, for example:
+///
+/// ```ignore
+/// let src = "
+///     { let x = 1 }
+///               ^ Expected a ; after `let` statement
+///     ";
+/// check_errors(src, |parser| parser.parse_expression_or_error());
+/// ```
+///
+/// The caret(s) indicate the span of the error, and the text that follows is the
+/// expected primary diagnostic message produced by the parser at that span.
+pub(super) fn check_errors<T>(src: &str, parse: impl FnOnce(&mut Parser<'_>) -> T) -> T {
+    let mut code_lines = Vec::new();
+    let mut expected_errors: Vec<(Span, String)> = Vec::new();
 
-pub(super) fn get_single_error(errors: &[ParserError], expected_span: Span) -> &ParserError {
-    if errors.is_empty() {
-        panic!("Expected an error, found none");
-    }
+    // Trim trailing whitespace so that "end of input" error spans line up with the last
+    // code character the test wrote, rather than the indentation of the closing `";`.
+    let trimmed = src.trim_end();
 
-    if errors.len() > 1 {
-        for error in errors {
-            println!("{error}");
+    let mut byte = 0;
+    let mut last_line_length = 0;
+    for line in trimmed.lines() {
+        if let Some((span, message)) = get_error_line_span_and_message(line, byte, last_line_length)
+        {
+            expected_errors.push((span, message));
+            continue;
         }
-        panic!("Expected one error, found {} errors (printed above)", errors.len());
+
+        code_lines.push(line);
+        byte += line.len() + 1; // For '\n'
+        last_line_length = line.len();
     }
 
-    assert_eq!(errors[0].span(), expected_span);
-    &errors[0]
+    let src = code_lines.join("\n");
+    let mut parser = Parser::for_str_with_dummy_file(&src);
+    let result = parse(&mut parser);
+
+    let mut actual_errors: Vec<(Span, String)> = parser
+        .errors
+        .iter()
+        .map(|error| {
+            let diagnostic: CustomDiagnostic = error.into();
+            let span = diagnostic.secondaries.first().map_or_else(
+                || panic!("Expected error to have a secondary label: {error}"),
+                |label| label.location.span,
+            );
+            (span, diagnostic.message)
+        })
+        .collect();
+
+    expected_errors.sort();
+    actual_errors.sort();
+
+    if expected_errors != actual_errors {
+        panic!(
+            "Parser errors didn't match annotations.\n\nExpected:\n{}\n\nActual:\n{}\n",
+            format_errors(&expected_errors),
+            format_errors(&actual_errors),
+        );
+    }
+
+    result
 }
 
-pub(super) fn get_single_error_reason(
-    errors: &[ParserError],
-    expected_span: Span,
-) -> &ParserErrorReason {
-    get_single_error(errors, expected_span).reason().unwrap()
+/// Helper for `check_errors` that returns the span of the `^^^^` annotation, together
+/// with the message that follows it on the same line.
+fn get_error_line_span_and_message(
+    line: &str,
+    byte: usize,
+    last_line_length: usize,
+) -> Option<(Span, String)> {
+    if !line.trim().starts_with('^') {
+        return None;
+    }
+
+    let chars = line.chars().collect::<Vec<_>>();
+    let first_caret = chars.iter().position(|c| *c == '^').unwrap();
+    let last_caret = chars.iter().rposition(|c| *c == '^').unwrap();
+    let start = byte - last_line_length;
+    let span = Span::from((start + first_caret - 1) as u32..(start + last_caret) as u32);
+    let message = line.trim().trim_start_matches('^').trim().to_string();
+    Some((span, message))
+}
+
+fn format_errors(errors: &[(Span, String)]) -> String {
+    if errors.is_empty() {
+        return "  (no errors)".to_string();
+    }
+    errors.iter().map(|(span, msg)| format!("  {span:?}: {msg}")).collect::<Vec<_>>().join("\n")
 }
 
 pub(super) fn expect_no_errors(errors: &[ParserError]) {

--- a/compiler/noirc_frontend/src/parser/parser/traits.rs
+++ b/compiler/noirc_frontend/src/parser/parser/traits.rs
@@ -304,10 +304,7 @@ mod tests {
         parse_program_with_dummy_file,
         parser::{
             ItemKind,
-            parser::{
-                ParserErrorReason,
-                tests::{expect_no_errors, get_single_error, get_source_with_error_span},
-            },
+            parser::tests::{check_errors, expect_no_errors},
         },
     };
 
@@ -357,10 +354,12 @@ mod tests {
 
     #[test]
     fn parse_empty_trait_alias() {
-        let src = "trait Foo = ;";
-        let (_module, errors) = parse_program_with_dummy_file(src);
-        assert_eq!(errors.len(), 2);
-        assert_eq!(errors[1].reason(), Some(ParserErrorReason::EmptyTraitAlias).as_ref());
+        let src = "
+        trait Foo = ;
+                  ^ Empty trait alias
+                    ^ Expected a trait bound but found ';'
+        ";
+        check_errors(src, |parser| parser.parse_program());
     }
 
     #[test]
@@ -416,10 +415,12 @@ mod tests {
 
     #[test]
     fn parse_empty_trait_alias_with_generics() {
-        let src = "trait Foo<A, B> = ;";
-        let (_module, errors) = parse_program_with_dummy_file(src);
-        assert_eq!(errors.len(), 2);
-        assert_eq!(errors[1].reason(), Some(ParserErrorReason::EmptyTraitAlias).as_ref());
+        let src = "
+        trait Foo<A, B> = ;
+                        ^ Empty trait alias
+                          ^ Expected a trait bound but found ';'
+        ";
+        check_errors(src, |parser| parser.parse_program());
     }
 
     #[test]
@@ -479,10 +480,12 @@ mod tests {
 
     #[test]
     fn parse_empty_trait_alias_with_where_clause() {
-        let src = "trait Foo<A, B> = where A: Z;";
-        let (_module, errors) = parse_program_with_dummy_file(src);
-        assert_eq!(errors.len(), 2);
-        assert_eq!(errors[1].reason(), Some(ParserErrorReason::EmptyTraitAlias).as_ref());
+        let src = "
+        trait Foo<A, B> = where A: Z;
+                        ^ Empty trait alias
+                          ^^^^^ Expected a trait bound but found 'where'
+        ";
+        check_errors(src, |parser| parser.parse_program());
     }
 
     #[test]
@@ -535,12 +538,9 @@ mod tests {
     fn parse_trait_with_constant_default_value() {
         let src = "
         trait Foo { let x: Field = 1 + 2; }
-                                   ^^^^^
+                                   ^^^^^ Associated trait constant default values are not supported
         ";
-        let (src, span) = get_source_with_error_span(src);
-        let (_module, errors) = parse_program_with_dummy_file(&src);
-        let error = get_single_error(&errors, span).to_string();
-        assert!(error.contains("Associated trait constant default values are not supported"));
+        check_errors(src, |parser| parser.parse_program());
     }
 
     #[test]
@@ -575,12 +575,9 @@ mod tests {
     fn parse_trait_function_with_visibility() {
         let src = "
         trait Foo { pub fn foo(); }
-                    ^^^
+                    ^^^ Visibility is ignored on a trait method
         ";
-        let (src, span) = get_source_with_error_span(src);
-        let (_module, errors) = parse_program_with_dummy_file(&src);
-        let error = get_single_error(&errors, span);
-        assert!(error.to_string().contains("Visibility is ignored on a trait method"));
+        check_errors(src, |parser| parser.parse_program());
     }
 
     #[test]

--- a/compiler/noirc_frontend/src/parser/parser/type_alias.rs
+++ b/compiler/noirc_frontend/src/parser/parser/type_alias.rs
@@ -92,10 +92,8 @@ mod tests {
         ast::{TypeAlias, UnresolvedType, UnresolvedTypeData},
         parse_program_with_dummy_file,
         parser::{
-            ItemKind, ParserErrorReason,
-            parser::tests::{
-                expect_no_errors, get_single_error_reason, get_source_with_error_span,
-            },
+            ItemKind,
+            parser::tests::{check_errors, expect_no_errors},
         },
     };
 
@@ -164,18 +162,14 @@ mod tests {
     fn parse_numeric_type_alias_without_type() {
         let src = "
         type Foo = 1 + 2;
-                   ^^^^^
+                   ^^^^^ type expression is not allowed for type aliases (Is this a numeric type alias? If so, the numeric type must be specified with `: <type>`
         ";
-        let (src, span) = get_source_with_error_span(src);
-        let (mut module, errors) = parse_program_with_dummy_file(&src);
-        assert!(!errors.is_empty());
+        let mut module = check_errors(src, |parser| parser.parse_program());
         assert_eq!(module.items.len(), 1);
         let item = module.items.remove(0);
         let ItemKind::TypeAlias(alias) = item.kind else {
             panic!("Expected type alias");
         };
         assert_eq!(alias.name.to_string(), "Foo");
-        let reason = get_single_error_reason(&errors, span);
-        assert!(matches!(reason, ParserErrorReason::UnexpectedTypeExpressionInTypeAlias));
     }
 }

--- a/compiler/noirc_frontend/src/parser/parser/type_expression.rs
+++ b/compiler/noirc_frontend/src/parser/parser/type_expression.rs
@@ -410,12 +410,9 @@ mod tests {
         BinaryTypeOperator,
         ast::{UnresolvedType, UnresolvedTypeData, UnresolvedTypeExpression},
         parser::{
-            Parser, ParserErrorReason,
-            parser::tests::{
-                expect_no_errors, get_single_error_reason, get_source_with_error_span,
-            },
+            Parser,
+            parser::tests::{check_errors, expect_no_errors},
         },
-        token::Token,
     };
 
     fn parse_type_expression_no_errors(src: &str) -> UnresolvedTypeExpression {
@@ -586,19 +583,9 @@ mod tests {
     fn parses_type_or_type_expression_tuple_type_missing_comma() {
         let src = "
         (Field bool)
-               ^^^^
+               ^^^^ Expected a `,` separating these two tuple items
         ";
-        let (src, span) = get_source_with_error_span(src);
-        let mut parser = Parser::for_str_with_dummy_file(&src);
-
-        let typ = parser.parse_type_or_type_expression().unwrap();
-
-        let reason = get_single_error_reason(&parser.errors, span);
-        let ParserErrorReason::ExpectedTokenSeparatingTwoItems { token, items } = reason else {
-            panic!("Expected a different error");
-        };
-        assert_eq!(token, &Token::Comma);
-        assert_eq!(*items, "tuple items");
+        let typ = check_errors(src, |parser| parser.parse_type_or_type_expression().unwrap());
 
         let UnresolvedTypeData::Tuple(types) = typ.typ else {
             panic!("Expected tuple type");

--- a/compiler/noirc_frontend/src/parser/parser/types.rs
+++ b/compiler/noirc_frontend/src/parser/parser/types.rs
@@ -316,13 +316,11 @@ impl Parser<'_> {
 
 #[cfg(test)]
 mod tests {
-    use insta::assert_snapshot;
-
     use crate::{
         ast::{UnresolvedType, UnresolvedTypeData},
         parser::{
             Parser,
-            parser::tests::{expect_no_errors, get_single_error, get_source_with_error_span},
+            parser::tests::{check_errors, expect_no_errors},
         },
     };
 
@@ -488,13 +486,9 @@ mod tests {
     fn errors_if_missing_right_bracket_after_vector_type() {
         let src = "
         [Field
-             ^
+             ^ Expected a ']' but found end of input
         ";
-        let (src, span) = get_source_with_error_span(src);
-        let mut parser = Parser::for_str_with_dummy_file(&src);
-        parser.parse_type();
-        let error = get_single_error(&parser.errors, span);
-        assert_snapshot!(error.to_string(), @"Expected a ']' but found end of input");
+        check_errors(src, |parser| parser.parse_type());
     }
 
     #[test]

--- a/compiler/noirc_frontend/src/parser/parser/where_clause.rs
+++ b/compiler/noirc_frontend/src/parser/parser/where_clause.rs
@@ -88,12 +88,9 @@ mod tests {
     use crate::{
         ast::UnresolvedTraitConstraint,
         parser::{
-            Parser, ParserErrorReason,
-            parser::tests::{
-                expect_no_errors, get_single_error_reason, get_source_with_error_span,
-            },
+            Parser,
+            parser::tests::{check_errors, expect_no_errors},
         },
-        token::Token,
     };
 
     fn parse_where_clause_no_errors(src: &str) -> Vec<UnresolvedTraitConstraint> {
@@ -146,18 +143,9 @@ mod tests {
     fn parses_two_where_clauses_missing_comma() {
         let src = "
         where Foo: Bar<T> i32: Qux {
-                          ^^^
+                          ^^^ Expected a `,` separating these two where clauses
         ";
-        let (src, span) = get_source_with_error_span(src);
-        let mut parser = Parser::for_str_with_dummy_file(&src);
-        let mut constraints = parser.parse_where_clause();
-
-        let reason = get_single_error_reason(&parser.errors, span);
-        let ParserErrorReason::ExpectedTokenSeparatingTwoItems { token, items } = reason else {
-            panic!("Expected a different error");
-        };
-        assert_eq!(token, &Token::Comma);
-        assert_eq!(*items, "where clauses");
+        let mut constraints = check_errors(src, |parser| parser.parse_where_clause());
 
         assert_eq!(constraints.len(), 2);
 


### PR DESCRIPTION
## Problem Resolved

No issue.

## Summary of Changes

At some point I introduced a small helper to easily check parser error locations, thought the format didn't contain the message or enum variant so that had to be checked separately. I didn't put too much effort into it because back then we only tested a few parser errors. Now that we have a lot of them it's a good time to have a better helper. The only downside is that we have to update the tests if error messages change, but that doesn't happen frequently.

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
