### PR TITLE
chore: Factor out more duplicate code

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/expressions.rs
+++ b/compiler/noirc_frontend/src/elaborator/expressions.rs
@@ -1,6 +1,6 @@
 //! Expression elaboration, covering all expression [kinds][ExpressionKind].
 
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap};
 
 use iter_extended::vecmap;
 use noirc_errors::{Located, Location, Span};
@@ -1326,9 +1326,12 @@ impl Elaborator<'_> {
             let field_location = field.location;
             let (resolved, field_type) = self.elaborate_expression(field);
 
-            if unseen_fields.remove(&field_name) {
-                seen_fields.insert(field_name.clone());
-
+            if self.check_constructor_field(
+                &field_name,
+                &mut seen_fields,
+                &mut unseen_fields,
+                &struct_type,
+            ) {
                 self.unify_with_coercions(
                     &field_type,
                     expected_type,
@@ -1342,15 +1345,6 @@ impl Elaborator<'_> {
                         ))
                     },
                 );
-            } else if seen_fields.contains(&field_name) {
-                // duplicate field
-                self.push_err(ResolverError::DuplicateField { field: field_name.clone() });
-            } else {
-                // field not required by struct
-                self.push_err(ResolverError::NoSuchField {
-                    field: field_name.clone(),
-                    struct_definition: struct_type.borrow().name.clone(),
-                });
             }
 
             if let Some((index, visibility)) = expected_index_and_visibility {
@@ -1370,6 +1364,42 @@ impl Elaborator<'_> {
             ret.push((field_name, resolved));
         }
 
+        self.report_missing_fields(unseen_fields, location, &struct_type);
+        ret
+    }
+
+    /// Check if `field` has already been seen or not in a constructor expression.
+    /// Returns `true` if the field hasn't been seen yet (moving it from unseen to seen).
+    /// Otherwise pushes a `DuplicateField` or `NoSuchField` error and returns `false`.
+    pub(super) fn check_constructor_field(
+        &mut self,
+        field: &Ident,
+        seen_fields: &mut HashSet<Ident>,
+        unseen_fields: &mut BTreeSet<Ident>,
+        struct_type: &Shared<DataType>,
+    ) -> bool {
+        if unseen_fields.remove(field) {
+            seen_fields.insert(field.clone());
+            true
+        } else if seen_fields.contains(field) {
+            self.push_err(ResolverError::DuplicateField { field: field.clone() });
+            false
+        } else {
+            self.push_err(ResolverError::NoSuchField {
+                field: field.clone(),
+                struct_definition: struct_type.borrow().name.clone(),
+            });
+            false
+        }
+    }
+
+    /// Push a `MissingFields` error for any struct fields not provided by a constructor.
+    pub(super) fn report_missing_fields(
+        &mut self,
+        unseen_fields: BTreeSet<Ident>,
+        location: Location,
+        struct_type: &Shared<DataType>,
+    ) {
         if !unseen_fields.is_empty() {
             self.push_err(ResolverError::MissingFields {
                 location,
@@ -1377,8 +1407,6 @@ impl Elaborator<'_> {
                 struct_definition: struct_type.borrow().name.clone(),
             });
         }
-
-        ret
     }
 
     /// This method also returns whether or not its lhs still needs to be dereferenced depending on

--- a/compiler/noirc_frontend/src/elaborator/path_resolution.rs
+++ b/compiler/noirc_frontend/src/elaborator/path_resolution.rs
@@ -743,8 +743,7 @@ impl Elaborator<'_> {
                             return Err(PathResolutionError::Unresolved(current_ident.clone()));
                         } else {
                             let traits = vecmap(method_traits, |trait_id| {
-                                let trait_ = self.interner.get_trait(trait_id);
-                                self.fully_qualified_trait_path(trait_)
+                                self.fully_qualified_trait_path_by_id(trait_id)
                             });
                             return Err(
                                 PathResolutionError::UnresolvedWithPossibleTraitsToImport {
@@ -760,8 +759,7 @@ impl Elaborator<'_> {
                         per_ns
                     }
                     MethodLookupResult::FoundOneTraitMethodButNotInScope(per_ns, trait_id) => {
-                        let trait_ = self.interner.get_trait(trait_id);
-                        let trait_name = self.fully_qualified_trait_path(trait_);
+                        let trait_name = self.fully_qualified_trait_path_by_id(trait_id);
                         errors.push(PathResolutionError::TraitMethodNotInScope {
                             ident: current_ident.clone(),
                             trait_name,
@@ -770,13 +768,12 @@ impl Elaborator<'_> {
                     }
                     MethodLookupResult::FoundMultipleTraitMethods(vec) => {
                         let traits = vecmap(vec, |(trait_id, name)| {
-                            let trait_ = self.interner.get_trait(trait_id);
                             self.usage_tracker.mark_as_used(
                                 importing_module,
                                 &name,
                                 Namespace::Type,
                             );
-                            self.fully_qualified_trait_path(trait_)
+                            self.fully_qualified_trait_path_by_id(trait_id)
                         });
                         return Err(PathResolutionError::MultipleTraitsInScope {
                             ident: current_ident.clone(),
@@ -1020,8 +1017,7 @@ impl Elaborator<'_> {
                 let same_trait =
                     in_scope.iter().all(|(_, trait_id, _)| *trait_id == first_trait_id);
                 if same_trait {
-                    let trait_name =
-                        self.fully_qualified_trait_path(self.interner.get_trait(first_trait_id));
+                    let trait_name = self.fully_qualified_trait_path_by_id(first_trait_id);
                     let type_name = self_type.to_string();
                     let impls = vecmap(&in_scope, |(_, _, impl_id)| {
                         let ordered = &self.interner.get_trait_generics_for_impl(*impl_id).ordered;
@@ -1043,8 +1039,7 @@ impl Elaborator<'_> {
                     }))
                 } else {
                     let mut traits = vecmap(&in_scope, |(_, trait_id, _)| {
-                        let trait_ = self.interner.get_trait(*trait_id);
-                        self.fully_qualified_trait_path(trait_)
+                        self.fully_qualified_trait_path_by_id(*trait_id)
                     });
                     traits.sort();
                     traits.dedup();
@@ -1138,6 +1133,7 @@ impl Elaborator<'_> {
             return Ok(func_id);
         }
 
+<<<<<<< Updated upstream
         // Otherwise look through trait methods
         let trait_methods = self.lookup_trait_methods(&typ, method_name, false);
         let starting_module = self.get_module(importing_module_id);
@@ -1146,6 +1142,37 @@ impl Elaborator<'_> {
         for (func_id, trait_id, _) in &trait_methods {
             if let Some(name) = starting_module.find_trait_in_scope(*trait_id) {
                 results.push((*trait_id, *func_id, name));
+=======
+        let ident = || method_name_ident.clone();
+        match self.classify_method_candidates(inherent, trait_candidates, importing_module_id) {
+            MethodLookupResult::FoundMethod(func_id)
+            | MethodLookupResult::FoundTraitMethod(func_id, _) => Ok(func_id),
+            MethodLookupResult::FoundOneTraitMethodButNotInScope(func_id, trait_id) => {
+                let trait_name = self.fully_qualified_trait_path_by_id(trait_id);
+                errors.push(PathResolutionError::TraitMethodNotInScope {
+                    ident: ident(),
+                    trait_name,
+                });
+                Ok(func_id)
+            }
+            MethodLookupResult::FoundMultipleTraitMethods(traits) => {
+                let traits = vecmap(traits, |(trait_id, name)| {
+                    self.usage_tracker.mark_as_used(importing_module_id, &name, Namespace::Type);
+                    self.fully_qualified_trait_path_by_id(trait_id)
+                });
+                Err(PathResolutionError::MultipleTraitsInScope { ident: ident(), traits })
+            }
+            MethodLookupResult::NotFound(trait_ids) if trait_ids.is_empty() => {
+                Err(PathResolutionError::Unresolved(ident()))
+            }
+            MethodLookupResult::NotFound(trait_ids) => {
+                let traits =
+                    vecmap(trait_ids, |trait_id| self.fully_qualified_trait_path_by_id(trait_id));
+                Err(PathResolutionError::UnresolvedWithPossibleTraitsToImport {
+                    ident: ident(),
+                    traits,
+                })
+>>>>>>> Stashed changes
             }
         }
 

--- a/compiler/noirc_frontend/src/elaborator/path_resolution.rs
+++ b/compiler/noirc_frontend/src/elaborator/path_resolution.rs
@@ -1133,7 +1133,6 @@ impl Elaborator<'_> {
             return Ok(func_id);
         }
 
-<<<<<<< Updated upstream
         // Otherwise look through trait methods
         let trait_methods = self.lookup_trait_methods(&typ, method_name, false);
         let starting_module = self.get_module(importing_module_id);
@@ -1142,45 +1141,13 @@ impl Elaborator<'_> {
         for (func_id, trait_id, _) in &trait_methods {
             if let Some(name) = starting_module.find_trait_in_scope(*trait_id) {
                 results.push((*trait_id, *func_id, name));
-=======
-        let ident = || method_name_ident.clone();
-        match self.classify_method_candidates(inherent, trait_candidates, importing_module_id) {
-            MethodLookupResult::FoundMethod(func_id)
-            | MethodLookupResult::FoundTraitMethod(func_id, _) => Ok(func_id),
-            MethodLookupResult::FoundOneTraitMethodButNotInScope(func_id, trait_id) => {
-                let trait_name = self.fully_qualified_trait_path_by_id(trait_id);
-                errors.push(PathResolutionError::TraitMethodNotInScope {
-                    ident: ident(),
-                    trait_name,
-                });
-                Ok(func_id)
-            }
-            MethodLookupResult::FoundMultipleTraitMethods(traits) => {
-                let traits = vecmap(traits, |(trait_id, name)| {
-                    self.usage_tracker.mark_as_used(importing_module_id, &name, Namespace::Type);
-                    self.fully_qualified_trait_path_by_id(trait_id)
-                });
-                Err(PathResolutionError::MultipleTraitsInScope { ident: ident(), traits })
-            }
-            MethodLookupResult::NotFound(trait_ids) if trait_ids.is_empty() => {
-                Err(PathResolutionError::Unresolved(ident()))
-            }
-            MethodLookupResult::NotFound(trait_ids) => {
-                let traits =
-                    vecmap(trait_ids, |trait_id| self.fully_qualified_trait_path_by_id(trait_id));
-                Err(PathResolutionError::UnresolvedWithPossibleTraitsToImport {
-                    ident: ident(),
-                    traits,
-                })
->>>>>>> Stashed changes
             }
         }
 
         if results.is_empty() {
             if trait_methods.len() == 1 {
                 let (func_id, trait_id, _) = trait_methods.first().expect("Expected an item");
-                let trait_ = self.interner.get_trait(*trait_id);
-                let trait_name = self.fully_qualified_trait_path(trait_);
+                let trait_name = self.fully_qualified_trait_path_by_id(*trait_id);
                 let ident = method_name_ident.clone();
                 errors.push(PathResolutionError::TraitMethodNotInScope { ident, trait_name });
                 return Ok(*func_id);

--- a/compiler/noirc_frontend/src/elaborator/patterns.rs
+++ b/compiler/noirc_frontend/src/elaborator/patterns.rs
@@ -421,38 +421,24 @@ impl Elaborator<'_> {
                 parameter_names_in_list,
             );
 
-            if unseen_fields.contains(&field) {
-                unseen_fields.remove(&field);
-                seen_fields.insert(field.clone());
-
+            if self.check_constructor_field(
+                &field,
+                &mut seen_fields,
+                &mut unseen_fields,
+                struct_type,
+            ) {
                 self.check_struct_field_visibility(
                     &struct_type.borrow(),
                     field.as_str(),
                     visibility,
                     field.location(),
                 );
-            } else if seen_fields.contains(&field) {
-                // duplicate field
-                self.push_err(ResolverError::DuplicateField { field: field.clone() });
-            } else {
-                // field not required by struct
-                self.push_err(ResolverError::NoSuchField {
-                    field: field.clone(),
-                    struct_definition: struct_type.borrow().name.clone(),
-                });
             }
 
             ret.push((field, resolved));
         }
 
-        if !unseen_fields.is_empty() {
-            self.push_err(ResolverError::MissingFields {
-                location,
-                missing_fields: unseen_fields.into_iter().map(|field| field.to_string()).collect(),
-                struct_definition: struct_type.borrow().name.clone(),
-            });
-        }
-
+        self.report_missing_fields(unseen_fields, location, struct_type);
         ret
     }
 

--- a/compiler/noirc_frontend/src/elaborator/types.rs
+++ b/compiler/noirc_frontend/src/elaborator/types.rs
@@ -951,26 +951,26 @@ impl Elaborator<'_> {
                 return Some(generic.into_named_generic(None));
             }
         } else if let Some(typ) = self.lookup_associated_type_on_self(path) {
-            if let Some(last_segment) = path.segments.last()
-                && last_segment.generics.is_some()
-            {
-                self.push_err(ResolverError::GenericsOnAssociatedType {
-                    location: last_segment.turbofish_location(),
-                });
-            }
+            self.error_if_generics_on_associated_type(path);
             return Some(typ);
         } else if let Some(typ) = self.lookup_associated_type_on_generic(path) {
-            if let Some(last_segment) = path.segments.last()
-                && last_segment.generics.is_some()
-            {
-                self.push_err(ResolverError::GenericsOnAssociatedType {
-                    location: last_segment.turbofish_location(),
-                });
-            }
+            self.error_if_generics_on_associated_type(path);
             return Some(typ);
         }
 
         None
+    }
+
+    /// Associated types cannot carry turbofish generics; report an error if the path's last
+    /// segment has any.
+    fn error_if_generics_on_associated_type(&mut self, path: &TypedPath) {
+        if let Some(last_segment) = path.segments.last()
+            && last_segment.generics.is_some()
+        {
+            self.push_err(ResolverError::GenericsOnAssociatedType {
+                location: last_segment.turbofish_location(),
+            });
+        }
     }
 
     /// Look up a path as a global used as a numeric type (e.g. `global N: u32 = 5;`
@@ -1575,10 +1575,8 @@ impl Elaborator<'_> {
         if matches.len() > 1 {
             let location = path.location;
             let ident = Ident::new(method_name.to_string(), location);
-            let traits = vecmap(matches, |(_, trait_id)| {
-                let trait_ = self.interner.get_trait(trait_id);
-                self.fully_qualified_trait_path(trait_)
-            });
+            let traits =
+                vecmap(matches, |(_, trait_id)| self.fully_qualified_trait_path_by_id(trait_id));
             let errors = vec![PathResolutionError::MultipleTraitsInScope { ident, traits }];
             return Some(TraitPathResolution {
                 method: TraitPathResolutionMethod::MultipleTraitsInScope,
@@ -3039,8 +3037,7 @@ impl Elaborator<'_> {
             if traits.len() == 1 {
                 // This is the backwards-compatible case where there's a single trait but it's not in scope
                 let trait_id = *traits.iter().next().unwrap();
-                let trait_ = self.interner.get_trait(trait_id);
-                let trait_name = self.fully_qualified_trait_path(trait_);
+                let trait_name = self.fully_qualified_trait_path_by_id(trait_id);
                 let method =
                     self.trait_hir_method_reference(trait_id, trait_methods, method_name, location);
                 let error = PathResolutionError::TraitMethodNotInScope {
@@ -3049,10 +3046,8 @@ impl Elaborator<'_> {
                 };
                 return (Some(method), Some(error));
             } else {
-                let traits = vecmap(traits, |trait_id| {
-                    let trait_ = self.interner.get_trait(trait_id);
-                    self.fully_qualified_trait_path(trait_)
-                });
+                let traits =
+                    vecmap(traits, |trait_id| self.fully_qualified_trait_path_by_id(trait_id));
                 let method_not_found = None;
                 let error = PathResolutionError::UnresolvedWithPossibleTraitsToImport {
                     ident: Ident::new(method_name.into(), location),
@@ -3063,10 +3058,7 @@ impl Elaborator<'_> {
         }
 
         if traits_in_scope.len() > 1 {
-            let traits = vecmap(traits, |trait_id| {
-                let trait_ = self.interner.get_trait(trait_id);
-                self.fully_qualified_trait_path(trait_)
-            });
+            let traits = vecmap(traits, |trait_id| self.fully_qualified_trait_path_by_id(trait_id));
             let method_not_found = None;
             let error = PathResolutionError::MultipleTraitsInScope {
                 ident: Ident::new(method_name.into(), location),
@@ -3223,10 +3215,8 @@ impl Elaborator<'_> {
 
         if matches.len() > 1 {
             let ident = Ident::new(method_name.to_string(), location);
-            let traits = vecmap(matches, |method| {
-                let trait_ = self.interner.get_trait(method.trait_id);
-                self.fully_qualified_trait_path(trait_)
-            });
+            let traits =
+                vecmap(matches, |method| self.fully_qualified_trait_path_by_id(method.trait_id));
             self.push_err(PathResolutionError::MultipleTraitsInScope { ident, traits });
             return None;
         }
@@ -3685,6 +3675,10 @@ impl Elaborator<'_> {
             trait_generics: parent_trait_bound.trait_generics.map(|typ| typ.substitute(&bindings)),
             ..*parent_trait_bound
         }
+    }
+
+    pub(crate) fn fully_qualified_trait_path_by_id(&self, trait_id: TraitId) -> String {
+        self.fully_qualified_trait_path(self.interner.get_trait(trait_id))
     }
 
     pub(crate) fn fully_qualified_trait_path(&self, trait_: &Trait) -> String {


### PR DESCRIPTION
## Problem Resolved

Resolves <!-- Link to GitHub Issue -->

## Summary of Changes

Some more duplicate code that is now factored out:
- Constructor utils for checking for duplicate or missing fields
- Get a trait & its fully qualified path
- error_if_generics_on_associated_type helper

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
