### PR TITLE
chore: add new failing test to keccak256

### DIFF
--- a/.github/critical_libraries_status/noir-lang/keccak256/.failures.jsonl
+++ b/.github/critical_libraries_status/noir-lang/keccak256/.failures.jsonl
@@ -1,4 +1,5 @@
 {"suite":"keccak256","name":"keccak256::oracle_tests::test_keccak256_1"}
 {"suite":"keccak256","name":"keccak256::oracle_tests::test_keccak256_100"}
 {"suite":"keccak256","name":"keccak256::oracle_tests::test_keccak256_135"}
+{"suite":"keccak256","name":"keccak256::oracle_tests::test_keccak256_136"}
 {"suite":"keccak256","name":"keccak256::oracle_tests::test_keccak256_256"}


### PR DESCRIPTION
## Problem Resolved

Resolves CI failure.

## Summary of Changes

The commit to this repository isn't pinned and apparently a [new test](https://github.com/noir-lang/keccak256/pull/20) that uses an oracle was added.

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
