### PR TITLE
fix: zeroed array of references must not share one allocation

### DIFF
--- a/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
@@ -1554,8 +1554,15 @@ fn zeroed(return_type: Type, location: Location) -> Value {
         Type::FieldElement => Value::field(FieldElement::zero()),
         Type::Array(elem, length_type) => {
             if let Ok(length) = length_type.evaluate_to_u32(location) {
-                let element = zeroed(elem.as_ref().clone(), location);
-                let array = std::iter::repeat_n(element, length as usize).collect();
+                let array = if elem.contains_reference() {
+                    // A reference becomes a fresh `Value::Pointer`. Cloning one shares its
+                    // underlying cell, so build an independent zeroed value per slot instead
+                    // of repeating a single element, matching the `Tuple` arm below.
+                    (0..length).map(|_| zeroed(elem.as_ref().clone(), location)).collect()
+                } else {
+                    let element = zeroed(elem.as_ref().clone(), location);
+                    std::iter::repeat_n(element, length as usize).collect()
+                };
                 Value::Array(array, Type::Array(elem, length_type))
             } else {
                 // Assume we can resolve the length later

--- a/compiler/noirc_frontend/src/monomorphization/ast.rs
+++ b/compiler/noirc_frontend/src/monomorphization/ast.rs
@@ -578,6 +578,22 @@ impl Type {
         }
     }
 
+    /// Returns true if this type is, or transitively contains, a reference.
+    pub fn contains_reference(&self) -> bool {
+        match self {
+            Type::Reference(..) => true,
+            Type::Array(_, element) | Type::Vector(element) => element.contains_reference(),
+            Type::Tuple(fields) => fields.iter().any(Type::contains_reference),
+            Type::FmtString(_, fields) => fields.contains_reference(),
+            Type::Field
+            | Type::Integer(..)
+            | Type::Bool
+            | Type::String(_)
+            | Type::Unit
+            | Type::Function(..) => false,
+        }
+    }
+
     /// Returns the element type of this array or vector
     pub fn array_element_type(&self) -> Option<&Type> {
         match self {

--- a/compiler/noirc_frontend/src/monomorphization/builtin.rs
+++ b/compiler/noirc_frontend/src/monomorphization/builtin.rs
@@ -188,13 +188,26 @@ impl Monomorphizer<'_> {
             ast::Type::Bool => ast::Expression::Literal(ast::Literal::Bool(false)),
             ast::Type::Unit => ast::Expression::Literal(ast::Literal::Unit),
             ast::Type::Array(length, element_type) => {
-                let element = self.zeroed_value_of_type(element_type, location);
-                ast::Expression::Literal(ast::Literal::Repeated {
-                    element: Box::new(element),
-                    length: *length,
-                    is_vector: false,
-                    typ: ast::Type::Array(*length, element_type.clone()),
-                })
+                let typ = ast::Type::Array(*length, element_type.clone());
+                if element_type.contains_reference() {
+                    // A reference lowers to a single `allocate`, so a repeated array literal would
+                    // make every slot share one allocation. Author N independent elements instead
+                    // so each slot gets its own cell, matching the `Tuple` arm below.
+                    let contents =
+                        vecmap(0..*length, |_| self.zeroed_value_of_type(element_type, location));
+                    ast::Expression::Literal(ast::Literal::Array(ast::ArrayLiteral {
+                        contents,
+                        typ,
+                    }))
+                } else {
+                    let element = self.zeroed_value_of_type(element_type, location);
+                    ast::Expression::Literal(ast::Literal::Repeated {
+                        element: Box::new(element),
+                        length: *length,
+                        is_vector: false,
+                        typ,
+                    })
+                }
             }
             ast::Type::String(length) => {
                 ast::Expression::Literal(ast::Literal::Str(vec![0; *length as usize]))

--- a/compiler/noirc_frontend/src/monomorphization/tests.rs
+++ b/compiler/noirc_frontend/src/monomorphization/tests.rs
@@ -1725,3 +1725,26 @@ fn static_assert_called_directly_still_works() {
     get_monomorphized_with_stdlib(src, &[STATIC_ASSERT_STDLIB])
         .expect("direct call to static_assert should still monomorphize");
 }
+
+const ZEROED_STDLIB: &str = "
+    #[builtin(zeroed)]
+    pub fn zeroed<T>() -> T {}
+";
+
+#[test]
+fn zeroed_array_of_references_does_not_alias() {
+    // Each slot of a zeroed `[&mut Field; N]` must get its own `allocate`. Wrapping a single
+    // `&mut 0` sub-expression in a repeated array literal would make every slot share one
+    // allocation, so a write through one slot would be visible through all the others.
+    let src = r#"
+    fn main() {
+        let _arr: [&mut Field; 3] = zeroed();
+    }
+    "#;
+    let program = get_monomorphized_with_stdlib(src, &[ZEROED_STDLIB]).unwrap();
+    insta::assert_snapshot!(program, @r"
+    fn main$f0() -> () {
+        let _arr$l0 = [(&mut 0); 3]
+    }
+    ");
+}

--- a/compiler/noirc_frontend/src/monomorphization/tests.rs
+++ b/compiler/noirc_frontend/src/monomorphization/tests.rs
@@ -1744,7 +1744,7 @@ fn zeroed_array_of_references_does_not_alias() {
     let program = get_monomorphized_with_stdlib(src, &[ZEROED_STDLIB]).unwrap();
     insta::assert_snapshot!(program, @r"
     fn main$f0() -> () {
-        let _arr$l0 = [(&mut 0); 3]
+        let _arr$l0 = [(&mut 0), (&mut 0), (&mut 0)]
     }
     ");
 }

--- a/compiler/noirc_frontend/src/tests/metaprogramming.rs
+++ b/compiler/noirc_frontend/src/tests/metaprogramming.rs
@@ -1366,6 +1366,25 @@ fn zeroed_comptime_type() {
 }
 
 #[test]
+fn zeroed_array_of_references_does_not_alias_in_comptime() {
+    // Each slot of a zeroed `[&mut Field; N]` must own its own allocation in the comptime
+    // interpreter. If the slots aliased, writing through one would be observable through the
+    // others and the comptime asserts below would fail during elaboration.
+    let src = r#"
+    fn main() {
+        comptime {
+            let arr: [&mut Field; 3] = zeroed();
+            *arr[1] = 7;
+            assert_eq(*arr[0], 0);
+            assert_eq(*arr[1], 7);
+            assert_eq(*arr[2], 0);
+        }
+    }
+    "#;
+    check_errors_with_stdlib(src, [stdlib_src::ZEROED]);
+}
+
+#[test]
 fn recursive_attribute_causes_expansion_limit_error() {
     use crate::elaborator::MAX_MACRO_EXPANSION_DEPTH;
     use crate::hir::comptime::InterpreterError;

--- a/test_programs/execution_success/zeroed_array_of_references/Nargo.toml
+++ b/test_programs/execution_success/zeroed_array_of_references/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "zeroed_array_of_references"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.33.0"
+
+[dependencies]

--- a/test_programs/execution_success/zeroed_array_of_references/src/main.nr
+++ b/test_programs/execution_success/zeroed_array_of_references/src/main.nr
@@ -1,0 +1,19 @@
+use std::mem::zeroed;
+
+// Each slot of a zeroed array of references must own its own allocation, just like
+// the fields of a zeroed tuple do. Writing through one slot must not be observable
+// through the others.
+fn main() {
+    let arr: [&mut Field; 3] = zeroed();
+    *arr[1] = 7;
+    assert_eq(*arr[0], 0);
+    assert_eq(*arr[1], 7);
+    assert_eq(*arr[2], 0);
+
+    // The reference can also be nested under a tuple inside the array.
+    let nested: [(&mut Field,); 3] = zeroed();
+    *nested[1].0 = 42;
+    assert_eq(*nested[0].0, 0);
+    assert_eq(*nested[1].0, 42);
+    assert_eq(*nested[2].0, 0);
+}

--- a/tooling/nargo_cli/tests/snapshots/execution_success/zeroed_array_of_references/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/zeroed_array_of_references/execute__tests__expanded.snap
@@ -1,0 +1,18 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: expanded_code
+---
+use std::mem::zeroed;
+
+fn main() {
+    let arr: [&mut Field; 3] = zeroed();
+    *arr[1_u32] = 7_Field;
+    assert(*arr[0_u32] == 0_Field);
+    assert(*arr[1_u32] == 7_Field);
+    assert(*arr[2_u32] == 0_Field);
+    let nested: [(&mut Field,); 3] = zeroed();
+    *nested[1_u32].0 = 42_Field;
+    assert(*nested[0_u32].0 == 0_Field);
+    assert(*nested[1_u32].0 == 42_Field);
+    assert(*nested[2_u32].0 == 0_Field);
+}

--- a/tooling/nargo_cli/tests/snapshots/execution_success/zeroed_array_of_references/execute__tests__stdout.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/zeroed_array_of_references/execute__tests__stdout.snap
@@ -1,0 +1,5 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: stdout
+---
+


### PR DESCRIPTION
This is likely not very important to fix, but I was surprised that `std::mem::zeroed()` for an array of pointers returned the same pointer in all slots. I mean, that's expected for an repeated array literal, but I don't know if it's expected for `std::mem::zeroed()`, hence this PR.

## Summary

`std::mem::zeroed::<[&mut U; N]>()` produced an array whose slots all shared a **single** allocation — a write through one slot was visible through every other slot. Tuple and struct fields were unaffected (each gets its own zeroed element), so the asymmetry between *tuple of N refs* (independent) and *array of N refs* (aliased) was a silent footgun.

Resolves https://github.com/noir-lang/noir-claude/issues/1084
Resolves https://github.com/noir-lang/noir-claude/issues/1114

### Root cause

The `Array` arm of `zeroed_value_of_type` wrapped a single `&mut 0` sub-expression in `Literal::Repeated`, which evaluates the element once and replicates the resulting *value* (one `ValueId`), not the expression. The same aliasing existed in the comptime interpreter's `zeroed`, where `repeat_n` cloned a single `Value::Pointer` and shared its underlying cell.

Before the fix, initial SSA for `let arr: [&mut Field; 3] = zeroed()` was:

```
v0 = allocate -> &mut Field
store Field 0 at v0
v2 = make_array [v0, v0, v0] : [&mut Field; 3]   // <-- aliased
```

### Fix

Both `zeroed` implementations now fan out into `N` independent zeroed elements (matching the `Tuple` arm) **when the element type transitively contains a reference**, keeping the cheaper repeated literal otherwise:

- `compiler/noirc_frontend/src/monomorphization/builtin.rs` — runtime ACIR/Brillig path.
- `compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs` — comptime path.

After the fix the array lowers to three distinct `allocate` instructions.

## Tests

- Monomorphization snapshot test (committed red-then-green per the repo convention).
- A comptime-block unit test in `tests/metaprogramming.rs`.
- `test_programs/execution_success/zeroed_array_of_references` — end-to-end across ACIR, Brillig and comptime (`--force-comptime`), covering both the array-of-refs case and the tuple-under-array generalization.

## Verification

- Full `noirc_frontend` suite passes (1819 tests).
- New program passes all 16 integration variants.
- Representative `zeroed`-heavy programs (e.g. `uhashmap`) still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)