### PR TITLE
fix: two-pass trait constraint resolution

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/function_context.rs
+++ b/compiler/noirc_frontend/src/elaborator/function_context.rs
@@ -155,10 +155,35 @@ impl Elaborator<'_> {
     #[tracing::instrument(level = "trace", skip_all)]
     pub(super) fn check_and_pop_function_context(&mut self) {
         let context = self.function_context.pop().expect("Imbalanced function_context pushes");
+        self.bind_type_variables_from_trait_constraints(&context.trait_constraints);
         self.check_defaultable_type_variables(context.defaultable_type_variables);
         self.check_integer_literal_fit_their_type(context.integer_literal_expr_ids);
         self.check_trait_constraints(context.trait_constraints);
         self.check_required_type_variables(context.required_type_variables);
+    }
+
+    /// Best-effort trait-constraint resolution that runs before integer-literal defaulting.
+    ///
+    /// When a constraint has exactly one impl that unifies with the current types,
+    /// `find_impl` succeeds and auto-applies its type bindings — including binding
+    /// `IntegerOrField` type variables to whatever the impl requires (e.g. `i32`).
+    /// Defaulting then becomes a no-op for those variables, so the real
+    /// [Self::check_trait_constraints] pass sees the impl-chosen type rather than
+    /// the defaulted `Field`.
+    ///
+    /// On failure (no match, multiple matches, or insufficient annotations), no
+    /// bindings are applied and no error is reported — the constraint is left
+    /// for the post-defaulting pass, which is responsible for the final verdict
+    /// and error reporting.
+    #[tracing::instrument(level = "trace", skip_all)]
+    fn bind_type_variables_from_trait_constraints(
+        &self,
+        trait_constraints: &[LocalTraitConstraint],
+    ) {
+        let current_trait_self = self.current_trait.and_then(|_| self.self_type.clone());
+        for local in trait_constraints {
+            let _ = local.constraint.find_impl(self.interner, current_trait_self.as_ref());
+        }
     }
 
     fn check_defaultable_type_variables(&self, type_variables: Vec<Type>) {

--- a/compiler/noirc_frontend/src/tests/traits/trait_method_resolution.rs
+++ b/compiler/noirc_frontend/src/tests/traits/trait_method_resolution.rs
@@ -532,6 +532,42 @@ fn calls_trait_method_using_struct_name_when_multiple_impls_exist() {
     assert_no_errors(src);
 }
 
+/// Regression test for https://github.com/noir-lang/noir/issues/8963
+///
+/// When a path-based trait call like `U60Repr::from2(x)` has multiple candidate
+/// impls, only one of which is compatible with the argument type, the trait
+/// solver must run before integer-literal defaulting — otherwise the array's
+/// element type defaults to `Field` and the only matching impl (`From2<[i32; 3]>`)
+/// is no longer reachable.
+#[test]
+fn calls_trait_method_using_struct_name_picks_impl_before_defaulting_integers() {
+    let src = r#"
+    trait From2<T> {
+        fn from2(input: T) -> Self;
+    }
+
+    struct U60Repr {}
+
+    impl From2<[i32; 3]> for U60Repr {
+        fn from2(_: [i32; 3]) -> Self {
+            U60Repr {}
+        }
+    }
+
+    impl From2<i32> for U60Repr {
+        fn from2(_: i32) -> Self {
+            U60Repr {}
+        }
+    }
+
+    fn main() {
+        let x = [1, 2, 3];
+        let _ = U60Repr::from2(x);
+    }
+    "#;
+    assert_no_errors(src);
+}
+
 #[test]
 fn suggests_importing_trait_via_reexport() {
     let src = r#"


### PR DESCRIPTION
## Summary

Fixes [#8963](https://github.com/noir-lang/noir/issues/8963): when a path-based trait call like `U60Repr::from2(x)` has multiple candidate impls, integer-literal defaulting was freezing the argument's element type to `Field` before the trait solver had a chance to pick the only impl that actually matched.

### Root cause

Path resolution of `U60Repr::from2` runs in `resolve_type_method_or_trait_method`. With two impls of `From2` on `U60Repr`, `trait_hir_method_reference` cannot take the single-impl fast path and instead returns a `HirMethodReference::TraitItemId` with fresh, unbound trait generics — effectively a deferred constraint `U60Repr: From2<?T>` whose impl choice is postponed.

After the call type-checks (binding `?T := [?N; 3]` where `?N : IntegerOrField`), the end-of-function pass `check_and_pop_function_context` ran in this order:

1. Default type variables → `?N := Field`
2. Check integer literal range
3. Verify trait constraints → searches for `From2<[Field; 3]>` → no impl matches → error

The bug only manifests when multiple impls exist, because with a single impl `trait_hir_method_reference` returns the concrete impl's `FuncId` directly and there is no deferred constraint to race with defaulting.

### Why swapping the order doesn't work

The obvious patch — run `check_trait_constraints` before `check_defaultable_type_variables` — fixes this case but breaks the opposite one: constraints like `Default::default()` need defaulting to make progress before any impl can be picked. Running the verifying pass first would emit spurious `TypeAnnotationsNeeded`/`NoImplFound` errors for those.

### The fix

Add a best-effort pre-pass before defaulting. For each pending constraint, call `find_impl` and discard the result:

- On success, `find_impl` auto-applies its type bindings (e.g. binding `?N := i32` from the `From2<[i32; 3]>` impl), and defaulting becomes a no-op for those variables.
- On failure (no match, multiple matches, missing annotations), nothing is bound and no error is emitted — the constraint is left for the existing post-defaulting `check_trait_constraints` pass, which remains the authoritative source for both impl selection and error reporting.

This keeps the existing pipeline's error behavior intact while letting impl-chosen types win over defaults when the choice is already unique.

## Test plan

- [x] `noirc_frontend` unit tests (1796/1796 pass, including new regression test `calls_trait_method_using_struct_name_picks_impl_before_defaulting_integers`)
- [x] `noirc_evaluator` + `noirc_driver` tests (1507/1507 pass)
- [x] `nargo_cli` integration `execute` suite (8655/8655 pass)
- [x] Original repro from #8963 compiles cleanly with `nargo check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)