### PR TITLE
chore(docs): Add links to BigNum, BigCurve, and Base64 in docs

### DIFF
--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -86,7 +86,22 @@ export default {
         },
         {
           type: 'link',
-          label: 'Ecosystem Libraries',
+          label: 'BigNum',
+          href: 'https://github.com/noir-lang/noir-bignum',
+        },
+        {
+          type: 'link',
+          label: 'BigCurve',
+          href: 'https://github.com/noir-lang/noir_bigcurve',
+        },
+        {
+          type: 'link',
+          label: 'Base64',
+          href: 'https://github.com/noir-lang/noir_base64',
+        },
+        {
+          type: 'link',
+          label: 'More Libraries',
           href: 'https://github.com/noir-lang/awesome-noir?tab=readme-ov-file#libraries',
         },
       ],


### PR DESCRIPTION
## Problem Resolved

Resolves https://github.com/noir-lang/noir/issues/12868.

## Summary of Changes

Add links the BigNum, BigCurve, and Base64 libraries in docs' sidebar.

## User Documentation

Check one:
- [ ] No user documentation needed.
- [x] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
