### PR TITLE
fix(lsp): don't OOB when completing trait impl function

### DIFF
--- a/tooling/lsp/src/requests/completion.rs
+++ b/tooling/lsp/src/requests/completion.rs
@@ -1376,8 +1376,8 @@ impl Visitor for NodeFinder<'_> {
                     while cursor < bytes.len() && bytes[cursor].is_ascii_whitespace() {
                         cursor += 1;
                     }
-                    let char = bytes[cursor] as char;
-                    if char != '(' && char != '<' {
+                    let char = bytes.get(cursor).copied().map(char::from);
+                    if !matches!(char, Some('(') | Some('<')) {
                         self.suggest_trait_impl_function(noir_trait_impl, noir_function);
                         return false;
                     }

--- a/tooling/lsp/src/requests/completion/tests.rs
+++ b/tooling/lsp/src/requests/completion/tests.rs
@@ -2617,7 +2617,7 @@ fn main() {
     }
 
     #[test]
-    async fn test_suggests_trait_impl_function_when_impl_does_not_have_closing_curly() {
+    async fn suggests_trait_impl_function_when_impl_does_not_have_closing_curly() {
         let src = r#"
         trait Trait {
             fn foo(x: i32) -> i32;

--- a/tooling/lsp/src/requests/completion/tests.rs
+++ b/tooling/lsp/src/requests/completion/tests.rs
@@ -2617,6 +2617,29 @@ fn main() {
     }
 
     #[test]
+    async fn test_suggests_trait_impl_function_when_impl_does_not_have_closing_curly() {
+        let src = r#"
+        trait Trait {
+            fn foo(x: i32) -> i32;
+        }
+
+        struct Foo {}
+
+        impl Trait for Foo {
+            fn f>|<
+        "#;
+
+        assert_completion(
+            src,
+            vec![trait_impl_method_completion_item(
+                "fn foo(..)",
+                "foo(x: i32) -> i32 {\n    ${1}\n}",
+            )],
+        )
+        .await;
+    }
+
+    #[test]
     async fn test_suggests_when_assignment_follows_in_chain_1() {
         let src = r#"
         struct Foo {


### PR DESCRIPTION
## Problem Resolved

Resolves  https://github.com/noir-lang/noir-claude/issues/1187
Resolves [AZTBOT-1079](https://linear.app/aztec-foundation/issue/AZTBOT-1079/lsp-textdocumentcompletion-panics-with-index-out-of-bounds-in)

## Summary of Changes



## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
