### PR TITLE
fix: Improve the reporting of global and function name clashes

### DIFF
--- a/compiler/noirc_frontend/src/hir/def_collector/dc_mod.rs
+++ b/compiler/noirc_frontend/src/hir/def_collector/dc_mod.rs
@@ -419,7 +419,7 @@ impl ModCollector<'_> {
 
             if let Err((first_def, second_def)) = result {
                 let err = DefCollectorErrorKind::Duplicate {
-                    typ: DuplicateType::Function,
+                    typ: DuplicateType::TypeDefinition,
                     first_def,
                     second_def,
                 };

--- a/compiler/noirc_frontend/src/hir/def_collector/errors.rs
+++ b/compiler/noirc_frontend/src/hir/def_collector/errors.rs
@@ -161,12 +161,15 @@ impl<'a> From<&'a DefCollectorErrorKind> for Diagnostic {
                 let primary_message =
                     format!("Duplicate definitions of {typ} with name {first_def} found");
                 {
+                    // The secondaries point at both definitions, which may be of different
+                    // kinds when names clash across namespaces, so they stay kind-neutral
+                    // rather than repeating `typ` (which describes only the second one).
                     let mut diag = Diagnostic::simple_error(
                         primary_message,
-                        format!("Second {typ} found here"),
+                        "Second definition found here".to_string(),
                         second_def.location(),
                     );
-                    diag.add_secondary(format!("First {typ} found here"), first_def.location());
+                    diag.add_secondary("First definition found here".to_string(), first_def.location());
                     diag
                 }
             }

--- a/compiler/noirc_frontend/src/locations.rs
+++ b/compiler/noirc_frontend/src/locations.rs
@@ -21,7 +21,7 @@ pub(crate) struct LocationIndices {
 impl LocationIndices {
     pub(crate) fn add_location(&mut self, location: Location, node_index: PetGraphIndex) {
         // Some location spans are empty: maybe they are from fictitious nodes?
-        if location.span.start() == location.span.end() {
+        if location.span.is_empty() {
             return;
         }
 

--- a/compiler/noirc_frontend/src/tests/aliases.rs
+++ b/compiler/noirc_frontend/src/tests/aliases.rs
@@ -1,6 +1,22 @@
 use crate::tests::{UnstableFeature, assert_no_errors, check_errors, check_errors_using_features};
 
 #[test]
+fn duplicate_type_aliases_report_type_definition() {
+    let src = r#"
+    type Foo = u32;
+         ~~~ First type definition found here
+    type Foo = u8;
+         ^^^ Duplicate definitions of type definition with name Foo found
+         ~~~ Second type definition found here
+
+    fn main() {
+        let _: Foo = 0;
+    }
+    "#;
+    check_errors(src);
+}
+
+#[test]
 fn allows_usage_of_type_alias_as_argument_type() {
     let src = r#"
     type Foo = Field;

--- a/compiler/noirc_frontend/src/tests/aliases.rs
+++ b/compiler/noirc_frontend/src/tests/aliases.rs
@@ -4,10 +4,10 @@ use crate::tests::{UnstableFeature, assert_no_errors, check_errors, check_errors
 fn duplicate_type_aliases_report_type_definition() {
     let src = r#"
     type Foo = u32;
-         ~~~ First type definition found here
+         ~~~ First definition found here
     type Foo = u8;
          ^^^ Duplicate definitions of type definition with name Foo found
-         ~~~ Second type definition found here
+         ~~~ Second definition found here
 
     fn main() {
         let _: Foo = 0;

--- a/compiler/noirc_frontend/src/tests/enums.rs
+++ b/compiler/noirc_frontend/src/tests/enums.rs
@@ -10,11 +10,11 @@ fn error_with_duplicate_enum_variant() {
     let src = r#"
     pub enum Foo {
         Bar(i32),
-        ~~~ First enum variant found here
+        ~~~ First definition found here
         ~~~ Previous impl defined here
         Bar(u8),
         ^^^ Duplicate definitions of enum variant with name Bar found
-        ~~~ Second enum variant found here
+        ~~~ Second definition found here
         ^^^ Impl for type `Foo` overlaps with existing impl
         ~~~ Overlapping impl
     }

--- a/compiler/noirc_frontend/src/tests/structs.rs
+++ b/compiler/noirc_frontend/src/tests/structs.rs
@@ -13,10 +13,10 @@ fn duplicate_struct_field() {
     let src = r#"
     pub struct Foo {
         x: i32,
-        ~ First struct field found here
+        ~ First definition found here
         x: i32,
         ^ Duplicate definitions of struct field with name x found
-        ~ Second struct field found here
+        ~ Second definition found here
     }
     "#;
     check_errors(src);

--- a/compiler/noirc_frontend/src/tests/traits/trait_associated_items.rs
+++ b/compiler/noirc_frontend/src/tests/traits/trait_associated_items.rs
@@ -2461,10 +2461,10 @@ fn trait_associated_constant_duplicate_is_an_error() {
     let src = r#"
     pub trait Foo {
         let N: u32;
-            ~ First trait associated item found here
+            ~ First definition found here
         let N: u8;
             ^ Duplicate definitions of trait associated item with name N found
-            ~ Second trait associated item found here
+            ~ Second definition found here
     }
     "#;
     check_errors(src);

--- a/compiler/noirc_frontend/src/tests/traits/trait_impl_validation.rs
+++ b/compiler/noirc_frontend/src/tests/traits/trait_impl_validation.rs
@@ -216,7 +216,7 @@ fn check_impl_struct_not_trait() {
 fn check_trait_duplicate_declaration() {
     let src = "
     trait Default2 {
-          ~~~~~~~~ First trait definition found here
+          ~~~~~~~~ First definition found here
         fn default(x: Field, y: Field) -> Self;
     }
 
@@ -233,7 +233,7 @@ fn check_trait_duplicate_declaration() {
 
     trait Default2 {
           ^^^^^^^^ Duplicate definitions of trait definition with name Default2 found
-          ~~~~~~~~ Second trait definition found here
+          ~~~~~~~~ Second definition found here
         fn default(x: Field) -> Self;
     }
     ";

--- a/compiler/noirc_frontend/src/tests/traits/trait_method_signatures.rs
+++ b/compiler/noirc_frontend/src/tests/traits/trait_method_signatures.rs
@@ -18,13 +18,13 @@ fn check_trait_implementation_duplicate_method() {
     impl Default2 for Foo {
         // Duplicate trait methods should not compile
         fn default(x: Field, y: Field) -> Field {
-           ~~~~~~~ First trait associated item found here
+           ~~~~~~~ First definition found here
             y + 2 * x
         }
         // Duplicate trait methods should not compile
         fn default(x: Field, y: Field) -> Field {
            ^^^^^^^ Duplicate definitions of trait associated item with name default found
-           ~~~~~~~ Second trait associated item found here
+           ~~~~~~~ Second definition found here
             x + 2 * y
         }
     }

--- a/compiler/noirc_frontend/src/tests/unused_items.rs
+++ b/compiler/noirc_frontend/src/tests/unused_items.rs
@@ -74,6 +74,28 @@ fn unused_global_clashing_with_function_is_reported_as_global() {
 }
 
 #[test]
+fn cross_namespace_name_clash_misses_unused_warning_but_is_not_an_error() {
+    // A type-namespace item (`struct N`) and a value-namespace item (`fn N`) may legally
+    // share a name within a module, so this is *not* a duplicate-definition error and the
+    // program compiles. The usage tracker keys unused items by name only, so the struct and
+    // the function share one slot: constructing the struct clears it, and the genuinely
+    // unused `fn N` produces no "unused function" warning.
+    //
+    // The absence below is a missing *warning*, not a missing *error*: unused warnings live
+    // in the same diagnostics vec that `assert_no_errors` inspects, so this assertion passing
+    // is itself the proof that the warning was dropped. Were the tracker namespace-aware we'd
+    // expect an "unused function N" warning here and this would become a `check_errors` test.
+    let src = r#"
+    struct N {}
+    fn N() {}
+    fn main() {
+        let _ = N {};
+    }
+    "#;
+    assert_no_errors(src);
+}
+
+#[test]
 fn errors_on_unused_function() {
     let src = r#"
     contract some_contract {

--- a/compiler/noirc_frontend/src/tests/unused_items.rs
+++ b/compiler/noirc_frontend/src/tests/unused_items.rs
@@ -59,15 +59,17 @@ fn unused_global_clashing_with_function_is_reported_as_global() {
     // The global and the function share the `values` namespace, so collecting the
     // function clashes with the already-collected global. The unused warning must
     // still describe the surviving item (the global) and point at its location,
-    // rather than borrowing the function's kind.
+    // rather than borrowing the function's kind. The duplicate-definition secondaries
+    // stay kind-neutral ("First/Second definition found here") so they don't mislabel
+    // the global as a function the way the primary's `typ` does.
     let src = r#"
     global N: u32 = 10;
            ^ unused global N
            ~ unused global
-           ~ First function found here
+           ~ First definition found here
     fn N() {}
        ^ Duplicate definitions of function with name N found
-       ~ Second function found here
+       ~ Second definition found here
     fn main() {}
     "#;
     check_errors(src);

--- a/compiler/noirc_frontend/src/tests/unused_items.rs
+++ b/compiler/noirc_frontend/src/tests/unused_items.rs
@@ -76,6 +76,7 @@ fn unused_global_clashing_with_function_is_reported_as_global() {
 }
 
 #[test]
+#[should_panic(expected = "Expected some errors but got none")]
 fn cross_namespace_name_clash_misses_unused_warning_but_is_not_an_error() {
     // A type-namespace item (`struct N`) and a value-namespace item (`fn N`) may legally
     // share a name within a module, so this is *not* a duplicate-definition error and the
@@ -83,18 +84,17 @@ fn cross_namespace_name_clash_misses_unused_warning_but_is_not_an_error() {
     // the function share one slot: constructing the struct clears it, and the genuinely
     // unused `fn N` produces no "unused function" warning.
     //
-    // The absence below is a missing *warning*, not a missing *error*: unused warnings live
-    // in the same diagnostics vec that `assert_no_errors` inspects, so this assertion passing
-    // is itself the proof that the warning was dropped. Were the tracker namespace-aware we'd
-    // expect an "unused function N" warning here and this would become a `check_errors` test.
+    // The absence below is a missing *warning*, not a missing *error*, so there is no miscompilation.
+    // TODO(#11927): The test is here to highlight this gap, until it's fixed in
     let src = r#"
     struct N {}
     fn N() {}
+       ^ unused function N
     fn main() {
         let _ = N {};
     }
     "#;
-    assert_no_errors(src);
+    check_errors(src);
 }
 
 #[test]
@@ -262,7 +262,7 @@ fn no_warning_on_indirect_struct_if_it_has_an_abi_attribute() {
         struct Bar {
             field: Field,
         }
-    
+
         #[abi(functions)]
         struct Foo {
             bar: Bar,

--- a/compiler/noirc_frontend/src/tests/unused_items.rs
+++ b/compiler/noirc_frontend/src/tests/unused_items.rs
@@ -55,6 +55,25 @@ fn errors_on_unused_pub_crate_import() {
 }
 
 #[test]
+fn unused_global_clashing_with_function_is_reported_as_global() {
+    // The global and the function share the `values` namespace, so collecting the
+    // function clashes with the already-collected global. The unused warning must
+    // still describe the surviving item (the global) and point at its location,
+    // rather than borrowing the function's kind.
+    let src = r#"
+    global N: u32 = 10;
+           ^ unused global N
+           ~ unused global
+           ~ First function found here
+    fn N() {}
+       ^ Duplicate definitions of function with name N found
+       ~ Second function found here
+    fn main() {}
+    "#;
+    check_errors(src);
+}
+
+#[test]
 fn errors_on_unused_function() {
     let src = r#"
     contract some_contract {

--- a/compiler/noirc_frontend/src/usage_tracker.rs
+++ b/compiler/noirc_frontend/src/usage_tracker.rs
@@ -49,7 +49,12 @@ impl UsageTracker {
     ) {
         // Empty spans could come from implicitly injected imports, and we don't want to track those
         if visibility != ItemVisibility::Public && name.span().start() < name.span().end() {
-            self.unused_items.entry(module_id).or_default().insert(name, item);
+            // Two items can share a name within a module (e.g. a global and a function),
+            // which is a duplicate-definition error reported elsewhere. `HashMap::insert`
+            // keeps the existing key but swaps the value, leaving the recorded location and
+            // item kind describing different definitions. Keep the first item we saw so the
+            // unused warning stays self-consistent.
+            self.unused_items.entry(module_id).or_default().entry(name).or_insert(item);
         }
     }
 

--- a/compiler/noirc_frontend/src/usage_tracker.rs
+++ b/compiler/noirc_frontend/src/usage_tracker.rs
@@ -33,6 +33,13 @@ impl UnusedItem {
 
 #[derive(Debug, Default)]
 pub struct UsageTracker {
+    /// Unused items per module, keyed only by name. Noir's type and value namespaces are
+    /// separate, so a type-namespace item and a value-namespace item can legally share a
+    /// name within a module (e.g. `struct N` and `fn N`) without a duplicate-definition
+    /// error. Keying by name alone conflates the two: only one is tracked, and marking
+    /// either as used clears the shared slot. The worst case is a *missing* unused warning
+    /// for the untracked sibling — never a missing error, since genuine same-namespace
+    /// clashes are caught as duplicate definitions before reaching here.
     unused_items: HashMap<ModuleId, HashMap<Ident, UnusedItem>>,
     unused_impl_functions: HashMap<FuncId, Ident>,
 }

--- a/compiler/noirc_frontend/src/usage_tracker.rs
+++ b/compiler/noirc_frontend/src/usage_tracker.rs
@@ -55,7 +55,7 @@ impl UsageTracker {
         visibility: ItemVisibility,
     ) {
         // Empty spans could come from implicitly injected imports, and we don't want to track those
-        if visibility != ItemVisibility::Public && name.span().start() < name.span().end() {
+        if visibility != ItemVisibility::Public && !name.span().is_empty() {
             // Two items can share a name within a module (e.g. a global and a function),
             // which is a duplicate-definition error reported elsewhere. `HashMap::insert`
             // keeps the existing key but swaps the value, leaving the recorded location and
@@ -97,7 +97,7 @@ impl UsageTracker {
         name: Ident,
         visibility: ItemVisibility,
     ) {
-        if visibility != ItemVisibility::Public && name.span().start() < name.span().end() {
+        if visibility != ItemVisibility::Public && !name.span().is_empty() {
             self.unused_impl_functions.insert(func_id, name);
         }
     }

--- a/compiler/noirc_span/src/position.rs
+++ b/compiler/noirc_span/src/position.rs
@@ -88,6 +88,12 @@ impl Span {
         self.0.end().into()
     }
 
+    /// Returns `true` if the span covers no characters, i.e. its start and end coincide
+    /// (as produced by [`Span::empty`]).
+    pub fn is_empty(&self) -> bool {
+        self.start() == self.end()
+    }
+
     pub fn contains(&self, other: &Span) -> bool {
         self.start() <= other.start() && self.end() >= other.end()
     }
@@ -148,5 +154,13 @@ mod tests {
 
         assert!(!Span::from(5..10).intersects(&Span::from(11..12)));
         assert!(!Span::from(11..12).intersects(&Span::from(5..10)));
+    }
+
+    #[test]
+    fn test_is_empty() {
+        assert!(Span::empty(5).is_empty());
+        assert!(Span::from(5..5).is_empty());
+        assert!(!Span::single_char(5).is_empty());
+        assert!(!Span::from(5..10).is_empty());
     }
 }

--- a/tooling/nargo_cli/tests/snapshots/compile_failure/dep_submodule_overlap/execute__tests__stderr.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_failure/dep_submodule_overlap/execute__tests__stderr.snap
@@ -13,20 +13,20 @@ error: Duplicate definitions of import with name MyStruct found
   ┌─ src/main.nr:1:23
   │
 1 │ use reexporting_lib::{MyStruct, lib};
-  │                       -------- First import found here
+  │                       -------- First definition found here
   ·
 4 │ use crate::lib::MyStruct;
-  │                 -------- Second import found here
+  │                 -------- Second definition found here
   │
 
 error: Duplicate definitions of import with name lib found
   ┌─ src/main.nr:1:33
   │
 1 │ use reexporting_lib::{MyStruct, lib};
-  │                                 --- Second import found here
+  │                                 --- Second definition found here
 2 │ 
 3 │ mod lib;
-  │     --- First import found here
+  │     --- First definition found here
   │
 
 error: Could not resolve 'is_struct_zero' in path

--- a/tooling/nargo_cli/tests/snapshots/compile_failure/dup_trait_items_1/execute__tests__stderr.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_failure/dup_trait_items_1/execute__tests__stderr.snap
@@ -13,18 +13,18 @@ error: Duplicate definitions of trait associated item with name SomeFunc found
   ┌─ src/main.nr:2:6
   │
 2 │   fn SomeFunc();
-  │      -------- First trait associated item found here
+  │      -------- First definition found here
 3 │   fn SomeFunc();
-  │      -------- Second trait associated item found here
+  │      -------- Second definition found here
   │
 
 error: Duplicate definitions of trait associated item with name SomeFunc found
   ┌─ src/main.nr:2:6
   │
 2 │   fn SomeFunc();
-  │      -------- First trait associated item found here
+  │      -------- First definition found here
 3 │   fn SomeFunc();
-  │      -------- Second trait associated item found here
+  │      -------- Second definition found here
   │
 
 Aborting due to 2 previous errors

--- a/tooling/nargo_cli/tests/snapshots/compile_failure/dup_trait_items_2/execute__tests__stderr.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_failure/dup_trait_items_2/execute__tests__stderr.snap
@@ -13,18 +13,18 @@ error: Duplicate definitions of trait associated item with name SomeConst found
   ┌─ src/main.nr:2:7
   │
 2 │   let SomeConst: u32;
-  │       --------- First trait associated item found here
+  │       --------- First definition found here
 3 │   let SomeConst: Field;
-  │       --------- Second trait associated item found here
+  │       --------- Second definition found here
   │
 
 error: Duplicate definitions of trait associated item with name SomeConst found
   ┌─ src/main.nr:2:7
   │
 2 │   let SomeConst: u32;
-  │       --------- First trait associated item found here
+  │       --------- First definition found here
 3 │   let SomeConst: Field;
-  │       --------- Second trait associated item found here
+  │       --------- Second definition found here
   │
 
 Aborting due to 2 previous errors

--- a/tooling/nargo_cli/tests/snapshots/compile_failure/dup_trait_items_3/execute__tests__stderr.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_failure/dup_trait_items_3/execute__tests__stderr.snap
@@ -13,18 +13,18 @@ error: Duplicate definitions of trait associated item with name SomeType found
   ┌─ src/main.nr:2:8
   │
 2 │   type SomeType;
-  │        -------- First trait associated item found here
+  │        -------- First definition found here
 3 │   type SomeType;
-  │        -------- Second trait associated item found here
+  │        -------- Second definition found here
   │
 
 error: Duplicate definitions of trait associated item with name SomeType found
   ┌─ src/main.nr:2:8
   │
 2 │   type SomeType;
-  │        -------- First trait associated item found here
+  │        -------- First definition found here
 3 │   type SomeType;
-  │        -------- Second trait associated item found here
+  │        -------- Second definition found here
   │
 
 Aborting due to 2 previous errors

--- a/tooling/nargo_cli/tests/snapshots/compile_failure/dup_trait_items_4/execute__tests__stderr.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_failure/dup_trait_items_4/execute__tests__stderr.snap
@@ -13,18 +13,18 @@ error: Duplicate definitions of trait associated item with name MyItem found
   ┌─ src/main.nr:2:7
   │
 2 │   let MyItem: u32;
-  │       ------ First trait associated item found here
+  │       ------ First definition found here
 3 │   fn MyItem();
-  │      ------ Second trait associated item found here
+  │      ------ Second definition found here
   │
 
 error: Duplicate definitions of trait associated item with name MyItem found
   ┌─ src/main.nr:2:7
   │
 2 │   let MyItem: u32;
-  │       ------ First trait associated item found here
+  │       ------ First definition found here
 3 │   fn MyItem();
-  │      ------ Second trait associated item found here
+  │      ------ Second definition found here
   │
 
 Aborting due to 2 previous errors

--- a/tooling/nargo_cli/tests/snapshots/compile_failure/dup_trait_items_5/execute__tests__stderr.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_failure/dup_trait_items_5/execute__tests__stderr.snap
@@ -13,18 +13,18 @@ error: Duplicate definitions of trait associated item with name MyItem found
   ┌─ src/main.nr:2:6
   │
 2 │   fn MyItem();
-  │      ------ First trait associated item found here
+  │      ------ First definition found here
 3 │   let MyItem: u32;
-  │       ------ Second trait associated item found here
+  │       ------ Second definition found here
   │
 
 error: Duplicate definitions of trait associated item with name MyItem found
   ┌─ src/main.nr:2:6
   │
 2 │   fn MyItem();
-  │      ------ First trait associated item found here
+  │      ------ First definition found here
 3 │   let MyItem: u32;
-  │       ------ Second trait associated item found here
+  │       ------ Second definition found here
   │
 
 Aborting due to 2 previous errors

--- a/tooling/nargo_cli/tests/snapshots/compile_failure/dup_trait_items_6/execute__tests__stderr.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_failure/dup_trait_items_6/execute__tests__stderr.snap
@@ -13,18 +13,18 @@ error: Duplicate definitions of trait associated item with name SomeFunc found
   ┌─ src/main.nr:2:6
   │
 2 │   fn SomeFunc() { };
-  │      -------- First trait associated item found here
+  │      -------- First definition found here
 3 │   fn SomeFunc() { };
-  │      -------- Second trait associated item found here
+  │      -------- Second definition found here
   │
 
 error: Duplicate definitions of trait associated item with name SomeFunc found
   ┌─ src/main.nr:2:6
   │
 2 │   fn SomeFunc() { };
-  │      -------- First trait associated item found here
+  │      -------- First definition found here
 3 │   fn SomeFunc() { };
-  │      -------- Second trait associated item found here
+  │      -------- Second definition found here
   │
 
 error: Expected a trait item but found ';'

--- a/tooling/nargo_cli/tests/snapshots/compile_failure/duplicate_declaration/execute__tests__stderr.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_failure/duplicate_declaration/execute__tests__stderr.snap
@@ -13,10 +13,10 @@ error: Duplicate definitions of function with name hello found
   ┌─ src/main.nr:2:4
   │
 2 │ fn hello(x: Field) -> Field {
-  │    ----- First function found here
+  │    ----- First definition found here
   ·
 6 │ fn hello(x: Field) -> Field {
-  │    ----- Second function found here
+  │    ----- Second definition found here
   │
 
 Aborting due to 1 previous error

--- a/tooling/nargo_cli/tests/snapshots/compile_failure/trait_allowed_item_name_matches/execute__tests__stderr.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_failure/trait_allowed_item_name_matches/execute__tests__stderr.snap
@@ -6,36 +6,36 @@ error: Duplicate definitions of trait associated item with name Tralala found
   ┌─ src/main.nr:3:10
   │
 3 │     type Tralala;
-  │          ------- First trait associated item found here
+  │          ------- First definition found here
 4 │     let Tralala: u32;
-  │         ------- Second trait associated item found here
+  │         ------- Second definition found here
   │
 
 error: Duplicate definitions of trait associated item with name Tralala found
    ┌─ src/main.nr:9:9
    │
  9 │     let Tralala: u32;
-   │         ------- First trait associated item found here
+   │         ------- First definition found here
 10 │     type Tralala;
-   │          ------- Second trait associated item found here
+   │          ------- Second definition found here
    │
 
 error: Duplicate definitions of trait associated item with name Tralala found
    ┌─ src/main.nr:15:10
    │
 15 │     type Tralala;
-   │          ------- First trait associated item found here
+   │          ------- First definition found here
 16 │     fn Tralala();
-   │        ------- Second trait associated item found here
+   │        ------- Second definition found here
    │
 
 error: Duplicate definitions of trait associated item with name Tralala found
    ┌─ src/main.nr:21:8
    │
 21 │     fn Tralala();
-   │        ------- First trait associated item found here
+   │        ------- First definition found here
 22 │     type Tralala;
-   │          ------- Second trait associated item found here
+   │          ------- Second definition found here
    │
 
 Aborting due to 4 previous errors

--- a/tooling/nargo_cli/tests/snapshots/compile_failure/trait_associated_items_clash/execute__tests__stderr.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_failure/trait_associated_items_clash/execute__tests__stderr.snap
@@ -6,20 +6,20 @@ error: Duplicate definitions of trait associated item with name N found
   ┌─ src/main.nr:2:9
   │
 2 │     let N: u32;
-  │         - First trait associated item found here
+  │         - First definition found here
 3 │ 
 4 │     fn N() {}
-  │        - Second trait associated item found here
+  │        - Second definition found here
   │
 
 error: Duplicate definitions of trait associated item with name N found
   ┌─ src/main.nr:2:9
   │
 2 │     let N: u32;
-  │         - First trait associated item found here
+  │         - First definition found here
 3 │ 
 4 │     fn N() {}
-  │        - Second trait associated item found here
+  │        - Second definition found here
   │
 
 Aborting due to 2 previous errors


### PR DESCRIPTION
## Problem Resolved

Follow up for https://github.com/noir-lang/noir/pull/11933 and https://cantina.xyz/code/24c6f940-d8af-4a25-9b28-b2e42dea31fe/findings/19#comment-8b319fa8-eab1-4e4d-a52f-6015592f1c0f

## Summary of Changes

* Remove the `{typ}` from the secondary messages of `Duplicate` definitions: when we find a duplicate, the second item we find determines the `typ`, however the first item might have a different type. For example functions and globals are in the same namespace, so they can clash, but reporting "first function definition here" while pointing at the global was confusing.
* Report duplicate type-aliases as `TypeDefinition`, rather than a `Function`
* Change `UsageTracker::add_unused_item` to keep the first entry, with its original definition: a second item with the same name might have a different type (e.g. global vs function), and replacing the value would cause the error to point at the original ident at the original location with a potentially different type, which is confusing.
* Add `Span::is_empty` helper
* Added a test and comments to note that if we do have clashes between items that _don't_ share the same namespace (e.g. types and functions) are not reported as duplicates, and then using one of them clears both from being unused, missing a warning if the other item was unused. This should never leave to miscompilation though, so it's not fixed.

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
