### PR TITLE
feat: impl doc comments

### DIFF
--- a/compiler/noirc_frontend/src/ast/traits.rs
+++ b/compiler/noirc_frontend/src/ast/traits.rs
@@ -10,7 +10,7 @@ use crate::ast::{
 use crate::token::SecondaryAttribute;
 
 use super::{
-    Documented, GenericTypeArgs, IdentOrQuotedType, ItemVisibility, UnresolvedGeneric,
+    DocComment, Documented, GenericTypeArgs, IdentOrQuotedType, ItemVisibility, UnresolvedGeneric,
     UnresolvedTypeData,
 };
 
@@ -63,6 +63,7 @@ pub struct TypeImpl {
     pub generics: UnresolvedGenerics,
     pub where_clause: Vec<UnresolvedTraitConstraint>,
     pub methods: Vec<(Documented<NoirFunction>, Location)>,
+    pub doc_comments: Vec<DocComment>,
 }
 
 /// Ast node for an implementation of a trait for a particular type

--- a/compiler/noirc_frontend/src/elaborator/comptime.rs
+++ b/compiler/noirc_frontend/src/elaborator/comptime.rs
@@ -695,6 +695,7 @@ impl<'context> Elaborator<'context> {
                     generics: target.generics.clone(),
                     where_clause: target.where_clause.clone(),
                     methods: vec![(Documented::new(function, item.doc_comments), location)],
+                    doc_comments: Vec::new(),
                 };
                 let module = self.module_id();
                 dc_mod::collect_impl(

--- a/compiler/noirc_frontend/src/elaborator/function.rs
+++ b/compiler/noirc_frontend/src/elaborator/function.rs
@@ -171,6 +171,7 @@ impl Elaborator<'_> {
                     generics: resolved_generics,
                     methods: unresolved_impl.methods.function_ids(),
                     where_clause: resolved_where_clause.clone(),
+                    doc_comments: unresolved_impl.doc_comments.clone(),
                 },
             );
 

--- a/compiler/noirc_frontend/src/hir/def_collector/dc_crate.rs
+++ b/compiler/noirc_frontend/src/hir/def_collector/dc_crate.rs
@@ -18,7 +18,7 @@ use crate::hir::resolution::import::{
 };
 use crate::hir::resolution::visibility::trait_visibility_for_method_is_satisfied;
 
-use crate::ast::{Expression, NoirEnumeration, PathKind, TypeAlias};
+use crate::ast::{DocComment, Expression, NoirEnumeration, PathKind, TypeAlias};
 use crate::node_interner::{
     FuncId, GlobalId, ImplId, ModuleAttributes, NodeInterner, ReferenceId, TraitId, TraitImplId,
     TypeAliasId, TypeId,
@@ -202,6 +202,7 @@ pub(crate) struct UnresolvedImpl {
     pub object_type_location: Location,
     pub methods: UnresolvedFunctions,
     pub impl_id: ImplId,
+    pub doc_comments: Vec<DocComment>,
 }
 
 /// Maps the type and the module id in which an impl is defined to the impls collected for it.

--- a/compiler/noirc_frontend/src/hir/def_collector/dc_mod.rs
+++ b/compiler/noirc_frontend/src/hir/def_collector/dc_mod.rs
@@ -1474,6 +1474,7 @@ pub fn collect_impl(
         object_type_location: r#impl.type_location,
         methods: unresolved_functions,
         impl_id,
+        doc_comments: r#impl.doc_comments,
     });
 }
 

--- a/compiler/noirc_frontend/src/hir/printer/items.rs
+++ b/compiler/noirc_frontend/src/hir/printer/items.rs
@@ -8,7 +8,7 @@ mod types;
 
 use crate::{
     Kind, NamedGeneric, QuotedType, ResolvedGenerics, Type,
-    ast::{IntegerBitSize, ItemVisibility},
+    ast::{DocComment, IntegerBitSize, ItemVisibility},
     hir::def_map::ModuleId,
     hir_def::traits::TraitConstraint,
     modules::module_def_id_to_reference_id,
@@ -83,6 +83,7 @@ pub struct Impl {
     pub typ: Type,
     pub where_clause: Vec<TraitConstraint>,
     pub methods: Vec<(ItemVisibility, FuncId)>,
+    pub doc_comments: Vec<DocComment>,
 }
 
 #[derive(Clone)]
@@ -270,6 +271,7 @@ impl<'context> ItemBuilder<'context> {
             typ: impl_.typ.clone(),
             where_clause: impl_.where_clause.clone(),
             methods,
+            doc_comments: impl_.doc_comments.clone(),
         }
     }
 

--- a/compiler/noirc_frontend/src/hir/printer/mod.rs
+++ b/compiler/noirc_frontend/src/hir/printer/mod.rs
@@ -7,7 +7,7 @@ use crate::hir::resolution::visibility::module_def_id_visibility;
 use crate::node_interner::TraitImplId;
 use crate::{
     DataType, Kind, NamedGeneric, ResolvedGenerics, Type,
-    ast::{Ident, ItemVisibility},
+    ast::{DocComment, Ident, ItemVisibility},
     graph::Dependency,
     hir::{
         comptime::{Value, tokens_to_string_with_indent},
@@ -185,7 +185,10 @@ impl<'context, 'string> ItemPrinter<'context, 'string> {
         let Some(doc_comments) = self.interner.doc_comments(reference_id) else {
             return;
         };
+        self.show_doc_comment_lines(doc_comments);
+    }
 
+    fn show_doc_comment_lines(&mut self, doc_comments: &[DocComment]) {
         for located_comment in doc_comments {
             let comment = &located_comment.contents;
             if comment.contains('\n') {
@@ -342,6 +345,7 @@ impl<'context, 'string> ItemPrinter<'context, 'string> {
     fn show_impl(&mut self, impl_: Impl) {
         let typ = impl_.typ;
 
+        self.show_doc_comment_lines(&impl_.doc_comments);
         self.push_str("impl");
         self.show_generics(&impl_.generics);
         self.push(' ');

--- a/compiler/noirc_frontend/src/hir_def/traits.rs
+++ b/compiler/noirc_frontend/src/hir_def/traits.rs
@@ -2,7 +2,7 @@ use iter_extended::vecmap;
 use rustc_hash::FxHashMap as HashMap;
 
 use crate::ResolvedGeneric;
-use crate::ast::{Ident, ItemVisibility, NoirFunction};
+use crate::ast::{DocComment, Ident, ItemVisibility, NoirFunction};
 use crate::elaborator::types::SELF_TYPE_NAME;
 use crate::hir::type_check::generics::TraitGenerics;
 use crate::node_interner::{
@@ -135,6 +135,9 @@ pub struct Impl {
 
     /// The impl's where clause. Empty if there is no where clause.
     pub where_clause: Vec<TraitConstraint>,
+
+    /// The doc comments written on top of the impl block. Empty if there are none.
+    pub doc_comments: Vec<DocComment>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/compiler/noirc_frontend/src/parser/mod.rs
+++ b/compiler/noirc_frontend/src/parser/mod.rs
@@ -125,7 +125,7 @@ impl ParsedModule {
                 ItemKind::Enum(typ) => module.push_enum(typ, item.doc_comments),
                 ItemKind::Trait(noir_trait) => module.push_trait(noir_trait, item.doc_comments),
                 ItemKind::TraitImpl(trait_impl) => module.push_trait_impl(trait_impl),
-                ItemKind::Impl(r#impl) => module.push_impl(r#impl),
+                ItemKind::Impl(r#impl) => module.push_impl(r#impl, item.doc_comments),
                 ItemKind::TypeAlias(type_alias) => {
                     module.push_type_alias(type_alias, item.doc_comments);
                 }
@@ -266,7 +266,8 @@ impl SortedModule {
         self.trait_impls.push(trait_impl);
     }
 
-    fn push_impl(&mut self, r#impl: TypeImpl) {
+    fn push_impl(&mut self, mut r#impl: TypeImpl, doc_comments: Vec<DocComment>) {
+        r#impl.doc_comments = doc_comments;
         self.impls.push(r#impl);
     }
 

--- a/compiler/noirc_frontend/src/parser/parser/impls.rs
+++ b/compiler/noirc_frontend/src/parser/parser/impls.rs
@@ -43,7 +43,14 @@ impl Parser<'_> {
     ) -> TypeImpl {
         let where_clause = self.parse_where_clause();
         let methods = self.parse_type_impl_body();
-        TypeImpl { object_type, type_location, generics, where_clause, methods }
+        TypeImpl {
+            object_type,
+            type_location,
+            generics,
+            where_clause,
+            methods,
+            doc_comments: Vec::new(),
+        }
     }
 
     /// TypeImplBody = '{' TypeImplItem* '}'

--- a/compiler/noirc_frontend/src/tests/expand.rs
+++ b/compiler/noirc_frontend/src/tests/expand.rs
@@ -220,6 +220,45 @@ fn expands_separate_inherent_impl_blocks_separately() {
     ");
 }
 
+#[test]
+fn expands_inherent_impl_with_doc_comment() {
+    let src = r#"
+    struct Foo {
+        x: Field,
+    }
+
+    /// Methods for Foo.
+    impl Foo {
+        fn get(self) -> Field {
+            self.x
+        }
+    }
+
+    fn main() {
+        let foo = Foo { x: 1 };
+        let _ = foo.get();
+    }
+    "#;
+    let expanded = assert_no_errors_and_to_string(src);
+    insta::assert_snapshot!(expanded, @r"
+    struct Foo {
+        x: Field,
+    }
+
+    /// Methods for Foo.
+    impl Foo {
+        fn get(self) -> Field {
+            self.x
+        }
+    }
+
+    fn main() {
+        let foo: Foo = Foo { x: 1_Field};
+        let _: Field = foo.get();
+    }
+    ");
+}
+
 // A method that binds an associated type on the impl's generic (`T: Foo<Assoc = Field>`)
 // keeps that binding: it is distinct from the impl's own `T: Foo` and must not be deduplicated
 // against it just because they share the same type and trait.

--- a/tooling/lsp/src/with_file.rs
+++ b/tooling/lsp/src/with_file.rs
@@ -158,6 +158,7 @@ fn type_impl_with_file(type_impl: TypeImpl, file: FileId) -> TypeImpl {
         generics: unresolved_generics_with_file(type_impl.generics, file),
         where_clause: unresolved_trait_constraints_with_file(type_impl.where_clause, file),
         methods: documented_noir_functions_with_file(type_impl.methods, file),
+        doc_comments: type_impl.doc_comments,
     }
 }
 

--- a/tooling/nargo_doc/src/html.rs
+++ b/tooling/nargo_doc/src/html.rs
@@ -843,6 +843,9 @@ impl HTMLCreator {
         let indent = 0;
         self.render_where_clause(&impl_.where_clause, indent);
         self.output.push_str("</code></h3>\n\n");
+
+        self.render_comments(impl_.comments.as_ref(), 3);
+
         let output_id = true;
 
         self.self_type = Some(impl_.r#type.clone());

--- a/tooling/nargo_doc/src/items.rs
+++ b/tooling/nargo_doc/src/items.rs
@@ -241,6 +241,7 @@ pub struct Impl {
     pub r#type: Type,
     pub where_clause: Vec<TraitConstraint>,
     pub methods: Vec<Function>,
+    pub comments: Option<Comments>,
 }
 
 #[derive(Clone, PartialEq, Eq, Hash, Debug)]

--- a/tooling/nargo_doc/src/lib.rs
+++ b/tooling/nargo_doc/src/lib.rs
@@ -391,6 +391,8 @@ impl DocItemBuilder<'_> {
             Generic { name, numeric }
         });
         let r#type = self.convert_type(&impl_.typ);
+        let comments =
+            (!impl_.doc_comments.is_empty()).then(|| self.doc_comments_from(&impl_.doc_comments));
         let where_clause =
             vecmap(&impl_.where_clause, |constraint| self.convert_trait_constraint(constraint));
         self.trait_constraints = where_clause.clone();
@@ -401,7 +403,7 @@ impl DocItemBuilder<'_> {
             .map(|(_, func_id)| self.convert_function(func_id))
             .collect();
         self.trait_constraints.clear();
-        Impl { generics, r#type, where_clause, methods }
+        Impl { generics, r#type, where_clause, methods, comments }
     }
 
     fn convert_trait_impl(&mut self, item_trait_impl: expand_items::TraitImpl) -> TraitImpl {
@@ -745,9 +747,13 @@ impl DocItemBuilder<'_> {
     }
 
     fn doc_comments(&mut self, id: ReferenceId) -> Option<(String, Links)> {
+        let comments = self.interner.doc_comments(id)?;
+        Some(self.doc_comments_from(comments))
+    }
+
+    fn doc_comments_from(&mut self, comments: &[DocComment]) -> (String, Links) {
         self.link_finder.reset();
 
-        let comments = self.interner.doc_comments(id)?;
         let mut links = Vec::new();
         let mut line = 0;
 
@@ -769,7 +775,7 @@ impl DocItemBuilder<'_> {
 
         let comments =
             vecmap(comments, |comment| comment.contents.clone()).join("\n").trim().to_string();
-        Some((comments, links))
+        (comments, links)
     }
 
     /// The idea of this method is to find occurrences of markdown links and references in comments.


### PR DESCRIPTION
## Problem Resolved

No issue.

## Summary of Changes

Follow-up to https://github.com/noir-lang/noir/pull/12995

We always recorded an impl's doc comments during parsing. However, because we used to not record impls permanently after elaboration, these comments were a bit hard to extract, to show in `nargo doc` and `nargo expand`. I checked and `cargo doc` does show doc comments attached on impls, so this PR does that too. It can help explain why different impls for a same type exist.

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
