### PR TITLE
fix: record trait default method locations for backtraces

### DIFF
--- a/compiler/noirc_frontend/src/error_reporting.rs
+++ b/compiler/noirc_frontend/src/error_reporting.rs
@@ -8,7 +8,11 @@ use noirc_errors::{
 
 use crate::{
     ParsedModule,
-    ast::{LetStatement, NoirFunction, NoirTrait, NoirTraitImpl, TypeImpl, Visitor},
+    ast::{
+        BlockExpression, FunctionReturnType, Ident, LetStatement, NoirFunction, NoirTrait,
+        NoirTraitImpl, TypeImpl, UnresolvedGenerics, UnresolvedTraitConstraint, UnresolvedType,
+        Visitor,
+    },
     hir::ParsedFiles,
     parser::ParsedSubModule,
 };
@@ -131,6 +135,29 @@ impl Visitor for FunctionLocationsCollector<'_> {
         let name = function.name().to_string();
         let full_name = self.fully_qualified_name(&name);
         self.function_locations.insert(function.location(), full_name);
+
+        false
+    }
+
+    fn visit_trait_item_function(
+        &mut self,
+        name: &Ident,
+        _generics: &UnresolvedGenerics,
+        _parameters: &[(Ident, UnresolvedType)],
+        _return_type: &FunctionReturnType,
+        _where_clause: &[UnresolvedTraitConstraint],
+        body: &Option<BlockExpression>,
+    ) -> bool {
+        // Only default methods (those with a body) produce call-stack frames; a bodiless
+        // trait method declaration has no code to attribute a diagnostic to.
+        if let Some(body) = body {
+            let location = match body.statements.last() {
+                Some(last_statement) => name.location().merge(last_statement.location),
+                None => name.location(),
+            };
+            let full_name = self.fully_qualified_name(name.as_str());
+            self.function_locations.insert(location, full_name);
+        }
 
         false
     }

--- a/test_programs/compile_failure/trait_default_method_call_stack/Nargo.toml
+++ b/test_programs/compile_failure/trait_default_method_call_stack/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "trait_default_method_call_stack"
+type = "bin"
+authors = [""]
+compiler_version = ">=0.31.0"
+
+[dependencies]

--- a/test_programs/compile_failure/trait_default_method_call_stack/src/main.nr
+++ b/test_programs/compile_failure/trait_default_method_call_stack/src/main.nr
@@ -1,0 +1,13 @@
+trait Failer {
+    fn fail(self) {
+        std::static_assert(false, "trait default failure");
+    }
+}
+
+struct S {}
+
+impl Failer for S {}
+
+fn main() {
+    S {}.fail();
+}

--- a/tooling/nargo_cli/tests/snapshots/compile_failure/trait_default_method_call_stack/execute__tests__stderr.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_failure/trait_default_method_call_stack/execute__tests__stderr.snap
@@ -1,0 +1,17 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: stderr
+---
+error: trait default failure
+  ┌─ src/main.nr:3:9
+  │
+3 │         std::static_assert(false, "trait default failure");
+  │         --------------------------------------------------
+  │
+  = Call stack:
+    1: main
+            at src/main.nr:12:5
+    2: Failer::fail
+            at src/main.nr:3:9
+
+Aborting due to 1 previous error


### PR DESCRIPTION
## Problem Resolved

Resolves https://github.com/noir-lang/noir-claude/issues/1204

## Summary of Changes

Trait default methods weren't included in the ranges for backtraces (to figure out their names) so now they are.

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
