### PR TITLE
fix: make missing-Brillig-constraint check order-independent

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/checks/check_for_missing_brillig_constraints.rs
+++ b/compiler/noirc_evaluator/src/ssa/checks/check_for_missing_brillig_constraints.rs
@@ -700,10 +700,37 @@ impl Context {
         func: &Function,
         all_functions: &BTreeMap<FunctionId, Function>,
     ) -> Self {
+        // Persists across passes: an output shown to be constrained anywhere in the
+        // function stays constrained, so a later constraint can rely on it regardless
+        // of the source order of the two assertions. This is what makes the check
+        // order-independent and requires iterating to a fixed point below.
+        let mut all_constrained = ValueSet::new(&func.dfg);
+
+        loop {
+            let before = self.tainted.len();
+            self.constrain_tainted_pass(func, all_functions, &mut all_constrained);
+
+            // Re-walk only while we are still making progress and work remains. Fully
+            // constrained functions empty `tainted` in the first pass (no extra walk),
+            // and genuinely under-constrained ones make no progress and stop here too.
+            if self.tainted.is_empty() || self.tainted.len() == before {
+                break;
+            }
+        }
+
+        self
+    }
+
+    /// A single Reverse Post Order walk attempting to constrain Brillig outputs,
+    /// accumulating cleared outputs into `all_constrained`. See [`Self::constrain_tainted`].
+    fn constrain_tainted_pass(
+        &mut self,
+        func: &Function,
+        all_functions: &BTreeMap<FunctionId, Function>,
+        all_constrained: &mut ValueSet,
+    ) {
         // Constraints on tainted output cannot be used to connect output to input.
         let mut all_tainted = ValueSet::new(&func.dfg);
-        // Unless such output has already been shown to be constrained.
-        let mut all_constrained = ValueSet::new(&func.dfg);
         // Skip checks until we encounter the tainted instruction.
         let mut active_tainted = HashSet::new();
 
@@ -747,7 +774,7 @@ impl Context {
                             parents,
                             equivalences,
                             &all_tainted,
-                            &mut all_constrained,
+                            &mut *all_constrained,
                             self.max_ancestor_distance,
                         );
 
@@ -760,8 +787,6 @@ impl Context {
                 }
             }
         }
-
-        self
     }
 
     /// Every Brillig call not properly constrained should remain in the tainted set
@@ -1896,5 +1921,60 @@ mod tests {
             1,
             "arr[idx] == x with dynamic idx does not constrain arr[0] = brillig(x)"
         );
+    }
+
+    #[test]
+    #[traced_test]
+    /// Regression test for <https://github.com/noir-lang/noir/issues/12506>:
+    /// an equivalence between two Brillig outputs must clear the second call
+    /// even when it appears *before* the constraint that pins the first output.
+    /// The result must not depend on the source order of the two assertions.
+    fn equivalence_before_pin_is_order_independent() {
+        let program = r#"
+        acir(inline) fn main f0 {
+          b0(v0: Field):
+            v1 = add v0, Field 3
+            v2 = call f1(v1) -> Field
+            v3 = call f1(v1) -> Field
+            constrain v2 == v3   // (A) equivalence of the two outputs, seen first
+            constrain v2 == v1   // (B) pins the first output to an input-derived value
+            return
+        }
+
+        brillig(inline) fn read_imm f1 {
+          b0(v0: Field):
+            return v0
+        }
+        "#;
+
+        let ssa_level_warnings = check_for_missing_brillig_constraints_in_ssa(program);
+        assert_eq!(ssa_level_warnings.len(), 0);
+    }
+
+    #[test]
+    #[traced_test]
+    /// Mirror of [`equivalence_before_pin_is_order_independent`] with the
+    /// assertions in the opposite order, which already compiled cleanly before
+    /// the fix. Both orders must now agree (no warning).
+    fn pin_before_equivalence_is_order_independent() {
+        let program = r#"
+        acir(inline) fn main f0 {
+          b0(v0: Field):
+            v1 = add v0, Field 3
+            v2 = call f1(v1) -> Field
+            v3 = call f1(v1) -> Field
+            constrain v2 == v1   // (B) pins the first output to an input-derived value
+            constrain v2 == v3   // (A) equivalence of the two outputs
+            return
+        }
+
+        brillig(inline) fn read_imm f1 {
+          b0(v0: Field):
+            return v0
+        }
+        "#;
+
+        let ssa_level_warnings = check_for_missing_brillig_constraints_in_ssa(program);
+        assert_eq!(ssa_level_warnings.len(), 0);
     }
 }


### PR DESCRIPTION
## Problem Resolved

Resolves #12506

## Summary of Changes

Makes the `check_for_missing_brillig_constraints` no longer ordering-dependent

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
