### PR TITLE
fix: Implement attributes on trait methods

### DIFF
--- a/compiler/noirc_frontend/src/ast/traits.rs
+++ b/compiler/noirc_frontend/src/ast/traits.rs
@@ -7,7 +7,7 @@ use crate::ast::{
     BlockExpression, Expression, FunctionReturnType, Ident, NoirFunction, Path, UnresolvedGenerics,
     UnresolvedType,
 };
-use crate::token::SecondaryAttribute;
+use crate::token::{Attributes, SecondaryAttribute};
 
 use super::{
     DocComment, Documented, GenericTypeArgs, IdentOrQuotedType, ItemVisibility, UnresolvedGeneric,
@@ -43,6 +43,7 @@ pub enum TraitItem {
         return_type: FunctionReturnType,
         where_clause: Vec<UnresolvedTraitConstraint>,
         body: Option<BlockExpression>,
+        attributes: Attributes,
     },
     Constant {
         name: Ident,
@@ -185,7 +186,15 @@ impl Display for TraitItem {
                 is_unconstrained,
                 visibility,
                 is_comptime,
+                attributes,
             } => {
+                if let Some(attribute) = attributes.function() {
+                    writeln!(f, "{attribute}")?;
+                }
+                for attribute in &attributes.secondary {
+                    writeln!(f, "{attribute}")?;
+                }
+
                 let generics = vecmap(generics, |generic| generic.to_string());
                 let parameters = vecmap(parameters, |(name, typ)| format!("{name}: {typ}"));
                 let where_clause = vecmap(where_clause, ToString::to_string);

--- a/compiler/noirc_frontend/src/ast/visitor.rs
+++ b/compiler/noirc_frontend/src/ast/visitor.rs
@@ -776,6 +776,7 @@ impl TraitItem {
                 is_unconstrained: _,
                 visibility: _,
                 is_comptime: _,
+                attributes: _,
             } => {
                 if visitor.visit_trait_item_function(
                     name,

--- a/compiler/noirc_frontend/src/elaborator/traits.rs
+++ b/compiler/noirc_frontend/src/elaborator/traits.rs
@@ -895,6 +895,7 @@ impl Elaborator<'_> {
                 is_unconstrained,
                 visibility: _,
                 is_comptime: _,
+                attributes,
             } = &item.item
             {
                 self.recover_generics(|this| {
@@ -941,6 +942,7 @@ impl Elaborator<'_> {
                     );
                     // Trait functions always have the same visibility as the trait they are in
                     def.visibility = unresolved_trait.trait_def.visibility;
+                    def.attributes = attributes.clone();
 
                     let default_impl = unresolved_trait
                         .fns_with_default_impl

--- a/compiler/noirc_frontend/src/hir/def_collector/dc_mod.rs
+++ b/compiler/noirc_frontend/src/hir/def_collector/dc_mod.rs
@@ -556,6 +556,7 @@ impl ModCollector<'_> {
                         is_unconstrained,
                         visibility: _,
                         is_comptime,
+                        attributes,
                     } => {
                         let func_id = context.def_interner.push_empty_fn();
                         if !method_ids.contains_key(name.as_str()) {
@@ -566,8 +567,7 @@ impl ModCollector<'_> {
                         let modifiers = FunctionModifiers {
                             name: name.to_string(),
                             visibility: trait_definition.visibility,
-                            // TODO(Maddiaa): Investigate trait implementations with attributes see: https://github.com/noir-lang/noir/issues/2629
-                            attributes: crate::token::Attributes::empty(),
+                            attributes: attributes.clone(),
                             generic_count: generics.len(),
                             is_comptime: *is_comptime,
                             name_location: location,
@@ -594,16 +594,17 @@ impl ModCollector<'_> {
                         ) {
                             Ok(()) => {
                                 if let Some(body) = body {
-                                    let impl_method =
-                                        NoirFunction::normal(FunctionDefinition::normal(
-                                            name,
-                                            *is_unconstrained,
-                                            generics,
-                                            parameters,
-                                            body.clone(),
-                                            where_clause.clone(),
-                                            return_type,
-                                        ));
+                                    let mut def = FunctionDefinition::normal(
+                                        name,
+                                        *is_unconstrained,
+                                        generics,
+                                        parameters,
+                                        body.clone(),
+                                        where_clause.clone(),
+                                        return_type,
+                                    );
+                                    def.attributes = attributes.clone();
+                                    let impl_method = NoirFunction::normal(def);
                                     unresolved_functions.push_fn(
                                         self.module_id,
                                         func_id,

--- a/compiler/noirc_frontend/src/parser/parser/function.rs
+++ b/compiler/noirc_frontend/src/parser/parser/function.rs
@@ -335,7 +335,10 @@ impl Parser<'_> {
         (Visibility::Private, self.location_at_previous_token_end())
     }
 
-    fn validate_attributes(&mut self, attributes: Vec<(Attribute, Location)>) -> Attributes {
+    pub(super) fn validate_attributes(
+        &mut self,
+        attributes: Vec<(Attribute, Location)>,
+    ) -> Attributes {
         let mut function = None;
         let mut secondary = Vec::new();
 

--- a/compiler/noirc_frontend/src/parser/parser/traits.rs
+++ b/compiler/noirc_frontend/src/parser/parser/traits.rs
@@ -229,8 +229,11 @@ impl Parser<'_> {
         Some(TraitItem::Constant { name, typ })
     }
 
-    /// `TraitFunction` = Modifiers Function
+    /// `TraitFunction` = Attributes Modifiers Function
     fn parse_trait_function(&mut self) -> Option<TraitItem> {
+        let attributes = self.parse_attributes();
+        let attributes = self.validate_attributes(attributes);
+
         let modifiers = self.parse_modifiers(
             false, // allow mut
         );
@@ -275,6 +278,7 @@ impl Parser<'_> {
             return_type: function.return_type,
             where_clause: function.where_clause,
             body: function.body,
+            attributes,
         })
     }
 }
@@ -555,6 +559,37 @@ mod tests {
         };
         assert!(body.is_none());
         assert!(!noir_trait.is_alias);
+    }
+
+    #[test]
+    fn parse_trait_with_function_with_function_attribute() {
+        let src = "trait Foo { #[no_predicates] fn foo(x: Field) -> Field { x } }";
+        let mut noir_trait = parse_trait_no_errors(src);
+        assert_eq!(noir_trait.items.len(), 1);
+
+        let item = noir_trait.items.remove(0).item;
+        let TraitItem::Function { attributes, .. } = item else {
+            panic!("Expected function");
+        };
+        assert!(matches!(
+            attributes.function.map(|(attr, _)| attr.kind),
+            Some(crate::token::FunctionAttributeKind::NoPredicates)
+        ));
+        assert!(attributes.secondary.is_empty());
+    }
+
+    #[test]
+    fn parse_trait_with_function_with_secondary_attribute() {
+        let src = "trait Foo { #[my_tag] fn foo(); }";
+        let mut noir_trait = parse_trait_no_errors(src);
+        assert_eq!(noir_trait.items.len(), 1);
+
+        let item = noir_trait.items.remove(0).item;
+        let TraitItem::Function { attributes, .. } = item else {
+            panic!("Expected function");
+        };
+        assert!(attributes.function.is_none());
+        assert_eq!(attributes.secondary.len(), 1);
     }
 
     #[test]

--- a/compiler/noirc_frontend/src/tests/runtime.rs
+++ b/compiler/noirc_frontend/src/tests/runtime.rs
@@ -281,6 +281,21 @@ fn deny_inline_attribute_on_unconstrained() {
 }
 
 #[test]
+fn deny_inline_attribute_on_unconstrained_trait_method() {
+    let src = r#"
+        pub trait Foo {
+            #[no_predicates]
+            ^^^^^^^^^^^^^^^^ misplaced #[no_predicates] attribute on unconstrained function foo. Only allowed on constrained functions
+            ~~~~~~~~~~~~~~~~ misplaced #[no_predicates] attribute
+            unconstrained fn foo(x: Field, y: Field) {
+                assert(x != y);
+            }
+        }
+    "#;
+    check_errors(src);
+}
+
+#[test]
 fn deny_fold_attribute_on_unconstrained() {
     let src = r#"
         #[fold]

--- a/tooling/lsp/src/with_file.rs
+++ b/tooling/lsp/src/with_file.rs
@@ -270,6 +270,7 @@ fn trait_item_with_file(item: TraitItem, file: FileId) -> TraitItem {
             return_type,
             where_clause,
             body,
+            attributes,
         } => TraitItem::Function {
             is_unconstrained,
             visibility,
@@ -282,6 +283,7 @@ fn trait_item_with_file(item: TraitItem, file: FileId) -> TraitItem {
             return_type: function_return_type_with_file(return_type, file),
             where_clause: unresolved_trait_constraints_with_file(where_clause, file),
             body: body.map(|body| block_expression_with_file(body, file)),
+            attributes: attributes_with_file(attributes, file),
         },
         TraitItem::Constant { name, typ } => TraitItem::Constant {
             name: ident_with_file(name, file),

--- a/tooling/nargo_fmt/src/formatter/traits.rs
+++ b/tooling/nargo_fmt/src/formatter/traits.rs
@@ -2,7 +2,7 @@ use noirc_errors::Location;
 use noirc_frontend::shared::Visibility;
 use noirc_frontend::{
     ast::{NoirTrait, Param, Pattern, TraitItem},
-    token::{Attributes, Keyword, Token},
+    token::{Keyword, Token},
 };
 
 use super::{Formatter, function::FunctionToFormat};
@@ -86,6 +86,7 @@ impl Formatter<'_> {
                 return_type,
                 where_clause,
                 body,
+                attributes,
             } => {
                 let parameters = parameters
                     .into_iter()
@@ -99,7 +100,7 @@ impl Formatter<'_> {
                     .collect();
 
                 let func = FunctionToFormat {
-                    attributes: Attributes::empty(),
+                    attributes,
                     visibility,
                     name,
                     generics,
@@ -260,6 +261,24 @@ mod tests {
         let expected = "mod moo {
     trait Foo {
         /// hello
+        fn foo() {
+            1
+        }
+    }
+}
+";
+        assert_format(src, expected);
+    }
+
+    #[test]
+    fn format_trait_with_function_with_attribute() {
+        let src = " mod moo { trait Foo {
+            #[no_predicates]
+            fn  foo ( ) { 1 }
+         } }";
+        let expected = "mod moo {
+    trait Foo {
+        #[no_predicates]
         fn foo() {
             1
         }


### PR DESCRIPTION
## Problem Resolved

Resolves #12810

## Summary of Changes

Implements attributes on trait default methods. Previously an attribute like `#[no_predicates]` would be silently ignored.

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
