### PR TITLE
fix: reject macro-spliced private types

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/visibility.rs
+++ b/compiler/noirc_frontend/src/elaborator/visibility.rs
@@ -14,7 +14,10 @@ use crate::{
         },
     },
     hir_def::function::FuncMeta,
-    modules::{get_ancestor_module_reexport, module_def_id_is_visible},
+    modules::{
+        get_ancestor_module_reexport_ignoring_dependencies,
+        module_def_id_is_visible_ignoring_dependencies,
+    },
     node_interner::{FuncId, FunctionModifiers},
 };
 
@@ -103,40 +106,40 @@ impl Elaborator<'_> {
         visibility
     }
 
-    /// Whether a foreign data type can be named from the current module: directly, via a
-    /// `pub use` re-export of the type itself, or via a re-export of one of its ancestor
-    /// modules. This mirrors what naming the type by hand would require, so a macro-spliced
-    /// resolved type cannot expose a dependency-private type that hand-written code could not.
+    /// Whether a foreign data type's visibility is public enough to be exposed from the current
+    /// module: the type itself (and its enclosing modules) is visible, the type is `pub use`
+    /// re-exported, or one of its ancestor modules is re-exported.
+    ///
+    /// Unlike path resolution, this ignores whether the defining crate is a direct dependency. A
+    /// maximally-public type reached from a transitive dependency (e.g. by a macro reflecting over
+    /// an accessible value's field) is part of the public API surface and is not "more private"
+    /// than the item it is spliced into, even though it could not be named by an explicit path.
     fn foreign_type_is_visible(&self, struct_type: &DataType) -> bool {
         let module_def_id = ModuleDefId::TypeId(struct_type.id);
         let visibility = struct_type.visibility;
-        let dependencies = &self.crate_graph[self.crate_id].dependencies;
 
-        module_def_id_is_visible(
+        module_def_id_is_visible_ignoring_dependencies(
             module_def_id,
             self.module_id(),
             visibility,
             None,
             self.interner,
             self.def_maps,
-            dependencies,
         ) || self.interner.get_reexports(module_def_id).iter().any(|reexport| {
-            module_def_id_is_visible(
+            module_def_id_is_visible_ignoring_dependencies(
                 module_def_id,
                 self.module_id(),
                 reexport.visibility,
                 Some(reexport.module_id),
                 self.interner,
                 self.def_maps,
-                dependencies,
             )
-        }) || get_ancestor_module_reexport(
+        }) || get_ancestor_module_reexport_ignoring_dependencies(
             module_def_id,
             visibility,
             self.module_id(),
             self.interner,
             self.def_maps,
-            dependencies,
         )
         .is_some()
     }

--- a/compiler/noirc_frontend/src/elaborator/visibility.rs
+++ b/compiler/noirc_frontend/src/elaborator/visibility.rs
@@ -5,12 +5,16 @@ use noirc_errors::{Located, Location};
 use crate::{
     DataType, StructField, Type,
     ast::{Ident, ItemVisibility, NoirStruct},
-    hir::resolution::{
-        errors::ResolverError,
-        import::PathResolutionError,
-        visibility::{method_call_is_visible, struct_member_is_visible},
+    hir::{
+        def_map::ModuleDefId,
+        resolution::{
+            errors::ResolverError,
+            import::PathResolutionError,
+            visibility::{method_call_is_visible, struct_member_is_visible},
+        },
     },
     hir_def::function::FuncMeta,
+    modules::{get_ancestor_module_reexport, module_def_id_is_visible},
     node_interner::{FuncId, FunctionModifiers},
 };
 
@@ -99,6 +103,44 @@ impl Elaborator<'_> {
         visibility
     }
 
+    /// Whether a foreign data type can be named from the current module: directly, via a
+    /// `pub use` re-export of the type itself, or via a re-export of one of its ancestor
+    /// modules. This mirrors what naming the type by hand would require, so a macro-spliced
+    /// resolved type cannot expose a dependency-private type that hand-written code could not.
+    fn foreign_type_is_visible(&self, struct_type: &DataType) -> bool {
+        let module_def_id = ModuleDefId::TypeId(struct_type.id);
+        let visibility = struct_type.visibility;
+        let dependencies = &self.crate_graph[self.crate_id].dependencies;
+
+        module_def_id_is_visible(
+            module_def_id,
+            self.module_id(),
+            visibility,
+            None,
+            self.interner,
+            self.def_maps,
+            dependencies,
+        ) || self.interner.get_reexports(module_def_id).iter().any(|reexport| {
+            module_def_id_is_visible(
+                module_def_id,
+                self.module_id(),
+                reexport.visibility,
+                Some(reexport.module_id),
+                self.interner,
+                self.def_maps,
+                dependencies,
+            )
+        }) || get_ancestor_module_reexport(
+            module_def_id,
+            visibility,
+            self.module_id(),
+            self.interner,
+            self.def_maps,
+            dependencies,
+        )
+        .is_some()
+    }
+
     #[tracing::instrument(level = "trace", skip_all)]
     pub(super) fn check_function_visibility(
         &mut self,
@@ -167,9 +209,6 @@ impl Elaborator<'_> {
                 let struct_type = struct_type.borrow();
                 let struct_module_id = struct_type.id.module_id();
 
-                // We only check this in types in the same crate. If it's in a different crate
-                // then it's either accessible (all good) or it's not, in which case a different
-                // error will happen somewhere else, but no need to error again here.
                 if struct_module_id.krate == self.crate_id {
                     let aliased_visibility = self.find_struct_visibility(&struct_type);
                     if aliased_visibility < visibility {
@@ -179,6 +218,15 @@ impl Elaborator<'_> {
                             location,
                         });
                     }
+                } else if !self.foreign_type_is_visible(&struct_type) {
+                    // A foreign type written by hand would be rejected by the path resolver if it
+                    // weren't accessible. A macro can splice in a resolved type that never goes
+                    // through path resolution, so the same accessibility check is enforced here.
+                    self.push_err(ResolverError::TypeIsMorePrivateThenItem {
+                        typ: struct_type.name.to_string(),
+                        item: name.to_string(),
+                        location,
+                    });
                 }
 
                 for generic in generics {

--- a/compiler/noirc_frontend/src/modules.rs
+++ b/compiler/noirc_frontend/src/modules.rs
@@ -238,11 +238,61 @@ pub fn module_def_id_relative_path(
 pub fn module_def_id_is_visible(
     module_def_id: ModuleDefId,
     current_module_id: ModuleId,
+    visibility: ItemVisibility,
+    defining_module: Option<ModuleId>,
+    interner: &NodeInterner,
+    def_maps: &DefMaps,
+    dependencies: &[Dependency],
+) -> bool {
+    module_def_id_is_visible_impl(
+        module_def_id,
+        current_module_id,
+        visibility,
+        defining_module,
+        interner,
+        def_maps,
+        Some(dependencies),
+    )
+}
+
+/// Like `module_def_id_is_visible`, but only considers visibility modifiers and ignores whether
+/// the defining crate is reachable through the current crate's dependency edges.
+///
+/// This is used by the macro-spliced-type leak check: a maximally-public type that lives in a
+/// transitive dependency is legitimately part of the public API surface even though it cannot be
+/// named by an explicit path from the current crate (which would require a direct dependency edge).
+/// The leak check only cares whether the type's own visibility (and its enclosing modules') is
+/// public enough, not about path reachability.
+pub fn module_def_id_is_visible_ignoring_dependencies(
+    module_def_id: ModuleDefId,
+    current_module_id: ModuleId,
+    visibility: ItemVisibility,
+    defining_module: Option<ModuleId>,
+    interner: &NodeInterner,
+    def_maps: &DefMaps,
+) -> bool {
+    module_def_id_is_visible_impl(
+        module_def_id,
+        current_module_id,
+        visibility,
+        defining_module,
+        interner,
+        def_maps,
+        None,
+    )
+}
+
+/// When `dependencies` is `Some`, an item in a crate that is neither the current crate nor one of
+/// its dependencies is considered not visible. When `None`, only the visibility modifiers along the
+/// module chain are checked.
+fn module_def_id_is_visible_impl(
+    module_def_id: ModuleDefId,
+    current_module_id: ModuleId,
     mut visibility: ItemVisibility,
     mut defining_module: Option<ModuleId>,
     interner: &NodeInterner,
     def_maps: &DefMaps,
-    dependencies: &[Dependency],
+    dependencies: Option<&[Dependency]>,
 ) -> bool {
     // First find out which module we need to check.
     // If a module is trying to be referenced, it's that module. Otherwise it's the module that contains the item.
@@ -261,7 +311,8 @@ pub fn module_def_id_is_visible(
 
         // If the target module isn't in the same crate as `module_id` or isn't in one of its
         // dependencies, then it's not visible.
-        if module_id.krate != current_module_id.krate
+        if let Some(dependencies) = dependencies
+            && module_id.krate != current_module_id.krate
             && dependencies.iter().all(|dep| dep.crate_id != module_id.krate)
         {
             return false;
@@ -292,10 +343,47 @@ pub fn get_ancestor_module_reexport(
     def_maps: &DefMaps,
     dependencies: &[Dependency],
 ) -> Option<Reexport> {
+    get_ancestor_module_reexport_impl(
+        module_def_id,
+        visibility,
+        current_module_id,
+        interner,
+        def_maps,
+        Some(dependencies),
+    )
+}
+
+/// Like `get_ancestor_module_reexport`, but ignores whether the defining crate is reachable through
+/// the current crate's dependency edges (see `module_def_id_is_visible_ignoring_dependencies`).
+pub fn get_ancestor_module_reexport_ignoring_dependencies(
+    module_def_id: ModuleDefId,
+    visibility: ItemVisibility,
+    current_module_id: ModuleId,
+    interner: &NodeInterner,
+    def_maps: &DefMaps,
+) -> Option<Reexport> {
+    get_ancestor_module_reexport_impl(
+        module_def_id,
+        visibility,
+        current_module_id,
+        interner,
+        def_maps,
+        None,
+    )
+}
+
+fn get_ancestor_module_reexport_impl(
+    module_def_id: ModuleDefId,
+    visibility: ItemVisibility,
+    current_module_id: ModuleId,
+    interner: &NodeInterner,
+    def_maps: &DefMaps,
+    dependencies: Option<&[Dependency]>,
+) -> Option<Reexport> {
     let parent_module = get_parent_module(module_def_id, interner, def_maps)?;
     let reexport =
         interner.get_reexports(ModuleDefId::ModuleId(parent_module)).iter().find(|reexport| {
-            module_def_id_is_visible(
+            module_def_id_is_visible_impl(
                 ModuleDefId::ModuleId(reexport.module_id),
                 current_module_id,
                 reexport.visibility,
@@ -310,7 +398,7 @@ pub fn get_ancestor_module_reexport(
     }
 
     // Try searching in the parent's parent module.
-    let mut grandparent_module_reexport = get_ancestor_module_reexport(
+    let mut grandparent_module_reexport = get_ancestor_module_reexport_impl(
         ModuleDefId::ModuleId(parent_module),
         visibility,
         current_module_id,
@@ -320,7 +408,7 @@ pub fn get_ancestor_module_reexport(
     )?;
 
     // If we can find one, we need to check if ModuleDefId is actually visible from the grandparent module
-    if !module_def_id_is_visible(
+    if !module_def_id_is_visible_impl(
         module_def_id,
         current_module_id,
         visibility,

--- a/test_programs/compile_failure/comptime_leak_private_dependency_type/Nargo.toml
+++ b/test_programs/compile_failure/comptime_leak_private_dependency_type/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "comptime_leak_private_dependency_type"
+type = "bin"
+authors = [""]
+
+[dependencies]
+mylib = { path = "./mylib" }

--- a/test_programs/compile_failure/comptime_leak_private_dependency_type/mylib/Nargo.toml
+++ b/test_programs/compile_failure/comptime_leak_private_dependency_type/mylib/Nargo.toml
@@ -1,0 +1,4 @@
+[package]
+name = "mylib"
+type = "lib"
+authors = [""]

--- a/test_programs/compile_failure/comptime_leak_private_dependency_type/mylib/src/lib.nr
+++ b/test_programs/compile_failure/comptime_leak_private_dependency_type/mylib/src/lib.nr
@@ -1,0 +1,13 @@
+mod hidden {
+    pub struct Secret {
+        pub value: Field,
+    }
+}
+
+pub struct PublicBox {
+    secret: hidden::Secret,
+}
+
+pub fn anchor() -> Field {
+    0
+}

--- a/test_programs/compile_failure/comptime_leak_private_dependency_type/src/main.nr
+++ b/test_programs/compile_failure/comptime_leak_private_dependency_type/src/main.nr
@@ -1,0 +1,26 @@
+use mylib::{anchor, PublicBox};
+
+// A macro must not be able to splice a dependency-private type into a public API. The
+// `hidden::Secret` type is reachable here only by reflecting over `PublicBox`'s field; it
+// cannot be named by hand, so it must not leak through a `pub fn` return or public struct field.
+comptime fn emit_private_type_api(_f: FunctionDefinition) -> Quoted {
+    let typ = quote { PublicBox }.as_type();
+    let (def, generics) = typ.as_data_type().unwrap();
+    let fields = def.fields(generics);
+    let private_type = fields[0].1;
+
+    quote {
+        pub fn leaked_private_type_api() -> Option<$private_type> {
+            Option::none()
+        }
+
+        pub struct LeakedPublicField {
+            pub value: Option<$private_type>,
+        }
+    }
+}
+
+#[emit_private_type_api]
+fn main() -> pub Field {
+    anchor()
+}

--- a/test_programs/compile_success_empty/comptime_reexported_dependency_type/Nargo.toml
+++ b/test_programs/compile_success_empty/comptime_reexported_dependency_type/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "comptime_reexported_dependency_type"
+type = "bin"
+authors = [""]
+
+[dependencies]
+mylib = { path = "./mylib" }

--- a/test_programs/compile_success_empty/comptime_reexported_dependency_type/mylib/Nargo.toml
+++ b/test_programs/compile_success_empty/comptime_reexported_dependency_type/mylib/Nargo.toml
@@ -1,0 +1,4 @@
+[package]
+name = "mylib"
+type = "lib"
+authors = [""]

--- a/test_programs/compile_success_empty/comptime_reexported_dependency_type/mylib/src/lib.nr
+++ b/test_programs/compile_success_empty/comptime_reexported_dependency_type/mylib/src/lib.nr
@@ -1,0 +1,13 @@
+mod hidden {
+    pub struct Secret {
+        pub value: Field,
+    }
+}
+
+// `Secret` lives in a private module but is publicly re-exported, so it is part of the
+// library's public API and may legitimately appear in a downstream crate's public API.
+pub use hidden::Secret;
+
+pub struct PublicBox {
+    secret: Secret,
+}

--- a/test_programs/compile_success_empty/comptime_reexported_dependency_type/src/main.nr
+++ b/test_programs/compile_success_empty/comptime_reexported_dependency_type/src/main.nr
@@ -1,0 +1,23 @@
+use mylib::PublicBox;
+
+// `Secret` is reached by reflecting over `PublicBox`'s field, but the library re-exports it
+// publicly, so splicing it into a public API is allowed: hand-written code could name it too.
+comptime fn emit_reexported_type_api(_f: FunctionDefinition) -> Quoted {
+    let typ = quote { PublicBox }.as_type();
+    let (def, generics) = typ.as_data_type().unwrap();
+    let fields = def.fields(generics);
+    let reexported_type = fields[0].1;
+
+    quote {
+        pub fn reexported_type_api() -> Option<$reexported_type> {
+            Option::none()
+        }
+
+        pub struct ReexportedPublicField {
+            pub value: Option<$reexported_type>,
+        }
+    }
+}
+
+#[emit_reexported_type_api]
+fn main() {}

--- a/test_programs/compile_success_empty/comptime_transitive_public_dependency_type/Nargo.toml
+++ b/test_programs/compile_success_empty/comptime_transitive_public_dependency_type/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "comptime_transitive_public_dependency_type"
+type = "bin"
+authors = [""]
+
+[dependencies]
+midlib = { path = "./midlib" }

--- a/test_programs/compile_success_empty/comptime_transitive_public_dependency_type/midlib/Nargo.toml
+++ b/test_programs/compile_success_empty/comptime_transitive_public_dependency_type/midlib/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "midlib"
+type = "lib"
+authors = [""]
+
+[dependencies]
+leaflib = { path = "./leaflib" }

--- a/test_programs/compile_success_empty/comptime_transitive_public_dependency_type/midlib/leaflib/Nargo.toml
+++ b/test_programs/compile_success_empty/comptime_transitive_public_dependency_type/midlib/leaflib/Nargo.toml
@@ -1,0 +1,4 @@
+[package]
+name = "leaflib"
+type = "lib"
+authors = [""]

--- a/test_programs/compile_success_empty/comptime_transitive_public_dependency_type/midlib/leaflib/src/lib.nr
+++ b/test_programs/compile_success_empty/comptime_transitive_public_dependency_type/midlib/leaflib/src/lib.nr
@@ -1,0 +1,5 @@
+pub mod deep {
+    pub struct LeafPublic {
+        pub value: Field,
+    }
+}

--- a/test_programs/compile_success_empty/comptime_transitive_public_dependency_type/midlib/src/lib.nr
+++ b/test_programs/compile_success_empty/comptime_transitive_public_dependency_type/midlib/src/lib.nr
@@ -1,0 +1,7 @@
+// `LeafPublic` is a maximally-public type (`pub struct` in `pub mod`) that lives in `leaflib`, a
+// transitive dependency of the downstream binary. The binary can reach it only by reflecting over
+// `PublicBox`'s field, but because the type is fully public it is part of the public API surface
+// and may legitimately be spliced into the binary's public API.
+pub struct PublicBox {
+    inner: leaflib::deep::LeafPublic,
+}

--- a/test_programs/compile_success_empty/comptime_transitive_public_dependency_type/src/main.nr
+++ b/test_programs/compile_success_empty/comptime_transitive_public_dependency_type/src/main.nr
@@ -1,0 +1,25 @@
+use midlib::PublicBox;
+
+// This macro runs while elaborating the downstream binary, which does NOT depend on `leaflib`
+// directly (only transitively, through `midlib`). `LeafPublic` is reached by reflecting over
+// `PublicBox`'s field. It is maximally public, so splicing it into a public API is allowed:
+// it is part of the dependency graph's public surface, not "more private" than the item.
+comptime fn emit_transitive_type_api(_f: FunctionDefinition) -> Quoted {
+    let typ = quote { PublicBox }.as_type();
+    let (def, generics) = typ.as_data_type().unwrap();
+    let fields = def.fields(generics);
+    let transitive_type = fields[0].1;
+
+    quote {
+        pub fn transitive_type_api() -> Option<$transitive_type> {
+            Option::none()
+        }
+
+        pub struct TransitivePublicField {
+            pub value: Option<$transitive_type>,
+        }
+    }
+}
+
+#[emit_transitive_type_api]
+fn main() {}

--- a/tooling/nargo_cli/build.rs
+++ b/tooling/nargo_cli/build.rs
@@ -250,7 +250,7 @@ const TESTS_WITHOUT_STDOUT_CHECK: [&str; 0] = [];
 /// These tests are ignored because of existing bugs in `nargo expand`.
 /// As the bugs are fixed these tests should be removed from this list.
 /// (some are ignored on purpose for the same reason as `IGNORED_NARGO_EXPAND_EXECUTION_TESTS`)
-const IGNORED_NARGO_EXPAND_COMPILE_SUCCESS_EMPTY_TESTS: [&str; 9] = [
+const IGNORED_NARGO_EXPAND_COMPILE_SUCCESS_EMPTY_TESTS: [&str; 10] = [
     // There's no "src/main.nr" here so it's trickier to make this work
     "overlapping_dep_and_mod",
     // this one works, but copying its `Nargo.toml` file to somewhere else doesn't work
@@ -271,6 +271,9 @@ const IGNORED_NARGO_EXPAND_COMPILE_SUCCESS_EMPTY_TESTS: [&str; 9] = [
     // The expanded code names a transitive-only dependency (`leaflib`) by path, which isn't
     // directly importable when the expansion is recompiled as a standalone program.
     "comptime_as_typed_expr_public_type_trait_method",
+    // The expanded code names a transitive-only dependency (`leaflib`) by path, which isn't
+    // directly importable when the expansion is recompiled as a standalone program.
+    "comptime_transitive_public_dependency_type",
 ];
 
 /// These tests are ignored because of existing bugs in `nargo expand`.

--- a/tooling/nargo_cli/tests/snapshots/compile_failure/comptime_leak_private_dependency_type/execute__tests__stderr.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_failure/comptime_leak_private_dependency_type/execute__tests__stderr.snap
@@ -1,0 +1,25 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: stderr
+---
+error: Type `Secret` is more private than item `LeakedPublicField::value`
+   ┌─ src/main.nr:18:17
+   │
+18 │             pub value: Option<$private_type>,
+   │                 -----
+   ·
+23 │ #[emit_private_type_api]
+   │ ------------------------ While running this function attribute
+   │
+
+error: Type `Secret` is more private than item `leaked_private_type_api`
+   ┌─ src/main.nr:13:16
+   │
+13 │         pub fn leaked_private_type_api() -> Option<$private_type> {
+   │                -----------------------
+   ·
+23 │ #[emit_private_type_api]
+   │ ------------------------ While running this function attribute
+   │
+
+Aborting due to 2 previous errors

--- a/tooling/nargo_cli/tests/snapshots/compile_success_empty/comptime_reexported_dependency_type/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_empty/comptime_reexported_dependency_type/execute__tests__expanded.snap
@@ -1,0 +1,30 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: expanded_code
+---
+use mylib::PublicBox;
+
+comptime fn emit_reexported_type_api(_f: FunctionDefinition) -> Quoted {
+    let typ: Type = quote { PublicBox }.as_type();
+    let (def, generics): (TypeDefinition, [Type]) = typ.as_data_type().unwrap();
+    let fields: [(Quoted, Type, Quoted)] = def.fields(generics);
+    let reexported_type: Type = fields[0_u32].1;
+    quote {
+        pub fn reexported_type_api() -> Option<$reexported_type> {
+            Option::none()
+        }
+        pub struct ReexportedPublicField {
+            pub value: Option<$reexported_type>,
+        }
+    }
+}
+
+pub fn reexported_type_api() -> Option<mylib::Secret> {
+    Option::<mylib::Secret>::none()
+}
+
+pub struct ReexportedPublicField {
+    pub value: Option<mylib::Secret>,
+}
+
+fn main() {}

--- a/tooling/nargo_cli/tests/snapshots/compile_success_empty/comptime_transitive_public_dependency_type/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_empty/comptime_transitive_public_dependency_type/execute__tests__expanded.snap
@@ -1,0 +1,30 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: expanded_code
+---
+use midlib::PublicBox;
+
+comptime fn emit_transitive_type_api(_f: FunctionDefinition) -> Quoted {
+    let typ: Type = quote { PublicBox }.as_type();
+    let (def, generics): (TypeDefinition, [Type]) = typ.as_data_type().unwrap();
+    let fields: [(Quoted, Type, Quoted)] = def.fields(generics);
+    let transitive_type: Type = fields[0_u32].1;
+    quote {
+        pub fn transitive_type_api() -> Option<$transitive_type> {
+            Option::none()
+        }
+        pub struct TransitivePublicField {
+            pub value: Option<$transitive_type>,
+        }
+    }
+}
+
+pub fn transitive_type_api() -> Option<leaflib::deep::LeafPublic> {
+    Option::<leaflib::deep::LeafPublic>::none()
+}
+
+pub struct TransitivePublicField {
+    pub value: Option<leaflib::deep::LeafPublic>,
+}
+
+fn main() {}


### PR DESCRIPTION
## Problem Resolved

Resolves https://cantina.xyz/code/af01d57f-6e50-4de3-ad6d-7e9f7ff2d7d1/findings/8

## Summary of Changes

Changes `check_type_is_not_more_private_then_item` to also check types outside the current crate.

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
