### PR TITLE
fix(lsp): let signature help work for "foo(" calls

### DIFF
--- a/tooling/lsp/src/requests/signature_help.rs
+++ b/tooling/lsp/src/requests/signature_help.rs
@@ -367,8 +367,9 @@ impl Visitor for SignatureFinder<'_> {
     fn visit_call_expression(&mut self, call_expression: &CallExpression, span: Span) -> bool {
         call_expression.accept_children(self);
 
-        let arguments_span =
-            Span::from(call_expression.func.location.span.end() + 1..span.end() - 1);
+        let arguments_start = call_expression.func.location.span.end() + 1;
+        let arguments_end = (span.end() - 1).max(arguments_start);
+        let arguments_span = Span::from(arguments_start..arguments_end);
         let span = call_expression.func.location.span;
         let name_span = Span::from(span.end() - 1..span.end());
         let has_self = false;

--- a/tooling/lsp/src/requests/signature_help/tests.rs
+++ b/tooling/lsp/src/requests/signature_help/tests.rs
@@ -311,4 +311,20 @@ mod signature_help_tests {
 
         assert_eq!(signature.active_parameter, Some(0));
     }
+
+    #[test]
+    async fn test_signature_help_for_incomplete_call_after_open_paren() {
+        let src = r#"
+        fn foo(x: i32, y: Field) -> u32 { 0 }
+
+        fn bar() {
+            foo(>|<
+        }
+        "#;
+
+        let signature_help = get_signature_help(src).await;
+        let signature = &signature_help.signatures[0];
+        assert_eq!(signature.label, "fn foo(x: i32, y: Field) -> u32");
+        assert_eq!(signature.active_parameter, Some(0));
+    }
 }


### PR DESCRIPTION
## Problem Resolved

Resolves https://github.com/noir-lang/noir-claude/issues/1186
Resolves [AZTBOT-1078](https://linear.app/aztec-foundation/issue/AZTBOT-1078/lsp-signature-help-panics-on-incomplete-foo-visit-call-expression)

## Summary of Changes



## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
