### PR TITLE
fix: avoid constant-folding ICE on const Brillig calls with ZST array arguments

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/interpreter/value.rs
+++ b/compiler/noirc_evaluator/src/ssa/interpreter/value.rs
@@ -303,6 +303,7 @@ impl Value {
         element_types: Vec<Type>,
         length: SemanticLength,
     ) -> Self {
+        assert_eq!(length.0 as usize * element_types.len(), elements.len());
         Self::ArrayOrVector(ArrayValue {
             elements: Shared::new(elements),
             rc: Shared::new(1),

--- a/compiler/noirc_evaluator/src/ssa/interpreter/value.rs
+++ b/compiler/noirc_evaluator/src/ssa/interpreter/value.rs
@@ -290,11 +290,24 @@ impl Value {
         assert!(!element_types.is_empty());
 
         let length = assert_u32(elements.len() / element_types.len());
+        Self::array_with_length(elements, element_types, SemanticLength(length))
+    }
+
+    /// Build an array value with an explicit semantic length.
+    ///
+    /// Unlike [`Value::array`], this supports zero-sized element types (empty `element_types`),
+    /// where the length cannot be recovered by dividing the flattened element count by the number
+    /// of element types.
+    pub(crate) fn array_with_length(
+        elements: Vec<Value>,
+        element_types: Vec<Type>,
+        length: SemanticLength,
+    ) -> Self {
         Self::ArrayOrVector(ArrayValue {
             elements: Shared::new(elements),
             rc: Shared::new(1),
             element_types: Arc::new(element_types),
-            length: Some(SemanticLength(length)),
+            length: Some(length),
         })
     }
 
@@ -330,7 +343,7 @@ impl Value {
                     vecmap(element_types.iter(), |typ| Self::uninitialized(typ, id));
                 let elements = std::iter::repeat_n(first_elements, assert_usize(length.0));
                 let elements = elements.flatten().collect();
-                Self::array(elements, element_types.to_vec())
+                Self::array_with_length(elements, element_types.to_vec(), *length)
             }
             Type::Vector(element_types) => Self::uninitialized_vector(element_types, 0, id),
             Type::Function => Value::ForeignFunction("uninitialized!".to_string()),

--- a/compiler/noirc_evaluator/src/ssa/opt/constant_folding/interpret.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/constant_folding/interpret.rs
@@ -94,14 +94,14 @@ fn const_ir_value_to_interpreter_value(value_id: ValueId, dfg: &DataFlowGraph) -
                 .expect("Should be a valid constant")
         }
         Type::Reference(..) => unreachable!("References cannot be constant values"),
-        Type::Array(element_types, _) => {
+        Type::Array(element_types, length) => {
             let (array_constant, _) =
                 dfg.get_array_constant(value_id).expect("Should have an array constant");
             let mut elements = Vec::new();
             for element in array_constant {
                 elements.push(const_ir_value_to_interpreter_value(element, dfg));
             }
-            InterpreterValue::array(elements, element_types.to_vec())
+            InterpreterValue::array_with_length(elements, element_types.to_vec(), *length)
         }
         Type::Vector(element_types) => {
             let (array_constant, _) =

--- a/compiler/noirc_evaluator/src/ssa/opt/constant_folding/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/constant_folding/mod.rs
@@ -1230,6 +1230,40 @@ mod test {
         assert_ssa_does_not_change(src, |ssa| ssa.fold_constants_using_constraints(MIN_ITER));
     }
 
+    // Regression for noir-claude#1224.
+    // A constant zero-sized-type array (empty `element_types`, e.g. `[(); 3]`) passed as a
+    // constant argument to a brillig call reaches the constant-folding interpreter, which must
+    // rehydrate it into an interpreter value without panicking on the empty element-type list.
+    #[test]
+    fn interpret_call_with_zero_sized_type_array_argument() {
+        let src = "
+        acir(inline) fn main f0 {
+          b0():
+            v0 = make_array [] : [(); 3]
+            v1 = call f1(v0) -> [(); 3]
+            return v1
+        }
+        brillig(inline) fn id_zst f1 {
+          b0(v0: [(); 3]):
+            return v0
+        }
+        ";
+        let ssa = Ssa::from_str(src).unwrap();
+        let ssa = ssa.fold_constants(MIN_ITER);
+        assert_ssa_snapshot!(ssa, @r"
+        acir(inline) fn main f0 {
+          b0():
+            v0 = make_array [] : [(); 3]
+            v1 = make_array [] : [(); 3]
+            return v1
+        }
+        brillig(inline) fn id_zst f1 {
+          b0(v0: [(); 3]):
+            return v0
+        }
+        ");
+    }
+
     // In ACIR, arrays are value-semantic: `array_set` produces a fresh array and never mutates
     // its input, so a later identical `make_array` can still be deduplicated against the original
     // even though `array_set` wrote "to" it. (In Brillig the same dedup would be unsafe because the


### PR DESCRIPTION
Fixes https://github.com/noir-lang/noir-claude/issues/1224

## Summary

`fold_constants` tries to interpret Brillig calls whose arguments are all constant. A valid Noir program can pass a constant zero-sized-type array (`[Empty; 3]` / `[(); N]`) into a used unconstrained function parameter. That array reaches `const_ir_value_to_interpreter_value`, which rehydrated it through `Value::array`. `Value::array` recovers the array length via `elements.len() / element_types.len()` — for a ZST array both are `0`, so it trips `assert!(!element_types.is_empty())` and **ICEs while compiling a valid program** (compile-time DoS; no incorrect ACIR is produced).

Minimal reproduction:

```rust
struct Empty {}

unconstrained fn id_zst(arr: [Empty; 3]) -> [Empty; 3] {
    arr
}

fn main(x: pub Field) -> pub Field {
    let arr: [Empty; 3] = [Empty {}; 3];
    let arr2 = unsafe { id_zst(arr) };
    let _ = arr2[2];
    x + 1
}
```

```
The application panicked (crashed).
Message:  assertion failed: !element_types.is_empty()
Location: compiler/noirc_evaluator/src/ssa/interpreter/value.rs:290
```

## Fix

The semantic length of a ZST array is only knowable from `Type::Array(_, length)`, which the two ICE-capable callers (`const_ir_value_to_interpreter_value` and `Value::uninitialized`) already hold. This PR:

- Adds `Value::array_with_length`, the authoritative primitive that takes the length explicitly.
- Routes the two callers that hold a `Type::Array(_, length)` through it.
- Keeps `Value::array`'s element-count derivation for the callers that only have the elements (delegating to the new primitive). That derivation is still needed: for **composite** arrays the length is `elements.len() / element_types.len()`, not `elements.len()`, so it cannot simply be replaced by passing `elements.len()` at each call site.

This mirrors how `Interpreter::interpret_make_array` already constructs ZST arrays from the result type.

## Tests

- Adds regression test `interpret_call_with_zst_array_argument` in `constant_folding` (folds the ZST Brillig call to the correctly-typed `[(); 3]` result instead of panicking).
- Full `interpreter::` and `constant_folding::` suites pass (181/181).


🤖 Generated with [Claude Code](https://claude.com/claude-code)