### PR TITLE
chore: Document security issues around macros

### DIFF
--- a/docs/docs/noir/concepts/comptime.md
+++ b/docs/docs/noir/concepts/comptime.md
@@ -370,3 +370,46 @@ Registering a derive function could be done as follows:
 #include_code derive_via noir_stdlib/src/meta/mod.nr rust
 
 #include_code big-derive-usage-example noir_stdlib/src/meta/mod.nr rust
+
+---
+
+## Security considerations
+
+Comptime code in a dependency runs as part of your build and can shape the program that ultimately
+gets compiled. Two patterns in particular deserve attention before deploying a program that uses
+third-party comptime code.
+
+### Comptime functions that return `Quoted`
+
+A `Quoted` value is a token stream that becomes program source when it is unquoted or returned from
+an attribute macro. A comptime function in a dependency that returns `Quoted` to your crate — or an
+attribute macro it provides that you apply to one of your own items — can introduce arbitrary items,
+expressions, or trait impls into your crate. The injected code runs as if you had written it
+yourself, even though it does not appear in your source files.
+
+Returning `Quoted` is a deliberate feature of the metaprogramming API and is what makes macros
+useful. The risk is not the feature itself but trusting comptime output from code you have not
+reviewed. When using third-party comptime code:
+
+- Treat any attribute macro a dependency exposes, and any `Quoted` value it returns to you, as code
+  you are vendoring into your crate.
+- Run `nargo expand` on your package after pulling in or upgrading an untrusted dependency, and
+  review the expanded output. The expanded source is the code that actually compiles into your
+  circuit, and is the only authoritative view of what a macro inserted.
+
+### `FunctionDefinition::disable`
+
+The [`disable`](../standard_library/meta/function_def.md#disable) method lets a comptime function
+mark another function as un-callable. A disabled function does not fail at compile time: it fails
+only when something tries to call it, with the error message that was passed to `disable`. A
+malicious or careless dependency that calls `disable` on one of your functions (for example, a
+contract entry point) can therefore take that functionality offline without producing any build-time
+signal.
+
+To catch this before deployment:
+
+- Exercise every externally reachable function — every contract entry point, every public API your
+  callers will hit — at least once in your test suite. A disabled function errors the first time
+  it is invoked, so even a minimal smoke test of each endpoint is enough to detect this case.
+- Run `nargo expand` on your package and inspect the expanded source for `disable` calls on
+  functions that you did not intend to disable.

--- a/docs/docs/noir/standard_library/meta/function_def.md
+++ b/docs/docs/noir/standard_library/meta/function_def.md
@@ -47,6 +47,24 @@ it is already called elsewhere without an error.
 Before switching over to use these newly generated functions, users should run `nargo expand` on any
 untrusted dependencies to ensure their bodies are as expected.
 
+Because a dependency's attribute macro can call `disable` on any function it can name, an untrusted or
+malicious dependency may use `disable` to silently turn off functionality in your program — for example,
+disabling a contract entry point so that it can no longer be invoked. A disabled function does not fail
+at compile time: it fails only when something tries to call it, producing the error message supplied to
+`disable`. This makes it possible to ship a program in which an endpoint or feature has been
+unintentionally taken offline, and gives opportunities for malicious DoS behaviors
+
+Before deploying a program that pulls in third-party comptime code, you should:
+
+- Exercise every entry point of the program (and any externally reachable function) at least once
+  during testing. A `disable`d function errors loudly the first time it is called, so even a minimal
+  smoke test of each endpoint is enough to surface this class of issue.
+- Run `nargo expand` on any untrusted dependencies and review the output for `disable` calls on
+  functions you did not expect to be disabled.
+
+See also the [Security considerations](../../concepts/comptime.md#security-considerations) section of
+the comptime documentation.
+
 ### has_named_attribute
 
 #include_code has_named_attribute noir_stdlib/src/meta/function_def.nr rust

--- a/docs/docs/noir/standard_library/meta/quoted.md
+++ b/docs/docs/noir/standard_library/meta/quoted.md
@@ -70,3 +70,20 @@ Returns a vector of the individual tokens that form this token stream.
 impl Eq for Quoted
 impl Hash for Quoted
 ```
+
+## Security
+
+A `Quoted` value returned by a comptime function from an untrusted dependency is added, when unquoted,
+to the program's source as if you had written it yourself. It can therefore introduce arbitrary items,
+expressions, or trait impls into the crate that calls it, including code that the caller did not write
+or would not approve.
+
+When pulling in comptime code from a dependency you do not control:
+
+- Treat any `Quoted` it returns to you, and any attribute macro it provides, as code you are about
+  to vendor into your own crate.
+- Use `nargo expand` to view the program after macro expansion, and review the result before
+  deployment. The expanded source is the code that actually compiles into your circuit.
+
+See also the [Security considerations](../../concepts/comptime.md#security-considerations) section
+of the comptime documentation.


### PR DESCRIPTION
## Problem Resolved

Resolves audit issue [Comptime code can manipulate caller crate](https://app.audithub.dev/app/organizations/161/projects/600/project-viewer?version=1408&issueId=848)


## Summary of Changes
I updated the docs to explain the potential issues related to macros


## User Documentation

Check one:
- [ ] No user documentation needed.
- [X] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
