### PR TITLE
fix: Make attr eval order deterministic in impls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3996,6 +3996,7 @@ dependencies = [
  "cfg-if",
  "fm",
  "im",
+ "indexmap 2.14.0",
  "insta",
  "iter-extended",
  "itertools 0.14.0",

--- a/compiler/noirc_frontend/Cargo.toml
+++ b/compiler/noirc_frontend/Cargo.toml
@@ -19,6 +19,7 @@ noirc_errors.workspace = true
 noirc_artifacts.workspace = true
 noirc_printable_type.workspace = true
 fm.workspace = true
+indexmap.workspace = true
 iter-extended.workspace = true
 itertools.workspace = true
 thiserror.workspace = true

--- a/compiler/noirc_frontend/src/hir/def_collector/dc_crate.rs
+++ b/compiler/noirc_frontend/src/hir/def_collector/dc_crate.rs
@@ -198,8 +198,7 @@ impl CollectedItems {
 ///
 /// The keys are unresolved types, which are not `Ord`, so a `BTreeMap` cannot be used here.
 /// An `IndexMap` is used instead of a `HashMap` because iteration order is observable
-/// (attribute run order, method declaration order) and so must be deterministic: it follows
-/// insertion (source) order.
+/// (attribute run order, method declaration order). Using an `IndexMap` keeps source-order for evaluation.
 pub(crate) type ImplMap = IndexMap<
     (UnresolvedType, LocalModuleId),
     Vec<(UnresolvedGenerics, Vec<UnresolvedTraitConstraint>, Location, UnresolvedFunctions)>,

--- a/compiler/noirc_frontend/src/hir/def_collector/dc_crate.rs
+++ b/compiler/noirc_frontend/src/hir/def_collector/dc_crate.rs
@@ -34,7 +34,9 @@ use crate::parser::{ParserError, SortedModule};
 use noirc_errors::{CustomDiagnostic, Location, Span};
 
 use fm::FileId;
+use indexmap::IndexMap;
 use iter_extended::vecmap;
+use rustc_hash::FxBuildHasher;
 use rustc_hash::FxHashMap as HashMap;
 use rustc_hash::FxHashSet as HashSet;
 use std::collections::BTreeMap;
@@ -194,12 +196,14 @@ impl CollectedItems {
 /// impl along with the generics declared on the impl itself. This also contains the Span
 /// of the object_type of the impl, used to issue an error if the object type fails to resolve.
 ///
-/// Note that because these are keyed by unresolved types, the impl map is one of the few instances
-/// of HashMap rather than BTreeMap. For this reason, we should be careful not to iterate over it
-/// since it would be non-deterministic.
-pub(crate) type ImplMap = HashMap<
+/// The keys are unresolved types, which are not `Ord`, so a `BTreeMap` cannot be used here.
+/// An `IndexMap` is used instead of a `HashMap` because iteration order is observable
+/// (attribute run order, method declaration order) and so must be deterministic: it follows
+/// insertion (source) order.
+pub(crate) type ImplMap = IndexMap<
     (UnresolvedType, LocalModuleId),
     Vec<(UnresolvedGenerics, Vec<UnresolvedTraitConstraint>, Location, UnresolvedFunctions)>,
+    FxBuildHasher,
 >;
 
 /// Wraps a list of compilation errors.
@@ -395,7 +399,7 @@ impl DefCollector {
                 enums: BTreeMap::new(),
                 type_aliases: BTreeMap::new(),
                 traits: BTreeMap::new(),
-                impls: HashMap::default(),
+                impls: ImplMap::default(),
                 globals: vec![],
                 trait_impls: vec![],
                 module_attributes: vec![],

--- a/compiler/noirc_frontend/src/tests/metaprogramming.rs
+++ b/compiler/noirc_frontend/src/tests/metaprogramming.rs
@@ -766,6 +766,68 @@ fn sibling_modules_run_in_textual_order() {
     assert_no_errors(src);
 }
 
+/// Attributes on methods of macro-generated impl blocks all share the source location
+/// of the quoted fragment they were generated from, so the `(module, span)` run-order
+/// sort cannot order them. Their run order must then follow generation order — which
+/// requires the collection that holds the impls to iterate in insertion order.
+#[test]
+fn macro_generated_impl_attributes_run_in_generation_order() {
+    let src = r#"
+        comptime mut global counter: Field = 0;
+
+        pub struct A {}
+        pub struct B {}
+        pub struct C {}
+        pub struct D {}
+        pub struct E {}
+        pub struct F {}
+        pub struct G {}
+        pub struct H {}
+
+        #[gen_impls]
+        fn dummy() {}
+
+        comptime fn gen_impls(_: FunctionDefinition) -> Quoted {
+            let types: [(Quoted, Quoted); 8] = [
+                (quote { A }, quote { 0 }),
+                (quote { B }, quote { 1 }),
+                (quote { C }, quote { 2 }),
+                (quote { D }, quote { 3 }),
+                (quote { E }, quote { 4 }),
+                (quote { F }, quote { 5 }),
+                (quote { G }, quote { 6 }),
+                (quote { H }, quote { 7 }),
+            ];
+            let mut result = quote {};
+            for index in 0..8 {
+                let (typ, i) = types[index];
+                result = quote { $result
+                    impl $typ { #[assert_gen_order($i)] fn method(_self: Self) {} }
+                };
+            }
+            result
+        }
+
+        comptime fn assert_gen_order(_: FunctionDefinition, expected: Field) {
+            assert(counter == expected);
+            counter += 1;
+        }
+
+        fn main() {
+            dummy();
+            let _ = A {}.method();
+            let _ = B {}.method();
+            let _ = C {}.method();
+            let _ = D {}.method();
+            let _ = E {}.method();
+            let _ = F {}.method();
+            let _ = G {}.method();
+            let _ = H {}.method();
+        }
+    "#;
+    assert_no_errors(src);
+}
+
 #[test]
 fn child_module_attributes_run_before_parent() {
     let src = r#"

--- a/compiler/noirc_frontend/src/tests/structs.rs
+++ b/compiler/noirc_frontend/src/tests/structs.rs
@@ -382,13 +382,13 @@ fn overlapping_inherent_impls() {
 
         impl<T> Foo<T> {
             pub fn method(_self: Self) {}
-                   ^^^^^^ Impl for type `Foo<i32>` overlaps with existing impl
-                   ~~~~~~ Overlapping impl
+                   ~~~~~~ Previous impl defined here
         }
 
         impl Foo<i32> {
             pub fn method(_self: Self) {}
-                   ~~~~~~ Previous impl defined here
+                   ^^^^^^ Impl for type `Foo<T>` overlaps with existing impl
+                   ~~~~~~ Overlapping impl
         }
 
         fn main() {
@@ -527,8 +527,7 @@ fn trait_as_type_overlapping() {
 
         impl<T> Foo<T> {
             pub fn method(_self: Self) -> impl MyTrait<T> {
-                   ^^^^^^ Impl for type `Foo<i32>` overlaps with existing impl
-                   ~~~~~~ Overlapping impl
+                   ~~~~~~ Previous impl defined here
                 // This return type is TraitAsType with NamedGeneric inside
                 MyImpl { _x: _self._x }
             }
@@ -536,7 +535,8 @@ fn trait_as_type_overlapping() {
 
         impl Foo<i32> {
             pub fn method(_self: Self) -> impl MyTrait<i32> {
-                   ~~~~~~ Previous impl defined here
+                   ^^^^^^ Impl for type `Foo<T>` overlaps with existing impl
+                   ~~~~~~ Overlapping impl
                 MyImpl { _x: _self._x }
             }
         }

--- a/design/comptime.md
+++ b/design/comptime.md
@@ -4,6 +4,10 @@ Attributes in comptime code run in order from top to the bottom of a file. Attri
 from sub-modules are run before their parent modules, and attributes from sibling modules
 are run in the order their modules are declared in the parent module.
 
+This is implemented by sorting collected attributes by `(module topological order, span start)`.
+That key can tie for macro-generated items, which can share a single source location. Ties are
+broken by collection order, so every container iterated during collection must be ordered (issue #12933).
+
 `comptime` blocks within functions are affected by function's arbitrary elaboration order.
 Since functions are lazily elaborated now, this will affect ordering of comptime blocks as well.
 

--- a/noir_stdlib/docs/std/primitive.array.html
+++ b/noir_stdlib/docs/std/primitive.array.html
@@ -126,26 +126,6 @@ the given array is interpreted as-is as a string.</p>
 }</code></pre></div>
 </div></div><h3><code class="code-header">impl&lt;let N: <a href="../std/primitive.u32.html" class="primitive">u32</a>, T&gt; [T; N]</code></h3>
 
-<div class="padded-methods"><code id="sort_via" class="code-header">pub fn <a href="#sort_via"><span class="fn">sort_via</span></a>&lt;Env&gt;(&mut self: &Self, ordering: fn[Env](T, T) -> <a href="../std/primitive.bool.html" class="primitive">bool</a>) -> Self
-<div class="where-clause">where
-    T: <a href="../std/cmp/trait.Eq.html" class="trait">Eq</a></div></code>
-
-<div class="padded-description"><div class="comments">
-<p>Returns a new sorted array by sorting it with a custom comparison function.
-The original array remains untouched.
-The ordering function must return true if the first argument should be sorted to be before the second argument or is equal to the second argument.</p>
-<p>Using this method with an operator like <code>&lt;</code> that does not return <code>true</code> for equal values will result in an assertion failure for arrays with equal elements.</p>
-<p>Example:</p>
-<pre><code><span class="kw">fn</span> main() {
-    <span class="kw">let</span> arr = [<span class="number">42</span>, <span class="number">32</span>]
-    <span class="kw">let</span> sorted_ascending = arr.sort_via(|a, b| a &lt;= b);
-    <span class="kw">assert</span>(sorted_ascending == [<span class="number">32</span>, <span class="number">42</span>]); <span class="comment">// verifies</span>
-
-    <span class="kw">let</span> sorted_descending = arr.sort_via(|a, b| a &gt;= b);
-    <span class="kw">assert</span>(sorted_descending == [<span class="number">32</span>, <span class="number">42</span>]); <span class="comment">// does not verify</span>
-}</code></pre></div>
-</div></div><h3><code class="code-header">impl&lt;let N: <a href="../std/primitive.u32.html" class="primitive">u32</a>, T&gt; [T; N]</code></h3>
-
 <div class="padded-methods"><code id="len" class="code-header">pub fn <a href="#len"><span class="fn">len</span></a>(self) -> <a href="../std/primitive.u32.html" class="primitive">u32</a></code>
 
 <div class="padded-description"><div class="comments">
@@ -292,6 +272,26 @@ sort any type, you should use the <a href="../std/primitive.array.html#sort_via"
     <span class="kw">let</span> arr = [<span class="number">42</span>, <span class="number">32</span>];
     <span class="kw">let</span> sorted = arr.sort();
     <span class="kw">assert</span>(sorted == [<span class="number">32</span>, <span class="number">42</span>]);
+}</code></pre></div>
+</div></div><h3><code class="code-header">impl&lt;let N: <a href="../std/primitive.u32.html" class="primitive">u32</a>, T&gt; [T; N]</code></h3>
+
+<div class="padded-methods"><code id="sort_via" class="code-header">pub fn <a href="#sort_via"><span class="fn">sort_via</span></a>&lt;Env&gt;(&mut self: &Self, ordering: fn[Env](T, T) -> <a href="../std/primitive.bool.html" class="primitive">bool</a>) -> Self
+<div class="where-clause">where
+    T: <a href="../std/cmp/trait.Eq.html" class="trait">Eq</a></div></code>
+
+<div class="padded-description"><div class="comments">
+<p>Returns a new sorted array by sorting it with a custom comparison function.
+The original array remains untouched.
+The ordering function must return true if the first argument should be sorted to be before the second argument or is equal to the second argument.</p>
+<p>Using this method with an operator like <code>&lt;</code> that does not return <code>true</code> for equal values will result in an assertion failure for arrays with equal elements.</p>
+<p>Example:</p>
+<pre><code><span class="kw">fn</span> main() {
+    <span class="kw">let</span> arr = [<span class="number">42</span>, <span class="number">32</span>]
+    <span class="kw">let</span> sorted_ascending = arr.sort_via(|a, b| a &lt;= b);
+    <span class="kw">assert</span>(sorted_ascending == [<span class="number">32</span>, <span class="number">42</span>]); <span class="comment">// verifies</span>
+
+    <span class="kw">let</span> sorted_descending = arr.sort_via(|a, b| a &gt;= b);
+    <span class="kw">assert</span>(sorted_descending == [<span class="number">32</span>, <span class="number">42</span>]); <span class="comment">// does not verify</span>
 }</code></pre></div>
 </div></div></main>
 </span>


### PR DESCRIPTION
## Problem Resolved

Resolves https://github.com/noir-lang/noir/issues/12933

## Summary of Changes

Uses an IndexMap to get deterministic ordering when iterating evaluating attributes on impls.

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
