### PR TITLE
chore(ci): remove rust-cache from publish-nargo

### DIFF
--- a/.github/workflows/publish-nargo.yml
+++ b/.github/workflows/publish-nargo.yml
@@ -47,12 +47,6 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-        with:
-          key: ${{ matrix.target }}
-          cache-on-failure: true
-          save-if: ${{ github.event_name != 'merge_group' }}
-
       - uses: taiki-e/install-action@just
 
       - name: Build binaries
@@ -153,12 +147,6 @@ jobs:
         uses: dtolnay/rust-toolchain@1.89.0
         with:
           targets: ${{ matrix.target }}
-
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-        with:
-          key: ${{ matrix.target }}
-          cache-on-failure: true
-          save-if: ${{ github.event_name != 'merge_group' }}
 
       - uses: taiki-e/install-action@just
 


### PR DESCRIPTION
## Problem

GitHub's Actions cache budget is a fixed **10 GB per repository** (not configurable on any plan). The repo is currently *over* it (~10.9 GB across 27 caches), so GitHub is continuously LRU-evicting caches.

The dominant consumer is **`publish-nargo`**: it builds nargo for 5 distribution targets on every PR and saves a `rust-cache` per target, totalling **~7 GB (≈65% of the budget)**:

| cache key (publish-nargo) | size | versions |
|---|---|---|
| `aarch64-apple-darwin` | 2385 MB | ×5 |
| `x86_64-unknown-linux-gnu` | 1469 MB | ×3 |
| `aarch64-unknown-linux-gnu` | 1461 MB | ×3 |
| `x86_64-unknown-linux-musl` | 982 MB | ×2 |
| `x86_64-apple-darwin` | 958 MB | ×2 |

Those "versions" are not distinct data — they are the *same* cache copied across refs. GitHub scopes cache writes per branch, so **every PR (and merge-queue run) that runs `publish-nargo` saves its own ~2.4 GB set of copies**, and they pile up. The casualty is the **test workflow's `x86_64-unknown-linux-gnu-debug` cache**, which is currently fully evicted — so `build-test-artifacts` recompiles its dependency tree from scratch on PRs.

## Change

Remove the two `Swatinem/rust-cache` steps from `publish-nargo` entirely.

The cache was never actually reused across PRs: `publish-nargo` has no `push: master` trigger, so there is no master-scoped (shared) cache for PRs to restore from, and GitHub does not let a PR read sibling PRs' caches — every copy was scoped to the PR that wrote it. So the step only ever piled up duplicate per-PR copies that were never restored elsewhere; merely disabling writes (`save-if: false`) would have left an inert step that does a lookup which can never hit. Removing it is the honest expression of "we don't cache `publish-nargo`". These builds now run **cold** (see "Why this is safe").

## Why this is safe

- All 5 release targets are still built on every PR — release/cross packaging is still validated. The targets just build cold once the old caches age out.
- Build-time headroom is fine: warm builds are ~7–14 min and the warm/cold gap is only ~3–5 min (the optimized nargo compile dominates, and rust-cache evicts workspace crates anyway), so cold builds land ~15–20 min against the 30-min job timeout.
- **Benchmarks are unaffected** — `reports.yml` builds its own `nargo` (`build-nargo` job); it does not consume `publish-nargo`'s artifacts.

## Why `save-if: false` and not "save only on master"

An alternative is to add a `push: master` trigger and use `save-if: ${{ github.ref == 'refs/heads/master' }}`, which would collapse the per-PR duplicates down to one shared copy per target (~2.4 GB) and keep PR release builds warm. We deliberately chose **not** to:

- The cache only saves ~3–5 min per target, and `publish-nargo` is release-packaging *validation* that runs in parallel — it is **not on the developer-facing critical path**, so nobody is blocked waiting on it.
- Keeping it warm would add a `publish-nargo` run on **every merge to master** (5 release-target builds), likely costing more runner-minutes than the PR-time minutes it saves, and it would still park ~2.4 GB in the budget.

So caching here spends compute and budget to speed up a path no one waits on. The caching made sense as the repo-wide rust-cache default for the high-frequency, critical-path workflows (notably `test-rust-workspace`, the developer inner loop), and `publish-nargo` simply inherited that default — back when the repo was under the 10 GB cap and the duplication was free. It only turned net-negative once the aggregate crossed the cap and began evicting the caches that matter.

## Confirmed: the cache was never restored

Comparing the last two CI runs on this branch — one with the `rust-cache` step still present (`save-if: false`) and one with it removed — the `Build binaries` step takes the same time either way (~9–13 min per target). The give-away is in the run that still had the step:

```
Run Swatinem/rust-cache…  = 0.1 min   (~6 seconds)
Post Run Swatinem/rust-cache… = 0.0 min
```

A real ~480 MB restore would take tens of seconds; a ~6-second restore is a **cache miss** — it pulled nothing, exactly as expected (no master-scoped cache, and PRs can't read sibling PRs' caches). So these builds were already cold; the step was a lookup that always missed and a save that never ran. Removing it costs no build time and reclaims ~7 GB.

## Effect

Freeing ~7 GB lets the test workflow's dependency cache survive instead of being evicted, so `build-test-artifacts` restores dependencies rather than recompiling them — faster and more consistent on every PR. (Compiling noir's own crates and linking are unchanged; those are addressed by the mold linker change and a potential future external sccache.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
