### PR TITLE
fix(licm): don't use loop bounds as a value range for non-unit-step != loops

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/opt/loop_invariant.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/loop_invariant.rs
@@ -314,13 +314,11 @@ impl LoopContext {
         }
         let induction = get_induction_var_bounds(inserter, loop_, pre_header);
         let does_loop_execute = does_loop_execute(induction.map(|(_, bounds, _)| bounds));
-        // `does_loop_execute` is sound for any step, but the `[lower, upper)` interval only bounds
-        // the induction variable's visited values for some step/guard combinations. Only record it
-        // as a value range when it actually over-approximates those values, otherwise simplifying
-        // from the bounds (e.g. folding a comparison) would be unsound.
-        let induction_variable = induction
-            .filter(|(_, bounds, step)| bounds.over_approximates_visited_values(*step))
-            .map(|(var, bounds, step)| (var, bounds, step));
+        // Only keep the bounds when every value the induction variable visits stays within them.
+        // Otherwise using them as a value range (e.g. to fold a comparison or prove an add cannot
+        // overflow) would be unsound.
+        let induction_variable =
+            induction.filter(|(_, bounds, step)| bounds.visited_values_stay_within_bounds(*step));
 
         Self {
             // There is only ever one current induction variable for a loop.
@@ -503,12 +501,11 @@ impl<'f> LoopInvariantContext<'f> {
         }
 
         // We're now done with this loop so it's now safe to insert its bounds into `outer_induction_variables`.
-        // Only record bounds that over-approximate the visited values: the outer-bound consumers
-        // (array-access hoisting, `match_induction_and_constant`) use the interval as a value
-        // range, which a non-unit-step `!=`-guarded loop would violate.
+        // As above, only record the bounds when every visited value stays within them, otherwise
+        // using them as a value range would be unsound.
         if let Some((induction_variable, bounds, step)) =
             get_induction_var_bounds(&self.inserter, loop_, pre_header)
-            && bounds.over_approximates_visited_values(step)
+            && bounds.visited_values_stay_within_bounds(step)
         {
             self.outer_induction_variables.insert(induction_variable, bounds);
         }

--- a/compiler/noirc_evaluator/src/ssa/opt/loop_invariant.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/loop_invariant.rs
@@ -237,13 +237,9 @@ struct LoopInvariantContext<'f> {
 /// Context with the scope of just one loop.
 struct LoopContext {
     pre_header: BasicBlockId,
-    /// Maps current loop induction variable with a fixed lower and upper loop bound.
-    /// If the loop doesn't have constant bounds then it's `None`.
-    induction_variable: Option<(ValueId, (IntegerConstant, IntegerConstant))>,
-
-    /// The constant step by which the induction variable advances each iteration.
-    /// None if the step is not a constant.
-    induction_step: Option<IntegerConstant>,
+    /// Maps current loop induction variable with its bounds and step.
+    /// If the loop doesn't have constant bounds with then it's `None`.
+    induction_variable: Option<(ValueId, LoopBounds, IntegerConstant)>,
 
     /// Indicate whether this loop has fixed bounds that are guaranteed to execute at least once.
     does_loop_execute: bool,
@@ -322,15 +318,13 @@ impl LoopContext {
         // the induction variable's visited values for some step/guard combinations. Only record it
         // as a value range when it actually over-approximates those values, otherwise simplifying
         // from the bounds (e.g. folding a comparison) would be unsound.
-        let (induction_variable, induction_step) = induction
+        let induction_variable = induction
             .filter(|(_, bounds, step)| bounds.over_approximates_visited_values(*step))
-            .map(|(var, bounds, step)| ((var, (bounds.lower, bounds.upper)), step))
-            .unzip();
+            .map(|(var, bounds, step)| (var, bounds, step));
 
         Self {
             // There is only ever one current induction variable for a loop.
             induction_variable,
-            induction_step,
             does_loop_execute,
             pre_header,
             defined_in_loop,
@@ -353,16 +347,13 @@ impl LoopContext {
     }
 
     /// Get the induction variable bounds if it the current variable matches the `id`.
-    fn get_current_induction_variable_bounds(
-        &self,
-        id: ValueId,
-    ) -> Option<(IntegerConstant, IntegerConstant)> {
-        self.induction_variable.filter(|(val, _)| *val == id).map(|(_, bounds)| bounds)
+    fn get_current_induction_variable_bounds(&self, id: ValueId) -> Option<LoopBounds> {
+        self.induction_variable.filter(|(val, _, _)| *val == id).map(|(_, bounds, _)| bounds)
     }
 
     /// Get the induction variable's per-iteration step if the current variable matches `id`.
     fn get_current_induction_step(&self, id: ValueId) -> Option<IntegerConstant> {
-        self.induction_variable.filter(|(val, _)| *val == id).and(self.induction_step)
+        self.induction_variable.filter(|(val, _, _)| *val == id).map(|(_, _, step)| step)
     }
 
     /// Update any values defined in the loop and loop invariants after

--- a/compiler/noirc_evaluator/src/ssa/opt/loop_invariant.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/loop_invariant.rs
@@ -318,7 +318,12 @@ impl LoopContext {
         }
         let induction = get_induction_var_bounds(inserter, loop_, pre_header);
         let does_loop_execute = does_loop_execute(induction.map(|(_, bounds, _)| bounds));
+        // `does_loop_execute` is sound for any step, but the `[lower, upper)` interval only bounds
+        // the induction variable's visited values for some step/guard combinations. Only record it
+        // as a value range when it actually over-approximates those values, otherwise simplifying
+        // from the bounds (e.g. folding a comparison) would be unsound.
         let (induction_variable, induction_step) = induction
+            .filter(|(_, bounds, step)| bounds.over_approximates_visited_values(*step))
             .map(|(var, bounds, step)| ((var, (bounds.lower, bounds.upper)), step))
             .unzip();
 
@@ -507,8 +512,12 @@ impl<'f> LoopInvariantContext<'f> {
         }
 
         // We're now done with this loop so it's now safe to insert its bounds into `outer_induction_variables`.
-        if let Some((induction_variable, bounds, _)) =
+        // Only record bounds that over-approximate the visited values: the outer-bound consumers
+        // (array-access hoisting, `match_induction_and_constant`) use the interval as a value
+        // range, which a non-unit-step `!=`-guarded loop would violate.
+        if let Some((induction_variable, bounds, step)) =
             get_induction_var_bounds(&self.inserter, loop_, pre_header)
+            && bounds.over_approximates_visited_values(step)
         {
             self.outer_induction_variables.insert(induction_variable, bounds);
         }
@@ -3771,6 +3780,77 @@ mod control_dependence {
             jmp b1(v5)
           b3():
             return v0
+        }
+        ");
+    }
+
+    #[test]
+    fn neq_guarded_loop_non_unit_step_does_not_use_bounds() {
+        // Regression for noir-lang/noir-claude#102: a `while i != 4` loop lowers to an `Eq`
+        // header with the body on the *else* branch, which `get_const_upper_bound` records as
+        // `[0, 4)`. That interval only bounds the induction variable when the step lands it
+        // exactly on `4`. Here the step is `3`, so `i` runs `0, 3, 6, 9, ...` and skips the
+        // guard value entirely, escaping `[0, 4)`. LICM must therefore not use those bounds to
+        // fold `i < 5` to `true` (deleting the constraint) nor to rewrite the checked add to
+        // `unchecked_add` — both would accept executions that should fail at `i == 6`.
+        let src = r#"
+        brillig(inline) predicate_pure fn main f0 {
+          b0():
+            jmp b1(u8 0)
+          b1(v0: u8):
+            v3 = eq v0, u8 4
+            jmpif v3 then: b3(), else: b2()
+          b2():
+            v5 = lt v0, u8 5
+            constrain v5 == u1 1
+            v8 = add v0, u8 3
+            jmp b1(v8)
+          b3():
+            return
+        }
+        "#;
+        assert_ssa_does_not_change(src, Ssa::loop_invariant_code_motion);
+    }
+
+    #[test]
+    fn neq_guarded_loop_unit_step_still_uses_bounds() {
+        // Counterpart to `neq_guarded_loop_non_unit_step_does_not_use_bounds`: with a unit step the
+        // `while i != 4` loop visits exactly `0, 1, 2, 3` and stays within `[0, 4)`, so the bounds
+        // remain a sound value range. LICM must still fold `i < 4` to `true` and rewrite the
+        // checked add to `unchecked_add`, otherwise the `NotEqual` fix would needlessly disable
+        // simplification for ordinary unit-step `!=`-guarded loops.
+        let src = r#"
+        brillig(inline) predicate_pure fn main f0 {
+          b0():
+            jmp b1(u8 0)
+          b1(v0: u8):
+            v3 = eq v0, u8 4
+            jmpif v3 then: b3(), else: b2()
+          b2():
+            v5 = lt v0, u8 4
+            constrain v5 == u1 1
+            v8 = add v0, u8 1
+            jmp b1(v8)
+          b3():
+            return
+        }
+        "#;
+
+        let ssa = Ssa::from_str(src).unwrap();
+        let ssa = ssa.loop_invariant_code_motion();
+
+        assert_ssa_snapshot!(ssa, @r"
+        brillig(inline) predicate_pure fn main f0 {
+          b0():
+            jmp b1(u8 0)
+          b1(v0: u8):
+            v3 = eq v0, u8 4
+            jmpif v3 then: b3(), else: b2()
+          b2():
+            v5 = unchecked_add v0, u8 1
+            jmp b1(v5)
+          b3():
+            return
         }
         ");
     }

--- a/compiler/noirc_evaluator/src/ssa/opt/loop_invariant/simplify.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/loop_invariant/simplify.rs
@@ -8,7 +8,7 @@ use crate::ssa::{
         integer::IntegerConstant,
         value::ValueId,
     },
-    opt::loop_invariant::BlockContext,
+    opt::{LoopBounds, loop_invariant::BlockContext},
 };
 use noirc_errors::call_stack::CallStackId;
 
@@ -27,7 +27,7 @@ impl LoopInvariantContext<'_> {
         match binary.operator {
             BinaryOp::Div | BinaryOp::Mod => {
                 // Division can be evaluated if we ensure that the divisor cannot be zero
-                let Some((left, value, lower, upper)) =
+                let Some((left, value, bounds)) =
                     self.match_induction_and_constant(loop_context, &binary.lhs, &binary.rhs, true)
                 else {
                     // Not a constant vs non-constant case, we cannot evaluate it.
@@ -37,7 +37,7 @@ impl LoopInvariantContext<'_> {
                 // An inverted range means the variable is not a proper ascending induction
                 // variable, so these bounds are bogus and cannot prove the divisor is non-zero.
                 // Mirrors the guard in `simplify_induction_variable_in_binary`.
-                if lower > upper {
+                if bounds.lower > bounds.upper {
                     return false;
                 }
 
@@ -49,9 +49,9 @@ impl LoopInvariantContext<'_> {
                 } else {
                     // Otherwise we are dividing a constant with the induction variable, and we have to check whether
                     // at any point in the loop the induction variable can be zero.
-                    let can_be_zero = lower.is_negative() && !upper.is_negative()
-                        || lower.is_zero()
-                        || upper.is_zero();
+                    let can_be_zero = bounds.lower.is_negative() && !bounds.upper.is_negative()
+                        || bounds.lower.is_zero()
+                        || bounds.upper.is_zero();
 
                     if !can_be_zero {
                         return true;
@@ -194,20 +194,20 @@ impl LoopInvariantContext<'_> {
         lhs: &ValueId,
         rhs: &ValueId,
     ) -> Option<(bool, ValueId, ValueId, IntegerConstant)> {
-        let (is_left, lower, upper) = match (
+        let (is_left, bounds) = match (
             loop_context.get_current_induction_variable_bounds(*lhs),
             loop_context.get_current_induction_variable_bounds(*rhs),
         ) {
-            (_, Some((lower, upper))) => Some((false, lower, upper)),
-            (Some((lower, upper)), _) => Some((true, lower, upper)),
+            (_, Some(bounds)) => Some((false, bounds)),
+            (Some(bounds), _) => Some((true, bounds)),
             _ => None,
         }?;
 
         let induction_variable = if is_left { *lhs } else { *rhs };
         let step = loop_context.get_current_induction_step(induction_variable)?;
 
-        let (upper_field, upper_type) = upper.dec()?.into_numeric_constant();
-        let (lower_field, lower_type) = lower.into_numeric_constant();
+        let (upper_field, upper_type) = bounds.upper.dec()?.into_numeric_constant();
+        let (lower_field, lower_type) = bounds.lower.into_numeric_constant();
 
         let min_iter = self.inserter.function.dfg.make_constant(lower_field, lower_type);
         let max_iter = self.inserter.function.dfg.make_constant(upper_field, upper_type);
@@ -258,7 +258,7 @@ impl LoopInvariantContext<'_> {
         lhs: &ValueId,
         rhs: &ValueId,
         only_outer_induction: bool,
-    ) -> Option<(bool, IntegerConstant, IntegerConstant, IntegerConstant)> {
+    ) -> Option<(bool, IntegerConstant, LoopBounds)> {
         let lhs_const = self.inserter.function.dfg.get_integer_constant(*lhs);
         let rhs_const = self.inserter.function.dfg.get_integer_constant(*rhs);
         match (
@@ -267,20 +267,16 @@ impl LoopInvariantContext<'_> {
             loop_context
                 .get_current_induction_variable_bounds(*lhs)
                 .filter(|_| !only_outer_induction)
-                .or(self.outer_induction_variables.get(lhs).map(|b| (b.lower, b.upper))),
+                .or(self.outer_induction_variables.get(lhs).copied()),
             loop_context
                 .get_current_induction_variable_bounds(*rhs)
                 .filter(|_| !only_outer_induction)
-                .or(self.outer_induction_variables.get(rhs).map(|b| (b.lower, b.upper))),
+                .or(self.outer_induction_variables.get(rhs).copied()),
         ) {
             // LHS is a constant, RHS is the induction variable with a known lower and upper bound.
-            (Some(lhs), None, None, Some((lower_bound, upper_bound))) => {
-                Some((false, lhs, lower_bound, upper_bound))
-            }
+            (Some(lhs), None, None, Some(bounds)) => Some((false, lhs, bounds)),
             // RHS is a constant, LHS is the induction variable with a known lower an upper bound
-            (None, Some(rhs), Some((lower_bound, upper_bound)), None) => {
-                Some((true, rhs, lower_bound, upper_bound))
-            }
+            (None, Some(rhs), Some(bounds), None) => Some((true, rhs, bounds)),
             _ => None,
         }
     }
@@ -302,7 +298,7 @@ impl LoopInvariantContext<'_> {
         // Note that here we allow all_induction_variables
         let operand_type = self.inserter.function.dfg.type_of_value(binary.lhs).unwrap_numeric();
 
-        let Some((is_induction_var_lhs, constant, lower_bound, upper_bound)) =
+        let Some((is_induction_var_lhs, constant, bounds)) =
             self.match_induction_and_constant(loop_context, &binary.lhs, &binary.rhs, is_header)
         else {
             return SimplifyResult::None;
@@ -312,7 +308,7 @@ impl LoopInvariantContext<'_> {
         // (see `back_edge_advances_monotonically`), so `i` truly counts upward through
         // `[lower_bound, upper_bound)`. If the constants are still inverted the loop
         // body never executes; bail out instead of simplifying dead code.
-        if lower_bound > upper_bound {
+        if bounds.lower > bounds.upper {
             return SimplifyResult::None;
         }
 
@@ -332,15 +328,15 @@ impl LoopInvariantContext<'_> {
             BinaryOp::Sub { .. } => {
                 if is_induction_var_lhs {
                     // `i - const` can overflow at either extreme of `i`.
-                    Some([(lower_bound, constant), (upper_bound, constant)])
+                    Some([(bounds.lower, constant), (bounds.upper, constant)])
                 } else {
                     // `const - i` can overflow at either extreme of `i`.
-                    Some([(constant, lower_bound), (constant, upper_bound)])
+                    Some([(constant, bounds.lower), (constant, bounds.upper)])
                 }
             }
             BinaryOp::Add { .. } | BinaryOp::Mul { .. } => {
                 // `i + const` / `i * const` can overflow at either extreme of `i`.
-                Some([(constant, lower_bound), (constant, upper_bound)])
+                Some([(constant, bounds.lower), (constant, bounds.upper)])
             }
             BinaryOp::Div | BinaryOp::Mod => return SimplifyResult::None,
             _ => None,
@@ -368,7 +364,7 @@ impl LoopInvariantContext<'_> {
         // Handle comparisons. (The upper_bound is exclusive).
         match binary.operator {
             BinaryOp::Eq => {
-                if constant >= upper_bound || constant < lower_bound {
+                if constant >= bounds.upper || constant < bounds.lower {
                     // `i == const` cannot be true if the constant is out of range.
                     SimplifyResult::SimplifiedTo(self.false_value)
                 } else {
@@ -377,11 +373,11 @@ impl LoopInvariantContext<'_> {
             }
             BinaryOp::Lt => match is_induction_var_lhs {
                 // `i < const`
-                true if upper_bound <= constant => SimplifyResult::SimplifiedTo(self.true_value),
-                true if lower_bound >= constant => SimplifyResult::SimplifiedTo(self.false_value),
+                true if bounds.upper <= constant => SimplifyResult::SimplifiedTo(self.true_value),
+                true if bounds.lower >= constant => SimplifyResult::SimplifiedTo(self.false_value),
                 // `const < i`
-                false if lower_bound > constant => SimplifyResult::SimplifiedTo(self.true_value),
-                false if constant.inc().is_some_and(|constant| upper_bound <= constant) => {
+                false if bounds.lower > constant => SimplifyResult::SimplifiedTo(self.true_value),
+                false if constant.inc().is_some_and(|constant| bounds.upper <= constant) => {
                     // If `const >= upper_bound - 1` then it will never be less than `i`.
                     SimplifyResult::SimplifiedTo(self.false_value)
                 }

--- a/compiler/noirc_evaluator/src/ssa/opt/unrolling.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/unrolling.rs
@@ -440,18 +440,13 @@ pub(crate) struct Loop {
 /// upper 5) looks identical to an executed `for i in 0..5`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum LoopBoundKind {
-    /// `i < upper`: the body executes iff `lower < upper`. The guard caps every visited value
-    /// below `upper`, so `[lower, upper)` over-approximates the visited values for any step.
+    /// `i < upper`: the body executes iff `lower < upper`.
     LessThan,
     /// `i == upper - 1` (an `Eq`/`Not` header with the body on the `then` branch):
-    /// the body executes iff `lower == upper - 1`. The body only ever runs on the single value
-    /// `upper - 1`, so `[lower, upper)` over-approximates the visited values for any step.
+    /// the body executes iff `lower == upper - 1`.
     Equal,
     /// `i != upper` (an `Eq` header with the body on the *else* branch): the body executes iff
-    /// `lower != upper`. Unlike `LessThan`, the guard only stops the loop when the induction
-    /// variable lands *exactly* on `upper`; a non-unit step can skip over `upper` and run the
-    /// body on values past it, so `[lower, upper)` over-approximates the visited values only when
-    /// the step is `0` or `1`.
+    /// `lower != upper`.
     NotEqual,
 }
 
@@ -480,16 +475,16 @@ impl LoopBounds {
         }
     }
 
-    /// Whether the `[lower, upper)` interval over-approximates the values the induction variable
-    /// actually visits, given its per-iteration `step`. This is what makes it sound to use the
-    /// bounds for value-range reasoning (e.g. proving a comparison or that an arithmetic operation
-    /// cannot overflow).
+    /// Whether every value the induction variable takes on stays inside `[lower, upper)`, given
+    /// its per-iteration `step`. When this holds we can safely use the bounds as the variable's
+    /// value range (e.g. to fold a comparison or prove an arithmetic operation cannot overflow).
     ///
-    /// A `NotEqual` guard only stops the loop when the induction variable lands exactly on
-    /// `upper`; a non-unit step can step over `upper` and visit larger values, so the interval is
-    /// only an over-approximation when the step is `0` (constant induction variable) or `1`. The
-    /// other guard kinds bound the visited values for any step (see [`LoopBoundKind`]).
-    pub(super) fn over_approximates_visited_values(self, step: IntegerConstant) -> bool {
+    /// `LessThan` and `Equal` keep the variable inside the bounds for any step: their guards stop
+    /// the loop at or before `upper`. A `NotEqual` guard only stops the loop when the variable
+    /// lands exactly on `upper`, so a step larger than `1` can jump past `upper` and keep going,
+    /// taking on values outside `[lower, upper)`. So `NotEqual` only stays within the bounds when
+    /// the step is `0` (the variable never moves) or `1` (it can't skip over `upper`).
+    pub(super) fn visited_values_stay_within_bounds(self, step: IntegerConstant) -> bool {
         match self.kind {
             LoopBoundKind::LessThan | LoopBoundKind::Equal => true,
             LoopBoundKind::NotEqual => step.is_zero() || step.is_one(),

--- a/compiler/noirc_evaluator/src/ssa/opt/unrolling.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/unrolling.rs
@@ -440,11 +440,19 @@ pub(crate) struct Loop {
 /// upper 5) looks identical to an executed `for i in 0..5`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum LoopBoundKind {
-    /// `i < upper`: the body executes iff `lower < upper`.
+    /// `i < upper`: the body executes iff `lower < upper`. The guard caps every visited value
+    /// below `upper`, so `[lower, upper)` over-approximates the visited values for any step.
     LessThan,
     /// `i == upper - 1` (an `Eq`/`Not` header with the body on the `then` branch):
-    /// the body executes iff `lower == upper - 1`.
+    /// the body executes iff `lower == upper - 1`. The body only ever runs on the single value
+    /// `upper - 1`, so `[lower, upper)` over-approximates the visited values for any step.
     Equal,
+    /// `i != upper` (an `Eq` header with the body on the *else* branch): the body executes iff
+    /// `lower != upper`. Unlike `LessThan`, the guard only stops the loop when the induction
+    /// variable lands *exactly* on `upper`; a non-unit step can skip over `upper` and run the
+    /// body on values past it, so `[lower, upper)` over-approximates the visited values only when
+    /// the step is `0` or `1`.
+    NotEqual,
 }
 
 /// The constant `[lower, upper)` bounds of a loop together with the [`LoopBoundKind`] describing
@@ -460,12 +468,31 @@ impl LoopBounds {
     /// Whether the loop body is guaranteed to execute at least once.
     pub(super) fn loop_executes(self) -> bool {
         match self.kind {
-            LoopBoundKind::LessThan => {
+            // `lower < upper` for `LessThan`, and `lower != upper` for `NotEqual`; for an
+            // ascending induction variable starting at or below `upper` these coincide, so both
+            // reduce to `upper > lower`.
+            LoopBoundKind::LessThan | LoopBoundKind::NotEqual => {
                 self.upper.reduce(self.lower, |u, l| u > l, |u, l| u > l).unwrap_or(false)
             }
             // `lower == upper - 1`, expressed as `lower + 1 == upper` so a `lower` at the type's
             // maximum (where `inc` would overflow) correctly reads as "does not execute".
             LoopBoundKind::Equal => self.lower.inc() == Some(self.upper),
+        }
+    }
+
+    /// Whether the `[lower, upper)` interval over-approximates the values the induction variable
+    /// actually visits, given its per-iteration `step`. This is what makes it sound to use the
+    /// bounds for value-range reasoning (e.g. proving a comparison or that an arithmetic operation
+    /// cannot overflow).
+    ///
+    /// A `NotEqual` guard only stops the loop when the induction variable lands exactly on
+    /// `upper`; a non-unit step can step over `upper` and visit larger values, so the interval is
+    /// only an over-approximation when the step is `0` (constant induction variable) or `1`. The
+    /// other guard kinds bound the visited values for any step (see [`LoopBoundKind`]).
+    pub(super) fn over_approximates_visited_values(self, step: IntegerConstant) -> bool {
+        match self.kind {
+            LoopBoundKind::LessThan | LoopBoundKind::Equal => true,
+            LoopBoundKind::NotEqual => step.is_zero() || step.is_one(),
         }
     }
 }
@@ -793,13 +820,15 @@ impl Loop {
                 //
                 // If `b2` is the loop body: the body runs only on the single value `rhs`, so
                 // upper = rhs + 1 and the bound is `Equal` (it enters iff `lower == rhs`).
-                // If `b3` is the loop body: the body runs while `v != rhs` (i.e. `v < rhs` for an
-                // increasing induction variable), so upper = rhs and the bound is `LessThan`.
+                // If `b3` is the loop body: the body runs while `v != rhs`, so upper = rhs and the
+                // bound is `NotEqual`. For a unit step this matches `v < rhs`, but a non-unit step
+                // can skip over `rhs` and run the body on larger values, which `NotEqual` records
+                // so later value-range reasoning does not assume `v < rhs`.
                 let const_rhs = dfg.get_integer_constant(*rhs)?;
                 if then_branch_is_body {
                     Some((const_rhs.inc()?, LoopBoundKind::Equal))
                 } else {
-                    Some((const_rhs, LoopBoundKind::LessThan))
+                    Some((const_rhs, LoopBoundKind::NotEqual))
                 }
             }
             Instruction::Not(operand) => {

--- a/test_programs/execution_failure/brillig_loop_non_unit_step_off_lattice/Nargo.toml
+++ b/test_programs/execution_failure/brillig_loop_non_unit_step_off_lattice/Nargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "brillig_loop_non_unit_step_off_lattice"
+type = "bin"
+authors = [""]
+
+[dependencies]

--- a/test_programs/execution_failure/brillig_loop_non_unit_step_off_lattice/src/main.nr
+++ b/test_programs/execution_failure/brillig_loop_non_unit_step_off_lattice/src/main.nr
@@ -1,0 +1,27 @@
+// Regression for noir-lang/noir-claude#102.
+//
+// The `if i == 4 { break }` guard makes LICM record the induction variable's bounds as `[0, 4)`,
+// but the step is 3, so `i` runs `0, 3, 6, ...` and skips the guard value entirely. The bounds are
+// therefore not an upper bound on `i`. LICM must not use them to delete `assert(i < 5)` (which must
+// fail at `i == 6`) nor to turn the checked `i + 3` into an unchecked add.
+unconstrained fn main() -> pub u8 {
+    let mut i: u8 = 0;
+    let mut counter: u8 = 0;
+
+    loop {
+        if i == 4 {
+            break;
+        }
+
+        assert(i < 5);
+
+        if counter == 3 {
+            break;
+        }
+
+        i = i + 3;
+        counter = counter + 1;
+    }
+
+    i
+}

--- a/tooling/nargo_cli/tests/snapshots/execution_failure/brillig_loop_non_unit_step_off_lattice/execute__tests__acir_stderr.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_failure/brillig_loop_non_unit_step_off_lattice/execute__tests__acir_stderr.snap
@@ -1,0 +1,15 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: stderr
+---
+error: Failed to solve program: 'Failed to solve brillig function'
+   ┌─ src/main.nr:16:9
+   │
+16 │         assert(i < 5);
+   │         -------------
+   │
+   = Call stack:
+     1: main
+             at src/main.nr:16:9
+
+Failed to solve program: 'Failed to solve brillig function'

--- a/tooling/nargo_cli/tests/snapshots/execution_failure/brillig_loop_non_unit_step_off_lattice/execute__tests__brillig_stderr.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_failure/brillig_loop_non_unit_step_off_lattice/execute__tests__brillig_stderr.snap
@@ -1,0 +1,15 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: stderr
+---
+error: Failed to solve program: 'Failed to solve brillig function'
+   ┌─ src/main.nr:16:9
+   │
+16 │         assert(i < 5);
+   │         -------------
+   │
+   = Call stack:
+     1: main
+             at src/main.nr:16:9
+
+Failed to solve program: 'Failed to solve brillig function'

--- a/tooling/nargo_cli/tests/snapshots/execution_failure/brillig_loop_non_unit_step_off_lattice/execute__tests__comptime_stderr.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_failure/brillig_loop_non_unit_step_off_lattice/execute__tests__comptime_stderr.snap
@@ -1,0 +1,15 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: stderr
+---
+error: Assertion failed
+   ┌─ src/main.nr:16:16
+   │
+16 │         assert(i < 5);
+   │                -----
+   │
+   = Call stack:
+     1: ?
+             at src/main.nr:7:18
+
+Error interpreting main function


### PR DESCRIPTION
## Problem

A `while i != K` loop (e.g. an unconstrained `loop { if i == K { break } ... }`) lowers to an `Eq` header with the body on the *else* branch. `get_const_upper_bound` recorded this as `LoopBoundKind::LessThan` with `upper = K` — i.e. it treated `i != K` as `i < K`.

That equivalence only holds at **unit step**. With a non-unit step the induction variable can step *over* `K`:

```rust
unconstrained fn main() -> pub u8 {
    let mut i: u8 = 0;
    let mut counter: u8 = 0;
    loop {
        if i == 4 { break; }   // guard value 4
        assert(i < 5);
        if counter == 3 { break; }
        i = i + 3;             // step 3: i runs 0, 3, 6, ... and skips 4
        counter = counter + 1;
    }
    i
}
```

LICM recorded `i`'s bounds as `[0, 4)`, but `i` actually reaches `6`. It then used that bogus interval to (a) fold `i < 5` to `true`, **deleting the `assert`**, and (b) rewrite the checked `i + 3` to `unchecked_add`. The program — which must fail at `i == 6` — instead executed successfully and returned `9`.

## Fix

The `[lower, upper)` interval answers two different questions, and they were conflated:

1. **Does the body run at least once?** — step-independent, sound for any guard.
2. **Is `[lower, upper)` an over-approximation of the values `i` actually visits?** — only true for some step/guard combinations.

This PR:

- Adds `LoopBoundKind::NotEqual` for the `!=`-exit shape (previously mislabeled `LessThan`).
- Adds `LoopBounds::over_approximates_visited_values(step)`: true for `LessThan`/`Equal` at any step, and for `NotEqual` only when the step is `0` or `1`.
- LICM records the value-range bounds (current-loop and `outer_induction_variables`) only when that predicate holds, while still using the step-independent `does_loop_execute` decision.

`NotEqual` behaves identically to `LessThan` for `loop_executes`, so unrolling and the static-assert pass are unaffected. Unit-step `!=` loops keep all their existing simplifications.

## Tests

- `brillig_loop_non_unit_step_off_lattice` (execution_failure) — the source repro above; now correctly fails at `assert(i < 5)` across the comptime interpreter, ACIR, and Brillig paths.
- `neq_guarded_loop_non_unit_step_does_not_use_bounds` — SSA unit test (red→green): the step-3 case is no longer simplified.
- `neq_guarded_loop_unit_step_still_uses_bounds` — guards against over-conservatism: ordinary unit-step `!=` loops still fold the comparison and go unchecked.

Full `noirc_evaluator` lib suite (1631 tests) and all loop-related execution tests pass.

Fixes noir-lang/noir-claude#102

🤖 Generated with [Claude Code](https://claude.com/claude-code)