### PR TITLE
fix(frontend): disallow pub on fold function parameters and return

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/function.rs
+++ b/compiler/noirc_frontend/src/elaborator/function.rs
@@ -504,10 +504,12 @@ impl Elaborator<'_> {
         }
     }
 
-    /// True if the `pub` keyword is allowed on parameters in this function
-    /// `pub` on function parameters is only allowed for entry point functions
+    /// True if the `pub` keyword is allowed on parameters in this function.
+    /// `pub` on function parameters is only allowed for entry point functions: a `#[fold]`
+    /// function is compiled to its own circuit but is only ever called internally, so its
+    /// inputs are not public inputs of the program.
     fn pub_allowed(&self, func: &NoirFunction, in_contract: bool, is_crate_root: bool) -> bool {
-        func.is_entry_point(in_contract, is_crate_root) || func.attributes().is_foldable()
+        func.is_entry_point(in_contract, is_crate_root)
     }
 
     /// Resolves function parameters and validates their types for entry points.
@@ -637,8 +639,7 @@ impl Elaborator<'_> {
         self.run_lint(|_| lints::no_predicates_on_entry_point(func, modifiers).map(Into::into));
         self.run_lint(|_| lints::missing_pub(func, modifiers).map(Into::into));
         self.run_lint(|_| {
-            let pub_allowed = func.is_entry_point || modifiers.attributes.is_foldable();
-            lints::unnecessary_pub_return(func, modifiers, pub_allowed).map(Into::into)
+            lints::unnecessary_pub_return(func, modifiers, func.is_entry_point).map(Into::into)
         });
         self.run_lint(|_| lints::oracle_not_marked_unconstrained(func, modifiers).map(Into::into));
         self.run_lint(|_| lints::oracle_returns_multiple_vectors(func, modifiers).map(Into::into));

--- a/compiler/noirc_frontend/src/tests/visibility.rs
+++ b/compiler/noirc_frontend/src/tests/visibility.rs
@@ -863,6 +863,40 @@ fn unnecessary_pub_on_argument() {
 }
 
 #[test]
+fn unnecessary_pub_on_fold_function_parameter() {
+    let src = "
+    fn main(x: Field) -> pub Field {
+        foo(x)
+    }
+
+    #[fold]
+    fn foo(x: pub Field) -> Field {
+              ^^^ unnecessary pub keyword on parameter for function foo
+              ~~~ unnecessary pub parameter
+        x + 1
+    }
+    ";
+    check_errors(src);
+}
+
+#[test]
+fn unnecessary_pub_on_fold_function_return_type() {
+    let src = "
+    fn main(x: Field) -> pub Field {
+        foo(x)
+    }
+
+    #[fold]
+    fn foo(x: Field) -> pub Field {
+                        ^^^ unnecessary pub keyword on return type for function foo
+                        ~~~ unnecessary pub return type
+        x + 1
+    }
+    ";
+    check_errors(src);
+}
+
+#[test]
 fn errors_if_calling_private_inherent_impl_method_from_outside_impl_module() {
     // Regression test: inherent impl methods defined in a submodule on a type from the parent
     // module should not be callable from outside the impl's defining module.


### PR DESCRIPTION
## Summary

Resolves noir-lang/noir-claude#1269, taking the approach suggested in review of #12883: rather than plumbing fold parameter visibility through ACIR generation, we disallow public inputs on `#[fold]` functions entirely.

A `#[fold]` function is compiled to its own circuit but is only ever called internally via ACIR calls — its inputs and outputs are not public inputs/outputs of the program. Allowing `pub` on a fold function's parameters or return type was therefore meaningless, and (as the linked issue showed) could corrupt the public/private interface of the emitted fold circuit.

## Change

`pub` was special-cased to be allowed on foldable functions in two places in the elaborator (parameter and return-type checks). This removes that exception, so `#[fold]` functions are treated like any other non-entry-point function: `pub` on a parameter or the return type is rejected with the existing "unnecessary pub" error.

```noir
#[fold]
fn foo(x: pub Field) -> Field { x + 1 }
//        ^^^ unnecessary pub keyword on parameter for function foo
```

## Breaking change

Programs that previously compiled with `pub` on a `#[fold]` function's parameters or return type will now fail to compile. No in-tree test program or stdlib function relied on this (verified by scanning all `.nr` sources).

## Testing

- New regression tests `unnecessary_pub_on_fold_function_parameter` and `unnecessary_pub_on_fold_function_return_type` in `compiler/noirc_frontend/src/tests/visibility.rs`.
- Full `noirc_frontend` lib suite (1829) passes; `nargo_cli` fold execution tests (133) pass.
- clippy + fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
