### PR TITLE
fix(stdlib): preserve tail storage in constrained extend_from_bounded_vec

### DIFF
--- a/noir_stdlib/src/collections/bounded_vec.nr
+++ b/noir_stdlib/src/collections/bounded_vec.nr
@@ -334,13 +334,14 @@ impl<T, let MaxLen: u32> BoundedVec<T, MaxLen> {
             };
 
             for src in 0..max {
-                // Since we are iterating to the static capacity of the arrays,
-                // the destination could be out of bounds. If that's the case,
-                // overwrite the last item, which we'll fixup in the end.
+                // Real iterations (`src < append_len`) always have `dst` in bounds,
+                // since we asserted `self.len + append_len <= MaxLen`. The padding
+                // iterations are routed to the last slot, which we restore at the end,
+                // so they never clobber meaningful in-bounds tail storage.
                 // NB using cmp::min resulted in more opcodes here.
                 let mut dst = self.len + src;
-                if dst >= MaxLen { dst = MaxLen - 1; };
-                // Assigning the source or zeroed to avoid having to merge arrays in SSA.
+                if src >= append_len { dst = MaxLen - 1; };
+                // Assigning the source or the saved last to avoid having to merge arrays in SSA.
                 self.storage[dst] = if src < append_len {
                     vec.get_unchecked(src)
                 } else {
@@ -1366,8 +1367,8 @@ mod bounded_vec_tests {
 
         #[test]
         fn extend_from_bounded_vec_empty_self() {
-            // self.len == 0 with Len > MaxLen: the loop doesn't reach
-            // the last storage slot, so the fixup must write it.
+            // self.len == 0 with Len > MaxLen: the source is clamped to
+            // MaxLen elements, filling the destination exactly to capacity.
             let mut vec1: BoundedVec<u32, 3> = BoundedVec::new();
             let vec2: BoundedVec<u32, 5> = BoundedVec::from_array([1, 2, 3]);
 
@@ -1377,6 +1378,21 @@ mod bounded_vec_tests {
             assert_eq(vec1.get(0), 1);
             assert_eq(vec1.get(1), 2);
             assert_eq(vec1.get(2), 3);
+        }
+
+        #[test]
+        #[test_unconstrained]
+        fn extend_from_bounded_vec_preserves_tail_storage() {
+            // The destination has meaningful (nonzero) storage past `len`.
+            // Extending must leave that tail untouched, identically in the
+            // constrained and unconstrained branches.
+            let mut dst: BoundedVec<u32, 4> = BoundedVec::from_parts([10, 99, 123, 7], 1);
+            let src: BoundedVec<u32, 4> = BoundedVec::from_parts([20, 0, 0, 0], 1);
+
+            dst.extend_from_bounded_vec(src);
+
+            assert_eq(dst.len(), 2);
+            assert_eq(dst.storage(), [10, 20, 123, 7]);
         }
 
         #[test]


### PR DESCRIPTION
## Summary

`BoundedVec::extend_from_bounded_vec` did not preserve the same backing storage in constrained and unconstrained execution. For the same valid inputs and final length, the constrained branch overwrote slots past the new `len` with the destination's old last element, while the unconstrained branch left those slots unchanged. The divergent slots are observable through the safe `storage()` method.

Example: extending `[10, 99, 123, 7]` (len 1) by `[20, 0, 0, 0]` (len 1):
- constrained (before): `[10, 20, 7, 7]`
- unconstrained: `[10, 20, 123, 7]`

## Root cause

The constrained branch can't cheaply loop `0..append_len` with a dynamic bound in ACIR, so it iterates over the static capacity `min(Len, MaxLen)`, clamping out-of-bounds writes to `MaxLen - 1`. It clamped only the *out-of-bounds* padding iterations; the *in-bounds* padding iterations (`src >= append_len` but `self.len + src < MaxLen`) wrote the saved old last element into meaningful tail slots, corrupting them.

## Fix

Real iterations (`src < append_len`) always have `dst` in bounds, since we assert `self.len + append_len <= MaxLen`. So route **every** padding iteration to the last slot `MaxLen - 1`, not just the out-of-bounds ones. The existing end-of-loop fixup restores `MaxLen - 1`, so in-bounds tail slots are never written and the constrained result matches the unconstrained one. This is also consistent with how the rest of `BoundedVec` (e.g. `push`) treats unused capacity: it leaves it untouched.

## Performance

ACIR opcode counts (via `nargo info`) — this also *improves* circuit size, because padding writes now target a constant index (`MaxLen - 1`) rather than the dynamic `self.len + src`:

| Program | before | after |
|---|---|---|
| `regression_11889` | 2,239 | 1,856 |

## Tests

Added `extend_from_bounded_vec_preserves_tail_storage`, run in both constrained and unconstrained mode via `#[test_unconstrained]`, asserting `storage() == [10, 20, 123, 7]` for a destination with meaningful tail storage. It fails on the constrained run before the fix and passes after. All existing `bounded_vec` stdlib tests continue to pass across every force mode, and `regression_11889` / `regression_11294` still execute correctly.

Fixes https://github.com/noir-lang/noir-claude/issues/1353

🤖 Generated with [Claude Code](https://claude.com/claude-code)
