### PR TITLE
fix(ssa): immutable-reference call arguments must keep prior stores live

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/opt/load_store_forwarding.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/load_store_forwarding.rs
@@ -138,14 +138,22 @@ fn forward_loads_and_stores_in_block(
                 instruction.for_each_value(|v| call_values.push(v));
                 for value in call_values {
                     let value = inserter.resolve(value);
-                    // A call can only write through an argument that exposes a
-                    // mutable reference.
-                    if !inserter.function.dfg.type_of_value(value).contains_mutable_reference() {
+                    let typ = inserter.function.dfg.type_of_value(value);
+                    if !typ.contains_reference() {
                         continue;
                     }
                     let value = GlobalValueId::new(inserter.function, value);
-                    // check against `a` for consistency with other checks, but here it does not matter.
-                    known_values.retain(|_k, (a, _)| !analysis.may_reference(value, *a));
+                    // We check against the original address `a` for consistency with the other
+                    // handlers, but here it does not matter.
+
+                    // A call can only *write* through an argument that exposes a mutable
+                    // reference, so cached loaded values are only invalidated by those.
+                    if typ.contains_mutable_reference() {
+                        known_values.retain(|_k, (a, _)| !analysis.may_reference(value, *a));
+                    }
+                    // Any reference argument, mutable or not, can be *read* by the callee,
+                    // so a prior store to an aliasing address is observable and must be kept
+                    // live rather than eliminated as a dead store.
                     last_stores.retain(|_k, (a, _)| !analysis.may_reference(value, *a));
                 }
             }
@@ -1372,10 +1380,8 @@ mod tests {
     #[test]
     fn call_with_immutable_reference_does_not_invalidate_cache() {
         // A call that only receives an immutable reference cannot write through
-        // it, so cached values for that address must remain valid after the call.
-        // Currently the pass treats &T the same as &mut T in the call handler
-        // (is_simple_ref fires for both), so it incorrectly invalidates the
-        // cached load and fails to forward v2 to v1.
+        // it, so cached values for that address must remain valid after the call
+        // and the second load can be forwarded to v1.
         let src = "
         brillig(inline) fn main f0 {
           b0(v0: &Field):
@@ -1393,7 +1399,7 @@ mod tests {
         let ssa = ssa.load_store_forwarding();
 
         // The call only holds an immutable reference; it cannot modify v0's
-        // memory. The second load should be forwarded to v1.
+        // memory. The second load is forwarded to v1.
         assert_ssa_snapshot!(ssa, @r"
         brillig(inline) fn main f0 {
           b0(v0: &Field):
@@ -1403,6 +1409,47 @@ mod tests {
         }
         brillig(inline) fn f1 f1 {
           b0(v0: &Field):
+            return
+        }
+        ");
+    }
+
+    #[test]
+    fn call_with_immutable_reference_keeps_observed_store_live() {
+        // A call that receives an immutable reference can still *read* through it.
+        // A store before such a call is therefore observable and must not be
+        // eliminated as dead when a later store overwrites the same address.
+        // Regression test for https://github.com/noir-lang/noir-claude/issues/1378.
+        let src = "
+        acir(inline) fn foo f0 {
+          b0(v0: &mut Field, v1: &Field):
+            store Field 1 at v0
+            call f1(v1)
+            store Field 2 at v0
+            return
+        }
+        acir(inline) fn reader f1 {
+          b0(v0: &Field):
+            v1 = load v0 -> Field
+            return
+        }
+        ";
+        let ssa = Ssa::from_str(src).unwrap();
+        let ssa = ssa.load_store_forwarding();
+
+        // The `store Field 1 at v0` is read by the call through the immutable
+        // alias v1, so it must survive.
+        assert_ssa_snapshot!(ssa, @r"
+        acir(inline) fn foo f0 {
+          b0(v0: &mut Field, v1: &Field):
+            store Field 1 at v0
+            call f1(v1)
+            store Field 2 at v0
+            return
+        }
+        acir(inline) fn reader f1 {
+          b0(v0: &Field):
+            v1 = load v0 -> Field
             return
         }
         ");

--- a/test_programs/execution_failure/immutable_ref_call_reads_store/Nargo.toml
+++ b/test_programs/execution_failure/immutable_ref_call_reads_store/Nargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "immutable_ref_call_reads_store"
+type = "bin"
+authors = [""]
+
+[dependencies]

--- a/test_programs/execution_failure/immutable_ref_call_reads_store/src/main.nr
+++ b/test_programs/execution_failure/immutable_ref_call_reads_store/src/main.nr
@@ -1,0 +1,20 @@
+// A call that receives an immutable reference can still read through it, so the
+// store before `reader(v1)` is observable and must not be eliminated as dead by
+// the later store. If load/store forwarding wrongly drops the first store,
+// `reader` reads the initial 0 and the assertion incorrectly passes.
+// Regression test for https://github.com/noir-lang/noir-claude/issues/1378.
+fn main() {
+    let v0 = &mut 0;
+    foo(v0, v0);
+}
+
+fn foo(v0: &mut Field, v1: &Field) {
+    *v0 = 1;
+    reader(v1);
+    *v0 = 2;
+}
+
+fn reader(v0: &Field) {
+    let v1 = *v0;
+    assert_eq(v1, 0);
+}

--- a/tooling/nargo_cli/tests/snapshots/execution_failure/immutable_ref_call_reads_store/execute__tests__acir_stderr.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_failure/immutable_ref_call_reads_store/execute__tests__acir_stderr.snap
@@ -1,0 +1,33 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: stderr
+---
+bug: Assertion is always false
+   ┌─ src/main.nr:19:5
+   │
+19 │     assert_eq(v1, 0);
+   │     ---------------- As a result, the compiled circuit is ensured to fail. Other assertions may also fail during execution
+   │
+   = Call stack:
+     1: main
+             at src/main.nr:8:5
+     2: foo
+             at src/main.nr:13:5
+     3: reader
+             at src/main.nr:19:5
+
+error: Failed constraint
+   ┌─ src/main.nr:19:5
+   │
+19 │     assert_eq(v1, 0);
+   │     ----------------
+   │
+   = Call stack:
+     1: main
+             at src/main.nr:8:5
+     2: foo
+             at src/main.nr:13:5
+     3: reader
+             at src/main.nr:19:5
+
+Failed to solve program: 'Cannot satisfy constraint'

--- a/tooling/nargo_cli/tests/snapshots/execution_failure/immutable_ref_call_reads_store/execute__tests__brillig_stderr.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_failure/immutable_ref_call_reads_store/execute__tests__brillig_stderr.snap
@@ -1,0 +1,19 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: stderr
+---
+error: Failed to solve program: 'Failed to solve brillig function'
+   ┌─ src/main.nr:19:5
+   │
+19 │     assert_eq(v1, 0);
+   │     ----------------
+   │
+   = Call stack:
+     1: main
+             at src/main.nr:8:5
+     2: foo
+             at src/main.nr:13:5
+     3: reader
+             at src/main.nr:19:5
+
+Failed to solve program: 'Failed to solve brillig function'

--- a/tooling/nargo_cli/tests/snapshots/execution_failure/immutable_ref_call_reads_store/execute__tests__comptime_stderr.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_failure/immutable_ref_call_reads_store/execute__tests__comptime_stderr.snap
@@ -1,0 +1,19 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: stderr
+---
+error: Assertion failed
+   ┌─ src/main.nr:19:15
+   │
+19 │     assert_eq(v1, 0);
+   │               -----
+   │
+   = Call stack:
+     1: ?
+             at src/main.nr:6:4
+     2: main
+             at src/main.nr:8:5
+     3: foo
+             at src/main.nr:13:5
+
+Error interpreting main function


### PR DESCRIPTION
## Problem Resolved

Fixes https://github.com/noir-lang/noir-claude/issues/1378

## Summary of Changes

#12877 changed the load/store-forwarding `Call` handler to gate on `contains_mutable_reference()`, on the premise that an immutable `&T` cannot write through the call. That premise is correct for invalidating cached **loads** (`known_values`), but the same gate was also applied to `last_stores`, which tracks dead-store-elimination candidates.

A callee can still **read** through an immutable `&T`, so a store before `call reader(&T)` is observable and must not be deleted when a later store overwrites the same address. With the mutable-only gate, such a store was incorrectly eliminated — a dead-store-elimination miscompile.

Minimal source reproduction (now in `execution_failure/immutable_ref_call_reads_store`):

```rust
fn main() {
    let v0 = &mut 0;
    foo(v0, v0);
}

fn foo(v0: &mut Field, v1: &Field) {
    *v0 = 1;
    reader(v1);   // reads through the immutable alias -> observes `*v0 = 1`
    *v0 = 2;
}

fn reader(v0: &Field) {
    let v1 = *v0;
    assert_eq(v1, 0);   // must fail (v1 == 1)
}
```

Before the fix, `*v0 = 1` was dropped, `reader` read the initial `0`, and the assertion wrongly passed (execution succeeded). After the fix it correctly fails to satisfy the constraint.

The fix splits the call handler into two gates that match what each map actually tracks:

- `known_values` (invalidated by **writes**) keeps the `contains_mutable_reference()` gate — this preserves the #12877 / #12333 load-forwarding optimization.
- `last_stores` (kept live by **reads**) uses the broader `contains_reference()` gate.

### Alternative considered

We could instead fully revert #12877. The optimization it introduced showed no measurable benefit on existing test programs, so a revert would also be sound and slightly simpler. We kept the optimization here because this targeted fix is small and preserves a valid optimization, but a revert is a reasonable alternative if we'd rather keep LSF maximally simple.

## Tests

- SSA unit test `call_with_immutable_reference_keeps_observed_store_live` (red before the fix, green after); the existing `..._does_not_invalidate_cache` test still guards the load-forwarding optimization.
- Source-level regression `execution_failure/immutable_ref_call_reads_store`, with acir / brillig / comptime stderr snapshots. Verified it wrongly succeeds on the buggy compiler and correctly fails after the fix.

## User Documentation

Check one:
- [X] No user documentation needed.

## PR Checklist

- [X] I have tested the changes locally.
- [X] I have formatted the changes with cargo fmt and nargo fmt on default settings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)