### PR TITLE
chore: decouple the frontend's numeric constant representation from the field

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4134,6 +4134,7 @@ dependencies = [
  "num-integer",
  "num-traits",
  "rand 0.8.5",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -196,7 +196,7 @@ hex = "0.4.2"
 const_format = "0.2.30"
 indexmap = "^2.10.0"
 libfuzzer-sys = "0.4"
-num-bigint = "0.4"
+num-bigint = { version = "0.4", features = ["serde"] }
 num-traits = "0.2"
 num_enum = "0.7.3"
 num-integer = "0.1"

--- a/compiler/noirc_frontend/src/ast/expression.rs
+++ b/compiler/noirc_frontend/src/ast/expression.rs
@@ -13,7 +13,6 @@ use crate::shared::Visibility;
 use crate::signed_field::SignedField;
 use crate::token::{Attributes, FmtStrFragment, IntegerTypeSuffix, Token, Tokens};
 use crate::{Kind, Type};
-use acvm::FieldElement;
 use iter_extended::vecmap;
 use noirc_errors::{Located, Location, Span};
 
@@ -207,14 +206,14 @@ impl ExpressionKind {
                     kind: ExpressionKind::Literal(Literal::Integer(field, suffix)), ..
                 },
             ) if !field.is_negative() => {
-                ExpressionKind::Literal(Literal::Integer(-*field, *suffix))
+                ExpressionKind::Literal(Literal::Integer(-field.clone(), *suffix))
             }
             _ => ExpressionKind::Prefix(Box::new(PrefixExpression { operator, rhs })),
         }
     }
 
-    pub fn integer(contents: FieldElement, suffix: Option<IntegerTypeSuffix>) -> ExpressionKind {
-        ExpressionKind::Literal(Literal::Integer(SignedField::positive(contents), suffix))
+    pub fn integer(contents: SignedField, suffix: Option<IntegerTypeSuffix>) -> ExpressionKind {
+        ExpressionKind::Literal(Literal::Integer(contents, suffix))
     }
 
     pub fn boolean(contents: bool) -> ExpressionKind {

--- a/compiler/noirc_frontend/src/ast/mod.rs
+++ b/compiler/noirc_frontend/src/ast/mod.rs
@@ -537,7 +537,7 @@ impl UnresolvedTypeExpression {
         match self {
             UnresolvedTypeExpression::Variable(path) => ExpressionKind::Variable(path.clone()),
             UnresolvedTypeExpression::Constant(int, suffix, _) => {
-                ExpressionKind::Literal(Literal::Integer(*int, *suffix))
+                ExpressionKind::Literal(Literal::Integer(int.clone(), *suffix))
             }
             UnresolvedTypeExpression::BinaryOperation(lhs, op, rhs, location) => {
                 ExpressionKind::Infix(Box::new(InfixExpression {

--- a/compiler/noirc_frontend/src/ast/statement.rs
+++ b/compiler/noirc_frontend/src/ast/statement.rs
@@ -1,7 +1,6 @@
 use std::fmt::Display;
 
-use acvm::FieldElement;
-use acvm::acir::AcirField;
+use crate::signed_field::SignedField;
 use iter_extended::vecmap;
 use noirc_errors::{Located, Location, Span};
 
@@ -780,7 +779,7 @@ impl ForRange {
             }
             ForRange::Array(array) => {
                 let array_location = array.location;
-                let start_range = ExpressionKind::integer(FieldElement::zero(), None);
+                let start_range = ExpressionKind::integer(SignedField::zero(), None);
                 let start_range = Expression::new(start_range, array_location);
 
                 let next_unique_id = unique_name_counter;

--- a/compiler/noirc_frontend/src/ast/visitor.rs
+++ b/compiler/noirc_frontend/src/ast/visitor.rs
@@ -1007,7 +1007,7 @@ impl Literal {
             }
             Literal::Bool(value) => visitor.visit_literal_bool(*value, span),
             Literal::Integer(value, suffix) => {
-                visitor.visit_literal_integer(*value, *suffix, span);
+                visitor.visit_literal_integer(value.clone(), *suffix, span);
             }
             Literal::Str(str) => visitor.visit_literal_str(str, span),
             Literal::RawStr(str, length) => visitor.visit_literal_raw_str(str, *length, span),
@@ -1565,7 +1565,7 @@ impl UnresolvedTypeExpression {
                 }
             }
             UnresolvedTypeExpression::Constant(value, suffix, location) => {
-                visitor.visit_constant_type_expression(*value, *suffix, location.span);
+                visitor.visit_constant_type_expression(value.clone(), *suffix, location.span);
             }
             UnresolvedTypeExpression::BinaryOperation(lhs, op, rhs, location) => {
                 if visitor.visit_binary_type_expression(lhs, *op, rhs, location.span) {

--- a/compiler/noirc_frontend/src/elaborator/enums.rs
+++ b/compiler/noirc_frontend/src/elaborator/enums.rs
@@ -485,7 +485,7 @@ impl Elaborator<'_> {
                 };
                 unify_with_expected_type(self, &actual);
 
-                let expr = HirExpression::Literal(HirLiteral::Integer(value));
+                let expr = HirExpression::Literal(HirLiteral::Integer(value.clone()));
                 let location = expr_location;
                 let expr_id = self.interner.push_expr_full(expr, location, actual.clone());
                 self.push_integer_literal_expr_id(expr_id);
@@ -1116,8 +1116,10 @@ impl<'elab, 'ctx> MatchCompiler<'elab, 'ctx> {
         for mut row in rows {
             if let Some(col) = row.remove_column(branch_var) {
                 let (key, cons) = match col.pattern {
-                    Pattern::Int(val) => ((val, val), Constructor::Int(val)),
-                    Pattern::Range(start, stop) => ((start, stop), Constructor::Range(start, stop)),
+                    Pattern::Int(val) => ((val.clone(), val.clone()), Constructor::Int(val)),
+                    Pattern::Range(start, stop) => {
+                        ((start.clone(), stop.clone()), Constructor::Range(start, stop))
+                    }
                     // Any other pattern shouldn't have an integer type and we expect a type
                     // check error to already have been issued.
                     _ => continue,
@@ -1458,18 +1460,18 @@ impl<'elab, 'ctx> MatchCompiler<'elab, 'ctx> {
 
         let mut missing_cases = rangemap::RangeInclusiveSet::new();
 
-        let int_max = SignedField::positive(typ.integral_maximum_size().unwrap());
+        let int_max = typ.integral_maximum_size().unwrap();
         let int_min = typ.integral_minimum_size().unwrap();
         missing_cases.insert(int_min..=int_max);
 
         for case in cases {
             match &case.constructor {
                 Constructor::Int(signed_field) => {
-                    missing_cases.remove(*signed_field..=*signed_field);
+                    missing_cases.remove(signed_field.clone()..=signed_field.clone());
                 }
                 Constructor::Range(start, end) => {
                     // Our ranges are exclusive, so adjust for that
-                    missing_cases.remove(*start..=end.sub_one());
+                    missing_cases.remove(start.clone()..=end.sub_one());
                 }
                 _ => unreachable!(
                     "missing_integer_cases should only be called with Int or Range constructors"

--- a/compiler/noirc_frontend/src/elaborator/types.rs
+++ b/compiler/noirc_frontend/src/elaborator/types.rs
@@ -783,7 +783,8 @@ impl Elaborator<'_> {
                     return None;
                 };
 
-                let Ok(global_value) = kind.ensure_value_fits(global_value, location) else {
+                let Ok(global_value) = kind.ensure_value_fits(global_value.clone(), location)
+                else {
                     self.push_err(ResolverError::GlobalDoesNotFitItsType {
                         location,
                         global_value,
@@ -865,7 +866,7 @@ impl Elaborator<'_> {
                             });
                             return Type::Error;
                         }
-                        match op.function(lhs, rhs, &lhs_kind, location) {
+                        match op.function(lhs.clone(), rhs.clone(), &lhs_kind, location) {
                             Ok(result) => Type::Constant(result, lhs_kind),
                             Err(err) => {
                                 let err = Box::new(err);
@@ -1517,9 +1518,7 @@ impl Elaborator<'_> {
 
         use HirExpression::Literal;
         let from_value_opt = match self.interner.expression(from_expr_id) {
-            Literal(HirLiteral::Integer(field)) if !field.is_negative() => {
-                Some(field.absolute_value())
-            }
+            Literal(HirLiteral::Integer(field)) if !field.is_negative() => Some(field.clone()),
 
             // TODO(https://github.com/noir-lang/noir/issues/6247):
             // handle negative literals

--- a/compiler/noirc_frontend/src/hir/comptime/hir_to_display_ast.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/hir_to_display_ast.rs
@@ -104,7 +104,7 @@ impl HirExpression {
             HirExpression::Literal(HirLiteral::Integer(value)) => {
                 // Losing the integer suffix information here, but this should just be for
                 // displaying these values anyway
-                ExpressionKind::Literal(Literal::Integer(*value, None))
+                ExpressionKind::Literal(Literal::Integer(value.clone(), None))
             }
             HirExpression::Literal(HirLiteral::Str(string)) => {
                 ExpressionKind::Literal(Literal::Str(string.clone()))
@@ -279,7 +279,9 @@ impl Constructor {
             Constructor::True => ExpressionKind::Literal(Literal::Bool(true)),
             Constructor::False => ExpressionKind::Literal(Literal::Bool(false)),
             Constructor::Unit => ExpressionKind::Literal(Literal::Unit),
-            Constructor::Int(value) => ExpressionKind::Literal(Literal::Integer(*value, None)),
+            Constructor::Int(value) => {
+                ExpressionKind::Literal(Literal::Integer(value.clone(), None))
+            }
             Constructor::Tuple(_) => ExpressionKind::Tuple(arguments),
             Constructor::Variant(typ, index) => {
                 let typ = typ.follow_bindings_shallow();
@@ -472,7 +474,7 @@ impl Type {
             Type::Forall(_, typ) => return typ.to_display_ast(),
             Type::Constant(value, kind) => {
                 UnresolvedTypeData::Expression(UnresolvedTypeExpression::Constant(
-                    *value,
+                    value.clone(),
                     kind.as_integer_type_suffix(),
                     Location::dummy(),
                 ))
@@ -550,7 +552,7 @@ impl HirArrayLiteral {
                 let length = match length {
                     Type::Constant(length, kind) => {
                         let suffix = kind.as_integer_type_suffix();
-                        let literal = Literal::Integer(*length, suffix);
+                        let literal = Literal::Integer(length.clone(), suffix);
                         let expr_kind = ExpressionKind::Literal(literal);
                         Box::new(Expression::new(expr_kind, location))
                     }

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
@@ -1003,7 +1003,7 @@ impl<'local, 'interner> Interpreter<'local, 'interner> {
                     let first_field = fields.iter().next();
                     match first_field {
                         Some((_, value)) => match &*value.borrow() {
-                            Value::Field(ordering) => Some(*ordering),
+                            Value::Field(ordering) => Some(ordering.clone()),
                             _ => None,
                         },
                         None => None,

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
@@ -2058,14 +2058,16 @@ fn expr_as_integer(
     expr_as(interner, arguments, return_type.clone(), location, |expr| match expr {
         ExprValue::Expression(ExpressionKind::Literal(Literal::Integer(field, _suffix))) => {
             Some(Value::Tuple(vec![
-                Shared::new(Value::Field(SignedField::positive(field.absolute_value()))),
+                Shared::new(Value::Field(SignedField::from_field_element(field.absolute_value()))),
                 Shared::new(Value::Bool(field.is_negative())),
             ]))
         }
         ExprValue::Expression(ExpressionKind::Resolved(id)) => {
             if let HirExpression::Literal(HirLiteral::Integer(field)) = interner.expression(&id) {
                 Some(Value::Tuple(vec![
-                    Shared::new(Value::Field(SignedField::positive(field.absolute_value()))),
+                    Shared::new(Value::Field(SignedField::from_field_element(
+                        field.absolute_value(),
+                    ))),
                     Shared::new(Value::Bool(field.is_negative())),
                 ]))
             } else {
@@ -3254,10 +3256,14 @@ fn derive_generators(
         let y_big: BigUint = generator.y.into();
         let y = FieldElement::from_be_bytes_reduce(&y_big.to_bytes_be());
         let mut embedded_curve_point_fields = HashMap::default();
-        embedded_curve_point_fields
-            .insert(x_field_name.clone(), Shared::new(Value::Field(SignedField::positive(x))));
-        embedded_curve_point_fields
-            .insert(y_field_name.clone(), Shared::new(Value::Field(SignedField::positive(y))));
+        embedded_curve_point_fields.insert(
+            x_field_name.clone(),
+            Shared::new(Value::Field(SignedField::from_field_element(x))),
+        );
+        embedded_curve_point_fields.insert(
+            y_field_name.clone(),
+            Shared::new(Value::Field(SignedField::from_field_element(y))),
+        );
         embedded_curve_point_fields
             .insert(is_infinite_field_name.clone(), Shared::new(Value::Bool(is_infinite)));
         let embedded_curve_point_struct =

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter/cast.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter/cast.rs
@@ -115,12 +115,65 @@ fn convert_to_field(value: Value, location: Location) -> IResult<(FieldElement, 
     })
 }
 
+/// Sign- or zero-extends an integer or boolean to its 128-bit two's-complement
+/// bit pattern.
+fn integer_bit_pattern(value: &Value) -> Option<u128> {
+    Some(match value {
+        Value::U1(value) => u128::from(*value),
+        Value::U8(value) => u128::from(*value),
+        Value::U16(value) => u128::from(*value),
+        Value::U32(value) => u128::from(*value),
+        Value::U64(value) => u128::from(*value),
+        Value::U128(value) => *value,
+        Value::Bool(value) => u128::from(*value),
+        Value::I8(value) => i128::from(*value) as u128,
+        Value::I16(value) => i128::from(*value) as u128,
+        Value::I32(value) => i128::from(*value) as u128,
+        Value::I64(value) => i128::from(*value) as u128,
+        _ => return None,
+    })
+}
+
+/// Casts an integer bit pattern to another integer type without touching the field.
+fn integer_to_integer(
+    bits: u128,
+    sign: Signedness,
+    bit_size: IntegerBitSize,
+    location: Location,
+) -> IResult<Value> {
+    use IntegerBitSize::*;
+    let unsupported =
+        || InterpreterError::TypeUnsupported { typ: Type::Integer(sign, bit_size), location };
+    Ok(match (sign, bit_size) {
+        (Signedness::Unsigned, One) => Value::U1(bits != 0),
+        (Signedness::Unsigned, Eight) => Value::U8(bits as u8),
+        (Signedness::Unsigned, Sixteen) => Value::U16(bits as u16),
+        (Signedness::Unsigned, ThirtyTwo) => Value::U32(bits as u32),
+        (Signedness::Unsigned, SixtyFour) => Value::U64(bits as u64),
+        (Signedness::Unsigned, HundredTwentyEight) => Value::U128(bits),
+        (Signedness::Signed, One) => return Err(unsupported()),
+        (Signedness::Signed, Eight) => Value::I8(bits as i8),
+        (Signedness::Signed, Sixteen) => Value::I16(bits as i16),
+        (Signedness::Signed, ThirtyTwo) => Value::I32(bits as i32),
+        (Signedness::Signed, SixtyFour) => Value::I64(bits as i64),
+        (Signedness::Signed, HundredTwentyEight) => return Err(unsupported()),
+    })
+}
+
 /// evaluate_cast without recursion
 pub(super) fn evaluate_cast_one_step(
     output_type: &Type,
     location: Location,
     evaluated_lhs: Value,
 ) -> IResult<Value> {
+    // Integer-to-integer casts are pure bit operations and must not round-trip
+    // through a field element, which would be lossy when the source exceeds p.
+    if let Type::Integer(sign, bit_size) = output_type.follow_bindings()
+        && let Some(bits) = integer_bit_pattern(&evaluated_lhs)
+    {
+        return integer_to_integer(bits, sign, bit_size, location);
+    }
+
     let lhs_type = evaluated_lhs.get_type().into_owned();
     let (lhs, lhs_is_negative) = convert_to_field(evaluated_lhs, location)?;
 

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter/foreign.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter/foreign.rs
@@ -234,13 +234,14 @@ fn poseidon2_permutation(arguments: Vec<(Value, Location)>, location: Location) 
     let input = check_one_argument(arguments, location)?;
 
     let (input, typ) = get_array_map(input, get_field)?;
-    let input = vecmap(input, SignedField::to_field_element);
+    let input = vecmap(input, |f| f.to_field_element());
 
     let fields = Bn254BlackBoxSolver
         .poseidon2_permutation(&input)
         .map_err(|error| InterpreterError::BlackBoxError(error, location))?;
 
-    let array = fields.into_iter().map(|f| Value::Field(SignedField::positive(f))).collect();
+    let array =
+        fields.into_iter().map(|f| Value::Field(SignedField::from_field_element(f))).collect();
     Ok(Value::Array(array, typ))
 }
 
@@ -303,8 +304,8 @@ fn to_embedded_curve_point(
 ) -> Value {
     to_struct(
         [
-            ("x", Value::Field(SignedField::positive(x))),
-            ("y", Value::Field(SignedField::positive(y))),
+            ("x", Value::Field(SignedField::from_field_element(x))),
+            ("y", Value::Field(SignedField::from_field_element(y))),
             ("is_infinite", Value::Bool(is_infinite)),
         ],
         typ,

--- a/compiler/noirc_frontend/src/hir/comptime/value.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/value.rs
@@ -743,9 +743,9 @@ impl Value {
             }
             Value::Field(value) => {
                 if value.is_negative() {
-                    vec![Token::Minus, Token::Int(value.absolute_value(), None)]
+                    vec![Token::Minus, Token::Int(value.absolute_value().into(), None)]
                 } else {
-                    vec![Token::Int(value.absolute_value(), None)]
+                    vec![Token::Int(value.absolute_value().into(), None)]
                 }
             }
             Value::String(value) | Value::CtString(value) => {

--- a/compiler/noirc_frontend/src/hir/type_check/errors.rs
+++ b/compiler/noirc_frontend/src/hir/type_check/errors.rs
@@ -1,7 +1,6 @@
 use std::collections::BTreeSet;
 use std::rc::Rc;
 
-use acvm::FieldElement;
 use iter_extended::vecmap;
 use noirc_errors::CustomDiagnostic as Diagnostic;
 use noirc_errors::Location;
@@ -51,7 +50,7 @@ pub enum TypeCheckError {
     OverflowingConstant {
         value: SignedField,
         kind: Kind,
-        maximum_size: FieldElement,
+        maximum_size: SignedField,
         location: Location,
     },
     #[error(

--- a/compiler/noirc_frontend/src/hir_def/types.rs
+++ b/compiler/noirc_frontend/src/hir_def/types.rs
@@ -5,8 +5,6 @@ use rustc_hash::FxHashMap as HashMap;
 #[cfg(test)]
 use proptest_derive::Arbitrary;
 
-use acvm::{AcirField, FieldElement};
-
 use crate::{
     ast::{BinaryOpKind, IntegerBitSize, ItemVisibility, UnresolvedTypeExpression},
     elaborator::types::SELF_TYPE_NAME,
@@ -270,7 +268,7 @@ impl Kind {
         }
     }
 
-    fn integral_maximum_size(&self) -> Option<FieldElement> {
+    fn integral_maximum_size(&self) -> Option<SignedField> {
         match self.follow_bindings() {
             Kind::Any | Kind::IntegerOrField | Kind::Integer | Kind::Normal => None,
             Self::Numeric(typ) => typ.integral_maximum_size(),
@@ -291,7 +289,7 @@ impl Kind {
         location: Location,
     ) -> Result<SignedField, TypeCheckError> {
         if let Some(maximum_size) = self.integral_maximum_size()
-            && value > SignedField::positive(maximum_size)
+            && value > maximum_size
         {
             return Err(TypeCheckError::OverflowingConstant {
                 value,
@@ -3133,7 +3131,7 @@ impl Type {
         }
     }
 
-    pub(crate) fn integral_maximum_size(&self) -> Option<FieldElement> {
+    pub(crate) fn integral_maximum_size(&self) -> Option<SignedField> {
         match self {
             Type::FieldElement => None,
             Type::Integer(sign, num_bits) => {
@@ -3144,7 +3142,7 @@ impl Type {
                 let max = if max_bit_size == 128 { u128::MAX } else { (1u128 << max_bit_size) - 1 };
                 Some(max.into())
             }
-            Type::Bool => Some(FieldElement::one()),
+            Type::Bool => Some(SignedField::one()),
             Type::TypeVariable(var) => {
                 let binding = &var.1;
                 match &*binding.borrow() {
@@ -3305,7 +3303,7 @@ impl BinaryTypeOperator {
                 BinaryTypeOperator::Subtraction => Ok(a - b),
                 BinaryTypeOperator::Multiplication => Ok(a * b),
                 BinaryTypeOperator::Division => (!b.is_zero())
-                    .then(|| a / b)
+                    .then(|| a.clone() / b.clone())
                     .ok_or(TypeCheckError::DivisionByZero { lhs: a, rhs: b, location }),
                 BinaryTypeOperator::Modulo => {
                     Err(TypeCheckError::ModuloOnFields { lhs: a, rhs: b, location })

--- a/compiler/noirc_frontend/src/hir_def/types/arithmetic.rs
+++ b/compiler/noirc_frontend/src/hir_def/types/arithmetic.rs
@@ -76,9 +76,10 @@ impl Type {
 
                 // evaluate_to_field_element also calls canonicalize so if we just called
                 // `self.evaluate_to_field_element(..)` we'd get infinite recursion.
-                if let Ok(lhs_value) = lhs_evaluated
-                    && let Ok(rhs_value) = rhs_evaluated
-                    && let Ok(result) = op.function(lhs_value, rhs_value, &kind, dummy_location)
+                if let Ok(lhs_value) = &lhs_evaluated
+                    && let Ok(rhs_value) = &rhs_evaluated
+                    && let Ok(result) =
+                        op.function(lhs_value.clone(), rhs_value.clone(), &kind, dummy_location)
                 {
                     return Type::Constant(result, kind);
                 }
@@ -88,7 +89,7 @@ impl Type {
 
                 // See if this is `X * 1` or `X / 1` in which case we can simplify it to `X`
                 if matches!(op, BinaryTypeOperator::Multiplication | BinaryTypeOperator::Division)
-                    && let Ok(rhs_value) = rhs_evaluated
+                    && let Ok(rhs_value) = &rhs_evaluated
                     && rhs_value.is_one()
                 {
                     return lhs;
@@ -96,7 +97,7 @@ impl Type {
 
                 // See if this is `X + 0` or `X - 0`, in which case we can simplify it to `X`
                 if matches!(op, BinaryTypeOperator::Addition | BinaryTypeOperator::Subtraction)
-                    && let Ok(rhs_value) = rhs_evaluated
+                    && let Ok(rhs_value) = &rhs_evaluated
                     && rhs_value.is_zero()
                 {
                     return lhs;
@@ -159,7 +160,7 @@ impl Type {
         } else {
             SignedField::one()
         };
-        let mut constant = zero_value;
+        let mut constant = zero_value.clone();
 
         // Push each non-constant term to `sorted` to sort them. Recur on InfixExprs with the same operator.
         while let Some(item) = queue.pop() {
@@ -170,9 +171,12 @@ impl Type {
                 }
                 Type::Constant(new_constant, new_constant_kind) => {
                     let dummy_location = Location::dummy();
-                    if let Ok(result) =
-                        op.function(constant, new_constant, &new_constant_kind, dummy_location)
-                    {
+                    if let Ok(result) = op.function(
+                        constant.clone(),
+                        new_constant.clone(),
+                        &new_constant_kind,
+                        dummy_location,
+                    ) {
                         constant = result;
                     } else {
                         let constant = Type::Constant(new_constant, new_constant_kind);
@@ -690,7 +694,7 @@ mod proptests {
             let (infix_expr, typ, _value_generator) = infix_type_gen;
             let bindings: Vec<_> = first_n_variables(typ.clone(), num_variables)
                 .zip(values.iter().map(|value| {
-                    Type::Constant(*value, Kind::numeric(typ.clone()))
+                    Type::Constant(value.clone(), Kind::numeric(typ.clone()))
                 }))
                 .collect();
             (infix_expr, typ, bindings)
@@ -727,7 +731,7 @@ mod proptests {
                         "convert_infix_type_expr_to_expr: unexpected non-numeric kind: {kind}"
                     ),
                 };
-                let literal = Literal::Integer(*value, Some(integer_type_suffix));
+                let literal = Literal::Integer(value.clone(), Some(integer_type_suffix));
                 ExpressionKind::Literal(literal)
             }
             Type::TypeVariable(type_var) => unimplemented!(
@@ -907,7 +911,7 @@ mod proptests {
         let n = Type::TypeVariable(var_n);
 
         // large_field ≈ 2^200
-        let large_field = SignedField::positive(FieldElement::from_be_bytes_reduce(&[
+        let large_field = SignedField::from_field_element(FieldElement::from_be_bytes_reduce(&[
             0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
             0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
             0x00, 0x00, 0x00, 0x00,

--- a/compiler/noirc_frontend/src/hir_def/types/unification.rs
+++ b/compiler/noirc_frontend/src/hir_def/types/unification.rs
@@ -276,7 +276,7 @@ impl Type {
                     if let Some(inverse) = op.approx_inverse() {
                         // Handle cases like `4 = a + b` by trying to solve to `a = 4 - b`
                         let new_type = Type::inverted_infix_expr(
-                            Box::new(Constant(*value, kind.clone())),
+                            Box::new(Constant(value.clone(), kind.clone())),
                             inverse,
                             rhs.clone(),
                         );

--- a/compiler/noirc_frontend/src/lexer/lexer.rs
+++ b/compiler/noirc_frontend/src/lexer/lexer.rs
@@ -6,6 +6,7 @@ use super::{
         FmtStrFragment, IntegerTypeSuffix, Keyword, LocatedToken, SpannedToken, Token, Tokens,
     },
 };
+use crate::signed_field::SignedField;
 use acvm::{AcirField, FieldElement};
 use fm::FileId;
 use noirc_errors::{Location, Position, Span};
@@ -442,8 +443,7 @@ impl<'a> Lexer<'a> {
                         limit: self.max_integer.to_string(),
                     });
                 }
-                let big_uint = bigint.magnitude();
-                FieldElement::from_be_bytes_reduce(&big_uint.to_bytes_be())
+                SignedField::positive(bigint)
             }
             Err(_) => {
                 return Err(LexerErrorKind::InvalidIntegerLiteral {
@@ -1079,7 +1079,7 @@ mod tests {
             Token::Keyword(Keyword::Let),
             Token::Ident("x".to_string()),
             Token::Assign,
-            Token::Int(FieldElement::from(5_i128), None),
+            Token::Int(SignedField::from(5_i128), None),
         ];
 
         let mut lexer = Lexer::new_with_dummy_file(input);
@@ -1101,7 +1101,7 @@ mod tests {
             Token::Keyword(Keyword::Let),
             Token::Ident("x".to_string()),
             Token::Assign,
-            Token::Int(FieldElement::from(5_i128), None),
+            Token::Int(SignedField::from(5_i128), None),
         ];
 
         let mut lexer = Lexer::new_with_dummy_file(input);
@@ -1149,7 +1149,7 @@ mod tests {
             Token::Keyword(Keyword::Let),
             Token::Ident("x".to_string()),
             Token::Assign,
-            Token::Int(FieldElement::from(5_i128), None),
+            Token::Int(SignedField::from(5_i128), None),
         ];
 
         let mut lexer = Lexer::new_with_dummy_file(input);

--- a/compiler/noirc_frontend/src/lexer/token.rs
+++ b/compiler/noirc_frontend/src/lexer/token.rs
@@ -1,4 +1,4 @@
-use acvm::FieldElement;
+use crate::signed_field::SignedField;
 use noirc_errors::{Located, Location, Position, Span, Spanned};
 use std::fmt::{self, Display};
 
@@ -67,7 +67,7 @@ impl IntegerTypeSuffix {
 #[derive(PartialEq, Eq, Hash, Debug, Clone, PartialOrd, Ord)]
 pub enum Token {
     Ident(String),
-    Int(FieldElement, Option<IntegerTypeSuffix>),
+    Int(SignedField, Option<IntegerTypeSuffix>),
     Bool(bool),
     Str(String),
     /// the u8 is the number of hashes, i.e. r###..
@@ -342,8 +342,8 @@ impl Display for Token {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             Token::Ident(ref s) => write!(f, "{s}"),
-            Token::Int(n, Some(suffix)) => write!(f, "{n}_{suffix}"),
-            Token::Int(n, None) => write!(f, "{n}"),
+            Token::Int(ref n, Some(suffix)) => write!(f, "{n}_{suffix}"),
+            Token::Int(ref n, None) => write!(f, "{n}"),
             Token::Bool(b) => write!(f, "{b}"),
             Token::Str(ref b) => write!(f, "{b:?}"),
             Token::FmtStr(ref b, _length) => write!(f, "f{b:?}"),

--- a/compiler/noirc_frontend/src/monomorphization/mod.rs
+++ b/compiler/noirc_frontend/src/monomorphization/mod.rs
@@ -66,7 +66,6 @@ use crate::{
     node_interner::{self, DefinitionKind, NodeInterner, StmtId, TraitImplKind},
 };
 use crate::{NamedGeneric, TypeVariable, TypeVariableId};
-use acvm::{FieldElement, acir::AcirField};
 use ast::{GlobalId, IdentId, While};
 use iter_extended::{btree_map, try_vecmap, vecmap};
 use noirc_errors::Location;
@@ -1120,8 +1119,7 @@ impl<'interner> Monomorphizer<'interner> {
         let location = self.interner.expr_location(&id);
         let variants = unwrap_enum_type(typ, location)?;
 
-        let tag_value = FieldElement::from(constructor.variant_index);
-        let tag_value = SignedField::positive(tag_value);
+        let tag_value = SignedField::from(constructor.variant_index);
         let tag = ast::Literal::Integer(tag_value, ast::Type::Field, location);
         let mut fields = vec![ast::Expression::Literal(tag)];
 
@@ -2794,15 +2792,14 @@ impl<'interner> Monomorphizer<'interner> {
                 // of the fact the Ordering struct contains a single Field type, and our SSA
                 // pass will automatically unpack tuple values.
                 let ordering_value = if matches!(operator.kind, Less | GreaterEqual) {
-                    FieldElement::zero() // Ordering::Less
+                    SignedField::zero() // Ordering::Less
                 } else {
-                    2u128.into() // Ordering::Greater
+                    SignedField::from(2u128) // Ordering::Greater
                 };
 
                 let operator =
                     if matches!(operator.kind, Less | Greater) { Equal } else { NotEqual };
 
-                let ordering_value = SignedField::positive(ordering_value);
                 let int_value = ast::Literal::Integer(ordering_value, ast::Type::Field, location);
                 let rhs = Box::new(ast::Expression::Literal(int_value));
                 let lhs = Box::new(ast::Expression::ExtractTupleField(Box::new(result), 0));

--- a/compiler/noirc_frontend/src/parser/parser.rs
+++ b/compiler/noirc_frontend/src/parser/parser.rs
@@ -1,4 +1,4 @@
-use acvm::{AcirField, FieldElement};
+use crate::signed_field::SignedField;
 use fm::FileId;
 use modifiers::Modifiers;
 use noirc_errors::{Location, Span};
@@ -243,7 +243,7 @@ impl<'a> Parser<'a> {
                 )) => {
                     let location = error.location();
                     self.errors.push(error.into());
-                    let token = LocatedToken::new(Token::Int(FieldElement::zero(), None), location);
+                    let token = LocatedToken::new(Token::Int(SignedField::zero(), None), location);
                     return (token, last_comments);
                 }
                 Some(Err(lexer_error)) => self.errors.push(lexer_error.into()),
@@ -305,7 +305,7 @@ impl<'a> Parser<'a> {
         false
     }
 
-    fn eat_int(&mut self) -> Option<(FieldElement, Option<IntegerTypeSuffix>)> {
+    fn eat_int(&mut self) -> Option<(SignedField, Option<IntegerTypeSuffix>)> {
         if matches!(self.token.token(), Token::Int(..)) {
             let token = self.bump();
             match token.into_token() {

--- a/compiler/noirc_frontend/src/parser/parser/function.rs
+++ b/compiler/noirc_frontend/src/parser/parser/function.rs
@@ -12,7 +12,6 @@ use crate::{
     },
     parser::ParserErrorReason,
 };
-use acvm::AcirField;
 
 use noirc_errors::{Location, Span};
 

--- a/compiler/noirc_frontend/src/parser/parser/type_expression.rs
+++ b/compiler/noirc_frontend/src/parser/parser/type_expression.rs
@@ -171,8 +171,7 @@ impl Parser<'_> {
     /// ConstantTypeExpression = int
     fn parse_constant_type_expression(&mut self) -> Option<UnresolvedTypeExpression> {
         let (int, suffix) = self.eat_int()?;
-        let signed_field = SignedField::positive(int);
-        Some(UnresolvedTypeExpression::Constant(signed_field, suffix, self.previous_token_location))
+        Some(UnresolvedTypeExpression::Constant(int, suffix, self.previous_token_location))
     }
 
     /// VariableTypeExpression = Path

--- a/compiler/noirc_frontend/src/signed_field.rs
+++ b/compiler/noirc_frontend/src/signed_field.rs
@@ -1,54 +1,76 @@
 use acvm::{AcirField, FieldElement};
+use num_bigint::{BigInt, Sign};
+use num_traits::{One, Signed, ToPrimitive, Zero};
 
-#[derive(Debug, Copy, Clone, serde::Deserialize, serde::Serialize)]
-pub struct SignedField {
-    field: FieldElement,
-    is_negative: bool,
+/// A signed, arbitrary-precision integer carrying numeric literals and
+/// compile-time constants through the frontend. The field is only consulted at
+/// [`Self::to_field_element`], [`Self::absolute_value`] and
+/// [`Self::from_field_element`].
+#[derive(
+    Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, serde::Deserialize, serde::Serialize,
+)]
+pub struct SignedField(BigInt);
+
+/// Interpret a field element as a non-negative integer in `[0, p)`.
+fn field_to_bigint(field: FieldElement) -> BigInt {
+    BigInt::from_bytes_be(Sign::Plus, &field.to_be_bytes())
+}
+
+/// Reduce a signed integer to its field element, negating if negative.
+fn bigint_to_field(value: &BigInt) -> FieldElement {
+    let (sign, magnitude) = value.to_bytes_be();
+    let field = FieldElement::from_be_bytes_reduce(&magnitude);
+    if sign == Sign::Minus { -field } else { field }
 }
 
 impl SignedField {
-    pub fn new(field: FieldElement, mut is_negative: bool) -> Self {
-        if field.is_zero() {
-            is_negative = false;
-        }
-        Self { field, is_negative }
+    /// Construct from a field-element magnitude and a sign.
+    pub fn new(field: FieldElement, is_negative: bool) -> Self {
+        let magnitude = field_to_bigint(field);
+        Self(if is_negative { -magnitude } else { magnitude })
     }
 
-    pub fn positive(field: impl Into<FieldElement>) -> Self {
-        Self { field: field.into(), is_negative: false }
+    pub fn positive(value: impl Into<BigInt>) -> Self {
+        Self(value.into())
     }
 
-    pub fn negative(field: impl Into<FieldElement>) -> Self {
-        Self::new(field.into(), true)
+    pub fn negative(value: impl Into<BigInt>) -> Self {
+        Self(-value.into().abs())
+    }
+
+    /// Construct directly from a field element (a genuine field constant),
+    /// interpreting it as a non-negative integer in `[0, p)`.
+    pub fn from_field_element(field: FieldElement) -> Self {
+        Self(field_to_bigint(field))
     }
 
     pub fn zero() -> SignedField {
-        Self { field: FieldElement::zero(), is_negative: false }
+        Self(BigInt::zero())
     }
 
     pub fn one() -> SignedField {
-        Self { field: FieldElement::one(), is_negative: false }
+        Self(BigInt::one())
     }
 
-    /// Returns the inner FieldElement which will always be positive
+    /// The magnitude as a field element (reduced mod p if it exceeds the modulus).
     pub fn absolute_value(&self) -> FieldElement {
-        self.field
+        FieldElement::from_be_bytes_reduce(&self.0.magnitude().to_bytes_be())
     }
 
     pub fn is_negative(&self) -> bool {
-        self.is_negative
+        self.0.sign() == Sign::Minus
     }
 
     pub fn is_positive(&self) -> bool {
-        !self.is_negative
+        !self.is_negative()
     }
 
     pub fn is_zero(&self) -> bool {
-        self.field.is_zero()
+        self.0.is_zero()
     }
 
     pub fn is_one(&self) -> bool {
-        self.is_positive() && self.field.is_one()
+        self.0.is_one()
     }
 
     /// Convert a signed integer to a SignedField, carefully handling
@@ -57,97 +79,53 @@ impl SignedField {
     #[inline]
     pub fn from_signed<T>(value: T) -> Self
     where
-        T: num_traits::Signed + AbsU128,
+        T: Signed + AbsU128,
     {
         let negative = value.is_negative();
-        let value = value.abs_u128();
-        SignedField::new(value.into(), negative)
+        let magnitude = BigInt::from(value.abs_u128());
+        Self(if negative { -magnitude } else { magnitude })
     }
 
     /// Convert a SignedField into an unsigned integer type (up to u128),
     /// returning None if the value does not fit (e.g. if it is negative).
     #[inline]
-    pub fn try_to_unsigned<T: TryFrom<u128>>(self) -> Option<T> {
-        if self.is_negative {
+    pub fn try_to_unsigned<T: TryFrom<u128>>(&self) -> Option<T> {
+        if self.is_negative() {
             return None;
         }
 
         assert!(size_of::<T>() <= size_of::<u128>());
-        let u128_value = self.field.try_into_u128()?;
+        let u128_value = self.0.to_u128()?;
         u128_value.try_into().ok()
     }
 
     /// Convert a SignedField into a signed integer type (up to i128),
-    /// returning None if the value does not fit. This function is more complex
-    /// for handling negative values, specifically INT_MIN which we can't cast from
-    /// a u128 to i128 without wrapping it.
+    /// returning None if the value does not fit.
     #[inline]
-    pub fn try_to_signed<T>(self) -> Option<T>
+    pub fn try_to_signed<T>(&self) -> Option<T>
     where
-        T: TryFrom<u128> + TryFrom<i128> + num_traits::Signed + num_traits::Bounded + AbsU128,
-        u128: TryFrom<T>,
+        T: TryFrom<i128>,
     {
-        let u128_value = self.field.try_into_u128()?;
-
-        if self.is_negative {
-            // The positive version of the minimum value of this type.
-            // E.g. 128 for i8.
-            let positive_min = T::min_value().abs_u128();
-
-            // If it is the min value, we can't negate it without overflowing
-            // so test for it and return it directly
-            if u128_value == positive_min {
-                Some(T::min_value())
-            } else {
-                let i128_value = -(u128_value as i128);
-                T::try_from(i128_value).ok()
-            }
-        } else {
-            T::try_from(u128_value).ok()
-        }
+        let i128_value = self.0.to_i128()?;
+        T::try_from(i128_value).ok()
     }
 
-    pub fn to_field_element(self) -> FieldElement {
-        if self.is_negative { -self.field } else { self.field }
+    pub fn to_field_element(&self) -> FieldElement {
+        bigint_to_field(&self.0)
     }
 
-    pub fn to_u128(self) -> u128 {
+    pub fn to_u128(&self) -> u128 {
         assert!(self.is_positive());
-        self.to_field_element().to_u128()
+        self.0.magnitude().to_u128().expect("value does not fit in u128")
     }
 
-    pub fn to_i128(self) -> i128 {
+    pub fn to_i128(&self) -> i128 {
         if self.is_negative() {
-            let value = self.field.to_u128();
+            let value = self.0.magnitude().to_u128().expect("value does not fit in i128");
             if value == ((i128::MAX as u128) + 1) { i128::MIN } else { -(value as i128) }
         } else {
-            self.field.to_u128() as i128
+            self.0.magnitude().to_u128().expect("value does not fit in i128") as i128
         }
-    }
-}
-
-impl PartialEq for SignedField {
-    fn eq(&self, other: &Self) -> bool {
-        // When comparing two signed fields, comparing the two instances:
-        // 1. SignedField { is_negative: true, field: 1 }
-        // 2. SignedField { is_negative: false, field: -1 }
-        // the result should be true. In reality `field: -1` is just the maximum
-        // field value, which turns out to be represented as "-1" in its string
-        // representation. Nonetheless, the actual field value is the same.
-        if self.is_negative == other.is_negative {
-            self.field == other.field
-        } else {
-            self.field == -other.field
-        }
-    }
-}
-
-impl Eq for SignedField {}
-
-impl std::hash::Hash for SignedField {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        let fe = if self.is_negative { -self.field } else { self.field };
-        fe.hash(state);
     }
 }
 
@@ -155,23 +133,7 @@ impl std::ops::Add for SignedField {
     type Output = Self;
 
     fn add(self, rhs: Self) -> Self::Output {
-        if self.is_negative == rhs.is_negative {
-            Self::new(self.field + rhs.field, self.is_negative)
-        } else if self.is_negative && !rhs.is_negative {
-            if self.field > rhs.field {
-                // For example "-4 + 3", so "-(4 - 3)"
-                Self::new(self.field - rhs.field, true)
-            } else {
-                // For example "-4 + 5", so "5 - 4"
-                Self::new(rhs.field - self.field, false)
-            }
-        } else if rhs.field > self.field {
-            // For example "4 + (-5)", so "-(5 - 4)"
-            Self::new(rhs.field - self.field, true)
-        } else {
-            // For example "4 + (-3)", so "4 - 3"
-            Self::new(self.field - rhs.field, false)
-        }
+        Self(self.0 + rhs.0)
     }
 }
 
@@ -179,7 +141,7 @@ impl std::ops::Sub for SignedField {
     type Output = Self;
 
     fn sub(self, rhs: Self) -> Self::Output {
-        self + -rhs
+        Self(self.0 - rhs.0)
     }
 }
 
@@ -187,23 +149,23 @@ impl std::ops::Mul for SignedField {
     type Output = Self;
 
     fn mul(self, rhs: Self) -> Self::Output {
-        if self.field.is_zero() || rhs.field.is_zero() {
-            return Self::zero();
-        }
-
-        Self::new(self.field * rhs.field, self.is_negative ^ rhs.is_negative)
+        Self(self.0 * rhs.0)
     }
 }
 
 impl std::ops::Div for SignedField {
     type Output = Self;
 
+    /// Division is a field operation (multiplication by the modular inverse), so
+    /// it is only meaningful for `Field`-typed values. The magnitudes are divided
+    /// in the field and the signs are combined.
     fn div(self, rhs: Self) -> Self::Output {
-        if self.field.is_zero() {
+        if self.0.is_zero() {
             return Self::zero();
         }
 
-        Self::new(self.field / rhs.field, self.is_negative ^ rhs.is_negative)
+        let quotient = self.absolute_value() / rhs.absolute_value();
+        Self::new(quotient, self.is_negative() ^ rhs.is_negative())
     }
 }
 
@@ -211,26 +173,7 @@ impl std::ops::Neg for SignedField {
     type Output = Self;
 
     fn neg(self) -> Self::Output {
-        Self::new(self.field, self.is_positive())
-    }
-}
-
-impl Ord for SignedField {
-    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        if self.is_negative != other.is_negative {
-            if self.is_negative { std::cmp::Ordering::Less } else { std::cmp::Ordering::Greater }
-        } else if self.is_negative {
-            // Negative comparisons should be reversed so that -2 < -1
-            other.field.cmp(&self.field)
-        } else {
-            self.field.cmp(&other.field)
-        }
-    }
-}
-
-impl PartialOrd for SignedField {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        Some(self.cmp(other))
+        Self(-self.0)
     }
 }
 
@@ -240,81 +183,31 @@ impl From<bool> for SignedField {
     }
 }
 
-impl From<u8> for SignedField {
-    fn from(value: u8) -> Self {
-        u32::from(value).into()
-    }
-}
-
-impl From<u16> for SignedField {
-    fn from(value: u16) -> Self {
-        u32::from(value).into()
-    }
-}
-
-impl From<u32> for SignedField {
-    fn from(value: u32) -> Self {
-        Self::new(value.into(), false)
-    }
-}
-
-impl From<u64> for SignedField {
-    fn from(value: u64) -> Self {
-        u128::from(value).into()
-    }
-}
-
-impl From<u128> for SignedField {
-    fn from(value: u128) -> Self {
-        Self::new(value.into(), false)
-    }
-}
-
-impl From<i8> for SignedField {
-    fn from(value: i8) -> Self {
-        i128::from(value).into()
-    }
-}
-
-impl From<i16> for SignedField {
-    fn from(value: i16) -> Self {
-        i128::from(value).into()
-    }
-}
-
-impl From<i32> for SignedField {
-    fn from(value: i32) -> Self {
-        i128::from(value).into()
-    }
-}
-
-impl From<i64> for SignedField {
-    fn from(value: i64) -> Self {
-        i128::from(value).into()
-    }
-}
-
-impl From<i128> for SignedField {
-    fn from(value: i128) -> Self {
-        if value == i128::MIN {
-            Self::new(FieldElement::from((i128::MAX as u128) + 1), true)
-        } else if value < 0 {
-            Self::new((-value).into(), true)
-        } else {
-            Self::new(value.into(), false)
+macro_rules! impl_from_integer_for_signed_field {
+    ($typ:ty) => {
+        impl From<$typ> for SignedField {
+            fn from(value: $typ) -> Self {
+                Self(BigInt::from(value))
+            }
         }
-    }
+    };
 }
 
-impl From<usize> for SignedField {
-    fn from(value: usize) -> Self {
-        Self::new(value.into(), false)
-    }
-}
+impl_from_integer_for_signed_field!(u8);
+impl_from_integer_for_signed_field!(u16);
+impl_from_integer_for_signed_field!(u32);
+impl_from_integer_for_signed_field!(u64);
+impl_from_integer_for_signed_field!(u128);
+impl_from_integer_for_signed_field!(i8);
+impl_from_integer_for_signed_field!(i16);
+impl_from_integer_for_signed_field!(i32);
+impl_from_integer_for_signed_field!(i64);
+impl_from_integer_for_signed_field!(i128);
+impl_from_integer_for_signed_field!(usize);
 
 impl From<FieldElement> for SignedField {
     fn from(value: FieldElement) -> Self {
-        Self::new(value, false)
+        Self::from_field_element(value)
     }
 }
 
@@ -330,34 +223,17 @@ where
 
 impl std::fmt::Display for SignedField {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        if self.is_negative {
-            write!(f, "-")?;
-        }
-        write!(f, "{}", self.field)
+        write!(f, "{}", self.0)
     }
 }
 
 impl rangemap::StepLite for SignedField {
     fn add_one(&self) -> Self {
-        if self.is_negative {
-            if self.field.is_one() {
-                Self::new(FieldElement::zero(), false)
-            } else {
-                Self::new(self.field - FieldElement::one(), self.is_negative)
-            }
-        } else {
-            Self::new(self.field + FieldElement::one(), self.is_negative)
-        }
+        Self(&self.0 + 1)
     }
 
     fn sub_one(&self) -> Self {
-        if self.is_negative {
-            Self::new(self.field + FieldElement::one(), self.is_negative)
-        } else if self.field.is_zero() {
-            Self::new(FieldElement::one(), true)
-        } else {
-            Self::new(self.field - FieldElement::one(), self.is_negative)
-        }
+        Self(&self.0 - 1)
     }
 }
 
@@ -417,21 +293,21 @@ mod tests {
         let one = SignedField::one();
         let two = SignedField::positive(2_u32);
         let three = SignedField::positive(3_u32);
-        assert_eq!(one + two, three); // positive + positive
+        assert_eq!(one.clone() + two.clone(), three.clone()); // positive + positive
 
         let minus_one = SignedField::negative(1_u32);
         let minus_two = SignedField::negative(2_u32);
         let minus_three = SignedField::negative(3_u32);
-        assert_eq!(two + minus_one, one); // positive + negative
+        assert_eq!(two + minus_one.clone(), one.clone()); // positive + negative
 
-        assert_eq!(minus_three + one, minus_two); // negative + positive
+        assert_eq!(minus_three.clone() + one.clone(), minus_two); // negative + positive
 
-        assert_eq!(minus_one + minus_two, minus_three); // negative + negative
+        assert_eq!(minus_one.clone() + minus_two, minus_three); // negative + negative
 
-        assert_eq!(one + zero, one);
-        assert_eq!(zero + one, one);
-        assert_eq!(minus_one + zero, minus_one);
-        assert_eq!(zero + minus_one, minus_one);
+        assert_eq!(one.clone() + zero.clone(), one.clone());
+        assert_eq!(zero.clone() + one.clone(), one.clone());
+        assert_eq!(minus_one.clone() + zero.clone(), minus_one.clone());
+        assert_eq!(zero + minus_one.clone(), minus_one);
     }
 
     #[test]
@@ -440,19 +316,19 @@ mod tests {
         let one = SignedField::one();
         let two = SignedField::positive(2_u32);
         let three = SignedField::positive(3_u32);
-        assert_eq!(three - two, one); // positive - positive
+        assert_eq!(three.clone() - two.clone(), one.clone()); // positive - positive
 
         let minus_one = SignedField::negative(1_u32);
         let minus_three = SignedField::negative(3_u32);
-        assert_eq!(two - minus_one, three); // positive - negative
+        assert_eq!(two.clone() - minus_one.clone(), three); // positive - negative
 
-        assert_eq!(minus_one - two, minus_three); // negative - positive
+        assert_eq!(minus_one.clone() - two.clone(), minus_three.clone()); // negative - positive
 
-        assert_eq!(minus_one - minus_three, two); // negative - negative
+        assert_eq!(minus_one.clone() - minus_three, two); // negative - negative
 
-        assert_eq!(one - zero, one);
-        assert_eq!(minus_one - zero, minus_one);
-        assert_eq!(zero - one, minus_one);
+        assert_eq!(one.clone() - zero.clone(), one.clone());
+        assert_eq!(minus_one.clone() - zero.clone(), minus_one.clone());
+        assert_eq!(zero.clone() - one.clone(), minus_one.clone());
         assert_eq!(zero - minus_one, one);
     }
 
@@ -466,14 +342,14 @@ mod tests {
         let minus_three = SignedField::negative(3_u32);
         let minus_six = SignedField::negative(6_u32);
 
-        assert_eq!(two * three, six); // positive * positive
-        assert_eq!(two * minus_three, minus_six); // positive * negative
-        assert_eq!(minus_two * three, minus_six); // negative * positive
-        assert_eq!(minus_two * minus_three, six); // negative * negative
-        assert_eq!(two * zero, zero);
-        assert_eq!(minus_two * zero, zero);
-        assert_eq!(zero * two, zero);
-        assert_eq!(zero * minus_two, zero);
+        assert_eq!(two.clone() * three.clone(), six.clone()); // positive * positive
+        assert_eq!(two.clone() * minus_three.clone(), minus_six.clone()); // positive * negative
+        assert_eq!(minus_two.clone() * three, minus_six); // negative * positive
+        assert_eq!(minus_two.clone() * minus_three, six); // negative * negative
+        assert_eq!(two * zero.clone(), zero.clone());
+        assert_eq!(minus_two * zero.clone(), zero.clone());
+        assert_eq!(zero.clone() * SignedField::positive(2_u32), zero.clone());
+        assert_eq!(zero.clone() * SignedField::negative(2_u32), zero);
     }
 
     #[test]
@@ -486,35 +362,32 @@ mod tests {
         let minus_three = SignedField::negative(3_u32);
         let minus_six = SignedField::negative(6_u32);
 
-        assert_eq!(six / two, three); // positive / positive
-        assert_eq!(six / minus_three, minus_two); // positive / negative
-        assert_eq!(minus_six / three, minus_two); // negative / positive
-        assert_eq!(minus_six / minus_three, two); // negative / negative
-        assert_eq!(zero / two, zero);
-        assert_eq!(zero / minus_two, zero);
+        assert_eq!(six.clone() / two.clone(), three.clone()); // positive / positive
+        assert_eq!(six / minus_three.clone(), minus_two.clone()); // positive / negative
+        assert_eq!(minus_six.clone() / three, minus_two); // negative / positive
+        assert_eq!(minus_six / minus_three, two.clone()); // negative / negative
+        assert_eq!(zero.clone() / two, zero.clone());
+        assert_eq!(zero / SignedField::negative(2_u32), SignedField::zero());
     }
 
     #[test]
     fn is_zero() {
         assert!(SignedField::zero().is_zero());
-        assert!(SignedField::negative(FieldElement::zero()).is_zero());
+        assert!(SignedField::negative(0u32).is_zero());
         assert!(!SignedField::one().is_zero());
     }
 
     #[test]
     fn is_one() {
         assert!(SignedField::one().is_one());
-        assert!(!SignedField::negative(FieldElement::one()).is_one());
+        assert!(!SignedField::negative(1u32).is_one());
         assert!(!SignedField::zero().is_one());
     }
 
     #[test]
     fn to_i128() {
-        assert_eq!(SignedField::positive(FieldElement::from(i128::MAX)).to_i128(), i128::MAX);
-        assert_eq!(
-            SignedField::negative(FieldElement::from((i128::MAX as u128) + 1)).to_i128(),
-            i128::MIN
-        );
+        assert_eq!(SignedField::from(i128::MAX).to_i128(), i128::MAX);
+        assert_eq!(SignedField::from(i128::MIN).to_i128(), i128::MIN);
     }
 
     #[test]
@@ -524,13 +397,14 @@ mod tests {
         assert_eq!(SignedField::from(i128::MIN + 1).to_i128(), i128::MIN + 1);
     }
 
+    // negative(1) and from_field_element(-1) (p-1) share a field element but are
+    // distinct integers.
     #[test]
-    fn equality() {
-        let a = SignedField::negative(FieldElement::one());
-        let b = SignedField::positive(-FieldElement::one());
-        assert_eq!(a, a);
-        assert_eq!(b, b);
-        assert_eq!(a, b);
-        assert_eq!(b, a);
+    fn de_conflated_field_equality() {
+        let neg_one = SignedField::negative(1u32);
+        let field_neg_one = SignedField::from_field_element(-FieldElement::one());
+
+        assert_ne!(neg_one, field_neg_one);
+        assert_eq!(neg_one.to_field_element(), field_neg_one.to_field_element());
     }
 }


### PR DESCRIPTION
## Summary

The frontend represents numeric literals and compile-time constants using the field element type (`FieldElement`), and evaluates integer casts by routing the value through a field element. This bakes in assumptions that only hold when the field is large relative to the integer types — that any integer round-trips through a field element unchanged, and that an integer literal can never exceed the field modulus.

This makes the representation independent of the field. **No change to the surface language or to observable behaviour** — a cleanup that removes an implicit dependency on the choice of field.

## Changes

- **`SignedField`** (the carrier for numeric literals and compile-time constants) was `(FieldElement, is_negative)` and is now a `BigInt`. Construction, arithmetic, equality and ordering are exact integer operations; the field is consulted only at the explicit materialization points (`to_field_element`, `absolute_value`, `from_field_element`). This also removes the hand-rolled sign-magnitude arithmetic and `INT_MIN` special-casing the field-element magnitude required.
- **`Token::Int`** carries a `SignedField` instead of a `FieldElement`; the lexer stores the parsed literal exactly instead of reducing it modulo the field characteristic.
- **Integer-to-integer casts** in the comptime interpreter are evaluated on the integer bit pattern directly instead of through a field element. Casts that genuinely involve a `Field` (or produce a `Bool`) keep the existing path.
- **`Type::integral_maximum_size`** returns a `SignedField` (matching `integral_minimum_size`) instead of a `FieldElement`, and the remaining places that built an integer as a field element only to wrap it straight back into a `SignedField` (enum discriminants, comparison-operator orderings, `SignedField::to_u128`) construct it directly.

## Note

The serde representation of `SignedField` changes as a result, so serialized artifacts containing constants are not wire-compatible across this change.

## Testing

The full `noirc_frontend` test suite and clippy pass; no test for any field other than the currently-supported one was added.
