### PR TITLE
fix(comptime): reject Field division by zero in Integer::Div

### DIFF
--- a/compiler/noirc_frontend/src/hir/comptime/integer.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/integer.rs
@@ -335,6 +335,7 @@ impl std::ops::Div for Integer {
 
     fn div(self, rhs: Self) -> Self::Output {
         match (self, rhs) {
+            (Integer::Field(_), Integer::Field(rhs)) if rhs.is_zero() => None,
             (Integer::Field(lhs), Integer::Field(rhs)) => Some(Integer::Field(lhs / rhs)),
             (Integer::U8(lhs), Integer::U8(rhs)) => lhs.checked_div(rhs).map(Integer::U8),
             (Integer::U16(lhs), Integer::U16(rhs)) => lhs.checked_div(rhs).map(Integer::U16),
@@ -654,8 +655,9 @@ mod tests {
     fn field_division_by_zero() {
         let a = Integer::Field(FieldElement::from(5u64));
         let b = Integer::Field(FieldElement::zero());
-        // Field division always "succeeds" (FieldElement handles it internally)
-        assert!((a / b).is_some());
+        // Division by zero must honor the `None`-on-failure contract rather than
+        // silently canonicalizing to the field-element inverse of zero (which is zero).
+        assert_eq!(a / b, None);
     }
 
     #[test]

--- a/compiler/noirc_frontend/src/tests/arithmetic_generics.rs
+++ b/compiler/noirc_frontend/src/tests/arithmetic_generics.rs
@@ -219,6 +219,26 @@ fn arithmetic_generics_checked_cast_fails_to_evaluate_field_destination() {
 }
 
 #[test]
+fn arithmetic_generics_field_division_by_zero() {
+    // A type-level `Field` division by zero must be rejected rather than
+    // silently canonicalized to zero (the field-element inverse of zero).
+    let source = r#"
+        struct W<let N: Field> {}
+
+        fn foo<let N: Field>(_x: W<N>) -> W<N / (N - N)> {
+            W {}
+        }
+
+        fn main() {
+            let w_5: W<5Field> = W {};
+            let _w = foo(w_5);
+                     ^^^ Division by zero: 0x05 / 0x00
+        }
+    "#;
+    check_monomorphization_error(source);
+}
+
+#[test]
 fn global_numeric_generic_larger_than_u32() {
     // Regression test for https://github.com/noir-lang/noir/issues/6125
     let source = r#"

--- a/test_programs/compile_failure/arithmetic_generics_field_division_by_zero/Nargo.toml
+++ b/test_programs/compile_failure/arithmetic_generics_field_division_by_zero/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "arithmetic_generics_field_division_by_zero"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.33.0"
+
+[dependencies]

--- a/test_programs/compile_failure/arithmetic_generics_field_division_by_zero/src/main.nr
+++ b/test_programs/compile_failure/arithmetic_generics_field_division_by_zero/src/main.nr
@@ -1,0 +1,13 @@
+// A type-level `Field` division by zero must be rejected rather than silently
+// canonicalized to zero (the field-element inverse of zero is zero).
+struct W<let N: Field> {}
+
+fn foo<let N: Field>(_x: W<N>) -> W<N / (N - N)> {
+    W {}
+}
+
+fn main() {
+    let w_5: W<5Field> = W {};
+    // error: Division by zero: 0x05 / 0x00
+    let _w = foo(w_5);
+}

--- a/tooling/nargo_cli/tests/snapshots/compile_failure/arithmetic_generics_field_division_by_zero/execute__tests__stderr.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_failure/arithmetic_generics_field_division_by_zero/execute__tests__stderr.snap
@@ -1,0 +1,12 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: stderr
+---
+error: Division by zero: 0x05 / 0x00
+   ┌─ src/main.nr:12:14
+   │
+12 │     let _w = foo(w_5);
+   │              ---
+   │
+
+Aborting due to 1 previous error


### PR DESCRIPTION
## Summary

Fixes https://github.com/noir-lang/noir-claude/issues/835

`impl Div for Integer` returned `Some(Integer::Field(0))` for `5Field / 0Field` instead of `None`, violating the documented contract (`integer.rs:272`) that all `Integer` operations return `None` on overflow or type mismatch. Because the field-element layer defines `inverse(0)` as zero, `lhs / 0` silently became zero.

This is reachable from **type-level / numeric-generic field division**. `BinaryTypeOperator::Division` maps the `Option` to a `DivisionByZero` error, but the missing guard meant `5Field / 0Field` was canonicalized to the constant `0` instead of being rejected. For example, the following compiled with exit code 0:

```rust
struct W<let N: Field> {}

fn foo<let N: Field>(_x: W<N>) -> W<N / (N - N)> {
    W {}
}

fn main() {
    let w_5: W<5Field> = W {};
    let _w = foo(w_5); // silently canonicalized N / 0 to 0
}
```

The ordinary `comptime` infix division path has its own zero guard and was already correct; this only affected the `Integer::Div` primitive and its type-level callers.

## Fix

Guard the `Field` arm of `Integer::Div` before performing field division:

```rust
(Integer::Field(_), Integer::Field(rhs)) if rhs.is_zero() => None,
(Integer::Field(lhs), Integer::Field(rhs)) => Some(Integer::Field(lhs / rhs)),
```

With the contract honored, `BinaryTypeOperator::Division` now produces a `Division by zero` error, and the type-level caller in `types/arithmetic.rs` falls through (keeping the type symbolic) rather than canonicalizing to `0` — the error then surfaces at evaluation.

## Tests

- **Noir regression test** (`compile_failure/arithmetic_generics_field_division_by_zero`): the program above now fails to compile with `Division by zero: 0x05 / 0x00`.
- **Frontend unit test** `arithmetic_generics_field_division_by_zero`: asserts the same monomorphization error.
- **Updated** the existing `field_division_by_zero` unit test to assert the `None` contract (previously asserted `.is_some()`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)