### PR TITLE
fix: Monomorphization error when calling a disabled function

### DIFF
--- a/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
@@ -2734,9 +2734,12 @@ fn function_def_disable(
 
     let func_meta = interpreter.elaborator.function_meta_mut(func_id);
 
-    // Lie and say that the body of this function is resolved in order to avoid any
-    // errors from resolving it since it is now disabled. The addition of `deprecated(deny, _)`
-    // above should ensure it is never called.
+    // Mark the body resolved so it is never elaborated: macro authors disable functions whose
+    // bodies are placeholders or are no longer valid, and type-checking those would raise spurious
+    // errors. The `deprecated(deny, _)` attribute added above makes calls error during elaboration.
+    // A disabled function therefore has no interned `HirFunction`; monomorphization rejects any that
+    // it still manages to reach via `MonomorphizationError::CalledDisabledFunction` rather than
+    // reading the missing body and panicking.
     func_meta.function_body = FunctionBody::Resolved;
     Ok(Value::Unit)
 }

--- a/compiler/noirc_frontend/src/monomorphization/errors.rs
+++ b/compiler/noirc_frontend/src/monomorphization/errors.rs
@@ -37,6 +37,7 @@ pub enum MonomorphizationError {
     ComplexType { complexity: usize, max_complexity: usize, location: Location },
     CannotUseFunctionAsValue { name: String, location: Location },
     GlobalContainsFunctionPointer { typ: String, location: Location },
+    CalledDisabledFunction { name: String, location: Location },
 }
 
 impl MonomorphizationError {
@@ -75,7 +76,8 @@ impl MonomorphizationError {
             | MonomorphizationError::InvalidTypeForEntryPoint { location, .. }
             | MonomorphizationError::ComplexType { location, .. }
             | MonomorphizationError::CannotUseFunctionAsValue { location, .. }
-            | MonomorphizationError::GlobalContainsFunctionPointer { location, .. } => *location,
+            | MonomorphizationError::GlobalContainsFunctionPointer { location, .. }
+            | MonomorphizationError::CalledDisabledFunction { location, .. } => *location,
             MonomorphizationError::InterpreterError(error) => error.location(),
         }
     }
@@ -117,6 +119,11 @@ impl From<MonomorphizationError> for CustomDiagnostic {
             MonomorphizationError::ComptimeTypeInRuntimeCode { typ, location } => {
                 let message = format!("Comptime-only type `{typ}` used in runtime code");
                 let secondary = "Comptime type used here".into();
+                return CustomDiagnostic::simple_error(message, secondary, *location);
+            }
+            MonomorphizationError::CalledDisabledFunction { name, location } => {
+                let message = format!("Called disabled function `{name}`");
+                let secondary = "This function was disabled by a comptime attribute".into();
                 return CustomDiagnostic::simple_error(message, secondary, *location);
             }
             MonomorphizationError::RecursiveType { typ, location } => {

--- a/compiler/noirc_frontend/src/monomorphization/mod.rs
+++ b/compiler/noirc_frontend/src/monomorphization/mod.rs
@@ -610,7 +610,14 @@ impl<'interner> Monomorphizer<'interner> {
             return Err(MonomorphizationError::ComptimeFnInRuntimeCode { name, location });
         }
 
-        let body_expr_id = self.interner.function(&f).as_expr();
+        // A disabled function (`FunctionDefinition::disable`) has its body marked resolved without
+        // being elaborated, so it has no interned expression. A call to it should have been rejected
+        // during elaboration by the `deprecated(deny, _)` lint; if one still reaches here (e.g. a
+        // call constructed via `as_typed_expr` that bypasses that lint), error cleanly instead of
+        // panicking on the missing body.
+        let Some(body_expr_id) = self.interner.function(&f).try_as_expr() else {
+            return Err(MonomorphizationError::CalledDisabledFunction { name, location });
+        };
         let body_return_type = self.interner.id_type(body_expr_id);
         let return_target_type = match meta.return_type() {
             Type::TraitAsType(..) => &body_return_type,

--- a/test_programs/compile_failure/comptime_fn_disable_as_typed_expr/Nargo.toml
+++ b/test_programs/compile_failure/comptime_fn_disable_as_typed_expr/Nargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "comptime_fn_disable_as_typed_expr"
+type = "bin"
+authors = [""]
+
+[dependencies]

--- a/test_programs/compile_failure/comptime_fn_disable_as_typed_expr/src/main.nr
+++ b/test_programs/compile_failure/comptime_fn_disable_as_typed_expr/src/main.nr
@@ -1,0 +1,36 @@
+// A `disable`d function's body is intentionally never type-checked, so the type-incoherent body of
+// `tag` below (returning `bool` where `u32` is declared) does not raise a type error. Capturing the
+// method via `as_typed_expr` before disabling it then splicing a call bypasses the `deprecated(deny)`
+// lint, so the call reaches monomorphization. That must produce a clean "called disabled function"
+// error rather than panicking on the method's missing body.
+trait Tag {
+    fn tag() -> u32;
+}
+
+pub struct Victim {}
+
+impl Tag for Victim {
+    fn tag() -> u32 {
+        true
+    }
+}
+
+comptime fn evil(_self: FunctionDefinition) -> Quoted {
+    let victim_typ = quote { Victim }.as_type();
+    let tag_constraint = quote { Tag }.as_trait_constraint();
+    let foreign_impl = victim_typ.get_trait_impl(tag_constraint).unwrap();
+    let m = foreign_impl.methods()[0];
+    let typed = m.as_typed_expr();
+    m.disable(f"tag is disabled");
+
+    quote {
+        pub fn use_disabled() -> u32 {
+            $typed()
+        }
+    }
+}
+
+#[evil]
+fn main() {
+    let _ = use_disabled();
+}

--- a/tooling/nargo_cli/tests/snapshots/compile_failure/comptime_fn_disable_as_typed_expr/execute__tests__stderr.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_failure/comptime_fn_disable_as_typed_expr/execute__tests__stderr.snap
@@ -1,0 +1,12 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: stderr
+---
+error: Called disabled function `tag`
+   ┌─ src/main.nr:23:17
+   │
+23 │     let typed = m.as_typed_expr();
+   │                 ----------------- This function was disabled by a comptime attribute
+   │
+
+Aborting due to 1 previous error


### PR DESCRIPTION
## Problem Resolved

Resolves https://github.com/noir-lang/noir-claude/issues/892

## Summary of Changes

Adds a monomorphization error when calling a `#[disable]`'d function

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
