### PR TITLE
fix: mark all `UHashMap` methods as unconstrained

### DIFF
--- a/noir_stdlib/docs/std/collections/umap/struct.UHashMap.html
+++ b/noir_stdlib/docs/std/collections/umap/struct.UHashMap.html
@@ -73,7 +73,7 @@
 <div class="padded-description"><div class="comments">
 <p>Clears the map, removing all key-value entries.</p>
 </div>
-</div><code id="contains_key" class="code-header">pub fn <a href="#contains_key"><span class="fn">contains_key</span></a>(&mut self: &Self, key: K) -> <a href="../../../std/primitive.bool.html" class="primitive">bool</a>
+</div><code id="contains_key" class="code-header">pub unconstrained fn <a href="#contains_key"><span class="fn">contains_key</span></a>(&mut self: &Self, key: K) -> <a href="../../../std/primitive.bool.html" class="primitive">bool</a>
 <div class="where-clause">where
     K: <a href="../../../std/hash/trait.Hash.html" class="trait">Hash</a>,
     K: <a href="../../../std/cmp/trait.Eq.html" class="trait">Eq</a>,

--- a/noir_stdlib/docs/std/collections/umap/struct.UHashMap.html
+++ b/noir_stdlib/docs/std/collections/umap/struct.UHashMap.html
@@ -68,7 +68,7 @@
 <div class="where-clause">where
     B: <a href="../../../std/hash/trait.BuildHasher.html" class="trait">BuildHasher</a></div></code>
 
-<code id="clear" class="code-header">pub fn <a href="#clear"><span class="fn">clear</span></a>(&mut self)</code>
+<code id="clear" class="code-header">pub unconstrained fn <a href="#clear"><span class="fn">clear</span></a>(&mut self)</code>
 
 <div class="padded-description"><div class="comments">
 <p>Clears the map, removing all key-value entries.</p>
@@ -82,24 +82,24 @@
 <div class="padded-description"><div class="comments">
 <p>Returns true if the map contains a value for the specified key.</p>
 </div>
-</div><code id="is_empty" class="code-header">pub fn <a href="#is_empty"><span class="fn">is_empty</span></a>(&mut self: &Self) -> <a href="../../../std/primitive.bool.html" class="primitive">bool</a></code>
+</div><code id="is_empty" class="code-header">pub unconstrained fn <a href="#is_empty"><span class="fn">is_empty</span></a>(&mut self: &Self) -> <a href="../../../std/primitive.bool.html" class="primitive">bool</a></code>
 
 <div class="padded-description"><div class="comments">
 <p>Returns true if the map contains no elements.</p>
 </div>
-</div><code id="entries" class="code-header">pub fn <a href="#entries"><span class="fn">entries</span></a>(&mut self: &Self) -> [(K, V)]</code>
+</div><code id="entries" class="code-header">pub unconstrained fn <a href="#entries"><span class="fn">entries</span></a>(&mut self: &Self) -> [(K, V)]</code>
 
 <div class="padded-description"><div class="comments">
 <p>Returns a vector of all valid entries in this UHashMap.
 The length of the returned vector will always match the length of this UHashMap.</p>
 </div>
-</div><code id="keys" class="code-header">pub fn <a href="#keys"><span class="fn">keys</span></a>(&mut self: &Self) -> [K]</code>
+</div><code id="keys" class="code-header">pub unconstrained fn <a href="#keys"><span class="fn">keys</span></a>(&mut self: &Self) -> [K]</code>
 
 <div class="padded-description"><div class="comments">
 <p>Returns a vector containing all the keys within this UHashMap.
 The length of the returned vector will always match the length of this UHashMap.</p>
 </div>
-</div><code id="values" class="code-header">pub fn <a href="#values"><span class="fn">values</span></a>(&mut self: &Self) -> [V]</code>
+</div><code id="values" class="code-header">pub unconstrained fn <a href="#values"><span class="fn">values</span></a>(&mut self: &Self) -> [V]</code>
 
 <div class="padded-description"><div class="comments">
 <p>Returns a vector containing all the values within this UHashMap.
@@ -123,22 +123,22 @@ The length of the returned vector will always match the length of this UHashMap.
 <div class="padded-description"><div class="comments">
 <p>For each key applies mutator function.</p>
 </div>
-</div><code id="iter_values_mut" class="code-header">pub fn <a href="#iter_values_mut"><span class="fn">iter_values_mut</span></a>(&mut self, f: fn(V) -> V)</code>
+</div><code id="iter_values_mut" class="code-header">pub unconstrained fn <a href="#iter_values_mut"><span class="fn">iter_values_mut</span></a>(&mut self, f: fn(V) -> V)</code>
 
 <div class="padded-description"><div class="comments">
 <p>For each value applies mutator function.</p>
 </div>
-</div><code id="retain" class="code-header">pub fn <a href="#retain"><span class="fn">retain</span></a>(&mut self, f: fn(K, V) -> <a href="../../../std/primitive.bool.html" class="primitive">bool</a>)</code>
+</div><code id="retain" class="code-header">pub unconstrained fn <a href="#retain"><span class="fn">retain</span></a>(&mut self, f: fn(K, V) -> <a href="../../../std/primitive.bool.html" class="primitive">bool</a>)</code>
 
 <div class="padded-description"><div class="comments">
 <p>Retains only the elements specified by the predicate.</p>
 </div>
-</div><code id="len" class="code-header">pub fn <a href="#len"><span class="fn">len</span></a>(&mut self: &Self) -> <a href="../../../std/primitive.u32.html" class="primitive">u32</a></code>
+</div><code id="len" class="code-header">pub unconstrained fn <a href="#len"><span class="fn">len</span></a>(&mut self: &Self) -> <a href="../../../std/primitive.u32.html" class="primitive">u32</a></code>
 
 <div class="padded-description"><div class="comments">
 <p>Amount of active key-value entries.</p>
 </div>
-</div><code id="capacity" class="code-header">pub fn <a href="#capacity"><span class="fn">capacity</span></a>(&mut self: &Self) -> <a href="../../../std/primitive.u32.html" class="primitive">u32</a></code>
+</div><code id="capacity" class="code-header">pub unconstrained fn <a href="#capacity"><span class="fn">capacity</span></a>(&mut self: &Self) -> <a href="../../../std/primitive.u32.html" class="primitive">u32</a></code>
 
 <div class="padded-description"><div class="comments">
 <p>Get the current capacity of the inner table.</p>

--- a/noir_stdlib/src/collections/umap.nr
+++ b/noir_stdlib/src/collections/umap.nr
@@ -103,14 +103,13 @@ impl<K, V, B> UHashMap<K, V, B> {
 
     /// Returns true if the map contains a value for the specified key.
     // docs:start:contains_key
-    pub fn contains_key(&self, key: K) -> bool
+    pub unconstrained fn contains_key(&self, key: K) -> bool
     where
         K: Hash + Eq,
         B: BuildHasher,
     {
         // docs:end:contains_key
-        // Safety: unconstrained context
-        unsafe { self.get(key) }.is_some()
+        self.get(key).is_some()
     }
 
     /// Returns true if the map contains no elements.

--- a/noir_stdlib/src/collections/umap.nr
+++ b/noir_stdlib/src/collections/umap.nr
@@ -95,7 +95,7 @@ impl<K, V, B> UHashMap<K, V, B> {
 
     /// Clears the map, removing all key-value entries.
     // docs:start:clear
-    pub fn clear(&mut self) {
+    pub unconstrained fn clear(&mut self) {
         // docs:end:clear
         self._table = [Slot::default()].as_vector();
         self._len = 0;
@@ -114,7 +114,7 @@ impl<K, V, B> UHashMap<K, V, B> {
 
     /// Returns true if the map contains no elements.
     // docs:start:is_empty
-    pub fn is_empty(&self) -> bool {
+    pub unconstrained fn is_empty(&self) -> bool {
         // docs:end:is_empty
         self._len == 0
     }
@@ -122,7 +122,7 @@ impl<K, V, B> UHashMap<K, V, B> {
     /// Returns a vector of all valid entries in this UHashMap.
     /// The length of the returned vector will always match the length of this UHashMap.
     // docs:start:entries
-    pub fn entries(&self) -> [(K, V)] {
+    pub unconstrained fn entries(&self) -> [(K, V)] {
         // docs:end:entries
         let mut entries = [].as_vector();
 
@@ -145,7 +145,7 @@ impl<K, V, B> UHashMap<K, V, B> {
     /// Returns a vector containing all the keys within this UHashMap.
     /// The length of the returned vector will always match the length of this UHashMap.
     // docs:start:keys
-    pub fn keys(&self) -> [K] {
+    pub unconstrained fn keys(&self) -> [K] {
         // docs:end:keys
         let mut keys = [].as_vector();
 
@@ -167,7 +167,7 @@ impl<K, V, B> UHashMap<K, V, B> {
     /// Returns a vector containing all the values within this UHashMap.
     /// The length of the returned vector will always match the length of this UHashMap.
     // docs:start:values
-    pub fn values(&self) -> [V] {
+    pub unconstrained fn values(&self) -> [V] {
         // docs:end:values
         let mut values = [].as_vector();
 
@@ -230,7 +230,7 @@ impl<K, V, B> UHashMap<K, V, B> {
 
     /// For each value applies mutator function.
     // docs:start:iter_values_mut
-    pub fn iter_values_mut(&mut self, f: fn(V) -> V) {
+    pub unconstrained fn iter_values_mut(&mut self, f: fn(V) -> V) {
         // docs:end:iter_values_mut
         for i in 0..self._table.len() {
             let mut slot = self._table[i];
@@ -243,7 +243,7 @@ impl<K, V, B> UHashMap<K, V, B> {
 
     /// Retains only the elements specified by the predicate.
     // docs:start:retain
-    pub fn retain(&mut self, f: fn(K, V) -> bool) {
+    pub unconstrained fn retain(&mut self, f: fn(K, V) -> bool) {
         // docs:end:retain
         for index in 0..self._table.len() {
             let mut slot = self._table[index];
@@ -259,14 +259,14 @@ impl<K, V, B> UHashMap<K, V, B> {
 
     /// Amount of active key-value entries.
     // docs:start:len
-    pub fn len(&self) -> u32 {
+    pub unconstrained fn len(&self) -> u32 {
         // docs:end:len
         self._len
     }
 
     /// Get the current capacity of the inner table.
     // docs:start:capacity
-    pub fn capacity(&self) -> u32 {
+    pub unconstrained fn capacity(&self) -> u32 {
         // docs:end:capacity
         self._table.len()
     }
@@ -426,29 +426,38 @@ where
 {
     fn eq(self, other: UHashMap<K, V, B>) -> bool {
         // docs:end:eq
-        let mut equal = false;
+        if crate::runtime::is_unconstrained() {
+            // Safety: Checked above to be in unconstrained context.
+            unsafe {
+                let mut equal = false;
 
-        if self.len() == other.len() {
-            equal = true;
-            for slot in self._table {
-                // Not marked as deleted and has key-value.
-                if equal & slot.is_valid() {
-                    // Safety: unconstrained context
-                    let other_value = unsafe { other.get(slot._key) };
+                if self.len() == other.len() {
+                    equal = true;
+                    for slot in self._table {
+                        // Not marked as deleted and has key-value.
+                        if equal & slot.is_valid() {
+                            // Safety: unconstrained context
+                            let other_value = other.get(slot._key);
 
-                    if other_value.is_none() {
-                        equal = false;
-                    } else {
-                        let other_value = other_value.unwrap_unchecked();
-                        if slot._value != other_value {
-                            equal = false;
+                            if other_value.is_none() {
+                                equal = false;
+                            } else {
+                                let other_value = other_value.unwrap_unchecked();
+                                if slot._value != other_value {
+                                    equal = false;
+                                }
+                            }
                         }
                     }
                 }
-            }
-        }
 
-        equal
+                equal
+            }
+        } else {
+            crate::panic::panic(
+                "Equality check on UHashMap is not supported in constrained context",
+            )
+        }
     }
 }
 

--- a/test_programs/execution_success/regression_4663/src/main.nr
+++ b/test_programs/execution_success/regression_4663/src/main.nr
@@ -17,7 +17,7 @@ impl Default for DummyHasher {
     }
 }
 
-fn main() {
+unconstrained fn main() {
     let map: UHashMap<u64, u64, BuildHasherDefault<DummyHasher>> = UHashMap::default();
     println(map == map);
 }

--- a/test_programs/execution_success/uhashmap/src/main.nr
+++ b/test_programs/execution_success/uhashmap/src/main.nr
@@ -292,9 +292,8 @@ unconstrained fn doc_tests() {
 }
 
 // docs:start:get_example
-fn get_example(map: &UHashMap<Field, Field, BuildHasherDefault<Poseidon2Hasher>>) {
-    // Safety: testing context
-    let x = unsafe { map.get(12) };
+unconstrained fn get_example(map: &UHashMap<Field, Field, BuildHasherDefault<Poseidon2Hasher>>) {
+    let x = map.get(12);
 
     if x.is_some() {
         assert(x.unwrap() == 42);
@@ -302,7 +301,9 @@ fn get_example(map: &UHashMap<Field, Field, BuildHasherDefault<Poseidon2Hasher>>
 }
 // docs:end:get_example
 
-fn entries_examples(map: &UHashMap<Field, Field, BuildHasherDefault<Poseidon2Hasher>>) {
+unconstrained fn entries_examples(
+    map: &UHashMap<Field, Field, BuildHasherDefault<Poseidon2Hasher>>,
+) {
     // docs:start:entries_example
     let entries = map.entries();
 
@@ -319,8 +320,7 @@ fn entries_examples(map: &UHashMap<Field, Field, BuildHasherDefault<Poseidon2Has
     let keys = map.keys();
 
     for key in keys {
-        // Safety: testing context
-        let value = unsafe { map.get(key) }.unwrap_unchecked();
+        let value = map.get(key).unwrap_unchecked();
         println(f"{key} -> {value}");
     }
     // docs:end:keys_example

--- a/tooling/nargo_cli/tests/snapshots/execution_success/regression_4663/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/regression_4663/execute__tests__expanded.snap
@@ -24,7 +24,7 @@ impl Default for DummyHasher {
     }
 }
 
-fn main() {
+unconstrained fn main() {
     let map: UHashMap<u64, u64, BuildHasherDefault<DummyHasher>> =
         UHashMap::<u64, u64, BuildHasherDefault<DummyHasher>>::default();
     println(map == map);

--- a/tooling/nargo_cli/tests/snapshots/execution_success/uhashmap/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/uhashmap/execute__tests__expanded.snap
@@ -260,15 +260,16 @@ unconstrained fn doc_tests() {
     assert(map1 == map2);
 }
 
-fn get_example(map: &UHashMap<Field, Field, BuildHasherDefault<Poseidon2Hasher>>) {
-    // Safety: comment added by `nargo expand`
-    let x: Option<Field> = unsafe { map.get(12_Field) };
+unconstrained fn get_example(map: &UHashMap<Field, Field, BuildHasherDefault<Poseidon2Hasher>>) {
+    let x: Option<Field> = map.get(12_Field);
     if x.is_some() {
         assert(x.unwrap() == 42_Field);
     }
 }
 
-fn entries_examples(map: &UHashMap<Field, Field, BuildHasherDefault<Poseidon2Hasher>>) {
+unconstrained fn entries_examples(
+    map: &UHashMap<Field, Field, BuildHasherDefault<Poseidon2Hasher>>,
+) {
     let entries: [(Field, Field)] = map.entries();
     for i in 0_u32..map.capacity() {
         if i < entries.len() {
@@ -282,8 +283,7 @@ fn entries_examples(map: &UHashMap<Field, Field, BuildHasherDefault<Poseidon2Has
         for ___i1 in 0_u32..___i0.len() {
             let key: Field = ___i0[___i1];
             {
-                // Safety: comment added by `nargo expand`
-                let value: Field = unsafe { map.get(key) }.unwrap_unchecked();
+                let value: Field = map.get(key).unwrap_unchecked();
                 println(f"{key} -> {value}");
             }
         }


### PR DESCRIPTION
## Problem Resolved

Resolves https://github.com/noir-lang/noir-claude/issues/822

## Summary of Changes

`UHashMap` is intended to only be used in an unconstrained or comptime runtime however we mark a lot of the methods as constrained. This PR marks all methods as unconstrained and makes `UHashMap::eq` panic in a constrained runtime to enforce this. 

## User Documentation

Check one:
- [ ] No user documentation needed.
- [x] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
