### PR TITLE
chore: validate write_heap_array lengths

### DIFF
--- a/acvm-repo/brillig_vm/src/black_box.rs
+++ b/acvm-repo/brillig_vm/src/black_box.rs
@@ -25,12 +25,20 @@ fn read_heap_array<'a, F: AcirField>(
 
 /// Write values to a [array][HeapArray] in memory.
 fn write_heap_array<F: AcirField>(
+    bb_func: BlackBoxFunc,
     memory: &mut Memory<F>,
     array: &HeapArray,
     values: &[MemoryValue<F>],
-) {
+) -> Result<(), BlackBoxResolutionError> {
+    if values.len() != array.size.0 as usize {
+        return Err(BlackBoxResolutionError::Failed(
+            bb_func,
+            format!("Expected output of size {} but encountered {}", array.size.0, values.len()),
+        ));
+    }
     let items_start = memory.read_ref(array.pointer);
     memory.write_slice(items_start, values);
+    Ok(())
 }
 
 /// Extracts the last byte of every value
@@ -87,20 +95,20 @@ pub(crate) fn evaluate_black_box<F: AcirField, Solver: BlackBoxFunctionSolver<F>
                 })?;
             let ciphertext = aes128_encrypt(&inputs, iv, key)?;
 
-            write_heap_array(memory, outputs, &to_value_vec(&ciphertext));
+            write_heap_array(bb_func, memory, outputs, &to_value_vec(&ciphertext))?;
 
             Ok(())
         }
         BlackBoxOp::Blake2s { message, output } => {
             let message = to_u8_vec(read_heap_array(memory, message));
             let bytes = blake2s(message.as_slice())?;
-            write_heap_array(memory, output, &to_value_vec(&bytes));
+            write_heap_array(BlackBoxFunc::Blake2s, memory, output, &to_value_vec(&bytes))?;
             Ok(())
         }
         BlackBoxOp::Blake3 { message, output } => {
             let message = to_u8_vec(read_heap_array(memory, message));
             let bytes = blake3(message.as_slice())?;
-            write_heap_array(memory, output, &to_value_vec(&bytes));
+            write_heap_array(BlackBoxFunc::Blake3, memory, output, &to_value_vec(&bytes))?;
             Ok(())
         }
         BlackBoxOp::Keccakf1600 { input, output } => {
@@ -113,7 +121,7 @@ pub(crate) fn evaluate_black_box<F: AcirField, Solver: BlackBoxFunctionSolver<F>
             let new_state = keccakf1600(state)?;
 
             let new_state: Vec<MemoryValue<F>> = new_state.into_iter().map(|x| x.into()).collect();
-            write_heap_array(memory, output, &new_state);
+            write_heap_array(BlackBoxFunc::Keccakf1600, memory, output, &new_state)?;
             Ok(())
         }
         BlackBoxOp::EcdsaSecp256k1 {
@@ -195,10 +203,11 @@ pub(crate) fn evaluate_black_box<F: AcirField, Solver: BlackBoxFunctionSolver<F>
                 true, // Predicate is always true as brillig has control flow to handle false case
             )?;
             write_heap_array(
+                BlackBoxFunc::MultiScalarMul,
                 memory,
                 result,
                 &[MemoryValue::new_field(x), MemoryValue::new_field(y)],
-            );
+            )?;
             Ok(())
         }
         BlackBoxOp::EmbeddedCurveAdd { input1_x, input1_y, input2_x, input2_y, result } => {
@@ -212,10 +221,11 @@ pub(crate) fn evaluate_black_box<F: AcirField, Solver: BlackBoxFunctionSolver<F>
             )?;
 
             write_heap_array(
+                BlackBoxFunc::EmbeddedCurveAdd,
                 memory,
                 result,
                 &[MemoryValue::new_field(x), MemoryValue::new_field(y)],
-            );
+            )?;
             Ok(())
         }
         BlackBoxOp::Poseidon2Permutation { message, output } => {
@@ -226,7 +236,7 @@ pub(crate) fn evaluate_black_box<F: AcirField, Solver: BlackBoxFunctionSolver<F>
             for i in result {
                 values.push(MemoryValue::new_field(i));
             }
-            write_heap_array(memory, output, &values);
+            write_heap_array(BlackBoxFunc::Poseidon2Permutation, memory, output, &values)?;
             Ok(())
         }
         BlackBoxOp::Sha256Compression { input, hash_values, output } => {
@@ -256,7 +266,7 @@ pub(crate) fn evaluate_black_box<F: AcirField, Solver: BlackBoxFunctionSolver<F>
             sha256_compression(&mut state, &message);
             let state = state.map(|x| x.into());
 
-            write_heap_array(memory, output, &state);
+            write_heap_array(BlackBoxFunc::Sha256Compression, memory, output, &state)?;
             Ok(())
         }
         BlackBoxOp::ToRadix { input, radix, output_pointer, num_limbs, output_bits } => {


### PR DESCRIPTION
## Problem Resolved

Resolves https://github.com/noir-lang/noir-claude/issues/703

## Summary of Changes

This PR just makes sure the array lengths here match. There's no way to currently trigger this code, but the assertion makes sense so it's mainly a defensive measure.

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
