### PR TITLE
chore: clarify unbound type variable handling in monomorphization

### DIFF
--- a/compiler/noirc_frontend/src/monomorphization/mod.rs
+++ b/compiler/noirc_frontend/src/monomorphization/mod.rs
@@ -1828,6 +1828,7 @@ impl<'interner> Monomorphizer<'interner> {
                 if let TypeBinding::Bound(binding) = &*type_var.borrow() {
                     return Self::convert_type_helper(binding, location, seen_types);
                 }
+                // This used to default to Field, but doing so could result in an invalid SSA.
                 return Err(MonomorphizationError::NoDefaultType { location });
             }
 

--- a/compiler/noirc_frontend/src/monomorphization/mod.rs
+++ b/compiler/noirc_frontend/src/monomorphization/mod.rs
@@ -1838,12 +1838,6 @@ impl<'interner> Monomorphizer<'interner> {
             }
 
             HirType::TypeVariable(binding) => {
-                let input_type = typ.as_ref().clone();
-                if !seen_types.insert(input_type.clone()) {
-                    let typ = input_type;
-                    return Err(MonomorphizationError::RecursiveType { typ, location });
-                }
-
                 let type_var_kind = match &*binding.borrow() {
                     // `convert_type_helper` resolves its input with `follow_bindings_shallow`,
                     // which substitutes bound type variables before we reach this match, so any

--- a/compiler/noirc_frontend/src/monomorphization/mod.rs
+++ b/compiler/noirc_frontend/src/monomorphization/mod.rs
@@ -1857,10 +1857,9 @@ impl<'interner> Monomorphizer<'interner> {
 
                 let monomorphized_default =
                     Self::convert_type_helper(&default, location, seen_types)?;
+
                 binding.bind(default);
 
-                // No need to remove `input_type` from `seen_types`: the type variable is now bound,
-                // so `follow_bindings_shallow` substitutes it away and it is never traversed here again.
                 monomorphized_default
             }
 

--- a/compiler/noirc_frontend/src/monomorphization/mod.rs
+++ b/compiler/noirc_frontend/src/monomorphization/mod.rs
@@ -1837,30 +1837,10 @@ impl<'interner> Monomorphizer<'interner> {
                 Self::convert_type_helper(to, location, seen_types)?
             }
 
-            HirType::TypeVariable(binding) => {
-                let type_var_kind = match &*binding.borrow() {
-                    // `convert_type_helper` resolves its input with `follow_bindings_shallow`,
-                    // which substitutes bound type variables before we reach this match, so any
-                    // type variable that gets here is necessarily unbound.
-                    TypeBinding::Bound(_) => {
-                        unreachable!("Bound type variables are resolved by follow_bindings_shallow")
-                    }
-                    TypeBinding::Unbound(_, type_var_kind) => type_var_kind.clone(),
-                };
-
-                // Default any remaining unbound type variables.
-                // This should only happen if the variable in question is unused
-                // and within a larger generic type.
-                let Some(default) = type_var_kind.default_type() else {
-                    return Err(MonomorphizationError::NoDefaultType { location });
-                };
-
-                let monomorphized_default =
-                    Self::convert_type_helper(&default, location, seen_types)?;
-
-                binding.bind(default);
-
-                monomorphized_default
+            HirType::TypeVariable(_) => {
+                unreachable!(
+                    "All type variables should already be bound at this point, and the follow_bindings_shallow call above should have went through them."
+                )
             }
 
             HirType::DataType(def, args) => {

--- a/compiler/noirc_frontend/src/monomorphization/mod.rs
+++ b/compiler/noirc_frontend/src/monomorphization/mod.rs
@@ -1823,24 +1823,17 @@ impl<'interner> Monomorphizer<'interner> {
             HirType::TraitAsType(..) => {
                 unreachable!("All TraitAsType should be replaced before calling convert_type");
             }
-            HirType::NamedGeneric(NamedGeneric { type_var, .. }) => {
+            HirType::NamedGeneric(NamedGeneric { type_var, .. })
+            | HirType::TypeVariable(type_var) => {
                 if let TypeBinding::Bound(binding) = &*type_var.borrow() {
                     return Self::convert_type_helper(binding, location, seen_types);
                 }
-                // This used to default to Field, but doing so could result in an invalid SSA.
                 return Err(MonomorphizationError::NoDefaultType { location });
             }
 
             HirType::CheckedCast { from, to } => {
                 Self::check_checked_cast(from, to, location)?;
                 Self::convert_type_helper(to, location, seen_types)?
-            }
-
-            HirType::TypeVariable(type_var) => {
-                let TypeBinding::Bound(binding) = &*type_var.borrow() else {
-                    return Err(MonomorphizationError::NoDefaultType { location });
-                };
-                return Self::convert_type_helper(binding, location, seen_types);
             }
 
             HirType::DataType(def, args) => {

--- a/compiler/noirc_frontend/src/monomorphization/mod.rs
+++ b/compiler/noirc_frontend/src/monomorphization/mod.rs
@@ -1773,8 +1773,7 @@ impl<'interner> Monomorphizer<'interner> {
         location: Location,
         seen_types: &mut HashSet<Type>,
     ) -> Result<ast::Type, MonomorphizationError> {
-        let typ = typ.follow_bindings_shallow();
-        Ok(match typ.as_ref() {
+        Ok(match typ {
             HirType::FieldElement => ast::Type::Field,
             HirType::Integer(sign, bits) => ast::Type::Integer(*sign, *bits),
             HirType::Bool => ast::Type::Bool,
@@ -1837,10 +1836,11 @@ impl<'interner> Monomorphizer<'interner> {
                 Self::convert_type_helper(to, location, seen_types)?
             }
 
-            HirType::TypeVariable(_) => {
-                unreachable!(
-                    "All type variables should already be bound at this point, and the follow_bindings_shallow call above should have went through them."
-                )
+            HirType::TypeVariable(type_var) => {
+                let TypeBinding::Bound(binding) = &*type_var.borrow() else {
+                    return Err(MonomorphizationError::NoDefaultType { location });
+                };
+                return Self::convert_type_helper(binding, location, seen_types);
             }
 
             HirType::DataType(def, args) => {
@@ -1850,7 +1850,7 @@ impl<'interner> Monomorphizer<'interner> {
                     Self::check_type(arg, location)?;
                 }
 
-                let input_type = typ.as_ref().clone();
+                let input_type = typ.clone();
                 if !seen_types.insert(input_type.clone()) {
                     let typ = input_type;
                     return Err(MonomorphizationError::RecursiveType { typ, location });

--- a/compiler/noirc_frontend/src/monomorphization/mod.rs
+++ b/compiler/noirc_frontend/src/monomorphization/mod.rs
@@ -1845,10 +1845,11 @@ impl<'interner> Monomorphizer<'interner> {
                 }
 
                 let type_var_kind = match &*binding.borrow() {
-                    TypeBinding::Bound(binding) => {
-                        let typ = Self::convert_type_helper(binding, location, seen_types);
-                        seen_types.remove(&input_type);
-                        return typ;
+                    // `convert_type_helper` resolves its input with `follow_bindings_shallow`,
+                    // which substitutes bound type variables before we reach this match, so any
+                    // type variable that gets here is necessarily unbound.
+                    TypeBinding::Bound(_) => {
+                        unreachable!("Bound type variables are resolved by follow_bindings_shallow")
                     }
                     TypeBinding::Unbound(_, type_var_kind) => type_var_kind.clone(),
                 };
@@ -1863,6 +1864,9 @@ impl<'interner> Monomorphizer<'interner> {
                 let monomorphized_default =
                     Self::convert_type_helper(&default, location, seen_types)?;
                 binding.bind(default);
+
+                // No need to remove `input_type` from `seen_types`: the type variable is now bound,
+                // so `follow_bindings_shallow` substitutes it away and it is never traversed here again.
                 monomorphized_default
             }
 

--- a/compiler/noirc_frontend/src/monomorphization/mod.rs
+++ b/compiler/noirc_frontend/src/monomorphization/mod.rs
@@ -1844,10 +1844,11 @@ impl<'interner> Monomorphizer<'interner> {
                     Self::check_type(arg, location)?;
                 }
 
-                let input_type = typ.clone();
-                if !seen_types.insert(input_type.clone()) {
-                    let typ = input_type;
-                    return Err(MonomorphizationError::RecursiveType { typ, location });
+                if !seen_types.insert(typ.clone()) {
+                    return Err(MonomorphizationError::RecursiveType {
+                        typ: typ.clone(),
+                        location,
+                    });
                 }
 
                 let def = def.borrow();
@@ -1856,7 +1857,7 @@ impl<'interner> Monomorphizer<'interner> {
                         Self::convert_type_helper(&field, location, seen_types)
                     })?;
 
-                    seen_types.remove(&input_type);
+                    seen_types.remove(typ);
                     ast::Type::Tuple(fields)
                 } else if let Some(variants) = def.get_variants(args) {
                     // Enums are represented as (tag, variant1, variant2, .., variantN)
@@ -1867,7 +1868,7 @@ impl<'interner> Monomorphizer<'interner> {
                         })?;
                         fields.push(ast::Type::Tuple(variant_fields));
                     }
-                    seen_types.remove(&input_type);
+                    seen_types.remove(typ);
                     ast::Type::Tuple(fields)
                 } else {
                     unreachable!("Data type has no body")


### PR DESCRIPTION
## Summary

Addresses an audit finding about `convert_type_helper` in the monomorphizer (`compiler/noirc_frontend/src/monomorphization/mod.rs`). The report flagged an asymmetry: in the `Type::TypeVariable` arm, the input type is inserted into `seen_types` (used to detect infinitely recursive types), but on the path where the variable has no binding and is defaulted, it is never removed — unlike the bound path, which removes it. The concern was that this could cause valid types (e.g. a tuple referencing the same type variable twice) to fail to compile with a spurious `RecursiveType` error.

## Investigation

The described impact is **not reachable**, because `convert_type_helper` resolves its input with `follow_bindings_shallow` at the top of the function. That substitutes away bound type variables (and aliases) before the match runs. Consequently:

- A `Type::TypeVariable` only ever reaches the `TypeVariable` arm while **unbound** — so the `TypeBinding::Bound` branch (the *only* place that removed `input_type` from `seen_types`) is **dead code**.
- On the live (unbound) path the variable is bound to its default before returning. Any later occurrence of the same variable — e.g. the second element of a `(T, T)` tuple — is substituted away by `follow_bindings_shallow` and never re-reaches the seen-check. So the check can't fire spuriously, and the stale `seen_types` entry is harmless (it is keyed by the unbound-variable hash and nothing else can collide with it).

This was confirmed empirically: instrumenting both the bound arm and the seen-check and compiling all 976 programs under `test_programs/` showed the bound arm executed **0 times** and the type-variable seen-check fired **0 times**. A `(x, x)` program compiles fine.

## Change

Purely a clarity fix — **no behavior change**:

- Replace the dead `TypeBinding::Bound` branch with `unreachable!`, documenting the `follow_bindings_shallow` invariant rather than carrying logic that can never run.
- Add a comment on the defaulting path explaining why no `seen_types.remove` is needed (the variable is now bound and is substituted away on any later traversal).

## Testing

There is intentionally **no regression test**: the flagged scenario is unreachable from Noir source, so there is no red-to-green behavior to capture. Verification:

- `cargo nextest run -p noirc_frontend` — 1844 passed
- `cargo nextest run -p nargo_cli --test execute` — 8821 passed
- Instrumentation sweep over all 976 `test_programs/` confirming the `unreachable!` invariant holds

Resolves audit issue https://app.audithub.dev/app/organizations/161/projects/787/project-viewer?version=1681&issueId=1006 and https://linear.app/aztec-foundation/issue/NRSEC-118

🤖 Generated with [Claude Code](https://claude.com/claude-code)