### PR TITLE
fix(frontend): key elided associated-type bounds on rigid generic

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/function.rs
+++ b/compiler/noirc_frontend/src/elaborator/function.rs
@@ -476,9 +476,9 @@ impl Elaborator<'_> {
         let mut generics = Vec::with_capacity(associated_generics.len());
         let mut associated_generics_trait_constraints = Vec::new();
 
-        for (associated_generic, bounds) in associated_generics {
+        for (associated_generic, named_generic, bounds) in associated_generics {
             for bound in bounds {
-                let typ = Type::TypeVariable(associated_generic.type_var.clone());
+                let typ = named_generic.clone();
                 let location = associated_generic.location;
                 self.add_trait_bound_to_scope(location, &typ, &bound);
                 associated_generics_trait_constraints

--- a/compiler/noirc_frontend/src/elaborator/function.rs
+++ b/compiler/noirc_frontend/src/elaborator/function.rs
@@ -476,16 +476,16 @@ impl Elaborator<'_> {
         let mut generics = Vec::with_capacity(associated_generics.len());
         let mut associated_generics_trait_constraints = Vec::new();
 
-        for (associated_generic, named_generic, bounds) in associated_generics {
-            for bound in bounds {
-                let typ = named_generic.clone();
-                let location = associated_generic.location;
+        for desugared in associated_generics {
+            for bound in desugared.bounds {
+                let typ = desugared.named_generic.clone();
+                let location = desugared.generic.location;
                 self.add_trait_bound_to_scope(location, &typ, &bound);
                 associated_generics_trait_constraints
                     .push(TraitConstraint { typ, trait_bound: bound });
             }
 
-            generics.push(associated_generic.type_var);
+            generics.push(desugared.generic.type_var);
         }
 
         // We put associated generics first, as they are implicit and implicit generics

--- a/compiler/noirc_frontend/src/elaborator/trait_impls.rs
+++ b/compiler/noirc_frontend/src/elaborator/trait_impls.rs
@@ -1059,16 +1059,16 @@ impl Elaborator<'_> {
 
         let new_generics = self.desugar_trait_constraints(&mut trait_impl.where_clause);
         let mut new_generics_trait_constraints = Vec::new();
-        for (new_generic, named_generic, bounds) in new_generics {
-            for bound in bounds {
-                let typ = named_generic.clone();
-                let location = new_generic.location;
+        for desugared in new_generics {
+            for bound in desugared.bounds {
+                let typ = desugared.named_generic.clone();
+                let location = desugared.generic.location;
                 self.add_trait_bound_to_scope(location, &typ, &bound);
                 new_generics_trait_constraints
                     .push((TraitConstraint { typ, trait_bound: bound }, location));
             }
-            trait_impl.resolved_generics.push(new_generic.clone());
-            self.generics.push(new_generic);
+            trait_impl.resolved_generics.push(desugared.generic.clone());
+            self.generics.push(desugared.generic);
         }
 
         // We need to resolve the where clause before any associated types to be

--- a/compiler/noirc_frontend/src/elaborator/trait_impls.rs
+++ b/compiler/noirc_frontend/src/elaborator/trait_impls.rs
@@ -1059,9 +1059,9 @@ impl Elaborator<'_> {
 
         let new_generics = self.desugar_trait_constraints(&mut trait_impl.where_clause);
         let mut new_generics_trait_constraints = Vec::new();
-        for (new_generic, bounds) in new_generics {
+        for (new_generic, named_generic, bounds) in new_generics {
             for bound in bounds {
-                let typ = Type::TypeVariable(new_generic.type_var.clone());
+                let typ = named_generic.clone();
                 let location = new_generic.location;
                 self.add_trait_bound_to_scope(location, &typ, &bound);
                 new_generics_trait_constraints

--- a/compiler/noirc_frontend/src/elaborator/traits.rs
+++ b/compiler/noirc_frontend/src/elaborator/traits.rs
@@ -208,6 +208,37 @@ struct TraitScopeState {
     local_module: Option<crate::hir::def_map::LocalModuleId>,
 }
 
+/// A generic synthesized for an associated type that was elided from a trait bound.
+///
+/// For example, given `trait Foo { type Bar: Baz; }`, the where clause in:
+///
+/// ```noir
+/// fn foo<T>() where T: Foo { ... }
+/// ```
+///
+/// is desugared to mention the elided associated type explicitly:
+///
+/// ```noir
+/// fn foo<T, A>() where T: Foo<Bar = A> { ... }
+/// ```
+///
+/// producing one `DesugaredAssociatedGeneric` for the freshly introduced `A`.
+pub(super) struct DesugaredAssociatedGeneric {
+    /// The implicit generic to add to the item's generics list: the `A` above.
+    ///
+    /// Its `type_var` is bindable and is instantiated fresh at each call site, the same
+    /// way an explicit generic is.
+    pub(super) generic: ResolvedGeneric,
+    /// The rigid [`Type::NamedGeneric`] form of [`Self::generic`]: `<T as Foo>::Bar` above.
+    ///
+    /// Used as the object type of the assumed trait bound (`<T as Foo>::Bar: Baz`). It wraps
+    /// the same type variable as [`Self::generic`], but in its rigid form so trait lookup can't
+    /// wildcard-match it against unrelated concrete types.
+    pub(super) named_generic: Type,
+    /// The bounds declared on the associated type: the `Baz` from `type Bar: Baz` above.
+    pub(super) bounds: Vec<ResolvedTraitBound>,
+}
+
 impl Elaborator<'_> {
     /// Sets up the elaborator scope for processing a trait.
     /// Returns state that must be passed to `exit_trait_scope` to restore the previous state.
@@ -265,10 +296,10 @@ impl Elaborator<'_> {
             let new_generics =
                 self.desugar_trait_constraints(&mut unresolved_trait.trait_def.where_clause);
 
-            let new_generics = vecmap(new_generics, |(generic, _named_generic, _bounds)| {
-                // TODO: use `_bounds` variable above
+            let new_generics = vecmap(new_generics, |desugared| {
+                // TODO: use `desugared.bounds` here
                 // See https://github.com/noir-lang/noir/issues/8601
-                generic
+                desugared.generic
             });
             self.generics.extend(new_generics);
 
@@ -357,7 +388,7 @@ impl Elaborator<'_> {
     pub(super) fn desugar_trait_constraints(
         &mut self,
         where_clause: &mut [UnresolvedTraitConstraint],
-    ) -> Vec<(ResolvedGeneric, Type, Vec<ResolvedTraitBound>)> {
+    ) -> Vec<DesugaredAssociatedGeneric> {
         where_clause
             .iter_mut()
             .flat_map(|constraint| {
@@ -383,7 +414,7 @@ impl Elaborator<'_> {
         &mut self,
         object: &UnresolvedType,
         bound: &mut TraitBound,
-    ) -> Vec<(ResolvedGeneric, Type, Vec<ResolvedTraitBound>)> {
+    ) -> Vec<DesugaredAssociatedGeneric> {
         let mut added_generics = Vec::new();
         let trait_path = self.validate_path(bound.trait_path.clone());
 
@@ -445,11 +476,11 @@ impl Elaborator<'_> {
                     .unwrap_or_default();
 
                 bound.trait_generics.named_args.push((ident, typ));
-                added_generics.push((
-                    ResolvedGeneric { name, location, type_var },
+                added_generics.push(DesugaredAssociatedGeneric {
+                    generic: ResolvedGeneric { name, location, type_var },
                     named_generic,
-                    associated_type_bounds,
-                ));
+                    bounds: associated_type_bounds,
+                });
             }
         }
 

--- a/compiler/noirc_frontend/src/elaborator/traits.rs
+++ b/compiler/noirc_frontend/src/elaborator/traits.rs
@@ -265,7 +265,7 @@ impl Elaborator<'_> {
             let new_generics =
                 self.desugar_trait_constraints(&mut unresolved_trait.trait_def.where_clause);
 
-            let new_generics = vecmap(new_generics, |(generic, _bounds)| {
+            let new_generics = vecmap(new_generics, |(generic, _named_generic, _bounds)| {
                 // TODO: use `_bounds` variable above
                 // See https://github.com/noir-lang/noir/issues/8601
                 generic
@@ -357,7 +357,7 @@ impl Elaborator<'_> {
     pub(super) fn desugar_trait_constraints(
         &mut self,
         where_clause: &mut [UnresolvedTraitConstraint],
-    ) -> Vec<(ResolvedGeneric, Vec<ResolvedTraitBound>)> {
+    ) -> Vec<(ResolvedGeneric, Type, Vec<ResolvedTraitBound>)> {
         where_clause
             .iter_mut()
             .flat_map(|constraint| {
@@ -383,7 +383,7 @@ impl Elaborator<'_> {
         &mut self,
         object: &UnresolvedType,
         bound: &mut TraitBound,
-    ) -> Vec<(ResolvedGeneric, Vec<ResolvedTraitBound>)> {
+    ) -> Vec<(ResolvedGeneric, Type, Vec<ResolvedTraitBound>)> {
         let mut added_generics = Vec::new();
         let trait_path = self.validate_path(bound.trait_path.clone());
 
@@ -429,6 +429,12 @@ impl Elaborator<'_> {
                     _ => unreachable!("into_implicit_named_generic returns a NamedGeneric"),
                 };
 
+                // Keep the rigid named-generic form of the associated type. The assumed trait
+                // bound for it must be keyed on this rigid type rather than a bare (bindable)
+                // `Type::TypeVariable`, otherwise the assumed impl wildcard-matches arbitrary
+                // concrete object types during trait lookup.
+                let named_generic = typ.clone();
+
                 let typ = self.interner.push_quoted_type(typ);
                 let typ = UnresolvedTypeData::Resolved(typ).with_location(location);
                 let ident = Ident::new(associated_type.name.as_ref().clone(), location);
@@ -439,8 +445,11 @@ impl Elaborator<'_> {
                     .unwrap_or_default();
 
                 bound.trait_generics.named_args.push((ident, typ));
-                added_generics
-                    .push((ResolvedGeneric { name, location, type_var }, associated_type_bounds));
+                added_generics.push((
+                    ResolvedGeneric { name, location, type_var },
+                    named_generic,
+                    associated_type_bounds,
+                ));
             }
         }
 

--- a/compiler/noirc_frontend/src/hir_def/types.rs
+++ b/compiler/noirc_frontend/src/hir_def/types.rs
@@ -492,6 +492,8 @@ pub type GenericTypeVars = Vec<TypeVariable>;
 /// correctly resolving types.
 pub type ResolvedGenerics = Vec<ResolvedGeneric>;
 
+/// A single generic parameter (e.g. one `T` from a `<T, U>` list) after name resolution:
+/// its name, the type variable it binds, and where it was declared.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ResolvedGeneric {
     pub name: Rc<String>,

--- a/compiler/noirc_frontend/src/tests/traits/trait_associated_items.rs
+++ b/compiler/noirc_frontend/src/tests/traits/trait_associated_items.rs
@@ -2516,3 +2516,42 @@ fn associated_constant_shorthand_on_generic_trait_is_ambiguous_with_multiple_imp
     "#;
     check_errors(src);
 }
+
+#[test]
+fn elided_bounded_associated_type_does_not_wildcard_match_unrelated_type() {
+    // `where T: Foo` elides `Foo`'s bounded associated type `Bar: Baz`, so the
+    // elaborator synthesizes an implicit generic for it and assumes `<T as Foo>::Bar: Baz`.
+    // That assumed bound must be keyed on the rigid associated-type generic, not on a
+    // bindable type variable. Otherwise the assumed `Baz` impl wildcard-matches the
+    // unrelated `u32` query from `needs_baz`, binding the synthetic generic to `u32` and
+    // misreporting the failure at the call site instead of in `caller`'s body.
+    let src = r#"
+    pub trait Baz { fn baz() -> u32; }
+    pub trait Foo {
+        type Bar: Baz;
+        fn make_bar(self) -> Self::Bar;
+    }
+
+    fn needs_baz<X>(_x: X) -> u32 where X: Baz { X::baz() }
+
+    fn caller<T>(_t: T) -> u32 where T: Foo {
+        needs_baz(5_u32)
+        ^^^^^^^^^ No matching impl found for `u32: Baz`
+        ~~~~~~~~~ No impl for `u32: Baz`
+    }
+
+    pub struct S {}
+    impl Baz for S { fn baz() -> u32 { 2 } }
+    pub struct M {}
+    impl Foo for M {
+        type Bar = S;
+        fn make_bar(self) -> S { S {} }
+    }
+
+    fn main() {
+        let m: M = M {};
+        let _ = caller(m);
+    }
+    "#;
+    check_errors(src);
+}


### PR DESCRIPTION
## Description

### Problem

When a `where T: Foo` clause elides a trait's **bounded associated type** (e.g. `type Bar: Baz`), the elaborator synthesizes an implicit generic for the missing associated type and registers an assumed `<T as Foo>::Bar: Baz` implementation.

That assumed impl was keyed on `Type::TypeVariable(generic.type_var)` — a **bindable** type variable — rather than the rigid `Type::NamedGeneric` that `add_missing_named_generics` already constructs. Because an unbound `Type::TypeVariable` is bindable, the assumed impl behaved as a wildcard `_: Baz`: trait lookup for an unrelated concrete type (e.g. `u32: Baz`) would unify against it, **destructively binding the synthetic associated generic to `u32`**. With a single matching impl the binding was committed and leaked outward, so an invalid function body was accepted and the failure was misreported at every call site as `M: Foo<Bar = u32>` / `u32: Baz` instead of inside the function body.

### Fix

Thread the rigid `NamedGeneric` produced by `add_missing_named_generics` through `desugar_trait_constraints` to the function and trait-impl where-clause handling, and use it as the assumed impl's object type. A `NamedGeneric` is rigid in unification, so it no longer wildcard-matches unrelated query types, and the error is reported in the correct location.

Fixes https://github.com/noir-lang/noir-claude/issues/1058
Fixes https://linear.app/aztec-foundation/issue/AZTBOT-960/noirc-frontend-desugared-associated-type-generic-stored-as-bindable

### Before / after

```noir
trait Baz { fn baz() -> u32; }
trait Foo {
    type Bar: Baz;
    fn make_bar(self) -> Self::Bar;
}

fn needs_baz<X>(_x: X) -> u32 where X: Baz { X::baz() }

fn caller<T>(_t: T) -> u32 where T: Foo {
    needs_baz(5_u32)   // invalid: nothing guarantees `u32: Baz`
}
```

Before — error misattributed to the call site with a bogus `Bar = u32`:

```
error: No matching impl found for `M: Foo<Bar = u32>`
error: No matching impl found for `u32: Baz`
   ┌─ src/main.nr:23:12
23 │     assert(caller(m) == 99);
   │            ------ ...
```

After — error reported at the actual mistake inside `caller`:

```
error: No matching impl found for `u32: Baz`
   ┌─ src/main.nr:10:5
10 │     needs_baz(5_u32)
   │     --------- No impl for `u32: Baz`
```

---

### ELI5

Imagine a trait `Foo` that promises *"I have an associated type `Bar`, and whatever `Bar` is, it must implement `Baz`"*:

```noir
trait Baz { fn baz() -> u32; }
trait Foo { type Bar: Baz; }
```

A function that says only `T: Foo` (without naming `Bar`) knows *nothing* about `u32`, so this is wrong and should be rejected:

```noir
fn caller<T>(_t: T) -> u32 where T: Foo {
    needs_baz(5_u32)   // requires `u32: Baz` — never guaranteed
}
```

Internally the compiler rewrites `where T: Foo` into `where T: Foo<Bar = SomeHiddenType>`, invents a placeholder for the hidden `Bar`, and records an assumption: *"the hidden `Bar` implements `Baz`."*

There are two ways to represent that placeholder:

| Kind | Behavior in type matching |
|------|---------------------------|
| `NamedGeneric` ("rigid") | Matches only *itself* — a name tag: "I am specifically `T::Bar`." |
| `TypeVariable` ("bindable") | Matches *anything* — a blank that gets filled in, i.e. a wildcard `_`. |

The bug filed the assumption under the **bindable** kind, so instead of *"`T::Bar` implements `Baz`"* it effectively recorded *"**anything** implements `Baz`"*. When `needs_baz(5_u32)` asked *"does `u32` implement `Baz`?"*, that wildcard matched and **glued the hidden `Bar` to `u32`**. The bad binding leaked outward, so the error landed on the **caller** (`M: Foo<Bar = u32>`) instead of the buggy body.

The fix files the assumption under the **rigid** key that was already built — `let typ = named_generic.clone();` instead of `Type::TypeVariable(...)`. Now *"`T::Bar` implements `Baz`"* only matches `T::Bar`, never `u32`, the blank is never glued, and the error points at the real mistake.

In one sentence: **a "must implement `Baz`" assumption about a hidden associated type was stored as a match-anything wildcard instead of a match-only-itself name tag, so unrelated types slipped through and the blame landed on callers instead of the buggy function body.**

## Additional Context

None.

## Documentation

- [x] This PR requires documentation updates when merged.
  - [x] I will submit a noir-lang/docs PR. <!-- not required -->
  - [ ] I will submit a docs issue.

## PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
