### PR TITLE
chore(ssa): Implement the `rc_invariant::call` check

### DIFF
--- a/compiler/noirc_evaluator/src/errors.rs
+++ b/compiler/noirc_evaluator/src/errors.rs
@@ -107,6 +107,17 @@ pub enum RuntimeError {
         /// label so the user can see both the write and the read.
         aliased_use_call_stack: CallStack,
     },
+    #[error("{message}")]
+    CallArgAliasViolation {
+        message: String,
+        /// Location of the `call` whose callee may mutate an array argument
+        /// in place.
+        call_stack: CallStack,
+        /// Location of the downstream instruction that reads the same
+        /// argument storage through an alias. Rendered as a secondary
+        /// diagnostic label so the user can see both the call and the read.
+        aliased_use_call_stack: CallStack,
+    },
     #[error(
         "The return value has {num_witnesses} elements which exceeds the limit of {max_witnesses}"
     )]
@@ -165,6 +176,7 @@ impl RuntimeError {
             | RuntimeError::UnconstrainedCallingConstrained { call_stack, .. }
             | RuntimeError::SsaValidationError { call_stack, .. }
             | RuntimeError::ArraySetAliasViolation { call_stack, .. }
+            | RuntimeError::CallArgAliasViolation { call_stack, .. }
             | RuntimeError::ReturnLimitExceeded { call_stack, .. } => call_stack,
         }
     }
@@ -226,6 +238,26 @@ impl RuntimeError {
                 if !secondary.is_dummy() {
                     diagnostic.add_secondary(
                         "aliased read of the same storage".to_string(),
+                        secondary,
+                    );
+                }
+                diagnostic
+            }
+            RuntimeError::CallArgAliasViolation {
+                message,
+                call_stack,
+                aliased_use_call_stack,
+            } => {
+                let primary = call_stack.last_or_dummy();
+                let secondary = aliased_use_call_stack.last_or_dummy();
+                let mut diagnostic = CustomDiagnostic::simple_error(
+                    message,
+                    "call whose callee may mutate an array argument in place".to_string(),
+                    primary,
+                );
+                if !secondary.is_dummy() {
+                    diagnostic.add_secondary(
+                        "aliased read of the same argument storage".to_string(),
                         secondary,
                     );
                 }

--- a/compiler/noirc_evaluator/src/ssa/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/mod.rs
@@ -214,7 +214,10 @@ pub fn primary_passes(options: &SsaEvaluatorOptions) -> Vec<SsaPass<'_>> {
             .and_then(Ssa::remove_redundant_params)
             .and_then_validate(|#[allow(unused)] ssa| {
                 #[cfg(debug_assertions)]
-                validation::rc_invariant::array_set::verify(ssa)?;
+                {
+                    validation::rc_invariant::array_set::verify(ssa)?;
+                    validation::rc_invariant::call::verify(ssa)?;
+                }
                 Ok(())
             }),
         SsaPass::new_try(Ssa::defunctionalize, "Defunctionalization"),

--- a/compiler/noirc_evaluator/src/ssa/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/mod.rs
@@ -214,10 +214,7 @@ pub fn primary_passes(options: &SsaEvaluatorOptions) -> Vec<SsaPass<'_>> {
             .and_then(Ssa::remove_redundant_params)
             .and_then_validate(|#[allow(unused)] ssa| {
                 #[cfg(debug_assertions)]
-                {
-                    validation::rc_invariant::array_set::verify(ssa)?;
-                    validation::rc_invariant::call::verify(ssa)?;
-                }
+                validation::rc_invariant::verify_all(ssa)?;
                 Ok(())
             }),
         SsaPass::new_try(Ssa::defunctionalize, "Defunctionalization"),

--- a/compiler/noirc_evaluator/src/ssa/validation/rc_invariant/array_set.rs
+++ b/compiler/noirc_evaluator/src/ssa/validation/rc_invariant/array_set.rs
@@ -17,11 +17,6 @@ use super::Context;
 
 /// Verifies the `array_set` / `inc_rc` aliasing invariant on every Brillig
 /// function in `ssa`. See the [`super`] module docs for details.
-///
-/// The entire module containing this function is gated behind
-/// `#[cfg(debug_assertions)]`, so it is a no-op (and absent at the linker
-/// level) in release builds — see the pipeline wiring in
-/// [`crate::ssa::primary_passes`].
 pub(crate) fn verify(ssa: &Ssa) -> RtResult<()> {
     for function in ssa.functions.values() {
         verify_function(function)?;

--- a/compiler/noirc_evaluator/src/ssa/validation/rc_invariant/array_set.rs
+++ b/compiler/noirc_evaluator/src/ssa/validation/rc_invariant/array_set.rs
@@ -4,6 +4,13 @@
 //! when the in-place mutation could be observed through an aliased read on a
 //! forward path. The aliasing/coverage/forward-walk machinery it drives lives
 //! in the parent [`super`] module.
+//!
+//! This is the canonical mutation site the shared algorithm is written around:
+//! the source is the `array_set`'s `array` operand, and the chain state is
+//! seeded from the write — `derived` with the `array_set`'s own result (which
+//! shares the source's storage at runtime) and `tainted_indices` with its
+//! constant write index — so chains of `array_set`s on the same storage are
+//! tracked index-aware.
 
 use crate::{
     errors::{RtResult, RuntimeError},

--- a/compiler/noirc_evaluator/src/ssa/validation/rc_invariant/array_set.rs
+++ b/compiler/noirc_evaluator/src/ssa/validation/rc_invariant/array_set.rs
@@ -42,25 +42,12 @@ fn verify_function(function: &Function) -> RtResult<()> {
 
     for block_id in function.reachable_blocks() {
         for (idx, instruction_id) in function.dfg[block_id].instructions().iter().enumerate() {
+            let instruction_id = *instruction_id;
             let Instruction::ArraySet { array, index: write_index, .. } =
-                function.dfg[*instruction_id]
+                function.dfg[instruction_id]
             else {
                 continue;
             };
-
-            let alias_set = ctx.alias_set_for(array, block_id, idx);
-
-            // Narrow the alias-set to the members that are *not* provably
-            // protected on every path to this `array_set`. An empty result
-            // means every member is RC-bumped or freshly allocated before the
-            // array_set on all paths, so the in-place mutation is never
-            // observable — accept without the forward walk. A covered member
-            // (e.g. an `inc_rc`'d sibling) is dropped so the forward walk does
-            // not falsely flag a read of storage the array_set never mutates.
-            let use_set = ctx.unprotected_aliases(&alias_set, array, block_id, idx);
-            if use_set.is_empty() {
-                continue;
-            }
 
             // The array_set's index, if constant — lets the walk skip
             // `array_get`s on disjoint constant indices (the pedersen-style
@@ -68,34 +55,33 @@ fn verify_function(function: &Function) -> RtResult<()> {
             // flag every aliased read.
             let write_index_const = function.dfg.get_numeric_constant(write_index);
 
-            // Expensive: forward CFG walk looking for an aliased read.
-            // A hit means the `array_set` may mutate storage in place
-            // (RC=1) and a downstream instruction will observe the
-            // pre-mutation contents through an aliased name.
-            if let Some(hit) = ctx.find_reachable_aliased_use(
-                &use_set,
+            // The array_set's own result seeds the chain-tracking `derived`
+            // set — it shares the source's storage at runtime.
+            let result = function.dfg.instruction_results(instruction_id)[0];
+
+            let Some(hit) = ctx.aliased_use_for_source(
                 array,
-                *instruction_id,
                 block_id,
                 idx,
+                instruction_id,
                 write_index_const,
-            ) {
-                let call_stack = function.dfg.get_instruction_call_stack(*instruction_id);
-                let aliased_use_call_stack =
-                    function.dfg.get_instruction_call_stack(hit.instruction);
-                let message = format!(
-                    "array_set in function {} on array {array} has an aliased read of {} on a \
-                     forward path with no preceding `inc_rc`; the in-place mutation would be \
-                     observable through that alias",
-                    function.name(),
-                    hit.value,
-                );
-                return Err(RuntimeError::ArraySetAliasViolation {
-                    message,
-                    call_stack,
-                    aliased_use_call_stack,
-                });
-            }
+                im::HashSet::unit(result),
+            ) else {
+                continue;
+            };
+
+            let message = format!(
+                "array_set in function {} on array {array} has an aliased read of {} on a \
+                 forward path with no preceding `inc_rc`; the in-place mutation would be \
+                 observable through that alias",
+                function.name(),
+                hit.value,
+            );
+            return Err(RuntimeError::ArraySetAliasViolation {
+                message,
+                call_stack: function.dfg.get_instruction_call_stack(instruction_id),
+                aliased_use_call_stack: function.dfg.get_instruction_call_stack(hit.instruction),
+            });
         }
     }
     Ok(())
@@ -2259,6 +2245,7 @@ mod tests {
                 block,
                 idx,
                 write_index_const,
+                im::HashSet::unit(function.dfg.instruction_results(instruction_id)[0]),
             )
             .is_some();
         assert!(
@@ -2304,6 +2291,7 @@ mod tests {
                 block,
                 idx,
                 write_index_const,
+                im::HashSet::unit(function.dfg.instruction_results(instruction_id)[0]),
             )
             .is_some();
         assert!(
@@ -2357,6 +2345,7 @@ mod tests {
                 block,
                 idx,
                 write_index_const,
+                im::HashSet::unit(function.dfg.instruction_results(instruction_id)[0]),
             )
             .is_some();
         assert!(
@@ -2460,6 +2449,7 @@ mod tests {
                 block,
                 idx,
                 write_index_const,
+                im::HashSet::unit(function.dfg.instruction_results(instruction_id)[0]),
             )
             .is_some();
         assert!(

--- a/compiler/noirc_evaluator/src/ssa/validation/rc_invariant/call.rs
+++ b/compiler/noirc_evaluator/src/ssa/validation/rc_invariant/call.rs
@@ -12,16 +12,190 @@
 //! sources, and gated on whether the callee can modify its arguments (mirroring
 //! `can_modify_args` in `ssa_gen`).
 
-use crate::{errors::RtResult, ssa::ssa_gen::Ssa};
+use rustc_hash::FxHashMap as HashMap;
 
-// TODO(noir-lang/noir-claude#1426): implement the call-argument check. It
-// should mirror `ssa_gen`'s `can_modify_args` (skip foreign calls, pure
-// builtins, and non-mutating callees), then run the shared coverage +
-// forward-walk machinery from [`super`] seeded on each array-typed call
-// argument, rejecting with a `CallArgAliasViolation`. Until then this is a
-// no-op so the combined pipeline check stays sound for the `array_set` case.
-pub(crate) fn verify(_ssa: &Ssa) -> RtResult<()> {
+use crate::{
+    errors::{RtResult, RuntimeError},
+    ssa::{
+        ir::{
+            function::{Function, FunctionId},
+            instruction::{Instruction, Intrinsic},
+            value::{Value, ValueId},
+        },
+        opt::pure::Purity,
+        ssa_gen::Ssa,
+    },
+};
+
+use super::Context;
+
+/// Verify the call-argument aliasing invariant on every Brillig function in
+/// `ssa`. See the module docs for the invariant.
+pub(crate) fn verify(ssa: &Ssa) -> RtResult<()> {
+    let may_mutate = compute_may_mutate_args(ssa);
+    for function in ssa.functions.values() {
+        verify_function(function, &may_mutate)?;
+    }
     Ok(())
+}
+
+/// Per-function check. Skips ACIR functions (the invariant only applies to
+/// Brillig, where a callee may mutate an argument in place). For every `call`
+/// whose callee may mutate its arguments, treats each array-typed argument as
+/// an all-index in-place mutation and runs the shared coverage + forward walk:
+/// a forward-reachable aliased read with no protecting `inc_rc` is a hazard.
+fn verify_function(function: &Function, may_mutate: &HashMap<FunctionId, bool>) -> RtResult<()> {
+    if !function.runtime().is_brillig() {
+        return Ok(());
+    }
+
+    let ctx = Context::new(function);
+
+    for block_id in function.reachable_blocks() {
+        for (idx, instruction_id) in function.dfg[block_id].instructions().iter().enumerate() {
+            let instruction_id = *instruction_id;
+            let Instruction::Call { func, arguments } = &function.dfg[instruction_id] else {
+                continue;
+            };
+
+            // Mirror `ssa_gen`'s `can_modify_args`: a callee that provably
+            // cannot mutate its arguments (a foreign call, a pure builtin, or a
+            // non-mutating function) has its argument clones elided by the
+            // ownership pass, so a reused argument legitimately carries no
+            // `inc_rc`. Skipping such calls is what keeps this check from
+            // flagging well-formed SSA.
+            if !callee_may_mutate_args(function, *func, may_mutate) {
+                continue;
+            }
+
+            // Treat the call as an all-index mutation of each array-*value*
+            // argument: `derived` is empty (the callee has no in-place result
+            // to chain from here) and the write index is unknown (it may touch
+            // any position). `is_array` matches a top-level array/vector value
+            // and so excludes a reference argument (`&mut [T; N]`): mutation
+            // through a reference is the explicit, caller-visible pattern the
+            // frontend passes a `&mut` for, not the value-array copy-on-write
+            // hazard this check is about (and a reference param already makes
+            // the callee impure). A top-level array of references (`[&mut T;
+            // N]`) is still a value and is checked.
+            let array_args: Vec<ValueId> = arguments
+                .iter()
+                .copied()
+                .filter(|&arg| function.dfg.type_of_value(arg).is_array())
+                .collect();
+            for arg in array_args {
+                let Some(hit) = ctx.aliased_use_for_source(
+                    arg,
+                    block_id,
+                    idx,
+                    instruction_id,
+                    None,
+                    im::HashSet::new(),
+                ) else {
+                    continue;
+                };
+
+                let message = format!(
+                    "call in function {} passes array {arg} that is read again as {} on a \
+                     forward path with no preceding `inc_rc`; if the callee mutates the argument \
+                     in place the mutation would be observable through that alias",
+                    function.name(),
+                    hit.value,
+                );
+                return Err(RuntimeError::CallArgAliasViolation {
+                    message,
+                    call_stack: function.dfg.get_instruction_call_stack(instruction_id),
+                    aliased_use_call_stack: function
+                        .dfg
+                        .get_instruction_call_stack(hit.instruction),
+                });
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Whether the callee referenced by `func` may mutate an array argument in a
+/// way observable to the caller. Mirrors `ssa_gen`'s `can_modify_args`:
+/// foreign calls only read their inputs; pure builtins that are safe for clone
+/// elision cannot mutate; an unresolved/dynamic callee is assumed to be able
+/// to; and a known function is looked up in the call-graph summary.
+fn callee_may_mutate_args(
+    function: &Function,
+    func: ValueId,
+    may_mutate: &HashMap<FunctionId, bool>,
+) -> bool {
+    match &function.dfg[func] {
+        Value::Function(callee) => may_mutate.get(callee).copied().unwrap_or(true),
+        Value::Intrinsic(intrinsic) => intrinsic_may_mutate_args(*intrinsic),
+        Value::ForeignFunction { .. } => false,
+        _ => true,
+    }
+}
+
+/// Whether a call to `intrinsic` may mutate an array argument in place,
+/// mirroring `is_pure_builtin_func` in `ssa_gen`: a pure intrinsic that is safe
+/// for clone elision in Brillig cannot, everything else conservatively can.
+fn intrinsic_may_mutate_args(intrinsic: Intrinsic) -> bool {
+    intrinsic.unsafe_for_clone_elision_in_brillig()
+        || !matches!(intrinsic.purity(), Purity::Pure | Purity::PureWithPredicate)
+}
+
+/// Compute, for every function, whether a call to it may mutate the storage of
+/// one of its array arguments observably to the caller.
+///
+/// A function may-mutate if it contains an in-place mutation (`array_set` or
+/// `store`), calls a may-mutate function, calls a mutating intrinsic, or calls
+/// an unresolved/dynamic target (assume the worst). Foreign calls contribute
+/// nothing — oracles only read their inputs. This is an over-approximation:
+/// the only callees marked *not* may-mutate are exactly those whose argument
+/// clones the ownership pass elides, so a reused argument with no `inc_rc`
+/// never trips the check on well-formed SSA. Propagated to a fixed point over
+/// the call graph.
+fn compute_may_mutate_args(ssa: &Ssa) -> HashMap<FunctionId, bool> {
+    let mut may_mutate: HashMap<FunctionId, bool> = HashMap::default();
+    let mut callees: HashMap<FunctionId, Vec<FunctionId>> = HashMap::default();
+
+    for function in ssa.functions.values() {
+        let mut base = false;
+        let mut calls = Vec::new();
+        for block_id in function.reachable_blocks() {
+            for instruction_id in function.dfg[block_id].instructions() {
+                match &function.dfg[*instruction_id] {
+                    Instruction::ArraySet { .. } | Instruction::Store { .. } => base = true,
+                    Instruction::Call { func, .. } => match &function.dfg[*func] {
+                        Value::Function(callee) => calls.push(*callee),
+                        Value::Intrinsic(intrinsic) => {
+                            base |= intrinsic_may_mutate_args(*intrinsic);
+                        }
+                        // Foreign calls only read their inputs.
+                        Value::ForeignFunction { .. } => {}
+                        // An unresolved or dynamic callee: assume the worst.
+                        _ => base = true,
+                    },
+                    _ => {}
+                }
+            }
+        }
+        may_mutate.insert(function.id(), base);
+        callees.insert(function.id(), calls);
+    }
+
+    let mut changed = true;
+    while changed {
+        changed = false;
+        for (&id, callee_ids) in &callees {
+            if may_mutate[&id] {
+                continue;
+            }
+            if callee_ids.iter().any(|c| may_mutate.get(c).copied().unwrap_or(true)) {
+                may_mutate.insert(id, true);
+                changed = true;
+            }
+        }
+    }
+
+    may_mutate
 }
 
 #[cfg(test)]
@@ -29,16 +203,18 @@ mod tests {
     use super::super::tests::assert_verifier_accepts_because;
     use crate::ssa::ssa_gen::Ssa;
 
-    /// Parse `src`, run the `call` verifier, and require it to reject the SSA.
-    /// Panics on any other outcome.
-    ///
-    // TODO(noir-lang/noir-claude#1426): once the call verifier produces a
-    // `CallArgAliasViolation`, assert that specific variant here (the way
-    // `array_set`'s reject helper asserts `ArraySetAliasViolation`) so it is
-    // clear the *call* verifier caught the hazard.
+    /// Parse `src`, run the `call` verifier, and require it to reject the SSA
+    /// with a [`crate::errors::RuntimeError::CallArgAliasViolation`]. Panics on
+    /// any other outcome. Runs `call::verify` directly (not the combined check)
+    /// so the assertion proves the *call* verifier is the one that caught the
+    /// hazard.
     fn assert_verifier_rejects(src: &str) {
         let ssa = Ssa::from_str(src).expect("SSA parses");
-        super::verify(&ssa).expect_err("expected the verifier to reject");
+        let err = super::verify(&ssa).expect_err("expected the verifier to reject");
+        assert!(
+            matches!(err, crate::errors::RuntimeError::CallArgAliasViolation { .. }),
+            "expected CallArgAliasViolation, got {err:?}",
+        );
     }
 
     /// Regression for noir-lang/noir-claude#1426. The ownership pass clones
@@ -53,13 +229,7 @@ mod tests {
     /// relies on being absent. The verifier must reject: both the reused arg
     /// in `main` and the reused-then-read arg in `f1` lack a preceding
     /// `inc_rc`.
-    ///
-    // TODO(noir-lang/noir-claude#1426): `call::verify` is still a no-op, so
-    // this test panics inside `assert_verifier_rejects`; `should_panic` marks
-    // that placeholder state. Drop `should_panic` once the call-argument check
-    // lands.
     #[test]
-    #[should_panic(expected = "expected the verifier to reject")]
     fn end_to_end_array_reused_across_call_without_inc_rc_is_rejected() {
         let src = r#"
             brillig(inline) fn main f0 {
@@ -119,6 +289,38 @@ mod tests {
         assert_verifier_accepts_because(
             src,
             "every reused array call-arg is protected by a preceding inc_rc",
+        );
+    }
+
+    /// Reduced from the `array_sort` execution test (`quicksort`): a `&mut`
+    /// **reference** to an array is passed to a callee that sorts it in place
+    /// and then loaded back. The argument is a reference, not an array value,
+    /// so it is *not* a copy-on-write hazard — mutation through a `&mut` is the
+    /// explicit, caller-visible pattern the frontend passes a reference for
+    /// (and a reference parameter already makes the callee impure). The call
+    /// verifier must skip reference arguments and accept; flagging this was a
+    /// false positive fixed by the `contains_reference` filter.
+    #[test]
+    fn end_to_end_reference_argument_read_back_after_call_is_accepted() {
+        let src = r#"
+            brillig(inline) fn main f0 {
+              b0(v0: [u8; 3]):
+                v1 = allocate -> &mut [u8; 3]
+                store v0 at v1
+                call f1(v1)
+                v2 = load v1 -> [u8; 3]
+                return v2
+            }
+            brillig(inline) fn sort_in_place f1 {
+              b0(v0: &mut [u8; 3]):
+                v1 = load v0 -> [u8; 3]
+                v3 = array_set v1, index u32 0, value u8 9
+                store v3 at v0
+                return
+            }"#;
+        assert_verifier_accepts_because(
+            src,
+            "the call argument is a &mut reference, not an array value, so it is not a COW hazard",
         );
     }
 }

--- a/compiler/noirc_evaluator/src/ssa/validation/rc_invariant/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/validation/rc_invariant/mod.rs
@@ -968,9 +968,54 @@ impl<'f> Context<'f> {
         }
     }
 
-    /// Forward CFG walk from after the `array_set` looking for a
-    /// non-terminator instruction that reads a value still in the alias
-    /// use-set.
+    /// Run the coverage narrowing + forward reachable-use walk for a single
+    /// potential in-place mutation of `source` at `(block, idx)` (the
+    /// instruction `mutator_id`). Returns the aliased use that would observe
+    /// the mutation, or `None` when `source` has no unprotected alias with a
+    /// forward-reachable read.
+    ///
+    /// `write_index_const` and `initial_derived` are forwarded to
+    /// [`Context::find_reachable_aliased_use`]: for an `array_set` they are the
+    /// (optional) constant write index and the singleton of the `array_set`'s
+    /// result; for a `call` argument they are `None` and the empty set.
+    fn aliased_use_for_source(
+        &self,
+        source: ValueId,
+        block: BasicBlockId,
+        idx: usize,
+        mutator_id: InstructionId,
+        write_index_const: Option<FieldElement>,
+        initial_derived: im::HashSet<ValueId>,
+    ) -> Option<AliasedUse> {
+        let alias_set = self.alias_set_for(source, block, idx);
+
+        // Narrow the alias-set to the members not provably protected on every
+        // path to the mutation. An empty result means every member is RC-bumped
+        // or freshly allocated beforehand on all paths, so the in-place
+        // mutation is never observable — accept without the forward walk.
+        let use_set = self.unprotected_aliases(&alias_set, source, block, idx);
+        if use_set.is_empty() {
+            return None;
+        }
+
+        // Expensive: forward CFG walk looking for an aliased read. A hit means
+        // the mutation may happen in place (RC=1) and a downstream instruction
+        // will observe the pre-mutation contents through an aliased name.
+        self.find_reachable_aliased_use(
+            &use_set,
+            source,
+            mutator_id,
+            block,
+            idx,
+            write_index_const,
+            initial_derived,
+        )
+    }
+
+    /// Forward CFG walk from after the *mutating instruction* — an
+    /// `array_set`, or a `call` that may mutate an array argument in place at
+    /// runtime — looking for a non-terminator instruction that reads a value
+    /// still in the alias use-set.
     ///
     /// **Use-set evolution.** Starts as `alias_set` — which is **already
     /// narrowed** to the uncovered members by [`Context::unprotected_aliases`]
@@ -985,7 +1030,7 @@ impl<'f> Context<'f> {
     /// the next block where it is re-bound to that block's parameter. The
     /// kill logic already accounts for these args.
     ///
-    /// The original `array_set` itself is also skipped, in case a cycle
+    /// The mutating instruction itself is also skipped, in case a cycle
     /// re-enters its block — it is, by construction, a use of its own
     /// source, not a hazard.
     ///
@@ -993,11 +1038,13 @@ impl<'f> Context<'f> {
     /// `use_set` to make the filter sound in the presence of `array_set`
     /// chains:
     ///
-    /// - **`derived`** tracks values that may share the `array_set`'s source
-    ///   storage at runtime through transitive in-place mutations. Seeded
-    ///   with the `array_set`'s own result; grown on every later `array_set`
-    ///   whose `array` operand is already in `derived`; propagated across
-    ///   block-param edges the same way the alias use-set is.
+    /// - **`derived`** tracks values that may share the source storage at
+    ///   runtime through transitive in-place mutations. Seeded by the caller
+    ///   via `initial_derived` (the `array_set`'s own result for an
+    ///   `array_set`; empty for a `call`, which has no in-place result to
+    ///   chain from); grown on every later `array_set` whose `array` operand
+    ///   is already in `derived`; propagated across block-param edges the
+    ///   same way the alias use-set is.
     /// - **`tainted_indices`** tracks the set of storage positions any
     ///   chain link may have already written. `Some(set)` accumulates
     ///   constant write indices (seeded with `write_index_const`); set to
@@ -1028,14 +1075,16 @@ impl<'f> Context<'f> {
     /// unioned into the frontier on entry; for `tainted_indices`, `None`
     /// is the absorbing element (a previously-`None` frontier covers any
     /// re-entry).
+    #[allow(clippy::too_many_arguments)]
     fn find_reachable_aliased_use(
         &self,
         alias_set: &im::HashSet<ValueId>,
         source: ValueId,
-        array_set_id: InstructionId,
-        array_set_block: BasicBlockId,
-        array_set_idx: usize,
+        mutator_id: InstructionId,
+        mutator_block: BasicBlockId,
+        mutator_idx: usize,
         write_index_const: Option<FieldElement>,
+        initial_derived: im::HashSet<ValueId>,
     ) -> Option<AliasedUse> {
         let mut visited: HashMap<BasicBlockId, WalkState> = HashMap::default();
 
@@ -1087,15 +1136,14 @@ impl<'f> Context<'f> {
         let use_set: im::HashSet<ValueId> =
             alias_set.iter().copied().filter(|v| !protected.contains(v)).collect();
 
-        let array_set_result = self.function.dfg.instruction_results(array_set_id)[0];
         let initial_state = WalkState {
             use_set,
-            derived: im::HashSet::unit(array_set_result),
+            derived: initial_derived,
             tainted: write_index_const.map(im::HashSet::unit),
         };
         let mut worklist: Vec<WalkFrame> = vec![WalkFrame {
-            block: array_set_block,
-            start_idx: array_set_idx + 1,
+            block: mutator_block,
+            start_idx: mutator_idx + 1,
             state: initial_state,
         }];
 
@@ -1126,7 +1174,7 @@ impl<'f> Context<'f> {
 
             let instructions = self.function.dfg[block].instructions();
             for &inst_id in instructions.iter().skip(start_idx) {
-                if inst_id == array_set_id {
+                if inst_id == mutator_id {
                     continue;
                 }
                 let inst = &self.function.dfg[inst_id];

--- a/compiler/noirc_evaluator/src/ssa/validation/rc_invariant/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/validation/rc_invariant/mod.rs
@@ -1,29 +1,38 @@
-//! Verifies the implicit invariant that Brillig SSA must satisfy around
-//! `array_set` and reference counts.
+//! Shared machinery for the Brillig reference-count aliasing invariant,
+//! applied by the [`array_set`] and [`call`] submodule verifiers.
 //!
 //! # The invariant
 //!
-//! In Brillig, `array_set vX, i, x` may modify `vX`'s storage in place at runtime
-//! when `vX`'s reference count is 1. SSA-level semantics still says `vX` is unchanged
-//! and the `array_set` produces a fresh value; the in-place mutation is a runtime
-//! optimization that's only sound when no later use can observe `vX`'s pre-mutation
-//! contents through aliasing.
+//! In Brillig, an operation may modify an array's storage in place at runtime
+//! when that storage's reference count is 1: an `array_set vX, i, x` whose
+//! source `vX` has RC 1 (see [`array_set`]), or a `call` whose callee mutates
+//! an argument it received at RC 1 — directly, or by returning an alias the
+//! caller then mutates (see [`call`]). SSA-level semantics still treat the
+//! source array value as unchanged, and a mutating instruction as producing a
+//! fresh value; the in-place mutation is a runtime optimization that's only
+//! sound when no later use can observe the source's pre-mutation contents
+//! through aliasing.
 //!
 //! Two mechanisms keep the optimization invisible to SSA semantics:
 //!
-//! 1. **`inc_rc`** before the `array_set` forces RC ≥ 2 at runtime so `array_set`
-//!    copies rather than mutating in place.
-//! 2. **Block-parameter threading** routes the post-mutation value forward as a new
-//!    SSA value (the `array_set`'s result), so no later instruction references
-//!    `vX` after the mutation.
+//! 1. **`inc_rc`** before the mutation forces RC ≥ 2 at runtime, so the
+//!    operation copies rather than mutating in place.
+//! 2. **Block-parameter threading** routes the post-mutation value forward as a
+//!    new SSA value, so no later instruction references the source after the
+//!    mutation.
 //!
-//! The frontend uses whichever mechanism the program needs. This pass verifies
-//! that one of them is in place for every `array_set` whose source has an
-//! aliased use reachable forward in the CFG.
+//! The frontend uses whichever mechanism the program needs. Each submodule
+//! identifies its own *mutation sites* and uses the shared [`Context`] to
+//! verify that one of these mechanisms is in place for every source whose
+//! storage has an aliased use reachable forward in the CFG.
 //!
 //! # Algorithm
 //!
-//! For each `array_set vX, …`:
+//! Driven by [`Context::aliased_use_for_source`] for a mutation of a *source*
+//! value `vX` at a given program point. The steps below use `array_set` as the
+//! canonical mutation site; the [`call`] verifier applies the same machinery to
+//! a call's array argument, seeding the chain state in step 5 empty (a call has
+//! no in-place result or known write index to chain from).
 //!
 //! 1. **Backward alias-set.** Compute the set of values that may share `vX`'s
 //!    storage *at the `array_set`'s program point* by walking block-parameter →
@@ -83,7 +92,9 @@
 //!    crossing we both **kill** params that the predecessor rebinds to a
 //!    non-alias and **add** params whose arg is still an alias (so alias
 //!    propagation stays accurate as the walk crosses joins and loops). The
-//!    walk maintains two additional pieces of state:
+//!    walk maintains two additional pieces of state, both seeded by the caller
+//!    — the [`array_set`] verifier from the write; the [`call`] verifier leaves
+//!    them empty / "all positions":
 //!
 //!    - **`derived`**, the set of values that may share the source's storage
 //!      through transitive in-place chain mutations. Seeded with the

--- a/compiler/noirc_evaluator/src/ssa/validation/rc_invariant/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/validation/rc_invariant/mod.rs
@@ -146,21 +146,38 @@ use std::collections::BTreeSet;
 
 use acvm::FieldElement;
 
-use crate::ssa::{
-    ir::{
-        basic_block::BasicBlockId,
-        cfg::ControlFlowGraph,
-        dom::DominatorTree,
-        function::Function,
-        instruction::{Instruction, InstructionId, TerminatorInstruction},
-        post_order::PostOrder,
-        value::ValueId,
+use crate::{
+    errors::RtResult,
+    ssa::{
+        ir::{
+            basic_block::BasicBlockId,
+            cfg::ControlFlowGraph,
+            dom::DominatorTree,
+            function::Function,
+            instruction::{Instruction, InstructionId, TerminatorInstruction},
+            post_order::PostOrder,
+            value::ValueId,
+        },
+        opt::{LoopOrder, Loops},
+        ssa_gen::Ssa,
     },
-    opt::{LoopOrder, Loops},
 };
 
 pub(crate) mod array_set;
 pub(crate) mod call;
+
+/// Run the full `rc_invariant` check — every submodule verifier — over
+/// `ssa`, returning the first violation.
+///
+/// The entire module containing this function is gated behind
+/// `#[cfg(debug_assertions)]`, so it is a no-op (and absent at the linker
+/// level) in release builds — see the pipeline wiring in
+/// [`crate::ssa::primary_passes`].
+pub(crate) fn verify_all(ssa: &Ssa) -> RtResult<()> {
+    array_set::verify(ssa)?;
+    call::verify(ssa)?;
+    Ok(())
+}
 
 /// Pre-computed indices over a Brillig function. The verifier's per-array_set
 /// checks read from these structures rather than re-scanning the function.
@@ -1586,16 +1603,7 @@ struct AliasedUse {
 /// property for both — *neither* verifier rejects — so it lives here.
 #[cfg(test)]
 pub(crate) mod tests {
-    use super::{array_set, call};
-    use crate::{errors::RtResult, ssa::ssa_gen::Ssa};
-
-    /// Run the full `rc_invariant` check — every submodule verifier — over
-    /// `ssa`, returning the first violation.
-    pub(crate) fn verify_all(ssa: &Ssa) -> RtResult<()> {
-        array_set::verify(ssa)?;
-        call::verify(ssa)?;
-        Ok(())
-    }
+    use crate::ssa::ssa_gen::Ssa;
 
     /// Assert the full `rc_invariant` check ([`verify_all`]) accepts `src`.
     pub(crate) fn assert_verifier_accepts(src: &str) {
@@ -1607,7 +1615,7 @@ pub(crate) mod tests {
     /// accepted (e.g. "loop exit reads a rebound block-param").
     pub(crate) fn assert_verifier_accepts_because(src: &str, reason: &str) {
         let ssa = Ssa::from_str(src).expect("SSA parses");
-        if let Err(err) = verify_all(&ssa) {
+        if let Err(err) = super::verify_all(&ssa) {
             if reason.is_empty() {
                 panic!("expected the verifier to accept, but it rejected: {err:?}");
             } else {


### PR DESCRIPTION
## Problem Resolved

Resolves https://github.com/noir-lang/noir-claude/issues/1426

## Summary of Changes

Implements `rc_invariant::call::verify` reusing the machinery shared with `rc_invariant::array_set`. 

The idea is that the `ownership` module inserts `.clone()` every time we pass an array to a function call. In some cases we might strip this away during SSA-gen: if we are calling a pure built-in, or an oracle (wrapper). The goal with this check is to reject SSA as malformed if the expected `inc_rc` is missing, rather than try to make the optimisations (such as the purity analysis in the ticket) more pessimistic. 

Like its `array_set` counterpart, the check is gated under the `debug_assertions` flag.


## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
