### PR TITLE
fix(expand): make it work in the stdlib

### DIFF
--- a/compiler/noirc_frontend/src/hir/printer/items.rs
+++ b/compiler/noirc_frontend/src/hir/printer/items.rs
@@ -38,16 +38,16 @@ pub enum Item {
 }
 
 impl Item {
-    pub fn module_def_id(&self) -> ModuleDefId {
-        match self {
+    pub fn module_def_id(&self) -> Option<ModuleDefId> {
+        Some(match self {
             Item::Module(module) => ModuleDefId::ModuleId(module.id),
             Item::DataType(data_type) => ModuleDefId::TypeId(data_type.id),
             Item::Trait(trait_) => ModuleDefId::TraitId(trait_.id),
             Item::TypeAlias(type_alias_id) => ModuleDefId::TypeAliasId(*type_alias_id),
-            Item::PrimitiveType(_) => panic!("No ModuleDefId for PrimitiveType"),
+            Item::PrimitiveType(_) => return None,
             Item::Global(global_id) => ModuleDefId::GlobalId(*global_id),
             Item::Function(func_id) => ModuleDefId::FunctionId(*func_id),
-        }
+        })
     }
 }
 

--- a/compiler/noirc_frontend/src/hir/printer/mod.rs
+++ b/compiler/noirc_frontend/src/hir/printer/mod.rs
@@ -171,7 +171,7 @@ impl<'context, 'string> ItemPrinter<'context, 'string> {
     }
 
     fn show_item_with_visibility(&mut self, item: Item, visibility: ItemVisibility) {
-        let module_def_id = item.module_def_id();
+        let Some(module_def_id) = item.module_def_id() else { return };
         let reference_id = module_def_id_to_reference_id(module_def_id);
         self.show_doc_comments(reference_id);
         self.show_module_def_id_attributes(module_def_id);

--- a/tooling/nargo_doc/src/lib.rs
+++ b/tooling/nargo_doc/src/lib.rs
@@ -160,7 +160,7 @@ impl DocItemBuilder<'_> {
         let module_def_id = if let expand_items::Item::PrimitiveType(..) = item {
             None
         } else {
-            Some(item.module_def_id())
+            item.module_def_id()
         };
         let converted_item = match item {
             expand_items::Item::Module(module) => {


### PR DESCRIPTION
## Problem Resolved

Resolves https://github.com/noir-lang/noir-claude/issues/1192
Resolves [AZTBOT-1084](https://linear.app/aztec-foundation/issue/AZTBOT-1084/lsp-nargoexpand-on-stdlib-uri-panics-in-hir-printer-primitivetype)

## Summary of Changes



## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
