### PR TITLE
chore: better error message when negating bool

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/types.rs
+++ b/compiler/noirc_frontend/src/elaborator/types.rs
@@ -2671,7 +2671,16 @@ impl Elaborator<'_> {
                         Ok((FieldElement, false))
                     }
 
-                    Bool => Ok((Bool, false)),
+                    Bool => {
+                        if *op == UnaryOp::Minus {
+                            return Err(TypeCheckError::InvalidUnaryOp {
+                                typ: rhs_type.to_string(),
+                                operator: "-",
+                                location,
+                            });
+                        }
+                        Ok((Bool, false))
+                    }
 
                     _ => Ok((rhs_type.clone(), true)),
                 }

--- a/compiler/noirc_frontend/src/tests/type_mismatch.rs
+++ b/compiler/noirc_frontend/src/tests/type_mismatch.rs
@@ -225,6 +225,17 @@ fn negate_unsigned() {
 }
 
 #[test]
+fn negate_bool() {
+    let src = r#"
+    fn main() {
+        let _var = -true;
+                   ^^^^^ Cannot apply unary operator `-` to type `bool`
+    }
+    "#;
+    check_errors(src);
+}
+
+#[test]
 fn tuple_mismatch() {
     let src = r#"
     fn main() {


### PR DESCRIPTION
## Problem Resolved

Resolves https://github.com/noir-lang/noir-claude/issues/310

## Summary of Changes

Doing `-true` eventually gave another, a bit cryptic error, but now it gives a better error.

The old error:

```
bug: Assertion is always false: attempt to subtract with overflow
  ┌─ src/main.nr:3:13
  │
3 │     let y = -true;
  │             -- As a result, the compiled circuit is ensured to fail. Other assertions may also fail during execution
  │
  = Call stack:
    1: main
            at src/main.nr:3:13
```

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
