### PR TITLE
chore(ssa): Cover more cases in `array_set_rc_invariant`

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/ir/target_cost.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/target_cost.rs
@@ -23,14 +23,17 @@ impl Instruction {
     /// Instructions with side effects (constraints, calls, memory ops) cannot be
     /// flattened because they would execute unconditionally in the merged block.
     ///
-    /// `Allocate` is not predicate-dependent and is safe to duplicate, but the caller
-    /// excludes it from the flatten-cost estimate before asking, so reaching it here is
-    /// an ICE.
+    /// `Allocate` and `IncrementRc` are safe to execute unconditionally, so the
+    /// caller excludes them from the flatten-cost estimate before asking;
+    /// reaching either here is an ICE. Hoisting an `inc_rc` out of a branch only
+    /// ever *raises* an array's runtime reference count, which makes a later
+    /// `array_set` copy rather than mutate in place — always sound (the
+    /// `array_set_rc_invariant` validator rejects any SSA whose result would
+    /// depend on the un-hoisted bump).
     ///
-    /// `IncrementRc` / `DecrementRc` ARE predicate-dependent: hoisting them out of a
-    /// branch changes an array's runtime reference count, which in turn changes the
-    /// copy-on-write behavior of a later `array_set`. They are reported as
-    /// non-flattenable, consistent with their `has_side_effects` classification.
+    /// `DecrementRc` is **not** safe to hoist: running it on a path that did not
+    /// before *lowers* a reference count, which can enable an unsafe in-place
+    /// mutation. It is reported as non-flattenable.
     ///
     /// Div/Mod and Shl/Shr are blocked unconditionally — even when `has_side_effects`
     /// would allow them (e.g. known non-zero divisor), they are rarely worth flattening.
@@ -43,11 +46,11 @@ impl Instruction {
                     true
                 }
             }
-            Instruction::Allocate => {
-                panic!("ICE: Caller should handle Allocate");
+            Instruction::Allocate | Instruction::IncrementRc { .. } => {
+                panic!("ICE: Caller should handle Allocate and IncrementRc");
             }
 
-            Instruction::IncrementRc { .. } | Instruction::DecrementRc { .. } => false,
+            Instruction::DecrementRc { .. } => false,
 
             // Calls are never worth flattening — even pure intrinsics can expand
             // into many Brillig opcodes, making unconditional execution expensive.

--- a/compiler/noirc_evaluator/src/ssa/opt/basic_conditional.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/basic_conditional.rs
@@ -243,21 +243,27 @@ fn differing_merge_cost(
 /// Computes a cost estimate for flattening a basic block in a conditional.
 ///
 /// Returns `None` if the block contains an instruction that cannot be safely
-/// flattened (side-effectful instructions like constraints, calls, reference-count
-/// ops, memory ops, div/mod, shifts — see `can_flatten_in_conditional`). Otherwise
+/// flattened (side-effectful instructions like constraints, calls, `dec_rc`,
+/// memory ops, div/mod, shifts — see `can_flatten_in_conditional`). Otherwise
 /// returns the estimated Brillig opcode cost.
 ///
-/// `Allocate` and `Noop` are excluded from the cost — they are safe to execute
-/// unconditionally and represent overhead that shouldn't influence the
-/// flatten/not-flatten decision. (`Allocate` must be skipped before the
-/// `can_flatten_in_conditional` call, which treats reaching it as an ICE.)
+/// `Allocate`, `IncrementRc`, and `Noop` are excluded from the cost — they are
+/// safe to execute unconditionally and represent overhead that shouldn't
+/// influence the flatten/not-flatten decision. (`Allocate` and `IncrementRc`
+/// must be skipped before the `can_flatten_in_conditional` call, which treats
+/// reaching them as an ICE.) Hoisting an `inc_rc` only ever raises a reference
+/// count, so the later `array_set` copies rather than mutating in place — sound,
+/// and guarded by the `array_set_rc_invariant` validator.
 fn block_flatten_cost(block: BasicBlockId, dfg: &DataFlowGraph) -> Option<u32> {
     let mut cost: u32 = 0;
     for instruction_id in dfg[block].instructions() {
         let instruction = &dfg[*instruction_id];
         // Skip memory management instructions that are safe to execute unconditionally —
         // these don't represent meaningful compute that should affect the decision.
-        if matches!(instruction, Instruction::Allocate | Instruction::Noop) {
+        if matches!(
+            instruction,
+            Instruction::Allocate | Instruction::IncrementRc { .. } | Instruction::Noop
+        ) {
             continue;
         }
 
@@ -487,12 +493,7 @@ impl Context<'_> {
 mod tests {
     use crate::{
         assert_ssa_snapshot,
-        ssa::{
-            Ssa,
-            interpreter::value::Value,
-            ir::types::Type,
-            opt::{assert_pass_does_not_affect_execution, assert_ssa_does_not_change},
-        },
+        ssa::{Ssa, opt::assert_ssa_does_not_change},
     };
 
     #[test]
@@ -756,41 +757,6 @@ mod tests {
             return v8
         }
         ");
-    }
-
-    /// A branch-local `inc_rc` must not be hoisted out of its branch when flattening.
-    ///
-    /// In Brillig, `array_set` mutates its array in place only when the runtime reference
-    /// count is 1, and `inc_rc` bumps that count. Flattening this diamond would move the
-    /// `then`-branch `inc_rc` into the unconditionally executed entry block, so it would run
-    /// even when the condition is false; the later `array_set` would then copy instead of
-    /// mutating in place. With `v0 = false` the `inc_rc` is skipped, `array_set` mutates `v1`
-    /// in place, and `array_get` observes `Field 7` — the pass must preserve that result.
-    #[test]
-    fn does_not_hoist_branch_local_inc_rc() {
-        let src = "
-            brillig(inline) fn main f0 {
-              b0(v0: u1, v1: [Field; 1]):
-                jmpif v0 then: b1(), else: b2()
-              b1():
-                inc_rc v1
-                jmp b3()
-              b2():
-                jmp b3()
-              b3():
-                v2 = array_set v1, index u32 0, value Field 7
-                v3 = array_get v1, index u32 0 -> Field
-                return v3
-            }
-            ";
-        let ssa = Ssa::from_str(src).unwrap();
-        let inputs = vec![
-            Value::bool(false),
-            Value::array(vec![Value::field(1_u128.into())], vec![Type::field()]),
-        ];
-        let (_, result) =
-            assert_pass_does_not_affect_execution(ssa, inputs, Ssa::flatten_basic_conditionals);
-        assert_eq!(result.unwrap(), vec![Value::field(7_u128.into())]);
     }
 
     /// Non-diamond (then-only) case with JmpIf arguments: the optimization must be

--- a/compiler/noirc_evaluator/src/ssa/validation/array_set_rc_invariant.rs
+++ b/compiler/noirc_evaluator/src/ssa/validation/array_set_rc_invariant.rs
@@ -812,14 +812,7 @@ impl<'f> Context<'f> {
         // path to the array_set to be walled by an `inc_rc` on the threaded
         // value or by a fresh allocation of it. See
         // [`Context::value_covered_on_all_paths`].
-        let mut visited: HashSet<(BasicBlockId, ValueId)> = HashSet::default();
-        self.value_covered_on_all_paths(
-            array_set_block,
-            source,
-            array_set_block,
-            Some(array_set_idx),
-            &mut visited,
-        )
+        self.value_covered_on_all_paths(array_set_block, source, array_set_idx)
     }
 
     /// Whether `value` is a fresh allocation whose storage is distinct on
@@ -842,114 +835,116 @@ impl<'f> Context<'f> {
     }
 
     /// Returns `true` if, on **every** control-flow path from the entry block
-    /// to `block`, the storage represented by `value` is protected before
-    /// reaching `block` — i.e. the threaded value is either RC-bumped by an
-    /// `inc_rc` or freshly allocated (`make_array`/`Call`).
+    /// to the array_set, the storage represented by its `source` is protected
+    /// before reaching the array_set — i.e. on each path the threaded value is
+    /// either RC-bumped by an `inc_rc` or an iteration-local fresh allocation
+    /// (`make_array`/`Call` that re-executes each iteration).
     ///
-    /// The walk threads the *exact* value backward: when it crosses a
-    /// block-parameter edge it follows the predecessor's argument, and when it
-    /// reaches an `array_set` result it continues with that `array_set`'s
-    /// `array` operand (the result shares the operand's storage). It thereby
-    /// recognizes path-specific protection that a block-level cut cannot:
-    /// `inc_rc` on one arm of a diamond and a fresh `make_array` on the other
-    /// (the `func_1`/`v20` fuzzer shape).
+    /// Implemented as a backward search for a *witness* of an **un**covered
+    /// path rather than recursion over all paths (the predecessor chain can be
+    /// thousands of blocks deep on large functions, which would risk stack
+    /// exhaustion). Each frame is a `(block, value, seed_idx)`:
     ///
-    /// `seed_idx` is `Some(array_set_idx)` on the initial call and `None`
-    /// afterward: in the array_set's own block only an `inc_rc` *before* the
-    /// array_set protects it, whereas any other block on a path executes fully
-    /// before the array_set, so an `inc_rc` anywhere in it counts.
+    /// - The walk threads the *exact* value backward: across a block-parameter
+    ///   edge it follows the predecessor's argument, and at an `array_set`
+    ///   result it continues with that `array_set`'s `array` operand (the
+    ///   result shares the operand's storage). This recognizes path-specific
+    ///   protection a block-level cut cannot — `inc_rc` on one arm of a diamond
+    ///   and a fresh `make_array` on the other, threaded through a loop (the
+    ///   `func_1`/`v20` fuzzer shape).
+    /// - A wall (`inc_rc` on the value, or an iteration-local fresh allocation)
+    ///   is a covered dead end and is not expanded.
+    /// - `seed_idx` is `Some(array_set_idx)` only for the array_set's own block
+    ///   and `None` for every upstream block: in the array_set's block only an
+    ///   `inc_rc` *before* the array_set protects it, whereas any other block
+    ///   on a path executes fully before the array_set, so an `inc_rc` anywhere
+    ///   in it counts.
+    /// - Reaching the entry block (or any block with no predecessors) with an
+    ///   unwalled value, or a value defined here by an unthreadable instruction
+    ///   (a non-iteration-local allocation, or an `array_get` of a nested
+    ///   array), is an uncovered terminal — return `false`.
+    /// - A revisited `(block, value)` is skipped: a cycle introduces no new
+    ///   entry-originating path, and the forward (pre-header) edges are
+    ///   explored independently.
     ///
-    /// Reaching the entry block (or any block with no predecessors) with an
-    /// unwalled value means the value is a function parameter / live-in whose
-    /// storage may be aliased and has no protection — not covered. Cycles are
-    /// treated as covered for that branch: a back-edge introduces no new
-    /// entry-originating path, and the forward (pre-header) edges are checked
-    /// independently.
-    ///
-    /// Crediting freshness only ever *accepts* more, so it can add
-    /// false-negatives (a freshly-allocated array read back through its own
-    /// name after an in-place mutation — a shape the frontend does not emit)
-    /// but never false-positives.
+    /// If no uncovered terminal is reachable, every path is covered. Crediting
+    /// freshness only ever *accepts* more, so it can add false-negatives (a
+    /// freshly-allocated array read back through its own name after an in-place
+    /// mutation — a shape the frontend does not emit) but never false-positives.
     fn value_covered_on_all_paths(
         &self,
-        block: BasicBlockId,
-        value: ValueId,
         array_set_block: BasicBlockId,
-        seed_idx: Option<usize>,
-        visited: &mut HashSet<(BasicBlockId, ValueId)>,
+        source: ValueId,
+        array_set_idx: usize,
     ) -> bool {
-        if !visited.insert((block, value)) {
-            // Already proven on another branch, or a cycle: introduces no new
-            // entry-originating path.
-            return true;
-        }
+        let mut visited: HashSet<(BasicBlockId, ValueId)> = HashSet::default();
+        let mut worklist: Vec<(BasicBlockId, ValueId, Option<usize>)> =
+            vec![(array_set_block, source, Some(array_set_idx))];
 
-        // Freshness wall: an iteration-local `make_array`/`Call` result is
-        // newly allocated storage on this path, distinct each iteration, so an
-        // in-place mutation of it is never observed through an alias.
-        if self.is_iteration_local_fresh(value, array_set_block) {
-            return true;
-        }
+        while let Some((block, value, seed_idx)) = worklist.pop() {
+            if !visited.insert((block, value)) {
+                continue;
+            }
 
-        // `inc_rc` wall: a bump on the threaded value in this block. In the
-        // array_set's own block (seed), only a bump *before* the array_set
-        // counts; elsewhere the whole block precedes the array_set on the path.
-        if let Some(locations) = self.inc_rc_locations.get(&value) {
-            for &(inc_block, inc_idx) in locations {
-                if inc_block == block && seed_idx.is_none_or(|limit| inc_idx < limit) {
-                    return true;
+            // Freshness wall: an iteration-local `make_array`/`Call` result is
+            // newly allocated storage on this path, distinct each iteration, so
+            // an in-place mutation of it is never observed through an alias.
+            if self.is_iteration_local_fresh(value, array_set_block) {
+                continue;
+            }
+
+            // `inc_rc` wall: a bump on the threaded value in this block.
+            if let Some(locations) = self.inc_rc_locations.get(&value)
+                && locations
+                    .iter()
+                    .any(|&(b, i)| b == block && seed_idx.is_none_or(|limit| i < limit))
+            {
+                continue;
+            }
+
+            // If `value` is defined in this block, the walk stops here (it
+            // cannot flow in from a predecessor).
+            if let Some(&(def_block, def_idx)) = self.array_value_defs.get(&value)
+                && def_block == block
+            {
+                let inst_id = self.function.dfg[block].instructions()[def_idx];
+                // An `array_set` result shares its operand's storage; continue
+                // threading with the operand (defined earlier in this block or
+                // flowing in as a parameter).
+                if let Instruction::ArraySet { array, .. } = self.function.dfg[inst_id] {
+                    worklist.push((block, array, seed_idx));
+                    continue;
                 }
+                // A non-iteration-local allocation or other instruction we
+                // cannot thread: an uncovered terminal.
+                return false;
+            }
+
+            // Flows in from predecessors.
+            let preds: Vec<BasicBlockId> = self.cfg.predecessors(block).collect();
+            if preds.is_empty() {
+                // Reached the entry / a source-less block unwalled: `value` is a
+                // function parameter / live-in with no protection on this path.
+                return false;
+            }
+            // If `value` is a parameter of this block, follow each predecessor's
+            // argument at that position; otherwise the same value flows in from
+            // every predecessor.
+            let params = self.function.dfg.block_parameters(block);
+            let param_pos = params.iter().position(|&p| p == value);
+            for &pred in &preds {
+                let next = match param_pos {
+                    Some(i) => match self.edge_arg(pred, block, i) {
+                        Some(arg) => arg,
+                        None => return false,
+                    },
+                    None => value,
+                };
+                worklist.push((pred, next, None));
             }
         }
 
-        // If `value` is defined in this block, the walk stops here (it cannot
-        // flow in from a predecessor).
-        if let Some(&(def_block, def_idx)) = self.array_value_defs.get(&value)
-            && def_block == block
-        {
-            let inst_id = self.function.dfg[block].instructions()[def_idx];
-            // An `array_set` result shares its operand's storage; continue
-            // threading with the operand (defined earlier in this block or
-            // flowing in as a parameter).
-            if let Instruction::ArraySet { array, .. } = self.function.dfg[inst_id] {
-                return self.value_covered_on_all_paths(
-                    block,
-                    array,
-                    array_set_block,
-                    seed_idx,
-                    visited,
-                );
-            }
-            // Defined here by some other instruction — a `make_array`/`Call`
-            // that is *not* iteration-local (a one-time allocation, handled
-            // above when it is), or an `array_get` of a nested array. We
-            // cannot prove protection — let the forward walk decide.
-            return false;
-        }
-
-        // Not walled and not defined here: `value` flows in from predecessors.
-        let preds: Vec<BasicBlockId> = self.cfg.predecessors(block).collect();
-        if preds.is_empty() {
-            // Reached the entry (or a source-less block): `value` is a function
-            // parameter / live-in with no protecting `inc_rc` or fresh
-            // allocation on this path.
-            return false;
-        }
-        // If `value` is a parameter of this block, follow each predecessor's
-        // argument at that position; otherwise the same value flows in from
-        // every predecessor.
-        let params = self.function.dfg.block_parameters(block);
-        let param_pos = params.iter().position(|&p| p == value);
-        preds.iter().all(|&pred| {
-            let next = match param_pos {
-                Some(i) => match self.edge_arg(pred, block, i) {
-                    Some(arg) => arg,
-                    None => return false,
-                },
-                None => value,
-            };
-            self.value_covered_on_all_paths(pred, next, array_set_block, None, visited)
-        })
+        true
     }
 
     /// The argument passed to parameter position `i` of `dest` on the edge

--- a/compiler/noirc_evaluator/src/ssa/validation/array_set_rc_invariant.rs
+++ b/compiler/noirc_evaluator/src/ssa/validation/array_set_rc_invariant.rs
@@ -39,10 +39,13 @@
 //!    parameter that is freshly re-allocated each iteration, the sibling is a
 //!    distinct per-iteration storage and is dropped (see
 //!    [`Context::swap_excluded_aliases`]).
-//! 2. **inc_rc precedence / back-edge-participant.** If some `inc_rc` on an
-//!    alias-set member either dominates the array_set or sits on a
-//!    non-source alias that's also a loop back-edge arg, accept — the
-//!    frontend is deliberately managing iteration aliasing.
+//! 2. **Per-path protection / back-edge-participant.** Accept if every path
+//!    to the array_set is protected — the source's storage, threaded
+//!    backward, is on each path either RC-bumped by an `inc_rc` or an
+//!    iteration-local fresh allocation (`make_array`/`Call` re-executed each
+//!    iteration). A back-edge-participant `inc_rc` on a non-source alias is
+//!    also accepted (the frontend is deliberately managing iteration
+//!    aliasing). See [`Context::some_inc_rc_precedes`].
 //! 3. **Protected-participant filter.** Before the forward walk, drop from
 //!    the use-set every alias-set member (other than the source) that both
 //!    carries its own `inc_rc` and is a loop back-edge *participant* (it
@@ -116,6 +119,8 @@
 //!   allocates** are likewise not tracked.
 
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
+
+use std::collections::BTreeSet;
 
 use acvm::FieldElement;
 
@@ -228,8 +233,19 @@ struct Context<'f> {
     cfg: ControlFlowGraph,
     /// Dominator tree. Used by [`Context::some_inc_rc_precedes`] as a fast
     /// path: a single `inc_rc` block that dominates the `array_set` covers
-    /// every path without the backward predecessor walk.
+    /// every path without the backward value walk.
     dom_tree: DominatorTree,
+    /// Array values that allocate fresh storage at their definition
+    /// (`make_array` / `Call` results). Used as a freshness wall by
+    /// [`Context::value_covered_on_all_paths`].
+    fresh_array_values: HashSet<ValueId>,
+    /// The block set of each loop in the function. The freshness wall only
+    /// credits a fresh allocation when its defining block and the array_set's
+    /// block lie in a common loop — i.e. the allocation re-executes every
+    /// iteration that reaches the array_set, so its storage is distinct per
+    /// iteration. A one-time allocation outside any shared loop is mutated in
+    /// place exactly once, so reading it back is a genuine hazard.
+    loop_blocks: Vec<BTreeSet<BasicBlockId>>,
     /// For each array-typed value `V`, the set of values that may share
     /// `V`'s storage **at `V`'s program point** — the source itself plus
     /// anything that flows backward into it through block-parameter →
@@ -374,12 +390,14 @@ impl<'f> Context<'f> {
         // which represent fresh-per-iteration storage and so don't
         // carry the array_set's pre-mutation aliasing forward through
         // the loop header.
+        let loops = Loops::find_all(function, LoopOrder::InsideOut);
         let back_edges: HashSet<(BasicBlockId, BasicBlockId)> =
-            Loops::find_all(function, LoopOrder::InsideOut)
-                .yet_to_unroll
-                .iter()
-                .map(|l| (l.back_edge_start, l.header))
-                .collect();
+            loops.yet_to_unroll.iter().map(|l| (l.back_edge_start, l.header)).collect();
+        // The block set of each loop, used by the freshness wall in
+        // [`Context::value_covered_on_all_paths`] to decide whether a fresh
+        // allocation re-executes on every iteration that reaches an array_set.
+        let loop_blocks: Vec<BTreeSet<BasicBlockId>> =
+            loops.yet_to_unroll.iter().map(|l| l.blocks.clone()).collect();
 
         let mut inc_rc_locations: HashMap<ValueId, Vec<(BasicBlockId, usize)>> = HashMap::default();
         let mut array_value_defs: HashMap<ValueId, (BasicBlockId, usize)> = HashMap::default();
@@ -493,6 +511,17 @@ impl<'f> Context<'f> {
             .filter(|v| make_array_values.contains(v) || call_result_values.contains(v))
             .collect();
 
+        // Array values that allocate **fresh** storage at their definition:
+        // `make_array` (a new array) and `Call` results (the callee allocates;
+        // the same heuristic [`Context::non_aliasing_array_values`] makes).
+        // `array_set` results are excluded — they may mutate in place rather
+        // than allocate. Used by the freshness wall in
+        // [`Context::value_covered_on_all_paths`]: storage that is freshly
+        // allocated on a path has no other live alias, so an in-place mutation
+        // there cannot be observed through one.
+        let fresh_array_values: HashSet<ValueId> =
+            make_array_values.union(&call_result_values).copied().collect();
+
         // Swap exclusions. For every loop back-edge `be_start → header`,
         // inspect each array-typed header parameter at `source_pos`: if
         // the back-edge rebinds it to a *sibling* header parameter
@@ -576,6 +605,8 @@ impl<'f> Context<'f> {
             function,
             cfg,
             dom_tree,
+            fresh_array_values,
+            loop_blocks,
             backward_aliases,
             array_value_defs,
             non_aliasing_array_values,
@@ -672,45 +703,51 @@ impl<'f> Context<'f> {
             .collect()
     }
 
-    /// Returns `true` if some `inc_rc r` for an `r ∈ alias_set` exists at a
-    /// program point that precedes the `array_set` on **every** path to it —
-    /// either in a strictly-earlier position within the same block, or in a
-    /// different block that **dominates** the array_set's block.
+    /// Returns `true` if the `array_set` is protected on **every** path to it,
+    /// so the short-circuit can accept it outright and skip the forward
+    /// aliased-read walk. Because acceptance is unconditional, the protection
+    /// must hold on every runtime path: an `inc_rc` that runs on only some
+    /// paths leaves the array_set unprotected (RC 1, mutating in place) on the
+    /// others.
     ///
-    /// # Why dominance, not mere RPO precedence
+    /// # Coverage must be per-path, not "some inc_rc precedes"
     ///
-    /// This short-circuit accepts the array_set outright, skipping the
-    /// forward aliased-read walk, so it must hold on *every* runtime path:
-    /// an `inc_rc` that runs on only some paths leaves the array_set
-    /// unprotected (RC 1, mutating in place) on the others. Dominance is
-    /// exactly that guarantee — the bump is on every path from entry to the
-    /// array_set.
-    ///
-    /// RPO precedence is *not* sufficient: a sibling-branch `inc_rc` has a
-    /// smaller RPO index than the common-successor block holding the
-    /// array_set, yet the other branch reaches the array_set without it.
-    /// That is the
+    /// A sibling-branch `inc_rc` has a smaller RPO index than the
+    /// common-successor block holding the array_set, yet the other branch
+    /// reaches the array_set without it. That is the
     /// `end_to_end_branch_local_inc_rc_does_not_protect_array_set_in_join_is_rejected`
-    /// shape — `inc_rc v1` on the `then` path, `array_set v1` in the join,
-    /// and a read of `v1` after it; on the `else` path the mutation is
-    /// observable and the verifier must reject.
+    /// shape — `inc_rc v1` on the `then` path, `array_set v1` in the join, and
+    /// a read of `v1` after it; on the `else` path the mutation is observable
+    /// and the verifier must reject. So mere flow-order precedence is not
+    /// enough; the bump must be on *every* path.
     ///
-    /// Genuinely path-specific protection (each aliasing path bumps RC, each
-    /// other path allocates fresh — e.g. `brillig_array_ifelse`) does **not**
-    /// rely on this short-circuit. When the short-circuit declines, the
-    /// forward walk runs, and it accepts those cases because the read is of a
-    /// sibling block-parameter the directed alias-set keeps out of the
-    /// source's class (the documented sibling false-negative). Absence of a
-    /// dominating `inc_rc` *combined* with a forward aliased read of an
-    /// alias-set member still flags as a hazard, which is the shape PR-12671
-    /// had. The back-edge-participant relaxation below covers `inc_rc`s
-    /// placed after the array_set, where iteration aliasing makes the bump's
-    /// program point misleading.
+    /// # What counts as protection on a path
+    ///
+    /// The check has two fast acceptances on alias-set members — a same-block
+    /// `inc_rc` *before* the array_set, and an `inc_rc` whose block
+    /// **dominates** the array_set (so it is trivially on every path) — plus
+    /// the back-edge-participant relaxation below. When none fire it threads
+    /// the source's storage backward through the CFG
+    /// ([`Context::value_covered_on_all_paths`]) and requires every path to be
+    /// walled by either:
+    ///
+    /// - an `inc_rc` on the threaded value (RC ≥ 2 ⇒ the array_set copies), or
+    /// - an **iteration-local** fresh allocation of it (a `make_array`/`Call`
+    ///   that re-executes each iteration ⇒ distinct storage with no alias).
+    ///
+    /// This accepts the genuinely path-specific shapes the frontend emits —
+    /// `inc_rc` on one arm of a diamond and a fresh `make_array` on the other,
+    /// threaded through a loop (the `func_1`/`v20` fuzzer case) — that neither
+    /// a single dominating `inc_rc` nor a block-level cut would. A fresh
+    /// allocation *outside* any shared loop is **not** credited: it is a
+    /// one-time storage the array_set mutates once, so reading it back is a
+    /// real hazard the forward walk must still flag
+    /// (`end_to_end_array_set_on_make_array_with_forward_read_is_rejected`).
     ///
     /// # Back-edge-participant relaxation
     ///
-    /// In addition to a dominating `inc_rc`, an `inc_rc` is also accepted
-    /// when it lives on an alias-set member that:
+    /// In addition, an `inc_rc` is also accepted when it lives on an alias-set
+    /// member that:
     ///
     /// - is **not** the array_set's own source (an `inc_rc` on the
     ///   source itself, *after* the array_set, doesn't protect that
@@ -740,12 +777,6 @@ impl<'f> Context<'f> {
         array_set_block: BasicBlockId,
         array_set_idx: usize,
     ) -> bool {
-        // Blocks (other than the array_set's own) that carry a protecting
-        // `inc_rc` on an alias-set member. Any such block, when it lies on a
-        // path to the array_set, fully executes before the array_set, so its
-        // `inc_rc` runs first. Collected here, then tested for coverage below.
-        let mut protection_blocks: HashSet<BasicBlockId> = HashSet::default();
-
         for value in alias_set {
             let Some(locations) = self.inc_rc_locations.get(value) else {
                 continue;
@@ -768,72 +799,184 @@ impl<'f> Context<'f> {
                     if inc_idx < array_set_idx {
                         return true;
                     }
-                } else {
-                    protection_blocks.insert(inc_block);
+                } else if self.dom_tree.dominates(inc_block, array_set_block) {
+                    // Fast path: an `inc_rc` block that dominates the array_set
+                    // is on every path to it. The common case (e.g. an
+                    // `inc_rc` in a loop pre-header).
+                    return true;
                 }
             }
         }
 
-        if protection_blocks.is_empty() {
+        // General case: thread the source's storage backward and require every
+        // path to the array_set to be walled by an `inc_rc` on the threaded
+        // value or by a fresh allocation of it. See
+        // [`Context::value_covered_on_all_paths`].
+        let mut visited: HashSet<(BasicBlockId, ValueId)> = HashSet::default();
+        self.value_covered_on_all_paths(
+            array_set_block,
+            source,
+            array_set_block,
+            Some(array_set_idx),
+            &mut visited,
+        )
+    }
+
+    /// Whether `value` is a fresh allocation whose storage is distinct on
+    /// every iteration that reaches the array_set in `array_set_block` — i.e.
+    /// a `make_array`/`Call` result whose defining block shares a loop with
+    /// `array_set_block`, so it re-executes each iteration. A fresh allocation
+    /// outside any shared loop is a one-time storage that the array_set
+    /// mutates exactly once; reading it back through the same name would
+    /// observe that mutation, so it does **not** count as protection.
+    fn is_iteration_local_fresh(&self, value: ValueId, array_set_block: BasicBlockId) -> bool {
+        if !self.fresh_array_values.contains(&value) {
             return false;
         }
+        let Some(&(def_block, _)) = self.array_value_defs.get(&value) else {
+            return false;
+        };
+        self.loop_blocks
+            .iter()
+            .any(|blocks| blocks.contains(&def_block) && blocks.contains(&array_set_block))
+    }
 
-        // Fast path: a single `inc_rc` block that dominates the array_set is
-        // on every path to it, so it covers the array_set without the
-        // backward predecessor walk. This is the common case (e.g. an
-        // `inc_rc` in a loop pre-header).
-        if protection_blocks.iter().any(|&b| self.dom_tree.dominates(b, array_set_block)) {
+    /// Returns `true` if, on **every** control-flow path from the entry block
+    /// to `block`, the storage represented by `value` is protected before
+    /// reaching `block` — i.e. the threaded value is either RC-bumped by an
+    /// `inc_rc` or freshly allocated (`make_array`/`Call`).
+    ///
+    /// The walk threads the *exact* value backward: when it crosses a
+    /// block-parameter edge it follows the predecessor's argument, and when it
+    /// reaches an `array_set` result it continues with that `array_set`'s
+    /// `array` operand (the result shares the operand's storage). It thereby
+    /// recognizes path-specific protection that a block-level cut cannot:
+    /// `inc_rc` on one arm of a diamond and a fresh `make_array` on the other
+    /// (the `func_1`/`v20` fuzzer shape).
+    ///
+    /// `seed_idx` is `Some(array_set_idx)` on the initial call and `None`
+    /// afterward: in the array_set's own block only an `inc_rc` *before* the
+    /// array_set protects it, whereas any other block on a path executes fully
+    /// before the array_set, so an `inc_rc` anywhere in it counts.
+    ///
+    /// Reaching the entry block (or any block with no predecessors) with an
+    /// unwalled value means the value is a function parameter / live-in whose
+    /// storage may be aliased and has no protection — not covered. Cycles are
+    /// treated as covered for that branch: a back-edge introduces no new
+    /// entry-originating path, and the forward (pre-header) edges are checked
+    /// independently.
+    ///
+    /// Crediting freshness only ever *accepts* more, so it can add
+    /// false-negatives (a freshly-allocated array read back through its own
+    /// name after an in-place mutation — a shape the frontend does not emit)
+    /// but never false-positives.
+    fn value_covered_on_all_paths(
+        &self,
+        block: BasicBlockId,
+        value: ValueId,
+        array_set_block: BasicBlockId,
+        seed_idx: Option<usize>,
+        visited: &mut HashSet<(BasicBlockId, ValueId)>,
+    ) -> bool {
+        if !visited.insert((block, value)) {
+            // Already proven on another branch, or a cycle: introduces no new
+            // entry-originating path.
             return true;
         }
 
-        // General case: no single block dominates, but the protection blocks
-        // may still *collectively* cover every path. The frontend emits one
-        // `inc_rc` per branch of a diamond (e.g. `inc_rc v` on both arms
-        // feeding the join that holds `array_set v`); together those cover
-        // every path even though neither dominates.
-        self.protection_blocks_cover_all_paths(array_set_block, &protection_blocks)
-    }
+        // Freshness wall: an iteration-local `make_array`/`Call` result is
+        // newly allocated storage on this path, distinct each iteration, so an
+        // in-place mutation of it is never observed through an alias.
+        if self.is_iteration_local_fresh(value, array_set_block) {
+            return true;
+        }
 
-    /// Returns `true` if every control-flow path from the entry block to
-    /// `array_set_block` passes through some block in `protection_blocks`.
-    ///
-    /// Walks predecessors backward from `array_set_block`, treating each
-    /// protection block as a wall (its predecessors are not explored, since
-    /// any path through it is already covered). If the walk reaches the
-    /// entry block — or any block with no predecessors — without being
-    /// walled, an unprotected path exists and the array_set is not covered.
-    fn protection_blocks_cover_all_paths(
-        &self,
-        array_set_block: BasicBlockId,
-        protection_blocks: &HashSet<BasicBlockId>,
-    ) -> bool {
-        let entry = self.function.entry_block();
-        // The array_set's own block isn't a protection block here (the
-        // same-block case is handled by the early return above), so an
-        // array_set in the entry block has no protecting predecessor.
-        if array_set_block == entry {
+        // `inc_rc` wall: a bump on the threaded value in this block. In the
+        // array_set's own block (seed), only a bump *before* the array_set
+        // counts; elsewhere the whole block precedes the array_set on the path.
+        if let Some(locations) = self.inc_rc_locations.get(&value) {
+            for &(inc_block, inc_idx) in locations {
+                if inc_block == block && seed_idx.is_none_or(|limit| inc_idx < limit) {
+                    return true;
+                }
+            }
+        }
+
+        // If `value` is defined in this block, the walk stops here (it cannot
+        // flow in from a predecessor).
+        if let Some(&(def_block, def_idx)) = self.array_value_defs.get(&value)
+            && def_block == block
+        {
+            let inst_id = self.function.dfg[block].instructions()[def_idx];
+            // An `array_set` result shares its operand's storage; continue
+            // threading with the operand (defined earlier in this block or
+            // flowing in as a parameter).
+            if let Instruction::ArraySet { array, .. } = self.function.dfg[inst_id] {
+                return self.value_covered_on_all_paths(
+                    block,
+                    array,
+                    array_set_block,
+                    seed_idx,
+                    visited,
+                );
+            }
+            // Defined here by some other instruction — a `make_array`/`Call`
+            // that is *not* iteration-local (a one-time allocation, handled
+            // above when it is), or an `array_get` of a nested array. We
+            // cannot prove protection — let the forward walk decide.
             return false;
         }
 
-        let mut visited: HashSet<BasicBlockId> = HashSet::default();
-        visited.insert(array_set_block);
-        let mut frontier: Vec<BasicBlockId> = self.cfg.predecessors(array_set_block).collect();
-
-        while let Some(block) = frontier.pop() {
-            if !visited.insert(block) {
-                continue;
-            }
-            if protection_blocks.contains(&block) {
-                continue;
-            }
-            let preds = self.cfg.predecessors(block);
-            if block == entry || preds.len() == 0 {
-                // An unprotected path reaches the entry: not covered.
-                return false;
-            }
-            frontier.extend(preds);
+        // Not walled and not defined here: `value` flows in from predecessors.
+        let preds: Vec<BasicBlockId> = self.cfg.predecessors(block).collect();
+        if preds.is_empty() {
+            // Reached the entry (or a source-less block): `value` is a function
+            // parameter / live-in with no protecting `inc_rc` or fresh
+            // allocation on this path.
+            return false;
         }
-        true
+        // If `value` is a parameter of this block, follow each predecessor's
+        // argument at that position; otherwise the same value flows in from
+        // every predecessor.
+        let params = self.function.dfg.block_parameters(block);
+        let param_pos = params.iter().position(|&p| p == value);
+        preds.iter().all(|&pred| {
+            let next = match param_pos {
+                Some(i) => match self.edge_arg(pred, block, i) {
+                    Some(arg) => arg,
+                    None => return false,
+                },
+                None => value,
+            };
+            self.value_covered_on_all_paths(pred, next, array_set_block, None, visited)
+        })
+    }
+
+    /// The argument passed to parameter position `i` of `dest` on the edge
+    /// from `pred`. `None` if `pred`'s terminator does not target `dest` or has
+    /// no argument at that position.
+    fn edge_arg(&self, pred: BasicBlockId, dest: BasicBlockId, i: usize) -> Option<ValueId> {
+        match self.function.dfg[pred].terminator()? {
+            TerminatorInstruction::Jmp { destination, arguments, .. } if *destination == dest => {
+                arguments.get(i).copied()
+            }
+            TerminatorInstruction::JmpIf {
+                then_destination,
+                then_arguments,
+                else_destination,
+                else_arguments,
+                ..
+            } => {
+                if *then_destination == dest {
+                    then_arguments.get(i).copied()
+                } else if *else_destination == dest {
+                    else_arguments.get(i).copied()
+                } else {
+                    None
+                }
+            }
+            _ => None,
+        }
     }
 
     /// Forward CFG walk from after the `array_set` looking for a
@@ -1946,6 +2089,51 @@ mod tests {
             src,
             "inc_rc v1 on both arms collectively cover every path to the array_set; \
              neither dominates b3 alone, but together they form a cut",
+        );
+    }
+
+    /// Path-specific protection mixing `inc_rc` and freshness across a loop.
+    /// The loop body block b5 holds `array_set v7` on its parameter and reads
+    /// `v7` (on the next iteration, via the back-edge). `v7` is fed by two
+    /// arms: b2 passes the loop-invariant `v1` after an `inc_rc v1`, while b3
+    /// passes a freshly allocated `make_array`. On every path the storage
+    /// `array_set v7` may mutate is either RC-bumped (`v1` via b2) or freshly
+    /// allocated this iteration (`v4` via b3), so no read ever observes an
+    /// in-place mutation through an alias. The verifier must accept.
+    ///
+    /// This is the minimized crux of a `comptime_vs_brillig_direct` fuzzer
+    /// case. It is the reason a coverage check that only recognizes `inc_rc`
+    /// blocks is insufficient: the b3 arm carries no `inc_rc`, only a fresh
+    /// allocation, so freshness must count as protection on that path.
+    #[test]
+    fn end_to_end_loop_param_protected_by_inc_rc_and_freshness_on_alternate_arms_is_accepted() {
+        let src = r#"
+            brillig(inline) fn main f0 {
+              b0(v0: u1, v1: [Field; 1]):
+                jmp b1(u32 0)
+              b1(v2: u32):
+                v3 = eq v2, u32 5
+                jmpif v3 then: b6(), else: b4()
+              b4():
+                jmpif v0 then: b2(), else: b3()
+              b2():
+                inc_rc v1
+                jmp b5(v1)
+              b3():
+                v4 = make_array [Field 0] : [Field; 1]
+                jmp b5(v4)
+              b5(v7: [Field; 1]):
+                v8 = array_get v7, index u32 0 -> Field
+                v9 = array_set v7, index u32 0, value Field 7
+                v10 = add v2, u32 1
+                jmp b1(v10)
+              b6():
+                return
+            }"#;
+        assert_verifier_accepts_because(
+            src,
+            "every path to array_set v7 either bumps RC (inc_rc v1 on the b2 arm) or \
+             allocates fresh storage (make_array on the b3 arm)",
         );
     }
 

--- a/compiler/noirc_evaluator/src/ssa/validation/array_set_rc_invariant.rs
+++ b/compiler/noirc_evaluator/src/ssa/validation/array_set_rc_invariant.rs
@@ -395,6 +395,16 @@ struct Context<'f> {
     /// requirement on `Q` is the second guard — a loop-invariant `Q`
     /// swapped into `P` would make `P_k = Q_{k-1} = Q_k` and genuinely
     /// alias.
+    ///
+    /// **Forward propagation.** After recording, exclusions are pushed
+    /// forward across non-back-edge parameter edges to a fixed point: on a
+    /// forward edge `R ← P`, `R` *is* `P` within the same iteration, so `R`
+    /// inherits `P`'s exclusions. This carries an exclusion from a swapped
+    /// loop-header parameter onto a successor parameter seeded from it — e.g.
+    /// an inner-loop header (the array_set's source) fed from the swapped
+    /// outer-loop parameter — so `Q` is dropped for the inner source too.
+    /// Back-edges are excluded from propagation: across one, `R` is a *prior*
+    /// iteration's `P`, a distinct storage.
     swap_excluded_aliases: HashMap<ValueId, HashSet<ValueId>>,
 }
 
@@ -624,6 +634,41 @@ impl<'f> Context<'f> {
                     continue;
                 }
                 swap_excluded_aliases.entry(source_param).or_default().insert(sibling);
+            }
+        }
+
+        // Propagate swap exclusions forward across non-back-edge
+        // block-parameter edges. On a forward edge `P ← A`, `P` is `A` within
+        // the same iteration, so `P`'s storage is `A`'s storage; a sibling
+        // distinct from `A`'s per-iteration storage is therefore distinct from
+        // `P`'s too. This carries an exclusion recorded on a loop-header
+        // parameter to a successor parameter seeded from it — e.g. an
+        // inner-loop header (the array_set source) fed from the swapped
+        // outer-loop parameter — so `alias_set_for` drops the sibling for the
+        // inner source as well. Back-edges are excluded: across one, `P` is a
+        // *prior* iteration's `A`, a distinct storage.
+        let mut changed = true;
+        while changed {
+            changed = false;
+            for (dest, edges) in &incoming_edges {
+                let params = function.dfg.block_parameters(*dest);
+                for (i, &param) in params.iter().enumerate() {
+                    for (pred, args) in edges {
+                        if back_edges.contains(&(*pred, *dest)) {
+                            continue;
+                        }
+                        let Some(&arg) = args.get(i) else { continue };
+                        let Some(arg_excl) = swap_excluded_aliases.get(&arg).cloned() else {
+                            continue;
+                        };
+                        let entry = swap_excluded_aliases.entry(param).or_default();
+                        for x in arg_excl {
+                            if x != param && entry.insert(x) {
+                                changed = true;
+                            }
+                        }
+                    }
+                }
             }
         }
 
@@ -2208,6 +2253,84 @@ mod tests {
             "the read is of v2, an inc_rc-covered alias of the source; only the \
              uncovered members (v3/v1) belong in the forward walk's use-set",
         );
+    }
+
+    /// Swap exclusion must reach an inner-loop array_set seeded from the
+    /// swapped outer-loop parameter. The outer loop (header b1) rotates its
+    /// array params on the back-edge — `a ← b` while `b ← make_array` — so the
+    /// swap filter records `b` (v4) as excluded from `a` (v3): they are
+    /// distinct per-iteration storage. The inner loop's parameter `c` (v7) is
+    /// seeded from `a` on the forward edge b2→b3, and the inner body does
+    /// `array_set c` and then reads `b`. Because `c = a` within the iteration,
+    /// `b` is distinct from `c` too, so the read is never a hazard. The
+    /// verifier must accept — which requires the swap exclusion on `a` to
+    /// propagate forward onto `c`.
+    ///
+    /// This is the minimized crux of a `comptime_vs_brillig_direct` fuzzer
+    /// false-positive (confirmed valid via `--release`): without the forward
+    /// propagation, `b` stays in `c`'s alias-set and the `array_get b` is
+    /// wrongly flagged.
+    #[test]
+    fn end_to_end_swap_exclusion_propagates_to_inner_loop_source_is_accepted() {
+        let src = r#"
+            brillig(inline) fn main f0 {
+              b0(v0: u1):
+                v1 = make_array [Field 0] : [Field; 1]
+                v2 = make_array [Field 1] : [Field; 1]
+                jmp b1(v1, v2, u32 0)
+              b1(v3: [Field; 1], v4: [Field; 1], v5: u32):
+                v6 = lt v5, u32 3
+                jmpif v6 then: b2(), else: b8()
+              b2():
+                jmp b3(v3, u32 0)
+              b3(v7: [Field; 1], v8: u32):
+                v9 = lt v8, u32 3
+                jmpif v9 then: b4(), else: b6()
+              b4():
+                v10 = array_set v7, index u32 0, value Field 7
+                v11 = array_get v4, index u32 0 -> Field
+                v12 = add v8, u32 1
+                jmp b3(v10, v12)
+              b6():
+                v14 = make_array [Field 2] : [Field; 1]
+                v15 = add v5, u32 1
+                jmp b1(v4, v14, v15)
+              b8():
+                return
+            }"#;
+        assert_verifier_accepts_because(
+            src,
+            "b (v4) is swap-excluded from a (v3); a is forwarded to the inner-loop \
+             source c (v7), so the exclusion must propagate and the array_get v4 is safe",
+        );
+    }
+
+    /// The linear analog of `make_array_with_forward_read` but via a `Call`
+    /// result: `v2 = v1 = v0` is the same fresh call-allocated storage,
+    /// `array_set v2` mutates it in place, and `array_get v1` reads it back —
+    /// a genuine hazard. A `Call` result must NOT be blanket-credited as
+    /// distinct-per-iteration freshness (it is one-time storage here), so the
+    /// verifier must reject, exactly as it does for the `make_array` analog.
+    #[test]
+    fn end_to_end_call_result_aliased_via_forward_block_param_with_forward_read_is_rejected() {
+        let src = r#"
+            brillig(inline) fn main f0 {
+              b0():
+                v0 = call f1() -> [Field; 1]
+                jmp b1(v0)
+              b1(v1: [Field; 1]):
+                jmp b2(v1)
+              b2(v2: [Field; 1]):
+                v3 = array_set v2, index u32 0, value Field 7
+                v4 = array_get v1, index u32 0 -> Field
+                return v4
+            }
+            brillig(inline) fn alloc f1 {
+              b0():
+                v0 = make_array [Field 0] : [Field; 1]
+                return v0
+            }"#;
+        assert_verifier_rejects(src);
     }
 
     /// Index-aware filter: a constant-index `array_set` followed by a

--- a/compiler/noirc_evaluator/src/ssa/validation/array_set_rc_invariant.rs
+++ b/compiler/noirc_evaluator/src/ssa/validation/array_set_rc_invariant.rs
@@ -176,11 +176,15 @@ fn verify_function(function: &Function) -> RtResult<()> {
 
             let alias_set = ctx.alias_set_for(array, block_id, idx);
 
-            // Cheap check first: if any `inc_rc` on an alias-set member
-            // dominates this `array_set`, treat the aliasing as already
-            // protected on every path. See `some_inc_rc_precedes` for the
-            // rationale (dominance, plus a back-edge-participant relaxation).
-            if ctx.some_inc_rc_precedes(&alias_set, array, block_id, idx) {
+            // Narrow the alias-set to the members that are *not* provably
+            // protected on every path to this `array_set`. An empty result
+            // means every member is RC-bumped or freshly allocated before the
+            // array_set on all paths, so the in-place mutation is never
+            // observable — accept without the forward walk. A covered member
+            // (e.g. an `inc_rc`'d sibling) is dropped so the forward walk does
+            // not falsely flag a read of storage the array_set never mutates.
+            let use_set = ctx.unprotected_aliases(&alias_set, array, block_id, idx);
+            if use_set.is_empty() {
                 continue;
             }
 
@@ -195,7 +199,7 @@ fn verify_function(function: &Function) -> RtResult<()> {
             // (RC=1) and a downstream instruction will observe the
             // pre-mutation contents through an aliased name.
             if let Some(hit) = ctx.find_reachable_aliased_use(
-                &alias_set,
+                &use_set,
                 array,
                 *instruction_id,
                 block_id,
@@ -703,73 +707,63 @@ impl<'f> Context<'f> {
             .collect()
     }
 
-    /// Returns `true` if the `array_set` is protected on **every** path to it,
-    /// so the short-circuit can accept it outright and skip the forward
-    /// aliased-read walk. Because acceptance is unconditional, the protection
-    /// must hold on every runtime path: an `inc_rc` that runs on only some
-    /// paths leaves the array_set unprotected (RC 1, mutating in place) on the
-    /// others.
+    /// The subset of `alias_set` whose members are **not** provably protected
+    /// on every path to the `array_set` — the use-set the forward walk must
+    /// check. An empty result means every member is protected, so the
+    /// `array_set` can be accepted without the forward walk.
     ///
-    /// # Coverage must be per-path, not "some inc_rc precedes"
+    /// A member is dropped (provably protected) when, on every runtime path,
+    /// the storage it represents is either RC-bumped by an `inc_rc` (so the
+    /// array_set copies) or an iteration-local fresh allocation (so it has no
+    /// other live alias). Dropping covered members is what stops the forward
+    /// walk from flagging a read of an `inc_rc`'d sibling on a path where the
+    /// array_set never mutates that storage (the alias-set-merging
+    /// false-positive). Keeping the uncovered members preserves real hazards,
+    /// such as the issue SSA where the source itself is uncovered and read
+    /// after the array_set.
+    fn unprotected_aliases(
+        &self,
+        alias_set: &im::HashSet<ValueId>,
+        source: ValueId,
+        array_set_block: BasicBlockId,
+        array_set_idx: usize,
+    ) -> im::HashSet<ValueId> {
+        // Fast full-accept short-circuits cover the whole array_set at once.
+        if self.some_inc_rc_precedes(alias_set, source, array_set_block, array_set_idx) {
+            return im::HashSet::new();
+        }
+        // Otherwise compute per-member coverage and keep only uncovered members.
+        let uncovered = self.compute_uncovered_values(source, array_set_block, array_set_idx);
+        alias_set.iter().copied().filter(|m| uncovered.contains(m)).collect()
+    }
+
+    /// Fast, whole-array_set acceptance predicate: returns `true` when some
+    /// `inc_rc` on an alias-set member protects the `array_set` on **every**
+    /// path. This is the cheap common case; per-path coverage that this misses
+    /// (e.g. `inc_rc` on one arm and a fresh allocation on the other) is
+    /// handled by [`Context::compute_uncovered_values`].
     ///
-    /// A sibling-branch `inc_rc` has a smaller RPO index than the
-    /// common-successor block holding the array_set, yet the other branch
-    /// reaches the array_set without it. That is the
-    /// `end_to_end_branch_local_inc_rc_does_not_protect_array_set_in_join_is_rejected`
-    /// shape — `inc_rc v1` on the `then` path, `array_set v1` in the join, and
-    /// a read of `v1` after it; on the `else` path the mutation is observable
-    /// and the verifier must reject. So mere flow-order precedence is not
-    /// enough; the bump must be on *every* path.
+    /// Three acceptances, each sound on every path:
     ///
-    /// # What counts as protection on a path
+    /// - **Same-block, before the array_set.** The block is on every path to
+    ///   its own array_set, so an earlier `inc_rc` always runs first.
+    /// - **Dominating block.** An `inc_rc` whose block dominates the array_set
+    ///   is on every path to it (e.g. an `inc_rc` in a loop pre-header).
+    /// - **Back-edge-participant relaxation.** An `inc_rc` on a *non-source*
+    ///   alias that appears as a jmp/jmpif arg on a loop **back-edge** is taken
+    ///   as a codegen signal regardless of program-point order: the frontend
+    ///   is deliberately managing iteration aliasing, and the bump's program
+    ///   point can come *after* the array_set — it is the back-edge thread-back
+    ///   that delivers the protection to the next iteration. Forward-edge cases
+    ///   don't need this because [`Context::backward_aliases`] keeps the
+    ///   forward-edge value out of the source's alias-set in the first place.
     ///
-    /// The check has two fast acceptances on alias-set members — a same-block
-    /// `inc_rc` *before* the array_set, and an `inc_rc` whose block
-    /// **dominates** the array_set (so it is trivially on every path) — plus
-    /// the back-edge-participant relaxation below. When none fire it threads
-    /// the source's storage backward through the CFG
-    /// ([`Context::value_covered_on_all_paths`]) and requires every path to be
-    /// walled by either:
+    /// Mere RPO precedence is *not* one of these: a sibling-branch `inc_rc`
+    /// precedes in RPO yet the other branch reaches the array_set without it
+    /// (`end_to_end_branch_local_inc_rc_does_not_protect_array_set_in_join_is_rejected`).
     ///
-    /// - an `inc_rc` on the threaded value (RC ≥ 2 ⇒ the array_set copies), or
-    /// - an **iteration-local** fresh allocation of it (a `make_array`/`Call`
-    ///   that re-executes each iteration ⇒ distinct storage with no alias).
-    ///
-    /// This accepts the genuinely path-specific shapes the frontend emits —
-    /// `inc_rc` on one arm of a diamond and a fresh `make_array` on the other,
-    /// threaded through a loop (the `func_1`/`v20` fuzzer case) — that neither
-    /// a single dominating `inc_rc` nor a block-level cut would. A fresh
-    /// allocation *outside* any shared loop is **not** credited: it is a
-    /// one-time storage the array_set mutates once, so reading it back is a
-    /// real hazard the forward walk must still flag
-    /// (`end_to_end_array_set_on_make_array_with_forward_read_is_rejected`).
-    ///
-    /// # Back-edge-participant relaxation
-    ///
-    /// In addition, an `inc_rc` is also accepted when it lives on an alias-set
-    /// member that:
-    ///
-    /// - is **not** the array_set's own source (an `inc_rc` on the
-    ///   source itself, *after* the array_set, doesn't protect that
-    ///   array_set — it would be suspicious frontend output rather
-    ///   than a signal); and
-    /// - appears as a jmp/jmpif arg on a loop **back-edge** somewhere
-    ///   in the function ([`Context::back_edge_args`]).
-    ///
-    /// The intuition: when the frontend emits an `inc_rc` on a
-    /// non-source alias that's threaded back through a loop, it's
-    /// deliberately managing iteration aliasing. The bump's program
-    /// point can come *after* the array_set in source order — it's
-    /// the back-edge thread-back that delivers the protection to the
-    /// next iteration. Forward-edge cases (e.g. re-seeding a value
-    /// with a global on a non-loop branch) don't need this relaxation
-    /// because [`Context::backward_aliases`] is precise enough to keep
-    /// the forward-edge value out of the source's alias-set in the
-    /// first place.
-    ///
-    /// Well-formed SSA contains no `DecrementRc`, so we don't need to
-    /// worry about a `dec_rc` intervening between the `inc_rc` and the
-    /// `array_set`.
+    /// Well-formed SSA contains no `DecrementRc`, so we don't need to worry
+    /// about a `dec_rc` intervening between the `inc_rc` and the `array_set`.
     fn some_inc_rc_precedes(
         &self,
         alias_set: &im::HashSet<ValueId>,
@@ -781,38 +775,20 @@ impl<'f> Context<'f> {
             let Some(locations) = self.inc_rc_locations.get(value) else {
                 continue;
             };
-            // Back-edge-participant relaxation: an `inc_rc` on a
-            // non-source alias that's also a loop back-edge arg is a
-            // codegen signal regardless of program-point order. The
-            // backward-alias walk already handles forward-edge
-            // threading precisely (the forward-edge value simply isn't
-            // in the source's backward set), so this relaxation only
-            // needs to cover back-edge iteration aliasing.
             if *value != source && self.back_edge_args.contains(value) {
                 return true;
             }
             for &(inc_block, inc_idx) in locations {
                 if inc_block == array_set_block {
-                    // Same block: protects every path iff it is strictly
-                    // earlier than the array_set (the block is on every
-                    // path to its own array_set).
                     if inc_idx < array_set_idx {
                         return true;
                     }
                 } else if self.dom_tree.dominates(inc_block, array_set_block) {
-                    // Fast path: an `inc_rc` block that dominates the array_set
-                    // is on every path to it. The common case (e.g. an
-                    // `inc_rc` in a loop pre-header).
                     return true;
                 }
             }
         }
-
-        // General case: thread the source's storage backward and require every
-        // path to the array_set to be walled by an `inc_rc` on the threaded
-        // value or by a fresh allocation of it. See
-        // [`Context::value_covered_on_all_paths`].
-        self.value_covered_on_all_paths(array_set_block, source, array_set_idx)
+        false
     }
 
     /// Whether `value` is a fresh allocation whose storage is distinct on
@@ -834,117 +810,155 @@ impl<'f> Context<'f> {
             .any(|blocks| blocks.contains(&def_block) && blocks.contains(&array_set_block))
     }
 
-    /// Returns `true` if, on **every** control-flow path from the entry block
-    /// to the array_set, the storage represented by its `source` is protected
-    /// before reaching the array_set — i.e. on each path the threaded value is
-    /// either RC-bumped by an `inc_rc` or an iteration-local fresh allocation
-    /// (`make_array`/`Call` that re-executes each iteration).
+    /// The set of values that lie on at least one **uncovered** backward path
+    /// from the array_set — a path on which the threaded source storage reaches
+    /// a function parameter / unthreadable root without crossing an `inc_rc` or
+    /// iteration-local-fresh wall. The caller intersects this with the
+    /// alias-set to obtain the forward walk's use-set; an empty intersection
+    /// means every member is protected, so the array_set is accepted.
     ///
-    /// Implemented as a backward search for a *witness* of an **un**covered
-    /// path rather than recursion over all paths (the predecessor chain can be
-    /// thousands of blocks deep on large functions, which would risk stack
-    /// exhaustion). Each frame is a `(block, value, seed_idx)`:
+    /// The walk threads the *exact* source storage backward: across a
+    /// block-parameter edge it follows the predecessor's argument, and at an
+    /// `array_set` result it continues with that `array_set`'s `array` operand
+    /// (the result shares the operand's storage). This recognizes path-specific
+    /// protection a block-level cut cannot — `inc_rc` on one arm of a diamond
+    /// and a fresh `make_array` on the other, threaded through a loop (the
+    /// `func_1`/`v20` fuzzer shape).
     ///
-    /// - The walk threads the *exact* value backward: across a block-parameter
-    ///   edge it follows the predecessor's argument, and at an `array_set`
-    ///   result it continues with that `array_set`'s `array` operand (the
-    ///   result shares the operand's storage). This recognizes path-specific
-    ///   protection a block-level cut cannot — `inc_rc` on one arm of a diamond
-    ///   and a fresh `make_array` on the other, threaded through a loop (the
-    ///   `func_1`/`v20` fuzzer shape).
-    /// - A wall (`inc_rc` on the value, or an iteration-local fresh allocation)
-    ///   is a covered dead end and is not expanded.
-    /// - `seed_idx` is `Some(array_set_idx)` only for the array_set's own block
-    ///   and `None` for every upstream block: in the array_set's block only an
-    ///   `inc_rc` *before* the array_set protects it, whereas any other block
-    ///   on a path executes fully before the array_set, so an `inc_rc` anywhere
-    ///   in it counts.
-    /// - Reaching the entry block (or any block with no predecessors) with an
-    ///   unwalled value, or a value defined here by an unthreadable instruction
-    ///   (a non-iteration-local allocation, or an `array_get` of a nested
-    ///   array), is an uncovered terminal — return `false`.
-    /// - A revisited `(block, value)` is skipped: a cycle introduces no new
-    ///   entry-originating path, and the forward (pre-header) edges are
-    ///   explored independently.
+    /// It is computed over the `(block, value)` threading graph in two phases,
+    /// iteratively (the predecessor chain can be thousands of blocks deep on
+    /// large functions, which recursion would risk overflowing):
     ///
-    /// If no uncovered terminal is reachable, every path is covered. Crediting
-    /// freshness only ever *accepts* more, so it can add false-negatives (a
-    /// freshly-allocated array read back through its own name after an in-place
-    /// mutation — a shape the frontend does not emit) but never false-positives.
-    fn value_covered_on_all_paths(
+    /// 1. **Build.** From the seed `(array_set_block, source)`, expand each
+    ///    state to its backward successors. A wall (`inc_rc` on the value, or
+    ///    an iteration-local fresh allocation) is a covered sink. Reaching a
+    ///    block with no predecessors, or a value defined by an unthreadable
+    ///    instruction (a non-iteration-local allocation, or an `array_get` of a
+    ///    nested array), or an edge whose argument can't be resolved, is an
+    ///    *uncovered terminal*. `seed_idx` limits the `inc_rc` wall to bumps
+    ///    *before* the array_set in its own block; any other block on a path
+    ///    executes fully before the array_set, so an `inc_rc` anywhere in it
+    ///    counts.
+    /// 2. **Propagate.** A state is uncovered if it is an uncovered terminal or
+    ///    has an uncovered successor; iterate to a fixed point. A cycle with no
+    ///    uncovered terminal stays covered (a back-edge introduces no new
+    ///    entry-originating path).
+    ///
+    /// Crediting freshness only ever shrinks the use-set, so it can add
+    /// false-negatives (a freshly-allocated array read back through its own
+    /// name after an in-place mutation — a shape the frontend does not emit)
+    /// but never false-positives.
+    fn compute_uncovered_values(
         &self,
-        array_set_block: BasicBlockId,
         source: ValueId,
+        array_set_block: BasicBlockId,
         array_set_idx: usize,
-    ) -> bool {
-        let mut visited: HashSet<(BasicBlockId, ValueId)> = HashSet::default();
+    ) -> HashSet<ValueId> {
+        struct Node {
+            successors: Vec<(BasicBlockId, ValueId)>,
+            uncovered_terminal: bool,
+        }
+
+        // Phase 1: build the backward threading graph.
+        let mut graph: HashMap<(BasicBlockId, ValueId), Node> = HashMap::default();
         let mut worklist: Vec<(BasicBlockId, ValueId, Option<usize>)> =
             vec![(array_set_block, source, Some(array_set_idx))];
 
         while let Some((block, value, seed_idx)) = worklist.pop() {
-            if !visited.insert((block, value)) {
+            if graph.contains_key(&(block, value)) {
                 continue;
             }
 
-            // Freshness wall: an iteration-local `make_array`/`Call` result is
-            // newly allocated storage on this path, distinct each iteration, so
-            // an in-place mutation of it is never observed through an alias.
+            // Wall: an iteration-local `make_array`/`Call` result is newly
+            // allocated storage on this path, distinct each iteration.
             if self.is_iteration_local_fresh(value, array_set_block) {
+                graph
+                    .insert((block, value), Node { successors: vec![], uncovered_terminal: false });
                 continue;
             }
 
-            // `inc_rc` wall: a bump on the threaded value in this block.
+            // Wall: an `inc_rc` on the threaded value in this block.
             if let Some(locations) = self.inc_rc_locations.get(&value)
                 && locations
                     .iter()
                     .any(|&(b, i)| b == block && seed_idx.is_none_or(|limit| i < limit))
             {
+                graph
+                    .insert((block, value), Node { successors: vec![], uncovered_terminal: false });
                 continue;
             }
 
-            // If `value` is defined in this block, the walk stops here (it
-            // cannot flow in from a predecessor).
+            // If `value` is defined in this block, the walk stops here.
             if let Some(&(def_block, def_idx)) = self.array_value_defs.get(&value)
                 && def_block == block
             {
                 let inst_id = self.function.dfg[block].instructions()[def_idx];
                 // An `array_set` result shares its operand's storage; continue
-                // threading with the operand (defined earlier in this block or
-                // flowing in as a parameter).
+                // threading with the operand.
                 if let Instruction::ArraySet { array, .. } = self.function.dfg[inst_id] {
+                    graph.insert(
+                        (block, value),
+                        Node { successors: vec![(block, array)], uncovered_terminal: false },
+                    );
                     worklist.push((block, array, seed_idx));
                     continue;
                 }
                 // A non-iteration-local allocation or other instruction we
                 // cannot thread: an uncovered terminal.
-                return false;
+                graph.insert((block, value), Node { successors: vec![], uncovered_terminal: true });
+                continue;
             }
 
             // Flows in from predecessors.
             let preds: Vec<BasicBlockId> = self.cfg.predecessors(block).collect();
             if preds.is_empty() {
-                // Reached the entry / a source-less block unwalled: `value` is a
-                // function parameter / live-in with no protection on this path.
-                return false;
+                // Reached the entry / a source-less block unwalled.
+                graph.insert((block, value), Node { successors: vec![], uncovered_terminal: true });
+                continue;
             }
             // If `value` is a parameter of this block, follow each predecessor's
             // argument at that position; otherwise the same value flows in from
             // every predecessor.
             let params = self.function.dfg.block_parameters(block);
             let param_pos = params.iter().position(|&p| p == value);
+            let mut successors = Vec::new();
+            let mut uncovered_terminal = false;
             for &pred in &preds {
                 let next = match param_pos {
                     Some(i) => match self.edge_arg(pred, block, i) {
                         Some(arg) => arg,
-                        None => return false,
+                        // An unresolvable edge argument: conservatively treat
+                        // as uncovered rather than silently dropping the path.
+                        None => {
+                            uncovered_terminal = true;
+                            continue;
+                        }
                     },
                     None => value,
                 };
+                successors.push((pred, next));
                 worklist.push((pred, next, None));
+            }
+            graph.insert((block, value), Node { successors, uncovered_terminal });
+        }
+
+        // Phase 2: propagate "uncovered" from terminals to a fixed point.
+        let mut uncovered: HashSet<(BasicBlockId, ValueId)> =
+            graph.iter().filter(|(_, n)| n.uncovered_terminal).map(|(k, _)| *k).collect();
+        let mut changed = true;
+        while changed {
+            changed = false;
+            for (state, node) in &graph {
+                if !uncovered.contains(state)
+                    && node.successors.iter().any(|s| uncovered.contains(s))
+                {
+                    uncovered.insert(*state);
+                    changed = true;
+                }
             }
         }
 
-        true
+        uncovered.into_iter().map(|(_, value)| value).collect()
     }
 
     /// The argument passed to parameter position `i` of `dest` on the edge
@@ -2129,6 +2143,45 @@ mod tests {
             src,
             "every path to array_set v7 either bumps RC (inc_rc v1 on the b2 arm) or \
              allocates fresh storage (make_array on the b3 arm)",
+        );
+    }
+
+    /// A covered alias that flows into the source must be dropped from the
+    /// forward walk's use-set, not flagged. `v3` (the array_set source) is fed
+    /// by `v2` on the b1 arm — where `v2` is `inc_rc`'d, so on that arm the
+    /// array_set copies and `v2` is never mutated — and by the function
+    /// parameter `v1` on the b2 arm (uncovered). The later `array_get v2` reads
+    /// the *covered* sibling: on the arm where `v3 = v2` the bump protects it,
+    /// and on the arm where `v3 = v1` the array_set mutates `v1`, not `v2`. So
+    /// the read is never a hazard and the verifier must accept — even though
+    /// `v2` is in the source's alias-set and is read after the array_set.
+    ///
+    /// This is the minimized crux of a `comptime_vs_brillig_direct` fuzzer
+    /// case. Seeding the forward walk with the *whole* alias-set (including the
+    /// covered `v2`) would falsely flag the `array_get v2`; keeping only the
+    /// uncovered members (`v3`/`v1`) avoids it. The source's own b2 arm stays
+    /// uncovered, so `some_inc_rc_precedes` does not accept the array_set
+    /// outright — the per-member coverage is what makes the difference.
+    #[test]
+    fn end_to_end_inc_rc_covered_alias_read_after_array_set_is_dropped_and_accepted() {
+        let src = r#"
+            brillig(inline) fn main f0 {
+              b0(v0: u1, v1: [Field; 1], v2: [Field; 1]):
+                jmpif v0 then: b1(), else: b2()
+              b1():
+                inc_rc v2
+                jmp b3(v2)
+              b2():
+                jmp b3(v1)
+              b3(v3: [Field; 1]):
+                v5 = array_set v3, index u32 0, value Field 7
+                v6 = array_get v2, index u32 0 -> Field
+                return v6
+            }"#;
+        assert_verifier_accepts_because(
+            src,
+            "the read is of v2, an inc_rc-covered alias of the source; only the \
+             uncovered members (v3/v1) belong in the forward walk's use-set",
         );
     }
 

--- a/compiler/noirc_evaluator/src/ssa/validation/array_set_rc_invariant.rs
+++ b/compiler/noirc_evaluator/src/ssa/validation/array_set_rc_invariant.rs
@@ -39,15 +39,26 @@
 //!    parameter that is freshly re-allocated each iteration, the sibling is a
 //!    distinct per-iteration storage and is dropped (see
 //!    [`Context::swap_excluded_aliases`]).
-//! 2. **Per-path protection / back-edge-participant.** Accept if every path
-//!    to the array_set is protected — the source's storage, threaded
-//!    backward, is on each path either RC-bumped by an `inc_rc` or an
-//!    iteration-local fresh allocation (`make_array`/`Call` re-executed each
-//!    iteration). A back-edge-participant `inc_rc` on a non-source alias is
-//!    also accepted (the frontend is deliberately managing iteration
-//!    aliasing). See [`Context::some_inc_rc_precedes`].
-//! 3. **Protected-participant filter.** Before the forward walk, drop from
-//!    the use-set every alias-set member (other than the source) that both
+//! 2. **Fast full-accept.** Accept the array_set outright (skipping the
+//!    forward walk) when some `inc_rc` on an alias-set member protects it on
+//!    every path by a cheap test: an `inc_rc` earlier in the array_set's own
+//!    block, in a block that **dominates** it, or — for a non-source alias —
+//!    on a loop **back-edge** (the back-edge-participant relaxation, where the
+//!    frontend is deliberately managing iteration aliasing). See
+//!    [`Context::some_inc_rc_precedes`].
+//! 3. **Per-member coverage → use-set.** Otherwise narrow the alias-set to the
+//!    members that are *not* provably protected, and seed the forward walk
+//!    with only those ([`Context::unprotected_aliases`]). Coverage is per
+//!    member: thread the source's storage backward through the CFG
+//!    ([`Context::compute_uncovered_values`]) and drop a member when, on every
+//!    path where it can be the source's storage at the array_set, that storage
+//!    is RC-bumped by an `inc_rc` or is an iteration-local fresh allocation (a
+//!    `MakeArray`/`Call` re-executed each loop iteration). Dropping covered
+//!    members is what stops the forward walk from flagging a read of, say, an
+//!    `inc_rc`'d sibling on a path where the array_set never mutates that
+//!    storage. An empty use-set means every member is protected — accept.
+//! 4. **Protected-participant filter.** A second narrowing inside the forward
+//!    walk: drop every use-set member (other than the source) that both
 //!    carries its own `inc_rc` and is a loop back-edge *participant* (it
 //!    flows — directly or through forward edges — into a back-edge arg
 //!    position). Being in the alias-set means the value flows *into* the
@@ -67,8 +78,8 @@
 //!    shape (an `inc_rc v` placed before `v` is threaded *forward* into the
 //!    latch that then closes the loop) without the unsoundness of crediting
 //!    an `inc_rc` to a value the array_set actually mutates first.
-//! 4. **Forward walk.** Otherwise, walk the CFG forward from the array_set with
-//!    the (filtered) alias-set as the initial use-set. At each block-parameter
+//! 5. **Forward walk.** Walk the CFG forward from the array_set with the
+//!    use-set as the initial set of live aliases. At each block-parameter
 //!    crossing we both **kill** params that the predecessor rebinds to a
 //!    non-alias and **add** params whose arg is still an alias (so alias
 //!    propagation stays accurate as the walk crosses joins and loops). The
@@ -117,6 +128,17 @@
 //! - **Nested-array `MakeArray`**, **`IfElse` on arrays**, **non-inlined
 //!   `Call` returns**, and **`Store`/`Load` on ineligible (nested-ref)
 //!   allocates** are likewise not tracked.
+//! - **Iteration-local fresh array read back within one iteration.** The
+//!   freshness wall (step 3) credits a `MakeArray`/`Call` that shares a loop
+//!   with the array_set as distinct per-iteration storage, which is sound
+//!   only because the result is normally threaded forward rather than the
+//!   freshly-allocated source being re-read after its in-place mutation. A
+//!   hand-written loop body that allocates an array, mutates it in place, and
+//!   then reads the *same* value back within the same iteration would not be
+//!   flagged. The frontend threads the `array_set` result instead of
+//!   re-reading the source, so it does not emit this shape; crediting
+//!   freshness only ever *accepts* more, so this can only be a false negative,
+//!   never a false positive.
 
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 
@@ -241,7 +263,7 @@ struct Context<'f> {
     dom_tree: DominatorTree,
     /// Array values that allocate fresh storage at their definition
     /// (`make_array` / `Call` results). Used as a freshness wall by
-    /// [`Context::value_covered_on_all_paths`].
+    /// [`Context::compute_uncovered_values`].
     fresh_array_values: HashSet<ValueId>,
     /// The block set of each loop in the function. The freshness wall only
     /// credits a fresh allocation when its defining block and the array_set's
@@ -398,7 +420,7 @@ impl<'f> Context<'f> {
         let back_edges: HashSet<(BasicBlockId, BasicBlockId)> =
             loops.yet_to_unroll.iter().map(|l| (l.back_edge_start, l.header)).collect();
         // The block set of each loop, used by the freshness wall in
-        // [`Context::value_covered_on_all_paths`] to decide whether a fresh
+        // [`Context::compute_uncovered_values`] to decide whether a fresh
         // allocation re-executes on every iteration that reaches an array_set.
         let loop_blocks: Vec<BTreeSet<BasicBlockId>> =
             loops.yet_to_unroll.iter().map(|l| l.blocks.clone()).collect();
@@ -520,7 +542,7 @@ impl<'f> Context<'f> {
         // the same heuristic [`Context::non_aliasing_array_values`] makes).
         // `array_set` results are excluded — they may mutate in place rather
         // than allocate. Used by the freshness wall in
-        // [`Context::value_covered_on_all_paths`]: storage that is freshly
+        // [`Context::compute_uncovered_values`]: storage that is freshly
         // allocated on a path has no other live alias, so an in-place mutation
         // there cannot be observed through one.
         let fresh_array_values: HashSet<ValueId> =
@@ -992,9 +1014,12 @@ impl<'f> Context<'f> {
     /// non-terminator instruction that reads a value still in the alias
     /// use-set.
     ///
-    /// **Use-set evolution.** Starts as `alias_set` and only shrinks. Kills
-    /// are applied **during propagation** to each successor — see
-    /// [`Context::succ_use_set`] for the kill rules.
+    /// **Use-set evolution.** Starts as `alias_set` — which is **already
+    /// narrowed** to the uncovered members by [`Context::unprotected_aliases`]
+    /// before this is called, so provably-protected aliases never enter the
+    /// walk — and only shrinks from there. Kills are applied **during
+    /// propagation** to each successor — see [`Context::succ_use_set`] for the
+    /// kill rules.
     ///
     /// **What counts as a use.** Only non-terminator operands. Terminator
     /// arguments are the legitimate threading mechanism the invariant

--- a/compiler/noirc_evaluator/src/ssa/validation/array_set_rc_invariant.rs
+++ b/compiler/noirc_evaluator/src/ssa/validation/array_set_rc_invariant.rs
@@ -40,7 +40,7 @@
 //!    distinct per-iteration storage and is dropped (see
 //!    [`Context::swap_excluded_aliases`]).
 //! 2. **inc_rc precedence / back-edge-participant.** If some `inc_rc` on an
-//!    alias-set member either RPO-precedes the array_set or sits on a
+//!    alias-set member either dominates the array_set or sits on a
 //!    non-source alias that's also a loop back-edge arg, accept — the
 //!    frontend is deliberately managing iteration aliasing.
 //! 3. **Protected-participant filter.** Before the forward walk, drop from
@@ -117,8 +117,6 @@
 
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 
-use std::cmp::Ordering;
-
 use acvm::FieldElement;
 
 use crate::{
@@ -174,9 +172,9 @@ fn verify_function(function: &Function) -> RtResult<()> {
             let alias_set = ctx.alias_set_for(array, block_id, idx);
 
             // Cheap check first: if any `inc_rc` on an alias-set member
-            // precedes this `array_set` in flow order, treat the aliasing
-            // as already protected. See `some_inc_rc_precedes` for the
-            // rationale (relaxed from dominance to RPO precedence).
+            // dominates this `array_set`, treat the aliasing as already
+            // protected on every path. See `some_inc_rc_precedes` for the
+            // rationale (dominance, plus a back-edge-participant relaxation).
             if ctx.some_inc_rc_precedes(&alias_set, array, block_id, idx) {
                 continue;
             }
@@ -224,7 +222,13 @@ fn verify_function(function: &Function) -> RtResult<()> {
 /// checks read from these structures rather than re-scanning the function.
 struct Context<'f> {
     function: &'f Function,
-    /// Dominator tree. Mutable because `dominates` populates an internal cache.
+    /// Control-flow graph. Used by [`Context::some_inc_rc_precedes`] to walk
+    /// predecessors backward when checking whether the `inc_rc`-carrying
+    /// blocks collectively cover every path to an `array_set`.
+    cfg: ControlFlowGraph,
+    /// Dominator tree. Used by [`Context::some_inc_rc_precedes`] as a fast
+    /// path: a single `inc_rc` block that dominates the `array_set` covers
+    /// every path without the backward predecessor walk.
     dom_tree: DominatorTree,
     /// For each array-typed value `V`, the set of values that may share
     /// `V`'s storage **at `V`'s program point** — the source itself plus
@@ -570,6 +574,7 @@ impl<'f> Context<'f> {
 
         Self {
             function,
+            cfg,
             dom_tree,
             backward_aliases,
             array_value_defs,
@@ -668,36 +673,44 @@ impl<'f> Context<'f> {
     }
 
     /// Returns `true` if some `inc_rc r` for an `r ∈ alias_set` exists at a
-    /// program point that precedes the `array_set` in flow order — either
-    /// in a strictly-earlier position within the same block, or in a
-    /// different block whose reverse-post-order index is smaller.
+    /// program point that precedes the `array_set` on **every** path to it —
+    /// either in a strictly-earlier position within the same block, or in a
+    /// different block that **dominates** the array_set's block.
     ///
-    /// # Why RPO precedence, not dominance
+    /// # Why dominance, not mere RPO precedence
     ///
-    /// The strict invariant would be "the `inc_rc` dominates the
-    /// `array_set`" — i.e., is on *every* path. But the frontend in
-    /// practice emits **path-specific** `inc_rc`s: each path that creates
-    /// an alias gets its own `inc_rc`, with no single dominating one. See
-    /// e.g. `brillig_array_ifelse` where `b1` has `inc_rc v8` and `b4` has
-    /// `inc_rc v2`, neither dominating the `array_set` in `b6`. On every
-    /// runtime path the alias is either covered by an `inc_rc` or the
-    /// values are freshly allocated, but the verifier can't observe
-    /// path-specific freshness with the current alias-set model.
+    /// This short-circuit accepts the array_set outright, skipping the
+    /// forward aliased-read walk, so it must hold on *every* runtime path:
+    /// an `inc_rc` that runs on only some paths leaves the array_set
+    /// unprotected (RC 1, mutating in place) on the others. Dominance is
+    /// exactly that guarantee — the bump is on every path from entry to the
+    /// array_set.
     ///
-    /// We weaken the check accordingly: presence of *any* `inc_rc` on an
-    /// alias-set member, anywhere earlier in flow, is taken as the
-    /// frontend signalling "I'm aware of this aliasing and have handled
-    /// it." Absence of any such `inc_rc` *combined* with a forward aliased
-    /// read (checked separately) still flags as a hazard, which is the
-    /// shape PR-12671 had. The back-edge-participant relaxation below
-    /// widens this further to cover `inc_rc`s placed after the
-    /// array_set, where iteration aliasing makes the bump's program
-    /// point misleading.
+    /// RPO precedence is *not* sufficient: a sibling-branch `inc_rc` has a
+    /// smaller RPO index than the common-successor block holding the
+    /// array_set, yet the other branch reaches the array_set without it.
+    /// That is the
+    /// `end_to_end_branch_local_inc_rc_does_not_protect_array_set_in_join_is_rejected`
+    /// shape — `inc_rc v1` on the `then` path, `array_set v1` in the join,
+    /// and a read of `v1` after it; on the `else` path the mutation is
+    /// observable and the verifier must reject.
+    ///
+    /// Genuinely path-specific protection (each aliasing path bumps RC, each
+    /// other path allocates fresh — e.g. `brillig_array_ifelse`) does **not**
+    /// rely on this short-circuit. When the short-circuit declines, the
+    /// forward walk runs, and it accepts those cases because the read is of a
+    /// sibling block-parameter the directed alias-set keeps out of the
+    /// source's class (the documented sibling false-negative). Absence of a
+    /// dominating `inc_rc` *combined* with a forward aliased read of an
+    /// alias-set member still flags as a hazard, which is the shape PR-12671
+    /// had. The back-edge-participant relaxation below covers `inc_rc`s
+    /// placed after the array_set, where iteration aliasing makes the bump's
+    /// program point misleading.
     ///
     /// # Back-edge-participant relaxation
     ///
-    /// In addition to RPO precedence, an `inc_rc` is also accepted when
-    /// it lives on an alias-set member that:
+    /// In addition to a dominating `inc_rc`, an `inc_rc` is also accepted
+    /// when it lives on an alias-set member that:
     ///
     /// - is **not** the array_set's own source (an `inc_rc` on the
     ///   source itself, *after* the array_set, doesn't protect that
@@ -727,6 +740,12 @@ impl<'f> Context<'f> {
         array_set_block: BasicBlockId,
         array_set_idx: usize,
     ) -> bool {
+        // Blocks (other than the array_set's own) that carry a protecting
+        // `inc_rc` on an alias-set member. Any such block, when it lies on a
+        // path to the array_set, fully executes before the array_set, so its
+        // `inc_rc` runs first. Collected here, then tested for coverage below.
+        let mut protection_blocks: HashSet<BasicBlockId> = HashSet::default();
+
         for value in alias_set {
             let Some(locations) = self.inc_rc_locations.get(value) else {
                 continue;
@@ -743,17 +762,78 @@ impl<'f> Context<'f> {
             }
             for &(inc_block, inc_idx) in locations {
                 if inc_block == array_set_block {
+                    // Same block: protects every path iff it is strictly
+                    // earlier than the array_set (the block is on every
+                    // path to its own array_set).
                     if inc_idx < array_set_idx {
                         return true;
                     }
-                } else if self.dom_tree.reverse_post_order_cmp(inc_block, array_set_block)
-                    == Ordering::Less
-                {
-                    return true;
+                } else {
+                    protection_blocks.insert(inc_block);
                 }
             }
         }
-        false
+
+        if protection_blocks.is_empty() {
+            return false;
+        }
+
+        // Fast path: a single `inc_rc` block that dominates the array_set is
+        // on every path to it, so it covers the array_set without the
+        // backward predecessor walk. This is the common case (e.g. an
+        // `inc_rc` in a loop pre-header).
+        if protection_blocks.iter().any(|&b| self.dom_tree.dominates(b, array_set_block)) {
+            return true;
+        }
+
+        // General case: no single block dominates, but the protection blocks
+        // may still *collectively* cover every path. The frontend emits one
+        // `inc_rc` per branch of a diamond (e.g. `inc_rc v` on both arms
+        // feeding the join that holds `array_set v`); together those cover
+        // every path even though neither dominates.
+        self.protection_blocks_cover_all_paths(array_set_block, &protection_blocks)
+    }
+
+    /// Returns `true` if every control-flow path from the entry block to
+    /// `array_set_block` passes through some block in `protection_blocks`.
+    ///
+    /// Walks predecessors backward from `array_set_block`, treating each
+    /// protection block as a wall (its predecessors are not explored, since
+    /// any path through it is already covered). If the walk reaches the
+    /// entry block — or any block with no predecessors — without being
+    /// walled, an unprotected path exists and the array_set is not covered.
+    fn protection_blocks_cover_all_paths(
+        &self,
+        array_set_block: BasicBlockId,
+        protection_blocks: &HashSet<BasicBlockId>,
+    ) -> bool {
+        let entry = self.function.entry_block();
+        // The array_set's own block isn't a protection block here (the
+        // same-block case is handled by the early return above), so an
+        // array_set in the entry block has no protecting predecessor.
+        if array_set_block == entry {
+            return false;
+        }
+
+        let mut visited: HashSet<BasicBlockId> = HashSet::default();
+        visited.insert(array_set_block);
+        let mut frontier: Vec<BasicBlockId> = self.cfg.predecessors(array_set_block).collect();
+
+        while let Some(block) = frontier.pop() {
+            if !visited.insert(block) {
+                continue;
+            }
+            if protection_blocks.contains(&block) {
+                continue;
+            }
+            let preds = self.cfg.predecessors(block);
+            if block == entry || preds.len() == 0 {
+                // An unprotected path reaches the entry: not covered.
+                return false;
+            }
+            frontier.extend(preds);
+        }
+        true
     }
 
     /// Forward CFG walk from after the `array_set` looking for a
@@ -1802,6 +1882,71 @@ mod tests {
                 return v3
             }"#;
         assert_verifier_accepts(src);
+    }
+
+    /// A branch-local `inc_rc` does **not** protect an `array_set` reached on a
+    /// path that skips it. `inc_rc v1` lives only on the `then` path (b1), but
+    /// the `array_set v1` in the join block b3 is also reachable via b2, which
+    /// has no `inc_rc`. On the `v0 = false` path `v1` has RC 1, so the
+    /// `array_set` mutates it in place and the following `array_get v1` observes
+    /// the mutation. The verifier must reject — a non-dominating `inc_rc`
+    /// cannot vouch for the array_set.
+    #[test]
+    fn end_to_end_branch_local_inc_rc_does_not_protect_array_set_in_join_is_rejected() {
+        let src = r#"
+            brillig(inline) fn main f0 {
+              b0(v0: u1, v1: [Field; 1]):
+                jmpif v0 then: b1(), else: b2()
+              b1():
+                inc_rc v1
+                jmp b3()
+              b2():
+                jmp b3()
+              b3():
+                v2 = array_set v1, index u32 0, value Field 7
+                v3 = array_get v1, index u32 0 -> Field
+                return v3
+            }"#;
+        assert_verifier_rejects(src);
+    }
+
+    /// Branch-local `inc_rc`s that **collectively** cover every path do
+    /// protect the `array_set`, even when no single one dominates it. Both
+    /// arms of the diamond (b1 *and* b2) bump `v1` before the join block b3
+    /// holds `array_set v1` and a read of `v1`. Neither `inc_rc` dominates b3
+    /// on its own, but every path to the array_set passes through one of
+    /// them, so `v1` has RC ≥ 2 on every path and the `array_set` always
+    /// copies. The verifier must accept.
+    ///
+    /// This is the minimized crux of a `comptime_vs_brillig_direct` fuzzer
+    /// case: the frontend emits one `inc_rc` per branch feeding a join, which
+    /// a single-block dominance check would wrongly reject. It is the exact
+    /// counterpart of
+    /// `end_to_end_branch_local_inc_rc_does_not_protect_array_set_in_join_is_rejected`
+    /// — adding the second arm's `inc_rc` is what flips it from a hazard to
+    /// safe.
+    #[test]
+    fn end_to_end_branch_local_inc_rcs_on_all_arms_protect_array_set_in_join_is_accepted() {
+        let src = r#"
+            brillig(inline) fn main f0 {
+              b0(v0: u1, v1: [Field; 1]):
+                jmpif v0 then: b1(), else: b2()
+              b1():
+                inc_rc v1
+                jmp b3()
+              b2():
+                inc_rc v1
+                jmp b3()
+              b3():
+                v2 = array_set v1, index u32 0, value Field 7
+                v3 = array_get v1, index u32 0 -> Field
+                return v3
+            }"#;
+        assert_verifier_accepts_because(
+            src,
+            "inc_rc v1 on both arms collectively cover every path to the array_set; \
+             neither dominates b3 alone, but together they form a cut",
+        );
     }
 
     /// Index-aware filter: a constant-index `array_set` followed by a
@@ -3151,19 +3296,20 @@ mod tests {
 
     /// Five `inc_rc` placements, each isolated on its own array parameter
     /// so the inc_rcs don't accidentally cover for each other. Tests the
-    /// **relaxed** precedence check (any `inc_rc` earlier in RPO suffices;
-    /// it does **not** need to dominate the array_set's block):
+    /// precedence check, which requires the `inc_rc` to be on **every** path
+    /// to the array_set — either earlier in the same block, or in a block
+    /// that **dominates** the array_set's block:
     ///   - `v0`: same-block, inc_rc *earlier* than the array_set → **precedes**.
-    ///   - `v1`: inc_rc in entry block → **precedes**.
-    ///   - `v2`: inc_rc in a sibling branch (b1) → **precedes** under the
-    ///     relaxed check (sibling blocks come earlier in RPO than the
-    ///     common-successor block); would fail a strict dominance check.
+    ///   - `v1`: inc_rc in entry block (dominates everything) → **precedes**.
+    ///   - `v2`: inc_rc in a sibling branch (b1) → does **not** precede.
+    ///     b1 doesn't dominate the common-successor block b3 (the b2 path
+    ///     skips the inc_rc), so the bump can't vouch for the array_set.
     ///   - `v3`: same-block, inc_rc *later* than the array_set → does
     ///     **not** precede (same-block comparison still requires earlier
     ///     position).
     ///   - `v4`: no inc_rc anywhere → does **not** precede.
     #[test]
-    fn inc_rc_precedence_recognizes_earlier_in_flow_positions() {
+    fn inc_rc_precedence_requires_dominating_position() {
         let src = r#"
             brillig(inline) fn main f0 {
               b0(v0: [u32; 2], v1: [u32; 2], v2: [u32; 2], v3: [u32; 2], v4: [u32; 2], v5: u1):
@@ -3205,7 +3351,7 @@ mod tests {
             } else if *source == v1 {
                 (true, "v1: entry-block inc_rc")
             } else if *source == v2 {
-                (true, "v2: inc_rc in sibling branch (precedes in RPO)")
+                (false, "v2: inc_rc in sibling branch does not dominate")
             } else if *source == v3 {
                 (false, "v3: same-block later inc_rc")
             } else if *source == v4 {

--- a/cspell.json
+++ b/cspell.json
@@ -357,6 +357,8 @@
         "unref",
         "unrepresentable",
         "unsignedinteger",
+        "unthreadable",
+        "unwalled",
         "upcasted",
         "urem",
         "USERPROFILE",

--- a/cspell.json
+++ b/cspell.json
@@ -252,6 +252,7 @@
         "Postcondition",
         "pprof",
         "precomputes",
+        "preds",
         "prehashed",
         "preheader",
         "preimage",


### PR DESCRIPTION
## Problem Resolved

Resolves https://linear.app/aztec-foundation/issue/AZTBOT-9/basic-conditional-flattens-branch-local-brillig-inc-rc-unconditionally

## Summary of Changes

* Makes the variant check more complex to catch the malformed SSA presented in those tickets without introducing false positives
* Reverts changes to https://github.com/noir-lang/noir/pull/12803 so we don't have tests about the outcome of a malformed SSA
* Replaces https://github.com/noir-lang/noir/pull/12978 which would have disabled further optimisations just to avoid the change in outcome on a malformed SSA


### Part 1 — validator: per-path `inc_rc` / freshness coverage

#### Problem

The validator accepted malformed SSA in which a **branch-local** `inc_rc` on
one path was treated as protecting an `array_set` reachable on another path
*without* it:

```
b0(v0: u1, v1: [Field; 1]):
  jmpif v0 then: b1(), else: b2()
b1(): inc_rc v1; jmp b3()      // only this arm bumps RC
b2():            jmp b3()
b3():
  v2 = array_set v1, index u32 0, value Field 7
  v3 = array_get v1, index u32 0 -> Field   // reads the source after the write
  return v3
```

On `v0 = false`, `v1` has RC 1, so `array_set` mutates it in place and the
`array_get` observes the mutation — but the verifier accepted it. Root cause:
`some_inc_rc_precedes` accepted whenever *any* `inc_rc` on an alias-set member
merely **preceded** the `array_set` in reverse-post-order — a per-program-point
test, not a per-path one, so a sibling-branch `inc_rc` wrongly vouched for the
join.

#### Change

Replaced the RPO-precedence short-circuit with **per-path coverage** that
narrows the forward walk's use-set, rather than a binary skip/run decision over
the whole backward alias-set.

- **`some_inc_rc_precedes`** now only does the cheap, always-sound full-accept
  cases: an `inc_rc` earlier in the `array_set`'s own block, in a **dominating**
  block, or — for a non-source alias — on a loop **back-edge** (the existing
  back-edge-participant relaxation).
- **`unprotected_aliases`** narrows the alias-set to the members *not* provably
  protected and seeds the forward walk with only those. Empty result → accept
  without walking.
- **`compute_uncovered_values`** computes that per member: it threads the
  source's storage backward through the CFG (following block-parameter args and
  `array_set`-result→operand edges) and drops a member when, on every path
  where it can be the source's storage, that storage is RC-bumped by an
  `inc_rc` or is an **iteration-local fresh** allocation (`make_array`/`Call`
  re-executed each loop iteration). It is iterative — build the `(block, value)`
  backward graph, then fixed-point propagate "uncovered" from terminals — so
  there is no recursion / stack-depth risk on large functions.
- **Swap-exclusion forward propagation.** The existing swap filter records that
  a sibling `Q` is distinct-per-iteration from a swapped loop-header parameter
  `P`. Those exclusions are now pushed **forward across non-back-edge parameter
  edges**: on `R ← P`, `R` *is* `P` within the iteration, so `R` inherits `P`'s
  exclusions. This carries the exclusion onto an inner-loop `array_set` source
  seeded from the swapped outer-loop parameter. Back-edges are excluded (across
  one, `R` is a *prior* iteration's `P` — distinct storage).

#### Why each refinement (each forced by a fuzzer counter-example)

1. **RPO → per-path** — catches the malformed issue SSA above.
2. **Per-path, not single-dominance** — a diamond with `inc_rc` on *both* arms
   feeding the join (neither dominating) is legitimate and must be accepted.
3. **Iteration-local freshness** — `inc_rc` on one loop arm and a fresh
   `make_array` on the other is a real frontend shape; freshness must count as
   protection, but only for allocations re-executed each iteration (a one-time
   `make_array` mutated then read back is still a genuine hazard, still
   rejected).
4. **Narrowed forward use-set** — seeding the forward walk with the *whole*
   alias-set flagged reads of a covered sibling alias on a path where the
   `array_set` never mutates that storage. Keeping only the uncovered members
   removes those false positives while preserving real hazards.
5. **Swap-exclusion propagation** — a nested-loop case where the swap exclusion
   was recorded on the outer-loop header but the `array_set` source was the
   inner-loop header seeded from it; the exclusion now reaches the inner source.

Refinements 2–5 were each a confirmed false-positive surfaced by the AST fuzzer
(`comptime_vs_brillig_direct` / `min_vs_full`) and validated against `master`.

#### Soundness

Coverage / freshness / swap-propagation only ever **drop** members from the
use-set, i.e. accept *more*. So the change can introduce (frontend-impossible)
false negatives — one documented gap: a fresh array mutated in place and read
back through its own name within a single loop iteration — but it can never
introduce a false positive that rejects a valid program. A blanket
"`Call` results are always fresh" shortcut was tried and **rejected as
unsound** (it accepted a linear `call → param → param; array_set; read-back`
hazard, the analog of `make_array_with_forward_read`); the swap-propagation fix
is targeted to the real pattern and leaves that hazard rejected.

---

### Part 2 — `basic_conditional`: drop the #12803 `inc_rc` workaround

#12803 stopped `basic_conditional` from flattening any Brillig conditional whose
branch contains an `inc_rc`, to prevent the bump being hoisted into the
unconditional entry block. That was a pass-level guard against the same
malformed COW shape the validator now owns.

- **Re-allow flattening branches with `inc_rc`.** Hoisting an `inc_rc` only ever
  *raises* a reference count, which makes the later `array_set` **copy** instead
  of mutating in place — always sound for a valid program (at worst an extra
  copy). The result only changes for the malformed shape, which the validator
  now flags.
- **`dec_rc` stays non-flattenable** — hoisting it *lowers* a reference count
  and can enable an unsafe in-place mutation.
- Removed `does_not_hoist_branch_local_inc_rc`, whose assertion (the COW result
  `7` must be preserved) contradicts the validator's verdict that the SSA is
  malformed. Kept the independent `assert_pass_does_not_affect_execution`
  deep-copy (`snapshot_args`) fix.

This was validated empirically: the full `nargo_cli` execution suite (8916
programs) and a 900 s × 6-target fuzz run show no reintroduced miscompile.

---

### Testing

- New validator regression tests for each crux: non-dominating branch-local
  `inc_rc` (reject), `inc_rc` on all arms (accept), loop `inc_rc` + freshness
  arms (accept), covered sibling alias read after the `array_set` (accept),
  swap-exclusion propagation into an inner-loop source (accept), and the
  `Call`-result forward-read hazard (reject).
- Full `noirc_evaluator` suite, `nargo_cli --test execute` (8916), fmt, and
  clippy all pass.
- `noir_ast_fuzzer_fuzz`: 900 s × 6 targets, non-deterministic, clean — the
  false-positive classes that previously surfaced within ~2 min no longer
  reproduce.



## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
