### PR TITLE
fix: disallow inlining closures

### DIFF
--- a/compiler/noirc_frontend/src/hir/comptime/value.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/value.rs
@@ -586,7 +586,15 @@ impl Value {
                 })?;
                 HirExpression::Literal(HirLiteral::Vector(HirArrayLiteral::Standard(elements)))
             }
-            Value::Closure(closure) => HirExpression::Lambda(closure.lambda.clone()),
+            Value::Closure(closure) => {
+                // Captures would point at interpreter-only locals that don't exist at runtime.
+                if closure.lambda.captures.is_empty() {
+                    HirExpression::Lambda(closure.lambda.clone())
+                } else {
+                    let value = Value::Closure(closure).display(interner, files).to_string();
+                    return Err(InterpreterError::CannotInlineMacro { value, typ, location });
+                }
+            }
             // Only convert pointers with auto_deref = true. These are mutable variables
             // and we don't need to wrap them in `&mut`.
             Value::Pointer(element, true, _) => {

--- a/compiler/noirc_frontend/src/monomorphization/mod.rs
+++ b/compiler/noirc_frontend/src/monomorphization/mod.rs
@@ -2585,7 +2585,15 @@ impl<'interner> Monomorphizer<'interner> {
         let value = match lvalue {
             HirLValue::Ident(ident, typ) => match self.lookup_captured_lvalue(ident.id) {
                 Some(value) => value,
-                None => ast::LValue::Ident(self.local_ident(&ident, &typ)?.unwrap()),
+                None => {
+                    let Some(ident) = self.local_ident(&ident, &typ)? else {
+                        return Err(MonomorphizationError::InternalError {
+                            location: ident.location,
+                            message: "ICE: lvalue not found during monomorphization",
+                        });
+                    };
+                    ast::LValue::Ident(ident)
+                }
             },
             HirLValue::MemberAccess { object, field_index, typ, location, .. } => {
                 let field_index = field_index.unwrap();
@@ -2720,7 +2728,12 @@ impl<'interner> Monomorphizer<'interner> {
                 }
                 None => {
                     let typ = self.interner.definition_type(capture.ident.id);
-                    let ident = self.local_ident(&capture.ident, &typ)?.unwrap();
+                    let Some(ident) = self.local_ident(&capture.ident, &typ)? else {
+                        return Err(MonomorphizationError::InternalError {
+                            location: capture.ident.location,
+                            message: "ICE: closure capture not found during monomorphization",
+                        });
+                    };
                     Ok(ast::Expression::Ident(ident))
                 }
             }

--- a/test_programs/compile_failure/global_captured_closure/Nargo.toml
+++ b/test_programs/compile_failure/global_captured_closure/Nargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "global_captured_closure"
+type = "bin"
+authors = [""]
+
+[dependencies]

--- a/test_programs/compile_failure/global_captured_closure/src/main.nr
+++ b/test_programs/compile_failure/global_captured_closure/src/main.nr
@@ -1,0 +1,8 @@
+global ADD_ONE: fn[(Field,)](Field) -> Field = {
+    let offset = 1;
+    |x: Field| x + offset
+};
+
+fn main(x: Field) -> pub Field {
+    ADD_ONE(x)
+}

--- a/test_programs/compile_failure/macro_unquote_captured_closure/Nargo.toml
+++ b/test_programs/compile_failure/macro_unquote_captured_closure/Nargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "macro_unquote_captured_closure"
+type = "bin"
+authors = [""]
+
+[dependencies]

--- a/test_programs/compile_failure/macro_unquote_captured_closure/src/main.nr
+++ b/test_programs/compile_failure/macro_unquote_captured_closure/src/main.nr
@@ -1,0 +1,10 @@
+comptime fn make_adder() -> Quoted {
+    let offset = 1;
+    let f = |x: Field| x + offset;
+    quote { $f }
+}
+
+fn main(x: Field) -> pub Field {
+    let f = make_adder!();
+    f(x)
+}

--- a/tooling/nargo_cli/tests/snapshots/compile_failure/global_captured_closure/execute__tests__stderr.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_failure/global_captured_closure/execute__tests__stderr.snap
@@ -1,0 +1,12 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: stderr
+---
+error: Cannot inline values of type `fn[(Field,)](Field) -> Field` into this position
+  ┌─ src/main.nr:1:8
+  │
+1 │ global ADD_ONE: fn[(Field,)](Field) -> Field = {
+  │        ------- Cannot inline value `(closure)`
+  │
+
+Aborting due to 1 previous error

--- a/tooling/nargo_cli/tests/snapshots/compile_failure/macro_unquote_captured_closure/execute__tests__stderr.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_failure/macro_unquote_captured_closure/execute__tests__stderr.snap
@@ -1,0 +1,12 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: stderr
+---
+error: Cannot inline values of type `fn[(Field,)](Field) -> Field` into this position
+  ┌─ src/main.nr:4:14
+  │
+4 │     quote { $f }
+  │              - Cannot inline value `(closure)`
+  │
+
+Aborting due to 1 previous error


### PR DESCRIPTION
## Problem Resolved

Resolves https://github.com/noir-lang/noir-claude/issues/1076
Resolves [AZTBOT-975](https://linear.app/aztec-foundation/issue/AZTBOT-975/noirc-frontend-valueinto-runtime-hir-expression-drops-closureenv-for)

## Summary of Changes



## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
