### PR TITLE
chore: Improve error handling for Brillig outputs mismatch

### DIFF
--- a/acvm-repo/acvm/src/pwg/brillig.rs
+++ b/acvm-repo/acvm/src/pwg/brillig.rs
@@ -283,22 +283,22 @@ impl<'b, B: BlackBoxFunctionSolver<F>, F: AcirField> BrilligSolver<'b, F, B> {
         for output in outputs {
             match output {
                 BrilligOutputs::Simple(witness) => {
-                    let value = memory
-                        .get(current_ret_data_idx)
-                        .expect("Return data index exceeds memory bounds");
+                    let value =
+                        memory.get(current_ret_data_idx).ok_or_else(|| self.outputs_mismatch())?;
                     insert_value(witness, value.to_field(), witness_map)?;
-                    current_ret_data_idx =
-                        current_ret_data_idx.checked_add(1).expect("Return data index overflow");
+                    current_ret_data_idx = current_ret_data_idx
+                        .checked_add(1)
+                        .ok_or_else(|| self.outputs_mismatch())?;
                 }
                 BrilligOutputs::Array(witness_arr) => {
                     for witness in witness_arr {
                         let value = memory
                             .get(current_ret_data_idx)
-                            .expect("Return data index exceeds memory bounds");
+                            .ok_or_else(|| self.outputs_mismatch())?;
                         insert_value(witness, value.to_field(), witness_map)?;
                         current_ret_data_idx = current_ret_data_idx
                             .checked_add(1)
-                            .expect("Return data index overflow");
+                            .ok_or_else(|| self.outputs_mismatch())?;
                     }
                 }
             }
@@ -306,12 +306,17 @@ impl<'b, B: BlackBoxFunctionSolver<F>, F: AcirField> BrilligSolver<'b, F, B> {
 
         let expected_end = return_data_offset
             .checked_add(return_data_size)
-            .expect("Return data offset and size overflow");
-        assert!(
-            current_ret_data_idx == expected_end,
-            "Brillig VM did not write the expected number of return values"
-        );
+            .ok_or_else(|| self.outputs_mismatch())?;
+        if current_ret_data_idx != expected_end {
+            return Err(self.outputs_mismatch());
+        }
         Ok(())
+    }
+
+    /// Error raised when the brillig return data described by the `Stop` opcode is
+    /// inconsistent with the expected call outputs (out of bounds, or a different count).
+    fn outputs_mismatch(&self) -> OpcodeResolutionError<F> {
+        OpcodeResolutionError::BrilligOutputsMismatch { function_id: self.function_id }
     }
 
     pub fn resolve_pending_foreign_call(&mut self, foreign_call_result: ForeignCallResult<F>) {
@@ -371,7 +376,7 @@ pub struct ForeignCallWaitInfo<F> {
 
 #[cfg(test)]
 mod tests {
-    use crate::pwg::BrilligSolver;
+    use crate::pwg::{BrilligSolver, OpcodeResolutionError};
     use acir::{
         FieldElement,
         brillig::{BinaryFieldOp, BitSize, HeapVector, IntegerBitSize, MemoryAddress, Opcode},
@@ -457,5 +462,105 @@ mod tests {
         solver.finalize(&mut initial_witness, &outputs).unwrap();
 
         assert_eq!(initial_witness[&Witness(4)], FieldElement::from(2u128));
+    }
+
+    /// A `Stop` opcode having return-data pointer outside of
+    /// the VM's allocated memory
+    #[test]
+    fn out_of_bounds_return_data_offset_errors_instead_of_panicking() {
+        let mut initial_witness = WitnessMap::from(BTreeMap::<Witness, FieldElement>::new());
+        let inputs: Vec<BrilligInputs<FieldElement>> = vec![];
+
+        let backend = acvm_blackbox_solver::StubbedBlackBoxSolver;
+        let bytecode = vec![
+            // The value stored here is dereferenced as the return-data offset; point it
+            // far beyond any memory the program actually wrote to.
+            Opcode::Const {
+                destination: MemoryAddress::Direct(10),
+                bit_size: BitSize::Integer(IntegerBitSize::U32),
+                value: FieldElement::from(1_000_000_u128),
+            },
+            Opcode::Const {
+                destination: MemoryAddress::Direct(11),
+                bit_size: BitSize::Integer(IntegerBitSize::U32),
+                value: FieldElement::from(1_u128),
+            },
+            Opcode::Stop {
+                return_data: HeapVector {
+                    pointer: MemoryAddress::Direct(10),
+                    size: MemoryAddress::Direct(11),
+                },
+            },
+        ];
+        let mut solver = BrilligSolver::new_call(
+            &initial_witness,
+            &HashMap::new(),
+            &inputs,
+            &bytecode,
+            &backend,
+            0,
+            BrilligFunctionId::default(),
+            false,
+            None,
+        )
+        .unwrap();
+        solver.solve().unwrap();
+
+        let outputs = vec![BrilligOutputs::Simple(Witness(4))];
+        let result = solver.finalize(&mut initial_witness, &outputs);
+        assert!(
+            matches!(result, Err(OpcodeResolutionError::BrilligOutputsMismatch { .. })),
+            "expected a BrilligOutputsMismatch error, got {result:?}"
+        );
+    }
+
+    /// A `Stop` opcode whose declared return-data size does not match the number of
+    /// `outputs`.
+    #[test]
+    fn return_data_size_mismatch_errors_instead_of_asserting() {
+        let mut initial_witness = WitnessMap::from(BTreeMap::<Witness, FieldElement>::new());
+        let inputs: Vec<BrilligInputs<FieldElement>> = vec![];
+
+        let backend = acvm_blackbox_solver::StubbedBlackBoxSolver;
+        let bytecode = vec![
+            // Dereferenced as the (in-bounds) return-data offset.
+            Opcode::Const {
+                destination: MemoryAddress::Direct(0),
+                bit_size: BitSize::Integer(IntegerBitSize::U32),
+                value: FieldElement::from(0_u128),
+            },
+            // Claim five return values while only a single output witness is provided.
+            Opcode::Const {
+                destination: MemoryAddress::Direct(5),
+                bit_size: BitSize::Integer(IntegerBitSize::U32),
+                value: FieldElement::from(5_u128),
+            },
+            Opcode::Stop {
+                return_data: HeapVector {
+                    pointer: MemoryAddress::Direct(0),
+                    size: MemoryAddress::Direct(5),
+                },
+            },
+        ];
+        let mut solver = BrilligSolver::new_call(
+            &initial_witness,
+            &HashMap::new(),
+            &inputs,
+            &bytecode,
+            &backend,
+            0,
+            BrilligFunctionId::default(),
+            false,
+            None,
+        )
+        .unwrap();
+        solver.solve().unwrap();
+
+        let outputs = vec![BrilligOutputs::Simple(Witness(4))];
+        let result = solver.finalize(&mut initial_witness, &outputs);
+        assert!(
+            matches!(result, Err(OpcodeResolutionError::BrilligOutputsMismatch { .. })),
+            "expected a BrilligOutputsMismatch error, got {result:?}"
+        );
     }
 }

--- a/acvm-repo/acvm/src/pwg/mod.rs
+++ b/acvm-repo/acvm/src/pwg/mod.rs
@@ -232,6 +232,8 @@ pub enum OpcodeResolutionError<F> {
         "{results_size:?} result values were provided for {outputs_size:?} call output witnesses, most likely due to bad ACIR codegen"
     )]
     AcirCallOutputsMismatch { opcode_location: ErrorLocation, results_size: u32, outputs_size: u32 },
+    #[error("Brillig function {function_id} returned data inconsistent with its call outputs")]
+    BrilligOutputsMismatch { function_id: BrilligFunctionId },
     #[error("(--pedantic): Predicates are expected to be 0 or 1, but found: {pred_value}")]
     PredicateLargerThanOne { opcode_location: ErrorLocation, pred_value: F },
     #[error("(--pedantic): Memory operations are expected to be 0 or 1, but found: {operation}")]


### PR DESCRIPTION
## Problem Resolved

Resolves [Malformed Brillig trap revert metadata can panic in payload extraction](https://cantina.xyz/code/50033e8c-8b46-41bc-b019-62098708057b/findings/14)

## Summary of Changes
Some more panics into errors


## User Documentation

Check one:
- [X] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
