### PR TITLE
fix(frontend): restore full method context on comptime macro re-entry

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/comptime.rs
+++ b/compiler/noirc_frontend/src/elaborator/comptime.rs
@@ -104,13 +104,32 @@ impl<'context> Elaborator<'context> {
     ) -> T {
         self.elaborate_item_from_comptime(reason, f, |elaborator| {
             if let Some(function) = current_function {
-                let (source_crate, source_module, all_generics) = elaborator
-                    .with_function_meta(function, |meta| {
-                        (meta.source_crate, meta.source_module, meta.all_generics.clone())
-                    });
+                let (
+                    source_crate,
+                    source_module,
+                    all_generics,
+                    self_type,
+                    trait_impl,
+                    trait_id,
+                    trait_bounds,
+                ) = elaborator.with_function_meta(function, |meta| {
+                    (
+                        meta.source_crate,
+                        meta.source_module,
+                        meta.all_generics.clone(),
+                        meta.self_type.clone(),
+                        meta.trait_impl,
+                        meta.trait_id,
+                        meta.all_trait_constraints().cloned().collect(),
+                    )
+                });
                 elaborator.current_item = Some(DependencyId::Function(function));
                 elaborator.crate_id = source_crate;
                 elaborator.local_module = Some(source_module);
+                elaborator.self_type = self_type;
+                elaborator.current_trait_impl = trait_impl;
+                elaborator.current_trait = trait_id;
+                elaborator.trait_bounds = trait_bounds;
                 elaborator.introduce_generics_into_scope(all_generics);
             }
         })

--- a/compiler/noirc_frontend/src/tests/metaprogramming.rs
+++ b/compiler/noirc_frontend/src/tests/metaprogramming.rs
@@ -2892,3 +2892,88 @@ fn comptime_error_on_macro_expansion() {
         "Expected a binary operation type error from each generated function, got: {messages:?}"
     );
 }
+
+#[test]
+fn self_in_macro_inside_comptime_block_inside_impl_method() {
+    let src = r#"
+    struct S { x: Field }
+
+    impl S {
+        fn foo(_self: Self) {
+            comptime {
+                let _: Quoted = quote { Self { x: 0 } };
+                let _ = make_self!();
+            };
+        }
+    }
+
+    comptime fn make_self() -> Quoted {
+        quote { Self { x: 0 } }
+    }
+
+    fn main() {
+        S { x: 0 }.foo();
+    }
+    "#;
+    assert_no_errors(src);
+}
+
+#[test]
+fn assoc_type_in_macro_inside_comptime_block_inside_impl_method() {
+    let src = r#"
+    struct S {}
+
+    trait HasAssoc {
+        type Assoc;
+        fn foo(self);
+    }
+
+    impl HasAssoc for S {
+        type Assoc = Field;
+        fn foo(_self: Self) {
+            comptime {
+                let _ = make!();
+            };
+        }
+    }
+
+    comptime fn make() -> Quoted {
+        quote { let _: Self::Assoc = 0; }
+    }
+
+    fn main() {
+        S {}.foo();
+    }
+    "#;
+    assert_no_errors(src);
+}
+
+#[test]
+fn qualified_self_assoc_in_macro_inside_comptime_block_inside_impl_method() {
+    let src = r#"
+    struct S {}
+
+    trait HasAssoc {
+        type Assoc;
+        fn foo(self);
+    }
+
+    impl HasAssoc for S {
+        type Assoc = Field;
+        fn foo(_self: Self) {
+            comptime {
+                let _ = make!();
+            };
+        }
+    }
+
+    comptime fn make() -> Quoted {
+        quote { let _: <Self as HasAssoc>::Assoc = 0; }
+    }
+
+    fn main() {
+        S {}.foo();
+    }
+    "#;
+    assert_no_errors(src);
+}


### PR DESCRIPTION
## Summary

Fixes https://github.com/noir-lang/noir-claude/issues/877.

`Elaborator::elaborate_item_from_comptime_in_function` creates a fresh elaborator for deferred comptime re-entry, but it only restored `current_item`, `crate_id`, `local_module`, and generics. It dropped `self_type`, `current_trait_impl`, `current_trait`, and `trait_bounds`, so macro-expanded code inside a method's `comptime { ... }` block resolved `Self` and trait context differently from normal elaboration of the same method.

The visible consequence was that `Self` in a quoted macro result failed with `Could not resolve 'Self' in path`:

```rust
impl S {
    fn foo(_self: Self) {
        comptime {
            let _ = make_self!(); // make_self!() -> quote { Self { x: 0 } }
        };
    }
}
```

The fix mirrors `elaborate_function`'s full method-context restoration so comptime re-entry sees the same `self_type`, trait impl, trait id, and trait constraints.

## Per-field necessity of the restored state

I added three regression tests and built a necessity matrix by toggling each restored field off (one at a time) and checking which test fails:

| Test (macro-expanded construct) | `self_type` off | `current_trait_impl` off | `current_trait` off | `trait_bounds` off |
|---|:--:|:--:|:--:|:--:|
| `self_in_macro…` — `Self { x: 0 }`, plain impl | **FAIL** | pass | pass | pass |
| `assoc_type_in_macro…` — `Self::Assoc`, trait impl | pass | **FAIL** | pass | pass |
| `qualified_self_assoc…` — `<Self as HasAssoc>::Assoc`, trait impl | **FAIL** | pass | pass | pass |

So the suite proves `self_type` and `current_trait_impl` are each individually required: each has a test that fails iff that one field is dropped.

## Why `current_trait` and `trait_bounds` are restored anyway (defensive)

I could not construct a valid program that proves `current_trait` or `trait_bounds` is needed through this path, and no test in the suite fails when either is dropped. Isolating them requires generic type parameters or an abstract `Self` (e.g. `T::Assoc` via a `where`-bound, or a trait default method), but the quoted code runs *inside* the `comptime { }` block, so it must also be comptime-interpretable — and `T` / abstract-`Self` are not concrete at comptime, so those constructs fail to interpret for unrelated reasons before they can isolate the field.

They are restored regardless, as correct defensive parity with `elaborate_function`: normal method elaboration sets all four fields together, and there is no reason comptime re-entry should diverge. Restoring only the two demonstrably-reachable fields would leave a latent inconsistency that a future change to trait-bound-dependent lookup or impl selection could turn into a real divergence. The cost is one extra `clone` of the trait constraints; the benefit is that comptime re-entry and normal elaboration share exactly the same method context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
