### PR TITLE
fix: check deferred private import in intermediate segments

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/path_resolution.rs
+++ b/compiler/noirc_frontend/src/elaborator/path_resolution.rs
@@ -631,6 +631,12 @@ impl Elaborator<'_> {
                 prev_segment.ident.is_self_type_name(),
             );
 
+            // An item brought into scope by an import that is not visible from here (kept in scope only
+            // because a colliding item in the other namespace was visible) is private when referenced.
+            if self.get_module(current_module_id).is_private_import_deferred(typ) {
+                errors.push(PathResolutionError::Private(prev_ident.clone()));
+            }
+
             let current_module_id_is_type;
 
             (current_module_id, current_module_id_is_type, intermediate_item) = match typ {

--- a/compiler/noirc_frontend/src/tests/visibility.rs
+++ b/compiler/noirc_frontend/src/tests/visibility.rs
@@ -1380,6 +1380,32 @@ fn errors_on_qualified_access_to_private_type_colliding_with_public_value() {
 }
 
 #[test]
+fn errors_when_using_private_type_imported_via_collision_as_path_prefix() {
+    // The private type must be rejected even when it only appears as an intermediate path
+    // prefix (calling an inherent associated function), not just as the final path item.
+    let src = r#"
+    mod moo {
+        struct Foo {}
+
+        impl Foo {
+            pub fn make() -> Self { Foo {} }
+        }
+
+        pub fn Foo() {}
+    }
+
+    use moo::Foo;
+
+    fn main() {
+        let _ = Foo::make();
+                ^^^ Foo is private and not visible from the current module
+                ~~~ Foo is private
+    }
+    "#;
+    check_errors(src);
+}
+
+#[test]
 fn errors_at_import_when_both_colliding_items_are_private() {
     // When a name resolves to a private item in both namespaces there is no visible item to make
     // the import legal, so the error is reported at the `use` itself (and only once), rather than


### PR DESCRIPTION
## Problem Resolved

Resolves https://github.com/noir-lang/noir-claude/issues/1372

## Summary of Changes

Follow-up to https://github.com/noir-lang/noir/pull/12848

We were checking this in a path's final segment but we need to do it in all segments.

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
