### PR TITLE
fix(frontend): Clean error when `break` in `while` condition w/o outer loop

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/statements.rs
+++ b/compiler/noirc_frontend/src/elaborator/statements.rs
@@ -562,11 +562,8 @@ impl Elaborator<'_> {
             });
         }
 
-        // The condition is the loop guard, evaluated outside the while's loop scope (like a
-        // `for` range). Both SSA codegen and the comptime interpreter treat a `break`/`continue`
-        // in it as targeting the enclosing loop, so it is elaborated under the enclosing loop's
-        // context — yielding a `JumpOutsideLoop` error rather than a backend panic when there is
-        // no enclosing loop.
+        // The condition is evaluated once per loop, however any `break` or `continue` in it
+        // targets the enclosing loop, so we have to elaborate it outside the scope of this loop.
         let location = while_.condition.type_location();
         let (condition, cond_type) = self.elaborate_expression(while_.condition);
         self.unify_or_type_mismatch(&cond_type, &Type::Bool, location);

--- a/compiler/noirc_frontend/src/elaborator/statements.rs
+++ b/compiler/noirc_frontend/src/elaborator/statements.rs
@@ -562,14 +562,18 @@ impl Elaborator<'_> {
             });
         }
 
+        // The condition is the loop guard, evaluated outside the while's loop scope (like a
+        // `for` range). Both SSA codegen and the comptime interpreter treat a `break`/`continue`
+        // in it as targeting the enclosing loop, so it is elaborated under the enclosing loop's
+        // context — yielding a `JumpOutsideLoop` error rather than a backend panic when there is
+        // no enclosing loop.
+        let location = while_.condition.type_location();
+        let (condition, cond_type) = self.elaborate_expression(while_.condition);
+        self.unify_or_type_mismatch(&cond_type, &Type::Bool, location);
+
         let old_loop = std::mem::take(&mut self.current_loop);
         self.current_loop = Some(Loop { is_for: false, has_break: false });
         self.push_scope();
-
-        let location = while_.condition.type_location();
-        let (condition, cond_type) = self.elaborate_expression(while_.condition);
-
-        self.unify_or_type_mismatch(&cond_type, &Type::Bool, location);
 
         let block_location = while_.body.type_location();
         let (block, block_type) = self.elaborate_expression(while_.body);

--- a/compiler/noirc_frontend/src/tests/control_flow.rs
+++ b/compiler/noirc_frontend/src/tests/control_flow.rs
@@ -96,6 +96,51 @@ fn break_and_continue_outside_loop() {
 }
 
 #[test]
+fn break_in_while_condition_without_enclosing_loop() {
+    // A `break` in a `while` condition targets the *enclosing* loop (the condition is the loop
+    // guard, evaluated outside the while's body scope, as in SSA codegen and the comptime
+    // interpreter). With no enclosing loop it is a break outside any loop, which must be a clean
+    // error rather than a backend panic.
+    let src = r#"
+        pub unconstrained fn foo(cond: bool) {
+            let mut i = 0;
+            while ({
+                if cond {
+                    break;
+                    ^^^^^^ break is only allowed within loops
+                }
+                i < 3
+            }) {
+                i += 1;
+            }
+        }
+    "#;
+    check_errors(src);
+}
+
+#[test]
+fn break_in_while_condition_targets_enclosing_loop() {
+    // The same `break` is accepted when the `while` is nested in another loop: it targets that
+    // enclosing loop, which therefore counts as having a break.
+    let src = r#"
+        pub unconstrained fn foo(cond: bool) {
+            loop {
+                let mut i = 0;
+                while ({
+                    if cond {
+                        break;
+                    }
+                    i < 3
+                }) {
+                    i += 1;
+                }
+            }
+        }
+    "#;
+    assert_no_errors(src);
+}
+
+#[test]
 fn break_in_infix_operand() {
     let src = r#"
     unconstrained fn main() {


### PR DESCRIPTION
## Problem Resolved

The behaviour of using `break` in the `while` condition came up in https://github.com/noir-lang/noir/pull/13153

`break` in the condition targets the outer loop, not the `while` itself. When I tried what happens if there is no outer loop, the compiler did not reject the code; instead I got panics at various places:

```noir
unconstrained fn main(cond: bool) -> pub u32 {
    let mut i = 0;
    while (
        {
            if cond {
                break;
            }
            i < 3
        }
    ) {
        i += 1;
    }
    i
}
```

It crashed at comptime:
```console
❯ cargo run -q -p nargo_cli -- execute --force --force-comptime 

The application panicked (crashed).
Message:  internal error: entered unreachable code: Uncaught InterpreterError::Break
Location: compiler/noirc_frontend/src/hir/comptime/errors.rs:763
```

and it crashed at SSA generation:
```console
❯ cargo run -q -p nargo_cli -- execute --force 
The application panicked (crashed).
Message:  current_loop: not in a loop!
Location: compiler/noirc_evaluator/src/ssa/ssa_gen/context.rs:998
```

## Summary of Changes

Elaborate `while.condition` before entering the scope of the `while` loop itself, so the compiler can correctly reject `break` and `continue` outside of any loop context. 

NB in Rust if we want to use `break` in a `while` condition we _have_ to target a _label_, so there is no confusion about what we are breaking out of.

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
