### PR TITLE
fix(wasm): reject unsafe numbers in ABI

### DIFF
--- a/tooling/noirc_abi_wasm/src/lib.rs
+++ b/tooling/noirc_abi_wasm/src/lib.rs
@@ -20,7 +20,7 @@ use serde::Serialize;
 use std::collections::BTreeMap;
 
 use gloo_utils::format::JsValueSerdeExt;
-use wasm_bindgen::{JsValue, prelude::wasm_bindgen};
+use wasm_bindgen::{JsCast, JsValue, prelude::wasm_bindgen};
 
 mod errors;
 mod js_witness_map;
@@ -62,11 +62,17 @@ pub fn abi_encode(
     console_error_panic_hook::set_once();
     let abi: Abi =
         JsValueSerdeExt::into_serde(&JsValue::from(abi)).map_err(|err| err.to_string())?;
+    let inputs_js = JsValue::from(inputs);
+    reject_unsafe_integers(&inputs_js)?;
     let inputs: BTreeMap<String, JsonTypes> =
-        JsValueSerdeExt::into_serde(&JsValue::from(inputs)).map_err(|err| err.to_string())?;
-    let return_value: Option<InputValue> = return_value
-        .map(|return_value| {
-            let toml_return_value = JsValueSerdeExt::into_serde(&JsValue::from(return_value))
+        JsValueSerdeExt::into_serde(&inputs_js).map_err(|err| err.to_string())?;
+    let return_value_js = return_value.map(JsValue::from);
+    if let Some(return_value_js) = &return_value_js {
+        reject_unsafe_integers(return_value_js)?;
+    }
+    let return_value: Option<InputValue> = return_value_js
+        .map(|return_value_js| {
+            let toml_return_value = JsValueSerdeExt::into_serde(&return_value_js)
                 .expect("could not decode return value");
             InputValue::try_from_json(
                 toml_return_value,
@@ -90,6 +96,41 @@ pub fn abi_encode(
     let witness_map = abi.encode(&parsed_inputs, return_value)?;
 
     Ok(witness_map.into())
+}
+
+/// Rejects any JavaScript `number` that is not a safe integer (i.e. fails `Number.isSafeInteger`).
+///
+/// JavaScript represents `number` as a 64-bit float, so an integer literal above `2^53 - 1` is
+/// silently rounded before it ever reaches wasm. Accepting such a value would encode a witness for
+/// a different field element than the one written at the call site. Callers must pass large values
+/// as strings, which preserve their exact decimal representation.
+fn reject_unsafe_integers(value: &JsValue) -> Result<(), JsAbiError> {
+    if let Some(number) = value.as_f64() {
+        if number.is_finite() && !js_sys::Number::is_safe_integer(value) {
+            return Err(JsAbiError::new(format!(
+                "Numeric input `{number}` is not a safe integer (its magnitude exceeds 2^53 - 1, \
+                 so JavaScript may have already rounded it); pass it as a string instead"
+            )));
+        }
+        return Ok(());
+    }
+
+    if js_sys::Array::is_array(value) {
+        let array = js_sys::Array::from(value);
+        for element in array.iter() {
+            reject_unsafe_integers(&element)?;
+        }
+        return Ok(());
+    }
+
+    if value.is_object() {
+        let object: &js_sys::Object = value.unchecked_ref();
+        for element in js_sys::Object::values(object).iter() {
+            reject_unsafe_integers(&element)?;
+        }
+    }
+
+    Ok(())
 }
 
 #[wasm_bindgen(js_name = abiDecode)]

--- a/tooling/noirc_abi_wasm/test/browser/errors.test.ts
+++ b/tooling/noirc_abi_wasm/test/browser/errors.test.ts
@@ -26,3 +26,9 @@ it('errors when passing an array in place of a field', async () => {
 
   expect(() => abiEncode(abi, inputs)).to.throw('cannot parse value `Array([String("1"), String("2")])` into Field');
 });
+
+it('errors when passing a JavaScript number that is not a safe integer', async () => {
+  const { abi, unsafeInteger } = await import('../shared/unsafe_integer');
+
+  expect(() => abiEncode(abi, { foo: unsafeInteger })).to.throw('is not a safe integer');
+});

--- a/tooling/noirc_abi_wasm/test/node/errors.test.ts
+++ b/tooling/noirc_abi_wasm/test/node/errors.test.ts
@@ -3,6 +3,7 @@ import { abiEncode } from '@noir-lang/noirc_abi';
 import { abi as abi_uint_overflow, inputs as inputs_uint_overflow } from '../shared/uint_overflow';
 import { abi as abi_field_as_array, inputs as inputs_field_as_array } from '../shared/field_as_array';
 import { abi as abi_array_as_field, inputs as inputs_array_as_field } from '../shared/array_as_field';
+import { abi as abi_unsafe_integer, unsafeInteger } from '../shared/unsafe_integer';
 
 it('errors when an integer input overflows', () => {
   expect(() => abiEncode(abi_uint_overflow, inputs_uint_overflow)).to.throw(
@@ -20,4 +21,8 @@ it('errors when passing an array in place of a field', () => {
   expect(() => abiEncode(abi_array_as_field, inputs_array_as_field)).to.throw(
     'cannot parse value `Array([String("1"), String("2")])` into Field',
   );
+});
+
+it('errors when passing a JavaScript number that is not a safe integer', () => {
+  expect(() => abiEncode(abi_unsafe_integer, { foo: unsafeInteger })).to.throw('is not a safe integer');
 });

--- a/tooling/noirc_abi_wasm/test/shared/unsafe_integer.ts
+++ b/tooling/noirc_abi_wasm/test/shared/unsafe_integer.ts
@@ -1,0 +1,18 @@
+import { Abi } from '@noir-lang/noirc_abi';
+
+export const abi: Abi = {
+  parameters: [
+    {
+      name: 'foo',
+      type: { kind: 'field' },
+      visibility: 'private',
+    },
+  ],
+  return_type: null,
+  error_types: {},
+};
+
+// `Number.MAX_SAFE_INTEGER + 2` is not representable as a JavaScript `number`: it rounds to
+// `2^53` before reaching wasm. Encoding it would silently produce a witness for a different field
+// element, so the encoder must reject it and require a string instead.
+export const unsafeInteger = Number.MAX_SAFE_INTEGER + 2;


### PR DESCRIPTION
## Problem Resolved

Resolves https://github.com/noir-lang/noir-claude/issues/919

## Summary of Changes

Rejects unsafe numbers in the wasm ABI if they don't end up representing the actual value they look to be showing, because of how numbers work in JS. There's a bit more explanation on the issue itself too.

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
