### PR TITLE
chore(ssa): Remove `dead_code` from `alias_analysis`

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/ir/union_find.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/union_find.rs
@@ -53,6 +53,9 @@ impl<K: Copy + Eq + Hash> UnionFind<K> {
 
     /// Return a map from each class representative to the number of values
     /// in that class.
+    // Only consumer is `AliasAnalysis::is_aliased`, which has no production
+    // caller yet.
+    #[allow(dead_code)]
     pub(crate) fn class_sizes(&self) -> HashMap<K, u32> {
         let mut sizes = HashMap::default();
         for &v in self.parent.keys() {

--- a/compiler/noirc_evaluator/src/ssa/opt/alias_analysis.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/alias_analysis.rs
@@ -1,7 +1,3 @@
-// The alias analysis is not consumed by any optimization pass yet,
-// remove it once the analysis is used.
-#![allow(dead_code)]
-
 //! Steensgaard-style alias analysis for SSA references.
 //!
 //! This is a flow-insensitive, unification-based alias analysis. It walks every
@@ -123,30 +119,6 @@ use crate::ssa::{
     ssa_gen::Ssa,
 };
 
-/// Scope of the analysis
-enum Scope<'a> {
-    /// Analyze a single function
-    Single(&'a Function),
-    /// Analyze the whole program. More precise; preferred over the single-function analysis.
-    Ssa(&'a Ssa),
-}
-
-impl Scope<'_> {
-    fn is_entry_point(&self, function_id: FunctionId) -> bool {
-        match self {
-            Scope::Single(function) => function.id() == function_id,
-            Scope::Ssa(ssa) => ssa.is_entry_point(function_id),
-        }
-    }
-
-    fn functions(&self) -> Vec<&Function> {
-        match self {
-            Scope::Single(f) => vec![*f],
-            Scope::Ssa(ssa) => ssa.functions.values().collect(),
-        }
-    }
-}
-
 /// GlobalValueId are ValueId along with their FunctionId,
 /// allowing to globally use ValueIds coming from several functions.
 #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
@@ -209,13 +181,7 @@ impl AliasAnalysis {
     ///
     /// The constraints are monotone and converge in a single pass.
     pub(crate) fn analyze(ssa: &Ssa) -> Self {
-        AliasAnalysisContext::analyze_with_scope(Scope::Ssa(ssa))
-    }
-    /// Build an analysis for one function in isolation. All calls are treated as
-    /// opaque via `unresolved_call`. Less precise than [`Self::analyze`] but usable
-    /// when the whole SSA is unavailable.
-    pub(crate) fn analyze_single_function(function: &Function) -> Self {
-        AliasAnalysisContext::analyze_with_scope(Scope::Single(function))
+        AliasAnalysisContext::analyze_ssa(ssa)
     }
 
     /// Returns `true` if `a` and `b` may refer to the same memory location.
@@ -261,6 +227,9 @@ impl AliasAnalysis {
     ///
     /// The per-class size table is populated on demand the first time this is
     /// called — consumers that only use [`Self::may_alias`] do not pay for it.
+    // Part of the analysis's query API, exercised by unit tests; no production
+    // consumer yet.
+    #[allow(dead_code)]
     pub(crate) fn is_aliased(&mut self, value: GlobalValueId) -> bool {
         let root = self.aliases.find(value);
         if self.class_sizes.is_none() {
@@ -300,6 +269,9 @@ impl AliasAnalysis {
     /// Returns `true` if `a` and `b` definitely refer to the same memory location
     /// Allocation site identity does not imply runtime cell identity when
     /// the site fires multiple times in one execution (e.g. loops, recursion)
+    // Part of the analysis's query API, exercised by unit tests; no production
+    // consumer yet.
+    #[allow(dead_code)]
     pub(crate) fn must_alias(&self, a: GlobalValueId, b: GlobalValueId) -> bool {
         if a == b {
             return true;
@@ -539,10 +511,10 @@ fn loop_blocks(function: &Function) -> HashSet<BasicBlockId> {
 }
 
 impl AliasAnalysisContext {
-    fn analyze_with_scope(scope: Scope) -> AliasAnalysis {
+    fn analyze_ssa(ssa: &Ssa) -> AliasAnalysis {
         // Precondition: globals are expected to be pure constants (numeric or
         // composite-of-numeric) as documented.
-        let functions = scope.functions();
+        let functions: Vec<&Function> = ssa.functions.values().collect();
         if let Some(first) = functions.first() {
             for (_, global) in first.dfg.globals.values_iter() {
                 assert!(
@@ -558,24 +530,20 @@ impl AliasAnalysisContext {
         // detection in `analyze_block` propagates transitively: when we reach a
         // callee, every site that has already flagged it as untrusted has
         // already run, and that knowledge feeds back into how we analyze it.
-        let pass1_functions: Vec<&Function> = match &scope {
-            Scope::Single(f) => vec![*f],
-            Scope::Ssa(ssa) => {
-                // The analysis tolerates incomplete call-graphs, via `unresolved_call` handling
-                let call_graph = CallGraph::from_ssa_partial(ssa);
-                let (sccs, recursive) = call_graph.sccs();
-                analysis.untrusted_site_functions = recursive;
-                sccs.into_iter().rev().flatten().filter_map(|fid| ssa.functions.get(&fid)).collect()
-            }
-        };
+        // The analysis tolerates incomplete call-graphs, via `unresolved_call` handling
+        let call_graph = CallGraph::from_ssa_partial(ssa);
+        let (sccs, recursive) = call_graph.sccs();
+        analysis.untrusted_site_functions = recursive;
+        let pass1_functions: Vec<&Function> =
+            sccs.into_iter().rev().flatten().filter_map(|fid| ssa.functions.get(&fid)).collect();
 
         for function in &pass1_functions {
-            analysis.analyze_function(&scope, function);
+            analysis.analyze_function(ssa, function);
         }
 
         // Pass 2: propagate sites for Load / ArrayGet from the allocation site of their address's pointees
         for function in &functions {
-            analysis.refine_allocation_sites(function, scope.is_entry_point(function.id()));
+            analysis.refine_allocation_sites(function, ssa.is_entry_point(function.id()));
         }
 
         let value_count = functions.iter().map(|f| (f.id(), f.dfg.num_values() as u32)).collect();
@@ -682,8 +650,8 @@ impl AliasAnalysisContext {
     /// Walk every block in one function, processing instructions and terminators.
     /// If the function is an entry point of the SSA, also unify its
     /// same-typed reference parameters.
-    fn analyze_function(&mut self, scope: &Scope, function: &Function) {
-        let is_entry_point = scope.is_entry_point(function.id());
+    fn analyze_function(&mut self, ssa: &Ssa, function: &Function) {
+        let is_entry_point = ssa.is_entry_point(function.id());
         if is_entry_point {
             // Unify the reference parameters of the entry point because the
             // external caller may pass the same reference to 2 reference parameters.
@@ -710,7 +678,7 @@ impl AliasAnalysisContext {
             // in `analyze_block`.
             let ignore_allocations_in_block =
                 function_is_untrusted || loop_block_set.contains(&block_id);
-            self.analyze_block(function, block_id, scope, ignore_allocations_in_block);
+            self.analyze_block(function, block_id, ssa, ignore_allocations_in_block);
         }
 
         if is_entry_point {
@@ -834,7 +802,7 @@ impl AliasAnalysisContext {
         &mut self,
         function: &Function,
         block_id: BasicBlockId,
-        scope: &Scope,
+        ssa: &Ssa,
         mut ignore_allocations_in_block: bool,
     ) {
         let block = &function.dfg[block_id];
@@ -862,13 +830,13 @@ impl AliasAnalysisContext {
                     self.join_reference(function, *value, *address);
                 }
                 Instruction::Call { func: callee_id, arguments } => {
-                    match (&function.dfg[*callee_id], scope) {
+                    match &function.dfg[*callee_id] {
                         // Inter-procedural analysis for resolved functions
                         // - merge arguments with their parameters,
                         // - process the function body (i.e analyze the instructions, but only once since it context-insensitive).
                         //   This is done through analyze_function() which process all the functions.
                         // - merge return values with the instruction results
-                        (Value::Function(callee_id), Scope::Ssa(ssa)) => {
+                        Value::Function(callee_id) => {
                             // Multi-invocation detection: a populated `return_values`
                             // entry means this is at least the second call site.
                             if self.return_values.contains_key(callee_id)
@@ -880,22 +848,20 @@ impl AliasAnalysisContext {
                                 ssa, *callee_id, function, arguments, results,
                             );
                         }
-                        (Value::Intrinsic(Intrinsic::Hint(_)), _) => {
+                        Value::Intrinsic(Intrinsic::Hint(_)) => {
                             self.unresolved_call(function, arguments, results);
                         }
-                        (Value::Intrinsic(intrinsic), _)
-                            if Self::is_vector_intrinsic(intrinsic) =>
-                        {
+                        Value::Intrinsic(intrinsic) if Self::is_vector_intrinsic(intrinsic) => {
                             // Merge input vector with output,
                             // Add the elements to the vector's pointee set
                             self.unify_vector_intrinsic(function, intrinsic, arguments, results);
                         }
-                        (Value::Intrinsic(intrinsic), _) => {
+                        Value::Intrinsic(intrinsic) => {
                             // Only Hint or Vector operations may alias.
                             assert!(!Self::intrinsic_may_alias(intrinsic));
                         }
                         // Foreign calls cannot call Noir functions, so we do not mark them as recursive
-                        (Value::ForeignFunction { .. }, _) => {
+                        Value::ForeignFunction { .. } => {
                             self.unresolved_call(function, arguments, results);
                         }
                         // Fallthrough for unresolved functions whose function body


### PR DESCRIPTION
## Problem Resolved

I noticed in https://github.com/noir-lang/noir/pull/13040 that `is_aliased` is only used in tests, but wasn't highlighted because the whole module had `#[allow(dead_code)]` on it.

## Summary of Changes

Removes the module level `#[allow(dead_code)]` and applies it only to the test-only methods. Not `#[cfg(test)]` so the cache invalidation can still be called from live code, without making it more cumbersome.

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
