### PR TITLE
fix: elaborate trait default methods only once

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/comptime.rs
+++ b/compiler/noirc_frontend/src/elaborator/comptime.rs
@@ -651,6 +651,7 @@ impl<'context> Elaborator<'context> {
                     resolved_object_type: None,
                     resolved_generics: Vec::new(),
                     unresolved_associated_types: Vec::new(),
+                    inherited_default_method_func_ids: Default::default(),
                 });
             }
             ItemKind::Global(global, visibility) => {

--- a/compiler/noirc_frontend/src/elaborator/expressions.rs
+++ b/compiler/noirc_frontend/src/elaborator/expressions.rs
@@ -923,6 +923,17 @@ impl Elaborator<'_> {
         let function_type = self.function_meta(func_id).typ.clone();
         self.try_add_mutable_reference_to_object(&function_type, &mut object_type, &mut object);
 
+        // When an impl inherits a trait's default method, the impl's slot points at the
+        // trait's own `FuncId`, so the function meta's self parameter is the trait's `Self`
+        // type variable. If we let the receiver be unified directly with that `Self` and a
+        // polymorphic receiver (e.g. an integer literal) is involved, the receiver will
+        // default to the kind's default type (e.g. `Field`) before the trait constraint
+        // check can pick the right impl. Capture the matching impl's concrete self type
+        // here so we can unify the receiver with it below, pinning the polymorphic type
+        // to the impl's type before defaulting runs.
+        let shared_trait_impl_self_type =
+            self.shared_trait_impl_self_type_for_method(func_id, &object_type, method_name);
+
         let generics = method_call.generics;
         let generics = generics.map(|generics| {
             vecmap(generics, |generic| {
@@ -957,6 +968,14 @@ impl Elaborator<'_> {
         // lambda parameter hints.
         if let Some(first_arg_type) = func_arg_types.and_then(|args| args.first()) {
             let _ = first_arg_type.unify(&object_type);
+            // For a shared trait-default method, also unify the impl's concrete self type
+            // with the receiver. The first arg is the trait's `Self` type variable, so the
+            // unify above only ties Self to the receiver (still polymorphic if the receiver
+            // was a literal). Unifying again with the impl's self type pins both Self and the
+            // receiver to the impl's concrete type before kind-based defaulting runs.
+            if let Some(impl_self_type) = &shared_trait_impl_self_type {
+                let _ = first_arg_type.unify(impl_self_type);
+            }
         }
 
         // These arguments will be given to the desugared function call.
@@ -1000,6 +1019,26 @@ impl Elaborator<'_> {
         let typ = self.type_check_call(&function_call, func_type, function_args, location);
 
         (function_call, typ)
+    }
+
+    /// If `func_id` is a trait method declaration whose `FuncId` is shared with this call's
+    /// matching impl (because the impl inherits the default body), return the impl's concrete
+    /// self type. Returns `None` when the function is a regular impl method or when zero/multiple
+    /// impls match the receiver — in those cases the existing impl-selection paths take over.
+    fn shared_trait_impl_self_type_for_method(
+        &self,
+        func_id: FuncId,
+        object_type: &Type,
+        method_name: &str,
+    ) -> Option<Type> {
+        let trait_id = self.interner.function_meta(&func_id).trait_id?;
+        let candidates = self.interner.lookup_trait_methods(object_type, method_name, true);
+        let mut matching = candidates
+            .into_iter()
+            .filter(|(f, t, _)| *f == func_id && *t == trait_id)
+            .map(|(_, _, self_typ)| self_typ);
+        let first = matching.next()?;
+        if matching.next().is_some() { None } else { Some(first) }
     }
 
     #[tracing::instrument(level = "trace", skip_all)]

--- a/compiler/noirc_frontend/src/elaborator/mod.rs
+++ b/compiler/noirc_frontend/src/elaborator/mod.rs
@@ -1074,7 +1074,7 @@ impl<'context> Elaborator<'context> {
     }
 
     #[tracing::instrument(level = "trace", skip_all)]
-    fn elaborate_trait_impl(&mut self, trait_impl: UnresolvedTraitImpl) {
+    fn elaborate_trait_impl(&mut self, mut trait_impl: UnresolvedTraitImpl) {
         self.local_module = Some(trait_impl.module_id);
 
         self.generics = trait_impl.resolved_generics.clone();
@@ -1086,13 +1086,26 @@ impl<'context> Elaborator<'context> {
         self.remove_trait_impl_assumed_trait_implementations(trait_impl.impl_id);
 
         for (module, function, noir_function) in &trait_impl.methods.functions {
+            if trait_impl.inherited_default_method_func_ids.contains(function) {
+                // Inherited defaults are typed once at the trait definition; their
+                // body matches the declaration by construction.
+                continue;
+            }
             self.local_module = Some(*module);
             let errors =
                 check_trait_impl_method_matches_declaration(self, *function, noir_function);
             self.push_errors(errors);
         }
 
-        self.elaborate_functions(trait_impl.methods);
+        let inherited_defaults = std::mem::take(&mut trait_impl.inherited_default_method_func_ids);
+        let methods = trait_impl.methods;
+        for (_, id, _) in methods.functions {
+            if inherited_defaults.contains(&id) {
+                continue;
+            }
+            self.elaborate_function(id);
+        }
+        self.generics.clear();
 
         self.self_type = None;
         self.current_trait_impl = None;

--- a/compiler/noirc_frontend/src/elaborator/mod.rs
+++ b/compiler/noirc_frontend/src/elaborator/mod.rs
@@ -1074,7 +1074,7 @@ impl<'context> Elaborator<'context> {
     }
 
     #[tracing::instrument(level = "trace", skip_all)]
-    fn elaborate_trait_impl(&mut self, mut trait_impl: UnresolvedTraitImpl) {
+    fn elaborate_trait_impl(&mut self, trait_impl: UnresolvedTraitImpl) {
         self.local_module = Some(trait_impl.module_id);
 
         self.generics = trait_impl.resolved_generics.clone();
@@ -1085,10 +1085,11 @@ impl<'context> Elaborator<'context> {
         self.check_trait_impl_where_clause_matches_trait_where_clause(&trait_impl);
         self.remove_trait_impl_assumed_trait_implementations(trait_impl.impl_id);
 
+        // Inherited defaults are typed once at the trait definition; their bodies match the
+        // declaration by construction and re-elaborating them per impl would duplicate
+        // diagnostics (and waste work).
         for (module, function, noir_function) in &trait_impl.methods.functions {
             if trait_impl.inherited_default_method_func_ids.contains(function) {
-                // Inherited defaults are typed once at the trait definition; their
-                // body matches the declaration by construction.
                 continue;
             }
             self.local_module = Some(*module);
@@ -1097,13 +1098,11 @@ impl<'context> Elaborator<'context> {
             self.push_errors(errors);
         }
 
-        let inherited_defaults = std::mem::take(&mut trait_impl.inherited_default_method_func_ids);
-        let methods = trait_impl.methods;
-        for (_, id, _) in methods.functions {
-            if inherited_defaults.contains(&id) {
+        for (_, id, _) in &trait_impl.methods.functions {
+            if trait_impl.inherited_default_method_func_ids.contains(id) {
                 continue;
             }
-            self.elaborate_function(id);
+            self.elaborate_function(*id);
         }
         self.generics.clear();
 

--- a/compiler/noirc_frontend/src/elaborator/path_resolution.rs
+++ b/compiler/noirc_frontend/src/elaborator/path_resolution.rs
@@ -1065,7 +1065,7 @@ impl Elaborator<'_> {
         let starting_module = self.get_module(importing_module_id);
 
         let mut results = Vec::new();
-        for (func_id, trait_id) in &trait_methods {
+        for (func_id, trait_id, _) in &trait_methods {
             if let Some(name) = starting_module.find_trait_in_scope(*trait_id) {
                 results.push((*trait_id, *func_id, name));
             }
@@ -1073,7 +1073,7 @@ impl Elaborator<'_> {
 
         if results.is_empty() {
             if trait_methods.len() == 1 {
-                let (func_id, trait_id) = trait_methods.first().expect("Expected an item");
+                let (func_id, trait_id, _) = trait_methods.first().expect("Expected an item");
                 let trait_ = self.interner.get_trait(*trait_id);
                 let trait_name = self.fully_qualified_trait_path(trait_);
                 let ident = method_name_ident.clone();
@@ -1082,7 +1082,7 @@ impl Elaborator<'_> {
             } else if trait_methods.is_empty() {
                 return Err(PathResolutionError::Unresolved(method_name_ident.clone()));
             } else {
-                let traits = vecmap(trait_methods, |(_, trait_id)| {
+                let traits = vecmap(trait_methods, |(_, trait_id, _)| {
                     self.fully_qualified_trait_path(self.interner.get_trait(trait_id))
                 });
                 let ident = method_name_ident.clone();

--- a/compiler/noirc_frontend/src/elaborator/trait_impls.rs
+++ b/compiler/noirc_frontend/src/elaborator/trait_impls.rs
@@ -203,6 +203,14 @@ impl Elaborator<'_> {
 
             let methods = trait_impl.methods.function_ids();
             for func_id in &methods {
+                // Slots inherited from the trait's default method point at the trait's
+                // own FuncId, which is shared by every inheriting impl. Skip per-impl
+                // bookkeeping for those — `func_id_to_trait` is single-valued and
+                // visibility/modifiers were set when the trait method was collected.
+                if trait_impl.inherited_default_method_func_ids.contains(func_id) {
+                    continue;
+                }
+
                 if self.interner.set_function_trait(*func_id, self_type.clone(), trait_id).is_some()
                 {
                     self.push_err(TypeCheckError::expecting_other_error(
@@ -312,29 +320,23 @@ impl Elaborator<'_> {
 
             if overrides.is_empty() {
                 if let Some(default_impl) = &method.default_impl {
-                    // copy 'where' clause from unresolved trait impl
-                    let mut default_impl_clone = default_impl.clone();
-                    default_impl_clone.def.where_clause.extend(trait_impl.where_clause.clone());
-
-                    let func_id = self.interner.push_empty_fn();
-                    let module = self.module_id();
-                    let location = default_impl.def.location;
-                    self.interner.push_function(func_id, &default_impl.def, module, location);
-                    self.recover_generics(|this| {
-                        let no_trait_id = None;
-                        let no_extra_trait_constraints = &[];
-                        this.define_function_meta(
-                            &mut default_impl_clone,
-                            func_id,
-                            no_trait_id,
-                            no_extra_trait_constraints,
-                        );
-                    });
-                    func_ids_in_trait.insert(func_id);
+                    // Reuse the trait's own FuncId for the default method instead of cloning
+                    // the body into a fresh FuncId per impl. The body has already been
+                    // elaborated once at the trait definition (`elaborate_traits` walks
+                    // `UnresolvedTrait::fns_with_default_impl`). Sharing the FuncId means
+                    // the body is type-checked exactly once, errors are reported once, and
+                    // paths in the body resolve from the trait's module rather than each
+                    // impl's. Per-call `Self` substitution still happens at the call site
+                    // via the instantiation bindings recorded during trait method
+                    // resolution, so dispatch needs no extra work.
+                    let trait_func_id =
+                        self.interner.get_trait(trait_id).method_ids[method.name.as_str()];
+                    trait_impl.inherited_default_method_func_ids.insert(trait_func_id);
+                    func_ids_in_trait.insert(trait_func_id);
                     ordered_methods.push((
                         method.default_impl_module_id,
-                        func_id,
-                        *default_impl_clone,
+                        trait_func_id,
+                        *default_impl.clone(),
                     ));
                 } else {
                     self.push_err(DefCollectorErrorKind::TraitMissingMethod {

--- a/compiler/noirc_frontend/src/elaborator/types.rs
+++ b/compiler/noirc_frontend/src/elaborator/types.rs
@@ -1361,13 +1361,73 @@ impl Elaborator<'_> {
         let path_resolution = self.use_path_as_type(path.clone()).ok()?;
         let func_id = path_resolution.item.function_id()?;
         let meta = self.interner.try_function_meta(&func_id)?;
-        let the_trait = self.interner.get_trait(meta.trait_id?);
+        let trait_id = meta.trait_id?;
+        let the_trait = self.interner.get_trait(trait_id);
         let method = the_trait.find_method(path.last_name(), self.interner)?;
-        let constraint = the_trait.as_constraint(path.location);
+        let mut constraint = the_trait.as_constraint(path.location);
+        // If the path went through a concrete type (e.g. `i32::method`, `Struct::trait_method`),
+        // override the constraint's `Self` type variable with that type so the impl gets
+        // selected at the call site rather than leaving `Self` unbound (which would force the
+        // user to add a type annotation). For the literal `Trait::method` form there is no
+        // concrete type available, so `Self` stays as the trait's type variable.
+        if let Some(concrete_self) = self.concrete_self_type_for_path_item(&path_resolution.item) {
+            constraint.typ = concrete_self;
+        }
         let trait_method = TraitItem { definition: method, constraint, assumed: false };
         let method = TraitPathResolutionMethod::TraitItem(trait_method);
         let item = Some(path_resolution.item);
         Some(TraitPathResolution { method, item, errors: path_resolution.errors })
+    }
+
+    /// For path resolutions that went through a typed item (e.g. `MyStruct::method`,
+    /// `i32::method`), return that concrete type. This is used so that a `Trait::method`
+    /// constraint built from one of these paths can be anchored on the concrete type rather
+    /// than the trait's unbound `Self` type variable.
+    fn concrete_self_type_for_path_item(&mut self, item: &PathResolutionItem) -> Option<Type> {
+        let mut errors = Vec::new();
+        let result = match item {
+            PathResolutionItem::PrimitiveFunction(primitive_type, _, _) => {
+                Some(primitive_type.to_type())
+            }
+            PathResolutionItem::TypeTraitFunction(self_type, _, _) => Some(self_type.clone()),
+            PathResolutionItem::Method(type_id, turbofish, _) => {
+                let generics = self.resolve_struct_id_turbofish_generics(
+                    *type_id,
+                    turbofish.clone(),
+                    &mut errors,
+                );
+                let datatype = self.get_type(*type_id);
+                Some(Type::DataType(datatype, generics))
+            }
+            PathResolutionItem::TypeAliasFunction(type_alias_id, turbofish, _) => {
+                let generics = self.resolve_type_alias_id_turbofish_generics(
+                    *type_alias_id,
+                    turbofish.clone(),
+                    &mut errors,
+                );
+                let type_alias = self.interner.get_type_alias(*type_alias_id);
+                let type_alias = type_alias.borrow();
+                Some(type_alias.get_type(&generics))
+            }
+            // `Self::method` inside an impl. Use the impl's self type so the trait constraint
+            // is anchored on it.
+            PathResolutionItem::SelfMethod(_) => self.self_type.clone(),
+            // `TraitFunction` is the bare `Trait::method` form — Self isn't pinned by the path.
+            // `ModuleFunction` and non-function variants don't carry a concrete self type that
+            // should override the trait constraint.
+            PathResolutionItem::TraitFunction(..)
+            | PathResolutionItem::ModuleFunction(_)
+            | PathResolutionItem::Module(..)
+            | PathResolutionItem::Type(..)
+            | PathResolutionItem::TypeAlias(..)
+            | PathResolutionItem::PrimitiveType(..)
+            | PathResolutionItem::Trait(..)
+            | PathResolutionItem::TraitAssociatedType(..)
+            | PathResolutionItem::Global(..)
+            | PathResolutionItem::TraitConstant(..) => None,
+        };
+        self.push_errors(errors);
+        result
     }
 
     /// This resolves a static trait method T::trait_method by iterating over the where clause
@@ -1500,7 +1560,7 @@ impl Elaborator<'_> {
         typ: &Type,
         method_name: &str,
         has_self_arg: bool,
-    ) -> Vec<(FuncId, TraitId)> {
+    ) -> Vec<(FuncId, TraitId, Type)> {
         self.resolve_method_candidate_metas(typ, method_name);
         self.interner.lookup_trait_methods(typ, method_name, has_self_arg)
     }
@@ -1512,7 +1572,7 @@ impl Elaborator<'_> {
         typ: &Type,
         method_name: &str,
         has_self_arg: bool,
-    ) -> Vec<(FuncId, TraitId)> {
+    ) -> Vec<(FuncId, TraitId, Type)> {
         for func_id in self.interner.generic_method_candidate_ids(method_name) {
             self.define_function_meta_if_undefined(func_id);
         }
@@ -2738,7 +2798,7 @@ impl Elaborator<'_> {
     #[tracing::instrument(level = "trace", skip_all)]
     fn return_trait_method_in_scope(
         &mut self,
-        trait_methods: &[(FuncId, TraitId)],
+        trait_methods: &[(FuncId, TraitId, Type)],
         method_name: &str,
         location: Location,
     ) -> Option<HirMethodReference> {
@@ -2752,7 +2812,7 @@ impl Elaborator<'_> {
     #[tracing::instrument(level = "trace", skip_all)]
     fn get_trait_method_in_scope(
         &mut self,
-        trait_methods: &[(FuncId, TraitId)],
+        trait_methods: &[(FuncId, TraitId, Type)],
         method_name: &str,
         location: Location,
     ) -> (Option<HirMethodReference>, Option<PathResolutionError>) {
@@ -2762,7 +2822,7 @@ impl Elaborator<'_> {
         // Only keep unique trait IDs: multiple trait methods might come from the same trait
         // but implemented with different generics (like `Convert<Field>` and `Convert<i32>`).
         let traits: HashSet<TraitId> =
-            trait_methods.iter().map(|(_, trait_id)| *trait_id).collect();
+            trait_methods.iter().map(|(_, trait_id, _)| *trait_id).collect();
 
         let traits_in_scope: Vec<_> = traits
             .iter()
@@ -2825,14 +2885,24 @@ impl Elaborator<'_> {
     fn trait_hir_method_reference(
         &self,
         trait_id: TraitId,
-        trait_methods: &[(FuncId, TraitId)],
+        trait_methods: &[(FuncId, TraitId, Type)],
         method_name: &str,
         location: Location,
     ) -> HirMethodReference {
-        // If we find a single trait impl method, return it so we don't have to later determine the impl
-        if trait_methods.len() == 1 {
-            let (func_id, _) = trait_methods[0];
-            return HirMethodReference::FuncId(func_id);
+        // If we find a single trait impl method, return it so we don't have to later determine the impl.
+        // Exception: if the single match points at the trait's own method declaration (which happens
+        // when an impl inherits the default body — the impl's slot shares the trait's `FuncId`),
+        // the function meta carries the trait's `Self` type variable, not the impl's concrete type.
+        // Fall through to the `TraitItemId` path so the caller can bind `Self` to the resolved
+        // self type via the trait constraint.
+        if trait_methods.len() == 1
+            && self
+                .interner
+                .try_function_meta(&trait_methods[0].0)
+                .is_none_or(|meta| meta.trait_id.is_none())
+        {
+            let (func_id, _, _) = &trait_methods[0];
+            return HirMethodReference::FuncId(*func_id);
         }
 
         // Return a TraitMethodId with unbound generics. These will later be bound by the type-checker.

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
@@ -839,7 +839,17 @@ impl<'local, 'interner> Interpreter<'local, 'interner> {
         // the matching trait impl method. We need to have them resolved first.
         self.elaborator.resolve_trait_method_metas_for(item.id().trait_id);
 
-        match resolve_trait_item(self.elaborator.interner, item.id(), id)? {
+        // `resolve_trait_item_impl` extends the call expression's stored instantiation
+        // bindings with the resolved impl's bindings (and, for shared default methods,
+        // pins the trait's `Self` to the impl's concrete self type). Snapshot and restore
+        // around the call so the same expression — visited again under a different
+        // monomorphization context — sees the elaboration-time bindings rather than
+        // leftover impl-specific entries from a previous visit. This mirrors the snapshot
+        // logic in `resolve_trait_item_expr` on the monomorphization side.
+        let saved_bindings = self.elaborator.interner.try_get_instantiation_bindings(id).cloned();
+        let resolved = resolve_trait_item(self.elaborator.interner, item.id(), id);
+
+        let result = match resolved? {
             crate::monomorphization::TraitItem::Method(func_id) => {
                 let bindings = self.elaborator.interner.get_instantiation_bindings(id).clone();
                 Ok(Value::Function(func_id, typ, Rc::new(bindings)))
@@ -847,7 +857,12 @@ impl<'local, 'interner> Interpreter<'local, 'interner> {
             crate::monomorphization::TraitItem::Constant { id: _, expected_type, value } => {
                 self.evaluate_numeric_generic(value, &expected_type, id)
             }
+        };
+
+        if let Some(saved) = saved_bindings {
+            self.elaborator.interner.store_instantiation_bindings(id, saved);
         }
+        result
     }
 
     fn evaluate_literal(&mut self, literal: HirLiteral, id: ExprId) -> IResult<Value> {

--- a/compiler/noirc_frontend/src/hir/def_collector/dc_crate.rs
+++ b/compiler/noirc_frontend/src/hir/def_collector/dc_crate.rs
@@ -104,6 +104,13 @@ pub struct UnresolvedTraitImpl {
     pub resolved_object_type: Option<Type>,
     pub resolved_generics: ResolvedGenerics,
     pub unresolved_associated_types: Vec<(Ident, UnresolvedType)>,
+
+    /// FuncIds in `methods.functions` that refer to a trait's own default-method
+    /// FuncId because this impl did not override the method. The default body
+    /// has already been elaborated once at the trait definition, so these
+    /// slots must not be re-registered or re-elaborated per impl. Populated by
+    /// `collect_trait_impl_methods`.
+    pub inherited_default_method_func_ids: rustc_hash::FxHashSet<FuncId>,
 }
 
 #[derive(Clone)]

--- a/compiler/noirc_frontend/src/hir/def_collector/dc_crate.rs
+++ b/compiler/noirc_frontend/src/hir/def_collector/dc_crate.rs
@@ -36,7 +36,8 @@ use noirc_errors::{CustomDiagnostic, Location, Span};
 use fm::FileId;
 use iter_extended::vecmap;
 use rustc_hash::FxHashMap as HashMap;
-use std::collections::{BTreeMap, HashSet};
+use rustc_hash::FxHashSet as HashSet;
+use std::collections::BTreeMap;
 use std::fmt::Write;
 use std::ops::IndexMut;
 use std::path::PathBuf;
@@ -110,7 +111,7 @@ pub struct UnresolvedTraitImpl {
     /// has already been elaborated once at the trait definition, so these
     /// slots must not be re-registered or re-elaborated per impl. Populated by
     /// `collect_trait_impl_methods`.
-    pub inherited_default_method_func_ids: rustc_hash::FxHashSet<FuncId>,
+    pub inherited_default_method_func_ids: HashSet<FuncId>,
 }
 
 #[derive(Clone)]
@@ -910,7 +911,7 @@ fn filter_expecting_other_errors(mut errors: Vec<CompilationError>) -> Vec<Compi
 /// in the output repeatedly.
 fn dedup_expecting_other_errors(mut errors: Vec<CompilationError>) -> Vec<CompilationError> {
     // Using a HashSet of the inner error, because CompilationError does not implement Ord or Hash.
-    let mut seen: HashSet<ExpectingOtherError> = HashSet::new();
+    let mut seen: HashSet<ExpectingOtherError> = HashSet::default();
     errors.retain(|error| match error.as_expecting_other_error() {
         Some(e) if seen.contains(e) => false,
         Some(e) => {

--- a/compiler/noirc_frontend/src/hir/def_collector/dc_mod.rs
+++ b/compiler/noirc_frontend/src/hir/def_collector/dc_mod.rs
@@ -263,6 +263,7 @@ impl ModCollector<'_> {
                 resolved_object_type: None,
                 resolved_generics: Vec::new(),
                 unresolved_associated_types: Vec::new(),
+                inherited_default_method_func_ids: Default::default(),
             };
 
             self.def_collector.items.trait_impls.push(unresolved_trait_impl);

--- a/compiler/noirc_frontend/src/hir/printer/mod.rs
+++ b/compiler/noirc_frontend/src/hir/printer/mod.rs
@@ -536,7 +536,14 @@ impl<'context, 'string> ItemPrinter<'context, 'string> {
             printed_item = true;
         }
 
+        // If a slot in the impl's methods list is the trait's own default-method
+        // `FuncId`, the impl inherited the default body — printing that method here
+        // would falsely suggest the user wrote an override.
+        let trait_method_func_ids: HashSet<FuncId> = trait_.method_ids.values().copied().collect();
         for method in &item_trait_impl.methods {
+            if trait_method_func_ids.contains(method) {
+                continue;
+            }
             if printed_item {
                 self.push_str("\n\n");
             }

--- a/compiler/noirc_frontend/src/hir_def/types/unification.rs
+++ b/compiler/noirc_frontend/src/hir_def/types/unification.rs
@@ -624,7 +624,8 @@ impl Type {
         match &this {
             Type::String(..) | Type::FmtString(..) => {
                 // as_ctstring is defined as a trait method
-                for (func_id, trait_id) in interner.lookup_trait_methods(&this, "as_ctstring", true)
+                for (func_id, trait_id, _) in
+                    interner.lookup_trait_methods(&this, "as_ctstring", true)
                 {
                     // Look up the one that's in the standard library.
                     let trait_ = interner.get_trait(trait_id);

--- a/compiler/noirc_frontend/src/monomorphization/mod.rs
+++ b/compiler/noirc_frontend/src/monomorphization/mod.rs
@@ -3297,25 +3297,21 @@ fn bind_trait_self_to_impl_self(
     impl_id: node_interner::TraitImplId,
     bindings: &mut TypeBindings,
 ) {
-    let trait_def = interner.get_trait(method_id.trait_id);
-    // Only bind `Self` when this impl's matching method *is* the trait's own `FuncId`
-    // (i.e. the impl inherits the default body). For overridden methods, `set_function_trait`
-    // already handles the `Self` binding from inside `function()`.
-    let trait_func_definition = interner.definition(method_id.item_id);
-    let DefinitionKind::Function(trait_func_id) = trait_func_definition.kind else {
+    // Only bind `Self` when the impl inherited the trait's default body, i.e. when
+    // the impl's slot for this method is the trait's own `FuncId`. For overridden
+    // methods the impl's per-impl `FuncId` has `func_id_to_trait` set, and
+    // `function()` already binds `Self` from there.
+    let DefinitionKind::Function(trait_func_id) = interner.definition(method_id.item_id).kind
+    else {
         return;
     };
     let impl_ = interner.get_trait_implementation(impl_id);
     let impl_ = impl_.borrow();
-    let trait_func_name = interner.function_name(&trait_func_id);
-    let impl_uses_trait_func_id = impl_
-        .methods
-        .iter()
-        .any(|m| interner.function_name(m) == trait_func_name && *m == trait_func_id);
-    if !impl_uses_trait_func_id {
+    if !impl_.methods.contains(&trait_func_id) {
         return;
     }
 
+    let trait_def = interner.get_trait(method_id.trait_id);
     let self_typevar = trait_def.self_type_typevar.clone();
     let kind = self_typevar.kind();
     let impl_self_type = impl_.typ.clone();

--- a/compiler/noirc_frontend/src/monomorphization/mod.rs
+++ b/compiler/noirc_frontend/src/monomorphization/mod.rs
@@ -3203,7 +3203,17 @@ fn resolve_trait_item_impl(
     })?;
 
     match trait_impl {
-        TraitImplKind::Normal(impl_id) => Ok(impl_id),
+        TraitImplKind::Normal(impl_id) => {
+            // If the impl's matching method shares the trait's default-method `FuncId`
+            // (the impl inherited the default), bind the trait's `Self` to the impl's self
+            // type so monomorphization of the shared body can look up impl-specific items
+            // (`Self::N`, etc.). For overridden impl methods this is a no-op — the impl's
+            // own `FuncId` carries the binding via `set_function_trait`.
+            let mut bindings = interner.get_instantiation_bindings(expr_id).clone();
+            bind_trait_self_to_impl_self(interner, method_id, impl_id, &mut bindings);
+            interner.store_instantiation_bindings(expr_id, bindings);
+            Ok(impl_id)
+        }
         TraitImplKind::Prepared { .. } => {
             unreachable!("ICE: Prepared trait impl should have been replaced by a Normal one")
         }
@@ -3228,6 +3238,8 @@ fn resolve_trait_item_impl(
                         impl_id,
                         &mut bindings,
                     );
+
+                    bind_trait_self_to_impl_self(interner, method_id, impl_id, &mut bindings);
 
                     interner.store_instantiation_bindings(expr_id, bindings);
                     Ok(impl_id)
@@ -3268,6 +3280,46 @@ fn resolve_trait_item_impl(
             }
         }
     }
+}
+
+/// Bind the trait's `Self` type variable to the impl's concrete self type when the impl's
+/// matching method shares the trait's default-method `FuncId`. In this case the impl has
+/// no per-impl `FuncId` to attach `func_id_to_trait` to, so `function()`'s usual `force_bind`
+/// of `Self` doesn't run; without this helper the shared body's references to `Self`
+/// (e.g. `Self::N`) can't resolve at monomorphization.
+///
+/// For impl methods with their own `FuncId` (the typical case), `set_function_trait` is set
+/// during elaboration and `function()` already binds `Self`, so this helper is a no-op for
+/// them.
+fn bind_trait_self_to_impl_self(
+    interner: &NodeInterner,
+    method_id: TraitItemId,
+    impl_id: node_interner::TraitImplId,
+    bindings: &mut TypeBindings,
+) {
+    let trait_def = interner.get_trait(method_id.trait_id);
+    // Only bind `Self` when this impl's matching method *is* the trait's own `FuncId`
+    // (i.e. the impl inherits the default body). For overridden methods, `set_function_trait`
+    // already handles the `Self` binding from inside `function()`.
+    let trait_func_definition = interner.definition(method_id.item_id);
+    let DefinitionKind::Function(trait_func_id) = trait_func_definition.kind else {
+        return;
+    };
+    let impl_ = interner.get_trait_implementation(impl_id);
+    let impl_ = impl_.borrow();
+    let trait_func_name = interner.function_name(&trait_func_id);
+    let impl_uses_trait_func_id = impl_
+        .methods
+        .iter()
+        .any(|m| interner.function_name(m) == trait_func_name && *m == trait_func_id);
+    if !impl_uses_trait_func_id {
+        return;
+    }
+
+    let self_typevar = trait_def.self_type_typevar.clone();
+    let kind = self_typevar.kind();
+    let impl_self_type = impl_.typ.clone();
+    bindings.insert(self_typevar.id(), (self_typevar, kind, impl_self_type));
 }
 
 /// Binds direct generics on a trait impl function to those on a corresponding trait function.

--- a/compiler/noirc_frontend/src/node_interner/methods.rs
+++ b/compiler/noirc_frontend/src/node_interner/methods.rs
@@ -138,7 +138,7 @@ impl Methods {
         typ: &Type,
         has_self_param: bool,
         interner: &NodeInterner,
-    ) -> Vec<(FuncId, TraitId)> {
+    ) -> Vec<(FuncId, TraitId, Type)> {
         let mut results = Vec::new();
 
         for trait_impl_method in &self.trait_impl_methods {
@@ -147,7 +147,7 @@ impl Methods {
             let trait_id = trait_impl_method.trait_id;
 
             if Self::method_matches(typ, has_self_param, method, method_type, interner) {
-                results.push((method, trait_id));
+                results.push((method, trait_id, method_type.clone()));
             }
         }
 

--- a/compiler/noirc_frontend/src/node_interner/mod.rs
+++ b/compiler/noirc_frontend/src/node_interner/mod.rs
@@ -1123,12 +1123,17 @@ impl NodeInterner {
     }
 
     /// Looks up methods that apply to the given type but are defined in traits.
+    ///
+    /// The third tuple element is the impl's self type as it was recorded when the impl was
+    /// registered (see [Self::add_method]). This is the concrete type the impl applies to,
+    /// not the trait's `Self` type variable — useful for callers that need to pin `Self`
+    /// for shared trait-method `FuncId`s (default methods inherited from the trait).
     pub fn lookup_trait_methods(
         &self,
         typ: &Type,
         method_name: &str,
         has_self_arg: bool,
-    ) -> Vec<(FuncId, TraitId)> {
+    ) -> Vec<(FuncId, TraitId, Type)> {
         let key = get_type_method_key(typ);
         if let Some(key) = key {
             self.methods
@@ -1175,13 +1180,15 @@ impl NodeInterner {
             .unwrap_or_default()
     }
 
-    /// Looks up methods at impls for all types `T`, e.g. `impl<T> Foo for T`
+    /// Looks up methods at impls for all types `T`, e.g. `impl<T> Foo for T`.
+    ///
+    /// See [Self::lookup_trait_methods] for the meaning of the third tuple element.
     pub fn lookup_generic_methods(
         &self,
         typ: &Type,
         method_name: &str,
         has_self_arg: bool,
-    ) -> Vec<(FuncId, TraitId)> {
+    ) -> Vec<(FuncId, TraitId, Type)> {
         self.methods
             .get(&TypeMethodKey::Generic)
             .and_then(|h| h.get(method_name))

--- a/compiler/noirc_frontend/src/tests/traits/trait_associated_items.rs
+++ b/compiler/noirc_frontend/src/tests/traits/trait_associated_items.rs
@@ -81,6 +81,92 @@ fn accesses_associated_constant_inside_trait_impl_using_self() {
     assert_no_errors(src);
 }
 
+/// Regression test for #9020: a default method body whose return value comes from an
+/// associated constant (`Self::N`) must monomorphize correctly when the impl inherits
+/// the default. Without binding the trait's `Self` to the impl's concrete type at
+/// monomorphization time, `Self::N` can't pick the right impl and fails with
+/// "Type annotations needed".
+#[test]
+fn shared_default_method_resolves_self_associated_constant() {
+    use crate::test_utils::get_monomorphized;
+    let src = r#"
+    trait Foo {
+        let N: i32;
+
+        fn n() -> i32 {
+            Self::N
+        }
+    }
+
+    impl Foo for i32 {
+        let N: i32 = 7i32;
+    }
+
+    fn main() {
+        let _ = i32::n();
+    }
+    "#;
+    let result = get_monomorphized(src);
+    assert!(result.is_ok(), "monomorphization failed: {result:?}");
+}
+
+/// Regression test for #9020: when one impl inherits a trait's default method and
+/// another impl overrides the same method, the two paths must not interfere with each
+/// other through the trait's shared `Self` type variable.
+#[test]
+fn shared_and_overridden_default_method_coexist() {
+    use crate::test_utils::get_monomorphized;
+    let src = r#"
+    pub trait H {
+        fn finish(self) -> Field;
+
+        fn finish_ref(&self) -> Field {
+            (*self).finish()
+        }
+    }
+
+    pub trait BH {
+        type Hasher: H;
+        fn build(self) -> Self::Hasher;
+    }
+
+    pub struct A {}
+    pub struct B {}
+    pub struct BA {}
+    pub struct BB {}
+
+    impl H for A {
+        // Override `finish_ref`.
+        fn finish(self) -> Field { let _ = self; self.finish_ref() }
+        fn finish_ref(&self) -> Field { let _ = self; 1 }
+    }
+    impl H for B {
+        // Inherit `finish_ref` default.
+        fn finish(self) -> Field { let _ = self; 2 }
+    }
+    impl BH for BA {
+        type Hasher = A;
+        fn build(self) -> A { let _ = self; A {} }
+    }
+    impl BH for BB {
+        type Hasher = B;
+        fn build(self) -> B { let _ = self; B {} }
+    }
+
+    pub fn use_hasher<X, T>(bh: T) -> Field where T: BH<Hasher = X>, X: H {
+        let h = bh.build();
+        h.finish_ref()
+    }
+
+    fn main() {
+        let _ = use_hasher(BA {});
+        let _ = use_hasher(BB {});
+    }
+    "#;
+    let result = get_monomorphized(src);
+    assert!(result.is_ok(), "monomorphization failed: {result:?}");
+}
+
 #[test]
 fn accesses_associated_constant_inside_trait_using_self() {
     let src = r#"

--- a/compiler/noirc_frontend/src/tests/traits/trait_default_methods.rs
+++ b/compiler/noirc_frontend/src/tests/traits/trait_default_methods.rs
@@ -93,12 +93,79 @@ fn trait_with_same_generic_in_different_default_methods() {
     assert_no_errors(src);
 }
 
-// Known bug: Numeric generic from generic trait not accessible in default method body
-/// TODO(https://github.com/noir-lang/noir/issues/11552): remove should_panic once fixed
+/// Regression test for https://github.com/noir-lang/noir/issues/8632
+/// (tracked as part of https://github.com/noir-lang/noir/issues/9020).
+///
+/// A default method body must resolve paths relative to the trait's defining
+/// module, not the impl's module. Here `helper` is defined in `my_trait` and
+/// is not imported into the outer module; the default body must still find it.
 #[test]
-#[should_panic(expected = "Expected no errors")]
+fn default_method_resolves_paths_in_trait_module() {
+    let src = r#"
+    mod my_trait {
+        pub(crate) fn helper(value: Field) -> Field {
+            value + 1
+        }
+
+        pub trait PartialTrait {
+            fn required(self) -> Field;
+
+            fn provided(self) -> Field {
+                helper(self.required())
+            }
+        }
+    }
+
+    use my_trait::PartialTrait;
+
+    pub struct Foo {}
+
+    impl PartialTrait for Foo {
+        fn required(self) -> Field {
+            let _ = self;
+            7
+        }
+    }
+
+    fn main() {
+        let f = Foo {};
+        let _ = f.provided();
+    }
+    "#;
+    assert_no_errors(src);
+}
+
+/// Regression test for https://github.com/noir-lang/noir/issues/9020.
+#[test]
+fn default_method_type_error_reported_once() {
+    let src = r#"
+    pub trait Foo {
+        fn foo(self) -> i32 {
+                        ^^^ expected type i32, found type bool
+                        ~~~ expected i32 because of return type
+            let _ = self;
+            true
+            ~~~~ bool returned here
+        }
+    }
+
+    pub struct A {}
+    pub struct B {}
+
+    impl Foo for A {}
+    impl Foo for B {}
+
+    fn main() {}
+    "#;
+    check_errors(src);
+}
+
+/// Regression test for https://github.com/noir-lang/noir/issues/11552.
+/// A numeric generic on a generic trait must be visible in a default method body.
+/// Was fixed as a side effect of #9020 (default bodies are now typed once at the
+/// trait definition, so trait generics naturally flow through).
+#[test]
 fn generic_trait_numeric_generic_default_method() {
-    // Bug: N from Fillable<let N: u32> not found in default method body
     let src = r#"
     trait Fillable<let N: u32> {
         fn value(self) -> Field;

--- a/compiler/noirc_frontend/src/tests/traits/trait_default_methods.rs
+++ b/compiler/noirc_frontend/src/tests/traits/trait_default_methods.rs
@@ -160,6 +160,78 @@ fn default_method_type_error_reported_once() {
     check_errors(src);
 }
 
+/// Multiple impls of the same trait inherit the trait's default method
+/// (so they share the same `FuncId`). A dot-notation call on an explicitly-typed
+/// receiver should resolve to the right impl. An ambiguous polymorphic receiver
+/// should produce a "no matching impl" diagnostic (after kind-based defaulting),
+/// not a panic and not "type annotations needed" for an internal type variable.
+#[test]
+fn shared_default_method_with_multiple_impls() {
+    let src = r#"
+    pub trait Identity {
+        fn id(self) -> Self {
+            self
+        }
+    }
+
+    impl Identity for u32 {}
+    impl Identity for u64 {}
+
+    fn main() {
+        // Explicit type annotations: each call resolves unambiguously.
+        let _ = 2_u32.id();
+        let _ = 2_u64.id();
+    }
+    "#;
+    assert_no_errors(src);
+}
+
+/// When one of the impls is for the receiver's *default* type (`Field` for an
+/// untyped integer literal), the polymorphic receiver defaults to `Field` and the
+/// constraint check picks that impl — no annotation needed.
+#[test]
+fn shared_default_method_with_field_and_int_impls() {
+    let src = r#"
+    pub trait Identity {
+        fn id(self) -> Self {
+            self
+        }
+    }
+
+    impl Identity for u32 {}
+    impl Identity for Field {}
+
+    fn main() {
+        // Polymorphic literal defaults to `Field`, dispatches to the `Field` impl.
+        let _ = 2.id();
+        // Explicit `u32` steers to the `u32` impl.
+        let _u: u32 = 2_u32.id();
+    }
+    "#;
+    assert_no_errors(src);
+}
+
+#[test]
+fn shared_default_method_with_multiple_impls_ambiguous_receiver() {
+    let src = r#"
+    pub trait Identity {
+        fn id(self) -> Self {
+            self
+        }
+    }
+
+    impl Identity for u32 {}
+    impl Identity for u64 {}
+
+    fn main() {
+        let _ = 2.id();
+                ^^^^ No matching impl found for `Field: Identity`
+                ~~~~ No impl for `Field: Identity`
+    }
+    "#;
+    check_errors(src);
+}
+
 /// Regression test for https://github.com/noir-lang/noir/issues/11552.
 /// A numeric generic on a generic trait must be visible in a default method body.
 /// Was fixed as a side effect of #9020 (default bodies are now typed once at the

--- a/compiler/noirc_frontend/src/tests/traits/trait_qualified_paths.rs
+++ b/compiler/noirc_frontend/src/tests/traits/trait_qualified_paths.rs
@@ -187,7 +187,6 @@ fn uses_self_type_in_trait_where_clause() {
                               ~~~~~ required by this bound in `Foo`
         fn foo(self) -> bool {
             self.trait_func()
-            ^^^^^^^^^^^^^^^^^ No method named 'trait_func' found for type 'Bar'
         }
     }
 

--- a/examples/coverage/lcov.info
+++ b/examples/coverage/lcov.info
@@ -4,8 +4,6 @@ FN:1,double
 FN:5,add
 FN:11,moo::triple
 FN:20,multi_line_function_decl
-FN:52,<u32 as Quadruple>::quadrupled
-FN:52,<u64 as Quadruple>::quadrupled
 FN:52,Quadruple::quadrupled
 FN:58,<u32 as Quadruple>::doubled
 FN:64,<u64 as Quadruple>::doubled
@@ -19,8 +17,6 @@ FNDA:0,double
 FNDA:0,add
 FNDA:0,moo::triple
 FNDA:0,multi_line_function_decl
-FNDA:0,<u32 as Quadruple>::quadrupled
-FNDA:0,<u64 as Quadruple>::quadrupled
 FNDA:0,Quadruple::quadrupled
 FNDA:0,<u32 as Quadruple>::doubled
 FNDA:0,<u64 as Quadruple>::doubled
@@ -30,7 +26,7 @@ FNDA:0,<u8 as Convert<u8>>::convert
 FNDA:0,<u8 as Convert<u16>>::convert
 FNDA:0,<u16 as Convert<u8>>::convert
 FNDA:0,<u16 as Convert<u16>>::convert
-FNF:15
+FNF:13
 FNH:0
 DA:1,0
 DA:2,0
@@ -156,16 +152,14 @@ LH:4
 end_of_record
 TN:test_quadrupled
 SF:src/lib.nr
-FN:52,<u32 as Quadruple>::quadrupled
-FN:52,<u64 as Quadruple>::quadrupled
+FN:52,Quadruple::quadrupled
 FN:58,<u32 as Quadruple>::doubled
 FN:64,<u64 as Quadruple>::doubled
-FNDA:1,<u32 as Quadruple>::quadrupled
-FNDA:1,<u64 as Quadruple>::quadrupled
+FNDA:2,Quadruple::quadrupled
 FNDA:2,<u32 as Quadruple>::doubled
 FNDA:2,<u64 as Quadruple>::doubled
-FNF:4
-FNH:4
+FNF:3
+FNH:3
 DA:52,2
 DA:53,10
 DA:58,2

--- a/tooling/lsp/src/requests/code_action/import_trait.rs
+++ b/tooling/lsp/src/requests/code_action/import_trait.rs
@@ -43,7 +43,8 @@ impl CodeActionFinder<'_> {
 
         let trait_methods =
             self.interner.lookup_trait_methods(typ, method_call.method_name.as_str(), true);
-        let trait_ids: HashSet<_> = trait_methods.iter().map(|(_, trait_id)| *trait_id).collect();
+        let trait_ids: HashSet<_> =
+            trait_methods.iter().map(|(_, trait_id, _)| *trait_id).collect();
 
         for trait_id in trait_ids {
             self.import_trait(trait_id);

--- a/tooling/nargo_cli/tests/snapshots/compile_success_empty/associated_types/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_empty/associated_types/execute__tests__expanded.snap
@@ -22,10 +22,6 @@ impl<let N: u32, T> Collection for [T; N] {
             Option::<T>::none()
         }
     }
-
-    fn ctake(self, index: u32) -> T {
-        self.cget(index).unwrap()
-    }
 }
 
 fn main() {

--- a/tooling/nargo_cli/tests/snapshots/compile_success_empty/comptime_location/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_empty/comptime_location/execute__tests__expanded.snap
@@ -58,10 +58,6 @@ impl Hasher for TestHasher {
         self.result
     }
 
-    fn finish_ref(&self) -> Field {
-        (*self).finish()
-    }
-
     fn write(&mut self, input: Field) {
         self.result = self.result + input;
     }

--- a/tooling/nargo_cli/tests/snapshots/compile_success_empty/comptime_trait_constraint/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_empty/comptime_trait_constraint/execute__tests__expanded.snap
@@ -21,10 +21,6 @@ impl Hasher for TestHasher {
         self.result
     }
 
-    fn finish_ref(&self) -> Field {
-        (*self).finish()
-    }
-
     fn write(&mut self, input: Field) {
         self.result = self.result + input;
     }

--- a/tooling/nargo_cli/tests/snapshots/compile_success_empty/impl_from_where_impl/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_empty/impl_from_where_impl/execute__tests__expanded.snap
@@ -17,10 +17,6 @@ where
     fn ok(self) -> Self {
         self
     }
-
-    fn ref_ok(self) -> Self {
-        self.ok()
-    }
 }
 
 fn main() {}

--- a/tooling/nargo_cli/tests/snapshots/compile_success_empty/nested_trait_associated_type_regression_8252/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_empty/nested_trait_associated_type_regression_8252/execute__tests__expanded.snap
@@ -14,20 +14,12 @@ struct Foo {}
 
 impl TraitWithAssociatedConstant for Foo {
     let N: u32 = 42;
-
-    fn foo(_: Self) -> bool {
-        true
-    }
 }
 
 struct Bar {}
 
 impl TraitWithAssociatedConstant for Bar {
     let N: u32 = 43;
-
-    fn foo(_: Self) -> bool {
-        true
-    }
 }
 
 struct Wrapper<T> {
@@ -39,10 +31,6 @@ where
     V: TraitWithAssociatedConstant,
 {
     let N: u32 = <V as TraitWithAssociatedConstant>::N;
-
-    fn foo(_: Self) -> bool {
-        true
-    }
 }
 
 impl<U> Eq for Wrapper<U>

--- a/tooling/nargo_cli/tests/snapshots/compile_success_empty/regression_10813/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_empty/regression_10813/execute__tests__expanded.snap
@@ -16,10 +16,6 @@ impl Foo for () {
     let Baz: u32 = 0;
 
     type Bar = Self;
-
-    fn foo(x: [Self; 0]) -> u32 {
-        x.len()
-    }
 }
 
 fn main() {

--- a/tooling/nargo_cli/tests/snapshots/compile_success_empty/regression_7038_2/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_empty/regression_7038_2/execute__tests__expanded.snap
@@ -17,9 +17,7 @@ where
 
 pub struct BN254Params {}
 
-impl CurveParamsTrait<MyBigNum> for BN254Params {
-    fn one() {}
-}
+impl CurveParamsTrait<MyBigNum> for BN254Params {}
 
 trait BigCurveTrait {
     fn two();

--- a/tooling/nargo_cli/tests/snapshots/compile_success_empty/trait_default_implementation/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_empty/trait_default_implementation/execute__tests__expanded.snap
@@ -19,13 +19,9 @@ impl MyDefault for Foo {
     fn my_default(x: Field, y: Field) -> Self {
         Self { bar: x, array: [x, y] }
     }
-
-    fn method2(x: Field) -> Field {
-        x
-    }
 }
 
 fn main(x: Field) {
-    let first: Field = Foo::method2(x);
+    let first: Field = <Foo as MyDefault>::method2(x);
     assert(first == x);
 }

--- a/tooling/nargo_cli/tests/snapshots/compile_success_empty/trait_function_calls/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_empty/trait_function_calls/execute__tests__expanded.snap
@@ -20,15 +20,6 @@ struct Struct1a {
 }
 
 impl Trait1a for Struct1a {
-    fn trait_method1(self) -> Field {
-        (self.trait_method2() * 7892_Field) - self.vl()
-    }
-
-    fn trait_method2(self) -> Field {
-        let _: Self = self;
-        43278_Field
-    }
-
     fn vl(self) -> Field {
         self.vl
     }
@@ -52,10 +43,6 @@ struct Struct1b {
 }
 
 impl Trait1b for Struct1b {
-    fn trait_method1(self) -> Field {
-        (self.trait_method2() * 2832_Field) - self.vl()
-    }
-
     fn trait_method2(self) -> Field {
         let _: Self = self;
         2394_Field
@@ -81,10 +68,6 @@ struct Struct1c {
 }
 
 impl Trait1c for Struct1c {
-    fn trait_method1(self) -> Field {
-        (self.trait_method2() * 7635_Field) - self.vl()
-    }
-
     fn trait_method2(self) -> Field {
         let _: Self = self;
         5485_Field
@@ -115,11 +98,6 @@ struct Struct1d {
 impl Trait1d for Struct1d {
     fn trait_method1(self) -> Field {
         (self.trait_method2() * 9342_Field) - self.vl
-    }
-
-    fn trait_method2(self) -> Field {
-        let _: Self = self;
-        29341_Field
     }
 
     fn vl(self) -> Field {
@@ -205,11 +183,6 @@ impl Trait1g for Struct1g {
     fn trait_method1(self) -> Field {
         (self.trait_method2() * 7854_Field) - self.vl
     }
-
-    fn trait_method2(self) -> Field {
-        let _: Self = self;
-        37845_Field
-    }
 }
 
 trait Trait1h {
@@ -274,14 +247,6 @@ struct Struct2a {
 }
 
 impl Trait2a for Struct2a {
-    fn trait_method1(self) -> Field {
-        (Self::trait_function2() * 2385_Field) - self.vl()
-    }
-
-    fn trait_function2() -> Field {
-        7843_Field
-    }
-
     fn vl(self) -> Field {
         self.vl
     }
@@ -304,10 +269,6 @@ struct Struct2b {
 }
 
 impl Trait2b for Struct2b {
-    fn trait_method1(self) -> Field {
-        (Self::trait_function2() * 6583_Field) - self.vl()
-    }
-
     fn trait_function2() -> Field {
         8477_Field
     }
@@ -332,10 +293,6 @@ struct Struct2c {
 }
 
 impl Trait2c for Struct2c {
-    fn trait_method1(self) -> Field {
-        (Self::trait_function2() * 2831_Field) - self.vl()
-    }
-
     fn trait_function2() -> Field {
         8342_Field
     }
@@ -363,11 +320,7 @@ struct Struct2d {
 
 impl Trait2d for Struct2d {
     fn trait_method1(self) -> Field {
-        (Self::trait_function2() * 3984_Field) - self.vl
-    }
-
-    fn trait_function2() -> Field {
-        384_Field
+        (<Self as Trait2d>::trait_function2() * 3984_Field) - self.vl
     }
 
     fn vl(self) -> Field {
@@ -447,11 +400,7 @@ struct Struct2g {
 
 impl Trait2g for Struct2g {
     fn trait_method1(self) -> Field {
-        (Self::trait_function2() * 9123_Field) - self.vl
-    }
-
-    fn trait_function2() -> Field {
-        19273_Field
+        (<Self as Trait2g>::trait_function2() * 9123_Field) - self.vl
     }
 }
 
@@ -515,15 +464,6 @@ struct Struct3a {
 }
 
 impl Trait3a for Struct3a {
-    fn trait_function1(a: Field, b: Self) -> Field {
-        ((b.trait_method2() * 8344_Field) - b.vl()) + a
-    }
-
-    fn trait_method2(self) -> Field {
-        let _: Self = self;
-        19212_Field
-    }
-
     fn vl(self) -> Field {
         self.vl
     }
@@ -547,10 +487,6 @@ struct Struct3b {
 }
 
 impl Trait3b for Struct3b {
-    fn trait_function1(a: Field, b: Self) -> Field {
-        ((b.trait_method2() * 9233_Field) - b.vl()) + a
-    }
-
     fn trait_method2(self) -> Field {
         let _: Self = self;
         2392_Field
@@ -576,10 +512,6 @@ struct Struct3c {
 }
 
 impl Trait3c for Struct3c {
-    fn trait_function1(a: Field, b: Self) -> Field {
-        ((b.trait_method2() * 2822_Field) - b.vl()) + a
-    }
-
     fn trait_method2(self) -> Field {
         let _: Self = self;
         7743_Field
@@ -610,11 +542,6 @@ struct Struct3d {
 impl Trait3d for Struct3d {
     fn trait_function1(a: Field, b: Self) -> Field {
         ((b.trait_method2() * 4933_Field) - b.vl) + a
-    }
-
-    fn trait_method2(self) -> Field {
-        let _: Self = self;
-        3328_Field
     }
 
     fn vl(self) -> Field {
@@ -700,11 +627,6 @@ impl Trait3g for Struct3g {
     fn trait_function1(a: Field, b: Self) -> Field {
         ((b.trait_method2() * 31337_Field) - b.vl) + a
     }
-
-    fn trait_method2(self) -> Field {
-        let _: Self = self;
-        8887_Field
-    }
 }
 
 trait Trait3h {
@@ -766,15 +688,7 @@ pub struct Struct4a {
     vl: Field,
 }
 
-impl Trait4a for Struct4a {
-    fn trait_function1() -> Field {
-        Self::trait_function2() * 3842_Field
-    }
-
-    fn trait_function2() -> Field {
-        2932_Field
-    }
-}
+impl Trait4a for Struct4a {}
 
 trait Trait4b {
     fn trait_function1() -> Field {
@@ -791,10 +705,6 @@ pub struct Struct4b {
 }
 
 impl Trait4b for Struct4b {
-    fn trait_function1() -> Field {
-        Self::trait_function2() * 3842_Field
-    }
-
     fn trait_function2() -> Field {
         9353_Field
     }
@@ -813,10 +723,6 @@ pub struct Struct4c {
 }
 
 impl Trait4c for Struct4c {
-    fn trait_function1() -> Field {
-        Self::trait_function2() * 7832_Field
-    }
-
     fn trait_function2() -> Field {
         2928_Field
     }
@@ -838,11 +744,7 @@ pub struct Struct4d {
 
 impl Trait4d for Struct4d {
     fn trait_function1() -> Field {
-        Self::trait_function2() * 8374_Field
-    }
-
-    fn trait_function2() -> Field {
-        9332_Field
+        <Self as Trait4d>::trait_function2() * 8374_Field
     }
 }
 
@@ -906,11 +808,7 @@ pub struct Struct4g {
 
 impl Trait4g for Struct4g {
     fn trait_function1() -> Field {
-        Self::trait_function2() * 3345_Field
-    }
-
-    fn trait_function2() -> Field {
-        2932_Field
+        <Self as Trait4g>::trait_function2() * 3345_Field
     }
 }
 
@@ -994,11 +892,11 @@ fn main() {
     let t2i: Struct2i = Struct2i { vl: 1821_Field };
     assert(t2i.trait_method1() == 7608881_Field);
     let t3a: Struct3a = Struct3a { vl: 93248_Field };
-    assert(Struct3a::trait_function1(5_Field, t3a) == 160211685_Field);
+    assert(<Struct3a as Trait3a>::trait_function1(5_Field, t3a) == 160211685_Field);
     let t3b: Struct3b = Struct3b { vl: 76763_Field };
-    assert(Struct3b::trait_function1(62_Field, t3b) == 22008635_Field);
+    assert(<Struct3b as Trait3b>::trait_function1(62_Field, t3b) == 22008635_Field);
     let t3c: Struct3c = Struct3c { vl: 3833_Field };
-    assert(Struct3c::trait_function1(25_Field, t3c) == 21846938_Field);
+    assert(<Struct3c as Trait3c>::trait_function1(25_Field, t3c) == 21846938_Field);
     let t3d: Struct3d = Struct3d { vl: 5645_Field };
     assert(Struct3d::trait_function1(73_Field, t3d) == 16411452_Field);
     let t3e: Struct3e = Struct3e { vl: 22912_Field };
@@ -1011,9 +909,9 @@ fn main() {
     assert(Struct3h::trait_function1(17_Field, t3h) == 469630485_Field);
     let t3i: Struct3i = Struct3i { vl: 39432_Field };
     assert(Struct3i::trait_function1(54_Field, t3i) == 104304046_Field);
-    assert(Struct4a::trait_function1() == 11264744_Field);
-    assert(Struct4b::trait_function1() == 35934226_Field);
-    assert(Struct4c::trait_function1() == 22932096_Field);
+    assert(<Struct4a as Trait4a>::trait_function1() == 11264744_Field);
+    assert(<Struct4b as Trait4b>::trait_function1() == 35934226_Field);
+    assert(<Struct4c as Trait4c>::trait_function1() == 22932096_Field);
     assert(Struct4d::trait_function1() == 78146168_Field);
     assert(Struct4e::trait_function1() == 473622182_Field);
     assert(Struct4f::trait_function1() == 93996448_Field);

--- a/tooling/nargo_cli/tests/snapshots/compile_success_empty/trait_inheritance/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_empty/trait_inheritance/execute__tests__expanded.snap
@@ -25,10 +25,6 @@ impl Foo for Struct {
 }
 
 impl Bar for Struct {
-    fn bar(self) -> Field {
-        self.foo() + 1_Field
-    }
-
     fn baz(self) -> Field {
         self.foo() + 2_Field
     }

--- a/tooling/nargo_cli/tests/snapshots/compile_success_empty/trait_override_implementation/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_empty/trait_override_implementation/execute__tests__expanded.snap
@@ -52,16 +52,8 @@ impl F for Bar {
         10_Field
     }
 
-    fn f2(_self: Self) -> Field {
-        2_Field
-    }
-
     fn f3(_self: Self) -> Field {
         30_Field
-    }
-
-    fn f4(_self: Self) -> Field {
-        4_Field
     }
 
     fn f5(_self: Self) -> Field {

--- a/tooling/nargo_cli/tests/snapshots/compile_success_empty/trait_static_methods/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_empty/trait_static_methods/execute__tests__expanded.snap
@@ -22,14 +22,6 @@ impl ATrait for Foo {
     fn asd() -> Self {
         Self { x: 100_Field }
     }
-
-    fn static_method() -> Field {
-        Self::static_method_2()
-    }
-
-    fn static_method_2() -> Field {
-        100_Field
-    }
 }
 
 struct Bar {
@@ -41,18 +33,14 @@ impl ATrait for Bar {
         Self { x: 100_Field }
     }
 
-    fn static_method() -> Field {
-        Self::static_method_2()
-    }
-
     fn static_method_2() -> Field {
         200_Field
     }
 }
 
 fn main() {
-    assert(Foo::static_method() == 100_Field);
-    assert(Bar::static_method() == 200_Field);
+    assert(<Foo as ATrait>::static_method() == 100_Field);
+    assert(<Bar as ATrait>::static_method() == 200_Field);
     let zero: Field = <Field as MyDefault>::my_default();
     assert(zero == 0_Field);
 }

--- a/tooling/nargo_cli/tests/snapshots/compile_success_empty/trait_where_clause/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_empty/trait_where_clause/execute__tests__expanded.snap
@@ -47,12 +47,7 @@ impl Asd for AddXY {
 
 struct Static100 {}
 
-impl StaticTrait for Static100 {
-    fn static_function(slf: Self) -> Field {
-        let _: Self = slf;
-        100_Field
-    }
-}
+impl StaticTrait for Static100 {}
 
 struct Static200 {}
 

--- a/tooling/nargo_cli/tests/snapshots/compile_success_no_bug/function_registry/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_no_bug/function_registry/execute__tests__expanded.snap
@@ -44,10 +44,6 @@ impl Hasher for DummyHasher {
         0_Field
     }
 
-    fn finish_ref(&self) -> Field {
-        (*self).finish()
-    }
-
     fn write(&mut self, _input: Field) {}
 }
 

--- a/tooling/nargo_cli/tests/snapshots/compile_success_no_bug/regression_10689/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_no_bug/regression_10689/execute__tests__expanded.snap
@@ -11,10 +11,6 @@ impl Hasher for DummyHasher {
         0_Field
     }
 
-    fn finish_ref(&self) -> Field {
-        (*self).finish()
-    }
-
     fn write(&mut self, _input: Field) {}
 }
 

--- a/tooling/nargo_cli/tests/snapshots/execution_success/comptime_quoted_hash/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/comptime_quoted_hash/execute__tests__expanded.snap
@@ -13,10 +13,6 @@ impl Hasher for TestHasher {
         self.result
     }
 
-    fn finish_ref(&self) -> Field {
-        (*self).finish()
-    }
-
     fn write(&mut self, input: Field) {
         self.result = self.result + input;
     }

--- a/tooling/nargo_cli/tests/snapshots/execution_success/comptime_trait_constraint_hash_and_eq/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/comptime_trait_constraint_hash_and_eq/execute__tests__expanded.snap
@@ -31,10 +31,6 @@ impl Hasher for TestHasher {
         self.result
     }
 
-    fn finish_ref(&self) -> Field {
-        (*self).finish()
-    }
-
     fn write(&mut self, input: Field) {
         self.result = self.result + input;
     }

--- a/tooling/nargo_cli/tests/snapshots/execution_success/derive/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/derive/execute__tests__expanded.snap
@@ -207,10 +207,6 @@ impl Hasher for TestHasher {
         self.result
     }
 
-    fn finish_ref(&self) -> Field {
-        (*self).finish()
-    }
-
     fn write(&mut self, input: Field) {
         self.result = self.result + input;
     }

--- a/tooling/nargo_cli/tests/snapshots/execution_success/regression_4663/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/regression_4663/execute__tests__expanded.snap
@@ -11,10 +11,6 @@ impl Hasher for DummyHasher {
         0_Field
     }
 
-    fn finish_ref(&self) -> Field {
-        (*self).finish()
-    }
-
     fn write(&mut self, _input: Field) {}
 }
 


### PR DESCRIPTION
## Problem Resolved

Resolves https://github.com/noir-lang/noir/issues/9020
Resolves https://github.com/noir-lang/noir/issues/8632
Resolves https://github.com/noir-lang/noir-claude/issues/1234
Resolves [AZTBOT-1125](https://linear.app/aztec-foundation/issue/AZTBOT-1125/inherited-trait-default-method-bodies-resolve-helpers-in-impl-module)

## Summary of Changes

This was a long-standing issue and with Claude it's now a bit easier to fix. The idea I gave Claude is to reuse the FuncId of the trait default method, in trait impls that don't override it.

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
