### PR TITLE
fix(brillig): make unsigned modulo unrepresentable on signed operands

### DIFF
--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_instructions/brillig_binary.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_instructions/brillig_binary.rs
@@ -64,10 +64,10 @@ impl<Registers: RegisterAllocator> BrilligBlock<'_, Registers> {
                 }
                 if is_signed {
                     self.convert_signed_modulo(left, right, result_variable);
-                    return;
                 } else {
-                    BrilligBinaryOp::Modulo
+                    self.brillig_context.unsigned_modulo_instruction(result_variable, left, right);
                 }
+                return;
             }
             BinaryOp::Add { .. } => BrilligBinaryOp::Add,
             BinaryOp::Sub { .. } => BrilligBinaryOp::Sub,

--- a/compiler/noirc_evaluator/src/brillig/brillig_ir/codegen_intrinsic.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_ir/codegen_intrinsic.rs
@@ -3,8 +3,6 @@ use acvm::acir::{
     brillig::{BlackBoxOp, IntegerBitSize},
 };
 
-use crate::brillig::brillig_ir::BrilligBinaryOp;
-
 use super::{
     BrilligContext,
     brillig_variable::{BrilligArray, SingleAddrVariable},
@@ -55,11 +53,10 @@ impl<F: AcirField + DebugToString, Registers: RegisterAllocator> BrilligContext<
             value_to_truncate.bit_size,
         );
 
-        self.binary_instruction(
+        self.unsigned_modulo_instruction(
+            destination_of_truncated_value,
             value_to_truncate,
             *modulus_var,
-            destination_of_truncated_value,
-            BrilligBinaryOp::Modulo,
         );
     }
 

--- a/compiler/noirc_evaluator/src/brillig/brillig_ir/debug_show.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_ir/debug_show.rs
@@ -67,7 +67,6 @@ impl DebugToString for BrilligBinaryOp {
             BrilligBinaryOp::Xor => "^".into(),
             BrilligBinaryOp::Shl => "<<".into(),
             BrilligBinaryOp::Shr => ">>".into(),
-            BrilligBinaryOp::Modulo => "%".into(),
         }
     }
 }
@@ -169,6 +168,16 @@ impl DebugShow {
         operation: BrilligBinaryOp,
     ) {
         debug_println!(self.enable_debug_trace, "  {} = {} {} {}", result, lhs, operation, rhs);
+    }
+
+    /// Processes an unsigned modulo instruction.
+    pub(crate) fn modulo_instruction(
+        &self,
+        lhs: MemoryAddress,
+        rhs: MemoryAddress,
+        result: MemoryAddress,
+    ) {
+        debug_println!(self.enable_debug_trace, "  {} = {} % {}", result, lhs, rhs);
     }
 
     /// Stores the value of `constant` in the `result` register.

--- a/compiler/noirc_evaluator/src/brillig/brillig_ir/instructions.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_ir/instructions.rs
@@ -516,7 +516,13 @@ impl From<BrilligBinaryOp> for BinaryFieldOp {
             BrilligBinaryOp::Equals => BinaryFieldOp::Equals,
             BrilligBinaryOp::LessThan => BinaryFieldOp::LessThan,
             BrilligBinaryOp::LessThanEquals => BinaryFieldOp::LessThanEquals,
-            _ => panic!("Unsupported operation: {operation:?} on a field"),
+            BrilligBinaryOp::And
+            | BrilligBinaryOp::Or
+            | BrilligBinaryOp::Xor
+            | BrilligBinaryOp::Shl
+            | BrilligBinaryOp::Shr => {
+                panic!("Unsupported operation: {operation:?} on a field")
+            }
         }
     }
 }
@@ -536,7 +542,9 @@ impl From<BrilligBinaryOp> for BinaryIntOp {
             BrilligBinaryOp::Xor => BinaryIntOp::Xor,
             BrilligBinaryOp::Shl => BinaryIntOp::Shl,
             BrilligBinaryOp::Shr => BinaryIntOp::Shr,
-            _ => panic!("Unsupported operation: {operation:?} on an integer"),
+            BrilligBinaryOp::FieldDiv => {
+                panic!("Unsupported operation: {operation:?} on an integer")
+            }
         }
     }
 }

--- a/compiler/noirc_evaluator/src/brillig/brillig_ir/instructions.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_ir/instructions.rs
@@ -38,6 +38,17 @@ impl<F: AcirField + DebugToString, Registers: RegisterAllocator> BrilligContext<
         self.binary(lhs, rhs, result, operation);
     }
 
+    /// Computes `left % right` for unsigned operands, writing the result to `result`.
+    pub(crate) fn unsigned_modulo_instruction(
+        &mut self,
+        result: SingleAddrVariable,
+        left: SingleAddrVariable,
+        right: SingleAddrVariable,
+    ) {
+        self.debug_show.modulo_instruction(left.address, right.address, result.address);
+        self.modulo(result, left, right);
+    }
+
     /// Processes a not instruction.
     ///
     /// Not is computed using a subtraction operation as there is no native not instruction
@@ -130,9 +141,7 @@ impl<F: AcirField + DebugToString, Registers: RegisterAllocator> BrilligContext<
             rhs.bit_size
         );
 
-        if let BrilligBinaryOp::Modulo = operation {
-            self.modulo(result, lhs, rhs);
-        } else if is_field_op {
+        if is_field_op {
             self.push_opcode(BrilligOpcode::BinaryFieldOp {
                 op: operation.into(),
                 destination: result.address,
@@ -494,8 +503,6 @@ pub enum BrilligBinaryOp {
     Xor,
     Shl,
     Shr,
-    // Modulo operation requires more than one brillig opcode
-    Modulo,
 }
 
 impl From<BrilligBinaryOp> for BinaryFieldOp {


### PR DESCRIPTION
## Summary

Fixes https://github.com/noir-lang/noir-claude/issues/270.

`BrilligBinaryOp::Modulo` was a synthetic pseudo-op: it was special-cased in `binary()` before the field/int dispatch and **panicked in both** `From<BrilligBinaryOp>` conversions, so it never corresponded to a real Brillig opcode. Its name also didn't signal that the division it performs internally is **unsigned** (unlike its sibling `UnsignedDiv`). A future caller could therefore route signed operands through it via the generic binary path and get silently incorrect results, since two's-complement negatives would be treated as large unsigned values.

Signedness simply does not exist at the Brillig layer — `SingleAddrVariable` is just an address plus a bit size, and `i32`/`u32` both collapse to `bit_size: 32` — so a runtime guard *inside* `modulo` is impossible. The audit finding is real but can only be addressed at the SSA→Brillig boundary, where the type is still known.

This PR enforces the invariant **at compile time** instead:

- Removes the `BrilligBinaryOp::Modulo` variant.
- Exposes unsigned modulo as a dedicated `unsigned_modulo_instruction` method — the sole entry point to the existing `modulo` helper.
- Requesting a modulo through the generic binary path is now *unrepresentable*, so signed operands cannot reach it by construction. `BrilligBinaryOp` now only holds ops that map to a real `BinaryIntOp`/`BinaryFieldOp` (both `From` impls lose a latent `panic!` arm for `Modulo`).
- Signed modulo continues to lower through `convert_signed_modulo` (signed division), unchanged.

## Behavior

Purely structural — no observable behavior change. The two former call sites (the unsigned-`Mod` branch in `convert_ssa_binary`, and the by-definition-unsigned truncation in `codegen_intrinsic`) now call the dedicated method directly.

## Testing

No new regression test: there is no source-reachable bug to reproduce (all current call sites already routed signed modulo correctly — this is defense-in-depth). The change is covered by existing modulo/truncation execution tests, including the `forcebrillig_true` variants that exercise this exact path:

```
cargo nextest run -p nargo_cli --test execute -- \
  signed_arithmetic signed_division signed_truncation \
  regression_dominated_truncate regression_truncate_unchecked_sub \
  modulus cast_signed_to_u1
# 118 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)