### PR TITLE
chore: document why fmtstr capture drop in hir_to_display_ast is safe

### DIFF
--- a/compiler/noirc_frontend/src/hir/comptime/hir_to_display_ast.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/hir_to_display_ast.rs
@@ -112,7 +112,8 @@ impl HirExpression {
                 ExpressionKind::Literal(Literal::Str(String::from_utf8_lossy(bytes).into_owned()))
             }
             HirExpression::Literal(HirLiteral::FmtStr(fragments, _exprs, length)) => {
-                // TODO: Is throwing away the exprs here valid?
+                // Dropping the captures is lossless: interpolations are single identifiers whose
+                // names are already in `fragments`, and re-elaboration re-resolves them by name.
                 ExpressionKind::Literal(Literal::FmtStr(fragments.clone(), *length))
             }
             HirExpression::Literal(HirLiteral::Unit) => ExpressionKind::Literal(Literal::Unit),


### PR DESCRIPTION
## Summary

Replaces the `TODO: Is throwing away the exprs here valid?` comment in `HirExpression::to_display_ast`'s `FmtStr` arm with an explanation of why dropping the captured `Vec<ExprId>` is safe.

It is safe — and not reproducible from Noir source — because:

- Fmt string interpolations are lexically restricted to a **single identifier** (`eat_fmt_string` in the lexer allows only `[A-Za-z_][A-Za-z0-9_]*`).
- So in `elaborate_fmt_string`, every captured `ExprId` is always an `Ident` whose name is exactly the fragment's interpolation string (or `Error`).
- The fragment already carries that name, so reconstructing `f"{name}"` from `fragments` alone is information-equivalent to keeping the exprs; re-elaboration re-resolves each `name` by name.

The downstream consequences raised in the issue (unhygienic rebinding on round-trip; `Quoted::eq`/`hash` collapsing distinct capture-type tuples) are properties of non-hygienic quoting and of fmt-string `Display` (which has no capture-type slot in either HIR or AST form), not of the drop itself. No Noir program can observe a difference, so there is no `.nr` regression test to add — the only PoC in the issue constructs `HirLiteral::FmtStr` by hand.

Fixes https://github.com/noir-lang/noir-claude/issues/865

🤖 Generated with [Claude Code](https://claude.com/claude-code)