### PR TITLE
fix: prevent stack overflow on deeply nested blocks

### DIFF
--- a/compiler/noirc_frontend/src/parser/parser/expression.rs
+++ b/compiler/noirc_frontend/src/parser/parser/expression.rs
@@ -1122,7 +1122,10 @@ impl Parser<'_> {
             return None;
         }
 
-        Some(self.parse_block_after_left_brace())
+        // Guard against deeply nested blocks overflowing the stack. On overflow this
+        // emits a recursion-depth error and skips to a recovery point, so `None` here
+        // means the block was abandoned rather than absent.
+        self.with_max_recursion_depth_guard(|this| Some(this.parse_block_after_left_brace()))
     }
 
     fn parse_block_after_left_brace(&mut self) -> BlockExpression {

--- a/compiler/noirc_frontend/src/tests/deeply_nested.rs
+++ b/compiler/noirc_frontend/src/tests/deeply_nested.rs
@@ -256,3 +256,21 @@ fn deeply_nested_expression_parser_overflow() {
 
     assert_parser_max_recursion_depth(&src, Some(1));
 }
+
+// stack overflow in the parser
+#[test]
+fn deeply_nested_blocks() {
+    // Creates: { { { ... { 0 } ... } } }
+    const DEPTH: usize = 2000;
+    let src = format!(
+        r#"
+    pub fn main() {{
+        {open}0{close}
+    }}
+    "#,
+        open = "{".repeat(DEPTH),
+        close = "}".repeat(DEPTH),
+    );
+
+    assert_parser_max_recursion_depth(&src, None);
+}


### PR DESCRIPTION
## Problem Resolved

Resolves #8354

## Summary of Changes

Adds a recursion guard when parsing blocks in the parser

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
