### PR TITLE
chore(stdlib): Allow `BoundedVec::set_len` to shorten the length

### DIFF
--- a/docs/docs/libraries/standard_library/containers/boundedvec.md
+++ b/docs/docs/libraries/standard_library/containers/boundedvec.md
@@ -185,8 +185,10 @@ Example:
 pub fn set_len(&mut self, len: u32) {
 ```
 
-Sets the length of the BoundedVec manually. This is useful to update the length after
-updating the content of the vector using `set_unchecked`.
+Sets the length of the BoundedVec manually to any value between `0` and `MaxLen`. Increasing the
+length is useful to expose elements written past the current length with `set_unchecked`; decreasing
+it discards trailing elements. This does not zero out the backing storage, so elements beyond the new
+length remain readable through [`storage`](#storage).
 
 Example:
 

--- a/noir_stdlib/docs/std/collections/bounded_vec/struct.BoundedVec.html
+++ b/noir_stdlib/docs/std/collections/bounded_vec/struct.BoundedVec.html
@@ -212,9 +212,12 @@ v.push(<span class="number">400</span>);
 </div><code id="set_len" class="code-header">pub fn <a href="#set_len"><span class="fn">set_len</span></a>(&mut self, len: <a href="../../../std/primitive.u32.html" class="primitive">u32</a>)</code>
 
 <div class="padded-description"><div class="comments">
-<p>Allows user to update the length of the vector once
-after doing multiple pushes.
-Example:</p>
+<p>Sets the length of the vector to any value between <code>0</code> and <code>MaxLen</code>.</p>
+<p>Increasing the length exposes elements that were written past the current
+length (e.g. with <code>set_unchecked</code>); decreasing it discards trailing
+elements. Note that this does not zero out any element of the backing storage,
+so elements beyond the new length remain readable through <code>storage</code>.</p>
+<p>Example:</p>
 <pre><code><span class="kw">let</span> <span class="kw">mut</span> v: BoundedVec&lt;Field, <span class="number">10</span>&gt; = BoundedVec::from([<span class="number">1</span>, <span class="number">2</span>, <span class="number">3</span>, <span class="number">4</span>, <span class="number">5</span>]);
 
 <span class="kw">assert</span>(v.len() == <span class="number">5</span>);
@@ -222,7 +225,11 @@ v.set_unchecked(<span class="number">5</span>, <span class="number">6</span>);
 v.set_unchecked(<span class="number">6</span>, <span class="number">7</span>);
 v.set_unchecked(<span class="number">7</span>, <span class="number">8</span>);
 v.set_len(<span class="number">8</span>);
-<span class="kw">assert</span>(v.len() == <span class="number">8</span>);</code></pre></div>
+<span class="kw">assert</span>(v.len() == <span class="number">8</span>);
+
+<span class="comment">// The length can also be reduced.</span>
+v.set_len(<span class="number">2</span>);
+<span class="kw">assert</span>(v.len() == <span class="number">2</span>);</code></pre></div>
 </div><code id="max_len" class="code-header">pub fn <a href="#max_len"><span class="fn">max_len</span></a>(_self: &Self) -> <a href="../../../std/primitive.u32.html" class="primitive">u32</a></code>
 
 <div class="padded-description"><div class="comments">

--- a/noir_stdlib/src/collections/bounded_vec.nr
+++ b/noir_stdlib/src/collections/bounded_vec.nr
@@ -209,8 +209,13 @@ impl<T, let MaxLen: u32> BoundedVec<T, MaxLen> {
         self.len
     }
 
-    /// Allows user to update the length of the vector once
-    /// after doing multiple pushes.
+    /// Sets the length of the vector to any value between `0` and `MaxLen`.
+    ///
+    /// Increasing the length exposes elements that were written past the current
+    /// length (e.g. with `set_unchecked`); decreasing it discards trailing
+    /// elements. Note that this does not zero out any element of the backing storage,
+    /// so elements beyond the new length remain readable through `storage`.
+    ///
     /// Example:
     ///
     /// ```noir
@@ -222,10 +227,13 @@ impl<T, let MaxLen: u32> BoundedVec<T, MaxLen> {
     /// v.set_unchecked(7, 8);
     /// v.set_len(8);
     /// assert(v.len() == 8);
+    ///
+    /// // The length can also be reduced.
+    /// v.set_len(2);
+    /// assert(v.len() == 2);
     /// ```
     pub fn set_len(&mut self, len: u32) {
         assert(len <= MaxLen, "set_len out of bounds");
-        assert(len >= self.len(), "can not set_len to a length shorter than the current length");
         self.len = len;
     }
 
@@ -750,17 +758,32 @@ mod bounded_vec_tests {
             vec.set_unchecked(3, 44);
             vec.set_unchecked(4, 55);
             vec.set_unchecked(5, 66);
-            vec.set_unchecked(6, 77);
+            // Index 6 is intentionally left untouched: it stays zeroed.
             vec.set_len(8);
             assert_eq(vec.len(), 8);
+
+            // The explicitly written elements are exposed at their indices...
+            assert_eq(vec.get(3), 44);
+            assert_eq(vec.get(4), 55);
+            assert_eq(vec.get(5), 66);
+            // ...while the gap between the last write and the new length is zeroed.
+            assert_eq(vec.get(6), 0);
+            assert_eq(vec.get(7), 0);
+
             vec.extend_from_array([88, 99]);
             assert_eq(vec.len(), 10);
         }
 
-        #[test(should_fail_with = "can not set_len to a length shorter than the current length")]
-        fn panics_when_set_len_to_shorter_length() {
-            let mut vec: BoundedVec<u32, 5> = BoundedVec::from_array([1, 2, 3]);
+        #[test]
+        fn set_len_can_reduce_the_length() {
+            let mut vec: BoundedVec<u32, 5> = BoundedVec::from_array([1, 2, 3, 4, 5]);
             vec.set_len(2);
+            assert_eq(vec.len(), 2);
+            // Reducing the length does not zero the backing storage, so the
+            // discarded elements remain readable through `storage`.
+            assert_eq(vec.storage()[2], 3);
+            assert_eq(vec.storage()[3], 4);
+            assert_eq(vec.storage()[4], 5);
         }
 
         #[test(should_fail_with = "set_len out of bounds")]

--- a/test_programs/noir_test_success/bounded_vec/src/main.nr
+++ b/test_programs/noir_test_success/bounded_vec/src/main.nr
@@ -148,8 +148,15 @@ fn set_len_docs_example() {
     v.set_unchecked(6, 7);
     v.set_unchecked(7, 8);
     assert(v.len() == 5);
-    v.set_len(9);
-    assert(v.len() == 9);
+
+    // Grow the length to expose the elements written above.
+    v.set_len(8);
+    assert(v.len() == 8);
+    assert(v.get(7) == 8);
+
+    // The length can also be reduced.
+    v.set_len(2);
+    assert(v.len() == 2);
     // docs:end:bounded-vec-set-len-example
 }
 


### PR DESCRIPTION
## Problem Resolved

Amends https://github.com/noir-lang/noir/pull/13136

I commented on the original PR that we could use `set_len` to shorten the vector, not just make it longer. At the time this was [rejected](https://github.com/noir-lang/noir/pull/11392#discussion_r2764073901) because of the invariant that we had to maintain, which was that items beyond `len` were `zeroed`, and that we should leave `set_len` _safe_, and have a dedicated `truncate` for making the vector shorter.

Later this invariant was removed, but we agreed to leave `set_len` as-is, and leave shortening to `truncate`, which is in another follow-up: https://github.com/noir-lang/noir/pull/13137

However, I still think the `set_len` being upward only is a bit awkward, and wanted to open this as a simple YES/NO about how we'd like to merge this feature.

## Summary of Changes

Changes `BoundedVec::set_len` to allow the user to set the length to anything between 0 and `MaxLen`. 


## User Documentation

Check one:
- [ ] No user documentation needed.
- [x] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
