### PR TITLE
fix(parser): preserve tails spliced onto interned lvalues in as_expr

### DIFF
--- a/compiler/noirc_frontend/src/parser/parser/expression.rs
+++ b/compiler/noirc_frontend/src/parser/parser/expression.rs
@@ -188,6 +188,28 @@ impl Parser<'_> {
         self.parse_index(atom, start_location)
     }
 
+    /// Parses any postfix tail after an already-parsed atom: calls, member accesses,
+    /// method calls and indexing (`AtomRhs*`). This is the same loop `parse_atom` runs
+    /// after its leading quark, exposed for callers that build the leading atom themselves.
+    pub(super) fn parse_atom_rhs_after_expression(
+        &mut self,
+        mut atom: Expression,
+        start_location: Location,
+    ) -> Expression {
+        let mut parsed;
+
+        loop {
+            (atom, parsed) = self.parse_atom_rhs(atom, start_location);
+            if parsed {
+                continue;
+            } else {
+                break;
+            }
+        }
+
+        atom
+    }
+
     pub(super) fn parse_member_accesses_or_method_calls_after_expression(
         &mut self,
         mut atom: Expression,

--- a/compiler/noirc_frontend/src/parser/parser/statement.rs
+++ b/compiler/noirc_frontend/src/parser/parser/statement.rs
@@ -168,10 +168,19 @@ impl Parser<'_> {
 
         let expression = self.parse_expression()?;
 
+        Some(self.parse_assignment_or_expression_statement(expression))
+    }
+
+    /// Given an already-parsed left-hand expression, parses an assignment (`= rhs`),
+    /// a compound assignment (`+= rhs`, etc.) or, if neither follows, an expression statement.
+    pub(super) fn parse_assignment_or_expression_statement(
+        &mut self,
+        expression: Expression,
+    ) -> StatementKind {
         if self.eat_assign() {
             if let Some(lvalue) = LValue::from_expression(expression.clone()) {
                 let expression = self.parse_expression_or_error();
-                return Some(StatementKind::Assign(AssignStatement { lvalue, expression }));
+                return StatementKind::Assign(AssignStatement { lvalue, expression });
             } else {
                 self.push_error(
                     ParserErrorReason::InvalidLeftHandSideOfAssignment,
@@ -183,7 +192,7 @@ impl Parser<'_> {
         if let Some(op) = self.next_is_op_assign() {
             if let Some(lvalue) = LValue::from_expression(expression.clone()) {
                 let expression = self.parse_expression_or_error();
-                return Some(StatementKind::AssignOp(AssignOpStatement { lvalue, op, expression }));
+                return StatementKind::AssignOp(AssignOpStatement { lvalue, op, expression });
             } else {
                 self.push_error(
                     ParserErrorReason::InvalidLeftHandSideOfAssignment,
@@ -192,7 +201,7 @@ impl Parser<'_> {
             }
         }
 
-        Some(StatementKind::Expression(expression))
+        StatementKind::Expression(expression)
     }
 
     /// Parses an expression that looks like a block (ends with '}'):

--- a/compiler/noirc_frontend/src/parser/parser/statement_or_expression_or_lvalue.rs
+++ b/compiler/noirc_frontend/src/parser/parser/statement_or_expression_or_lvalue.rs
@@ -1,5 +1,5 @@
 use crate::{
-    ast::{AssignStatement, Expression, ExpressionKind, LValue, Statement, StatementKind},
+    ast::{Expression, ExpressionKind, LValue, Statement, StatementKind},
     token::{Token, TokenKind},
 };
 
@@ -23,41 +23,36 @@ impl Parser<'_> {
     ) -> StatementOrExpressionOrLValue {
         let start_location = self.current_token_location;
 
-        // First check if it's an interned LValue
+        // First check if it's an interned LValue. An interned lvalue is really an interned
+        // expression (see `NodeInterner::push_lvalue`), so we treat it as the leading atom of
+        // an expression and let the normal postfix and assignment machinery consume whatever
+        // follows: `$lv`, `$lv.field`, `$lv.method(args)`, `$lv[i]`, `$lv = rhs`, `$lv += rhs`.
         if let Some(token) = self.eat_kind(TokenKind::InternedLValue) {
-            match token.into_token() {
-                Token::InternedLValue(interned) => {
-                    let location = self.location_since(start_location);
-                    let interned_lvalue = || LValue::Interned(interned, location);
+            let Token::InternedLValue(interned) = token.into_token() else {
+                unreachable!("eat_kind(InternedLValue) only matches InternedLValue tokens")
+            };
 
-                    // If it is, it could be something like `lvalue = expr`: check that.
-                    if self.eat(Token::Assign) {
-                        let expression = self.parse_expression_or_error();
-                        let kind = StatementKind::Assign(AssignStatement {
-                            lvalue: interned_lvalue(),
-                            expression,
-                        });
-                        return StatementOrExpressionOrLValue::Statement(Statement {
-                            kind,
-                            location: self.location_since(start_location),
-                        });
-                    } else if self.current_is(Token::Dot) {
-                        let object = Expression {
-                            kind: ExpressionKind::Interned(interned),
-                            location: self.location_since(start_location),
-                        };
-                        let access = self.parse_member_accesses_or_method_calls_after_expression(
-                            object,
-                            start_location,
-                        );
-                        if let Some(lvalue) = LValue::from_expression(access) {
-                            return StatementOrExpressionOrLValue::LValue(lvalue);
-                        }
-                    }
-                    return StatementOrExpressionOrLValue::LValue(interned_lvalue());
-                }
-                _ => unreachable!(),
-            }
+            let atom = Expression {
+                kind: ExpressionKind::Interned(interned),
+                location: self.location_since(start_location),
+            };
+            let atom = self.parse_atom_rhs_after_expression(atom, start_location);
+            let kind = self.parse_assignment_or_expression_statement(atom);
+
+            return match kind {
+                // We started from a spliced lvalue, so prefer an `LValue` result whenever the
+                // (postfix-extended) expression still denotes a place (`$lv`, `$lv.field`,
+                // `$lv[i]`). A non-place tail such as a method call stays an `Expression`
+                // rather than being silently dropped back to the bare lvalue.
+                StatementKind::Expression(expr) => match LValue::from_expression(expr.clone()) {
+                    Some(lvalue) => StatementOrExpressionOrLValue::LValue(lvalue),
+                    None => StatementOrExpressionOrLValue::Expression(expr),
+                },
+                kind => StatementOrExpressionOrLValue::Statement(Statement {
+                    kind,
+                    location: self.location_since(start_location),
+                }),
+            };
         }
 
         // Otherwise, check if it's a statement (which in turn checks if it's an expression)

--- a/test_programs/compile_success_empty/regression_852_method_call_tail/Nargo.toml
+++ b/test_programs/compile_success_empty/regression_852_method_call_tail/Nargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "regression_852_method_call_tail"
+type = "bin"
+authors = [""]
+
+[dependencies]

--- a/test_programs/compile_success_empty/regression_852_method_call_tail/src/main.nr
+++ b/test_programs/compile_success_empty/regression_852_method_call_tail/src/main.nr
@@ -1,0 +1,26 @@
+// Regression for noir-claude#852: when a tail is spliced onto an interned lvalue
+// (`$lv.method()`, `$lv[i]`, `$lv += rhs`, ...), `Quoted::as_expr` must preserve it
+// rather than silently dropping it down to the bare lvalue.
+fn main() {
+    comptime {
+        // `lv` is an interned lvalue extracted from the lhs of an assignment.
+        let lv = quote { x = 1 }.as_expr().unwrap().as_assign().unwrap().0;
+
+        // Method-call tail (the originally reported case).
+        let method_call = quote { $lv.foo() }.as_expr().unwrap();
+        assert(method_call.as_method_call().is_some(), "method-call tail dropped");
+
+        // Member-access tail.
+        let member_access = quote { $lv.bar }.as_expr().unwrap();
+        assert(member_access.as_member_access().is_some(), "member-access tail dropped");
+
+        // Assignment whose lhs is an indexed interned lvalue (exercises the `[i]` tail).
+        let index_assign = quote { $lv[0] = 1 }.as_expr().unwrap();
+        assert(index_assign.as_assign().is_some(), "indexed assignment dropped");
+
+        // Compound assignment (`+=`). There is no dedicated accessor, so observe that the
+        // parsed result no longer collapses to the bare lvalue `$lv`.
+        let compound_assign = quote { $lv += 1 }.as_expr().unwrap();
+        assert(compound_assign.quoted() != quote { $lv }, "compound-assignment tail dropped");
+    }
+}

--- a/tooling/nargo_cli/tests/snapshots/compile_success_empty/regression_852_method_call_tail/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_empty/regression_852_method_call_tail/execute__tests__expanded.snap
@@ -1,0 +1,7 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: expanded_code
+---
+fn main() {
+    ()
+}


### PR DESCRIPTION
## Summary

Comptime `Quoted::as_expr` silently dropped a `.method(args)` tail spliced onto an interned lvalue (`$lv.foo()`), collapsing it back to the bare `$lv` with no diagnostic — so macro-generated constraints/side-effects could vanish. The same affected `$lv[i]` and `$lv += rhs`.

`parse_statement_or_expression_or_lvalue` only special-cased `=` and `.` after the interned lvalue. Since an interned lvalue is really an interned expression (`NodeInterner::push_lvalue`), this now seeds it as the leading atom and reuses the existing postfix + assignment machinery, preferring an `LValue` result only when the parsed expression still denotes a place. This drops the per-token guessing and fixes `.method()`, `[i]` and `+=` uniformly.

Fixes noir-lang/noir-claude#852

## Test

`test_programs/compile_success_empty/regression_852_method_call_tail` asserts at comptime that method-call, member-access, indexed-assignment and compound-assignment tails survive `as_expr`. Verified red on the prior code, green after the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)