### PR TITLE
fix(brillig): assert opcode is a Call in add_unresolved_external_call

### DIFF
--- a/compiler/noirc_evaluator/src/brillig/brillig_ir/artifact.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_ir/artifact.rs
@@ -359,7 +359,10 @@ impl<F: Clone + std::fmt::Debug> BrilligArtifact<F> {
         call_instruction: BrilligOpcode<F>,
         destination: UnresolvedJumpLocation,
     ) {
-        // TODO: Add a check to ensure that the opcode is a call instruction
+        assert!(
+            matches!(call_instruction, BrilligOpcode::Call { .. }),
+            "expected a call instruction, but found {call_instruction:?}"
+        );
 
         self.unresolved_external_call_labels.push((self.index_of_next_opcode(), destination));
         self.push_opcode(call_instruction);


### PR DESCRIPTION
## Summary

`add_unresolved_external_call` in `compiler/noirc_evaluator/src/brillig/brillig_ir/artifact.rs` had a `TODO` acknowledging a missing validation that the passed opcode is actually a `Call`.

Without the check, a non-`Call` opcode passed by a future caller would be:
- silently mis-resolved in `resolve_jumps` if it were a `Jump`/`JumpIf` (treated as a call), creating incorrect control flow; or
- hit the opaque `unreachable!` at link time for any other opcode.

This replaces the `TODO` with an assertion mirroring the existing one in `add_unresolved_jump`, providing fail-fast behavior consistent with that sibling function.

All current callers already pass `BrilligOpcode::Call { location: 0 }`, so behavior is unchanged.

Fixes noir-lang/noir-claude#285

🤖 Generated with [Claude Code](https://claude.com/claude-code)