### PR TITLE
fix: push comptime interpreter call stack before mutating binding state

### DIFF
--- a/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
@@ -170,14 +170,24 @@ impl<'local, 'interner> Interpreter<'local, 'interner> {
 
         resolve_type_bindings(&mut instantiation_bindings);
 
+        self.elaborator.push_interpreter_call_stack(location)?;
+
         self.unbind_generics_from_previous_function();
         perform_instantiation_bindings(&instantiation_bindings);
 
         let impl_bindings =
-            perform_impl_bindings(self.elaborator.interner, trait_method, function, location)?;
+            match perform_impl_bindings(self.elaborator.interner, trait_method, function, location)
+            {
+                Ok(impl_bindings) => impl_bindings,
+                Err(error) => {
+                    self.elaborator.pop_interpreter_call_stack();
+                    undo_instantiation_bindings(instantiation_bindings);
+                    self.rebind_generics_from_previous_function();
+                    return Err(error);
+                }
+            };
 
         self.remember_function_bindings(&instantiation_bindings, &impl_bindings);
-        self.elaborator.push_interpreter_call_stack(location)?;
 
         if let Some(tracker) = self.elaborator.evaluation_tracker.as_mut() {
             tracker.track_function_call(function, location);
@@ -347,6 +357,8 @@ impl<'local, 'interner> Interpreter<'local, 'interner> {
         arguments: Vec<(Value, Location)>,
         call_location: Location,
     ) -> IResult<Value> {
+        self.elaborator.push_interpreter_call_stack(call_location)?;
+
         // Set the closure's scope to that of the function it was originally evaluated in
         let old_module = self.elaborator.replace_module(closure.module_scope);
         let old_function = std::mem::replace(&mut self.current_function, closure.function_scope);
@@ -355,7 +367,6 @@ impl<'local, 'interner> Interpreter<'local, 'interner> {
         perform_bindings(&closure.bindings);
 
         self.remember_closure_bindings(&closure.bindings);
-        self.elaborator.push_interpreter_call_stack(call_location)?;
 
         let result = self.call_closure_inner(closure.lambda, closure.env, arguments, call_location);
 


### PR DESCRIPTION
## Summary

`Interpreter::call_function` and `Interpreter::call_closure` performed several state-mutating operations before the fallible `push_interpreter_call_stack(...)?`:

- `call_function`: `unbind_generics_from_previous_function` + `perform_instantiation_bindings` + `perform_impl_bindings` + `remember_function_bindings`, then the push.
- `call_closure`: `replace_module` + `current_function` swap + `perform_bindings` + `remember_closure_bindings`, then the push.

When the push returns `InterpreterError::StackOverflow`, the `?` exits before the matching undo/restore steps run, so `force_bind`'d `TypeVariable` cells and the elaborator's `local_module`/`crate_id` can be left dirty past the `run_attribute` catch-and-continue boundary.

`push_interpreter_call_stack` checks the recursion limit *before* pushing and returns `Err` with no side effect, so this PR moves it ahead of every mutation in both frames. On overflow there is now nothing to roll back. The other fallible step in `call_function`, `perform_impl_bindings(...)?`, now rolls back the already-applied instantiation bindings and generic frame (and pops the call stack) before propagating its error.

## Is anything actually broken today?

No — and this PR intentionally does **not** add a regression test, because there is no observable behavior to assert. In practice only the single deepest frame's bindings could ever leak (every parent frame still runs its own unconditional undo on the way out), and those leaked cells are dead: per-call-site instantiation variables that nothing else references. That is why the originating audit never demonstrated an end-to-end miscompile.

The value here is making the "push before mutate, restore in LIFO" invariant **structural** rather than incidental. The code was previously correct by accident; today's safety relied on facts you have to re-derive by tracing rather than anything the structure enforces. Any future fallible step added mid-frame would silently reintroduce the leak. It costs essentially nothing to do the right thing here.

The only assertable property would be internal binding/scope state after the error, which is exactly the kind of implementation-coupled test the repo's testing guidance warns against — so no `.nr` or unit regression test accompanies this.

## Verification

- Both reproducers from the issue still report `Comptime Stack Overflow` byte-identically (no behavior change).
- Full `noirc_frontend` suite passes (1905 tests).

Fixes noir-lang/noir-claude#866

🤖 Generated with [Claude Code](https://claude.com/claude-code)