### PR TITLE
fix(lsp): show function where clauses in hover

### DIFF
--- a/tooling/lsp/src/requests/hover.rs
+++ b/tooling/lsp/src/requests/hover.rs
@@ -206,6 +206,53 @@ pub fn caller() {
     }
 
     #[test]
+    async fn hover_on_function_with_where_clause() {
+        assert_hover(
+            r#"pub trait Foo {}
+
+pub fn takes_foo<T>(value: T) where T: Foo {
+    let _ = value;
+}
+
+pub fn caller() {
+    >|<takes_foo(1);
+}"#,
+            r#"    two
+    pub fn takes_foo<T>(value: T) where T: Foo"#,
+        )
+        .await;
+    }
+
+    #[test]
+    async fn hover_on_method_shows_where_clause_including_enclosing_impl_bounds() {
+        // For an inherent impl, the compiler merges the impl's `where` clause into each
+        // method's own constraints during collection, so both `U: Foo` (the method's) and
+        // `T: Foo` (the impl's) appear here. They can't be told apart at this point because
+        // a method's own `where` clause may also constrain an impl generic.
+        assert_hover(
+            r#"pub trait Foo {}
+
+pub struct Wrapper<T> {
+    value: T,
+}
+
+impl<T> Wrapper<T> where T: Foo {
+    pub fn combine<U>(self, other: U) where U: Foo {
+        let _ = (self, other);
+    }
+}
+
+pub fn caller(w: Wrapper<u32>) {
+    w.>|<combine(1);
+}"#,
+            r#"    two::Wrapper
+    impl<T> Wrapper<T>
+    pub fn combine<U>(self, other: U) where U: Foo, T: Foo"#,
+        )
+        .await;
+    }
+
+    #[test]
     async fn hover_on_struct_method() {
         // cSpell:disable
         assert_hover(

--- a/tooling/lsp/src/requests/hover/from_reference.rs
+++ b/tooling/lsp/src/requests/hover/from_reference.rs
@@ -511,6 +511,22 @@ fn format_function(id: FuncId, args: &ProcessRequestCallbackArgs) -> String {
                 string.push_str(&format!("{return_type}"));
             }
         }
+
+        let trait_constraints = &func_meta.trait_constraints;
+        if !trait_constraints.is_empty() {
+            string.push_str(" where ");
+            for (index, constraint) in trait_constraints.iter().enumerate() {
+                if index > 0 {
+                    string.push_str(", ");
+                }
+                let constraint_type = &constraint.typ;
+                string.push_str(&format!("{constraint_type}"));
+                string.push_str(": ");
+                let trait_ = args.interner.get_trait(constraint.trait_bound.trait_id);
+                string.push_str(trait_.name.as_str());
+                string.push_str(&constraint.trait_bound.trait_generics.to_string());
+            }
+        }
     }
 
     if enum_variant.is_some() {


### PR DESCRIPTION
## Description

LSP hover built a function's signature from `FuncMeta` but never rendered its `where` clause. A function such as:

```rust
pub fn takes_foo<T>(value: T) where T: Foo { ... }
```

hovered as `pub fn takes_foo<T>(value: T)`, dropping the constraints entirely.

This renders the `where` clause from `FuncMeta::trait_constraints` after the return type, reusing the same shape as the trait-impl method stub generator.

Fixes #12952

## A note on enclosing impl bounds

For **trait impl** methods the parent `where` clause lives in `FuncMeta::extra_trait_constraints`, so reading `trait_constraints` correctly excludes it.

For **inherent impl** methods the compiler merges the enclosing `impl`'s `where` clause into each method's own constraints during def collection, so the method's own bounds and the impl's bounds are indistinguishable at the `FuncMeta` level. Hover therefore shows both (e.g. `where U: Foo, T: Foo`). This is consistent with how `nargo doc` and the trait-impl stub generator already render `trait_constraints`.

I plan a follow-up PR where we start capturing inherent impls together with their trait constraints, so that `trait_constraints` can mean "the function's own `where` clause" uniformly and we can show only a function's own constraints without also showing the parent's. That will also help `nargo expand` and `nargo doc` behave more correctly. I don't plan to do it right now — tracked in #12984.

## Tests

- `hover_on_function_with_where_clause` — the reported case: a free function's `where` clause now renders.
- `hover_on_method_shows_where_clause_including_enclosing_impl_bounds` — documents the inherent-impl merging behavior described above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
