### PR TITLE
fix(ssa): classify VectorPushBack as PureWithPredicate

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/ir/instruction.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/instruction.rs
@@ -251,10 +251,13 @@ impl Intrinsic {
 
             // Operations that remove items from a vector don't modify the vector, they just assert it's non-empty.
             // Vector insert also reads from its input vector, thus needing to assert that it is non-empty.
+            // Vector push back's ACIR lowering multiplies the write index by `current_side_effects_enabled_var`,
+            // so deduplicating two pushes across different `enable_side_effects` predicates is unsound.
             Intrinsic::VectorPopBack
             | Intrinsic::VectorPopFront
             | Intrinsic::VectorRemove
-            | Intrinsic::VectorInsert => Purity::PureWithPredicate,
+            | Intrinsic::VectorInsert
+            | Intrinsic::VectorPushBack => Purity::PureWithPredicate,
 
             Intrinsic::AssertConstant
             | Intrinsic::StaticAssert

--- a/compiler/noirc_evaluator/src/ssa/opt/constant_folding/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/constant_folding/mod.rs
@@ -1184,6 +1184,27 @@ mod test {
         assert_ssa_does_not_change(src, |ssa| ssa.fold_constants(MIN_ITER));
     }
 
+    // Regression for noir-claude#1021.
+    // Two identical `vector_push_back` calls under complementary
+    // `enable_side_effects` predicates must not be deduplicated: doing so
+    // replaces the second push's result with the first's, which observed the
+    // opposite predicate.
+    #[test]
+    fn vector_push_back_predicate_regression() {
+        let src = "
+        acir(inline) fn main f0 {
+          b0(v0: u1, v1: u32, v2: [Field], v3: Field):
+            enable_side_effects v0
+            v4, v5 = call vector_push_back(v1, v2, v3) -> (u32, [Field])
+            v6 = not v0
+            enable_side_effects v6
+            v7, v8 = call vector_push_back(v1, v2, v3) -> (u32, [Field])
+            return v8
+        }
+        ";
+        assert_ssa_does_not_change(src, |ssa| ssa.fold_constants(MIN_ITER));
+    }
+
     #[test]
     fn deduplicate_instructions_with_predicates() {
         let src = "


### PR DESCRIPTION
Fixes https://github.com/noir-lang/noir-claude/issues/1021
Fixes [NOIR-1613](https://linear.app/aztec-foundation/issue/NOIR-1613/vectorpushback-is-deduplicated-across-side-effect-predicates)

## Summary

- Promotes `Intrinsic::VectorPushBack` from `Purity::Pure` to `Purity::PureWithPredicate`, alongside the other vector mutation intrinsics (`VectorPopBack/PopFront/Remove/Insert`).
- Fixes a latent miscompile where two identical `vector_push_back` calls under complementary `EnableSideEffectsIf` predicates were deduplicated by the non-constraint-info constant folding pass (which drops the predicate from its cache key for `Pure` intrinsics). The replaced call then observed the wrong branch's predicate.
- The root cause is the mismatch between `purity()` returning `Pure` and `requires_acir_gen_predicate()` returning `true` for `VectorPushBack`: the ACIR lowering's heterogeneous path uses `get_flattened_index(..., is_safe_index: false, ...)`, which multiplies the write index by `current_side_effects_enabled_var`, so the lowered semantics do depend on the predicate.

## Reproducibility

The bug is verifiable at the SSA layer but **cannot be reproduced from Noir source code**. Any natural Noir construct that would create two duplicate `vector_push_back` calls (e.g. `if cond { v.push_back(x) } else { v.push_back(x) }`) gets hoisted by the pre-flattening Constant Folding pass *before* any `EnableSideEffectsIf` instructions are introduced, so only one push remains by the time predicates matter. The included regression test uses the SSA repro from the audit verbatim.

Because the trigger pattern doesn't arise from current source patterns, I don't expect end-user behavior to change today. But the structural mismatch is real, and any future SSA pass that produces the trigger pattern post-flattening would silently miscompile. Closing this off now keeps the door shut.

## Possible performance regression

This is a stricter dedup rule, so it can leave some `vector_push_back` calls un-deduplicated where they previously would have been. Concretely:
- `Pure` mapped to `CanBeDeduplicated::Always`.
- `PureWithPredicate` maps to `CanBeDeduplicated::UnderSamePredicate`, and the regular Constant Folding passes (without `use_constraint_info`) won't dedup it at all.

The most visible impact is on patterns like `if cond { v.push_back(x) } else { v.push_back(x) }`, where the early pre-flattening CSE hoist no longer fires — the program ends up with two push calls instead of one. Each extra push in the final ACIR is one extra array copy + predicate-gated index arithmetic.

I've added the `bench-show` label so the CI bench comparison runs and any real impact shows up in the PR. If the benchmarks come back clean, this is a strict correctness improvement and worth taking. If the regression is meaningful, the alternative fix (already noted in the audit) is to instead change `cache_predicate` in `constant_folding/mod.rs` to include the predicate whenever `requires_acir_gen_predicate()` is true — that preserves the pre-flattening dedup (since there's no predicate yet) while blocking the post-flattening unsound one.

## Note on VectorPushFront

`VectorPushFront` is left as `Pure`. Its ACIR lowering (`convert_vector_push_front`) doesn't use `get_flattened_index` or any dynamic predicate-gated memory write — it just constructs a new `AcirValue::Array` symbolically. `requires_acir_gen_predicate()` correctly returns `false` for it, so the classification is already self-consistent.

## Test plan

- [x] New regression test `vector_push_back_predicate_regression` in `compiler/noirc_evaluator/src/ssa/opt/constant_folding/mod.rs` (uses the SSA repro from the audit + `assert_ssa_does_not_change`). Confirmed it fails on the broken behavior (second push deleted, return rewritten to first call's result) and passes after the fix.
- [x] Full `noirc_evaluator` test suite: 1506 passed, 0 failed.
- [x] Full `nargo_cli` execute integration suite: 8667 passed, 0 failed.
- [x] SSA-level repro via `noir-ssa transform --source-path repro.ssa --ssa-pass "Constant Folding"` now preserves both pushes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)