### PR TITLE
fix(frontend): key foreign proxy cache on monomorphized type

### DIFF
--- a/compiler/noirc_frontend/src/monomorphization/proxies.rs
+++ b/compiler/noirc_frontend/src/monomorphization/proxies.rs
@@ -57,7 +57,7 @@ impl Program {
 struct ProxyContext {
     next_func_id: u32,
     in_unconstrained: bool,
-    replacements: HashMap<(Definition, /*unconstrained*/ bool), FuncId>,
+    replacements: HashMap<(Definition, Type, /*unconstrained*/ bool), FuncId>,
     proxies: Vec<(FuncId, (Ident, /*unconstrained*/ bool))>,
 }
 
@@ -120,7 +120,10 @@ impl ProxyContext {
         // since such a call would be rejected by the SSA validation.
         unconstrained |= matches!(ident.definition, Definition::Oracle { .. });
 
-        let key = (ident.definition.clone(), unconstrained);
+        // The proxy's signature is derived from `ident.typ` (see `make_proxy`), so the same
+        // string-keyed foreign definition used at different monomorphized types needs distinct
+        // proxies. Keying on the type as well as the definition keeps those instantiations apart.
+        let key = (ident.definition.clone(), (*ident.typ).clone(), unconstrained);
 
         let proxy_id = match self.replacements.get(&key) {
             Some(id) => *id,
@@ -373,7 +376,7 @@ mod tests {
         insta::assert_snapshot!(program, @r"
         unconstrained fn main$f0() -> () {
             call_one$f1((foo$f3, foo$f4));;
-            call_two$f2((foo$f3, foo$f4));
+            call_two$f2((foo$f5, foo$f6));
         }
         unconstrained fn call_one$f1(f$l0: (fn(Field) -> Field, unconstrained fn(Field) -> Field)) -> () {
             f$l0.1(0);
@@ -387,6 +390,14 @@ mod tests {
         }
         #[inline_always]
         unconstrained fn foo_proxy$f4(p0$l0: Field) -> Field {
+            foo$foo(p0$l0)
+        }
+        #[inline_always]
+        fn foo_proxy$f5(p0$l0: bool) -> bool {
+            foo$foo(p0$l0)
+        }
+        #[inline_always]
+        unconstrained fn foo_proxy$f6(p0$l0: bool) -> bool {
             foo$foo(p0$l0)
         }
         ");

--- a/compiler/noirc_frontend/src/monomorphization/proxies.rs
+++ b/compiler/noirc_frontend/src/monomorphization/proxies.rs
@@ -345,6 +345,54 @@ mod tests {
     }
 
     #[test]
+    fn creates_separate_proxies_for_different_foreign_instantiations() {
+        let src = "
+        unconstrained fn main() {
+            call_one(foo);
+            call_two(foo);
+        }
+
+        unconstrained fn call_one(f: unconstrained fn(Field) -> Field) {
+            f(0);
+        }
+
+        unconstrained fn call_two(f: unconstrained fn(bool) -> bool) {
+            f(true);
+        }
+
+        #[builtin(foo)]
+        pub fn foo<T>(x: T) -> T {}
+        ";
+
+        let program = get_monomorphized_with_options(
+            src,
+            GetProgramOptions { root_and_stdlib: true, ..Default::default() },
+        )
+        .unwrap();
+
+        insta::assert_snapshot!(program, @r"
+        unconstrained fn main$f0() -> () {
+            call_one$f1((foo$f3, foo$f4));;
+            call_two$f2((foo$f3, foo$f4));
+        }
+        unconstrained fn call_one$f1(f$l0: (fn(Field) -> Field, unconstrained fn(Field) -> Field)) -> () {
+            f$l0.1(0);
+        }
+        unconstrained fn call_two$f2(f$l1: (fn(bool) -> bool, unconstrained fn(bool) -> bool)) -> () {
+            f$l1.1(true);
+        }
+        #[inline_always]
+        fn foo_proxy$f3(p0$l0: Field) -> Field {
+            foo$foo(p0$l0)
+        }
+        #[inline_always]
+        unconstrained fn foo_proxy$f4(p0$l0: Field) -> Field {
+            foo$foo(p0$l0)
+        }
+        ");
+    }
+
+    #[test]
     fn creates_proxies_for_builtin_values() {
         let src = "
         unconstrained fn main() {

--- a/test_programs/execution_success/regression_foreign_proxy_generic/Nargo.toml
+++ b/test_programs/execution_success/regression_foreign_proxy_generic/Nargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "regression_foreign_proxy_generic"
+type = "bin"
+authors = [""]
+
+[dependencies]

--- a/test_programs/execution_success/regression_foreign_proxy_generic/src/main.nr
+++ b/test_programs/execution_success/regression_foreign_proxy_generic/src/main.nr
@@ -1,0 +1,18 @@
+// Passing a generic foreign function (`blake2s`) as a value at two different
+// monomorphized types must produce a distinct proxy per instantiation. A shared
+// proxy cache keyed only on the foreign name reused the first instantiation's
+// signature, silently constraining the second hash to zeros.
+fn call_one(f: fn([u8; 1]) -> [u8; 32]) -> [u8; 32] {
+    f([1])
+}
+
+fn call_two(f: fn([u8; 2]) -> [u8; 32]) -> [u8; 32] {
+    f([2, 3])
+}
+
+fn main() {
+    let a = call_one(std::hash::blake2s);
+    let b = call_two(std::hash::blake2s);
+    assert(a == std::hash::blake2s([1]));
+    assert(b == std::hash::blake2s([2, 3]));
+}

--- a/tooling/nargo_cli/build.rs
+++ b/tooling/nargo_cli/build.rs
@@ -186,7 +186,7 @@ const IGNORED_COMPTIME_INTERPRET_NOIR_TESTS: [&str; 1] = [
 ];
 
 /// `nargo execute --minimal-ssa` ignored tests
-const IGNORED_MINIMAL_EXECUTION_TESTS: [&str; 17] = [
+const IGNORED_MINIMAL_EXECUTION_TESTS: [&str; 18] = [
     // internal error: entered unreachable code: unsupported function call type Intrinsic(AssertConstant)
     // These tests contain calls to `assert_constant`, which are evaluated and removed in the full SSA
     // pipeline, but in the minimal they are untouched, and trying to remove them causes a failure because
@@ -206,6 +206,8 @@ const IGNORED_MINIMAL_EXECUTION_TESTS: [&str; 17] = [
     "conditional_black_box_function_pointer_call",
     "lambda_from_dynamic_if",
     "regression_10156",
+    // The constrained foreign-function proxy can't run in the Brillig-only minimal pipeline.
+    "regression_foreign_proxy_generic",
     // This relies on maximum inliner setting
     "reference_counts_inliner_max",
     "reference_counts_inliner_min",

--- a/tooling/nargo_cli/tests/snapshots/execution_success/regression_foreign_proxy_generic/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/regression_foreign_proxy_generic/execute__tests__expanded.snap
@@ -1,0 +1,18 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: expanded_code
+---
+fn call_one(f: fn([u8; 1]) -> [u8; 32]) -> [u8; 32] {
+    f([1_u8])
+}
+
+fn call_two(f: fn([u8; 2]) -> [u8; 32]) -> [u8; 32] {
+    f([2_u8, 3_u8])
+}
+
+fn main() {
+    let a: [u8; 32] = call_one(std::hash::blake2s);
+    let b: [u8; 32] = call_two(std::hash::blake2s);
+    assert(a == std::hash::blake2s([1_u8]));
+    assert(b == std::hash::blake2s([2_u8, 3_u8]));
+}

--- a/tooling/nargo_cli/tests/snapshots/execution_success/regression_foreign_proxy_generic/execute__tests__stdout.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/regression_foreign_proxy_generic/execute__tests__stdout.snap
@@ -1,0 +1,5 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: stdout
+---
+


### PR DESCRIPTION
## Summary

`Program::create_foreign_proxies` cached generated proxies by `(Definition, unconstrained)`. For `Definition::{LowLevel, Builtin, Oracle}` the `Definition` is only the opcode/name string (e.g. `"blake2s"`), with no type information. So a generic foreign function passed as a first-class value at two different monomorphized types (e.g. `fn([u8; 1]) -> [u8; 32]` and `fn([u8; 2]) -> [u8; 32]`) reused the **first** proxy's signature from the cache — silently producing wrong ACIR that constrained the second hash to thirty-two zeros instead of the correct `blake2s` output.

The fix includes the monomorphized `Ident::typ` in the proxy cache key, so each distinct instantiation gets its own proxy with the correct signature:

```rust
let key = (ident.definition.clone(), (*ident.typ).clone(), unconstrained);
```

## Testing

Following the red-green snapshot workflow (two commits preserved on the branch):

* **Red commit** — adds the monomorphization snapshot test `creates_separate_proxies_for_different_foreign_instantiations` and accepts the *buggy* snapshot, which shows the second call reusing the first instantiation's proxies/signature.
* **Green commit** — applies the fix; the snapshot now shows distinct proxies with the correct per-instantiation signature.

Also adds an end-to-end execution test (`test_programs/execution_success/regression_foreign_proxy_generic`) that passes `std::hash::blake2s` as a value at `[u8; 1]` and `[u8; 2]` and asserts both equal their direct-call results. Verified it **fails to satisfy the constraint without the fix** and **executes successfully with it**. The constrained proxy can't run in the Brillig-only minimal SSA pipeline, so the program is added to `IGNORED_MINIMAL_EXECUTION_TESTS` (same reason as the existing `conditional_black_box_function_pointer_call` entry).

Resolves noir-lang/noir-claude#1043<br>Resolves noir-lang/noir-claude#1043 (noir-lang/noir-claude#1043)

🤖 Generated with [Claude Code](<https://claude.com/claude-code>)