### PR TITLE
fix: reject comptime oracle functions

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/function.rs
+++ b/compiler/noirc_frontend/src/elaborator/function.rs
@@ -648,6 +648,7 @@ impl Elaborator<'_> {
             lints::unnecessary_pub_return(func, modifiers, func.is_entry_point).map(Into::into)
         });
         self.run_lint(|_| lints::oracle_not_marked_unconstrained(func, modifiers).map(Into::into));
+        self.run_lint(|_| lints::oracle_marked_as_comptime(modifiers, func).map(Into::into));
         self.run_lint(|_| lints::oracle_returns_multiple_vectors(func, modifiers).map(Into::into));
         self.run_lint(|_| lints::oracle_returns_reference(func, modifiers).map(Into::into));
         self.run_lint(|_| {

--- a/compiler/noirc_frontend/src/elaborator/lints.rs
+++ b/compiler/noirc_frontend/src/elaborator/lints.rs
@@ -139,6 +139,28 @@ pub(super) fn oracle_not_marked_unconstrained(
     }
 }
 
+/// Oracle definitions (functions with the `#[oracle]` attribute) cannot be marked as comptime.
+///
+/// An oracle is resolved at runtime by the external oracle handler, whereas a `comptime` function
+/// is evaluated at compile time, so the two are fundamentally incompatible.
+pub(super) fn oracle_marked_as_comptime(
+    modifiers: &FunctionModifiers,
+    func: &FuncMeta,
+) -> Option<ResolverError> {
+    if !modifiers.is_comptime {
+        return None;
+    }
+
+    let attribute = modifiers.attributes.function()?;
+    if attribute.kind.is_oracle() {
+        let ident = func_meta_name_ident(func, modifiers);
+        let location = attribute.location;
+        Some(ResolverError::OracleMarkedAsComptime { ident, location })
+    } else {
+        None
+    }
+}
+
 /// Oracle functions cannot return more than 1 vector in their output.
 ///
 /// This is currently a limitation with the AVM: to return multiple vectors

--- a/compiler/noirc_frontend/src/hir/resolution/errors.rs
+++ b/compiler/noirc_frontend/src/hir/resolution/errors.rs
@@ -82,6 +82,8 @@ pub enum ResolverError {
     OracleNameClashesWithStdlib { location: Location },
     #[error("Usage of the `#[oracle]` function attribute is only valid on unconstrained functions")]
     OracleMarkedAsConstrained { ident: Ident, location: Location },
+    #[error("Usage of the `#[oracle]` function attribute is not allowed on comptime functions")]
+    OracleMarkedAsComptime { ident: Ident, location: Location },
     #[error("Oracle functions cannot return multiple vectors")]
     OracleReturnsMultipleVectors { location: Location },
     #[error("Oracle functions cannot return references")]
@@ -314,6 +316,7 @@ impl ResolverError {
             | ResolverError::InlineNeverAttributeOnConstrained { location, .. }
             | ResolverError::OracleNameClashesWithStdlib { location, .. }
             | ResolverError::OracleMarkedAsConstrained { location, .. }
+            | ResolverError::OracleMarkedAsComptime { location, .. }
             | ResolverError::OracleReturnsMultipleVectors { location, .. }
             | ResolverError::OracleReturnsReference { location, .. }
             | ResolverError::OracleReturnsVectorWithNestedArray { location, .. }
@@ -564,6 +567,15 @@ impl<'a> From<&'a ResolverError> for Diagnostic {
                     *location,
                 );
                 diagnostic.add_secondary("Oracle functions must have the `unconstrained` keyword applied".into(), ident.location());
+                diagnostic
+            },
+            ResolverError::OracleMarkedAsComptime { ident, location } => {
+                let mut diagnostic = Diagnostic::simple_error(
+                    error.to_string(),
+                    String::new(),
+                    *location,
+                );
+                diagnostic.add_secondary("Oracle functions cannot be marked `comptime`".into(), ident.location());
                 diagnostic
             },
             ResolverError::OracleReturnsMultipleVectors { location } => {

--- a/compiler/noirc_frontend/src/tests/oracles.rs
+++ b/compiler/noirc_frontend/src/tests/oracles.rs
@@ -28,6 +28,24 @@ fn errors_if_oracle_declaration_has_function_body() {
 }
 
 #[test]
+fn deny_oracle_attribute_on_comptime() {
+    let src = r#"
+        #[oracle(foo)]
+        ^^^^^^^^^^^^^^ Usage of the `#[oracle]` function attribute is not allowed on comptime functions
+        pub unconstrained comptime fn foo(x: Field, y: Field) {}
+                                      ~~~ Oracle functions cannot be marked `comptime`
+
+        fn main() {
+            // safety: test
+            unsafe {
+                foo(1, 2);
+            }
+        }
+    "#;
+    check_errors(src);
+}
+
+#[test]
 fn errors_if_oracle_returns_multiple_vectors() {
     let src = r#"
     #[oracle(oracle_call)]

--- a/design/oracles.md
+++ b/design/oracles.md
@@ -3,3 +3,13 @@
 - Oracles should be able to accept & return function types even though they are lowered into
 field values during SSA. This is undocumented but shouldn't break anything. `println` currently
 would break if it weren't allowed to accept functions.
+
+# Modifier restrictions
+
+- An `#[oracle(...)]` function must be `unconstrained` (an oracle is resolved by the external
+oracle handler at runtime, which only happens in an unconstrained context).
+- An `#[oracle(...)]` function cannot be `comptime`. An oracle is resolved at runtime, whereas a
+`comptime` function is evaluated at compile time, so the two are fundamentally incompatible.
+Without this restriction a `comptime` oracle could still be called at runtime from Brillig (its
+empty body bypasses the usual "comptime functions are only callable at compile time" check),
+which contradicts the meaning of `comptime`.


### PR DESCRIPTION
## Summary

It was possible to define a `comptime` `#[oracle(...)]` function and call it at runtime from Brillig in an unconstrained context:

```noir
#[oracle(my_oracle_func)]
unconstrained comptime fn hello() {}

fn main() {
    unsafe {
        hello();
    }
}
```

An oracle is resolved by the external oracle handler at runtime, whereas a `comptime` function is evaluated at compile time, so the two are fundamentally incompatible. The oracle's empty body bypasses the usual "comptime functions are only callable at compile time" check, so a function declared `comptime` (compile-time-only) ended up executable at runtime — contradicting the meaning of `comptime`.

This PR rejects the combination during elaboration with a new `OracleMarkedAsComptime` resolver error.

Resolves https://cantina.xyz/code/af01d57f-6e50-4de3-ad6d-7e9f7ff2d7d1/findings/5
Resolves https://linear.app/aztec-foundation/issue/NRSEC-994

## Changes

- New `oracle_marked_as_comptime` lint in `elaborator/lints.rs`, registered in `run_function_lints`.
- New `OracleMarkedAsComptime` `ResolverError` variant + diagnostic.
- Regression test `deny_oracle_attribute_on_comptime` (written first, confirmed failing before the fix).
- Recorded the design decision in `design/oracles.md`.

## Notes

While here I audited the other attribute/modifier combinations. The codegen/inlining attributes (`#[fold]`, `#[no_predicates]`, `#[inline_always]`, `#[inline_never]`) are silently accepted on `comptime` functions where they do nothing, since a comptime-only function never reaches SSA/ACIR. Those are harmless dead annotations (no soundness issue) so they're left out of this PR; happy to add lints for them as a follow-up if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)