### PR TITLE
fix: range-check decoded ABI values to keep encode/decode symmetric

### DIFF
--- a/tooling/noirc_abi/src/errors.rs
+++ b/tooling/noirc_abi/src/errors.rs
@@ -72,4 +72,8 @@ pub enum AbiError {
     ReturnTypeMismatch { return_type: AbiType, value: InputValue },
     #[error("No return value is expected but received {0:?}")]
     UnexpectedReturnValue(InputValue),
+    #[error(
+        "Could not decode string parameter `{name}`: witness value {value} is not a valid byte (must be in the range 0..=255)"
+    )]
+    StringValueOutsideByteRange { name: String, value: FieldElement },
 }

--- a/tooling/noirc_abi/src/lib.rs
+++ b/tooling/noirc_abi/src/lib.rs
@@ -598,6 +598,6 @@ mod tests {
         assert!(i8_abi.decode(&witness_map_with_single_value(255)).is_ok());
 
         let string_abi = abi_with_single_param(AbiType::String { length: 1 });
-        assert!(string_abi.decode(&witness_map_with_single_value(b'a' as u128)).is_ok());
+        assert!(string_abi.decode(&witness_map_with_single_value(u128::from(b'a'))).is_ok());
     }
 }

--- a/tooling/noirc_abi/src/lib.rs
+++ b/tooling/noirc_abi/src/lib.rs
@@ -382,7 +382,11 @@ pub fn decode_value(
             let field_element =
                 field_iterator.next().ok_or_else(|| AbiError::MissingParam(name.to_string()))?;
 
-            InputValue::Field(field_element)
+            // Validate the decoded leaf against its declared type so that decode stays symmetric
+            // with encode, which rejects out-of-range integers and non-`{0,1}` booleans.
+            let input_value = InputValue::Field(field_element);
+            input_value.find_type_mismatch(value_type, name.to_string())?;
+            input_value
         }
         AbiType::Array { length, typ } => {
             let length = *length as usize;
@@ -396,6 +400,17 @@ pub fn decode_value(
         }
         AbiType::String { length } => {
             let field_elements: Vec<FieldElement> = field_iterator.take(*length as usize).collect();
+
+            // Each string character is a single byte, so reject any witness field that does not fit
+            // in `0..=255` rather than letting `decode_string_value` panic on a non-byte field.
+            for field_element in &field_elements {
+                if field_element.num_bits() > 8 {
+                    return Err(AbiError::StringValueOutsideByteRange {
+                        name: name.to_string(),
+                        value: *field_element,
+                    });
+                }
+            }
 
             InputValue::String(decode_string_value(&field_elements))
         }
@@ -506,9 +521,17 @@ pub fn display_abi_error<F: AcirField>(
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeMap;
+
+    use acvm::{
+        FieldElement,
+        acir::native_types::{Witness, WitnessMap},
+    };
     use proptest::prelude::*;
 
-    use crate::arbitrary::arb_abi_and_input_map;
+    use crate::{
+        Abi, AbiParameter, AbiType, AbiVisibility, Sign, arbitrary::arb_abi_and_input_map,
+    };
 
     proptest! {
         #[test]
@@ -519,5 +542,62 @@ mod tests {
             prop_assert_eq!(decoded_inputs, input_map);
             prop_assert_eq!(return_value, None);
         }
+    }
+
+    fn abi_with_single_param(typ: AbiType) -> Abi {
+        Abi {
+            parameters: vec![AbiParameter {
+                name: "x".to_string(),
+                typ,
+                visibility: AbiVisibility::Private,
+            }],
+            return_type: None,
+            error_types: BTreeMap::new(),
+        }
+    }
+
+    fn witness_map_with_single_value(value: u128) -> WitnessMap<FieldElement> {
+        WitnessMap::from(BTreeMap::from([(Witness(0), FieldElement::from(value))]))
+    }
+
+    #[test]
+    fn decode_rejects_out_of_range_boolean() {
+        let abi = abi_with_single_param(AbiType::Boolean);
+        assert!(abi.decode(&witness_map_with_single_value(2)).is_err());
+    }
+
+    #[test]
+    fn decode_rejects_out_of_range_unsigned_integer() {
+        let abi = abi_with_single_param(AbiType::Integer { sign: Sign::Unsigned, width: 8 });
+        assert!(abi.decode(&witness_map_with_single_value(256)).is_err());
+    }
+
+    #[test]
+    fn decode_rejects_out_of_range_signed_integer() {
+        let abi = abi_with_single_param(AbiType::Integer { sign: Sign::Signed, width: 8 });
+        assert!(abi.decode(&witness_map_with_single_value(256)).is_err());
+    }
+
+    #[test]
+    fn decode_rejects_non_byte_string_field() {
+        let abi = abi_with_single_param(AbiType::String { length: 1 });
+        // `256` does not fit in a single byte, so it is not a valid string character.
+        assert!(abi.decode(&witness_map_with_single_value(256)).is_err());
+    }
+
+    #[test]
+    fn decode_accepts_in_range_values() {
+        let bool_abi = abi_with_single_param(AbiType::Boolean);
+        assert!(bool_abi.decode(&witness_map_with_single_value(1)).is_ok());
+
+        let u8_abi = abi_with_single_param(AbiType::Integer { sign: Sign::Unsigned, width: 8 });
+        assert!(u8_abi.decode(&witness_map_with_single_value(255)).is_ok());
+
+        // `-1: i8` is stored as its in-range two's-complement representation (255).
+        let i8_abi = abi_with_single_param(AbiType::Integer { sign: Sign::Signed, width: 8 });
+        assert!(i8_abi.decode(&witness_map_with_single_value(255)).is_ok());
+
+        let string_abi = abi_with_single_param(AbiType::String { length: 1 });
+        assert!(string_abi.decode(&witness_map_with_single_value(b'a' as u128)).is_ok());
     }
 }


### PR DESCRIPTION
## Summary

`Abi::encode` validates each typed leaf against its `AbiType` slot (`find_type_mismatch` for parameters, `matches_abi` for the return value) — rejecting out-of-range integers and booleans that aren't `0`/`1`. `Abi::decode` / `decode_value` reconstructed `Boolean`, `Integer`, and `String` leaves from raw witness fields **without any equivalent domain check**, so `decode` returned `Ok` for witness maps that `encode` would reject for the same ABI.

Through `noirc_abi_wasm::abiDecode` (which takes a **caller-supplied** witness map) this surfaced as:
- **Silent corruption** — a witness of `2` for a `bool` slot rendered as `false` (`f.is_one()` is `false`), and re-encoding `false` produces `0`.
- **Out-of-range typed values** — `256` decoded under a `u8`/`i8` contract.
- **A panic** — a `String` slot with a field outside `0..=0xFF` hit the `assert!` in `noirc_printable_type::decode_string_value` instead of returning a typed error (an uncatchable abort in wasm).

## Fix

In `decode_value`:
- **Field / Integer / Boolean** leaves now run through the existing `find_type_mismatch`, so decode and encode share the *exact same* domain check by construction.
- **String** slots reject any field with `num_bits() > 8` and return a new `AbiError::StringValueOutsideByteRange` instead of letting `decode_string_value` panic.

The existing recursion through `Array` / `Struct` / `Tuple` covers nested cases automatically. `decode_string_value`'s signature is left untouched since it's shared with debug-print / mocker paths that operate on in-range execution values.

## Behavioral change (breaking at the API boundary)

`Abi::decode` / `abiDecode` now return `Err` for witness maps that did **not** come from executing the matching circuit (external / cached / serialized / wrong-ABI witnesses), where they previously returned `Ok` with non-canonical values. **Witnesses produced by the normal `nargo` / `noir_js` execute flow are unaffected** — every slot is already pinned to its type's range by execution, so the new checks never reject a legitimately-produced value.

## Testing

- New unit tests in `tooling/noirc_abi/src/lib.rs`: `decode` now rejects `bool=2`, `u8=256`, `i8=256`, and a non-byte `String` field (previously a panic), and still accepts in-range values including a negative `i8` (`-1` stored as its two's-complement `255`).
- The `encoding_and_decoding_returns_original_witness_map` proptest still passes (round-trip preserved).
- End-to-end `nargo execute` on a `(i8, u8, bool, str<3>)` return decodes correctly, confirming the legitimate flow is unaffected.
- `cargo fmt` + `cargo clippy -p noirc_abi` clean; dependent crates build.

## Related

Resolves noir-lang/noir-claude#932 (audit finding: `Abi::decode` skips the range/canonicality check that `Abi::encode` enforces).

🤖 Generated with [Claude Code](https://claude.com/claude-code)