### PR TITLE
chore(test): Update comments and add extra test in `load_store_forwarding`

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/opt/load_store_forwarding.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/load_store_forwarding.rs
@@ -765,11 +765,14 @@ mod tests {
     }
 
     // --- Regression tests for issues #12217-#12232 ---
-    // Multi-block tests: the pass skips these entirely (single-block restriction).
+    // Multi-block loop-aliasing cases. The pass processes every block with
+    // state reset at block entry, so a loop-carried alias established across
+    // the back-edge is never forwarded — the relevant load/store pairs sit in
+    // different iterations (i.e. across the block boundary).
 
     #[test]
     fn regression_12217_loop_alias_via_call_input() {
-        // Loop-carried alias established via function call input. Multi-block -> skipped.
+        // Loop-carried alias established via function call input. Cross-iteration alias, not forwarded (state resets at block entry).
         let src = "
         brillig(inline) fn bar f0 {
           b0(v0: &mut Field, v1: Field):
@@ -797,7 +800,7 @@ mod tests {
 
     #[test]
     fn regression_12219_loop_alias_via_call_return() {
-        // Loop-carried alias via returned reference from call. Multi-block -> skipped.
+        // Loop-carried alias via returned reference from call. Cross-iteration alias, not forwarded (state resets at block entry).
         let src = "
         brillig(inline) fn bar f0 {
           b0(v0: &mut Field, v1: Field):
@@ -825,7 +828,7 @@ mod tests {
 
     #[test]
     fn regression_12220_loop_alias_via_array_get() {
-        // Loop-carried alias via array_get with variable index. Multi-block -> skipped.
+        // Loop-carried alias via array_get with variable index. Cross-iteration alias, not forwarded (state resets at block entry).
         let src = "
         brillig(inline) fn bar f0 {
           b0(v0: &mut Field, v1: Field, v_idx: u32):
@@ -850,7 +853,7 @@ mod tests {
 
     #[test]
     fn regression_12221_loop_alias_via_jmpif() {
-        // Loop-carried alias via jmpif passing ref to non-header block. Multi-block -> skipped.
+        // Loop-carried alias via jmpif passing ref to non-header block. Cross-iteration alias, not forwarded (state resets at block entry).
         let src = "
         brillig(inline) fn bar f0 {
           b0(v0: &mut Field, v1: Field, v_cond: u1):
@@ -877,7 +880,7 @@ mod tests {
 
     #[test]
     fn regression_12222_loop_nested_refs_form1() {
-        // Array containing references stored in loop (Form 1 misses nested refs). Multi-block -> skipped.
+        // Array containing references stored in loop (Form 1 misses nested refs). Cross-iteration alias, not forwarded (state resets at block entry).
         let src = "
         brillig(inline) fn bar f0 {
           b0(v0: &mut Field, v1: Field):
@@ -903,7 +906,7 @@ mod tests {
 
     #[test]
     fn regression_12223_loop_nested_refs_form2() {
-        // Loop header block param of array-of-refs type (Form 2 misses nested refs). Multi-block -> skipped.
+        // Loop header block param of array-of-refs type (Form 2 misses nested refs). Cross-iteration alias, not forwarded (state resets at block entry).
         let src = "
         brillig(inline) fn bar f0 {
           b0(v0: &mut Field, v1: Field):

--- a/compiler/noirc_evaluator/src/ssa/opt/load_store_forwarding.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/load_store_forwarding.rs
@@ -604,11 +604,10 @@ mod tests {
 
     #[test]
     fn call_returning_alias_of_local_allocation_prevents_forwarding() {
-        // Bug: When a local allocation is passed to a call, it is removed from
-        // known_values/last_stores but NOT from local_allocations. If the callee
-        // returns an alias to the same memory, stores through the original address
-        // skip the conservative clear (because it's still in local_allocations),
-        // leaving stale entries for the alias.
+        // A call returns an alias of an address that is also stored to directly.
+        // v1 (the returned reference) and v0 (the call argument) point to the
+        // same memory, so a store through v0 must invalidate the cached value
+        // for v1 — otherwise a later load of v1 forwards a stale value.
         let src = "
         brillig(inline) fn main f0 {
           b0():

--- a/compiler/noirc_evaluator/src/ssa/opt/load_store_forwarding.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/load_store_forwarding.rs
@@ -1029,6 +1029,45 @@ mod tests {
     }
 
     #[test]
+    fn load_through_array_get_alias_keeps_aliased_store_live() {
+        // A store to v0, then v0 is extracted through make_array + array_get as
+        // a fresh ValueId v2, loaded through that alias, then v0 is overwritten.
+        // The load through the alias reads the first store, so that store must
+        // NOT be eliminated as dead by the later store to v0.
+        //
+        // Regression test for noir-lang/noir-claude#798: array_get gives v2 the
+        // allocation site of v0, so `may_alias(v2, v0)` clears `last_stores[v0]`
+        // on the load, the load forwards `Field 1`, and the final store does not
+        // treat `store Field 1 at v0` as a redundant prior write.
+        let src = "
+        brillig(inline) fn main f0 {
+          b0():
+            v0 = allocate -> &mut Field
+            store Field 1 at v0
+            v1 = make_array [v0] : [&mut Field; 1]
+            v2 = array_get v1, index u32 0 -> &mut Field
+            v3 = load v2 -> Field
+            store Field 2 at v0
+            return v3
+        }
+        ";
+        let ssa = Ssa::from_str(src).unwrap();
+        let ssa = ssa.load_store_forwarding();
+        // The load returns the value through the alias (`Field 1`), never the
+        // uninitialized `Field 0` that DSE of the first store would expose.
+        assert_ssa_snapshot!(ssa, @r"
+        brillig(inline) fn main f0 {
+          b0():
+            v0 = allocate -> &mut Field
+            store Field 1 at v0
+            v2 = make_array [v0] : [&mut Field; 1]
+            store Field 2 at v0
+            return Field 1
+        }
+        ");
+    }
+
+    #[test]
     fn regression_12234_if_else_over_params_does_not_alias_local_allocate() {
         // v5 is either v0 (function param) or v3 (block param fed by v0) —
         // both coming from the external caller. v2 is a local allocate, so


### PR DESCRIPTION
## Problem Resolved

Related to https://github.com/noir-lang/noir-claude/issues/798

## Summary of Changes

* Updates the comments to no longer say that `load_store_forwarding` is restricted to single-block functions
* Adds the PoC1 test from the issue to show that it has been fixed, as noted in https://github.com/noir-lang/noir-claude/issues/798#issuecomment-4565752267

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
