### PR TITLE
chore(cli): hide print-acir from help

### DIFF
--- a/compiler/noirc_driver/src/lib.rs
+++ b/compiler/noirc_driver/src/lib.rs
@@ -147,7 +147,7 @@ pub struct CompileOptions {
     pub show_brillig_opcode_advisories: bool,
 
     /// Display the ACIR for compiled circuit, including the Brillig bytecode.
-    #[arg(long)]
+    #[arg(long, hide = true)]
     pub print_acir: bool,
 
     /// Pretty print benchmark times of each code generation pass

--- a/tooling/nargo_cli/src/cli/mod.rs
+++ b/tooling/nargo_cli/src/cli/mod.rs
@@ -323,8 +323,8 @@ fn lock_workspace(
 
 #[cfg(test)]
 mod tests {
-    use super::NargoCli;
-    use clap::Parser;
+    use super::{NargoCli, NargoCommand};
+    use clap::{CommandFactory, Parser};
 
     fn parse_cli(cmd: &str) -> Result<NargoCli, clap::Error> {
         NargoCli::try_parse_from(cmd.split_ascii_whitespace())
@@ -377,5 +377,27 @@ mod tests {
             "nargo add my_alias --git https://example.com/repo --tag v1 --directory crates/lib --override",
         )
         .expect("a git dependency with all options should parse");
+    }
+
+    #[test]
+    fn compile_help_hides_print_acir() {
+        let mut command = NargoCli::command();
+        let compile = command.find_subcommand_mut("compile").expect("compile command exists");
+        let help = compile.render_help().to_string();
+
+        assert!(
+            !help.contains("--print-acir"),
+            "`--print-acir` is a compiler debugging flag and should stay hidden from help output"
+        );
+    }
+
+    #[test]
+    fn hidden_print_acir_flag_still_parses() {
+        let cli = parse_cli("nargo compile --print-acir").expect("hidden debug flag should parse");
+
+        let NargoCommand::Compile(command) = cli.command else {
+            panic!("expected compile command");
+        };
+        assert!(command.compile_options.print_acir);
     }
 }


### PR DESCRIPTION
## Problem Resolved

Part of #2130.

`--print-acir` is a compiler debugging flag, similar to the already-hidden `--show-ssa` and `--show-brillig` options. It still appeared in generated CLI help because it was the remaining visible field on `CompileOptions`.

## Summary of Changes

- Hide `--print-acir` from CLI help output.
- Keep the flag accepted for existing debugging workflows.
- Add CLI parser coverage for both behaviours.

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.

Validation:
- `cargo +1.89.0 fmt -p nargo_cli -p noirc_driver --check`
- `git diff --check`
- `cargo +1.89.0 test -p nargo_cli print_acir --lib`