### PR TITLE
feat(cli): `nargo add`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3522,6 +3522,7 @@ dependencies = [
  "dirs",
  "fm",
  "fs2",
+ "insta",
  "nargo",
  "noirc_driver",
  "noirc_frontend",
@@ -3531,6 +3532,7 @@ dependencies = [
  "test-case",
  "thiserror 2.0.18",
  "toml 0.8.23",
+ "toml_edit 0.22.27",
  "tracing",
  "url",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3465,6 +3465,7 @@ dependencies = [
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -212,6 +212,7 @@ serde_json = "1.0"
 smol_str = { version = "0.3.2", features = ["serde"] }
 thiserror = "2.0.18"
 toml = "0.8"
+toml_edit = "0.22"
 url = "2.5.4"
 base64 = "^0.22.1"
 rustc-hash = "2.1.2"

--- a/docs/docs/project_structure/dependencies.md
+++ b/docs/docs/project_structure/dependencies.md
@@ -36,6 +36,18 @@ If the module is in a subdirectory, you can define a subdirectory in your git re
 blob = {tag ="v1.2.1", git = "https://github.com/AztecProtocol/aztec-packages", directory = "noir-projects/noir-protocol-circuits/crates/blob"}
 ```
 
+:::tip
+
+Instead of editing _Nargo.toml_ by hand, you can let `nargo add` write the entry for you. It downloads the dependency, verifies it, and names the entry after the dependency's own package:
+
+```sh
+nargo add --git https://github.com/noir-lang/noir-bignum --tag v0.8.0
+```
+
+Add `--directory <subdir>` when the package lives in a subdirectory of the repository.
+
+:::
+
 :::info
 
 Currently, there are no requirements applied on the contents of `tag`. Requirements based on semver 2.0 guidelines could be introduced in the future.
@@ -67,6 +79,12 @@ Inside of the binary crate, you can specify:
 [dependencies]
 lib_a = { path = "../lib_a" }
 ```
+
+:::tip
+
+This entry can also be added with `nargo add --path ../lib_a` instead of editing _Nargo.toml_ by hand.
+
+:::
 
 ## Importing dependencies
 

--- a/tooling/lsp/src/notifications/mod.rs
+++ b/tooling/lsp/src/notifications/mod.rs
@@ -16,6 +16,7 @@ use async_lsp::lsp_types::{
 };
 use async_lsp::{ErrorCode, LanguageClient, ResponseError};
 use fm::{FileId, FileManager, FileMap, PathString};
+use nargo::constants::PKG_FILE;
 use nargo::package::{Package, PackageType};
 use nargo::workspace::Workspace;
 use noirc_driver::check_crate;
@@ -228,7 +229,7 @@ pub(crate) fn workspace_from_document_uri(
     match resolve_workspace_for_source_path(&file_path) {
         Ok(workspace) => {
             // If this workspace's Nargo.toml previously had errors, clear them now.
-            if let Ok(toml_uri) = Url::from_file_path(workspace.root_dir.join("Nargo.toml"))
+            if let Ok(toml_uri) = Url::from_file_path(workspace.root_dir.join(PKG_FILE))
                 && state.toml_files_with_errors.remove(&toml_uri)
             {
                 let _ = state.client.publish_diagnostics(PublishDiagnosticsParams {

--- a/tooling/nargo_cli/Cargo.toml
+++ b/tooling/nargo_cli/Cargo.toml
@@ -62,6 +62,7 @@ toml.workspace = true
 serde_json.workspace = true
 rayon.workspace = true
 thiserror.workspace = true
+url.workspace = true
 tower.workspace = true
 async-lsp = { workspace = true, features = [
     "client-monitor",

--- a/tooling/nargo_cli/src/cli/add_cmd.rs
+++ b/tooling/nargo_cli/src/cli/add_cmd.rs
@@ -1,4 +1,5 @@
 use clap::{ArgGroup, Args};
+use nargo::constants::PKG_FILE;
 use nargo::package::CrateName;
 use nargo::workspace::Workspace;
 use nargo_toml::{
@@ -61,7 +62,7 @@ pub(crate) fn run(args: AddCommand, workspace: Workspace) -> Result<(), CliError
     // A workspace root without a `default-member` (or `--workspace`) leaves no package selected.
     let index = workspace.selected_package_index.ok_or(CliError::AddRequiresPackageSelection)?;
     let package = &workspace.members[index];
-    let manifest_path = package.root_dir.join("Nargo.toml");
+    let manifest_path = package.root_dir.join(PKG_FILE);
 
     let dependency = match (&args.path, &args.git) {
         (Some(path), _) => DependencyConfig::Path { path: path.clone() },
@@ -114,7 +115,7 @@ mod tests {
         let pkg_dir = root.join(dir);
         std::fs::create_dir_all(pkg_dir.join("src")).unwrap();
         std::fs::write(
-            pkg_dir.join("Nargo.toml"),
+            pkg_dir.join(PKG_FILE),
             format!("[package]\nname = \"{name}\"\ntype = \"{package_type}\"\nauthors = [\"\"]\n\n[dependencies]\n"),
         )
         .unwrap();
@@ -125,7 +126,7 @@ mod tests {
     /// Resolves the package at `root/dir` into a single-package workspace.
     fn workspace_for(root: &Path, dir: &str) -> Workspace {
         resolve_workspace_from_toml(
-            &root.join(dir).join("Nargo.toml"),
+            &root.join(dir).join(PKG_FILE),
             PackageSelection::DefaultOrAll,
             None,
         )
@@ -151,7 +152,7 @@ mod tests {
         write_pkg(root, "the_bin", "demo", "bin");
         write_pkg(root, "the_lib", "cool_lib", "lib");
 
-        let manifest = root.join("the_bin").join("Nargo.toml");
+        let manifest = root.join("the_bin").join(PKG_FILE);
 
         // First add: the name is inferred from the dependency's own `Nargo.toml`.
         run(add_command("../the_lib", false), workspace_for(root, "the_bin")).unwrap();

--- a/tooling/nargo_cli/src/cli/add_cmd.rs
+++ b/tooling/nargo_cli/src/cli/add_cmd.rs
@@ -1,3 +1,5 @@
+use std::str::FromStr;
+
 use clap::{ArgGroup, Args};
 use nargo::constants::PKG_FILE;
 use nargo::package::CrateName;
@@ -5,10 +7,60 @@ use nargo::workspace::Workspace;
 use nargo_toml::{
     DependencyConfig, PackageSelection, add_dependency_to_manifest, resolve_dependency,
 };
+use thiserror::Error;
+use url::Url;
 
 use crate::errors::CliError;
 
 use super::{LockType, PackageOptions, WorkspaceCommand};
+
+/// URL of a git repository for a dependency, validated as it is parsed from the command line.
+///
+/// Only `https` URLs are accepted. A repository's web page offers an HTTPS and an SSH URL to copy;
+/// the SSH one is the scp-style `git@github.com:owner/repo.git`, which is not a URL and cannot be
+/// cached by host and path, so it is rejected with guidance to use the HTTPS form. `http` is
+/// rejected so credentials are never sent unencrypted.
+#[derive(Debug, Clone)]
+pub(crate) struct GitUrl(String);
+
+impl GitUrl {
+    fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+#[derive(Debug, Error)]
+pub(crate) enum GitUrlParseError {
+    #[error(
+        "`{input}` is not a valid git URL: {source}.\n\
+         Use the HTTPS URL from the repository's web page, e.g. `https://github.com/owner/repo`.\n\
+         SSH URLs like `git@github.com:owner/repo.git` are not supported."
+    )]
+    InvalidUrl { input: String, source: url::ParseError },
+    #[error(
+        "git dependencies must use an `https` URL, but `{input}` uses `{scheme}`.\n\
+         Use the HTTPS URL from the repository's web page, e.g. `https://github.com/owner/repo`."
+    )]
+    UnsupportedScheme { input: String, scheme: String },
+}
+
+impl FromStr for GitUrl {
+    type Err = GitUrlParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let url = Url::parse(s)
+            .map_err(|source| GitUrlParseError::InvalidUrl { input: s.to_string(), source })?;
+        // `https` is a special scheme, so a successfully parsed URL is guaranteed to have a host
+        // (a domain or an IP for a self-hosted server), which is all the cache path needs.
+        if url.scheme() != "https" {
+            return Err(GitUrlParseError::UnsupportedScheme {
+                input: s.to_string(),
+                scheme: url.scheme().to_string(),
+            });
+        }
+        Ok(GitUrl(s.to_string()))
+    }
+}
 
 /// Add a dependency to the package's `Nargo.toml`.
 ///
@@ -27,7 +79,7 @@ pub(crate) struct AddCommand {
 
     /// URL of a git repository to depend on.
     #[clap(long, conflicts_with = "path", requires = "tag")]
-    git: Option<String>,
+    git: Option<GitUrl>,
 
     /// Git branch or tag to use (required with `--git`).
     #[clap(long, requires = "git")]
@@ -67,7 +119,7 @@ pub(crate) fn run(args: AddCommand, workspace: Workspace) -> Result<(), CliError
     let dependency = match (&args.path, &args.git) {
         (Some(path), _) => DependencyConfig::Path { path: path.clone() },
         (None, Some(git)) => DependencyConfig::Git {
-            git: git.clone(),
+            git: git.as_str().to_string(),
             // `clap` guarantees `--tag` is present whenever `--git` is.
             tag: args.tag.clone().expect("--git requires --tag"),
             directory: args.directory.clone(),
@@ -172,5 +224,41 @@ mod tests {
 
         // With `--override` it succeeds.
         run(add_command("../the_lib", true), workspace_for(root, "the_bin")).unwrap();
+    }
+
+    #[test]
+    fn git_url_accepts_https_and_preserves_the_original_string() {
+        let url: GitUrl = "https://github.com/noir-lang/noir-bignum".parse().unwrap();
+        assert_eq!(url.as_str(), "https://github.com/noir-lang/noir-bignum");
+    }
+
+    #[test]
+    fn git_url_rejects_http_to_avoid_sending_credentials_in_the_clear() {
+        let err = "http://github.com/noir-lang/noir-bignum".parse::<GitUrl>().unwrap_err();
+        assert!(
+            matches!(err, GitUrlParseError::UnsupportedScheme { scheme, .. } if scheme == "http")
+        );
+    }
+
+    #[test]
+    fn git_url_rejects_ssh_scheme() {
+        let err = "ssh://git@github.com/noir-lang/noir-bignum".parse::<GitUrl>().unwrap_err();
+        assert!(
+            matches!(err, GitUrlParseError::UnsupportedScheme { scheme, .. } if scheme == "ssh")
+        );
+    }
+
+    #[test]
+    fn git_url_rejects_scp_style_ssh_url() {
+        // This is the form that produced the bare "relative URL without a base" error.
+        let err = "git@github.com:noir-lang/sha256.git".parse::<GitUrl>().unwrap_err();
+        assert!(matches!(err, GitUrlParseError::InvalidUrl { .. }));
+    }
+
+    #[test]
+    fn git_url_accepts_https_with_ip_host() {
+        // A self-hosted repository may be served from an IP address rather than a domain.
+        let url: GitUrl = "https://192.168.1.10/me/repo".parse().unwrap();
+        assert_eq!(url.as_str(), "https://192.168.1.10/me/repo");
     }
 }

--- a/tooling/nargo_cli/src/cli/add_cmd.rs
+++ b/tooling/nargo_cli/src/cli/add_cmd.rs
@@ -1,0 +1,175 @@
+use clap::{ArgGroup, Args};
+use nargo::package::CrateName;
+use nargo::workspace::Workspace;
+use nargo_toml::{
+    DependencyConfig, PackageSelection, add_dependency_to_manifest, resolve_dependency,
+};
+
+use crate::errors::CliError;
+
+use super::{LockType, PackageOptions, WorkspaceCommand};
+
+/// Add a dependency to the package's `Nargo.toml`.
+///
+/// The dependency is resolved (and, for git dependencies, downloaded) before the manifest is
+/// written, so a dependency that cannot be found never ends up in `Nargo.toml`.
+#[derive(Debug, Clone, Args)]
+#[clap(group(ArgGroup::new("source").required(true).args(["path", "git"])))]
+pub(crate) struct AddCommand {
+    /// Name to use for the dependency (the key under `[dependencies]`).
+    /// Defaults to the package name declared in the dependency's own `Nargo.toml`.
+    name: Option<CrateName>,
+
+    /// Path to a local dependency, relative to this package's `Nargo.toml`.
+    #[clap(long, conflicts_with = "git")]
+    path: Option<String>,
+
+    /// URL of a git repository to depend on.
+    #[clap(long, conflicts_with = "path", requires = "tag")]
+    git: Option<String>,
+
+    /// Git branch or tag to use (required with `--git`).
+    #[clap(long, requires = "git")]
+    tag: Option<String>,
+
+    /// Subdirectory within the git repository that contains the package.
+    #[clap(long, requires = "git")]
+    directory: Option<String>,
+
+    /// Replace the dependency if one with the same name already exists.
+    #[clap(long = "override")]
+    overwrite: bool,
+
+    #[clap(flatten)]
+    package_options: PackageOptions,
+}
+
+impl WorkspaceCommand for AddCommand {
+    fn package_selection(&self) -> PackageSelection {
+        self.package_options.package_selection()
+    }
+
+    fn lock_type(&self) -> LockType {
+        // We edit a workspace member's `Nargo.toml`. `lock_workspace` takes its lock on the
+        // manifest file itself, so an exclusive lock serializes concurrent `add` runs.
+        LockType::Exclusive
+    }
+}
+
+pub(crate) fn run(args: AddCommand, workspace: Workspace) -> Result<(), CliError> {
+    // Adding to several manifests at once is ambiguous, so we require a single selected package.
+    // A workspace root without a `default-member` (or `--workspace`) leaves no package selected.
+    let index = workspace.selected_package_index.ok_or(CliError::AddRequiresPackageSelection)?;
+    let package = &workspace.members[index];
+    let manifest_path = package.root_dir.join("Nargo.toml");
+
+    let dependency = match (&args.path, &args.git) {
+        (Some(path), _) => DependencyConfig::Path { path: path.clone() },
+        (None, Some(git)) => DependencyConfig::Git {
+            git: git.clone(),
+            // `clap` guarantees `--tag` is present whenever `--git` is.
+            tag: args.tag.clone().expect("--git requires --tag"),
+            directory: args.directory.clone(),
+        },
+        // `clap`'s required `source` group guarantees exactly one of `--path`/`--git`.
+        (None, None) => unreachable!("clap requires either --path or --git"),
+    };
+
+    // Resolve the dependency before touching the manifest: this validates that it exists and is
+    // not a binary, downloads git dependencies into the cache, and tells us where it landed.
+    let resolved = resolve_dependency(&package.root_dir, &dependency)?;
+
+    let name = match args.name {
+        Some(name) => name,
+        None => resolved.package_name().clone(),
+    };
+
+    add_dependency_to_manifest(&manifest_path, &name.to_string(), &dependency, args.overwrite)?;
+
+    let location = resolved.package().root_dir.display();
+    noirc_errors::println_to_stdout!("Added dependency `{name}`");
+    match &dependency {
+        DependencyConfig::Git { git, tag, .. } => {
+            noirc_errors::println_to_stdout!("    source: {git} (tag {tag})");
+        }
+        DependencyConfig::Path { path } => {
+            noirc_errors::println_to_stdout!("    source: {path}");
+        }
+    }
+    noirc_errors::println_to_stdout!("  location: {location}");
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use nargo_toml::{PackageSelection, resolve_workspace_from_toml};
+
+    use super::*;
+
+    /// Writes a package `Nargo.toml` and its entry file under `root/dir`.
+    fn write_pkg(root: &Path, dir: &str, name: &str, package_type: &str) {
+        let pkg_dir = root.join(dir);
+        std::fs::create_dir_all(pkg_dir.join("src")).unwrap();
+        std::fs::write(
+            pkg_dir.join("Nargo.toml"),
+            format!("[package]\nname = \"{name}\"\ntype = \"{package_type}\"\nauthors = [\"\"]\n\n[dependencies]\n"),
+        )
+        .unwrap();
+        let entry = if package_type == "lib" { "lib.nr" } else { "main.nr" };
+        std::fs::write(pkg_dir.join("src").join(entry), "").unwrap();
+    }
+
+    /// Resolves the package at `root/dir` into a single-package workspace.
+    fn workspace_for(root: &Path, dir: &str) -> Workspace {
+        resolve_workspace_from_toml(
+            &root.join(dir).join("Nargo.toml"),
+            PackageSelection::DefaultOrAll,
+            None,
+        )
+        .unwrap()
+    }
+
+    fn add_command(path: &str, overwrite: bool) -> AddCommand {
+        AddCommand {
+            name: None,
+            path: Some(path.to_string()),
+            git: None,
+            tag: None,
+            directory: None,
+            overwrite,
+            package_options: PackageOptions::default(),
+        }
+    }
+
+    #[test]
+    fn add_path_dependency_infers_name_and_guards_existing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        write_pkg(root, "the_bin", "demo", "bin");
+        write_pkg(root, "the_lib", "cool_lib", "lib");
+
+        let manifest = root.join("the_bin").join("Nargo.toml");
+
+        // First add: the name is inferred from the dependency's own `Nargo.toml`.
+        run(add_command("../the_lib", false), workspace_for(root, "the_bin")).unwrap();
+        let contents = std::fs::read_to_string(&manifest).unwrap();
+        assert!(
+            contents.contains(r#"cool_lib = { path = "../the_lib" }"#),
+            "expected the inferred dependency entry, got:\n{contents}"
+        );
+
+        // Re-adding the same dependency without `--override` is rejected.
+        let err = run(add_command("../the_lib", false), workspace_for(root, "the_bin"))
+            .expect_err("re-adding an existing dependency should fail");
+        assert!(matches!(
+            err,
+            CliError::ManifestError(nargo_toml::ManifestError::DependencyAlreadyExists(_))
+        ));
+
+        // With `--override` it succeeds.
+        run(add_command("../the_lib", true), workspace_for(root, "the_bin")).unwrap();
+    }
+}

--- a/tooling/nargo_cli/src/cli/mod.rs
+++ b/tooling/nargo_cli/src/cli/mod.rs
@@ -18,6 +18,7 @@ use color_eyre::eyre;
 
 use crate::errors::CliError;
 
+mod add_cmd;
 mod check_cmd;
 pub mod compile_cmd;
 mod dap_cmd;
@@ -108,6 +109,7 @@ enum NargoCommand {
     Interpret(interpret_cmd::InterpretCommand),
     New(new_cmd::NewCommand),
     Init(init_cmd::InitCommand),
+    Add(add_cmd::AddCommand),
     Fetch(fetch_cmd::FetchCommand),
     Execute(execute_cmd::ExecuteCommand),
     Export(export_cmd::ExportCommand),
@@ -151,6 +153,7 @@ pub(crate) fn start_cli() -> eyre::Result<()> {
     match command {
         NargoCommand::New(args) => new_cmd::run(args, config),
         NargoCommand::Init(args) => init_cmd::run(args, config),
+        NargoCommand::Add(args) => with_workspace(args, config, add_cmd::run),
         NargoCommand::Fetch(args) => {
             // Snapshot the dependency cache before resolution downloads anything, so the command
             // can report exactly what was fetched during this run.
@@ -323,17 +326,50 @@ mod tests {
     use super::NargoCli;
     use clap::Parser;
 
+    fn parse_cli(cmd: &str) -> Result<NargoCli, clap::Error> {
+        NargoCli::try_parse_from(cmd.split_ascii_whitespace())
+    }
+
     #[test]
     fn test_parse_target_dir() {
         let cmd = "nargo --program-dir . --target-dir ../foo/bar execute";
-        let cli = NargoCli::try_parse_from(cmd.split_ascii_whitespace()).expect("should parse");
+        let cli = parse_cli(cmd).expect("should parse");
 
         let target_dir = cli.config.target_dir.expect("should parse target dir");
         assert!(target_dir.is_absolute(), "should be made absolute");
         assert!(target_dir.ends_with("foo/bar"));
 
         let cmd = "nargo --program-dir . execute";
-        let cli = NargoCli::try_parse_from(cmd.split_ascii_whitespace()).expect("should parse");
+        let cli = parse_cli(cmd).expect("should parse");
         assert!(cli.config.target_dir.is_none());
+    }
+
+    #[test]
+    fn add_requires_a_source() {
+        parse_cli("nargo add my_lib").expect_err("either --path or --git is required");
+    }
+
+    #[test]
+    fn add_path_and_git_conflict() {
+        parse_cli("nargo add --path ../lib --git https://example.com/repo --tag v1")
+            .expect_err("--path and --git are mutually exclusive");
+    }
+
+    #[test]
+    fn add_git_requires_tag() {
+        parse_cli("nargo add --git https://example.com/repo").expect_err("--git requires --tag");
+    }
+
+    #[test]
+    fn add_accepts_path() {
+        parse_cli("nargo add --path ../lib").expect("a path dependency should parse");
+    }
+
+    #[test]
+    fn add_accepts_git_with_tag_directory_and_override() {
+        parse_cli(
+            "nargo add my_alias --git https://example.com/repo --tag v1 --directory crates/lib --override",
+        )
+        .expect("a git dependency with all options should parse");
     }
 }

--- a/tooling/nargo_cli/src/cli/mod.rs
+++ b/tooling/nargo_cli/src/cli/mod.rs
@@ -361,6 +361,12 @@ mod tests {
     }
 
     #[test]
+    fn add_rejects_scp_style_git_url() {
+        parse_cli("nargo add --git git@github.com:noir-lang/sha256.git --tag v0.3.0")
+            .expect_err("scp-style SSH URLs are not valid URLs and should be rejected");
+    }
+
+    #[test]
     fn add_accepts_path() {
         parse_cli("nargo add --path ../lib").expect("a path dependency should parse");
     }

--- a/tooling/nargo_cli/src/errors.rs
+++ b/tooling/nargo_cli/src/errors.rs
@@ -33,6 +33,11 @@ pub enum CliError {
     #[error("`--debug-compile-stdin` is incompatible with `--watch`")]
     CantWatchStdin,
 
+    #[error(
+        "Error: cannot determine which package to add the dependency to.\nUse `--package <name>` to select a single workspace member."
+    )]
+    AddRequiresPackageSelection,
+
     /// Artifact CLI error
     #[error(transparent)]
     ArtifactError(#[from] noir_artifact_cli::errors::CliError),

--- a/tooling/nargo_cli/tests/fetch.rs
+++ b/tooling/nargo_cli/tests/fetch.rs
@@ -6,6 +6,7 @@ use predicates::prelude::*;
 use std::process::Command;
 
 use assert_fs::prelude::{FileWriteStr, PathChild};
+use nargo::constants::PKG_FILE;
 
 /// A freshly created project has no dependencies, so `nargo fetch` should succeed
 /// without producing any output.
@@ -47,7 +48,7 @@ fn fetch_with_local_dependency() {
     cmd.assert().success();
 
     app_dir
-        .child("Nargo.toml")
+        .child(PKG_FILE)
         .write_str(
             "[package]\n\
              name = \"my_app\"\n\

--- a/tooling/nargo_cli/tests/hello_world.rs
+++ b/tooling/nargo_cli/tests/hello_world.rs
@@ -7,6 +7,7 @@ use predicates::prelude::*;
 use std::process::Command;
 
 use assert_fs::prelude::{FileWriteStr, PathAssert, PathChild};
+use nargo::constants::PKG_FILE;
 
 #[test]
 fn hello_world_example() {
@@ -30,7 +31,7 @@ fn hello_world_example() {
     )));
 
     project_dir.child("src").assert(predicate::path::is_dir());
-    project_dir.child("Nargo.toml").assert(predicate::path::is_file());
+    project_dir.child(PKG_FILE).assert(predicate::path::is_file());
 
     std::env::set_current_dir(&project_dir).unwrap();
 

--- a/tooling/nargo_cli/tests/interpret.rs
+++ b/tooling/nargo_cli/tests/interpret.rs
@@ -5,6 +5,7 @@ use predicates::prelude::*;
 use std::process::Command;
 
 use assert_fs::prelude::{FileWriteStr, PathChild, PathCreateDir};
+use nargo::constants::PKG_FILE;
 
 /// A `Prover.toml` whose array length disagrees with the declared parameter type
 /// should surface a clean error, the same way `nargo execute` does, instead of
@@ -14,7 +15,7 @@ fn interpret_with_array_length_mismatch_reports_clean_error() {
     let project_dir = assert_fs::TempDir::new().unwrap();
     project_dir.child("src").create_dir_all().unwrap();
     project_dir
-        .child("Nargo.toml")
+        .child(PKG_FILE)
         .write_str(
             r#"[package]
 name = "interpret_length_mismatch"

--- a/tooling/nargo_toml/Cargo.toml
+++ b/tooling/nargo_toml/Cargo.toml
@@ -20,6 +20,7 @@ noirc_frontend.workspace = true
 serde.workspace = true
 thiserror.workspace = true
 toml.workspace = true
+toml_edit.workspace = true
 url.workspace = true
 noirc_driver.workspace = true
 semver = "1.0.28"
@@ -29,3 +30,4 @@ tracing.workspace = true
 [dev-dependencies]
 tempfile.workspace = true
 test-case.workspace = true
+insta.workspace = true

--- a/tooling/nargo_toml/src/errors.rs
+++ b/tooling/nargo_toml/src/errors.rs
@@ -15,6 +15,17 @@ pub enum ManifestError {
     #[error("Cannot read file {0} - does it exist?")]
     ReadFailed(PathBuf),
 
+    #[error("Cannot write to file {0}")]
+    WriteFailed(PathBuf),
+
+    #[error(
+        "A dependency named `{0}` already exists. Pass `--override` to replace it, or remove it from Nargo.toml first"
+    )]
+    DependencyAlreadyExists(String),
+
+    #[error("The `dependencies` section in {0} is not a table")]
+    InvalidDependenciesTable(PathBuf),
+
     #[error("Nargo.toml is missing a parent directory")]
     MissingParent,
 
@@ -27,6 +38,10 @@ pub enum ManifestError {
     /// Package manifest is unreadable.
     #[error("Nargo.toml is badly formed, could not parse.\n\n{}", .0.message())]
     MalformedFile(#[from] toml::de::Error),
+
+    /// Package manifest could not be parsed while editing it.
+    #[error("Nargo.toml is badly formed, could not parse.\n\n{0}")]
+    MalformedFileEdit(#[from] toml_edit::TomlError),
 
     #[error(
         "Unexpected workspace definition found in {0}. If you're attempting to load this as a dependency, you may need to add a `directory` field to your `Nargo.toml` to show which package within the workspace to use"

--- a/tooling/nargo_toml/src/git.rs
+++ b/tooling/nargo_toml/src/git.rs
@@ -47,11 +47,13 @@ fn collect_cached_git_dependencies(cache_root: &Path) -> BTreeSet<PathBuf> {
     found
 }
 
-/// Creates a unique folder name for a GitHub repo
-/// by using its URL and tag
+/// Creates a unique folder name for a git repository by using its URL and tag.
+///
+/// The host (a domain like `github.com`, or an IP for a self-hosted server) is used as-is, so
+/// repositories on the same host share a parent directory in the cache.
 fn resolve_folder_name(base: &url::Url, tag: &str) -> String {
     let mut folder = PathBuf::from("");
-    for part in [base.domain().unwrap(), base.path(), tag] {
+    for part in [base.host_str().expect("git dependency URL must have a host"), base.path(), tag] {
         folder.push(part.trim_start_matches('/'));
     }
     folder.to_string_lossy().into_owned()
@@ -126,6 +128,14 @@ mod tests {
         let tag = "v0.4.2";
         let dir = resolve_folder_name(&Url::parse(url).unwrap(), tag);
         assert_eq!(dir, "github.com/noir-lang/noir-bignum/v0.4.2");
+    }
+
+    /// A self-hosted repository can be served from an IP address, which has no registrable domain.
+    #[test]
+    fn test_resolve_folder_name_with_ip_host() {
+        let dir =
+            resolve_folder_name(&Url::parse("https://192.168.1.10/me/repo").unwrap(), "v1.0.0");
+        assert_eq!(dir, "192.168.1.10/me/repo/v1.0.0");
     }
 
     /// Creates a clone root by making the directory tree `relative` under `cache_root` and

--- a/tooling/nargo_toml/src/lib.rs
+++ b/tooling/nargo_toml/src/lib.rs
@@ -10,6 +10,7 @@ use std::{
 use errors::SemverError;
 use fm::{FILE_EXTENSION, NormalizePath};
 use nargo::{
+    constants::PKG_FILE,
     package::{Dependency, Package, PackageType},
     workspace::Workspace,
 };
@@ -137,7 +138,7 @@ pub fn find_package_manifest(
 ///
 /// Returns a [`ManifestError`] if `current_path` does not contain a manifest file.
 pub fn get_package_manifest(current_path: &Path) -> Result<PathBuf, ManifestError> {
-    let toml_path = current_path.join("Nargo.toml");
+    let toml_path = current_path.join(PKG_FILE);
     if toml_path.exists() {
         Ok(toml_path)
     } else {
@@ -161,14 +162,14 @@ impl PackageConfig {
     ) -> Result<Package, ManifestError> {
         let name = &self.package.name;
         let name: CrateName = name.parse().map_err(|_| ManifestError::InvalidPackageName {
-            toml: root_dir.join("Nargo.toml"),
+            toml: root_dir.join(PKG_FILE),
             name: name.into(),
         })?;
 
         let mut dependencies: BTreeMap<CrateName, Dependency> = BTreeMap::new();
         for (name, dep_config) in &self.dependencies {
             let name = name.parse().map_err(|_| ManifestError::InvalidDependencyName {
-                toml: root_dir.join("Nargo.toml"),
+                toml: root_dir.join(PKG_FILE),
                 name: name.into(),
             })?;
             let resolved_dep = dep_config.resolve_to_dependency(root_dir, processed)?;
@@ -182,11 +183,11 @@ impl PackageConfig {
             Some("contract") => PackageType::Contract,
             Some(invalid) => {
                 return Err(ManifestError::InvalidPackageType(
-                    root_dir.join("Nargo.toml"),
+                    root_dir.join(PKG_FILE),
                     invalid.to_string(),
                 ));
             }
-            None => return Err(ManifestError::MissingPackageType(root_dir.join("Nargo.toml"))),
+            None => return Err(ManifestError::MissingPackageType(root_dir.join(PKG_FILE))),
         };
 
         let entry_path = if let Some(entry_path) = &self.package.entry {
@@ -195,7 +196,7 @@ impl PackageConfig {
                 custom_entry_path
             } else {
                 return Err(ManifestError::MissingEntryFile {
-                    toml: root_dir.join("Nargo.toml"),
+                    toml: root_dir.join(PKG_FILE),
                     entry: custom_entry_path,
                 });
             }
@@ -213,7 +214,7 @@ impl PackageConfig {
                 default_entry_path
             } else {
                 return Err(ManifestError::MissingDefaultEntryFile {
-                    toml: root_dir.join("Nargo.toml"),
+                    toml: root_dir.join(PKG_FILE),
                     entry: default_entry_path,
                     package_type,
                 });
@@ -335,7 +336,7 @@ impl DependencyConfig {
                     let internal_path = dir_path.join(directory).normalize();
                     if !internal_path.starts_with(&dir_path) {
                         return Err(ManifestError::InvalidDirectory {
-                            toml: pkg_root.join("Nargo.toml"),
+                            toml: pkg_root.join(PKG_FILE),
                             directory: directory.into(),
                         });
                     }
@@ -343,13 +344,13 @@ impl DependencyConfig {
                 } else {
                     dir_path
                 };
-                let toml_path = project_path.join("Nargo.toml");
+                let toml_path = project_path.join(PKG_FILE);
                 let package = resolve_package_from_toml(&toml_path, processed)?;
                 Dependency::Remote { package }
             }
             Self::Path { path } => {
                 let dir_path = pkg_root.join(path);
-                let toml_path = dir_path.join("Nargo.toml");
+                let toml_path = dir_path.join(PKG_FILE);
                 let package = resolve_package_from_toml(&toml_path, processed)?;
                 Dependency::Local { package }
             }
@@ -459,7 +460,7 @@ fn toml_to_workspace(
             let mut selected_package_index = None;
             for (index, member_path) in workspace_config.members.into_iter().enumerate() {
                 let package_root_dir = nargo_toml.root_dir.join(&member_path);
-                let package_toml_path = package_root_dir.join("Nargo.toml");
+                let package_toml_path = package_root_dir.join(PKG_FILE);
                 let member = resolve_package_from_toml(&package_toml_path, &mut resolved)?;
 
                 match &package_selection {
@@ -626,13 +627,15 @@ mod tests {
 
     use test_case::test_matrix;
 
+    use nargo::constants::PKG_FILE;
+
     use crate::{Config, DependencyConfig, ManifestError, add_dependency_to_manifest, find_root};
 
     /// Writes `contents` to a `Nargo.toml` in a fresh temp dir and returns the temp dir and the
     /// manifest path. The temp dir must be kept alive for the duration of the test.
     fn manifest_with(contents: &str) -> (tempfile::TempDir, PathBuf) {
         let tmp = tempfile::tempdir().unwrap();
-        let toml_path = tmp.path().join("Nargo.toml");
+        let toml_path = tmp.path().join(PKG_FILE);
         std::fs::write(&toml_path, contents).unwrap();
         (tmp, toml_path)
     }
@@ -809,7 +812,7 @@ my_lib = { path = "../my_lib" }
             let pkg_dir = root.join(dir);
             std::fs::create_dir_all(pkg_dir.join("src")).unwrap();
             std::fs::write(
-                pkg_dir.join("Nargo.toml"),
+                pkg_dir.join(PKG_FILE),
                 format!(
                     "[package]\nname = \"{name}\"\ntype = \"{package_type}\"\nauthors = [\"\"]\n"
                 ),
@@ -1034,7 +1037,7 @@ my_lib = { path = "../my_lib" }
             let dir = root.join(name);
             std::fs::create_dir_all(dir.join("src")).unwrap();
             std::fs::write(
-                dir.join("Nargo.toml"),
+                dir.join(PKG_FILE),
                 format!(
                     "[package]\nname = \"{name}\"\ntype = \"lib\"\nauthors = [\"\"]\n\n[dependencies]\n{dep_name} = {{ path = \"{dep_path}\" }}\n"
                 ),

--- a/tooling/nargo_toml/src/lib.rs
+++ b/tooling/nargo_toml/src/lib.rs
@@ -365,6 +365,68 @@ impl DependencyConfig {
     }
 }
 
+/// Resolves a single dependency relative to `pkg_root`, downloading it into the global cache
+/// if it is a git dependency that hasn't been fetched yet.
+///
+/// This performs the same validation as workspace resolution for one entry: it checks that the
+/// dependency's `Nargo.toml` exists and that it is not a binary package. The returned
+/// [`Dependency`] carries the on-disk [`Package`], whose `root_dir` is where the source lives.
+pub fn resolve_dependency(
+    pkg_root: &Path,
+    dep: &DependencyConfig,
+) -> Result<Dependency, ManifestError> {
+    let _lock = lock_git_deps().expect("Failed to lock git dependencies cache");
+    dep.resolve_to_dependency(pkg_root, &mut Vec::new())
+}
+
+/// Adds a dependency named `name` to the `[dependencies]` table of the manifest at `toml_path`,
+/// preserving the file's existing formatting and comments.
+///
+/// If a dependency with the same name is already present and `overwrite` is `false`, this returns
+/// [`ManifestError::DependencyAlreadyExists`] and leaves the file untouched.
+pub fn add_dependency_to_manifest(
+    toml_path: &Path,
+    name: &str,
+    dep: &DependencyConfig,
+    overwrite: bool,
+) -> Result<(), ManifestError> {
+    use toml_edit::{DocumentMut, Item, Table};
+
+    let contents = std::fs::read_to_string(toml_path)
+        .map_err(|_| ManifestError::ReadFailed(toml_path.to_path_buf()))?;
+    let mut doc = contents.parse::<DocumentMut>()?;
+
+    let dependencies = doc
+        .entry("dependencies")
+        .or_insert_with(|| Item::Table(Table::new()))
+        .as_table_mut()
+        .ok_or_else(|| ManifestError::InvalidDependenciesTable(toml_path.to_path_buf()))?;
+
+    if dependencies.contains_key(name) && !overwrite {
+        return Err(ManifestError::DependencyAlreadyExists(name.to_string()));
+    }
+
+    let mut entry = toml_edit::InlineTable::new();
+    match dep {
+        DependencyConfig::Path { path } => {
+            entry.insert("path", path.as_str().into());
+        }
+        DependencyConfig::Git { git, tag, directory } => {
+            entry.insert("git", git.as_str().into());
+            entry.insert("tag", tag.as_str().into());
+            if let Some(directory) = directory {
+                entry.insert("directory", directory.as_str().into());
+            }
+        }
+    }
+    dependencies[name] = toml_edit::value(entry);
+
+    std::fs::write(toml_path, doc.to_string())
+        .map_err(|_| ManifestError::WriteFailed(toml_path.to_path_buf()))?;
+
+    Ok(())
+}
+
 fn toml_to_workspace(
     nargo_toml: NargoToml,
     package_selection: PackageSelection,
@@ -564,7 +626,211 @@ mod tests {
 
     use test_case::test_matrix;
 
-    use crate::{Config, ManifestError, find_root};
+    use crate::{Config, DependencyConfig, ManifestError, add_dependency_to_manifest, find_root};
+
+    /// Writes `contents` to a `Nargo.toml` in a fresh temp dir and returns the temp dir and the
+    /// manifest path. The temp dir must be kept alive for the duration of the test.
+    fn manifest_with(contents: &str) -> (tempfile::TempDir, PathBuf) {
+        let tmp = tempfile::tempdir().unwrap();
+        let toml_path = tmp.path().join("Nargo.toml");
+        std::fs::write(&toml_path, contents).unwrap();
+        (tmp, toml_path)
+    }
+
+    #[test]
+    fn add_path_dependency_preserves_existing_content() {
+        let (_tmp, toml_path) = manifest_with(
+            r#"[package]
+name = "demo"
+type = "bin"
+authors = [""]
+
+[dependencies]
+# keep me around
+existing = { path = "../existing" }
+"#,
+        );
+
+        add_dependency_to_manifest(
+            &toml_path,
+            "my_lib",
+            &DependencyConfig::Path { path: "../my_lib".to_string() },
+            false,
+        )
+        .unwrap();
+
+        insta::assert_snapshot!(std::fs::read_to_string(&toml_path).unwrap(), @r#"
+        [package]
+        name = "demo"
+        type = "bin"
+        authors = [""]
+
+        [dependencies]
+        # keep me around
+        existing = { path = "../existing" }
+        my_lib = { path = "../my_lib" }
+        "#);
+    }
+
+    #[test]
+    fn add_git_dependency_with_directory() {
+        let (_tmp, toml_path) = manifest_with(
+            r#"[package]
+name = "demo"
+type = "bin"
+authors = [""]
+
+[dependencies]
+"#,
+        );
+
+        add_dependency_to_manifest(
+            &toml_path,
+            "bignum",
+            &DependencyConfig::Git {
+                git: "https://github.com/noir-lang/noir-bignum".to_string(),
+                tag: "v0.4.2".to_string(),
+                directory: Some("crates/bignum".to_string()),
+            },
+            false,
+        )
+        .unwrap();
+
+        insta::assert_snapshot!(std::fs::read_to_string(&toml_path).unwrap(), @r#"
+        [package]
+        name = "demo"
+        type = "bin"
+        authors = [""]
+
+        [dependencies]
+        bignum = { git = "https://github.com/noir-lang/noir-bignum", tag = "v0.4.2", directory = "crates/bignum" }
+        "#);
+    }
+
+    #[test]
+    fn add_dependency_creates_dependencies_section_when_absent() {
+        let (_tmp, toml_path) = manifest_with(
+            r#"[package]
+name = "demo"
+type = "bin"
+authors = [""]
+"#,
+        );
+
+        add_dependency_to_manifest(
+            &toml_path,
+            "my_lib",
+            &DependencyConfig::Path { path: "../my_lib".to_string() },
+            false,
+        )
+        .unwrap();
+
+        insta::assert_snapshot!(std::fs::read_to_string(&toml_path).unwrap(), @r#"
+        [package]
+        name = "demo"
+        type = "bin"
+        authors = [""]
+
+        [dependencies]
+        my_lib = { path = "../my_lib" }
+        "#);
+    }
+
+    #[test]
+    fn add_existing_dependency_without_override_errors_and_leaves_file_unchanged() {
+        let original = r#"[package]
+name = "demo"
+type = "bin"
+authors = [""]
+
+[dependencies]
+my_lib = { path = "../my_lib" }
+"#;
+        let (_tmp, toml_path) = manifest_with(original);
+
+        let error = add_dependency_to_manifest(
+            &toml_path,
+            "my_lib",
+            &DependencyConfig::Path { path: "../somewhere_else".to_string() },
+            false,
+        )
+        .expect_err("adding an existing dependency without --override should fail");
+
+        assert!(matches!(error, ManifestError::DependencyAlreadyExists(name) if name == "my_lib"));
+        assert_eq!(
+            std::fs::read_to_string(&toml_path).unwrap(),
+            original,
+            "the manifest must be left byte-for-byte unchanged"
+        );
+    }
+
+    #[test]
+    fn add_existing_dependency_with_override_replaces_entry() {
+        let (_tmp, toml_path) = manifest_with(
+            r#"[package]
+name = "demo"
+type = "bin"
+authors = [""]
+
+[dependencies]
+my_lib = { path = "../my_lib" }
+"#,
+        );
+
+        add_dependency_to_manifest(
+            &toml_path,
+            "my_lib",
+            &DependencyConfig::Path { path: "../somewhere_else".to_string() },
+            true,
+        )
+        .unwrap();
+
+        insta::assert_snapshot!(std::fs::read_to_string(&toml_path).unwrap(), @r#"
+        [package]
+        name = "demo"
+        type = "bin"
+        authors = [""]
+
+        [dependencies]
+        my_lib = { path = "../somewhere_else" }
+        "#);
+    }
+
+    #[test]
+    fn resolve_path_dependency_yields_package_name_and_rejects_binaries() {
+        use crate::resolve_dependency;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+
+        // Create a package of the given `type` whose declared name differs from its directory,
+        // so the test exercises name discovery rather than assuming the two coincide.
+        let write_pkg = |dir: &str, name: &str, package_type: &str| {
+            let pkg_dir = root.join(dir);
+            std::fs::create_dir_all(pkg_dir.join("src")).unwrap();
+            std::fs::write(
+                pkg_dir.join("Nargo.toml"),
+                format!(
+                    "[package]\nname = \"{name}\"\ntype = \"{package_type}\"\nauthors = [\"\"]\n"
+                ),
+            )
+            .unwrap();
+            let entry = if package_type == "lib" { "lib.nr" } else { "main.nr" };
+            std::fs::write(pkg_dir.join("src").join(entry), "").unwrap();
+        };
+
+        write_pkg("the_lib", "cool_lib", "lib");
+        write_pkg("the_bin", "cool_bin", "bin");
+
+        let dep = resolve_dependency(root, &DependencyConfig::Path { path: "the_lib".to_string() })
+            .expect("a library path dependency should resolve");
+        assert_eq!(dep.package_name().to_string(), "cool_lib");
+
+        match resolve_dependency(root, &DependencyConfig::Path { path: "the_bin".to_string() }) {
+            Err(ManifestError::BinaryDependency(name)) => assert_eq!(name.to_string(), "cool_bin"),
+            _ => panic!("a binary path dependency should be rejected"),
+        }
+    }
 
     #[test]
     fn parse_standard_toml() {


### PR DESCRIPTION
## Problem Resolved

Resolves #10885 

## Summary of Changes

Adds a `nargo add` command, based on `cargo add`, to add an entry to the `[dependencies]` in `Nargo.toml`. 

```console
❯ cargo run -q -p nargo_cli -- add --help
Add a dependency to the package's `Nargo.toml`.

The dependency is resolved (and, for git dependencies, downloaded) before the manifest is written, so a dependency that cannot be found never ends up in `Nargo.toml`.

Usage: nargo add [OPTIONS] <--path <PATH>|--git <GIT>> [NAME]

Arguments:
  [NAME]
          Name to use for the dependency (the key under `[dependencies]`). Defaults to the package name declared in the dependency's own `Nargo.toml`

Options:
      --path <PATH>
          Path to a local dependency, relative to this package's `Nargo.toml`

      --git <GIT>
          URL of a git repository to depend on

      --tag <TAG>
          Git branch or tag to use (required with `--git`)

      --directory <DIRECTORY>
          Subdirectory within the git repository that contains the package

      --override
          Replace the dependency if one with the same name already exists

      --package <PACKAGE>
          The name of the package to run the command on. By default run on the first one found moving up along the ancestors of the current directory

      --workspace
          Run on all packages in the workspace

  -h, --help
          Print help (see a summary with '-h')
```

A Git dependency is downloaded before being `add`-ed, and the place it was downloaded to is printed to the console, so the user can open the source code if they want to, or just use the LSP to navigate to it. I hope this fulfils what the ticket wanted to achieve, without having to add the dependency as a Git _submodule_.


### Example

```console
❯ nargo add --git https://github.com/noir-lang/sha256.git --tag v0.3.0
Added dependency `sha256`
    source: https://github.com/noir-lang/sha256.git (tag v0.3.0)
  location: /Users/aakoshh/nargo/github.com/noir-lang/sha256.git/v0.3.0
```



## User Documentation

Check one:
- [ ] No user documentation needed.
- [x] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
