### PR TITLE
chore(ssa): Return `false` from `Intrinsic::has_side_effect` for `VectorInsert`

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/ir/instruction.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/instruction.rs
@@ -199,13 +199,14 @@ impl Intrinsic {
             Intrinsic::ToBits(_) | Intrinsic::ToRadix(_) => true,
 
             // These imply a check that the vector is non-empty and should fail otherwise.
-            Intrinsic::VectorPopBack | Intrinsic::VectorPopFront | Intrinsic::VectorRemove | Intrinsic::VectorInsert => true,
+            Intrinsic::VectorPopBack | Intrinsic::VectorPopFront | Intrinsic::VectorRemove => true,
 
             Intrinsic::ArrayLen
             | Intrinsic::ArrayAsStrUnchecked
             | Intrinsic::AsVector
             | Intrinsic::VectorPushBack
             | Intrinsic::VectorPushFront
+            | Intrinsic::VectorInsert
             | Intrinsic::StrAsBytes
             | Intrinsic::IsUnconstrained
             | Intrinsic::DerivePedersenGenerators


### PR DESCRIPTION
## Problem Resolved

Follow up for https://github.com/noir-lang/noir/pull/11703/

## Summary of Changes

`Intrinsic::has_side_effect` had a comment for `VectorInsert` that the only reason it can fail is if the vector is empty, but since #11703 this is no longer true, we can always insert into an empty vector at index 0. 

The comments on `VectorInsert` note that there are assumed to be other checks to verify that we are not attempting to insert at an OOB index, ie. that `0 <= index <= length`, so the operation shouldn't fail because of this.

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
