### PR TITLE
chore: various small code improvements

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/ir/dfg/simplify/value_merger.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/dfg/simplify/value_merger.rs
@@ -7,7 +7,7 @@ use rustc_hash::FxHashMap as HashMap;
 
 use crate::{
     brillig::assert_u32,
-    errors::{RtResult, RuntimeError},
+    errors::{InternalError, RtResult, RuntimeError},
     ssa::{
         ir::{
             basic_block::BasicBlockId,
@@ -66,6 +66,19 @@ impl<'a> ValueMerger<'a> {
         // point at where we got the if-then-else; it's not clear which one is more useful.
         let call_stack = self.dfg.get_value_call_stack(value);
         if call_stack.is_empty() { self.dfg.get_call_stack(self.call_stack) } else { call_stack }
+    }
+
+    /// Returns the (tracked) size of a vector being merged.
+    /// Error if the size is not known.
+    fn vector_size_or_err(&self, value: ValueId) -> RtResult<SemanticLength> {
+        self.vector_sizes.get(&value).copied().ok_or_else(|| {
+            RuntimeError::InternalError(InternalError::General {
+                message: format!(
+                    "Merging values during flattening encountered vector {value} without a determinable size"
+                ),
+                call_stack: self.get_call_stack(value),
+            })
+        })
     }
 
     /// Merge two values a and b to a single value.
@@ -235,13 +248,8 @@ impl<'a> ValueMerger<'a> {
             _ => panic!("Expected vector type"),
         };
 
-        let then_len = self.vector_sizes.get(&then_value_id).copied().unwrap_or_else(|| {
-            panic!("ICE: Merging values during flattening encountered vector {then_value_id} without a preset size");
-        });
-
-        let else_len = self.vector_sizes.get(&else_value_id).copied().unwrap_or_else(|| {
-            panic!("ICE: Merging values during flattening encountered vector {else_value_id} without a preset size");
-        });
+        let then_len = self.vector_size_or_err(then_value_id)?;
+        let else_len = self.vector_size_or_err(else_value_id)?;
 
         let len = then_len.max(else_len);
         let element_count = ElementTypesLength(assert_u32(element_types.len()));

--- a/compiler/noirc_evaluator/src/ssa/opt/checked_to_unchecked.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/checked_to_unchecked.rs
@@ -53,8 +53,8 @@ impl Function {
             let unchecked = match binary.operator {
                 BinaryOp::Add { unchecked: false } => {
                     let bit_size = dfg.type_of_value(lhs).bit_size();
-                    let max_lhs_bits = get_max_num_bits(dfg, lhs, &mut value_max_num_bits);
-                    let max_rhs_bits = get_max_num_bits(dfg, rhs, &mut value_max_num_bits);
+                    let max_lhs_bits = required_bit_size(dfg, lhs, &mut value_max_num_bits);
+                    let max_rhs_bits = required_bit_size(dfg, rhs, &mut value_max_num_bits);
 
                     // 1. If both lhs and rhs have less max bits than the result it means their
                     //    value is at most `2^(n-1) - 1`, assuming `n = bit_size`. Adding those
@@ -71,7 +71,7 @@ impl Function {
                     // underflow because `256 >= 255`.
 
                     if let Some(lhs_const) = dfg.get_numeric_constant(lhs) {
-                        let max_rhs_bits = get_max_num_bits(dfg, rhs, &mut value_max_num_bits);
+                        let max_rhs_bits = required_bit_size(dfg, rhs, &mut value_max_num_bits);
                         let max_rhs =
                             if max_rhs_bits == 128 { u128::MAX } else { (1 << max_rhs_bits) - 1 };
 
@@ -85,10 +85,10 @@ impl Function {
                 }
                 BinaryOp::Mul { unchecked: false } => {
                     let bit_size = dfg.type_of_value(lhs).bit_size();
-                    let max_lhs_bits = get_max_num_bits(dfg, lhs, &mut value_max_num_bits);
-                    let max_rhs_bits = get_max_num_bits(dfg, rhs, &mut value_max_num_bits);
+                    let max_lhs_bits = required_bit_size(dfg, lhs, &mut value_max_num_bits);
+                    let max_rhs_bits = required_bit_size(dfg, rhs, &mut value_max_num_bits);
 
-                    // `get_max_num_bits` tracks the actual range of a value through casts,
+                    // `required_bit_size` tracks the actual range of a value through casts,
                     // truncations, and boolean multiplications — it may be smaller than the
                     // type's bit_size (e.g. a u8 upcast to u64 still has max_bits == 8).
                     //
@@ -99,7 +99,7 @@ impl Function {
                     //
                     // As a special case, when either operand has `max_bits == 1` its value
                     // is at most 1, so `x * 0 = 0` or `x * 1 = x` — neither can overflow.
-                    // This is sound as long as `get_max_num_bits` never returns 1 for a
+                    // This is sound as long as `required_bit_size` never returns 1 for a
                     // value that could actually exceed 1.
                     max_lhs_bits + max_rhs_bits <= bit_size
                         || max_lhs_bits == 1
@@ -119,10 +119,11 @@ impl Function {
     }
 }
 
+/// Returns a maximum number of bits the `value` requires.
 /// The logic here is almost the same as [`DataFlowGraph::get_value_max_num_bits`] except that
 /// - it takes into account that the bitsize of multiplying two bools is 1
 /// - it recurses by memoizing the results in `value_max_num_bits`
-fn get_max_num_bits(
+fn required_bit_size(
     dfg: &DataFlowGraph,
     value: ValueId,
     value_max_num_bits: &mut HashMap<ValueId, u32>,
@@ -138,22 +139,22 @@ fn get_max_num_bits(
             match dfg[instruction] {
                 Instruction::Cast(original_value, _) => {
                     let original_bit_size =
-                        get_max_num_bits(dfg, original_value, value_max_num_bits);
+                        required_bit_size(dfg, original_value, value_max_num_bits);
                     // We might have cast e.g. `u1` to `u8` to be able to do arithmetic,
                     // in which case we want to recover the original smaller bit size;
                     // OTOH if we cast down, then we don't need the higher original size.
                     value_bit_size.min(original_bit_size)
                 }
                 Instruction::Binary(Binary { lhs, operator: BinaryOp::Mul { .. }, rhs })
-                    if get_max_num_bits(dfg, lhs, value_max_num_bits) == 1
-                        && get_max_num_bits(dfg, rhs, value_max_num_bits) == 1 =>
+                    if required_bit_size(dfg, lhs, value_max_num_bits) == 1
+                        && required_bit_size(dfg, rhs, value_max_num_bits) == 1 =>
                 {
                     // When multiplying two values, if their bitsize is 1 then the result's bitsize will be 1 too
                     1
                 }
                 Instruction::Truncate { value, bit_size, .. } => {
                     let value_bit_size =
-                        value_bit_size.min(get_max_num_bits(dfg, value, value_max_num_bits));
+                        value_bit_size.min(required_bit_size(dfg, value, value_max_num_bits));
                     value_bit_size.min(bit_size)
                 }
                 _ => value_bit_size,

--- a/compiler/noirc_evaluator/src/ssa/opt/evaluate_static_assert_and_assert_constant.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/evaluate_static_assert_and_assert_constant.rs
@@ -178,6 +178,10 @@ fn evaluate_assert_constant(
     arguments: &[ValueId],
     error_on_failure: bool,
 ) -> Result<bool, RuntimeError> {
+    if arguments.is_empty() {
+        panic!("ICE: assert_constant called with no arguments")
+    }
+
     if arguments.iter().all(|arg| function.dfg.is_constant(*arg)) {
         Ok(false)
     } else if error_on_failure {

--- a/compiler/noirc_evaluator/src/ssa/opt/flatten_cfg.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/flatten_cfg.rs
@@ -301,6 +301,13 @@ struct ConditionalBranch {
     condition: ValueId,
 }
 
+/// Indicate the current processed branch
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum BranchPhase {
+    Then,
+    Else,
+}
+
 /// All bookkeeping for a single `jmpif` that is currently being flattened.
 ///
 /// Pushed onto `Context::condition_stack` when a `jmpif` is entered and popped when
@@ -329,6 +336,10 @@ struct ConditionalContext {
     /// When JmpIf's else_destination is the exit/merge block (no separate else block),
     /// stores the resolved else_arguments so `inline_branch_end` can use them.
     jmpif_else_arguments: Option<Vec<ValueId>>,
+    /// The processing of the conditional branches must start with `Then` before
+    /// `Else`. Tracking on which phase we are allows us to assert the processing
+    /// is done as expected.
+    phase: BranchPhase,
 }
 
 /// Flattens the control flow graph of the function such that it is left with a
@@ -631,6 +642,7 @@ impl<'f> Context<'f> {
             predicated_values: HashMap::default(),
             local_allocations,
             jmpif_else_arguments,
+            phase: BranchPhase::Then,
         };
         // Clear merge provenance from previous conditionals at this nesting level.
         // Provenance from a previous conditional's merges must not be re-used by
@@ -663,6 +675,12 @@ impl<'f> Context<'f> {
         assert_eq!(self.cfg.successors(*block).len(), 1);
 
         let mut cond_context = self.condition_stack.pop().unwrap();
+        assert_eq!(
+            cond_context.phase,
+            BranchPhase::Then,
+            "ICE: then_stop is expected to process the THEN branch"
+        );
+        cond_context.phase = BranchPhase::Else;
         cond_context.then_branch.last_block = Some(*block);
 
         let condition_call_stack =
@@ -763,10 +781,20 @@ impl<'f> Context<'f> {
             // `then_stop` has not been called, this means that the conditional statement has no else branch
             // so we simply do the `then_stop` now, sandwiched between pushing the context back on the stack,
             // then popping it again after `then_stop` is done popping and pushing.
+            assert_eq!(
+                cond_context.phase,
+                BranchPhase::Then,
+                "ICE: else_stop expect a single THEN branch"
+            );
             self.condition_stack.push(cond_context);
             self.then_stop(block);
             cond_context = self.condition_stack.pop().unwrap();
         }
+        assert_eq!(
+            cond_context.phase,
+            BranchPhase::Else,
+            "ICE: else_stop is expected to process the ELSE branch"
+        );
 
         let mut else_branch = cond_context.else_branch.unwrap();
         self.local_allocations = std::mem::take(&mut cond_context.local_allocations);
@@ -809,24 +837,14 @@ impl<'f> Context<'f> {
         assert_eq!(params.len(), then_args.len());
         // When JmpIf's else_destination is the exit block, the else_arguments were stored
         // in jmpif_else_arguments since there is no separate else block to read them from.
-        let (else_args, else_branch) =
-            match (cond_context.jmpif_else_arguments, cond_context.else_branch) {
-                (Some(args), Some(else_branch)) => (args, else_branch),
-                (None, Some(else_branch)) => {
-                    let last_else = else_branch.last_block.unwrap();
-                    let args =
-                        self.inserter.function.dfg[last_else].terminator_arguments().to_vec();
-                    (args, else_branch)
-                }
-                (Some(args), None) => {
-                    assert!(args.is_empty() && params.is_empty(), "malformed branch");
-                    return;
-                }
-                (None, None) => {
-                    assert!(params.is_empty(), "malformed branch");
-                    return;
-                }
-            };
+        let else_branch = cond_context.else_branch.expect("malformed branch");
+        let else_args = match cond_context.jmpif_else_arguments {
+            Some(args) => args,
+            None => {
+                let last_else = else_branch.last_block.unwrap();
+                self.inserter.function.dfg[last_else].terminator_arguments().to_vec()
+            }
+        };
         assert_eq!(params.len(), else_args.len());
 
         let args = vecmap(then_args.iter().zip_eq(else_args), |(then_arg, else_arg)| {

--- a/compiler/noirc_evaluator/src/ssa/opt/loop_invariant.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/loop_invariant.rs
@@ -484,6 +484,8 @@ impl<'f> LoopInvariantContext<'f> {
                     let dfg = &self.inserter.function.dfg;
                     // If the block has already been labelled as impure, we don't need to check the current
                     // instruction's side effects.
+                    // Note that purity is dependent on the instruction ordering, which is expected because
+                    // it tells us exactly if there is a side-effect instruction before the current one.
                     if !block_context.is_impure {
                         block_context.is_impure = dfg[instruction_id].has_side_effects(dfg);
                     }

--- a/compiler/noirc_evaluator/src/ssa/opt/remove_bit_shifts.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/remove_bit_shifts.rs
@@ -394,6 +394,8 @@ impl Context<'_, '_, '_> {
 
     /// Insert constraints ensuring that the right-hand side of a bit-shift operation
     /// is less than the bit size of the left-hand side.
+    /// We check against rhs bit size because this function does not see lhs,
+    /// but this is effectively lhs bit size because lhs and rhs have the same type.
     fn enforce_bitshift_rhs_lt_bit_size(&mut self, rhs: ValueId) {
         let one = self.numeric_constant(FieldElement::one(), NumericType::bool());
         let rhs_type = self.context.dfg.type_of_value(rhs);

--- a/compiler/noirc_evaluator/src/ssa/opt/remove_if_else.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/remove_if_else.rs
@@ -321,8 +321,11 @@ impl Context {
         if !matches!(*dfg.type_of_value(new), Type::Vector(_)) {
             return;
         }
-        let capacity = self.get_or_find_capacity(dfg, old);
-        self.vector_sizes.insert(new, f(capacity));
+
+        // Track new's capacity if old's is known, on a best-effort basis.
+        if let Some(capacity) = self.get_or_find_capacity(dfg, old) {
+            self.vector_sizes.insert(new, f(capacity));
+        }
     }
 
     /// Make sure the vector capacity is recorded.
@@ -330,17 +333,16 @@ impl Context {
         self.set_capacity(dfg, vector, vector, |c| c);
     }
 
-    /// Get the tracked size of array/vectors, or retrieve (and track) it for arrays.
-    fn get_or_find_capacity(&mut self, dfg: &DataFlowGraph, value: ValueId) -> SemanticLength {
+    /// Get size of array/vectors, and track it in `vector_sizes`.
+    fn get_or_find_capacity(
+        &mut self,
+        dfg: &DataFlowGraph,
+        value: ValueId,
+    ) -> Option<SemanticLength> {
         match self.vector_sizes.entry(value) {
-            Entry::Occupied(entry) => *entry.get(),
+            Entry::Occupied(entry) => Some(*entry.get()),
             Entry::Vacant(entry) => {
-                if let Some(length) = dfg.try_get_vector_capacity(value) {
-                    return *entry.insert(length);
-                }
-                // For non-constant vectors we can't tell the size, which would mean we can't merge it.
-                let dbg_value = &dfg[value];
-                unreachable!("ICE: No size for vector {value} = {dbg_value:?}")
+                dfg.try_get_vector_capacity(value).map(|len| *entry.insert(len))
             }
         }
     }
@@ -1268,5 +1270,36 @@ mod tests {
 
         let ssa = Ssa::from_str(src).unwrap();
         let _ = ssa.remove_if_else();
+    }
+
+    // The pass only tracks vector capacities through vector intrinsics and `array_set`,
+    // so it cannot recover the size of a vector produced by a `load` (or a non-intrinsic
+    // call). Such SSA is not produced by the frontend, but the SSA fuzzer and `noir-ssa`
+    // can feed it in. When such a vector reaches an `if_else` merge the size is needed but
+    // unavailable; the pass must surface a graceful error rather than panicking.
+    #[test]
+    fn merge_vector_without_determinable_size_errors() {
+        let src = "
+        acir(inline) impure fn main f0 {
+          b0(v0: u1, v1: &mut [Field]):
+            v2 = make_array [] : [Field]
+            v3 = load v1 -> [Field]
+            v4 = not v0
+            v5 = if v0 then v3 else (if v4) v2
+            enable_side_effects u1 1
+            v6 = array_get v5, index u32 0 -> Field
+            constrain v6 == Field 1
+            return
+        }
+        ";
+
+        let ssa = Ssa::from_str(src).unwrap();
+        let Err(err) = ssa.remove_if_else() else {
+            panic!("expected remove_if_else to error on a vector with no determinable size");
+        };
+        assert!(
+            format!("{err}").contains("without a determinable size"),
+            "unexpected error: {err}"
+        );
     }
 }

--- a/compiler/noirc_evaluator/src/ssa/opt/simplify_cfg.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/simplify_cfg.rs
@@ -49,9 +49,13 @@ impl Function {
         let mut cfg = ControlFlowGraph::with_function(self);
         let mut values_to_replace = ValueMapping::default();
         let mut stack = vec![self.entry_block()];
+        // Tracks which blocks are currently in `stack`
+        let mut queued: HashSet<BasicBlockId> = stack.iter().copied().collect();
         let mut visited = HashSet::new();
 
         while let Some(block) = stack.pop() {
+            queued.remove(&block);
+
             if cfg.predecessors(block).len() == 0 && block != self.entry_block() {
                 // If the block has no predecessors, it's no longer reachable and can be ignored.
                 cfg.invalidate_block_successors(block);
@@ -67,30 +71,41 @@ impl Function {
             let simplified = simplify_current_block(self, block, &mut cfg, &mut values_to_replace);
 
             if visited.insert(block) || simplified {
-                stack.extend(self.dfg[block].successors().filter(|block| !visited.contains(block)));
+                let successors: Vec<_> = self.dfg[block]
+                    .successors()
+                    .filter(|block| !visited.contains(block) && queued.insert(*block))
+                    .collect();
+                stack.extend(successors);
             }
 
             // If this block was simplified (e.g. a jmpif was folded to a jmp), its predecessors
             // may now have new simplification opportunities (e.g. converging branches).
             // Re-add them to the stack so they get re-checked.
             if simplified {
-                stack.extend(cfg.predecessors(block).filter(|b| visited.contains(b)));
+                let predecessors: Vec<_> = cfg
+                    .predecessors(block)
+                    .filter(|b| visited.contains(b) && queued.insert(*b))
+                    .collect();
+                stack.extend(predecessors);
             }
 
             let mut predecessors = cfg.predecessors(block);
-            if predecessors.len() == 1 {
+            let inlined = if predecessors.len() == 1 {
                 let predecessor =
                     predecessors.next().expect("Already checked length of predecessors");
                 drop(predecessors);
 
-                try_inline_successor(self, &mut cfg, predecessor, &mut values_to_replace);
+                try_inline_successor(self, &mut cfg, predecessor, &mut values_to_replace)
             } else {
                 drop(predecessors);
 
                 check_for_double_jmp(self, block, &mut cfg);
-            }
+                false
+            };
 
-            if !values_to_replace.is_empty() {
+            // When `block` is inlined into its predecessor it becomes empty and unreachable,
+            // so it no longer has a terminator worth updating.
+            if !inlined && !values_to_replace.is_empty() {
                 self.dfg.replace_values_in_block_terminator(block, &values_to_replace);
             }
         }
@@ -479,9 +494,8 @@ fn resolve_jmp_chain(function: &Function, mut current: BasicBlockId) -> BasicBlo
 
 /// If the given block has block parameters, replace them with the jump arguments from the predecessor.
 ///
-/// Currently, if this function is needed, `try_inline_into_predecessor` will also always apply,
-/// although in the future it is possible for only this function to apply if jmpif instructions
-/// with block arguments are ever added.
+/// This is only called for a predecessor that terminates in a plain `Jmp` whose sole successor is
+/// the given block, so whenever this function is needed `try_inline_into_predecessor` also applies.
 fn remove_block_parameters(
     function: &mut Function,
     block: BasicBlockId,
@@ -495,11 +509,8 @@ fn remove_block_parameters(
 
         let jump_args = match function.dfg[predecessor].unwrap_terminator_mut() {
             TerminatorInstruction::Jmp { arguments, .. } => std::mem::take(arguments),
-            TerminatorInstruction::JmpIf { .. } => unreachable!(
-                "If jmpif instructions are modified to support block arguments in the future, this match will need to be updated"
-            ),
             _ => unreachable!(
-                "Predecessor was already validated to have only a single jmp destination"
+                "Predecessor was already validated to terminate in a single jmp destination"
             ),
         };
 

--- a/docs/docs/language/ops.md
+++ b/docs/docs/language/ops.md
@@ -103,3 +103,6 @@ could be written as:
 let mut i = 0;
 i += 1;
 ```
+
+### Shift right
+Noir performs a logical shift for unsigned integers and an arithmetic (sign-preserving) shift for signed operands.


### PR DESCRIPTION
## Problem Resolved

Resolves #10654

## Summary of Changes
- evaluate_static_assert_and_assert_constant.rs/evaluate_assert_constant: assert at least one argument.
- remove_bit_shifts.rs: improved the documentation comment on enforce_bitshift_rhs_lt_bit_size.
- Noir language documentation: added  the semantics of right shift operations.
- remove_if_else.rs/remove_if_else: Error instead of panic in case of remaining Loads. Precondition checks were already added.
- make_constrain_not_equal.rs: Precondition checks were already added.
- array_set.rs: Precondition checks were already added.
- simplify_cfg.rs/simplify_function: avoid updating terminator if block was not inlined, and avoid processing a block already queued. Also I updated the comments about JmpIf arguments.
- flatten_cfg.rs: I do not think the current construct is fragile because the block ordering is hand-crafted on each step of the algorithm. However, I added a state to see which branch the algorithm is processing (then/else) and assert that the current branch is what the algorithm expect.
- flatten_cfg.rs/handle_instruction_side_effects: already fixed.
- flatten_cfg.rs/inline_branch_end: refactored the code based on cond_context.else_branch availability.
- checked_to_unchecked.rs/get_max_num_bits: renamed the function into `required_bit_size`
- loop_invariant.rs/LoopInvariantContext::hoist_loop_invariants: added a small comment to explain the dependence on instruction orders is expected.

## User Documentation

Check one:
- [ ] No user documentation needed.
- [X] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
