### PR TITLE
fix(frontend): identify trait generics by id in `<Self as Trait<..>>::Assoc` shortcut

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/types.rs
+++ b/compiler/noirc_frontend/src/elaborator/types.rs
@@ -1273,7 +1273,22 @@ impl Elaborator<'_> {
         let location = path.trait_path.location;
         let (ordered, named) = self.use_type_args(path.trait_generics.clone(), trait_id, location);
 
-        if !ordered.iter().all(|typ| matches!(typ, Type::NamedGeneric(_)))
+        let trait_generic_ids: Vec<_> = self
+            .interner
+            .get_trait(current_trait)
+            .generics
+            .iter()
+            .map(|g| g.type_var.id())
+            .collect();
+
+        if ordered.len() != trait_generic_ids.len() {
+            return None;
+        }
+        let ordered_match_trait_generics =
+            ordered.iter().zip(&trait_generic_ids).all(|(typ, trait_gen_id)| {
+                matches!(typ, Type::NamedGeneric(ng) if ng.type_var.id() == *trait_gen_id)
+            });
+        if !ordered_match_trait_generics
             || !named.iter().all(|typ| matches!(typ.typ, Type::TypeVariable(_)))
         {
             return None;

--- a/compiler/noirc_frontend/src/elaborator/types.rs
+++ b/compiler/noirc_frontend/src/elaborator/types.rs
@@ -1273,13 +1273,8 @@ impl Elaborator<'_> {
         let location = path.trait_path.location;
         let (ordered, named) = self.use_type_args(path.trait_generics.clone(), trait_id, location);
 
-        let trait_generic_ids: Vec<_> = self
-            .interner
-            .get_trait(current_trait)
-            .generics
-            .iter()
-            .map(|g| g.type_var.id())
-            .collect();
+        let trait_generic_ids: Vec<_> =
+            vecmap(&self.interner.get_trait(current_trait).generics, |g| g.type_var.id());
 
         if ordered.len() != trait_generic_ids.len() {
             return None;

--- a/compiler/noirc_frontend/src/elaborator/types.rs
+++ b/compiler/noirc_frontend/src/elaborator/types.rs
@@ -1285,7 +1285,7 @@ impl Elaborator<'_> {
             return None;
         }
         let ordered_match_trait_generics =
-            ordered.iter().zip(&trait_generic_ids).all(|(typ, trait_gen_id)| {
+            ordered.iter().zip_eq(&trait_generic_ids).all(|(typ, trait_gen_id)| {
                 matches!(typ, Type::NamedGeneric(ng) if ng.type_var.id() == *trait_gen_id)
             });
         if !ordered_match_trait_generics

--- a/compiler/noirc_frontend/src/tests/traits/trait_associated_items.rs
+++ b/compiler/noirc_frontend/src/tests/traits/trait_associated_items.rs
@@ -764,6 +764,23 @@ fn associated_type_behind_self_as_trait_with_different_generics() {
 }
 
 #[test]
+fn associated_type_behind_self_as_trait_with_method_generic() {
+    // Regression test: `<Self as Foo<U>>::Bar` where `U` is a method-level generic
+    // (distinct from the trait's own type parameter `Baz`) must not be silently
+    // rewritten to `Self::Bar` (which would resolve to `<Self as Foo<Baz>>::Bar`).
+    let src = r#"
+    pub trait Foo<Baz> {
+        type Bar;
+        fn bar<U>() -> <Self as Foo<U>>::Bar;
+                                ^^^ No matching impl found for `Self: Foo<U, Bar = _>`
+                                ~~~ No impl for `Self: Foo<U, Bar = _>`
+    }
+    fn main() {}
+    "#;
+    check_errors(src);
+}
+
+#[test]
 fn associated_constant_direct_access() {
     let src = "
     trait MyTrait {


### PR DESCRIPTION
Resolves https://github.com/noir-lang/noir-claude/issues/677

## Summary

The shortcut at [compiler/noirc_frontend/src/elaborator/types.rs:1276-1280](https://github.com/noir-lang/noir/blob/master/compiler/noirc_frontend/src/elaborator/types.rs#L1276-L1280) rewrites `<Self as Trait<TraitGenerics>>::Assoc` to `Self::Assoc` inside a trait definition. Its guard only checked the `Type::NamedGeneric` *variant*, so any in-scope named generic passed — including method-level generics that are distinct from the trait's own type parameters.

As a result, inside a trait definition `<Self as Foo<U>>::Bar` where `U` was a method-level generic was silently rewritten to `Self::Bar` and resolved as `<Self as Foo<TraitGen>>::Bar` — a different associated type — with no error.

The fix compares each resolved generic's `type_var.id()` against the corresponding trait generic's id, so the shortcut only fires when the path really refers to the current trait with its own parameters. Mismatched generics now fall through to the normal impl-lookup path, which surfaces the expected "No matching impl" error (mirroring the existing behavior for `<Self as Foo<u32>>::Bar`).

## Test plan

- [x] New regression test `associated_type_behind_self_as_trait_with_method_generic` fails before the fix (silent acceptance) and passes after
- [x] `cargo nextest run -p noirc_frontend` — 1809 tests pass
- [x] `cargo nextest run -p nargo_cli --test execute trait` — 179 trait integration tests pass
- [x] `cargo clippy -p noirc_frontend --all-targets` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)