### PR TITLE
chore(ci): retry flaky browser tests on a clean relaunch

### DIFF
--- a/.github/actions/retry/action.yml
+++ b/.github/actions/retry/action.yml
@@ -1,0 +1,43 @@
+name: Retry a flaky command
+description: >
+  Run a shell command, retrying from scratch up to a few times. Intended for
+  environmental flakes — notably WebKit content-process crashes ("Page crashed")
+  while instantiating WASM in the browser tests, which are engine/runner crashes
+  rather than test failures. Each attempt is a fresh invocation (a new process
+  and, for the browser tests, a freshly launched browser), so a retry is a
+  near-independent draw; resuming a crashed session would not be.
+
+inputs:
+  run:
+    description: The command to run.
+    required: true
+  max-attempts:
+    description: Maximum number of attempts (including the first).
+    required: false
+    default: "3"
+
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      env:
+        # Passed via env rather than inlined into the script to avoid embedding
+        # the command in the shell source.
+        RETRY_CMD: ${{ inputs.run }}
+        RETRY_MAX_ATTEMPTS: ${{ inputs.max-attempts }}
+      run: |
+        for i in $(seq 1 "$RETRY_MAX_ATTEMPTS"); do
+          echo "::group::Attempt $i/$RETRY_MAX_ATTEMPTS: $RETRY_CMD"
+          if bash -c "$RETRY_CMD"; then
+            echo "::endgroup::"
+            exit 0
+          fi
+          echo "::endgroup::"
+          echo "Attempt $i of $RETRY_MAX_ATTEMPTS failed."
+          if [ "$i" -lt "$RETRY_MAX_ATTEMPTS" ]; then
+            echo "Retrying with a fresh process..."
+            sleep 5
+          fi
+        done
+        echo "::error::Command failed after $RETRY_MAX_ATTEMPTS attempts: $RETRY_CMD"
+        exit 1

--- a/.github/workflows/test-js-packages.yml
+++ b/.github/workflows/test-js-packages.yml
@@ -270,7 +270,9 @@ jobs:
           browsers: "chromium webkit"
 
       - name: Run browser tests
-        run: yarn workspace @noir-lang/acvm_js test:browser
+        uses: ./.github/actions/retry
+        with:
+          run: yarn workspace @noir-lang/acvm_js test:browser
 
   test-noirc-abi:
     needs: [build-noirc-abi]
@@ -300,7 +302,9 @@ jobs:
         uses: ./.github/actions/install-playwright
 
       - name: Run browser tests
-        run: yarn workspace @noir-lang/noirc_abi test:browser
+        uses: ./.github/actions/retry
+        with:
+          run: yarn workspace @noir-lang/noirc_abi test:browser
 
   test-noir-js:
     needs: [build-binaries, build-acvm-js, build-noirc-abi]
@@ -380,7 +384,9 @@ jobs:
         run: yarn workspace @noir-lang/noir_wasm test:node
 
       - name: Run browser tests
-        run: yarn workspace @noir-lang/noir_wasm test:browser
+        uses: ./.github/actions/retry
+        with:
+          run: yarn workspace @noir-lang/noir_wasm test:browser
 
   test-noir-codegen:
     needs: [build-acvm-js, build-noirc-abi, build-binaries]


### PR DESCRIPTION
## Problem

The browser test jobs flake intermittently. Example: [this `ACVM JS (Browser)` run](https://github.com/noir-lang/noir/actions/runs/27626606368/job/81690718083) failed with:

```
❌ page.goto: Page crashed
   navigating to "http://localhost:8000/?wtr-session-id=…", waiting until "load"
   (failed on Webkit)
```

This is **WebKit's content process crashing**, not a test failure:
- Chromium runs the identical tests (13/13) green every time.
- The symptom is process death (`Page crashed`) during page load / WASM instantiation, not an assertion or timeout — and after it, even `about:blank` crashes during teardown (the browser is already dead).
- It's intermittent → resource/engine-dependent.

It's the well-known `playwright-webkit` + WASM crash class on Linux CI, tipped over by transient memory pressure on the shared runner. The two config-level causes one would suspect are already excluded: the runner config sets `concurrentBrowsers: 1, concurrency: 1` (serial), and the tests use single-threaded WASM (no `SharedArrayBuffer`/threads).

## Change

Add `.github/actions/retry`, a small composite action that re-runs a command from scratch up to 3 attempts, and use it for the three `test:browser` steps (`acvm_js`, `noirc_abi`, `noir_wasm`).

## Why a *clean-relaunch* retry (and why it's safe)

A WebKit crash leaves the browser/launcher wedged, so resuming the crashed session would just re-crash. Instead each attempt is a **fresh invocation** — new `web-test-runner` process, freshly launched browser — which is a near-independent draw, so the retry has a high pass rate. The retry is **bounded** (3 attempts) so a genuinely bad runner doesn't spin, and a **real, deterministic failure still fails all 3 attempts and goes red** — this only masks environmental crashes, not actual test failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)