### PR TITLE
fix(ownership): tripwire for array/slice match patterns in ownership pass

### DIFF
--- a/compiler/noirc_frontend/src/ownership/mod.rs
+++ b/compiler/noirc_frontend/src/ownership/mod.rs
@@ -37,6 +37,7 @@
 //! to find the last use of each local variable to identify where moves can occur.
 use crate::{
     ast::UnaryOp,
+    hir_def::expr::Constructor,
     monomorphization::ast::{
         Definition, Expression, Function, Ident, IdentId, LValue, Literal, LocalId, Program, Type,
         Unary,
@@ -346,6 +347,26 @@ impl Context {
         // The match will only destructure the value; it doesn't "use" the variable in a way that
         // requires additional cloning beyond what the last-use analysis already handles.
         for case in &mut match_expr.cases {
+            // The constructors below all bind whole values out of the matched aggregate
+            // (enum/tuple/struct fields), whose uses are protected by the normal last-use
+            // clone analysis at their use sites, so destructuring needs no extra handling here.
+            //
+            // This exhaustive match is a deliberate tripwire: if a constructor that binds a
+            // value out of a *nested* aggregate is ever added (e.g. array/slice patterns like
+            // `[head, tail @ ..]`), this stops compiling and forces a decision. Such bindings
+            // can alias nested array storage the same way an indexed lvalue does, so they must
+            // replicate the nested-array clone handling in `handle_lvalue`'s `LValue::Index`
+            // case, or matched bindings will silently alias the source and observe incorrect
+            // mutations. Do not just add the new variant to this arm — extend the clone logic.
+            match &case.constructor {
+                Constructor::True
+                | Constructor::False
+                | Constructor::Unit
+                | Constructor::Int(_)
+                | Constructor::Tuple(_)
+                | Constructor::Variant(..)
+                | Constructor::Range(..) => {}
+            }
             self.handle_expression(&mut case.branch);
         }
 


### PR DESCRIPTION
Fixes https://app.audithub.dev/app/organizations/161/projects/787/project-viewer?version=1681&issueId=1004
Fixes https://linear.app/aztec-foundation/issue/NRSEC-119

## Problem

The ownership pass's `handle_match` only recurses into case branches and assumes destructuring requires no additional ownership handling:

```rust
fn handle_match(&mut self, match_expr: &mut Match) {
    for case in &mut match_expr.cases {
        self.handle_expression(&mut case.branch);
    }
    ...
}
```

That assumption is correct for the currently supported match constructors — their bindings extract whole values out of the matched aggregate (enum/tuple/struct fields), and those bindings are protected by the normal last-use clone analysis at their *use* sites.

It would become incomplete, however, if Rust-style array/slice patterns such as `[head, tail @ ..]` were added. Those can bind a value out of a *nested* aggregate, which would alias nested array storage the same way an indexed lvalue does — without the copy-on-write protection that `handle_lvalue`'s `LValue::Index` case already applies. The result would be unconstrained code whose matched bindings silently alias nested array storage and observe incorrect mutations.

## Why no test / no clone code

This is **not source-reachable today** — no array/slice match patterns exist in the language — so there is no Noir program that can trigger the aliasing, and nothing to write a red test against. Adding speculative clone handling now would be dead, untestable code guarding a feature whose AST shape isn't decided yet.

## Fix

Replace the easy-to-ignore comment with a **compile-time tripwire**: an exhaustive `match` on the case constructor. The monomorphized `MatchCase.constructor` is `hir_def::expr::Constructor`, and array/slice patterns cannot be lowered without adding a new variant there (arrays have variable length). The moment such a variant is added, this match becomes non-exhaustive and the compiler refuses to build — landing the implementer directly on the explanation of why nested-array bindings need the same clone handling as `handle_lvalue`'s `Index` case, with an explicit instruction not to just add the variant to the arm but to extend the clone logic.

This converts a latent, documentation-only concern into one the compiler enforces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)