### PR TITLE
chore(ci): fix cargo-binstall rate-limit slowdowns in JS workflows

### DIFF
--- a/.github/workflows/publish-es-packages.yml
+++ b/.github/workflows/publish-es-packages.yml
@@ -16,6 +16,14 @@ run-name: Publish ES Packages from ${{ inputs.noir-ref }} under @${{ inputs.npm-
 
 permissions: {}
 
+# Authenticate cargo-binstall's GitHub API requests (run by `just build-package`
+# via install-js-tools). Unauthenticated they hit GitHub's 60 req/hour limit, get
+# 403, and binstall falls back to compiling the wasm toolchain from source —
+# turning a ~30s step into minutes. A valid token raises the limit to 5000/hour;
+# it needs no permission scopes for this (only public release metadata is read).
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
 jobs:
   build-noirc_abi_wasm:
     runs-on: ubuntu-22.04

--- a/.github/workflows/test-js-packages.yml
+++ b/.github/workflows/test-js-packages.yml
@@ -14,6 +14,14 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref || github.run_id }}
   cancel-in-progress: true
 
+# Authenticate cargo-binstall's GitHub API requests (run by `just build-package`
+# via install-js-tools). Unauthenticated they hit GitHub's 60 req/hour limit, get
+# 403, and binstall falls back to compiling the wasm toolchain from source —
+# turning a ~30s step into minutes. A valid token raises the limit to 5000/hour;
+# it needs no permission scopes for this (only public release metadata is read).
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
 jobs:
   critical-library-list:
     name: Load critical library list

--- a/.github/workflows/test-js-packages.yml
+++ b/.github/workflows/test-js-packages.yml
@@ -609,9 +609,13 @@ jobs:
           path: ./tooling/noirc_abi_wasm
 
       - name: Build noir_js
+        # @noir-lang/types and @noir-lang/noir_js are pure TypeScript (tsc) and
+        # don't need the wasm toolchain that `just build-package` installs via
+        # install-js-tools; the wasm packages they depend on are downloaded as
+        # prebuilt artifacts above. Build them directly to skip that install.
         run: |
-          just build-package @noir-lang/types
-          just build-package @noir-lang/noir_js
+          yarn workspace @noir-lang/types build
+          yarn workspace @noir-lang/noir_js build
 
       - name: Run examples
         run: just run-examples


### PR DESCRIPTION
## Background

The `Build noir_js` (and other `build-package`) steps occasionally jump from ~30s to several minutes. Root cause, from the logs of [a slow run](https://github.com/noir-lang/noir/actions/runs/27955921542/job/82725383453) ([here's another one](https://github.com/noir-lang/noir/actions/runs/27959559681/job/82738313392?pr=13140)):

```
cargo binstall wasm-pack@0.13.1 -y --force --locked
  GET https://api.github.com/.../releases/tags/0.13.1
    Received status code 403 Forbidden, will wait for 120s and retry
  WARN The package wasm-pack v0.13.1 will be installed from source (with cargo)
   Compiling libc v0.2.161 …
```

`just build-package` installs the wasm toolchain via `cargo binstall`, which queries the **GitHub API** to find prebuilt binaries. Run **unauthenticated**, it hits GitHub's 60 req/hour limit (shared per runner IP), gets `403`, waits 120s, then **falls back to compiling the toolchain from source** — minutes. It's intermittent because it depends on the shared IP's recent API usage.

This was a pipeline-wide gap: of the 10 `build-package` steps in `test-js-packages.yml`, only **1** passed a token; the rest rolled the unauthenticated dice.

## Fix 1 — authenticate cargo-binstall (commit 1)

Set `GITHUB_TOKEN` at the **workflow level** in `test-js-packages.yml` and `publish-es-packages.yml`, so every `binstall` in every job is authenticated (5000 req/hour → no 403, no source-compile fallback). The token needs no permission scopes (it only reads public release metadata), so `permissions: {}` is unaffected. (`publish-nargo` already sets the token on its build step.)

## Fix 2 — drop the unused wasm-toolchain install in "Example scripts" (commit 2)

That job builds only `@noir-lang/types` and `@noir-lang/noir_js`, both **pure TypeScript** (`tsc`), and the wasm packages they depend on are **downloaded as prebuilt artifacts** earlier in the job. So `install-js-tools` (pulled in by `just build-package`) installs a wasm toolchain that's never used. Build the two packages directly with `yarn workspace … build` instead — their deps are already installed by the `setup` step.

## Effect

- Fix 1 eliminates the random multi-minute `binstall` spikes across the whole JS pipeline.
- Fix 2 removes the wasted toolchain install from the Example scripts job entirely (even on a fast `binstall`, that's tens of seconds of downloading unused tools).

🤖 Generated with [Claude Code](https://claude.com/claude-code)