### PR TITLE
fix: Warn when a negative integer literal is casted to an integer type

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/types.rs
+++ b/compiler/noirc_frontend/src/elaborator/types.rs
@@ -21,7 +21,7 @@ use crate::{
     },
     elaborator::{Turbofish, UnstableFeature, path_resolution::PathResolution},
     hir::{
-        comptime::Integer,
+        comptime::{Integer, Value, evaluate_cast_one_step},
         def_collector::dc_crate::CompilationError,
         def_map::{ModuleDefId, ModuleId, fully_qualified_module_path},
         resolution::{
@@ -2135,8 +2135,23 @@ impl Elaborator<'_> {
             }
         };
 
-        // TODO(https://github.com/noir-lang/noir/issues/6247):
-        // handle negative literals
+        // Warn if a user casts to an integer from a negative field literal.
+        // `-1 as i8 == 0`, not `-1` which can be confusing.
+        if let Some(value) = from_value_opt
+            && -value < value
+            && to.is_integer()
+            && (from_follow_bindings.is_field() || from_follow_bindings.is_bindable())
+            && let Ok(Value::Integer(result)) =
+                evaluate_cast_one_step(&to, location, Value::field(value))
+        {
+            self.push_err(TypeCheckError::NegativeLiteralCastToInteger {
+                value,
+                result: result.to_string(),
+                to: to.clone(),
+                location,
+            });
+        }
+
         // when casting a polymorphic value to a specifically sized type,
         // check that it fits or throw a warning
         if let (Some(from_value), Some(to_maximum_size)) =

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
@@ -82,6 +82,7 @@ use super::value::{Closure, Value, unwrap_rc};
 
 mod builtin;
 mod cast;
+pub(crate) use cast::evaluate_cast_one_step;
 mod foreign;
 mod infix;
 mod tracker;
@@ -1288,7 +1289,7 @@ impl<'local, 'interner> Interpreter<'local, 'interner> {
     fn evaluate_cast(&mut self, cast: &HirCastExpression, id: ExprId) -> IResult<Value> {
         let evaluated_lhs = self.evaluate(cast.lhs)?;
         let location = self.elaborator.interner.expr_location(&id);
-        cast::evaluate_cast_one_step(&cast.r#type, location, evaluated_lhs)
+        evaluate_cast_one_step(&cast.r#type, location, evaluated_lhs)
     }
 
     fn evaluate_if(&mut self, if_: HirIfExpression) -> IResult<Value> {

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter/cast.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter/cast.rs
@@ -102,7 +102,7 @@ fn convert_to_2s_complement_field(value: Value, location: Location) -> IResult<F
 }
 
 /// evaluate_cast without recursion
-pub(super) fn evaluate_cast_one_step(
+pub(crate) fn evaluate_cast_one_step(
     output_type: &Type,
     location: Location,
     evaluated_lhs: Value,

--- a/compiler/noirc_frontend/src/hir/comptime/mod.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/mod.rs
@@ -21,5 +21,6 @@ mod value;
 pub use display::{tokens_to_string, tokens_to_string_with_indent};
 pub use errors::{ComptimeError, InterpreterError};
 pub use integer::Integer;
+pub(crate) use interpreter::evaluate_cast_one_step;
 pub use interpreter::{EvaluationTracker, Interpreter};
 pub use value::{FormatStringFragment, Value};

--- a/compiler/noirc_frontend/src/hir/type_check/errors.rs
+++ b/compiler/noirc_frontend/src/hir/type_check/errors.rs
@@ -93,6 +93,13 @@ pub enum TypeCheckError {
     InvalidCast { from: Type, location: Location, reason: String },
     #[error("Casting value of type {from} to a smaller type ({to})")]
     DownsizingCast { from: Type, to: Type, location: Location, reason: String },
+    #[error("Negative Field literal `{value}` cast to `{to}` evaluates to `{result}`")]
+    NegativeLiteralCastToInteger {
+        value: FieldElement,
+        result: String,
+        to: Type,
+        location: Location,
+    },
     #[error("Cannot cast `{typ}` as `bool`")]
     CannotCastNumericToBool { typ: Type, location: Location },
     #[error("Expected a function, but found a(n) {found}")]
@@ -323,6 +330,7 @@ impl TypeCheckError {
             | TypeCheckError::ArityMisMatch { location, .. }
             | TypeCheckError::InvalidCast { location, .. }
             | TypeCheckError::DownsizingCast { location, .. }
+            | TypeCheckError::NegativeLiteralCastToInteger { location, .. }
             | TypeCheckError::CannotCastNumericToBool { location, .. }
             | TypeCheckError::ExpectedFunction { location, .. }
             | TypeCheckError::AccessUnknownMember { location, .. }
@@ -560,6 +568,12 @@ impl<'a> From<&'a TypeCheckError> for Diagnostic {
             }
             TypeCheckError::DownsizingCast { location, reason, .. } => {
                 Diagnostic::simple_warning(error.to_string(), reason.clone(), *location)
+            }
+            TypeCheckError::NegativeLiteralCastToInteger { value, to, location, .. } => {
+                let secondary = format!(
+                    "If this isn't desired, try `{value}{to}` instead or bind to a variable first to silence this warning"
+                );
+                Diagnostic::simple_warning(error.to_string(), secondary, *location)
             }
             TypeCheckError::CannotCastNumericToBool { typ: _, location } => {
                 let secondary = "Compare with zero instead: ` != 0`".to_string();

--- a/compiler/noirc_frontend/src/tests/cast.rs
+++ b/compiler/noirc_frontend/src/tests/cast.rs
@@ -38,10 +38,8 @@ fn cast_suffixed_negative_literal_to_integer_does_not_warn() {
 fn cast_signed_i8_to_field_must_error() {
     let src = r#"
         fn main() {
-            assert((-1 as i8) as Field != 0);
-                   ^^^^^^^^^^^^^^^^^^^ Only unsigned integer types may be casted to Field
-                    ^^^^^^^^ Negative Field literal `-1` cast to `i8` evaluates to `0`
-                    ~~~~~~~~ If this isn't desired, try `-1i8` instead or bind to a variable first to silence this warning
+            assert(-1i8 as Field != 0);
+                   ^^^^^^^^^^^^^ Only unsigned integer types may be casted to Field
         }
     "#;
     check_errors(src);

--- a/compiler/noirc_frontend/src/tests/cast.rs
+++ b/compiler/noirc_frontend/src/tests/cast.rs
@@ -12,13 +12,23 @@ fn cast_256_to_u8_size_checks() {
     check_errors(src);
 }
 
-// TODO(https://github.com/noir-lang/noir/issues/6247):
-// add negative integer literal checks
 #[test]
-fn cast_negative_one_to_u8_size_checks() {
+fn cast_negative_literal_to_integer_warns() {
     let src = r#"
         fn main() {
-            assert((-1) as u8 != 0);
+            let _ = -1 as i8;
+                    ^^^^^^^^ Negative Field literal `-1` cast to `i8` evaluates to `0`
+                    ~~~~~~~~ If this isn't desired, try `-1i8` instead or bind to a variable first to silence this warning
+        }
+    "#;
+    check_errors(src);
+}
+
+#[test]
+fn cast_suffixed_negative_literal_to_integer_does_not_warn() {
+    let src = r#"
+        fn main() {
+            let _ = -1i8 as i8;
         }
     "#;
     assert_no_errors(src);
@@ -30,6 +40,8 @@ fn cast_signed_i8_to_field_must_error() {
         fn main() {
             assert((-1 as i8) as Field != 0);
                    ^^^^^^^^^^^^^^^^^^^ Only unsigned integer types may be casted to Field
+                    ^^^^^^^^ Negative Field literal `-1` cast to `i8` evaluates to `0`
+                    ~~~~~~~~ If this isn't desired, try `-1i8` instead or bind to a variable first to silence this warning
         }
     "#;
     check_errors(src);


### PR DESCRIPTION
## Problem Resolved

Resolves https://github.com/noir-lang/noir/issues/12794
Resolves https://github.com/noir-lang/noir-claude/issues/803
Resolves https://github.com/noir-lang/noir/issues/6247

## Summary of Changes

Adds a warning with the actual runtime value of the cast included in the warning. This triggers for casts to both signed & unsigned types since you may still have undesired behavior with unsigned types too. E.g. does a user doing `-1 as u8` expect 255? Currently it truncates to `0` like a cast to `i8` does so I thought the warning was appropriate.

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
