### PR TITLE
fix: checked cast destination eval

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/validation/array_set_rc_invariant.rs
+++ b/compiler/noirc_evaluator/src/ssa/validation/array_set_rc_invariant.rs
@@ -331,7 +331,7 @@ impl<'f> Context<'f> {
                         incoming_edges
                             .entry(*destination)
                             .or_default()
-                            .push((block_id, arguments.clone()));
+                            .push((block_id, arguments.to_vec()));
                         if back_edges.contains(&(block_id, *destination)) {
                             back_edge_args.extend(arguments.iter().copied());
                         }
@@ -346,11 +346,11 @@ impl<'f> Context<'f> {
                         incoming_edges
                             .entry(*then_destination)
                             .or_default()
-                            .push((block_id, then_arguments.clone()));
+                            .push((block_id, then_arguments.to_vec()));
                         incoming_edges
                             .entry(*else_destination)
                             .or_default()
-                            .push((block_id, else_arguments.clone()));
+                            .push((block_id, else_arguments.to_vec()));
                         if back_edges.contains(&(block_id, *then_destination)) {
                             back_edge_args.extend(then_arguments.iter().copied());
                         }
@@ -658,7 +658,8 @@ impl<'f> Context<'f> {
             }
 
             let instructions = self.function.dfg[block].instructions();
-            for inst_id in instructions.iter().skip(start_idx).copied() {
+            for inst_idx in start_idx..instructions.len() {
+                let inst_id = instructions[inst_idx];
                 if inst_id == array_set_id {
                     continue;
                 }
@@ -810,7 +811,7 @@ impl<'f> Context<'f> {
     ///      This keeps alias propagation accurate at joins and loop
     ///      back-edges.
     ///    - Otherwise (both in or both out), no change.
-    ///      Only array-typed params participate.
+    ///    Only array-typed params participate.
     ///
     /// 2. **Unconditional kill — instructions defined in `dest`.** For
     ///    each alias-set member whose defining block is `dest`: drop it.

--- a/compiler/noirc_evaluator/src/ssa/validation/array_set_rc_invariant.rs
+++ b/compiler/noirc_evaluator/src/ssa/validation/array_set_rc_invariant.rs
@@ -331,7 +331,7 @@ impl<'f> Context<'f> {
                         incoming_edges
                             .entry(*destination)
                             .or_default()
-                            .push((block_id, arguments.to_vec()));
+                            .push((block_id, arguments.clone()));
                         if back_edges.contains(&(block_id, *destination)) {
                             back_edge_args.extend(arguments.iter().copied());
                         }
@@ -346,11 +346,11 @@ impl<'f> Context<'f> {
                         incoming_edges
                             .entry(*then_destination)
                             .or_default()
-                            .push((block_id, then_arguments.to_vec()));
+                            .push((block_id, then_arguments.clone()));
                         incoming_edges
                             .entry(*else_destination)
                             .or_default()
-                            .push((block_id, else_arguments.to_vec()));
+                            .push((block_id, else_arguments.clone()));
                         if back_edges.contains(&(block_id, *then_destination)) {
                             back_edge_args.extend(then_arguments.iter().copied());
                         }
@@ -658,8 +658,7 @@ impl<'f> Context<'f> {
             }
 
             let instructions = self.function.dfg[block].instructions();
-            for inst_idx in start_idx..instructions.len() {
-                let inst_id = instructions[inst_idx];
+            for inst_id in instructions.iter().skip(start_idx).copied() {
                 if inst_id == array_set_id {
                     continue;
                 }
@@ -811,7 +810,7 @@ impl<'f> Context<'f> {
     ///      This keeps alias propagation accurate at joins and loop
     ///      back-edges.
     ///    - Otherwise (both in or both out), no change.
-    ///    Only array-typed params participate.
+    ///      Only array-typed params participate.
     ///
     /// 2. **Unconditional kill — instructions defined in `dest`.** For
     ///    each alias-set member whose defining block is `dest`: drop it.

--- a/compiler/noirc_frontend/src/hir/type_check/errors.rs
+++ b/compiler/noirc_frontend/src/hir/type_check/errors.rs
@@ -41,6 +41,8 @@ pub enum TypeCheckError {
     DivisionByZero { lhs: Integer, rhs: Integer, location: Location },
     #[error("Modulo on Field elements: {lhs} % {rhs}")]
     ModuloOnFields { lhs: FieldElement, rhs: FieldElement, location: Location },
+    #[error("Modulo by zero: {lhs} % {rhs}")]
+    ModuloByZero { lhs: Integer, rhs: Integer, location: Location },
     #[error("The value `{expr}` cannot fit into `{ty}` which has range `{range}`")]
     IntegerLiteralDoesNotFitItsType {
         expr: FieldElement,
@@ -333,6 +335,7 @@ impl TypeCheckError {
         match self {
             TypeCheckError::DivisionByZero { location, .. }
             | TypeCheckError::ModuloOnFields { location, .. }
+            | TypeCheckError::ModuloByZero { location, .. }
             | TypeCheckError::IntegerLiteralDoesNotFitItsType { location, .. }
             | TypeCheckError::OverflowingConstant { location, .. }
             | TypeCheckError::OverflowingBinaryOp { location, .. }
@@ -614,6 +617,7 @@ impl<'a> From<&'a TypeCheckError> for Diagnostic {
             | TypeCheckError::IntegerLiteralDoesNotFitItsType { location, .. }
             | TypeCheckError::OverflowingConstant { location, .. }
             | TypeCheckError::OverflowingBinaryOp { location, .. }
+            | TypeCheckError::ModuloByZero { location, .. }
             | TypeCheckError::FieldModulo { location }
             | TypeCheckError::FieldNot { location }
             | TypeCheckError::ConstrainedReferenceToUnconstrained { location }

--- a/compiler/noirc_frontend/src/hir/type_check/errors.rs
+++ b/compiler/noirc_frontend/src/hir/type_check/errors.rs
@@ -328,6 +328,7 @@ impl TypeCheckError {
             TypeCheckError::OverflowingBinaryOp { .. }
                 | TypeCheckError::DivisionByZero { .. }
                 | TypeCheckError::ModuloOnFields { .. }
+                | TypeCheckError::ModuloByZero { .. }
         )
     }
 

--- a/compiler/noirc_frontend/src/hir_def/types.rs
+++ b/compiler/noirc_frontend/src/hir_def/types.rs
@@ -3274,6 +3274,8 @@ impl BinaryTypeOperator {
             BinaryTypeOperator::Modulo => {
                 if let (Integer::Field(lhs), Integer::Field(rhs)) = (a, b) {
                     Err(TypeCheckError::ModuloOnFields { lhs, rhs, location })
+                } else if b.is_zero() {
+                    Err(TypeCheckError::ModuloByZero { lhs: a, rhs: b, location })
                 } else {
                     (a % b).ok_or_else(make_error)
                 }

--- a/compiler/noirc_frontend/src/hir_def/types/arithmetic.rs
+++ b/compiler/noirc_frontend/src/hir_def/types/arithmetic.rs
@@ -512,6 +512,45 @@ mod tests {
         let expected_result = u32t(64);
         assert_eq!(infix_canonicalized, expected_result);
     }
+
+    #[test]
+    fn errors_from_binary_type_operator_function_are_constant_arithmetic_failures() {
+        // `TypeCheckError::is_constant_arithmetic_failure` documents itself as matching
+        // the closed set of errors producible by `BinaryTypeOperator::function`, so every
+        // failure case of `function` must be in that set. An error missing from the set
+        // would be silently tolerated when evaluating the `from` side of a `CheckedCast`
+        // (see `Type::evaluate_to_integer_helper`).
+        use crate::hir::comptime::Integer;
+        use noirc_errors::Location;
+
+        let location = Location::dummy();
+        let field_zero = Integer::Field(FieldElement::zero());
+
+        let failures = [
+            BinaryTypeOperator::Division.function(Integer::U32(1), Integer::U32(0), location),
+            BinaryTypeOperator::Modulo.function(Integer::U32(1), Integer::U32(0), location),
+            BinaryTypeOperator::Modulo.function(field_zero, field_zero, location),
+            BinaryTypeOperator::Subtraction.function(Integer::U32(0), Integer::U32(1), location),
+            BinaryTypeOperator::Addition.function(
+                Integer::U32(u32::MAX),
+                Integer::U32(1),
+                location,
+            ),
+            BinaryTypeOperator::Multiplication.function(
+                Integer::U32(u32::MAX),
+                Integer::U32(2),
+                location,
+            ),
+        ];
+
+        for failure in failures {
+            let err = failure.expect_err("operation should fail");
+            assert!(
+                err.is_constant_arithmetic_failure(),
+                "expected a constant arithmetic failure, but got: {err:?}"
+            );
+        }
+    }
 }
 
 #[cfg(test)]

--- a/compiler/noirc_frontend/src/monomorphization/errors.rs
+++ b/compiler/noirc_frontend/src/monomorphization/errors.rs
@@ -17,6 +17,7 @@ pub enum MonomorphizationError {
     ComptimeTypeInRuntimeCode { typ: String, location: Location },
     CheckedTransmuteFailed { actual: String, expected: String, location: Location },
     CheckedCastFailed { actual: String, expected: Type, location: Location },
+    CheckedCastEvaluationFailed { err: TypeCheckError, location: Location },
     RecursiveType { typ: Type, location: Location },
     CannotComputeAssociatedConstant { name: String, err: TypeCheckError, location: Location },
     ReferenceReturnedFromIfOrMatch { typ: String, location: Location },
@@ -45,6 +46,7 @@ impl MonomorphizationError {
             | MonomorphizationError::ComptimeTypeInRuntimeCode { location, .. }
             | MonomorphizationError::CheckedTransmuteFailed { location, .. }
             | MonomorphizationError::CheckedCastFailed { location, .. }
+            | MonomorphizationError::CheckedCastEvaluationFailed { location, .. }
             | MonomorphizationError::RecursiveType { location, .. }
             | MonomorphizationError::NoDefaultType { location, .. }
             | MonomorphizationError::ReferenceReturnedFromIfOrMatch { location, .. }
@@ -90,6 +92,9 @@ impl From<MonomorphizationError> for CustomDiagnostic {
             MonomorphizationError::CheckedCastFailed { actual, expected, .. } => {
                 format!("Arithmetic generics simplification failed: `{actual:?}` != `{expected:?}`")
             }
+            // Show the underlying type-check error (e.g. a division by zero)
+            // as the user-facing diagnostic.
+            MonomorphizationError::CheckedCastEvaluationFailed { err, .. } => return err.into(),
             MonomorphizationError::NoDefaultType { location } => {
                 let message = "Type annotation needed".into();
                 let secondary = "Could not determine type of generic argument".into();

--- a/compiler/noirc_frontend/src/monomorphization/mod.rs
+++ b/compiler/noirc_frontend/src/monomorphization/mod.rs
@@ -2104,8 +2104,7 @@ impl<'interner> Monomorphizer<'interner> {
         // Evaluate `from` without simplifications so that arithmetic errors in
         // intermediate steps are still caught.
         let run_simplifications = false;
-        let from_value =
-            from.evaluate_to_integer_helper(&to.kind(), location, run_simplifications);
+        let from_value = from.evaluate_to_integer_helper(&to.kind(), location, run_simplifications);
         if from_value.is_err() || from_value.unwrap() != to_value {
             return Err(MonomorphizationError::CheckedCastFailed {
                 actual: to_value.to_string(),

--- a/compiler/noirc_frontend/src/monomorphization/mod.rs
+++ b/compiler/noirc_frontend/src/monomorphization/mod.rs
@@ -2073,9 +2073,9 @@ impl<'interner> Monomorphizer<'interner> {
         }
     }
 
-    /// Check that the 'from' and to' sides of a `CheckedCast` unify and
-    /// that if the 'to' side evaluates to a field element, then the 'from' side
-    /// evaluates to the same field element as well.
+    /// Check that the 'from' and 'to' sides of a `CheckedCast` unify, that the 'to' side
+    /// evaluates to an integer without failing (e.g. with a division by zero), and that
+    /// the 'from' side evaluates to that same integer.
     fn check_checked_cast(
         from: &Type,
         to: &Type,
@@ -2088,20 +2088,30 @@ impl<'interner> Monomorphizer<'interner> {
                 location,
             });
         }
-        let to_value = to.evaluate_to_integer(&to.kind(), location);
-        if let Ok(to_value) = to_value {
-            // Evaluate `from` without simplifications so that arithmetic errors in
-            // intermediate steps are still caught.
-            let run_simplifications = false;
-            let from_value =
-                from.evaluate_to_integer_helper(&to.kind(), location, run_simplifications);
-            if from_value.is_err() || from_value.unwrap() != to_value {
-                return Err(MonomorphizationError::CheckedCastFailed {
-                    actual: to_value.to_string(),
-                    expected: from.clone(),
-                    location,
-                });
+        let to_value = match to.evaluate_to_integer(&to.kind(), location) {
+            Ok(to_value) => to_value,
+            // A destination that is not yet a constant (it still contains an unbound,
+            // defaultable generic) is handled by the surrounding type conversion, which
+            // will either default the variable or error with `NoDefaultType`.
+            Err(err) if err.is_non_constant_evaluated() => return Ok(()),
+            // Any other failure (division by zero, modulo by zero, overflow, ...) means
+            // the destination type is invalid for the concrete generic values.
+            Err(err) => {
+                return Err(MonomorphizationError::CheckedCastEvaluationFailed { err, location });
             }
+        };
+
+        // Evaluate `from` without simplifications so that arithmetic errors in
+        // intermediate steps are still caught.
+        let run_simplifications = false;
+        let from_value =
+            from.evaluate_to_integer_helper(&to.kind(), location, run_simplifications);
+        if from_value.is_err() || from_value.unwrap() != to_value {
+            return Err(MonomorphizationError::CheckedCastFailed {
+                actual: to_value.to_string(),
+                expected: from.clone(),
+                location,
+            });
         }
         Ok(())
     }

--- a/compiler/noirc_frontend/src/tests/arithmetic_generics.rs
+++ b/compiler/noirc_frontend/src/tests/arithmetic_generics.rs
@@ -532,3 +532,29 @@ fn field_arithmetic_generic_large_value() {
     "#;
     assert_no_errors(src);
 }
+#[test]
+fn arithmetic_generics_modulo_by_zero_in_array_length() {
+    // With N = 0, the `N % N` subexpressions modulo by zero when the array
+    // length is evaluated at monomorphization.
+    let source = r#"
+        fn foo<let N: u32>() -> [Field; ((N % N) + 1) - (N % N)] {
+            let result: [Field; 1] = [0];
+            result
+        }
+
+        fn main() {
+            let _x = foo::<0>();
+        }
+    "#;
+
+    let monomorphization_error = get_monomorphized(source).unwrap_err();
+
+    let MonomorphizationError::UnknownArrayLength { ref err, .. } = monomorphization_error else {
+        panic!("unexpected error: {monomorphization_error:?}");
+    };
+    let TypeCheckError::ModuloByZero { lhs, rhs, .. } = err else {
+        panic!("Expected ModuloByZero, but found: {err:?}");
+    };
+    assert_eq!(*lhs, Integer::U32(0));
+    assert_eq!(*rhs, Integer::U32(0));
+}

--- a/compiler/noirc_frontend/src/tests/arithmetic_generics.rs
+++ b/compiler/noirc_frontend/src/tests/arithmetic_generics.rs
@@ -7,7 +7,6 @@ use test_case::test_case;
 
 use crate::hir::comptime::Integer;
 use crate::hir::type_check::TypeCheckError;
-use crate::hir_def::types::BinaryTypeOperator;
 use crate::monomorphization::errors::MonomorphizationError;
 use crate::test_utils::get_monomorphized;
 use crate::tests::{
@@ -193,20 +192,10 @@ fn arithmetic_generics_checked_cast_fails_to_evaluate_destination() {
         fn main() {
             let w_0: W<0> = W {};
             let _w = foo(w_0);
+                     ^^^ Modulo by zero: 0 % 0
         }
     "#;
-
-    let monomorphization_error = get_monomorphized(source).unwrap_err();
-
-    let MonomorphizationError::CheckedCastEvaluationFailed { ref err, .. } = monomorphization_error
-    else {
-        panic!("unexpected error: {monomorphization_error:?}");
-    };
-    let TypeCheckError::ModuloByZero { lhs, rhs, .. } = err else {
-        panic!("Expected ModuloByZero, but found: {err:?}");
-    };
-    assert_eq!(*lhs, Integer::U32(0));
-    assert_eq!(*rhs, Integer::U32(0));
+    check_monomorphization_error(source);
 }
 
 #[test]
@@ -223,20 +212,10 @@ fn arithmetic_generics_checked_cast_fails_to_evaluate_field_destination() {
         fn main() {
             let w_0: W<0Field> = W {};
             let _w = foo(w_0);
+                     ^^^ Modulo on Field elements: 0 % 0
         }
     "#;
-
-    let monomorphization_error = get_monomorphized(source).unwrap_err();
-
-    let MonomorphizationError::CheckedCastEvaluationFailed { ref err, .. } = monomorphization_error
-    else {
-        panic!("unexpected error: {monomorphization_error:?}");
-    };
-    let TypeCheckError::ModuloOnFields { lhs, rhs, .. } = err else {
-        panic!("Expected ModuloOnFields, but found: {err:?}");
-    };
-    assert_eq!(*lhs, FieldElement::zero());
-    assert_eq!(*rhs, FieldElement::zero());
+    check_monomorphization_error(source);
 }
 
 #[test]

--- a/compiler/noirc_frontend/src/tests/arithmetic_generics.rs
+++ b/compiler/noirc_frontend/src/tests/arithmetic_generics.rs
@@ -127,13 +127,12 @@ fn arithmetic_generics_checked_cast_zeros() {
     let monomorphization_error = get_monomorphized(source).unwrap_err();
 
     // Expect a CheckedCast (0 % 0) failure
-    if let MonomorphizationError::UnknownArrayLength { ref err, location: _ } =
+    if let MonomorphizationError::CheckedCastEvaluationFailed { ref err, location: _ } =
         monomorphization_error
     {
-        let TypeCheckError::OverflowingBinaryOp { op, lhs, rhs, .. } = err else {
-            panic!("Expected FailingBinaryOp, but found: {err:?}");
+        let TypeCheckError::ModuloByZero { lhs, rhs, .. } = err else {
+            panic!("Expected ModuloByZero, but found: {err:?}");
         };
-        assert_eq!(op, &BinaryTypeOperator::Modulo);
         assert_eq!(*lhs, Integer::U32(0));
         assert_eq!(*rhs, Integer::U32(0));
     } else {
@@ -164,7 +163,7 @@ fn arithmetic_generics_checked_cast_indirect_zeros() {
     let monomorphization_error = get_monomorphized(source).unwrap_err();
 
     // Expect a CheckedCast (0 % 0) failure
-    if let MonomorphizationError::UnknownArrayLength { ref err, location: _ } =
+    if let MonomorphizationError::CheckedCastEvaluationFailed { ref err, location: _ } =
         monomorphization_error
     {
         match err {
@@ -177,6 +176,67 @@ fn arithmetic_generics_checked_cast_indirect_zeros() {
     } else {
         panic!("unexpected error: {monomorphization_error:?}");
     }
+}
+
+#[test]
+fn arithmetic_generics_checked_cast_fails_to_evaluate_destination() {
+    // A CheckedCast whose destination type fails to evaluate (here `N % N`
+    // with N = 0) must be a compilation error, even when the value is never
+    // forced to a runtime value elsewhere.
+    let source = r#"
+        struct W<let N: u32> {}
+
+        fn foo<let N: u32>(_x: W<N>) -> W<(0 * N) / (N % N)> {
+            W {}
+        }
+
+        fn main() {
+            let w_0: W<0> = W {};
+            let _w = foo(w_0);
+        }
+    "#;
+
+    let monomorphization_error = get_monomorphized(source).unwrap_err();
+
+    let MonomorphizationError::CheckedCastEvaluationFailed { ref err, .. } = monomorphization_error
+    else {
+        panic!("unexpected error: {monomorphization_error:?}");
+    };
+    let TypeCheckError::ModuloByZero { lhs, rhs, .. } = err else {
+        panic!("Expected ModuloByZero, but found: {err:?}");
+    };
+    assert_eq!(*lhs, Integer::U32(0));
+    assert_eq!(*rhs, Integer::U32(0));
+}
+
+#[test]
+fn arithmetic_generics_checked_cast_fails_to_evaluate_field_destination() {
+    // Same as `arithmetic_generics_checked_cast_fails_to_evaluate_destination`
+    // but with a `Field` generic, where modulo is rejected outright.
+    let source = r#"
+        struct W<let N: Field> {}
+
+        fn foo<let N: Field>(_x: W<N>) -> W<(N - N) % (N - N)> {
+            W {}
+        }
+
+        fn main() {
+            let w_0: W<0Field> = W {};
+            let _w = foo(w_0);
+        }
+    "#;
+
+    let monomorphization_error = get_monomorphized(source).unwrap_err();
+
+    let MonomorphizationError::CheckedCastEvaluationFailed { ref err, .. } = monomorphization_error
+    else {
+        panic!("unexpected error: {monomorphization_error:?}");
+    };
+    let TypeCheckError::ModuloOnFields { lhs, rhs, .. } = err else {
+        panic!("Expected ModuloOnFields, but found: {err:?}");
+    };
+    assert_eq!(*lhs, FieldElement::zero());
+    assert_eq!(*rhs, FieldElement::zero());
 }
 
 #[test]

--- a/design/arithmetic_generics.md
+++ b/design/arithmetic_generics.md
@@ -31,10 +31,19 @@ When a `CheckedCast` is evaluated to a constant (`Type::evaluate_to_integer_help
   evaluates subexpressions speculatively while variables are still unbound.
 
 The monomorphizer's `check_checked_cast` performs a similar (stricter) check for
-`CheckedCast`s it encounters structurally, but array/string lengths never reach it: length
-types are resolved directly via `evaluate_to_u32`, so the evaluation rules above are the
-mechanism that catches intermediate over/underflow in lengths. For the same reason,
-`convert_type`/`check_type` do not recurse structurally into `from`: evaluation already
-traverses it (including nested `CheckedCast`s introduced by generic substitution), and a
-structural `check_type` on `from` could falsely reject unbound variables that were legitimately
-simplified away.
+`CheckedCast`s it encounters structurally (e.g. in struct generic arguments), but array/string
+lengths never reach it: length types are resolved directly via `evaluate_to_u32`, so the
+evaluation rules above are the mechanism that catches intermediate over/underflow in lengths.
+For the same reason, `convert_type`/`check_type` do not recurse structurally into `from`:
+evaluation already traverses it (including nested `CheckedCast`s introduced by generic
+substitution), and a structural `check_type` on `from` could falsely reject unbound variables
+that were legitimately simplified away.
+
+In `check_checked_cast`, a failure to evaluate the `to` side is itself a hard error
+(`MonomorphizationError::CheckedCastEvaluationFailed`, rendered as the underlying type-check
+error such as "Modulo by zero"). Without this, a destination type whose value is undefined for
+the concrete generics (e.g. `W<(0 * N) / (N % N)>` at `N = 0`) would silently skip the
+from/to comparison and compile, as long as the value was never forced elsewhere (e.g. used as
+an array length or a runtime value). The single exception is `NonConstantEvaluated`: the `to`
+side may still contain an unbound-but-defaultable generic, which the surrounding
+`convert_type`/`check_type` recursion will default or reject with `NoDefaultType`.

--- a/test_programs/compile_failure/arithmetic_generics_intermediate_underflow/src/main.nr
+++ b/test_programs/compile_failure/arithmetic_generics_intermediate_underflow/src/main.nr
@@ -9,7 +9,7 @@ fn seems_fine<let N: u32>(array: [Field; N]) -> [Field; N] {
     // But inside `seems_fine` we pop from the array which
     // requires the length to be greater than zero.
 
-    // error: Could not determine array length `(0 - 1)`
+    // error: `0 - 1` in the arithmetic generics here would overflow the bounds of a(n) `u32`
     push_zero(pop(array))
 }
 

--- a/tooling/nargo_cli/tests/snapshots/compile_failure/arithmetic_generics_intermediate_underflow/execute__tests__stderr.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_failure/arithmetic_generics_intermediate_underflow/execute__tests__stderr.snap
@@ -2,11 +2,11 @@
 source: tooling/nargo_cli/tests/execute.rs
 expression: stderr
 ---
-error: Invalid array length
+error: `0 - 1` in the arithmetic generics here would overflow the bounds of a(n) `u32`
    ┌─ src/main.nr:13:5
    │
 13 │     push_zero(pop(array))
-   │     --------- `0 - 1` in the arithmetic generics here would overflow the bounds of a(n) `u32`
+   │     ---------
    │
 
 Aborting due to 1 previous error


### PR DESCRIPTION
## Problem Resolved

Resolves https://app.audithub.dev/app/organizations/161/projects/787/project-viewer?issueId=992&version=1681

## Summary of Changes

Related but separate issue to https://github.com/noir-lang/noir/pull/12919. Avoids swallowing errors in check_checked_cast

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
