### PR TITLE
fix: ts codegen for Unit/void functions

### DIFF
--- a/tooling/noir_codegen/src/utils/typings_generator.ts
+++ b/tooling/noir_codegen/src/utils/typings_generator.ts
@@ -317,13 +317,19 @@ const codegenFunction = (
     ? `export const ${name}_circuit: CompiledCircuit = ${JSON.stringify(compiled_program)};`
     : '';
 
+  const returnType = function_signature.returnValue;
+  const hasReturnValue = returnType != null;
+  const body = hasReturnValue
+    ? `  const { returnValue } = await program.execute(args, foreignCallHandler);
+  return returnValue as ${returnType};`
+    : `  await program.execute(args, foreignCallHandler);`;
+
   return `${artifact}
 
-export async function ${name}(${args_with_types_joined_by_comma}): Promise<${function_signature.returnValue}> {
+export async function ${name}(${args_with_types_joined_by_comma}): Promise<${hasReturnValue ? returnType : 'void'}> {
   const program = new Noir(${name}_circuit);
   const args: InputMap = { ${args} };
-  const { returnValue } = await program.execute(args, foreignCallHandler);
-  return returnValue as ${function_signature.returnValue};
+${body}
 }
 `;
 };

--- a/tooling/noir_codegen/test/index.test.ts
+++ b/tooling/noir_codegen/test/index.test.ts
@@ -1,9 +1,12 @@
 import { expect } from 'chai';
+import { CompiledCircuit } from '@noir-lang/types';
+import { codegen } from '../src/index.js';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore File is codegenned at test time.
 import {
   exported_function_foo,
   exported_function_baz,
+  exported_function_void,
   MyStruct,
   u64,
   u32,
@@ -115,4 +118,26 @@ it('allows passing a custom foreign call handler', async () => {
 it('codegens a callable argless function', async () => {
   const val: u64 = await exported_function_baz();
   expect(val).to.be.eq('0x01');
+});
+
+it('codegens a callable function with no return value', async () => {
+  const result = await exported_function_void('1');
+  expect(result).to.be.undefined;
+});
+
+it('codegens `Promise<void>` for functions with no return value', () => {
+  const program: CompiledCircuit = {
+    abi: {
+      parameters: [{ name: 'x', type: { kind: 'integer', sign: 'unsigned', width: 64 }, visibility: 'private' }],
+      return_type: null,
+      error_types: {},
+    },
+    bytecode: '',
+  } as unknown as CompiledCircuit;
+
+  const generated = codegen([['my_void_fn', program]], false, false);
+
+  expect(generated).to.include('Promise<void>');
+  expect(generated).to.not.include('Promise<null>');
+  expect(generated).to.not.include('as null');
 });

--- a/tooling/noir_codegen/test/test_lib/src/lib.nr
+++ b/tooling/noir_codegen/test/test_lib/src/lib.nr
@@ -36,3 +36,8 @@ fn exported_function_bar(my_struct: NestedStruct<1, 2, 3, u64>) -> (u64) {
 fn exported_function_baz() -> u64 {
     1
 }
+
+#[export]
+fn exported_function_void(x: u64) {
+    assert(x < 10);
+}


### PR DESCRIPTION
## Problem Resolved

Resolves #9840 

## Summary of Changes

I don't know too much about the ts we generate so CC @TomAFrench for review

noir_codegen generated invalid TypeScript for `#[export]`ed functions with no return value. `function_signature.returnValue` was null, and interpolating it into the output template produced the text "null" yielding Promise<null> and return returnValue as null;, which breaks consumers' TypeScript builds.

codegenFunction now branches on whether a return value exists:
  - No return value: annotate Promise<void>, skip the returnValue destructuring (avoids an unused-variable error), and emit no return statement.
  - Has a return value: unchanged.

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [ ] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
