### PR TITLE
chore(docs): Fix stale image path in v1.0.0-beta.22 versioned docs

### DIFF
--- a/docs/versioned_docs/version-v1.0.0-beta.22/tutorials/noirjs_app.md
+++ b/docs/versioned_docs/version-v1.0.0-beta.22/tutorials/noirjs_app.md
@@ -283,7 +283,7 @@ yarn vite dev
 
 If it doesn't open a browser for you, just visit `localhost:5173`. You should now see the worst UI ever, with an ugly input.
 
-![Noir Webapp UI](@site/static/img/tutorials/noirjs_webapp/webapp1.png)
+![Noir Webapp UI](@site/static/img/guides/noirjs_webapp/webapp1.png)
 
 Now, our circuit requires a private input `fn main(age: u8)`, and fails if it is less than 18. Let's see if it works. Submit any number above 18 (as long as it fits in 8 bits) and you should get a valid proof. Otherwise the proof won't even generate correctly.
 


### PR DESCRIPTION
## Problem Resolved

The file path of an image in the docs' web app tutorial was stale and causes publishing to error: https://github.com/noir-lang/noir/actions/runs/26845536451/job/79163929493#step:6:1579

## Summary of Changes

Update the file path.

## User Documentation

Check one:
- [ ] No user documentation needed.
- [x] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
