### PR TITLE
chore(brillig): clarify black box predicate assertion message

### DIFF
--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_call/code_gen_call.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_call/code_gen_call.rs
@@ -232,10 +232,11 @@ impl<Registers: RegisterAllocator> BrilligBlock<'_, Registers> {
             let predicate = arguments
                 .pop()
                 .expect("ICE: ECDSA black box function must have a predicate argument");
+            let predicate_constant = dfg.get_numeric_constant_with_type(predicate);
             assert_eq!(
-                dfg.get_numeric_constant_with_type(predicate),
+                predicate_constant,
                 Some((FieldElement::one(), NumericType::bool())),
-                "ICE: ECDSA black box function must have a predicate argument with value 1"
+                "ICE: black box predicate argument must be the boolean constant `true`, but found {predicate_constant:?}"
             );
         }
 


### PR DESCRIPTION
## Summary

Minor but easy fix for a defensive assertion in Brillig codegen.

In `convert_ssa_black_box_call` ([code_gen_call.rs](compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_call/code_gen_call.rs)), the predicate argument of certain black box functions (ECDSA, MultiScalarMul, EmbeddedCurveAdd) is asserted to be the constant `true`. The assertion message claimed the predicate "must have value 1", but `get_numeric_constant_with_type` returns `None` for a *non-constant* predicate — so the message misdiagnosed that case (it isn't "wrong value", it's "not a constant at all").

This surfaces the actual looked-up value in the message instead:

- non-constant predicate → `...but found None`
- wrong-valued constant → `...but found Some((0, bool))`

The assertion itself is unchanged — it remains a hard `assert!` (not `debug_assert!`), so the defense-in-depth behavior is intact. This is purely a clearer diagnostic.

## No regression test

This assertion is **not reachable from Noir source** — it can only fire on a future compiler bug that feeds a non-constant predicate into the black box call. The change only touches the panic *message*, so there's no observable source-level behavior to test, and asserting on an exact panic string would be brittle.

Fixes noir-lang/noir-claude#477

🤖 Generated with [Claude Code](https://claude.com/claude-code)