### PR TITLE
fix(ssa): preserve truncating cast chain boundary

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/ir/dfg/simplify/cast.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/dfg/simplify/cast.rs
@@ -26,9 +26,17 @@ pub(super) fn simplify_cast(
     }
 
     if let Value::Instruction { instruction, .. } = &dfg[value]
-        && let Instruction::Cast(original_value, _) = &dfg[*instruction]
+        && let Instruction::Cast(original_value, intermediate_typ) = &dfg[*instruction]
     {
         let original_value = *original_value;
+        let original_typ = dfg.type_of_value(original_value).unwrap_numeric();
+        if intermediate_integer_cast_boundary_is_observable(
+            original_typ,
+            *intermediate_typ,
+            dst_typ,
+        ) {
+            return None;
+        }
         return match simplify_cast(original_value, dst_typ, dfg) {
             None => SimplifiedToInstruction(Instruction::Cast(original_value, dst_typ)),
             simpler => simpler,
@@ -119,9 +127,51 @@ pub(super) fn simplify_cast(
     }
 }
 
+fn intermediate_integer_cast_boundary_is_observable(
+    original_typ: NumericType,
+    intermediate_typ: NumericType,
+    dst_typ: NumericType,
+) -> bool {
+    match (intermediate_typ, dst_typ) {
+        (
+            NumericType::Signed { bit_size: intermediate_bit_size },
+            NumericType::Signed { bit_size: dst_bit_size },
+        )
+        | (
+            NumericType::Unsigned { bit_size: intermediate_bit_size },
+            NumericType::Unsigned { bit_size: dst_bit_size },
+        ) => intermediate_bit_size < dst_bit_size,
+        (
+            NumericType::Signed { bit_size: intermediate_bit_size },
+            NumericType::Unsigned { bit_size: dst_bit_size },
+        )
+        | (
+            NumericType::Unsigned { bit_size: intermediate_bit_size },
+            NumericType::Signed { bit_size: dst_bit_size },
+        ) => {
+            intermediate_bit_size < dst_bit_size
+                || match integer_bit_size(original_typ) {
+                    Some(original_bit_size) => original_bit_size < dst_bit_size,
+                    None => true,
+                }
+        }
+        _ => false,
+    }
+}
+
+fn integer_bit_size(typ: NumericType) -> Option<u32> {
+    match typ {
+        NumericType::Signed { bit_size } | NumericType::Unsigned { bit_size } => Some(bit_size),
+        NumericType::NativeField => None,
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use crate::{assert_ssa_snapshot, ssa::ssa_gen::Ssa};
+    use crate::{
+        assert_ssa_snapshot,
+        ssa::{opt::CONSTANT_FOLDING_MAX_ITER, ssa_gen::Ssa},
+    };
 
     #[test]
     fn unsigned_u8_to_i8_safe() {
@@ -294,6 +344,55 @@ mod tests {
         acir(inline) pure fn main f0 {
           b0():
             return i8 -128
+        }
+        ");
+    }
+
+    #[test]
+    fn does_not_simplify_through_observable_truncating_cast_boundary() {
+        let src = "
+        acir(inline) fn main f0 {
+          b0(v0: i8):
+            constrain v0 == i8 -1
+            v1 = cast v0 as u8
+            v2 = cast v1 as i16
+            v3 = cast v1 as u16
+            return v2, v3
+        }
+        ";
+
+        let ssa = Ssa::from_str_simplifying(src).unwrap();
+        let ssa = ssa.fold_constants_using_constraints(CONSTANT_FOLDING_MAX_ITER);
+
+        assert_ssa_snapshot!(ssa, @r"
+        acir(inline) fn main f0 {
+          b0(v0: i8):
+            constrain v0 == i8 -1
+            return i16 255, u16 255
+        }
+        ");
+    }
+
+    #[test]
+    fn does_not_simplify_through_same_width_signedness_cast_boundary() {
+        let src = "
+        acir(inline) fn main f0 {
+          b0(v0: i8):
+            constrain v0 == i8 -1
+            v1 = cast v0 as u16
+            v2 = cast v1 as i16
+            return v2
+        }
+        ";
+
+        let ssa = Ssa::from_str_simplifying(src).unwrap();
+        let ssa = ssa.fold_constants_using_constraints(CONSTANT_FOLDING_MAX_ITER);
+
+        assert_ssa_snapshot!(ssa, @r"
+        acir(inline) fn main f0 {
+          b0(v0: i8):
+            constrain v0 == i8 -1
+            return i16 255
         }
         ");
     }


### PR DESCRIPTION
## Problem Resolved

Resolves #12844

## Summary of Changes

Preserves observable integer cast boundaries when simplifying nested SSA casts. In particular, a cast through a narrower intermediate integer type must not be collapsed into a direct wider cast, because the intermediate truncation/sign boundary is part of the source semantics.

`simplify_cast` now leaves nested casts intact when the intermediate integer type is narrower than the final integer destination. This keeps chains such as `i8 -> u8 -> i16` available for normal constant folding, which produces `255` for `-1i8 as u8 as i16` instead of direct signed widening to `-1`.

The regression also covers a widened unsigned destination from the same intermediate boundary (`i8 -> u8 -> u16`).

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created:

## PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.

Local verification:

- `cargo fmt --check`
- `cargo test -p noirc_evaluator does_not_simplify_through_observable_truncating_cast_boundary --lib`

Targeted GitHub Actions verification:

- https://github.com/Kuhai9801/noir/actions/runs/26649773151