### PR TITLE
fix: Fix private trait's method being visible when imported directly

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/path_resolution.rs
+++ b/compiler/noirc_frontend/src/elaborator/path_resolution.rs
@@ -11,7 +11,9 @@ use crate::hir::resolution::import::{
 };
 
 use crate::hir::resolution::errors::ResolverError;
-use crate::hir::resolution::visibility::item_in_module_is_visible;
+use crate::hir::resolution::visibility::{
+    item_in_module_is_visible, trait_visibility_for_method_is_satisfied,
+};
 
 use crate::locations::ReferencesTracker;
 use crate::node_interner::{
@@ -821,7 +823,7 @@ impl Elaborator<'_> {
                 source_module,
                 visibility,
             ) {
-                errors.push(PathResolutionError::Private(name));
+                errors.push(PathResolutionError::Private(name.clone()));
             }
         } else if !item_in_module_is_visible(
             self.def_maps,
@@ -829,6 +831,20 @@ impl Elaborator<'_> {
             current_module_id,
             visibility,
         ) {
+            errors.push(PathResolutionError::Private(name.clone()));
+        }
+
+        // A trait method imported via `Type::method` must also be reachable through its trait's
+        // visibility (e.g. a `pub(crate) trait` is not accessible from another crate, even if the
+        // method's own visibility check above passes).
+        if let ModuleDefId::FunctionId(func_id) = module_def_id
+            && !trait_visibility_for_method_is_satisfied(
+                func_id,
+                importing_module,
+                self.interner,
+                self.def_maps,
+            )
+        {
             errors.push(PathResolutionError::Private(name));
         }
 

--- a/compiler/noirc_frontend/src/elaborator/types.rs
+++ b/compiler/noirc_frontend/src/elaborator/types.rs
@@ -25,8 +25,9 @@ use crate::{
         def_collector::dc_crate::CompilationError,
         def_map::{ModuleDefId, ModuleId, fully_qualified_module_path},
         resolution::{
-            errors::ResolverError, import::PathResolutionError,
-            visibility::item_in_module_is_visible,
+            errors::ResolverError,
+            import::PathResolutionError,
+            visibility::{item_in_module_is_visible, trait_visibility_for_method_is_satisfied},
         },
         type_check::{
             Source, TypeCheckError,
@@ -1714,6 +1715,17 @@ impl Elaborator<'_> {
                 let mut errors = path_resolution.errors;
                 if let Some(error) = error {
                     errors.push(error);
+                }
+
+                let importing_module =
+                    ModuleId { krate: self.crate_id, local_id: self.local_module() };
+                if !trait_visibility_for_method_is_satisfied(
+                    func_id,
+                    importing_module,
+                    self.interner,
+                    self.def_maps,
+                ) {
+                    errors.push(PathResolutionError::Private(last_segment.ident.clone()));
                 }
 
                 let method = TraitPathResolutionMethod::TraitItem(trait_method);

--- a/compiler/noirc_frontend/src/hir/def_collector/dc_crate.rs
+++ b/compiler/noirc_frontend/src/hir/def_collector/dc_crate.rs
@@ -12,7 +12,11 @@ use crate::usage_tracker::UnusedItem;
 use crate::{ResolvedGenerics, Type};
 
 use crate::hir::Context;
-use crate::hir::resolution::import::{ImportDirective, ResolvedImport, resolve_import};
+use crate::hir::def_map::ModuleDefId;
+use crate::hir::resolution::import::{
+    ImportDirective, PathResolutionError, ResolvedImport, resolve_import,
+};
+use crate::hir::resolution::visibility::trait_visibility_for_method_is_satisfied;
 
 use crate::ast::{Expression, NoirEnumeration, PathKind, TypeAlias};
 use crate::node_interner::{
@@ -681,6 +685,28 @@ impl DefCollector {
         errors: &mut CompilationErrors,
     ) {
         let local_module_id = collected_import.module_id;
+        let name = collected_import.name();
+
+        // Importing a trait method via `Type::method` must respect the trait's own visibility
+        // (e.g. a `pub(crate) trait` is not reachable from another crate, even though the
+        // method is registered as `Public` in the type's module scope). Compute this before
+        // taking a mutable borrow of `context.def_maps` below.
+        let importing_module = ModuleId { krate: crate_id, local_id: local_module_id };
+        for (module_def_id, _, _) in resolved_import.namespace.iter_items() {
+            if let ModuleDefId::FunctionId(func_id) = module_def_id
+                && !trait_visibility_for_method_is_satisfied(
+                    func_id,
+                    importing_module,
+                    &context.def_interner,
+                    &context.def_maps,
+                )
+            {
+                errors.push(DefCollectorErrorKind::PathResolutionError(
+                    PathResolutionError::Private(name.clone()),
+                ));
+            }
+        }
+
         let current_def_map = context.def_maps.get_mut(&crate_id).unwrap();
         let file_id = current_def_map.file_id(local_module_id);
 
@@ -690,7 +716,6 @@ impl DefCollector {
         }
 
         // Populate module namespaces according to the imports used
-        let name = collected_import.name();
         let visibility = collected_import.visibility;
         let is_prelude = collected_import.is_prelude;
         for (module_def_id, item_visibility, _) in resolved_import.namespace.iter_items() {
@@ -786,7 +811,7 @@ impl DefCollector {
 }
 
 fn add_import_reference(
-    def_id: crate::hir::def_map::ModuleDefId,
+    def_id: ModuleDefId,
     name: &Ident,
     interner: &mut NodeInterner,
     file_id: FileId,

--- a/compiler/noirc_frontend/src/hir/resolution/visibility.rs
+++ b/compiler/noirc_frontend/src/hir/resolution/visibility.rs
@@ -91,6 +91,28 @@ pub fn trait_member_is_visible(
     type_member_is_visible(trait_id.0, visibility, current_module_id, def_maps)
 }
 
+/// Returns true if the trait that `func_id` belongs to (as a trait declaration or trait impl)
+/// is visible from `current_module`. Returns true if `func_id` is not a trait method, or if
+/// its function meta has not been registered yet (in which case there's nothing to check).
+pub fn trait_visibility_for_method_is_satisfied(
+    func_id: FuncId,
+    current_module: ModuleId,
+    interner: &NodeInterner,
+    def_maps: &DefMaps,
+) -> bool {
+    let Some(func_meta) = interner.try_function_meta(&func_id) else { return true };
+    let visibility = interner.function_modifiers(&func_id).visibility;
+
+    if let Some(trait_id) = func_meta.trait_id {
+        return trait_member_is_visible(trait_id, visibility, current_module, def_maps);
+    }
+    if let Some(trait_impl_id) = func_meta.trait_impl {
+        let trait_id = interner.get_trait_implementation(trait_impl_id).borrow().trait_id;
+        return trait_member_is_visible(trait_id, visibility, current_module, def_maps);
+    }
+    true
+}
+
 /// Returns whether a struct or trait member with the given visibility is visible from `current_module_id`.
 fn type_member_is_visible(
     type_module_id: ModuleId,
@@ -146,21 +168,11 @@ pub fn method_call_is_visible(
         ItemVisibility::PublicCrate | ItemVisibility::Private => {
             let func_meta = interner.function_meta(&func_id);
 
-            if let Some(trait_id) = func_meta.trait_id {
-                return trait_member_is_visible(
-                    trait_id,
-                    modifiers.visibility,
+            if func_meta.trait_id.is_some() || func_meta.trait_impl.is_some() {
+                return trait_visibility_for_method_is_satisfied(
+                    func_id,
                     current_module,
-                    def_maps,
-                );
-            }
-
-            if let Some(trait_impl_id) = func_meta.trait_impl {
-                let trait_impl = interner.get_trait_implementation(trait_impl_id);
-                return trait_member_is_visible(
-                    trait_impl.borrow().trait_id,
-                    modifiers.visibility,
-                    current_module,
+                    interner,
                     def_maps,
                 );
             }

--- a/test_programs/compile_failure/trait_visibility_via_path/Nargo.toml
+++ b/test_programs/compile_failure/trait_visibility_via_path/Nargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "trait_visibility_via_path"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.33.0"
+
+[dependencies]
+victim = { path = "./victim" }

--- a/test_programs/compile_failure/trait_visibility_via_path/src/main.nr
+++ b/test_programs/compile_failure/trait_visibility_via_path/src/main.nr
@@ -1,0 +1,13 @@
+use victim;
+use victim::Vault::set_secret;
+
+fn main() {
+    let original_vault = victim::new();
+    let original_secret = victim::read(original_vault);
+    assert(original_secret == 1);
+
+    let hijacked_vault = set_secret(original_vault, 31337);
+
+    let hijacked_secret = victim::read(hijacked_vault);
+    assert(hijacked_secret == 31337);
+}

--- a/test_programs/compile_failure/trait_visibility_via_path/victim/Nargo.toml
+++ b/test_programs/compile_failure/trait_visibility_via_path/victim/Nargo.toml
@@ -1,0 +1,5 @@
+[package]
+name = "victim"
+type = "lib"
+authors = [""]
+compiler_version = ">=0.33.0"

--- a/test_programs/compile_failure/trait_visibility_via_path/victim/src/lib.nr
+++ b/test_programs/compile_failure/trait_visibility_via_path/victim/src/lib.nr
@@ -1,0 +1,22 @@
+pub(crate) trait Secret {
+    fn set_secret(v: Vault, new_secret: Field) -> Vault;
+}
+
+pub struct Vault {
+    pub value: Field,
+}
+
+pub fn new() -> Vault {
+    Vault { value: 1 }
+}
+
+pub fn read(v: Vault) -> Field {
+    v.value
+}
+
+impl Secret for Vault {
+    fn set_secret(mut v: Vault, new_secret: Field) -> Vault {
+        v.value = new_secret;
+        v
+    }
+}

--- a/tooling/nargo_cli/tests/snapshots/compile_failure/trait_visibility_via_path/execute__tests__stderr.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_failure/trait_visibility_via_path/execute__tests__stderr.snap
@@ -1,0 +1,19 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: stderr
+---
+error: set_secret is private and not visible from the current module
+  ┌─ src/main.nr:2:20
+  │
+2 │ use victim::Vault::set_secret;
+  │                    ---------- set_secret is private
+  │
+
+error: set_secret is private and not visible from the current module
+  ┌─ src/main.nr:9:26
+  │
+9 │     let hijacked_vault = set_secret(original_vault, 31337);
+  │                          ---------- set_secret is private
+  │
+
+Aborting due to 2 previous errors


### PR DESCRIPTION
## Problem Resolved

Resolves an issue that came up on slack: https://aztecfoundation.slack.com/archives/C0B1MPE4FAT/p1779393479552239

## Summary of Changes

Previously, when you had a `pub(crate)` trait, but imported its function directly from another crate, such as `use lib::foo::MyTrait::trait_method`, the compiler would not check the trait's visibility and would always allow importing `trait_method` directly. This fix ensures we always check the trait's visibility.

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
