### PR TITLE
feat(nargo): add `--define`/`-D` to override global constants from the CLI

### DIFF
--- a/compiler/noirc_driver/src/lib.rs
+++ b/compiler/noirc_driver/src/lib.rs
@@ -179,6 +179,14 @@ pub struct CompileOptions {
     #[arg(long)]
     pub debug_comptime_in_file: Option<String>,
 
+    /// Override a top-level global constant's value at compile time, e.g.
+    /// `-D MAX_SIZE=100`. Can be passed multiple times. The named global's
+    /// initializer is ignored and the given value is used instead, which lets a
+    /// single codebase produce differently-sized circuits. Only `bool`, `Field`,
+    /// and integer-typed globals are supported.
+    #[arg(short = 'D', long = "define", value_name = "NAME=VALUE", value_parser = parse_global_override)]
+    pub defines: Vec<(String, String)>,
+
     /// Outputs the paths to any modified artifacts
     #[arg(long, hide = true)]
     pub show_artifact_paths: bool,
@@ -321,6 +329,7 @@ impl Default for CompileOptions {
             instrument_debug: false,
             force_brillig: false,
             debug_comptime_in_file: None,
+            defines: Vec::new(),
             show_artifact_paths: false,
             skip_underconstrained_check: false,
             skip_brillig_constraints_check: false,
@@ -397,8 +406,22 @@ impl CompileOptions {
             debug_comptime_in_file: self.debug_comptime_in_file.as_deref(),
             enabled_unstable_features: &self.unstable_features,
             disable_required_unstable_features: self.no_unstable_features,
+            global_overrides: &self.defines,
         }
     }
+}
+
+/// Parses a `NAME=VALUE` global override as passed to `--define`/`-D`. The value
+/// may itself contain `=`; only the first `=` is treated as the separator.
+fn parse_global_override(arg: &str) -> Result<(String, String), String> {
+    let (name, value) = arg
+        .split_once('=')
+        .ok_or_else(|| format!("expected a `NAME=VALUE` global override, but found `{arg}`"))?;
+    let name = name.trim();
+    if name.is_empty() {
+        return Err(format!("global override is missing a name: `{arg}`"));
+    }
+    Ok((name.to_string(), value.to_string()))
 }
 
 #[derive(Debug)]

--- a/compiler/noirc_frontend/src/elaborator/globals.rs
+++ b/compiler/noirc_frontend/src/elaborator/globals.rs
@@ -158,14 +158,16 @@ impl Elaborator<'_> {
         let name = global.ident.to_string();
 
         // A CLI `--define NAME=VALUE` override replaces the global's initializer
-        // with a value parsed from the command line. Look it up by name; cloning
-        // the value releases the borrow on `self.options` before we mutate the
-        // interner below.
+        // with a value parsed from the command line. Look it up by name, taking
+        // the last entry so that a repeated `-D name=...` follows the usual
+        // "last one wins" convention. Cloning the value releases the borrow on
+        // `self.options` before we mutate the interner below.
         let override_value = self
             .options
             .global_overrides
             .iter()
-            .find(|(overridden_name, _)| *overridden_name == name)
+            .rev()
+            .find(|(overridden_name, _)| overridden_name == &name)
             .map(|(_, value)| value.clone());
 
         if let Some(raw) = override_value {
@@ -256,15 +258,18 @@ fn global_override_value(typ: &Type, raw: &str) -> Result<Value, String> {
     }
 }
 
-/// Parses a (possibly negative) decimal integer override into a [`FieldElement`].
-/// Negative values are encoded as negated fields, matching how the comptime
-/// interpreter represents signed integers.
+/// Parses a (possibly negative) integer override into a [`FieldElement`]. The
+/// magnitude may be decimal or `0x`-prefixed hex and may be any value up to the
+/// field modulus, so the full range of `Field` (and every integer type) is
+/// supported. Negative values are encoded as negated fields, matching how the
+/// comptime interpreter represents signed integers.
 fn parse_override_field(raw: &str) -> Result<FieldElement, String> {
     let raw = raw.trim();
-    let parse_magnitude =
-        |s: &str| s.parse::<u128>().map_err(|_| format!("`{raw}` is not a valid integer"));
-    match raw.strip_prefix('-') {
-        Some(magnitude) => Ok(-FieldElement::from(parse_magnitude(magnitude)?)),
-        None => Ok(FieldElement::from(parse_magnitude(raw)?)),
-    }
+    let (negative, magnitude) = match raw.strip_prefix('-') {
+        Some(magnitude) => (true, magnitude.trim_start()),
+        None => (false, raw),
+    };
+    let field = FieldElement::try_from_str(magnitude)
+        .ok_or_else(|| format!("`{raw}` is not a valid integer or `Field` value"))?;
+    Ok(if negative { -field } else { field })
 }

--- a/compiler/noirc_frontend/src/elaborator/globals.rs
+++ b/compiler/noirc_frontend/src/elaborator/globals.rs
@@ -22,9 +22,16 @@
 
 use std::collections::HashSet;
 
+use acvm::FieldElement;
+
 use crate::{
+    Type,
     ast::Pattern,
-    hir::{def_collector::dc_crate::UnresolvedGlobal, resolution::errors::ResolverError},
+    hir::{
+        comptime::{Integer, Value},
+        def_collector::dc_crate::UnresolvedGlobal,
+        resolution::errors::ResolverError,
+    },
     hir_def::{expr::HirExpression, stmt::HirStatement},
     node_interner::{DependencyId, GlobalId, GlobalValue},
     token::SecondaryAttributeKind,
@@ -148,6 +155,33 @@ impl Elaborator<'_> {
 
         let definition_id = global.definition_id;
         let location = global.location;
+        let name = global.ident.to_string();
+
+        // A CLI `--define NAME=VALUE` override replaces the global's initializer
+        // with a value parsed from the command line. Look it up by name; cloning
+        // the value releases the borrow on `self.options` before we mutate the
+        // interner below.
+        let override_value = self
+            .options
+            .global_overrides
+            .iter()
+            .find(|(overridden_name, _)| *overridden_name == name)
+            .map(|(_, value)| value.clone());
+
+        if let Some(raw) = override_value {
+            match global_override_value(&let_statement.r#type, &raw) {
+                Ok(value) => {
+                    self.debug_comptime(location, |interner, file_manager| {
+                        value.display(interner, file_manager).to_string()
+                    });
+                    self.interner.get_global_mut(global_id).value = GlobalValue::Resolved(value);
+                }
+                Err(message) => {
+                    self.push_err(ResolverError::InvalidGlobalOverride { name, message, location });
+                }
+            }
+            return;
+        }
 
         let expr = self.interner.expression(&let_statement.expression);
         if !matches!(expr, HirExpression::Error) {
@@ -192,5 +226,45 @@ impl Elaborator<'_> {
         } else {
             false
         }
+    }
+}
+
+/// Parses a `--define`/`-D` global override string into a comptime [`Value`] of
+/// the global's declared type. Only `bool`, `Field`, and integer-typed globals
+/// are supported; any other type, an out-of-range value, or a malformed value
+/// produces an error message describing the problem.
+fn global_override_value(typ: &Type, raw: &str) -> Result<Value, String> {
+    let typ = typ.follow_bindings();
+    match &typ {
+        Type::Bool => match raw.trim() {
+            "true" => Ok(Value::Bool(true)),
+            "false" => Ok(Value::Bool(false)),
+            other => {
+                Err(format!("expected `true` or `false` for a `bool` global, found `{other}`"))
+            }
+        },
+        Type::FieldElement | Type::Integer(..) => {
+            let field = parse_override_field(raw)?;
+            Integer::try_from_type(field, &typ)
+                .map(Value::Integer)
+                .ok_or_else(|| format!("value `{}` does not fit in type `{typ}`", raw.trim()))
+        }
+        other => Err(format!(
+            "`--define` overrides are only supported for `bool`, `Field`, and integer globals, \
+             but this global has type `{other}`"
+        )),
+    }
+}
+
+/// Parses a (possibly negative) decimal integer override into a [`FieldElement`].
+/// Negative values are encoded as negated fields, matching how the comptime
+/// interpreter represents signed integers.
+fn parse_override_field(raw: &str) -> Result<FieldElement, String> {
+    let raw = raw.trim();
+    let parse_magnitude =
+        |s: &str| s.parse::<u128>().map_err(|_| format!("`{raw}` is not a valid integer"));
+    match raw.strip_prefix('-') {
+        Some(magnitude) => Ok(-FieldElement::from(parse_magnitude(magnitude)?)),
+        None => Ok(FieldElement::from(parse_magnitude(raw)?)),
     }
 }

--- a/compiler/noirc_frontend/src/elaborator/options.rs
+++ b/compiler/noirc_frontend/src/elaborator/options.rs
@@ -43,6 +43,13 @@ pub struct GenericOptions<'a, T> {
 
     /// Deny crates from requiring unstable features.
     pub disable_required_unstable_features: bool,
+
+    /// `NAME=VALUE` overrides for top-level global constants, supplied on the
+    /// command line via `nargo --define`/`-D`. When a global's name matches an
+    /// entry here, its initializer is ignored and the parsed value is used
+    /// instead. Independent of `T`, so it is shared verbatim between
+    /// [`FrontendOptions`] and [`ElaboratorOptions`].
+    pub global_overrides: &'a [(String, String)],
 }
 
 /// Options from nargo_cli that need to be passed down to the elaborator
@@ -59,6 +66,7 @@ impl<T> GenericOptions<'_, T> {
             debug_comptime_in_file: None,
             enabled_unstable_features: &[UnstableFeature::Enums],
             disable_required_unstable_features: true,
+            global_overrides: &[],
         }
     }
 }

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
@@ -1977,6 +1977,7 @@ impl Context<'_, '_> {
 
             enabled_unstable_features,
             disable_required_unstable_features: false,
+            global_overrides: &[],
         };
         let module_id = ModuleId { krate: crate_id, local_id };
 

--- a/compiler/noirc_frontend/src/hir/def_collector/dc_crate.rs
+++ b/compiler/noirc_frontend/src/hir/def_collector/dc_crate.rs
@@ -549,6 +549,7 @@ impl DefCollector {
             debug_comptime_in_file,
             enabled_unstable_features: options.enabled_unstable_features,
             disable_required_unstable_features: options.disable_required_unstable_features,
+            global_overrides: options.global_overrides,
         };
 
         let more_errors =

--- a/compiler/noirc_frontend/src/hir/resolution/errors.rs
+++ b/compiler/noirc_frontend/src/hir/resolution/errors.rs
@@ -250,6 +250,8 @@ pub enum ResolverError {
     RemovedType { location: Location, typ: String, replacement: String },
     #[error("Recursion limit reached during elaboration")]
     MaximumRecursionDepthExceeded { location: Location },
+    #[error("Invalid `--define` override for global `{name}`: {message}")]
+    InvalidGlobalOverride { name: String, message: String, location: Location },
 }
 
 impl ResolverError {
@@ -337,7 +339,8 @@ impl ResolverError {
             | ResolverError::DataBusOnNonEntryPoint { location, .. }
             | ResolverError::DataBusOnWrongPosition { location, .. }
             | ResolverError::RemovedType { location, .. }
-            | ResolverError::MaximumRecursionDepthExceeded { location, .. } => *location,
+            | ResolverError::MaximumRecursionDepthExceeded { location, .. }
+            | ResolverError::InvalidGlobalOverride { location, .. } => *location,
             ResolverError::UnusedVariable { ident }
             | ResolverError::VariableDoesNotNeedToBeMutable { ident }
             | ResolverError::UnusedItem { ident, .. }
@@ -1093,6 +1096,13 @@ impl<'a> From<&'a ResolverError> for Diagnostic {
                 Diagnostic::simple_error(
                     "Reached the recursion limit during elaboration and type checking".into(),
                     "Try to simplify expressions".into(),
+                    *location,
+                )
+            },
+            ResolverError::InvalidGlobalOverride { name, message, location } => {
+                Diagnostic::simple_error(
+                    format!("Invalid `--define` override for global `{name}`"),
+                    message.clone(),
                     *location,
                 )
             },

--- a/compiler/noirc_frontend/src/hir_def/types/arithmetic.rs
+++ b/compiler/noirc_frontend/src/hir_def/types/arithmetic.rs
@@ -843,6 +843,7 @@ mod proptests {
                 debug_comptime_in_file: None,
                 enabled_unstable_features: &[],
                 disable_required_unstable_features: false,
+                global_overrides: &[],
             };
             let mut elaborator = Elaborator::from_context(
                 &mut context,

--- a/compiler/noirc_frontend/src/ownership/tests.rs
+++ b/compiler/noirc_frontend/src/ownership/tests.rs
@@ -482,6 +482,7 @@ fn dereference_immutable_reference() {
             debug_comptime_in_file: None,
             enabled_unstable_features: &[],
             disable_required_unstable_features: true,
+            global_overrides: &[],
         },
         ..Default::default()
     };

--- a/compiler/noirc_frontend/src/tests/globals.rs
+++ b/compiler/noirc_frontend/src/tests/globals.rs
@@ -1,6 +1,10 @@
+use acvm::FieldElement;
+
 use crate::elaborator::FrontendOptions;
+use crate::hir::comptime::Value;
 use crate::hir::def_collector::dc_crate::CompilationError;
 use crate::hir::resolution::errors::ResolverError;
+use crate::node_interner::GlobalValue;
 use crate::test_utils::{GetProgramOptions, get_program_with_options};
 use crate::tests::{
     assert_no_errors, check_errors, check_monomorphization_error, get_program_errors,
@@ -19,6 +23,33 @@ fn compile_with_defines(src: &str, defines: &[(String, String)]) -> Vec<Compilat
         },
     )
     .2
+}
+
+/// Compiles `src` with the given overrides, asserts it compiled without errors,
+/// and returns the resolved comptime value of the global named `name`. This lets
+/// a test verify that the override value was actually applied, even for globals
+/// (like `Field` or `bool`) whose value does not surface through type-checking.
+fn resolved_global(src: &str, defines: &[(String, String)], name: &str) -> Option<Value> {
+    let (_, context, errors) = get_program_with_options(
+        src,
+        GetProgramOptions {
+            frontend_options: FrontendOptions {
+                global_overrides: defines,
+                ..FrontendOptions::test_default()
+            },
+            ..Default::default()
+        },
+    );
+    assert!(errors.is_empty(), "expected no errors, got: {errors:?}");
+    context
+        .def_interner
+        .get_all_globals()
+        .iter()
+        .find(|global| global.ident.to_string() == name)
+        .and_then(|global| match &global.value {
+            GlobalValue::Resolved(value) => Some(value.clone()),
+            _ => None,
+        })
 }
 
 fn has_invalid_global_override(errors: &[CompilationError]) -> bool {
@@ -490,8 +521,8 @@ fn cli_define_overrides_field_global() {
         }
     ";
     let defines = vec![("X".to_string(), "42".to_string())];
-    let errors = compile_with_defines(src, &defines);
-    assert!(errors.is_empty(), "expected a `Field` override to compile, got: {errors:?}");
+    let value = resolved_global(src, &defines, "X");
+    assert_eq!(value, Some(Value::field(FieldElement::from(42_u128))));
 }
 
 #[test]
@@ -503,8 +534,50 @@ fn cli_define_overrides_bool_global() {
         }
     ";
     let defines = vec![("ENABLED".to_string(), "true".to_string())];
+    let value = resolved_global(src, &defines, "ENABLED");
+    assert_eq!(value, Some(Value::Bool(true)));
+}
+
+#[test]
+fn cli_define_supports_hex_and_wide_field_values() {
+    let src = "
+        global X: Field = 0;
+        fn main() -> pub Field {
+            X
+        }
+    ";
+
+    // `0x` hex is accepted.
+    let defines = vec![("X".to_string(), "0xff".to_string())];
+    assert_eq!(
+        resolved_global(src, &defines, "X"),
+        Some(Value::field(FieldElement::from(255_u128)))
+    );
+
+    // Values larger than `u128` are accepted for `Field` (2^128, which the old
+    // `u128`-based parser could not represent). Reaching this assertion at all
+    // means the value parsed without an `InvalidGlobalOverride` error.
+    let two_pow_128 = "340282366920938463463374607431768211456";
+    let defines = vec![("X".to_string(), two_pow_128.to_string())];
+    let value = resolved_global(src, &defines, "X");
+    assert!(
+        matches!(value, Some(Value::Integer(_))),
+        "expected a wide `Field` value, got: {value:?}"
+    );
+}
+
+#[test]
+fn cli_define_last_value_wins_for_repeated_name() {
+    // Repeating `-D N=...` follows the usual "last one wins" rule.
+    let src = "
+        global N: u32 = 0;
+        fn main() -> pub [Field; 3] {
+            [0; N]
+        }
+    ";
+    let defines = vec![("N".to_string(), "2".to_string()), ("N".to_string(), "3".to_string())];
     let errors = compile_with_defines(src, &defines);
-    assert!(errors.is_empty(), "expected a `bool` override to compile, got: {errors:?}");
+    assert!(errors.is_empty(), "expected the last override (N=3) to win, got: {errors:?}");
 }
 
 #[test]

--- a/compiler/noirc_frontend/src/tests/globals.rs
+++ b/compiler/noirc_frontend/src/tests/globals.rs
@@ -1,4 +1,34 @@
-use crate::tests::{assert_no_errors, check_errors, check_monomorphization_error};
+use crate::elaborator::FrontendOptions;
+use crate::hir::def_collector::dc_crate::CompilationError;
+use crate::hir::resolution::errors::ResolverError;
+use crate::test_utils::{GetProgramOptions, get_program_with_options};
+use crate::tests::{
+    assert_no_errors, check_errors, check_monomorphization_error, get_program_errors,
+};
+
+/// Compiles `src` with the given `--define`/`-D` global overrides and returns any errors.
+fn compile_with_defines(src: &str, defines: &[(String, String)]) -> Vec<CompilationError> {
+    get_program_with_options(
+        src,
+        GetProgramOptions {
+            frontend_options: FrontendOptions {
+                global_overrides: defines,
+                ..FrontendOptions::test_default()
+            },
+            ..Default::default()
+        },
+    )
+    .2
+}
+
+fn has_invalid_global_override(errors: &[CompilationError]) -> bool {
+    errors.iter().any(|error| {
+        matches!(
+            error,
+            CompilationError::ResolverError(ResolverError::InvalidGlobalOverride { .. })
+        )
+    })
+}
 
 #[test]
 fn deny_cyclic_globals() {
@@ -429,4 +459,115 @@ fn errors_if_global_is_needed_in_initialize_and_function_signature() {
     fn main() {}
     "#;
     check_errors(src);
+}
+
+#[test]
+fn cli_define_overrides_integer_global() {
+    // `N` is declared as 2, so `[0; N]` would normally be a `[Field; 2]` and
+    // disagree with the `[Field; 3]` return type. Overriding `N` to 3 makes the
+    // program type-check, which only happens if the CLI value actually replaces
+    // the global's initializer.
+    let src = "
+        global N: u32 = 2;
+        fn main() -> pub [Field; 3] {
+            [0; N]
+        }
+    ";
+
+    assert!(!get_program_errors(src).is_empty(), "expected a length mismatch without the override");
+
+    let defines = vec![("N".to_string(), "3".to_string())];
+    let errors = compile_with_defines(src, &defines);
+    assert!(errors.is_empty(), "expected override to make the program compile, got: {errors:?}");
+}
+
+#[test]
+fn cli_define_overrides_field_global() {
+    let src = "
+        global X: Field = 1;
+        fn main() -> pub Field {
+            X
+        }
+    ";
+    let defines = vec![("X".to_string(), "42".to_string())];
+    let errors = compile_with_defines(src, &defines);
+    assert!(errors.is_empty(), "expected a `Field` override to compile, got: {errors:?}");
+}
+
+#[test]
+fn cli_define_overrides_bool_global() {
+    let src = "
+        global ENABLED: bool = false;
+        fn main() -> pub bool {
+            ENABLED
+        }
+    ";
+    let defines = vec![("ENABLED".to_string(), "true".to_string())];
+    let errors = compile_with_defines(src, &defines);
+    assert!(errors.is_empty(), "expected a `bool` override to compile, got: {errors:?}");
+}
+
+#[test]
+fn cli_define_ignores_unknown_global() {
+    let src = "
+        global N: u32 = 2;
+        fn main() {
+            let _ = N;
+        }
+    ";
+    let defines = vec![("DOES_NOT_EXIST".to_string(), "5".to_string())];
+    let errors = compile_with_defines(src, &defines);
+    assert!(
+        errors.is_empty(),
+        "an override for an unknown global should be ignored, got: {errors:?}"
+    );
+}
+
+#[test]
+fn cli_define_rejects_malformed_value() {
+    let src = "
+        global N: u32 = 2;
+        fn main() {
+            let _ = N;
+        }
+    ";
+    let defines = vec![("N".to_string(), "not_a_number".to_string())];
+    let errors = compile_with_defines(src, &defines);
+    assert!(
+        has_invalid_global_override(&errors),
+        "expected an InvalidGlobalOverride error, got: {errors:?}"
+    );
+}
+
+#[test]
+fn cli_define_rejects_out_of_range_value() {
+    let src = "
+        global N: u8 = 2;
+        fn main() {
+            let _ = N;
+        }
+    ";
+    let defines = vec![("N".to_string(), "256".to_string())];
+    let errors = compile_with_defines(src, &defines);
+    assert!(
+        has_invalid_global_override(&errors),
+        "expected an InvalidGlobalOverride error for an out-of-range `u8`, got: {errors:?}"
+    );
+}
+
+#[test]
+fn cli_define_rejects_unsupported_type() {
+    let src = "
+        pub struct Point { x: Field, y: Field }
+        global P: Point = Point { x: 1, y: 2 };
+        fn main() {
+            let _ = P;
+        }
+    ";
+    let defines = vec![("P".to_string(), "3".to_string())];
+    let errors = compile_with_defines(src, &defines);
+    assert!(
+        has_invalid_global_override(&errors),
+        "expected an InvalidGlobalOverride error for a struct global, got: {errors:?}"
+    );
 }

--- a/docs/docs/language/globals.md
+++ b/docs/docs/language/globals.md
@@ -93,10 +93,12 @@ nargo compile -D N=256
 global N: u32 = 100; // compiled as 256 with the flag above
 ```
 
-The flag can be passed multiple times (`-D A=1 -D B=2`) and is matched against globals by name.
-Only `bool`, `Field`, and integer-typed globals can be overridden; supplying a malformed value,
-a value that does not fit the global's type, or a name with an unsupported type is an error,
-while a name that matches no global is ignored.
+The flag can be passed multiple times (`-D A=1 -D B=2`) and is matched against globals by name;
+if the same name is given more than once, the last value wins. Values may be written in decimal
+or `0x` hex, and the full range of `Field` is supported. Only `bool`, `Field`, and integer-typed
+globals can be overridden; supplying a malformed value, a value that does not fit the global's
+type, or a name with an unsupported type is an error, while a name that matches no global is
+ignored.
 
 This is useful for producing differently-sized circuits from a single codebase — for example
 compiling "small", "medium", and "large" variants by overriding a size global, instead of

--- a/docs/docs/language/globals.md
+++ b/docs/docs/language/globals.md
@@ -79,3 +79,25 @@ to make the global public or `pub(crate)` to make it public to just its crate:
 // This global is now public
 pub global N: u32 = 5;
 ```
+
+### Overriding globals from the command line
+
+A global's value can be overridden at compile time with the `--define` (`-D`) flag, ignoring
+its declared initializer:
+
+```bash
+nargo compile -D N=256
+```
+
+```rust
+global N: u32 = 100; // compiled as 256 with the flag above
+```
+
+The flag can be passed multiple times (`-D A=1 -D B=2`) and is matched against globals by name.
+Only `bool`, `Field`, and integer-typed globals can be overridden; supplying a malformed value,
+a value that does not fit the global's type, or a name with an unsupported type is an error,
+while a name that matches no global is ignored.
+
+This is useful for producing differently-sized circuits from a single codebase — for example
+compiling "small", "medium", and "large" variants by overriding a size global, instead of
+maintaining a separate package for each size.

--- a/tooling/lsp/src/notifications/mod.rs
+++ b/tooling/lsp/src/notifications/mod.rs
@@ -446,6 +446,7 @@ pub(crate) fn process_workspace_for_single_file_change(
         debug_comptime_in_file: None,
         enabled_unstable_features: &[UnstableFeature::Enums, UnstableFeature::TraitAsType],
         disable_required_unstable_features: false,
+        global_overrides: &[],
     };
 
     // This is when the type-checking of this single file happens


### PR DESCRIPTION
## Summary

Adds a `nargo compile -D NAME=VALUE` (also `--define`) flag that overrides a
top-level global constant at compile time. This lets a single codebase emit
differently-sized circuits — the "T-shirt sizing" (S/M/L) use case from the
issue — instead of duplicating a package per size.

```
nargo compile -D MAX_SIZE=256
```

```rust
global MAX_SIZE: u32 = 100; // overridden to 256 above
```

Closes #4930.

## Implementation

The override map is threaded along the existing `debug_comptime_in_file` path:
`CompileOptions` → `FrontendOptions` → `ElaboratorOptions` → the elaborator.

In `elaborate_comptime_global`, when a global's name matches a `-D` entry, its
initializer is skipped and the supplied string is parsed into a
`comptime::Value` of the global's **declared type** (reusing the existing
`Integer::try_from_type`). Supported types: `bool`, `Field`, and all integer
types. Malformed values, out-of-range values, and unsupported types produce a
clear `InvalidGlobalOverride` diagnostic. Overrides are applied by name; an
override for an unknown global is ignored.

## Testing

New tests in `compiler/noirc_frontend/src/tests/globals.rs`:
- integer override used as an array length (fails without `-D`, compiles with it),
- `Field` and `bool` overrides,
- unknown-name override is ignored,
- malformed value, out-of-range value, and unsupported (struct) type are rejected.

Verified end-to-end through the `nargo` binary: a program returning `[Field; 3]`
from `[0; N]` (`global N = 2`) fails to compile without the flag and compiles
(producing an artifact) with `-D N=3`. `cargo clippy` and `cargo fmt` are clean;
the `globals`, `ownership`, and `comptime` test modules pass with no regressions.

## Docs

The flag is documented under `docs/docs/language/globals.md` ("Overriding globals
from the command line"). The `nargo_commands` reference is generated from the
clap help text, which this PR also populates.

## Open questions / follow-ups

- Override matching is by bare global name; module-qualified targeting could be
  a future enhancement.