### PR TITLE
fix(frontend): bind impl-method generics on Normal trait-dispatch path

### DIFF
--- a/compiler/noirc_frontend/src/monomorphization/mod.rs
+++ b/compiler/noirc_frontend/src/monomorphization/mod.rs
@@ -3217,20 +3217,13 @@ fn resolve_trait_item_impl(
 
     match trait_impl {
         TraitImplKind::Normal(impl_id) => {
-            // If the impl's matching method shares the trait's default-method `FuncId`
-            // (the impl inherited the default), bind the trait's `Self` to the impl's self
-            // type so monomorphization of the shared body can look up impl-specific items
-            // (`Self::N`, etc.). For overridden impl methods this is a no-op — the impl's
-            // own `FuncId` carries the binding via `set_function_trait`.
-            let mut bindings = interner.get_instantiation_bindings(expr_id).clone();
-            bind_trait_impl_func_generics_to_trait_func_generics(
+            record_impl_instantiation_bindings(
                 interner,
                 method_id,
                 impl_id,
-                &mut bindings,
+                expr_id,
+                TypeBindings::default(),
             );
-            bind_trait_self_to_impl_self(interner, method_id, impl_id, &mut bindings);
-            interner.store_instantiation_bindings(expr_id, bindings);
             Ok(impl_id)
         }
         TraitImplKind::Prepared { .. } => {
@@ -3246,21 +3239,15 @@ fn resolve_trait_item_impl(
                 &trait_generics.named,
             ) {
                 Ok((TraitImplKind::Normal(impl_id), instantiation_bindings)) => {
-                    // Insert any additional instantiation bindings into this expression's instantiation bindings.
-                    // This is similar to what's done in `verify_trait_constraint` in the frontend.
-                    let mut bindings = interner.get_instantiation_bindings(expr_id).clone();
-                    bindings.extend(instantiation_bindings);
-
-                    bind_trait_impl_func_generics_to_trait_func_generics(
+                    // The extra bindings come from impl lookup, similar to
+                    // what's done in `verify_trait_constraint` in the frontend.
+                    record_impl_instantiation_bindings(
                         interner,
                         method_id,
                         impl_id,
-                        &mut bindings,
+                        expr_id,
+                        instantiation_bindings,
                     );
-
-                    bind_trait_self_to_impl_self(interner, method_id, impl_id, &mut bindings);
-
-                    interner.store_instantiation_bindings(expr_id, bindings);
                     Ok(impl_id)
                 }
                 Ok((TraitImplKind::Assumed { .. }, _instantiation_bindings)) => {
@@ -3299,6 +3286,29 @@ fn resolve_trait_item_impl(
             }
         }
     }
+}
+
+/// Apply all instantiation bindings needed once a concrete impl has been chosen for a
+/// trait-method call expression: merge in any bindings discovered during impl lookup,
+/// connect the impl method's direct generics to the trait method's generics, bind the
+/// trait's `Self` to the impl's self type when applicable, and store the result back.
+fn record_impl_instantiation_bindings(
+    interner: &mut NodeInterner,
+    method_id: TraitItemId,
+    impl_id: node_interner::TraitImplId,
+    expr_id: ExprId,
+    extra_bindings: TypeBindings,
+) {
+    let mut bindings = interner.get_instantiation_bindings(expr_id).clone();
+    bindings.extend(extra_bindings);
+    bind_trait_impl_func_generics_to_trait_func_generics(
+        interner,
+        method_id,
+        impl_id,
+        &mut bindings,
+    );
+    bind_trait_self_to_impl_self(interner, method_id, impl_id, &mut bindings);
+    interner.store_instantiation_bindings(expr_id, bindings);
 }
 
 /// Bind the trait's `Self` type variable to the impl's concrete self type when the impl's

--- a/compiler/noirc_frontend/src/monomorphization/mod.rs
+++ b/compiler/noirc_frontend/src/monomorphization/mod.rs
@@ -3223,6 +3223,12 @@ fn resolve_trait_item_impl(
             // (`Self::N`, etc.). For overridden impl methods this is a no-op — the impl's
             // own `FuncId` carries the binding via `set_function_trait`.
             let mut bindings = interner.get_instantiation_bindings(expr_id).clone();
+            bind_trait_impl_func_generics_to_trait_func_generics(
+                interner,
+                method_id,
+                impl_id,
+                &mut bindings,
+            );
             bind_trait_self_to_impl_self(interner, method_id, impl_id, &mut bindings);
             interner.store_instantiation_bindings(expr_id, bindings);
             Ok(impl_id)

--- a/compiler/noirc_frontend/src/tests/traits/trait_method_signatures.rs
+++ b/compiler/noirc_frontend/src/tests/traits/trait_method_signatures.rs
@@ -174,6 +174,26 @@ fn trait_method_numeric_generic_on_function() {
 }
 
 #[test]
+fn trait_method_numeric_generic_on_function_direct_dispatch() {
+    let src = r#"
+    trait Bar {
+        fn baz<let N: u32>() -> u32;
+    }
+
+    impl Bar for Field {
+        fn baz<let M: u32>() -> u32 {
+            M
+        }
+    }
+
+    fn main() {
+        let _ = <Field as Bar>::baz::<7>();
+    }
+    "#;
+    check_monomorphization_error(src);
+}
+
+#[test]
 fn check_trait_missing_implementation() {
     let src = "
     trait Default2 {


### PR DESCRIPTION
## Summary

- Calling a trait method via direct dispatch (`<Field as Bar>::baz::<7>()`) on a `TraitImplKind::Normal` impl whose body referenced a direct impl-method numeric generic that did not appear in the method signature failed monomorphization with `Invalid array length / Expected a constant, but found _`. The same impl reached through a where-clause path compiled fine.
- The Normal arm of `resolve_trait_item_impl` skipped `bind_trait_impl_func_generics_to_trait_func_generics`; only the Assumed arm called it. This commit applies the same call on the Normal arm, then extracts a small helper (`record_impl_instantiation_bindings`) so both arms share the same binding sequence.

Resolves https://github.com/noir-lang/noir-claude/issues/929

## Test plan

- [x] New regression test `trait_method_numeric_generic_on_function_direct_dispatch` in `compiler/noirc_frontend/src/tests/traits/trait_method_signatures.rs` covers the direct-dispatch path with a body-only impl-method numeric generic. Confirmed red before the fix, green after.
- [x] Existing `trait_method_numeric_generic_on_function` (where-clause path) still passes.
- [x] Full `cargo nextest run -p noirc_frontend` suite (1809 tests) passes.
- [x] `cargo clippy -p noirc_frontend --release --all-targets` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)