### PR TITLE
fix!: Error on immutable references to array elements

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/expressions.rs
+++ b/compiler/noirc_frontend/src/elaborator/expressions.rs
@@ -574,11 +574,12 @@ impl Elaborator<'_> {
         let trait_method_id = self.interner.get_prefix_operator_trait_method(&operator);
 
         if let UnaryOp::Reference { mutable } = operator
-            && mutable
+            && !skip_op
         {
-            // If skip_op is set we already know we have a mutable reference
-            if !skip_op {
+            if mutable {
                 self.check_can_mutate(rhs, rhs_location);
+            } else {
+                self.check_can_reference_array_element(rhs, rhs_location);
             }
         }
 
@@ -631,10 +632,24 @@ impl Elaborator<'_> {
                 }
             }
             HirExpression::Index(_) => {
-                self.push_err(TypeCheckError::MutableReferenceToArrayElement { location });
+                self.push_err(TypeCheckError::ReferenceToArrayElement { location });
             }
             HirExpression::MemberAccess(member_access) => {
                 self.check_can_mutate(member_access.lhs, location);
+            }
+            _ => (),
+        }
+    }
+
+    /// Pushes an error if a (shared) reference is being taken to an array element,
+    /// which is currently unsupported.
+    fn check_can_reference_array_element(&mut self, expr_id: ExprId, location: Location) {
+        match self.interner.expression(&expr_id) {
+            HirExpression::Index(_) => {
+                self.push_err(TypeCheckError::ReferenceToArrayElement { location });
+            }
+            HirExpression::MemberAccess(member_access) => {
+                self.check_can_reference_array_element(member_access.lhs, location);
             }
             _ => (),
         }

--- a/compiler/noirc_frontend/src/hir/type_check/errors.rs
+++ b/compiler/noirc_frontend/src/hir/type_check/errors.rs
@@ -132,8 +132,8 @@ pub enum TypeCheckError {
     CannotMutateImmutableVariable { name: String, location: Location },
     #[error("Variable {name} captured in lambda must be a mutable reference")]
     MutableCaptureWithoutRef { name: String, location: Location },
-    #[error("Mutable references to array indices are unsupported")]
-    MutableReferenceToArrayElement { location: Location },
+    #[error("References to array elements are unsupported")]
+    ReferenceToArrayElement { location: Location },
     #[error("No method named '{method_name}' found for type '{object_type}'")]
     UnresolvedMethodCall { method_name: String, object_type: Type, location: Location },
     #[error("Cannot invoke function field '{method_name}' on type '{object_type}' as a method")]
@@ -347,7 +347,7 @@ impl TypeCheckError {
             | TypeCheckError::CannotAssignToLValueBehindReference { location, .. }
             | TypeCheckError::CannotMutateImmutableVariable { location, .. }
             | TypeCheckError::MutableCaptureWithoutRef { location, .. }
-            | TypeCheckError::MutableReferenceToArrayElement { location }
+            | TypeCheckError::ReferenceToArrayElement { location }
             | TypeCheckError::UnresolvedMethodCall { location, .. }
             | TypeCheckError::CannotInvokeStructFieldFunctionType { location, .. }
             | TypeCheckError::IntegerSignedness { location, .. }
@@ -637,8 +637,8 @@ impl<'a> From<&'a TypeCheckError> for Diagnostic {
                 "Use '&mut' instead of 'mut' to capture a mutable variable.".to_string(),
                 *location,
             ),
-            TypeCheckError::MutableReferenceToArrayElement { location } => {
-                Diagnostic::simple_error("Mutable references to array elements are currently unsupported".into(), "Try storing the element in a fresh variable first".into(), *location)
+            TypeCheckError::ReferenceToArrayElement { location } => {
+                Diagnostic::simple_error("References to array elements are currently unsupported".into(), "Try storing the element in a fresh variable first".into(), *location)
             },
             TypeCheckError::TypeAnnotationsNeededForMethodCall { location } => {
                 let mut error = Diagnostic::simple_error(

--- a/compiler/noirc_frontend/src/tests/arrays.rs
+++ b/compiler/noirc_frontend/src/tests/arrays.rs
@@ -83,9 +83,22 @@ fn mutable_reference_to_array_element_as_func_arg() {
     fn main() {
         let state: [u32; 4] = [1, 2, 3, 4];
         foo(&mut state[0]);
-                 ^^^^^^^^ Mutable references to array elements are currently unsupported
+                 ^^^^^^^^ References to array elements are currently unsupported
                  ~~~~~~~~ Try storing the element in a fresh variable first
         assert_eq(state[0], 2); // expect:2 got:1
+    }
+    "#;
+    check_errors(src);
+}
+
+#[test]
+fn shared_reference_to_array_element() {
+    let src = r#"
+    fn main() {
+        let state: [u32; 4] = [1, 2, 3, 4];
+        let _r = &state[0];
+                  ^^^^^^^^ References to array elements are currently unsupported
+                  ~~~~~~~~ Try storing the element in a fresh variable first
     }
     "#;
     check_errors(src);

--- a/docs/docs/language/data_types/references.md
+++ b/docs/docs/language/data_types/references.md
@@ -145,7 +145,7 @@ the entire program.
 
 ### References to Array Elements
 
-Mutable references to array elements are not supported:
+References to array elements are not supported:
 
 ```rust
 fn foo(x: &mut u32) {
@@ -161,7 +161,7 @@ fn main() {
 The above will error with:
 
 ```
-error: Mutable references to array elements are currently unsupported
+error: References to array elements are currently unsupported
   ┌─ src/main.nr:6:18
   │
 6 │         foo(&mut state[0]);


### PR DESCRIPTION
## Problem Resolved

Resolves https://cantina.xyz/code/af01d57f-6e50-4de3-ad6d-7e9f7ff2d7d1/findings/7

## Summary of Changes

These copy internally and can be confusing - as evidenced by the linked audit issue. We already error for mutable references here but the check was also tangled with checking if the value could be mutated so it was never updated for immutable references.

## User Documentation

Check one:
- [ ] No user documentation needed.
- [x] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
