### PR TITLE
fix(frontend): disallow `#[fuzz]` attribute on `impl` methods

### DIFF
--- a/compiler/noirc_frontend/src/hir/def_collector/dc_mod.rs
+++ b/compiler/noirc_frontend/src/hir/def_collector/dc_mod.rs
@@ -235,6 +235,13 @@ impl ModCollector<'_> {
                     errors.push(error);
                 }
 
+                if noir_function.def.attributes.is_fuzzing_harness() {
+                    let error = DefCollectorErrorKind::FuzzOnAssociatedFunction {
+                        location: noir_function.name_ident().location(),
+                    };
+                    errors.push(error);
+                }
+
                 if noir_function.def.attributes.has_export() {
                     let error = DefCollectorErrorKind::ExportOnAssociatedFunction {
                         location: noir_function.name_ident().location(),
@@ -1439,6 +1446,13 @@ pub fn collect_impl(
 
         if method.def.attributes.is_test_function() {
             let error = DefCollectorErrorKind::TestOnAssociatedFunction {
+                location: method.name_ident().location(),
+            };
+            errors.push(error);
+            continue;
+        }
+        if method.def.attributes.is_fuzzing_harness() {
+            let error = DefCollectorErrorKind::FuzzOnAssociatedFunction {
                 location: method.name_ident().location(),
             };
             errors.push(error);

--- a/compiler/noirc_frontend/src/hir/def_collector/dc_mod.rs
+++ b/compiler/noirc_frontend/src/hir/def_collector/dc_mod.rs
@@ -228,17 +228,13 @@ impl ModCollector<'_> {
             let module = ModuleId { krate, local_id: self.module_id };
 
             for (_, func_id, noir_function) in &mut unresolved_functions.functions {
-                if noir_function.def.attributes.is_test_function() {
-                    let error = DefCollectorErrorKind::TestOnAssociatedFunction {
-                        location: noir_function.name_ident().location(),
-                    };
+                if let Some((_, location)) = noir_function.def.attributes.as_test_function() {
+                    let error = DefCollectorErrorKind::TestOnAssociatedFunction { location };
                     errors.push(error);
                 }
 
-                if noir_function.def.attributes.is_fuzzing_harness() {
-                    let error = DefCollectorErrorKind::FuzzOnAssociatedFunction {
-                        location: noir_function.name_ident().location(),
-                    };
+                if let Some((_, location)) = noir_function.def.attributes.as_fuzzing_harness() {
+                    let error = DefCollectorErrorKind::FuzzOnAssociatedFunction { location };
                     errors.push(error);
                 }
 
@@ -1444,17 +1440,13 @@ pub fn collect_impl(
         let doc_comments = method.doc_comments;
         let mut method = method.item;
 
-        if method.def.attributes.is_test_function() {
-            let error = DefCollectorErrorKind::TestOnAssociatedFunction {
-                location: method.name_ident().location(),
-            };
+        if let Some((_, location)) = method.def.attributes.as_test_function() {
+            let error = DefCollectorErrorKind::TestOnAssociatedFunction { location };
             errors.push(error);
             continue;
         }
-        if method.def.attributes.is_fuzzing_harness() {
-            let error = DefCollectorErrorKind::FuzzOnAssociatedFunction {
-                location: method.name_ident().location(),
-            };
+        if let Some((_, location)) = method.def.attributes.as_fuzzing_harness() {
+            let error = DefCollectorErrorKind::FuzzOnAssociatedFunction { location };
             errors.push(error);
             continue;
         }

--- a/compiler/noirc_frontend/src/hir/def_collector/errors.rs
+++ b/compiler/noirc_frontend/src/hir/def_collector/errors.rs
@@ -67,6 +67,8 @@ pub enum DefCollectorErrorKind {
     },
     #[error("The `#[test]` attribute may only be used on a non-associated function")]
     TestOnAssociatedFunction { location: Location },
+    #[error("The `#[fuzz]` attribute may only be used on a non-associated function")]
+    FuzzOnAssociatedFunction { location: Location },
     #[error("The `#[export]` attribute may only be used on a non-associated function")]
     ExportOnAssociatedFunction { location: Location },
     #[error(
@@ -100,6 +102,7 @@ impl DefCollectorErrorKind {
                 ..
             }
             | DefCollectorErrorKind::TestOnAssociatedFunction { location }
+            | DefCollectorErrorKind::FuzzOnAssociatedFunction { location }
             | DefCollectorErrorKind::ExportOnAssociatedFunction { location }
             | DefCollectorErrorKind::NonEnumNonStructTypeInImpl { location, .. }
             | DefCollectorErrorKind::ReferenceInTraitImpl { location, .. }
@@ -294,6 +297,11 @@ impl<'a> From<&'a DefCollectorErrorKind> for Diagnostic {
             }
             DefCollectorErrorKind::TestOnAssociatedFunction { location } => Diagnostic::simple_error(
                 "The `#[test]` attribute is disallowed on `impl` methods".into(),
+                String::new(),
+                *location,
+            ),
+            DefCollectorErrorKind::FuzzOnAssociatedFunction { location } => Diagnostic::simple_error(
+                "The `#[fuzz]` attribute is disallowed on `impl` methods".into(),
                 String::new(),
                 *location,
             ),

--- a/compiler/noirc_frontend/src/tests/runtime.rs
+++ b/compiler/noirc_frontend/src/tests/runtime.rs
@@ -408,6 +408,40 @@ fn disallows_test_attribute_on_trait_impl_method() {
 }
 
 #[test]
+fn disallows_fuzz_attribute_on_impl_method() {
+    // TODO: improve the error location
+    let src = "
+        pub struct Foo { }
+
+        impl Foo {
+
+#[fuzz]
+            fn foo(x: u32) { let _ = x; }
+               ^^^ The `#[fuzz]` attribute is disallowed on `impl` methods
+        }
+    ";
+    check_errors(src);
+}
+
+#[test]
+fn disallows_fuzz_attribute_on_trait_impl_method() {
+    let src = "
+        pub trait Trait {
+            fn foo(x: u32);
+        }
+
+        pub struct Foo { }
+
+        impl Trait for Foo {
+            #[fuzz]
+            fn foo(x: u32) { let _ = x; }
+               ^^^ The `#[fuzz]` attribute is disallowed on `impl` methods
+        }
+    ";
+    check_errors(src);
+}
+
+#[test]
 fn disallows_export_attribute_on_impl_method() {
     // TODO: improve the error location
     let src = "

--- a/compiler/noirc_frontend/src/tests/runtime.rs
+++ b/compiler/noirc_frontend/src/tests/runtime.rs
@@ -375,15 +375,13 @@ fn break_and_continue_in_constrained_fn() {
 
 #[test]
 fn disallows_test_attribute_on_impl_method() {
-    // TODO: improve the error location
     let src = "
         pub struct Foo { }
 
         impl Foo {
-
-#[test]
+            #[test]
+            ^^^^^^^ The `#[test]` attribute is disallowed on `impl` methods
             fn foo() { }
-               ^^^ The `#[test]` attribute is disallowed on `impl` methods
         }
     ";
     check_errors(src);
@@ -400,8 +398,8 @@ fn disallows_test_attribute_on_trait_impl_method() {
 
         impl Trait for Foo {
             #[test]
+            ^^^^^^^ The `#[test]` attribute is disallowed on `impl` methods
             fn foo() { }
-               ^^^ The `#[test]` attribute is disallowed on `impl` methods
         }
     ";
     check_errors(src);
@@ -409,15 +407,13 @@ fn disallows_test_attribute_on_trait_impl_method() {
 
 #[test]
 fn disallows_fuzz_attribute_on_impl_method() {
-    // TODO: improve the error location
     let src = "
         pub struct Foo { }
 
         impl Foo {
-
-#[fuzz]
+            #[fuzz]
+            ^^^^^^^ The `#[fuzz]` attribute is disallowed on `impl` methods
             fn foo(x: u32) { let _ = x; }
-               ^^^ The `#[fuzz]` attribute is disallowed on `impl` methods
         }
     ";
     check_errors(src);
@@ -434,8 +430,8 @@ fn disallows_fuzz_attribute_on_trait_impl_method() {
 
         impl Trait for Foo {
             #[fuzz]
+            ^^^^^^^ The `#[fuzz]` attribute is disallowed on `impl` methods
             fn foo(x: u32) { let _ = x; }
-               ^^^ The `#[fuzz]` attribute is disallowed on `impl` methods
         }
     ";
     check_errors(src);


### PR DESCRIPTION
## Description

The `#[fuzz]` attribute, like `#[test]`, only makes sense on non-associated functions. Previously it was silently accepted on `impl` and trait-`impl` methods. Now it produces the same kind of error as the `#[test]` attribute in that position:

```
            #[fuzz]
            ^^^^^^^ The `#[fuzz]` attribute is disallowed on `impl` methods
            fn foo(x: u32) { }
```

While here, this PR also improves the error location for **both** `#[test]` and `#[fuzz]`: the error now underlines the attribute itself rather than the function name (we already capture the attribute's span during parsing).

### Behavior across positions

| Position | `#[test]` | `#[fuzz]` |
|---|---|---|
| Trait *definition* method | already rejected at parse level (attributes aren't parseable on trait items) | same |
| Trait *impl* method | rejected (pre-existing) | now rejected |
| Inherent *impl* method | rejected (pre-existing) | now rejected |

## Resolves

Fixes noir-lang/noir-claude#1429

## Additional Context

None.

## Documentation

- [x] No documentation needed.

## PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)