### PR TITLE
fix: comptime as_witness returns unit, not its argument

### DIFF
--- a/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
@@ -371,7 +371,8 @@ fn as_vector(arguments: Vec<(Value, Location)>, location: Location) -> IResult<V
 }
 
 fn as_witness(arguments: Vec<(Value, Location)>, location: Location) -> IResult<Value> {
-    Ok(check_one_argument(arguments, location)?.0)
+    check_one_argument(arguments, location)?;
+    Ok(Value::Unit)
 }
 
 fn black_box(arguments: Vec<(Value, Location)>, location: Location) -> IResult<Value> {

--- a/compiler/noirc_frontend/src/tests/metaprogramming.rs
+++ b/compiler/noirc_frontend/src/tests/metaprogramming.rs
@@ -2041,3 +2041,26 @@ fn reference_generated_struct_in_an_enum_variant() {
     let features = vec![UnstableFeature::Enums];
     crate::tests::assert_no_errors_using_features(src, &features);
 }
+
+// Regression for https://github.com/noir-lang/noir-claude/issues/1047:
+// `as_witness` is declared `fn(Field) -> ()`, so calling it as the final expression
+// of an inferred `comptime` block must produce a unit value, not the `Field` argument.
+#[test]
+fn comptime_as_witness_returns_unit() {
+    let stdlib = r#"
+        #[builtin(as_witness)]
+        pub fn as_witness(_x: Field) {}
+    "#;
+    let src = r#"
+    fn main() -> pub Field {
+                     ^^^^^ expected type Field, found type ()
+                     ~~~~~ expected Field because of return type
+        let x = comptime {
+            as_witness(1)
+        };
+        x
+        ~ () returned here
+    }
+    "#;
+    check_errors_with_stdlib(src, [stdlib]);
+}


### PR DESCRIPTION
## Summary

The comptime `as_witness` builtin returned its `Field` argument instead of unit, contradicting its declared signature `fn(Field) -> ()` (and its documentation, which says it "has no effect in comptime code").

As a result, an inferred top-level `comptime { std::as_witness(1) }` block would synthesize a `Field` value and could drive a `pub Field` return:

```noir
fn main() -> pub Field {
    let x = comptime {
        std::as_witness(1)
    };
    x
}
```

This compiled and executed, even though the same call is correctly rejected as unit under an explicit annotation (`let x: Field = comptime { std::as_witness(1) }`) or inside a `comptime fn -> Field`.

## Fix

The comptime builtin now validates one argument and returns `Value::Unit`, matching:
- the stdlib signature `pub fn as_witness(x: Field) {}`,
- its doc comment ("This has no effect in unconstrained or comptime code"),
- the SSA validator (`AsWitness`: one `Field` argument, no results),
- the SSA interpreter (returns `vec![]`).

Since the offending program no longer compiles, the secondary `--debug-comptime-in-file` `zip_eq` panic reported in the issue is also resolved.

## Testing

Added regression test `comptime_as_witness_returns_unit` in `noirc_frontend`, which now reports `expected type Field, found type ()`. Verified red (no error before the fix) → green (error after). The full comptime/metaprogramming/interpreter suite passes. No existing `.nr` usages relied on the old return value — all use `as_witness` for its side effect as `fn(Field) -> ()`.

Resolves https://github.com/noir-lang/noir-claude/issues/1047

🤖 Generated with [Claude Code](https://claude.com/claude-code)