### PR TITLE
chore: reject Field comparison in comptime code

### DIFF
--- a/compiler/noirc_frontend/src/hir/comptime/integer.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/integer.rs
@@ -374,11 +374,12 @@ impl std::ops::Rem for Integer {
 
 impl Integer {
     /// `self < rhs`
-    /// Similar to the derived `impl Ord for Integer` but will return `None` when the integer
-    /// variants do not match.
+    /// Returns `None` when the integer variants do not match, and for `Field` operands:
+    /// fields have no ordering (their canonical representatives encode `-k` as `p - k`,
+    /// which would invert signed intuition), matching the elaborator's rejection of
+    /// `<`/`<=`/`>`/`>=` on `Field`.
     pub fn lt(&self, rhs: &Self) -> Option<bool> {
         match (self, rhs) {
-            (Integer::Field(lhs), Integer::Field(rhs)) => Some(lhs < rhs),
             (Integer::U8(lhs), Integer::U8(rhs)) => Some(lhs < rhs),
             (Integer::U16(lhs), Integer::U16(rhs)) => Some(lhs < rhs),
             (Integer::U32(lhs), Integer::U32(rhs)) => Some(lhs < rhs),
@@ -393,11 +394,12 @@ impl Integer {
     }
 
     /// `self <= rhs`
-    /// Similar to the derived `impl Ord for Integer` but will return `None` when the integer
-    /// variants do not match.
+    /// Returns `None` when the integer variants do not match, and for `Field` operands:
+    /// fields have no ordering (their canonical representatives encode `-k` as `p - k`,
+    /// which would invert signed intuition), matching the elaborator's rejection of
+    /// `<`/`<=`/`>`/`>=` on `Field`.
     pub fn lte(&self, rhs: &Self) -> Option<bool> {
         match (self, rhs) {
-            (Integer::Field(lhs), Integer::Field(rhs)) => Some(lhs <= rhs),
             (Integer::U8(lhs), Integer::U8(rhs)) => Some(lhs <= rhs),
             (Integer::U16(lhs), Integer::U16(rhs)) => Some(lhs <= rhs),
             (Integer::U32(lhs), Integer::U32(rhs)) => Some(lhs <= rhs),
@@ -665,5 +667,21 @@ mod tests {
         let a = Integer::Field(FieldElement::from(10u64));
         let b = Integer::Field(FieldElement::from(3u64));
         assert_eq!(a % b, None);
+    }
+
+    #[test]
+    fn field_lt_is_unordered() {
+        let neg_one = Integer::Field(Integer::I64(-1).as_field());
+        let zero = Integer::Field(FieldElement::zero());
+        assert_eq!(neg_one.lt(&zero), None);
+        assert_eq!(zero.lt(&neg_one), None);
+    }
+
+    #[test]
+    fn field_lte_is_unordered() {
+        let neg_one = Integer::Field(Integer::I64(-1).as_field());
+        let zero = Integer::Field(FieldElement::zero());
+        assert_eq!(neg_one.lte(&zero), None);
+        assert_eq!(zero.lte(&neg_one), None);
     }
 }

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter/infix.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter/infix.rs
@@ -83,12 +83,32 @@ pub(super) fn evaluate_infix(
         };
     }
 
-    /// Generate matches for comparison operations on all types, returning `Bool`.
+    /// Generate matches for equality operations on all types, returning `Bool`.
     macro_rules! match_cmp {
         (($lhs_value:ident as $lhs:ident $op:literal $rhs_value:ident as $rhs:ident) => $expr:expr) => {
             match_values! {
                 ($lhs_value as $lhs $op $rhs_value as $rhs) {
                     (Field, Field) to Bool => Some($expr),
+                    (I8,  I8)      to Bool => Some($expr),
+                    (I16, I16)     to Bool => Some($expr),
+                    (I32, I32)     to Bool => Some($expr),
+                    (I64, I64)     to Bool => Some($expr),
+                    (U8,  U8)      to Bool => Some($expr),
+                    (U16, U16)     to Bool => Some($expr),
+                    (U32, U32)     to Bool => Some($expr),
+                    (U64, U64)     to Bool => Some($expr),
+                    (U128, U128)   to Bool => Some($expr),
+                    Bool case to Bool => Some($expr),
+                }
+            }
+        };
+    }
+
+    /// Generate matches for ordering comparisons, returning `Bool`.
+    macro_rules! match_ord {
+        (($lhs_value:ident as $lhs:ident $op:literal $rhs_value:ident as $rhs:ident) => $expr:expr) => {
+            match_values! {
+                ($lhs_value as $lhs $op $rhs_value as $rhs) {
                     (I8,  I8)      to Bool => Some($expr),
                     (I16, I16)     to Bool => Some($expr),
                     (I32, I32)     to Bool => Some($expr),
@@ -179,16 +199,16 @@ pub(super) fn evaluate_infix(
         BinaryOpKind::NotEqual => match_cmp! {
             (lhs_value as lhs "!=" rhs_value as rhs) => lhs != rhs
         },
-        BinaryOpKind::Less => match_cmp! {
+        BinaryOpKind::Less => match_ord! {
             (lhs_value as lhs "<" rhs_value as rhs) => lhs < rhs
         },
-        BinaryOpKind::LessEqual => match_cmp! {
+        BinaryOpKind::LessEqual => match_ord! {
             (lhs_value as lhs "<=" rhs_value as rhs) => lhs <= rhs
         },
-        BinaryOpKind::Greater => match_cmp! {
+        BinaryOpKind::Greater => match_ord! {
             (lhs_value as lhs ">" rhs_value as rhs) => lhs > rhs
         },
-        BinaryOpKind::GreaterEqual => match_cmp! {
+        BinaryOpKind::GreaterEqual => match_ord! {
             (lhs_value as lhs ">=" rhs_value as rhs) => lhs >= rhs
         },
         BinaryOpKind::And => match_bitwise! {
@@ -257,6 +277,42 @@ mod tests {
         let result = evaluate_infix(lhs, rhs, operator, location).unwrap();
 
         assert_eq!(result, Value::u128(170141183460469231731687303715884105727));
+    }
+
+    #[test]
+    fn field_ordering_is_rejected() {
+        use crate::hir::comptime::Integer;
+        use acvm::{AcirField, FieldElement};
+
+        let neg_one = Value::field(Integer::I64(-1).as_field());
+        let zero = Value::field(FieldElement::zero());
+
+        for kind in [
+            BinaryOpKind::Less,
+            BinaryOpKind::LessEqual,
+            BinaryOpKind::Greater,
+            BinaryOpKind::GreaterEqual,
+        ] {
+            let operator = HirBinaryOp { kind, location: Location::dummy() };
+            let err = evaluate_infix(neg_one.clone(), zero.clone(), operator, Location::dummy())
+                .unwrap_err();
+            assert!(
+                matches!(err, InterpreterError::InvalidValuesForBinary { .. }),
+                "expected {kind:?} on fields to be rejected, got {err:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn field_equality_is_still_allowed() {
+        use acvm::FieldElement;
+
+        let one = Value::field(FieldElement::from(1u64));
+        let other_one = Value::field(FieldElement::from(1u64));
+
+        let operator = HirBinaryOp { kind: BinaryOpKind::Equal, location: Location::dummy() };
+        let result = evaluate_infix(one, other_one, operator, Location::dummy()).unwrap();
+        assert_eq!(result, Value::Bool(true));
     }
 
     #[test]


### PR DESCRIPTION
## Problem Resolved

Resolves https://github.com/noir-lang/noir-claude/issues/837

## Summary of Changes

This is a minor thing because the code is effectively dead, but it previously allowed comparing fields in comptime code with `<` and `<=`, something that we don't allow in Noir. This PR makes this code now return `None` instead of `Some`, as it's more correct.

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
