### PR TITLE
fix(ssa): keep checked overflow check when simplifying +0/-0/*1 on unfit operands

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/ir/dfg/simplify/binary.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/dfg/simplify/binary.rs
@@ -400,6 +400,29 @@ mod tests {
     }
 
     #[test]
+    fn does_not_drop_checked_overflow_on_add_zero_identity() {
+        // A checked `add v, 0` range-constrains its result to the type's bit width. When `v` is an
+        // unfit value (here produced by an unchecked overflowing add), simplifying the identity away
+        // would drop that overflow check and let an out-of-range value flow on.
+        let src = "
+        acir(inline) pure fn main f0 {
+          b0():
+            v2 = unchecked_add u8 255, u8 1
+            v4 = add v2, u8 0
+            return v4
+        }
+        ";
+        let ssa = Ssa::from_str_simplifying(src).unwrap();
+        assert_ssa_snapshot!(ssa, @r"
+        acir(inline) pure fn main f0 {
+          b0():
+            v2 = unchecked_add u8 255, u8 1
+            return v2
+        }
+        ");
+    }
+
+    #[test]
     fn does_not_simplify_signed_integer_or_max() {
         let src = "
         acir(inline) fn main f0 {

--- a/compiler/noirc_evaluator/src/ssa/ir/dfg/simplify/binary.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/dfg/simplify/binary.rs
@@ -8,6 +8,7 @@ use crate::ssa::ir::{
         binary::{BinaryEvaluationResult, eval_constant_binary_op},
     },
     types::NumericType,
+    value::ValueId,
 };
 use noirc_errors::call_stack::CallStackId;
 
@@ -80,29 +81,29 @@ pub(super) fn simplify_binary(
         rhs_value.is_some_and(|rhs| rhs_type.max_value().is_ok_and(|max_value| rhs == max_value));
 
     match binary.operator {
-        BinaryOp::Add { .. } => {
-            if lhs_is_zero {
+        BinaryOp::Add { unchecked } => {
+            if lhs_is_zero && can_simplify_arithmetic_identity(dfg, rhs, lhs_type, unchecked) {
                 return SimplifyResult::SimplifiedTo(rhs);
             }
-            if rhs_is_zero {
+            if rhs_is_zero && can_simplify_arithmetic_identity(dfg, lhs, lhs_type, unchecked) {
                 return SimplifyResult::SimplifiedTo(lhs);
             }
         }
-        BinaryOp::Sub { .. } => {
+        BinaryOp::Sub { unchecked } => {
             if lhs == rhs {
                 let zero = dfg.make_constant(FieldElement::zero(), lhs_type);
                 return SimplifyResult::SimplifiedTo(zero);
             }
 
-            if rhs_is_zero {
+            if rhs_is_zero && can_simplify_arithmetic_identity(dfg, lhs, lhs_type, unchecked) {
                 return SimplifyResult::SimplifiedTo(lhs);
             }
         }
-        BinaryOp::Mul { .. } => {
-            if lhs_is_one {
+        BinaryOp::Mul { unchecked } => {
+            if lhs_is_one && can_simplify_arithmetic_identity(dfg, rhs, lhs_type, unchecked) {
                 return SimplifyResult::SimplifiedTo(rhs);
             }
-            if rhs_is_one {
+            if rhs_is_one && can_simplify_arithmetic_identity(dfg, lhs, lhs_type, unchecked) {
                 return SimplifyResult::SimplifiedTo(lhs);
             }
             if lhs_is_zero || rhs_is_zero {
@@ -314,6 +315,44 @@ pub(super) fn simplify_binary(
     SimplifyResult::SimplifiedToInstruction(simplified)
 }
 
+/// Whether a `+0`/`-0`/`*1` identity may be replaced by `operand` without dropping the
+/// operation's overflow semantics.
+///
+/// A checked integer operation range-constrains its result to the type's bit width, so rewriting
+/// it to an operand would silently drop that check. This is only safe when:
+/// - the operation is unchecked (it imposes no range constraint), or
+/// - the type cannot overflow (field arithmetic), or
+/// - `operand` is already known to fit its type.
+///
+/// The only values that can hold a magnitude outside their type's range are results of unchecked
+/// `add`/`sub`/`mul`. Every other value — numeric constants, block parameters, casts (which
+/// truncate/extend to the target type) and checked arithmetic (whose result is range-constrained)
+/// — is guaranteed to fit its type.
+fn can_simplify_arithmetic_identity(
+    dfg: &DataFlowGraph,
+    operand: ValueId,
+    operand_type: NumericType,
+    unchecked: bool,
+) -> bool {
+    if unchecked || operand_type == NumericType::NativeField {
+        return true;
+    }
+
+    if let super::Value::Instruction { instruction, .. } = &dfg[operand] {
+        !matches!(
+            dfg[*instruction],
+            Instruction::Binary(Binary {
+                operator: BinaryOp::Add { unchecked: true }
+                    | BinaryOp::Sub { unchecked: true }
+                    | BinaryOp::Mul { unchecked: true },
+                ..
+            })
+        )
+    } else {
+        true
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::{
@@ -403,9 +442,10 @@ mod tests {
     fn does_not_drop_checked_overflow_on_add_zero_identity() {
         // A checked `add v, 0` range-constrains its result to the type's bit width. When `v` is an
         // unfit value (here produced by an unchecked overflowing add), simplifying the identity away
-        // would drop that overflow check and let an out-of-range value flow on.
+        // would drop that overflow check and let an out-of-range value flow on, so the checked add
+        // is preserved.
         let src = "
-        acir(inline) pure fn main f0 {
+        acir(inline) predicate_pure fn main f0 {
           b0():
             v2 = unchecked_add u8 255, u8 1
             v4 = add v2, u8 0
@@ -413,11 +453,52 @@ mod tests {
         }
         ";
         let ssa = Ssa::from_str_simplifying(src).unwrap();
-        assert_ssa_snapshot!(ssa, @r"
-        acir(inline) pure fn main f0 {
+        assert_normalized_ssa_equals(ssa, src);
+    }
+
+    #[test]
+    fn does_not_drop_checked_overflow_on_sub_zero_identity() {
+        let src = "
+        acir(inline) predicate_pure fn main f0 {
           b0():
             v2 = unchecked_add u8 255, u8 1
-            return v2
+            v4 = sub v2, u8 0
+            return v4
+        }
+        ";
+        let ssa = Ssa::from_str_simplifying(src).unwrap();
+        assert_normalized_ssa_equals(ssa, src);
+    }
+
+    #[test]
+    fn does_not_drop_checked_overflow_on_mul_one_identity() {
+        let src = "
+        acir(inline) predicate_pure fn main f0 {
+          b0():
+            v2 = unchecked_add u8 255, u8 1
+            v4 = mul v2, u8 1
+            return v4
+        }
+        ";
+        let ssa = Ssa::from_str_simplifying(src).unwrap();
+        assert_normalized_ssa_equals(ssa, src);
+    }
+
+    #[test]
+    fn simplifies_add_zero_identity_for_fitting_operand() {
+        // A checked `add v, 0` whose operand is a normal (fit) value is still simplified away.
+        let src = "
+        acir(inline) pure fn main f0 {
+          b0(v0: u8):
+            v1 = add v0, u8 0
+            return v1
+        }
+        ";
+        let ssa = Ssa::from_str_simplifying(src).unwrap();
+        assert_ssa_snapshot!(ssa, @"
+        acir(inline) pure fn main f0 {
+          b0(v0: u8):
+            return v0
         }
         ");
     }


### PR DESCRIPTION
## Description

Fixes https://github.com/noir-lang/noir-claude/issues/1026.

`simplify_binary` rewrote the algebraic identities `x + 0 -> x`, `x - 0 -> x` and `x * 1 -> x` for **checked** operations as well as unchecked ones. A checked unsigned/signed integer operation range-constrains its result to the type's bit width, so replacing it with an operand drops that overflow check. When the operand is an *unfit* value (e.g. the result of an unchecked overflowing add), this let an out-of-range integer-typed value flow on — both in ACIR (the range constraint is gone) and in the SSA interpreter (which no longer rejects it):

```ssa
acir(inline) predicate_pure fn main f0 {
  b0():
    v2 = unchecked_add u8 255, u8 1   // unfit: 256 in a u8
    v4 = add v2, u8 0                 // checked add — range-constrains the result
    return v4
}
```

Before this PR, Constant Folding dropped `v4 = add v2, u8 0`, leaving the out-of-range `256` to flow to `return`.

### This is a defensive fix — not reachable from Noir source

**There is no Noir program that reproduces this issue.** The triggering pattern (a *checked* `+0`/`-0`/`*1` whose operand is *unfit*) cannot be produced from `.nr` source, for two independent reasons:

1. Users can't produce an unfit integer-typed value: every user `+`/`-`/`*` is a checked op that ACIR range-constrains and the interpreter rejects on overflow. Unfit values only come from compiler-internal `BinaryOp::{Add,Sub,Mul} { unchecked: true }` (sign-extension casts, array-offset math), and those feed their fixed consumer (cast/array address), never a checked `+0`/`*1`.
2. The `+0`/`*1` identity is folded at SSA-gen time (the simplifier runs on insert), so a user-written `x + 0` never even survives as an instruction.

Accordingly the regression tests live at the SSA level (`Ssa::from_str_simplifying`) rather than as a `test_programs/*.nr` case — a Noir program could not guard this.

## Fix

The identity rewrites now go through `can_simplify_arithmetic_identity`, which only applies the rewrite when:
- the operation is **unchecked** (it imposes no range constraint), or
- the type cannot overflow (**field** arithmetic), or
- the operand is **known to fit** its type.

The only values that can exceed their type's range are results of unchecked `add`/`sub`/`mul`; every other operand (constants, parameters, casts, checked arithmetic) fits its type, so the common case is still optimized.

## Tests

- SSA-level regression tests for the `add`/`sub`/`mul` identities (checked op is preserved when the operand is unfit).
- A test confirming the common case (fit operand) is still simplified away — no circuit-size regression.
- Full `noirc_evaluator` lib suite passes (1633 tests).

The buggy (red) and fixed (green) snapshots are kept as separate commits per the snapshot-bugfix workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)