### PR TITLE
fix: report "Assertion is always false" diagnostic for contract crates

### DIFF
--- a/compiler/noirc_driver/src/lib.rs
+++ b/compiler/noirc_driver/src/lib.rs
@@ -613,12 +613,7 @@ pub fn compile_main(
         return Err(compilation_warnings);
     }
 
-    // Make sure we don't hide bugs, only warnings can be silenced.
-    warnings.extend(
-        compilation_warnings
-            .into_iter()
-            .filter(|diagnostic| !options.silence_warnings || !diagnostic.is_warning()),
-    );
+    warnings.extend(drop_silenced_warnings(compilation_warnings, options));
 
     if options.print_acir {
         noirc_errors::println_to_stdout!("Compiled ACIR for main:");
@@ -669,6 +664,10 @@ pub fn compile_contract(
             return Err(errors);
         }
     };
+
+    let compilation_warnings =
+        vecmap(compiled_contract.warnings.clone(), ssa_report_to_custom_diagnostic);
+    errors.extend(drop_silenced_warnings(compilation_warnings, options));
 
     if has_errors(&errors, options.deny_warnings) {
         Err(errors)
@@ -1058,6 +1057,18 @@ struct Contract {
     name: String,
     functions: Vec<ContractFunctionMeta>,
     outputs: ContractOutputs,
+}
+
+/// Removes warning diagnostics when `silence_warnings` is set, while always retaining bugs
+/// so that a `silence_warnings` flag cannot hide them.
+fn drop_silenced_warnings(
+    diagnostics: Vec<CustomDiagnostic>,
+    options: &CompileOptions,
+) -> Vec<CustomDiagnostic> {
+    diagnostics
+        .into_iter()
+        .filter(|diagnostic| !options.silence_warnings || !diagnostic.is_warning())
+        .collect()
 }
 
 fn ssa_report_to_custom_diagnostic(error: SsaReport) -> CustomDiagnostic {

--- a/compiler/noirc_driver/src/lib.rs
+++ b/compiler/noirc_driver/src/lib.rs
@@ -630,7 +630,7 @@ pub fn compile_contract(
     crate_id: CrateId,
     options: &CompileOptions,
 ) -> CompilationResult<CompiledContract> {
-    let (_, warnings) = check_crate(context, crate_id, options)?;
+    let (_, mut warnings) = check_crate(context, crate_id, options)?;
 
     let def_map = context.def_map(&crate_id).expect("The local crate should be analyzed already");
     let mut contracts = def_map.get_all_contracts();
@@ -655,11 +655,10 @@ pub fn compile_contract(
     let module_id = ModuleId { krate: crate_id, local_id: module_id };
     let contract = read_contract(context, module_id, name);
 
-    let mut errors = warnings;
-
     let compiled_contract = match compile_contract_inner(context, contract, options) {
         Ok(contract) => contract,
         Err(mut more_errors) => {
+            let mut errors = warnings;
             errors.append(&mut more_errors);
             return Err(errors);
         }
@@ -667,10 +666,10 @@ pub fn compile_contract(
 
     let compilation_warnings =
         vecmap(compiled_contract.warnings.clone(), ssa_report_to_custom_diagnostic);
-    errors.extend(drop_silenced_warnings(compilation_warnings, options));
+    warnings.extend(drop_silenced_warnings(compilation_warnings, options));
 
-    if has_errors(&errors, options.deny_warnings) {
-        Err(errors)
+    if options.deny_warnings && !warnings.is_empty() {
+        Err(warnings)
     } else {
         if options.print_acir {
             for contract_function in &compiled_contract.functions {
@@ -686,8 +685,7 @@ pub fn compile_contract(
                 println!("{}", contract_function.bytecode);
             }
         }
-        // errors here is either empty or contains only warnings
-        Ok((compiled_contract, errors))
+        Ok((compiled_contract, warnings))
     }
 }
 

--- a/compiler/noirc_driver/tests/contracts.rs
+++ b/compiler/noirc_driver/tests/contracts.rs
@@ -44,6 +44,28 @@ contract Bar {}";
     Ok(())
 }
 
+fn compile_contract_with_warnings(
+    source: &str,
+) -> (noirc_artifacts::contract::CompiledContract, Vec<CustomDiagnostic>) {
+    let root = Path::new("");
+    let file_name = Path::new("main.nr");
+    let mut file_manager = file_manager_with_stdlib(root);
+    file_manager.add_file_with_source(file_name, source.to_owned()).expect(
+        "Adding source buffer to file manager should never fail when file manager is empty",
+    );
+    let parsed_files = file_manager
+        .as_file_map()
+        .all_file_ids()
+        .map(|&file_id| (file_id, parse_file(&file_manager, file_id)))
+        .collect();
+
+    let mut context = Context::new(file_manager, parsed_files);
+    let root_crate_id = prepare_crate(&mut context, file_name);
+
+    noirc_driver::compile_contract(&mut context, root_crate_id, &CompileOptions::default())
+        .expect("contract should compile successfully")
+}
+
 fn compile_contract_source(source: &str) -> noirc_artifacts::contract::CompiledContract {
     let root = Path::new("");
     let file_name = Path::new("main.nr");
@@ -64,6 +86,30 @@ fn compile_contract_source(source: &str) -> noirc_artifacts::contract::CompiledC
         noirc_driver::compile_contract(&mut context, root_crate_id, &CompileOptions::default())
             .expect("contract should compile successfully");
     contract
+}
+
+#[test]
+fn reports_always_false_assertion_for_contracts() {
+    let source = "
+fn check<let CONSTRAINED: u32, let HANDSHAKE: u32>(x: Field) -> Field {
+    if CONSTRAINED == 1 {
+        assert(HANDSHAKE == 1, \"constrained delivery requires a handshake origin\");
+    }
+    x
+}
+
+contract VanillaContract {
+    pub fn entrypoint(x: pub Field) -> pub Field {
+        crate::check::<1, 0>(x)
+    }
+}";
+
+    let (_contract, warnings) = compile_contract_with_warnings(source);
+
+    assert!(
+        warnings.iter().any(|warning| warning.message.contains("Assertion is always false")),
+        "expected an 'Assertion is always false' diagnostic, got: {warnings:?}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Description

### Problem

The compile-time `bug: Assertion is always false` diagnostic that `nargo compile` emits for a `type = "bin"` crate was **silently dropped** for an identical `type = "contract"` crate. The contract compiled with no output (exit 0), yet its bytecode contained the same unsatisfiable `AssertZero` opcode that any proving backend would reject.

Reported in #12923 (hit while reviewing `AztecProtocol/aztec-packages#23865`). Contract authors are the typical users of this compile path, so the missing diagnostic is worse here than in the bin case.

### Root cause

The diagnostic originates as an `SsaReport::Bug(InternalBug::AssertFailed { .. })` during SSA→ACIR generation ([`acir_context/mod.rs`](https://github.com/noir-lang/noir/blob/master/compiler/noirc_evaluator/src/acir/acir_context/mod.rs)), identically for bin and contract code.

- `compile_main` converts `compiled_program.warnings` via `ssa_report_to_custom_diagnostic` and merges them into the returned diagnostics, which the CLI's `report_errors` then prints.
- `compile_contract` collected the same reports onto `CompiledContract.warnings` (the artifact field) but **never** converted them or threaded them into the returned diagnostics list, so `report_errors` never saw them.

`std::static_assert` worked in contracts because it raises a hard `RuntimeError` through the error channel that contracts already honor — only the always-false *report* channel was dropped.

### Fix

In `compile_contract`, convert the contract's SSA reports and merge them into the returned diagnostics, mirroring `compile_main`:
- true warnings are dropped only under `silence_warnings` (bugs are never silenced),
- the existing `has_errors` gate continues to honor `deny_warnings`.

The silence-filter policy is extracted into a small `drop_silenced_warnings` helper shared by both paths; `compile_main`'s `deny_warnings` handling is otherwise unchanged.

### Result

For the issue's repro contract:

```
bug: Assertion is always false: constrained delivery requires a handshake origin
  ┌─ src/main.nr:3:9
  │
3 │         assert(HANDSHAKE == 1, "constrained delivery requires a handshake origin");
  │         -------------------------------------------------------------------------- As a result, the compiled circuit is ensured to fail. ...
  = Call stack: ...
```

`nargo compile` now emits the identical `bug:` diagnostic (file:line + call stack) the bin crate produces and exits 0, and `nargo compile --deny-warnings` now exits 1 (was silently 0).

## Tests

Added `reports_always_false_assertion_for_contracts` in `compiler/noirc_driver/tests/contracts.rs`, which compiles the issue's exact repro as a contract and asserts the returned diagnostics contain "Assertion is always false". Verified red (empty diagnostics) before the fix and green after.

Fixes #12923

🤖 Generated with [Claude Code](https://claude.com/claude-code)