### PR TITLE
fix: check comptime-only types in constructor expressions

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/scope.rs
+++ b/compiler/noirc_frontend/src/elaborator/scope.rs
@@ -306,10 +306,16 @@ impl Elaborator<'_> {
             Ok(PathResolutionItem::Type(struct_id)) => {
                 let struct_type = self.get_type(struct_id);
                 let generics = struct_type.borrow().instantiate(self.interner);
-                Some(Type::DataType(struct_type, generics))
+                let typ = Type::DataType(struct_type, generics);
+                self.check_comptime_type_in_non_comptime_item(&typ, location);
+                Some(typ)
             }
             Ok(PathResolutionItem::TypeAlias(alias_id)) => {
                 let alias = self.interner.get_type_alias(alias_id);
+                self.check_comptime_type_in_non_comptime_item(
+                    &Type::Alias(alias.clone(), Vec::new()),
+                    location,
+                );
                 let alias = alias.borrow();
                 Some(alias.instantiate(self.interner))
             }

--- a/compiler/noirc_frontend/src/elaborator/types.rs
+++ b/compiler/noirc_frontend/src/elaborator/types.rs
@@ -686,7 +686,11 @@ impl Elaborator<'_> {
 
     /// Reports an error if `typ` is a comptime-only type and we are not in a comptime item
     #[tracing::instrument(level = "trace", skip_all)]
-    fn check_comptime_type_in_non_comptime_item(&mut self, typ: &Type, location: Location) {
+    pub(super) fn check_comptime_type_in_non_comptime_item(
+        &mut self,
+        typ: &Type,
+        location: Location,
+    ) {
         if self.in_comptime_context() {
             return;
         }

--- a/compiler/noirc_frontend/src/tests/metaprogramming.rs
+++ b/compiler/noirc_frontend/src/tests/metaprogramming.rs
@@ -51,6 +51,34 @@ fn comptime_type_in_runtime_code() {
 }
 
 #[test]
+fn comptime_type_in_constructor_in_runtime_code() {
+    let source = r#"
+    comptime struct MetaOnly {
+        value: Field,
+    }
+
+    struct RuntimeStruct {
+        value: Field,
+    }
+
+    comptime type MetaAlias = RuntimeStruct;
+
+    fn id<T>(x: T) -> T {
+        x
+    }
+
+    fn main() -> pub Field {
+        let direct = id(MetaOnly { value: 10 });
+                        ^^^^^^^^ Comptime-only type `MetaOnly` cannot be used in non-comptime function
+        let alias = MetaAlias { value: 32 };
+                    ^^^^^^^^^ Comptime-only type `MetaAlias` cannot be used in non-comptime function
+        direct.value + alias.value
+    }
+    "#;
+    check_errors(source);
+}
+
+#[test]
 fn macro_result_type_mismatch() {
     let src = r#"
         fn main() {


### PR DESCRIPTION
## Problem Resolved

Resolves https://linear.app/aztec-foundation/issue/NRSEC-1031
Resolves https://cantina.xyz/code/af01d57f-6e50-4de3-ad6d-7e9f7ff2d7d1/findings/39

## Summary of Changes

Constructor expressions go through a slightly different path so we need to check if the resolved types are not comptime-only. It's a bit hard to unify this code with the other code... but now every type-lookup instance is covered.

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
