### PR TITLE
fix(monomorphization): include closure env

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/ssa_gen/tests.rs
+++ b/compiler/noirc_evaluator/src/ssa/ssa_gen/tests.rs
@@ -18,6 +18,62 @@ use noirc_frontend::test_utils::{
     get_monomorphized_with_stdlib, stdlib_src,
 };
 
+#[test]
+fn zeroed_closure_type_arity() {
+    let src = r#"
+    fn main(x: u32) {
+        let f: fn[(Field,)](u32) -> [Field; 2] = zeroed();
+        let _ = f(x);
+    }
+    "#;
+    let program = get_monomorphized_with_stdlib(src, &[stdlib_src::ZEROED]).unwrap();
+    insta::assert_snapshot!(program.to_string(), @r"
+    fn main$f0(x$l0: u32) -> () {
+        let f$l5 = (((0), zeroed_lambda$f1), ((0), zeroed_lambda$f2));
+        let _$l7 = {
+            let tmp$l6 = f$l5.0;
+            tmp$l6.1(tmp$l6.0, x$l0)
+        }
+    }
+    fn zeroed_lambda$f1(mut env$l1: (Field,), _$l2: u32) -> [Field; 2] {
+        [0; 2]
+    }
+    unconstrained fn zeroed_lambda$f2(mut env$l3: (Field,), _$l4: u32) -> [Field; 2] {
+        [0; 2]
+    }
+    ");
+
+    let _ = generate_ssa(program).unwrap();
+}
+
+#[test]
+fn zeroed_closure_type_no_args() {
+    let src = r#"
+    fn main() {
+        let f: fn[(Field,)]() -> Field = zeroed();
+        let _ = f();
+    }
+    "#;
+    let program = get_monomorphized_with_stdlib(src, &[stdlib_src::ZEROED]).unwrap();
+    insta::assert_snapshot!(program.to_string(), @r"
+    fn main$f0() -> () {
+        let f$l2 = (((0), zeroed_lambda$f1), ((0), zeroed_lambda$f2));
+        let _$l4 = {
+            let tmp$l3 = f$l2.0;
+            tmp$l3.1(tmp$l3.0)
+        }
+    }
+    fn zeroed_lambda$f1(mut env$l0: (Field,)) -> Field {
+        0
+    }
+    unconstrained fn zeroed_lambda$f2(mut env$l1: (Field,)) -> Field {
+        0
+    }
+    ");
+
+    let _ = generate_ssa(program).unwrap();
+}
+
 fn get_initial_ssa(src: &str) -> Result<Ssa, RuntimeError> {
     let program = match get_monomorphized(src) {
         Ok(program) => program,

--- a/compiler/noirc_frontend/src/monomorphization/builtin.rs
+++ b/compiler/noirc_frontend/src/monomorphization/builtin.rs
@@ -260,7 +260,17 @@ impl Monomorphizer<'_> {
     ) -> ast::Expression {
         let lambda_name = "zeroed_lambda";
 
-        let parameters = vecmap(parameter_types, |parameter_type| {
+        let mut parameters = Vec::with_capacity(parameter_types.len() + 1);
+        if !matches!(env_type.as_ref(), ast::Type::Unit) {
+            parameters.push((
+                self.next_local_id(),
+                true,
+                "env".into(),
+                env_type.clone(),
+                Visibility::Private,
+            ));
+        }
+        parameters.extend(parameter_types.iter().map(|parameter_type| {
             (
                 self.next_local_id(),
                 false,
@@ -268,7 +278,7 @@ impl Monomorphizer<'_> {
                 Rc::new(parameter_type.clone()),
                 Visibility::Private,
             )
-        });
+        }));
 
         let body = self.zeroed_value_of_type(&ret_type, location);
 

--- a/compiler/noirc_frontend/src/monomorphization/tests.rs
+++ b/compiler/noirc_frontend/src/monomorphization/tests.rs
@@ -1231,6 +1231,34 @@ fn evaluates_builtin_zeroed_function() {
 }
 
 #[test]
+fn evaluates_builtin_zeroed_closure_type() {
+    let src = r#"
+    fn main(x: u32) {
+        let f: fn[(Field,)](u32) -> [Field; 2] = zeroed();
+        let _ = f(x);
+    }
+    "#;
+
+    let program = get_monomorphized_with_stdlib(src, &[stdlib_src::ZEROED]).unwrap();
+
+    insta::assert_snapshot!(program, @r"
+    fn main$f0(x$l0: u32) -> () {
+        let f$l5 = (((0), zeroed_lambda$f1), ((0), zeroed_lambda$f2));
+        let _$l7 = {
+            let tmp$l6 = f$l5.0;
+            tmp$l6.1(tmp$l6.0, x$l0)
+        }
+    }
+    fn zeroed_lambda$f1(mut env$l1: (Field,), _$l2: u32) -> [Field; 2] {
+        [0; 2]
+    }
+    unconstrained fn zeroed_lambda$f2(mut env$l3: (Field,), _$l4: u32) -> [Field; 2] {
+        [0; 2]
+    }
+    ");
+}
+
+#[test]
 fn evaluates_builtin_checked_transmute() {
     let src = r#"
     fn main() {


### PR DESCRIPTION
## Problem Resolved

Resolves https://github.com/noir-lang/noir-claude/issues/1111
Resolves [AZTBOT-1003](https://linear.app/aztec-foundation/issue/AZTBOT-1003/monomorphization-create-zeroed-function-omits-env-parameter-for)

## Summary of Changes



## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
