### PR TITLE
fix: elaborate numeric type alias in its module

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/variable.rs
+++ b/compiler/noirc_frontend/src/elaborator/variable.rs
@@ -84,6 +84,7 @@ impl Elaborator<'_> {
                 // but it is not a real variable so it does not resolve to a valid Identifier.
                 // In order to handle this, we retrieve the numeric generics expression that the type aliases to.
                 let type_alias = self.interner.get_type_alias(type_alias_id);
+                let alias_module_id = type_alias.borrow().module_id;
                 if let Some(type_alias_expr) = &type_alias.borrow().numeric_expr {
                     // Extract the declared numeric type from the type alias's kind.
                     let declared_type = match type_alias.borrow().typ.kind() {
@@ -149,7 +150,14 @@ impl Elaborator<'_> {
                     // literals queued for the function-context fit check during
                     // re-elaboration so the same overflow is not reported twice.
                     let literals_before = self.integer_literal_expr_ids_len();
+                    // Re-elaborate the alias body in the alias's defining module
+                    // so unqualified names resolve against the alias's scope,
+                    // not the caller's. Mirrors `define_type_alias` in mod.rs.
+                    let previous_module = self.replace_module(alias_module_id);
                     let (id, typ) = self.elaborate_expression(var_expr);
+                    if let Some(previous_module) = previous_module {
+                        self.replace_module(previous_module);
+                    }
                     self.truncate_integer_literal_expr_ids(literals_before);
                     self.pop_scope();
 

--- a/compiler/noirc_frontend/src/tests/aliases.rs
+++ b/compiler/noirc_frontend/src/tests/aliases.rs
@@ -195,7 +195,7 @@ fn numeric_type_alias_body_resolves_in_defining_module() {
     pub mod lib {
         pub global N: u32 = 2;
 
-        // This N must refere to the N above, not the global N one.
+        // This N must refer to the N above, not the global N one.
         // There was a bug around this.
         pub type Size: u32 = N;
     }

--- a/compiler/noirc_frontend/src/tests/aliases.rs
+++ b/compiler/noirc_frontend/src/tests/aliases.rs
@@ -190,6 +190,27 @@ fn type_alias_to_numeric_generic() {
 }
 
 #[test]
+fn numeric_type_alias_body_resolves_in_defining_module() {
+    let src = r#"
+    pub mod lib {
+        pub global N: u32 = 2;
+
+        // This N must refere to the N above, not the global N one.
+        // There was a bug around this.
+        pub type Size: u32 = N;
+    }
+
+    pub global N: u32 = 5;
+
+    fn main() {
+        comptime { assert_eq(lib::Size, 2); }
+        let _: [u32; lib::Size] = [0; lib::Size];
+    }
+    "#;
+    assert_no_errors(src);
+}
+
+#[test]
 fn disallows_composing_numeric_type_aliases_as_type_syntax() {
     // Double<Double<N>> uses type syntax (Named with generics), not expression syntax.
     // try_into_expression rejects Named with non-empty generics.


### PR DESCRIPTION
## Problem Resolved

Resolves https://github.com/noir-lang/noir-claude/issues/1106
Resolves [AZTBOT-998](https://linear.app/aztec-foundation/issue/AZTBOT-998/noirc-frontend-numeric-type-alias-value-position-re-elaborates-alias)

## Summary of Changes



## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
