### PR TITLE
chore(lsp): open real stdlib in debug mode

### DIFF
--- a/compiler/noirc_driver/src/lib.rs
+++ b/compiler/noirc_driver/src/lib.rs
@@ -53,7 +53,7 @@ mod stdlib;
 
 pub use abi_gen::gen_abi;
 pub use noirc_frontend::graph::{CrateId, CrateName};
-pub use stdlib::{stdlib_nargo_toml_source, stdlib_paths_with_source};
+pub use stdlib::{stdlib_disk_path, stdlib_nargo_toml_source, stdlib_paths_with_source};
 
 const STD_CRATE_NAME: &str = "std";
 const DEBUG_CRATE_NAME: &str = "__debug";

--- a/compiler/noirc_driver/src/stdlib.rs
+++ b/compiler/noirc_driver/src/stdlib.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use rust_embed::RustEmbed;
 
 #[derive(RustEmbed)]
@@ -26,4 +28,16 @@ pub fn stdlib_paths_with_source() -> Vec<(String, String)> {
 /// Returns the contents of the Nargo.toml file for the standard library as a string.
 pub fn stdlib_nargo_toml_source() -> String {
     include_str!("../../../noir_stdlib/Nargo.toml").to_string()
+}
+
+/// Returns the absolute path to the `noir_stdlib/src` directory on disk, when the
+/// running binary was built from the monorepo (debug build only) and the directory
+/// is still reachable from where the binary was compiled. Returns `None` for
+/// release builds or when the source tree is no longer present (e.g. a distributed
+/// `nargo`), so callers must fall back to the embedded stdlib copy.
+pub fn stdlib_disk_path() -> Option<PathBuf> {
+    if !cfg!(debug_assertions) {
+        return None;
+    }
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../noir_stdlib/src").canonicalize().ok()
 }

--- a/tooling/lsp/src/notifications/mod.rs
+++ b/tooling/lsp/src/notifications/mod.rs
@@ -632,7 +632,7 @@ fn uri_from_path(path: &Path) -> Option<Url> {
     if let Ok(uri) = Url::from_file_path(path) {
         Some(uri)
     } else if path.starts_with("std") {
-        Some(Url::parse(&format!("noir-std://{}", path.to_string_lossy())).unwrap())
+        Some(crate::requests::stdlib_path_to_uri(&path.to_string_lossy()))
     } else {
         None
     }

--- a/tooling/lsp/src/requests/hover.rs
+++ b/tooling/lsp/src/requests/hover.rs
@@ -255,6 +255,19 @@ fn use_struct_method() {
             .expect("Could not resolve root path");
         let workspace_on_src_lib_path = workspace_on_src_lib_path.to_string_lossy();
 
+        // Mirror the production gating: when the stdlib is reachable on disk
+        // (debug build of the monorepo), the hover link is a `file://` URI to
+        // the actual source; otherwise it falls back to the read-only `noir-std:`
+        // scheme. Driving the branch off `stdlib_disk_path()` keeps the test in
+        // sync if the gating condition changes.
+        let expected_bounded_vec_link = match noirc_driver::stdlib_disk_path() {
+            Some(disk_root) => {
+                let path = disk_root.join("collections/bounded_vec.nr");
+                format!("Go to [BoundedVec](file://{}", path.to_string_lossy())
+            }
+            None => "Go to [BoundedVec](noir-std:".to_string(),
+        };
+
         let hover_text = get_hover_text(
             r#"use one::subone;
 use std::collections::bounded_vec::BoundedVec;
@@ -265,7 +278,10 @@ fn instantiate_generic() {
         )
         .await;
         assert!(hover_text.contains("    let x: BoundedVec<SubOneStruct, 3>"));
-        assert!(hover_text.contains("Go to [BoundedVec](noir-std:"));
+        assert!(
+            hover_text.contains(&expected_bounded_vec_link),
+            "expected hover text to contain {expected_bounded_vec_link:?}, got: {hover_text}",
+        );
         assert!(
             hover_text.contains(&format!(
                 "[SubOneStruct](file://{workspace_on_src_lib_path}#L4,12-4,24)"

--- a/tooling/lsp/src/requests/mod.rs
+++ b/tooling/lsp/src/requests/mod.rs
@@ -553,10 +553,29 @@ pub(crate) fn to_lsp_location(
     if let Ok(uri) = Url::from_file_path(path.clone()) {
         Some(Location { uri, range })
     } else if path.starts_with("std/") {
-        Some(Location { uri: Url::from_str(&format!("noir-std://{path}")).unwrap(), range })
+        Some(Location { uri: stdlib_path_to_uri(&path), range })
     } else {
         None
     }
+}
+
+/// Map a canonical stdlib path (e.g. `std/array.nr`) to a URI for the LSP client.
+/// When the stdlib source is reachable on disk (debug builds compiled from the
+/// monorepo), emits a `file://` URI so editors open the real file and edits land
+/// on disk. Otherwise falls back to `noir-std://`, which the client resolves
+/// through the `nargo/stdSourceCode` custom request into a read-only document.
+pub(crate) fn stdlib_path_to_uri(stdlib_path: &str) -> Url {
+    if let Some(rest) = stdlib_path.strip_prefix("std/")
+        && let Some(disk_root) = noirc_driver::stdlib_disk_path()
+    {
+        let resolved = disk_root.join(rest);
+        if resolved.is_file()
+            && let Ok(uri) = Url::from_file_path(&resolved)
+        {
+            return uri;
+        }
+    }
+    Url::from_str(&format!("noir-std://{stdlib_path}")).unwrap()
 }
 
 pub(crate) fn on_shutdown(


### PR DESCRIPTION
## Problem Resolved

No issue.

## Summary of Changes

Just a little something I wanted to have for some time.

Before this PR, in LSP, navigating to an stdlib item always opened a read-only view of the file. With this PR, in debug mode, it opens the actual file.

Note: if you make changes to that file you then have to reload the LSP. However, I find that opening the real file, when I quickly want to make changes and test them, is faster than realizing it's a copy I can't modify, then having to modify the actual file, then having to restar the server anyway.

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
