### PR TITLE
chore(test): More oracle proxy tests

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/opt/defunctionalize.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/defunctionalize.rs
@@ -481,18 +481,7 @@ fn create_apply_functions(
         // function to dispatch constrains that we have an expected ID.
 
         let pre_runtime_filter_len = variants.len();
-        let variants: Vec<(FunctionId, RuntimeType)> = variants
-            .into_iter()
-            .filter(|(_, callee_runtime)| {
-                // Note that the Inline property is ignored.
-                caller_runtime.is_brillig() && callee_runtime.is_brillig()
-                    || caller_runtime.is_acir() && callee_runtime.is_acir()
-                    || caller_runtime.is_acir()
-                        && callee_runtime.is_brillig()
-                        && is_valid_across_boundaries(&signature)
-            })
-            .collect();
-
+        let variants = filter_apply_function_variants(&signature, caller_runtime, &variants);
         let dispatches_to_multiple_functions = variants.len() > 1;
 
         // This will be the same signature but with each function type replaced with
@@ -543,6 +532,26 @@ fn create_apply_functions(
     }
 
     Ok((apply_functions, purities))
+}
+
+/// Collect the function variants that can be called from a given runtime.
+fn filter_apply_function_variants(
+    signature: &Signature,
+    caller_runtime: RuntimeType,
+    variants: &[(FunctionId, RuntimeType)],
+) -> Vec<(FunctionId, RuntimeType)> {
+    variants
+        .iter()
+        .filter(|(_, callee_runtime)| {
+            // Note that the Inline property is ignored.
+            caller_runtime.is_brillig() && callee_runtime.is_brillig()
+                || caller_runtime.is_acir() && callee_runtime.is_acir()
+                || caller_runtime.is_acir()
+                    && callee_runtime.is_brillig()
+                    && is_valid_across_boundaries(signature)
+        })
+        .copied()
+        .collect()
 }
 
 /// Transforms a [FunctionId] into a [FieldElement]
@@ -888,6 +897,8 @@ fn replacement_types(types: &[Type]) -> Option<Vec<Type>> {
 
 #[cfg(test)]
 mod tests {
+    use noirc_frontend::test_utils::{GetProgramOptions, get_monomorphized_with_options};
+
     use crate::{
         assert_ssa_snapshot,
         ssa::{
@@ -897,7 +908,11 @@ mod tests {
                 value::{NumericValue, Value},
             },
             ir::function::FunctionId,
-            opt::{assert_pass_does_not_affect_execution, defunctionalize::create_apply_functions},
+            opt::{
+                assert_pass_does_not_affect_execution,
+                defunctionalize::{create_apply_functions, filter_apply_function_variants},
+            },
+            ssa_gen::generate_ssa,
         },
     };
 
@@ -2600,5 +2615,66 @@ mod tests {
 
         let expected: IResults = Ok(vec![Value::Numeric(NumericValue::Field(5u128.into()))]);
         assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn foreign_and_oracle_function_value_proxies() {
+        let src = r#"
+        mod std {
+            pub mod hash {
+                #[foreign(blake2s)]
+                pub fn blake2s<let N: u32>(input: [u8; N]) -> [u8; 32] {}
+            }
+        }
+
+        unconstrained fn encrypt_me(encryption_fn: unconstrained fn([u8; 4]) -> [u8; 32], input: [u8; 4]) -> [u8; 32] {
+            encryption_fn(input)
+        }
+
+        #[oracle(oracle_hash)]
+        unconstrained fn oracle_hash(input: [u8; 4]) -> [u8; 32] {}
+
+        unconstrained fn another_hash(_input: [u8; 4]) -> [u8; 32] { [0; 32] }
+
+        fn assert_output(output: [u8; 32]) {
+            for i in 0..32 {
+                assert(output[i] < 255);
+            }
+        }
+
+        pub fn main(input: pub [u8; 4]) -> pub [u8; 32] {
+            // Safety: calling unconstrained functions.
+            unsafe {
+                let output = encrypt_me(std::hash::blake2s, input);
+                assert_output(output);
+                let output = encrypt_me(oracle_hash, input);
+                assert_output(output);
+                let output = encrypt_me(another_hash, input);
+                assert_output(output);
+                output
+            }
+        }
+        "#;
+
+        let program = get_monomorphized_with_options(
+            src,
+            GetProgramOptions { root_and_stdlib: true, ..Default::default() },
+        )
+        .unwrap();
+        let ssa = generate_ssa(program).unwrap();
+
+        let mut ssa_variants = find_variants(&ssa);
+        let ((signature, caller_runtime), variants) = ssa_variants.pop_last().unwrap();
+        assert!(
+            ssa_variants.is_empty(),
+            "should have only one set of variants for one apply function"
+        );
+
+        assert!(caller_runtime.is_brillig());
+        assert_eq!(variants.len(), 4); // blake2s_proxy (acir + brillig) + oracle_hash_proxy + another_hash
+
+        let variants = filter_apply_function_variants(&signature, caller_runtime, &variants);
+        assert_eq!(variants.len(), 3); // blake2s_proxy + oracle_hash_proxy + another_hash
+        assert!(variants.iter().all(|(_, runtime)| runtime.is_brillig()));
     }
 }

--- a/test_programs/noir_test_success/oracle_proxy_name_collision/Nargo.toml
+++ b/test_programs/noir_test_success/oracle_proxy_name_collision/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "oracle_proxy_name_collision"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.23.0"
+
+[dependencies]

--- a/test_programs/noir_test_success/oracle_proxy_name_collision/src/main.nr
+++ b/test_programs/noir_test_success/oracle_proxy_name_collision/src/main.nr
@@ -1,0 +1,36 @@
+//! Regression test: a user-defined oracle whose name equals the name the proxy pass
+//! generates for another oracle used as a value.
+//!
+//! When `oracle_hash` is passed as a function value, `create_foreign_proxies` generates an
+//! internal function named `oracle_hash_proxy` that forwards to the `oracle_hash` oracle. That
+//! name collides with the user-defined `oracle_hash_proxy` oracle. The collision is only in the
+//! printed name: foreign calls dispatch by oracle name string and proxies dispatch by `FuncId`,
+//! so each call must still reach its intended oracle.
+use std::test::OracleMock;
+
+#[oracle(oracle_hash)]
+unconstrained fn oracle_hash(_input: Field) -> Field {}
+
+#[oracle(oracle_hash_proxy)]
+unconstrained fn oracle_hash_proxy(_input: Field) -> Field {}
+
+unconstrained fn call_with(f: unconstrained fn(Field) -> Field, input: Field) -> Field {
+    f(input)
+}
+
+#[test]
+unconstrained fn dispatches_to_correct_oracle_despite_proxy_name_collision() {
+    let _ = OracleMock::mock("oracle_hash").returns(1);
+    let _ = OracleMock::mock("oracle_hash_proxy").returns(2);
+
+    // Passing `oracle_hash` as a value generates an internal `oracle_hash_proxy` function that
+    // forwards to the `oracle_hash` oracle, so this must observe `oracle_hash`'s mock (1).
+    assert_eq(call_with(oracle_hash, 0), 1);
+
+    // Passing the user-defined `oracle_hash_proxy` oracle as a value must still reach its own
+    // oracle (2), not the internal proxy that forwards to `oracle_hash`.
+    assert_eq(call_with(oracle_hash_proxy, 0), 2);
+
+    // A direct call to `oracle_hash_proxy` must reach its oracle (2) as well.
+    assert_eq(oracle_hash_proxy(0), 2);
+}


### PR DESCRIPTION
## Problem Resolved

Resolves #10118 

## Summary of Changes

Add integration tests:
* The test suggested in the audit, which monomorphizes a program with oracles/builtins used as values, to show that they are found in the defunctionalization module
* A test to show that despite appearing like the `$_proxy` created for the oracle function could name-clash with a user defined oracle of the same name, dispatch happens by ID, which still correctly identifies the correct function.

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
