### PR TITLE
fix(ssa): keep sibling loop-bound error through ACIR unroll fallback

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/opt/unrolling.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/unrolling.rs
@@ -256,7 +256,7 @@ impl Function {
                 loops.callee_costs = callee_costs.clone();
 
                 let mut fallback_failed = HashSet::new();
-                let (fallback_unrolled, _, _fallback_errors) = self.try_unroll_loops_with_order(
+                let (fallback_unrolled, _, fallback_errors) = self.try_unroll_loops_with_order(
                     loops,
                     LoopOrder::OutsideIn,
                     &mut fallback_failed,
@@ -270,9 +270,13 @@ impl Function {
                     // OutsideIn made progress (unrolled outer loops, duplicating inner loops).
                     // The InsideOut errors referenced loop headers that were either inlined
                     // away by the outer-loop unroll or whose duplicates have constant bounds;
-                    // either way they are stale. Clear them so the next InsideOut pass starts
-                    // fresh and only reports loops that still genuinely fail.
-                    accumulated_errors.clear();
+                    // either way they are stale. The OutsideIn pass re-tried every current loop
+                    // from a fresh failed set, so `fallback_errors` already holds the genuine
+                    // failures (independent runtime-bound siblings that survive the unroll).
+                    // Replace the stale InsideOut errors with these so a sibling whose header is
+                    // now in `failed_to_unroll` — and thus skipped without erroring on the next
+                    // InsideOut pass — still has its `UnknownLoopBound` reported to the caller.
+                    accumulated_errors = fallback_errors;
                     continue;
                 }
                 // OutsideIn also made no progress — leave the InsideOut errors accumulated
@@ -2150,6 +2154,79 @@ mod tests {
         // Expected that we failed to unroll the loop
         let (_, errors) = try_unroll_loops(ssa);
         assert_eq!(errors.len(), 1, "Expected to fail to unroll loop");
+    }
+
+    // A nested loop whose inner bound depends on the outer induction variable is only
+    // unrollable via the ACIR InsideOut→OutsideIn fallback. When such a loop coexists with
+    // an independent runtime-bound sibling loop, the fallback used to clear the sibling's
+    // genuine `UnknownLoopBound` error, returning success while leaving the sibling loop in
+    // the SSA (which later panics in `checks.rs`). The sibling error must survive the fallback.
+    #[test]
+    fn fallback_keeps_sibling_loop_bound_error() {
+        // fn main(n: u32, x: Field) {
+        //     for i in 0..2 {
+        //         for j in 0..i {
+        //             assert(j < 2);
+        //         }
+        //     }
+        //     for k in 0..n {
+        //         assert(x == x);
+        //         assert(k < n);
+        //     }
+        // }
+        let src = "
+        acir(inline) fn main f0 {
+          b0(v0: u32, v1: Field):
+            jmp b1(u32 0)
+          b1(v2: u32):
+            v7 = lt v2, u32 2
+            jmpif v7 then: b2(), else: b3()
+          b2():
+            jmp b4(u32 0)
+          b3():
+            jmp b7(u32 0)
+          b4(v3: u32):
+            v13 = lt v3, v2
+            jmpif v13 then: b5(), else: b6()
+          b5():
+            v15 = lt v3, u32 2
+            constrain v15 == u1 1
+            v16 = unchecked_add v3, u32 1
+            jmp b4(v16)
+          b6():
+            v14 = unchecked_add v2, u32 1
+            jmp b1(v14)
+          b7(v4: u32):
+            v8 = lt v4, v0
+            jmpif v8 then: b8(), else: b9()
+          b8():
+            v9 = lt v4, v0
+            constrain v9 == u1 1
+            v12 = unchecked_add v4, u32 1
+            jmp b7(v12)
+          b9():
+            return
+        }
+        ";
+        let ssa = Ssa::from_str(src).unwrap();
+
+        let (ssa, errors) = try_unroll_loops(ssa);
+        assert_eq!(
+            errors.len(),
+            1,
+            "Expected the runtime-bound sibling loop to report its UnknownLoopBound error"
+        );
+        assert!(
+            matches!(errors[0], RuntimeError::UnknownLoopBound { .. }),
+            "Expected UnknownLoopBound, got {:?}",
+            errors[0]
+        );
+
+        // The nested fallback-resolvable loop unrolls; only the sibling runtime-bound loop remains.
+        assert!(
+            ssa.main().reachable_blocks().len() > 1,
+            "The runtime-bound sibling loop should still be present in the SSA"
+        );
     }
 
     #[test]

--- a/test_programs/compile_failure/unknown_loop_bound_with_fallback_sibling/Nargo.toml
+++ b/test_programs/compile_failure/unknown_loop_bound_with_fallback_sibling/Nargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "unknown_loop_bound_with_fallback_sibling"
+type = "bin"
+authors = [""]
+
+[dependencies]

--- a/test_programs/compile_failure/unknown_loop_bound_with_fallback_sibling/src/main.nr
+++ b/test_programs/compile_failure/unknown_loop_bound_with_fallback_sibling/src/main.nr
@@ -1,0 +1,17 @@
+// A nested loop whose inner bound depends on the outer induction variable is only
+// unrollable via the ACIR InsideOut->OutsideIn fallback. Paired with an independent
+// runtime-bound sibling loop, the fallback used to discard the sibling's genuine
+// `UnknownLoopBound` error and leave a residual loop, panicking in a later pass.
+// Compilation must instead report the loop bound error cleanly.
+fn main(n: u32, x: Field) {
+    for i in 0..2 {
+        for j in 0..i {
+            assert(j < 2);
+        }
+    }
+
+    for k in 0..n {
+        assert(x == x);
+        assert(k < n);
+    }
+}

--- a/tooling/nargo_cli/tests/snapshots/compile_failure/unknown_loop_bound_with_fallback_sibling/execute__tests__stderr.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_failure/unknown_loop_bound_with_fallback_sibling/execute__tests__stderr.snap
@@ -1,0 +1,15 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: stderr
+---
+error: Could not determine loop bound at compile-time
+   ┌─ src/main.nr:13:17
+   │
+13 │     for k in 0..n {
+   │                 - If attempting to fetch the length of a vector, try converting to an array. Vectors only use dynamic lengths.
+   │
+   = Call stack:
+     1: main
+             at src/main.nr:13:17
+
+Aborting due to 1 previous error


### PR DESCRIPTION
Resolves https://github.com/noir-lang/noir-claude/issues/1098

## ELI5

Loops in a circuit have to be "unrolled" (copy-pasted out), and to do that the compiler needs to know the iteration count up front. It tries the inner loop first (**InsideOut**); if an inner loop's count depends on the outer loop it gets stuck, so it falls back to doing the outer loop first (**OutsideIn**), which turns the inner counts into real numbers.

The compiler keeps a to-do list of "loops I couldn't unroll" so it can report them as errors. When the OutsideIn fallback made progress, it threw away that **entire** list, assuming all the complaints were now stale. But if the program also had a separate loop with a genuinely unknown count (`for k in 0..n`), its complaint got thrown away too — and because that loop was already marked "don't retry," nobody ever re-reported it. The compiler declared success while that loop was still sitting in the circuit, then crashed in a later safety check with `Function main still contains 1 loop(s)`.

**Fix:** the OutsideIn fallback already re-checks every loop and returns its own accurate complaint list. Instead of clearing all errors, we now keep that fresh list — so the genuinely-broken sibling loop still gets reported, and compilation fails cleanly.

## Before / after

```rust
fn main(n: u32, x: Field) {
    for i in 0..2 { for j in 0..i { assert(j < 2); } } // fallback-resolvable
    for k in 0..n { assert(k < n); }                   // genuinely unbounded
}
```

- **Before:** internal panic `Function main still contains 1 loop(s)` (`checks.rs:82`).
- **After:** `error: Could not determine loop bound at compile-time`.

## The change

In `try_unroll_loops` ([unrolling.rs](compiler/noirc_evaluator/src/ssa/opt/unrolling.rs)), the OutsideIn fallback's returned errors were ignored and `accumulated_errors.clear()` discarded everything. We now set `accumulated_errors = fallback_errors`, replacing only the stale InsideOut errors while preserving genuine failures of independent sibling loops that survive the fallback.

## Tests

- **SSA unit test** `fallback_keeps_sibling_loop_bound_error` in `unrolling.rs` — asserts the runtime-bound sibling reports exactly one `UnknownLoopBound` (was `0` before the fix).
- **End-to-end** `compile_failure/unknown_loop_bound_with_fallback_sibling` — the `compile_failure` harness asserts stderr does not contain `The application panicked (crashed).`, so it directly guards against the regression, plus snapshots the clean diagnostic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)