### PR TITLE
chore: unit test to demonstrate the simplification

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/opt/load_store_forwarding.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/load_store_forwarding.rs
@@ -1454,4 +1454,40 @@ mod tests {
         }
         ");
     }
+
+    #[test]
+    fn call_with_nested_reference() {
+        let src = "
+        acir(inline) fn main f0 {
+          b0():
+            v0 = allocate -> &mut Field
+            store Field 1 at v0
+            v1 = make_array [] : [&mut u32; 0]
+            call f1(v1)
+            v2 = load v0 -> Field
+            return v2
+        }
+        acir(inline) fn f1 f1 {
+          b0(v0: [&mut u32; 0]):
+            return
+        }
+        ";
+        let ssa = Ssa::from_str(src).unwrap();
+        let ssa = ssa.load_store_forwarding();
+        // The call `call f1(v1)` has a reference but it cannot impact v0.
+        assert_ssa_snapshot!(ssa, @r"
+        acir(inline) fn main f0 {
+          b0():
+            v0 = allocate -> &mut Field
+            store Field 1 at v0
+            v2 = make_array [] : [&mut u32; 0]
+            call f1(v2)
+            return Field 1
+        }
+        acir(inline) fn f1 f1 {
+          b0(v0: [&mut u32; 0]):
+            return
+        }
+        ");
+    }
 }


### PR DESCRIPTION
## Problem Resolved

Resolves #12318 

## Summary of Changes
The new alias analysis pass can handle the example in the issue, so I just added the unit test.


## User Documentation

Check one:
- [X] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
