### PR TITLE
feat: batch spill

### DIFF
--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_block.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_block.rs
@@ -200,6 +200,16 @@ impl<'block, Registers: RegisterAllocator> BrilligBlock<'block, Registers> {
     /// we don't have access to the spill manager the context necessary to properly spill an
     /// SSA variable, so we have to make room in anticipation of such need.
     pub(crate) fn ensure_register_capacity(&mut self, n: usize) {
+        if !self.needs_spill_for(n) {
+            return;
+        }
+        // We need to spill `n - available` registers.
+        // We spill them by batch, which is more efficient and avoids
+        // some address computations in case of consecutive slots.
+        let available = self.brillig_context.registers().available_registers();
+        self.spill_lru_values(n.saturating_sub(available));
+
+        // Fall back to single spills, in case of.
         while self.needs_spill_for(n) {
             self.spill_lru_value();
         }
@@ -214,6 +224,42 @@ impl<'block, Registers: RegisterAllocator> BrilligBlock<'block, Registers> {
     fn codegen_spill_store(&mut self, offset: usize, source_reg: MemoryAddress) {
         let addr = self.codegen_spill_slot_address(offset);
         self.brillig_context.store_instruction(addr, source_reg);
+    }
+
+    /// Emit the stores for a batch of spills, computing the slot addresses incrementally.
+    ///
+    /// `stores` pairs each spill slot offset with the register holding the value to store.
+    /// Emitting them together lets a run of consecutive slots share a single address
+    /// computation: the first non-zero offset in a run is materialized with the usual
+    /// const + add (via [`Self::codegen_spill_slot_address`]), and every following slot in
+    /// the run only needs a single increment of the scratch address register — replacing
+    /// the per-slot const + add (2 opcodes) with one. Slot 0 is the spill base pointer
+    /// itself, so its store needs no address computation at all.
+    fn codegen_spill_stores(&mut self, mut stores: Vec<(usize, MemoryAddress)>) {
+        stores.sort_by_key(|(offset, _)| *offset);
+
+        let (scratch_addr, _) = ReservedRegisters::spill_scratch();
+        // The offset currently materialized in `scratch_addr`, if any.
+        let mut previous_offset: Option<usize> = None;
+
+        for (offset, source_reg) in stores {
+            let addr = if offset == 0 {
+                // Slot 0 is the spill base pointer directly.
+                previous_offset = None;
+                ReservedRegisters::spill_base_pointer()
+            } else if previous_offset == Some(offset - 1) {
+                // Consecutive with the previous slot: bump the address by one.
+                self.brillig_context.memory_op_inc_by_usize_one(scratch_addr);
+                previous_offset = Some(offset);
+                scratch_addr
+            } else {
+                // fallback to computing the slot address.
+                let addr = self.codegen_spill_slot_address(offset);
+                previous_offset = Some(offset);
+                addr
+            };
+            self.brillig_context.store_instruction(addr, source_reg);
+        }
     }
 
     /// Spill a value: record it in the spill manager, optionally emit a store to its slot,
@@ -313,6 +359,43 @@ impl<'block, Registers: RegisterAllocator> BrilligBlock<'block, Registers> {
         let sm = self.function_context.spill_manager.as_mut().unwrap();
         let victim_id = sm.lru_victim().expect("No values available to spill");
         self.spill_value(victim_id, false, true);
+    }
+
+    /// Spill the `k` least-recently-used values in a single batch.
+    ///
+    /// Batched version of [`Self::spill_lru_value`]. It records all `k`
+    /// spills first, updates the LRU once, and emits all the stores together
+    /// which allows to share address computations.
+    fn spill_lru_values(&mut self, k: usize) {
+        let sm = self.function_context.spill_manager.as_ref().unwrap();
+        let victims = sm.lru_victims(k);
+        if victims.is_empty() {
+            return;
+        }
+
+        // Record each spill and collect the stores that must be emitted. A value that
+        // already has a slot keeps it and does not need a store.
+        let mut stores = Vec::with_capacity(victims.len());
+        for value_id in &victims {
+            let var = *self.function_context.ssa_value_allocations.get(value_id).unwrap();
+            let sm = self.function_context.spill_manager.as_mut().unwrap();
+            let prior_offset = sm.get_spill_offset(value_id);
+            let offset = prior_offset.unwrap_or_else(|| sm.allocate_spill_offset());
+            sm.record_spill(*value_id, offset, var);
+            if prior_offset.is_none() {
+                stores.push((offset, var.extract_register()));
+            }
+        }
+
+        // Drop every victim from the LRU in a single pass.
+        let victim_set: HashSet<ValueId> = victims.iter().copied().collect();
+        self.function_context.spill_manager.as_mut().unwrap().remove_victims_from_lru(&victim_set);
+
+        // Emit the stores while the source registers are still allocated, then free them.
+        self.codegen_spill_stores(stores);
+        for value_id in &victims {
+            self.variables.remove_variable(value_id, self.function_context, self.brillig_context);
+        }
     }
 
     /// Reload a previously spilled value into a freshly allocated register

--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/spill_manager.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/spill_manager.rs
@@ -229,6 +229,19 @@ impl SpillManager {
         None
     }
 
+    /// Batched version of [`Self::lru_victim`]
+    ///
+    /// Return up to `k` least-recently-used values that are not currently spilled,
+    /// ordered least-recently-used first.
+    pub(crate) fn lru_victims(&self, k: usize) -> Vec<ValueId> {
+        self.lru_order.iter().copied().filter(|v| !self.is_spilled(v)).take(k).collect()
+    }
+
+    /// Remove every value in `victims` from LRU tracking in one shot.
+    pub(crate) fn remove_victims_from_lru(&mut self, victims: &HashSet<ValueId>) {
+        self.lru_order.retain(|v| !victims.contains(v));
+    }
+
     /// Record that a value has been spilled.
     ///
     /// If the value already has a record (e.g., it was reloaded and then
@@ -379,6 +392,7 @@ impl SpillManager {
 #[cfg(test)]
 mod tests {
     use acvm::acir::brillig::MemoryAddress;
+    use rustc_hash::FxHashSet as HashSet;
 
     use crate::{
         brillig::brillig_ir::brillig_variable::{BrilligVariable, SingleAddrVariable},
@@ -411,6 +425,26 @@ mod tests {
 
         // Victim should now be v1
         assert_eq!(sm.lru_victim(), Some(v1));
+    }
+
+    #[test]
+    fn remove_many_from_lru_drops_the_whole_set_in_one_pass() {
+        let mut sm = SpillManager::new();
+        let v0 = Id::test_new(0);
+        let v1 = Id::test_new(1);
+        let v2 = Id::test_new(2);
+        let v3 = Id::test_new(3);
+
+        sm.touch(v0);
+        sm.touch(v1);
+        sm.touch(v2);
+        sm.touch(v3);
+
+        let victims: HashSet<_> = [v0, v2].into_iter().collect();
+        sm.remove_victims_from_lru(&victims);
+
+        // Surviving entries keep their relative order: [v1, v3].
+        assert_eq!(sm.lru_victims(10), vec![v1, v3]);
     }
 
     #[test]

--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/tests/spill.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/tests/spill.rs
@@ -380,6 +380,46 @@ fn brillig_spill_does_not_leak_reloaded_permanent_values_bytecode() {
     ");
 }
 
+/// Quantify the opcode saving from batching consecutive spill-slot stores.
+///
+/// `codegen_make_array` calls `ensure_register_capacity(4)`. With all three
+/// parameters live across the array construction and only 4 usable registers,
+/// that one call must spill four values at once into freshly allocated,
+/// consecutive spill slots (0–3).
+/// Each consecutive slot after the first in a run is emitted as the increment
+/// `@3 = u32 add @3, @2` followed by a `store` — 2 opcodes — in place of the
+/// `const` + `add` + `store` (3 opcodes) the per-slot path would emit.
+#[test]
+fn brillig_spill_batch_reduces_consecutive_spill_opcodes() {
+    let src = "
+    brillig(inline) fn main f0 {
+      b0(v0: u32, v1: u32, v2: u32):
+        v4 = make_array [u32 0] : [u32; 1]
+        v5 = array_get v4, index u32 0 -> u32
+        v6 = unchecked_add v5, v0
+        v7 = unchecked_add v6, v1
+        v8 = unchecked_add v7, v2
+        return v8
+    }
+    ";
+
+    let layout = LayoutConfig::new(6, 16, MAX_SCRATCH_SPACE);
+    let options = BrilligOptions { layout, ..Default::default() };
+    let brillig = ssa_to_brillig_artifacts_with_options(src, &options);
+    let bytecode = brillig.ssa_function_to_brillig[&Id::test_new(0)].to_string();
+
+    // An increment-based spill advances the held scratch address to the next
+    // consecutive slot with `@3 = u32 add @3, @2` instead of recomputing the
+    // address with `const` + `add`.
+    let incremental_spills =
+        bytecode.lines().filter(|line| line.contains("@3 = u32 add @3, @2")).count();
+    assert!(
+        incremental_spills >= 2,
+        "expected the make_array batch to emit at least two increment-based spills, \
+         got {incremental_spills}"
+    );
+}
+
 /// Regression for issue #12266.
 ///
 /// On the previously buggy path, `spill_non_param_live_ins` marked reloaded values as


### PR DESCRIPTION
## Problem Resolved

Resolves #12291

## Summary of Changes
Batch spill in one shot instead of one-by-one.


## User Documentation

Check one:
- [X] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
