### PR TITLE
fix(ssa): keep capacity backing in interpreter vector_pop_back

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/interpreter/intrinsics.rs
+++ b/compiler/noirc_evaluator/src/ssa/interpreter/intrinsics.rs
@@ -568,13 +568,16 @@ impl<W: Write> Interpreter<'_, W> {
         }
         check_vector_can_pop_all_element_types(args[1], &vector)?;
 
-        // The vector might contain more elements than its length.
-        // We want the last valid element, ignoring any extras following it.
-        // We don't ever access the extras, so we might as well remove any.
-        vector_elements.truncate(element_types.len() * length as usize);
-        let mut popped_elements =
-            vecmap(0..element_types.len(), |_| vector_elements.pop().unwrap());
-        popped_elements.reverse();
+        // The vector might contain more elements than its semantic length when it is the result of
+        // merging vectors of different lengths: its backing array is padded out to the larger
+        // capacity. The popped element lives at the semantic last index, but the backing capacity
+        // only shrinks by one element, matching how `vector_pop_front`/`vector_remove` and ACIR
+        // codegen keep the trailing capacity. Truncating to the semantic length here instead would
+        // make a later merge over-read this result when the semantic length is below the capacity.
+        let width = element_types.len();
+        let last_index = width * (length as usize - 1);
+        let popped_elements = vector_elements[last_index..last_index + width].to_vec();
+        vector_elements.truncate(vector_elements.len() - width);
 
         let new_length = Value::u32(length - 1);
         let new_vector = Value::vector(vector_elements, element_types);

--- a/compiler/noirc_evaluator/src/ssa/opt/remove_if_else.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/remove_if_else.rs
@@ -530,6 +530,8 @@ fn remove_if_else_post_check(func: &Function) {
 
 #[cfg(test)]
 mod tests {
+    use acvm::{AcirField, FieldElement};
+
     use crate::{
         assert_ssa_snapshot,
         ssa::{
@@ -1163,6 +1165,71 @@ mod tests {
             return v26, v28, v18
         }
         "#);
+    }
+
+    // Regression test for an over-read of a `vector_pop_back` result after merging two vectors
+    // of unequal capacity. The source program is:
+    // ```
+    // fn main(choose: bool, do_pop: bool) -> pub Field {
+    //     let mut v: [Field] = if choose { [1].as_vector() } else { [2, 3].as_vector() };
+    //     if do_pop {
+    //         let (new_v, _) = v.pop_back();
+    //         v = new_v;
+    //     }
+    //     if v.len() == 0 { 0 } else { v[0] }
+    // }
+    // ```
+    // With `choose = true` the merged vector has semantic length 1 but backing capacity 2, so
+    // popping it yields an empty vector. The merge of the pop result must not over-read it.
+    #[test]
+    fn merge_vector_pop_back_with_smaller_semantic_length_than_capacity() {
+        let src = r#"
+        acir(inline) predicate_pure fn main f0 {
+          b0(v0: u1, v1: u1):
+            enable_side_effects v0
+            v3 = make_array [Field 1] : [Field]
+            v4 = not v0
+            enable_side_effects v4
+            v7 = make_array [Field 2, Field 3] : [Field]
+            enable_side_effects u1 1
+            v9 = cast v0 as u32
+            v10 = cast v4 as u32
+            v12 = unchecked_mul v10, u32 2
+            v13 = unchecked_add v9, v12
+            v14 = if v0 then v3 else (if v4) v7
+            enable_side_effects v1
+            v16, v17, v18 = call vector_pop_back(v13, v14) -> (u32, [Field], Field)
+            v19 = not v1
+            enable_side_effects u1 1
+            v20 = cast v1 as u32
+            v21 = cast v19 as u32
+            v22 = unchecked_mul v20, v16
+            v23 = unchecked_mul v21, v13
+            v24 = unchecked_add v22, v23
+            v25 = if v1 then v17 else (if v19) v14
+            v27 = eq v24, u32 0
+            enable_side_effects v27
+            v28 = not v27
+            enable_side_effects v28
+            v29 = unchecked_mul v27, v28
+            constrain v29 == u1 0, "Index out of bounds"
+            v31 = array_get v25, index u32 0 -> Field
+            enable_side_effects u1 1
+            v32 = cast v27 as Field
+            v33 = cast v28 as Field
+            v34 = mul v33, v31
+            return v34
+        }
+        "#;
+        let ssa = Ssa::from_str(src).unwrap();
+        let ssa = ssa.remove_if_else().unwrap();
+
+        // choose = true, do_pop = true: the merged vector is `[1]` (length 1), popping it leaves an
+        // empty vector, so `v.len() == 0` holds and the result is `0`. This must not fail with an
+        // out-of-bounds read on the popped vector.
+        let args = vec![Value::bool(true), Value::bool(true)];
+        let result = ssa.interpret(args).unwrap();
+        assert_eq!(result, vec![Value::field(FieldElement::zero())]);
     }
 
     // Regression test for https://github.com/noir-lang/noir/issues/10978

--- a/test_programs/execution_success/vector_pop_back_remove_if_else_bug/Nargo.toml
+++ b/test_programs/execution_success/vector_pop_back_remove_if_else_bug/Nargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "vector_pop_back_remove_if_else_bug"
+type = "bin"
+authors = [""]
+
+[dependencies]

--- a/test_programs/execution_success/vector_pop_back_remove_if_else_bug/Prover.toml
+++ b/test_programs/execution_success/vector_pop_back_remove_if_else_bug/Prover.toml
@@ -1,0 +1,3 @@
+choose = true
+do_pop = true
+return = "0"

--- a/test_programs/execution_success/vector_pop_back_remove_if_else_bug/src/main.nr
+++ b/test_programs/execution_success/vector_pop_back_remove_if_else_bug/src/main.nr
@@ -1,0 +1,21 @@
+// Merging two vectors of unequal capacity produces a vector whose backing capacity (2) can exceed
+// its semantic length (1). Popping that vector must not leave a `remove_if_else` merge over-reading
+// the popped result, which would otherwise read element 0 of an empty vector.
+fn main(choose: bool, do_pop: bool) -> pub Field {
+    let mut v: [Field] = if choose {
+        [1].as_vector()
+    } else {
+        [2, 3].as_vector()
+    };
+
+    if do_pop {
+        let (new_v, _) = v.pop_back();
+        v = new_v;
+    }
+
+    if v.len() == 0 {
+        0
+    } else {
+        v[0]
+    }
+}

--- a/tooling/nargo_cli/tests/snapshots/execution_success/vector_pop_back_remove_if_else_bug/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/vector_pop_back_remove_if_else_bug/execute__tests__expanded.snap
@@ -1,0 +1,20 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: expanded_code
+---
+fn main(choose: bool, do_pop: bool) -> pub Field {
+    let mut v: [Field] = if choose {
+        [1_Field].as_vector()
+    } else {
+        [2_Field, 3_Field].as_vector()
+    };
+    if do_pop {
+        let (new_v, _): ([Field], Field) = v.pop_back();
+        v = new_v;
+    };
+    if v.len() == 0_u32 {
+        0_Field
+    } else {
+        v[0_u32]
+    }
+}

--- a/tooling/nargo_cli/tests/snapshots/execution_success/vector_pop_back_remove_if_else_bug/execute__tests__stdout.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/vector_pop_back_remove_if_else_bug/execute__tests__stdout.snap
@@ -1,0 +1,5 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: stdout
+---
+[vector_pop_back_remove_if_else_bug] Circuit output: 0x00


### PR DESCRIPTION
## Summary

`remove_if_else` can merge two vectors of unequal length (e.g. `[1]` vs `[2, 3]`). The merged vector's backing array is padded out to the larger capacity, while its semantic length is tracked separately and can be smaller. Popping such a vector and then merging the pop result made `nargo interpret` fail right after the **Remove IfElse** pass, even though `nargo execute` produced the correct output.

The root cause is a single inconsistency in the SSA interpreter: `vector_pop_back` truncated the backing array down to the semantic length *before* popping, throwing away the trailing capacity. Its sibling intrinsics `vector_pop_front` (`drain(0..width)`) and `vector_remove` (`drain(index..index+width)`), as well as ACIR codegen (`convert_vector_pop_back` reads the full backing and pops the last backing block), all keep that capacity and shrink the backing by exactly one element.

So when the merged vector had semantic length 1 but capacity 2, `pop_back` produced an **empty** vector in the interpreter. The `array_get`/`make_array` merge that `remove_if_else` generates then read element 0 of that empty vector → `Array index 0 is out of bounds for array of length 0`. Brillig never hit this (its `array_get` is pure, returning uninitialized on OOB) and `remove_if_else` is ACIR-only, so the failure was specific to interpreting the ACIR pipeline.

## Fix

Read the popped element at the semantic last index `width * (length - 1)` and shrink the backing by a single element-block, instead of truncating to the semantic length first. This matches the other shrink intrinsics and ACIR codegen. For the common case where the backing equals the semantic length the behavior is unchanged.

## Repro

```rust
fn main(choose: bool, do_pop: bool) -> pub Field {
    let mut v: [Field] = if choose { [1].as_vector() } else { [2, 3].as_vector() };
    if do_pop {
        let (new_v, _) = v.pop_back();
        v = new_v;
    }
    if v.len() == 0 { 0 } else { v[0] }
}
```

With `choose = true, do_pop = true`, `nargo interpret` previously failed after Remove IfElse with an out-of-bounds read; it now returns `0`.

## Tests

- **SSA-level unit regression** in `remove_if_else.rs`: runs `remove_if_else` then `interpret`, asserting `Field 0`. Confirmed it fails with `IndexOutOfBounds { index: 0, length: 0 }` without the fix.
- **Source-level end-to-end regression** `test_programs/execution_success/vector_pop_back_remove_if_else_bug/`. Every `execution_success` program is also run through `nargo interpret`, which interprets after *every* SSA pass across both runtimes and all inliner settings — guarding the exact "output changes between passes" symptom.

Resolves https://github.com/noir-lang/noir-claude/issues/1367

🤖 Generated with [Claude Code](https://claude.com/claude-code)