### PR TITLE
fix(ssa): Use `canonic_eq` in `Store`/`Load` validation

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/interpreter/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/interpreter/mod.rs
@@ -1379,7 +1379,7 @@ impl<'ssa, W: Write> Interpreter<'ssa, W> {
             elements.iter().zip(element_types.iter().cycle()).enumerate()
         {
             let actual_type = element.get_type();
-            if &actual_type != expected_type {
+            if !actual_type.canonical_eq(expected_type) {
                 return Err(internal(InternalError::MakeArrayElementTypeMismatch {
                     result,
                     index,

--- a/compiler/noirc_evaluator/src/ssa/interpreter/tests/instructions.rs
+++ b/compiler/noirc_evaluator/src/ssa/interpreter/tests/instructions.rs
@@ -1162,6 +1162,31 @@ fn make_array() {
 }
 
 #[test]
+fn make_array_allows_reference_mutability_mismatch() {
+    // Reference mutability is a frontend concern with no meaning at the SSA
+    // level: the validator accepts a `&mut T` value in a `&T` MakeArray slot,
+    // and the interpreter must agree so that running the post-validation SSA
+    // doesn't fail with `MakeArrayElementTypeMismatch`. The unconstrained
+    // SSA-gen pattern this guards is a tuple `[&mut T, &T]` constructed from
+    // a mutable allocate alongside an immutable one — exactly what the
+    // `pass_vs_prev` fuzzer surfaces when it interprets intermediate SSA
+    // between passes.
+    executes_with_no_errors(
+        "
+        brillig(inline) fn main f0 {
+          b0():
+            v0 = allocate -> &mut Field
+            store Field 1 at v0
+            v1 = allocate -> &Field
+            store Field 2 at v1
+            v2 = make_array [v0, v1] : [&Field; 2]
+            return
+        }
+    ",
+    );
+}
+
+#[test]
 fn nop() {
     executes_with_no_errors(
         "

--- a/compiler/noirc_evaluator/src/ssa/validation/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/validation/mod.rs
@@ -315,7 +315,7 @@ impl<'f> Validator<'f> {
                 };
 
                 let value_type = dfg.type_of_value(*value);
-                if **address_value_type != *value_type {
+                if !address_value_type.canonical_eq(&value_type) {
                     panic!(
                         "Store address type {address_value_type} does not match value type {value_type}"
                     );
@@ -1203,8 +1203,10 @@ impl<'f> Validator<'f> {
                 };
                 let result = dfg.instruction_results(instruction)[0];
                 let result_type = dfg.type_of_value(result);
-                if *result_type != *expected_type {
-                    panic!("load should return {expected_type}, not {result_type}");
+                if !result_type.canonical_eq(expected_type) {
+                    panic!(
+                        "load should return {expected_type}, not {result_type}; address = {address}, result = {result}"
+                    );
                 }
             }
             Instruction::Store { address, value } => {
@@ -1212,8 +1214,10 @@ impl<'f> Validator<'f> {
                     return;
                 };
                 let value_type = dfg.type_of_value(*value);
-                if *value_type != *expected_type {
-                    panic!("store value should have type {expected_type}, not {value_type}");
+                if !value_type.canonical_eq(expected_type) {
+                    panic!(
+                        "store value should have type {expected_type}, not {value_type}; address = {address}, value = {value}"
+                    );
                 }
             }
             _ => (),
@@ -2097,6 +2101,63 @@ mod tests {
             v1 = allocate -> &mut &mut Field
             store v0 at v1
             v2 = make_array [v1] : [&mut &Field; 1]
+            return
+        }
+        ";
+        let _ = Ssa::from_str(src).unwrap();
+    }
+
+    #[test]
+    fn store_allows_reference_mutability_mismatch() {
+        // Reference mutability is a frontend concern with no meaning at the SSA
+        // level, so a `&mut Field` value is accepted at a `&mut &Field` slot
+        // (and vice versa). The minimal SSA-gen pattern this guards is an
+        // assignment like `b.1 = &b.0` inside an unconstrained mutable tuple:
+        // the slot is allocated as `&mut &T` while the right-hand side carries
+        // `&mut T` because `b.0` itself lives in a mutable binding.
+        let src = "
+        acir(inline) fn main f0 {
+          b0():
+            v0 = allocate -> &mut Field
+            v1 = allocate -> &mut &Field
+            store v0 at v1
+            return
+        }
+        ";
+        let _ = Ssa::from_str(src).unwrap();
+
+        let src = "
+        acir(inline) fn main f0 {
+          b0():
+            v0 = allocate -> &Field
+            v1 = allocate -> &mut &mut Field
+            store v0 at v1
+            return
+        }
+        ";
+        let _ = Ssa::from_str(src).unwrap();
+    }
+
+    #[test]
+    fn load_allows_reference_mutability_mismatch() {
+        // The Load path mirrors the Store path: when an Allocate's recorded
+        // element type only differs from the Load result type by reference
+        // mutability we must accept it.
+        let src = "
+        acir(inline) fn main f0 {
+          b0():
+            v0 = allocate -> &mut &mut Field
+            v1 = load v0 -> &Field
+            return
+        }
+        ";
+        let _ = Ssa::from_str(src).unwrap();
+
+        let src = "
+        acir(inline) fn main f0 {
+          b0():
+            v0 = allocate -> &mut &Field
+            v1 = load v0 -> &mut Field
             return
         }
         ";

--- a/test_programs/compile_success_no_bug/regression_12733/src/main.nr
+++ b/test_programs/compile_success_no_bug/regression_12733/src/main.nr
@@ -22,6 +22,23 @@ fn main(mut a: bool) {
     // Call argument: top-level `&mut → &` (already handled by
     // is_mut_ref_to_immutable_ref).
     baz(&a);
+
+    // Store-into-Allocate path: a mutable unconstrained tuple whose declared
+    // type contains a `&bool` slot is allocated as `&mut &bool`, but `&tup.0`
+    // inside `qux` produces `&mut bool` because `tup.0` lives in the mutable
+    // binding. The SSA validator must accept storing the latter into the
+    // former — same mutability-equivalence rule as the MakeArray / Call /
+    // Block-argument positions above.
+    // safety: no actual unsafety, only exercising unconstrained SSA-gen
+    unsafe {
+        qux(a);
+    }
+}
+
+unconstrained fn qux(a: bool) {
+    let mut tup: (bool, &bool) = (a, &a);
+    let _x = tup.1;
+    tup.1 = &tup.0;
 }
 
 fn foo(mut a: bool) -> &bool {

--- a/tooling/nargo_cli/tests/snapshots/compile_success_no_bug/regression_12732/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_no_bug/regression_12732/execute__tests__expanded.snap
@@ -1,0 +1,10 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: expanded_code
+---
+fn main() {
+    foo(&[1_Field]);
+    foo(&[2_Field]);
+}
+
+fn foo<T>(_x: &T) {}

--- a/tooling/nargo_cli/tests/snapshots/compile_success_no_bug/regression_12733/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_no_bug/regression_12733/execute__tests__expanded.snap
@@ -11,6 +11,16 @@ fn main(mut a: bool) {
     let arr: [&bool; 1] = [&a; 1];
     bar(arr);
     baz(&a);
+    // Safety: comment added by `nargo expand`
+    unsafe {
+        qux(a);
+    }
+}
+
+unconstrained fn qux(a: bool) {
+    let mut tup: (bool, &bool) = (a, &a);
+    let _x: &bool = tup.1;
+    tup.1 = &tup.0;
 }
 
 fn foo(mut a: bool) -> &bool {


### PR DESCRIPTION
## Problem Resolved

Resolves #12733 
Follow up for https://github.com/noir-lang/noir/pull/12751
Discovered in https://github.com/noir-lang/noir/pull/12735



## Summary of Changes

Previously we thought the `Store` and `Load` validation were fine to use strict equality, but the fuzzer found more cases where this wasn't true.

The SSA interpreter also used strict equality in `interpret_make_array`.

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
