### PR TITLE
fix: Add lint checks for databus visibility on parameters and return …

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/function.rs
+++ b/compiler/noirc_frontend/src/elaborator/function.rs
@@ -363,6 +363,17 @@ impl Elaborator<'_> {
 
         let is_crate_root = self.is_at_crate_root();
         let is_entry_point = func.is_entry_point(self.is_function_in_contract(), is_crate_root);
+
+        self.run_lint(|_| {
+            lints::databus_visibility_on_return(
+                func,
+                func.def.return_visibility,
+                func.def.return_visibility_location,
+                is_entry_point,
+            )
+            .map(Into::into)
+        });
+
         // Temporary allow vectors for contract functions, until contracts are re-factored.
         if !func.attributes().has_contract_library_method() {
             let output = true;
@@ -546,7 +557,7 @@ impl Elaborator<'_> {
                 .map(Into::into)
             });
             self.run_lint(|_| {
-                lints::databus_on_non_entry_point(
+                lints::databus_visibility_on_parameter(
                     func,
                     visibility,
                     visibility_location,

--- a/compiler/noirc_frontend/src/elaborator/lints.rs
+++ b/compiler/noirc_frontend/src/elaborator/lints.rs
@@ -414,28 +414,59 @@ pub(super) fn unnecessary_pub_argument(
     }
 }
 
-/// call_data and return_data visibility modifiers are only allowed on entry point functions.
-pub(super) fn databus_on_non_entry_point(
+/// `call_data` marks a parameter and `return_data` a return, so only `call_data` is
+/// meaningful on a parameter, and only on an entry point function.
+pub(super) fn databus_visibility_on_parameter(
     func: &NoirFunction,
     visibility: Visibility,
     visibility_location: Location,
     is_entry_point: bool,
 ) -> Option<ResolverError> {
-    if is_entry_point {
-        return None;
-    }
-
     match visibility {
-        Visibility::CallData(_) | Visibility::ReturnData => {
-            let name = func.name().to_string();
-            let visibility = visibility.to_string();
-            Some(ResolverError::DataBusOnNonEntryPoint {
-                name,
-                location: visibility_location,
-                visibility,
-            })
+        Visibility::ReturnData => Some(ResolverError::DataBusOnWrongPosition {
+            visibility: visibility.to_string(),
+            position: "a parameter",
+            allowed: "the return value",
+            location: visibility_location,
+        }),
+        Visibility::CallData(_) if !is_entry_point => {
+            Some(databus_on_non_entry_point(func, visibility, visibility_location))
         }
         _ => None,
+    }
+}
+
+/// `return_data` marks a return and `call_data` a parameter, so only `return_data` is
+/// meaningful on a return value, and only on an entry point function.
+pub(super) fn databus_visibility_on_return(
+    func: &NoirFunction,
+    visibility: Visibility,
+    visibility_location: Location,
+    is_entry_point: bool,
+) -> Option<ResolverError> {
+    match visibility {
+        Visibility::CallData(_) => Some(ResolverError::DataBusOnWrongPosition {
+            visibility: visibility.to_string(),
+            position: "the return value",
+            allowed: "a parameter",
+            location: visibility_location,
+        }),
+        Visibility::ReturnData if !is_entry_point => {
+            Some(databus_on_non_entry_point(func, visibility, visibility_location))
+        }
+        _ => None,
+    }
+}
+
+fn databus_on_non_entry_point(
+    func: &NoirFunction,
+    visibility: Visibility,
+    visibility_location: Location,
+) -> ResolverError {
+    ResolverError::DataBusOnNonEntryPoint {
+        name: func.name().to_string(),
+        location: visibility_location,
+        visibility: visibility.to_string(),
     }
 }
 

--- a/compiler/noirc_frontend/src/hir/resolution/errors.rs
+++ b/compiler/noirc_frontend/src/hir/resolution/errors.rs
@@ -229,6 +229,13 @@ pub enum ResolverError {
     PatternBoundMoreThanOnce { ident: Ident },
     #[error("{visibility} attribute is only allowed on entry point functions")]
     DataBusOnNonEntryPoint { visibility: String, name: String, location: Location },
+    #[error("{visibility} attribute is not allowed on {position}")]
+    DataBusOnWrongPosition {
+        visibility: String,
+        position: &'static str,
+        allowed: &'static str,
+        location: Location,
+    },
     #[error("Associated type in `impl` without body")]
     AssociatedTypeInImplWithoutBody { ident: Ident },
     #[error("#[varargs] can only be applied to comptime functions")]
@@ -328,6 +335,7 @@ impl ResolverError {
             | ResolverError::UnnecessaryPub { location, .. }
             | ResolverError::NecessaryPub { location, .. }
             | ResolverError::DataBusOnNonEntryPoint { location, .. }
+            | ResolverError::DataBusOnWrongPosition { location, .. }
             | ResolverError::RemovedType { location, .. }
             | ResolverError::MaximumRecursionDepthExceeded { location, .. } => *location,
             ResolverError::UnusedVariable { ident }
@@ -1031,6 +1039,13 @@ impl<'a> From<&'a ResolverError> for Diagnostic {
                 diag.add_note(
                     format!("The {visibility} attribute only has effects for the entry-point function of a program. Thus, adding it to other function can be deceiving and should be removed)"));
                 diag
+            },
+            ResolverError::DataBusOnWrongPosition { visibility, position, allowed, location } => {
+                Diagnostic::simple_error(
+                    format!("{visibility} attribute is not allowed on {position}"),
+                    format!("{visibility} is only allowed on {allowed}"),
+                    *location,
+                )
             },
             ResolverError::AssociatedTypeInImplWithoutBody { ident } => {
                 Diagnostic::simple_error(

--- a/compiler/noirc_frontend/src/tests/visibility.rs
+++ b/compiler/noirc_frontend/src/tests/visibility.rs
@@ -807,6 +807,32 @@ fn main(a: u32) -> pub u32 {
 fn inner(a: call_data(0) u32) -> return_data u32 {
             ~~~~~~~~~~~~ unnecessary call_data(0)
             ^^^^^^^^^^^^ unnecessary call_data(0) attribute for function inner
+                                 ~~~~~~~~~~~ unnecessary return_data
+                                 ^^^^^^^^^^^ unnecessary return_data attribute for function inner
+    a
+}
+    ";
+    check_errors(src);
+}
+
+#[test]
+fn return_data_not_allowed_on_parameter() {
+    let src = "
+fn main(a: return_data u32) -> pub u32 {
+           ~~~~~~~~~~~ return_data is only allowed on the return value
+           ^^^^^^^^^^^ return_data attribute is not allowed on a parameter
+    a
+}
+    ";
+    check_errors(src);
+}
+
+#[test]
+fn call_data_not_allowed_on_return_value() {
+    let src = "
+fn main(a: u32) -> call_data(0) u32 {
+                   ~~~~~~~~~~~~ call_data(0) is only allowed on a parameter
+                   ^^^^^^^^^^^^ call_data(0) attribute is not allowed on the return value
     a
 }
     ";


### PR DESCRIPTION
…values

## Problem Resolved

Follow-up on [Disallow usage of data bus outside of the main function](https://cantina.xyz/code/5a1f2b42-25a3-4569-81ed-282b9bd7bdb4/findings/12)

## Summary of Changes
Check databus visibility attributes also on return values.


## User Documentation

Check one:
- [X] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
