### PR TITLE
fix(ci): skip playwright install-deps for chromium-only jobs

### DIFF
--- a/.github/actions/install-playwright/action.yml
+++ b/.github/actions/install-playwright/action.yml
@@ -31,7 +31,24 @@ runs:
       with:
         run: timeout 240 npx -y playwright@${{ inputs.playwright-version }} install ${{ inputs.browsers }}
 
+    # GitHub-hosted Ubuntu runner images already ship Chromium's system
+    # libraries, so `install-deps` is only needed for engines like WebKit.
+    # Running it otherwise is a pure apt round-trip against the Azure-hosted
+    # Ubuntu mirrors — the slowest and flakiest part of this action — so skip it
+    # for chromium-only installs.
+    #
+    # Failures here are best-effort rather than fatal: this is `apt-get` under
+    # the hood, and mirror congestion is a persistent (not transient) condition,
+    # so the retry wrapper's "near-independent draw" assumption does not hold —
+    # all attempts in the same window hit the same slow mirror. A genuinely
+    # missing library surfaces loudly at browser-launch time anyway, whereas a
+    # congested mirror should not red the whole build, so we run once and warn.
     - name: Install Playwright system dependencies
-      uses: ./.github/actions/retry
-      with:
-        run: timeout 120 npx -y playwright@${{ inputs.playwright-version }} install-deps ${{ inputs.browsers }}
+      if: contains(inputs.browsers, 'webkit') || contains(inputs.browsers, 'firefox')
+      shell: bash
+      env:
+        PLAYWRIGHT_VERSION: ${{ inputs.playwright-version }}
+        BROWSERS: ${{ inputs.browsers }}
+      run: |
+        timeout 120 npx -y "playwright@${PLAYWRIGHT_VERSION}" install-deps ${BROWSERS} \
+          || echo "::warning::playwright install-deps failed; continuing (browser launch will fail later if a library is genuinely missing)"


### PR DESCRIPTION
## Problem

The `js` CI workflow has been intermittently failing to install Playwright, even with retries. Example: [run 28097769472](https://github.com/noir-lang/noir/actions/runs/28097769472/job/83191733721).

The failing step is **`install-deps`**, not the browser download:

```
Command failed after 3 attempts: timeout 120 npx -y playwright@1.58.2 install-deps chromium
```

`playwright install-deps` is a thin wrapper around `sudo apt-get update && sudo apt-get install …` for the system libraries the browser links against. Its success depends entirely on the Azure-hosted Ubuntu apt mirrors, which is the slowest and flakiest part of the action.

The 3 retries don't help: apt-mirror congestion is a **persistent, correlated** condition, not a transient flake. All three attempts run in the same ~6-minute window against the same slow mirror, so they tend to fail together — the retry action's "near-independent draw" assumption (designed for WebKit content-process crashes) doesn't hold here.

Two aggravating details:
- `install-deps` was neither cached nor gated on the browser cache — it shelled out to apt on **every** browser-test run.
- The GitHub-hosted Ubuntu runner images **already ship Chromium's system libraries**, so for chromium-only jobs the step is a pure apt round-trip that does nothing useful.

## What's effectively used

Browsers are launched via `@web/test-runner` (`web-test-runner.config.mjs`), not Playwright's own runner, so what gets *installed* and what's *launched* can differ. They line up:

| Job | Installs (action input) | Actually launched (`web-test-runner.config`) |
|---|---|---|
| `noirc_abi` | chromium (default) | **chromium** only |
| `compiler/wasm` | chromium (default) | **chromium** only |
| `integration-tests` | chromium (default) | **chromium** only |
| `acvm_js` | `chromium webkit` | **chromium + webkit** |

Firefox is commented out everywhere; webkit is launched only in `acvm_js`. So `acvm_js` is the only job that genuinely needs system libs beyond what the runner image ships — and it's exactly where the failing run originated.

## Change

In `.github/actions/install-playwright/action.yml`:

1. **Skip `install-deps` for chromium-only jobs.** Gate the step on the browser list containing `webkit` or `firefox`. The three chromium-only jobs skip the apt round-trip entirely.
2. **Make it best-effort when it does run** (`acvm_js`). Drop the retry wrapper (retrying a congested mirror doesn't help) and run once; on failure, emit a `::warning::` and continue instead of failing the job. A genuinely missing library still surfaces loudly at browser-launch time.

The browser-binary `install` step is untouched — it's a real network download where the cache + retry genuinely help.

The `firefox` branch in the condition is currently dead (firefox is commented out everywhere) but kept as cheap insurance for if a firefox launcher is uncommented later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)