### PR TITLE
fix(acvm): treat Opcode::Call as a side-effect boundary in RangeOptimizer

### DIFF
--- a/acvm-repo/acvm/src/compiler/optimizers/redundant_range.rs
+++ b/acvm-repo/acvm/src/compiler/optimizers/redundant_range.rs
@@ -564,6 +564,40 @@ mod tests {
     }
 
     #[test]
+    fn acir_call_is_a_side_effect_boundary() {
+        // An `Opcode::Call` dispatches into a separate ACIR circuit that can transitively run
+        // side-effecting Brillig. Just like a `BrilligCall`, it must act as a side-effect boundary:
+        // a caller-side explicit RANGE before the call must not be removed even when a later
+        // implied constraint (here `ASSERT w1 = 0`) would otherwise make it redundant.
+        let src = "
+        private parameters: [w1, w2]
+        public parameters: []
+        return values: []
+        BLACKBOX::RANGE input: w1, bits: 32
+        CALL func: 1, predicate: 1, inputs: [w2], outputs: []
+        ASSERT w1 = 0
+        ";
+        let circuit = Circuit::from_str(src).unwrap();
+        assert!(CircuitSimulator::check_circuit(&circuit).is_none());
+
+        let acir_opcode_positions: Vec<usize> =
+            circuit.opcodes.iter().enumerate().map(|(i, _)| i).collect();
+        let brillig_side_effects = BTreeMap::new();
+        let optimizer = RangeOptimizer::new(circuit, &brillig_side_effects);
+        let (optimized_circuit, _) = optimizer.replace_redundant_ranges(acir_opcode_positions);
+        assert!(CircuitSimulator::check_circuit(&optimized_circuit).is_none());
+
+        // BUG: the range is dropped across the `CALL`, which is wrongly treated as transparent.
+        assert_circuit_snapshot!(optimized_circuit, @r"
+        private parameters: [w1, w2]
+        public parameters: []
+        return values: []
+        CALL func: 1, predicate: 1, inputs: [w2], outputs: []
+        ASSERT w1 = 0
+        ");
+    }
+
+    #[test]
     fn array_implied_ranges() {
         // The optimizer should use knowledge about array lengths and witnesses used to index these to remove range opcodes, when possible.
         // The `BLACKBOX::RANGE` call is removed because its range is larger than the array's length

--- a/acvm-repo/acvm/src/compiler/optimizers/redundant_range.rs
+++ b/acvm-repo/acvm/src/compiler/optimizers/redundant_range.rs
@@ -246,6 +246,12 @@ impl<'a, F: AcirField> RangeOptimizer<'a, F> {
                     }
                     None
                 }
+                Opcode::Call { .. } => {
+                    // A call into a separate ACIR circuit can transitively execute side-effecting
+                    // Brillig, so it must act as a side-effect boundary like a direct Brillig call.
+                    next_side_effect = idx;
+                    None
+                }
                 _ => None,
             }) else {
                 // If its not the range opcode, add it to the opcode list and continue.
@@ -587,11 +593,12 @@ mod tests {
         let (optimized_circuit, _) = optimizer.replace_redundant_ranges(acir_opcode_positions);
         assert!(CircuitSimulator::check_circuit(&optimized_circuit).is_none());
 
-        // BUG: the range is dropped across the `CALL`, which is wrongly treated as transparent.
+        // The range must be retained before the `CALL`.
         assert_circuit_snapshot!(optimized_circuit, @r"
         private parameters: [w1, w2]
         public parameters: []
         return values: []
+        BLACKBOX::RANGE input: w1, bits: 32
         CALL func: 1, predicate: 1, inputs: [w2], outputs: []
         ASSERT w1 = 0
         ");

--- a/test_programs/execution_failure/range_check_before_acir_call/Nargo.toml
+++ b/test_programs/execution_failure/range_check_before_acir_call/Nargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "range_check_before_acir_call"
+type = "bin"
+authors = [""]
+
+[dependencies]

--- a/test_programs/execution_failure/range_check_before_acir_call/Prover.toml
+++ b/test_programs/execution_failure/range_check_before_acir_call/Prover.toml
@@ -1,0 +1,3 @@
+# 2^40, which is outside the 32-bit range asserted in `main`.
+w1 = "1099511627776"
+w2 = "7"

--- a/test_programs/execution_failure/range_check_before_acir_call/src/main.nr
+++ b/test_programs/execution_failure/range_check_before_acir_call/src/main.nr
@@ -1,0 +1,27 @@
+fn main(w1: Field, w2: Field) {
+    // Explicit in-circuit range check on a `Field` parameter. The ABI does not
+    // pre-constrain `w1`, so an out-of-range value can be supplied as input and
+    // this constraint is what must reject it.
+    w1.assert_max_bit_size::<32>();
+
+    // `callee` is `#[fold]`, so it is compiled to a separate ACIR circuit and
+    // invoked via `Opcode::Call`. The RangeOptimizer must treat that call as a
+    // side-effect boundary and keep the range check above ahead of it.
+    callee(w2);
+
+    // A small implied range on `w1`. This must not cause the explicit range
+    // check above to be removed across the `callee` ACIR call.
+    assert(w1 == 5);
+}
+
+#[fold]
+fn callee(w2: Field) {
+    // Safety: only a print.
+    unsafe {
+        side_effect(w2);
+    }
+}
+
+unconstrained fn side_effect(w2: Field) {
+    println(w2);
+}

--- a/tooling/nargo_cli/tests/snapshots/execution_failure/range_check_before_acir_call/execute__tests__acir_stderr.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_failure/range_check_before_acir_call/execute__tests__acir_stderr.snap
@@ -2,14 +2,16 @@
 source: tooling/nargo_cli/tests/execute.rs
 expression: stderr
 ---
-error: Failed constraint
-   ┌─ src/main.nr:14:5
+error: Assertion failed: call to assert_max_bit_size
+   ┌─ std/field/mod.nr:17:9
    │
-14 │     assert(w1 == 5);
-   │     ---------------
+17 │         __assert_max_bit_size(self, BIT_SIZE);
+   │         -------------------------------------
    │
    = Call stack:
      1: main
-             at src/main.nr:14:5
+             at src/main.nr:5:5
+     2: Field::assert_max_bit_size
+             at std/field/mod.nr:17:9
 
-Failed to solve program: 'Cannot satisfy constraint'
+Failed assertion

--- a/tooling/nargo_cli/tests/snapshots/execution_failure/range_check_before_acir_call/execute__tests__acir_stderr.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_failure/range_check_before_acir_call/execute__tests__acir_stderr.snap
@@ -1,0 +1,15 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: stderr
+---
+error: Failed constraint
+   ┌─ src/main.nr:14:5
+   │
+14 │     assert(w1 == 5);
+   │     ---------------
+   │
+   = Call stack:
+     1: main
+             at src/main.nr:14:5
+
+Failed to solve program: 'Cannot satisfy constraint'

--- a/tooling/nargo_cli/tests/snapshots/execution_failure/range_check_before_acir_call/execute__tests__brillig_stderr.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_failure/range_check_before_acir_call/execute__tests__brillig_stderr.snap
@@ -1,0 +1,17 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: stderr
+---
+error: Assertion failed: call to assert_max_bit_size
+   ┌─ std/field/mod.nr:17:9
+   │
+17 │         __assert_max_bit_size(self, BIT_SIZE);
+   │         -------------------------------------
+   │
+   = Call stack:
+     1: main
+             at src/main.nr:5:5
+     2: Field::assert_max_bit_size
+             at std/field/mod.nr:17:9
+
+Failed assertion

--- a/tooling/nargo_cli/tests/snapshots/execution_failure/range_check_before_acir_call/execute__tests__comptime_stderr.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_failure/range_check_before_acir_call/execute__tests__comptime_stderr.snap
@@ -1,0 +1,19 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: stderr
+---
+error: call to assert_max_bit_size: 0x010000000000 has 41 bits which do not fit in 32 bits
+   ┌─ std/field/mod.nr:17:9
+   │
+17 │         __assert_max_bit_size(self, BIT_SIZE);
+   │         ------------------------------------- Assertion failed
+   │
+   = Call stack:
+     1: ?
+             at src/main.nr:1:4
+     2: main
+             at src/main.nr:5:5
+     3: Field::assert_max_bit_size
+             at std/field/mod.nr:17:9
+
+Error interpreting main function


### PR DESCRIPTION
Fixes https://github.com/noir-lang/noir-claude/issues/916

## Problem

`RangeOptimizer::replace_redundant_ranges` only treats `Opcode::BrilligCall` as a side-effect boundary in its reverse pass. `Opcode::Call` — which dispatches into a separate ACIR circuit (emitted for `#[fold]` functions) and can transitively execute side-effecting Brillig/oracle/foreign calls in the callee — fell into the `_ => None` arm and was treated as transparent.

As a result, a caller-side explicit `BLACKBOX::RANGE` could be removed *across* an ACIR call whenever a later implied constraint (e.g. an `assert(w1 == k)` or array indexing) made it look redundant. A range check that was meant to gate entry into the callee is then bypassed during witness generation.

This is reachable from real Noir source. With a `Field` parameter and an explicit `assert_max_bit_size`, the range check is an in-circuit constraint (not pre-applied by the ABI), so an out-of-range value can be supplied:

```rust
fn main(w1: Field, w2: Field) {
    w1.assert_max_bit_size::<32>(); // range check on w1
    callee(w2);                     // #[fold] -> Opcode::Call, runs side-effecting Brillig
    assert(w1 == 5);                // implied small range "redundifies" the check above
}

#[fold]
fn callee(w2: Field) { /* unsafe { println(w2) } */ }
```

Fed `w1 = 2^40`, the ACIR runtime previously dropped the range and only failed at the later `assert` — *after* `callee` had already run its side effect — while the Brillig and comptime runtimes correctly failed at the range check.

## Impact

Two properties to keep separate:

- **Proof-system (cryptographic) soundness is preserved.** A prover still cannot forge a valid proof for a false statement: for an out-of-range witness the optimized circuit remains unsatisfiable, because the range is only dropped when a stricter constraint follows that rejects the same values.
- **Side-effect correctness is broken — this is the actual bug.** During witness generation the solver now enters the callee and executes its side-effecting Brillig/oracle/foreign calls before the later constraint fails. A range check meant to prevent ever entering the ACIR call is bypassed, so an oracle side effect can be produced when it never should have been (potential information disclosure, unintended external writes, spurious logs). This is not a harmless reordering.

## Fix

Add an `Opcode::Call { .. }` arm that updates `next_side_effect`, mirroring the conservative handling of unknown Brillig calls. This can only ever *retain* more ranges, never remove more.

## Tests

Following the red→green snapshot workflow (two commits preserved on the branch):

- `acir_call_is_a_side_effect_boundary` — optimizer unit test in `redundant_range.rs`: the explicit `RANGE` is retained before `CALL func: 1`.
- `range_check_before_acir_call` — `execution_failure` integration test. The red commit captured the buggy stderr (acir failing at the later `assert`, diverging from brillig/comptime); the green commit's acir snapshot now fails at the range check, matching the other runtimes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
