### PR TITLE
chore: Retry `install-playwright` with a timeout

### DIFF
--- a/.github/actions/install-playwright/action.yml
+++ b/.github/actions/install-playwright/action.yml
@@ -21,14 +21,17 @@ runs:
         path: ~/.cache/ms-playwright
         key: playwright-${{ inputs.playwright-version }}-${{ inputs.browsers }}-${{ runner.os }}
 
-    # Composite-action steps do not support `timeout-minutes`, so the `npx` calls
-    # are bounded with coreutils `timeout` to fail fast (exit 124) instead of
-    # hanging until the job-level limit when a download or apt mirror stalls.
+    # Composite-action steps do not support `timeout-minutes`, so each `npx` call
+    # is bounded with coreutils `timeout`: a stalled download or apt mirror fails
+    # fast (exit 124) and the retry wrapper takes a fresh, near-independent draw
+    # rather than hanging until the job-level limit.
     - name: Install Playwright browsers
       if: steps.playwright-cache.outputs.cache-hit != 'true'
-      shell: bash
-      run: timeout 600 npx -y playwright@${{ inputs.playwright-version }} install ${{ inputs.browsers }}
+      uses: ./.github/actions/retry
+      with:
+        run: timeout 240 npx -y playwright@${{ inputs.playwright-version }} install ${{ inputs.browsers }}
 
     - name: Install Playwright system dependencies
-      shell: bash
-      run: timeout 300 npx -y playwright@${{ inputs.playwright-version }} install-deps ${{ inputs.browsers }}
+      uses: ./.github/actions/retry
+      with:
+        run: timeout 120 npx -y playwright@${{ inputs.playwright-version }} install-deps ${{ inputs.browsers }}

--- a/.github/actions/install-playwright/action.yml
+++ b/.github/actions/install-playwright/action.yml
@@ -21,11 +21,14 @@ runs:
         path: ~/.cache/ms-playwright
         key: playwright-${{ inputs.playwright-version }}-${{ inputs.browsers }}-${{ runner.os }}
 
+    # Composite-action steps do not support `timeout-minutes`, so the `npx` calls
+    # are bounded with coreutils `timeout` to fail fast (exit 124) instead of
+    # hanging until the job-level limit when a download or apt mirror stalls.
     - name: Install Playwright browsers
       if: steps.playwright-cache.outputs.cache-hit != 'true'
       shell: bash
-      run: npx -y playwright@${{ inputs.playwright-version }} install ${{ inputs.browsers }}
+      run: timeout 600 npx -y playwright@${{ inputs.playwright-version }} install ${{ inputs.browsers }}
 
     - name: Install Playwright system dependencies
       shell: bash
-      run: npx -y playwright@${{ inputs.playwright-version }} install-deps ${{ inputs.browsers }}
+      run: timeout 300 npx -y playwright@${{ inputs.playwright-version }} install-deps ${{ inputs.browsers }}


### PR DESCRIPTION
## Problem Resolved

Installing Playwright timed out in https://github.com/noir-lang/noir/actions/runs/27785905683/job/82222647933

## Summary of Changes

Adds a timeout to the steps in `install-playwright` and sends them through the `retry` action, so hopefully a one-off glitch with `apt` mirrors don't end up stalling a build by 30 minutes and then failing it.

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
