### PR TITLE
fix: prune stale folded str<N> assertion error selectors from ABI

### DIFF
--- a/compiler/noirc_driver/tests/print_acir.rs
+++ b/compiler/noirc_driver/tests/print_acir.rs
@@ -9,6 +9,7 @@ use std::path::Path;
 
 use acvm::acir::circuit::Circuit;
 use acvm::acir::native_types::Witness;
+use noirc_abi::AbiErrorType;
 use noirc_driver::{
     CompileOptions, display_compiled_program, file_manager_with_stdlib, prepare_crate,
 };
@@ -65,6 +66,57 @@ fn print_acir_renders_static_assertion_payload() {
     let parsed = Circuit::from_str(circuit_text).expect("ACIR display should be parseable");
     assert_eq!(parsed.private_parameters, [Witness(0)].into_iter().collect());
     assert_eq!(parsed.opcodes, program.program.functions[0].opcodes);
+}
+
+#[test]
+fn folded_generic_str_assertion_has_no_stale_error_type() {
+    // A generic `str<N>` assertion message records a dynamic `custom string` error
+    // selector during SSA generation, but the constant string folds to a static-string
+    // assertion payload during ACIR lowering. The ABI should only advertise the
+    // reachable static-string selector, not the stale pre-fold dynamic selector.
+    let source = r#"
+    fn fail_with_generic_msg<T>(predicate: bool, msg: T) {
+        assert(predicate, msg);
+    }
+
+    fn main(x: pub Field) {
+        fail_with_generic_msg(x == 0, "bad");
+    }
+    "#;
+
+    let program = compile(source, false);
+
+    let error_types: Vec<&AbiErrorType> = program.abi.error_types.values().collect();
+    assert_eq!(
+        error_types,
+        vec![&AbiErrorType::String { string: "bad".to_string() }],
+        "expected only the reachable static-string error type"
+    );
+}
+
+#[test]
+fn dynamic_custom_error_type_is_preserved() {
+    // A non-string assertion payload is never folded to a static string, so its dynamic
+    // selector is genuinely emitted and must remain in the ABI.
+    let source = r#"
+    struct MyError {
+        code: Field,
+    }
+
+    fn main(x: pub Field) {
+        assert(x == 0, MyError { code: x });
+    }
+    "#;
+
+    let program = compile(source, false);
+
+    let error_types: Vec<&AbiErrorType> = program.abi.error_types.values().collect();
+    assert_eq!(error_types.len(), 1, "expected the dynamic custom error type to be retained");
+    assert!(
+        matches!(error_types[0], AbiErrorType::Custom(_)),
+        "expected a custom error type, got {:?}",
+        error_types[0]
+    );
 }
 
 #[test]

--- a/compiler/noirc_evaluator/src/acir/ssa.rs
+++ b/compiler/noirc_evaluator/src/acir/ssa.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashSet};
 
 use acvm::{
     FieldElement,
@@ -9,7 +9,13 @@ use noirc_frontend::Type as HirType;
 use crate::{
     brillig::{Brillig, BrilligOptions},
     errors::RuntimeError,
-    ssa::ssa_gen::Ssa,
+    ssa::{
+        ir::{
+            instruction::{ConstrainError, Instruction},
+            printer::try_to_extract_string_from_error_payload,
+        },
+        ssa_gen::Ssa,
+    },
 };
 
 use super::{Context, GeneratedAcir, SharedContext, acir_context::BrilligStdLib};
@@ -85,5 +91,39 @@ pub(super) fn codegen_acir(
         .map(|brillig| BrilligBytecode { function_name: brillig.name, bytecode: brillig.byte_code })
         .collect();
 
-    Ok((acirs, brillig_bytecode, ssa.error_selector_to_type))
+    // Dynamic error types are recorded speculatively during SSA generation, but a constant
+    // `str<N>` payload is folded into a static-string assertion during ACIR/Brillig lowering.
+    // Once folded, the dynamic selector is never emitted, so it must not survive into the ABI.
+    // Keep only the dynamic selectors that lowering actually emits as selector+payload data.
+    let used_selectors = used_dynamic_error_selectors(&ssa);
+    let mut error_selector_to_type = ssa.error_selector_to_type;
+    error_selector_to_type.retain(|selector, _| used_selectors.contains(selector));
+
+    Ok((acirs, brillig_bytecode, error_selector_to_type))
+}
+
+/// Collects the dynamic error selectors that ACIR/Brillig lowering emits as selector+payload data,
+/// i.e. those whose payload is *not* folded into a static string. This mirrors the fold decision in
+/// [`crate::acir::Context::convert_constrain_error`] and its Brillig counterpart so the two stay in sync.
+fn used_dynamic_error_selectors(ssa: &Ssa) -> HashSet<ErrorSelector> {
+    let mut used = HashSet::new();
+    for function in ssa.functions.values() {
+        let dfg = &function.dfg;
+        for block in function.reachable_blocks() {
+            for instruction in dfg[block].instructions() {
+                let (Instruction::Constrain(_, _, Some(error))
+                | Instruction::ConstrainNotEqual(_, _, Some(error))) = &dfg[*instruction]
+                else {
+                    continue;
+                };
+                if let ConstrainError::Dynamic(selector, is_string_type, values) = error
+                    && try_to_extract_string_from_error_payload(*is_string_type, values, dfg)
+                        .is_none()
+                {
+                    used.insert(*selector);
+                }
+            }
+        }
+    }
+    used
 }

--- a/compiler/noirc_evaluator/src/ssa/function_builder/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/function_builder/mod.rs
@@ -42,6 +42,9 @@ pub struct FunctionBuilder {
     current_block: BasicBlockId,
     finished_functions: Vec<Function>,
     call_stack: CallStackId,
+    /// Types of dynamic assertion messages, keyed by their error selector. Only dynamic messages
+    /// are recorded here; static string messages are handled inline (see
+    /// `FunctionContext::codegen_constrain_error`).
     error_types: BTreeMap<ErrorSelector, HirType>,
 
     /// Whether instructions are simplified as soon as they are inserted into this builder.

--- a/compiler/noirc_evaluator/src/ssa/ssa_gen/program.rs
+++ b/compiler/noirc_evaluator/src/ssa/ssa_gen/program.rs
@@ -30,8 +30,12 @@ pub struct Ssa {
     /// as the final program artifact will be a list of only entry point functions.
     #[serde(skip)]
     entry_point_to_generated_index: BTreeMap<FunctionId, u32>,
-    // We can skip serializing this field as the error selector types end up as part of the
-    // ABI not the actual SSA IR.
+    /// Types of dynamic assertion messages, keyed by their error selector. Only dynamic messages
+    /// are recorded here; static string messages are handled inline (see
+    /// `FunctionContext::codegen_constrain_error`).
+    ///
+    /// We can skip serializing this field as the error selector types end up as part of the
+    /// ABI not the actual SSA IR.
     #[serde(skip)]
     pub error_selector_to_type: BTreeMap<ErrorSelector, HirType>,
 }


### PR DESCRIPTION
## Summary

Fixes https://github.com/noir-lang/noir-claude/issues/1374 and https://linear.app/aztec-foundation/issue/AZTBOT-1255/folded-dynamic-strlessngreater-assertions-leave-stale-abi-custom

A generic or otherwise non-literal `str<N>` assertion message records a dynamic `custom string` error selector during SSA generation (`codegen_constrain_error` in `ssa_gen/mod.rs`), *before* lowering knows whether the payload will actually be emitted dynamically. When the payload turns out to be a constant string, ACIR/Brillig lowering folds it into a static-string assertion (`generate_assertion_message_payload`), and the dynamic selector is never emitted by the compiled circuit. The stale selector nevertheless survived into `abi.error_types`.

### Reproduction

```noir
fn fail_with_generic_msg<T>(predicate: bool, msg: T) {
    assert(predicate, msg);
}

fn main(x: pub Field) {
    fail_with_generic_msg(x == 0, "bad");
}
```

The compiled ACIR contains exactly one reachable, static assertion (`ASSERT w0 = 0 // bad`), and the runtime error display is correct. But the artifact advertised **two** error types:

```json
{
  "8268090971085425825": { "error_kind": "string", "string": "bad" },
  "9230725515038505495": { "error_kind": "custom", "kind": "string", "length": 3 }
}
```

The second entry is the pre-fold dynamic `str<3>` selector — never referenced by the emitted assertion. This is not a soundness issue, but downstream tooling that treats `abi.error_types` as the exact assertion error surface can document or expose a stale, unreachable error type.

## Fix

In `codegen_acir`, after generating ACIR/Brillig, prune `error_selector_to_type` down to the dynamic selectors that lowering actually emits as selector+payload data. `used_dynamic_error_selectors` scans every `Constrain` / `ConstrainNotEqual` and applies the same fold predicate the lowering uses (`try_to_extract_string_from_error_payload`), so a dynamic selector is kept iff at least one assertion emits it dynamically.

## Why prune by reachability instead of discarding the payload at the fold site

The obvious-looking fix is to remove the dynamic selector right where lowering decides to fold the constant string. That is **unsound**, because the dynamic selector is keyed by *type*, not by assertion site. A single `str<N>` selector can back both:

- an assertion with a constant message (folds to a static string), and
- an assertion with a genuinely runtime message (e.g. `dynamic_string_assert`: `fn main(msg: str<3>, cond: bool) { assert(cond, msg); }`), which must stay dynamic.

Both share the same selector. Discarding it at the first fold would drop the selector that the second, non-folded assertion still emits — breaking runtime error decoding for it.

So the decision can only be made *globally*, after seeing every assertion that references the selector. Pruning by reachability — keep the selector iff some assertion still emits it dynamically — is the only correct option, and it naturally also drops selectors whose only assertion was optimized away entirely. The pruning predicate is deliberately the same function the lowering paths already use, so the two stay in sync.

## Testing

- `compiler/noirc_driver/tests/print_acir.rs`:
  - `folded_generic_str_assertion_has_no_stale_error_type` — the repro above; asserts the ABI advertises only the reachable static-string selector. (Fails before the fix with the stale `Custom(String { length: 3 })` entry.)
  - `dynamic_custom_error_type_is_preserved` — a non-string custom error is never folded, so its dynamic selector must be retained (guards against over-pruning).
- Full `noirc_evaluator` suite (1692 tests) and `noirc_abi` suite pass.
- `execution_failure` integration tests for the dynamic/runtime assertion paths pass, including `dynamic_string_assert`, `assert_msg_runtime` (f-strings), and the Brillig variants — confirming genuinely-emitted dynamic error types are preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)