### PR TITLE
fix(comptime): copy vector pop/remove temporaries to avoid aliasing source

### DIFF
--- a/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
@@ -804,7 +804,10 @@ fn vector_remove(
         return failing_constraint(message, location, call_stack);
     }
 
-    let element = Shared::new(values.remove(index));
+    // The removed element is returned by value, so it must not keep sharing interior
+    // `Shared<Value>` cells with the source vector (otherwise a `&mut` into the temporary
+    // would write back through to the original vector).
+    let element = Shared::new(values.remove(index).move_struct());
     Ok(Value::Tuple(vec![Shared::new(Value::Vector(values, typ)), element]))
 }
 
@@ -826,6 +829,10 @@ fn vector_pop_front(
     let (mut values, typ) = get_vector(argument)?;
     match values.pop_front() {
         Some(element) => {
+            // The popped element is returned by value, so it must not keep sharing interior
+            // `Shared<Value>` cells with the source vector (otherwise a `&mut` into the
+            // temporary would write back through to the original vector).
+            let element = element.move_struct();
             Ok(Value::Tuple(vec![Shared::new(element), Shared::new(Value::Vector(values, typ))]))
         }
         None => failing_constraint(
@@ -846,6 +853,10 @@ fn vector_pop_back(
     let (mut values, typ) = get_vector(argument)?;
     match values.pop_back() {
         Some(element) => {
+            // The popped element is returned by value, so it must not keep sharing interior
+            // `Shared<Value>` cells with the source vector (otherwise a `&mut` into the
+            // temporary would write back through to the original vector).
+            let element = element.move_struct();
             Ok(Value::Tuple(vec![Shared::new(Value::Vector(values, typ)), Shared::new(element)]))
         }
         None => failing_constraint(

--- a/test_programs/execution_success/vector_pop_temporary_alias/Nargo.toml
+++ b/test_programs/execution_success/vector_pop_temporary_alias/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "vector_pop_temporary_alias"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.24.0"
+
+[dependencies]

--- a/test_programs/execution_success/vector_pop_temporary_alias/src/main.nr
+++ b/test_programs/execution_success/vector_pop_temporary_alias/src/main.nr
@@ -1,0 +1,33 @@
+struct Cell {
+    value: Field,
+}
+
+// Taking `&mut` into the by-value temporary returned by a vector pop/remove must
+// not alias the original vector's elements: the methods take `self` by value and
+// leave the original vector unchanged.
+fn main() {
+    assert_eq(pop_front_does_not_leak(), 1);
+    assert_eq(pop_back_does_not_leak(), 2);
+    assert_eq(remove_does_not_leak(), 1);
+}
+
+fn pop_front_does_not_leak() -> Field {
+    let original = [Cell { value: 1 }, Cell { value: 2 }].as_vector();
+    let value_ref = &mut original.pop_front().0.value;
+    *value_ref = 9;
+    original[0].value
+}
+
+fn pop_back_does_not_leak() -> Field {
+    let original = [Cell { value: 1 }, Cell { value: 2 }].as_vector();
+    let value_ref = &mut original.pop_back().1.value;
+    *value_ref = 9;
+    original[1].value
+}
+
+fn remove_does_not_leak() -> Field {
+    let original = [Cell { value: 1 }, Cell { value: 2 }].as_vector();
+    let value_ref = &mut original.remove(0).1.value;
+    *value_ref = 9;
+    original[0].value
+}

--- a/tooling/nargo_cli/tests/snapshots/execution_success/vector_pop_temporary_alias/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/vector_pop_temporary_alias/execute__tests__expanded.snap
@@ -1,0 +1,34 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: expanded_code
+---
+struct Cell {
+    value: Field,
+}
+
+fn main() {
+    assert(pop_front_does_not_leak() == 1_Field);
+    assert(pop_back_does_not_leak() == 2_Field);
+    assert(remove_does_not_leak() == 1_Field);
+}
+
+fn pop_front_does_not_leak() -> Field {
+    let original: [Cell] = [Cell { value: 1_Field }, Cell { value: 2_Field }].as_vector();
+    let value_ref: &mut Field = &mut original.pop_front().0.value;
+    *value_ref = 9_Field;
+    original[0_u32].value
+}
+
+fn pop_back_does_not_leak() -> Field {
+    let original: [Cell] = [Cell { value: 1_Field }, Cell { value: 2_Field }].as_vector();
+    let value_ref: &mut Field = &mut original.pop_back().1.value;
+    *value_ref = 9_Field;
+    original[1_u32].value
+}
+
+fn remove_does_not_leak() -> Field {
+    let original: [Cell] = [Cell { value: 1_Field }, Cell { value: 2_Field }].as_vector();
+    let value_ref: &mut Field = &mut original.remove(0_u32).1.value;
+    *value_ref = 9_Field;
+    original[0_u32].value
+}

--- a/tooling/nargo_cli/tests/snapshots/execution_success/vector_pop_temporary_alias/execute__tests__stdout.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/vector_pop_temporary_alias/execute__tests__stdout.snap
@@ -1,0 +1,5 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: stdout
+---
+


### PR DESCRIPTION
This is very unlikely to happen in practice, but the test program did behave different in comptime mode compared to the other backends so it's probably worth fixing it for consistency.

## Description

### Problem

The comptime interpreter can expose a mutable reference into an original vector element through chained field access on the temporary tuple returned by `[T]::pop_front`, `[T]::pop_back`, or `[T]::remove`. A source expression like `&mut original.pop_front().0.value` should refer to the popped by-value temporary, but it writes through to `original[0].value` and bakes the wrong comptime value into the circuit.

This only affects comptime execution (`nargo execute --force-comptime`); the SSA path copies by value.

### Root cause

`vector_pop_front`, `vector_pop_back`, and `vector_remove` returned the extracted element wrapped in `Shared::new(element)` whose interior `Shared<Value>` cells still aliased the source vector's storage. `Value::move_struct` (which breaks aliasing on a move) only deep-copies `Struct`/`Tuple` field cells and does **not** recurse into `Array`/`Vector` contents, so the popped struct element kept sharing its field cells with the source vector.

### Fix

Apply `move_struct()` to the extracted element in all three builtins before wrapping it in `Shared::new`, so the returned by-value temporary no longer shares cells with the source vector.

### Regression test

Added `test_programs/execution_success/vector_pop_temporary_alias`, covering `pop_front().0`, `pop_back().1`, and `remove(0).1`. The nargo_cli harness runs every test program under all backends including `--force-comptime`; the asserts fail on the buggy comptime path and pass after the fix.

Resolves https://github.com/noir-lang/noir-claude/issues/1321

## Additional Context

None.

## Documentation

- [x] No documentation needed.

## PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)