### PR TITLE
fix(ssa): Exclude swapped-in loop siblings from `array_set` RC alias-set in `array_set_rc_invariant`

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/ssa_gen/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/ssa_gen/mod.rs
@@ -710,7 +710,13 @@ impl FunctionContext<'_> {
             };
             let max_value = if bit_size == 128 { u128::MAX } else { (1u128 << bit_size) - 1 };
 
-            if end_constant.into_numeric_constant().0.to_u128() < max_value {
+            // Compare against the type's maximum using the *signed-aware* value: a negative
+            // signed `end` round-tripped through `to_u128` would look huge and wrongly fail
+            // this check, forcing an unnecessary final-iteration peel. `max_value` is the
+            // type's max (`2^(bit_size-1) - 1` for signed), which always fits in `i128`.
+            let end_below_max = end_constant
+                .apply(|signed| signed < max_value as i128, |unsigned| unsigned < max_value);
+            if end_below_max {
                 let end_constant_plus_one = end_constant.inc().expect(
                     "Expected to be able to increment end_constant as it's less than max_value",
                 );

--- a/compiler/noirc_evaluator/src/ssa/ssa_gen/tests.rs
+++ b/compiler/noirc_evaluator/src/ssa/ssa_gen/tests.rs
@@ -487,6 +487,47 @@ fn for_loop_inclusive_end_is_known_and_not_a_maximum() {
 }
 
 #[test]
+fn for_loop_inclusive_signed_negative_end_is_not_a_maximum() {
+    // Regression test for the peel-avoidance check using a *signed-aware* comparison.
+    // A negative signed `end` is below the type's maximum, so the inclusive loop should
+    // lower to an exclusive loop up to `end + 1` (here `-3..=-1` becomes `-3..0`) rather
+    // than peeling a final iteration. Round-tripping `end` through `to_u128` would make a
+    // negative value look huge and wrongly force the peel.
+    let assert_src = "
+    fn main() -> pub i16 {
+        let mut sum = 0;
+        for i in -3..=-1_i16 {
+          sum += i;
+        }
+        sum
+    }
+    ";
+    let ssa = get_initial_ssa(assert_src).unwrap();
+
+    // We end up generating an exclusive for loop up to 0 (no peeled final iteration).
+    assert_ssa_snapshot!(ssa, @r"
+    acir(inline) fn main f0 {
+      b0():
+        v1 = allocate -> &mut i16
+        store i16 0 at v1
+        jmp b1(i16 -3)
+      b1(v0: i16):
+        v4 = lt v0, i16 0
+        jmpif v4 then: b2(), else: b3()
+      b2():
+        v6 = load v1 -> i16
+        v7 = add v6, v0
+        store v7 at v1
+        v9 = unchecked_add v0, i16 1
+        jmp b1(v9)
+      b3():
+        v5 = load v1 -> i16
+        return v5
+    }
+    ");
+}
+
+#[test]
 fn for_loop_inclusive_max_value_with_break() {
     let assert_src = "
     unconstrained fn main(cond: bool) -> pub u8 {

--- a/compiler/noirc_evaluator/src/ssa/validation/array_set_rc_invariant.rs
+++ b/compiler/noirc_evaluator/src/ssa/validation/array_set_rc_invariant.rs
@@ -39,12 +39,25 @@
 //!    alias-set member either RPO-precedes the array_set or sits on a
 //!    non-source alias that's also a loop back-edge arg, accept — the
 //!    frontend is deliberately managing iteration aliasing.
-//! 3. **Forward walk.** Otherwise, walk the CFG forward from the array_set with
-//!    the alias-set as the initial use-set. At each block-parameter crossing
-//!    we both **kill** params that the predecessor rebinds to a non-alias and
-//!    **add** params whose arg is still an alias (so alias propagation stays
-//!    accurate as the walk crosses joins and loops). The walk maintains two
-//!    additional pieces of state:
+//! 3. **Protected-participant filter.** Before the forward walk, drop from
+//!    the use-set every non-source alias that is both a loop back-edge
+//!    *participant* (it flows — directly or through forward edges — into a
+//!    back-edge arg position) and carries its own `inc_rc`. Such a value is
+//!    RC ≥ 2 whenever it equals the source's storage, so reads of it can't
+//!    observe an in-place mutation. The gate is **per value** on that
+//!    value's own `inc_rc`: a back-edge position fed by an `inc_rc`'d value
+//!    on one predecessor edge and an unprotected value on another drops only
+//!    the protected value, leaving the unprotected one for the walk to flag.
+//!    This is what lets the verifier accept the latch-block shape (an
+//!    `inc_rc v` placed before `v` is threaded *forward* into the latch that
+//!    then closes the loop) without the unsoundness of crediting a sibling's
+//!    `inc_rc` to an unprotected value.
+//! 4. **Forward walk.** Otherwise, walk the CFG forward from the array_set with
+//!    the (filtered) alias-set as the initial use-set. At each block-parameter
+//!    crossing we both **kill** params that the predecessor rebinds to a
+//!    non-alias and **add** params whose arg is still an alias (so alias
+//!    propagation stays accurate as the walk crosses joins and loops). The
+//!    walk maintains two additional pieces of state:
 //!
 //!    - **`derived`**, the set of values that may share the source's storage
 //!      through transitive in-place chain mutations. Seeded with the
@@ -162,6 +175,7 @@ fn verify_function(function: &Function) -> RtResult<()> {
             // pre-mutation contents through an aliased name.
             if let Some(hit) = ctx.find_reachable_aliased_use(
                 &alias_set,
+                array,
                 *instruction_id,
                 block_id,
                 idx,
@@ -260,6 +274,30 @@ struct Context<'f> {
     /// set in the first place — so this signal only needs to cover
     /// loop back-edges.
     back_edge_args: HashSet<ValueId>,
+    /// The backward-alias closure of [`Context::back_edge_args`]: every
+    /// value that flows (directly or through forward block-parameter
+    /// edges) into a loop back-edge arg position. A value `v` is a
+    /// back-edge *participant* when its storage can become a loop-header
+    /// parameter's storage across a back-edge — even when `v` itself is
+    /// not the literal arg, but reaches one through a forward edge first
+    /// (e.g. `inc_rc v; jmp latch(v)` then `latch: jmp header(v)`, where
+    /// only the latch's param is the literal back-edge arg).
+    ///
+    /// Used by the **protected-participant filter** in
+    /// [`Context::find_reachable_aliased_use`]: a non-source alias that is
+    /// both a back-edge participant **and** carries its own `inc_rc` is
+    /// RC ≥ 2 whenever it equals the source's storage, so reads of it
+    /// can't observe an in-place mutation and it is dropped from the
+    /// forward walk's use-set.
+    ///
+    /// The filter is gated **per value** on that value's own `inc_rc`:
+    /// membership in this set alone never exonerates anything. This is
+    /// what keeps it sound where widening the relaxation to "some
+    /// participant has an `inc_rc`" would not — a back-edge position fed
+    /// by an `inc_rc`'d value on one predecessor edge and an unprotected
+    /// value on another only drops the protected value, leaving the
+    /// unprotected one for the forward walk to flag.
+    back_edge_participants: HashSet<ValueId>,
 }
 
 impl<'f> Context<'f> {
@@ -373,6 +411,21 @@ impl<'f> Context<'f> {
 
         let backward_aliases = compute_backward_aliases(function, &rpo, &incoming_edges);
 
+        // Backward-alias closure of the literal back-edge args: every
+        // value that can become a loop-header parameter's storage across
+        // a back-edge, including those that only reach the back-edge arg
+        // position through a forward edge first. A literal back-edge arg
+        // that is a block parameter contributes its whole backward set;
+        // an instruction result or function parameter contributes only
+        // itself (its backward set is the singleton).
+        let mut back_edge_participants: HashSet<ValueId> = HashSet::default();
+        for &arg in &back_edge_args {
+            back_edge_participants.insert(arg);
+            if let Some(arg_set) = backward_aliases.get(&arg) {
+                back_edge_participants.extend(arg_set.iter().copied());
+            }
+        }
+
         Self {
             function,
             dom_tree,
@@ -382,6 +435,7 @@ impl<'f> Context<'f> {
             iteration_local_make_arrays,
             inc_rc_locations,
             back_edge_args,
+            back_edge_participants,
         }
     }
 
@@ -613,6 +667,7 @@ impl<'f> Context<'f> {
     fn find_reachable_aliased_use(
         &self,
         alias_set: &im::HashSet<ValueId>,
+        source: ValueId,
         array_set_id: InstructionId,
         array_set_block: BasicBlockId,
         array_set_idx: usize,
@@ -620,9 +675,35 @@ impl<'f> Context<'f> {
     ) -> Option<AliasedUse> {
         let mut visited: HashMap<BasicBlockId, WalkState> = HashMap::default();
 
+        // Protected-participant filter. Drop from the use-set every
+        // non-source alias that is both a loop back-edge participant
+        // ([`Context::back_edge_participants`]) and carries its own
+        // `inc_rc`: such a value is RC ≥ 2 whenever it equals `source`'s
+        // storage (the `inc_rc` runs before it crosses the back-edge into
+        // the loop-header parameter), so reads of it can't observe an
+        // in-place mutation. Removing it also lets the per-arg kill rule
+        // in [`Context::succ_use_set`] drop the loop-header parameter on
+        // the back-edge, since the value threaded back is this protected
+        // participant rather than a still-live alias.
+        //
+        // The gate is **per value** on that value's own `inc_rc` — a
+        // sibling's `inc_rc` never exonerates an unprotected value. A
+        // back-edge position fed by an `inc_rc`'d value on one
+        // predecessor edge and an unprotected value on another drops only
+        // the former; the latter stays for the walk to flag.
+        let use_set: im::HashSet<ValueId> = alias_set
+            .iter()
+            .copied()
+            .filter(|&v| {
+                v == source
+                    || !(self.inc_rc_locations.contains_key(&v)
+                        && self.back_edge_participants.contains(&v))
+            })
+            .collect();
+
         let array_set_result = self.function.dfg.instruction_results(array_set_id)[0];
         let initial_state = WalkState {
-            use_set: alias_set.clone(),
+            use_set,
             derived: im::HashSet::unit(array_set_result),
             tainted: write_index_const.map(im::HashSet::unit),
         };
@@ -1717,6 +1798,110 @@ mod tests {
         );
     }
 
+    /// End-to-end regression for an AST-fuzzer-discovered pattern where
+    /// the `inc_rc`'d value reaches the loop back-edge through a *latch*
+    /// block rather than as the literal back-edge arg. Source-level shape
+    /// (`func_1` from the minimized repro):
+    ///
+    /// ```ignore
+    /// for _ in 0..2 {
+    ///     c.0 = if a { c.0[0] = 40; b.3 } else { [50; 1] };
+    /// }
+    /// assert(b.3[0] == 10);
+    /// ```
+    ///
+    /// The loop variable `v28` (`c.0`) is path-dependent: on the first
+    /// iteration it is the forward seed `v6`, and the `array_set v28`
+    /// mutates that (dead-after) storage; on later iterations it is `v4`
+    /// (`b.3`), threaded back as `v4 → v23 → v28`. The frontend emits
+    /// `inc_rc v4` in `b4` right before threading `v4` forward into the
+    /// latch `b6`, so by the time `v4` re-enters as `v28` its `RC ≥ 2`
+    /// and the `array_set` copies — the post-loop `array_get v4` reads
+    /// pristine storage.
+    ///
+    /// The literal back-edge arg is `v23` (the latch param), not `v4`, so
+    /// the back-edge-participant relaxation in
+    /// [`Context::some_inc_rc_precedes`] does not fire. Acceptance comes
+    /// from the protected-participant filter in
+    /// [`Context::find_reachable_aliased_use`]: `v4` is a back-edge
+    /// participant (it flows into `v23` through the forward `b4 → b6`
+    /// edge) and carries its own `inc_rc`, so it is dropped from the
+    /// use-set; the per-arg kill rule then drops `v28` along the
+    /// back-edge and the `array_get v4` is never flagged.
+    #[test]
+    fn end_to_end_inc_rcd_value_reaches_back_edge_through_latch_is_accepted() {
+        let src = r#"
+            brillig(inline) fn func_1 f0 {
+              b0(v0: u1, v4: [i32; 1], v6: [i32; 1]):
+                jmp b1(u32 0, v6)
+              b1(v14: u32, v28: [i32; 1]):
+                v15 = lt v14, u32 2
+                jmpif v15 then: b2(), else: b3()
+              b2():
+                jmpif v0 then: b4(), else: b5()
+              b3():
+                v25 = array_get v4, index u32 0 -> i32
+                constrain v25 == i32 10, "HNJ"
+                return
+              b4():
+                v20 = array_set v28, index u32 0, value i32 40
+                inc_rc v4
+                jmp b6(v4, v20)
+              b5():
+                v22 = make_array [i32 50] : [i32; 1]
+                jmp b6(v22, v28)
+              b6(v23: [i32; 1], v29: [i32; 1]):
+                v24 = unchecked_add v14, u32 1
+                jmp b1(v24, v23)
+            }"#;
+        assert_verifier_accepts_because(
+            src,
+            "v4 is a back-edge participant (flows into the latch param v23 via the forward b4->b6 edge) with its own inc_rc, so the protected-participant filter drops it and the array_get v4 is never flagged",
+        );
+    }
+
+    /// Soundness counterpart to
+    /// [`end_to_end_inc_rcd_value_reaches_back_edge_through_latch_is_accepted`]:
+    /// a latch `b6` joins two predecessors that feed the loop's back-edge
+    /// position, one carrying an `inc_rc`'d value (`v0`) and the other an
+    /// unprotected entry parameter (`v1`) with no `inc_rc`. On the path
+    /// through `b5` the loop variable becomes `v1`, and `array_set v4`
+    /// mutates `v1`'s storage in place (RC = 1); the post-loop
+    /// `array_get v1` then observes that mutation — a genuine hazard.
+    ///
+    /// The protected-participant filter must **not** be fooled into
+    /// exonerating `v1` because its *sibling* `v0` is protected: the
+    /// filter is gated per value on that value's own `inc_rc`. `v1` has
+    /// none, so it stays in the use-set and the walk flags the read.
+    /// (Widening the relaxation to "some back-edge participant has an
+    /// `inc_rc`" would wrongly accept this.)
+    #[test]
+    fn end_to_end_latch_join_with_unprotected_sibling_is_rejected() {
+        let src = r#"
+            brillig(inline) fn main f0 {
+              b0(v0: [i32; 1], v1: [i32; 1], v2: u1):
+                jmp b1(u32 0, v0)
+              b1(v3: u32, v4: [i32; 1]):
+                v5 = lt v3, u32 2
+                jmpif v5 then: b2(), else: b3()
+              b2():
+                v6 = array_set v4, index u32 0, value i32 40
+                jmpif v2 then: b4(), else: b5()
+              b3():
+                v7 = array_get v1, index u32 0 -> i32
+                return
+              b4():
+                inc_rc v0
+                jmp b6(v0)
+              b5():
+                jmp b6(v1)
+              b6(v8: [i32; 1]):
+                v9 = unchecked_add v3, u32 1
+                jmp b1(v9, v8)
+            }"#;
+        assert_verifier_rejects(src);
+    }
+
     /// End-to-end regression for an AST-fuzzer-discovered minimal shape:
     /// two array-typed function entry parameters flow into the same
     /// downstream block parameter via a *forward* if-else sibling join
@@ -2442,11 +2627,19 @@ mod tests {
         let ssa = Ssa::from_str(src).unwrap();
         let function = ssa.main();
         let ctx = Context::new(function);
-        let ArraySetSite { block, idx, instruction_id, alias_set, write_index_const, .. } =
-            first_array_set(function, &ctx).expect("array_set present");
+        let ArraySetSite {
+            block, idx, instruction_id, source, alias_set, write_index_const, ..
+        } = first_array_set(function, &ctx).expect("array_set present");
 
         let has_use = ctx
-            .find_reachable_aliased_use(&alias_set, instruction_id, block, idx, write_index_const)
+            .find_reachable_aliased_use(
+                &alias_set,
+                source,
+                instruction_id,
+                block,
+                idx,
+                write_index_const,
+            )
             .is_some();
         assert!(
             !has_use,
@@ -2479,11 +2672,19 @@ mod tests {
         let ssa = Ssa::from_str(src).unwrap();
         let function = ssa.main();
         let ctx = Context::new(function);
-        let ArraySetSite { block, idx, instruction_id, alias_set, write_index_const, .. } =
-            first_array_set(function, &ctx).expect("array_set present");
+        let ArraySetSite {
+            block, idx, instruction_id, source, alias_set, write_index_const, ..
+        } = first_array_set(function, &ctx).expect("array_set present");
 
         let has_use = ctx
-            .find_reachable_aliased_use(&alias_set, instruction_id, block, idx, write_index_const)
+            .find_reachable_aliased_use(
+                &alias_set,
+                source,
+                instruction_id,
+                block,
+                idx,
+                write_index_const,
+            )
             .is_some();
         assert!(
             has_use,
@@ -2524,11 +2725,19 @@ mod tests {
         let ssa = Ssa::from_str(src).unwrap();
         let function = ssa.main();
         let ctx = Context::new(function);
-        let ArraySetSite { block, idx, instruction_id, alias_set, write_index_const, .. } =
-            first_array_set(function, &ctx).expect("array_set present");
+        let ArraySetSite {
+            block, idx, instruction_id, source, alias_set, write_index_const, ..
+        } = first_array_set(function, &ctx).expect("array_set present");
 
         let has_use = ctx
-            .find_reachable_aliased_use(&alias_set, instruction_id, block, idx, write_index_const)
+            .find_reachable_aliased_use(
+                &alias_set,
+                source,
+                instruction_id,
+                block,
+                idx,
+                write_index_const,
+            )
             .is_some();
         assert!(
             !has_use,
@@ -2619,11 +2828,19 @@ mod tests {
         let ssa = Ssa::from_str(src).unwrap();
         let function = ssa.main();
         let ctx = Context::new(function);
-        let ArraySetSite { block, idx, instruction_id, alias_set, write_index_const, .. } =
-            first_array_set(function, &ctx).expect("array_set present");
+        let ArraySetSite {
+            block, idx, instruction_id, source, alias_set, write_index_const, ..
+        } = first_array_set(function, &ctx).expect("array_set present");
 
         let has_use = ctx
-            .find_reachable_aliased_use(&alias_set, instruction_id, block, idx, write_index_const)
+            .find_reachable_aliased_use(
+                &alias_set,
+                source,
+                instruction_id,
+                block,
+                idx,
+                write_index_const,
+            )
             .is_some();
         assert!(
             !has_use,

--- a/compiler/noirc_evaluator/src/ssa/validation/array_set_rc_invariant.rs
+++ b/compiler/noirc_evaluator/src/ssa/validation/array_set_rc_invariant.rs
@@ -30,11 +30,15 @@
 //!    predecessor-arg edges backward to a fixed point. Only aliasing introduced
 //!    by the values that flow *into* `vX`'s binding is included. Filtered to
 //!    drop values that can't represent pre-mutation storage: `array_set` /
-//!    `Call` results (always fresh), iteration-local `MakeArray`s (back-edge
-//!    args), and instruction results defined in the array_set's own block at
-//!    an index after the array_set (they can land in the backward set
-//!    through a forward-then-back round-trip, but don't exist as storage
-//!    at the array_set's program point yet).
+//!    `Call` results (always fresh), iteration-local fresh results (`MakeArray`
+//!    or `Call` on back-edge args), instruction results defined in the
+//!    array_set's own block at an index after the array_set (they can land in
+//!    the backward set through a forward-then-back round-trip, but don't exist
+//!    as storage at the array_set's program point yet), and **swap-excluded
+//!    siblings** — when `vX` is a loop-header parameter swapped onto a sibling
+//!    parameter that is freshly re-allocated each iteration, the sibling is a
+//!    distinct per-iteration storage and is dropped (see
+//!    [`Context::swap_excluded_aliases`]).
 //! 2. **inc_rc precedence / back-edge-participant.** If some `inc_rc` on an
 //!    alias-set member either RPO-precedes the array_set or sits on a
 //!    non-source alias that's also a loop back-edge arg, accept — the
@@ -108,8 +112,8 @@
 //!   `end_to_end_sibling_args_across_jmp_is_false_negative` tests pin this
 //!   down as documented false negatives.
 //! - **Nested-array `MakeArray`**, **`IfElse` on arrays**, **non-inlined
-//!   `Call` returns**, **`Store`/`Load` on ineligible (nested-ref)
-//!   allocates** — same as before.
+//!   `Call` returns**, and **`Store`/`Load` on ineligible (nested-ref)
+//!   allocates** are likewise not tracked.
 
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 

--- a/compiler/noirc_evaluator/src/ssa/validation/array_set_rc_invariant.rs
+++ b/compiler/noirc_evaluator/src/ssa/validation/array_set_rc_invariant.rs
@@ -77,8 +77,14 @@
 //!      positions" if any chain link uses a dynamic index.
 //!
 //!    An `array_get` on a use-set member is a hazard iff its read index is
-//!    covered by `tainted_indices`. Non-`array_get` uses are always hazards.
-//!    An `inc_rc v` with `v ∈ use_set ∪ derived` lifts the storage's RC,
+//!    covered by `tainted_indices`. An `array_set` on a use-set member is
+//!    index-aware too: it produces a copy of the source with one index
+//!    overwritten, so it observes (copies forward) only the indices it does
+//!    *not* write — a hazard iff some `tainted_indices` position differs
+//!    from its write index (a same-index write overwrites the mutation and
+//!    is not a hazard; it instead extends the chain). All other uses are
+//!    always hazards. An `inc_rc v` with `v ∈ use_set ∪ derived` lifts the
+//!    storage's RC,
 //!    so chain writes after it run on fresh storage — `derived` is cleared
 //!    at that point. `tainted_indices` is *not* cleared: prior chain writes
 //!    have already mutated the source's storage.
@@ -658,8 +664,12 @@ impl<'f> Context<'f> {
     /// is a hazard iff `tainted_indices` covers `idx`. With both indices
     /// constant, that's a set-membership test; otherwise (either side
     /// dynamic, or `tainted_indices == None`) the verifier conservatively
-    /// flags. Non-`array_get` uses on a `use_set` member are always
-    /// flagged — the SSA-vs-runtime divergence isn't index-local for them.
+    /// flags. An `array_set v, idx, _` with `v ∈ use_set` is index-aware in
+    /// the same way: it copies forward every position except `idx`, so it
+    /// is a hazard iff some `tainted_indices` position differs from `idx`
+    /// (a same-index write overwrites the mutation and extends the chain
+    /// instead). All other uses on a `use_set` member are always flagged —
+    /// the SSA-vs-runtime divergence isn't index-local for them.
     ///
     /// **IncrementRc clears `derived`.** A program-point `inc_rc v` with
     /// `v ∈ use_set ∪ derived` lifts the storage's RC ≥ 2, so any
@@ -792,18 +802,39 @@ impl<'f> Context<'f> {
                     // skip if encountered.
                     Instruction::DecrementRc { .. } => {}
                     Instruction::ArraySet { array, index, value, .. } => {
-                        if state.use_set.contains(array) {
-                            return Some(AliasedUse { instruction: inst_id, value: *array });
+                        let array_in_use = state.use_set.contains(array);
+                        if array_in_use {
+                            // Index-aware, mirroring the `array_get` rule below.
+                            // `array_set v, i, x` produces a *copy* of `v` with
+                            // index `i` overwritten, so it only observes (copies
+                            // forward) the indices it does **not** write. It can
+                            // therefore surface the source's in-place mutation
+                            // only if it copies a tainted index — i.e. some
+                            // tainted index differs from this write index. A
+                            // write to the (sole) tainted index overwrites the
+                            // mutation and observes nothing. A dynamic write or
+                            // read index, or fully-tainted (`None`) storage, is
+                            // flagged conservatively.
+                            let write_idx = self.function.dfg.get_numeric_constant(*index);
+                            let observes_tainted = match (&state.tainted, write_idx) {
+                                (None, _) | (_, None) => true,
+                                (Some(t), Some(c)) => t.iter().any(|i| *i != c),
+                            };
+                            if observes_tainted {
+                                return Some(AliasedUse { instruction: inst_id, value: *array });
+                            }
                         }
                         if self.function.dfg.type_of_value(*value).contains_an_array()
                             && state.use_set.contains(value)
                         {
                             return Some(AliasedUse { instruction: inst_id, value: *value });
                         }
-                        // Chain extension: this array_set writes through a
-                        // value that may share the source's storage with
-                        // this iteration's earlier in-place mutations.
-                        if state.derived.contains(array) {
+                        // Chain extension: a write through a value that may
+                        // share the source's storage — a `derived` member, or a
+                        // `use_set` member whose write we just cleared as
+                        // non-observing — keeps mutating that storage, so record
+                        // its write index and track the result.
+                        if state.derived.contains(array) || array_in_use {
                             match (
                                 state.tainted.as_mut(),
                                 self.function.dfg.get_numeric_constant(*index),
@@ -1200,6 +1231,99 @@ mod tests {
             "expected ArraySetAliasViolation, got {err:?}",
         );
     }
+    /// A read value that carries its own `inc_rc` **and** is a loop
+    /// back-edge participant is **still a hazard** when it merely
+    /// *receives* the source's storage on a forward edge. Here `array_set s`
+    /// (b1) mutates `s` in place, then `p := s` (b1 → b2) and `p` is read by
+    /// the `call` in b2. `p` has an `inc_rc` and is a back-edge arg (b3 → b2),
+    /// but the `inc_rc` runs *after* the mutation and `p` flows *out of* the
+    /// source (`p ← s`), not into it — so the bump can't protect the
+    /// array_set. The read observes the in-place mutation; the verifier must
+    /// reject.
+    ///
+    /// This pins the soundness boundary of the protected-participant filter:
+    /// it excludes a value only when that value is in the *source's*
+    /// alias-set (flows *into* the source, so its `inc_rc` is loop-carried
+    /// before the mutation).
+    #[test]
+    fn end_to_end_forward_threaded_read_with_inc_rc_participant_is_rejected() {
+        let src = r#"
+            brillig(inline) fn f f0 {
+              b0(v0: u1, vs: [u32; 1]):
+                jmp b1(vs)
+              b1(s: [u32; 1]):
+                v1 = array_set s, index u32 0, value u32 9
+                jmp b2(s)
+              b2(p: [u32; 1]):
+                inc_rc p
+                v2 = call f0(v0, p) -> u1
+                jmpif v0 then: b3(), else: b4()
+              b3():
+                jmp b2(p)
+              b4():
+                jmp b1(v1)
+            }"#;
+        assert_verifier_rejects(src);
+    }
+
+    /// Inclusive-range (`..=`) peel, accepted by the index-aware
+    /// `array_set`-use rule. This is the SSA the frontend emits for
+    ///
+    /// ```ignore
+    /// for _ in 254_u8..=255_u8 { c4[0] = 9; c4 = c3; c3 = [b[0]]; }
+    /// ```
+    ///
+    /// An inclusive range lowers to an exclusive loop plus a duplicated
+    /// **peel** of the final iteration (see `codegen_for` in `ssa_gen`).
+    /// Here `b1`/`b2` are the loop and `b4` is the peel; the loop variable
+    /// `v29` (`c4`) is `array_set` in *both*, at the **same** constant
+    /// index `0`. The forward walk from the loop's `array_set v29` (`b2`)
+    /// reaches the peel's `array_set v29` (`b4`) — but that write
+    /// *overwrites* index `0`, the only tainted index, so it can't observe
+    /// the loop's in-place mutation. Index-aware handling of `array_set`
+    /// uses (the same `tainted`-index test the `array_get` rule uses)
+    /// therefore accepts it, matching the runtime: the program executes
+    /// identically under Brillig and comptime.
+    ///
+    /// This is *not* peel detection — there's no reliable post-`mem2reg`
+    /// marker for a peel block. It's a precise consequence of `array_set`
+    /// semantics (a write observes only the indices it doesn't overwrite),
+    /// so it also covers the corresponding `..` case and any other shape
+    /// where the aliased write hits the same index. A peel whose duplicated
+    /// body *reads* a tainted index some other way (e.g. an `array_get` or
+    /// a `call`) is still flagged.
+    #[test]
+    fn end_to_end_inclusive_range_peel_array_set_same_index_is_accepted() {
+        let src = r#"
+            brillig(inline) fn main f0 {
+              b0():
+                v1 = make_array [u8 1] : [u8; 1]
+                v4 = make_array [u8 2] : [u8; 1]
+                v7 = make_array [u8 3] : [u8; 1]
+                jmp b1(u8 254, v1, v4)
+              b1(v10: u8, v28: [u8; 1], v29: [u8; 1]):
+                v13 = lt v10, u8 255
+                jmpif v13 then: b2(), else: b3()
+              b2():
+                v18 = array_set v29, index u32 0, value u8 9
+                v20 = make_array [u8 3] : [u8; 1]
+                v21 = unchecked_add v10, u8 1
+                jmp b1(v21, v20, v28)
+              b3():
+                jmpif u1 1 then: b4(), else: b5(v28, v29)
+              b4():
+                v25 = array_set v29, index u32 0, value u8 9
+                v27 = make_array [u8 3] : [u8; 1]
+                jmp b5(v27, v28)
+              b5(v30: [u8; 1], v31: [u8; 1]):
+                return
+            }"#;
+        assert_verifier_accepts_because(
+            src,
+            "the peel's array_set v29 (b4) overwrites index 0 — the only index the loop's \
+             array_set v29 (b2) tainted — so it observes no in-place mutation",
+        );
+    }
 
     /// ACIR functions are skipped: `inc_rc` / `dec_rc` are no-ops in ACIR and
     /// `array_set` always produces a fresh array.
@@ -1360,11 +1484,14 @@ mod tests {
         assert_verifier_rejects(src);
     }
 
-    /// The index filter applies *only* to `array_get`. A non-`array_get`
-    /// use of the alias (here a second `array_set` on the same source
-    /// with a different constant index) is still flagged conservatively,
-    /// because the SSA-vs-runtime divergence isn't local to the read
-    /// index for those use kinds.
+    /// A second `array_set` on the alias at a **different** constant index
+    /// is a hazard: it produces a copy of the source, so it observes
+    /// (copies forward) the source's tainted index `0` at its non-written
+    /// positions. The index-aware `array_set`-use rule flags it precisely
+    /// because the write index `1` differs from the tainted index `0`.
+    /// (Compare
+    /// [`Self::end_to_end_inclusive_range_peel_array_set_same_index_is_accepted`],
+    /// where the write hits the same index and is accepted.)
     #[test]
     fn end_to_end_array_set_followed_by_another_array_set_on_alias_is_rejected() {
         let src = r#"
@@ -1376,6 +1503,29 @@ mod tests {
                 return v7
             }"#;
         assert_verifier_rejects(src);
+    }
+
+    /// Counterpart to the different-index case: a second `array_set` on the
+    /// alias at the **same** constant index as the source overwrites the
+    /// only tainted index, so it observes none of the source's in-place
+    /// mutation and is accepted — the `array_set`-use analogue of the
+    /// disjoint-`array_get` rule. At runtime `v3`'s write to index 0 is
+    /// dead (overwritten by `v5`), and `v7` reads `v5`'s result.
+    #[test]
+    fn end_to_end_array_set_followed_by_another_array_set_same_index_is_accepted() {
+        let src = r#"
+            brillig(inline) fn main f0 {
+              b0(v0: [u32; 2]):
+                v3 = array_set v0, index u32 0, value u32 99
+                v5 = array_set v0, index u32 0, value u32 88
+                v7 = array_get v5, index u32 0 -> u32
+                return v7
+            }"#;
+        assert_verifier_accepts_because(
+            src,
+            "the second array_set on v0 writes the same index 0 the first tainted, overwriting \
+             it rather than observing the in-place mutation",
+        );
     }
 
     /// Chain of `array_set`s on the same backing storage where the read

--- a/compiler/noirc_evaluator/src/ssa/validation/array_set_rc_invariant.rs
+++ b/compiler/noirc_evaluator/src/ssa/validation/array_set_rc_invariant.rs
@@ -314,6 +314,30 @@ struct Context<'f> {
     /// value on another only drops the protected value, leaving the
     /// unprotected one for the forward walk to flag.
     back_edge_participants: HashSet<ValueId>,
+    /// **Swap exclusions.** For a loop-header parameter `P`, the set of
+    /// sibling parameters `Q` that `P` is rebound to on the loop
+    /// back-edge (`P ← Q`, the array-variable swap `c4 = c3`) while `Q`
+    /// is simultaneously rebound to a freshly-allocated, iteration-local
+    /// `make_array` (`c3 = [..]`). Such a `Q` is a *distinct
+    /// per-iteration storage* that `P` only *becomes* in a later
+    /// iteration — never the storage this iteration's `array_set` on `P`
+    /// mutates (the swap rotates a fresh allocation into `P` while the
+    /// mutated storage is left behind, dead). `Q` is dropped from `P`'s
+    /// alias-set in [`Context::alias_set_for`], which makes the forward
+    /// walk both **kill** `P` where the back-edge rebinds it to `Q` and
+    /// decline to **add** a fresh alias of `Q` past any later edge (the
+    /// inclusive-range *peel* re-runs the same swap on a *forward* exit
+    /// edge — excluding `Q` at the seed covers that edge too, which a
+    /// kill keyed on the back-edge alone could not).
+    ///
+    /// Guarded by a **back-edge-only** check: if `Q` also flows into `P`
+    /// on a forward edge, `P` and `Q` can already alias *within* an
+    /// iteration (the array_set would mutate `Q`'s live storage), so the
+    /// exclusion would be unsound and is not recorded. The freshening
+    /// requirement on `Q` is the second guard — a loop-invariant `Q`
+    /// swapped into `P` would make `P_k = Q_{k-1} = Q_k` and genuinely
+    /// alias.
+    swap_excluded_aliases: HashMap<ValueId, HashSet<ValueId>>,
 }
 
 impl<'f> Context<'f> {
@@ -442,6 +466,87 @@ impl<'f> Context<'f> {
         let iteration_local_make_arrays: HashSet<ValueId> =
             make_array_values.intersection(&back_edge_args).copied().collect();
 
+        // Swap exclusions. For every loop back-edge `be_start → header`,
+        // inspect each array-typed header parameter `p` at position `i`:
+        // if the back-edge rebinds it to a *sibling* header parameter
+        // `q` (`p ← q`) whose own back-edge arg is an iteration-local
+        // `make_array`, and `p` and `q` receive distinct storage on every
+        // forward edge into the header, record `q` as excluded from `p`'s
+        // alias-set. See [`Context::swap_excluded_aliases`].
+        let mut swap_excluded_aliases: HashMap<ValueId, HashSet<ValueId>> = HashMap::default();
+        for &(be_start, header) in &back_edges {
+            let Some(edges) = incoming_edges.get(&header) else { continue };
+            let Some(be_args) =
+                edges.iter().find(|(pred, _)| *pred == be_start).map(|(_, args)| args)
+            else {
+                continue;
+            };
+            let params = function.dfg.block_parameters(header);
+            for (source_pos, &source_param) in params.iter().enumerate() {
+                if !function.dfg.type_of_value(source_param).contains_an_array() {
+                    continue;
+                }
+                let Some(&sibling) = be_args.get(source_pos) else { continue };
+                // `source_param ← sibling` must be a genuine swap to a
+                // *different* sibling header parameter (not self-threading,
+                // not a result).
+                if sibling == source_param {
+                    continue;
+                }
+                let Some(sibling_pos) = params.iter().position(|&pp| pp == sibling) else {
+                    continue;
+                };
+                // The sibling's own back-edge arg must be a
+                // freshly-allocated, iteration-local `make_array` (the
+                // `c3 = [..]` half of the swap).
+                if !be_args
+                    .get(sibling_pos)
+                    .is_some_and(|a| iteration_local_make_arrays.contains(a))
+                {
+                    continue;
+                }
+                // Loop-entry guard. On every *forward* edge into the
+                // header, the source param and the sibling must receive
+                // **distinct** storage, or they can already alias at the
+                // array_set in the entry iteration (`source_0 = sibling_0`)
+                // and the exclusion would mask a real hazard. Two ways
+                // that can happen:
+                //
+                // - the sibling flows into the source's forward arg
+                //   (`sibling ∈ backward(source_forward_arg)`) — the
+                //   source *is* the sibling from the start.
+                // - the source's and sibling's forward args share a
+                //   backward-set member — e.g. `jmp header(v, v)` feeds the
+                //   same `v` to both, so they're runtime-equal even though
+                //   the directed backward walk keeps them in separate sets.
+                let backward_set = |v: ValueId| -> im::HashSet<ValueId> {
+                    backward_aliases.get(&v).cloned().unwrap_or_else(|| im::HashSet::unit(v))
+                };
+                let entry_aliased = edges
+                    .iter()
+                    .filter(|(pred, _)| !back_edges.contains(&(*pred, header)))
+                    .any(|(_, args)| {
+                        let Some(&source_forward_arg) = args.get(source_pos) else {
+                            return false;
+                        };
+                        let source_forward_aliases = backward_set(source_forward_arg);
+                        if source_forward_aliases.contains(&sibling) {
+                            return true;
+                        }
+                        args.get(sibling_pos).is_some_and(|&sibling_forward_arg| {
+                            let sibling_forward_aliases = backward_set(sibling_forward_arg);
+                            source_forward_aliases
+                                .iter()
+                                .any(|x| sibling_forward_aliases.contains(x))
+                        })
+                    });
+                if entry_aliased {
+                    continue;
+                }
+                swap_excluded_aliases.entry(source_param).or_default().insert(sibling);
+            }
+        }
+
         Self {
             function,
             dom_tree,
@@ -452,6 +557,7 @@ impl<'f> Context<'f> {
             inc_rc_locations,
             back_edge_args,
             back_edge_participants,
+            swap_excluded_aliases,
         }
     }
 
@@ -525,6 +631,9 @@ impl<'f> Context<'f> {
                     return false;
                 }
                 if self.iteration_local_make_arrays.contains(&v) {
+                    return false;
+                }
+                if self.swap_excluded_aliases.get(&source).is_some_and(|qs| qs.contains(&v)) {
                     return false;
                 }
                 if let Some(&(def_block, def_idx)) = self.array_value_defs.get(&v)
@@ -1325,8 +1434,7 @@ mod tests {
         );
     }
 
-    /// **Known false positive — multi-index inclusive-range (`..=`) peel.**
-    ///
+    /// Multi-index inclusive-range (`..=`) peel with the swap `c4 = c3`.
     /// SSA for
     ///
     /// ```ignore
@@ -1335,23 +1443,20 @@ mod tests {
     ///
     /// Same peel shape as
     /// [`Self::end_to_end_inclusive_range_peel_array_set_same_index_is_accepted`],
-    /// but the loop body now writes **both** indices, so the source's chain
-    /// taints `{0, 1}`. The peel's `array_set v38` (`b4`) writes index `0`,
-    /// which overwrites tainted index `0` but still copies tainted index `1`
-    /// forward — so the index-aware `array_set`-use rule (correctly, for its
-    /// model) flags it: a single write can't overwrite both tainted indices.
-    ///
-    /// It is nonetheless a **false positive**: the program executes
-    /// identically under Brillig and comptime. The real reason is invisible
-    /// to the validator — the loop body mutates one storage (`v6`) while the
-    /// peel mutates a *different* one (the old `c3`), and both writes are
-    /// dead; `backward(v38)` conflates the two per-iteration storages into a
-    /// single alias-set. The same-index case happens to be rescued by the
-    /// overwrite rule; the multi-index case is the residual limitation,
-    /// pinned here. (Replacing `..=` with `..` removes the peel and the
-    /// flag.)
+    /// but the loop body writes **both** indices, so the index-aware
+    /// `array_set`-use rule alone can't rescue it (the peel's single-index
+    /// write copies the other tainted index forward). It is accepted by the
+    /// **swap exclusion** instead: on the back-edge `jmp b1(v28, v27, v37)`
+    /// the source param `v38` (`c4`) is rebound to its sibling `v37` (`c3`),
+    /// whose own back-edge arg `v27` is an iteration-local `make_array` — so
+    /// `v37` is a distinct per-iteration storage and is dropped from
+    /// `backward(v38)`. With `v37` gone, the walk kills `v38` on the
+    /// back-edge, and the peel's `array_set v38` (`b4`) — which sources the
+    /// same header param — never sees it in the use-set. The loop body
+    /// mutates one storage while the peel mutates a different one and both
+    /// writes are dead; Brillig and comptime agree.
     #[test]
-    fn end_to_end_multi_index_inclusive_range_peel_is_a_known_false_positive() {
+    fn end_to_end_multi_index_inclusive_range_peel_swap_is_accepted() {
         let src = r#"
             brillig(inline) fn main f0 {
               b0():
@@ -1378,39 +1483,37 @@ mod tests {
               b5(v39: [u8; 2], v40: [u8; 2]):
                 return
             }"#;
-        assert_verifier_rejects(src);
+        assert_verifier_accepts_because(
+            src,
+            "the back-edge swap v38 ← v37 with v37 freshened by the iteration-local \
+             make_array v27 drops v37 from v38's alias-set, so the walk kills v38 on the \
+             back-edge and the peel's array_set v38 (b4) — sourcing the same header param — \
+             is not flagged",
+        );
     }
 
-    /// **Known false positive — the general form (no peel).** SSA for
+    /// The general form (no peel): a swap `c4 = c3` followed by a
+    /// whole-array read. SSA for
     ///
     /// ```ignore
     /// for _ in 253_u8..255_u8 { c4[0] = 9; c4[1] = 19; c4 = c3; c3 = [b[0], b[1]]; }
     /// println(c4);
     /// ```
     ///
-    /// This is an **exclusive** (`..`) loop — *no peel* — yet it's still
-    /// rejected, which shows the false positive isn't peel-specific. The
-    /// shared root is the swap `c4 = c3`: it threads `v30` (`c3`) into
-    /// `v31` (`c4`) on the back-edge (`jmp b1(.., v26, v30)`), so `v30`
-    /// joins `backward(v31)`. The loop's `array_set v31` (`b2`) mutates
-    /// `c4`'s storage, but its result (`v24`) is **discarded** and `v31` is
-    /// rebound to `v30` — so the mutated storage is dead. At the loop exit
-    /// `v31` holds a fresh `c3`-derived array (`v26`), distinct from any
-    /// mutated storage, and `call f1(v31)` (the `println`) reads it. Because
-    /// a `call` observes the *whole* array, the index-aware `array_set` rule
-    /// doesn't apply, and there's no `inc_rc` (the frontend correctly
-    /// omitted it — the storages are genuinely distinct), so no relaxation
-    /// applies either.
-    ///
-    /// It is a **false positive** (Brillig == comptime). The alias-set
-    /// conflates the loop variable's distinct per-iteration storages across
-    /// the swap; the inclusive-range peel
-    /// ([`Self::end_to_end_multi_index_inclusive_range_peel_is_a_known_false_positive`])
-    /// is just one way to reach such a forward read. A sound fix needs
-    /// per-iteration storage/liveness disambiguation (recognizing the
-    /// mutated storage is dead after the swap), not anything peel-specific.
+    /// This is an **exclusive** (`..`) loop — *no peel* — exercising the
+    /// swap exclusion directly. On the back-edge `jmp b1(v27, v26, v30)`
+    /// the source param `v31` (`c4`) is rebound to its sibling `v30` (`c3`),
+    /// whose own back-edge arg `v26` is an iteration-local `make_array`, so
+    /// `v30` is dropped from `backward(v31)`. The walk then kills `v31` on
+    /// the back-edge, and the loop-exit `call f1(v31)` (`b3`, the `println`)
+    /// reads a value no longer in the use-set. The loop's `array_set v31`
+    /// mutates `c4`'s storage, but its result is discarded and `v31` is
+    /// rebound to a fresh `c3`-derived array — the mutated storage is dead,
+    /// and a whole-array read of the swapped-in value observes nothing.
+    /// There is no `inc_rc` (the frontend correctly omitted it — the
+    /// storages are genuinely distinct); Brillig and comptime agree.
     #[test]
-    fn end_to_end_loop_swap_then_whole_array_read_is_a_known_false_positive() {
+    fn end_to_end_loop_swap_then_whole_array_read_is_accepted() {
         let src = r#"
             brillig(inline) fn main f0 {
               b0():
@@ -1432,6 +1535,76 @@ mod tests {
             }
             brillig(inline) fn observe f1 {
               b0(v0: [u8; 2]):
+                return
+            }"#;
+        assert_verifier_accepts_because(
+            src,
+            "the back-edge swap v31 ← v30 with v30 freshened by the iteration-local \
+             make_array v26 drops v30 from v31's alias-set, so the walk kills v31 on the \
+             back-edge and the loop-exit whole-array read call f1(v31) is not flagged",
+        );
+    }
+
+    /// **Swap-exclusion soundness canary — freshening guard.** The swap
+    /// `v3 ← v2` (`P ← Q`) is present on the back-edge, but `v2`'s own
+    /// back-edge arg is `v2` itself (loop-**invariant** `c3`, not a fresh
+    /// `make_array`). Then `P_k = Q_{k-1} = Q_0 = Q_k`, so `P` and `Q`
+    /// genuinely share storage from the first swap on: the in-loop
+    /// `array_set v3` mutates it and `array_get v2` observes the mutation.
+    /// The exclusion must **not** fire (its freshening precondition fails),
+    /// and the verifier must reject. Guards against dropping `v2` purely
+    /// because it's swapped into the source.
+    #[test]
+    fn end_to_end_swap_with_loop_invariant_sibling_is_rejected() {
+        let src = r#"
+            brillig(inline) fn main f0 {
+              b0():
+                v0 = make_array [u8 1] : [u8; 1]
+                v1 = make_array [u8 2] : [u8; 1]
+                jmp b1(u8 0, v0, v1)
+              b1(v10: u8, v2: [u8; 1], v3: [u8; 1]):
+                v12 = lt v10, u8 5
+                jmpif v12 then: b2(), else: b3()
+              b2():
+                v15 = array_set v3, index u32 0, value u8 9
+                v17 = array_get v2, index u32 0 -> u8
+                constrain v17 == u8 1
+                v18 = unchecked_add v10, u8 1
+                jmp b1(v18, v2, v2)
+              b3():
+                return
+            }"#;
+        assert_verifier_rejects(src);
+    }
+
+    /// **Swap-exclusion soundness canary — loop-entry guard.** The swap
+    /// `v3 ← v2` with `v2` freshened by an iteration-local `make_array`
+    /// (`v9`) *does* satisfy the freshening precondition, but the
+    /// pre-header feeds the **same** array `v0` to both header params
+    /// (`jmp b1(.., v0, v0)`), so `P_0 = Q_0 = v0`: at the entry
+    /// iteration the `array_set v3` mutates the storage that `array_get
+    /// v2` then reads. The directed backward walk keeps `v2` and `v3` in
+    /// separate sets, so without the loop-entry guard the exclusion would
+    /// fire and mask this hazard. It must **not** fire; the verifier must
+    /// reject.
+    #[test]
+    fn end_to_end_swap_with_sibling_same_value_entry_is_rejected() {
+        let src = r#"
+            brillig(inline) fn main f0 {
+              b0():
+                v0 = make_array [u8 1] : [u8; 1]
+                jmp b1(u8 0, v0, v0)
+              b1(v10: u8, v2: [u8; 1], v3: [u8; 1]):
+                v12 = lt v10, u8 5
+                jmpif v12 then: b2(), else: b3()
+              b2():
+                v15 = array_set v3, index u32 0, value u8 9
+                v17 = array_get v2, index u32 0 -> u8
+                constrain v17 == u8 1
+                v9 = make_array [u8 3] : [u8; 1]
+                v18 = unchecked_add v10, u8 1
+                jmp b1(v18, v9, v2)
+              b3():
                 return
             }"#;
         assert_verifier_rejects(src);

--- a/compiler/noirc_evaluator/src/ssa/validation/array_set_rc_invariant.rs
+++ b/compiler/noirc_evaluator/src/ssa/validation/array_set_rc_invariant.rs
@@ -1325,6 +1325,118 @@ mod tests {
         );
     }
 
+    /// **Known false positive — multi-index inclusive-range (`..=`) peel.**
+    ///
+    /// SSA for
+    ///
+    /// ```ignore
+    /// for _ in 254_u8..=255_u8 { c4[0] = 9; c4[1] = 19; c4 = c3; c3 = [b[0], b[1]]; }
+    /// ```
+    ///
+    /// Same peel shape as
+    /// [`Self::end_to_end_inclusive_range_peel_array_set_same_index_is_accepted`],
+    /// but the loop body now writes **both** indices, so the source's chain
+    /// taints `{0, 1}`. The peel's `array_set v38` (`b4`) writes index `0`,
+    /// which overwrites tainted index `0` but still copies tainted index `1`
+    /// forward — so the index-aware `array_set`-use rule (correctly, for its
+    /// model) flags it: a single write can't overwrite both tainted indices.
+    ///
+    /// It is nonetheless a **false positive**: the program executes
+    /// identically under Brillig and comptime. The real reason is invisible
+    /// to the validator — the loop body mutates one storage (`v6`) while the
+    /// peel mutates a *different* one (the old `c3`), and both writes are
+    /// dead; `backward(v38)` conflates the two per-iteration storages into a
+    /// single alias-set. The same-index case happens to be rescued by the
+    /// overwrite rule; the multi-index case is the residual limitation,
+    /// pinned here. (Replacing `..=` with `..` removes the peel and the
+    /// flag.)
+    #[test]
+    fn end_to_end_multi_index_inclusive_range_peel_is_a_known_false_positive() {
+        let src = r#"
+            brillig(inline) fn main f0 {
+              b0():
+                v2 = make_array [u8 1, u8 11] : [u8; 2]
+                v6 = make_array [u8 2, u8 12] : [u8; 2]
+                v10 = make_array [u8 3, u8 13] : [u8; 2]
+                jmp b1(u8 254, v2, v6)
+              b1(v13: u8, v37: [u8; 2], v38: [u8; 2]):
+                v16 = lt v13, u8 255
+                jmpif v16 then: b2(), else: b3()
+              b2():
+                v22 = array_set v38, index u32 0, value u8 9
+                v25 = array_set v22, index u32 1, value u8 19
+                v27 = make_array [u8 3, u8 13] : [u8; 2]
+                v28 = unchecked_add v13, u8 1
+                jmp b1(v28, v27, v37)
+              b3():
+                jmpif u1 1 then: b4(), else: b5(v37, v38)
+              b4():
+                v32 = array_set v38, index u32 0, value u8 9
+                v34 = array_set v32, index u32 1, value u8 19
+                v36 = make_array [u8 3, u8 13] : [u8; 2]
+                jmp b5(v36, v37)
+              b5(v39: [u8; 2], v40: [u8; 2]):
+                return
+            }"#;
+        assert_verifier_rejects(src);
+    }
+
+    /// **Known false positive — the general form (no peel).** SSA for
+    ///
+    /// ```ignore
+    /// for _ in 253_u8..255_u8 { c4[0] = 9; c4[1] = 19; c4 = c3; c3 = [b[0], b[1]]; }
+    /// println(c4);
+    /// ```
+    ///
+    /// This is an **exclusive** (`..`) loop — *no peel* — yet it's still
+    /// rejected, which shows the false positive isn't peel-specific. The
+    /// shared root is the swap `c4 = c3`: it threads `v30` (`c3`) into
+    /// `v31` (`c4`) on the back-edge (`jmp b1(.., v26, v30)`), so `v30`
+    /// joins `backward(v31)`. The loop's `array_set v31` (`b2`) mutates
+    /// `c4`'s storage, but its result (`v24`) is **discarded** and `v31` is
+    /// rebound to `v30` — so the mutated storage is dead. At the loop exit
+    /// `v31` holds a fresh `c3`-derived array (`v26`), distinct from any
+    /// mutated storage, and `call f1(v31)` (the `println`) reads it. Because
+    /// a `call` observes the *whole* array, the index-aware `array_set` rule
+    /// doesn't apply, and there's no `inc_rc` (the frontend correctly
+    /// omitted it — the storages are genuinely distinct), so no relaxation
+    /// applies either.
+    ///
+    /// It is a **false positive** (Brillig == comptime). The alias-set
+    /// conflates the loop variable's distinct per-iteration storages across
+    /// the swap; the inclusive-range peel
+    /// ([`Self::end_to_end_multi_index_inclusive_range_peel_is_a_known_false_positive`])
+    /// is just one way to reach such a forward read. A sound fix needs
+    /// per-iteration storage/liveness disambiguation (recognizing the
+    /// mutated storage is dead after the swap), not anything peel-specific.
+    #[test]
+    fn end_to_end_loop_swap_then_whole_array_read_is_a_known_false_positive() {
+        let src = r#"
+            brillig(inline) fn main f0 {
+              b0():
+                v2 = make_array [u8 1, u8 11] : [u8; 2]
+                v6 = make_array [u8 2, u8 12] : [u8; 2]
+                jmp b1(u8 253, v2, v6)
+              b1(v13: u8, v30: [u8; 2], v31: [u8; 2]):
+                v14 = lt v13, u8 255
+                jmpif v14 then: b2(), else: b3()
+              b2():
+                v21 = array_set v31, index u32 0, value u8 9
+                v24 = array_set v21, index u32 1, value u8 19
+                v26 = make_array [u8 3, u8 13] : [u8; 2]
+                v27 = unchecked_add v13, u8 1
+                jmp b1(v27, v26, v30)
+              b3():
+                call f1(v31)
+                return
+            }
+            brillig(inline) fn observe f1 {
+              b0(v0: [u8; 2]):
+                return
+            }"#;
+        assert_verifier_rejects(src);
+    }
+
     /// ACIR functions are skipped: `inc_rc` / `dec_rc` are no-ops in ACIR and
     /// `array_set` always produces a fresh array.
     #[test]

--- a/compiler/noirc_evaluator/src/ssa/validation/array_set_rc_invariant.rs
+++ b/compiler/noirc_evaluator/src/ssa/validation/array_set_rc_invariant.rs
@@ -40,18 +40,26 @@
 //!    non-source alias that's also a loop back-edge arg, accept — the
 //!    frontend is deliberately managing iteration aliasing.
 //! 3. **Protected-participant filter.** Before the forward walk, drop from
-//!    the use-set every non-source alias that is both a loop back-edge
-//!    *participant* (it flows — directly or through forward edges — into a
-//!    back-edge arg position) and carries its own `inc_rc`. Such a value is
-//!    RC ≥ 2 whenever it equals the source's storage, so reads of it can't
-//!    observe an in-place mutation. The gate is **per value** on that
-//!    value's own `inc_rc`: a back-edge position fed by an `inc_rc`'d value
-//!    on one predecessor edge and an unprotected value on another drops only
-//!    the protected value, leaving the unprotected one for the walk to flag.
-//!    This is what lets the verifier accept the latch-block shape (an
-//!    `inc_rc v` placed before `v` is threaded *forward* into the latch that
-//!    then closes the loop) without the unsoundness of crediting a sibling's
-//!    `inc_rc` to an unprotected value.
+//!    the use-set every alias-set member (other than the source) that both
+//!    carries its own `inc_rc` and is a loop back-edge *participant* (it
+//!    flows — directly or through forward edges — into a back-edge arg
+//!    position). Being in the alias-set means the value flows *into* the
+//!    source, so combined with its back-edge participation the `inc_rc` is
+//!    loop-carried: it runs before the value crosses the back-edge that
+//!    re-binds it onto the source, so by the time the value's storage
+//!    equals the source's it is RC ≥ 2 and the array_set copies. Reads of
+//!    it therefore can't observe an in-place mutation. The gate is **per
+//!    value** on that value's own `inc_rc`: a back-edge position fed by an
+//!    `inc_rc`'d value on one predecessor edge and an unprotected value on
+//!    another drops only the protected value, leaving the unprotected one
+//!    for the walk to flag. Restricting to alias-set members is the
+//!    soundness guard — a value that merely *receives* the source's storage
+//!    (a forward successor, not in the source's backward set) has its
+//!    `inc_rc` run *after* the array_set and so is not protected; it stays
+//!    in the use-set. This is what lets the verifier accept the latch-block
+//!    shape (an `inc_rc v` placed before `v` is threaded *forward* into the
+//!    latch that then closes the loop) without the unsoundness of crediting
+//!    an `inc_rc` to a value the array_set actually mutates first.
 //! 4. **Forward walk.** Otherwise, walk the CFG forward from the array_set with
 //!    the (filtered) alias-set as the initial use-set. At each block-parameter
 //!    crossing we both **kill** params that the predecessor rebinds to a
@@ -284,11 +292,13 @@ struct Context<'f> {
     /// only the latch's param is the literal back-edge arg).
     ///
     /// Used by the **protected-participant filter** in
-    /// [`Context::find_reachable_aliased_use`]: a non-source alias that is
-    /// both a back-edge participant **and** carries its own `inc_rc` is
-    /// RC ≥ 2 whenever it equals the source's storage, so reads of it
-    /// can't observe an in-place mutation and it is dropped from the
-    /// forward walk's use-set.
+    /// [`Context::find_reachable_aliased_use`]: a value that is in the
+    /// array_set source's alias-set (so it flows *into* the source),
+    /// is a back-edge participant, and carries its own `inc_rc` is
+    /// RC ≥ 2 whenever it equals the source's storage (the `inc_rc` is
+    /// loop-carried — it runs before the value crosses the back-edge onto
+    /// the source), so reads of it can't observe an in-place mutation and
+    /// it is dropped from the forward walk's use-set.
     ///
     /// The filter is gated **per value** on that value's own `inc_rc`:
     /// membership in this set alone never exonerates anything. This is
@@ -675,12 +685,25 @@ impl<'f> Context<'f> {
     ) -> Option<AliasedUse> {
         let mut visited: HashMap<BasicBlockId, WalkState> = HashMap::default();
 
-        // Protected-participant set. A non-source alias that is both a
-        // loop back-edge participant ([`Context::back_edge_participants`])
-        // and carries its own `inc_rc` is RC ≥ 2 whenever it equals
-        // `source`'s storage (the `inc_rc` runs before it crosses the
-        // back-edge into the loop-header parameter), so reads of it can't
-        // observe an in-place mutation.
+        // Protected-participant set. Exclude a non-source alias `v` when
+        // all three hold:
+        //
+        // 1. `v ∈ alias_set` — `v` is in `source`'s backward set, i.e. it
+        //    actually *flows into* `source`. This is the soundness guard:
+        //    a value that only *receives* `source`'s storage (a forward
+        //    successor) is not in the backward set, so its `inc_rc` runs
+        //    *after* the array_set and cannot protect it. Requiring
+        //    membership keeps such values in the use-set to be flagged.
+        // 2. `v` carries its own `inc_rc` — combined with (3), the bump
+        //    runs before `v` crosses the back-edge that re-binds it onto
+        //    `source`'s loop-header parameter, so by the time `v`'s
+        //    storage equals `source`'s it is RC ≥ 2 and the array_set
+        //    copies rather than mutating in place.
+        // 3. `v` is a loop back-edge participant
+        //    ([`Context::back_edge_participants`]) — its storage reaches
+        //    `source` through a back-edge (possibly via a forward edge
+        //    into the back-edge arg first), which is what makes the
+        //    `inc_rc` loop-carried.
         //
         // The gate is **per value** on that value's own `inc_rc` — a
         // sibling's `inc_rc` never exonerates an unprotected value. A
@@ -698,18 +721,14 @@ impl<'f> Context<'f> {
         // the loop-header parameter on the back-edge, since the value
         // threaded back is this protected participant rather than a
         // still-live alias.
-        //
-        // `protected` is computed over *all* back-edge participants, not
-        // just the current `alias_set` members: the forward walk's
-        // add-rule can pull a participant into the use-set that wasn't in
-        // the source's static alias-set (it reaches the source's storage
-        // only along the walked path), and that value must be excluded
-        // too.
-        let protected: im::HashSet<ValueId> = self
-            .back_edge_participants
+        let protected: im::HashSet<ValueId> = alias_set
             .iter()
             .copied()
-            .filter(|&v| v != source && self.inc_rc_locations.contains_key(&v))
+            .filter(|&v| {
+                v != source
+                    && self.inc_rc_locations.contains_key(&v)
+                    && self.back_edge_participants.contains(&v)
+            })
             .collect();
         let use_set: im::HashSet<ValueId> =
             alias_set.iter().copied().filter(|v| !protected.contains(v)).collect();
@@ -1923,259 +1942,50 @@ mod tests {
         assert_verifier_rejects(src);
     }
 
-    /// End-to-end regression for an AST-fuzzer-discovered pattern with
-    /// *nested* loops where the protected back-edge participant is itself
-    /// an inner-loop-header parameter that other in-use aliases flow into.
-    /// Source-level shape (`func_1` from the minimized repro):
+    /// End-to-end regression for an AST-fuzzer-discovered pattern (minimized):
+    /// the protected back-edge participant is itself an inner-loop-header
+    /// parameter that an in-use alias flows into, so the forward walk's
+    /// add-rule would otherwise re-introduce it.
     ///
-    /// ```ignore
-    /// for _ in 0..2 {
-    ///     c.4[0] = if b.2[1] {
-    ///         for _ in 0..2 {
-    ///             if func_1(a, c, (.., c.2, b.4, ["E"]), ..) { c = (.., b.2, [b.3[0]], c.3); }
-    ///         }
-    ///         "F"
-    ///     } else { c.4[0] };
-    /// }
-    /// ```
+    /// `v78` (the inner-loop-header param read by the `call` in `b7`) is in
+    /// `v85`'s backward alias-set — via `v85 <- v79 <- v91 <- v78`, where the
+    /// `b7 -> b11` edge crosses `v78` into the source column (`v91`). It
+    /// carries its own `inc_rc` and is a back-edge participant (it reaches
+    /// the `b11 -> b6` back-edge arg `v91`). The `inc_rc` is therefore
+    /// loop-carried: by the time `v78`'s storage comes around to be the
+    /// `array_set v85` source it is RC >= 2, so the array_set copies and the
+    /// `call`'s read is safe.
     ///
-    /// The outer-latch `array_set v85` (`c.4[0] = …`) has `v85`'s alias-set
-    /// pull in the inner-loop-header param `v78` transitively through the
-    /// loop structure. `v78` carries its own `inc_rc` (the calling-
-    /// convention RC bump before it is passed to the recursive `call`),
-    /// and it is a back-edge participant (it flows into `v90`, an inner
-    /// back-edge arg). So the protected-participant filter drops it — but
-    /// because `v78` is an inner-loop-header parameter, the forward walk's
-    /// add-rule re-introduces it the moment another in-use alias flows
-    /// into `v78`'s position, and the `call` then reads it.
-    ///
-    /// The fix makes the removal *sticky*: a protected participant is kept
-    /// out of the use-set for the whole walk (the add-rule never
-    /// re-introduces it), not just at the initial seed.
+    /// The removal must be **sticky**: `v78` is dropped from the seed, but
+    /// without excluding it from the add-rule too it is re-introduced the
+    /// moment the in-use alias `v72` flows into it at `b6`, and the `call`
+    /// is flagged. (`v72`, the second outer column, is the live carrier that
+    /// survives the outer back-edge and re-feeds `v78`.)
     #[test]
-    fn end_to_end_protected_participant_is_inner_loop_header_param_is_accepted() {
+    fn end_to_end_sticky_removal_of_inner_loop_header_participant_is_accepted() {
         let src = r#"
-            brillig(inline_always) fn func_1 f0 {
-              b0(v0: u1, v1: u1, v3: u1, v5: u1, v7: [u1; 2], v9: [[u8; 1]; 1], v11: [[u8; 1]; 1], v13: u1, v15: u1, v17: u1, v19: [u1; 2], v21: [[u8; 1]; 1], v23: [[u8; 1]; 1], v25: &mut u32):
-                jmp b1(u32 0, v13, v19, v21, v23)
-              b1(v28: u32, v68: u1, v71: [u1; 2], v72: [[u8; 1]; 1], v73: [[u8; 1]; 1]):
-                v29 = lt v28, u32 2
-                jmpif v29 then: b2(), else: b3()
-              b2():
-                v33 = array_get v7, index u32 1 -> u1
-                jmpif v33 then: b4(), else: b5()
+            brillig(inline) fn f f0 {
+              b0(v0: u1, v72i: [u32; 1], v73i: [u32; 1]):
+                jmp b1(v72i, v73i)
+              b1(v72: [u32; 1], v73: [u32; 1]):
+                jmpif v0 then: b6(v72, v73), else: b3()
               b3():
-                return u1 1
-              b4():
-                jmp b6(u32 0, v68, v71, v72, v73)
-              b5():
-                v63 = array_get v73, index u32 0 -> [u8; 1]
-                inc_rc v63
-                jmp b12(v63, v68, v71, v72, v73)
-              b6(v34: u32, v74: u1, v77: [u1; 2], v78: [[u8; 1]; 1], v79: [[u8; 1]; 1]):
-                v35 = lt v34, u32 2
-                jmpif v35 then: b7(), else: b8()
-              b7():
-                inc_rc v77
-                inc_rc v78
-                inc_rc v79
-                inc_rc v77
-                inc_rc v11
-                v49 = make_array b"E"
-                v50 = make_array [v49] : [[u8; 1]; 1]
-                v51 = call f0(v0, v74, v15, v17, v77, v78, v79, u1 0, v15, v17, v77, v11, v50, v25) -> u1
-                jmpif v51 then: b9(), else: b10()
-              b8():
-                v61 = make_array b"F"
-                jmp b12(v61, v74, v77, v78, v79)
-              b9():
-                inc_rc v7
-                v56 = array_get v9, index u32 0 -> [u8; 1]
-                inc_rc v56
-                v57 = make_array [v56] : [[u8; 1]; 1]
-                jmp b11(u1 0, v7, v57, v78)
-              b10():
-                jmp b11(v74, v77, v78, v79)
-              b11(v86: u1, v89: [u1; 2], v90: [[u8; 1]; 1], v91: [[u8; 1]; 1]):
-                v59 = unchecked_add v34, u32 1
-                jmp b6(v59, v86, v89, v90, v91)
-              b12(v64: [u8; 1], v80: u1, v83: [u1; 2], v84: [[u8; 1]; 1], v85: [[u8; 1]; 1]):
-                v66 = array_set v85, index u32 0, value v64
-                v67 = unchecked_add v28, u32 1
-                jmp b1(v67, v80, v83, v84, v66)
-            }"#;
-        assert_verifier_accepts_because(
-            src,
-            "v78 is an inner-loop-header param that is a back-edge participant with its own inc_rc; sticky removal keeps it out of the use-set so the add-rule can't re-introduce it for the recursive call to read",
-        );
-    }
-
-    /// End-to-end regression for an AST-fuzzer-discovered pattern (the
-    /// `..=` inclusive-range duplicated-body variant of
-    /// [`end_to_end_protected_participant_is_inner_loop_header_param_is_accepted`]).
-    /// The protected participant `v167` is an inner-loop-header parameter
-    /// that the forward walk's add-rule pulls into the use-set *even
-    /// though it is not in the `array_set` source `v209`'s static
-    /// alias-set* — `v167` lives in the duplicated last-iteration body
-    /// (`b33`) and reaches `v209`'s storage only along the walked path.
-    ///
-    /// This pins down that the protected set must be computed over *all*
-    /// back-edge participants, not just the source's static alias-set:
-    /// `v167` has its own `inc_rc` (the calling-convention bump before the
-    /// recursive `call`) and is a back-edge participant (it flows into
-    /// `v180`, the `b41 → b33` back-edge arg), so it is excluded from the
-    /// use-set globally and the add-rule never re-introduces it.
-    #[test]
-    fn end_to_end_protected_participant_added_outside_static_alias_set_is_accepted() {
-        let src = r#"
-            brillig(inline_always) fn func_1 f0 {
-              b0(v0: u1, v1: u1, v3: u1, v5: u1, v7: [u1; 2], v9: [[u8; 1]; 1], v11: [[u8; 1]; 1], v13: u1, v15: u1, v17: u1, v19: [u1; 2], v21: [[u8; 1]; 1], v23: [[u8; 1]; 1], v25: &mut u32):
-                v26 = load v25 -> u32
-                v28 = eq v26, u32 0
-                jmpif v28 then: b1(), else: b2()
-              b1():
-                jmp b3(v7, v13, v21, v23)
-              b2():
-                v30 = load v25 -> u32
-                v32 = sub v30, u32 1
-                store v32 at v25
-                jmp b4(i16 -26238, v7, v13, v21, v23)
-              b3(v216: [u1; 2], v217: u1, v221: [[u8; 1]; 1], v222: [[u8; 1]; 1]):
                 return u1 0
-              b4(v36: i16, v148: [u1; 2], v149: u1, v153: [[u8; 1]; 1], v154: [[u8; 1]; 1]):
-                v38 = lt v36, i16 -26235
-                jmpif v38 then: b5(), else: b6()
-              b5():
-                jmp b7(v148, v149, v153, v154, u32 0)
-              b6():
-                jmpif u1 1 then: b24(), else: b25(v148, v149, v153, v154)
-              b7(v189: [u1; 2], v190: u1, v194: [[u8; 1]; 1], v195: [[u8; 1]; 1], v196: u32):
-                v41 = eq v196, u32 0
-                jmpif v41 then: b9(), else: b10()
-              b8():
-                v99 = unchecked_add v36, i16 1
-                jmp b4(v99, v189, v190, v194, v195)
-              b9():
-                jmp b8()
-              b10():
-                v43 = add v196, u32 1
-                v46 = array_get v189, index u32 1 -> u1
-                jmpif v46 then: b12(), else: b13()
-              b11():
-                jmp b7(v203, v204, v208, v91, v43)
-              b12():
-                inc_rc v19
-                jmp b14(i32 -261577443, v190, v194, v195)
-              b13():
-                v88 = array_get v195, index u32 0 -> [u8; 1]
-                inc_rc v88
-                jmp b23(v88, v189, v190, v194, v195)
-              b14(v50: i32, v197: u1, v201: [[u8; 1]; 1], v202: [[u8; 1]; 1]):
-                v51 = lt v50, i32 -261577442
-                jmpif v51 then: b15(), else: b16()
-              b15():
-                inc_rc v19
-                inc_rc v201
-                inc_rc v202
-                inc_rc v19
-                inc_rc v11
-                v64 = make_array b"S"
-                v65 = make_array [v64] : [[u8; 1]; 1]
-                v66 = call f0(v0, v197, v15, v17, v19, v201, v202, u1 0, v15, v17, v19, v11, v65, v25) -> u1
-                jmpif v66 then: b17(), else: b18()
-              b16():
-                v86 = make_array b"T"
-                jmp b23(v86, v19, v197, v201, v202)
-              b17():
-                jmp b19(i32 -439841945)
-              b18():
-                jmp b19(i32 -569613121)
-              b19(v69: i32):
-                v71 = lt v69, i32 -255727548
-                v72 = not v71
-                jmpif v72 then: b20(), else: b21()
-              b20():
-                inc_rc v19
-                v78 = array_get v9, index u32 0 -> [u8; 1]
+              b6(v78: [u32; 1], v79: [u32; 1]):
+                jmpif v0 then: b7(), else: b12(v78, v79)
+              b7():
                 inc_rc v78
-                v79 = make_array [v78] : [[u8; 1]; 1]
-                jmp b22(u1 0, v79, v201)
-              b21():
-                jmp b22(v197, v201, v202)
-              b22(v210: u1, v214: [[u8; 1]; 1], v215: [[u8; 1]; 1]):
-                constrain u1 0 == u1 1, "LCC"
-                v84 = unchecked_add v50, i32 1
-                jmp b14(v84, v210, v214, v215)
-              b23(v89: [u8; 1], v203: [u1; 2], v204: u1, v208: [[u8; 1]; 1], v209: [[u8; 1]; 1]):
-                v91 = array_set v209, index u32 0, value v89
-                jmp b11()
-              b24():
-                jmp b26(v148, v149, v153, v154, u32 0)
-              b25(v182: [u1; 2], v183: u1, v187: [[u8; 1]; 1], v188: [[u8; 1]; 1]):
-                jmp b3(v182, v183, v187, v188)
-              b26(v155: [u1; 2], v156: u1, v160: [[u8; 1]; 1], v161: [[u8; 1]; 1], v162: u32):
-                v103 = eq v162, u32 0
-                jmpif v103 then: b28(), else: b29()
-              b27():
-                jmp b25(v155, v156, v160, v161)
-              b28():
-                jmp b27()
-              b29():
-                v105 = add v162, u32 1
-                v107 = array_get v155, index u32 1 -> u1
-                jmpif v107 then: b31(), else: b32()
-              b30():
-                jmp b26(v169, v170, v174, v140, v105)
-              b31():
-                inc_rc v19
-                jmp b33(i32 -261577443, v156, v160, v161)
-              b32():
-                v137 = array_get v161, index u32 0 -> [u8; 1]
-                inc_rc v137
-                jmp b42(v137, v155, v156, v160, v161)
-              b33(v109: i32, v163: u1, v167: [[u8; 1]; 1], v168: [[u8; 1]; 1]):
-                v110 = lt v109, i32 -261577442
-                jmpif v110 then: b34(), else: b35()
-              b34():
-                inc_rc v19
-                inc_rc v167
-                inc_rc v168
-                inc_rc v19
-                inc_rc v11
-                v121 = make_array b"S"
-                v122 = make_array [v121] : [[u8; 1]; 1]
-                v123 = call f0(v0, v163, v15, v17, v19, v167, v168, u1 0, v15, v17, v19, v11, v122, v25) -> u1
-                jmpif v123 then: b36(), else: b37()
-              b35():
-                v135 = make_array b"T"
-                jmp b42(v135, v19, v163, v167, v168)
-              b36():
-                jmp b38(i32 -439841945)
-              b37():
-                jmp b38(i32 -569613121)
-              b38(v124: i32):
-                v125 = lt v124, i32 -255727548
-                v126 = not v125
-                jmpif v126 then: b39(), else: b40()
-              b39():
-                inc_rc v19
-                v131 = array_get v9, index u32 0 -> [u8; 1]
-                inc_rc v131
-                v132 = make_array [v131] : [[u8; 1]; 1]
-                jmp b41(u1 0, v132, v167)
-              b40():
-                jmp b41(v163, v167, v168)
-              b41(v176: u1, v180: [[u8; 1]; 1], v181: [[u8; 1]; 1]):
-                constrain u1 0 == u1 1, "LCC"
-                v134 = unchecked_add v109, i32 1
-                jmp b33(v134, v176, v180, v181)
-              b42(v138: [u8; 1], v169: [u1; 2], v170: u1, v174: [[u8; 1]; 1], v175: [[u8; 1]; 1]):
-                v140 = array_set v175, index u32 0, value v138
-                jmp b30()
+                v51 = call f0(v0, v78, v79) -> u1
+                jmp b11(v79, v78)
+              b11(v90: [u32; 1], v91: [u32; 1]):
+                jmp b6(v90, v91)
+              b12(v84: [u32; 1], v85: [u32; 1]):
+                v66 = array_set v85, index u32 0, value u32 9
+                jmp b1(v84, v66)
             }"#;
         assert_verifier_accepts_because(
             src,
-            "v167 (and v201/v202 etc.) are protected back-edge participants pulled into the use-set by the walk's add-rule outside v209's static alias-set; the global protected set excludes them so neither array_set is flagged",
+            "v78 is an inner-loop-header param in v85's backward set with its own loop-carried inc_rc and back-edge participation; sticky removal keeps it out of the use-set so the add-rule can't re-introduce it for the call to read",
         );
     }
 

--- a/compiler/noirc_evaluator/src/ssa/validation/array_set_rc_invariant.rs
+++ b/compiler/noirc_evaluator/src/ssa/validation/array_set_rc_invariant.rs
@@ -318,7 +318,9 @@ struct Context<'f> {
     /// sibling parameters `Q` that `P` is rebound to on the loop
     /// back-edge (`P ← Q`, the array-variable swap `c4 = c3`) while `Q`
     /// is simultaneously rebound to a freshly-allocated, iteration-local
-    /// `make_array` (`c3 = [..]`). Such a `Q` is a *distinct
+    /// value — a `make_array` (`c3 = [..]`) or a `Call` result
+    /// (`c3 = f()`), but never an `array_set` result (which may be an
+    /// in-place mutation, not a fresh allocation). Such a `Q` is a *distinct
     /// per-iteration storage* that `P` only *becomes* in a later
     /// iteration — never the storage this iteration's `array_set` on `P`
     /// mutates (the swap rotates a fresh allocation into `P` while the
@@ -369,6 +371,7 @@ impl<'f> Context<'f> {
         let mut array_value_defs: HashMap<ValueId, (BasicBlockId, usize)> = HashMap::default();
         let mut non_aliasing_array_values: HashSet<ValueId> = HashSet::default();
         let mut make_array_values: HashSet<ValueId> = HashSet::default();
+        let mut call_result_values: HashSet<ValueId> = HashSet::default();
         let mut back_edge_args: HashSet<ValueId> = HashSet::default();
         // For each destination block, the list of `(predecessor, args)`
         // pairs collected from terminators. Used to drive the backward
@@ -387,8 +390,9 @@ impl<'f> Context<'f> {
                     inc_rc_locations.entry(*value).or_default().push((block_id, idx));
                 }
 
+                let is_call = matches!(instruction, Instruction::Call { .. });
                 let is_non_aliasing =
-                    matches!(instruction, Instruction::ArraySet { .. } | Instruction::Call { .. });
+                    is_call || matches!(instruction, Instruction::ArraySet { .. });
                 let is_make_array = matches!(instruction, Instruction::MakeArray { .. });
                 for &result in function.dfg.instruction_results(*instruction_id) {
                     if function.dfg.type_of_value(result).contains_an_array() {
@@ -398,6 +402,9 @@ impl<'f> Context<'f> {
                         }
                         if is_make_array {
                             make_array_values.insert(result);
+                        }
+                        if is_call {
+                            call_result_values.insert(result);
                         }
                     }
                 }
@@ -466,13 +473,28 @@ impl<'f> Context<'f> {
         let iteration_local_make_arrays: HashSet<ValueId> =
             make_array_values.intersection(&back_edge_args).copied().collect();
 
+        // A back-edge arg is iteration-local *fresh* if it re-allocates
+        // distinct storage every iteration: a `make_array` (re-executes)
+        // or a `Call` result (the callee allocates fresh — the same
+        // assumption [`Context::non_aliasing_array_values`] makes).
+        // `array_set` results are deliberately *excluded*: an `array_set`
+        // may mutate its source in place, so its result can be the *same*
+        // storage as a prior iteration's, breaking the distinct-generation
+        // guarantee the swap exclusion relies on.
+        let iteration_local_fresh: HashSet<ValueId> = back_edge_args
+            .iter()
+            .copied()
+            .filter(|v| make_array_values.contains(v) || call_result_values.contains(v))
+            .collect();
+
         // Swap exclusions. For every loop back-edge `be_start → header`,
-        // inspect each array-typed header parameter `p` at position `i`:
-        // if the back-edge rebinds it to a *sibling* header parameter
-        // `q` (`p ← q`) whose own back-edge arg is an iteration-local
-        // `make_array`, and `p` and `q` receive distinct storage on every
-        // forward edge into the header, record `q` as excluded from `p`'s
-        // alias-set. See [`Context::swap_excluded_aliases`].
+        // inspect each array-typed header parameter at `source_pos`: if
+        // the back-edge rebinds it to a *sibling* header parameter
+        // (`source ← sibling`) whose own back-edge arg is an
+        // iteration-local fresh allocation, and the source and sibling
+        // receive distinct storage on every forward edge into the header,
+        // record the sibling as excluded from the source's alias-set. See
+        // [`Context::swap_excluded_aliases`].
         let mut swap_excluded_aliases: HashMap<ValueId, HashSet<ValueId>> = HashMap::default();
         for &(be_start, header) in &back_edges {
             let Some(edges) = incoming_edges.get(&header) else { continue };
@@ -496,13 +518,10 @@ impl<'f> Context<'f> {
                 let Some(sibling_pos) = params.iter().position(|&pp| pp == sibling) else {
                     continue;
                 };
-                // The sibling's own back-edge arg must be a
-                // freshly-allocated, iteration-local `make_array` (the
-                // `c3 = [..]` half of the swap).
-                if !be_args
-                    .get(sibling_pos)
-                    .is_some_and(|a| iteration_local_make_arrays.contains(a))
-                {
+                // The sibling's own back-edge arg must be an
+                // iteration-local fresh allocation (the `c3 = [..]` or
+                // `c3 = f()` half of the swap).
+                if !be_args.get(sibling_pos).is_some_and(|a| iteration_local_fresh.contains(a)) {
                     continue;
                 }
                 // Loop-entry guard. On every *forward* edge into the
@@ -1604,6 +1623,86 @@ mod tests {
                 v9 = make_array [u8 3] : [u8; 1]
                 v18 = unchecked_add v10, u8 1
                 jmp b1(v18, v9, v2)
+              b3():
+                return
+            }"#;
+        assert_verifier_rejects(src);
+    }
+
+    /// The swap freshening accepts a `Call` result, not only a
+    /// `make_array`. Same shape as
+    /// [`Self::end_to_end_loop_swap_then_whole_array_read_is_accepted`],
+    /// but the sibling `v2` (`c3`) is freshened by `v20 = call f1()`
+    /// (`c3 = f()`) rather than a literal `make_array`. A `Call` result is
+    /// a fresh per-iteration allocation (the same assumption the
+    /// non-aliasing filter makes), so `v2` is dropped from `v3`'s
+    /// alias-set, the walk kills `v3` on the back-edge, and the loop-exit
+    /// `call f2(v3)` is not flagged.
+    #[test]
+    fn end_to_end_swap_freshened_by_call_is_accepted() {
+        let src = r#"
+            brillig(inline) fn main f0 {
+              b0():
+                v0 = make_array [u8 1] : [u8; 1]
+                v1 = make_array [u8 2] : [u8; 1]
+                jmp b1(u8 0, v0, v1)
+              b1(v10: u8, v2: [u8; 1], v3: [u8; 1]):
+                v12 = lt v10, u8 5
+                jmpif v12 then: b2(), else: b3()
+              b2():
+                v15 = array_set v3, index u32 0, value u8 9
+                v20 = call f1() -> [u8; 1]
+                v18 = unchecked_add v10, u8 1
+                jmp b1(v18, v20, v2)
+              b3():
+                call f2(v3)
+                return
+            }
+            brillig(inline) fn alloc f1 {
+              b0():
+                v0 = make_array [u8 7] : [u8; 1]
+                return v0
+            }
+            brillig(inline) fn observe f2 {
+              b0(v0: [u8; 1]):
+                return
+            }"#;
+        assert_verifier_accepts_because(
+            src,
+            "v2 is freshened on the back-edge by a Call result (v20), a fresh per-iteration \
+             allocation, so the swap exclusion drops v2 from v3's alias-set and the loop-exit \
+             read call f2(v3) is not flagged",
+        );
+    }
+
+    /// **Swap-exclusion soundness canary — `array_set` results are not
+    /// fresh.** The sibling `v2` (`c3`) is freshened on the back-edge by
+    /// `v20 = array_set v2, …` — an `array_set` result, which may be an
+    /// **in-place** mutation rather than a new allocation. So
+    /// `v2_k = v2_{k-1}`'s storage, and after the swap `v3` aliases it: the
+    /// in-loop `array_set v3` mutates the storage that `array_get v2` then
+    /// reads. The exclusion must **not** fire (an `array_set` result is
+    /// excluded from `iteration_local_fresh`), and the verifier must
+    /// reject. Guards against widening the freshening to all
+    /// non-aliasing results.
+    #[test]
+    fn end_to_end_swap_freshened_by_array_set_result_is_rejected() {
+        let src = r#"
+            brillig(inline) fn main f0 {
+              b0():
+                v0 = make_array [u8 1] : [u8; 1]
+                v1 = make_array [u8 2] : [u8; 1]
+                jmp b1(u8 0, v0, v1)
+              b1(v10: u8, v2: [u8; 1], v3: [u8; 1]):
+                v12 = lt v10, u8 5
+                jmpif v12 then: b2(), else: b3()
+              b2():
+                v15 = array_set v3, index u32 0, value u8 9
+                v17 = array_get v2, index u32 0 -> u8
+                constrain v17 == u8 1
+                v20 = array_set v2, index u32 0, value u8 5
+                v18 = unchecked_add v10, u8 1
+                jmp b1(v18, v20, v2)
               b3():
                 return
             }"#;

--- a/compiler/noirc_evaluator/src/ssa/validation/array_set_rc_invariant.rs
+++ b/compiler/noirc_evaluator/src/ssa/validation/array_set_rc_invariant.rs
@@ -428,17 +428,13 @@ impl<'f> Context<'f> {
             }
         }
 
-        // A `make_array` is iteration-local iff its result reaches a loop
-        // back-edge — directly as a back-edge arg, or through forward
-        // block-parameter edges into one (membership in
-        // `back_edge_participants`). Either way it re-executes every
-        // iteration, so the storage a loop-header parameter receives from
-        // it is freshly allocated per iteration rather than the same
-        // storage an `array_set` may mutate in place. Such a result can't
-        // carry an `array_set` source's pre-mutation aliasing across
-        // iterations, so it is dropped from every alias-set.
+        // A `make_array` is iteration-local iff its result appears on a
+        // loop back-edge: that's the signal that it re-executes each
+        // iteration, so the storage the loop-header parameter receives
+        // through the back-edge is freshly allocated rather than the
+        // same storage the array_set may mutate in place.
         let iteration_local_make_arrays: HashSet<ValueId> =
-            make_array_values.intersection(&back_edge_participants).copied().collect();
+            make_array_values.intersection(&back_edge_args).copied().collect();
 
         Self {
             function,

--- a/compiler/noirc_evaluator/src/ssa/validation/array_set_rc_invariant.rs
+++ b/compiler/noirc_evaluator/src/ssa/validation/array_set_rc_invariant.rs
@@ -256,26 +256,32 @@ struct Context<'f> {
     ///   documented gap. In practice the frontend's array-returning
     ///   functions allocate fresh storage.
     non_aliasing_array_values: HashSet<ValueId>,
-    /// `MakeArray` results that appear as a jmp/jmpif arg on at least one
-    /// loop back-edge. Such a `make_array` re-executes on every loop
-    /// iteration and represents fresh storage per iteration, so any
-    /// back-edge that puts it in a loop-header parameter's class is
-    /// conflating distinct runtime storages across iterations. Filtered
-    /// out of the alias-set on lookup — see [`Context::alias_set_for`].
+    /// Back-edge args that re-allocate distinct storage every iteration:
+    /// `MakeArray` results (re-executes each iteration) and `Call` results
+    /// (the callee allocates fresh). `array_set` results are excluded —
+    /// they may mutate in place, so they aren't guaranteed-fresh. Two uses:
     ///
-    /// `MakeArray` results that are *not* back-edge args are kept in the
-    /// alias-set: they represent a one-time allocation whose storage
-    /// the array_set may mutate in place.
-    iteration_local_make_arrays: HashSet<ValueId>,
+    /// - [`Context::alias_set_for`] drops such values from the alias-set:
+    ///   a back-edge that puts one in a loop-header parameter's class is
+    ///   conflating distinct runtime storages across iterations. (`Call`
+    ///   results are also dropped there by
+    ///   [`Context::non_aliasing_array_values`]; the overlap is harmless.)
+    /// - the swap freshening guard in [`Context::new`] requires the
+    ///   swapped-out sibling to be one of these — see
+    ///   [`Context::swap_excluded_aliases`].
+    ///
+    /// Values that are *not* back-edge args are kept in the alias-set:
+    /// they represent a one-time allocation whose storage the array_set
+    /// may mutate in place.
+    iteration_local_fresh: HashSet<ValueId>,
     /// `inc_rc value` instructions indexed by their operand. Each entry is
     /// the `(block, instruction-position-within-block)` of one `inc_rc`.
     inc_rc_locations: HashMap<ValueId, Vec<(BasicBlockId, usize)>>,
     /// Values that appear at least once as a jmp/jmpif arg on a loop
     /// back-edge. Used by both:
     ///
-    /// - [`Context::iteration_local_make_arrays`] (computed via the
-    ///   intersection `make_array_values ∩ back_edge_args` in
-    ///   [`Context::new`]); and
+    /// - [`Context::iteration_local_fresh`] (the back-edge args that are
+    ///   `make_array` or `Call` results, computed in [`Context::new`]); and
     /// - the **back-edge-participant relaxation** in
     ///   [`Context::some_inc_rc_precedes`]: an `inc_rc` on a non-source
     ///   alias that's also a back-edge arg is taken as a codegen
@@ -465,14 +471,6 @@ impl<'f> Context<'f> {
             }
         }
 
-        // A `make_array` is iteration-local iff its result appears on a
-        // loop back-edge: that's the signal that it re-executes each
-        // iteration, so the storage the loop-header parameter receives
-        // through the back-edge is freshly allocated rather than the
-        // same storage the array_set may mutate in place.
-        let iteration_local_make_arrays: HashSet<ValueId> =
-            make_array_values.intersection(&back_edge_args).copied().collect();
-
         // A back-edge arg is iteration-local *fresh* if it re-allocates
         // distinct storage every iteration: a `make_array` (re-executes)
         // or a `Call` result (the callee allocates fresh — the same
@@ -572,7 +570,7 @@ impl<'f> Context<'f> {
             backward_aliases,
             array_value_defs,
             non_aliasing_array_values,
-            iteration_local_make_arrays,
+            iteration_local_fresh,
             inc_rc_locations,
             back_edge_args,
             back_edge_participants,
@@ -601,16 +599,15 @@ impl<'f> Context<'f> {
     ///   create a real alias, and we'd miss that. In practice the
     ///   frontend's array-returning functions allocate fresh storage.
     ///
-    /// Also drop **iteration-local `MakeArray` results** — those that
-    /// appear on at least one loop back-edge
-    /// ([`Context::iteration_local_make_arrays`]). A `make_array` on a
-    /// back-edge re-executes each iteration and allocates fresh
-    /// storage, so the loop-header parameter it feeds on the back-edge
-    /// holds a *different* allocation in the next iteration than the
-    /// one this iteration's `array_set` may have mutated.
-    /// **Non-back-edge `MakeArray` results stay in the alias-set** —
-    /// they represent a one-time allocation whose storage the
-    /// array_set can mutate in place.
+    /// Also drop **iteration-local fresh results** — `MakeArray` (or
+    /// `Call`) results that appear on at least one loop back-edge
+    /// ([`Context::iteration_local_fresh`]). Such a value re-allocates
+    /// fresh storage each iteration, so the loop-header parameter it
+    /// feeds on the back-edge holds a *different* allocation in the next
+    /// iteration than the one this iteration's `array_set` may have
+    /// mutated. **Non-back-edge `MakeArray` results stay in the
+    /// alias-set** — they represent a one-time allocation whose storage
+    /// the array_set can mutate in place.
     ///
     /// **Post-array_set-in-same-block filter.** Drop instruction
     /// results whose defining position is in `array_set_block` at an
@@ -649,7 +646,7 @@ impl<'f> Context<'f> {
                 if self.non_aliasing_array_values.contains(&v) {
                     return false;
                 }
-                if self.iteration_local_make_arrays.contains(&v) {
+                if self.iteration_local_fresh.contains(&v) {
                     return false;
                 }
                 if self.swap_excluded_aliases.get(&source).is_some_and(|qs| qs.contains(&v)) {
@@ -2697,7 +2694,7 @@ mod tests {
     /// `make_array` defined in the same block as (and *after*) the
     /// `array_set`, whose result feeds the loop-header parameter on the
     /// loop's back-edge. The make_array is iteration-local (back-edge
-    /// arg), so the `iteration_local_make_arrays` filter drops it from
+    /// arg), so the `iteration_local_fresh` filter drops it from
     /// the alias-set: the per-arg kill at the back-edge then sees the
     /// arg ∉ use_set and correctly drops the loop-header parameter, so
     /// the walk terminates without flagging the loop-body reads.
@@ -2831,7 +2828,7 @@ mod tests {
     /// runtime the parameter is rebound to a fresh `make_array` on
     /// every back-edge crossing, so the iteration-aliasing is illusory.
     ///
-    /// The `iteration_local_make_arrays` filter drops a `make_array`
+    /// The `iteration_local_fresh` filter drops a `make_array`
     /// result that appears on a loop back-edge: the make_array always
     /// allocates fresh top-level storage, so it
     /// can't represent the pre-mutation storage of any array_set source.
@@ -3089,7 +3086,7 @@ mod tests {
     }
 
     /// Minimal SSA pinning down the **unique necessity** of the
-    /// [`Context::iteration_local_make_arrays`] filter. The other
+    /// [`Context::iteration_local_fresh`] filter. The other
     /// "value can't share storage at the array_set's program point"
     /// filters — `non_aliasing_array_values` (ArraySet/Call results),
     /// `post-array_set-in-same-block`, and the walk's `def-block-entry`
@@ -3122,7 +3119,7 @@ mod tests {
     ///   in use_set, the rule sees the arg as "still an alias" and
     ///   keeps `v1`. The subsequent `array_get v1` in `b1` then flags.
     ///
-    /// `iteration_local_make_arrays` filters `v4` at alias-set
+    /// `iteration_local_fresh` filters `v4` at alias-set
     /// construction time so it's never in the use_set in the first
     /// place. The kill rule on `b3 → b1` then correctly fires, `v1`
     /// is dropped, and the walk terminates without flagging.
@@ -3144,7 +3141,7 @@ mod tests {
             }"#;
         assert_verifier_accepts_because(
             src,
-            "v4 is a make_array on the b3 → b1 back-edge — iteration-local fresh storage. The iteration_local_make_arrays filter drops it from v1's alias-set, enabling the per-arg kill at the back-edge to correctly fire on v1. Without this filter, the walk would falsely flag the b1.array_get v1 on re-entry.",
+            "v4 is a make_array on the b3 → b1 back-edge — iteration-local fresh storage. The iteration_local_fresh filter drops it from v1's alias-set, enabling the per-arg kill at the back-edge to correctly fire on v1. Without this filter, the walk would falsely flag the b1.array_get v1 on re-entry.",
         );
     }
 

--- a/compiler/noirc_evaluator/src/ssa/validation/array_set_rc_invariant.rs
+++ b/compiler/noirc_evaluator/src/ssa/validation/array_set_rc_invariant.rs
@@ -675,31 +675,44 @@ impl<'f> Context<'f> {
     ) -> Option<AliasedUse> {
         let mut visited: HashMap<BasicBlockId, WalkState> = HashMap::default();
 
-        // Protected-participant filter. Drop from the use-set every
-        // non-source alias that is both a loop back-edge participant
-        // ([`Context::back_edge_participants`]) and carries its own
-        // `inc_rc`: such a value is RC ≥ 2 whenever it equals `source`'s
-        // storage (the `inc_rc` runs before it crosses the back-edge into
-        // the loop-header parameter), so reads of it can't observe an
-        // in-place mutation. Removing it also lets the per-arg kill rule
-        // in [`Context::succ_use_set`] drop the loop-header parameter on
-        // the back-edge, since the value threaded back is this protected
-        // participant rather than a still-live alias.
+        // Protected-participant set. A non-source alias that is both a
+        // loop back-edge participant ([`Context::back_edge_participants`])
+        // and carries its own `inc_rc` is RC ≥ 2 whenever it equals
+        // `source`'s storage (the `inc_rc` runs before it crosses the
+        // back-edge into the loop-header parameter), so reads of it can't
+        // observe an in-place mutation.
         //
         // The gate is **per value** on that value's own `inc_rc` — a
         // sibling's `inc_rc` never exonerates an unprotected value. A
-        // back-edge position fed by an `inc_rc`'d value on one
-        // predecessor edge and an unprotected value on another drops only
-        // the former; the latter stays for the walk to flag.
-        let use_set: im::HashSet<ValueId> = alias_set
+        // back-edge position fed by an `inc_rc`'d value on one predecessor
+        // edge and an unprotected value on another protects only the
+        // former; the latter stays in the use-set for the walk to flag.
+        //
+        // The removal is **sticky**: protected members are kept out of the
+        // use-set for the whole walk, not just the initial seed. A
+        // protected participant that is itself a loop-header parameter
+        // would otherwise be re-introduced the moment another in-use alias
+        // flows into its position (the add-rule in
+        // [`Context::succ_use_set`]); excluding it there too keeps it out.
+        // Dropping it from the seed also lets the per-arg kill rule drop
+        // the loop-header parameter on the back-edge, since the value
+        // threaded back is this protected participant rather than a
+        // still-live alias.
+        //
+        // `protected` is computed over *all* back-edge participants, not
+        // just the current `alias_set` members: the forward walk's
+        // add-rule can pull a participant into the use-set that wasn't in
+        // the source's static alias-set (it reaches the source's storage
+        // only along the walked path), and that value must be excluded
+        // too.
+        let protected: im::HashSet<ValueId> = self
+            .back_edge_participants
             .iter()
             .copied()
-            .filter(|&v| {
-                v == source
-                    || !(self.inc_rc_locations.contains_key(&v)
-                        && self.back_edge_participants.contains(&v))
-            })
+            .filter(|&v| v != source && self.inc_rc_locations.contains_key(&v))
             .collect();
+        let use_set: im::HashSet<ValueId> =
+            alias_set.iter().copied().filter(|v| !protected.contains(v)).collect();
 
         let array_set_result = self.function.dfg.instruction_results(array_set_id)[0];
         let initial_state = WalkState {
@@ -825,7 +838,7 @@ impl<'f> Context<'f> {
             let Some(terminator) = self.function.dfg[block].terminator() else { continue };
             match terminator {
                 TerminatorInstruction::Jmp { destination, arguments, .. } => {
-                    let next = self.succ_walk_state(*destination, arguments, &state);
+                    let next = self.succ_walk_state(*destination, arguments, &state, &protected);
                     worklist.push(WalkFrame { block: *destination, start_idx: 0, state: next });
                 }
                 TerminatorInstruction::JmpIf {
@@ -836,14 +849,14 @@ impl<'f> Context<'f> {
                     ..
                 } => {
                     let then_state =
-                        self.succ_walk_state(*then_destination, then_arguments, &state);
+                        self.succ_walk_state(*then_destination, then_arguments, &state, &protected);
                     worklist.push(WalkFrame {
                         block: *then_destination,
                         start_idx: 0,
                         state: then_state,
                     });
                     let else_state =
-                        self.succ_walk_state(*else_destination, else_arguments, &state);
+                        self.succ_walk_state(*else_destination, else_arguments, &state, &protected);
                     worklist.push(WalkFrame {
                         block: *else_destination,
                         start_idx: 0,
@@ -867,10 +880,11 @@ impl<'f> Context<'f> {
         dest: BasicBlockId,
         arguments: &[ValueId],
         state: &WalkState,
+        protected: &im::HashSet<ValueId>,
     ) -> WalkState {
         WalkState {
-            use_set: self.succ_use_set(dest, arguments, &state.use_set),
-            derived: self.succ_use_set(dest, arguments, &state.derived),
+            use_set: self.succ_use_set(dest, arguments, &state.use_set, protected),
+            derived: self.succ_use_set(dest, arguments, &state.derived, protected),
             tainted: state.tainted.clone(),
         }
     }
@@ -888,9 +902,13 @@ impl<'f> Context<'f> {
     ///      result, excluded at lookup time): drop it.
     ///    - **Add.** If the param is not in `use_set` but the arg is,
     ///      this edge introduces a fresh alias: the param at `dest`'s
-    ///      entry shares storage with an alias-set member, so add it.
-    ///      This keeps alias propagation accurate at joins and loop
-    ///      back-edges.
+    ///      entry shares storage with an alias-set member, so add it —
+    ///      *unless* the param is a protected back-edge participant
+    ///      ([`Context::find_reachable_aliased_use`]), which must stay out
+    ///      of the use-set for the whole walk (its own `inc_rc` keeps it
+    ///      RC ≥ 2). Without this exclusion a protected participant that
+    ///      is itself a loop-header parameter would be re-introduced the
+    ///      moment any in-use alias flowed into its position.
     ///    - Otherwise (both in or both out), no change.
     ///    Only array-typed params participate.
     ///
@@ -905,6 +923,7 @@ impl<'f> Context<'f> {
         dest: BasicBlockId,
         arguments: &[ValueId],
         use_set: &im::HashSet<ValueId>,
+        protected: &im::HashSet<ValueId>,
     ) -> im::HashSet<ValueId> {
         let mut result = use_set.clone();
 
@@ -921,7 +940,9 @@ impl<'f> Context<'f> {
                     result.remove(&param);
                 }
                 (false, true) => {
-                    result.insert(param);
+                    if !protected.contains(&param) {
+                        result.insert(param);
+                    }
                 }
                 _ => {}
             }
@@ -1900,6 +1921,262 @@ mod tests {
                 jmp b1(v9, v8)
             }"#;
         assert_verifier_rejects(src);
+    }
+
+    /// End-to-end regression for an AST-fuzzer-discovered pattern with
+    /// *nested* loops where the protected back-edge participant is itself
+    /// an inner-loop-header parameter that other in-use aliases flow into.
+    /// Source-level shape (`func_1` from the minimized repro):
+    ///
+    /// ```ignore
+    /// for _ in 0..2 {
+    ///     c.4[0] = if b.2[1] {
+    ///         for _ in 0..2 {
+    ///             if func_1(a, c, (.., c.2, b.4, ["E"]), ..) { c = (.., b.2, [b.3[0]], c.3); }
+    ///         }
+    ///         "F"
+    ///     } else { c.4[0] };
+    /// }
+    /// ```
+    ///
+    /// The outer-latch `array_set v85` (`c.4[0] = …`) has `v85`'s alias-set
+    /// pull in the inner-loop-header param `v78` transitively through the
+    /// loop structure. `v78` carries its own `inc_rc` (the calling-
+    /// convention RC bump before it is passed to the recursive `call`),
+    /// and it is a back-edge participant (it flows into `v90`, an inner
+    /// back-edge arg). So the protected-participant filter drops it — but
+    /// because `v78` is an inner-loop-header parameter, the forward walk's
+    /// add-rule re-introduces it the moment another in-use alias flows
+    /// into `v78`'s position, and the `call` then reads it.
+    ///
+    /// The fix makes the removal *sticky*: a protected participant is kept
+    /// out of the use-set for the whole walk (the add-rule never
+    /// re-introduces it), not just at the initial seed.
+    #[test]
+    fn end_to_end_protected_participant_is_inner_loop_header_param_is_accepted() {
+        let src = r#"
+            brillig(inline_always) fn func_1 f0 {
+              b0(v0: u1, v1: u1, v3: u1, v5: u1, v7: [u1; 2], v9: [[u8; 1]; 1], v11: [[u8; 1]; 1], v13: u1, v15: u1, v17: u1, v19: [u1; 2], v21: [[u8; 1]; 1], v23: [[u8; 1]; 1], v25: &mut u32):
+                jmp b1(u32 0, v13, v19, v21, v23)
+              b1(v28: u32, v68: u1, v71: [u1; 2], v72: [[u8; 1]; 1], v73: [[u8; 1]; 1]):
+                v29 = lt v28, u32 2
+                jmpif v29 then: b2(), else: b3()
+              b2():
+                v33 = array_get v7, index u32 1 -> u1
+                jmpif v33 then: b4(), else: b5()
+              b3():
+                return u1 1
+              b4():
+                jmp b6(u32 0, v68, v71, v72, v73)
+              b5():
+                v63 = array_get v73, index u32 0 -> [u8; 1]
+                inc_rc v63
+                jmp b12(v63, v68, v71, v72, v73)
+              b6(v34: u32, v74: u1, v77: [u1; 2], v78: [[u8; 1]; 1], v79: [[u8; 1]; 1]):
+                v35 = lt v34, u32 2
+                jmpif v35 then: b7(), else: b8()
+              b7():
+                inc_rc v77
+                inc_rc v78
+                inc_rc v79
+                inc_rc v77
+                inc_rc v11
+                v49 = make_array b"E"
+                v50 = make_array [v49] : [[u8; 1]; 1]
+                v51 = call f0(v0, v74, v15, v17, v77, v78, v79, u1 0, v15, v17, v77, v11, v50, v25) -> u1
+                jmpif v51 then: b9(), else: b10()
+              b8():
+                v61 = make_array b"F"
+                jmp b12(v61, v74, v77, v78, v79)
+              b9():
+                inc_rc v7
+                v56 = array_get v9, index u32 0 -> [u8; 1]
+                inc_rc v56
+                v57 = make_array [v56] : [[u8; 1]; 1]
+                jmp b11(u1 0, v7, v57, v78)
+              b10():
+                jmp b11(v74, v77, v78, v79)
+              b11(v86: u1, v89: [u1; 2], v90: [[u8; 1]; 1], v91: [[u8; 1]; 1]):
+                v59 = unchecked_add v34, u32 1
+                jmp b6(v59, v86, v89, v90, v91)
+              b12(v64: [u8; 1], v80: u1, v83: [u1; 2], v84: [[u8; 1]; 1], v85: [[u8; 1]; 1]):
+                v66 = array_set v85, index u32 0, value v64
+                v67 = unchecked_add v28, u32 1
+                jmp b1(v67, v80, v83, v84, v66)
+            }"#;
+        assert_verifier_accepts_because(
+            src,
+            "v78 is an inner-loop-header param that is a back-edge participant with its own inc_rc; sticky removal keeps it out of the use-set so the add-rule can't re-introduce it for the recursive call to read",
+        );
+    }
+
+    /// End-to-end regression for an AST-fuzzer-discovered pattern (the
+    /// `..=` inclusive-range duplicated-body variant of
+    /// [`end_to_end_protected_participant_is_inner_loop_header_param_is_accepted`]).
+    /// The protected participant `v167` is an inner-loop-header parameter
+    /// that the forward walk's add-rule pulls into the use-set *even
+    /// though it is not in the `array_set` source `v209`'s static
+    /// alias-set* — `v167` lives in the duplicated last-iteration body
+    /// (`b33`) and reaches `v209`'s storage only along the walked path.
+    ///
+    /// This pins down that the protected set must be computed over *all*
+    /// back-edge participants, not just the source's static alias-set:
+    /// `v167` has its own `inc_rc` (the calling-convention bump before the
+    /// recursive `call`) and is a back-edge participant (it flows into
+    /// `v180`, the `b41 → b33` back-edge arg), so it is excluded from the
+    /// use-set globally and the add-rule never re-introduces it.
+    #[test]
+    fn end_to_end_protected_participant_added_outside_static_alias_set_is_accepted() {
+        let src = r#"
+            brillig(inline_always) fn func_1 f0 {
+              b0(v0: u1, v1: u1, v3: u1, v5: u1, v7: [u1; 2], v9: [[u8; 1]; 1], v11: [[u8; 1]; 1], v13: u1, v15: u1, v17: u1, v19: [u1; 2], v21: [[u8; 1]; 1], v23: [[u8; 1]; 1], v25: &mut u32):
+                v26 = load v25 -> u32
+                v28 = eq v26, u32 0
+                jmpif v28 then: b1(), else: b2()
+              b1():
+                jmp b3(v7, v13, v21, v23)
+              b2():
+                v30 = load v25 -> u32
+                v32 = sub v30, u32 1
+                store v32 at v25
+                jmp b4(i16 -26238, v7, v13, v21, v23)
+              b3(v216: [u1; 2], v217: u1, v221: [[u8; 1]; 1], v222: [[u8; 1]; 1]):
+                return u1 0
+              b4(v36: i16, v148: [u1; 2], v149: u1, v153: [[u8; 1]; 1], v154: [[u8; 1]; 1]):
+                v38 = lt v36, i16 -26235
+                jmpif v38 then: b5(), else: b6()
+              b5():
+                jmp b7(v148, v149, v153, v154, u32 0)
+              b6():
+                jmpif u1 1 then: b24(), else: b25(v148, v149, v153, v154)
+              b7(v189: [u1; 2], v190: u1, v194: [[u8; 1]; 1], v195: [[u8; 1]; 1], v196: u32):
+                v41 = eq v196, u32 0
+                jmpif v41 then: b9(), else: b10()
+              b8():
+                v99 = unchecked_add v36, i16 1
+                jmp b4(v99, v189, v190, v194, v195)
+              b9():
+                jmp b8()
+              b10():
+                v43 = add v196, u32 1
+                v46 = array_get v189, index u32 1 -> u1
+                jmpif v46 then: b12(), else: b13()
+              b11():
+                jmp b7(v203, v204, v208, v91, v43)
+              b12():
+                inc_rc v19
+                jmp b14(i32 -261577443, v190, v194, v195)
+              b13():
+                v88 = array_get v195, index u32 0 -> [u8; 1]
+                inc_rc v88
+                jmp b23(v88, v189, v190, v194, v195)
+              b14(v50: i32, v197: u1, v201: [[u8; 1]; 1], v202: [[u8; 1]; 1]):
+                v51 = lt v50, i32 -261577442
+                jmpif v51 then: b15(), else: b16()
+              b15():
+                inc_rc v19
+                inc_rc v201
+                inc_rc v202
+                inc_rc v19
+                inc_rc v11
+                v64 = make_array b"S"
+                v65 = make_array [v64] : [[u8; 1]; 1]
+                v66 = call f0(v0, v197, v15, v17, v19, v201, v202, u1 0, v15, v17, v19, v11, v65, v25) -> u1
+                jmpif v66 then: b17(), else: b18()
+              b16():
+                v86 = make_array b"T"
+                jmp b23(v86, v19, v197, v201, v202)
+              b17():
+                jmp b19(i32 -439841945)
+              b18():
+                jmp b19(i32 -569613121)
+              b19(v69: i32):
+                v71 = lt v69, i32 -255727548
+                v72 = not v71
+                jmpif v72 then: b20(), else: b21()
+              b20():
+                inc_rc v19
+                v78 = array_get v9, index u32 0 -> [u8; 1]
+                inc_rc v78
+                v79 = make_array [v78] : [[u8; 1]; 1]
+                jmp b22(u1 0, v79, v201)
+              b21():
+                jmp b22(v197, v201, v202)
+              b22(v210: u1, v214: [[u8; 1]; 1], v215: [[u8; 1]; 1]):
+                constrain u1 0 == u1 1, "LCC"
+                v84 = unchecked_add v50, i32 1
+                jmp b14(v84, v210, v214, v215)
+              b23(v89: [u8; 1], v203: [u1; 2], v204: u1, v208: [[u8; 1]; 1], v209: [[u8; 1]; 1]):
+                v91 = array_set v209, index u32 0, value v89
+                jmp b11()
+              b24():
+                jmp b26(v148, v149, v153, v154, u32 0)
+              b25(v182: [u1; 2], v183: u1, v187: [[u8; 1]; 1], v188: [[u8; 1]; 1]):
+                jmp b3(v182, v183, v187, v188)
+              b26(v155: [u1; 2], v156: u1, v160: [[u8; 1]; 1], v161: [[u8; 1]; 1], v162: u32):
+                v103 = eq v162, u32 0
+                jmpif v103 then: b28(), else: b29()
+              b27():
+                jmp b25(v155, v156, v160, v161)
+              b28():
+                jmp b27()
+              b29():
+                v105 = add v162, u32 1
+                v107 = array_get v155, index u32 1 -> u1
+                jmpif v107 then: b31(), else: b32()
+              b30():
+                jmp b26(v169, v170, v174, v140, v105)
+              b31():
+                inc_rc v19
+                jmp b33(i32 -261577443, v156, v160, v161)
+              b32():
+                v137 = array_get v161, index u32 0 -> [u8; 1]
+                inc_rc v137
+                jmp b42(v137, v155, v156, v160, v161)
+              b33(v109: i32, v163: u1, v167: [[u8; 1]; 1], v168: [[u8; 1]; 1]):
+                v110 = lt v109, i32 -261577442
+                jmpif v110 then: b34(), else: b35()
+              b34():
+                inc_rc v19
+                inc_rc v167
+                inc_rc v168
+                inc_rc v19
+                inc_rc v11
+                v121 = make_array b"S"
+                v122 = make_array [v121] : [[u8; 1]; 1]
+                v123 = call f0(v0, v163, v15, v17, v19, v167, v168, u1 0, v15, v17, v19, v11, v122, v25) -> u1
+                jmpif v123 then: b36(), else: b37()
+              b35():
+                v135 = make_array b"T"
+                jmp b42(v135, v19, v163, v167, v168)
+              b36():
+                jmp b38(i32 -439841945)
+              b37():
+                jmp b38(i32 -569613121)
+              b38(v124: i32):
+                v125 = lt v124, i32 -255727548
+                v126 = not v125
+                jmpif v126 then: b39(), else: b40()
+              b39():
+                inc_rc v19
+                v131 = array_get v9, index u32 0 -> [u8; 1]
+                inc_rc v131
+                v132 = make_array [v131] : [[u8; 1]; 1]
+                jmp b41(u1 0, v132, v167)
+              b40():
+                jmp b41(v163, v167, v168)
+              b41(v176: u1, v180: [[u8; 1]; 1], v181: [[u8; 1]; 1]):
+                constrain u1 0 == u1 1, "LCC"
+                v134 = unchecked_add v109, i32 1
+                jmp b33(v134, v176, v180, v181)
+              b42(v138: [u8; 1], v169: [u1; 2], v170: u1, v174: [[u8; 1]; 1], v175: [[u8; 1]; 1]):
+                v140 = array_set v175, index u32 0, value v138
+                jmp b30()
+            }"#;
+        assert_verifier_accepts_because(
+            src,
+            "v167 (and v201/v202 etc.) are protected back-edge participants pulled into the use-set by the walk's add-rule outside v209's static alias-set; the global protected set excludes them so neither array_set is flagged",
+        );
     }
 
     /// End-to-end regression for an AST-fuzzer-discovered minimal shape:

--- a/compiler/noirc_evaluator/src/ssa/validation/array_set_rc_invariant.rs
+++ b/compiler/noirc_evaluator/src/ssa/validation/array_set_rc_invariant.rs
@@ -411,14 +411,6 @@ impl<'f> Context<'f> {
             }
         }
 
-        // A `make_array` is iteration-local iff its result appears on a
-        // loop back-edge: that's the signal that it re-executes each
-        // iteration, so the storage the loop-header parameter receives
-        // through the back-edge is freshly allocated rather than the
-        // same storage the array_set may mutate in place.
-        let iteration_local_make_arrays: HashSet<ValueId> =
-            make_array_values.intersection(&back_edge_args).copied().collect();
-
         let backward_aliases = compute_backward_aliases(function, &rpo, &incoming_edges);
 
         // Backward-alias closure of the literal back-edge args: every
@@ -435,6 +427,18 @@ impl<'f> Context<'f> {
                 back_edge_participants.extend(arg_set.iter().copied());
             }
         }
+
+        // A `make_array` is iteration-local iff its result reaches a loop
+        // back-edge — directly as a back-edge arg, or through forward
+        // block-parameter edges into one (membership in
+        // `back_edge_participants`). Either way it re-executes every
+        // iteration, so the storage a loop-header parameter receives from
+        // it is freshly allocated per iteration rather than the same
+        // storage an `array_set` may mutate in place. Such a result can't
+        // carry an `array_set` source's pre-mutation aliasing across
+        // iterations, so it is dropped from every alias-set.
+        let iteration_local_make_arrays: HashSet<ValueId> =
+            make_array_values.intersection(&back_edge_participants).copied().collect();
 
         Self {
             function,

--- a/cspell.json
+++ b/cspell.json
@@ -349,6 +349,7 @@
         "underflows",
         "ungzip",
         "uninstantiated",
+        "unioned",
         "unnormalized",
         "unoptimized",
         "unref",


### PR DESCRIPTION
## Problem Resolved

Fixes the nightly fuzzer issues listed in https://gist.github.com/AztecBot/c0767e3e617d957b9d6f92f1f9a2695d

## Summary of Changes


The `array_set` RC-invariant validator (PR #12707) flags a Brillig `array_set`
whose source has a forward, aliased read with no preceding `inc_rc` — the case
where an in-place mutation (RC = 1) would be observable. The AST fuzzer found
several **false positives**: shapes the validator rejected even though Brillig
and comptime agree and the frontend correctly emitted no `inc_rc`. This PR
fixes them (plus one related lowering bug the investigation surfaced), without
weakening the validator on genuine hazards.

### 1. `..=` lowering for negative signed bounds

Inclusive ranges lower to an exclusive loop plus a peeled final iteration; the
peel is skipped when `end < type-max`. That check round-tripped the `end`
constant through `to_u128()`, so a **negative** signed bound looked huge and
wrongly failed it — forcing an unnecessary peel (and, downstream, a validator
false positive). Now compares signed-aware via `IntegerConstant`. Test:
`for_loop_inclusive_signed_negative_end_is_not_a_maximum` (ssa_gen).

### 2. Loop-carried `inc_rc` recognition

When the frontend manages iteration aliasing, the `inc_rc` can sit on a
back-edge value *after* the `array_set` in source order (the back-edge
thread-back delivers the protection to the next iteration). Two additions:

- **Back-edge-participant relaxation** in `some_inc_rc_precedes`: an `inc_rc`
  on a non-source alias that is also a loop back-edge arg counts as a codegen
  signal regardless of program-point order.
- **Protected-participant filter** before the forward walk: drop use-set
  members that carry their own `inc_rc` and are back-edge participants (the
  bump is loop-carried, so the value is RC ≥ 2 by the time it equals the
  source's storage). Gated **per value**, restricted to alias-set members (a
  value that only *receives* the source's storage isn't protected), and
  **sticky** across the whole walk.

Tests: `inc_rcd_value_reaches_back_edge_through_latch_is_accepted`,
`sticky_removal_of_inner_loop_header_participant_is_accepted`, plus the
`latch_join_with_unprotected_sibling` and
`forward_threaded_read_with_inc_rc_participant` soundness canaries (reject).

### 3. Index-aware hazard rule

The forward walk tracks the storage positions a chain has written
(`tainted_indices`); a read is a hazard only when it can observe a tainted one:

- `array_get` flags only if its read index is tainted.
- `array_set` flags only if it copies forward a tainted index it does **not**
  overwrite; a same-index write overwrites the mutation and instead extends the
  chain.

Tests: `array_set_followed_by_another_array_set_same_index_is_accepted`,
`inclusive_range_peel_array_set_same_index_is_accepted`.

### 4. Swap exclusion

The array-variable swap pattern:

```noir
for _ in .. {
    c4[0] = 9;     // array_set on c4
    c4 = c3;       // swap: c4 takes c3's storage
    c3 = [..];     // c3 freshly re-allocated
}
println(c4);       // whole-array read of the loop-exit value
```

On the back-edge the source param (`c4`) is rebound to its sibling (`c3`), so
`c3` joins `backward(c4)`, and the validator treats the loop-exit value as
aliasing `c4`'s mutated storage — but they are *distinct per-iteration
allocations*. The `..=` **peel** re-runs the same swap on a forward exit edge,
reaching the false positive a second way.

Fix: a **swap exclusion** computed in `Context::new`, applied at the alias-set
seed (`alias_set_for`). When a loop-header param `P` is rebound on the
back-edge to a sibling `Q` (`P ← Q`) whose own back-edge arg is freshly
re-allocated, `Q` is dropped from `P`'s alias-set. Being seed-level, it fixes
both the loop-body walk and the peel's forward-edge walk at once. Two soundness
guards:

- **Freshening** — `Q`'s back-edge arg must re-allocate distinct storage each
  iteration (else a loop-invariant `Q` gives `P_k = Q_{k-1} = Q_k`, a real
  alias). The freshening set is `iteration_local_fresh = (MakeArray ∪ Call
  results) ∩ back-edge args`; `array_set` results are excluded (may be
  in-place, not fresh).
- **Loop-entry** — `P` and `Q` must receive distinct storage on every forward
  edge into the header (catches `jmp header(v, v)` sibling-same-value, which
  the directed backward walk can't see).

Tests: `multi_index_inclusive_range_peel_swap_is_accepted`,
`loop_swap_then_whole_array_read_is_accepted`, and four soundness canaries that
each flip to a false negative if a guard is removed —
`swap_with_loop_invariant_sibling` (reject), `swap_with_sibling_same_value_entry`
(reject), `swap_freshened_by_call` (accept), `swap_freshened_by_array_set_result`
(reject).

### Cleanup

- `iteration_local_fresh` subsumes the earlier `iteration_local_make_arrays`
  field (its extra `Call` results are already dropped in `alias_set_for` by the
  non-aliasing filter, so behavior is unchanged).
- Module docs updated (Algorithm + Known limitations); `cspell.json` gains
  `unioned`.

All prior guardrails unchanged; the validator runs only in debug builds
(`#[cfg(debug_assertions)]`) and after the first `mem2reg_brillig`, before LICM.

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
