### PR TITLE
fix(lsp): correct trait impl generics on hover

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/variable.rs
+++ b/compiler/noirc_frontend/src/elaborator/variable.rs
@@ -196,14 +196,10 @@ impl Elaborator<'_> {
 
             // If this is a function call on a type that has generics, we need to bind those generic types.
             if !type_generics.is_empty() {
-                // `all_generics` has the enclosing type generics first, followed by `direct_generics`
-                // (the method's own generics). We must only bind the type-level portion here;
-                // method generics are handled separately by the method turbofish.
+                // We must only bind the type-level portion here; method generics are handled
+                // separately by the method turbofish.
                 let func_meta = self.function_meta(*func_id);
-                let impl_generic_count =
-                    func_meta.all_generics.len() - func_meta.direct_generics.len();
-                let impl_generics =
-                    vecmap(&func_meta.all_generics[..impl_generic_count], |g| g.type_var.clone());
+                let impl_generics = vecmap(func_meta.impl_generics(), |g| g.type_var.clone());
                 let self_type =
                     func_meta.self_type.as_ref().map(|t| t.follow_bindings_shallow().into_owned());
 
@@ -659,13 +655,9 @@ impl Elaborator<'_> {
             self.intern_expr(HirExpression::Ident(ident.clone(), generics.clone()), ident_location);
 
         // If the method has a self type (it's an impl or trait impl), bind `typ` to the instantiated self type.
-        let (self_type_generics_count, function_typ, function_self_type) =
-            self.with_function_meta(func_id, |meta| {
-                (
-                    meta.all_generics.len() - meta.direct_generics.len(),
-                    meta.typ.clone(),
-                    meta.self_type.clone(),
-                )
+        let (self_type_generics_count, function_typ, function_self_type) = self
+            .with_function_meta(func_id, |meta| {
+                (meta.impl_generics_count(), meta.typ.clone(), meta.self_type.clone())
             });
         let bindings = if self_type_generics_count > 0 {
             if let Type::Forall(type_vars, _) = &function_typ

--- a/compiler/noirc_frontend/src/hir_def/function.rs
+++ b/compiler/noirc_frontend/src/hir_def/function.rs
@@ -196,6 +196,18 @@ impl FuncMeta {
         self.kind.can_ignore_return_type()
     }
 
+    /// Number of generics introduced by the enclosing `impl<...>` (or trait `Self`),
+    /// i.e. the prefix of `all_generics` that is not part of `direct_generics`.
+    pub fn impl_generics_count(&self) -> usize {
+        self.all_generics.len() - self.direct_generics.len()
+    }
+
+    /// The generics introduced by the enclosing `impl<...>` (or trait `Self`).
+    /// These are the leading entries of `all_generics`; the remainder are `direct_generics`.
+    pub fn impl_generics(&self) -> &[ResolvedGeneric] {
+        &self.all_generics[..self.impl_generics_count()]
+    }
+
     pub fn is_unconstrained(&self) -> bool {
         match &self.typ {
             Type::Function(_, _, _, unconstrained) => {

--- a/tooling/lsp/src/requests/hover.rs
+++ b/tooling/lsp/src/requests/hover.rs
@@ -432,6 +432,19 @@ mod hover_tests {
     }
 
     #[test]
+    async fn hover_on_trait_impl_function_self_generics() {
+        assert_hover(
+            "workspace",
+            "two/src/lib.nr",
+            Position { line: 139, character: 6 },
+            "    two
+    impl<A, B> NoGenericsTrait for (A, B)
+    fn quux(self)",
+        )
+        .await;
+    }
+
+    #[test]
     async fn hover_on_trait_impl_method_uses_docs_from_trait_method() {
         let hover_text =
             get_hover_text("workspace", "two/src/lib.nr", Position { line: 92, character: 8 })

--- a/tooling/lsp/src/requests/hover/from_reference.rs
+++ b/tooling/lsp/src/requests/hover/from_reference.rs
@@ -385,31 +385,18 @@ fn format_function(id: FuncId, args: &ProcessRequestCallbackArgs) -> String {
         let trait_impl = trait_impl.borrow();
         let trait_ = args.interner.get_trait(trait_impl.trait_id);
 
-        let ordered_generics = args.interner.get_ordered_generics_for_impl(trait_impl_id);
-
-        let generics = ordered_generics
+        let impl_generics: Vec<_> = func_meta
+            .all_generics
             .iter()
-            .filter_map(|generic| {
-                if let Type::NamedGeneric(generic) = generic {
-                    Some(generic.name.as_str())
-                } else {
-                    None
-                }
-            })
-            .collect::<Vec<_>>();
+            .take(func_meta.all_generics.len() - func_meta.direct_generics.len())
+            .cloned()
+            .collect();
+
+        let ordered_generics = args.interner.get_ordered_generics_for_impl(trait_impl_id);
 
         string.push('\n');
         string.push_str("    impl");
-        if !generics.is_empty() {
-            string.push('<');
-            for (index, generic) in generics.into_iter().enumerate() {
-                if index > 0 {
-                    string.push_str(", ");
-                }
-                string.push_str(generic);
-            }
-            string.push('>');
-        }
+        format_generics(&impl_generics, &mut string);
 
         string.push(' ');
         string.push_str(trait_.name.as_str());

--- a/tooling/lsp/src/requests/hover/from_reference.rs
+++ b/tooling/lsp/src/requests/hover/from_reference.rs
@@ -10,7 +10,7 @@ use noirc_frontend::modules::get_parent_module;
 use noirc_frontend::node_interner::{GlobalValue, TraitAssociatedTypeId};
 use noirc_frontend::shared::Visibility;
 use noirc_frontend::{
-    DataType, EnumVariant, ResolvedGenerics, Shared, StructField, Type, TypeAlias, TypeBinding,
+    DataType, EnumVariant, ResolvedGeneric, Shared, StructField, Type, TypeAlias, TypeBinding,
     TypeVariable,
     ast::ItemVisibility,
     hir::def_map::ModuleId,
@@ -385,18 +385,11 @@ fn format_function(id: FuncId, args: &ProcessRequestCallbackArgs) -> String {
         let trait_impl = trait_impl.borrow();
         let trait_ = args.interner.get_trait(trait_impl.trait_id);
 
-        let impl_generics: Vec<_> = func_meta
-            .all_generics
-            .iter()
-            .take(func_meta.all_generics.len() - func_meta.direct_generics.len())
-            .cloned()
-            .collect();
-
         let ordered_generics = args.interner.get_ordered_generics_for_impl(trait_impl_id);
 
         string.push('\n');
         string.push_str("    impl");
-        format_generics(&impl_generics, &mut string);
+        format_generics(func_meta.impl_generics(), &mut string);
 
         string.push(' ');
         string.push_str(trait_.name.as_str());
@@ -435,17 +428,12 @@ fn format_function(id: FuncId, args: &ProcessRequestCallbackArgs) -> String {
             string.push_str("    ");
             string.push_str("impl");
 
-            let impl_generics: Vec<_> = func_meta
-                .all_generics
-                .iter()
-                .take(func_meta.all_generics.len() - func_meta.direct_generics.len())
-                .cloned()
-                .collect();
-            format_generics(&impl_generics, &mut string);
+            let impl_generics = func_meta.impl_generics();
+            format_generics(impl_generics, &mut string);
 
             string.push(' ');
             string.push_str(data_type.name.as_str());
-            format_generic_names(&impl_generics, &mut string);
+            format_generic_names(impl_generics, &mut string);
         }
 
         true
@@ -649,21 +637,21 @@ fn format_local(id: DefinitionId, args: &ProcessRequestCallbackArgs) -> String {
     }
 }
 
-fn format_generics(generics: &ResolvedGenerics, string: &mut String) {
+fn format_generics(generics: &[ResolvedGeneric], string: &mut String) {
     format_generics_impl(
         generics, false, // only show names
         string,
     );
 }
 
-fn format_generic_names(generics: &ResolvedGenerics, string: &mut String) {
+fn format_generic_names(generics: &[ResolvedGeneric], string: &mut String) {
     format_generics_impl(
         generics, true, // only show names
         string,
     );
 }
 
-fn format_generics_impl(generics: &ResolvedGenerics, only_show_names: bool, string: &mut String) {
+fn format_generics_impl(generics: &[ResolvedGeneric], only_show_names: bool, string: &mut String) {
     if generics.is_empty() {
         return;
     }

--- a/tooling/lsp/test_programs/workspace/two/src/lib.nr
+++ b/tooling/lsp/test_programs/workspace/two/src/lib.nr
@@ -126,3 +126,16 @@ fn use_invalid_global() {
 fn hover_on_numeric_generic<let N: u32>() {
     println(N);
 }
+
+trait NoGenericsTrait {
+    fn quux(self);
+}
+
+impl<A, B> NoGenericsTrait for (A, B) {
+    fn quux(self) {}
+}
+
+fn call_quux() {
+    let t: (i32, i32) = (1, 2);
+    t.quux();
+}


### PR DESCRIPTION
## Problem Resolved

Resolves https://github.com/noir-lang/noir-claude/issues/1188
Resolves [AZTBOT-1080](https://linear.app/aztec-foundation/issue/AZTBOT-1080/lsp-hover-omits-impl-generics-when-trait-impl-generics-only-appear-in)

## Summary of Changes



## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
