### PR TITLE
fix(brillig): reclaim spill slot when a reloaded transient value dies

### DIFF
--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_block.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_block.rs
@@ -835,6 +835,13 @@ impl<'block, Registers: RegisterAllocator> BrilligBlock<'block, Registers> {
                             self.brillig_context,
                         );
                         if let Some(sm) = self.function_context.spill_manager.as_mut() {
+                            // A value can reach this branch while still owning a spill slot: a
+                            // transiently spilled value that was reloaded into a register
+                            // (TransientReloaded) is no longer `is_spilled`, yet its slot stays
+                            // reserved. Release it so the offset returns to the free list. For a
+                            // value with no spill record, or a permanently spilled one, this is a
+                            // no-op.
+                            sm.remove_spill(dead_variable);
                             sm.remove_from_lru(dead_variable);
                         }
                     }

--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/tests/spill.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/tests/spill.rs
@@ -12,6 +12,71 @@ use crate::{
     ssa::ir::map::Id,
 };
 
+/// The prologue reserves the spill region with `<dst> = const u32 N` at bytecode
+/// index 1, where `N == SpillManager::max_spill_offset` — the number of slots the
+/// frame allocates on every call. Extract `N`.
+fn spill_region_size(bytecode: &str) -> u32 {
+    let line = bytecode
+        .lines()
+        .map(str::trim)
+        .find(|line| line.starts_with("1:") && line.contains("const u32"))
+        .expect("prologue spill-region constant at bytecode index 1");
+    line.rsplit(' ').next().unwrap().parse().expect("spill-region constant is a u32")
+}
+
+/// Regression: a transiently spilled value that is reloaded for one last use and
+/// then dies in the same block must return its spill slot to the free list.
+///
+/// `max_stack_frame_size = 6` leaves 4 usable registers (sp[2..5]), but `main`
+/// takes 5 parameters, so codegen spills from the first instruction. As the chain
+/// is evaluated, several values are transiently spilled, reloaded into a register
+/// for a single use, and then die — all within `b0`. At the moment such a value
+/// dies it is in the `TransientReloaded` state: the live value is in a register
+/// and its spill slot is still allocated.
+///
+/// `convert_ssa_instruction`'s dead-variable cleanup decides what to do via
+/// `is_spilled`, which is `true` only for `Transient`/`Permanent`. A
+/// `TransientReloaded` value matches neither, so cleanup takes the
+/// register-freeing branch and never calls `remove_spill`: the `SpillRecord`
+/// lingers in `records` and its offset is never pushed back onto
+/// `free_spill_slots`. The next `allocate_spill_offset` bumps `next_spill_offset`
+/// instead of reusing the dead slot, so `max_spill_offset` — and the spill region
+/// the prologue reserves on every call — grows by one for each such pattern.
+///
+/// The leak has no soundness impact — the skipped offset is never reused
+/// incorrectly — so it is purely a memory-footprint regression. Here the true
+/// peak of simultaneously live spills is 5 slots, but the bug inflates the
+/// reserved spill region to 6.
+#[test]
+fn brillig_spill_reloaded_transient_value_reclaims_slot_when_it_dies() {
+    let src = "
+    brillig(inline) fn main f0 {
+      b0(v0: u32, v1: u32, v2: u32, v3: u32, v4: u32):
+        v5 = unchecked_add v0, v1
+        v6 = unchecked_add v2, v3
+        v7 = unchecked_add v4, v5
+        v8 = unchecked_add v6, v7
+        v9 = unchecked_add v0, v8
+        return v9
+    }
+    ";
+
+    let layout = LayoutConfig::new(6, 16, MAX_SCRATCH_SPACE);
+    let options = BrilligOptions { layout, ..Default::default() };
+
+    // A leak-free allocator reserves 5 slots (the peak number of values spilled
+    // at once). The bug reserves 6 because a reloaded transient value's slot is
+    // never reclaimed when it dies.
+    let brillig = ssa_to_brillig_artifacts_with_options(src, &options);
+    let main = &brillig.ssa_function_to_brillig[&Id::test_new(0)];
+    let spill_region = spill_region_size(&main.to_string());
+    assert_eq!(
+        spill_region, 5,
+        "spill region grew to {spill_region}: a reloaded transient value leaked its \
+         spill slot instead of returning it to the free list when it died"
+    );
+}
+
 /// Verify that spill/reload instructions are emitted when register
 /// pressure exceeds the stack frame limit.
 ///


### PR DESCRIPTION
## Summary

Fixes the spill-slot leak described in [AuditHub issue 1164](https://app.audithub.dev/app/organizations/161/projects/974/project-viewer?issueId=1164&version=2198) / [NRSEC-906](https://linear.app/aztec-foundation/issue/NRSEC-906).

When a transiently spilled value is reloaded into a register, its spill status flips from `Transient` to `TransientReloaded` via `unmark_spilled`: the register holds the live value while the spill slot stays reserved in case the value must be spilled again. When that value later dies in the same block, the slot is supposed to return to the free list — but it didn't.

`convert_ssa_instruction`'s dead-variable cleanup decides what to do by calling `is_spilled`, which is `true` only for `Transient` and `Permanent`. A `TransientReloaded` value matches neither, so the cleanup fell into the register-freeing branch: the register was freed and the LRU entry removed, but `remove_spill` was never called. The `SpillRecord` stayed in `records` and its offset was never pushed back onto `free_spill_slots`. The next `allocate_spill_offset` then bumped `next_spill_offset` instead of reusing the dead slot, and `max_spill_offset` — the size of the spill region the function prologue reserves on **every** call — grew by one for every spill→reload→die pattern.

## Impact

**No soundness impact** — the leaked offset is simply skipped, never reused incorrectly. The cost is an inflated per-call memory footprint: each spill→reload→die pattern the code generator emits adds one slot to the spill region the prologue allocates on every invocation.

## Fix

Release the spill slot in the register-freeing cleanup branch as well, so a `TransientReloaded` value's offset returns to `free_spill_slots` when it dies. `remove_spill` is a no-op for values with no spill record and for permanently spilled values (whose slot must remain authoritative across block boundaries), so calling it is safe for every value that reaches this branch.

## Testing

Adds `brillig_spill_reloaded_transient_value_reclaims_slot_when_it_dies`, which compiles a 5-parameter function under a 4-register layout so values are spilled, reloaded for a single use, and die within the block. It asserts the prologue's reserved spill region equals the true live peak (5 slots); on the buggy code it grew to 6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)