### PR TITLE
fix(licm): only apply to ascending loops

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/opt/loop_invariant.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/loop_invariant.rs
@@ -94,7 +94,7 @@ use crate::ssa::{
         dom::DominatorTree,
         function::Function,
         function_inserter::FunctionInserter,
-        instruction::{Instruction, InstructionId},
+        instruction::{Binary, BinaryOp, Instruction, InstructionId, TerminatorInstruction},
         integer::IntegerConstant,
         post_order::PostOrder,
         types::{NumericType, Type},
@@ -811,13 +811,9 @@ fn does_loop_execute(bounds: Option<(IntegerConstant, IntegerConstant)>) -> bool
         .unwrap_or(false)
 }
 
-/// Keep track of a loop induction variable and respective upper bound.
-///
-/// In the case of a nested loop, this will be used by later loops to determine
-/// whether they have operations reliant upon the maximum induction variable.
-///
-/// When within the current loop, the known upper bound can be used to simplify instructions,
-/// such as transforming a checked add to an unchecked add.
+/// Keep track of a loop induction variable and respective lower/upper bound,
+/// but only when the loop's back-edge proves the bounds are real iteration
+/// invariants (see [`back_edge_advances_monotonically`]).
 fn get_induction_var_bounds(
     inserter: &FunctionInserter,
     loop_: &Loop,
@@ -826,7 +822,49 @@ fn get_induction_var_bounds(
     let bounds =
         loop_.get_const_bounds(&inserter.function.dfg, pre_header, |v| inserter.resolve(v))?;
     let induction_variable = get_induction_variable(inserter, loop_)?;
+    if !back_edge_advances_monotonically(&inserter.function.dfg, loop_, induction_variable) {
+        return None;
+    }
     Some((induction_variable, bounds))
+}
+
+/// Whether the loop's back-edge passes back an induction value of the form
+/// `induction_variable + positive_constant`. This is what makes the lower/upper
+/// bounds returned by [`Loop::get_const_bounds`] true loop invariants —
+/// otherwise the values reaching the header on each iteration may fall outside
+/// the inferred `[lower, upper)` interval, and downstream passes that rely on
+/// the bounds (e.g. converting checked arithmetic to unchecked) become unsound.
+fn back_edge_advances_monotonically(
+    dfg: &DataFlowGraph,
+    loop_: &Loop,
+    induction_variable: ValueId,
+) -> bool {
+    let Some(TerminatorInstruction::Jmp { destination, arguments, .. }) =
+        dfg[loop_.back_edge_start].terminator()
+    else {
+        return false;
+    };
+    if *destination != loop_.header || arguments.is_empty() {
+        return false;
+    }
+    let Some(instruction) = dfg.get_local_or_global_instruction(arguments[0]) else {
+        return false;
+    };
+    let Instruction::Binary(Binary { lhs, operator: BinaryOp::Add { .. }, rhs }) = instruction
+    else {
+        return false;
+    };
+    let step_value = if *lhs == induction_variable {
+        *rhs
+    } else if *rhs == induction_variable {
+        *lhs
+    } else {
+        return false;
+    };
+    let Some(step) = dfg.get_integer_constant(step_value) else {
+        return false;
+    };
+    !step.is_zero() && !step.is_negative()
 }
 
 /// Indicate whether an instruction can be hoisted.
@@ -1007,6 +1045,82 @@ mod tests {
         let ssa = Ssa::from_str(src).unwrap();
         let _ =
             assert_pass_does_not_affect_execution(ssa, Vec::new(), Ssa::loop_invariant_code_motion);
+    }
+
+    #[test]
+    fn decreasing_while_back_edge_keeps_sub_checked() {
+        // Regression for noir-lang/noir-claude#1303: `get_const_bounds` infers `[5, 10)`
+        // from the pre-header and the `lt` in the header, but the back-edge subtracts 1
+        // each iteration so `v0` actually takes the values 5, 4, 3, 2, 1, 0. LICM must
+        // not rewrite `sub v0, u32 2` to `unchecked_sub` here.
+        let src = r#"
+        brillig(inline) predicate_pure fn main f0 {
+          b0():
+            jmp b1(u32 5)
+          b1(v0: u32):
+            v4 = lt v0, u32 10
+            jmpif v4 then: b2(), else: b3()
+          b2():
+            v5 = mul v0, v0
+            v7 = eq v5, u32 0
+            v9 = sub v0, u32 2
+            jmpif v7 then: b4(v9), else: b1(v9)
+          b3():
+            jmp b4(v0)
+          b4(v1: u32):
+            return v1
+        }
+        "#;
+        assert_ssa_does_not_change(src, Ssa::loop_invariant_code_motion);
+    }
+
+    #[test]
+    fn decreasing_while_keeps_constrain_not_equal() {
+        // Latent vulnerability tied to noir-lang/noir-claude#1303: with a decreasing
+        // back-edge, `[5, 10)` is not a real loop invariant, so the rewrite of
+        // `constrain v0 != 3` in `simplify_not_equal_constraint` (which would lift the
+        // constrain into the pre-header as `3 < 5 || 3 > 10`, always true) must not
+        // fire. Pre-fix, the constrain was silently elided, hiding a real failure when
+        // `v0` reached 3.
+        let src = r#"
+        brillig(inline) predicate_pure fn main f0 {
+          b0():
+            jmp b1(u32 5)
+          b1(v0: u32):
+            v3 = lt v0, u32 10
+            jmpif v3 then: b2(), else: b3()
+          b2():
+            constrain v0 != u32 3
+            v6 = sub v0, u32 1
+            jmp b1(v6)
+          b3():
+            return
+        }
+        "#;
+        assert_ssa_does_not_change(src, Ssa::loop_invariant_code_motion);
+    }
+
+    #[test]
+    fn non_additive_back_edge_keeps_sub_checked() {
+        // Sibling regression for the same bug class: the back-edge multiplies the
+        // induction variable, so the inferred `[5, 10)` interval is not a true loop
+        // invariant.
+        let src = r#"
+        brillig(inline) fn main f0 {
+          b0():
+            jmp b1(u32 5)
+          b1(v0: u32):
+            v3 = lt v0, u32 10
+            jmpif v3 then: b2(), else: b3()
+          b2():
+            v5 = sub v0, u32 1
+            v7 = unchecked_mul v0, u32 2
+            jmp b1(v7)
+          b3():
+            return v0
+        }
+        "#;
+        assert_ssa_does_not_change(src, Ssa::loop_invariant_code_motion);
     }
 
     #[test]
@@ -1679,8 +1793,8 @@ mod tests {
 
     #[test]
     fn transform_safe_sub_to_unchecked() {
-        // This test is identical to `do_not_transform_unsafe_sub_to_unchecked`, except the loop
-        // in this test starts with a lower bound of `1`.
+        // Like `do_not_transform_unsafe_sub_to_unchecked`, but the loop starts with a
+        // lower bound of `1` so `v2 - 1` cannot underflow at any iteration.
         let src = "
         brillig(inline) fn main f0 {
           b0(v0: u32, v1: u32):
@@ -1692,13 +1806,14 @@ mod tests {
               return
           b3():
               v8 = sub v2, u32 1
-              jmp b1(v8)
+              v9 = unchecked_add v2, u32 1
+              jmp b1(v9)
         }
         ";
 
         let ssa = Ssa::from_str(src).unwrap();
 
-        // `v8 = sub v2, u32 1` in b3 should now be `v9 = unchecked_sub v2, u32 1` in b3
+        // `v8 = sub v2, u32 1` in b3 should now be `unchecked_sub v2, u32 1` in b3
         let ssa = ssa.loop_invariant_code_motion();
         assert_ssa_snapshot!(ssa, @r"
         brillig(inline) fn main f0 {
@@ -1711,7 +1826,8 @@ mod tests {
             return
           b3():
             v6 = unchecked_sub v2, u32 1
-            jmp b1(v6)
+            v7 = unchecked_add v2, u32 1
+            jmp b1(v7)
         }
         ");
     }

--- a/compiler/noirc_evaluator/src/ssa/opt/loop_invariant.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/loop_invariant.rs
@@ -884,7 +884,7 @@ fn back_edge_advances_monotonically(
     let Some(step) = dfg.get_integer_constant(step_value) else {
         return false;
     };
-    if step.is_zero() || step.is_negative() {
+    if step.is_negative() {
         return false;
     }
     if *unchecked {

--- a/compiler/noirc_evaluator/src/ssa/opt/loop_invariant.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/loop_invariant.rs
@@ -94,7 +94,10 @@ use crate::ssa::{
         dom::DominatorTree,
         function::Function,
         function_inserter::FunctionInserter,
-        instruction::{Binary, BinaryOp, Instruction, InstructionId, TerminatorInstruction},
+        instruction::{
+            Binary, BinaryOp, Instruction, InstructionId, TerminatorInstruction,
+            binary::{BinaryEvaluationResult, eval_constant_binary_op},
+        },
         integer::IntegerConstant,
         post_order::PostOrder,
         types::{NumericType, Type},
@@ -822,22 +825,35 @@ fn get_induction_var_bounds(
     let bounds =
         loop_.get_const_bounds(&inserter.function.dfg, pre_header, |v| inserter.resolve(v))?;
     let induction_variable = get_induction_variable(inserter, loop_)?;
-    if !back_edge_advances_monotonically(&inserter.function.dfg, loop_, induction_variable) {
+    if !back_edge_advances_monotonically(
+        &inserter.function.dfg,
+        loop_,
+        induction_variable,
+        bounds.1,
+    ) {
         return None;
     }
     Some((induction_variable, bounds))
 }
 
-/// Whether the loop's back-edge passes back an induction value of the form
-/// `induction_variable + positive_constant`. This is what makes the lower/upper
-/// bounds returned by [`Loop::get_const_bounds`] true loop invariants —
-/// otherwise the values reaching the header on each iteration may fall outside
-/// the inferred `[lower, upper)` interval, and downstream passes that rely on
-/// the bounds (e.g. converting checked arithmetic to unchecked) become unsound.
+/// Whether the loop's back-edge preserves the inferred `[lower, upper)` interval.
+/// Two shapes qualify:
+///
+/// 1. The back-edge passes the induction variable through unchanged
+///    (`jmp header(v_induction, ..)`). This is the canonical form a zero-step
+///    loop is reduced to once `x + 0` has been folded; the variable is constant
+///    at `lower`, which is a subset of `[lower, upper)`.
+/// 2. The back-edge passes back `induction_variable + positive_constant`. For
+///    an unchecked Add we additionally verify that the largest reachable
+///    induction value (`upper - 1`) plus the step does not wrap the underlying
+///    numeric type — otherwise wrapping could deposit an out-of-range value
+///    back into the header. A checked Add cannot violate the invariant: any
+///    wrap would trap before the back-edge fires.
 fn back_edge_advances_monotonically(
     dfg: &DataFlowGraph,
     loop_: &Loop,
     induction_variable: ValueId,
+    upper: IntegerConstant,
 ) -> bool {
     let Some(TerminatorInstruction::Jmp { destination, arguments, .. }) =
         dfg[loop_.back_edge_start].terminator()
@@ -847,10 +863,14 @@ fn back_edge_advances_monotonically(
     if *destination != loop_.header || arguments.is_empty() {
         return false;
     }
+    if arguments[0] == induction_variable {
+        return true;
+    }
     let Some(instruction) = dfg.get_local_or_global_instruction(arguments[0]) else {
         return false;
     };
-    let Instruction::Binary(Binary { lhs, operator: BinaryOp::Add { .. }, rhs }) = instruction
+    let Instruction::Binary(Binary { lhs, operator: BinaryOp::Add { unchecked }, rhs }) =
+        instruction
     else {
         return false;
     };
@@ -864,7 +884,29 @@ fn back_edge_advances_monotonically(
     let Some(step) = dfg.get_integer_constant(step_value) else {
         return false;
     };
-    !step.is_zero() && !step.is_negative()
+    if step.is_zero() || step.is_negative() {
+        return false;
+    }
+    if *unchecked {
+        let Some(max_induction_value) = upper.dec() else {
+            return false;
+        };
+        let operand_type = dfg.type_of_value(induction_variable).unwrap_numeric();
+        let (max_field, _) = max_induction_value.into_numeric_constant();
+        let (step_field, _) = step.into_numeric_constant();
+        match eval_constant_binary_op(
+            max_field,
+            step_field,
+            BinaryOp::Add { unchecked: false },
+            operand_type,
+        ) {
+            BinaryEvaluationResult::Success(..) => {}
+            BinaryEvaluationResult::CouldNotEvaluate | BinaryEvaluationResult::Failure(..) => {
+                return false;
+            }
+        }
+    }
+    true
 }
 
 /// Indicate whether an instruction can be hoisted.
@@ -1098,6 +1140,70 @@ mod tests {
         }
         "#;
         assert_ssa_does_not_change(src, Ssa::loop_invariant_code_motion);
+    }
+
+    #[test]
+    fn wrapping_unchecked_back_edge_keeps_add_checked() {
+        // With bounds `(0, 251)` but a step of `10` from an unchecked back-edge,
+        // `v0` wraps past `upper - 1 = 250` (250 + 10 = 260, wrap to 4) and
+        // re-enters the body with values not in the inferred interval. LICM must
+        // not record bounds, so the checked `add v0, u8 4` stays checked even
+        // though both `0 + 4` and `251 + 4` evaluate safely at the extremes.
+        let src = r#"
+        brillig(inline) fn main f0 {
+          b0():
+            jmp b1(u8 0)
+          b1(v0: u8):
+            v3 = lt v0, u8 251
+            jmpif v3 then: b2(), else: b3()
+          b2():
+            v5 = add v0, u8 4
+            v7 = unchecked_add v0, u8 10
+            jmp b1(v7)
+          b3():
+            return
+        }
+        "#;
+        assert_ssa_does_not_change(src, Ssa::loop_invariant_code_motion);
+    }
+
+    #[test]
+    fn back_edge_passing_induction_through_unchanged_still_allows_simplification() {
+        // After `x + 0` is folded by an earlier pass the back-edge becomes a
+        // plain `jmp header(v_induction, ..)`. The induction variable is then
+        // constant at the lower bound, which is still inside `[lower, upper)`,
+        // so `sub v0, u32 1` may be rewritten to `unchecked_sub` because the
+        // bound extremes prove it cannot underflow.
+        let src = "
+        brillig(inline) fn main f0 {
+          b0():
+            jmp b1(u32 1)
+          b1(v0: u32):
+            v3 = lt v0, u32 4
+            jmpif v3 then: b2(), else: b3()
+          b2():
+            v5 = sub v0, u32 1
+            jmp b1(v0)
+          b3():
+            return
+        }
+        ";
+        let ssa = Ssa::from_str(src).unwrap();
+        let ssa = ssa.loop_invariant_code_motion();
+        assert_ssa_snapshot!(ssa, @r"
+        brillig(inline) fn main f0 {
+          b0():
+            jmp b1(u32 1)
+          b1(v0: u32):
+            v3 = lt v0, u32 4
+            jmpif v3 then: b2(), else: b3()
+          b2():
+            v4 = unchecked_sub v0, u32 1
+            jmp b1(v0)
+          b3():
+            return
+        }
+        ");
     }
 
     #[test]

--- a/compiler/noirc_evaluator/src/ssa/opt/loop_invariant/simplify.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/loop_invariant/simplify.rs
@@ -257,8 +257,10 @@ impl LoopInvariantContext<'_> {
             return SimplifyResult::None;
         };
 
-        // All simplifications below assume the induction variable counts upward: lower_bound ≤ i < upper_bound.
-        // If the bounds are inverted the variable is not a proper ascending induction variable, so bail out.
+        // A monotone-ascending back-edge is already enforced when bounds are recorded
+        // (see `back_edge_advances_monotonically`), so `i` truly counts upward through
+        // `[lower_bound, upper_bound)`. If the constants are still inverted the loop
+        // body never executes; bail out instead of simplifying dead code.
         if lower_bound > upper_bound {
             return SimplifyResult::None;
         }

--- a/test_programs/execution_failure/regression_claude_1303/Nargo.toml
+++ b/test_programs/execution_failure/regression_claude_1303/Nargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "regression_claude_1303"
+type = "bin"
+authors = [""]
+
+[dependencies]

--- a/test_programs/execution_failure/regression_claude_1303/src/main.nr
+++ b/test_programs/execution_failure/regression_claude_1303/src/main.nr
@@ -1,0 +1,10 @@
+// Regression test for noir-lang/noir-claude#1303: LICM used to rewrite the
+// checked `i - 1` into `unchecked_sub` for this decreasing `while` loop,
+// returning the wrapped value 4294967295 instead of trapping on underflow.
+unconstrained fn main() -> pub u32 {
+    let mut i: u32 = 5;
+    while i < 10 {
+        i = i - 1;
+    }
+    i
+}

--- a/tooling/nargo_cli/tests/snapshots/execution_failure/regression_claude_1303/execute__tests__acir_stderr.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_failure/regression_claude_1303/execute__tests__acir_stderr.snap
@@ -1,0 +1,15 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: stderr
+---
+error: Assertion failed: attempt to subtract with overflow
+  ┌─ src/main.nr:7:13
+  │
+7 │         i = i - 1;
+  │             -----
+  │
+  = Call stack:
+    1: main
+            at src/main.nr:7:13
+
+Failed assertion

--- a/tooling/nargo_cli/tests/snapshots/execution_failure/regression_claude_1303/execute__tests__brillig_stderr.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_failure/regression_claude_1303/execute__tests__brillig_stderr.snap
@@ -1,0 +1,15 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: stderr
+---
+error: Assertion failed: attempt to subtract with overflow
+  ┌─ src/main.nr:7:13
+  │
+7 │         i = i - 1;
+  │             -----
+  │
+  = Call stack:
+    1: main
+            at src/main.nr:7:13
+
+Failed assertion

--- a/tooling/nargo_cli/tests/snapshots/execution_failure/regression_claude_1303/execute__tests__comptime_stderr.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_failure/regression_claude_1303/execute__tests__comptime_stderr.snap
@@ -1,0 +1,12 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: stderr
+---
+error: Attempt to subtract with overflow
+  ┌─ src/main.nr:7:13
+  │
+7 │         i = i - 1;
+  │             -----
+  │
+
+Error interpreting main function


### PR DESCRIPTION
## Problem Resolved

Resolves https://github.com/noir-lang/noir-claude/issues/1303
Resolves [AZTBOT-1192](https://linear.app/aztec-foundation/issue/AZTBOT-1192/licm-converts-checked-subtraction-to-unchecked-for-decreasing-while)

## Summary of Changes



## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
