### PR TITLE
fix: check trait impl associated constant visibility

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/trait_impls.rs
+++ b/compiler/noirc_frontend/src/elaborator/trait_impls.rs
@@ -28,7 +28,7 @@ use crate::{
 };
 
 use iter_extended::vecmap;
-use noirc_errors::Location;
+use noirc_errors::{Located, Location};
 use rustc_hash::FxHashMap as HashMap;
 use rustc_hash::FxHashSet as HashSet;
 
@@ -153,6 +153,11 @@ impl Elaborator<'_> {
                         unresolved_type,
                         &associated_type.typ.kind(),
                         wildcard_allowed,
+                    );
+                    self.check_trait_impl_associated_type_visibility(
+                        trait_id,
+                        &associated_type.name,
+                        &resolved_type,
                     );
                     if let Err(error) = named_generic.type_var.try_bind(
                         resolved_type,
@@ -566,6 +571,30 @@ impl Elaborator<'_> {
         }
 
         self.interner.push_fn_meta(override_meta, *func_id);
+    }
+
+    /// Check that an associated type in a trait impl is not assigned a type that is more
+    /// private than the trait itself. Otherwise, a private type would leak through the
+    /// trait's public surface.
+    #[tracing::instrument(level = "trace", skip_all)]
+    fn check_trait_impl_associated_type_visibility(
+        &mut self,
+        trait_id: TraitId,
+        associated_type_name: &Ident,
+        resolved_type: &Type,
+    ) {
+        let the_trait = self.interner.get_trait(trait_id);
+        let trait_visibility = the_trait.visibility;
+        let item = Ident::from(Located::from(
+            associated_type_name.location(),
+            format!("{}::{}", the_trait.name, associated_type_name),
+        ));
+        self.check_type_is_not_more_private_then_item(
+            &item,
+            trait_visibility,
+            resolved_type,
+            associated_type_name.location(),
+        );
     }
 
     #[tracing::instrument(level = "trace", skip_all)]

--- a/compiler/noirc_frontend/src/tests/visibility.rs
+++ b/compiler/noirc_frontend/src/tests/visibility.rs
@@ -196,6 +196,47 @@ fn errors_if_pub_trait_returns_private_struct() {
 }
 
 #[test]
+fn errors_if_trait_impl_associated_type_leaks_private_type() {
+    let src = r#"
+    struct Priv {}
+
+    pub trait T {
+        type Item;
+    }
+
+    impl T for u32 {
+        type Item = Priv;
+             ^^^^ Type `Priv` is more private than item `T::Item`
+    }
+
+    pub fn no_unused_warnings() {
+        let _ = Priv {};
+    }
+    "#;
+    check_errors(src);
+}
+
+#[test]
+fn does_not_error_if_private_trait_impl_associated_type_uses_private_type() {
+    let src = r#"
+    struct Priv {}
+
+    trait T {
+        type Item;
+    }
+
+    impl T for u32 {
+        type Item = Priv;
+    }
+
+    fn main() {
+        let _ = Priv {};
+    }
+    "#;
+    assert_no_errors(src);
+}
+
+#[test]
 fn does_not_error_if_trait_with_default_visibility_returns_struct_with_default_visibility() {
     let src = r#"
     struct Foo {}


### PR DESCRIPTION
## Problem Resolved

Resolves https://github.com/noir-lang/noir-claude/issues/1082
Resolves [AZTBOT-981](https://linear.app/aztec-foundation/issue/AZTBOT-981/noirc-frontend-visibility-should-check-function-args-and-return-are)

## Summary of Changes



## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
