### PR TITLE
fix(nargo): include validation policy in artifact cache reuse

### DIFF
--- a/compiler/noirc_driver/src/lib.rs
+++ b/compiler/noirc_driver/src/lib.rs
@@ -349,6 +349,28 @@ impl Default for CompileOptions {
 }
 
 impl CompileOptions {
+    pub fn validation_options_hash(&self) -> u64 {
+        let mut hash = 0xcbf2_9ce4_8422_2325;
+        fn write_hash(hash: &mut u64, bytes: &[u8]) {
+            for byte in bytes {
+                *hash ^= u64::from(*byte);
+                *hash = hash.wrapping_mul(0x0000_0100_0000_01b3);
+            }
+        }
+
+        write_hash(&mut hash, &[self.skip_underconstrained_check as u8]);
+        write_hash(&mut hash, &[self.skip_brillig_constraints_check as u8]);
+        write_hash(
+            &mut hash,
+            &u64::from(self.brillig_constraints_check_max_array_output_length).to_le_bytes(),
+        );
+        write_hash(
+            &mut hash,
+            &u64::from(self.brillig_constraints_check_max_ancestor_distance).to_le_bytes(),
+        );
+        hash
+    }
+
     pub fn as_ssa_options(&self, package_build_path: PathBuf) -> SsaEvaluatorOptions {
         SsaEvaluatorOptions {
             ssa_logging: if !self.show_ssa_pass.is_empty() {
@@ -999,10 +1021,10 @@ pub fn compile_no_check(
 
     // Hash the AST program, which is going to be used to fingerprint the compilation artifact.
     let hash = rustc_hash::FxBuildHasher.hash_one(&program);
+    let validation_options_hash = options.validation_options_hash();
 
     if let Some(cached_program) = cached_program
-        && !force_compile
-        && cached_program.hash == hash
+        && can_reuse_cached_program(&cached_program, hash, validation_options_hash, force_compile)
     {
         info!("Program matches existing artifact, returning early");
         return Ok(cached_program);
@@ -1026,6 +1048,7 @@ pub fn compile_no_check(
 
     Ok(CompiledProgram {
         hash,
+        validation_options_hash,
         program,
         debug,
         abi,
@@ -1033,6 +1056,17 @@ pub fn compile_no_check(
         noir_version: NOIR_ARTIFACT_VERSION_STRING.to_string(),
         warnings,
     })
+}
+
+fn can_reuse_cached_program(
+    cached_program: &CompiledProgram,
+    hash: u64,
+    validation_options_hash: u64,
+    force_compile: bool,
+) -> bool {
+    !force_compile
+        && cached_program.hash == hash
+        && cached_program.validation_options_hash == validation_options_hash
 }
 
 /// Specifies a contract function and extra metadata that
@@ -1142,5 +1176,85 @@ impl<F: AcirField> std::fmt::Display for ProgramDisplay<'_, F> {
             })
             .collect::<HashMap<_, _>>();
         display_program(self.program, Some(&error_types), f)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{CompileOptions, can_reuse_cached_program};
+    use noirc_artifacts::program::CompiledProgram;
+    use std::collections::BTreeMap;
+
+    fn assert_validation_hash_changes(mut mutate: impl FnMut(&mut CompileOptions)) {
+        let strict_options = CompileOptions::default();
+        let mut changed_options = strict_options.clone();
+        mutate(&mut changed_options);
+
+        assert_ne!(
+            strict_options.validation_options_hash(),
+            changed_options.validation_options_hash()
+        );
+    }
+
+    #[test]
+    fn validation_options_hash_tracks_validation_options() {
+        assert_validation_hash_changes(|options| options.skip_underconstrained_check = true);
+        assert_validation_hash_changes(|options| options.skip_brillig_constraints_check = true);
+        assert_validation_hash_changes(|options| {
+            options.brillig_constraints_check_max_array_output_length += 1;
+        });
+        assert_validation_hash_changes(|options| {
+            options.brillig_constraints_check_max_ancestor_distance += 1;
+        });
+    }
+
+    #[test]
+    fn validation_options_hash_has_stable_encoding() {
+        let mut options = CompileOptions::default();
+        options.skip_underconstrained_check = true;
+        options.brillig_constraints_check_max_array_output_length = 7;
+        options.brillig_constraints_check_max_ancestor_distance = 9;
+
+        assert_eq!(options.validation_options_hash(), 0x31c6_df08_0dc8_0c6a);
+    }
+
+    #[test]
+    fn cached_program_reuse_requires_matching_validation_options_hash() {
+        let cached_program = CompiledProgram {
+            noir_version: String::new(),
+            hash: 1,
+            validation_options_hash: 2,
+            program: Default::default(),
+            abi: Default::default(),
+            debug: Vec::new(),
+            file_map: BTreeMap::new(),
+            warnings: Vec::new(),
+        };
+
+        assert!(can_reuse_cached_program(&cached_program, 1, 2, false));
+        assert!(!can_reuse_cached_program(&cached_program, 1, 3, false));
+        assert!(!can_reuse_cached_program(&cached_program, 2, 2, false));
+        assert!(!can_reuse_cached_program(&cached_program, 1, 2, true));
+    }
+
+    #[test]
+    fn legacy_zero_validation_hash_does_not_match_current_defaults() {
+        let cached_program = CompiledProgram {
+            noir_version: String::new(),
+            hash: 1,
+            validation_options_hash: 0,
+            program: Default::default(),
+            abi: Default::default(),
+            debug: Vec::new(),
+            file_map: BTreeMap::new(),
+            warnings: Vec::new(),
+        };
+
+        assert!(!can_reuse_cached_program(
+            &cached_program,
+            1,
+            CompileOptions::default().validation_options_hash(),
+            false
+        ));
     }
 }

--- a/compiler/wasm/src/compile.rs
+++ b/compiler/wasm/src/compile.rs
@@ -39,6 +39,7 @@ export type ContractArtifact = {
 export type ProgramArtifact = {
     noir_version: string;
     hash: number;
+    validation_options_hash: string;
     abi: any;
     bytecode: string;
     debug_symbols: any;

--- a/compiler/wasm/src/types/noir_artifact.ts
+++ b/compiler/wasm/src/types/noir_artifact.ts
@@ -99,6 +99,8 @@ export interface ProgramArtifact {
   noir_version: string;
   /** The hash of the circuit. */
   hash?: string;
+  /** Hash of compile options that affect validation of the generated program. */
+  validation_options_hash?: string;
   /** * The ABI of the function. */
   abi: Abi;
   /** The bytecode of the circuit in base64. */

--- a/tooling/noirc_artifacts/src/contract.rs
+++ b/tooling/noirc_artifacts/src/contract.rs
@@ -101,6 +101,7 @@ impl ContractFunctionArtifact {
         CompiledProgram {
             noir_version,
             hash: self.hash,
+            validation_options_hash: 0,
             program: self.bytecode,
             abi: self.abi,
             debug: self.debug_symbols.debug_infos,

--- a/tooling/noirc_artifacts/src/program.rs
+++ b/tooling/noirc_artifacts/src/program.rs
@@ -23,6 +23,12 @@ pub struct ProgramArtifact {
     #[serde(serialize_with = "serialize_hash", deserialize_with = "deserialize_hash")]
     pub hash: u64,
 
+    /// Hash of compile options that affect validation of the generated program.
+    ///
+    /// Used together with [`Self::hash`] to decide whether an artifact can be reused.
+    #[serde(default, serialize_with = "serialize_hash", deserialize_with = "deserialize_hash")]
+    pub validation_options_hash: u64,
+
     pub abi: Abi,
 
     #[serde(
@@ -45,6 +51,7 @@ impl From<CompiledProgram> for ProgramArtifact {
     fn from(compiled_program: CompiledProgram) -> Self {
         ProgramArtifact {
             hash: compiled_program.hash,
+            validation_options_hash: compiled_program.validation_options_hash,
             abi: compiled_program.abi,
             noir_version: compiled_program.noir_version,
             bytecode: compiled_program.program,
@@ -58,6 +65,7 @@ impl From<ProgramArtifact> for CompiledProgram {
     fn from(program: ProgramArtifact) -> Self {
         CompiledProgram {
             hash: program.hash,
+            validation_options_hash: program.validation_options_hash,
             abi: program.abi,
             noir_version: program.noir_version,
             program: program.bytecode,
@@ -76,6 +84,10 @@ pub struct CompiledProgram {
     ///
     /// Used to short-circuit compilation in the case of the source code not changing since the last compilation.
     pub hash: u64,
+
+    /// Hash of compile options that affect validation of the generated program.
+    #[serde(default)]
+    pub validation_options_hash: u64,
 
     #[serde(
         serialize_with = "Program::serialize_program_base64",

--- a/tooling/profiler/src/cli/execution_flamegraph_cmd.rs
+++ b/tooling/profiler/src/cli/execution_flamegraph_cmd.rs
@@ -228,6 +228,7 @@ mod tests {
         let artifact = ProgramArtifact {
             noir_version: "0.0.0".to_string(),
             hash: 27,
+            validation_options_hash: 0,
             abi: noirc_abi::Abi::default(),
             bytecode: Program {
                 functions: vec![Circuit {

--- a/tooling/profiler/src/cli/gates_flamegraph_cmd.rs
+++ b/tooling/profiler/src/cli/gates_flamegraph_cmd.rs
@@ -184,6 +184,7 @@ mod tests {
         let artifact = ProgramArtifact {
             noir_version: "0.0.0".to_string(),
             hash: 27,
+            validation_options_hash: 0,
             abi: noirc_abi::Abi::default(),
             bytecode: Program {
                 functions: vec![Circuit {

--- a/tooling/profiler/src/cli/opcodes_flamegraph_cmd.rs
+++ b/tooling/profiler/src/cli/opcodes_flamegraph_cmd.rs
@@ -197,6 +197,7 @@ mod tests {
         let artifact = ProgramArtifact {
             noir_version: "0.0.0".to_string(),
             hash: 27,
+            validation_options_hash: 0,
             abi: noirc_abi::Abi::default(),
             bytecode: Program {
                 functions: vec![Circuit {
@@ -253,6 +254,7 @@ mod tests {
         let artifact = ProgramArtifact {
             noir_version: "0.0.0".to_string(),
             hash: 27,
+            validation_options_hash: 0,
             abi: noirc_abi::Abi::default(),
             bytecode: Program {
                 functions: vec![Circuit {

--- a/tooling/ssa_executor/src/compiler.rs
+++ b/tooling/ssa_executor/src/compiler.rs
@@ -86,6 +86,7 @@ pub fn compile_from_artifacts(artifacts: ArtifactsAndWarnings) -> CompiledProgra
     let file_map = BTreeMap::new();
     CompiledProgram {
         hash: 1, // const hash, doesn't matter in this case
+        validation_options_hash: 0,
         program,
         debug,
         abi: Abi { parameters: vec![], return_type: None, error_types: BTreeMap::new() },


### PR DESCRIPTION
## Problem Resolved

Resolves #12843

## Summary of Changes

Prevents `nargo compile` from reusing a cached program artifact when the current validation policy differs from the policy used to produce the artifact.

Adds a `validation_options_hash` to program artifacts and compares it with the current `CompileOptions` before accepting a cached program in `compile_no_check`. Old artifacts default to `0`, so they fail closed and recompile under the current validation policy.

The hash currently covers the options that directly control the validation checks involved in this cache boundary:

- `skip_underconstrained_check`
- `skip_brillig_constraints_check`
- `brillig_constraints_check_max_array_output_length`
- `brillig_constraints_check_max_ancestor_distance`

The cache reuse predicate is directly unit-tested with the same program hash and different validation-option hashes. The wasm artifact TypeScript shape is also updated so generated program artifacts expose the new serialized field.

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created:

## PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.

Local verification:

- `cargo fmt --check`
- `cargo test -p noirc_driver validation_options_hash --lib`

Targeted GitHub Actions verification:

- https://github.com/Kuhai9801/noir/actions/runs/26651437898