### PR TITLE
fix(ssa): restore unfit operands in the interpreter's checked arithmetic

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/interpreter/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/interpreter/mod.rs
@@ -1543,8 +1543,11 @@ macro_rules! apply_int_binop_opt {
     ($lhs:expr, $rhs:expr, $binary:expr, $f:expr, $display_binary:expr) => {{
         use value::NumericValue::*;
 
-        let lhs = $lhs;
-        let rhs = $rhs;
+        // A checked op consuming an operand that escaped its type via an overflowing unchecked
+        // op must see the wrapped, in-range value the backends carry forward, not the extended
+        // `Unfit` field; otherwise it would error where ACIR/Brillig succeed. See `restore_unfit`.
+        let lhs = restore_unfit($lhs)?;
+        let rhs = restore_unfit($rhs)?;
         let binary = $binary;
         let operator = binary.operator;
 
@@ -1638,6 +1641,32 @@ macro_rules! apply_int_comparison_op {
             }
         }
     }};
+}
+
+/// "Restore" a value that escaped its type via an overflowing unchecked operation into the
+/// wrapped, in-range value that the ACIR and Brillig backends carry forward.
+///
+/// An overflowing unchecked op leaves a [`value::Fitted::Unfit`] field that exceeds the operand's
+/// type (e.g. `unchecked_mul i32 i32::MAX, 2` yields the field `4294967294`). The backends do not
+/// keep that extended value: Brillig wraps in its fixed-width registers and ACIR truncates when
+/// lowering the consuming checked op, so both treat the operand as its `bit_size`-bit representative
+/// (`i32 -2`). Truncating here mirrors that, so a checked op over an `Unfit` operand evaluates
+/// consistently with the backends instead of erroring. Operands that already fit are returned
+/// unchanged.
+fn restore_unfit(value: NumericValue) -> IResult<NumericValue> {
+    use value::Fitted::Unfit;
+    use value::NumericValue::*;
+
+    let (U8(Unfit(field)) | U16(Unfit(field)) | U32(Unfit(field)) | U64(Unfit(field))
+    | U128(Unfit(field)) | I8(Unfit(field)) | I16(Unfit(field)) | I32(Unfit(field))
+    | I64(Unfit(field))) = value
+    else {
+        return Ok(value);
+    };
+
+    let typ = value.get_type();
+    let truncated = truncate_field(field, typ.bit_size::<FieldElement>());
+    NumericValue::from_constant(truncated, typ)
 }
 
 fn evaluate_binary(

--- a/compiler/noirc_evaluator/src/ssa/interpreter/tests/instructions.rs
+++ b/compiler/noirc_evaluator/src/ssa/interpreter/tests/instructions.rs
@@ -112,6 +112,61 @@ fn add_unchecked_signed() {
     assert_eq!(value, make_unfit(129u32, NumericType::signed(8)));
 }
 
+// Regression test for noir-lang/noir-claude#1430.
+//
+// A checked arithmetic op whose operand escaped its type via an earlier overflowing unchecked
+// op (a `Fitted::Unfit` value) must evaluate against the operand's wrapped, in-range value —
+// the value ACIR (which truncates when lowering the checked op) and Brillig (fixed-width
+// registers) carry forward — instead of erroring. Otherwise the interpreter reports an overflow
+// where the backends, and the expanded SSA after `expand_signed_checks`, return the wrapped
+// result.
+#[test]
+fn checked_signed_op_over_unfit_operand_wraps() {
+    // `unchecked_mul i32 i32::MAX, 2` yields the field 4294967294, whose i32 bit pattern is -2.
+    let value = expect_value(
+        "
+        acir(inline) fn main f0 {
+          b0():
+            v0 = unchecked_mul i32 2147483647, i32 2
+            v1 = add v0, i32 0
+            return v1
+        }
+    ",
+    );
+    assert_eq!(value, Value::i32(-2));
+
+    // The second operand is irrelevant; the divergence was about the unfit operand: -2 + 5 = 3.
+    let value = expect_value(
+        "
+        acir(inline) fn main f0 {
+          b0():
+            v0 = unchecked_mul i32 2147483647, i32 2
+            v1 = add v0, i32 5
+            return v1
+        }
+    ",
+    );
+    assert_eq!(value, Value::i32(3));
+}
+
+// Companion to [`checked_signed_op_over_unfit_operand_wraps`] exercising an unfit value that
+// exceeds the type's bit width (so wrapping must truncate modulo `2^bit_size`, not just
+// reinterpret): `unchecked_add u8 200, u8 100` yields 300, which wraps to `u8 44`.
+#[test]
+fn checked_unsigned_op_over_unfit_operand_wraps() {
+    let value = expect_value(
+        "
+        acir(inline) fn main f0 {
+          b0():
+            v0 = unchecked_add u8 200, u8 100
+            v1 = add v0, u8 0
+            return v1
+        }
+    ",
+    );
+    assert_eq!(value, Value::u8(44));
+}
+
 #[test]
 fn sub_unsigned() {
     let value = expect_value(


### PR DESCRIPTION
Fixes noir-lang/noir-claude#1430

## The report

`expand_signed_checks` rewrites a checked signed `add`/`sub`/`mul` into unchecked arithmetic plus explicit overflow checks. The issue observed that, on validator-accepted SSA, an operand produced by a *prior overflowing unchecked op* makes the original checked op error in the SSA interpreter, while the SSA *after* `expand_signed_checks` returns a fitted value — a semantic-preservation gap.

Minimal repro (SSA interpreter):

```
acir(inline) fn main f0 {
  b0():
    v0 = unchecked_mul i32 2147483647, i32 2   // overflows -> Fitted::Unfit(4294967294)
    v1 = add v0, i32 0                          // checked add over an Unfit operand
    return v1
}
```

- baseline interpret → `Err(overflow ... add i32 (4294967294), i32 0)`
- after `expand signed checks` → `Ok(i32 -2)`

## Root cause: the interpreter is the outlier, not the pass

The interpreter tracks values that overflowed an unchecked op as `Fitted::Unfit(field)` (it keeps the *extended* field rather than wrapping). The checked-arithmetic path (`apply_int_binop_opt` → `apply_fit_binop_opt`) only handles `(Fit, Fit)` and treats **any** `Unfit` operand as overflow.

But that `Unfit` value is a perfectly valid bit pattern: `4294967294` (`0xFFFFFFFE`) *is* `i32 -2`. And a checked op is a **reconvergence point** for the two backends:

- **Brillig** uses fixed-width registers, so the multiply already wrapped to `-2`.
- **ACIR** keeps the overflowed product as the symbolic field expression `w0*w1` and only reduces it inside the *lowered* checked op. Executing the compiled ACIR of `unchecked_mul` + `add v, 5` confirms this — there is **no witness holding `4294967294`**; the truncation to range happens in the checked add:

  ```
  RANGE w0 to 32 bits;  RANGE w1 to 32 bits
  BRILLIG CALL inputs: [w0*w1 + 5, 4294967296] outputs: [w3, w4]   // (w0*w1+5) divmod 2^32
  ASSERT w4 = w0*w1 - 4294967296*w3 + 5                            // w4 = (w0*w1+5) mod 2^32 = 3
  ... sign / overflow-check constraints ...
  ASSERT w2 = w4                                                   // return = 3
  ```

So both backends, and the expanded SSA, agree on the wrapped result; only the interpreter errored.

## The fix

`restore_unfit` truncates an `Unfit` operand to its `bit_size` and reinterprets it (exactly the value Brillig wraps to / ACIR truncates to) before applying the checked op. It is wired into the `apply_int_binop_opt` path only (checked `Add`/`Sub`/`Mul`/`Div`/`Mod`). Genuine overflow of two **fit** operands still errors — that path is untouched (`add i8 100, i8 100` still reports overflow).

With the fix, baseline and post-`expand_signed_checks` interpretation both return `Ok(i32 -2)`, for both the constant repro and its variable-operand analogue (`unchecked_mul v0, v1` with overflowing inputs, which validation accepts).

## Alternatives explored and rejected

1. **Producer-side SSA validation** — reject any `unchecked_*` whose *constant* operands provably overflow. Rejected: it only catches the constant form; the variable-operand form (`unchecked_mul v0, v1` + overflowing args) is valid SSA and still diverged. It also invalidated several deliberate tests that build overflowing-unchecked SSA on purpose (the `simplify` identity tests, interpreter `unchecked` tests, an ACIR PoC), since the value is a legal bit pattern and there is nothing genuinely malformed to reject.

2. **Consumer-side SSA validation** — reject a checked signed op whose operand is a provably-overflowing unchecked op. Same fundamental gap (only the constant, statically-visible form), and more ad hoc.

3. **Fix `expand_signed_checks` itself** — make the pass preserve the rejection. Not implementable: the operand is a valid bit pattern, so no range-check/constraint can flag it (a `range_check` to `bit_size` *passes* for `4294967294`), and the pass cannot change the baseline it is compared against. The pass output was already bit-correct.

We landed on fixing the interpreter because that is where the divergence actually lived: the interpreter was stricter than the bit-level semantics the backends implement. The fix makes the interpreter's checked op mirror what ACIR/Brillig do at that point — reduce the operand modulo `2^bit_size` — rather than error.

## Not source-reachable

This cannot arise from real Noir source: signed arithmetic is checked at SSA-gen, and unchecked signed ops only appear via `checked_to_unchecked`, which runs *after* `expand_signed_checks`; the frontend never emits an unchecked op that overflows. The scenario is reachable only through hand-written / fuzzer SSA (and the `pass_vs_prev` fuzzer, whose whole purpose is interpreter-vs-pass consistency).

## Testing

- New regression tests `checked_signed_op_over_unfit_operand_wraps` and `checked_unsigned_op_over_unfit_operand_wraps` in `interpreter/tests/instructions.rs` (the second exercises an unfit value beyond the bit width, `u8` 300 → 44, so wrapping must truncate modulo `2^bit_size`, not just reinterpret).
- Full `noirc_evaluator` suite, `noir_ssa_fuzzer`, `ast_fuzzer` smoke, and the `nargo_cli` execute regression slice all pass; clippy + fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
