### PR TITLE
fix(ssa_gen): always record error type, even for strings

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/ssa_gen/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/ssa_gen/mod.rs
@@ -1473,12 +1473,7 @@ impl FunctionContext<'_> {
             let selector = error_type.selector();
             let values = self.codegen_expression(assert_message_expression)?.into_value_list(self);
             let is_string_type = matches!(assert_message_typ, HirType::String(_));
-            // Record custom types in the builder, outside of SSA instructions
-            // This is made to avoid having Hir types in the SSA code.
-            if !is_string_type {
-                self.builder.record_error_type(selector, assert_message_typ.clone());
-            }
-
+            self.builder.record_error_type(selector, assert_message_typ.clone());
             Ok(Some(ConstrainError::Dynamic(selector, is_string_type, values)))
         }
     }

--- a/test_programs/execution_failure/dynamic_string_assert/Nargo.toml
+++ b/test_programs/execution_failure/dynamic_string_assert/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "dynamic_string_assert"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.23.0"
+
+[dependencies]

--- a/test_programs/execution_failure/dynamic_string_assert/Prover.toml
+++ b/test_programs/execution_failure/dynamic_string_assert/Prover.toml
@@ -1,0 +1,2 @@
+msg = "bad"
+cond = false

--- a/test_programs/execution_failure/dynamic_string_assert/src/main.nr
+++ b/test_programs/execution_failure/dynamic_string_assert/src/main.nr
@@ -1,0 +1,3 @@
+fn main(msg: str<3>, cond: bool) {
+    assert(cond, msg);
+}

--- a/tooling/nargo_cli/tests/snapshots/execution_failure/dynamic_string_assert/execute__tests__acir_stderr.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_failure/dynamic_string_assert/execute__tests__acir_stderr.snap
@@ -1,0 +1,15 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: stderr
+---
+error: Assertion failed: bad
+  ┌─ src/main.nr:2:5
+  │
+2 │     assert(cond, msg);
+  │     -----------------
+  │
+  = Call stack:
+    1: main
+            at src/main.nr:2:5
+
+Failed assertion

--- a/tooling/nargo_cli/tests/snapshots/execution_failure/dynamic_string_assert/execute__tests__brillig_stderr.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_failure/dynamic_string_assert/execute__tests__brillig_stderr.snap
@@ -1,0 +1,15 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: stderr
+---
+error: Assertion failed: bad
+  ┌─ src/main.nr:2:5
+  │
+2 │     assert(cond, msg);
+  │     -----------------
+  │
+  = Call stack:
+    1: main
+            at src/main.nr:2:5
+
+Failed assertion

--- a/tooling/nargo_cli/tests/snapshots/execution_failure/dynamic_string_assert/execute__tests__comptime_stderr.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_failure/dynamic_string_assert/execute__tests__comptime_stderr.snap
@@ -1,0 +1,15 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: stderr
+---
+error: bad
+  ┌─ src/main.nr:2:12
+  │
+2 │     assert(cond, msg);
+  │            ---- Assertion failed
+  │
+  = Call stack:
+    1: ?
+            at src/main.nr:1:4
+
+Error interpreting main function


### PR DESCRIPTION
## Problem Resolved

Resolves https://github.com/noir-lang/noir/issues/11017
Resolves https://github.com/noir-lang/noir-claude/issues/1032

## Summary of Changes

The check `if !is_string_type` was there presumably because if you have `assert(condition, "message");` then there's no need to record that as it's a static string, but the string could be dynamic, which is what the code missed.

Claude initially put a pretty verbose comment on top of this line explaining this, but I think it's not necessary.

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
