### PR TITLE
fix: simplify ref-deref respect mutability

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/ssa_gen/tests.rs
+++ b/compiler/noirc_evaluator/src/ssa/ssa_gen/tests.rs
@@ -1038,6 +1038,36 @@ fn can_reborrow_through_immutable_ref() {
     ");
 }
 
+/// `&mut *p` where `p` is an immutable `&u64` bound to a variable must still reborrow
+/// as a writable reference aliasing the original location, just like the parenthesized
+/// `&mut (*p)` form. The re-borrow simplification must not collapse to `p` and inherit
+/// its immutable type, which previously rejected `*p1 = 15`.
+#[test]
+fn mut_reborrow_through_immutable_ref_variable() {
+    let src = "
+    fn main() {
+        let mut f: u64 = 10;
+        let p = &f;
+        let p1 = &mut *p;
+        *p1 = 15;
+        assert(f == 15);
+    }
+    ";
+    let ssa = get_initial_ssa(src).unwrap();
+    assert_ssa_snapshot!(ssa, @r"
+    acir(inline) fn main f0 {
+      b0():
+        v0 = allocate -> &mut u64
+        store u64 10 at v0
+        store u64 15 at v0
+        v3 = load v0 -> u64
+        v4 = eq v3, u64 15
+        constrain v3 == u64 15
+        return
+    }
+    ");
+}
+
 /// Reassigning a mutable tuple using its own fields (`b = (false, b.0)`) must load
 /// the old values before any stores. Regression test for a lazy `codegen_ident` bug
 /// where stores were interleaved with lazy loads, causing stale reads.

--- a/compiler/noirc_frontend/src/elaborator/expressions.rs
+++ b/compiler/noirc_frontend/src/elaborator/expressions.rs
@@ -543,16 +543,6 @@ impl Elaborator<'_> {
             return (rhs, typ);
         }
 
-        // Simplify `&*x` and `&mut *x` to just `x`
-        if let UnaryOp::Reference { .. } = prefix.operator
-            && let ExpressionKind::Prefix(ref inner) = prefix.rhs.kind
-            && let UnaryOp::Dereference { .. } = inner.operator
-        {
-            let ExpressionKind::Prefix(inner) = prefix.rhs.kind else { unreachable!() };
-            let (rhs, typ) = self.elaborate_expression(inner.rhs);
-            return (rhs, typ);
-        }
-
         let rhs_location = prefix.rhs.location;
         let operator = prefix.operator;
 
@@ -566,6 +556,20 @@ impl Elaborator<'_> {
             let (rhs, rhs_type) = self.elaborate_expression(prefix.rhs);
             (rhs, rhs_type, false)
         };
+
+        // Simplify `&*x` and `&mut *x` to just `x` when the reborrow preserves mutability:
+        // A reborrow that changes mutability (e.g. `&mut *x` where `x: &T`) is left
+        // as the full `&[mut] (*x)`
+        if let UnaryOp::Reference { mutable } = operator
+            && let HirExpression::Prefix(deref) = self.interner.expression(&rhs)
+            && let UnaryOp::Dereference { .. } = deref.operator
+        {
+            let inner_type = self.interner.id_type(deref.rhs);
+            if matches!(inner_type.follow_bindings(), Type::Reference(_, inner_mutable) if inner_mutable == mutable)
+            {
+                return (deref.rhs, inner_type);
+            }
+        }
 
         let trait_method_id = self.interner.get_prefix_operator_trait_method(&operator);
 

--- a/compiler/noirc_frontend/src/tests/references.rs
+++ b/compiler/noirc_frontend/src/tests/references.rs
@@ -263,6 +263,24 @@ fn disallows_mutating_non_mutable_ref_array_index() {
 }
 
 #[test]
+fn disallows_writing_through_immutable_reborrow_of_mutable_reference() {
+    // `&*p` is an immutable `&T` view even when `p` is `&mut T`. The re-borrow
+    // simplification must not collapse `&*p` to `p` and keep its `&mut` type, which
+    // would let writes through an explicitly immutable reborrow slip through.
+    let src = r#"
+    fn main() {
+        let mut f: u64 = 10;
+        let p = &mut f;
+        let q = &*p;
+        *q = 5;
+        ^^ Expected type &mut _, found type &u64
+         ^ `q` is a `&` reference, so it cannot be written to
+    }
+    "#;
+    check_errors(src);
+}
+
+#[test]
 fn disallows_mutating_non_mutable_nested_reference_in_tuple_1() {
     let src = r#"
     fn main() {


### PR DESCRIPTION
## Problem Resolved

Resolves [Missing `*&` no-op folding in prefix elaboration](https://app.audithub.dev/app/organizations/161/projects/599/project-viewer?version=1406&issueId=921)

## Summary of Changes
Simplification now takes mutability into account.


## User Documentation

Check one:
- [X] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
