### PR TITLE
fix(acir): Handle empty array `value_types` in `make_array_set_result_value`

### DIFF
--- a/compiler/noirc_evaluator/src/acir/arrays.rs
+++ b/compiler/noirc_evaluator/src/acir/arrays.rs
@@ -875,7 +875,14 @@ impl Context<'_> {
         };
 
         let value_types = flat_element_types(&array_typ);
-        assert_eq!(len.to_usize() % value_types.len(), 0);
+        if value_types.is_empty() {
+            // An element type with zero flattened width (e.g. `str<0>` or `[T; 0]`)
+            // forces the whole array to flatten to nothing, so there is no per-element
+            // stride to check the length against.
+            assert_eq!(len.to_usize(), 0, "zero-width elements imply a zero flattened length");
+        } else {
+            assert_eq!(len.to_usize() % value_types.len(), 0);
+        }
 
         Ok(AcirValue::DynamicArray(AcirDynamicArray {
             block_id,

--- a/compiler/noirc_evaluator/src/acir/tests/arrays.rs
+++ b/compiler/noirc_evaluator/src/acir/tests/arrays.rs
@@ -322,6 +322,31 @@ fn zero_length_array_constant() {
 }
 
 #[test]
+fn zero_length_array_dynamic_set() {
+    // An array of zero-width elements (here `[u8; 0]`, the lowering of `str<0>`)
+    // has a flattened size of zero, so each element flattens to zero numeric types.
+    // A dynamic `array_set` must not divide by that empty `value_types` length.
+    let src = "
+    acir(inline) fn main f0 {
+      b0(v0: u32):
+        v1 = make_array b\"\"
+        v2 = make_array [v1, v1, v1, v1] : [[u8; 0]; 4]
+        v3 = array_set v2, index v0, value v1
+        return v3
+    }
+    ";
+    let program = ssa_to_acir_program(src);
+
+    assert_circuit_snapshot!(program, @r"
+    func 0
+    private parameters: [w0]
+    public parameters: []
+    return values: []
+    BLACKBOX::RANGE input: w0, bits: 32
+    ");
+}
+
+#[test]
 fn zero_length_array_dynamic_predicate() {
     let src = "
     acir(inline) fn main f0 {


### PR DESCRIPTION
## Problem Resolved

Resolves a panic discovered by the fuzzer:
```
NOIR_AST_FUZZER_SEED=0xe90ad37c00100000 cargo test -p noir_ast_fuzzer_fuzz acir_vs_brillig
```

The code has an array in it with all empty elements, which is subsequently modified at a dynamic index:
```noir
 let mut a: [str<0>; 4] = [""; 4];
...
a[idx_c] = a[3_u32];
```
resulting in a crash on an assertion added in #11719:
```
The application panicked (crashed).
Message:  attempt to calculate the remainder with a divisor of zero
Location: compiler/noirc_evaluator/src/acir/arrays.rs:878
```

## Summary of Changes

Avoid dividing by `value_types.len()` when it's empty. 
There is another place in #11719 where `value_types.len()` is used with a `%` but there it's safe, because we are in a loop that won't be entered if there are no elements.

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
