### PR TITLE
chore: use builtin on top of trait impl methods

### DIFF
--- a/compiler/noirc_frontend/src/monomorphization/mod.rs
+++ b/compiler/noirc_frontend/src/monomorphization/mod.rs
@@ -2154,13 +2154,15 @@ impl<'interner> Monomorphizer<'interner> {
         function_type: HirType,
         trait_item_id: TraitItemId,
     ) -> Result<ast::Expression, MonomorphizationError> {
+        let location = self.interner.expr_location(&expr_id);
+        let typ = Rc::new(Self::convert_type(&function_type, location)?);
+
         let Definition::Function(func_id) =
             self.lookup_function(func_id, expr_id, &function_type, &[], Some(trait_item_id), true)?
         else {
             unreachable!();
         };
 
-        let location = self.interner.expr_location(&expr_id);
         let name = self.interner.definition_name(trait_item_id.item_id).to_string();
 
         Ok(ast::Expression::Ident(ast::Ident {
@@ -2168,7 +2170,7 @@ impl<'interner> Monomorphizer<'interner> {
             mutable: false,
             location: None,
             name,
-            typ: Rc::new(Self::convert_type(&function_type, location)?),
+            typ,
             id: self.next_ident_id(),
         }))
     }

--- a/noir_stdlib/src/meta/ctstring.nr
+++ b/noir_stdlib/src/meta/ctstring.nr
@@ -48,21 +48,18 @@ pub trait AsCtString {
 // docs:end:as-ctstring
 
 impl<let N: u32> AsCtString for str<N> {
-    comptime fn as_ctstring(self) -> CtString {
-        str_as_ctstring(self)
-    }
+    #[builtin(str_as_ctstring)]
+    comptime fn as_ctstring(self) -> CtString {}
 }
 
 impl<let N: u32, T> AsCtString for fmtstr<N, T> {
-    comptime fn as_ctstring(self) -> CtString {
-        fmtstr_as_ctstring(self)
-    }
+    #[builtin(fmtstr_as_ctstring)]
+    comptime fn as_ctstring(self) -> CtString {}
 }
 
 impl crate::cmp::Eq for CtString {
-    comptime fn eq(self, other: Self) -> bool {
-        ctstring_eq(self, other)
-    }
+    #[builtin(ctstring_eq)]
+    comptime fn eq(self, other: Self) -> bool {}
 }
 
 impl crate::hash::Hash for CtString {
@@ -73,15 +70,6 @@ impl crate::hash::Hash for CtString {
         state.write(ctstring_hash(self));
     }
 }
-
-#[builtin(str_as_ctstring)]
-comptime fn str_as_ctstring<let N: u32>(_s: str<N>) -> CtString {}
-
-#[builtin(fmtstr_as_ctstring)]
-comptime fn fmtstr_as_ctstring<let N: u32, T>(_s: fmtstr<N, T>) -> CtString {}
-
-#[builtin(ctstring_eq)]
-comptime fn ctstring_eq(_first: CtString, _second: CtString) -> bool {}
 
 #[builtin(ctstring_hash)]
 comptime fn ctstring_hash(_string: CtString) -> Field {}

--- a/noir_stdlib/src/meta/function_def.nr
+++ b/noir_stdlib/src/meta/function_def.nr
@@ -70,13 +70,9 @@ impl crate::hash::Hash for FunctionDefinition {
 }
 
 impl crate::cmp::Eq for FunctionDefinition {
-    comptime fn eq(self, other: Self) -> bool {
-        function_def_eq(self, other)
-    }
+    #[builtin(function_def_eq)]
+    comptime fn eq(self, other: Self) -> bool {}
 }
-
-#[builtin(function_def_eq)]
-comptime fn function_def_eq(_first: FunctionDefinition, _second: FunctionDefinition) -> bool {}
 
 #[builtin(function_def_hash)]
 comptime fn function_def_hash(_function: FunctionDefinition) -> Field {}

--- a/noir_stdlib/src/meta/location.nr
+++ b/noir_stdlib/src/meta/location.nr
@@ -2,9 +2,8 @@ use crate::cmp::Eq;
 use crate::hash::{Hash, Hasher};
 
 impl Eq for Location {
-    comptime fn eq(self, other: Self) -> bool {
-        location_eq(self, other)
-    }
+    #[builtin(location_eq)]
+    comptime fn eq(self, other: Self) -> bool {}
 }
 
 impl Hash for Location {
@@ -15,9 +14,6 @@ impl Hash for Location {
         state.write(location_hash(self));
     }
 }
-
-#[builtin(location_eq)]
-comptime fn location_eq(_first: Location, _second: Location) -> bool {}
 
 #[builtin(location_hash)]
 comptime fn location_hash(_loc: Location) -> Field {}

--- a/noir_stdlib/src/meta/module.nr
+++ b/noir_stdlib/src/meta/module.nr
@@ -57,13 +57,9 @@ impl crate::hash::Hash for Module {
 }
 
 impl crate::cmp::Eq for Module {
-    comptime fn eq(self, other: Self) -> bool {
-        module_eq(self, other)
-    }
+    #[builtin(module_eq)]
+    comptime fn eq(self, other: Self) -> bool {}
 }
-
-#[builtin(module_eq)]
-comptime fn module_eq(_first: Module, _second: Module) -> bool {}
 
 #[builtin(module_hash)]
 comptime fn module_hash(_module: Module) -> Field {}

--- a/noir_stdlib/src/meta/quoted.nr
+++ b/noir_stdlib/src/meta/quoted.nr
@@ -34,9 +34,8 @@ impl Quoted {
 }
 
 impl Eq for Quoted {
-    comptime fn eq(self, other: Quoted) -> bool {
-        quoted_eq(self, other)
-    }
+    #[builtin(quoted_eq)]
+    comptime fn eq(self, other: Quoted) -> bool {}
 }
 
 impl crate::hash::Hash for Quoted {
@@ -47,9 +46,6 @@ impl crate::hash::Hash for Quoted {
         state.write(quoted_hash(self))
     }
 }
-
-#[builtin(quoted_eq)]
-comptime fn quoted_eq(_first: Quoted, _second: Quoted) -> bool {}
 
 #[builtin(quoted_hash)]
 comptime fn quoted_hash(_quoted: Quoted) -> Field {}

--- a/noir_stdlib/src/meta/trait_constraint.nr
+++ b/noir_stdlib/src/meta/trait_constraint.nr
@@ -2,9 +2,8 @@ use crate::cmp::Eq;
 use crate::hash::{Hash, Hasher};
 
 impl Eq for TraitConstraint {
-    comptime fn eq(self, other: Self) -> bool {
-        constraint_eq(self, other)
-    }
+    #[builtin(trait_constraint_eq)]
+    comptime fn eq(self, other: Self) -> bool {}
 }
 
 impl Hash for TraitConstraint {
@@ -15,9 +14,6 @@ impl Hash for TraitConstraint {
         state.write(constraint_hash(self));
     }
 }
-
-#[builtin(trait_constraint_eq)]
-comptime fn constraint_eq(_first: TraitConstraint, _second: TraitConstraint) -> bool {}
 
 #[builtin(trait_constraint_hash)]
 comptime fn constraint_hash(_constraint: TraitConstraint) -> Field {}

--- a/noir_stdlib/src/meta/trait_def.nr
+++ b/noir_stdlib/src/meta/trait_def.nr
@@ -14,9 +14,8 @@ impl TraitDefinition {
 }
 
 impl Eq for TraitDefinition {
-    comptime fn eq(self, other: Self) -> bool {
-        trait_def_eq(self, other)
-    }
+    #[builtin(trait_def_eq)]
+    comptime fn eq(self, other: Self) -> bool {}
 }
 
 impl Hash for TraitDefinition {
@@ -27,9 +26,6 @@ impl Hash for TraitDefinition {
         state.write(trait_def_hash(self));
     }
 }
-
-#[builtin(trait_def_eq)]
-comptime fn trait_def_eq(_first: TraitDefinition, _second: TraitDefinition) -> bool {}
 
 #[builtin(trait_def_hash)]
 comptime fn trait_def_hash(_def: TraitDefinition) -> Field {}

--- a/noir_stdlib/src/meta/typ.nr
+++ b/noir_stdlib/src/meta/typ.nr
@@ -200,9 +200,8 @@ impl Eq for Type {
     /// Note that this is syntactic equality, this is not the same as whether two types will type check
     /// to be the same type. Unless type inference or generics are being used however, users should not
     /// typically have to worry about this distinction.
-    comptime fn eq(self, other: Self) -> bool {
-        type_eq(self, other)
-    }
+    #[builtin(type_eq)]
+    comptime fn eq(self, other: Self) -> bool {}
 }
 
 impl crate::hash::Hash for Type {
@@ -213,9 +212,6 @@ impl crate::hash::Hash for Type {
         state.write(type_hash(self))
     }
 }
-
-#[builtin(type_eq)]
-comptime fn type_eq(_first: Type, _second: Type) -> bool {}
 
 #[builtin(type_hash)]
 comptime fn type_hash(_typ: Type) -> Field {}

--- a/noir_stdlib/src/meta/type_def.nr
+++ b/noir_stdlib/src/meta/type_def.nr
@@ -83,13 +83,9 @@ impl crate::hash::Hash for TypeDefinition {
 }
 
 impl crate::cmp::Eq for TypeDefinition {
-    comptime fn eq(self, other: Self) -> bool {
-        type_def_eq(self, other)
-    }
+    #[builtin(type_def_eq)]
+    comptime fn eq(self, other: Self) -> bool {}
 }
-
-#[builtin(type_def_eq)]
-comptime fn type_def_eq(_first: TypeDefinition, _second: TypeDefinition) -> bool {}
 
 #[builtin(type_def_hash)]
 comptime fn type_def_hash(_type: TypeDefinition) -> Field {}


### PR DESCRIPTION
## Problem Resolved

No issue.

## Summary of Changes

A few comptime types built-ins were done using an indirection. That works but it's simpler to have the impl or trait impl method be built-in itself. When interpreting these it's a bit faster not having to interpret the body that ends up calling the built-in method, and it's also slightly less code.

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
