### PR TITLE
fix(frontend): infer trait generic in default method body

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/expressions.rs
+++ b/compiler/noirc_frontend/src/elaborator/expressions.rs
@@ -1981,16 +1981,7 @@ impl Elaborator<'_> {
         // In `<Type as Trait>::method` we know `Self` is `Type` so we bind that now
         bindings.insert(self_type.id(), (self_type, kind, constraint.typ));
 
-        // TODO: set this to `true`. See https://github.com/noir-lang/noir/issues/8687
-        let push_required_type_variables = self.current_trait.is_none();
-
-        let typ = self.type_check_variable_with_bindings(
-            ident,
-            &id,
-            generics,
-            bindings,
-            push_required_type_variables,
-        );
+        let typ = self.type_check_variable_with_bindings(ident, &id, generics, bindings);
         let id = self.intern_expr_type(id, typ.clone());
         (id, typ)
     }

--- a/compiler/noirc_frontend/src/elaborator/types.rs
+++ b/compiler/noirc_frontend/src/elaborator/types.rs
@@ -3381,6 +3381,22 @@ impl Elaborator<'_> {
             let self_type = the_trait.self_type_typevar.clone();
             let kind = the_trait.self_type_typevar.kind();
             bindings.insert(self_type.id(), (self_type, kind, constraint.typ.clone()));
+
+            // When the constraint is `assumed` (e.g. for a call on `self` inside a trait
+            // default method), the trait's generics in the bound point back at the trait's
+            // own type variables, so `bind_generic`'s occurs check skips them as `t = t`.
+            // Without these bindings, instantiating the called method replaces its forall'd
+            // `T` with a fresh type variable, leaving the result rendered as `_` and
+            // unsoundly unifying with any type. Pin each trait generic to its own
+            // `NamedGeneric` here so the method's `T` resolves to the trait's `T`.
+            for (param, arg) in
+                the_trait.generics.iter().zip(&constraint.trait_bound.trait_generics.ordered)
+            {
+                bindings.insert(
+                    param.type_var.id(),
+                    (param.type_var.clone(), param.kind(), arg.clone()),
+                );
+            }
         }
     }
 

--- a/compiler/noirc_frontend/src/elaborator/variable.rs
+++ b/compiler/noirc_frontend/src/elaborator/variable.rs
@@ -282,15 +282,7 @@ impl Elaborator<'_> {
             let id = self
                 .intern_expr(HirExpression::Ident(hir_ident.clone(), generics.clone()), location);
 
-            // TODO: set this to `true`. See https://github.com/noir-lang/noir/issues/8687
-            let push_required_type_variables = self.current_trait.is_none();
-            let typ = self.type_check_variable_with_bindings(
-                hir_ident,
-                &id,
-                generics,
-                bindings,
-                push_required_type_variables,
-            );
+            let typ = self.type_check_variable_with_bindings(hir_ident, &id, generics, bindings);
             let id = self.intern_expr_type(id, typ.clone());
             (id, typ)
         } else {
@@ -685,15 +677,7 @@ impl Elaborator<'_> {
             TypeBindings::default()
         };
 
-        // TODO: set this to `true`. See https://github.com/noir-lang/noir/issues/8687
-        let push_required_type_variables = self.current_trait.is_none();
-        let typ = self.type_check_variable_with_bindings(
-            ident,
-            &id,
-            generics,
-            bindings,
-            push_required_type_variables,
-        );
+        let typ = self.type_check_variable_with_bindings(ident, &id, generics, bindings);
         let id = self.intern_expr_type(id, typ.clone());
 
         (id, typ)
@@ -767,22 +751,16 @@ impl Elaborator<'_> {
         generics: Option<Vec<Type>>,
     ) -> Type {
         let bindings = TypeBindings::default();
-        // TODO: set this to `true`. See https://github.com/noir-lang/noir/issues/8687
-        let push_required_type_variables = self.current_trait.is_none();
-        self.type_check_variable_with_bindings(
-            ident,
-            expr_id,
-            generics,
-            bindings,
-            push_required_type_variables,
-        )
+        self.type_check_variable_with_bindings(ident, expr_id, generics, bindings)
     }
 
     /// Perform the type checking of an interned expression and a corresponding identifier,
     /// returning the instantiated [Type].
     ///
-    /// If `push_required_type_variables`, the bindings are added to the function context,
-    /// to be checked before it's finished.
+    /// The instantiation bindings are pushed as required type variables on the current
+    /// function context, to be checked at end-of-function. `push_required_type_variable`
+    /// already skips this in a comptime context, where unbound generics on quoted typed
+    /// expressions are expected.
     #[tracing::instrument(level = "trace", skip_all)]
     pub(crate) fn type_check_variable_with_bindings(
         &mut self,
@@ -790,7 +768,6 @@ impl Elaborator<'_> {
         expr_id: &PushedExpr<HasLocation>,
         generics: Option<Vec<Type>>,
         mut bindings: TypeBindings,
-        push_required_type_variables: bool,
     ) -> Type {
         // Add type bindings from any constraints that were used.
         // We need to do this first since otherwise instantiating the type below
@@ -917,21 +894,18 @@ impl Elaborator<'_> {
             }
         }
 
-        if push_required_type_variables {
-            // Record required type variables in a predictable order to avoid nondeterminism in error messages.
-            let required_type_variables =
-                btree_map(bindings.values(), |(type_variable, _, typ)| {
-                    (type_variable.id(), typ.clone())
-                });
+        // Record required type variables in a predictable order to avoid nondeterminism in error messages.
+        let required_type_variables = btree_map(bindings.values(), |(type_variable, _, typ)| {
+            (type_variable.id(), typ.clone())
+        });
 
-            for (type_variable_id, typ) in required_type_variables {
-                self.push_required_type_variable(
-                    type_variable_id,
-                    typ,
-                    BindableTypeVariableKind::Ident(ident.id),
-                    ident.location,
-                );
-            }
+        for (type_variable_id, typ) in required_type_variables {
+            self.push_required_type_variable(
+                type_variable_id,
+                typ,
+                BindableTypeVariableKind::Ident(ident.id),
+                ident.location,
+            );
         }
 
         self.interner.store_instantiation_bindings(**expr_id, bindings);

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
@@ -2608,14 +2608,7 @@ fn function_def_as_typed_expr(
     let typ =
         interpreter.elaborate_in_function(interpreter.current_function, reason, |elaborator| {
             let bindings = TypeBindings::default();
-            let push_required_type_variables = false;
-            elaborator.type_check_variable_with_bindings(
-                hir_ident,
-                &expr_id,
-                generics,
-                bindings,
-                push_required_type_variables,
-            )
+            elaborator.type_check_variable_with_bindings(hir_ident, &expr_id, generics, bindings)
         });
     let expr_id = interpreter.elaborator.intern_expr_type(expr_id, typ);
     Ok(Value::TypedExpr(TypedExpr::ExprId(expr_id)))

--- a/compiler/noirc_frontend/src/tests/traits/trait_default_methods.rs
+++ b/compiler/noirc_frontend/src/tests/traits/trait_default_methods.rs
@@ -271,3 +271,22 @@ fn generic_trait_numeric_generic_default_method() {
     "#;
     assert_no_errors(src);
 }
+
+/// Regression test for https://github.com/noir-lang/noir/issues/8687.
+#[test]
+fn issue_8687_trait_default_method_return_type_is_trait_generic() {
+    let src = r#"
+    pub trait Trait<T> {
+        fn one(self) -> T;
+
+        fn foo(self) {
+            let t = self.one();
+            let _: i32 = t;
+                         ^ Expected type i32, found type T
+        }
+    }
+
+    fn main() {}
+    "#;
+    check_errors(src);
+}


### PR DESCRIPTION
## Summary

- Resolves https://github.com/noir-lang/noir/issues/8687.
- In a trait default method, a call on `self` to another trait method whose return type uses a trait generic `T` now produces a value of type `T` instead of an unbound type variable that silently unifies with anything.
- Removes the four `push_required_type_variables = self.current_trait.is_none()` band-aids that suppressed unbound-typevar diagnostics inside trait bodies, and drops the (now-unused) `push_required_type_variables` parameter.

## Root cause

For `self.one()` inside `fn foo` of `pub trait Trait<T> { fn one(self) -> T; fn foo(self) { let t = self.one(); } }`, the elaborator builds an assumed trait constraint whose `trait_generics.ordered[0]` is `NamedGeneric T(T_typevar)` — a named-generic wrapping the trait's own `T` typevar. `bind_generic`'s `occurs` check then skipped that binding as a trivial `t = t`, so when the called method's type `forall '1 '2. fn(Self'2) -> T'1` was instantiated, `'1` (which has the same id as `T_typevar`) had no binding and was replaced by a fresh free typevar. The result rendered as `_` in LSP and unsoundly unified with any type at later use sites.

The fix pins each trait generic to itself inside the `assumed` branch of `bind_generics_from_trait_constraint`, bypassing the `occurs` guard for this case only. Scoping the fix to `assumed` constraints avoids regressing real-impl lookups (where the same self-binding would prevent the impl's concrete generics from filling in unbound positions).

## Test plan

- [x] `cargo nextest run --workspace` (14,132 passed, 59 skipped)
- [x] New regression test `issue_8687_trait_default_method_return_type_is_trait_generic` — verified red on `master` (no error reported before the fix) and green after.