### PR TITLE
chore(comptime performance): Add bottom limit for comptime scopes that can be queried

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/comptime.rs
+++ b/compiler/noirc_frontend/src/elaborator/comptime.rs
@@ -197,11 +197,13 @@ impl<'context> Elaborator<'context> {
         result
     }
 
-    /// Populate the elaborator's scope with all comptime variables.
+    /// Populate the elaborator's scope with the comptime variables visible to the current function.
     ///
-    /// When elaborating code generated at comptime, we need to make all comptime
-    /// variables available in the runtime scope. We iterate from global to local
-    /// scope so that more local definitions naturally shadow outer ones.
+    /// When elaborating code generated at comptime, we need to make the comptime variables in scope
+    /// available in the runtime scope. The visible scopes are the global scope together with those
+    /// at or above the comptime scope floor; scopes belonging to enclosing callers are skipped, just
+    /// as the interpreter skips them. We iterate from global to local scope so that more local
+    /// definitions naturally shadow outer ones.
     ///
     /// Within a single scope, bindings are registered in ascending
     /// [crate::node_interner::DefinitionId] order. `DefinitionId`s are minted monotonically
@@ -211,8 +213,12 @@ impl<'context> Elaborator<'context> {
     /// directly would instead pick a binding by hash-bucket order.
     #[tracing::instrument(level = "trace", skip_all)]
     fn populate_scope_from_comptime_scopes(&mut self) {
-        for scope in &self.interner.comptime_scopes {
-            let mut definition_ids: Vec<_> = scope.keys().copied().collect();
+        let floor = self.interner.comptime_scope_floor;
+        let len = self.interner.comptime_scopes.len();
+
+        for index in std::iter::once(0).chain(floor..len) {
+            let mut definition_ids: Vec<_> =
+                self.interner.comptime_scopes[index].keys().copied().collect();
             definition_ids.sort();
             for definition_id in &definition_ids {
                 let definition = self.interner.definition(*definition_id);

--- a/compiler/noirc_frontend/src/elaborator/globals.rs
+++ b/compiler/noirc_frontend/src/elaborator/globals.rs
@@ -168,8 +168,12 @@ impl Elaborator<'_> {
 
         let expr = self.interner.expression(&let_statement.expression);
         if !matches!(expr, HirExpression::Error) {
-            // Globals must be elaborated at the global scope
+            // Globals must be elaborated at the global scope: drain every non-global scope so the
+            // initializer is defined into the global scope, and lower the scope floor to one so the
+            // initializer's own block-local scopes (which may be pushed when evaluating it during an
+            // enclosing comptime call) remain visible.
             let saved_scopes: Vec<_> = self.interner.comptime_scopes.drain(1..).collect();
+            let saved_floor = std::mem::replace(&mut self.interner.comptime_scope_floor, 1);
 
             let mut interpreter = self.setup_interpreter();
 
@@ -192,6 +196,7 @@ impl Elaborator<'_> {
             }
 
             self.interner.comptime_scopes.extend(saved_scopes);
+            self.interner.comptime_scope_floor = saved_floor;
         }
     }
 

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
@@ -412,23 +412,27 @@ impl<'local, 'interner> Interpreter<'local, 'interner> {
     /// Enters a function, pushing a new scope and resetting any required state.
     /// Returns the previous values of the internal state, to be reset when
     /// [Self::exit_function] is called.
-    pub(super) fn enter_function(&mut self) -> (bool, Vec<HashMap<DefinitionId, Value>>) {
-        // Drain every scope except the global scope
-        let mut scope = Vec::new();
-        if self.elaborator.interner.comptime_scopes.len() > 1 {
-            scope = self.elaborator.interner.comptime_scopes.drain(1..).collect();
-        }
+    ///
+    /// Rather than physically removing the caller's scopes, the scope floor is raised to the top
+    /// of the scope stack so the callee only sees its own scopes plus the global scope. This keeps
+    /// entering a function O(1) regardless of how deep the call stack is.
+    pub(super) fn enter_function(&mut self) -> (bool, usize) {
+        let interner = &mut self.elaborator.interner;
+        let previous_floor =
+            std::mem::replace(&mut interner.comptime_scope_floor, interner.comptime_scopes.len());
         self.push_scope();
-        (std::mem::take(&mut self.in_loop), scope)
+        (std::mem::take(&mut self.in_loop), previous_floor)
     }
 
     /// Resets the per-function state to the value previously returned by [Self::enter_function]
-    pub(super) fn exit_function(&mut self, mut state: (bool, Vec<HashMap<DefinitionId, Value>>)) {
+    pub(super) fn exit_function(&mut self, state: (bool, usize)) {
         self.in_loop = state.0;
 
-        // Keep only the global scope
-        self.elaborator.interner.comptime_scopes.truncate(1);
-        self.elaborator.interner.comptime_scopes.append(&mut state.1);
+        // Drop every scope this function pushed (the current floor is the length recorded on entry)
+        // before restoring the caller's floor.
+        let interner = &mut self.elaborator.interner;
+        interner.comptime_scopes.truncate(interner.comptime_scope_floor);
+        interner.comptime_scope_floor = state.1;
     }
 
     /// Pushes a new scope to define any variables in.
@@ -611,8 +615,14 @@ impl<'local, 'interner> Interpreter<'local, 'interner> {
 
     /// Mutate an existing variable, potentially from a prior scope
     fn mutate(&mut self, id: DefinitionId, argument: Value, location: Location) -> IResult<()> {
-        for scope in self.elaborator.interner.comptime_scopes.iter_mut().rev() {
-            if let Entry::Occupied(mut entry) = scope.entry(id) {
+        let floor = self.elaborator.interner.comptime_scope_floor;
+        let scopes = &mut self.elaborator.interner.comptime_scopes;
+
+        // Search the current function's scopes from innermost outwards, then fall back to the
+        // global scope at index zero. Scopes belonging to enclosing callers (below the floor)
+        // are skipped so a callee cannot mutate its caller's locals.
+        for index in (floor..scopes.len()).rev().chain(std::iter::once(0)) {
+            if let Entry::Occupied(mut entry) = scopes[index].entry(id) {
                 match entry.get() {
                     Value::Pointer(reference, true, _) => {
                         // We can't store to the reference directly, we need to check if the value
@@ -637,8 +647,14 @@ impl<'local, 'interner> Interpreter<'local, 'interner> {
 
     /// Lookup the comptime value of the given definition
     pub fn lookup_id(&self, id: DefinitionId, location: Location) -> IResult<Value> {
-        for scope in self.elaborator.interner.comptime_scopes.iter().rev() {
-            if let Some(value) = scope.get(&id) {
+        let floor = self.elaborator.interner.comptime_scope_floor;
+        let scopes = &self.elaborator.interner.comptime_scopes;
+
+        // Search the current function's scopes from innermost outwards, then fall back to the
+        // global scope at index zero. Scopes belonging to enclosing callers (below the floor)
+        // are skipped so a callee cannot see its caller's locals.
+        for index in (floor..scopes.len()).rev().chain(std::iter::once(0)) {
+            if let Some(value) = scopes[index].get(&id) {
                 return Ok(value.clone());
             }
         }

--- a/compiler/noirc_frontend/src/node_interner/mod.rs
+++ b/compiler/noirc_frontend/src/node_interner/mod.rs
@@ -293,6 +293,12 @@ pub struct NodeInterner {
     /// share the same global values.
     pub(crate) comptime_scopes: Vec<HashMap<DefinitionId, comptime::Value>>,
 
+    /// Index into [Self::comptime_scopes] of the first scope visible to the comptime function
+    /// currently being interpreted. The visible scopes are the global scope (index zero) together
+    /// with `comptime_scopes[comptime_scope_floor..]`; scopes between them belong to enclosing
+    /// callers and are hidden so a callee cannot see its caller's locals.
+    pub(crate) comptime_scope_floor: usize,
+
     /// Captures the documentation comments for each module, struct, trait, function, etc.
     pub(crate) doc_comments: HashMap<ReferenceId, Vec<DocComment>>,
 
@@ -529,6 +535,7 @@ impl Default for NodeInterner {
             reference_graph_indices: HashMap::default(),
             auto_import_names: HashMap::default(),
             comptime_scopes: vec![HashMap::default()],
+            comptime_scope_floor: 1,
             trait_impl_generic_types: HashMap::default(),
             trait_impl_associated_constants: HashMap::default(),
             doc_comments: HashMap::default(),


### PR DESCRIPTION
## Problem Resolved

## Summary of Changes

Slightly improves comptime performance (~2%). Before on each call we were swapping out the maps of each variable in scope, causing us to allocate a Vec holding them on every call. Now we just save a floor telling the interpreter not to query items past that limit. Scope 0 is the global scope so that is still queried even with a floor.

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
