### PR TITLE
feat: Handle `super::super` in paths

### DIFF
--- a/compiler/noirc_frontend/src/ast/statement.rs
+++ b/compiler/noirc_frontend/src/ast/statement.rs
@@ -339,8 +339,9 @@ pub enum PathKind {
     Crate,
     Absolute,
     Plain,
-    /// One or more stacked `super` qualifiers, e.g. `super::` (depth 1) or `super::super::`
-    /// (depth 2). The depth is always at least 1.
+    /// One or more stacked `super` qualifiers. The payload is the number of *extra* `super`s
+    /// beyond the first, so `super::` is `Super(0)` and `super::super::` is `Super(1)`. Every
+    /// `usize` is therefore a valid value.
     Super(usize),
     /// This path is a Crate or Dep path which always points to the given crate.
     /// This is used to implement `$crate::<path-in-macro-crate>` imports for macros, similar to Rust.
@@ -1046,8 +1047,8 @@ impl Display for PathKind {
         match self {
             PathKind::Crate => write!(f, "crate"),
             PathKind::Absolute => write!(f, ""),
-            PathKind::Super(count) => {
-                for i in 0..*count {
+            PathKind::Super(extras) => {
+                for i in 0..=*extras {
                     if i > 0 {
                         write!(f, "::")?;
                     }

--- a/compiler/noirc_frontend/src/ast/statement.rs
+++ b/compiler/noirc_frontend/src/ast/statement.rs
@@ -339,7 +339,9 @@ pub enum PathKind {
     Crate,
     Absolute,
     Plain,
-    Super,
+    /// One or more stacked `super` qualifiers, e.g. `super::` (depth 1) or `super::super::`
+    /// (depth 2). The depth is always at least 1.
+    Super(usize),
     /// This path is a Crate or Dep path which always points to the given crate.
     /// This is used to implement `$crate::<path-in-macro-crate>` imports for macros, similar to Rust.
     Resolved(CrateId),
@@ -1044,7 +1046,15 @@ impl Display for PathKind {
         match self {
             PathKind::Crate => write!(f, "crate"),
             PathKind::Absolute => write!(f, ""),
-            PathKind::Super => write!(f, "super"),
+            PathKind::Super(count) => {
+                for i in 0..*count {
+                    if i > 0 {
+                        write!(f, "::")?;
+                    }
+                    write!(f, "super")?;
+                }
+                Ok(())
+            }
             PathKind::Plain => write!(f, "plain"),
             PathKind::Resolved(_) => write!(f, "$crate"),
         }

--- a/compiler/noirc_frontend/src/hir/resolution/import.rs
+++ b/compiler/noirc_frontend/src/hir/resolution/import.rs
@@ -244,7 +244,7 @@ pub(crate) fn first_segment_is_always_visible(
     starting_module: ModuleId,
 ) -> bool {
     match path.kind {
-        PathKind::Crate | PathKind::Super => true,
+        PathKind::Crate | PathKind::Super(_) => true,
         PathKind::Plain => importing_module == starting_module,
         PathKind::Resolved(_) => false,
         PathKind::Absolute => {
@@ -266,7 +266,7 @@ impl PathResolutionTargetResolver<'_, '_> {
             PathKind::Crate => self.resolve_crate_path(path, self.importing_module.krate),
             PathKind::Plain => self.resolve_plain_path(path, self.importing_module),
             PathKind::Absolute => self.resolve_absolute_path(path),
-            PathKind::Super => self.resolve_super_path(path),
+            PathKind::Super(count) => self.resolve_super_path(path, count),
             PathKind::Resolved(crate_id) => self.resolve_crate_path(path, crate_id),
         }
     }
@@ -337,19 +337,22 @@ impl PathResolutionTargetResolver<'_, '_> {
         Ok((path, *dep_module))
     }
 
-    /// Resolve a path such as `super::foo::bar`:
-    /// * get the parent of the current importing module
-    /// * return the path still with [PathKind::Super], paired up with the parent module
+    /// Resolve a path such as `super::foo::bar` or `super::super::foo::bar`:
+    /// * walk up `count` parents of the current importing module (one per `super`)
+    /// * return the path still with [PathKind::Super], paired up with the ancestor module
     fn resolve_super_path(
         &self,
         path: TypedPath,
+        count: usize,
     ) -> Result<(TypedPath, ModuleId), PathResolutionError> {
-        let Some(parent_module_id) = get_module(self.def_maps, self.importing_module).parent else {
-            return Err(PathResolutionError::NoSuper(path.kind_location));
-        };
-
-        let current_module =
-            ModuleId { krate: self.importing_module.krate, local_id: parent_module_id };
+        let mut current_module = self.importing_module;
+        for _ in 0..count {
+            let Some(parent_module_id) = get_module(self.def_maps, current_module).parent else {
+                return Err(PathResolutionError::NoSuper(path.kind_location));
+            };
+            current_module =
+                ModuleId { krate: self.importing_module.krate, local_id: parent_module_id };
+        }
         Ok((path, current_module))
     }
 }

--- a/compiler/noirc_frontend/src/hir/resolution/import.rs
+++ b/compiler/noirc_frontend/src/hir/resolution/import.rs
@@ -266,7 +266,7 @@ impl PathResolutionTargetResolver<'_, '_> {
             PathKind::Crate => self.resolve_crate_path(path, self.importing_module.krate),
             PathKind::Plain => self.resolve_plain_path(path, self.importing_module),
             PathKind::Absolute => self.resolve_absolute_path(path),
-            PathKind::Super(count) => self.resolve_super_path(path, count),
+            PathKind::Super(extras) => self.resolve_super_path(path, extras),
             PathKind::Resolved(crate_id) => self.resolve_crate_path(path, crate_id),
         }
     }
@@ -338,15 +338,15 @@ impl PathResolutionTargetResolver<'_, '_> {
     }
 
     /// Resolve a path such as `super::foo::bar` or `super::super::foo::bar`:
-    /// * walk up `count` parents of the current importing module (one per `super`)
+    /// * walk up `extras + 1` parents of the current importing module (one per `super`)
     /// * return the path still with [PathKind::Super], paired up with the ancestor module
     fn resolve_super_path(
         &self,
         path: TypedPath,
-        count: usize,
+        extras: usize,
     ) -> Result<(TypedPath, ModuleId), PathResolutionError> {
         let mut current_module = self.importing_module;
-        for _ in 0..count {
+        for _ in 0..=extras {
             let Some(parent_module_id) = get_module(self.def_maps, current_module).parent else {
                 return Err(PathResolutionError::NoSuper(path.kind_location));
             };

--- a/compiler/noirc_frontend/src/parser/parser/path.rs
+++ b/compiler/noirc_frontend/src/parser/parser/path.rs
@@ -190,7 +190,7 @@ impl Parser<'_> {
         } else if self.eat_keyword(Keyword::Crate) {
             PathKind::Crate
         } else if self.eat_keyword(Keyword::Super) {
-            PathKind::Super(1)
+            PathKind::Super(0)
         } else if let Token::InternedCrate(crate_id) = self.token.token() {
             let crate_id = *crate_id;
             self.bump();
@@ -202,11 +202,12 @@ impl Parser<'_> {
             self.eat_or_error(Token::DoubleColon);
         }
 
-        // Accept stacked `super` qualifiers such as `super::super::foo`.
-        if let PathKind::Super(count) = &mut kind {
+        // Accept stacked `super` qualifiers such as `super::super::foo`, counting each one
+        // beyond the first as an "extra".
+        if let PathKind::Super(extras) = &mut kind {
             while self.eat_keyword(Keyword::Super) {
                 self.eat_or_error(Token::DoubleColon);
-                *count += 1;
+                *extras += 1;
             }
         }
 
@@ -318,7 +319,7 @@ mod tests {
     fn parses_super_two_segments() {
         let src = "super::foo::bar";
         let path = parse_path_no_errors(src);
-        assert_eq!(path.kind, PathKind::Super(1));
+        assert_eq!(path.kind, PathKind::Super(0));
         assert_eq!(path.segments.len(), 2);
         assert_eq!(path.segments[0].ident.to_string(), "foo");
         assert!(path.segments[0].generics.is_none());
@@ -330,7 +331,7 @@ mod tests {
     fn parses_stacked_super_two_segments() {
         let src = "super::super::foo::bar";
         let path = parse_path_no_errors(src);
-        assert_eq!(path.kind, PathKind::Super(2));
+        assert_eq!(path.kind, PathKind::Super(1));
         assert_eq!(path.segments.len(), 2);
         assert_eq!(path.segments[0].ident.to_string(), "foo");
         assert_eq!(path.segments[1].ident.to_string(), "bar");

--- a/compiler/noirc_frontend/src/parser/parser/path.rs
+++ b/compiler/noirc_frontend/src/parser/parser/path.rs
@@ -182,7 +182,7 @@ impl Parser<'_> {
         let start_location = self.current_token_location;
         let mut deprecated_dep_found = false;
 
-        let kind = if self.at(Token::DoubleColon) {
+        let mut kind = if self.at(Token::DoubleColon) {
             PathKind::Absolute
         } else if self.eat_keyword(Keyword::Dep) {
             deprecated_dep_found = true;
@@ -190,7 +190,7 @@ impl Parser<'_> {
         } else if self.eat_keyword(Keyword::Crate) {
             PathKind::Crate
         } else if self.eat_keyword(Keyword::Super) {
-            PathKind::Super
+            PathKind::Super(1)
         } else if let Token::InternedCrate(crate_id) = self.token.token() {
             let crate_id = *crate_id;
             self.bump();
@@ -200,6 +200,14 @@ impl Parser<'_> {
         };
         if kind != PathKind::Plain {
             self.eat_or_error(Token::DoubleColon);
+        }
+
+        // Accept stacked `super` qualifiers such as `super::super::foo`.
+        if let PathKind::Super(count) = &mut kind {
+            while self.eat_keyword(Keyword::Super) {
+                self.eat_or_error(Token::DoubleColon);
+                *count += 1;
+            }
         }
 
         if deprecated_dep_found {
@@ -310,12 +318,22 @@ mod tests {
     fn parses_super_two_segments() {
         let src = "super::foo::bar";
         let path = parse_path_no_errors(src);
-        assert_eq!(path.kind, PathKind::Super);
+        assert_eq!(path.kind, PathKind::Super(1));
         assert_eq!(path.segments.len(), 2);
         assert_eq!(path.segments[0].ident.to_string(), "foo");
         assert!(path.segments[0].generics.is_none());
         assert_eq!(path.segments[1].ident.to_string(), "bar");
         assert!(path.segments[1].generics.is_none());
+    }
+
+    #[test]
+    fn parses_stacked_super_two_segments() {
+        let src = "super::super::foo::bar";
+        let path = parse_path_no_errors(src);
+        assert_eq!(path.kind, PathKind::Super(2));
+        assert_eq!(path.segments.len(), 2);
+        assert_eq!(path.segments[0].ident.to_string(), "foo");
+        assert_eq!(path.segments[1].ident.to_string(), "bar");
     }
 
     #[test]

--- a/compiler/noirc_frontend/src/parser/parser/use_tree.rs
+++ b/compiler/noirc_frontend/src/parser/parser/use_tree.rs
@@ -236,7 +236,7 @@ mod tests {
         let src = "use super::foo;";
         let (use_tree, visibility) = parse_use_tree_no_errors(src);
         assert_eq!(visibility, ItemVisibility::Private);
-        assert_eq!(use_tree.prefix.kind, PathKind::Super(1));
+        assert_eq!(use_tree.prefix.kind, PathKind::Super(0));
         assert_eq!("super::foo", use_tree.to_string());
         let UseTreeKind::Path(ident, alias) = use_tree.kind else {
             panic!("Expected path");
@@ -250,7 +250,7 @@ mod tests {
         let src = "use super::super::foo;";
         let (use_tree, visibility) = parse_use_tree_no_errors(src);
         assert_eq!(visibility, ItemVisibility::Private);
-        assert_eq!(use_tree.prefix.kind, PathKind::Super(2));
+        assert_eq!(use_tree.prefix.kind, PathKind::Super(1));
         assert_eq!("super::super::foo", use_tree.to_string());
         let UseTreeKind::Path(ident, alias) = use_tree.kind else {
             panic!("Expected path");

--- a/compiler/noirc_frontend/src/parser/parser/use_tree.rs
+++ b/compiler/noirc_frontend/src/parser/parser/use_tree.rs
@@ -236,8 +236,22 @@ mod tests {
         let src = "use super::foo;";
         let (use_tree, visibility) = parse_use_tree_no_errors(src);
         assert_eq!(visibility, ItemVisibility::Private);
-        assert_eq!(use_tree.prefix.kind, PathKind::Super);
+        assert_eq!(use_tree.prefix.kind, PathKind::Super(1));
         assert_eq!("super::foo", use_tree.to_string());
+        let UseTreeKind::Path(ident, alias) = use_tree.kind else {
+            panic!("Expected path");
+        };
+        assert_eq!("foo", ident.to_string());
+        assert!(alias.is_none());
+    }
+
+    #[test]
+    fn parse_with_stacked_super_prefix() {
+        let src = "use super::super::foo;";
+        let (use_tree, visibility) = parse_use_tree_no_errors(src);
+        assert_eq!(visibility, ItemVisibility::Private);
+        assert_eq!(use_tree.prefix.kind, PathKind::Super(2));
+        assert_eq!("super::super::foo", use_tree.to_string());
         let UseTreeKind::Path(ident, alias) = use_tree.kind else {
             panic!("Expected path");
         };

--- a/compiler/noirc_frontend/src/tests/imports.rs
+++ b/compiler/noirc_frontend/src/tests/imports.rs
@@ -44,6 +44,56 @@ fn use_super_in_path() {
 }
 
 #[test]
+fn use_super_super() {
+    let src = r#"
+    fn some_func() {}
+
+    mod foo {
+        mod bar {
+            use super::super::some_func;
+
+            pub fn baz() {
+                some_func();
+            }
+        }
+    }
+
+    fn main() { }
+    "#;
+    assert_no_errors(src);
+}
+
+#[test]
+fn use_super_super_in_path() {
+    let src = r#"
+    fn some_func() {}
+
+    mod foo {
+        mod bar {
+            pub fn func() {
+                super::super::some_func();
+            }
+        }
+    }
+
+    fn main() { }
+    "#;
+    assert_no_errors(src);
+}
+
+#[test]
+fn no_super_super() {
+    // `foo` is only one level deep, so `super::super` walks past the crate root.
+    let src = "
+    mod foo {
+        use super::super::some_func;
+            ^^^^^ There is no super module
+    }
+    ";
+    check_errors(src);
+}
+
+#[test]
 fn can_use_pub_use_item() {
     let src = r#"
     mod foo {

--- a/tooling/lsp/src/requests/completion.rs
+++ b/tooling/lsp/src/requests/completion.rs
@@ -915,14 +915,16 @@ impl<'a> NodeFinder<'a> {
                     module_data = root_module_data;
                     skip_prelude_items = true;
                 }
-                PathKind::Super => {
-                    let Some(parent) = module_data.parent else {
-                        return;
-                    };
-                    let Some(parent_module_data) = def_map.get(parent) else {
-                        return;
-                    };
-                    module_data = parent_module_data;
+                PathKind::Super(count) => {
+                    for _ in 0..count {
+                        let Some(parent) = module_data.parent else {
+                            return;
+                        };
+                        let Some(parent_module_data) = def_map.get(parent) else {
+                            return;
+                        };
+                        module_data = parent_module_data;
+                    }
                     skip_prelude_items = true;
                 }
                 PathKind::Absolute => (),

--- a/tooling/lsp/src/requests/completion.rs
+++ b/tooling/lsp/src/requests/completion.rs
@@ -915,8 +915,8 @@ impl<'a> NodeFinder<'a> {
                     module_data = root_module_data;
                     skip_prelude_items = true;
                 }
-                PathKind::Super(count) => {
-                    for _ in 0..count {
+                PathKind::Super(extras) => {
+                    for _ in 0..=extras {
                         let Some(parent) = module_data.parent else {
                             return;
                         };

--- a/tooling/lsp/src/use_segment_positions.rs
+++ b/tooling/lsp/src/use_segment_positions.rs
@@ -87,7 +87,7 @@ impl UseSegmentPositions {
     fn gather_use_tree_segments(&mut self, use_tree: &UseTree, mut prefix: String) {
         let kind_string = match use_tree.prefix.kind {
             PathKind::Crate => Some("crate".to_string()),
-            PathKind::Super(count) => Some(vec!["super"; count].join("::")),
+            PathKind::Super(extras) => Some(vec!["super"; extras + 1].join("::")),
             PathKind::Absolute | PathKind::Plain => None,
             PathKind::Resolved(_) => Some("$crate".to_string()),
         };

--- a/tooling/lsp/src/use_segment_positions.rs
+++ b/tooling/lsp/src/use_segment_positions.rs
@@ -87,7 +87,7 @@ impl UseSegmentPositions {
     fn gather_use_tree_segments(&mut self, use_tree: &UseTree, mut prefix: String) {
         let kind_string = match use_tree.prefix.kind {
             PathKind::Crate => Some("crate".to_string()),
-            PathKind::Super => Some("super".to_string()),
+            PathKind::Super(count) => Some(vec!["super"; count].join("::")),
             PathKind::Absolute | PathKind::Plain => None,
             PathKind::Resolved(_) => Some("$crate".to_string()),
         };

--- a/tooling/nargo_fmt/src/formatter/path.rs
+++ b/tooling/nargo_fmt/src/formatter/path.rs
@@ -22,9 +22,11 @@ impl Formatter<'_> {
                 }
                 self.write_token(Token::DoubleColon);
             }
-            PathKind::Super => {
-                self.write_keyword(Keyword::Super);
-                self.write_token(Token::DoubleColon);
+            PathKind::Super(count) => {
+                for _ in 0..count {
+                    self.write_keyword(Keyword::Super);
+                    self.write_token(Token::DoubleColon);
+                }
             }
             PathKind::Resolved(_) => unreachable!("$crate should be unreachable here"),
         }

--- a/tooling/nargo_fmt/src/formatter/path.rs
+++ b/tooling/nargo_fmt/src/formatter/path.rs
@@ -22,8 +22,8 @@ impl Formatter<'_> {
                 }
                 self.write_token(Token::DoubleColon);
             }
-            PathKind::Super(count) => {
-                for _ in 0..count {
+            PathKind::Super(extras) => {
+                for _ in 0..=extras {
                     self.write_keyword(Keyword::Super);
                     self.write_token(Token::DoubleColon);
                 }

--- a/tooling/nargo_fmt/src/formatter/use_tree.rs
+++ b/tooling/nargo_fmt/src/formatter/use_tree.rs
@@ -170,6 +170,13 @@ mod tests {
     }
 
     #[test]
+    fn format_use_with_stacked_super() {
+        let src = "use  super :: super :: foo ;";
+        let expected = "use super::super::foo;\n";
+        assert_format(src, expected);
+    }
+
+    #[test]
     fn format_use_list_two_items() {
         let src = " use foo::{ bar,  baz  };";
         let expected = "use foo::{bar, baz};\n";

--- a/tooling/nargo_fmt/src/formatter/use_tree_merge.rs
+++ b/tooling/nargo_fmt/src/formatter/use_tree_merge.rs
@@ -265,9 +265,9 @@ fn merge_imports_in_tree(imports: Vec<UseTree>, mut tree: &mut ImportTree) {
     for import in imports {
         let mut tree = match import.prefix.kind {
             PathKind::Crate => tree.insert(Segment::Crate),
-            PathKind::Super(count) => {
+            PathKind::Super(extras) => {
                 let mut subtree = tree.insert(Segment::Super);
-                for _ in 1..count {
+                for _ in 0..extras {
                     subtree = subtree.insert(Segment::Super);
                 }
                 subtree

--- a/tooling/nargo_fmt/src/formatter/use_tree_merge.rs
+++ b/tooling/nargo_fmt/src/formatter/use_tree_merge.rs
@@ -265,7 +265,13 @@ fn merge_imports_in_tree(imports: Vec<UseTree>, mut tree: &mut ImportTree) {
     for import in imports {
         let mut tree = match import.prefix.kind {
             PathKind::Crate => tree.insert(Segment::Crate),
-            PathKind::Super => tree.insert(Segment::Super),
+            PathKind::Super(count) => {
+                let mut subtree = tree.insert(Segment::Super);
+                for _ in 1..count {
+                    subtree = subtree.insert(Segment::Super);
+                }
+                subtree
+            }
             PathKind::Absolute => tree.insert(Segment::Absolute),
             PathKind::Plain => &mut tree,
             PathKind::Resolved(_) => unreachable!("$crate shouldn't be possible here"),
@@ -350,6 +356,13 @@ mod tests {
     fn format_simple_use_with_path_kind() {
         let src = "use  super :: foo ;";
         let expected = "use super::foo;\n";
+        assert_format(src, expected);
+    }
+
+    #[test]
+    fn format_merged_use_with_stacked_super() {
+        let src = "use super::super::foo; use super::super::bar;";
+        let expected = "use super::super::{bar, foo};\n";
         assert_format(src, expected);
     }
 


### PR DESCRIPTION
## Problem Resolved

Resolves an observation made in https://app.audithub.dev/app/organizations/161/projects/599/project-viewer?version=1406&issueId=930

## Summary of Changes

Allows multiple `super` segments to appear next to each other in a path.

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
