### PR TITLE
chore: Refactor some unbounded recursion into iterative implementation

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/ir/value.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/value.rs
@@ -101,8 +101,14 @@ impl ValueMapping {
         }
     }
 
-    pub(crate) fn get(&self, value: ValueId) -> ValueId {
-        if let Some(replacement) = self.map.get(&value) { self.get(*replacement) } else { value }
+    pub(crate) fn get(&self, mut value: ValueId) -> ValueId {
+        // Follow the replacement chain iteratively. A recursive walk would use one stack
+        // frame per link, and on large programs the chain can be thousands deep — enough
+        // to overflow the (smaller) wasm stack.
+        while let Some(replacement) = self.map.get(&value) {
+            value = *replacement;
+        }
+        value
     }
 
     pub(crate) fn is_empty(&self) -> bool {

--- a/compiler/noirc_evaluator/src/ssa/opt/constant_folding/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/constant_folding/mod.rs
@@ -158,7 +158,7 @@ impl Function {
             })
             .collect::<HashMap<_, _>>();
 
-        let mut dom = loops.dom;
+        let dom = loops.dom;
         let mutated_types = find_mutated_block_param_array_types(self);
         let mut context = Context::new(use_constraint_info, mutated_types.clone());
 
@@ -168,7 +168,7 @@ impl Function {
             while let Some(block) = context.block_queue.pop_front() {
                 context.fold_constants_in_block(
                     &mut self.dfg,
-                    &mut dom,
+                    &dom,
                     &mut loop_headers,
                     block,
                     interpreter,
@@ -344,7 +344,7 @@ impl Context {
     fn fold_constants_in_block(
         &mut self,
         dfg: &mut DataFlowGraph,
-        dom: &mut DominatorTree,
+        dom: &DominatorTree,
         loop_headers: &mut HashMap<BasicBlockId, HashSet<ValueId>>,
         block_id: BasicBlockId,
         interpreter: &mut Interpreter<Empty>,
@@ -398,7 +398,7 @@ impl Context {
     fn fold_constants_into_instruction(
         &mut self,
         dfg: &mut DataFlowGraph,
-        dom: &mut DominatorTree,
+        dom: &DominatorTree,
         loop_headers: &mut HashMap<BasicBlockId, HashSet<ValueId>>,
         block: BasicBlockId,
         id: InstructionId,
@@ -579,7 +579,7 @@ impl Context {
         instruction_id: InstructionId,
         block: BasicBlockId,
         dfg: &DataFlowGraph,
-        dom: &mut DominatorTree,
+        dom: &DominatorTree,
         constraint_simplification_mapping: Option<&HashMap<ValueId, SimplificationCache>>,
     ) -> Instruction {
         let mut instruction = dfg[instruction_id].clone();
@@ -779,7 +779,7 @@ impl Context {
 // constraints to the cache.
 fn resolve_cache(
     block: BasicBlockId,
-    dom: &mut DominatorTree,
+    dom: &DominatorTree,
     cache: Option<&HashMap<ValueId, SimplificationCache>>,
     mut value_id: ValueId,
 ) -> ValueId {

--- a/compiler/noirc_evaluator/src/ssa/opt/constant_folding/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/constant_folding/mod.rs
@@ -781,17 +781,19 @@ fn resolve_cache(
     block: BasicBlockId,
     dom: &mut DominatorTree,
     cache: Option<&HashMap<ValueId, SimplificationCache>>,
-    value_id: ValueId,
+    mut value_id: ValueId,
 ) -> ValueId {
-    match cache.and_then(|cache| cache.get(&value_id)) {
-        Some(simplification_cache) => {
-            if let Some(simplified) = simplification_cache.get(block, dom) {
-                resolve_cache(block, dom, cache, simplified)
-            } else {
-                value_id
-            }
-        }
-        None => value_id,
+    // Follow the simplification chain iteratively. A recursive walk would use one stack
+    // frame per link, and on large programs the chain can be thousands deep — enough to
+    // overflow the (smaller) wasm stack.
+    loop {
+        let Some(simplification_cache) = cache.and_then(|cache| cache.get(&value_id)) else {
+            return value_id;
+        };
+        let Some(simplified) = simplification_cache.get(block, dom) else {
+            return value_id;
+        };
+        value_id = simplified;
     }
 }
 


### PR DESCRIPTION
## Problem Resolved

The large baseline test committed in #13108 didn't compile in Wasm: https://github.com/noir-lang/noir/actions/runs/27764091827/job/82147148565

The suspicion was that it ran out of the 1MB stack available for Wasm compilation (we use 4MB in native). The test was excluded, but we went looking for where we have no stack overflow protection.

## Summary of Changes

Refactors two instances of unbounded recursion.

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
