### PR TITLE
chore(ci): strip debug info from archived test binaries

### DIFF
--- a/.github/workflows/test-rust-workspace-arm64.yml
+++ b/.github/workflows/test-rust-workspace-arm64.yml
@@ -48,6 +48,12 @@ jobs:
         run: cargo nextest archive --workspace --archive-file nextest-archive-arm64.tar.zst
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # The archive is uploaded once and downloaded by every test partition.
+          # Debug info dominates its size but is never read during a CI test run
+          # (a failure is reproduced locally with a normal debug build), so drop
+          # it to keep the per-partition `Download archive` step off the timeout.
+          CARGO_PROFILE_DEV_DEBUG: "0"
+          CARGO_PROFILE_TEST_DEBUG: "0"
 
       # `compile_fail` runs trybuild, which spawns its own `cargo build` and
       # needs the cargo registry to resolve transitive proc-macro deps. The

--- a/.github/workflows/test-rust-workspace-msrv.yml
+++ b/.github/workflows/test-rust-workspace-msrv.yml
@@ -62,6 +62,12 @@ jobs:
         run: cargo nextest archive --workspace --archive-file nextest-archive.tar.zst
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # The archive is uploaded once and downloaded by every test partition.
+          # Debug info dominates its size but is never read during a CI test run
+          # (a failure is reproduced locally with a normal debug build), so drop
+          # it to keep the per-partition `Download archive` step off the timeout.
+          CARGO_PROFILE_DEV_DEBUG: "0"
+          CARGO_PROFILE_TEST_DEBUG: "0"
 
       # `compile_fail` runs trybuild, which spawns its own `cargo build` and
       # needs the cargo registry to resolve transitive proc-macro deps. The

--- a/.github/workflows/test-rust-workspace.yml
+++ b/.github/workflows/test-rust-workspace.yml
@@ -49,6 +49,12 @@ jobs:
         run: cargo nextest archive --workspace --archive-file nextest-archive.tar.zst
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # The archive is uploaded once and downloaded by every test partition.
+          # Debug info dominates its size but is never read during a CI test run
+          # (a failure is reproduced locally with a normal debug build), so drop
+          # it to keep the per-partition `Download archive` step off the timeout.
+          CARGO_PROFILE_DEV_DEBUG: "0"
+          CARGO_PROFILE_TEST_DEBUG: "0"
 
       # `compile_fail` runs trybuild, which spawns its own `cargo build` and
       # needs the cargo registry to resolve transitive proc-macro deps. The


### PR DESCRIPTION


## Problem Resolved

Resolves intermittent CI issues.

## Summary of Changes

The `nextest archive` tarball is built once and downloaded by all 8 test partitions. Its size is dominated by DWARF debug info, which is never read during a CI test run — a failure is reproduced locally with an ordinary debug build. Dropping it (CI-only, via CARGO_PROFILE_*_DEBUG=0) shrinks the artifact so the per-partition `Download archive` step stops blowing past the job timeout when GitHub's artifact backend is throttling.

I checked the artifact sizes:
- Before: 2.44 GB
- After: 221 MB

That's 91% smaller.

The "Download archive" step used to take between 2 minutes and 12 minutes, now it takes between 10 seconds and 15 seconds.

If a test fails on CI we can always re-run it locally with debug info to see backtraces, etc.

Here are the times it took to run the partitions:

<img width="971" height="367" alt="image" src="https://github.com/user-attachments/assets/f749546d-4882-4b3a-aa69-a9dbb61be375" />

The slowest one is 3 because it has the fuzzing test.

I still think improving the test run is good, though (the other PRs that are about moving test programs to unit tests, or trying to reduce the amount of test programs). Everything helps.

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
