### PR TITLE
fix: revalidate resolved TypedExpr values in their final expansion context

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/expressions.rs
+++ b/compiler/noirc_frontend/src/elaborator/expressions.rs
@@ -2055,20 +2055,7 @@ impl Elaborator<'_> {
     pub(super) fn revalidate_resolved_expression(&mut self, expr_id: ExprId) {
         match self.interner.expression(&expr_id) {
             HirExpression::Ident(ident, _) => {
-                // A reference to a comptime local is normally replaced by its value when used in
-                // runtime code (see `elaborate_variable`). A resolved expression bypasses that, so
-                // a raw reference to a comptime local can only have come from a scope that is no
-                // longer live here.
-                if !self.in_comptime_context()
-                    && let Some(definition) = self.interner.try_definition(ident.id)
-                    && definition.is_comptime_local()
-                {
-                    let name = definition.name.clone();
-                    self.push_err(ResolverError::ComptimeVariableEscapesScope {
-                        name,
-                        location: ident.location,
-                    });
-                }
+                self.revalidate_resolved_comptime_local(&ident);
             }
             HirExpression::Call(call) => {
                 self.revalidate_resolved_expression(call.func);
@@ -2112,8 +2099,18 @@ impl Elaborator<'_> {
                 | HirLiteral::Str(_)
                 | HirLiteral::Unit => {}
             },
-            HirExpression::Block(block) | HirExpression::Unsafe(block) => {
+            HirExpression::Block(block) => {
                 self.revalidate_resolved_block(&block);
+            }
+            HirExpression::Unsafe(block) => {
+                // Mirror `elaborate_unsafe_block`: an unconstrained call inside the block crosses
+                // the runtime boundary legally, so the boundary check must see that we are inside an
+                // unsafe block rather than reporting a spurious error.
+                let old_status = self.unsafe_block_status;
+                self.unsafe_block_status =
+                    UnsafeBlockStatus::InUnsafeBlockWithoutUnconstrainedCalls;
+                self.revalidate_resolved_block(&block);
+                self.unsafe_block_status = old_status;
             }
             HirExpression::Prefix(prefix) => {
                 self.revalidate_resolved_expression(prefix.rhs);
@@ -2185,6 +2182,7 @@ impl Elaborator<'_> {
                     self.revalidate_resolved_expression(let_statement.expression);
                 }
                 HirStatement::Assign(assign) => {
+                    self.revalidate_resolved_lvalue(&assign.lvalue);
                     self.revalidate_resolved_expression(assign.expression);
                 }
                 HirStatement::For(for_statement) => {
@@ -2223,6 +2221,37 @@ impl Elaborator<'_> {
         if self.in_constrained_function() {
             let location = self.interner.statement_location(statement);
             self.push_err(ResolverError::JumpInConstrainedFn { is_break, location });
+        }
+    }
+
+    /// Reject a reference to a comptime local that escapes into runtime code.
+    ///
+    /// A reference to a comptime local is normally replaced by its value when used in runtime code
+    /// (see `elaborate_variable`). A resolved expression bypasses that, so a raw reference to a
+    /// comptime local can only have come from a scope that is no longer live here.
+    fn revalidate_resolved_comptime_local(&mut self, ident: &HirIdent) {
+        if !self.in_comptime_context()
+            && let Some(definition) = self.interner.try_definition(ident.id)
+            && definition.is_comptime_local()
+        {
+            let name = definition.name.clone();
+            self.push_err(ResolverError::ComptimeVariableEscapesScope {
+                name,
+                location: ident.location,
+            });
+        }
+    }
+
+    fn revalidate_resolved_lvalue(&mut self, lvalue: &HirLValue) {
+        match lvalue {
+            HirLValue::Ident(ident, _) => self.revalidate_resolved_comptime_local(ident),
+            HirLValue::MemberAccess { object, .. } => self.revalidate_resolved_lvalue(object),
+            HirLValue::Index { array, index, .. } => {
+                self.revalidate_resolved_lvalue(array);
+                self.revalidate_resolved_expression(*index);
+            }
+            HirLValue::Dereference { lvalue, .. } => self.revalidate_resolved_lvalue(lvalue),
+            HirLValue::Error { .. } => {}
         }
     }
 

--- a/compiler/noirc_frontend/src/elaborator/expressions.rs
+++ b/compiler/noirc_frontend/src/elaborator/expressions.rs
@@ -2192,20 +2192,37 @@ impl Elaborator<'_> {
                     self.revalidate_resolved_expression(for_statement.end_range);
                     self.revalidate_resolved_expression(for_statement.block);
                 }
-                HirStatement::Loop(block) => self.revalidate_resolved_expression(block),
+                HirStatement::Loop(block) => {
+                    if self.in_constrained_function() {
+                        let location = self.interner.statement_location(*statement);
+                        self.push_err(ResolverError::LoopInConstrainedFn { location });
+                    }
+                    self.revalidate_resolved_expression(block);
+                }
                 HirStatement::While(condition, block) => {
+                    if self.in_constrained_function() {
+                        let location = self.interner.statement_location(*statement);
+                        self.push_err(ResolverError::WhileInConstrainedFn { location });
+                    }
                     self.revalidate_resolved_expression(condition);
                     self.revalidate_resolved_expression(block);
                 }
                 HirStatement::Expression(expr) | HirStatement::Semi(expr) => {
                     self.revalidate_resolved_expression(expr);
                 }
-                HirStatement::Break
-                | HirStatement::Continue
-                | HirStatement::Comptime(_)
+                HirStatement::Break => self.revalidate_resolved_jump(*statement, true),
+                HirStatement::Continue => self.revalidate_resolved_jump(*statement, false),
+                HirStatement::Comptime(_)
                 | HirStatement::TraitAssociatedConstant
                 | HirStatement::Error => {}
             }
+        }
+    }
+
+    fn revalidate_resolved_jump(&mut self, statement: StmtId, is_break: bool) {
+        if self.in_constrained_function() {
+            let location = self.interner.statement_location(statement);
+            self.push_err(ResolverError::JumpInConstrainedFn { is_break, location });
         }
     }
 

--- a/compiler/noirc_frontend/src/elaborator/expressions.rs
+++ b/compiler/noirc_frontend/src/elaborator/expressions.rs
@@ -159,7 +159,10 @@ impl Elaborator<'_> {
             ExpressionKind::Unsafe(unsafe_expression) => {
                 self.elaborate_unsafe_block(unsafe_expression, target_type)
             }
-            ExpressionKind::Resolved(id) => return (id, self.interner.id_type(id)),
+            ExpressionKind::Resolved(id) => {
+                self.revalidate_resolved_expression(id);
+                return (id, self.interner.id_type(id));
+            }
             ExpressionKind::Interned(id) => {
                 let expr_kind = self.interner.get_expression_kind(id);
                 let expr = Expression::new(expr_kind.clone(), expr.location);
@@ -2037,5 +2040,192 @@ impl Elaborator<'_> {
         let typ = self.type_check_variable_with_bindings(ident, &id, generics, bindings);
         let id = self.intern_expr_type(id, typ.clone());
         (id, typ)
+    }
+
+    /// Re-validate an already-elaborated expression that is being spliced into the current context
+    /// via an unquote marker (an `ExpressionKind::Resolved`).
+    ///
+    /// `Expr::resolve` elaborates a quoted expression eagerly, in whatever function/runtime-mode/
+    /// module context it was given, and stores the resulting `ExprId` inside a `TypedExpr`. When
+    /// that `TypedExpr` is later unquoted into a different expansion the context-sensitive checks
+    /// performed during the original elaboration no longer hold. Without revalidation a constrained
+    /// function could reach an unconstrained one without an `unsafe` block, `verify_proof_with_type`
+    /// could end up in Brillig, or a reference to a comptime local could escape its defining scope
+    /// and reach later compiler phases. We re-run those checks here against the splice site.
+    pub(super) fn revalidate_resolved_expression(&mut self, expr_id: ExprId) {
+        match self.interner.expression(&expr_id) {
+            HirExpression::Ident(ident, _) => {
+                // A reference to a comptime local is normally replaced by its value when used in
+                // runtime code (see `elaborate_variable`). A resolved expression bypasses that, so
+                // a raw reference to a comptime local can only have come from a scope that is no
+                // longer live here.
+                if !self.in_comptime_context()
+                    && let Some(definition) = self.interner.try_definition(ident.id)
+                    && definition.is_comptime_local()
+                {
+                    let name = definition.name.clone();
+                    self.push_err(ResolverError::ComptimeVariableEscapesScope {
+                        name,
+                        location: ident.location,
+                    });
+                }
+            }
+            HirExpression::Call(call) => {
+                self.revalidate_resolved_expression(call.func);
+                for argument in &call.arguments {
+                    self.revalidate_resolved_expression(*argument);
+                }
+
+                let func_type = self.interner.id_type(call.func);
+                let args = vecmap(&call.arguments, |argument| {
+                    (
+                        self.interner.id_type(*argument),
+                        *argument,
+                        self.interner.expr_location(argument),
+                    )
+                });
+                let crossing_runtime_boundary =
+                    self.check_call_runtime_boundary(call.func, &func_type, &args, call.location);
+                if crossing_runtime_boundary {
+                    let return_type = self.interner.id_type(expr_id);
+                    self.check_unconstrained_call_return(&return_type, call.location);
+                }
+            }
+            HirExpression::Literal(literal) => match literal {
+                HirLiteral::Array(array) | HirLiteral::Vector(array) => match array {
+                    HirArrayLiteral::Standard(elements) => {
+                        for element in elements {
+                            self.revalidate_resolved_expression(element);
+                        }
+                    }
+                    HirArrayLiteral::Repeated { repeated_element, length: _ } => {
+                        self.revalidate_resolved_expression(repeated_element);
+                    }
+                },
+                HirLiteral::FmtStr(_, exprs, _) => {
+                    for expr in exprs {
+                        self.revalidate_resolved_expression(expr);
+                    }
+                }
+                HirLiteral::Bool(_)
+                | HirLiteral::Integer(_)
+                | HirLiteral::Str(_)
+                | HirLiteral::Unit => {}
+            },
+            HirExpression::Block(block) | HirExpression::Unsafe(block) => {
+                self.revalidate_resolved_block(&block);
+            }
+            HirExpression::Prefix(prefix) => {
+                self.revalidate_resolved_expression(prefix.rhs);
+            }
+            HirExpression::Infix(infix) => {
+                self.revalidate_resolved_expression(infix.lhs);
+                self.revalidate_resolved_expression(infix.rhs);
+            }
+            HirExpression::Index(index) => {
+                self.revalidate_resolved_expression(index.collection);
+                self.revalidate_resolved_expression(index.index);
+            }
+            HirExpression::Constructor(constructor) => {
+                for (_, field) in constructor.fields {
+                    self.revalidate_resolved_expression(field);
+                }
+            }
+            HirExpression::EnumConstructor(constructor) => {
+                for argument in constructor.arguments {
+                    self.revalidate_resolved_expression(argument);
+                }
+            }
+            HirExpression::MemberAccess(member_access) => {
+                self.revalidate_resolved_expression(member_access.lhs);
+            }
+            HirExpression::Constrain(constrain) => {
+                self.revalidate_resolved_expression(constrain.0);
+                if let Some(message) = constrain.2 {
+                    self.revalidate_resolved_expression(message);
+                }
+            }
+            HirExpression::Cast(cast) => {
+                self.revalidate_resolved_expression(cast.lhs);
+            }
+            HirExpression::If(if_expr) => {
+                self.revalidate_resolved_expression(if_expr.condition);
+                self.revalidate_resolved_expression(if_expr.consequence);
+                if let Some(alternative) = if_expr.alternative {
+                    self.revalidate_resolved_expression(alternative);
+                }
+            }
+            HirExpression::Tuple(elements) => {
+                for element in elements {
+                    self.revalidate_resolved_expression(element);
+                }
+            }
+            HirExpression::Lambda(lambda) => {
+                // A lambda body has its own runtime mode, so re-run the checks with that mode in
+                // effect rather than the enclosing function's.
+                self.lambda_stack.push(LambdaContext {
+                    captures: Vec::new(),
+                    scope_index: 0,
+                    unconstrained: lambda.unconstrained,
+                });
+                self.revalidate_resolved_expression(lambda.body);
+                self.lambda_stack.pop();
+            }
+            HirExpression::Match(match_expr) => {
+                self.revalidate_resolved_match(&match_expr);
+            }
+            HirExpression::Quote(_) | HirExpression::Unquote(_) | HirExpression::Error => {}
+        }
+    }
+
+    fn revalidate_resolved_block(&mut self, block: &HirBlockExpression) {
+        for statement in &block.statements {
+            match self.interner.statement(statement) {
+                HirStatement::Let(let_statement) => {
+                    self.revalidate_resolved_expression(let_statement.expression);
+                }
+                HirStatement::Assign(assign) => {
+                    self.revalidate_resolved_expression(assign.expression);
+                }
+                HirStatement::For(for_statement) => {
+                    self.revalidate_resolved_expression(for_statement.start_range);
+                    self.revalidate_resolved_expression(for_statement.end_range);
+                    self.revalidate_resolved_expression(for_statement.block);
+                }
+                HirStatement::Loop(block) => self.revalidate_resolved_expression(block),
+                HirStatement::While(condition, block) => {
+                    self.revalidate_resolved_expression(condition);
+                    self.revalidate_resolved_expression(block);
+                }
+                HirStatement::Expression(expr) | HirStatement::Semi(expr) => {
+                    self.revalidate_resolved_expression(expr);
+                }
+                HirStatement::Break
+                | HirStatement::Continue
+                | HirStatement::Comptime(_)
+                | HirStatement::TraitAssociatedConstant
+                | HirStatement::Error => {}
+            }
+        }
+    }
+
+    fn revalidate_resolved_match(&mut self, match_expr: &HirMatch) {
+        match match_expr {
+            HirMatch::Success(expr) => self.revalidate_resolved_expression(*expr),
+            HirMatch::Failure { .. } => {}
+            HirMatch::Guard { cond, body, otherwise } => {
+                self.revalidate_resolved_expression(*cond);
+                self.revalidate_resolved_expression(*body);
+                self.revalidate_resolved_match(otherwise);
+            }
+            HirMatch::Switch(_, cases, default) => {
+                for case in cases {
+                    self.revalidate_resolved_match(&case.body);
+                }
+                if let Some(default) = default {
+                    self.revalidate_resolved_match(default);
+                }
+            }
+        }
     }
 }

--- a/compiler/noirc_frontend/src/elaborator/types.rs
+++ b/compiler/noirc_frontend/src/elaborator/types.rs
@@ -3353,22 +3353,53 @@ impl Elaborator<'_> {
             lints::deprecated_function(elaborator.interner, call.func).map(Into::into)
         });
 
+        let crossing_runtime_boundary =
+            self.check_call_runtime_boundary(call.func, &func_type, &args, location);
+
+        let return_type = self.bind_function_type(func_type, args, location);
+
+        if crossing_runtime_boundary {
+            self.check_unconstrained_call_return(&return_type, location);
+        }
+
+        return_type
+    }
+
+    /// Re-runs the runtime-mode-dependent validity checks for a call against the *current*
+    /// elaboration context: that `verify_proof_with_type` is not reached from an unconstrained
+    /// context, and that a constrained function only reaches an unconstrained one from within an
+    /// `unsafe` block (with its arguments suitably constrained).
+    ///
+    /// Returns whether the call crosses the constrained/unconstrained boundary, in which case the
+    /// caller must also validate the return type with [`Self::check_unconstrained_call_return`]
+    /// once it is known.
+    ///
+    /// This is shared between regular call type-checking and the revalidation of resolved
+    /// expressions spliced in from a comptime `Expr::resolve`, which were originally elaborated in
+    /// a different context (see [`Self::revalidate_resolved_expression`]).
+    pub(super) fn check_call_runtime_boundary(
+        &mut self,
+        func: ExprId,
+        func_type: &Type,
+        args: &[(Type, ExprId, Location)],
+        location: Location,
+    ) -> bool {
         let is_current_func_constrained = self.in_constrained_function();
         if !is_current_func_constrained {
             // Check if we're calling verify_proof_with_type in an unconstrained context
             self.run_lint(|elaborator| {
-                lints::error_if_verify_proof_with_type(elaborator.interner, call.func, location)
+                lints::error_if_verify_proof_with_type(elaborator.interner, func, location)
             });
         }
 
         let func_type_is_unconstrained =
-            if let Type::Function(_args, _ret, _env, unconstrained) = &func_type {
+            if let Type::Function(_args, _ret, _env, unconstrained) = func_type {
                 *unconstrained
             } else {
                 false
             };
 
-        let func_is_unconstrained_call = match self.is_unconstrained_call(call.func, location) {
+        let func_is_unconstrained_call = match self.is_unconstrained_call(func, location) {
             Ok(result) => result,
             Err(error) => {
                 self.push_err(error);
@@ -3397,24 +3428,28 @@ impl Elaborator<'_> {
             // the check reports a spurious "mutable reference" error. This
             // matters inside recursive `elaborate_items` (from `run_attributes`)
             // where outer-pending structs haven't been drained yet.
-            for (typ, _, _) in &args {
+            for (typ, _, _) in args {
                 self.define_deferred_data_types_in(typ);
             }
 
-            let errors = lints::unconstrained_function_args(&args);
+            let errors = lints::unconstrained_function_args(args);
             self.push_errors(errors);
         }
 
-        let return_type = self.bind_function_type(func_type, args, location);
+        crossing_runtime_boundary
+    }
 
-        if crossing_runtime_boundary {
-            self.define_deferred_data_types_in(&return_type);
-            self.run_lint(|_| {
-                lints::unconstrained_function_return(&return_type, location).map(Into::into)
-            });
-        }
-
-        return_type
+    /// Companion to [`Self::check_call_runtime_boundary`]: validates the return type of a call that
+    /// crosses the constrained/unconstrained boundary.
+    pub(super) fn check_unconstrained_call_return(
+        &mut self,
+        return_type: &Type,
+        location: Location,
+    ) {
+        self.define_deferred_data_types_in(return_type);
+        self.run_lint(|_| {
+            lints::unconstrained_function_return(return_type, location).map(Into::into)
+        });
     }
 
     /// Check if the callee is an unconstrained function, or a variable referring to one.

--- a/compiler/noirc_frontend/src/hir/resolution/errors.rs
+++ b/compiler/noirc_frontend/src/hir/resolution/errors.rs
@@ -167,6 +167,8 @@ pub enum ResolverError {
     ComptimeTypeInNonComptimeItem { typ: String, location: Location, item: &'static str },
     #[error("Comptime variable `{name}` cannot be mutated in a non-comptime context")]
     MutatingComptimeInNonComptimeContext { name: String, location: Location },
+    #[error("Comptime variable `{name}` cannot be used in runtime code")]
+    ComptimeVariableEscapesScope { name: String, location: Location },
     #[error("Failed to parse `{statement}` as an expression")]
     InvalidInternedStatementInExpr { statement: String, location: Location },
     #[error("{0}")]
@@ -306,6 +308,7 @@ impl ResolverError {
             | ResolverError::QuoteInRuntimeCode { location }
             | ResolverError::ComptimeTypeInNonComptimeItem { location, .. }
             | ResolverError::MutatingComptimeInNonComptimeContext { location, .. }
+            | ResolverError::ComptimeVariableEscapesScope { location, .. }
             | ResolverError::InvalidInternedStatementInExpr { location, .. }
             | ResolverError::InvalidSyntaxInPattern { location }
             | ResolverError::NonIntegerGlobalUsedInPattern { location, .. }
@@ -854,6 +857,13 @@ impl<'a> From<&'a ResolverError> for Diagnostic {
                 Diagnostic::simple_error(
                     format!("Comptime variable `{name}` cannot be mutated in a non-comptime context"),
                     format!("`{name}` mutated here"),
+                    *location,
+                )
+            },
+            ResolverError::ComptimeVariableEscapesScope { name, location } => {
+                Diagnostic::simple_error(
+                    format!("Comptime variable `{name}` cannot be used in runtime code"),
+                    format!("`{name}` was resolved in a comptime scope that is no longer in scope here"),
                     *location,
                 )
             },

--- a/compiler/noirc_frontend/src/tests/metaprogramming.rs
+++ b/compiler/noirc_frontend/src/tests/metaprogramming.rs
@@ -3092,7 +3092,8 @@ fn resolve_revalidates_while_loop_spliced_into_constrained() {
     let src = r#"
     comptime fn emit(_f: FunctionDefinition) -> Quoted {
         let body = quote { { while true {} } }.as_expr().unwrap().resolve(Option::none());
-                          ^^^^^^^^^^^^^^^^^^^^ `while` is only allowed in unconstrained functions
+                             ^^^^^^^^^^^^^ `while` is only allowed in unconstrained functions
+                             ~~~~~~~~~~~~~ Constrained code must always have a known number of loop iterations
         quote {
             fn generated() {
                 $body
@@ -3101,6 +3102,7 @@ fn resolve_revalidates_while_loop_spliced_into_constrained() {
     }
 
     #[emit]
+    ~~~~~~~ While running this function attribute
     fn main() {
         generated()
     }
@@ -3113,7 +3115,10 @@ fn resolve_revalidates_loop_spliced_into_constrained() {
     let src = r#"
     comptime fn emit(_f: FunctionDefinition) -> Quoted {
         let body = quote { { loop { break; } } }.as_expr().unwrap().resolve(Option::none());
-                          ^^^^^^^^^^^^^^^^^^^^^^ `loop` is only allowed in unconstrained functions
+                             ^^^^^^^^^^^^^^^ `loop` is only allowed in unconstrained functions
+                             ~~~~~~~~~~~~~~~ Constrained code must always have a known number of loop iterations
+                                    ^^^^^^ break is only allowed in unconstrained functions
+                                    ~~~~~~ Constrained code must always have a known number of loop iterations
         quote {
             fn generated() {
                 $body
@@ -3122,6 +3127,7 @@ fn resolve_revalidates_loop_spliced_into_constrained() {
     }
 
     #[emit]
+    ~~~~~~~ While running this function attribute
     fn main() {
         generated()
     }
@@ -3134,7 +3140,8 @@ fn resolve_revalidates_break_spliced_into_constrained() {
     let src = r#"
     comptime fn emit(_f: FunctionDefinition) -> Quoted {
         let body = quote { { for _ in 0..3 { break; } } }.as_expr().unwrap().resolve(Option::none());
-                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ break is only allowed in unconstrained functions
+                                             ^^^^^^ break is only allowed in unconstrained functions
+                                             ~~~~~~ Constrained code must always have a known number of loop iterations
         quote {
             fn generated() {
                 $body
@@ -3143,6 +3150,7 @@ fn resolve_revalidates_break_spliced_into_constrained() {
     }
 
     #[emit]
+    ~~~~~~~ While running this function attribute
     fn main() {
         generated()
     }

--- a/compiler/noirc_frontend/src/tests/metaprogramming.rs
+++ b/compiler/noirc_frontend/src/tests/metaprogramming.rs
@@ -2524,6 +2524,11 @@ const META_API_STDLIB: &str = r#"
         #[builtin(function_def_as_typed_expr)]
         pub comptime fn as_typed_expr(self) -> TypedExpr {}
     }
+
+    impl TypedExpr {
+        #[builtin(typed_expr_as_function_definition)]
+        pub comptime fn as_function_definition(self) -> Option<FunctionDefinition> {}
+    }
 "#;
 
 #[test]
@@ -2976,4 +2981,108 @@ fn qualified_self_assoc_in_macro_inside_comptime_block_inside_impl_method() {
     }
     "#;
     assert_no_errors(src);
+}
+
+// `Expr::resolve` elaborates a quoted expression eagerly and stores the resulting `ExprId`
+// inside a `TypedExpr`. When that `TypedExpr` is later unquoted into a different context the
+// elaborator must revalidate it against the splice site rather than trusting the context it
+// was originally resolved in. The following tests pin that revalidation.
+
+#[test]
+fn resolve_does_not_let_comptime_local_escape_into_runtime() {
+    let src = r#"
+    comptime fn emit(_f: FunctionDefinition) -> Quoted {
+        let secret = 42;
+        let _ = secret;
+        let typed = quote { secret }.as_expr().unwrap().resolve(Option::none());
+                            ^^^^^^ Comptime variable `secret` cannot be used in runtime code
+                            ~~~~~~ `secret` was resolved in a comptime scope that is no longer in scope here
+        quote {
+            fn generated() -> Field {
+                $typed
+            }
+        }
+    }
+
+    #[emit]
+    ~~~~~~~ While running this function attribute
+    fn main() -> pub Field {
+        generated()
+    }
+    "#;
+    check_errors_with_stdlib(src, [META_API_STDLIB]);
+}
+
+#[test]
+fn resolve_revalidates_unconstrained_call_spliced_into_constrained() {
+    let src = r#"
+    unconstrained fn helper() -> Field {
+        0
+    }
+
+    comptime fn emit(_f: FunctionDefinition) -> Quoted {
+        let call = quote { helper() }.as_expr().unwrap().resolve(Option::none());
+                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Call to unconstrained function from constrained function is unsafe and must be in an unconstrained function or unsafe block
+        quote {
+            fn generated() -> Field {
+                $call
+            }
+        }
+    }
+
+    #[emit]
+    ~~~~~~~ While running this function attribute
+    fn main() -> pub Field {
+        generated()
+    }
+    "#;
+    check_errors_with_stdlib(src, [META_API_STDLIB]);
+}
+
+#[test]
+fn resolve_revalidates_verify_proof_spliced_into_unconstrained() {
+    let stdlib = r#"
+    pub fn verify_proof_with_type<let N: u32, let M: u32, let K: u32>(
+        _verification_key: [Field; N],
+        _proof: [Field; M],
+        _public_inputs: [Field; K],
+        _key_hash: Field,
+        _proof_type: u32,
+    ) {}
+    "#;
+    let src = r#"
+    comptime fn emit(_f: FunctionDefinition) -> Quoted {
+        let scope = quote { safe_scope }
+            .as_expr()
+            .unwrap()
+            .resolve(Option::none())
+            .as_function_definition()
+            .unwrap();
+
+        let call = quote {
+            crate::verify_proof_with_type([0; 114], [0; 94], [0], 0, 0)
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Cannot call `std::verify_proof_with_type` in unconstrained context
+        }
+            .as_expr()
+            .unwrap()
+            .resolve(Option::some(scope));
+
+        quote {
+            unconstrained fn generated() {
+                $call
+            }
+        }
+    }
+
+    fn safe_scope() {}
+
+    #[emit]
+    ~~~~~~~ While running this function attribute
+    fn main() {
+        safe_scope();
+        // Safety: test
+        unsafe { generated() };
+    }
+    "#;
+    check_errors_with_stdlib(src, [META_API_STDLIB, stdlib]);
 }

--- a/compiler/noirc_frontend/src/tests/metaprogramming.rs
+++ b/compiler/noirc_frontend/src/tests/metaprogramming.rs
@@ -3212,3 +3212,75 @@ fn resolve_allows_unconstrained_call_spliced_into_unsafe_block() {
     "#;
     check_errors_with_stdlib(src, [META_API_STDLIB]);
 }
+
+// An assignment target referencing a comptime local must be revalidated just like a read: the
+// `Assign` lvalue is walked so the comptime local cannot escape into runtime code (where it would
+// otherwise reach monomorphization with no value).
+#[test]
+fn resolve_does_not_let_comptime_local_escape_via_assignment_lvalue() {
+    let src = r#"
+    comptime fn emit(_f: FunctionDefinition) -> Quoted {
+        let mut secret = 42;
+        secret = 0;
+        let _ = secret;
+        let typed = quote { { secret = 1; } }.as_expr().unwrap().resolve(Option::none());
+                              ^^^^^^ Comptime variable `secret` cannot be used in runtime code
+                              ~~~~~~ `secret` was resolved in a comptime scope that is no longer in scope here
+        quote {
+            fn generated() {
+                $typed
+            }
+        }
+    }
+
+    #[emit]
+    ~~~~~~~ While running this function attribute
+    fn main() {
+        generated()
+    }
+    "#;
+    check_errors_with_stdlib(src, [META_API_STDLIB]);
+}
+
+// Revalidation must preserve the unsafe-block context of a resolved expression: an unconstrained
+// call wrapped in an `unsafe` block *inside* the resolved expression crosses the boundary legally,
+// so it must not be reported as needing an `unsafe` block at the splice site.
+#[test]
+fn resolve_allows_unconstrained_call_in_resolved_unsafe_block() {
+    let src = r#"
+    unconstrained fn helper() -> Field {
+        0
+    }
+
+    comptime fn emit(_f: FunctionDefinition) -> Quoted {
+        let scope = quote { constrained_scope }
+            .as_expr()
+            .unwrap()
+            .resolve(Option::none())
+            .as_function_definition()
+            .unwrap();
+
+        let call = quote {
+            // Safety: test
+            unsafe { helper() }
+        }
+            .as_expr()
+            .unwrap()
+            .resolve(Option::some(scope));
+
+        quote {
+            fn generated() -> Field {
+                $call
+            }
+        }
+    }
+
+    fn constrained_scope() {}
+
+    #[emit]
+    fn main() -> pub Field {
+        generated()
+    }
+    "#;
+    check_errors_with_stdlib(src, [META_API_STDLIB]);
+}

--- a/compiler/noirc_frontend/src/tests/metaprogramming.rs
+++ b/compiler/noirc_frontend/src/tests/metaprogramming.rs
@@ -3086,3 +3086,121 @@ fn resolve_revalidates_verify_proof_spliced_into_unconstrained() {
     "#;
     check_errors_with_stdlib(src, [META_API_STDLIB, stdlib]);
 }
+
+#[test]
+fn resolve_revalidates_while_loop_spliced_into_constrained() {
+    let src = r#"
+    comptime fn emit(_f: FunctionDefinition) -> Quoted {
+        let body = quote { { while true {} } }.as_expr().unwrap().resolve(Option::none());
+                          ^^^^^^^^^^^^^^^^^^^^ `while` is only allowed in unconstrained functions
+        quote {
+            fn generated() {
+                $body
+            }
+        }
+    }
+
+    #[emit]
+    fn main() {
+        generated()
+    }
+    "#;
+    check_errors_with_stdlib(src, [META_API_STDLIB]);
+}
+
+#[test]
+fn resolve_revalidates_loop_spliced_into_constrained() {
+    let src = r#"
+    comptime fn emit(_f: FunctionDefinition) -> Quoted {
+        let body = quote { { loop { break; } } }.as_expr().unwrap().resolve(Option::none());
+                          ^^^^^^^^^^^^^^^^^^^^^^ `loop` is only allowed in unconstrained functions
+        quote {
+            fn generated() {
+                $body
+            }
+        }
+    }
+
+    #[emit]
+    fn main() {
+        generated()
+    }
+    "#;
+    check_errors_with_stdlib(src, [META_API_STDLIB]);
+}
+
+#[test]
+fn resolve_revalidates_break_spliced_into_constrained() {
+    let src = r#"
+    comptime fn emit(_f: FunctionDefinition) -> Quoted {
+        let body = quote { { for _ in 0..3 { break; } } }.as_expr().unwrap().resolve(Option::none());
+                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ break is only allowed in unconstrained functions
+        quote {
+            fn generated() {
+                $body
+            }
+        }
+    }
+
+    #[emit]
+    fn main() {
+        generated()
+    }
+    "#;
+    check_errors_with_stdlib(src, [META_API_STDLIB]);
+}
+
+// The revalidation walk recurses into the structure of a resolved expression, so a
+// boundary-crossing call nested inside a block is caught the same as a top-level one.
+#[test]
+fn resolve_revalidates_unconstrained_call_nested_in_block() {
+    let src = r#"
+    unconstrained fn helper() -> Field {
+        0
+    }
+
+    comptime fn emit(_f: FunctionDefinition) -> Quoted {
+        let body = quote { { helper() } }.as_expr().unwrap().resolve(Option::none());
+                             ^^^^^^^^ Call to unconstrained function from constrained function is unsafe and must be in an unconstrained function or unsafe block
+        quote {
+            fn generated() -> Field {
+                $body
+            }
+        }
+    }
+
+    #[emit]
+    ~~~~~~~ While running this function attribute
+    fn main() -> pub Field {
+        generated()
+    }
+    "#;
+    check_errors_with_stdlib(src, [META_API_STDLIB]);
+}
+
+// Revalidation must not reject a resolved unconstrained call that is spliced into an
+// `unsafe` block: the boundary is crossed legally there, exactly as for hand-written code.
+#[test]
+fn resolve_allows_unconstrained_call_spliced_into_unsafe_block() {
+    let src = r#"
+    unconstrained fn helper() -> Field {
+        0
+    }
+
+    comptime fn emit(_f: FunctionDefinition) -> Quoted {
+        let call = quote { helper() }.as_expr().unwrap().resolve(Option::none());
+        quote {
+            fn generated() -> Field {
+                // Safety: test
+                unsafe { $call }
+            }
+        }
+    }
+
+    #[emit]
+    fn main() -> pub Field {
+        generated()
+    }
+    "#;
+    check_errors_with_stdlib(src, [META_API_STDLIB]);
+}


### PR DESCRIPTION
## Summary

`Expr::resolve` elaborates a quoted expression eagerly — in whatever function / runtime-mode / module context it is given — and caches the resulting `ExprId` inside a `TypedExpr`. When that `TypedExpr` is later unquoted into a *different* expansion, the elaborator's `ExpressionKind::Resolved` arm returned the cached `ExprId` verbatim with **no revalidation**. Context-sensitive checks that ran during the original `resolve` were never re-applied at the splice site, so they could be bypassed by resolving code in one context and unquoting it in another.

This bypass is reachable from ordinary Noir source and produced several failures, none of which were caught at the frontend:

- A reference to a comptime local could escape its defining scope into runtime code, reaching monomorphization with no value (`error: ICE: Variable not found during monomorphization`).
- `verify_proof_with_type` resolved in a constrained scope could be moved into an `unconstrained` function, **panicking** in brillig codegen (`ICE: BlackBoxFunc::RecursiveAggregation calls are disallowed in Brillig`).
- An unconstrained call resolved in a comptime context could be spliced into a constrained function without an `unsafe` block, silently skipping the frontend safety check.
- A `loop` / `while` / `break` / `continue` resolved inside a block expression could be spliced into a constrained function, bypassing the "only allowed in unconstrained functions" checks. The `while` case in particular went on to **panic** in SSA unrolling (`back edge should have at least 1 argument`).

## Fix

Walk the resolved expression at the splice site and re-run the context-sensitive checks against the **current** context:

- A reference to a comptime local is rejected when it escapes into runtime code (new `ResolverError::ComptimeVariableEscapesScope`).
- Calls re-run the constrained/unconstrained boundary checks (factored out of `type_check_call` into `check_call_runtime_boundary` / `check_unconstrained_call_return`), so `verify_proof_with_type` cannot be smuggled into Brillig and a constrained function cannot reach an unconstrained one outside an `unsafe` block.
- `loop` / `while` / `break` / `continue` re-run the constrained-context checks, mirroring `elaborate_loop` / `elaborate_while` / `elaborate_jump`.

The walk recurses through the structure of the resolved expression (blocks, `if`, calls, etc.), and is gated correctly: a resolved unconstrained call spliced into an `unsafe { }` block still compiles, and `resolve` results used within `comptime { }` blocks (e.g. `.get_type()` / `.as_function_definition()`) are unaffected.

## Testing

Regression tests in `metaprogramming.rs`, one per failure mode, split into red/green commits so the buggy-then-fixed transition is preserved:

- comptime-local escape, unconstrained-call boundary, `verify_proof_with_type`-in-Brillig
- `loop`, `while`, and `break` spliced into constrained code
- characterization tests locking in the recursion: a boundary-crossing call nested in a resolved block is still caught, and one spliced into an `unsafe` block is still allowed.

All 2129 `noirc_frontend` tests pass (including `comptime_as_typed_expr_visibility` — no false positives), and the existing `resolve`-using test programs (`comptime_shadowed_variable_resolution`, `comptime_typed_expr`, `comptime_function_definition`, `comptime_location`, `comptime_resolve_associated_constant_scope`, and `comptime_expr`'s 33 tests) continue to pass.

## Notes

- These reproductions are compiler **robustness** failures (ICEs / panics) and a bypassed frontend safety check; none produced a silently-unsound proving artifact. The fix closes the missing-revalidation class regardless.
- `resolve` already enforces item **visibility** at resolve-time (via `caller_module`, covered by `comptime_as_typed_expr_visibility`), so this PR does not add splice-time visibility revalidation. That would be a natural follow-up if desired.