### PR TITLE
fix: unify in comptime checked_transmute

### DIFF
--- a/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
@@ -388,7 +388,7 @@ fn checked_transmute(
 ) -> IResult<Value> {
     let (value, location) = check_one_argument(arguments, location)?;
 
-    if value.get_type().as_ref() != &return_type {
+    if value.get_type().try_unify_with_default_bindings(&return_type).is_err() {
         return Err(InterpreterError::CheckedTransmuteFailed {
             actual: value.get_type().into_owned(),
             expected: return_type,

--- a/compiler/noirc_frontend/src/monomorphization/builtin.rs
+++ b/compiler/noirc_frontend/src/monomorphization/builtin.rs
@@ -128,7 +128,7 @@ impl Monomorphizer<'_> {
         expected: &Type,
         location: Location,
     ) -> Result<(), MonomorphizationError> {
-        if actual.try_unify(expected, &mut TypeBindings::default()).is_ok() {
+        if actual.try_unify_with_default_bindings(expected).is_ok() {
             Ok(())
         } else {
             let actual = actual.to_string();

--- a/compiler/noirc_frontend/src/monomorphization/builtin.rs
+++ b/compiler/noirc_frontend/src/monomorphization/builtin.rs
@@ -5,7 +5,7 @@ use iter_extended::vecmap;
 use noirc_errors::Location;
 
 use crate::{
-    Type, TypeBindings,
+    Type,
     ast::IntegerBitSize,
     monomorphization::{
         CanonicalBindings, Monomorphizer,

--- a/test_programs/compile_success_empty/checked_transmute/src/main.nr
+++ b/test_programs/compile_success_empty/checked_transmute/src/main.nr
@@ -3,6 +3,10 @@ use std::mem::checked_transmute;
 fn main() {
     // 1*(2 + 3) = 1*2 + 1*3 = 5
     let _: [Field; 5] = distribute::<1, 2, 3>([1, 2, 3, 4, 5]);
+
+    comptime {
+        let _: [Field; 5] = distribute::<1, 2, 3>([1, 2, 3, 4, 5]);
+    }
 }
 
 pub fn distribute<let N: u32, let A: u32, let B: u32>(

--- a/tooling/nargo_cli/tests/snapshots/compile_success_empty/checked_transmute/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_empty/checked_transmute/execute__tests__expanded.snap
@@ -6,6 +6,7 @@ use std::mem::checked_transmute;
 
 fn main() {
     let _: [Field; 5] = distribute::<1, 2, 3>([1_Field, 2_Field, 3_Field, 4_Field, 5_Field]);
+    ()
 }
 
 pub fn distribute<let N: u32, let A: u32, let B: u32>(


### PR DESCRIPTION
## Problem Resolved

Resolves https://github.com/noir-lang/noir-claude/issues/833

## Summary of Changes

The same code but in comptime failed to compile: we need to use `try_unify`, like we do in the non-comptime check (it's in the diff: I changed it to use `try_unify_with_default_bindings` so now both sites are consistent).

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
