### PR TITLE
fix: Parse type-level integers in .as_type

### DIFF
--- a/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
@@ -978,12 +978,19 @@ fn quoted_as_type(
     location: Location,
 ) -> IResult<Value> {
     let argument = check_one_argument(arguments, location)?;
-    let typ = parse(interpreter.elaborator, argument, Parser::parse_type_or_error, "a type")?;
+    let typ = parse(
+        interpreter.elaborator,
+        argument,
+        Parser::parse_type_or_type_expression_or_error,
+        "a type",
+    )?;
     let reason = Some(ElaborateReason::EvaluatingComptimeCall("Quoted::as_type", location));
     let wildcard_allowed = WildcardAllowed::No(WildcardDisallowedContext::QuotedAsType);
     let typ =
         interpreter.elaborate_in_function(interpreter.current_function, reason, |elaborator| {
-            elaborator.use_type(typ, wildcard_allowed)
+            // `Kind::Any` so a numeric type expression (e.g. `quote { 4 }`) resolves to a
+            // `Type::Constant` rather than being rejected as a non-`Normal` kind.
+            elaborator.use_type_with_kind(typ, &Kind::Any, wildcard_allowed)
         });
     Ok(Value::Type(typ))
 }

--- a/compiler/noirc_frontend/src/parser/parser/types.rs
+++ b/compiler/noirc_frontend/src/parser/parser/types.rs
@@ -28,6 +28,18 @@ impl Parser<'_> {
         }
     }
 
+    /// Like [`Self::parse_type_or_error`], but also accepts a numeric type expression
+    /// (such as `4` or `N + 1`) as a standalone type. Used where a quoted token stream
+    /// is reinterpreted as a type, since numeric values are valid in type-level positions.
+    pub(crate) fn parse_type_or_type_expression_or_error(&mut self) -> UnresolvedType {
+        if let Some(typ) = self.parse_type_or_type_expression() {
+            typ
+        } else {
+            self.expected_label(ParsingRuleLabel::Type);
+            UnresolvedTypeData::Error.with_location(self.location_at_previous_token_end())
+        }
+    }
+
     /// Tries to parse a type. If the current token doesn't denote a type and it's not
     /// one of `stop_tokens`, try to parse a type starting from the next token (and so on).
     pub(crate) fn parse_type_or_error_with_recovery(

--- a/docs/docs/libraries/standard_library/meta/quoted.md
+++ b/docs/docs/libraries/standard_library/meta/quoted.md
@@ -49,6 +49,9 @@ Example:
 Interprets this token stream as a resolved type. Panics if the token
 stream doesn't parse to a type or if the type isn't a valid type in scope.
 
+A numeric literal such as `4` is interpreted as the type-level integer `4`, so it
+can be used to fill a numeric generic slot, such as for an array length.
+
 #include_code implements_example test_programs/compile_success_empty/comptime_type/src/main.nr rust
 
 ### location

--- a/test_programs/compile_success_empty/type_def_fields_numeric_generic/Nargo.toml
+++ b/test_programs/compile_success_empty/type_def_fields_numeric_generic/Nargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "type_def_fields_numeric_generic"
+type = "bin"
+authors = [""]
+
+[dependencies]

--- a/test_programs/compile_success_empty/type_def_fields_numeric_generic/src/main.nr
+++ b/test_programs/compile_success_empty/type_def_fields_numeric_generic/src/main.nr
@@ -1,0 +1,21 @@
+// Numeric values are valid in type-level positions, so `Quoted::as_type` accepts a numeric
+// literal and yields a constant type. That constant can then fill `Foo`'s `Numeric(u32)`
+// generic slot when applying `TypeDefinition::fields`.
+pub struct Foo<let N: u32, T> {
+    a: [T; N],
+}
+
+fn main() {
+    comptime {
+        let (foo_def, _) =
+            quote { Foo<3, Field> }.as_type().as_data_type().unwrap();
+
+        // Ensure `4` can be parsed as a type
+        let four_t = quote { 4 }.as_type();
+        let field_t = quote { Field }.as_type();
+
+        let fields = foo_def.fields([four_t, field_t].as_vector());
+        assert_eq(fields.len(), 1);
+        assert_eq(fields[0].1, quote { [Field; 4] }.as_type());
+    }
+}

--- a/test_programs/compile_success_empty/type_def_fields_numeric_generic/src/main.nr
+++ b/test_programs/compile_success_empty/type_def_fields_numeric_generic/src/main.nr
@@ -7,8 +7,7 @@ pub struct Foo<let N: u32, T> {
 
 fn main() {
     comptime {
-        let (foo_def, _) =
-            quote { Foo<3, Field> }.as_type().as_data_type().unwrap();
+        let (foo_def, _) = quote { Foo<3, Field> }.as_type().as_data_type().unwrap();
 
         // Ensure `4` can be parsed as a type
         let four_t = quote { 4 }.as_type();

--- a/tooling/nargo_cli/tests/snapshots/compile_success_empty/type_def_fields_numeric_generic/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_empty/type_def_fields_numeric_generic/execute__tests__expanded.snap
@@ -1,0 +1,11 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: expanded_code
+---
+pub struct Foo<let N: u32, T> {
+    a: [T; N],
+}
+
+fn main() {
+    ()
+}


### PR DESCRIPTION
## Problem Resolved

Resolves an issue that came up on slack

## Summary of Changes

`quote { 4 }.as_type()` was failing previously because we did not parse integers as types. We should allow this though since it is otherwise much more difficult to get a value of an integer constant type.

## User Documentation

Check one:
- [ ] No user documentation needed.
- [x] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
