### PR TITLE
fix: Add mono error for functions in globals

### DIFF
--- a/compiler/noirc_frontend/src/monomorphization/errors.rs
+++ b/compiler/noirc_frontend/src/monomorphization/errors.rs
@@ -36,6 +36,7 @@ pub enum MonomorphizationError {
     InvalidTypeForEntryPoint { invalid_type: InvalidType, location: Location },
     ComplexType { complexity: usize, max_complexity: usize, location: Location },
     CannotUseFunctionAsValue { name: String, location: Location },
+    GlobalContainsFunctionPointer { typ: String, location: Location },
 }
 
 impl MonomorphizationError {
@@ -73,7 +74,8 @@ impl MonomorphizationError {
             | MonomorphizationError::VectorWithNestedArrayReturnedFromOracle { location, .. }
             | MonomorphizationError::InvalidTypeForEntryPoint { location, .. }
             | MonomorphizationError::ComplexType { location, .. }
-            | MonomorphizationError::CannotUseFunctionAsValue { location, .. } => *location,
+            | MonomorphizationError::CannotUseFunctionAsValue { location, .. }
+            | MonomorphizationError::GlobalContainsFunctionPointer { location, .. } => *location,
             MonomorphizationError::InterpreterError(error) => error.location(),
         }
     }
@@ -233,6 +235,12 @@ impl From<MonomorphizationError> for CustomDiagnostic {
                     "`{name}` cannot be used as a function value; it must be called directly"
                 );
                 let secondary = "Used as a value here".to_string();
+                return CustomDiagnostic::simple_error(message, secondary, *location);
+            }
+            MonomorphizationError::GlobalContainsFunctionPointer { typ, location } => {
+                let message = "Globals cannot contain function pointers".to_string();
+                let secondary =
+                    format!("This global has type `{typ}`, which contains a function pointer");
                 return CustomDiagnostic::simple_error(message, secondary, *location);
             }
         };

--- a/compiler/noirc_frontend/src/monomorphization/mod.rs
+++ b/compiler/noirc_frontend/src/monomorphization/mod.rs
@@ -1656,13 +1656,18 @@ impl<'interner> Monomorphizer<'interner> {
             // just with an extra step of indirection through a global variable.
             // For simplicity, we chose to instead inline closures at their callsite as we do not expect
             // placing a closure in the global context to change the final result of the program.
-            if !contains_function {
-                if typ.contains_function() {
-                    return Err(MonomorphizationError::GlobalContainsFunctionPointer {
-                        typ: typ.to_string(),
-                        location: global_location,
-                    });
-                }
+            if contains_function {
+                // Value has a closure, for simplicity we chose to inline closures at their
+                // callsite as we do not expect placing a closure in the global context
+                // to change the final result of the program.
+                expr
+            } else if typ.contains_function() {
+                // Type indicates function pointer which is invalid in the global context.
+                return Err(MonomorphizationError::GlobalContainsFunctionPointer {
+                    typ: typ.to_string(),
+                    location: global_location,
+                });
+            } else {
                 let new_id = self.next_global_id();
                 self.globals.entry(id).or_default().insert(typ.clone(), new_id);
                 let typ = Self::convert_type(&typ, location)?;
@@ -1676,8 +1681,6 @@ impl<'interner> Monomorphizer<'interner> {
                     id: self.next_ident_id(),
                 };
                 ast::Expression::Ident(ident)
-            } else {
-                expr
             }
         };
         Ok(expr)

--- a/compiler/noirc_frontend/src/monomorphization/mod.rs
+++ b/compiler/noirc_frontend/src/monomorphization/mod.rs
@@ -1611,6 +1611,7 @@ impl<'interner> Monomorphizer<'interner> {
     ) -> Result<ast::Expression, MonomorphizationError> {
         let global = self.interner.get_global(global_id);
         let id = global.id;
+        let global_location = global.location;
 
         // Follow bindings otherwise it's not safe to use it as a hash map key.
         let typ = typ.follow_bindings();
@@ -1656,6 +1657,12 @@ impl<'interner> Monomorphizer<'interner> {
             // For simplicity, we chose to instead inline closures at their callsite as we do not expect
             // placing a closure in the global context to change the final result of the program.
             if !contains_function {
+                if typ.contains_function() {
+                    return Err(MonomorphizationError::GlobalContainsFunctionPointer {
+                        typ: typ.to_string(),
+                        location: global_location,
+                    });
+                }
                 let new_id = self.next_global_id();
                 self.globals.entry(id).or_default().insert(typ.clone(), new_id);
                 let typ = Self::convert_type(&typ, location)?;

--- a/compiler/noirc_frontend/src/tests/globals.rs
+++ b/compiler/noirc_frontend/src/tests/globals.rs
@@ -481,6 +481,20 @@ fn comptime_global_used_in_runtime_code() {
 }
 
 #[test]
+fn global_containing_function_pointer_errors() {
+    let src = r#"
+    global FN_ARRAY: [fn()] = @[];
+           ^^^^^^^^ Globals cannot contain function pointers
+           ~~~~~~~~ This global has type `[fn() -> ()]`, which contains a function pointer
+
+    fn main() {
+        let _ = FN_ARRAY;
+    }
+    "#;
+    check_monomorphization_error(src);
+}
+
+#[test]
 fn comptime_global_closure_cannot_be_inlined_into_runtime() {
     let src = r#"
     fn bar() {}


### PR DESCRIPTION
## Problem Resolved

Resolves https://cantina.xyz/code/af01d57f-6e50-4de3-ad6d-7e9f7ff2d7d1/findings/38

## Summary of Changes

This was originally an SSA validation panic, this PR changes it into a monomorphization error

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
