### PR TITLE
fix: Fix more overlapping impls

### DIFF
--- a/compiler/noirc_frontend/src/node_interner/trait_impl.rs
+++ b/compiler/noirc_frontend/src/node_interner/trait_impl.rs
@@ -28,6 +28,12 @@ pub(crate) enum TraitLookupMode {
     /// Looks up implementation for bindable object types, and matches only [TraitImplKind::Assumed].
     /// The returned bindings are not expected to be applied.
     SelfAssumedOnly,
+    /// Used only when registering a new impl, to detect whether it overlaps an existing one.
+    /// Unlike [Default](TraitLookupMode::Default), this does not bail out for bindable object types:
+    /// overlap detection must consider generic impls such as `impl<T> Foo for T` or
+    /// `impl<T> Foo for Bar<T>`. Any existing impl whose object type unifies with the new one is
+    /// reported as the overlap, even when several do.
+    Overlapping,
 }
 
 impl NodeInterner {
@@ -254,20 +260,34 @@ impl NodeInterner {
             trait_id,
             ordered_generics,
             &associated_types,
-            TraitLookupMode::Default,
+            TraitLookupMode::Overlapping,
         );
 
         match existing {
-            Ok((TraitImplKind::Normal(existing), ..)) => {
-                let existing_impl = self.get_trait_implementation(existing);
-                let existing_impl = existing_impl.borrow();
-                return Ok(Err(existing_impl.ident.location()));
+            Ok((TraitImplKind::Normal(existing), mut bindings, _)) => {
+                // The object types unify, but the impls only truly overlap if the new impl's own
+                // `where` clause is also satisfiable under that unification. Noir's coherence is
+                // where-clause-aware: `impl<T> Two for T where T: One` does not overlap
+                // `impl Two for u32` when `u32: One` does not hold. The matched impl's where
+                // clause was already validated during the lookup; here we validate the new one's.
+                let where_clause = trait_impl.borrow().where_clause.clone();
+                let overlaps = self
+                    .validate_where_clause(
+                        &where_clause,
+                        &mut bindings,
+                        &substitutions,
+                        IMPL_SEARCH_RECURSION_LIMIT,
+                    )
+                    .is_ok();
+
+                if overlaps {
+                    let existing_impl = self.get_trait_implementation(existing);
+                    let existing_impl = existing_impl.borrow();
+                    return Ok(Err(existing_impl.ident.location()));
+                }
             }
-            Ok((TraitImplKind::Prepared(_, location), ..)) => {
-                // A different Prepared impl matched; this would be a full conflict later if we added both normal ones.
-                return Ok(Err(location));
-            }
-            Err(_) | Ok((TraitImplKind::Assumed { .. }, ..)) => {
+            // `Overlapping` lookups skip `Prepared` entries, so only `Normal` impls are matched.
+            Err(_) | Ok((TraitImplKind::Assumed { .. } | TraitImplKind::Prepared(..), ..)) => {
                 // Ignoring overlapping `TraitImplKind::Assumed` impls here is perfectly fine.
                 // It should never happen since impls are defined at global scope, but even
                 // if they were, we should never prevent defining a new impl because a 'where'
@@ -400,7 +420,7 @@ impl NodeInterner {
         let object_type = object_type.substitute(type_bindings);
         let is_bindable = object_type.is_bindable();
 
-        if is_bindable && !matches!(mode, TraitLookupMode::SelfAssumedOnly) {
+        if is_bindable && matches!(mode, TraitLookupMode::Default) {
             return Err(ImplSearchErrorKind::TypeAnnotationsNeededOnObjectType);
         }
 
@@ -415,6 +435,10 @@ impl NodeInterner {
         for (existing_object_type, impl_kind) in impls {
             let skip = match mode {
                 TraitLookupMode::Default => false,
+                // Match only finalized impls when detecting overlaps. Skipping `Prepared` entries
+                // keeps detection deterministic: each overlapping pair is reported exactly once,
+                // when the second impl is collected and finds the first (now `Normal`).
+                TraitLookupMode::Overlapping => matches!(impl_kind, TraitImplKind::Prepared(..)),
                 TraitLookupMode::SelfAssumedOnly => {
                     !matches!(impl_kind, TraitImplKind::Assumed { .. })
                 }
@@ -509,7 +533,13 @@ impl NodeInterner {
             let (impl_, fresh_bindings, instantiation_bindings, _) = matching_impls.pop().unwrap();
             *type_bindings = fresh_bindings;
             Ok((impl_, instantiation_bindings))
-        } else if is_bindable {
+        } else if matches!(mode, TraitLookupMode::Overlapping) && !matching_impls.is_empty() {
+            // For overlap detection any matching impl is a conflict, even if several match.
+            // Report the first one as the overlapping impl.
+            let (impl_, fresh_bindings, instantiation_bindings, _) = matching_impls.swap_remove(0);
+            *type_bindings = fresh_bindings;
+            Ok((impl_, instantiation_bindings))
+        } else if is_bindable && !matches!(mode, TraitLookupMode::Overlapping) {
             Err(ImplSearchErrorKind::TypeAnnotationsNeededOnObjectType)
         } else if matching_impls.is_empty() {
             let mut errors = match where_clause_error {

--- a/compiler/noirc_frontend/src/node_interner/trait_impl.rs
+++ b/compiler/noirc_frontend/src/node_interner/trait_impl.rs
@@ -286,13 +286,14 @@ impl NodeInterner {
                     return Ok(Err(existing_impl.ident.location()));
                 }
             }
-            // `Overlapping` lookups skip `Prepared` entries, so only `Normal` impls are matched.
-            Err(_) | Ok((TraitImplKind::Assumed { .. } | TraitImplKind::Prepared(..), ..)) => {
+            Err(_) | Ok((TraitImplKind::Assumed { .. }, ..)) => {
                 // Ignoring overlapping `TraitImplKind::Assumed` impls here is perfectly fine.
                 // It should never happen since impls are defined at global scope, but even
                 // if they were, we should never prevent defining a new impl because a 'where'
                 // clause already assumes it exists.
             }
+            // `Overlapping` lookups skip `Prepared` entries, so only `Normal` impls are matched.
+            Ok((TraitImplKind::Prepared(..), ..)) => unreachable!(),
         }
 
         for method in &trait_impl.borrow().methods {

--- a/compiler/noirc_frontend/src/tests/structs.rs
+++ b/compiler/noirc_frontend/src/tests/structs.rs
@@ -629,7 +629,7 @@ fn returns_trait_as_type_overlap() {
 }
 
 #[test]
-fn type_alias_resolves_to_same_type_in_trait_impl() {
+fn type_alias_resolving_to_same_type_overlaps_in_trait_impl() {
     let src = r#"
     trait Foo {
         fn foo(self) {
@@ -640,9 +640,12 @@ fn type_alias_resolves_to_same_type_in_trait_impl() {
     type Bar<T> = T;
 
     impl<T> Foo for T { }
+            ~~~ Previous impl defined here
     impl<T> Foo for Bar<T> { }
+                    ^^^^^^ Impl for type `Bar<T>` overlaps with existing impl
+                    ~~~~~~ Overlapping impl
     "#;
-    assert_no_errors(src);
+    check_errors(src);
 }
 
 #[test]
@@ -657,16 +660,19 @@ fn non_overlapping_trait_impls_with_generic() {
     pub struct Bar<T, let N: u32> {}
 
     impl<T> Foo for Bar<T, 0> { }
-                    ^^^^^^^^^ Impl for type `Bar<T, 0>` overlaps with existing impl
-                    ~~~~~~~~~ Overlapping impl
+            ~~~ Previous impl defined here
+            ~~~ Previous impl defined here
+            ~~~ Previous impl defined here
     impl<T> Foo for Bar<T, 1> { }
     impl<T, let N: u32> Foo for Bar<T, N> { }
-                        ~~~ Previous impl defined here
+                                ^^^^^^^^^ Impl for type `Bar<T, N>` overlaps with existing impl
+                                ~~~~~~~~~ Overlapping impl
     impl Foo for Bar<(), 0> { }
                  ^^^^^^^^^^ Impl for type `Bar<(), 0>` overlaps with existing impl
                  ~~~~~~~~~~ Overlapping impl
-                 ~~~~~~~~~~ Previous impl defined here
     impl<let N: u32> Foo for Bar<(), N> { }
+                             ^^^^^^^^^^ Impl for type `Bar<(), N>` overlaps with existing impl
+                             ~~~~~~~~~~ Overlapping impl
     "#;
     check_errors(src);
 }

--- a/compiler/noirc_frontend/src/tests/traits/trait_impl_validation.rs
+++ b/compiler/noirc_frontend/src/tests/traits/trait_impl_validation.rs
@@ -505,6 +505,21 @@ fn overlapping_generic_impls() {
 }
 
 #[test]
+fn overlapping_blanket_impl_with_generic_struct() {
+    let src = r#"
+    pub trait Foo {}
+    pub struct Bar<T> {}
+    impl<T> Foo for Bar<T> {}
+            ~~~ Previous impl defined here
+    impl<T> Foo for T {}
+                    ^ Impl for type `T` overlaps with existing impl
+                    ~ Overlapping impl
+    fn main() {}
+    "#;
+    check_errors(src);
+}
+
+#[test]
 fn does_not_crash_when_trait_impl_is_defined_multiple_times() {
     let src = r#"
     pub struct Wrap { }


### PR DESCRIPTION
## Problem Resolved

Resolves https://github.com/noir-lang/noir/issues/11730

## Summary of Changes

Among other cases, we now error if a type alias like `Foo<T> = T` is implemented when `T` is also implemented for the same trait.

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
