### PR TITLE
fix(acir): add defensive checks from security audit

### DIFF
--- a/acvm-repo/acvm/src/compiler/mod.rs
+++ b/acvm-repo/acvm/src/compiler/mod.rs
@@ -22,7 +22,7 @@ mod optimizers;
 mod simulator;
 pub mod validator;
 
-pub use simulator::CircuitSimulator;
+pub use simulator::{CircuitSimulator, SimulationFailure};
 
 /// This module can move and decompose acir opcodes into multiple opcodes. The transformation map allows consumers of this module to map
 /// metadata they had about the opcodes to the new opcode structure generated after the transformation.

--- a/acvm-repo/acvm/src/compiler/simulator.rs
+++ b/acvm-repo/acvm/src/compiler/simulator.rs
@@ -27,26 +27,45 @@ pub struct CircuitSimulator {
     initialized_blocks: HashSet<BlockId>,
 }
 
+/// The reason a circuit was deemed unsolvable by the [`CircuitSimulator`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SimulationFailure {
+    /// The opcode at this index cannot be solved from the witnesses known at that point.
+    UnsolvableOpcode(usize),
+    /// All opcodes can be solved, but this circuit return value is never computed by any of them.
+    UnsolvableOutput(Witness),
+}
+
 impl CircuitSimulator {
     /// Check whether the circuit is solvable in theory.
     ///
     /// # Returns
     ///
     /// Returns `None` if the circuit is deemed to be solvable
-    /// Otherwise returns `Some(index)` where `index` is the opcode index of the first unsolvable opcode.
-    pub fn check_circuit<F: AcirField>(circuit: &Circuit<F>) -> Option<usize> {
+    /// Otherwise returns `Some(failure)` describing the first unsolvable opcode or return value.
+    pub fn check_circuit<F: AcirField>(circuit: &Circuit<F>) -> Option<SimulationFailure> {
         Self::default().run_check_circuit(circuit)
     }
 
     /// Simulate solving a circuit symbolically by keeping track of the witnesses that can be solved.
-    /// Returns the index of an opcode that cannot be solved, if any.
+    /// Returns the first opcode that cannot be solved, or a return value that no opcode computes, if any.
     #[tracing::instrument(level = "trace", skip_all)]
-    fn run_check_circuit<F: AcirField>(&mut self, circuit: &Circuit<F>) -> Option<usize> {
+    fn run_check_circuit<F: AcirField>(
+        &mut self,
+        circuit: &Circuit<F>,
+    ) -> Option<SimulationFailure> {
         let circuit_inputs = circuit.circuit_arguments();
         self.solvable_witnesses.extend(circuit_inputs.iter());
         for (i, op) in circuit.opcodes.iter().enumerate() {
             if !self.try_solve(op) {
-                return Some(i);
+                return Some(SimulationFailure::UnsolvableOpcode(i));
+            }
+        }
+        // All opcodes can be solved; the declared return values must also be solvable,
+        // otherwise the circuit promises an output it never computes.
+        for ret in &circuit.return_values.0 {
+            if !self.solvable_witnesses.contains(ret) {
+                return Some(SimulationFailure::UnsolvableOutput(*ret));
             }
         }
         None
@@ -223,8 +242,8 @@ pub(crate) fn unresolved_witnesses<F: AcirField>(
 
 #[cfg(test)]
 mod tests {
-    use crate::compiler::CircuitSimulator;
-    use acir::circuit::Circuit;
+    use crate::compiler::{CircuitSimulator, simulator::SimulationFailure};
+    use acir::{circuit::Circuit, native_types::Witness};
 
     #[test]
     fn reports_none_for_empty_circuit() {
@@ -340,7 +359,10 @@ mod tests {
         ASSERT w4 = w3
         ";
         let disconnected_circuit = Circuit::from_str(src).unwrap();
-        assert_eq!(CircuitSimulator::check_circuit(&disconnected_circuit), Some(1));
+        assert_eq!(
+            CircuitSimulator::check_circuit(&disconnected_circuit),
+            Some(SimulationFailure::UnsolvableOpcode(1))
+        );
     }
 
     #[test]
@@ -353,7 +375,10 @@ mod tests {
         INIT b0 = [w0]
         ";
         let circuit = Circuit::from_str(src).unwrap();
-        assert_eq!(CircuitSimulator::check_circuit(&circuit), Some(1));
+        assert_eq!(
+            CircuitSimulator::check_circuit(&circuit),
+            Some(SimulationFailure::UnsolvableOpcode(1))
+        );
     }
 
     #[test]
@@ -366,7 +391,10 @@ mod tests {
         INIT b0 = [w0]
         ";
         let circuit = Circuit::from_str(src).unwrap();
-        assert_eq!(CircuitSimulator::check_circuit(&circuit), Some(1));
+        assert_eq!(
+            CircuitSimulator::check_circuit(&circuit),
+            Some(SimulationFailure::UnsolvableOpcode(1))
+        );
     }
 
     #[test]
@@ -380,7 +408,10 @@ mod tests {
         ASSERT w0 = w1*w1
         ";
         let circuit = Circuit::from_str(src).unwrap();
-        assert_eq!(CircuitSimulator::check_circuit(&circuit), Some(0));
+        assert_eq!(
+            CircuitSimulator::check_circuit(&circuit),
+            Some(SimulationFailure::UnsolvableOpcode(0))
+        );
     }
 
     #[test]
@@ -393,7 +424,10 @@ mod tests {
         WRITE b0[w0] = w2
         ";
         let circuit = Circuit::from_str(src).unwrap();
-        assert_eq!(CircuitSimulator::check_circuit(&circuit), Some(1));
+        assert_eq!(
+            CircuitSimulator::check_circuit(&circuit),
+            Some(SimulationFailure::UnsolvableOpcode(1))
+        );
     }
 
     #[test]
@@ -410,6 +444,44 @@ mod tests {
     }
 
     #[test]
+    fn reports_failure_for_uncomputed_return_value() {
+        let src = "
+        private parameters: [w0]
+        public parameters: []
+        return values: [w2]
+        ASSERT w1 = w0
+        ";
+        let circuit = Circuit::from_str(src).unwrap();
+        assert_eq!(
+            CircuitSimulator::check_circuit(&circuit),
+            Some(SimulationFailure::UnsolvableOutput(Witness(2)))
+        );
+    }
+
+    #[test]
+    fn reports_none_for_computed_return_value() {
+        let src = "
+        private parameters: [w0]
+        public parameters: []
+        return values: [w1]
+        ASSERT w1 = w0
+        ";
+        let circuit = Circuit::from_str(src).unwrap();
+        assert!(CircuitSimulator::check_circuit(&circuit).is_none());
+    }
+
+    #[test]
+    fn reports_none_for_return_value_that_is_also_a_parameter() {
+        let src = "
+        private parameters: [w0]
+        public parameters: []
+        return values: [w0]
+        ";
+        let circuit = Circuit::from_str(src).unwrap();
+        assert!(CircuitSimulator::check_circuit(&circuit).is_none());
+    }
+
+    #[test]
     fn reports_some_when_expression_can_simplify() {
         let src = "
         private parameters: []
@@ -419,6 +491,9 @@ mod tests {
         ASSERT w2 = w1
         ";
         let empty_circuit = Circuit::from_str(src).unwrap();
-        assert_eq!(CircuitSimulator::check_circuit(&empty_circuit), Some(1));
+        assert_eq!(
+            CircuitSimulator::check_circuit(&empty_circuit),
+            Some(SimulationFailure::UnsolvableOpcode(1))
+        );
     }
 }

--- a/acvm-repo/brillig/src/lengths.rs
+++ b/acvm-repo/brillig/src/lengths.rs
@@ -229,3 +229,34 @@ impl Div<ElementsFlattenedLength> for FlattenedLength {
 fn assert_usize(value: u32) -> usize {
     value.try_into().expect("Failed conversion from u32 to usize")
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn flattened_length_divides_evenly_by_elements_flattened_length() {
+        assert_eq!(FlattenedLength(6) / ElementsFlattenedLength(2), SemanticLength(3));
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "Division of FlattenedLength 5 by ElementsFlattenedLength 2 has remainder"
+    )]
+    fn flattened_length_division_with_remainder_panics() {
+        let _ = FlattenedLength(5) / ElementsFlattenedLength(2);
+    }
+
+    #[test]
+    fn semi_flattened_length_divides_evenly_by_element_types_length() {
+        assert_eq!(SemiFlattenedLength(6) / ElementTypesLength(3), SemanticLength(2));
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "Division of SemiFlattenedLength 7 by ElementTypesLength 3 has remainder"
+    )]
+    fn semi_flattened_length_division_with_remainder_panics() {
+        let _ = SemiFlattenedLength(7) / ElementTypesLength(3);
+    }
+}

--- a/compiler/noirc_evaluator/src/acir/acir_context/mod.rs
+++ b/compiler/noirc_evaluator/src/acir/acir_context/mod.rs
@@ -1396,6 +1396,15 @@ impl<F: AcirField> AcirContext<F> {
             Some(value) => {
                 let mut values = Vec::new();
                 self.initialize_array_inner(&mut values, value)?;
+                if values.len() != len {
+                    return Err(InternalError::General {
+                        message: format!(
+                            "Attempted to initialize an array of flattened length {len} with {} values",
+                            values.len()
+                        ),
+                        call_stack: self.get_call_stack(),
+                    });
+                }
                 values
             }
         };
@@ -1577,6 +1586,28 @@ mod tests {
     #[should_panic = "Field cannot represent this power of two"]
     fn power_of_two_panics_on_overflow() {
         power_of_two::<FieldElement>(FieldElement::max_num_bits());
+    }
+
+    #[test]
+    fn initialize_array_rejects_length_mismatch() {
+        use crate::acir::AcirValue;
+        use crate::errors::InternalError;
+        use crate::ssa::ir::types::NumericType;
+        use acvm::acir::brillig::lengths::FlattenedLength;
+        use acvm::acir::circuit::opcodes::{BlockId, BlockType};
+
+        let mut context = AcirContext::<FieldElement>::new(BrilligStdLib::default());
+        let var = context.add_constant(FieldElement::one());
+        let value = AcirValue::Array(im::vector![AcirValue::Var(var, NumericType::NativeField)]);
+
+        // Claim a flattened length of 2 but provide only a single value.
+        let result = context.initialize_array(
+            BlockId(0),
+            FlattenedLength(2),
+            Some(value),
+            BlockType::Memory,
+        );
+        assert!(matches!(result, Err(InternalError::General { .. })));
     }
 
     proptest! {

--- a/compiler/noirc_evaluator/src/acir/call/intrinsics/mod.rs
+++ b/compiler/noirc_evaluator/src/acir/call/intrinsics/mod.rs
@@ -133,10 +133,10 @@ impl Context<'_> {
             Intrinsic::AsWitness => {
                 let arg = arguments[0];
                 let input = self.convert_value(arg, dfg).into_var()?;
-                Ok(self
-                    .acir_context
-                    .get_or_create_witness_var(input)
-                    .map(|val| self.convert_vars_to_values(vec![val], dfg, result_ids))?)
+                // `as_witness` exists only for its side effect of creating a witness for the
+                // input; it returns no values.
+                self.acir_context.get_or_create_witness_var(input)?;
+                Ok(Vec::new())
             }
             Intrinsic::DerivePedersenGenerators => Err(RuntimeError::AssertConstantFailed {
                 call_stack: self.acir_context.get_call_stack(),

--- a/compiler/noirc_evaluator/src/acir/call/intrinsics/vector_ops.rs
+++ b/compiler/noirc_evaluator/src/acir/call/intrinsics/vector_ops.rs
@@ -4,7 +4,7 @@ use crate::acir::arrays::ElementTypeSizesArrayShift;
 use crate::acir::types::flat_element_types;
 use crate::acir::{AcirDynamicArray, AcirValue, AcirVar};
 use crate::brillig::assert_u32;
-use crate::errors::RuntimeError;
+use crate::errors::{InternalError, RuntimeError};
 use crate::ssa::ir::types::{NumericType, Type};
 use crate::ssa::ir::{dfg::DataFlowGraph, value::ValueId};
 use acvm::acir::brillig::lengths::FlattenedLength;
@@ -13,6 +13,50 @@ use acvm::{AcirField, FieldElement};
 use super::Context;
 
 impl Context<'_> {
+    /// Checks that an intrinsic vector operation received one element value per type in the
+    /// vector's logical element (composite elements are passed as separate flattened values).
+    fn check_vector_element_count(
+        &self,
+        op: &str,
+        elements: &[ValueId],
+        vector_typ: &Type,
+    ) -> Result<(), RuntimeError> {
+        let expected = vector_typ.element_size().to_usize();
+        if elements.len() != expected {
+            return Err(InternalError::General {
+                message: format!(
+                    "{op} received {} element values but the vector's logical element consists of {expected} values",
+                    elements.len(),
+                ),
+                call_stack: self.acir_context.get_call_stack(),
+            }
+            .into());
+        }
+        Ok(())
+    }
+
+    /// Checks that an intrinsic vector operation which returns the updated length, the updated
+    /// vector and one logical element (popped or removed) received the matching number of
+    /// result values.
+    fn check_vector_result_count(
+        &self,
+        op: &str,
+        result_ids: &[ValueId],
+        vector_typ: &Type,
+    ) -> Result<(), RuntimeError> {
+        let expected = 2 + vector_typ.element_size().to_usize();
+        if result_ids.len() != expected {
+            return Err(InternalError::General {
+                message: format!(
+                    "{op} received {} result values but expected {expected}",
+                    result_ids.len(),
+                ),
+                call_stack: self.acir_context.get_call_stack(),
+            }
+            .into());
+        }
+        Ok(())
+    }
     /// Pushes one or more elements to the back of a non-nested vector.
     ///
     /// # Arguments
@@ -43,6 +87,7 @@ impl Context<'_> {
 
         let vector = self.convert_value(vector_contents, dfg);
         let vector_typ = dfg.type_of_value(vector_contents);
+        self.check_vector_element_count("vector_push_back", elements_to_push, &vector_typ)?;
 
         let new_vector_val = if let Some(len_const) = dfg.get_numeric_constant(arguments[0]) {
             // Length is known at compile time - we can precisely determine where to write
@@ -176,6 +221,7 @@ impl Context<'_> {
 
         let vector = self.convert_value(vector_contents, dfg);
         let vector_type = dfg.type_of_value(vector_contents);
+        self.check_vector_element_count("vector_push_front", elements_to_push, &vector_type)?;
         let mut new_vector = self.read_array_with_type(vector, &vector_type)?;
 
         // We must directly push front elements for non-nested vectors
@@ -236,6 +282,7 @@ impl Context<'_> {
         let block_id = self.ensure_array_is_initialized(vector_contents_id, dfg)?;
         let vector_contents_value = self.convert_value(vector_contents_id, dfg);
         let vector_type = dfg.type_of_value(vector_contents_id);
+        self.check_vector_result_count("vector_pop_back", result_ids, &vector_type)?;
 
         // Check if we're trying to pop from a known empty vector.
         if self.has_zero_length(vector_contents_id, dfg) {
@@ -389,6 +436,7 @@ impl Context<'_> {
         let block_id = self.ensure_array_is_initialized(vector_contents_id, dfg)?;
         let vector_contents_value = self.convert_value(vector_contents_id, dfg);
         let vector_type = dfg.type_of_value(vector_contents_id);
+        self.check_vector_result_count("vector_pop_front", result_ids, &vector_type)?;
         let element_size = vector_type.element_size();
 
         // Check if we're trying to pop from a known empty vector.
@@ -494,6 +542,7 @@ impl Context<'_> {
         let mut vector_size: FlattenedLength = super::arrays::flattened_value_size(&vector);
 
         let elements_to_insert = &arguments[3..];
+        self.check_vector_element_count("vector_insert", elements_to_insert, &vector_typ)?;
 
         // Fetch the flattened index from the user provided index argument.
         let item_size = self.acir_context.add_constant(elements_to_insert.len());
@@ -716,6 +765,7 @@ impl Context<'_> {
         let vector_contents = arguments[1];
 
         let vector_typ = dfg.type_of_value(vector_contents);
+        self.check_vector_result_count("vector_remove", result_ids, &vector_typ)?;
         let block_id = self.ensure_array_is_initialized(vector_contents, dfg)?;
 
         // Check if we're trying to remove from an empty vector

--- a/compiler/noirc_evaluator/src/acir/call/mod.rs
+++ b/compiler/noirc_evaluator/src/acir/call/mod.rs
@@ -71,7 +71,11 @@ impl Context<'_> {
                         let outputs = self
                             .convert_ssa_intrinsic_call(*intrinsic, arguments, dfg, result_ids)?;
 
-                        assert_eq!(result_ids.len(), outputs.len());
+                        assert_eq!(
+                            result_ids.len(),
+                            outputs.len(),
+                            "ICE: intrinsic call produced a different number of outputs than result ids"
+                        );
                         self.handle_ssa_call_outputs(result_ids, outputs, dfg)?;
                     }
                     Value::ForeignFunction { .. } => unreachable!(
@@ -288,6 +292,10 @@ impl Context<'_> {
                 values.push(Self::convert_var_type_to_values(&result_type, &mut vars));
             }
         }
+        assert!(
+            vars.next().is_none(),
+            "ICE: not all ACIR vars from a function call were consumed when converting to values"
+        );
         values
     }
 
@@ -311,12 +319,29 @@ impl Context<'_> {
                 AcirValue::Array(element_values)
             }
             Type::Numeric(numeric_type) => {
-                let var = vars.next().unwrap();
+                let var = vars
+                    .next()
+                    .expect("ICE: ran out of ACIR vars while converting call outputs to values");
                 AcirValue::Var(var, *numeric_type)
             }
             typ => {
                 panic!("Unexpected type {typ} in convert_var_type_to_values");
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Context;
+    use crate::acir::AcirVar;
+    use crate::ssa::ir::types::{NumericType, Type};
+
+    #[test]
+    #[should_panic(expected = "ICE: ran out of ACIR vars")]
+    fn convert_var_type_to_values_panics_on_exhausted_vars() {
+        let typ = Type::Numeric(NumericType::NativeField);
+        let mut vars = Vec::<AcirVar>::new().into_iter();
+        let _ = Context::convert_var_type_to_values(&typ, &mut vars);
     }
 }

--- a/compiler/noirc_evaluator/src/acir/tests/intrinsics.rs
+++ b/compiler/noirc_evaluator/src/acir/tests/intrinsics.rs
@@ -1137,3 +1137,120 @@ fn recursive_aggregation_proof_type_truncation_poc() {
         "unexpected error message: {message}"
     );
 }
+
+#[test]
+fn vector_push_back_with_wrong_element_count_is_an_error() {
+    // The vector's logical element is a tuple of two fields, but only one value is pushed.
+    let src = "
+    acir(inline) fn main f0 {
+      b0():
+        v0 = make_array [Field 1, Field 2] : [(Field, Field)]
+        v2, v3 = call vector_push_back(u32 1, v0, Field 5) -> (u32, [(Field, Field)])
+        return v2
+    }
+    ";
+    let err = try_ssa_to_acir(src).expect_err("expected an error for mismatched element count");
+    let message = err.to_string();
+    assert!(
+        message.contains("vector_push_back received 1 element values")
+            && message.contains("consists of 2 values"),
+        "unexpected error message: {message}"
+    );
+}
+
+#[test]
+fn vector_push_front_with_wrong_element_count_is_an_error() {
+    let src = "
+    acir(inline) fn main f0 {
+      b0():
+        v0 = make_array [Field 1, Field 2] : [(Field, Field)]
+        v2, v3 = call vector_push_front(u32 1, v0, Field 5) -> (u32, [(Field, Field)])
+        return v2
+    }
+    ";
+    let err = try_ssa_to_acir(src).expect_err("expected an error for mismatched element count");
+    let message = err.to_string();
+    assert!(
+        message.contains("vector_push_front received 1 element values")
+            && message.contains("consists of 2 values"),
+        "unexpected error message: {message}"
+    );
+}
+
+#[test]
+fn vector_insert_with_wrong_element_count_is_an_error() {
+    let src = "
+    acir(inline) fn main f0 {
+      b0():
+        v0 = make_array [Field 1, Field 2] : [(Field, Field)]
+        v2, v3 = call vector_insert(u32 1, v0, u32 0, Field 5) -> (u32, [(Field, Field)])
+        return v2
+    }
+    ";
+    let err = try_ssa_to_acir(src).expect_err("expected an error for mismatched element count");
+    let message = err.to_string();
+    assert!(
+        message.contains("vector_insert received 1 element values")
+            && message.contains("consists of 2 values"),
+        "unexpected error message: {message}"
+    );
+}
+
+#[test]
+fn vector_pop_back_with_wrong_result_count_is_an_error() {
+    // Popping from a vector of two-field tuples must produce 2 + 2 results,
+    // but only 3 result ids are declared.
+    let src = "
+    acir(inline) fn main f0 {
+      b0():
+        v0 = make_array [Field 1, Field 2] : [(Field, Field)]
+        v2, v3, v4 = call vector_pop_back(u32 1, v0) -> (u32, [(Field, Field)], Field)
+        return v2
+    }
+    ";
+    let err = try_ssa_to_acir(src).expect_err("expected an error for mismatched result count");
+    let message = err.to_string();
+    assert!(
+        message.contains("vector_pop_back received 3 result values")
+            && message.contains("expected 4"),
+        "unexpected error message: {message}"
+    );
+}
+
+#[test]
+fn vector_pop_front_with_wrong_result_count_is_an_error() {
+    let src = "
+    acir(inline) fn main f0 {
+      b0():
+        v0 = make_array [Field 1, Field 2] : [(Field, Field)]
+        v2, v3, v4 = call vector_pop_front(u32 1, v0) -> (Field, u32, [(Field, Field)])
+        return v3
+    }
+    ";
+    let err = try_ssa_to_acir(src).expect_err("expected an error for mismatched result count");
+    let message = err.to_string();
+    assert!(
+        message.contains("vector_pop_front received 3 result values")
+            && message.contains("expected 4"),
+        "unexpected error message: {message}"
+    );
+}
+
+#[test]
+fn vector_remove_with_wrong_result_count_is_an_error() {
+    let src = "
+    acir(inline) fn main f0 {
+      b0():
+        v0 = make_array [Field 1, Field 2] : [(Field, Field)]
+        v2, v3, v4 = call vector_remove(u32 1, v0, u32 0) -> (u32, [(Field, Field)], Field)
+        return v2
+    }
+    ";
+    let err = try_ssa_to_acir(src).expect_err("expected an error for mismatched result count");
+    let message = err.to_string();
+    assert!(
+        message.contains("vector_remove received 3 result values")
+            && message.contains("expected 4"),
+        "unexpected error message: {message}"
+    );
+}

--- a/tooling/nargo/src/ops/check.rs
+++ b/tooling/nargo/src/ops/check.rs
@@ -1,4 +1,7 @@
-use acvm::{acir::circuit::AcirOpcodeLocation, compiler::CircuitSimulator};
+use acvm::{
+    acir::circuit::AcirOpcodeLocation,
+    compiler::{CircuitSimulator, SimulationFailure},
+};
 use noirc_artifacts::program::CompiledProgram;
 use noirc_driver::ErrorsAndWarnings;
 use noirc_errors::CustomDiagnostic;
@@ -7,28 +10,40 @@ use noirc_errors::CustomDiagnostic;
 #[tracing::instrument(level = "trace", skip_all)]
 pub fn check_program(compiled_program: &CompiledProgram) -> Result<(), ErrorsAndWarnings> {
     for (i, circuit) in compiled_program.program.functions.iter().enumerate() {
-        if let Some(opcode) = CircuitSimulator::check_circuit(circuit) {
-            let diag = if let Some(call_stack) =
-                compiled_program.debug[i].acir_locations.get(&AcirOpcodeLocation::new(opcode))
-            {
-                let call_stack =
-                    compiled_program.debug[i].location_tree.get_call_stack(*call_stack);
-                CustomDiagnostic::from_message(
-                    &format!("Circuit \"{}\" is not solvable", circuit.function_name),
-                    call_stack.last_or_dummy().file,
-                )
-                .with_call_stack(call_stack)
-            } else {
-                CustomDiagnostic::from_message(
-                    &format!(
-                        "Circuit \"{}\" is not solvable for opcode \"{}\"",
-                        circuit.function_name, opcode
-                    ),
-                    fm::FileId::dummy(),
-                )
-            };
-            return Err(vec![diag]);
-        }
+        let Some(failure) = CircuitSimulator::check_circuit(circuit) else {
+            continue;
+        };
+        let diag = match failure {
+            SimulationFailure::UnsolvableOpcode(opcode) => {
+                if let Some(call_stack) =
+                    compiled_program.debug[i].acir_locations.get(&AcirOpcodeLocation::new(opcode))
+                {
+                    let call_stack =
+                        compiled_program.debug[i].location_tree.get_call_stack(*call_stack);
+                    CustomDiagnostic::from_message(
+                        &format!("Circuit \"{}\" is not solvable", circuit.function_name),
+                        call_stack.last_or_dummy().file,
+                    )
+                    .with_call_stack(call_stack)
+                } else {
+                    CustomDiagnostic::from_message(
+                        &format!(
+                            "Circuit \"{}\" is not solvable for opcode \"{}\"",
+                            circuit.function_name, opcode
+                        ),
+                        fm::FileId::dummy(),
+                    )
+                }
+            }
+            SimulationFailure::UnsolvableOutput(witness) => CustomDiagnostic::from_message(
+                &format!(
+                    "Circuit \"{}\" has a return value \"{}\" that is never computed",
+                    circuit.function_name, witness
+                ),
+                fm::FileId::dummy(),
+            ),
+        };
+        return Err(vec![diag]);
     }
     Ok(())
 }


### PR DESCRIPTION
## Problem Resolved

https://linear.app/aztec-foundation/issue/NRSEC-981 - but does not add the various type wrappers to limit the size of this PR

## Summary of Changes

New defensive checks:

- **`CircuitSimulator` now reports uncomputed return values.** `check_circuit` returns `Option<SimulationFailure>` (`UnsolvableOpcode(usize)` / `UnsolvableOutput(Witness)`) instead of `Option<usize>`. Previously a circuit whose declared return value was never computed by any opcode was reported as solvable. `nargo`'s `check_program` emits a dedicated diagnostic for the new case.
- **`initialize_array` validates its length argument** against the number of flattened values actually produced, returning an `InternalError` on mismatch instead of silently emitting a memory block of the wrong size.
- **Vector intrinsics validate their arity.** `vector_push_back`/`vector_push_front`/`vector_insert` check that the number of element values matches the vector's logical element, and `vector_pop_back`/`vector_pop_front`/`vector_remove` check the result-id count. The new SSA-level tests show such malformed (but validator-passing) SSA previously either compiled silently to a wrong circuit or panicked without context.
- **`convert_vars_to_values` asserts both collections are fully consumed**: a clear ICE message when the var iterator is exhausted early, and an assert that no vars are left over at the end.
- **Test coverage for the flattened-length divisibility panics** in `brillig::lengths` (`FlattenedLength / ElementsFlattenedLength` and `SemiFlattenedLength / ElementTypesLength`). The audit's divisibility recommendation was already enforced centrally by these `Div` impls; they just had no tests.

**Real bug caught by the new checks:** the leftover-vars assert immediately fired on the `as_witness` execution test — the `Intrinsic::AsWitness` handler routed its var through `convert_vars_to_values` with no result ids, silently dropping it. It now creates the witness for its side effect and returns no values.

Audit items already addressed on `master` (no change in this PR): `proof_type` u32 truncation (#11661) and `handle_ssa_call_outputs` zip exhaustion (#11849). The audit's struct-containerization recommendation (privatizing fields of `Witness`, `Circuit`, `Program`, etc.) was deliberately deferred and is not part of this PR.

Test runs: `brillig` 19/19, `acvm` 140/140, `nargo` 8/8, `noirc_evaluator` 1644/1644, `nargo_cli --test execute` 8916/8916.

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)