### PR TITLE
fix(frontend): keep singleton tuple arity in comptime pattern reflection

### DIFF
--- a/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin/builtin_helpers.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin/builtin_helpers.rs
@@ -446,6 +446,11 @@ fn gather_hir_pattern_tokens(
                 }
                 gather_hir_pattern_tokens(interner, pattern, tokens);
             }
+            // A singleton tuple `(x,)` requires a trailing comma to distinguish it from a
+            // parenthesized pattern `(x)`.
+            if patterns.len() == 1 {
+                tokens.push(Token::Comma);
+            }
             tokens.push(Token::RightParen);
         }
         HirPattern::Struct(typ, fields, _) => {

--- a/test_programs/compile_success_empty/comptime_function_definition/src/main.nr
+++ b/test_programs/compile_success_empty/comptime_function_definition/src/main.nr
@@ -18,6 +18,11 @@ pub fn foo(
     1
 }
 
+#[singleton_tuple_attr]
+pub fn singleton_tuples(((nested,),): ((Field,),)) {
+    let _ = nested;
+}
+
 #[test]
 #[deprecated]
 #[check_named_attribute]
@@ -54,6 +59,15 @@ comptime fn function_attr(f: FunctionDefinition) {
     assert(f.has_named_attribute("function_attr"));
 
     assert_eq(f.visibility(), quote { pub })
+}
+
+comptime fn singleton_tuple_attr(f: FunctionDefinition) {
+    let parameters = f.parameters();
+    assert_eq(parameters.len(), 1);
+
+    // A singleton tuple in a nested position must keep its trailing comma:
+    // `((nested,),)` must not be reflected as `((nested))`.
+    assert_eq(parameters[0].0, quote { ((nested,),) });
 }
 
 comptime fn check_named_attribute(f: FunctionDefinition) {

--- a/tooling/nargo_cli/tests/snapshots/compile_success_empty/comptime_function_definition/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_empty/comptime_function_definition/execute__tests__expanded.snap
@@ -21,6 +21,10 @@ pub fn foo(
     1_i32
 }
 
+pub fn singleton_tuples(((nested,),): ((Field,),)) {
+    let _: Field = nested;
+}
+
 #[test]
 #[deprecated]
 fn some_test() {}
@@ -50,6 +54,12 @@ comptime fn function_attr(f: FunctionDefinition) {
     assert(f.name() == quote { foo });
     assert(f.has_named_attribute("function_attr"));
     assert(f.visibility() == quote { pub })
+}
+
+comptime fn singleton_tuple_attr(f: FunctionDefinition) {
+    let parameters: [(Quoted, Type)] = f.parameters();
+    assert(parameters.len() == 1_u32);
+    assert(parameters[0_u32].0 == quote { ((nested,),) });
 }
 
 comptime fn check_named_attribute(f: FunctionDefinition) {


### PR DESCRIPTION
## Description

### Problem

`FunctionDefinition::parameters()` reflects each parameter pattern via `hir_pattern_to_tokens`, whose recursive helper `gather_hir_pattern_tokens` interleaves commas *between* tuple elements but never emits the trailing comma a singleton tuple requires. As a result a parameter pattern such as `((nested,),)` is reflected to a comptime macro as `((nested))` — silently turning a singleton tuple `(T,)` into a parenthesized scalar `T`.

A comptime attribute/derive macro that inspects a function signature and splices `parameters[i].0` back into generated code will therefore silently change the destructure shape, with no diagnostic.

Fixes https://github.com/noir-lang/noir-claude/issues/1113

### Summary of changes

- Emit a trailing `Token::Comma` in the `HirPattern::Tuple` arm of `gather_hir_pattern_tokens` when the tuple has exactly one element, mirroring the parser rule (`(x,)` is a singleton tuple, `(x)` is parenthesized) and `Display for Pattern`.
- Added a regression test in `comptime_function_definition` reflecting `((nested,),)` and asserting it round-trips to `quote { ((nested,),) }`.

### Note

The original issue also suggested covering the struct-destructure-field case (`Wrapper { value: (inner,) }`). That case currently triggers a *separate, pre-existing* panic during elaboration (`patterns.rs:403`) when a comptime attribute reflects a struct-destructure parameter whose field is itself a tuple pattern, so it is excluded here and handled in a follow-up.

## Additional Context

## Documentation\n
Check one:
- [x] No documentation needed.

## PR Checklist
- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)