### PR TITLE
fix: don't leak private type/value through colliding import

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/path_resolution.rs
+++ b/compiler/noirc_frontend/src/elaborator/path_resolution.rs
@@ -838,6 +838,12 @@ impl Elaborator<'_> {
             errors.push(PathResolutionError::Private(name.clone()));
         }
 
+        // An item brought into scope by an import that is not visible from here (kept in scope only
+        // because a colliding item in the other namespace was visible) is private when referenced.
+        if self.get_module(current_module_id).is_private_import_deferred(module_def_id) {
+            errors.push(PathResolutionError::Private(name.clone()));
+        }
+
         // A trait method imported via `Type::method` must also be reachable through its trait's
         // visibility (e.g. a `pub(crate) trait` is not accessible from another crate, even if the
         // method's own visibility check above passes).

--- a/compiler/noirc_frontend/src/hir/def_collector/dc_crate.rs
+++ b/compiler/noirc_frontend/src/hir/def_collector/dc_crate.rs
@@ -723,6 +723,12 @@ impl DefCollector {
             errors.push(DefCollectorErrorKind::PathResolutionError(error));
         }
 
+        // An item that resolved alongside a visible colliding item but is not itself visible:
+        // bring it into scope below, but remember that referencing it is a privacy error.
+        if let Some(module_def_id) = resolved_import.deferred_private {
+            current_def_map.index_mut(local_module_id).defer_private_import(module_def_id);
+        }
+
         // Populate module namespaces according to the imports used
         let visibility = collected_import.visibility;
         let is_prelude = collected_import.is_prelude;

--- a/compiler/noirc_frontend/src/hir/def_map/module_data.rs
+++ b/compiler/noirc_frontend/src/hir/def_map/module_data.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use noirc_errors::Location;
 
@@ -33,6 +33,12 @@ pub struct ModuleData {
     /// This is stored separately from `scope` to quickly check if a trait is in scope.
     traits_in_scope: HashMap<TraitId, Ident>,
 
+    /// Items brought into `scope` by an import that are not actually visible from this module.
+    /// This happens when a `use` resolves to a name that exists in both the type and value
+    /// namespaces and only some of those items are visible: the visible item makes the import
+    /// legal, while the invisible one is kept here so that referencing it reports a privacy error.
+    deferred_private_imports: HashSet<ModuleDefId>,
+
     pub location: Location,
 
     /// True if this module is a `contract Foo { ... }` module containing contract functions
@@ -65,6 +71,7 @@ impl ModuleData {
             scope: ItemScope::default(),
             definitions: ItemScope::default(),
             traits_in_scope: HashMap::new(),
+            deferred_private_imports: HashSet::new(),
             location,
             is_contract,
             is_type,
@@ -78,6 +85,17 @@ impl ModuleData {
 
     pub fn definitions(&self) -> &ItemScope {
         &self.definitions
+    }
+
+    /// Records that `id` was imported into this module but is not visible from here, so that
+    /// referencing it can be reported as a privacy error at the use site rather than at the import.
+    pub fn defer_private_import(&mut self, id: ModuleDefId) {
+        self.deferred_private_imports.insert(id);
+    }
+
+    /// Returns `true` if `id` was imported into this module without being visible from here.
+    pub fn is_private_import_deferred(&self, id: ModuleDefId) -> bool {
+        self.deferred_private_imports.contains(&id)
     }
 
     fn declare(
@@ -226,5 +244,6 @@ impl ModuleData {
     pub fn clear(&mut self) {
         self.scope.clear();
         self.definitions.clear();
+        self.deferred_private_imports.clear();
     }
 }

--- a/compiler/noirc_frontend/src/hir/resolution/import.rs
+++ b/compiler/noirc_frontend/src/hir/resolution/import.rs
@@ -85,7 +85,12 @@ impl PathResolutionError {
 pub struct ResolvedImport {
     // The symbol which we have resolved to
     pub namespace: PerNs,
-    // The module which we must add the resolved namespace to
+    // An item in `namespace` that is not visible from the importing module, yet is still brought
+    // into scope because the colliding item in the other namespace made the import legal. Referencing
+    // it reports a privacy error at the use site (see `ModuleData::defer_private_import`). At most one
+    // item can be in this situation, since a name resolves to at most one type and one value.
+    pub deferred_private: Option<ModuleDefId>,
+    // Errors encountered while resolving the import.
     pub errors: Vec<PathResolutionError>,
 }
 
@@ -361,6 +366,7 @@ impl<'def_maps, 'usage_tracker, 'references_tracker>
         if path.segments.is_empty() {
             return Ok(ResolvedImport {
                 namespace: PerNs::types(starting_module.into()),
+                deferred_private: None,
                 errors: Vec::new(),
             });
         }
@@ -437,16 +443,39 @@ impl<'def_maps, 'usage_tracker, 'references_tracker>
             current_ns = found_ns;
         }
 
-        let (module_def_id, visibility, _) =
+        let (module_def_id, _, _) =
             current_ns.values.or(current_ns.types).expect("Found empty namespace");
 
         self.add_reference(module_def_id, path.segments.last().unwrap().ident.location(), false);
 
-        if !self.item_in_module_is_visible(current_module_id, visibility) {
+        // The final segment resolves to at most one item in the type namespace and one in the value
+        // namespace. Evaluate the visibility of each occupied slot independently.
+        let type_item = current_ns
+            .types
+            .map(|(id, vis, _)| (id, self.item_in_module_is_visible(current_module_id, vis)));
+        let value_item = current_ns
+            .values
+            .map(|(id, vis, _)| (id, self.item_in_module_is_visible(current_module_id, vis)));
+
+        let both_namespaces_occupied = type_item.is_some() && value_item.is_some();
+        let any_visible = [type_item, value_item].into_iter().flatten().any(|(_, visible)| visible);
+
+        let mut deferred_private = None;
+        if both_namespaces_occupied && any_visible {
+            // A name collision where at least one item is visible, so the import itself is legal.
+            // The other item, if it is private, is still brought into scope; referencing it is
+            // reported as a privacy error at the use site rather than here. Since at most one of the
+            // two slots can be invisible in this branch, there is at most one such item.
+            deferred_private = [type_item, value_item]
+                .into_iter()
+                .flatten()
+                .find_map(|(id, visible)| (!visible).then_some(id));
+        } else if !any_visible {
+            // A single private item, or a collision where both items are private: report it here.
             errors.push(PathResolutionError::Private(path.last_ident()));
         }
 
-        Ok(ResolvedImport { namespace: current_ns, errors })
+        Ok(ResolvedImport { namespace: current_ns, deferred_private, errors })
     }
 
     fn add_reference(

--- a/compiler/noirc_frontend/src/tests/visibility.rs
+++ b/compiler/noirc_frontend/src/tests/visibility.rs
@@ -1077,3 +1077,156 @@ fn private_inherent_impl_method_accessible_from_nested_child_of_impl_module() {
     "#;
     assert_no_errors(src);
 }
+
+#[test]
+fn errors_when_using_private_type_imported_via_value_name_collision() {
+    // A module has a private type and a public value sharing the same name.
+    // Importing the name is allowed (the public value is visible), but using
+    // the private type must still be rejected.
+    let src = r#"
+    mod moo {
+        struct Foo {}
+
+        pub fn Foo() {}
+    }
+
+    use moo::Foo;
+
+    fn main() {
+        let _ = Foo {};
+                ^^^ Foo is private and not visible from the current module
+                ~~~ Foo is private
+    }
+    "#;
+    check_errors(src);
+}
+
+#[test]
+fn allows_importing_value_when_colliding_type_is_public() {
+    // The mirror of the collision case: when both the type and the value are
+    // visible, importing and using either must keep working.
+    let src = r#"
+    mod moo {
+        pub struct Foo {}
+
+        pub fn Foo() {}
+    }
+
+    use moo::Foo;
+
+    fn main() {
+        let _ = Foo {};
+        Foo();
+    }
+    "#;
+    assert_no_errors(src);
+}
+
+#[test]
+fn allows_calling_value_when_using_private_type_imported_via_collision_still_errors() {
+    // The public value of the collision is still usable; only the private type is rejected.
+    let src = r#"
+    mod moo {
+        struct Foo {}
+
+        pub fn Foo() {}
+    }
+
+    use moo::Foo;
+
+    fn main() {
+        Foo();
+        let _ = Foo {};
+                ^^^ Foo is private and not visible from the current module
+                ~~~ Foo is private
+    }
+    "#;
+    check_errors(src);
+}
+
+#[test]
+fn errors_when_using_private_value_imported_via_type_name_collision() {
+    // Mirror of the type/value collision: a private value and a public type share a name.
+    // Importing is allowed (the type is visible), but calling the private value is rejected.
+    let src = r#"
+    mod moo {
+        pub struct Foo {}
+
+        fn Foo() {}
+    }
+
+    use moo::Foo;
+
+    fn main() {
+        let _ = Foo {};
+        Foo();
+        ^^^ Foo is private and not visible from the current module
+        ~~~ Foo is private
+    }
+    "#;
+    check_errors(src);
+}
+
+#[test]
+fn errors_when_using_private_type_imported_via_aliased_collision() {
+    // Aliasing the import must not launder the private type into scope either.
+    let src = r#"
+    mod moo {
+        struct Foo {}
+
+        pub fn Foo() {}
+    }
+
+    use moo::Foo as Leaked;
+
+    fn main() {
+        let _ = Leaked {};
+                ^^^^^^ Leaked is private and not visible from the current module
+                ~~~~~~ Leaked is private
+    }
+    "#;
+    check_errors(src);
+}
+
+#[test]
+fn errors_on_qualified_access_to_private_type_colliding_with_public_value() {
+    // Direct qualified access to the private type is rejected regardless of the import path.
+    let src = r#"
+    mod moo {
+        struct Foo {}
+
+        pub fn Foo() {}
+    }
+
+    fn main() {
+        let _ = moo::Foo {};
+                     ^^^ Foo is private and not visible from the current module
+                     ~~~ Foo is private
+    }
+    "#;
+    check_errors(src);
+}
+
+#[test]
+fn errors_at_import_when_both_colliding_items_are_private() {
+    // When a name resolves to a private item in both namespaces there is no visible item to make
+    // the import legal, so the error is reported at the `use` itself (and only once), rather than
+    // being deferred to the use site.
+    let src = r#"
+    mod moo {
+        struct Foo {}
+
+        fn Foo() {}
+    }
+
+    use moo::Foo;
+             ^^^ Foo is private and not visible from the current module
+             ~~~ Foo is private
+
+    fn main() {
+        let _ = Foo {};
+        Foo();
+    }
+    "#;
+    check_errors(src);
+}


### PR DESCRIPTION
## Problem

`resolve_import` validated the visibility of only a single representative item for the final path segment — `current_ns.values.or(current_ns.types)` — while `process_resolved_import` brought *every* namespace slot into scope.

So when a module had a private item and a public item sharing a name (e.g. a private type `foo` and a public function `foo`), the public item satisfied the visibility check and the private item was silently imported alongside it, becoming fully usable downstream — even though direct qualified access to it (`dep::foo`) was still correctly rejected.

```noir
mod dep {
    struct foo {}      // private type
    pub fn foo() {}    // public value
}

use dep::foo;

fn main() -> pub Field {
    let leaked = foo {};   // <- previously compiled, leaking the private type
    leaked.pass()
}
```

This breaks Noir's nominal type privacy.

## Fix

Check each occupied namespace slot (type and value) independently in `resolve_import`:

- **A single item, or a collision where both items are private** → error at the `use` itself (unchanged behavior).
- **A collision where at least one item is visible** → the import is legal, so no error at the `use`. The private item (at most one) is still brought into scope, but it is recorded as a *deferred private import* on the module. Referencing it is then reported as a privacy error **at the use site** (`foo is private and not visible from the current module`), matching how direct qualified access already behaves.

A name resolves to at most one type and one value, so at most one item is ever deferred per import (`ResolvedImport.deferred_private: Option<ModuleDefId>`); the per-module set accumulates across all `use`s in a module.

Multi-segment paths through a leaked type already errored correctly via the resolution loop, so only the terminal single-name case needed the deferred check.

## Tests

Added regression tests in `tests/visibility.rs`:

- private type + public value collision errors on type use (core repro)
- mirror: private value + public type errors on value call
- public value still callable while the private type is rejected
- aliased import (`use dep::foo as Leaked`) still errors
- qualified direct access still errors
- both-public collision remains fully usable (control)
- both-private collision errors once, at the `use` line

Full `noirc_frontend` suite (1817 tests) passes; clippy and fmt clean.

Resolves https://github.com/noir-lang/noir-claude/issues/959

🤖 Generated with [Claude Code](https://claude.com/claude-code)