### PR TITLE
fix: keep fold entry-point signatures attached to their circuits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3799,7 +3799,6 @@ dependencies = [
  "noirc_driver",
  "noirc_errors",
  "noirc_evaluator",
- "noirc_frontend",
  "thiserror 2.0.18",
 ]
 

--- a/compiler/noirc_driver/tests/print_acir.rs
+++ b/compiler/noirc_driver/tests/print_acir.rs
@@ -114,14 +114,14 @@ fn print_acir_keeps_fold_signatures_with_their_circuits() {
     ASSERT w2 = w3 + w4
 
     func 1
-    private parameters: []
-    public parameters: [w0]
+    private parameters: [w0]
+    public parameters: []
     return values: [w1]
     ASSERT w1 = w0 + 2
 
     func 2
-    private parameters: [w0]
-    public parameters: []
+    private parameters: []
+    public parameters: [w0]
     return values: [w1]
     ASSERT w1 = w0 + 1
     ");

--- a/compiler/noirc_driver/tests/print_acir.rs
+++ b/compiler/noirc_driver/tests/print_acir.rs
@@ -68,6 +68,66 @@ fn print_acir_renders_static_assertion_payload() {
 }
 
 #[test]
+fn print_acir_keeps_fold_signatures_with_their_circuits() {
+    // Two nested `#[fold]` entry points whose parameter visibilities differ.
+    // `first_fold` takes a `pub` parameter and returns private; `second_fold`
+    // takes a private parameter and returns `pub`. The wrappers force the SSA
+    // function ids of the folds to be assigned in the opposite order from the
+    // monomorphized source order, which used to swap the public/private witness
+    // signatures of the emitted fold circuits.
+    let source = r#"
+    fn main(x: Field, y: Field) -> pub Field {
+        let a = first_wrapper(x);
+        let b = second_wrapper(y);
+        a + b
+    }
+
+    fn first_wrapper(x: Field) -> Field {
+        first_fold(x)
+    }
+
+    fn second_wrapper(y: Field) -> Field {
+        second_fold(y)
+    }
+
+    #[fold]
+    fn first_fold(x: pub Field) -> Field {
+        x + 1
+    }
+
+    #[fold]
+    fn second_fold(y: Field) -> pub Field {
+        y + 2
+    }
+    "#;
+
+    let program = compile(source, false);
+    let displayed = display_compiled_program(&program);
+
+    insta::assert_snapshot!(displayed, @r"
+    func 0
+    private parameters: [w0, w1]
+    public parameters: []
+    return values: [w2]
+    CALL func: 2, predicate: 1, inputs: [w0], outputs: [w3]
+    CALL func: 1, predicate: 1, inputs: [w1], outputs: [w4]
+    ASSERT w2 = w3 + w4
+
+    func 1
+    private parameters: []
+    public parameters: [w0]
+    return values: [w1]
+    ASSERT w1 = w0 + 2
+
+    func 2
+    private parameters: [w0]
+    public parameters: []
+    return values: [w1]
+    ASSERT w1 = w0 + 1
+    ");
+}
+
+#[test]
 fn print_acir_renders_brillig_assertion_payload() {
     let source = r#"
     fn main(x: u32) {

--- a/compiler/noirc_evaluator/src/acir/acir_context/generated_acir/mod.rs
+++ b/compiler/noirc_evaluator/src/acir/acir_context/generated_acir/mod.rs
@@ -19,6 +19,7 @@ use acvm::acir::{
     native_types::{Expression, Witness},
 };
 use noirc_artifacts::{debug::ProcedureDebugId, ssa::SsaReport};
+use noirc_frontend::shared::Visibility;
 
 use crate::{
     ErrorType,
@@ -56,6 +57,11 @@ pub struct GeneratedAcir<F: AcirField> {
 
     /// All witness indices which are inputs to the main function
     pub input_witnesses: Vec<Witness>,
+
+    /// Field count and visibility of each entry point parameter, in parameter order.
+    /// Used to split `input_witnesses` into public and private parameters when assembling
+    /// the final circuit.
+    pub arg_size_and_visibility: Vec<(u32, Visibility)>,
 
     /// Brillig function id -> Opcodes locations map
     /// This map is used to prevent redundant locations being stored for the same Brillig entry point.

--- a/compiler/noirc_evaluator/src/acir/acir_context/mod.rs
+++ b/compiler/noirc_evaluator/src/acir/acir_context/mod.rs
@@ -1611,10 +1611,10 @@ mod tests {
 
             context.bound_constraint_with_offset(lhs, rhs, offset_var, 128, one).unwrap();
 
-            let circuit = context.finish(Vec::new(), Vec::new());
+            let mut circuit = context.finish(Vec::new(), Vec::new());
+            circuit.arg_size_and_visibility = vec![(1, Visibility::Private)];
             let circuit = convert_generated_acir_into_circuit(
                 circuit,
-                &[(1, Visibility::Private)],
                 BTreeMap::default(),
                 BTreeMap::default(),
                 BTreeMap::default(),
@@ -1666,10 +1666,10 @@ mod tests {
 
         context.bound_constraint_with_offset(lhs, rhs, one, 128, one).unwrap();
 
-        let circuit = context.finish(Vec::new(), Vec::new());
+        let mut circuit = context.finish(Vec::new(), Vec::new());
+        circuit.arg_size_and_visibility = vec![(1, Visibility::Private)];
         let circuit = convert_generated_acir_into_circuit(
             circuit,
-            &[(1, Visibility::Private)],
             BTreeMap::default(),
             BTreeMap::default(),
             BTreeMap::default(),

--- a/compiler/noirc_evaluator/src/acir/ssa.rs
+++ b/compiler/noirc_evaluator/src/acir/ssa.rs
@@ -5,6 +5,7 @@ use acvm::{
     acir::circuit::{ErrorSelector, brillig::BrilligBytecode},
 };
 use noirc_frontend::Type as HirType;
+use noirc_frontend::shared::Visibility;
 
 use crate::{
     brillig::{Brillig, BrilligOptions},
@@ -75,6 +76,23 @@ pub(super) fn codegen_acir(
             }
 
             generated_acir.name = function.name().to_owned();
+            // Attach the entry point's parameter signature, used to split the input witnesses
+            // into public and private parameters. SSA parsed from text carries no visibility,
+            // so fall back to treating every input as private.
+            generated_acir.arg_size_and_visibility = match ssa.entry_point_signature(function.id())
+            {
+                Some(signature) => signature.clone(),
+                None => {
+                    // When SSA is generated from a program every ACIR entry point is queued and
+                    // recorded under its assigned function id, so a signature is always present.
+                    assert!(
+                        ssa.entry_point_signatures.is_empty(),
+                        "entry point {} has no recorded parameter signature",
+                        function.id()
+                    );
+                    vec![(generated_acir.input_witnesses.len() as u32, Visibility::Private)]
+                }
+            };
             acirs.push(generated_acir);
         }
     }

--- a/compiler/noirc_evaluator/src/acir/tests/mod.rs
+++ b/compiler/noirc_evaluator/src/acir/tests/mod.rs
@@ -45,38 +45,18 @@ pub(crate) fn try_ssa_to_acir(
     src: &str,
 ) -> Result<(Program<FieldElement>, Vec<DebugInfo>), RuntimeError> {
     let ssa = Ssa::from_str(src).unwrap();
-    let arg_size_and_visibilities = ssa
-        .functions
-        .iter()
-        .filter(|(id, function)| {
-            function.runtime().is_acir()
-                && (**id == ssa.main_id || function.runtime().is_entry_point())
-        })
-        .map(|(_, function)| {
-            // Make all arguments private for the sake of simplicity.
-            let param_size: u32 = function
-                .parameters()
-                .iter()
-                .map(|param| function.dfg.type_of_value(*param).flattened_size().0)
-                .sum();
-            vec![(param_size, Visibility::Private)]
-        })
-        .collect::<Vec<_>>();
 
     let brillig = ssa.to_brillig(&BrilligOptions::default());
 
+    // SSA parsed from text has no parameter visibility, so ACIR generation treats every input as
+    // private (see `codegen_acir`).
     let (acir_functions, brillig_functions, _) =
         ssa.generate_entry_point_index().into_acir(&brillig, &BrilligOptions::default())?;
 
     let artifacts =
         ArtifactsAndWarnings((acir_functions, brillig_functions, BTreeMap::default()), vec![]);
-    let program_artifact = combine_artifacts(
-        artifacts,
-        &arg_size_and_visibilities,
-        BTreeMap::default(),
-        BTreeMap::default(),
-        BTreeMap::default(),
-    );
+    let program_artifact =
+        combine_artifacts(artifacts, BTreeMap::default(), BTreeMap::default(), BTreeMap::default());
     let program = program_artifact.program;
     let debug = program_artifact.debug;
     Ok((program, debug))

--- a/compiler/noirc_evaluator/src/acir/tests/mod.rs
+++ b/compiler/noirc_evaluator/src/acir/tests/mod.rs
@@ -10,7 +10,6 @@ use acvm::{
     pwg::{ACVM, ACVMStatus},
 };
 use noirc_artifacts::debug::DebugInfo;
-use noirc_frontend::shared::Visibility;
 use std::collections::BTreeMap;
 
 use crate::{

--- a/compiler/noirc_evaluator/src/ssa/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/mod.rs
@@ -33,8 +33,6 @@ use acvm::{
 };
 
 use ir::instruction::ErrorType;
-use iter_extended::vecmap;
-use itertools::Itertools;
 use noirc_artifacts::{
     debug::{DebugFunctions, DebugInfo, DebugTypes, DebugVariables, LocationTree},
     ssa::SsaReport,
@@ -42,7 +40,7 @@ use noirc_artifacts::{
 use noirc_errors::call_stack::CallStackId;
 
 use noirc_frontend::monomorphization::ast::Program;
-use noirc_frontend::{monomorphization::ast, shared::Visibility};
+use noirc_frontend::shared::Visibility;
 use ssa_gen::Ssa;
 use tracing::{Level, span};
 
@@ -552,23 +550,13 @@ pub fn create_program_with_passes(
     let debug_types = program.debug_types.clone();
     let debug_functions = program.debug_functions.clone();
 
-    let entry_points = program.functions.iter().filter(|function| function.is_entry_point);
-    let arg_size_and_visibilities = vecmap(entry_points, resolve_function_signature);
-
     let artifacts = optimize_into_acir(program, options, passes, files)?;
 
-    Ok(combine_artifacts(
-        artifacts,
-        &arg_size_and_visibilities,
-        debug_variables,
-        debug_functions,
-        debug_types,
-    ))
+    Ok(combine_artifacts(artifacts, debug_variables, debug_functions, debug_types))
 }
 
 pub fn combine_artifacts(
     artifacts: ArtifactsAndWarnings,
-    arg_size_and_visibilities: &[Vec<(u32, Visibility)>],
     debug_variables: DebugVariables,
     debug_functions: DebugFunctions,
     debug_types: DebugTypes,
@@ -576,18 +564,11 @@ pub fn combine_artifacts(
     let ArtifactsAndWarnings((generated_acirs, generated_brillig, error_types), ssa_level_warnings) =
         artifacts;
 
-    assert_eq!(
-        generated_acirs.len(),
-        arg_size_and_visibilities.len(),
-        "The generated ACIRs should match the supplied function signatures"
-    );
     let functions: Vec<SsaCircuitArtifact> = generated_acirs
         .into_iter()
-        .zip_eq(arg_size_and_visibilities)
-        .map(|(acir, arg_size_and_visibility)| {
+        .map(|acir| {
             convert_generated_acir_into_circuit(
                 acir,
-                arg_size_and_visibility,
                 // TODO: get rid of these clones
                 debug_variables.clone(),
                 debug_functions.clone(),
@@ -604,18 +585,8 @@ pub fn combine_artifacts(
     SsaProgramArtifact::new(functions, generated_brillig, error_types, ssa_level_warnings)
 }
 
-/// Given a function, return each parameter's field count and visibility
-fn resolve_function_signature(function: &ast::Function) -> Vec<(u32, Visibility)> {
-    function
-        .parameters
-        .iter()
-        .map(|(_, _, _, typ, visibility)| (typ.entry_point_field_count(), *visibility))
-        .collect()
-}
-
 pub fn convert_generated_acir_into_circuit(
     mut generated_acir: GeneratedAcir<FieldElement>,
-    arg_size_and_visibility: &[(u32, Visibility)],
     debug_variables: DebugVariables,
     debug_functions: DebugFunctions,
     debug_types: DebugTypes,
@@ -631,11 +602,12 @@ pub fn convert_generated_acir_into_circuit(
         warnings,
         name,
         brillig_procedure_locs,
+        arg_size_and_visibility,
         ..
     } = generated_acir;
 
     let (public_parameter_witnesses, private_parameters) =
-        split_public_and_private_inputs(arg_size_and_visibility, &input_witnesses);
+        split_public_and_private_inputs(&arg_size_and_visibility, &input_witnesses);
 
     let public_parameters = PublicInputs(public_parameter_witnesses);
     let return_values = PublicInputs(return_witnesses.iter().copied().collect());

--- a/compiler/noirc_evaluator/src/ssa/ssa_gen/context.rs
+++ b/compiler/noirc_evaluator/src/ssa/ssa_gen/context.rs
@@ -10,7 +10,7 @@ use noirc_frontend::ast::BinaryOpKind;
 use noirc_frontend::monomorphization::ast::{
     self, FuncId, GlobalId, InlineType, LocalId, Parameters, Program,
 };
-use noirc_frontend::shared::Signedness;
+use noirc_frontend::shared::{Signedness, Visibility};
 
 use crate::errors::RuntimeError;
 use crate::ssa::function_builder::FunctionBuilder;
@@ -1094,6 +1094,26 @@ impl SharedContext {
         self.functions.write().expect("Failed to write to self.functions").insert(id, next_id);
 
         next_id
+    }
+
+    /// The field count and visibility of each entry point's parameters, keyed by the SSA function
+    /// id the entry point was assigned. This pairs the visibility (only known in the monomorphized
+    /// AST) with the SSA function id so ACIR generation can split a circuit's inputs into public
+    /// and private parameters.
+    pub(super) fn entry_point_signatures(&self) -> BTreeMap<IrFunctionId, Vec<(u32, Visibility)>> {
+        let functions = self.functions.read().expect("Failed to read self.functions");
+        functions
+            .iter()
+            .filter_map(|(func_id, ssa_id)| {
+                let function = &self.program[*func_id];
+                function.is_entry_point.then(|| {
+                    let signature = vecmap(&function.parameters, |(_, _, _, typ, visibility)| {
+                        (typ.entry_point_field_count(), *visibility)
+                    });
+                    (*ssa_id, signature)
+                })
+            })
+            .collect()
     }
 }
 

--- a/compiler/noirc_evaluator/src/ssa/ssa_gen/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/ssa_gen/mod.rs
@@ -135,7 +135,8 @@ pub fn generate_ssa(program: Program) -> Result<Ssa, RuntimeError> {
         function_context.codegen_function_body(&function.body)?;
     }
 
-    let ssa = function_context.builder.finish();
+    let mut ssa = function_context.builder.finish();
+    ssa.entry_point_signatures = context.entry_point_signatures();
 
     validate_ssa_or_err(ssa)
 }

--- a/compiler/noirc_evaluator/src/ssa/ssa_gen/program.rs
+++ b/compiler/noirc_evaluator/src/ssa/ssa_gen/program.rs
@@ -12,6 +12,7 @@ use crate::ssa::ir::{
     value::Value,
 };
 use noirc_frontend::hir_def::types::Type as HirType;
+use noirc_frontend::shared::Visibility;
 
 use super::ValueId;
 
@@ -34,6 +35,14 @@ pub struct Ssa {
     // ABI not the actual SSA IR.
     #[serde(skip)]
     pub error_selector_to_type: BTreeMap<ErrorSelector, HirType>,
+    /// Field count and visibility of each entry point's parameters, keyed by SSA function id.
+    ///
+    /// The visibility of a parameter is only known in the monomorphized AST, not the SSA, so it
+    /// is captured during SSA generation and carried here keyed by the SSA function id the entry
+    /// point was assigned. ACIR generation looks it up to split a circuit's input witnesses into
+    /// public and private parameters.
+    #[serde(skip)]
+    pub entry_point_signatures: BTreeMap<FunctionId, Vec<(u32, Visibility)>>,
 }
 
 impl Ssa {
@@ -54,7 +63,19 @@ impl Ssa {
             next_id: AtomicCounter::starting_after(max_id),
             entry_point_to_generated_index: BTreeMap::new(),
             error_selector_to_type: error_types,
+            entry_point_signatures: BTreeMap::new(),
         }
+    }
+
+    /// The field count and visibility of `function`'s parameters, if it is an entry point that
+    /// recorded its signature during SSA generation. ACIR generation falls back to treating all
+    /// inputs as private when this is absent (e.g. for SSA parsed from text, which has no
+    /// visibility information).
+    pub(crate) fn entry_point_signature(
+        &self,
+        function: FunctionId,
+    ) -> Option<&Vec<(u32, Visibility)>> {
+        self.entry_point_signatures.get(&function)
     }
 
     /// Returns the entry-point function of the program

--- a/tooling/ssa_executor/Cargo.toml
+++ b/tooling/ssa_executor/Cargo.toml
@@ -15,7 +15,6 @@ workspace = true
 [dependencies]
 noirc_errors.workspace = true
 noirc_evaluator.workspace = true
-noirc_frontend.workspace = true
 noirc_driver.workspace = true
 noirc_abi.workspace = true
 noirc_artifacts.workspace = true

--- a/tooling/ssa_executor/src/compiler.rs
+++ b/tooling/ssa_executor/src/compiler.rs
@@ -12,7 +12,6 @@ use noirc_evaluator::{
         ssa_gen::{Ssa, validate_ssa},
     },
 };
-use noirc_frontend::shared::Visibility;
 use std::panic::AssertUnwindSafe;
 use std::{collections::BTreeMap, path::PathBuf};
 
@@ -69,20 +68,8 @@ pub fn optimize_ssa_into_acir(
 /// Compiles the given FunctionBuilder into a CompiledProgram
 /// its taken from noirc_driver::compile_no_check, but modified to accept ArtifactsAndWarnings
 pub fn compile_from_artifacts(artifacts: ArtifactsAndWarnings) -> CompiledProgram {
-    let dummy_arg_info: Vec<Vec<(u32, Visibility)>> = artifacts
-        .0
-        .0
-        .iter()
-        .map(|acir| vec![(acir.input_witnesses.len() as u32, Visibility::Private)])
-        .collect();
-
-    let SsaProgramArtifact { program, debug, warnings, .. } = combine_artifacts(
-        artifacts,
-        &dummy_arg_info,
-        BTreeMap::new(),
-        BTreeMap::new(),
-        BTreeMap::new(),
-    );
+    let SsaProgramArtifact { program, debug, warnings, .. } =
+        combine_artifacts(artifacts, BTreeMap::new(), BTreeMap::new(), BTreeMap::new());
     let file_map = BTreeMap::new();
     CompiledProgram {
         hash: 1, // const hash, doesn't matter in this case


### PR DESCRIPTION
## Summary

Resolves noir-lang/noir-claude#1269.

Nested `#[fold]` entry points with differing parameter visibility could have their public/private witness signatures swapped in the emitted ACIR: a declared `pub` input became private, and a declared private input became public.

The root cause was an order-dependent positional join. `combine_artifacts` collected a side vector of parameter visibilities in monomorphized `program.functions` order, then `zip_eq`'d it against the generated ACIRs, which are emitted in SSA `FunctionId` order. Because the ssa-gen function queue is LIFO, two nested folds can be assigned SSA function ids in the opposite order from their source order, so the two vectors disagreed and the signatures landed on the wrong circuits.

### Minimal reproduction

```noir
fn main(x: Field, y: Field) -> pub Field {
    let a = first_wrapper(x);
    let b = second_wrapper(y);
    a + b
}

fn first_wrapper(x: Field) -> Field { first_fold(x) }
fn second_wrapper(y: Field) -> Field { second_fold(y) }

#[fold]
fn first_fold(x: pub Field) -> Field { x + 1 }

#[fold]
fn second_fold(y: Field) -> pub Field { y + 2 }
```

Before the fix, `first_fold`'s `pub` parameter was emitted as private and `second_fold`'s private parameter as public.

## Fix

Attach each entry point's parameter signature to the circuit it describes instead of joining a parallel vector by position:

- `Ssa` carries `entry_point_signatures`, a map from SSA `FunctionId` to the parameter field-counts and visibilities, captured during SSA generation (where the AST visibility is still available).
- ACIR generation looks up the signature by the function's own id and stores it on the `GeneratedAcir`, so the public/private split travels with the circuit.
- `combine_artifacts` reads each ACIR's own signature; the positional side vector and the `zip_eq` are removed.

SSA parsed from text has no visibility information and still falls back to treating every input as private.

## Testing

- New regression test `print_acir_keeps_fold_signatures_with_their_circuits` in `compiler/noirc_driver/tests/print_acir.rs`, split into a red commit (buggy snapshot) and a green commit (fixed snapshot).
- `noirc_evaluator` (1518), `noirc_driver`, and `nargo_cli` fold + contract execution tests pass.
- clippy + fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
