### PR TITLE
fix(monomorphization): set unconstrained flag on no-capture lambda type

### DIFF
--- a/compiler/noirc_frontend/src/monomorphization/mod.rs
+++ b/compiler/noirc_frontend/src/monomorphization/mod.rs
@@ -2757,7 +2757,7 @@ impl<'interner> Monomorphizer<'interner> {
             parameter_types,
             Rc::new(ret_type),
             Rc::new(ast::Type::Unit),
-            false,
+            self.in_unconstrained_function,
         );
 
         let name = lambda_name.to_owned();


### PR DESCRIPTION
## Summary

`lambda_no_capture` hardcoded `unconstrained: false` in the returned ident's `ast::Type::Function`, regardless of `self.in_unconstrained_function`. The function *body* was already marked correctly (`unconstrained: self.in_unconstrained_function`), and `closure_with_shared_env` already sets the type flag to match the variant. This one-line change makes the two paths consistent.

## Impact

Minor / no correctness impact. The `unconstrained` flag on `ast::Type::Function` is not read by any downstream pass for correctness decisions:

- SSA gen's `convert_non_tuple_type` maps `ast::Type::Function(_, _, _, _)` → `Type::Function` (the SSA IR has no unconstrained field on function types).
- ACIR/Brillig dispatch uses `func.unconstrained` (the body field, set correctly), not the type flag.

As a result the change is not observable in compiled output, nor in `--show-monomorphized` (non-capturing lambda idents render by name inside a `(constrained, unconstrained)` tuple; their type is never printed). It is purely an internal type-metadata consistency fix, so there is no meaningful regression test to add.

Fixes noir-lang/noir-claude#757.

🤖 Generated with [Claude Code](https://claude.com/claude-code)