### PR TITLE
fix: Check failures in intermediate CheckedCasts in monomorphization

### DIFF
--- a/compiler/noirc_frontend/src/hir/type_check/errors.rs
+++ b/compiler/noirc_frontend/src/hir/type_check/errors.rs
@@ -317,6 +317,18 @@ impl TypeCheckError {
         matches!(self, TypeCheckError::NonConstantEvaluated { .. })
     }
 
+    /// True for errors describing an arithmetic failure on constant operands
+    /// (the closed set of errors producible by [BinaryTypeOperator::function]),
+    /// as opposed to errors meaning an expression could not be reduced to a constant.
+    pub(crate) fn is_constant_arithmetic_failure(&self) -> bool {
+        matches!(
+            self,
+            TypeCheckError::OverflowingBinaryOp { .. }
+                | TypeCheckError::DivisionByZero { .. }
+                | TypeCheckError::ModuloOnFields { .. }
+        )
+    }
+
     pub fn location(&self) -> Location {
         match self {
             TypeCheckError::DivisionByZero { location, .. }

--- a/compiler/noirc_frontend/src/hir/type_check/errors.rs
+++ b/compiler/noirc_frontend/src/hir/type_check/errors.rs
@@ -41,6 +41,8 @@ pub enum TypeCheckError {
     DivisionByZero { lhs: Integer, rhs: Integer, location: Location },
     #[error("Modulo on Field elements: {lhs} % {rhs}")]
     ModuloOnFields { lhs: FieldElement, rhs: FieldElement, location: Location },
+    #[error("Modulo by zero: {lhs} % {rhs}")]
+    ModuloByZero { lhs: Integer, rhs: Integer, location: Location },
     #[error("The value `{expr}` cannot fit into `{ty}` which has range `{range}`")]
     IntegerLiteralDoesNotFitItsType {
         expr: FieldElement,
@@ -326,6 +328,7 @@ impl TypeCheckError {
             TypeCheckError::OverflowingBinaryOp { .. }
                 | TypeCheckError::DivisionByZero { .. }
                 | TypeCheckError::ModuloOnFields { .. }
+                | TypeCheckError::ModuloByZero { .. }
         )
     }
 
@@ -333,6 +336,7 @@ impl TypeCheckError {
         match self {
             TypeCheckError::DivisionByZero { location, .. }
             | TypeCheckError::ModuloOnFields { location, .. }
+            | TypeCheckError::ModuloByZero { location, .. }
             | TypeCheckError::IntegerLiteralDoesNotFitItsType { location, .. }
             | TypeCheckError::OverflowingConstant { location, .. }
             | TypeCheckError::OverflowingBinaryOp { location, .. }
@@ -614,6 +618,7 @@ impl<'a> From<&'a TypeCheckError> for Diagnostic {
             | TypeCheckError::IntegerLiteralDoesNotFitItsType { location, .. }
             | TypeCheckError::OverflowingConstant { location, .. }
             | TypeCheckError::OverflowingBinaryOp { location, .. }
+            | TypeCheckError::ModuloByZero { location, .. }
             | TypeCheckError::FieldModulo { location }
             | TypeCheckError::FieldNot { location }
             | TypeCheckError::ConstrainedReferenceToUnconstrained { location }

--- a/compiler/noirc_frontend/src/hir_def/types.rs
+++ b/compiler/noirc_frontend/src/hir_def/types.rs
@@ -2479,27 +2479,26 @@ impl Type {
             Type::CheckedCast { from, to } => {
                 let to_value = to.evaluate_to_integer(target_kind, location)?;
 
-                // if both 'to' and 'from' evaluate to a constant,
-                // return None unless they match
-                let skip_simplifications = false;
-                if let Ok(from_value) =
-                    from.evaluate_to_integer_helper(target_kind, location, skip_simplifications)
-                {
-                    if to_value == from_value {
-                        Ok(to_value)
-                    } else {
-                        let to = *to;
-                        let from = *from;
-                        Err(TypeCheckError::TypeCanonicalizationMismatch {
-                            to,
-                            from,
-                            to_value,
-                            from_value,
-                            location,
-                        })
-                    }
-                } else {
-                    Ok(to_value)
+                // Evaluate `from` without simplifications so that arithmetic errors in
+                // intermediate steps (which simplification may have removed from `to`)
+                // are still caught.
+                let run_simplifications = false;
+                match from.evaluate_to_integer_helper(target_kind, location, run_simplifications) {
+                    // If both `to` and `from` evaluate to a constant they must match
+                    Ok(from_value) if from_value == to_value => Ok(to_value),
+                    Ok(from_value) => Err(TypeCheckError::TypeCanonicalizationMismatch {
+                        to: *to,
+                        from: *from,
+                        to_value,
+                        from_value,
+                        location,
+                    }),
+                    // A definite arithmetic failure (e.g. underflow) in the unsimplified
+                    // expression must be reported even though `to` evaluated successfully.
+                    Err(err) if err.is_constant_arithmetic_failure() => Err(err),
+                    // `from` may contain type variables that were simplified out of `to`,
+                    // in which case it cannot be evaluated to a constant - that is fine.
+                    Err(_) => Ok(to_value),
                 }
             }
             other => Err(TypeCheckError::NonConstantEvaluated { typ: other, location }),

--- a/compiler/noirc_frontend/src/hir_def/types.rs
+++ b/compiler/noirc_frontend/src/hir_def/types.rs
@@ -3274,6 +3274,8 @@ impl BinaryTypeOperator {
             BinaryTypeOperator::Modulo => {
                 if let (Integer::Field(lhs), Integer::Field(rhs)) = (a, b) {
                     Err(TypeCheckError::ModuloOnFields { lhs, rhs, location })
+                } else if b.is_zero() {
+                    Err(TypeCheckError::ModuloByZero { lhs: a, rhs: b, location })
                 } else {
                     (a % b).ok_or_else(make_error)
                 }

--- a/compiler/noirc_frontend/src/hir_def/types/arithmetic.rs
+++ b/compiler/noirc_frontend/src/hir_def/types/arithmetic.rs
@@ -40,9 +40,9 @@ impl Type {
     /// Only simplify constants and drop/skip any CheckedCast's
     fn canonicalize_checked_helper(&self) -> Type {
         let found_checked_cast = true;
-        let skip_simplifications = false;
+        let run_simplifications = false;
         // We expect `self` to have already called `follow_bindings`
-        self.canonicalize_helper(found_checked_cast, skip_simplifications)
+        self.canonicalize_helper(found_checked_cast, run_simplifications)
     }
 
     /// Run all simplifications and drop/skip any CheckedCast's

--- a/compiler/noirc_frontend/src/hir_def/types/arithmetic.rs
+++ b/compiler/noirc_frontend/src/hir_def/types/arithmetic.rs
@@ -512,6 +512,45 @@ mod tests {
         let expected_result = u32t(64);
         assert_eq!(infix_canonicalized, expected_result);
     }
+
+    #[test]
+    fn errors_from_binary_type_operator_function_are_constant_arithmetic_failures() {
+        // `TypeCheckError::is_constant_arithmetic_failure` documents itself as matching
+        // the closed set of errors producible by `BinaryTypeOperator::function`, so every
+        // failure case of `function` must be in that set. An error missing from the set
+        // would be silently tolerated when evaluating the `from` side of a `CheckedCast`
+        // (see `Type::evaluate_to_integer_helper`).
+        use crate::hir::comptime::Integer;
+        use noirc_errors::Location;
+
+        let location = Location::dummy();
+        let field_zero = Integer::Field(FieldElement::zero());
+
+        let failures = [
+            BinaryTypeOperator::Division.function(Integer::U32(1), Integer::U32(0), location),
+            BinaryTypeOperator::Modulo.function(Integer::U32(1), Integer::U32(0), location),
+            BinaryTypeOperator::Modulo.function(field_zero, field_zero, location),
+            BinaryTypeOperator::Subtraction.function(Integer::U32(0), Integer::U32(1), location),
+            BinaryTypeOperator::Addition.function(
+                Integer::U32(u32::MAX),
+                Integer::U32(1),
+                location,
+            ),
+            BinaryTypeOperator::Multiplication.function(
+                Integer::U32(u32::MAX),
+                Integer::U32(2),
+                location,
+            ),
+        ];
+
+        for failure in failures {
+            let err = failure.expect_err("operation should fail");
+            assert!(
+                err.is_constant_arithmetic_failure(),
+                "expected a constant arithmetic failure, but got: {err:?}"
+            );
+        }
+    }
 }
 
 #[cfg(test)]

--- a/compiler/noirc_frontend/src/monomorphization/errors.rs
+++ b/compiler/noirc_frontend/src/monomorphization/errors.rs
@@ -17,6 +17,7 @@ pub enum MonomorphizationError {
     ComptimeTypeInRuntimeCode { typ: String, location: Location },
     CheckedTransmuteFailed { actual: String, expected: String, location: Location },
     CheckedCastFailed { actual: String, expected: Type, location: Location },
+    CheckedCastEvaluationFailed { err: TypeCheckError, location: Location },
     RecursiveType { typ: Type, location: Location },
     CannotComputeAssociatedConstant { name: String, err: TypeCheckError, location: Location },
     ReferenceReturnedFromIfOrMatch { typ: String, location: Location },
@@ -45,6 +46,7 @@ impl MonomorphizationError {
             | MonomorphizationError::ComptimeTypeInRuntimeCode { location, .. }
             | MonomorphizationError::CheckedTransmuteFailed { location, .. }
             | MonomorphizationError::CheckedCastFailed { location, .. }
+            | MonomorphizationError::CheckedCastEvaluationFailed { location, .. }
             | MonomorphizationError::RecursiveType { location, .. }
             | MonomorphizationError::NoDefaultType { location, .. }
             | MonomorphizationError::ReferenceReturnedFromIfOrMatch { location, .. }
@@ -90,6 +92,9 @@ impl From<MonomorphizationError> for CustomDiagnostic {
             MonomorphizationError::CheckedCastFailed { actual, expected, .. } => {
                 format!("Arithmetic generics simplification failed: `{actual:?}` != `{expected:?}`")
             }
+            // Show the underlying type-check error (e.g. a division by zero)
+            // as the user-facing diagnostic.
+            MonomorphizationError::CheckedCastEvaluationFailed { err, .. } => return err.into(),
             MonomorphizationError::NoDefaultType { location } => {
                 let message = "Type annotation needed".into();
                 let secondary = "Could not determine type of generic argument".into();

--- a/compiler/noirc_frontend/src/monomorphization/mod.rs
+++ b/compiler/noirc_frontend/src/monomorphization/mod.rs
@@ -2090,9 +2090,11 @@ impl<'interner> Monomorphizer<'interner> {
         }
         let to_value = to.evaluate_to_integer(&to.kind(), location);
         if let Ok(to_value) = to_value {
-            let skip_simplifications = false;
+            // Evaluate `from` without simplifications so that arithmetic errors in
+            // intermediate steps are still caught.
+            let run_simplifications = false;
             let from_value =
-                from.evaluate_to_integer_helper(&to.kind(), location, skip_simplifications);
+                from.evaluate_to_integer_helper(&to.kind(), location, run_simplifications);
             if from_value.is_err() || from_value.unwrap() != to_value {
                 return Err(MonomorphizationError::CheckedCastFailed {
                     actual: to_value.to_string(),

--- a/compiler/noirc_frontend/src/monomorphization/mod.rs
+++ b/compiler/noirc_frontend/src/monomorphization/mod.rs
@@ -2073,9 +2073,9 @@ impl<'interner> Monomorphizer<'interner> {
         }
     }
 
-    /// Check that the 'from' and to' sides of a `CheckedCast` unify and
-    /// that if the 'to' side evaluates to a field element, then the 'from' side
-    /// evaluates to the same field element as well.
+    /// Check that the 'from' and 'to' sides of a `CheckedCast` unify, that the 'to' side
+    /// evaluates to an integer without failing (e.g. with a division by zero), and that
+    /// the 'from' side evaluates to that same integer.
     fn check_checked_cast(
         from: &Type,
         to: &Type,
@@ -2088,20 +2088,29 @@ impl<'interner> Monomorphizer<'interner> {
                 location,
             });
         }
-        let to_value = to.evaluate_to_integer(&to.kind(), location);
-        if let Ok(to_value) = to_value {
-            // Evaluate `from` without simplifications so that arithmetic errors in
-            // intermediate steps are still caught.
-            let run_simplifications = false;
-            let from_value =
-                from.evaluate_to_integer_helper(&to.kind(), location, run_simplifications);
-            if from_value.is_err() || from_value.unwrap() != to_value {
-                return Err(MonomorphizationError::CheckedCastFailed {
-                    actual: to_value.to_string(),
-                    expected: from.clone(),
-                    location,
-                });
+        let to_value = match to.evaluate_to_integer(&to.kind(), location) {
+            Ok(to_value) => to_value,
+            // A destination that is not yet a constant (it still contains an unbound,
+            // defaultable generic) is handled by the surrounding type conversion, which
+            // will either default the variable or error with `NoDefaultType`.
+            Err(err) if err.is_non_constant_evaluated() => return Ok(()),
+            // Any other failure (division by zero, modulo by zero, overflow, ...) means
+            // the destination type is invalid for the concrete generic values.
+            Err(err) => {
+                return Err(MonomorphizationError::CheckedCastEvaluationFailed { err, location });
             }
+        };
+
+        // Evaluate `from` without simplifications so that arithmetic errors in
+        // intermediate steps are still caught.
+        let run_simplifications = false;
+        let from_value = from.evaluate_to_integer_helper(&to.kind(), location, run_simplifications);
+        if from_value.is_err() || from_value.unwrap() != to_value {
+            return Err(MonomorphizationError::CheckedCastFailed {
+                actual: to_value.to_string(),
+                expected: from.clone(),
+                location,
+            });
         }
         Ok(())
     }

--- a/compiler/noirc_frontend/src/tests/arithmetic_generics.rs
+++ b/compiler/noirc_frontend/src/tests/arithmetic_generics.rs
@@ -10,7 +10,9 @@ use crate::hir::type_check::TypeCheckError;
 use crate::hir_def::types::BinaryTypeOperator;
 use crate::monomorphization::errors::MonomorphizationError;
 use crate::test_utils::get_monomorphized;
-use crate::tests::{assert_no_errors, check_errors, get_program_errors};
+use crate::tests::{
+    assert_no_errors, check_errors, check_monomorphization_error, get_program_errors,
+};
 
 #[test]
 fn arithmetic_generics_canonicalization_deduplication_regression() {
@@ -77,24 +79,11 @@ fn arithmetic_generics_intermediate_underflow_simplified_out_of_to() {
 
         fn main() {
             let _x = intermediate_underflow::<0>();
+                     ^^^^^^^^^^^^^^^^^^^^^^ Invalid array length
+                     ~~~~~~~~~~~~~~~~~~~~~~ `0 - 1` in the arithmetic generics here would overflow the bounds of a(n) `u32`
         }
     "#;
-
-    let monomorphization_error = get_monomorphized(source).unwrap_err();
-
-    // Expect a (0 - 1) underflow failure
-    if let MonomorphizationError::UnknownArrayLength { ref err, location: _ } =
-        monomorphization_error
-    {
-        let TypeCheckError::OverflowingBinaryOp { op, lhs, rhs, .. } = err else {
-            panic!("Expected OverflowingBinaryOp, but found: {err:?}");
-        };
-        assert_eq!(op, &BinaryTypeOperator::Subtraction);
-        assert_eq!(*lhs, Integer::U32(0));
-        assert_eq!(*rhs, Integer::U32(1));
-    } else {
-        panic!("unexpected error: {monomorphization_error:?}");
-    }
+    check_monomorphization_error(source);
 }
 
 #[test]
@@ -112,8 +101,7 @@ fn arithmetic_generics_intermediate_expression_with_no_underflow() {
             let _x = intermediate_underflow::<5>();
         }
     "#;
-
-    assert!(get_monomorphized(source).is_ok());
+    check_monomorphization_error(source);
 }
 
 #[test]

--- a/compiler/noirc_frontend/src/tests/arithmetic_generics.rs
+++ b/compiler/noirc_frontend/src/tests/arithmetic_generics.rs
@@ -61,6 +61,62 @@ fn checked_casts_do_not_prevent_canonicalization() {
 }
 
 #[test]
+fn arithmetic_generics_intermediate_underflow_simplified_out_of_to() {
+    // The type expression `(N - 1) + 1` creates a CheckedCast where:
+    //   from = (N - 1) + 1   (unsimplified, preserves intermediate steps)
+    //   to   = N             (simplified via (X - M) + M -> X)
+    //
+    // With N = 0, the `(0 - 1)` subexpression of `from` underflows u32 even though
+    // the simplified `to` side evaluates to 0 without error. The underflow in the
+    // unsimplified expression must still be reported.
+    let source = r#"
+        fn intermediate_underflow<let N: u32>() -> [Field; (N - 1) + 1] {
+            let result: [Field; N] = [0; N];
+            result
+        }
+
+        fn main() {
+            let _x = intermediate_underflow::<0>();
+        }
+    "#;
+
+    let monomorphization_error = get_monomorphized(source).unwrap_err();
+
+    // Expect a (0 - 1) underflow failure
+    if let MonomorphizationError::UnknownArrayLength { ref err, location: _ } =
+        monomorphization_error
+    {
+        let TypeCheckError::OverflowingBinaryOp { op, lhs, rhs, .. } = err else {
+            panic!("Expected OverflowingBinaryOp, but found: {err:?}");
+        };
+        assert_eq!(op, &BinaryTypeOperator::Subtraction);
+        assert_eq!(*lhs, Integer::U32(0));
+        assert_eq!(*rhs, Integer::U32(1));
+    } else {
+        panic!("unexpected error: {monomorphization_error:?}");
+    }
+}
+
+#[test]
+fn arithmetic_generics_intermediate_expression_with_no_underflow() {
+    // Companion to `arithmetic_generics_intermediate_underflow_simplified_out_of_to`:
+    // with N = 5 no intermediate step of `(N - 1) + 1` over/underflows, so the
+    // program must compile.
+    let source = r#"
+        fn intermediate_underflow<let N: u32>() -> [Field; (N - 1) + 1] {
+            let result: [Field; N] = [0; N];
+            result
+        }
+
+        fn main() {
+            let _x = intermediate_underflow::<5>();
+        }
+    "#;
+
+    assert!(get_monomorphized(source).is_ok());
+}
+
+#[test]
 fn arithmetic_generics_checked_cast_zeros() {
     let source = r#"
         struct W<let N: u32> {}

--- a/compiler/noirc_frontend/src/tests/arithmetic_generics.rs
+++ b/compiler/noirc_frontend/src/tests/arithmetic_generics.rs
@@ -7,7 +7,6 @@ use test_case::test_case;
 
 use crate::hir::comptime::Integer;
 use crate::hir::type_check::TypeCheckError;
-use crate::hir_def::types::BinaryTypeOperator;
 use crate::monomorphization::errors::MonomorphizationError;
 use crate::test_utils::get_monomorphized;
 use crate::tests::{
@@ -127,13 +126,12 @@ fn arithmetic_generics_checked_cast_zeros() {
     let monomorphization_error = get_monomorphized(source).unwrap_err();
 
     // Expect a CheckedCast (0 % 0) failure
-    if let MonomorphizationError::UnknownArrayLength { ref err, location: _ } =
+    if let MonomorphizationError::CheckedCastEvaluationFailed { ref err, location: _ } =
         monomorphization_error
     {
-        let TypeCheckError::OverflowingBinaryOp { op, lhs, rhs, .. } = err else {
-            panic!("Expected FailingBinaryOp, but found: {err:?}");
+        let TypeCheckError::ModuloByZero { lhs, rhs, .. } = err else {
+            panic!("Expected ModuloByZero, but found: {err:?}");
         };
-        assert_eq!(op, &BinaryTypeOperator::Modulo);
         assert_eq!(*lhs, Integer::U32(0));
         assert_eq!(*rhs, Integer::U32(0));
     } else {
@@ -164,7 +162,7 @@ fn arithmetic_generics_checked_cast_indirect_zeros() {
     let monomorphization_error = get_monomorphized(source).unwrap_err();
 
     // Expect a CheckedCast (0 % 0) failure
-    if let MonomorphizationError::UnknownArrayLength { ref err, location: _ } =
+    if let MonomorphizationError::CheckedCastEvaluationFailed { ref err, location: _ } =
         monomorphization_error
     {
         match err {
@@ -177,6 +175,47 @@ fn arithmetic_generics_checked_cast_indirect_zeros() {
     } else {
         panic!("unexpected error: {monomorphization_error:?}");
     }
+}
+
+#[test]
+fn arithmetic_generics_checked_cast_fails_to_evaluate_destination() {
+    // A CheckedCast whose destination type fails to evaluate (here `N % N`
+    // with N = 0) must be a compilation error, even when the value is never
+    // forced to a runtime value elsewhere.
+    let source = r#"
+        struct W<let N: u32> {}
+
+        fn foo<let N: u32>(_x: W<N>) -> W<(0 * N) / (N % N)> {
+            W {}
+        }
+
+        fn main() {
+            let w_0: W<0> = W {};
+            let _w = foo(w_0);
+                     ^^^ Modulo by zero: 0 % 0
+        }
+    "#;
+    check_monomorphization_error(source);
+}
+
+#[test]
+fn arithmetic_generics_checked_cast_fails_to_evaluate_field_destination() {
+    // Same as `arithmetic_generics_checked_cast_fails_to_evaluate_destination`
+    // but with a `Field` generic, where modulo is rejected outright.
+    let source = r#"
+        struct W<let N: Field> {}
+
+        fn foo<let N: Field>(_x: W<N>) -> W<(N - N) % (N - N)> {
+            W {}
+        }
+
+        fn main() {
+            let w_0: W<0Field> = W {};
+            let _w = foo(w_0);
+                     ^^^ Modulo on Field elements: 0 % 0
+        }
+    "#;
+    check_monomorphization_error(source);
 }
 
 #[test]
@@ -471,4 +510,30 @@ fn field_arithmetic_generic_large_value() {
         }
     "#;
     assert_no_errors(src);
+}
+#[test]
+fn arithmetic_generics_modulo_by_zero_in_array_length() {
+    // With N = 0, the `N % N` subexpressions modulo by zero when the array
+    // length is evaluated at monomorphization.
+    let source = r#"
+        fn foo<let N: u32>() -> [Field; ((N % N) + 1) - (N % N)] {
+            let result: [Field; 1] = [0];
+            result
+        }
+
+        fn main() {
+            let _x = foo::<0>();
+        }
+    "#;
+
+    let monomorphization_error = get_monomorphized(source).unwrap_err();
+
+    let MonomorphizationError::UnknownArrayLength { ref err, .. } = monomorphization_error else {
+        panic!("unexpected error: {monomorphization_error:?}");
+    };
+    let TypeCheckError::ModuloByZero { lhs, rhs, .. } = err else {
+        panic!("Expected ModuloByZero, but found: {err:?}");
+    };
+    assert_eq!(*lhs, Integer::U32(0));
+    assert_eq!(*rhs, Integer::U32(0));
 }

--- a/design/arithmetic_generics.md
+++ b/design/arithmetic_generics.md
@@ -1,0 +1,40 @@
+# Arithmetic Generics
+
+## `CheckedCast` and intermediate over/underflow
+
+Arithmetic expressions over numeric generics (e.g. `(N - 1) + 1`) are simplified during
+elaboration so that types like `[Field; (N - 1) + 1]` and `[Field; N]` unify. Simplification
+can remove intermediate steps that would over/underflow at certain instantiations: `(N - 1) + 1`
+simplifies to `N`, which evaluates fine for `N = 0` even though the `(0 - 1)` step underflows
+`u32`.
+
+To keep those failures detectable, simplification does not rewrite the expression in place.
+Instead the elaborator wraps every arithmetic-generic expression in
+`Type::CheckedCast { from, to }`, where `to` is the fully simplified form (used for
+unification and evaluation) and `from` is the original expression with only constant folding
+applied (see `Type::canonicalize` in `compiler/noirc_frontend/src/hir_def/types/arithmetic.rs`).
+
+When a `CheckedCast` is evaluated to a constant (`Type::evaluate_to_integer_helper` in
+`compiler/noirc_frontend/src/hir_def/types.rs`):
+
+- `to` is evaluated first; its errors always propagate.
+- `from` is then evaluated *without* simplifications, so every intermediate step of the
+  original expression is computed on the concrete constants.
+- If both sides evaluate, their values must match (`TypeCanonicalizationMismatch` otherwise).
+- If `from` fails with a definite arithmetic failure on constant operands — the closed set of
+  errors produced by `BinaryTypeOperator::function`, see
+  `TypeCheckError::is_constant_arithmetic_failure` — that error propagates even though `to`
+  evaluated successfully. This is what rejects `(N - 1) + 1` at `N = 0`.
+- Any other failure of `from` is tolerated and `to`'s value is used. This is required because
+  `from` may contain type variables that simplification cancelled out of `to` (e.g.
+  `from = (M + N) - M`, `to = N` with `M` unbound), and because canonicalization itself
+  evaluates subexpressions speculatively while variables are still unbound.
+
+The monomorphizer's `check_checked_cast` performs a similar (stricter) check for
+`CheckedCast`s it encounters structurally, but array/string lengths never reach it: length
+types are resolved directly via `evaluate_to_u32`, so the evaluation rules above are the
+mechanism that catches intermediate over/underflow in lengths. For the same reason,
+`convert_type`/`check_type` do not recurse structurally into `from`: evaluation already
+traverses it (including nested `CheckedCast`s introduced by generic substitution), and a
+structural `check_type` on `from` could falsely reject unbound variables that were legitimately
+simplified away.

--- a/design/arithmetic_generics.md
+++ b/design/arithmetic_generics.md
@@ -31,10 +31,19 @@ When a `CheckedCast` is evaluated to a constant (`Type::evaluate_to_integer_help
   evaluates subexpressions speculatively while variables are still unbound.
 
 The monomorphizer's `check_checked_cast` performs a similar (stricter) check for
-`CheckedCast`s it encounters structurally, but array/string lengths never reach it: length
-types are resolved directly via `evaluate_to_u32`, so the evaluation rules above are the
-mechanism that catches intermediate over/underflow in lengths. For the same reason,
-`convert_type`/`check_type` do not recurse structurally into `from`: evaluation already
-traverses it (including nested `CheckedCast`s introduced by generic substitution), and a
-structural `check_type` on `from` could falsely reject unbound variables that were legitimately
-simplified away.
+`CheckedCast`s it encounters structurally (e.g. in struct generic arguments), but array/string
+lengths never reach it: length types are resolved directly via `evaluate_to_u32`, so the
+evaluation rules above are the mechanism that catches intermediate over/underflow in lengths.
+For the same reason, `convert_type`/`check_type` do not recurse structurally into `from`:
+evaluation already traverses it (including nested `CheckedCast`s introduced by generic
+substitution), and a structural `check_type` on `from` could falsely reject unbound variables
+that were legitimately simplified away.
+
+In `check_checked_cast`, a failure to evaluate the `to` side is itself a hard error
+(`MonomorphizationError::CheckedCastEvaluationFailed`, rendered as the underlying type-check
+error such as "Modulo by zero"). Without this, a destination type whose value is undefined for
+the concrete generics (e.g. `W<(0 * N) / (N % N)>` at `N = 0`) would silently skip the
+from/to comparison and compile, as long as the value was never forced elsewhere (e.g. used as
+an array length or a runtime value). The single exception is `NonConstantEvaluated`: the `to`
+side may still contain an unbound-but-defaultable generic, which the surrounding
+`convert_type`/`check_type` recursion will default or reject with `NoDefaultType`.

--- a/test_programs/compile_failure/arithmetic_generics_intermediate_underflow/src/main.nr
+++ b/test_programs/compile_failure/arithmetic_generics_intermediate_underflow/src/main.nr
@@ -9,7 +9,7 @@ fn seems_fine<let N: u32>(array: [Field; N]) -> [Field; N] {
     // But inside `seems_fine` we pop from the array which
     // requires the length to be greater than zero.
 
-    // error: Could not determine array length `(0 - 1)`
+    // error: `0 - 1` in the arithmetic generics here would overflow the bounds of a(n) `u32`
     push_zero(pop(array))
 }
 

--- a/test_programs/compile_failure/arithmetic_generics_intermediate_underflow_simplified/Nargo.toml
+++ b/test_programs/compile_failure/arithmetic_generics_intermediate_underflow_simplified/Nargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "arithmetic_generics_intermediate_underflow_simplified"
+type = "bin"
+authors = [""]
+
+[dependencies]

--- a/test_programs/compile_failure/arithmetic_generics_intermediate_underflow_simplified/src/main.nr
+++ b/test_programs/compile_failure/arithmetic_generics_intermediate_underflow_simplified/src/main.nr
@@ -1,0 +1,14 @@
+// The type expression `(N - 1) + 1` simplifies to `N`, but its unsimplified
+// form is kept so that intermediate steps are checked at monomorphization.
+// With N = 0, the `(0 - 1)` subexpression underflows u32 even though the
+// simplified form evaluates to 0 without error, so this must fail to compile.
+// Unlike `arithmetic_generics_intermediate_underflow`, where the underflow is
+// visible in the simplified form, here it only exists in an intermediate step.
+fn intermediate_underflow<let N: u32>() -> [Field; (N - 1) + 1] {
+    let result: [Field; N] = std::mem::zeroed();
+    result
+}
+
+fn main() {
+    let _x = intermediate_underflow::<0>();
+}

--- a/tooling/nargo_cli/tests/snapshots/compile_failure/arithmetic_generics_intermediate_underflow/execute__tests__stderr.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_failure/arithmetic_generics_intermediate_underflow/execute__tests__stderr.snap
@@ -2,11 +2,11 @@
 source: tooling/nargo_cli/tests/execute.rs
 expression: stderr
 ---
-error: Invalid array length
+error: `0 - 1` in the arithmetic generics here would overflow the bounds of a(n) `u32`
    ┌─ src/main.nr:13:5
    │
 13 │     push_zero(pop(array))
-   │     --------- `0 - 1` in the arithmetic generics here would overflow the bounds of a(n) `u32`
+   │     ---------
    │
 
 Aborting due to 1 previous error

--- a/tooling/nargo_cli/tests/snapshots/compile_failure/arithmetic_generics_intermediate_underflow_simplified/execute__tests__stderr.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_failure/arithmetic_generics_intermediate_underflow_simplified/execute__tests__stderr.snap
@@ -1,0 +1,12 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: stderr
+---
+error: Invalid array length
+   ┌─ src/main.nr:13:14
+   │
+13 │     let _x = intermediate_underflow::<0>();
+   │              ---------------------- `0 - 1` in the arithmetic generics here would overflow the bounds of a(n) `u32`
+   │
+
+Aborting due to 1 previous error


### PR DESCRIPTION
## Problem Resolved

Resolves https://app.audithub.dev/app/organizations/161/projects/787/project-viewer?issueId=991&version=1681

## Summary of Changes

Ensures errors from evaluating type-level arithmetic aren't silently dropped

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
