### PR TITLE
fix(fuzz): Handle `Div` overflow message equivalence

### DIFF
--- a/tooling/ast_fuzzer/src/compare/interpreted.rs
+++ b/tooling/ast_fuzzer/src/compare/interpreted.rs
@@ -182,6 +182,9 @@ impl Comparable for ssa::interpreter::errors::InterpreterError {
                         || msg == "attempt to shift right with overflow"
                         || msg == "attempt to shift left with overflow"
                 }
+                // Signed division of `i_N::MIN / -1` overflows. The `expand_signed_math` pass and
+                // the constant-folding of binary ops produce the message with different casing.
+                BinaryOp::Div => msg.to_lowercase() == "attempt to divide with overflow",
                 _ => false,
             },
             (


### PR DESCRIPTION
## Problem Resolved

Resolves a false-positive in the fuzzer:
```
NOIR_AST_FUZZER_SEED=0x1e4fbca400100000 cargo test -p noir_ast_fuzzer_fuzz
NOIR_AST_FUZZER_SEED=0x9bec063200100000 cargo test -p noir_ast_fuzzer_fuzz
```

```
---- targets::pass_vs_prev::tests::fuzz_with_arbtest stdout ----
---
Comparison failed:
both programs failed in non-equivalent ways:
An overflow occurred while evaluating `div i8 -128, i8 -1` (div i8 -128, i8 -1)
!~
constrain v41 == v42, "attempt to divide with overflow" failed:
    u1 0 != u1 1

Overflow { operator: Div, instruction: "`div i8 -128, i8 -1` (div i8 -128, i8 -1)" }
ConstrainEqFailed { lhs: "u1 0", lhs_id: Id(41), rhs: "u1 1", rhs_id: Id(42), msg: Some("attempt to divide with overflow") }
```

## Summary of Changes

Add handling of `Div` to `impl Comparable for ssa::interpreter::errors::InterpreterError`. 

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
