### PR TITLE
fix(nargo): accept package name argument in init

### DIFF
--- a/tooling/nargo_cli/src/cli/init_cmd.rs
+++ b/tooling/nargo_cli/src/cli/init_cmd.rs
@@ -12,7 +12,11 @@ use std::path::PathBuf;
 #[derive(Debug, Clone, Args)]
 pub(crate) struct InitCommand {
     /// Name of the package [default: current directory name]
-    #[clap(long)]
+    #[arg(value_name = "name")]
+    package_name: Option<CrateName>,
+
+    /// Name of the package [default: current directory name]
+    #[clap(long, conflicts_with = "package_name")]
     name: Option<CrateName>,
 
     /// Use a library template
@@ -33,7 +37,7 @@ const CONTRACT_EXAMPLE: &str = include_str!("./noir_template_files/contract.nr")
 const LIB_EXAMPLE: &str = include_str!("./noir_template_files/library.nr");
 
 pub(crate) fn run(args: InitCommand, config: NargoConfig) -> Result<(), CliError> {
-    let package_name = match args.name {
+    let package_name = match args.name.or(args.package_name) {
         Some(name) => name,
         None => {
             let name = config.program_dir.file_name().unwrap().to_str().unwrap();

--- a/tooling/nargo_cli/src/errors.rs
+++ b/tooling/nargo_cli/src/errors.rs
@@ -26,7 +26,7 @@ pub enum CliError {
     NargoInitCannotBeRunOnExistingPackages,
 
     #[error(
-        "Error: {0}\nIf you need a package name to not match the directory name, consider using the `--name` flag."
+        "Error: {0}\nIf you need a package name to not match the directory name, pass it to `nargo init <name>` or use the `--name` flag."
     )]
     InvalidPackageName(String),
 

--- a/tooling/nargo_cli/tests/init.rs
+++ b/tooling/nargo_cli/tests/init.rs
@@ -1,0 +1,23 @@
+use assert_cmd::prelude::*;
+use assert_fs::prelude::{PathAssert, PathChild, PathCreateDir};
+use predicates::prelude::*;
+use std::process::Command;
+
+#[test]
+fn init_accepts_package_name_as_positional_argument() {
+    let test_dir = assert_fs::TempDir::new().unwrap();
+    let project_dir = test_dir.child("my-project");
+    project_dir.create_dir_all().unwrap();
+
+    #[allow(deprecated)]
+    let mut cmd = Command::cargo_bin("nargo").unwrap();
+    cmd.current_dir(&project_dir).arg("init").arg("my_project");
+    cmd.assert().success();
+
+    project_dir.child("src").assert(predicate::path::is_dir());
+    project_dir.child("src/main.nr").assert(predicate::path::is_file());
+    project_dir
+        .child("Nargo.toml")
+        .assert(predicate::path::is_file())
+        .assert(predicate::str::contains(r#"name = "my_project""#));
+}


### PR DESCRIPTION
## Problem Resolved

Resolves #3007

## Summary of Changes

- Allow `nargo init <name>` to set the package name directly.
- Keep the existing `nargo init --name <name>` behavior for compatibility.
- Make the positional package name conflict with `--name` to avoid ambiguous input.
- Update the invalid package name hint to mention both supported ways to provide a custom name.
- Add an integration test covering initialization from a directory whose name differs from the package name.


## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
