### PR TITLE
fix(frontend): keep all captures when lowering comptime fmtstr with duplicate names

### DIFF
--- a/compiler/noirc_frontend/src/hir/comptime/value.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/value.rs
@@ -267,7 +267,6 @@ impl Value {
                 // block expression.
                 let mut statements = Vec::new();
                 let mut new_fragments = Vec::with_capacity(fragments.len());
-                let mut has_values = false;
                 let mut seen_names: HashSet<String> = HashSet::default();
                 for fragment in fragments.iter() {
                     let new_fragment = match fragment {
@@ -275,8 +274,6 @@ impl Value {
                             FmtStrFragment::String(string.clone())
                         }
                         FormatStringFragment::Value { name, value } => {
-                            has_values = true;
-
                             // A name might be interpolated multiple times. In that case it will always
                             // have the same value: we just need one `let` for it. We must still emit an
                             // interpolation fragment per occurrence so the lowered format string keeps
@@ -305,7 +302,7 @@ impl Value {
                     new_fragments.push(new_fragment);
                 }
                 let fmtstr = Literal(FmtStr(new_fragments, length));
-                if has_values {
+                if !statements.is_empty() {
                     statements.push(Statement {
                         kind: StatementKind::Expression(Expression { kind: fmtstr, location }),
                         location,

--- a/compiler/noirc_frontend/src/hir/comptime/value.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/value.rs
@@ -275,26 +275,30 @@ impl Value {
                             FmtStrFragment::String(string.clone())
                         }
                         FormatStringFragment::Value { name, value } => {
-                            // A name might be interpolated multiple times. In that case it will always
-                            // have the same value: we just need one `let` for it.
-                            if !seen_names.insert(name.clone()) {
-                                continue;
-                            }
-
                             has_values = true;
 
-                            let expression = value.clone().into_expression(elaborator, location)?;
-                            let let_statement = LetStatement {
-                                pattern: Pattern::Identifier(Ident::new(name.clone(), location)),
-                                r#type: None,
-                                expression,
-                                attributes: Vec::new(),
-                                comptime: false,
-                                is_global_let: false,
-                            };
-                            let statement =
-                                Statement { kind: StatementKind::Let(let_statement), location };
-                            statements.push(statement);
+                            // A name might be interpolated multiple times. In that case it will always
+                            // have the same value: we just need one `let` for it. We must still emit an
+                            // interpolation fragment per occurrence so the lowered format string keeps
+                            // the same number of captures as the source template.
+                            if seen_names.insert(name.clone()) {
+                                let expression =
+                                    value.clone().into_expression(elaborator, location)?;
+                                let let_statement = LetStatement {
+                                    pattern: Pattern::Identifier(Ident::new(
+                                        name.clone(),
+                                        location,
+                                    )),
+                                    r#type: None,
+                                    expression,
+                                    attributes: Vec::new(),
+                                    comptime: false,
+                                    is_global_let: false,
+                                };
+                                let statement =
+                                    Statement { kind: StatementKind::Let(let_statement), location };
+                                statements.push(statement);
+                            }
                             FmtStrFragment::Interpolation(name.clone(), location)
                         }
                     };

--- a/compiler/noirc_frontend/src/tests/expressions.rs
+++ b/compiler/noirc_frontend/src/tests/expressions.rs
@@ -71,6 +71,20 @@ fn resolve_fmt_strings() {
 }
 
 #[test]
+fn comptime_fmt_string_with_duplicate_name_keeps_all_captures() {
+    let src = r#"
+    fn main() {
+        let s = comptime {
+            let n: u8 = 7;
+            f"a{n}b{n}c"
+        };
+        let _: fmtstr<9, (u8, u8)> = s;
+    }
+    "#;
+    assert_no_errors(src);
+}
+
+#[test]
 fn resolve_fmt_string_with_global() {
     let src = r#"
     global VALUE: u32 = 42;


### PR DESCRIPTION
Fixes https://github.com/noir-lang/noir-claude/issues/893

## Problem

When a comptime format string uses the same interpolation name more than once, like:

```noir
comptime {
    let n: u8 = 7;
    f"a{n}b{n}c"
}
```

the lowering in `Value::into_expression` dropped the duplicate interpolation fragment but kept the original template length. This gave the value the wrong type: `fmtstr<9, (u8,)>` instead of `fmtstr<9, (u8, u8)>`. The same format string outside of `comptime` compiles fine.

This rejects valid annotated code and can let a mismatched fmtstr type reach runtime consumers.

## Fix

The dedup now only skips the extra `let` statement for a repeated name. One interpolation fragment is emitted per occurrence, so the lowered type keeps all captures. This matches the `into_runtime_hir_expression` path that already handles this shape correctly.

## Test

Added `comptime_fmt_string_with_duplicate_name_keeps_all_captures` in `tests/expressions.rs`, which failed before the fix and passes after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)