### PR TITLE
chore: refactor variable path resolution

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/function.rs
+++ b/compiler/noirc_frontend/src/elaborator/function.rs
@@ -241,14 +241,7 @@ impl Elaborator<'_> {
         let Some(info) = self.unresolved_function_metas.remove(&func_id) else {
             return;
         };
-        // Removing the function from `unresolved_function_metas` is permanent: it will never be
-        // re-resolved. The usage its signature records (e.g. an import used only in a parameter
-        // type) is therefore a committed fact, so it must survive even when this runs inside a
-        // failing speculative probe — which rolls back usage-marks but cannot undo the structural
-        // removal above. Suspend the probe's undo log so those marks are kept.
-        let suspended = self.usage_tracker.suspend_speculative();
         self.resolve_unresolved_function_meta(func_id, info);
-        self.usage_tracker.resume_speculative(suspended);
     }
 
     /// Lazily resolves a function's [`FuncMeta`] if needed, then returns it.

--- a/compiler/noirc_frontend/src/elaborator/function.rs
+++ b/compiler/noirc_frontend/src/elaborator/function.rs
@@ -257,12 +257,6 @@ impl Elaborator<'_> {
         self.interner.function_meta(&func_id)
     }
 
-    /// Lazily resolves a function's [FuncMeta] if needed, then returns it if it exists .
-    pub(crate) fn try_function_meta(&mut self, func_id: FuncId) -> Option<&FuncMeta> {
-        self.define_function_meta_if_undefined(func_id);
-        self.interner.try_function_meta(&func_id)
-    }
-
     /// Mutable counterpart of [`Self::function_meta`].
     pub(crate) fn function_meta_mut(&mut self, func_id: FuncId) -> &mut FuncMeta {
         self.define_function_meta_if_undefined(func_id);

--- a/compiler/noirc_frontend/src/elaborator/mod.rs
+++ b/compiler/noirc_frontend/src/elaborator/mod.rs
@@ -770,25 +770,6 @@ impl<'context> Elaborator<'context> {
         (result, has_new_errors)
     }
 
-    /// Run a resolution speculatively, keeping the usage it records only if it succeeds.
-    ///
-    /// Some resolutions probe a path before knowing it's the right kind — e.g. resolving `N` as a
-    /// type to check whether `N()` is a `Type::method` call. Such a probe marks the segments it
-    /// walks as used/referenced, but a *failed* probe must not leave those marks behind (they would
-    /// wrongly silence an unused warning for a same-named type or import). This wraps `f` in a
-    /// usage-tracker transaction: if `f` returns `Some`, the marks are committed; if it returns
-    /// `None`, they are rolled back.
-    pub(crate) fn speculatively<T>(&mut self, f: impl FnOnce(&mut Self) -> Option<T>) -> Option<T> {
-        let transaction = self.usage_tracker.begin_speculative();
-        let result = f(self);
-        if result.is_some() {
-            self.usage_tracker.commit_speculative(transaction);
-        } else {
-            self.usage_tracker.rollback_speculative(transaction);
-        }
-        result
-    }
-
     #[tracing::instrument(level = "trace", skip_all)]
     fn run_lint(&mut self, lint: impl Fn(&Elaborator) -> Option<CompilationError>) {
         if let Some(error) = lint(self) {

--- a/compiler/noirc_frontend/src/elaborator/path_resolution.rs
+++ b/compiler/noirc_frontend/src/elaborator/path_resolution.rs
@@ -870,8 +870,7 @@ impl Elaborator<'_> {
     /// `ident` as one of that type's enum variant constructors.
     ///
     /// These are the only function-like items kept in a type's module scope: inherent and trait
-    /// methods are not declared there and resolve through the interner's type-directed lookup (see
-    /// [Elaborator::resolve_type_method_or_trait_method]).
+    /// methods are not declared there and resolve through the interner's type-directed lookup.
     fn resolve_method(&self, current_module: &ModuleData, ident: &Ident) -> Option<PerNs> {
         current_module
             .scope()

--- a/compiler/noirc_frontend/src/elaborator/patterns.rs
+++ b/compiler/noirc_frontend/src/elaborator/patterns.rs
@@ -844,11 +844,8 @@ impl Elaborator<'_> {
             None => None,
         };
 
-        match self.lookup_item_as_value(path) {
-            Ok(ItemAsValue::Definition { id, item }) => Ok(IdentFromPath::Definition { id, item }),
-            Ok(ItemAsValue::TypeAlias(type_alias_id)) => {
-                Ok(IdentFromPath::TypeAlias(type_alias_id))
-            }
+        match self.ident_from_value_item(path) {
+            Ok(ident) => Ok(ident),
             Err(ResolverError::PathResolutionError(PathResolutionError::Unresolved(ident))) => {
                 // If we can't resolve a path, but we have an error from trying to resolve a variable
                 // (in which case the path was a single segment), prefer saying "variable not found"
@@ -873,5 +870,20 @@ impl Elaborator<'_> {
                 }
             }
         }
+    }
+
+    /// Resolve a [`TypedPath`] to the value item it names — a global, function, enum-variant
+    /// global, trait associated constant, or numeric type alias — as an [`IdentFromPath`]. Unlike
+    /// [`Self::get_ident_from_path_or_error`] this never tries a local variable, so it is what a
+    /// multi-segment path (which can never name a local variable) needs.
+    #[tracing::instrument(level = "trace", skip_all)]
+    pub(crate) fn ident_from_value_item(
+        &mut self,
+        path: TypedPath,
+    ) -> Result<IdentFromPath, ResolverError> {
+        self.lookup_item_as_value(path).map(|item| match item {
+            ItemAsValue::Definition { id, item } => IdentFromPath::Definition { id, item },
+            ItemAsValue::TypeAlias(type_alias_id) => IdentFromPath::TypeAlias(type_alias_id),
+        })
     }
 }

--- a/compiler/noirc_frontend/src/elaborator/types.rs
+++ b/compiler/noirc_frontend/src/elaborator/types.rs
@@ -1455,22 +1455,21 @@ impl Elaborator<'_> {
         path: &TypedPath,
         trait_id: TraitId,
     ) -> Option<TraitPathResolution> {
-        if path.kind == PathKind::Plain && path.segments.len() == 2 {
-            let is_self_type = path.segments[0].ident.is_self_type_name();
-            let method = &path.segments[1].ident;
-
-            if is_self_type {
-                let the_trait = self.interner.get_trait(trait_id);
-                // Allow referring to trait constants via Self:: as well
-                let definition =
-                    the_trait.find_method_or_constant(method.as_str(), self.interner)?;
-                let constraint = the_trait.as_constraint(path.location);
-                let trait_method = TraitItem { definition, constraint, assumed: true };
-                let method = TraitPathResolutionMethod::TraitItem(trait_method);
-                return Some(TraitPathResolution { method, item: None, errors: Vec::new() });
-            }
+        // Reached only for a plain `Self::…` prefix, so the only thing left to distinguish is the
+        // single-segment `Self::item` form (a longer `Self::A::b` is left to the bounds fallback).
+        debug_assert!(path.kind == PathKind::Plain && path.segments[0].ident.is_self_type_name());
+        if path.segments.len() != 2 {
+            return None;
         }
-        None
+
+        let method = &path.segments[1].ident;
+        let the_trait = self.interner.get_trait(trait_id);
+        // Allow referring to trait constants via Self:: as well
+        let definition = the_trait.find_method_or_constant(method.as_str(), self.interner)?;
+        let constraint = the_trait.as_constraint(path.location);
+        let trait_method = TraitItem { definition, constraint, assumed: true };
+        let method = TraitPathResolutionMethod::TraitItem(trait_method);
+        Some(TraitPathResolution { method, item: None, errors: Vec::new() })
     }
 
     /// Classify the prefix (every segment but the last) of a path used as an expression. This does

--- a/compiler/noirc_frontend/src/elaborator/types.rs
+++ b/compiler/noirc_frontend/src/elaborator/types.rs
@@ -1853,7 +1853,7 @@ impl Elaborator<'_> {
         // path as a value (which also reports the error if it is none of these).
         match trait_resolution {
             Some(resolution) => self.variable_from_trait_resolution(path.location, resolution),
-            None => self.resolve_variable_in_scope(path),
+            None => self.resolve_value_item(path),
         }
     }
 
@@ -2215,7 +2215,7 @@ impl Elaborator<'_> {
     /// the caller never needs a further fallback. [`Self::resolve_path_prefix`] classifies the
     /// prefix once; the last segment is resolved against that classification, and anything that is
     /// not a method/trait-item (an enum variant, a module value, an associated constant, …) is
-    /// resolved by [`Self::resolve_variable_in_scope`] on the whole path.
+    /// resolved by [`Self::resolve_value_item`] on the whole path.
     ///
     /// Returns `None` only when an error has already been reported (an ambiguous trait method, or
     /// an unresolved name), so the caller should produce an error expression rather than retry.
@@ -2267,7 +2267,7 @@ impl Elaborator<'_> {
                 resolution,
             ),
             // A module prefix: the last segment is an ordinary value item, resolved as a value.
-            PathPrefixKind::Module => self.resolve_variable_in_scope(path),
+            PathPrefixKind::Module => self.resolve_value_item(path),
             // No usable prefix: the path names nothing, and a value lookup would only rediscover
             // the resolution failure already carried here, so report it directly.
             PathPrefixKind::NoPrefix { error } => {
@@ -2294,7 +2294,7 @@ impl Elaborator<'_> {
         last_segment: TypedPathSegment,
         turbofish: Option<Turbofish>,
     ) -> Option<VariableResolution> {
-        if let Some((expr_id, typ)) = self.elaborate_variable_as_self_method_or_associated_constant(
+        if let Some((expr_id, typ)) = self.resolve_variable_as_self_method_or_associated_constant(
             &path,
             self_type,
             trait_impl_id,

--- a/compiler/noirc_frontend/src/elaborator/types.rs
+++ b/compiler/noirc_frontend/src/elaborator/types.rs
@@ -2183,30 +2183,30 @@ impl Elaborator<'_> {
     #[tracing::instrument(level = "trace", skip_all)]
     pub(super) fn resolve_prefixed_variable(
         &mut self,
-        path: &TypedPath,
+        path: TypedPath,
     ) -> Option<VariableResolution> {
-        let ResolvedPrefix { last_segment, turbofish, kind } = self.resolve_path_prefix(path);
+        let ResolvedPrefix { last_segment, turbofish, kind } = self.resolve_path_prefix(&path);
 
         match kind {
             // `Self` is contextual; each context resolves the last segment its own way.
             PathPrefixKind::SelfInTraitImpl => {
-                self.resolve_self_in_trait_impl(path, last_segment, turbofish)
+                self.resolve_self_in_trait_impl(&path, last_segment, turbofish)
             }
             PathPrefixKind::SelfInTrait => {
-                self.resolve_self_in_trait(path, last_segment, turbofish)
+                self.resolve_self_in_trait(&path, last_segment, turbofish)
             }
             // `Self` is a concrete type here (classification guarantees `self_type` exists), so it
             // resolves exactly like `Type::method`.
             PathPrefixKind::SelfInImpl => {
-                self.resolve_self_as_concrete_type(path, last_segment, turbofish)
+                self.resolve_self_as_concrete_type(&path, last_segment, turbofish)
             }
             PathPrefixKind::BoundedGeneric(bounds) => {
-                self.resolve_bounded_generic_item(path, bounds, &last_segment, turbofish)
+                self.resolve_bounded_generic_item(&path, bounds, &last_segment, turbofish)
             }
             PathPrefixKind::Type { resolution } => {
                 let is_self_prefix = false;
                 self.resolve_method_on_type_prefix(
-                    path,
+                    &path,
                     last_segment,
                     turbofish,
                     is_self_prefix,
@@ -2216,7 +2216,7 @@ impl Elaborator<'_> {
             // A trait prefix: the last segment is either a trait static method (`Trait::method`)
             // or an associated constant (`Trait::CONST`).
             PathPrefixKind::Trait { trait_id, resolution } => self.resolve_trait_item_on_prefix(
-                path,
+                &path,
                 trait_id,
                 turbofish,
                 &last_segment,
@@ -2225,7 +2225,7 @@ impl Elaborator<'_> {
             // A module prefix's value item, or a prefix that isn't an item carrier at all: resolve
             // the whole path as a value (reporting the error if it doesn't resolve).
             PathPrefixKind::Module | PathPrefixKind::NoPrefix => {
-                self.resolve_variable_in_scope(path.clone())
+                self.resolve_variable_in_scope(path)
             }
             // `Self` with no self type in scope: report it directly.
             PathPrefixKind::SelfNotInScope => {

--- a/compiler/noirc_frontend/src/elaborator/types.rs
+++ b/compiler/noirc_frontend/src/elaborator/types.rs
@@ -73,37 +73,40 @@ pub(super) enum TraitPathResolutionMethod {
     MultipleTraitsInScope,
 }
 
-/// What the prefix of a path (every segment but the last) resolves to, used to decide how the
-/// last segment should be interpreted when the path is used as an expression. Only meaningful
-/// for paths with at least two segments; a single-segment path has no prefix.
+/// How a path used as an expression resolves to a trait item, keyed by what the path's prefix
+/// (every segment but the last) is. Produced by [`Elaborator::resolve_path_prefix`], which
+/// classifies the path into exactly one of these so [`Elaborator::resolve_trait_generic_path`]
+/// is a single dispatch rather than a chain of fallible probes.
+///
+/// The first three forms cannot be recognized from the prefix alone — they depend on elaborator
+/// context (the current trait, in-scope bounds) or on resolving the whole path — so for them
+/// detection and resolution are inseparable and the resolved [`TraitPathResolution`] is carried
+/// directly. The last three are distinguished purely by resolving the prefix.
 #[derive(Debug)]
 pub(super) enum PathPrefixKind {
-    /// A trait, e.g. the `Trait` in `Trait::CONST`. The last segment is one of the trait's items.
-    Trait(TraitId),
-    /// A concrete type, type alias, primitive type, or `Self` bound to a data type — e.g. the
-    /// `Type` in `Type::method`. The last segment is an inherent method, a qualified trait
-    /// method, or an associated constant.
-    Type,
-    /// A module, or anything else that cannot prefix an associated item (e.g. `foo::bar` in
-    /// `foo::bar::GLOBAL`). The last segment is an ordinary value item, resolved elsewhere.
+    /// `Self::item` inside a trait *definition*, resolved as an assumed constraint on `Self`.
+    SelfInTraitDefinition(TraitPathResolution),
+    /// The whole path canonically names a trait method, e.g. `Trait::method` or
+    /// `Type::trait_method` resolved through the module system.
+    CanonicalTraitMethod(TraitPathResolution),
+    /// `T::method` where a `T: Trait` bound on the generic `T` is in scope.
+    BoundedGeneric(TraitPathResolution),
+    /// The prefix is a trait, e.g. the `Trait` in `Trait::CONST`. The last segment is an
+    /// associated constant.
+    Trait { trait_id: TraitId, last_segment: TypedPathSegment, resolution: PathResolution },
+    /// The prefix is a concrete type, type alias, primitive type, or `Self` bound to a data
+    /// type — e.g. the `Type` in `Type::method`. The last segment is an inherent or qualified
+    /// trait method.
+    Type {
+        last_segment: TypedPathSegment,
+        turbofish: Option<Turbofish>,
+        is_self_prefix: bool,
+        resolution: PathResolution,
+    },
+    /// The prefix is a module, or anything else that cannot prefix an associated item (e.g.
+    /// `foo::bar` in `foo::bar::GLOBAL`). The last segment is an ordinary value item, resolved
+    /// elsewhere.
     Other,
-}
-
-/// The prefix of a path used as an expression, resolved once so the last segment can be
-/// interpreted without re-resolving the leading segments. Produced by
-/// [`Elaborator::resolve_path_prefix`].
-#[derive(Debug)]
-pub(super) struct ResolvedPathPrefix {
-    /// The path's last segment: the item being accessed on the prefix.
-    last_segment: TypedPathSegment,
-    /// Turbofish on the segment immediately before the last (the prefix's own turbofish).
-    turbofish: Option<Turbofish>,
-    /// Whether the prefix is exactly `Self`.
-    is_self_prefix: bool,
-    /// The resolved prefix and any errors gathered while resolving it.
-    resolution: PathResolution,
-    /// The classified kind of the resolved prefix.
-    kind: PathPrefixKind,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1499,14 +1502,32 @@ impl Elaborator<'_> {
         Some(TraitPathResolution { method, item, errors: path_resolution.errors })
     }
 
-    /// Resolve the prefix of a path used as an expression: every segment but the last, resolved
-    /// as a type. The result lets the caller interpret the last segment based on what the prefix
-    /// is, without re-resolving the leading segments for each candidate interpretation.
+    /// Classify a path used as an expression into the single [`PathPrefixKind`] that describes how
+    /// to resolve it to a trait item. Returns `None` if the path names no trait item (so the caller
+    /// falls back to plain value resolution).
     ///
-    /// Returns `None` if the path has fewer than two segments (so there is no prefix) or the
-    /// prefix cannot be resolved as a type or module.
+    /// The classification order is significant: it decides which interpretation wins when a path
+    /// is ambiguous, and mirrors the historical probe order. The first three forms cannot be told
+    /// apart from the prefix alone — their detection requires resolving against the current trait,
+    /// the in-scope bounds, or the whole path — so they are attempted first and carry their result.
+    /// Only if none of them match is the prefix (every segment but the last) resolved as a type to
+    /// distinguish the trait-, type-, and module-prefixed forms.
     #[tracing::instrument(level = "trace", skip_all)]
-    fn resolve_path_prefix(&mut self, path: &TypedPath) -> Option<ResolvedPathPrefix> {
+    fn resolve_path_prefix(&mut self, path: &TypedPath) -> Option<PathPrefixKind> {
+        // `Self::item` inside a trait definition (assumed constraint on `Self`).
+        if let Some(resolution) = self.resolve_trait_static_method_by_self(path) {
+            return Some(PathPrefixKind::SelfInTraitDefinition(resolution));
+        }
+        // The whole path canonically names a trait method (`Trait::method`, `Type::trait_method`).
+        if let Some(resolution) = self.resolve_trait_static_method(path) {
+            return Some(PathPrefixKind::CanonicalTraitMethod(resolution));
+        }
+        // `T::method` via a `T: Trait` bound on the generic `T`.
+        if let Some(resolution) = self.resolve_trait_method_by_named_generic(path) {
+            return Some(PathPrefixKind::BoundedGeneric(resolution));
+        }
+
+        // The remaining forms are distinguished by resolving the prefix as a type.
         if path.segments.len() < 2 {
             return None;
         }
@@ -1517,15 +1538,24 @@ impl Elaborator<'_> {
         let is_self_prefix = path.first_name() == Some(SELF_TYPE_NAME);
 
         let resolution = self.use_path_as_type(path).ok()?;
-        let kind = match &resolution.item {
-            PathResolutionItem::Trait(trait_id) => PathPrefixKind::Trait(*trait_id),
-            PathResolutionItem::Type(..)
-            | PathResolutionItem::TypeAlias(..)
-            | PathResolutionItem::PrimitiveType(..) => PathPrefixKind::Type,
-            _ => PathPrefixKind::Other,
+        let trait_id = match &resolution.item {
+            PathResolutionItem::Trait(trait_id) => Some(*trait_id),
+            _ => None,
         };
+        let is_type_prefix = matches!(
+            &resolution.item,
+            PathResolutionItem::Type(..)
+                | PathResolutionItem::TypeAlias(..)
+                | PathResolutionItem::PrimitiveType(..)
+        );
 
-        Some(ResolvedPathPrefix { last_segment, turbofish, is_self_prefix, resolution, kind })
+        Some(if let Some(trait_id) = trait_id {
+            PathPrefixKind::Trait { trait_id, last_segment, resolution }
+        } else if is_type_prefix {
+            PathPrefixKind::Type { last_segment, turbofish, is_self_prefix, resolution }
+        } else {
+            PathPrefixKind::Other
+        })
     }
 
     /// Resolves `Trait::SOME_CONSTANT` to the trait's associated constant, given a prefix that has
@@ -1540,15 +1570,16 @@ impl Elaborator<'_> {
         &self,
         trait_id: TraitId,
         location: Location,
-        prefix: ResolvedPathPrefix,
+        last_segment: TypedPathSegment,
+        resolution: PathResolution,
     ) -> Option<TraitPathResolution> {
         let the_trait = self.interner.get_trait(trait_id);
         let definition =
-            the_trait.associated_constant_ids.get(prefix.last_segment.ident.as_str()).copied()?;
+            the_trait.associated_constant_ids.get(last_segment.ident.as_str()).copied()?;
         let constraint = the_trait.as_constraint(location);
         let trait_item = TraitItem { definition, constraint, assumed: true };
         let method = TraitPathResolutionMethod::TraitItem(trait_item);
-        Some(TraitPathResolution { method, item: None, errors: prefix.resolution.errors })
+        Some(TraitPathResolution { method, item: None, errors: resolution.errors })
     }
 
     /// For path resolutions that went through a typed item (e.g. `MyStruct::method`,
@@ -1767,14 +1798,14 @@ impl Elaborator<'_> {
     fn resolve_method_on_type_prefix(
         &mut self,
         location: Location,
-        prefix: ResolvedPathPrefix,
+        last_segment: TypedPathSegment,
+        turbofish: Option<Turbofish>,
+        is_self_prefix: bool,
+        path_resolution: PathResolution,
     ) -> Option<TraitPathResolution> {
         // `Self::method` must anchor on the impl's own `self_type` and produce a `SelfMethod`, so it
         // gets dedicated handling (in `resolve_self_or_inherent_method`) distinct from a plain
         // `TypeName::method`.
-        let ResolvedPathPrefix { last_segment, turbofish, is_self_prefix, resolution, .. } = prefix;
-        let path_resolution = resolution;
-
         let mut errors = Vec::new();
         let typ = self.path_resolution_item_to_type(
             &path_resolution.item,
@@ -2181,49 +2212,36 @@ impl Elaborator<'_> {
     /// Returns the trait method, trait constraint, and whether the impl is assumed to exist by a where clause or not
     /// E.g. `t.method()` with `where T: Foo<Bar>` in scope will return `(Foo::method, T, vec![Bar])`
     ///
-    /// The forms are tried in order; the order is significant, as it decides which interpretation
-    /// wins when a path is ambiguous:
-    ///
-    /// 1. `Self::item` inside a trait *definition*, resolved as an assumed constraint on `Self`
-    ///    ([`Self::resolve_trait_static_method_by_self`]).
-    /// 2. `Trait::static_method` or `Type::trait_method`
-    ///    ([`Self::resolve_trait_static_method`]).
-    /// 3. `T::method` where a `T: Trait` bound is in scope
-    ///    ([`Self::resolve_trait_method_by_named_generic`]).
-    ///
-    /// The remaining forms are distinguished by what the path's *prefix* (every segment but the
-    /// last) resolves to, so the prefix is resolved once ([`Self::resolve_path_prefix`]) and the
-    /// last segment is interpreted accordingly:
-    ///
-    /// 4. prefix is a type/alias/primitive ⇒ `Type::method` / `Type::<..>::method`, an inherent or
-    ///    qualified trait method ([`Self::resolve_method_on_type_prefix`]).
-    /// 5. prefix is a trait ⇒ `Trait::CONST`, a trait's associated constant
-    ///    ([`Self::resolve_trait_constant_on_prefix`]).
+    /// [`Self::resolve_path_prefix`] classifies the path into one [`PathPrefixKind`], so this is a
+    /// single dispatch. The classification order (which interpretation wins when a path is
+    /// ambiguous) lives in `resolve_path_prefix`; here each kind maps to the way its last segment
+    /// is turned into a [`TraitPathResolution`].
     #[tracing::instrument(level = "trace", skip_all)]
     pub(super) fn resolve_trait_generic_path(
         &mut self,
         path: &TypedPath,
     ) -> Option<TraitPathResolution> {
-        // Forms the module resolver can't classify from the prefix alone: an assumed `Self`
-        // constraint inside a trait definition, a trait method reached through the canonical
-        // trait/type path, or a method on a generic with an in-scope bound.
-        if let Some(resolution) = self.resolve_trait_static_method_by_self(path) {
-            return Some(resolution);
-        }
-        if let Some(resolution) = self.resolve_trait_static_method(path) {
-            return Some(resolution);
-        }
-        if let Some(resolution) = self.resolve_trait_method_by_named_generic(path) {
-            return Some(resolution);
-        }
+        match self.resolve_path_prefix(path)? {
+            // These forms were resolved as they were classified (see `resolve_path_prefix`).
+            PathPrefixKind::SelfInTraitDefinition(resolution)
+            | PathPrefixKind::CanonicalTraitMethod(resolution)
+            | PathPrefixKind::BoundedGeneric(resolution) => Some(resolution),
 
-        // Forms distinguished by what the prefix resolves to.
-        let prefix = self.resolve_path_prefix(path)?;
-        match prefix.kind {
-            PathPrefixKind::Type => self.resolve_method_on_type_prefix(path.location, prefix),
-            PathPrefixKind::Trait(trait_id) => {
-                self.resolve_trait_constant_on_prefix(trait_id, path.location, prefix)
-            }
+            PathPrefixKind::Type { last_segment, turbofish, is_self_prefix, resolution } => self
+                .resolve_method_on_type_prefix(
+                    path.location,
+                    last_segment,
+                    turbofish,
+                    is_self_prefix,
+                    resolution,
+                ),
+            PathPrefixKind::Trait { trait_id, last_segment, resolution } => self
+                .resolve_trait_constant_on_prefix(
+                    trait_id,
+                    path.location,
+                    last_segment,
+                    resolution,
+                ),
             PathPrefixKind::Other => None,
         }
     }

--- a/compiler/noirc_frontend/src/elaborator/types.rs
+++ b/compiler/noirc_frontend/src/elaborator/types.rs
@@ -45,8 +45,8 @@ use crate::{
     },
     modules::{get_ancestor_module_reexport, module_def_id_is_visible},
     node_interner::{
-        DependencyId, ExprId, FuncId, GlobalValue, TraitId, TraitImplKind, TraitItemId,
-        TraitLookupMode,
+        DependencyId, ExprId, FuncId, GlobalValue, TraitId, TraitImplId, TraitImplKind,
+        TraitItemId, TraitLookupMode,
     },
     shared::Signedness,
 };
@@ -91,14 +91,14 @@ struct ResolvedPrefix {
 /// "rest" (last segment, turbofish) lives on [`ResolvedPrefix`].
 #[derive(Debug)]
 enum PathPrefixKind {
-    /// `Self` inside a trait *impl*, where `Self` is a concrete type with associated items. The
-    /// last segment is an associated-type method, an associated constant, a primitive-`Self`
-    /// method, or a plain method on the self type
-    /// ([`Elaborator::resolve_self_in_trait_impl`]).
-    SelfInTraitImpl,
-    /// `Self` inside a trait *definition*: an assumed constraint on the current trait (or a
-    /// supertrait reached through it) ([`Elaborator::resolve_self_in_trait`]).
-    SelfInTrait,
+    /// `Self` inside a trait *impl*, where `Self` is the impl's concrete type (carried here, along
+    /// with the impl) since a trait impl always has both. The last segment is an associated-type
+    /// method, an associated constant, a primitive-`Self` method, or a plain method on the self
+    /// type ([`Elaborator::resolve_self_in_trait_impl`]).
+    SelfInTraitImpl { self_type: Type, trait_impl_id: TraitImplId },
+    /// `Self` inside a trait *definition* (carried here): an assumed constraint on the current
+    /// trait (or a supertrait reached through it) ([`Elaborator::resolve_self_in_trait`]).
+    SelfInTrait { trait_id: TraitId },
     /// `Self` as a plain concrete type (an inherent impl, or any other context where `Self` names
     /// a data type): the last segment resolves like `Type::method`
     /// ([`Elaborator::resolve_self_in_impl`]).
@@ -1450,15 +1450,11 @@ impl Elaborator<'_> {
     ///
     /// Returns the trait method, trait constraint, and whether the impl is assumed to exist by a where clause or not
     /// E.g. `t.method()` with `where T: Foo<Bar>` in scope will return `(Foo::method, T, vec![Bar])`
-    fn resolve_trait_static_method_by_self(&self, path: &TypedPath) -> Option<TraitPathResolution> {
-        // If we are inside a trait impl, `Self` is known to be a concrete type so we don't have
-        // to solve the path via trait method lookup.
-        if self.current_trait_impl.is_some() {
-            return None;
-        }
-
-        let trait_id = self.current_trait?;
-
+    fn resolve_trait_static_method_by_self(
+        &self,
+        path: &TypedPath,
+        trait_id: TraitId,
+    ) -> Option<TraitPathResolution> {
         if path.kind == PathKind::Plain && path.segments.len() == 2 {
             let is_self_type = path.segments[0].ident.is_self_type_name();
             let method = &path.segments[1].ident;
@@ -1479,7 +1475,8 @@ impl Elaborator<'_> {
 
     /// Classify the prefix (every segment but the last) of a path used as an expression. This does
     /// not resolve the last segment — it only answers "what is the prefix?", which the caller uses
-    /// to decide how to resolve the last segment. Returns `None` if the path has no prefix.
+    /// to decide how to resolve the last segment. The caller only invokes this for a path that has
+    /// a prefix (more than one segment).
     ///
     /// The classification order is significant: it decides which interpretation wins when a path
     /// is ambiguous, and mirrors the historical probe order. `Self` and a bounded generic are
@@ -1503,10 +1500,12 @@ impl Elaborator<'_> {
             // `Self` is contextual; which kind it is depends only on where we are (a trait impl, a
             // trait definition, somewhere `Self` is a plain type, or nowhere at all), so it is
             // classified here and the matching arm resolves the last segment.
-            if self.current_trait_impl.is_some() {
-                PathPrefixKind::SelfInTraitImpl
-            } else if self.current_trait.is_some() {
-                PathPrefixKind::SelfInTrait
+            if let Some(trait_impl_id) = self.current_trait_impl {
+                let self_type =
+                    self.self_type.clone().expect("a trait impl always has a self type");
+                PathPrefixKind::SelfInTraitImpl { self_type, trait_impl_id }
+            } else if let Some(trait_id) = self.current_trait {
+                PathPrefixKind::SelfInTrait { trait_id }
             } else if self.self_type.is_some() {
                 PathPrefixKind::SelfInImpl
             } else {
@@ -2189,11 +2188,16 @@ impl Elaborator<'_> {
 
         match kind {
             // `Self` is contextual; each context resolves the last segment its own way.
-            PathPrefixKind::SelfInTraitImpl => {
-                self.resolve_self_in_trait_impl(path, last_segment, turbofish)
-            }
-            PathPrefixKind::SelfInTrait => {
-                self.resolve_self_in_trait(path, last_segment, turbofish)
+            PathPrefixKind::SelfInTraitImpl { self_type, trait_impl_id } => self
+                .resolve_self_in_trait_impl(
+                    path,
+                    self_type,
+                    trait_impl_id,
+                    last_segment,
+                    turbofish,
+                ),
+            PathPrefixKind::SelfInTrait { trait_id } => {
+                self.resolve_self_in_trait(path, trait_id, last_segment, turbofish)
             }
             // `Self` is a concrete type here (classification guarantees `self_type` exists), so it
             // resolves exactly like `Type::method`.
@@ -2242,12 +2246,16 @@ impl Elaborator<'_> {
     fn resolve_self_in_trait_impl(
         &mut self,
         path: TypedPath,
+        self_type: Type,
+        trait_impl_id: TraitImplId,
         last_segment: TypedPathSegment,
         turbofish: Option<Turbofish>,
     ) -> Option<VariableResolution> {
-        if let Some((expr_id, typ)) =
-            self.elaborate_variable_as_self_method_or_associated_constant(&path)
-        {
+        if let Some((expr_id, typ)) = self.elaborate_variable_as_self_method_or_associated_constant(
+            &path,
+            self_type,
+            trait_impl_id,
+        ) {
             return Some(VariableResolution::Expression(expr_id, typ));
         }
         self.resolve_self_as_concrete_type(path, last_segment, turbofish)
@@ -2258,10 +2266,11 @@ impl Elaborator<'_> {
     fn resolve_self_in_trait(
         &mut self,
         path: TypedPath,
+        trait_id: TraitId,
         last_segment: TypedPathSegment,
         turbofish: Option<Turbofish>,
     ) -> Option<VariableResolution> {
-        if let Some(resolution) = self.resolve_trait_static_method_by_self(&path) {
+        if let Some(resolution) = self.resolve_trait_static_method_by_self(&path, trait_id) {
             return self.variable_from_trait_resolution(path.location, resolution);
         }
         // Fall back to a supertrait reached through the assumed `Self` bound.

--- a/compiler/noirc_frontend/src/elaborator/types.rs
+++ b/compiler/noirc_frontend/src/elaborator/types.rs
@@ -1483,11 +1483,16 @@ impl Elaborator<'_> {
         let last_segment = prefix.pop();
         let turbofish = prefix.last_segment().turbofish();
 
-        let kind = if path.segments[0].ident.is_self_type_name() {
+        // `Self` and a generic parameter are only meaningful as a plain path: `crate::Self` /
+        // `super::T` name an item in another module, not the contextual `Self` or an in-scope
+        // generic, so they must not be classified as such.
+        let kind = if path.kind == PathKind::Plain && path.segments[0].ident.is_self_type_name() {
             // `Self` is contextual (the current trait, or a concrete self type), so it is classified
             // by syntax alone; its handler resolves what it means.
             PathPrefixKind::SelfType
-        } else if let Some(bounds) = self.matching_generic_bounds(path) {
+        } else if path.kind == PathKind::Plain
+            && let Some(bounds) = self.matching_generic_bounds(path)
+        {
             // A generic parameter (e.g. `T`) with a `T: Trait` bound in scope. A generic is not in
             // the module namespace, so this is recognized from the in-scope bounds, not resolution.
             PathPrefixKind::BoundedGeneric(bounds)

--- a/compiler/noirc_frontend/src/elaborator/types.rs
+++ b/compiler/noirc_frontend/src/elaborator/types.rs
@@ -55,6 +55,7 @@ use crate::{
 use super::{
     Elaborator, PathResolutionTarget, UnsafeBlockStatus, lints,
     path_resolution::{PathResolutionItem, PathResolutionMode, TypedPath, TypedPathSegment},
+    variable::PrefixedVariable,
 };
 
 pub const SELF_TYPE_NAME: &str = "Self";
@@ -2144,19 +2145,15 @@ impl Elaborator<'_> {
         TraitPathResolution { method, item: Some(item), errors }
     }
 
-    /// Try to resolve a [`TypedPath`] to a trait item (method or associated constant).
-    ///
-    /// Returns the trait method, trait constraint, and whether the impl is assumed to exist by a where clause or not
-    /// E.g. `t.method()` with `where T: Foo<Bar>` in scope will return `(Foo::method, T, vec![Bar])`
-    ///
-    /// [`Self::resolve_path_prefix`] classifies the prefix once; here the last segment is resolved
-    /// against that classification.
+    /// Resolve a [`TypedPath`] that has a prefix to the trait item it names (method or associated
+    /// constant). [`Self::resolve_path_prefix`] classifies the prefix once; the last segment is
+    /// resolved against that classification, and the result is mapped to a [`PrefixedVariable`].
     #[tracing::instrument(level = "trace", skip_all)]
     pub(super) fn resolve_trait_generic_path(
         &mut self,
         path: &TypedPath,
-    ) -> Option<TraitPathResolution> {
-        match self.resolve_path_prefix(path)? {
+    ) -> Option<PrefixedVariable> {
+        let resolution = match self.resolve_path_prefix(path)? {
             // `Self` in a trait definition: a method/constant of the current trait, falling back to
             // a supertrait reached through the assumed `Self` bound.
             PathPrefixKind::SelfTrait => self
@@ -2182,7 +2179,9 @@ impl Elaborator<'_> {
                     resolution,
                 ),
             PathPrefixKind::Module => None,
-        }
+        }?;
+
+        Some(self.prefixed_variable_from_trait_resolution(path.location, resolution))
     }
 
     /// Unify two types, modifying both in the process.

--- a/compiler/noirc_frontend/src/elaborator/types.rs
+++ b/compiler/noirc_frontend/src/elaborator/types.rs
@@ -2331,16 +2331,21 @@ impl Elaborator<'_> {
     ) -> Option<VariableResolution> {
         let mut prefix = path.clone();
         prefix.pop();
-        match self.use_path_as_type(prefix).ok() {
-            Some(type_resolution) => self.resolve_method_on_type_prefix(
+        match self.use_path_as_type(prefix) {
+            Ok(type_resolution) => self.resolve_method_on_type_prefix(
                 path,
                 last_segment,
                 turbofish,
                 true, // is_self_prefix
                 type_resolution,
             ),
-            // The `Self` prefix doesn't resolve as a type; resolve the whole path as a value.
-            None => self.resolve_variable_in_scope(path),
+            // The `Self` prefix itself doesn't resolve as a type (e.g. `Self::not_a_type::method`):
+            // report that resolution failure, which already points at the offending segment, rather
+            // than re-resolving the whole path as a value just to rediscover it.
+            Err(error) => {
+                self.push_err(error);
+                None
+            }
         }
     }
 

--- a/compiler/noirc_frontend/src/elaborator/types.rs
+++ b/compiler/noirc_frontend/src/elaborator/types.rs
@@ -86,9 +86,14 @@ pub(super) enum PathPrefixKind {
     /// A generic parameter with a `: Trait` bound in scope (e.g. `T` in `T::method`). The last
     /// segment is a method or associated constant reached through one of those bounds.
     BoundedGeneric,
-    /// A trait (e.g. `Trait` in `Trait::CONST`). The last segment is an associated constant.
-    /// (`Trait::method` is handled earlier as a canonical trait method.)
-    Trait { trait_id: TraitId, last_segment: TypedPathSegment, resolution: PathResolution },
+    /// A trait (e.g. `Trait` in `Trait::method` / `Trait::CONST`). The last segment is a trait
+    /// static method or an associated constant. `turbofish` is the trait segment's turbofish.
+    Trait {
+        trait_id: TraitId,
+        turbofish: Option<Turbofish>,
+        last_segment: TypedPathSegment,
+        resolution: PathResolution,
+    },
     /// A concrete type, type alias, primitive type, or `Self` bound to a data type (e.g. `Type`
     /// in `Type::method`). The last segment is an inherent or qualified trait method.
     Type {
@@ -1455,38 +1460,6 @@ impl Elaborator<'_> {
         None
     }
 
-    /// This resolves `TraitName::some_static_method`
-    ///
-    /// Returns the trait method, trait constraint, and whether the impl is assumed to exist by a where clause or not
-    /// E.g. `t.method()` with `where T: Foo<Bar>` in scope will return `(Foo::method, T, vec![Bar])`
-    #[tracing::instrument(level = "trace", skip_all)]
-    fn resolve_trait_static_method(&mut self, path: &TypedPath) -> Option<TraitPathResolution> {
-        // This is a speculative probe: the path may turn out not to be a trait static method at
-        // all (e.g. a plain `N()` call where `N` is also a struct or imported type). Resolving it
-        // marks the segments along the way as used/referenced, but a *failed* probe must not leave
-        // those marks behind — otherwise a same-named type or import is wrongly considered used.
-        // When it *does* resolve to a trait static method (e.g. `T::from(..)`), this resolution is
-        // the only thing that marks the trait/type used, so the marks must be kept.
-        self.speculatively(|this| this.resolve_trait_static_method_inner(path))
-    }
-
-    fn resolve_trait_static_method_inner(
-        &mut self,
-        path: &TypedPath,
-    ) -> Option<TraitPathResolution> {
-        let path_resolution = self.resolve_path_as_type(path.clone()).ok()?;
-        let func_id = path_resolution.item.function_id()?;
-        let meta = self.try_function_meta(func_id)?;
-        let trait_id = meta.trait_id?;
-        let the_trait = self.interner.get_trait(trait_id);
-        let method = the_trait.find_method(path.last_name(), self.interner)?;
-        let constraint = the_trait.as_constraint(path.location);
-        let trait_method = TraitItem { definition: method, constraint, assumed: false };
-        let method = TraitPathResolutionMethod::TraitItem(trait_method);
-        let item = Some(path_resolution.item);
-        Some(TraitPathResolution { method, item, errors: path_resolution.errors })
-    }
-
     /// Classify the prefix (every segment but the last) of a path used as an expression. This does
     /// not resolve the last segment — it only answers "what is the prefix?", which the caller uses
     /// to decide how to resolve the last segment. Returns `None` if the path has no prefix.
@@ -1536,7 +1509,7 @@ impl Elaborator<'_> {
         );
 
         Some(if let Some(trait_id) = trait_id {
-            PathPrefixKind::Trait { trait_id, last_segment, resolution }
+            PathPrefixKind::Trait { trait_id, turbofish, last_segment, resolution }
         } else if is_type_prefix {
             PathPrefixKind::Type { last_segment, turbofish, is_self_prefix, resolution }
         } else {
@@ -1554,28 +1527,48 @@ impl Elaborator<'_> {
         })
     }
 
-    /// Resolves `Trait::SOME_CONSTANT` to the trait's associated constant, given a prefix that has
-    /// already been resolved to a trait.
+    /// Resolves the last segment of a `Trait::item` path against a prefix already resolved to a
+    /// trait. The segment is either a trait static method (`Trait::method`) or an associated
+    /// constant (`Trait::CONST`); returns `None` if it is neither.
     ///
-    /// An associated constant is not a function, so resolving the full path as a type fails (only
-    /// paths ending in a type or function resolve that way). Instead the trait prefix is resolved
-    /// separately and the constant looked up by name. The resulting `TraitItem` is lowered to the
-    /// selected impl's value during monomorphization, mirroring how `Self::SOME_CONSTANT` is
-    /// handled by [`Self::resolve_trait_static_method_by_self`].
-    fn resolve_trait_constant_on_prefix(
-        &self,
+    /// The method is looked up directly on the trait rather than by re-resolving the whole path:
+    /// the trait was already marked when its prefix was resolved, so only the method's own
+    /// reference/dependency is recorded here (as inherent-method resolution does). An associated
+    /// constant is not a function, so it could not be resolved as a path anyway; its `TraitItem`
+    /// is lowered to the selected impl's value during monomorphization.
+    fn resolve_trait_item_on_prefix(
+        &mut self,
         trait_id: TraitId,
+        turbofish: Option<Turbofish>,
+        last_segment: &TypedPathSegment,
         location: Location,
-        last_segment: TypedPathSegment,
         resolution: PathResolution,
     ) -> Option<TraitPathResolution> {
         let the_trait = self.interner.get_trait(trait_id);
-        let definition =
-            the_trait.associated_constant_ids.get(last_segment.ident.as_str()).copied()?;
+        let name = last_segment.ident.as_str();
+        let method_func_id = the_trait.method_ids.get(name).copied();
+        let associated_constant = the_trait.associated_constant_ids.get(name).copied();
         let constraint = the_trait.as_constraint(location);
+
+        if let Some(func_id) = method_func_id {
+            let definition = self.interner.function_definition_id(func_id);
+            self.record_direct_method_reference(func_id, &last_segment.ident);
+            let trait_item = TraitItem { definition, constraint, assumed: false };
+            let item = PathResolutionItem::TraitFunction(trait_id, turbofish, func_id);
+            return Some(TraitPathResolution {
+                method: TraitPathResolutionMethod::TraitItem(trait_item),
+                item: Some(item),
+                errors: resolution.errors,
+            });
+        }
+
+        let definition = associated_constant?;
         let trait_item = TraitItem { definition, constraint, assumed: true };
-        let method = TraitPathResolutionMethod::TraitItem(trait_item);
-        Some(TraitPathResolution { method, item: None, errors: resolution.errors })
+        Some(TraitPathResolution {
+            method: TraitPathResolutionMethod::TraitItem(trait_item),
+            item: None,
+            errors: resolution.errors,
+        })
     }
 
     /// This resolves a static trait method `T::trait_method` by iterating over the where clause
@@ -2180,16 +2173,14 @@ impl Elaborator<'_> {
                 ),
             // A trait prefix: the last segment is either a trait static method (`Trait::method`)
             // or an associated constant (`Trait::CONST`).
-            PathPrefixKind::Trait { trait_id, last_segment, resolution } => {
-                self.resolve_trait_static_method(path).or_else(|| {
-                    self.resolve_trait_constant_on_prefix(
-                        trait_id,
-                        path.location,
-                        last_segment,
-                        resolution,
-                    )
-                })
-            }
+            PathPrefixKind::Trait { trait_id, turbofish, last_segment, resolution } => self
+                .resolve_trait_item_on_prefix(
+                    trait_id,
+                    turbofish,
+                    &last_segment,
+                    path.location,
+                    resolution,
+                ),
             PathPrefixKind::Module => None,
         }
     }

--- a/compiler/noirc_frontend/src/elaborator/types.rs
+++ b/compiler/noirc_frontend/src/elaborator/types.rs
@@ -1526,7 +1526,23 @@ impl Elaborator<'_> {
                     PathResolutionItem::Type(..)
                     | PathResolutionItem::TypeAlias(..)
                     | PathResolutionItem::PrimitiveType(..) => PathPrefixKind::Type { resolution },
-                    _ => PathPrefixKind::Module,
+                    PathResolutionItem::Module(..) => PathPrefixKind::Module,
+                    // Resolving a type path falls back to the value namespace, so the prefix can
+                    // also resolve to a value item; that (and an associated type) can't carry the
+                    // last segment as an associated item, so there is no usable prefix and the
+                    // whole path is resolved as a value. Listed explicitly (rather than `_`) so a
+                    // new `PathResolutionItem` must be classified here.
+                    PathResolutionItem::TraitAssociatedType(..)
+                    | PathResolutionItem::Global(..)
+                    | PathResolutionItem::EnumVariant(..)
+                    | PathResolutionItem::ModuleFunction(..)
+                    | PathResolutionItem::Method(..)
+                    | PathResolutionItem::SelfMethod(..)
+                    | PathResolutionItem::TypeAliasFunction(..)
+                    | PathResolutionItem::TraitFunction(..)
+                    | PathResolutionItem::TypeTraitFunction(..)
+                    | PathResolutionItem::PrimitiveFunction(..)
+                    | PathResolutionItem::TraitConstant(..) => PathPrefixKind::NoPrefix,
                 },
                 Err(_) => PathPrefixKind::NoPrefix,
             }

--- a/compiler/noirc_frontend/src/elaborator/types.rs
+++ b/compiler/noirc_frontend/src/elaborator/types.rs
@@ -75,15 +75,16 @@ enum TraitPathResolutionMethod {
 }
 
 /// What the prefix of a path (every segment but the last) is, when the path is used as an
-/// expression. Produced by [`Elaborator::resolve_path_prefix`]; [`Elaborator::resolve_trait_generic_path`]
+/// expression. Produced by [`Elaborator::resolve_path_prefix`]; [`Elaborator::resolve_prefixed_variable`]
 /// then resolves the last segment against it. Only the data needed to resolve the last segment is
 /// carried — this describes *what the prefix is*, not the already-resolved item.
 #[derive(Debug)]
 pub(super) enum PathPrefixKind {
-    /// `Self` inside a trait *definition*: the prefix is the current trait (an assumed `Self`
-    /// constraint). The last segment is a method or associated constant of that trait or a
-    /// supertrait.
-    SelfTrait,
+    /// The prefix starts with `Self`. What `Self` means is contextual — the current trait in a
+    /// trait definition, or a concrete self type in an impl — and the forms differ
+    /// (`Self::method`, `Self::CONST`, `Self::AssocType::method`), so the dedicated handler
+    /// ([`Elaborator::resolve_self_prefix`]) enumerates the cases.
+    SelfType,
     /// A generic parameter with a `: Trait` bound in scope (e.g. `T` in `T::method`). The last
     /// segment is a method or associated constant reached through one of those bounds.
     BoundedGeneric,
@@ -1466,23 +1467,20 @@ impl Elaborator<'_> {
     /// to decide how to resolve the last segment. Returns `None` if the path has no prefix.
     ///
     /// The classification order is significant: it decides which interpretation wins when a path
-    /// is ambiguous, and mirrors the historical probe order. `Self` inside a trait definition and a
-    /// bounded generic are recognized from context (the current trait, the in-scope bounds) before
-    /// the prefix is resolved as a type to tell trait-, type-, and module-prefixed forms apart.
+    /// is ambiguous, and mirrors the historical probe order. `Self` and a bounded generic are
+    /// recognized from context (`Self` is contextual; a generic is not in the module namespace)
+    /// before the prefix is resolved as a type to tell trait-, type-, and module-prefixed forms
+    /// apart.
     #[tracing::instrument(level = "trace", skip_all)]
     fn resolve_path_prefix(&mut self, path: &TypedPath) -> Option<PathPrefixKind> {
         if path.segments.len() < 2 {
             return None;
         }
 
-        // `Self` inside a trait definition: `Self` is the current trait, not a concrete type.
-        if path.kind == PathKind::Plain
-            && path.segments.len() == 2
-            && path.segments[0].ident.is_self_type_name()
-            && self.current_trait_impl.is_none()
-            && self.current_trait.is_some()
-        {
-            return Some(PathPrefixKind::SelfTrait);
+        // `Self` is contextual (the current trait, or a concrete self type), so it is classified
+        // by syntax alone; its handler resolves what it means.
+        if path.segments[0].ident.is_self_type_name() {
+            return Some(PathPrefixKind::SelfType);
         }
 
         // A generic parameter (e.g. `T`) with a `T: Trait` bound in scope. A generic is not in the
@@ -2145,20 +2143,18 @@ impl Elaborator<'_> {
         TraitPathResolution { method, item: Some(item), errors }
     }
 
-    /// Resolve a [`TypedPath`] that has a prefix to the trait item it names (method or associated
-    /// constant). [`Self::resolve_path_prefix`] classifies the prefix once; the last segment is
-    /// resolved against that classification, and the result is mapped to a [`PrefixedVariable`].
+    /// Resolve a [`TypedPath`] that has a prefix (more than one segment) to the item it names.
+    /// [`Self::resolve_path_prefix`] classifies the prefix once; the last segment is resolved
+    /// against that classification and mapped to a [`PrefixedVariable`].
     #[tracing::instrument(level = "trace", skip_all)]
-    pub(super) fn resolve_trait_generic_path(
+    pub(super) fn resolve_prefixed_variable(
         &mut self,
         path: &TypedPath,
     ) -> Option<PrefixedVariable> {
         let resolution = match self.resolve_path_prefix(path)? {
-            // `Self` in a trait definition: a method/constant of the current trait, falling back to
-            // a supertrait reached through the assumed `Self` bound.
-            PathPrefixKind::SelfTrait => self
-                .resolve_trait_static_method_by_self(path)
-                .or_else(|| self.resolve_trait_method_by_named_generic(path)),
+            // `Self` is contextual; its handler produces the `PrefixedVariable` directly (it may be
+            // an elaborated expression, not a trait resolution).
+            PathPrefixKind::SelfType => return self.resolve_self_prefix(path),
             PathPrefixKind::BoundedGeneric => self.resolve_trait_method_by_named_generic(path),
             PathPrefixKind::Type { last_segment, turbofish, is_self_prefix, resolution } => self
                 .resolve_method_on_type_prefix(
@@ -2181,6 +2177,49 @@ impl Elaborator<'_> {
             PathPrefixKind::Module => None,
         }?;
 
+        Some(self.prefixed_variable_from_trait_resolution(path.location, resolution))
+    }
+
+    /// Resolve a `Self::…` path used as an expression. `Self` is contextual, so this enumerates its
+    /// cases:
+    /// - inside a trait impl: `Self::AssocType::method`, `Self::CONST`, or a method on a primitive
+    ///   `Self` (handled by [`Self::elaborate_variable_as_self_method_or_associated_constant`]);
+    /// - inside a trait definition: a method or constant of the current trait (or a supertrait),
+    ///   resolved as an assumed constraint on `Self`;
+    /// - otherwise (`Self` is a concrete data type, e.g. inside an impl method): `Self::method`,
+    ///   resolved the same way as `Type::method`.
+    fn resolve_self_prefix(&mut self, path: &TypedPath) -> Option<PrefixedVariable> {
+        // Cases the module resolver can't reach: a method/constant on a primitive `Self`, an
+        // associated constant, or a method on an associated type (all inside a trait impl).
+        if let Some((expr_id, typ)) =
+            self.elaborate_variable_as_self_method_or_associated_constant(path)
+        {
+            return Some(PrefixedVariable::Resolved(VariableResolution::Expression(expr_id, typ)));
+        }
+
+        // Inside a trait definition, `Self` is the trait: resolve to an assumed constraint on it,
+        // falling back to a supertrait reached through that bound.
+        if self.current_trait.is_some() && self.current_trait_impl.is_none() {
+            let resolution = self
+                .resolve_trait_static_method_by_self(path)
+                .or_else(|| self.resolve_trait_method_by_named_generic(path))?;
+            return Some(self.prefixed_variable_from_trait_resolution(path.location, resolution));
+        }
+
+        // Otherwise `Self` is a concrete data type: resolve the method exactly as `Type::method`
+        // does, on `Self`'s type.
+        let mut prefix = path.clone();
+        let last_segment = prefix.pop();
+        let turbofish = prefix.last_segment().turbofish();
+        let type_resolution = self.use_path_as_type(prefix).ok()?;
+        let is_self_prefix = true;
+        let resolution = self.resolve_method_on_type_prefix(
+            path.location,
+            last_segment,
+            turbofish,
+            is_self_prefix,
+            type_resolution,
+        )?;
         Some(self.prefixed_variable_from_trait_resolution(path.location, resolution))
     }
 

--- a/compiler/noirc_frontend/src/elaborator/types.rs
+++ b/compiler/noirc_frontend/src/elaborator/types.rs
@@ -119,9 +119,10 @@ enum PathPrefixKind {
     /// The prefix is `Self` but there is no self type in scope (e.g. in a free function), so `Self`
     /// names nothing.
     SelfNotInScope,
-    /// The prefix resolves to nothing that can carry an associated item (it is not a type, trait,
-    /// or module). The whole path is resolved as a value, which reports the error if there is one.
-    NoPrefix,
+    /// The prefix resolves to nothing that can carry an associated item: it is not a type, trait,
+    /// or module, so the path names nothing. The carried error (either the prefix's own resolution
+    /// failure, or that its last segment is a value rather than a namespace) is reported as-is.
+    NoPrefix { error: PathResolutionError },
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1518,6 +1519,7 @@ impl Elaborator<'_> {
             PathPrefixKind::BoundedGeneric(bounds)
         } else {
             // Otherwise the prefix is resolved as a type to distinguish trait/type/module.
+            let prefix_last_ident = prefix.last_segment().ident;
             match self.use_path_as_type(prefix) {
                 Ok(resolution) => match &resolution.item {
                     PathResolutionItem::Trait(trait_id) => {
@@ -1527,11 +1529,11 @@ impl Elaborator<'_> {
                     | PathResolutionItem::TypeAlias(..)
                     | PathResolutionItem::PrimitiveType(..) => PathPrefixKind::Type { resolution },
                     PathResolutionItem::Module(..) => PathPrefixKind::Module,
-                    // Resolving a type path falls back to the value namespace, so the prefix can
-                    // also resolve to a value item; that (and an associated type) can't carry the
-                    // last segment as an associated item, so there is no usable prefix and the
-                    // whole path is resolved as a value. Listed explicitly (rather than `_`) so a
-                    // new `PathResolutionItem` must be classified here.
+                    // Resolving a type path falls back to the value namespace, so the prefix's last
+                    // segment can also resolve to a value item; that (and an associated type) can't
+                    // carry the last segment of the path as an associated item, so the path names
+                    // nothing. Listed explicitly (rather than `_`) so a new `PathResolutionItem`
+                    // must be classified here.
                     PathResolutionItem::TraitAssociatedType(..)
                     | PathResolutionItem::Global(..)
                     | PathResolutionItem::EnumVariant(..)
@@ -1542,9 +1544,11 @@ impl Elaborator<'_> {
                     | PathResolutionItem::TraitFunction(..)
                     | PathResolutionItem::TypeTraitFunction(..)
                     | PathResolutionItem::PrimitiveFunction(..)
-                    | PathResolutionItem::TraitConstant(..) => PathPrefixKind::NoPrefix,
+                    | PathResolutionItem::TraitConstant(..) => PathPrefixKind::NoPrefix {
+                        error: PathResolutionError::Unresolved(prefix_last_ident),
+                    },
                 },
-                Err(_) => PathPrefixKind::NoPrefix,
+                Err(error) => PathPrefixKind::NoPrefix { error },
             }
         };
 
@@ -2262,10 +2266,13 @@ impl Elaborator<'_> {
                 &last_segment,
                 resolution,
             ),
-            // A module prefix's value item, or a prefix that isn't an item carrier at all: resolve
-            // the whole path as a value (reporting the error if it doesn't resolve).
-            PathPrefixKind::Module | PathPrefixKind::NoPrefix => {
-                self.resolve_variable_in_scope(path)
+            // A module prefix: the last segment is an ordinary value item, resolved as a value.
+            PathPrefixKind::Module => self.resolve_variable_in_scope(path),
+            // No usable prefix: the path names nothing, and a value lookup would only rediscover
+            // the resolution failure already carried here, so report it directly.
+            PathPrefixKind::NoPrefix { error } => {
+                self.push_err(error);
+                None
             }
             // `Self` with no self type in scope: report it directly.
             PathPrefixKind::SelfNotInScope => {

--- a/compiler/noirc_frontend/src/elaborator/types.rs
+++ b/compiler/noirc_frontend/src/elaborator/types.rs
@@ -37,8 +37,8 @@ use crate::{
     },
     hir_def::{
         expr::{
-            HirBinaryOp, HirCallExpression, HirExpression, HirLiteral, HirMemberAccess,
-            HirMethodReference, HirPrefixExpression, HirTraitMethodReference, TraitItem,
+            HirBinaryOp, HirCallExpression, HirExpression, HirIdent, HirLiteral, HirMemberAccess,
+            HirMethodReference, HirPrefixExpression, HirTraitMethodReference, ImplKind, TraitItem,
         },
         function::FuncMeta,
         stmt::HirStatement,
@@ -55,20 +55,20 @@ use crate::{
 use super::{
     Elaborator, PathResolutionTarget, UnsafeBlockStatus, lints,
     path_resolution::{PathResolutionItem, PathResolutionMode, TypedPath, TypedPathSegment},
-    variable::PrefixedVariable,
+    variable::{PrefixedVariable, VariableResolution},
 };
 
 pub const SELF_TYPE_NAME: &str = "Self";
 
 #[derive(Debug)]
-pub(super) struct TraitPathResolution {
-    pub(super) method: TraitPathResolutionMethod,
-    pub(super) item: Option<PathResolutionItem>,
-    pub(super) errors: Vec<PathResolutionError>,
+struct TraitPathResolution {
+    method: TraitPathResolutionMethod,
+    item: Option<PathResolutionItem>,
+    errors: Vec<PathResolutionError>,
 }
 
 #[derive(Debug)]
-pub(super) enum TraitPathResolutionMethod {
+enum TraitPathResolutionMethod {
     NotATraitMethod(FuncId),
     TraitItem(TraitItem),
     MultipleTraitsInScope,
@@ -2182,6 +2182,39 @@ impl Elaborator<'_> {
         }?;
 
         Some(self.prefixed_variable_from_trait_resolution(path.location, resolution))
+    }
+
+    /// Turn a [`TraitPathResolution`] into the [`PrefixedVariable`] a prefixed path resolves to,
+    /// pushing the resolution's errors. An unresolvable trait method (`MultipleTraitsInScope`) has
+    /// already reported its error, so it becomes [`PrefixedVariable::Errored`] rather than an
+    /// identifier (and the caller must not fall back to value resolution).
+    fn prefixed_variable_from_trait_resolution(
+        &mut self,
+        location: Location,
+        resolution: TraitPathResolution,
+    ) -> PrefixedVariable {
+        self.push_errors(resolution.errors);
+        let item = resolution.item;
+        match resolution.method {
+            TraitPathResolutionMethod::NotATraitMethod(func_id) => {
+                let ident = HirIdent {
+                    location,
+                    id: self.interner.function_definition_id(func_id),
+                    impl_kind: ImplKind::NotATraitMethod,
+                };
+                PrefixedVariable::Resolved(VariableResolution::Ident(ident, item))
+            }
+            TraitPathResolutionMethod::TraitItem(trait_item) => {
+                let ident = HirIdent {
+                    location,
+                    id: trait_item.definition,
+                    impl_kind: ImplKind::TraitItem(trait_item),
+                };
+                PrefixedVariable::Resolved(VariableResolution::Ident(ident, item))
+            }
+            // An error has already been pushed, don't return an identifier.
+            TraitPathResolutionMethod::MultipleTraitsInScope => PrefixedVariable::Errored,
+        }
     }
 
     /// Unify two types, modifying both in the process.

--- a/compiler/noirc_frontend/src/elaborator/types.rs
+++ b/compiler/noirc_frontend/src/elaborator/types.rs
@@ -1615,7 +1615,13 @@ impl Elaborator<'_> {
             None
         };
 
-        self.variable_or_value_fallback(path, trait_resolution)
+        // A trait prefix can only carry a trait method or associated constant; if the last segment
+        // is neither, it names nothing.
+        self.variable_from_trait_resolution_or_unresolved(
+            path.location,
+            last_segment,
+            trait_resolution,
+        )
     }
 
     /// Resolves `T::item` to a method or associated constant of a generic `T`, given the `T: Trait`
@@ -1670,7 +1676,13 @@ impl Elaborator<'_> {
             None
         };
 
-        self.variable_or_value_fallback(path, trait_resolution)
+        // The generic is in scope; the last segment must be a method or associated constant
+        // reached through one of its bounds. If it is neither, it names nothing.
+        self.variable_from_trait_resolution_or_unresolved(
+            path.location,
+            last_segment,
+            trait_resolution,
+        )
     }
 
     fn find_methods_or_constants_in_trait(
@@ -2295,7 +2307,11 @@ impl Elaborator<'_> {
         if let Some(bounds) = self.matching_generic_bounds(&path) {
             return self.resolve_bounded_generic_item(path, bounds, &last_segment, turbofish);
         }
-        self.resolve_variable_in_scope(path)
+        // `Self` here is the trait itself, so the last segment can only be a trait static method or
+        // associated constant (handled above); anything else names nothing. Report the last
+        // segment rather than the in-scope `Self`.
+        self.push_err(PathResolutionError::Unresolved(last_segment.ident.clone()));
+        None
     }
 
     /// Resolve `Self::method` (or `Self::AssocType::method`) by resolving the `Self` prefix as a
@@ -2366,6 +2382,26 @@ impl Elaborator<'_> {
         match trait_resolution {
             Some(resolution) => self.variable_from_trait_resolution(path.location, resolution),
             None => self.resolve_variable_in_scope(path),
+        }
+    }
+
+    /// Like [`Self::variable_or_value_fallback`], but for a prefix whose last segment can only be a
+    /// trait item — a trait (`Trait::x`) or a bounded generic (`T::x`). When it is not one, the
+    /// path names nothing, so report the last segment as unresolved directly: a value lookup would
+    /// fail anyway, and on a trait or generic prefix it blames the (in-scope) prefix segment rather
+    /// than the missing item.
+    fn variable_from_trait_resolution_or_unresolved(
+        &mut self,
+        location: Location,
+        last_segment: &TypedPathSegment,
+        trait_resolution: Option<TraitPathResolution>,
+    ) -> Option<VariableResolution> {
+        match trait_resolution {
+            Some(resolution) => self.variable_from_trait_resolution(location, resolution),
+            None => {
+                self.push_err(PathResolutionError::Unresolved(last_segment.ident.clone()));
+                None
+            }
         }
     }
 

--- a/compiler/noirc_frontend/src/elaborator/types.rs
+++ b/compiler/noirc_frontend/src/elaborator/types.rs
@@ -55,7 +55,7 @@ use crate::{
 use super::{
     Elaborator, PathResolutionTarget, UnsafeBlockStatus, lints,
     path_resolution::{PathResolutionItem, PathResolutionMode, TypedPath, TypedPathSegment},
-    variable::{PrefixedVariable, VariableResolution},
+    variable::VariableResolution,
 };
 
 pub const SELF_TYPE_NAME: &str = "Self";
@@ -2143,17 +2143,29 @@ impl Elaborator<'_> {
         TraitPathResolution { method, item: Some(item), errors }
     }
 
-    /// Resolve a [`TypedPath`] that has a prefix (more than one segment) to the item it names.
-    /// [`Self::resolve_path_prefix`] classifies the prefix once; the last segment is resolved
-    /// against that classification and mapped to a [`PrefixedVariable`].
+    /// Resolve a [`TypedPath`] that has a prefix (more than one segment) to the item it names —
+    /// fully: it always resolves the path, reports an error, or falls back to a value lookup, so
+    /// the caller never needs a further fallback. [`Self::resolve_path_prefix`] classifies the
+    /// prefix once; the last segment is resolved against that classification, and anything that is
+    /// not a method/trait-item (an enum variant, a module value, an associated constant, …) is
+    /// resolved by [`Self::resolve_variable_in_scope`] on the whole path.
+    ///
+    /// Returns `None` only when an error has already been reported (an ambiguous trait method, or
+    /// an unresolved name), so the caller should produce an error expression rather than retry.
     #[tracing::instrument(level = "trace", skip_all)]
     pub(super) fn resolve_prefixed_variable(
         &mut self,
         path: &TypedPath,
-    ) -> Option<PrefixedVariable> {
-        let resolution = match self.resolve_path_prefix(path)? {
-            // `Self` is contextual; its handler produces the `PrefixedVariable` directly (it may be
-            // an elaborated expression, not a trait resolution).
+    ) -> Option<VariableResolution> {
+        let Some(kind) = self.resolve_path_prefix(path) else {
+            // The prefix doesn't resolve to a type/trait/module; let the value lookup of the whole
+            // path resolve it or report the error.
+            return self.resolve_variable_in_scope(path.clone());
+        };
+
+        let trait_resolution = match kind {
+            // `Self` is contextual; its handler produces the resolution directly (it may be an
+            // elaborated expression, not a trait resolution).
             PathPrefixKind::SelfType => return self.resolve_self_prefix(path),
             PathPrefixKind::BoundedGeneric => self.resolve_trait_method_by_named_generic(path),
             PathPrefixKind::Type { last_segment, turbofish, is_self_prefix, resolution } => self
@@ -2175,9 +2187,14 @@ impl Elaborator<'_> {
                     resolution,
                 ),
             PathPrefixKind::Module => None,
-        }?;
+        };
 
-        Some(self.prefixed_variable_from_trait_resolution(path.location, resolution))
+        match trait_resolution {
+            Some(resolution) => self.variable_from_trait_resolution(path.location, resolution),
+            // Not a method or trait item: resolve the whole path as a value (a module value, an
+            // enum variant, an associated constant, …).
+            None => self.resolve_variable_in_scope(path.clone()),
+        }
     }
 
     /// Resolve a `Self::…` path used as an expression. `Self` is contextual, so this enumerates its
@@ -2188,50 +2205,58 @@ impl Elaborator<'_> {
     ///   resolved as an assumed constraint on `Self`;
     /// - otherwise (`Self` is a concrete data type, e.g. inside an impl method): `Self::method`,
     ///   resolved the same way as `Type::method`.
-    fn resolve_self_prefix(&mut self, path: &TypedPath) -> Option<PrefixedVariable> {
+    ///
+    /// Anything that isn't one of these (e.g. `Self::Variant`) falls back to a value lookup.
+    fn resolve_self_prefix(&mut self, path: &TypedPath) -> Option<VariableResolution> {
         // Cases the module resolver can't reach: a method/constant on a primitive `Self`, an
         // associated constant, or a method on an associated type (all inside a trait impl).
         if let Some((expr_id, typ)) =
             self.elaborate_variable_as_self_method_or_associated_constant(path)
         {
-            return Some(PrefixedVariable::Resolved(VariableResolution::Expression(expr_id, typ)));
+            return Some(VariableResolution::Expression(expr_id, typ));
         }
 
         // Inside a trait definition, `Self` is the trait: resolve to an assumed constraint on it,
         // falling back to a supertrait reached through that bound.
         if self.current_trait.is_some() && self.current_trait_impl.is_none() {
-            let resolution = self
+            return match self
                 .resolve_trait_static_method_by_self(path)
-                .or_else(|| self.resolve_trait_method_by_named_generic(path))?;
-            return Some(self.prefixed_variable_from_trait_resolution(path.location, resolution));
+                .or_else(|| self.resolve_trait_method_by_named_generic(path))
+            {
+                Some(resolution) => self.variable_from_trait_resolution(path.location, resolution),
+                None => self.resolve_variable_in_scope(path.clone()),
+            };
         }
 
         // Otherwise `Self` is a concrete data type: resolve the method exactly as `Type::method`
-        // does, on `Self`'s type.
+        // does, on `Self`'s type. A non-method (e.g. `Self::Variant`) falls back to a value lookup.
         let mut prefix = path.clone();
         let last_segment = prefix.pop();
         let turbofish = prefix.last_segment().turbofish();
-        let type_resolution = self.use_path_as_type(prefix).ok()?;
-        let is_self_prefix = true;
-        let resolution = self.resolve_method_on_type_prefix(
-            path.location,
-            last_segment,
-            turbofish,
-            is_self_prefix,
-            type_resolution,
-        )?;
-        Some(self.prefixed_variable_from_trait_resolution(path.location, resolution))
+        let resolution = self.use_path_as_type(prefix).ok().and_then(|type_resolution| {
+            self.resolve_method_on_type_prefix(
+                path.location,
+                last_segment,
+                turbofish,
+                true, // is_self_prefix
+                type_resolution,
+            )
+        });
+        match resolution {
+            Some(resolution) => self.variable_from_trait_resolution(path.location, resolution),
+            None => self.resolve_variable_in_scope(path.clone()),
+        }
     }
 
-    /// Turn a [`TraitPathResolution`] into the [`PrefixedVariable`] a prefixed path resolves to,
-    /// pushing the resolution's errors. An unresolvable trait method (`MultipleTraitsInScope`) has
-    /// already reported its error, so it becomes [`PrefixedVariable::Errored`] rather than an
-    /// identifier (and the caller must not fall back to value resolution).
-    fn prefixed_variable_from_trait_resolution(
+    /// Turn a [`TraitPathResolution`] into the [`VariableResolution`] a prefixed path resolves to,
+    /// pushing the resolution's errors. Returns `None` for an ambiguous trait method
+    /// (`MultipleTraitsInScope`), whose error was already reported, so the caller produces an error
+    /// expression rather than falling back to a value lookup.
+    fn variable_from_trait_resolution(
         &mut self,
         location: Location,
         resolution: TraitPathResolution,
-    ) -> PrefixedVariable {
+    ) -> Option<VariableResolution> {
         self.push_errors(resolution.errors);
         let item = resolution.item;
         match resolution.method {
@@ -2241,7 +2266,7 @@ impl Elaborator<'_> {
                     id: self.interner.function_definition_id(func_id),
                     impl_kind: ImplKind::NotATraitMethod,
                 };
-                PrefixedVariable::Resolved(VariableResolution::Ident(ident, item))
+                Some(VariableResolution::Ident(ident, item))
             }
             TraitPathResolutionMethod::TraitItem(trait_item) => {
                 let ident = HirIdent {
@@ -2249,10 +2274,9 @@ impl Elaborator<'_> {
                     id: trait_item.definition,
                     impl_kind: ImplKind::TraitItem(trait_item),
                 };
-                PrefixedVariable::Resolved(VariableResolution::Ident(ident, item))
+                Some(VariableResolution::Ident(ident, item))
             }
-            // An error has already been pushed, don't return an identifier.
-            TraitPathResolutionMethod::MultipleTraitsInScope => PrefixedVariable::Errored,
+            TraitPathResolutionMethod::MultipleTraitsInScope => None,
         }
     }
 

--- a/compiler/noirc_frontend/src/elaborator/types.rs
+++ b/compiler/noirc_frontend/src/elaborator/types.rs
@@ -73,40 +73,33 @@ pub(super) enum TraitPathResolutionMethod {
     MultipleTraitsInScope,
 }
 
-/// How a path used as an expression resolves to a trait item, keyed by what the path's prefix
-/// (every segment but the last) is. Produced by [`Elaborator::resolve_path_prefix`], which
-/// classifies the path into exactly one of these so [`Elaborator::resolve_trait_generic_path`]
-/// is a single dispatch rather than a chain of fallible probes.
-///
-/// The first three forms cannot be recognized from the prefix alone — they depend on elaborator
-/// context (the current trait, in-scope bounds) or on resolving the whole path — so for them
-/// detection and resolution are inseparable and the resolved [`TraitPathResolution`] is carried
-/// directly. The last three are distinguished purely by resolving the prefix.
+/// What the prefix of a path (every segment but the last) is, when the path is used as an
+/// expression. Produced by [`Elaborator::resolve_path_prefix`]; [`Elaborator::resolve_trait_generic_path`]
+/// then resolves the last segment against it. Only the data needed to resolve the last segment is
+/// carried — this describes *what the prefix is*, not the already-resolved item.
 #[derive(Debug)]
 pub(super) enum PathPrefixKind {
-    /// `Self::item` inside a trait *definition*, resolved as an assumed constraint on `Self`.
-    SelfInTraitDefinition(TraitPathResolution),
-    /// The whole path canonically names a trait method, e.g. `Trait::method` or
-    /// `Type::trait_method` resolved through the module system.
-    CanonicalTraitMethod(TraitPathResolution),
-    /// `T::method` where a `T: Trait` bound on the generic `T` is in scope.
-    BoundedGeneric(TraitPathResolution),
-    /// The prefix is a trait, e.g. the `Trait` in `Trait::CONST`. The last segment is an
-    /// associated constant.
+    /// `Self` inside a trait *definition*: the prefix is the current trait (an assumed `Self`
+    /// constraint). The last segment is a method or associated constant of that trait or a
+    /// supertrait.
+    SelfTrait,
+    /// A generic parameter with a `: Trait` bound in scope (e.g. `T` in `T::method`). The last
+    /// segment is a method or associated constant reached through one of those bounds.
+    BoundedGeneric,
+    /// A trait (e.g. `Trait` in `Trait::CONST`). The last segment is an associated constant.
+    /// (`Trait::method` is handled earlier as a canonical trait method.)
     Trait { trait_id: TraitId, last_segment: TypedPathSegment, resolution: PathResolution },
-    /// The prefix is a concrete type, type alias, primitive type, or `Self` bound to a data
-    /// type — e.g. the `Type` in `Type::method`. The last segment is an inherent or qualified
-    /// trait method.
+    /// A concrete type, type alias, primitive type, or `Self` bound to a data type (e.g. `Type`
+    /// in `Type::method`). The last segment is an inherent or qualified trait method.
     Type {
         last_segment: TypedPathSegment,
         turbofish: Option<Turbofish>,
         is_self_prefix: bool,
         resolution: PathResolution,
     },
-    /// The prefix is a module, or anything else that cannot prefix an associated item (e.g.
-    /// `foo::bar` in `foo::bar::GLOBAL`). The last segment is an ordinary value item, resolved
-    /// elsewhere.
-    Other,
+    /// A module, or anything else that cannot prefix an associated item (e.g. `foo::bar` in
+    /// `foo::bar::GLOBAL`). The last segment is an ordinary value item, resolved elsewhere.
+    Module,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1502,36 +1495,37 @@ impl Elaborator<'_> {
         Some(TraitPathResolution { method, item, errors: path_resolution.errors })
     }
 
-    /// Classify a path used as an expression into the single [`PathPrefixKind`] that describes how
-    /// to resolve it to a trait item. Returns `None` if the path names no trait item (so the caller
-    /// falls back to plain value resolution).
+    /// Classify the prefix (every segment but the last) of a path used as an expression. This does
+    /// not resolve the last segment — it only answers "what is the prefix?", which the caller uses
+    /// to decide how to resolve the last segment. Returns `None` if the path has no prefix.
     ///
     /// The classification order is significant: it decides which interpretation wins when a path
-    /// is ambiguous, and mirrors the historical probe order. The first three forms cannot be told
-    /// apart from the prefix alone — their detection requires resolving against the current trait,
-    /// the in-scope bounds, or the whole path — so they are attempted first and carry their result.
-    /// Only if none of them match is the prefix (every segment but the last) resolved as a type to
-    /// distinguish the trait-, type-, and module-prefixed forms.
+    /// is ambiguous, and mirrors the historical probe order. `Self` inside a trait definition and a
+    /// bounded generic are recognized from context (the current trait, the in-scope bounds) before
+    /// the prefix is resolved as a type to tell trait-, type-, and module-prefixed forms apart.
     #[tracing::instrument(level = "trace", skip_all)]
     fn resolve_path_prefix(&mut self, path: &TypedPath) -> Option<PathPrefixKind> {
-        // `Self::item` inside a trait definition (assumed constraint on `Self`).
-        if let Some(resolution) = self.resolve_trait_static_method_by_self(path) {
-            return Some(PathPrefixKind::SelfInTraitDefinition(resolution));
-        }
-        // The whole path canonically names a trait method (`Trait::method`, `Type::trait_method`).
-        if let Some(resolution) = self.resolve_trait_static_method(path) {
-            return Some(PathPrefixKind::CanonicalTraitMethod(resolution));
-        }
-        // `T::method` via a `T: Trait` bound on the generic `T`.
-        if let Some(resolution) = self.resolve_trait_method_by_named_generic(path) {
-            return Some(PathPrefixKind::BoundedGeneric(resolution));
-        }
-
-        // The remaining forms are distinguished by resolving the prefix as a type.
         if path.segments.len() < 2 {
             return None;
         }
 
+        // `Self` inside a trait definition: `Self` is the current trait, not a concrete type.
+        if path.kind == PathKind::Plain
+            && path.segments.len() == 2
+            && path.segments[0].ident.is_self_type_name()
+            && self.current_trait_impl.is_none()
+            && self.current_trait.is_some()
+        {
+            return Some(PathPrefixKind::SelfTrait);
+        }
+
+        // A generic parameter (e.g. `T`) with a `T: Trait` bound in scope. A generic is not in the
+        // module namespace, so this must be recognized from the in-scope bounds, not by resolution.
+        if path.segments.len() == 2 && self.path_head_is_bounded_generic(path) {
+            return Some(PathPrefixKind::BoundedGeneric);
+        }
+
+        // Otherwise the prefix is resolved as a type to distinguish trait/type/module.
         let mut path = path.clone();
         let last_segment = path.pop();
         let turbofish = path.last_segment().turbofish();
@@ -1554,7 +1548,17 @@ impl Elaborator<'_> {
         } else if is_type_prefix {
             PathPrefixKind::Type { last_segment, turbofish, is_self_prefix, resolution }
         } else {
-            PathPrefixKind::Other
+            PathPrefixKind::Module
+        })
+    }
+
+    /// Whether the path's first segment names a generic parameter that has a `: Trait` bound in
+    /// scope (so `Head::item` resolves through that bound). Mirrors the constraint scan in
+    /// [`Self::resolve_trait_method_by_named_generic`].
+    fn path_head_is_bounded_generic(&self, path: &TypedPath) -> bool {
+        let head = path.segments[0].ident.as_str();
+        self.trait_bounds.iter().any(|constraint| {
+            matches!(&constraint.typ, Type::NamedGeneric(generic) if generic.name.as_str() == head)
         })
     }
 
@@ -2212,21 +2216,27 @@ impl Elaborator<'_> {
     /// Returns the trait method, trait constraint, and whether the impl is assumed to exist by a where clause or not
     /// E.g. `t.method()` with `where T: Foo<Bar>` in scope will return `(Foo::method, T, vec![Bar])`
     ///
-    /// [`Self::resolve_path_prefix`] classifies the path into one [`PathPrefixKind`], so this is a
-    /// single dispatch. The classification order (which interpretation wins when a path is
-    /// ambiguous) lives in `resolve_path_prefix`; here each kind maps to the way its last segment
-    /// is turned into a [`TraitPathResolution`].
+    /// A `Type::method`/`Trait::method` whose whole path canonically names a trait method is
+    /// resolved first: that resolution goes through the module system and takes precedence over
+    /// the prefix-classified forms (and is a no-op for `Self`-in-a-definition and bare generics,
+    /// so it does not disturb their precedence). Otherwise [`Self::resolve_path_prefix`] classifies
+    /// the prefix once and the last segment is resolved against that classification.
     #[tracing::instrument(level = "trace", skip_all)]
     pub(super) fn resolve_trait_generic_path(
         &mut self,
         path: &TypedPath,
     ) -> Option<TraitPathResolution> {
-        match self.resolve_path_prefix(path)? {
-            // These forms were resolved as they were classified (see `resolve_path_prefix`).
-            PathPrefixKind::SelfInTraitDefinition(resolution)
-            | PathPrefixKind::CanonicalTraitMethod(resolution)
-            | PathPrefixKind::BoundedGeneric(resolution) => Some(resolution),
+        if let Some(resolution) = self.resolve_trait_static_method(path) {
+            return Some(resolution);
+        }
 
+        match self.resolve_path_prefix(path)? {
+            // `Self` in a trait definition: a method/constant of the current trait, falling back to
+            // a supertrait reached through the assumed `Self` bound.
+            PathPrefixKind::SelfTrait => self
+                .resolve_trait_static_method_by_self(path)
+                .or_else(|| self.resolve_trait_method_by_named_generic(path)),
+            PathPrefixKind::BoundedGeneric => self.resolve_trait_method_by_named_generic(path),
             PathPrefixKind::Type { last_segment, turbofish, is_self_prefix, resolution } => self
                 .resolve_method_on_type_prefix(
                     path.location,
@@ -2242,7 +2252,7 @@ impl Elaborator<'_> {
                     last_segment,
                     resolution,
                 ),
-            PathPrefixKind::Other => None,
+            PathPrefixKind::Module => None,
         }
     }
 

--- a/compiler/noirc_frontend/src/elaborator/types.rs
+++ b/compiler/noirc_frontend/src/elaborator/types.rs
@@ -113,9 +113,15 @@ enum PathPrefixKind {
     /// A concrete type, type alias, or primitive type (e.g. `Type` in `Type::method`). The last
     /// segment is an inherent or qualified trait method.
     Type { resolution: PathResolution },
-    /// A module, or anything else that cannot prefix an associated item (e.g. `foo::bar` in
-    /// `foo::bar::GLOBAL`). The last segment is an ordinary value item, resolved elsewhere.
+    /// A module (e.g. `foo::bar` in `foo::bar::GLOBAL`). The last segment is an ordinary value
+    /// item, resolved as a value.
     Module,
+    /// The prefix is `Self` but there is no self type in scope (e.g. in a free function), so `Self`
+    /// names nothing.
+    SelfNotInScope,
+    /// The prefix resolves to nothing that can carry an associated item (it is not a type, trait,
+    /// or module). The whole path is resolved as a value, which reports the error if there is one.
+    NoPrefix,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1481,10 +1487,10 @@ impl Elaborator<'_> {
     /// before the prefix is resolved as a type to tell trait-, type-, and module-prefixed forms
     /// apart.
     #[tracing::instrument(level = "trace", skip_all)]
-    fn resolve_path_prefix(&mut self, path: &TypedPath) -> Option<ResolvedPrefix> {
-        if path.segments.len() < 2 {
-            return None;
-        }
+    fn resolve_path_prefix(&mut self, path: &TypedPath) -> ResolvedPrefix {
+        // The caller (`resolve_variable`) only takes this path for a multi-segment path, so popping
+        // the last segment is always valid.
+        debug_assert!(path.segments.len() >= 2);
 
         let mut prefix = path.clone();
         let last_segment = prefix.pop();
@@ -1495,8 +1501,8 @@ impl Elaborator<'_> {
         // generic, so they must not be classified as such.
         let kind = if path.kind == PathKind::Plain && path.segments[0].ident.is_self_type_name() {
             // `Self` is contextual; which kind it is depends only on where we are (a trait impl, a
-            // trait definition, or somewhere `Self` is a plain type), so it is classified here and
-            // the matching handler resolves the last segment.
+            // trait definition, somewhere `Self` is a plain type, or nowhere at all), so it is
+            // classified here and the matching arm resolves the last segment.
             if self.current_trait_impl.is_some() {
                 PathPrefixKind::SelfInTraitImpl
             } else if self.current_trait.is_some() {
@@ -1504,10 +1510,7 @@ impl Elaborator<'_> {
             } else if self.self_type.is_some() {
                 PathPrefixKind::SelfInImpl
             } else {
-                // `Self` with no self type in scope (e.g. in a free function): report it directly
-                // rather than re-resolving the path just to discover the same thing.
-                self.push_err(PathResolutionError::Unresolved(path.segments[0].ident.clone()));
-                return None;
+                PathPrefixKind::SelfNotInScope
             }
         } else if path.kind == PathKind::Plain
             && let Some(bounds) = self.matching_generic_bounds(path)
@@ -1517,19 +1520,21 @@ impl Elaborator<'_> {
             PathPrefixKind::BoundedGeneric(bounds)
         } else {
             // Otherwise the prefix is resolved as a type to distinguish trait/type/module.
-            let resolution = self.use_path_as_type(prefix).ok()?;
-            match &resolution.item {
-                PathResolutionItem::Trait(trait_id) => {
-                    PathPrefixKind::Trait { trait_id: *trait_id, resolution }
-                }
-                PathResolutionItem::Type(..)
-                | PathResolutionItem::TypeAlias(..)
-                | PathResolutionItem::PrimitiveType(..) => PathPrefixKind::Type { resolution },
-                _ => PathPrefixKind::Module,
+            match self.use_path_as_type(prefix) {
+                Ok(resolution) => match &resolution.item {
+                    PathResolutionItem::Trait(trait_id) => {
+                        PathPrefixKind::Trait { trait_id: *trait_id, resolution }
+                    }
+                    PathResolutionItem::Type(..)
+                    | PathResolutionItem::TypeAlias(..)
+                    | PathResolutionItem::PrimitiveType(..) => PathPrefixKind::Type { resolution },
+                    _ => PathPrefixKind::Module,
+                },
+                Err(_) => PathPrefixKind::NoPrefix,
             }
         };
 
-        Some(ResolvedPrefix { last_segment, turbofish, kind })
+        ResolvedPrefix { last_segment, turbofish, kind }
     }
 
     /// If the path's first segment names a generic parameter with `: Trait` bound(s) in scope,
@@ -2180,16 +2185,7 @@ impl Elaborator<'_> {
         &mut self,
         path: &TypedPath,
     ) -> Option<VariableResolution> {
-        let Some(ResolvedPrefix { last_segment, turbofish, kind }) = self.resolve_path_prefix(path)
-        else {
-            // A plain `Self` with no self type in scope was already reported by
-            // `resolve_path_prefix`, so don't fall back. Any other unresolved prefix resolves the
-            // whole path as a value (or reports the error there).
-            if path.kind == PathKind::Plain && path.segments[0].ident.is_self_type_name() {
-                return None;
-            }
-            return self.resolve_variable_in_scope(path.clone());
-        };
+        let ResolvedPrefix { last_segment, turbofish, kind } = self.resolve_path_prefix(path);
 
         match kind {
             // `Self` is contextual; each context resolves the last segment its own way.
@@ -2226,8 +2222,16 @@ impl Elaborator<'_> {
                 &last_segment,
                 resolution,
             ),
-            // A module prefix: the last segment is an ordinary value item, resolved as a value.
-            PathPrefixKind::Module => self.resolve_variable_in_scope(path.clone()),
+            // A module prefix's value item, or a prefix that isn't an item carrier at all: resolve
+            // the whole path as a value (reporting the error if it doesn't resolve).
+            PathPrefixKind::Module | PathPrefixKind::NoPrefix => {
+                self.resolve_variable_in_scope(path.clone())
+            }
+            // `Self` with no self type in scope: report it directly.
+            PathPrefixKind::SelfNotInScope => {
+                self.push_err(PathResolutionError::Unresolved(path.segments[0].ident.clone()));
+                None
+            }
         }
     }
 

--- a/compiler/noirc_frontend/src/elaborator/types.rs
+++ b/compiler/noirc_frontend/src/elaborator/types.rs
@@ -74,10 +74,22 @@ enum TraitPathResolutionMethod {
     MultipleTraitsInScope,
 }
 
+/// A path's prefix resolved into [its kind](PathPrefixKind) plus the "rest" — the last segment
+/// (the item accessed on the prefix) and the prefix's own turbofish. Produced by
+/// [`Elaborator::resolve_path_prefix`]; [`Elaborator::resolve_prefixed_variable`] resolves the last
+/// segment against the kind without re-deriving anything from the original path.
+#[derive(Debug)]
+pub(super) struct ResolvedPrefix {
+    /// The path's last segment: the item being accessed on the prefix.
+    last_segment: TypedPathSegment,
+    /// Turbofish on the prefix's own last segment (e.g. the `<T>` in `Foo::<T>::bar`).
+    turbofish: Option<Turbofish>,
+    kind: PathPrefixKind,
+}
+
 /// What the prefix of a path (every segment but the last) is, when the path is used as an
-/// expression. Produced by [`Elaborator::resolve_path_prefix`]; [`Elaborator::resolve_prefixed_variable`]
-/// then resolves the last segment against it. Only the data needed to resolve the last segment is
-/// carried — this describes *what the prefix is*, not the already-resolved item.
+/// expression. This describes *what the prefix is*, not the already-resolved item; the shared
+/// "rest" (last segment, turbofish) lives on [`ResolvedPrefix`].
 #[derive(Debug)]
 pub(super) enum PathPrefixKind {
     /// The prefix starts with `Self`. What `Self` means is contextual — the current trait in a
@@ -89,21 +101,11 @@ pub(super) enum PathPrefixKind {
     /// segment is a method or associated constant reached through one of those bounds.
     BoundedGeneric,
     /// A trait (e.g. `Trait` in `Trait::method` / `Trait::CONST`). The last segment is a trait
-    /// static method or an associated constant. `turbofish` is the trait segment's turbofish.
-    Trait {
-        trait_id: TraitId,
-        turbofish: Option<Turbofish>,
-        last_segment: TypedPathSegment,
-        resolution: PathResolution,
-    },
-    /// A concrete type, type alias, primitive type, or `Self` bound to a data type (e.g. `Type`
-    /// in `Type::method`). The last segment is an inherent or qualified trait method.
-    Type {
-        last_segment: TypedPathSegment,
-        turbofish: Option<Turbofish>,
-        is_self_prefix: bool,
-        resolution: PathResolution,
-    },
+    /// static method or an associated constant.
+    Trait { trait_id: TraitId, resolution: PathResolution },
+    /// A concrete type, type alias, or primitive type (e.g. `Type` in `Type::method`). The last
+    /// segment is an inherent or qualified trait method.
+    Type { resolution: PathResolution },
     /// A module, or anything else that cannot prefix an associated item (e.g. `foo::bar` in
     /// `foo::bar::GLOBAL`). The last segment is an ordinary value item, resolved elsewhere.
     Module,
@@ -1472,48 +1474,38 @@ impl Elaborator<'_> {
     /// before the prefix is resolved as a type to tell trait-, type-, and module-prefixed forms
     /// apart.
     #[tracing::instrument(level = "trace", skip_all)]
-    fn resolve_path_prefix(&mut self, path: &TypedPath) -> Option<PathPrefixKind> {
+    fn resolve_path_prefix(&mut self, path: &TypedPath) -> Option<ResolvedPrefix> {
         if path.segments.len() < 2 {
             return None;
         }
 
-        // `Self` is contextual (the current trait, or a concrete self type), so it is classified
-        // by syntax alone; its handler resolves what it means.
-        if path.segments[0].ident.is_self_type_name() {
-            return Some(PathPrefixKind::SelfType);
-        }
+        let mut prefix = path.clone();
+        let last_segment = prefix.pop();
+        let turbofish = prefix.last_segment().turbofish();
 
-        // A generic parameter (e.g. `T`) with a `T: Trait` bound in scope. A generic is not in the
-        // module namespace, so this must be recognized from the in-scope bounds, not by resolution.
-        if path.segments.len() == 2 && self.path_head_is_bounded_generic(path) {
-            return Some(PathPrefixKind::BoundedGeneric);
-        }
-
-        // Otherwise the prefix is resolved as a type to distinguish trait/type/module.
-        let mut path = path.clone();
-        let last_segment = path.pop();
-        let turbofish = path.last_segment().turbofish();
-        let is_self_prefix = path.first_name() == Some(SELF_TYPE_NAME);
-
-        let resolution = self.use_path_as_type(path).ok()?;
-        let trait_id = match &resolution.item {
-            PathResolutionItem::Trait(trait_id) => Some(*trait_id),
-            _ => None,
-        };
-        let is_type_prefix = matches!(
-            &resolution.item,
-            PathResolutionItem::Type(..)
-                | PathResolutionItem::TypeAlias(..)
-                | PathResolutionItem::PrimitiveType(..)
-        );
-
-        Some(if let Some(trait_id) = trait_id {
-            PathPrefixKind::Trait { trait_id, turbofish, last_segment, resolution }
-        } else if is_type_prefix {
-            PathPrefixKind::Type { last_segment, turbofish, is_self_prefix, resolution }
+        let kind = if path.segments[0].ident.is_self_type_name() {
+            // `Self` is contextual (the current trait, or a concrete self type), so it is classified
+            // by syntax alone; its handler resolves what it means.
+            PathPrefixKind::SelfType
+        } else if path.segments.len() == 2 && self.path_head_is_bounded_generic(path) {
+            // A generic parameter (e.g. `T`) with a `T: Trait` bound in scope. A generic is not in
+            // the module namespace, so this is recognized from the in-scope bounds, not resolution.
+            PathPrefixKind::BoundedGeneric
         } else {
-            PathPrefixKind::Module
-        })
+            // Otherwise the prefix is resolved as a type to distinguish trait/type/module.
+            let resolution = self.use_path_as_type(prefix).ok()?;
+            match &resolution.item {
+                PathResolutionItem::Trait(trait_id) => {
+                    PathPrefixKind::Trait { trait_id: *trait_id, resolution }
+                }
+                PathResolutionItem::Type(..)
+                | PathResolutionItem::TypeAlias(..)
+                | PathResolutionItem::PrimitiveType(..) => PathPrefixKind::Type { resolution },
+                _ => PathPrefixKind::Module,
+            }
+        };
+
+        Some(ResolvedPrefix { last_segment, turbofish, kind })
     }
 
     /// Whether the path's first segment names a generic parameter that has a `: Trait` bound in
@@ -2157,7 +2149,8 @@ impl Elaborator<'_> {
         &mut self,
         path: &TypedPath,
     ) -> Option<VariableResolution> {
-        let Some(kind) = self.resolve_path_prefix(path) else {
+        let Some(ResolvedPrefix { last_segment, turbofish, kind }) = self.resolve_path_prefix(path)
+        else {
             // The prefix doesn't resolve to a type/trait/module; let the value lookup of the whole
             // path resolve it or report the error.
             return self.resolve_variable_in_scope(path.clone());
@@ -2165,27 +2158,28 @@ impl Elaborator<'_> {
 
         let trait_resolution = match kind {
             // `Self` is contextual; its handler produces the resolution directly (it may be an
-            // elaborated expression, not a trait resolution).
+            // elaborated expression, not a trait resolution) and works from the path.
             PathPrefixKind::SelfType => return self.resolve_self_prefix(path),
             PathPrefixKind::BoundedGeneric => self.resolve_trait_method_by_named_generic(path),
-            PathPrefixKind::Type { last_segment, turbofish, is_self_prefix, resolution } => self
-                .resolve_method_on_type_prefix(
+            PathPrefixKind::Type { resolution } => {
+                let is_self_prefix = false;
+                self.resolve_method_on_type_prefix(
                     path.location,
                     last_segment,
                     turbofish,
                     is_self_prefix,
                     resolution,
-                ),
+                )
+            }
             // A trait prefix: the last segment is either a trait static method (`Trait::method`)
             // or an associated constant (`Trait::CONST`).
-            PathPrefixKind::Trait { trait_id, turbofish, last_segment, resolution } => self
-                .resolve_trait_item_on_prefix(
-                    trait_id,
-                    turbofish,
-                    &last_segment,
-                    path.location,
-                    resolution,
-                ),
+            PathPrefixKind::Trait { trait_id, resolution } => self.resolve_trait_item_on_prefix(
+                trait_id,
+                turbofish,
+                &last_segment,
+                path.location,
+                resolution,
+            ),
             PathPrefixKind::Module => None,
         };
 

--- a/compiler/noirc_frontend/src/elaborator/types.rs
+++ b/compiler/noirc_frontend/src/elaborator/types.rs
@@ -101,7 +101,7 @@ enum PathPrefixKind {
     SelfInTrait { trait_id: TraitId },
     /// `Self` as a plain concrete type (an inherent impl, or any other context where `Self` names
     /// a data type): the last segment resolves like `Type::method`
-    /// ([`Elaborator::resolve_self_in_impl`]).
+    /// ([`Elaborator::resolve_self_as_concrete_type`]).
     SelfInImpl,
     /// A generic parameter with `: Trait` bound(s) in scope (e.g. `T` in `T::method`); the carried
     /// constraints are the matched bounds. The last segment is a method or associated constant

--- a/compiler/noirc_frontend/src/elaborator/types.rs
+++ b/compiler/noirc_frontend/src/elaborator/types.rs
@@ -1563,37 +1563,40 @@ impl Elaborator<'_> {
     /// is lowered to the selected impl's value during monomorphization.
     fn resolve_trait_item_on_prefix(
         &mut self,
+        path: &TypedPath,
         trait_id: TraitId,
         turbofish: Option<Turbofish>,
         last_segment: &TypedPathSegment,
-        location: Location,
         resolution: PathResolution,
-    ) -> Option<TraitPathResolution> {
+    ) -> Option<VariableResolution> {
         let the_trait = self.interner.get_trait(trait_id);
         let name = last_segment.ident.as_str();
         let method_func_id = the_trait.method_ids.get(name).copied();
         let associated_constant = the_trait.associated_constant_ids.get(name).copied();
-        let constraint = the_trait.as_constraint(location);
+        let constraint = the_trait.as_constraint(path.location);
 
-        if let Some(func_id) = method_func_id {
+        let trait_resolution = if let Some(func_id) = method_func_id {
             let definition = self.interner.function_definition_id(func_id);
             self.record_direct_method_reference(func_id, &last_segment.ident);
             let trait_item = TraitItem { definition, constraint, assumed: false };
             let item = PathResolutionItem::TraitFunction(trait_id, turbofish, func_id);
-            return Some(TraitPathResolution {
+            Some(TraitPathResolution {
                 method: TraitPathResolutionMethod::TraitItem(trait_item),
                 item: Some(item),
                 errors: resolution.errors,
-            });
-        }
+            })
+        } else if let Some(definition) = associated_constant {
+            let trait_item = TraitItem { definition, constraint, assumed: true };
+            Some(TraitPathResolution {
+                method: TraitPathResolutionMethod::TraitItem(trait_item),
+                item: None,
+                errors: resolution.errors,
+            })
+        } else {
+            None
+        };
 
-        let definition = associated_constant?;
-        let trait_item = TraitItem { definition, constraint, assumed: true };
-        Some(TraitPathResolution {
-            method: TraitPathResolutionMethod::TraitItem(trait_item),
-            item: None,
-            errors: resolution.errors,
-        })
+        self.variable_or_value_fallback(path, trait_resolution)
     }
 
     /// Resolves `T::item` to a method or associated constant of a generic `T`, given the `T: Trait`
@@ -1603,11 +1606,11 @@ impl Elaborator<'_> {
     #[tracing::instrument(level = "trace", skip_all)]
     fn resolve_bounded_generic_item(
         &mut self,
+        path: &TypedPath,
         bounds: Vec<TraitConstraint>,
         last_segment: &TypedPathSegment,
         turbofish: Option<Turbofish>,
-        location: Location,
-    ) -> Option<TraitPathResolution> {
+    ) -> Option<VariableResolution> {
         let method_name = last_segment.ident.as_str();
 
         let mut matches = Vec::new();
@@ -1622,7 +1625,7 @@ impl Elaborator<'_> {
             ));
         }
 
-        if matches.len() == 1 {
+        let trait_resolution = if matches.len() == 1 {
             let method = matches.remove(0).0;
 
             // A turbofish on the generic itself (e.g. `T::<u32>::method`) is not allowed.
@@ -1633,22 +1636,22 @@ impl Elaborator<'_> {
                 });
             }
 
-            return Some(TraitPathResolution { method, item: None, errors: Vec::new() });
-        }
-
-        if matches.len() > 1 {
-            let ident = Ident::new(method_name.to_string(), location);
+            Some(TraitPathResolution { method, item: None, errors: Vec::new() })
+        } else if matches.len() > 1 {
+            let ident = Ident::new(method_name.to_string(), path.location);
             let traits =
                 vecmap(matches, |(_, trait_id)| self.fully_qualified_trait_path_by_id(trait_id));
             let errors = vec![PathResolutionError::MultipleTraitsInScope { ident, traits }];
-            return Some(TraitPathResolution {
+            Some(TraitPathResolution {
                 method: TraitPathResolutionMethod::MultipleTraitsInScope,
                 item: None,
                 errors,
-            });
-        }
+            })
+        } else {
+            None
+        };
 
-        None
+        self.variable_or_value_fallback(path, trait_resolution)
     }
 
     fn find_methods_or_constants_in_trait(
@@ -1746,21 +1749,26 @@ impl Elaborator<'_> {
     #[tracing::instrument(level = "trace", skip_all)]
     fn resolve_method_on_type_prefix(
         &mut self,
-        location: Location,
+        path: &TypedPath,
         last_segment: TypedPathSegment,
         turbofish: Option<Turbofish>,
         is_self_prefix: bool,
         path_resolution: PathResolution,
-    ) -> Option<TraitPathResolution> {
+    ) -> Option<VariableResolution> {
         // `Self::method` must anchor on the impl's own `self_type` and produce a `SelfMethod`, so it
         // gets dedicated handling (in `resolve_self_or_inherent_method`) distinct from a plain
         // `TypeName::method`.
         let mut errors = Vec::new();
-        let typ = self.path_resolution_item_to_type(
+        let Some(typ) = self.path_resolution_item_to_type(
             &path_resolution.item,
             turbofish.clone(),
             &mut errors,
-        )?;
+        ) else {
+            // The prefix isn't a type/alias/primitive, so the last segment isn't a method on it;
+            // resolve the whole path as a value instead.
+            self.push_errors(errors);
+            return self.resolve_variable_in_scope(path.clone());
+        };
 
         let method_name = last_segment.ident.as_str();
 
@@ -1770,7 +1778,7 @@ impl Elaborator<'_> {
         // Resolve inherent methods (`TypeName::method`, and `Self::method`) through this
         // type-directed lookup. Names that aren't an inherent method here (associated constants,
         // trait methods not in scope) fall through to trait-method resolution.
-        if turbofish.is_some() {
+        let trait_resolution = if turbofish.is_some() {
             self.resolve_turbofish_type_method(
                 typ,
                 direct_method,
@@ -1778,7 +1786,7 @@ impl Elaborator<'_> {
                 turbofish,
                 path_resolution,
                 errors,
-                location,
+                path.location,
             )
         } else if let Some(direct_method) = direct_method {
             Some(self.resolve_self_or_inherent_method(
@@ -1798,9 +1806,11 @@ impl Elaborator<'_> {
                 turbofish,
                 path_resolution,
                 errors,
-                location,
+                path.location,
             )
-        }
+        };
+
+        self.variable_or_value_fallback(path, trait_resolution)
     }
 
     /// Resolves a turbofished `TypeName::<..>::method` path. Resolves to the single inherent method
@@ -2181,27 +2191,26 @@ impl Elaborator<'_> {
             return self.resolve_variable_in_scope(path.clone());
         };
 
-        let trait_resolution = match kind {
-            // Each `Self` context produces its resolution directly (it may be an elaborated
-            // expression, not a trait resolution).
+        match kind {
+            // `Self` is contextual; each context resolves the last segment its own way.
             PathPrefixKind::SelfInTraitImpl => {
-                return self.resolve_self_in_trait_impl(path, last_segment, turbofish);
+                self.resolve_self_in_trait_impl(path, last_segment, turbofish)
             }
             PathPrefixKind::SelfInTrait => {
-                return self.resolve_self_in_trait(path, last_segment, turbofish);
+                self.resolve_self_in_trait(path, last_segment, turbofish)
             }
             // `Self` is a concrete type here (classification guarantees `self_type` exists), so it
             // resolves exactly like `Type::method`.
             PathPrefixKind::SelfInImpl => {
-                return self.resolve_self_as_concrete_type(path, last_segment, turbofish);
+                self.resolve_self_as_concrete_type(path, last_segment, turbofish)
             }
             PathPrefixKind::BoundedGeneric(bounds) => {
-                self.resolve_bounded_generic_item(bounds, &last_segment, turbofish, path.location)
+                self.resolve_bounded_generic_item(path, bounds, &last_segment, turbofish)
             }
             PathPrefixKind::Type { resolution } => {
                 let is_self_prefix = false;
                 self.resolve_method_on_type_prefix(
-                    path.location,
+                    path,
                     last_segment,
                     turbofish,
                     is_self_prefix,
@@ -2211,20 +2220,14 @@ impl Elaborator<'_> {
             // A trait prefix: the last segment is either a trait static method (`Trait::method`)
             // or an associated constant (`Trait::CONST`).
             PathPrefixKind::Trait { trait_id, resolution } => self.resolve_trait_item_on_prefix(
+                path,
                 trait_id,
                 turbofish,
                 &last_segment,
-                path.location,
                 resolution,
             ),
-            PathPrefixKind::Module => None,
-        };
-
-        match trait_resolution {
-            Some(resolution) => self.variable_from_trait_resolution(path.location, resolution),
-            // Not a method or trait item: resolve the whole path as a value (a module value, an
-            // enum variant, an associated constant, …).
-            None => self.resolve_variable_in_scope(path.clone()),
+            // A module prefix: the last segment is an ordinary value item, resolved as a value.
+            PathPrefixKind::Module => self.resolve_variable_in_scope(path.clone()),
         }
     }
 
@@ -2254,14 +2257,14 @@ impl Elaborator<'_> {
         last_segment: TypedPathSegment,
         turbofish: Option<Turbofish>,
     ) -> Option<VariableResolution> {
-        let resolution = self.resolve_trait_static_method_by_self(path).or_else(|| {
-            let bounds = self.matching_generic_bounds(path)?;
-            self.resolve_bounded_generic_item(bounds, &last_segment, turbofish, path.location)
-        });
-        match resolution {
-            Some(resolution) => self.variable_from_trait_resolution(path.location, resolution),
-            None => self.resolve_variable_in_scope(path.clone()),
+        if let Some(resolution) = self.resolve_trait_static_method_by_self(path) {
+            return self.variable_from_trait_resolution(path.location, resolution);
         }
+        // Fall back to a supertrait reached through the assumed `Self` bound.
+        if let Some(bounds) = self.matching_generic_bounds(path) {
+            return self.resolve_bounded_generic_item(path, bounds, &last_segment, turbofish);
+        }
+        self.resolve_variable_in_scope(path.clone())
     }
 
     /// Resolve `Self::method` (or `Self::AssocType::method`) by resolving the `Self` prefix as a
@@ -2275,17 +2278,15 @@ impl Elaborator<'_> {
     ) -> Option<VariableResolution> {
         let mut prefix = path.clone();
         prefix.pop();
-        let resolution = self.use_path_as_type(prefix).ok().and_then(|type_resolution| {
-            self.resolve_method_on_type_prefix(
-                path.location,
+        match self.use_path_as_type(prefix).ok() {
+            Some(type_resolution) => self.resolve_method_on_type_prefix(
+                path,
                 last_segment,
                 turbofish,
                 true, // is_self_prefix
                 type_resolution,
-            )
-        });
-        match resolution {
-            Some(resolution) => self.variable_from_trait_resolution(path.location, resolution),
+            ),
+            // The `Self` prefix doesn't resolve as a type; resolve the whole path as a value.
             None => self.resolve_variable_in_scope(path.clone()),
         }
     }
@@ -2319,6 +2320,21 @@ impl Elaborator<'_> {
                 Some(VariableResolution::Ident(ident, item))
             }
             TraitPathResolutionMethod::MultipleTraitsInScope => None,
+        }
+    }
+
+    /// Map a prefix's last-segment resolution to a [`VariableResolution`]: a `Some` trait
+    /// resolution becomes the trait item (or `None` for an already-reported ambiguity), while a
+    /// `None` means the last segment is not a method/trait item, so the whole path is resolved as a
+    /// value (a module value, an enum variant, an associated constant, …) or its error reported.
+    fn variable_or_value_fallback(
+        &mut self,
+        path: &TypedPath,
+        trait_resolution: Option<TraitPathResolution>,
+    ) -> Option<VariableResolution> {
+        match trait_resolution {
+            Some(resolution) => self.variable_from_trait_resolution(path.location, resolution),
+            None => self.resolve_variable_in_scope(path.clone()),
         }
     }
 

--- a/compiler/noirc_frontend/src/elaborator/types.rs
+++ b/compiler/noirc_frontend/src/elaborator/types.rs
@@ -14,8 +14,7 @@ use rustc_hash::FxHashMap as HashMap;
 pub(crate) use similarly_named_types::SimilarlyNamedType;
 
 use crate::{
-    BinaryTypeOperator, Kind, NamedGeneric, ResolvedGeneric, Type, TypeBinding, TypeBindings,
-    UnificationError,
+    BinaryTypeOperator, Kind, ResolvedGeneric, Type, TypeBinding, TypeBindings, UnificationError,
     ast::{
         AsTraitPath, BinaryOpKind, GenericTypeArgs, Ident, IntegerBitSize, PathKind, UnaryOp,
         UnresolvedType, UnresolvedTypeData, UnresolvedTypeExpression, WILDCARD_TYPE,
@@ -97,9 +96,10 @@ pub(super) enum PathPrefixKind {
     /// (`Self::method`, `Self::CONST`, `Self::AssocType::method`), so the dedicated handler
     /// ([`Elaborator::resolve_self_prefix`]) enumerates the cases.
     SelfType,
-    /// A generic parameter with a `: Trait` bound in scope (e.g. `T` in `T::method`). The last
-    /// segment is a method or associated constant reached through one of those bounds.
-    BoundedGeneric,
+    /// A generic parameter with `: Trait` bound(s) in scope (e.g. `T` in `T::method`); the carried
+    /// constraints are the matched bounds. The last segment is a method or associated constant
+    /// reached through one of them.
+    BoundedGeneric(Vec<TraitConstraint>),
     /// A trait (e.g. `Trait` in `Trait::method` / `Trait::CONST`). The last segment is a trait
     /// static method or an associated constant.
     Trait { trait_id: TraitId, resolution: PathResolution },
@@ -1487,10 +1487,10 @@ impl Elaborator<'_> {
             // `Self` is contextual (the current trait, or a concrete self type), so it is classified
             // by syntax alone; its handler resolves what it means.
             PathPrefixKind::SelfType
-        } else if path.segments.len() == 2 && self.path_head_is_bounded_generic(path) {
+        } else if let Some(bounds) = self.matching_generic_bounds(path) {
             // A generic parameter (e.g. `T`) with a `T: Trait` bound in scope. A generic is not in
             // the module namespace, so this is recognized from the in-scope bounds, not resolution.
-            PathPrefixKind::BoundedGeneric
+            PathPrefixKind::BoundedGeneric(bounds)
         } else {
             // Otherwise the prefix is resolved as a type to distinguish trait/type/module.
             let resolution = self.use_path_as_type(prefix).ok()?;
@@ -1508,14 +1508,24 @@ impl Elaborator<'_> {
         Some(ResolvedPrefix { last_segment, turbofish, kind })
     }
 
-    /// Whether the path's first segment names a generic parameter that has a `: Trait` bound in
-    /// scope (so `Head::item` resolves through that bound). Mirrors the constraint scan in
-    /// [`Self::resolve_trait_method_by_named_generic`].
-    fn path_head_is_bounded_generic(&self, path: &TypedPath) -> bool {
+    /// If the path's first segment names a generic parameter with `: Trait` bound(s) in scope,
+    /// return those matching bounds (so `Head::item` can be resolved through them). Only meaningful
+    /// for a two-segment path; a generic is not in the module namespace, so this scans the in-scope
+    /// bounds rather than resolving.
+    fn matching_generic_bounds(&self, path: &TypedPath) -> Option<Vec<TraitConstraint>> {
+        if path.segments.len() != 2 {
+            return None;
+        }
         let head = path.segments[0].ident.as_str();
-        self.trait_bounds.iter().any(|constraint| {
-            matches!(&constraint.typ, Type::NamedGeneric(generic) if generic.name.as_str() == head)
-        })
+        let bounds: Vec<_> = self
+            .trait_bounds
+            .iter()
+            .filter(|constraint| {
+                matches!(&constraint.typ, Type::NamedGeneric(generic) if generic.name.as_str() == head)
+            })
+            .cloned()
+            .collect();
+        (!bounds.is_empty()).then_some(bounds)
     }
 
     /// Resolves the last segment of a `Trait::item` path against a prefix already resolved to a
@@ -1562,51 +1572,40 @@ impl Elaborator<'_> {
         })
     }
 
-    /// This resolves a static trait method `T::trait_method` by iterating over the where clause
-    ///
-    /// Returns the trait method, trait constraint, and whether the impl is assumed from a where
-    /// clause. This is always true since this helper searches where clauses for a generic constraint.
-    /// E.g. `t.method()` with `where T: Foo<Bar>` in scope will return `(Foo::method, T, vec![Bar])`
+    /// Resolves `T::item` to a method or associated constant of a generic `T`, given the `T: Trait`
+    /// bounds matched in scope (and the trait/supertrait hierarchy they reach). Reports an error and
+    /// resolves to nothing identifiable when the item is ambiguous across in-scope traits.
+    /// E.g. `t.method()` with `where T: Foo<Bar>` in scope returns `(Foo::method, T, vec![Bar])`.
     #[tracing::instrument(level = "trace", skip_all)]
-    fn resolve_trait_method_by_named_generic(
+    fn resolve_bounded_generic_item(
         &mut self,
-        path: &TypedPath,
+        bounds: Vec<TraitConstraint>,
+        last_segment: &TypedPathSegment,
+        turbofish: Option<Turbofish>,
+        location: Location,
     ) -> Option<TraitPathResolution> {
-        if path.segments.len() != 2 {
-            return None;
-        }
-
-        let type_name = path.segments[0].ident.as_str();
-        let method_name = path.last_name();
+        let method_name = last_segment.ident.as_str();
 
         let mut matches = Vec::new();
         let mut visited = BTreeSet::new();
-
-        for constraint in self.trait_bounds.clone() {
-            if let Type::NamedGeneric(NamedGeneric { name, .. }) = &constraint.typ {
-                // if `path` is `T::method_name`, we're looking for constraint of the form `T: SomeTrait`
-                if type_name != name.as_str() {
-                    continue;
-                }
-
-                let the_trait = self.interner.get_trait(constraint.trait_bound.trait_id);
-                matches.extend(self.find_methods_or_constants_in_trait(
-                    path,
-                    constraint,
-                    the_trait,
-                    &mut visited,
-                ));
-            }
+        for constraint in bounds {
+            let the_trait = self.interner.get_trait(constraint.trait_bound.trait_id);
+            matches.extend(self.find_methods_or_constants_in_trait(
+                method_name,
+                constraint,
+                the_trait,
+                &mut visited,
+            ));
         }
 
         if matches.len() == 1 {
             let method = matches.remove(0).0;
 
-            if path.segments[0].generics.is_some() {
-                let turbofish_location = path.segments[0].turbofish_location();
+            // A turbofish on the generic itself (e.g. `T::<u32>::method`) is not allowed.
+            if let Some(turbofish) = &turbofish {
                 self.push_err(PathResolutionError::TurbofishNotAllowedOnItem {
                     item: "generic parameter".to_string(),
-                    location: turbofish_location,
+                    location: turbofish.location,
                 });
             }
 
@@ -1614,7 +1613,6 @@ impl Elaborator<'_> {
         }
 
         if matches.len() > 1 {
-            let location = path.location;
             let ident = Ident::new(method_name.to_string(), location);
             let traits =
                 vecmap(matches, |(_, trait_id)| self.fully_qualified_trait_path_by_id(trait_id));
@@ -1631,7 +1629,7 @@ impl Elaborator<'_> {
 
     fn find_methods_or_constants_in_trait(
         &self,
-        path: &TypedPath,
+        method_name: &str,
         constraint: TraitConstraint,
         the_trait: &Trait,
         visited: &mut BTreeSet<TraitId>,
@@ -1643,8 +1641,7 @@ impl Elaborator<'_> {
 
         let mut matches = Vec::new();
 
-        if let Some(definition) = the_trait.find_method_or_constant(path.last_name(), self.interner)
-        {
+        if let Some(definition) = the_trait.find_method_or_constant(method_name, self.interner) {
             let trait_item =
                 TraitItem { definition, constraint: constraint.clone(), assumed: true };
             let method = TraitPathResolutionMethod::TraitItem(trait_item);
@@ -1657,7 +1654,7 @@ impl Elaborator<'_> {
             let constraint =
                 TraitConstraint { typ: constraint.typ.clone(), trait_bound: trait_bound.clone() };
             matches.extend(self.find_methods_or_constants_in_trait(
-                path,
+                method_name,
                 constraint,
                 parent_trait,
                 visited,
@@ -2160,7 +2157,9 @@ impl Elaborator<'_> {
             // `Self` is contextual; its handler produces the resolution directly (it may be an
             // elaborated expression, not a trait resolution) and works from the path.
             PathPrefixKind::SelfType => return self.resolve_self_prefix(path),
-            PathPrefixKind::BoundedGeneric => self.resolve_trait_method_by_named_generic(path),
+            PathPrefixKind::BoundedGeneric(bounds) => {
+                self.resolve_bounded_generic_item(bounds, &last_segment, turbofish, path.location)
+            }
             PathPrefixKind::Type { resolution } => {
                 let is_self_prefix = false;
                 self.resolve_method_on_type_prefix(
@@ -2210,13 +2209,18 @@ impl Elaborator<'_> {
             return Some(VariableResolution::Expression(expr_id, typ));
         }
 
+        let mut prefix = path.clone();
+        let last_segment = prefix.pop();
+        let turbofish = prefix.last_segment().turbofish();
+
         // Inside a trait definition, `Self` is the trait: resolve to an assumed constraint on it,
         // falling back to a supertrait reached through that bound.
         if self.current_trait.is_some() && self.current_trait_impl.is_none() {
-            return match self
-                .resolve_trait_static_method_by_self(path)
-                .or_else(|| self.resolve_trait_method_by_named_generic(path))
-            {
+            let resolution = self.resolve_trait_static_method_by_self(path).or_else(|| {
+                let bounds = self.matching_generic_bounds(path)?;
+                self.resolve_bounded_generic_item(bounds, &last_segment, turbofish, path.location)
+            });
+            return match resolution {
                 Some(resolution) => self.variable_from_trait_resolution(path.location, resolution),
                 None => self.resolve_variable_in_scope(path.clone()),
             };
@@ -2224,9 +2228,6 @@ impl Elaborator<'_> {
 
         // Otherwise `Self` is a concrete data type: resolve the method exactly as `Type::method`
         // does, on `Self`'s type. A non-method (e.g. `Self::Variant`) falls back to a value lookup.
-        let mut prefix = path.clone();
-        let last_segment = prefix.pop();
-        let turbofish = prefix.last_segment().turbofish();
         let resolution = self.use_path_as_type(prefix).ok().and_then(|type_resolution| {
             self.resolve_method_on_type_prefix(
                 path.location,

--- a/compiler/noirc_frontend/src/elaborator/types.rs
+++ b/compiler/noirc_frontend/src/elaborator/types.rs
@@ -1568,7 +1568,7 @@ impl Elaborator<'_> {
     /// is lowered to the selected impl's value during monomorphization.
     fn resolve_trait_item_on_prefix(
         &mut self,
-        path: &TypedPath,
+        path: TypedPath,
         trait_id: TraitId,
         turbofish: Option<Turbofish>,
         last_segment: &TypedPathSegment,
@@ -1611,7 +1611,7 @@ impl Elaborator<'_> {
     #[tracing::instrument(level = "trace", skip_all)]
     fn resolve_bounded_generic_item(
         &mut self,
-        path: &TypedPath,
+        path: TypedPath,
         bounds: Vec<TraitConstraint>,
         last_segment: &TypedPathSegment,
         turbofish: Option<Turbofish>,
@@ -1754,7 +1754,7 @@ impl Elaborator<'_> {
     #[tracing::instrument(level = "trace", skip_all)]
     fn resolve_method_on_type_prefix(
         &mut self,
-        path: &TypedPath,
+        path: TypedPath,
         last_segment: TypedPathSegment,
         turbofish: Option<Turbofish>,
         is_self_prefix: bool,
@@ -1772,7 +1772,7 @@ impl Elaborator<'_> {
             // The prefix isn't a type/alias/primitive, so the last segment isn't a method on it;
             // resolve the whole path as a value instead.
             self.push_errors(errors);
-            return self.resolve_variable_in_scope(path.clone());
+            return self.resolve_variable_in_scope(path);
         };
 
         let method_name = last_segment.ident.as_str();
@@ -2190,23 +2190,23 @@ impl Elaborator<'_> {
         match kind {
             // `Self` is contextual; each context resolves the last segment its own way.
             PathPrefixKind::SelfInTraitImpl => {
-                self.resolve_self_in_trait_impl(&path, last_segment, turbofish)
+                self.resolve_self_in_trait_impl(path, last_segment, turbofish)
             }
             PathPrefixKind::SelfInTrait => {
-                self.resolve_self_in_trait(&path, last_segment, turbofish)
+                self.resolve_self_in_trait(path, last_segment, turbofish)
             }
             // `Self` is a concrete type here (classification guarantees `self_type` exists), so it
             // resolves exactly like `Type::method`.
             PathPrefixKind::SelfInImpl => {
-                self.resolve_self_as_concrete_type(&path, last_segment, turbofish)
+                self.resolve_self_as_concrete_type(path, last_segment, turbofish)
             }
             PathPrefixKind::BoundedGeneric(bounds) => {
-                self.resolve_bounded_generic_item(&path, bounds, &last_segment, turbofish)
+                self.resolve_bounded_generic_item(path, bounds, &last_segment, turbofish)
             }
             PathPrefixKind::Type { resolution } => {
                 let is_self_prefix = false;
                 self.resolve_method_on_type_prefix(
-                    &path,
+                    path,
                     last_segment,
                     turbofish,
                     is_self_prefix,
@@ -2216,7 +2216,7 @@ impl Elaborator<'_> {
             // A trait prefix: the last segment is either a trait static method (`Trait::method`)
             // or an associated constant (`Trait::CONST`).
             PathPrefixKind::Trait { trait_id, resolution } => self.resolve_trait_item_on_prefix(
-                &path,
+                path,
                 trait_id,
                 turbofish,
                 &last_segment,
@@ -2241,12 +2241,12 @@ impl Elaborator<'_> {
     /// plain method on the self type, resolved like `Type::method`.
     fn resolve_self_in_trait_impl(
         &mut self,
-        path: &TypedPath,
+        path: TypedPath,
         last_segment: TypedPathSegment,
         turbofish: Option<Turbofish>,
     ) -> Option<VariableResolution> {
         if let Some((expr_id, typ)) =
-            self.elaborate_variable_as_self_method_or_associated_constant(path)
+            self.elaborate_variable_as_self_method_or_associated_constant(&path)
         {
             return Some(VariableResolution::Expression(expr_id, typ));
         }
@@ -2257,18 +2257,18 @@ impl Elaborator<'_> {
     /// assumed constraint on the current trait, falling back to a supertrait reached through it.
     fn resolve_self_in_trait(
         &mut self,
-        path: &TypedPath,
+        path: TypedPath,
         last_segment: TypedPathSegment,
         turbofish: Option<Turbofish>,
     ) -> Option<VariableResolution> {
-        if let Some(resolution) = self.resolve_trait_static_method_by_self(path) {
+        if let Some(resolution) = self.resolve_trait_static_method_by_self(&path) {
             return self.variable_from_trait_resolution(path.location, resolution);
         }
         // Fall back to a supertrait reached through the assumed `Self` bound.
-        if let Some(bounds) = self.matching_generic_bounds(path) {
+        if let Some(bounds) = self.matching_generic_bounds(&path) {
             return self.resolve_bounded_generic_item(path, bounds, &last_segment, turbofish);
         }
-        self.resolve_variable_in_scope(path.clone())
+        self.resolve_variable_in_scope(path)
     }
 
     /// Resolve `Self::method` (or `Self::AssocType::method`) by resolving the `Self` prefix as a
@@ -2276,7 +2276,7 @@ impl Elaborator<'_> {
     /// (e.g. `Self::Variant`) falls back to a value lookup of the whole path.
     fn resolve_self_as_concrete_type(
         &mut self,
-        path: &TypedPath,
+        path: TypedPath,
         last_segment: TypedPathSegment,
         turbofish: Option<Turbofish>,
     ) -> Option<VariableResolution> {
@@ -2291,7 +2291,7 @@ impl Elaborator<'_> {
                 type_resolution,
             ),
             // The `Self` prefix doesn't resolve as a type; resolve the whole path as a value.
-            None => self.resolve_variable_in_scope(path.clone()),
+            None => self.resolve_variable_in_scope(path),
         }
     }
 
@@ -2333,12 +2333,12 @@ impl Elaborator<'_> {
     /// value (a module value, an enum variant, an associated constant, …) or its error reported.
     fn variable_or_value_fallback(
         &mut self,
-        path: &TypedPath,
+        path: TypedPath,
         trait_resolution: Option<TraitPathResolution>,
     ) -> Option<VariableResolution> {
         match trait_resolution {
             Some(resolution) => self.variable_from_trait_resolution(path.location, resolution),
-            None => self.resolve_variable_in_scope(path.clone()),
+            None => self.resolve_variable_in_scope(path),
         }
     }
 

--- a/compiler/noirc_frontend/src/elaborator/types.rs
+++ b/compiler/noirc_frontend/src/elaborator/types.rs
@@ -1480,15 +1480,7 @@ impl Elaborator<'_> {
         let trait_id = meta.trait_id?;
         let the_trait = self.interner.get_trait(trait_id);
         let method = the_trait.find_method(path.last_name(), self.interner)?;
-        let mut constraint = the_trait.as_constraint(path.location);
-        // If the path went through a concrete type (e.g. `i32::method`, `Struct::trait_method`),
-        // override the constraint's `Self` type variable with that type so the impl gets
-        // selected at the call site rather than leaving `Self` unbound (which would force the
-        // user to add a type annotation). For the literal `Trait::method` form there is no
-        // concrete type available, so `Self` stays as the trait's type variable.
-        if let Some(concrete_self) = self.concrete_self_type_for_path_item(&path_resolution.item) {
-            constraint.typ = concrete_self;
-        }
+        let constraint = the_trait.as_constraint(path.location);
         let trait_method = TraitItem { definition: method, constraint, assumed: false };
         let method = TraitPathResolutionMethod::TraitItem(trait_method);
         let item = Some(path_resolution.item);
@@ -1584,58 +1576,6 @@ impl Elaborator<'_> {
         let trait_item = TraitItem { definition, constraint, assumed: true };
         let method = TraitPathResolutionMethod::TraitItem(trait_item);
         Some(TraitPathResolution { method, item: None, errors: resolution.errors })
-    }
-
-    /// For path resolutions that went through a typed item (e.g. `MyStruct::method`,
-    /// `i32::method`), return that concrete type. This is used so that a `Trait::method`
-    /// constraint built from one of these paths can be anchored on the concrete type rather
-    /// than the trait's unbound `Self` type variable.
-    fn concrete_self_type_for_path_item(&mut self, item: &PathResolutionItem) -> Option<Type> {
-        let mut errors = Vec::new();
-        let result = match item {
-            PathResolutionItem::PrimitiveFunction(primitive_type, _, _) => {
-                Some(primitive_type.to_type())
-            }
-            PathResolutionItem::TypeTraitFunction(self_type, _, _) => Some(self_type.clone()),
-            PathResolutionItem::Method(type_id, turbofish, _) => {
-                let generics = self.resolve_struct_id_turbofish_generics(
-                    *type_id,
-                    turbofish.clone(),
-                    &mut errors,
-                );
-                let datatype = self.get_type(*type_id);
-                Some(Type::DataType(datatype, generics))
-            }
-            PathResolutionItem::TypeAliasFunction(type_alias_id, turbofish, _) => {
-                let generics = self.resolve_type_alias_id_turbofish_generics(
-                    *type_alias_id,
-                    turbofish.clone(),
-                    &mut errors,
-                );
-                let type_alias = self.interner.get_type_alias(*type_alias_id);
-                let type_alias = type_alias.borrow();
-                Some(type_alias.get_type(&generics))
-            }
-            // `Self::method` inside an impl. Use the impl's self type so the trait constraint
-            // is anchored on it.
-            PathResolutionItem::SelfMethod(_) => self.self_type.clone(),
-            // `TraitFunction` is the bare `Trait::method` form — Self isn't pinned by the path.
-            // `ModuleFunction` and non-function variants don't carry a concrete self type that
-            // should override the trait constraint.
-            PathResolutionItem::TraitFunction(..)
-            | PathResolutionItem::ModuleFunction(_)
-            | PathResolutionItem::Module(..)
-            | PathResolutionItem::Type(..)
-            | PathResolutionItem::TypeAlias(..)
-            | PathResolutionItem::PrimitiveType(..)
-            | PathResolutionItem::Trait(..)
-            | PathResolutionItem::TraitAssociatedType(..)
-            | PathResolutionItem::Global(..)
-            | PathResolutionItem::EnumVariant(..)
-            | PathResolutionItem::TraitConstant(..) => None,
-        };
-        self.push_errors(errors);
-        result
     }
 
     /// This resolves a static trait method `T::trait_method` by iterating over the where clause

--- a/compiler/noirc_frontend/src/elaborator/types.rs
+++ b/compiler/noirc_frontend/src/elaborator/types.rs
@@ -73,6 +73,39 @@ pub(super) enum TraitPathResolutionMethod {
     MultipleTraitsInScope,
 }
 
+/// What the prefix of a path (every segment but the last) resolves to, used to decide how the
+/// last segment should be interpreted when the path is used as an expression. Only meaningful
+/// for paths with at least two segments; a single-segment path has no prefix.
+#[derive(Debug)]
+pub(super) enum PathPrefixKind {
+    /// A trait, e.g. the `Trait` in `Trait::CONST`. The last segment is one of the trait's items.
+    Trait(TraitId),
+    /// A concrete type, type alias, primitive type, or `Self` bound to a data type — e.g. the
+    /// `Type` in `Type::method`. The last segment is an inherent method, a qualified trait
+    /// method, or an associated constant.
+    Type,
+    /// A module, or anything else that cannot prefix an associated item (e.g. `foo::bar` in
+    /// `foo::bar::GLOBAL`). The last segment is an ordinary value item, resolved elsewhere.
+    Other,
+}
+
+/// The prefix of a path used as an expression, resolved once so the last segment can be
+/// interpreted without re-resolving the leading segments. Produced by
+/// [`Elaborator::resolve_path_prefix`].
+#[derive(Debug)]
+pub(super) struct ResolvedPathPrefix {
+    /// The path's last segment: the item being accessed on the prefix.
+    last_segment: TypedPathSegment,
+    /// Turbofish on the segment immediately before the last (the prefix's own turbofish).
+    turbofish: Option<Turbofish>,
+    /// Whether the prefix is exactly `Self`.
+    is_self_prefix: bool,
+    /// The resolved prefix and any errors gathered while resolving it.
+    resolution: PathResolution,
+    /// The classified kind of the resolved prefix.
+    kind: PathPrefixKind,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum WildcardAllowed {
     Yes,
@@ -1466,34 +1499,56 @@ impl Elaborator<'_> {
         Some(TraitPathResolution { method, item, errors: path_resolution.errors })
     }
 
-    /// This resolves `TraitName::SOME_CONSTANT` to the trait's associated constant.
+    /// Resolve the prefix of a path used as an expression: every segment but the last, resolved
+    /// as a type. The result lets the caller interpret the last segment based on what the prefix
+    /// is, without re-resolving the leading segments for each candidate interpretation.
     ///
-    /// An associated constant is not a function, so `resolve_path_as_type` fails on the full
-    /// path (it only resolves paths ending in a type or function). Instead we resolve the
-    /// leading segments to a trait and look the constant up by name. The resulting `TraitItem`
-    /// is lowered to the selected impl's value during monomorphization, mirroring how
-    /// `Self::SOME_CONSTANT` is handled by `resolve_trait_static_method_by_self`.
-    fn resolve_trait_static_constant(&mut self, path: &TypedPath) -> Option<TraitPathResolution> {
+    /// Returns `None` if the path has fewer than two segments (so there is no prefix) or the
+    /// prefix cannot be resolved as a type or module.
+    #[tracing::instrument(level = "trace", skip_all)]
+    fn resolve_path_prefix(&mut self, path: &TypedPath) -> Option<ResolvedPathPrefix> {
         if path.segments.len() < 2 {
             return None;
         }
 
-        self.speculatively(|this| {
-            let mut trait_path = path.clone();
-            let constant = trait_path.pop().ident;
+        let mut path = path.clone();
+        let last_segment = path.pop();
+        let turbofish = path.last_segment().turbofish();
+        let is_self_prefix = path.first_name() == Some(SELF_TYPE_NAME);
 
-            let resolution = this.resolve_path_as_type(trait_path).ok()?;
-            let PathResolutionItem::Trait(trait_id) = resolution.item else {
-                return None;
-            };
+        let resolution = self.use_path_as_type(path).ok()?;
+        let kind = match &resolution.item {
+            PathResolutionItem::Trait(trait_id) => PathPrefixKind::Trait(*trait_id),
+            PathResolutionItem::Type(..)
+            | PathResolutionItem::TypeAlias(..)
+            | PathResolutionItem::PrimitiveType(..) => PathPrefixKind::Type,
+            _ => PathPrefixKind::Other,
+        };
 
-            let the_trait = this.interner.get_trait(trait_id);
-            let definition = the_trait.associated_constant_ids.get(constant.as_str()).copied()?;
-            let constraint = the_trait.as_constraint(path.location);
-            let trait_item = TraitItem { definition, constraint, assumed: true };
-            let method = TraitPathResolutionMethod::TraitItem(trait_item);
-            Some(TraitPathResolution { method, item: None, errors: resolution.errors })
-        })
+        Some(ResolvedPathPrefix { last_segment, turbofish, is_self_prefix, resolution, kind })
+    }
+
+    /// Resolves `Trait::SOME_CONSTANT` to the trait's associated constant, given a prefix that has
+    /// already been resolved to a trait.
+    ///
+    /// An associated constant is not a function, so resolving the full path as a type fails (only
+    /// paths ending in a type or function resolve that way). Instead the trait prefix is resolved
+    /// separately and the constant looked up by name. The resulting `TraitItem` is lowered to the
+    /// selected impl's value during monomorphization, mirroring how `Self::SOME_CONSTANT` is
+    /// handled by [`Self::resolve_trait_static_method_by_self`].
+    fn resolve_trait_constant_on_prefix(
+        &self,
+        trait_id: TraitId,
+        location: Location,
+        prefix: ResolvedPathPrefix,
+    ) -> Option<TraitPathResolution> {
+        let the_trait = self.interner.get_trait(trait_id);
+        let definition =
+            the_trait.associated_constant_ids.get(prefix.last_segment.ident.as_str()).copied()?;
+        let constraint = the_trait.as_constraint(location);
+        let trait_item = TraitItem { definition, constraint, assumed: true };
+        let method = TraitPathResolutionMethod::TraitItem(trait_item);
+        Some(TraitPathResolution { method, item: None, errors: prefix.resolution.errors })
     }
 
     /// For path resolutions that went through a typed item (e.g. `MyStruct::method`,
@@ -1701,32 +1756,24 @@ impl Elaborator<'_> {
         }
     }
 
+    /// Resolves `Type::method` (or `Type::<..>::method`) given a prefix already resolved to a type,
+    /// type alias, or primitive type.
     ///
     /// When turbofish generics are present, uses type-directed lookup to select the correct impl
     /// (e.g. `S::<u32, u64>::foo` picks the impl whose self type unifies with `S<u32, u64>`).
     /// Without turbofish, returns `None` so the caller falls back to module-based lookup, which
     /// handles `Self::method`, visibility checks, and associated constants correctly.
     #[tracing::instrument(level = "trace", skip_all)]
-    fn resolve_type_method_or_trait_method(
+    fn resolve_method_on_type_prefix(
         &mut self,
-        path: &TypedPath,
+        location: Location,
+        prefix: ResolvedPathPrefix,
     ) -> Option<TraitPathResolution> {
-        if path.segments.len() < 2 {
-            return None;
-        }
-
-        let mut path = path.clone();
-        let location = path.location;
-        let last_segment = path.pop();
-        let before_last_segment = path.last_segment();
-        let turbofish = before_last_segment.turbofish();
-
         // `Self::method` must anchor on the impl's own `self_type` and produce a `SelfMethod`, so it
         // gets dedicated handling (in `resolve_self_or_inherent_method`) distinct from a plain
         // `TypeName::method`.
-        let is_self_prefix = path.first_name() == Some(SELF_TYPE_NAME);
-
-        let path_resolution = self.use_path_as_type(path).ok()?;
+        let ResolvedPathPrefix { last_segment, turbofish, is_self_prefix, resolution, .. } = prefix;
+        let path_resolution = resolution;
 
         let mut errors = Vec::new();
         let typ = self.path_resolution_item_to_type(
@@ -2143,20 +2190,42 @@ impl Elaborator<'_> {
     ///    ([`Self::resolve_trait_static_method`]).
     /// 3. `T::method` where a `T: Trait` bound is in scope
     ///    ([`Self::resolve_trait_method_by_named_generic`]).
-    /// 4. `Type::method` or `Type::<..>::method`, an inherent or qualified trait method
-    ///    ([`Self::resolve_type_method_or_trait_method`]).
-    /// 5. `Trait::CONST`, a trait's associated constant
-    ///    ([`Self::resolve_trait_static_constant`]).
+    ///
+    /// The remaining forms are distinguished by what the path's *prefix* (every segment but the
+    /// last) resolves to, so the prefix is resolved once ([`Self::resolve_path_prefix`]) and the
+    /// last segment is interpreted accordingly:
+    ///
+    /// 4. prefix is a type/alias/primitive ⇒ `Type::method` / `Type::<..>::method`, an inherent or
+    ///    qualified trait method ([`Self::resolve_method_on_type_prefix`]).
+    /// 5. prefix is a trait ⇒ `Trait::CONST`, a trait's associated constant
+    ///    ([`Self::resolve_trait_constant_on_prefix`]).
     #[tracing::instrument(level = "trace", skip_all)]
     pub(super) fn resolve_trait_generic_path(
         &mut self,
         path: &TypedPath,
     ) -> Option<TraitPathResolution> {
-        self.resolve_trait_static_method_by_self(path)
-            .or_else(|| self.resolve_trait_static_method(path))
-            .or_else(|| self.resolve_trait_method_by_named_generic(path))
-            .or_else(|| self.resolve_type_method_or_trait_method(path))
-            .or_else(|| self.resolve_trait_static_constant(path))
+        // Forms the module resolver can't classify from the prefix alone: an assumed `Self`
+        // constraint inside a trait definition, a trait method reached through the canonical
+        // trait/type path, or a method on a generic with an in-scope bound.
+        if let Some(resolution) = self.resolve_trait_static_method_by_self(path) {
+            return Some(resolution);
+        }
+        if let Some(resolution) = self.resolve_trait_static_method(path) {
+            return Some(resolution);
+        }
+        if let Some(resolution) = self.resolve_trait_method_by_named_generic(path) {
+            return Some(resolution);
+        }
+
+        // Forms distinguished by what the prefix resolves to.
+        let prefix = self.resolve_path_prefix(path)?;
+        match prefix.kind {
+            PathPrefixKind::Type => self.resolve_method_on_type_prefix(path.location, prefix),
+            PathPrefixKind::Trait(trait_id) => {
+                self.resolve_trait_constant_on_prefix(trait_id, path.location, prefix)
+            }
+            PathPrefixKind::Other => None,
+        }
     }
 
     /// Unify two types, modifying both in the process.

--- a/compiler/noirc_frontend/src/elaborator/types.rs
+++ b/compiler/noirc_frontend/src/elaborator/types.rs
@@ -78,7 +78,7 @@ enum TraitPathResolutionMethod {
 /// [`Elaborator::resolve_path_prefix`]; [`Elaborator::resolve_prefixed_variable`] resolves the last
 /// segment against the kind without re-deriving anything from the original path.
 #[derive(Debug)]
-pub(super) struct ResolvedPrefix {
+struct ResolvedPrefix {
     /// The path's last segment: the item being accessed on the prefix.
     last_segment: TypedPathSegment,
     /// Turbofish on the prefix's own last segment (e.g. the `<T>` in `Foo::<T>::bar`).
@@ -90,7 +90,7 @@ pub(super) struct ResolvedPrefix {
 /// expression. This describes *what the prefix is*, not the already-resolved item; the shared
 /// "rest" (last segment, turbofish) lives on [`ResolvedPrefix`].
 #[derive(Debug)]
-pub(super) enum PathPrefixKind {
+enum PathPrefixKind {
     /// The prefix starts with `Self`. What `Self` means is contextual — the current trait in a
     /// trait definition, or a concrete self type in an impl — and the forms differ
     /// (`Self::method`, `Self::CONST`, `Self::AssocType::method`), so the dedicated handler

--- a/compiler/noirc_frontend/src/elaborator/types.rs
+++ b/compiler/noirc_frontend/src/elaborator/types.rs
@@ -2216,20 +2216,13 @@ impl Elaborator<'_> {
     /// Returns the trait method, trait constraint, and whether the impl is assumed to exist by a where clause or not
     /// E.g. `t.method()` with `where T: Foo<Bar>` in scope will return `(Foo::method, T, vec![Bar])`
     ///
-    /// A `Type::method`/`Trait::method` whose whole path canonically names a trait method is
-    /// resolved first: that resolution goes through the module system and takes precedence over
-    /// the prefix-classified forms (and is a no-op for `Self`-in-a-definition and bare generics,
-    /// so it does not disturb their precedence). Otherwise [`Self::resolve_path_prefix`] classifies
-    /// the prefix once and the last segment is resolved against that classification.
+    /// [`Self::resolve_path_prefix`] classifies the prefix once; here the last segment is resolved
+    /// against that classification.
     #[tracing::instrument(level = "trace", skip_all)]
     pub(super) fn resolve_trait_generic_path(
         &mut self,
         path: &TypedPath,
     ) -> Option<TraitPathResolution> {
-        if let Some(resolution) = self.resolve_trait_static_method(path) {
-            return Some(resolution);
-        }
-
         match self.resolve_path_prefix(path)? {
             // `Self` in a trait definition: a method/constant of the current trait, falling back to
             // a supertrait reached through the assumed `Self` bound.
@@ -2245,13 +2238,18 @@ impl Elaborator<'_> {
                     is_self_prefix,
                     resolution,
                 ),
-            PathPrefixKind::Trait { trait_id, last_segment, resolution } => self
-                .resolve_trait_constant_on_prefix(
-                    trait_id,
-                    path.location,
-                    last_segment,
-                    resolution,
-                ),
+            // A trait prefix: the last segment is either a trait static method (`Trait::method`)
+            // or an associated constant (`Trait::CONST`).
+            PathPrefixKind::Trait { trait_id, last_segment, resolution } => {
+                self.resolve_trait_static_method(path).or_else(|| {
+                    self.resolve_trait_constant_on_prefix(
+                        trait_id,
+                        path.location,
+                        last_segment,
+                        resolution,
+                    )
+                })
+            }
             PathPrefixKind::Module => None,
         }
     }

--- a/compiler/noirc_frontend/src/elaborator/types.rs
+++ b/compiler/noirc_frontend/src/elaborator/types.rs
@@ -1783,10 +1783,13 @@ impl Elaborator<'_> {
             turbofish.clone(),
             &mut errors,
         ) else {
-            // The prefix isn't a type/alias/primitive, so the last segment isn't a method on it;
-            // resolve the whole path as a value instead.
-            self.push_errors(errors);
-            return self.resolve_variable_in_scope(path);
+            // Both callers pass a prefix already known to name a concrete type — the `Type` prefix
+            // kind is classified as exactly a type/alias/primitive, and `Self` (the other caller)
+            // resolves to its concrete self type — so this conversion cannot fail.
+            unreachable!(
+                "a type-prefix path must resolve to a type, got {:?}",
+                path_resolution.item
+            );
         };
 
         let method_name = last_segment.ident.as_str();

--- a/compiler/noirc_frontend/src/elaborator/types.rs
+++ b/compiler/noirc_frontend/src/elaborator/types.rs
@@ -1844,7 +1844,13 @@ impl Elaborator<'_> {
             )
         };
 
-        self.variable_or_value_fallback(path, trait_resolution)
+        // The last segment isn't an inherent or qualified trait method on the type; it may still be
+        // an enum variant or an associated constant accessed as `Type::CONST`, so resolve the whole
+        // path as a value (which also reports the error if it is none of these).
+        match trait_resolution {
+            Some(resolution) => self.variable_from_trait_resolution(path.location, resolution),
+            None => self.resolve_variable_in_scope(path),
+        }
     }
 
     /// Resolves a turbofished `TypeName::<..>::method` path. Resolves to the single inherent method
@@ -2370,26 +2376,12 @@ impl Elaborator<'_> {
         }
     }
 
-    /// Map a prefix's last-segment resolution to a [`VariableResolution`]: a `Some` trait
-    /// resolution becomes the trait item (or `None` for an already-reported ambiguity), while a
-    /// `None` means the last segment is not a method/trait item, so the whole path is resolved as a
-    /// value (a module value, an enum variant, an associated constant, …) or its error reported.
-    fn variable_or_value_fallback(
-        &mut self,
-        path: TypedPath,
-        trait_resolution: Option<TraitPathResolution>,
-    ) -> Option<VariableResolution> {
-        match trait_resolution {
-            Some(resolution) => self.variable_from_trait_resolution(path.location, resolution),
-            None => self.resolve_variable_in_scope(path),
-        }
-    }
-
-    /// Like [`Self::variable_or_value_fallback`], but for a prefix whose last segment can only be a
-    /// trait item — a trait (`Trait::x`) or a bounded generic (`T::x`). When it is not one, the
-    /// path names nothing, so report the last segment as unresolved directly: a value lookup would
-    /// fail anyway, and on a trait or generic prefix it blames the (in-scope) prefix segment rather
-    /// than the missing item.
+    /// Map a trait/bounded-generic prefix's last-segment resolution to a [`VariableResolution`]: a
+    /// `Some` trait resolution becomes the trait item (or `None` for an already-reported
+    /// ambiguity), while a `None` means the last segment is not a method or associated constant of
+    /// the trait, which is the only thing such a prefix can carry, so report it as unresolved
+    /// directly. A value lookup would fail anyway, and on a trait or generic prefix it blames the
+    /// (in-scope) prefix segment rather than the missing item.
     fn variable_from_trait_resolution_or_unresolved(
         &mut self,
         location: Location,

--- a/compiler/noirc_frontend/src/elaborator/types.rs
+++ b/compiler/noirc_frontend/src/elaborator/types.rs
@@ -91,11 +91,18 @@ struct ResolvedPrefix {
 /// "rest" (last segment, turbofish) lives on [`ResolvedPrefix`].
 #[derive(Debug)]
 enum PathPrefixKind {
-    /// The prefix starts with `Self`. What `Self` means is contextual — the current trait in a
-    /// trait definition, or a concrete self type in an impl — and the forms differ
-    /// (`Self::method`, `Self::CONST`, `Self::AssocType::method`), so the dedicated handler
-    /// ([`Elaborator::resolve_self_prefix`]) enumerates the cases.
-    SelfType,
+    /// `Self` inside a trait *impl*, where `Self` is a concrete type with associated items. The
+    /// last segment is an associated-type method, an associated constant, a primitive-`Self`
+    /// method, or a plain method on the self type
+    /// ([`Elaborator::resolve_self_in_trait_impl`]).
+    SelfInTraitImpl,
+    /// `Self` inside a trait *definition*: an assumed constraint on the current trait (or a
+    /// supertrait reached through it) ([`Elaborator::resolve_self_in_trait`]).
+    SelfInTrait,
+    /// `Self` as a plain concrete type (an inherent impl, or any other context where `Self` names
+    /// a data type): the last segment resolves like `Type::method`
+    /// ([`Elaborator::resolve_self_in_impl`]).
+    SelfInImpl,
     /// A generic parameter with `: Trait` bound(s) in scope (e.g. `T` in `T::method`); the carried
     /// constraints are the matched bounds. The last segment is a method or associated constant
     /// reached through one of them.
@@ -1487,9 +1494,21 @@ impl Elaborator<'_> {
         // `super::T` name an item in another module, not the contextual `Self` or an in-scope
         // generic, so they must not be classified as such.
         let kind = if path.kind == PathKind::Plain && path.segments[0].ident.is_self_type_name() {
-            // `Self` is contextual (the current trait, or a concrete self type), so it is classified
-            // by syntax alone; its handler resolves what it means.
-            PathPrefixKind::SelfType
+            // `Self` is contextual; which kind it is depends only on where we are (a trait impl, a
+            // trait definition, or somewhere `Self` is a plain type), so it is classified here and
+            // the matching handler resolves the last segment.
+            if self.current_trait_impl.is_some() {
+                PathPrefixKind::SelfInTraitImpl
+            } else if self.current_trait.is_some() {
+                PathPrefixKind::SelfInTrait
+            } else if self.self_type.is_some() {
+                PathPrefixKind::SelfInImpl
+            } else {
+                // `Self` with no self type in scope (e.g. in a free function): report it directly
+                // rather than re-resolving the path just to discover the same thing.
+                self.push_err(PathResolutionError::Unresolved(path.segments[0].ident.clone()));
+                return None;
+            }
         } else if path.kind == PathKind::Plain
             && let Some(bounds) = self.matching_generic_bounds(path)
         {
@@ -2153,15 +2172,29 @@ impl Elaborator<'_> {
     ) -> Option<VariableResolution> {
         let Some(ResolvedPrefix { last_segment, turbofish, kind }) = self.resolve_path_prefix(path)
         else {
-            // The prefix doesn't resolve to a type/trait/module; let the value lookup of the whole
-            // path resolve it or report the error.
+            // A plain `Self` with no self type in scope was already reported by
+            // `resolve_path_prefix`, so don't fall back. Any other unresolved prefix resolves the
+            // whole path as a value (or reports the error there).
+            if path.kind == PathKind::Plain && path.segments[0].ident.is_self_type_name() {
+                return None;
+            }
             return self.resolve_variable_in_scope(path.clone());
         };
 
         let trait_resolution = match kind {
-            // `Self` is contextual; its handler produces the resolution directly (it may be an
-            // elaborated expression, not a trait resolution) and works from the path.
-            PathPrefixKind::SelfType => return self.resolve_self_prefix(path),
+            // Each `Self` context produces its resolution directly (it may be an elaborated
+            // expression, not a trait resolution).
+            PathPrefixKind::SelfInTraitImpl => {
+                return self.resolve_self_in_trait_impl(path, last_segment, turbofish);
+            }
+            PathPrefixKind::SelfInTrait => {
+                return self.resolve_self_in_trait(path, last_segment, turbofish);
+            }
+            // `Self` is a concrete type here (classification guarantees `self_type` exists), so it
+            // resolves exactly like `Type::method`.
+            PathPrefixKind::SelfInImpl => {
+                return self.resolve_self_as_concrete_type(path, last_segment, turbofish);
+            }
             PathPrefixKind::BoundedGeneric(bounds) => {
                 self.resolve_bounded_generic_item(bounds, &last_segment, turbofish, path.location)
             }
@@ -2195,44 +2228,53 @@ impl Elaborator<'_> {
         }
     }
 
-    /// Resolve a `Self::…` path used as an expression. `Self` is contextual, so this enumerates its
-    /// cases:
-    /// - inside a trait impl: `Self::AssocType::method`, `Self::CONST`, or a method on a primitive
-    ///   `Self` (handled by [`Self::elaborate_variable_as_self_method_or_associated_constant`]);
-    /// - inside a trait definition: a method or constant of the current trait (or a supertrait),
-    ///   resolved as an assumed constraint on `Self`;
-    /// - otherwise (`Self` is a concrete data type, e.g. inside an impl method): `Self::method`,
-    ///   resolved the same way as `Type::method`.
-    ///
-    /// Anything that isn't one of these (e.g. `Self::Variant`) falls back to a value lookup.
-    fn resolve_self_prefix(&mut self, path: &TypedPath) -> Option<VariableResolution> {
-        // Cases the module resolver can't reach: a method/constant on a primitive `Self`, an
-        // associated constant, or a method on an associated type (all inside a trait impl).
+    /// `Self::…` inside a trait impl. `Self` is the impl's concrete type with associated items, so
+    /// the last segment may be an associated-type method, an associated constant, or a method on a
+    /// primitive `Self` (none of which a plain type-prefix resolution reaches); otherwise it is a
+    /// plain method on the self type, resolved like `Type::method`.
+    fn resolve_self_in_trait_impl(
+        &mut self,
+        path: &TypedPath,
+        last_segment: TypedPathSegment,
+        turbofish: Option<Turbofish>,
+    ) -> Option<VariableResolution> {
         if let Some((expr_id, typ)) =
             self.elaborate_variable_as_self_method_or_associated_constant(path)
         {
             return Some(VariableResolution::Expression(expr_id, typ));
         }
+        self.resolve_self_as_concrete_type(path, last_segment, turbofish)
+    }
 
-        let mut prefix = path.clone();
-        let last_segment = prefix.pop();
-        let turbofish = prefix.last_segment().turbofish();
-
-        // Inside a trait definition, `Self` is the trait: resolve to an assumed constraint on it,
-        // falling back to a supertrait reached through that bound.
-        if self.current_trait.is_some() && self.current_trait_impl.is_none() {
-            let resolution = self.resolve_trait_static_method_by_self(path).or_else(|| {
-                let bounds = self.matching_generic_bounds(path)?;
-                self.resolve_bounded_generic_item(bounds, &last_segment, turbofish, path.location)
-            });
-            return match resolution {
-                Some(resolution) => self.variable_from_trait_resolution(path.location, resolution),
-                None => self.resolve_variable_in_scope(path.clone()),
-            };
+    /// `Self::…` inside a trait definition. `Self` is the trait, so the last segment resolves to an
+    /// assumed constraint on the current trait, falling back to a supertrait reached through it.
+    fn resolve_self_in_trait(
+        &mut self,
+        path: &TypedPath,
+        last_segment: TypedPathSegment,
+        turbofish: Option<Turbofish>,
+    ) -> Option<VariableResolution> {
+        let resolution = self.resolve_trait_static_method_by_self(path).or_else(|| {
+            let bounds = self.matching_generic_bounds(path)?;
+            self.resolve_bounded_generic_item(bounds, &last_segment, turbofish, path.location)
+        });
+        match resolution {
+            Some(resolution) => self.variable_from_trait_resolution(path.location, resolution),
+            None => self.resolve_variable_in_scope(path.clone()),
         }
+    }
 
-        // Otherwise `Self` is a concrete data type: resolve the method exactly as `Type::method`
-        // does, on `Self`'s type. A non-method (e.g. `Self::Variant`) falls back to a value lookup.
+    /// Resolve `Self::method` (or `Self::AssocType::method`) by resolving the `Self` prefix as a
+    /// type and looking the last segment up on it, exactly as `Type::method` does. A non-method
+    /// (e.g. `Self::Variant`) falls back to a value lookup of the whole path.
+    fn resolve_self_as_concrete_type(
+        &mut self,
+        path: &TypedPath,
+        last_segment: TypedPathSegment,
+        turbofish: Option<Turbofish>,
+    ) -> Option<VariableResolution> {
+        let mut prefix = path.clone();
+        prefix.pop();
         let resolution = self.use_path_as_type(prefix).ok().and_then(|type_resolution| {
             self.resolve_method_on_type_prefix(
                 path.location,

--- a/compiler/noirc_frontend/src/elaborator/types.rs
+++ b/compiler/noirc_frontend/src/elaborator/types.rs
@@ -2129,10 +2129,24 @@ impl Elaborator<'_> {
         TraitPathResolution { method, item: Some(item), errors }
     }
 
-    /// Try to resolve a [`TypedPath`] to a trait method path.
+    /// Try to resolve a [`TypedPath`] to a trait item (method or associated constant).
     ///
     /// Returns the trait method, trait constraint, and whether the impl is assumed to exist by a where clause or not
     /// E.g. `t.method()` with `where T: Foo<Bar>` in scope will return `(Foo::method, T, vec![Bar])`
+    ///
+    /// The forms are tried in order; the order is significant, as it decides which interpretation
+    /// wins when a path is ambiguous:
+    ///
+    /// 1. `Self::item` inside a trait *definition*, resolved as an assumed constraint on `Self`
+    ///    ([`Self::resolve_trait_static_method_by_self`]).
+    /// 2. `Trait::static_method` or `Type::trait_method`
+    ///    ([`Self::resolve_trait_static_method`]).
+    /// 3. `T::method` where a `T: Trait` bound is in scope
+    ///    ([`Self::resolve_trait_method_by_named_generic`]).
+    /// 4. `Type::method` or `Type::<..>::method`, an inherent or qualified trait method
+    ///    ([`Self::resolve_type_method_or_trait_method`]).
+    /// 5. `Trait::CONST`, a trait's associated constant
+    ///    ([`Self::resolve_trait_static_constant`]).
     #[tracing::instrument(level = "trace", skip_all)]
     pub(super) fn resolve_trait_generic_path(
         &mut self,

--- a/compiler/noirc_frontend/src/elaborator/variable.rs
+++ b/compiler/noirc_frontend/src/elaborator/variable.rs
@@ -501,7 +501,7 @@ impl Elaborator<'_> {
     #[tracing::instrument(level = "trace", skip_all)]
     fn resolve_variable(&mut self, path: TypedPath) -> Option<VariableResolution> {
         if path.segments.len() > 1 {
-            self.resolve_prefixed_variable(&path)
+            self.resolve_prefixed_variable(path)
         } else {
             self.resolve_variable_in_scope(path)
         }

--- a/compiler/noirc_frontend/src/elaborator/variable.rs
+++ b/compiler/noirc_frontend/src/elaborator/variable.rs
@@ -12,7 +12,9 @@ use crate::elaborator::TypedPath;
 use crate::elaborator::function_context::BindableTypeVariableKind;
 use crate::elaborator::path_resolution::PathResolutionItem;
 use crate::elaborator::patterns::{IdentFromPath, Variable};
-use crate::elaborator::types::{SELF_TYPE_NAME, TraitPathResolutionMethod, WildcardAllowed};
+use crate::elaborator::types::{
+    SELF_TYPE_NAME, TraitPathResolution, TraitPathResolutionMethod, WildcardAllowed,
+};
 use crate::hir::def_collector::dc_crate::CompilationError;
 use crate::hir::resolution::errors::ResolverError;
 use crate::hir::type_check::TypeCheckError;
@@ -47,7 +49,7 @@ pub(crate) enum VariableResolution {
 /// result from that method means the path names no item accessed through its prefix, so the
 /// caller falls back to plain value resolution; a `Some` distinguishes the two handled outcomes.
 #[allow(clippy::large_enum_variant)]
-enum PrefixedVariable {
+pub(super) enum PrefixedVariable {
     /// The path resolved to this item.
     Resolved(VariableResolution),
     /// The path named a prefixed item but it could not be resolved unambiguously; an error was
@@ -550,39 +552,40 @@ impl Elaborator<'_> {
         }
 
         // A trait item reached through the prefix.
-        let trait_path_resolution = self.resolve_trait_generic_path(path)?;
-        self.push_errors(trait_path_resolution.errors);
+        self.resolve_trait_generic_path(path)
+    }
 
-        Some(match trait_path_resolution.method {
+    /// Turn a [`TraitPathResolution`] into the [`PrefixedVariable`] a prefixed path resolves to,
+    /// pushing the resolution's errors. An unresolvable trait method (`MultipleTraitsInScope`) has
+    /// already reported its error, so it becomes [`PrefixedVariable::Errored`] rather than an
+    /// identifier (and the caller must not fall back to value resolution).
+    pub(super) fn prefixed_variable_from_trait_resolution(
+        &mut self,
+        location: Location,
+        resolution: TraitPathResolution,
+    ) -> PrefixedVariable {
+        self.push_errors(resolution.errors);
+        let item = resolution.item;
+        match resolution.method {
             TraitPathResolutionMethod::NotATraitMethod(func_id) => {
                 let ident = HirIdent {
-                    location: path.location,
+                    location,
                     id: self.interner.function_definition_id(func_id),
                     impl_kind: ImplKind::NotATraitMethod,
                 };
-                PrefixedVariable::Resolved(VariableResolution::Ident(
-                    ident,
-                    trait_path_resolution.item,
-                ))
+                PrefixedVariable::Resolved(VariableResolution::Ident(ident, item))
             }
-
-            TraitPathResolutionMethod::TraitItem(item) => {
+            TraitPathResolutionMethod::TraitItem(trait_item) => {
                 let ident = HirIdent {
-                    location: path.location,
-                    id: item.definition,
-                    impl_kind: ImplKind::TraitItem(item),
+                    location,
+                    id: trait_item.definition,
+                    impl_kind: ImplKind::TraitItem(trait_item),
                 };
-                PrefixedVariable::Resolved(VariableResolution::Ident(
-                    ident,
-                    trait_path_resolution.item,
-                ))
+                PrefixedVariable::Resolved(VariableResolution::Ident(ident, item))
             }
-
-            TraitPathResolutionMethod::MultipleTraitsInScope => {
-                // An error has already been pushed, don't return an identifier
-                PrefixedVariable::Errored
-            }
-        })
+            // An error has already been pushed, don't return an identifier.
+            TraitPathResolutionMethod::MultipleTraitsInScope => PrefixedVariable::Errored,
+        }
     }
 
     /// Solve any generics that are part of the path before the function, for example:

--- a/compiler/noirc_frontend/src/elaborator/variable.rs
+++ b/compiler/noirc_frontend/src/elaborator/variable.rs
@@ -396,11 +396,8 @@ impl Elaborator<'_> {
         &mut self,
         variable: &TypedPath,
     ) -> Option<(ExprId, Type)> {
-        // We need at least 2 segments and the first must be `Self`
-        if variable.segments.len() < 2 || !variable.segments[0].ident.is_self_type_name() {
-            return None;
-        }
-
+        // The caller only reaches this for a `Self`-prefixed path with at least two segments
+        // (the `PathPrefixKind::SelfType` classification), so that is taken as a precondition.
         let location = variable.location;
         let name = variable.segments[1].ident.as_str();
         let self_type = self.self_type.as_ref()?;

--- a/compiler/noirc_frontend/src/elaborator/variable.rs
+++ b/compiler/noirc_frontend/src/elaborator/variable.rs
@@ -395,12 +395,9 @@ impl Elaborator<'_> {
     pub(super) fn elaborate_variable_as_self_method_or_associated_constant(
         &mut self,
         variable: &TypedPath,
+        self_type: Type,
+        trait_impl_id: TraitImplId,
     ) -> Option<(ExprId, Type)> {
-        // Reached only for a `Self`-prefixed path with at least two segments. These forms need the
-        // impl's concrete `Self` and its associated items.
-        let self_type = self.self_type.clone()?;
-        let trait_impl_id = self.current_trait_impl?;
-
         match &variable.segments[1..] {
             [associated_type, method] => {
                 let associated_type = self

--- a/compiler/noirc_frontend/src/elaborator/variable.rs
+++ b/compiler/noirc_frontend/src/elaborator/variable.rs
@@ -501,10 +501,10 @@ impl Elaborator<'_> {
     #[tracing::instrument(level = "trace", skip_all)]
     fn resolve_variable(&mut self, path: TypedPath) -> Option<VariableResolution> {
         if path.segments.len() > 1 {
-            return self.resolve_prefixed_variable(&path);
+            self.resolve_prefixed_variable(&path)
+        } else {
+            self.resolve_variable_in_scope(path)
         }
-
-        self.resolve_variable_in_scope(path)
     }
 
     /// Resolve a path in the current scope to a local variable or a value item (global, function,

--- a/compiler/noirc_frontend/src/elaborator/variable.rs
+++ b/compiler/noirc_frontend/src/elaborator/variable.rs
@@ -413,7 +413,7 @@ impl Elaborator<'_> {
     /// In the third case, we resolve the associated type first, then elaborate the method
     /// call on that resolved type.
     #[tracing::instrument(level = "trace", skip_all)]
-    fn elaborate_variable_as_self_method_or_associated_constant(
+    pub(super) fn elaborate_variable_as_self_method_or_associated_constant(
         &mut self,
         variable: &TypedPath,
     ) -> Option<(ExprId, Type)> {
@@ -503,13 +503,13 @@ impl Elaborator<'_> {
     /// A path with a prefix (more than one segment) may name an item accessed *through* that
     /// prefix: a `Self`-prefixed associated item (elaborated directly to an expression), or a
     /// trait item reached through `Self`, a trait, a concrete type, or an in-scope generic bound
-    /// (see [`Self::resolve_variable_with_prefix`]). A single-segment path — or a prefixed path
+    /// (see [`Self::resolve_prefixed_variable`]). A single-segment path — or a prefixed path
     /// that names no such item — resolves to a local variable, a definition (global, function,
     /// enum-variant global), or a numeric type alias (see [`Self::get_ident_from_path`]).
     #[tracing::instrument(level = "trace", skip_all)]
     fn resolve_variable(&mut self, path: TypedPath) -> Option<VariableResolution> {
         if path.segments.len() > 1
-            && let Some(resolution) = self.resolve_variable_with_prefix(&path)
+            && let Some(resolution) = self.resolve_prefixed_variable(&path)
         {
             return resolution.into_option();
         }
@@ -536,21 +536,6 @@ impl Elaborator<'_> {
             }
             IdentFromPath::TypeAlias(type_alias_id) => VariableResolution::TypeAlias(type_alias_id),
         })
-    }
-
-    /// Resolve a path that has a prefix (more than one segment) to an item accessed *through* that
-    /// prefix. Returns `None` if the path names no such item, so the caller falls back to plain
-    /// value resolution.
-    fn resolve_variable_with_prefix(&mut self, path: &TypedPath) -> Option<PrefixedVariable> {
-        // A `Self`-prefixed associated item inside a trait impl, elaborated directly.
-        if let Some((expr_id, typ)) =
-            self.elaborate_variable_as_self_method_or_associated_constant(path)
-        {
-            return Some(PrefixedVariable::Resolved(VariableResolution::Expression(expr_id, typ)));
-        }
-
-        // A trait item reached through the prefix.
-        self.resolve_trait_generic_path(path)
     }
 
     /// Solve any generics that are part of the path before the function, for example:

--- a/compiler/noirc_frontend/src/elaborator/variable.rs
+++ b/compiler/noirc_frontend/src/elaborator/variable.rs
@@ -43,6 +43,27 @@ pub(crate) enum VariableResolution {
     TypeAlias(TypeAliasId),
 }
 
+/// Outcome of [`Elaborator::resolve_variable_with_prefix`] for a path that has a prefix. A `None`
+/// result from that method means the path names no item accessed through its prefix, so the
+/// caller falls back to plain value resolution; a `Some` distinguishes the two handled outcomes.
+#[allow(clippy::large_enum_variant)]
+enum PrefixedVariable {
+    /// The path resolved to this item.
+    Resolved(VariableResolution),
+    /// The path named a prefixed item but it could not be resolved unambiguously; an error was
+    /// already reported, so no value-resolution fallback should be attempted.
+    Errored,
+}
+
+impl PrefixedVariable {
+    fn into_option(self) -> Option<VariableResolution> {
+        match self {
+            PrefixedVariable::Resolved(resolution) => Some(resolution),
+            PrefixedVariable::Errored => None,
+        }
+    }
+}
+
 impl Elaborator<'_> {
     #[tracing::instrument(level = "trace", skip_all)]
     pub(super) fn elaborate_variable(&mut self, variable: Path) -> (ExprId, Type) {
@@ -479,59 +500,20 @@ impl Elaborator<'_> {
 
     /// Resolve a [`TypedPath`] used as an expression to the item it names.
     ///
-    /// This is the single place that enumerates every form a path-as-expression can take. The
-    /// forms are tried in the order below; the order is significant, as it decides which
-    /// interpretation wins when a path is ambiguous:
-    ///
-    /// 1. `Self::AssocType::method`, `Self::CONST`, or `Self::method` (primitive `Self`), inside
-    ///    a trait impl — elaborated directly to an expression
-    ///    (see [`Self::elaborate_variable_as_self_method_or_associated_constant`]).
-    /// 2. A trait item reached through `Self`, a trait, a concrete type, or an in-scope generic
-    ///    bound — e.g. `Self::item` in a trait definition, `Trait::method`, `Type::method`,
-    ///    `T::method` where `T: Trait`, or `Trait::CONST`
-    ///    (see [`Self::resolve_trait_generic_path`] for the individual forms).
-    /// 3. A local variable, a definition (global, function, enum-variant global), or a numeric
-    ///    type alias (see [`Self::get_ident_from_path`]).
+    /// A path with a prefix (more than one segment) may name an item accessed *through* that
+    /// prefix: a `Self`-prefixed associated item (elaborated directly to an expression), or a
+    /// trait item reached through `Self`, a trait, a concrete type, or an in-scope generic bound
+    /// (see [`Self::resolve_variable_with_prefix`]). A single-segment path — or a prefixed path
+    /// that names no such item — resolves to a local variable, a definition (global, function,
+    /// enum-variant global), or a numeric type alias (see [`Self::get_ident_from_path`]).
     #[tracing::instrument(level = "trace", skip_all)]
     fn resolve_variable(&mut self, path: TypedPath) -> Option<VariableResolution> {
-        // Case 1
-        if let Some((expr_id, typ)) =
-            self.elaborate_variable_as_self_method_or_associated_constant(&path)
+        if path.segments.len() > 1
+            && let Some(resolution) = self.resolve_variable_with_prefix(&path)
         {
-            return Some(VariableResolution::Expression(expr_id, typ));
+            return resolution.into_option();
         }
 
-        // Case 2
-        if let Some(trait_path_resolution) = self.resolve_trait_generic_path(&path) {
-            self.push_errors(trait_path_resolution.errors);
-
-            return match trait_path_resolution.method {
-                TraitPathResolutionMethod::NotATraitMethod(func_id) => {
-                    let ident = HirIdent {
-                        location: path.location,
-                        id: self.interner.function_definition_id(func_id),
-                        impl_kind: ImplKind::NotATraitMethod,
-                    };
-                    Some(VariableResolution::Ident(ident, trait_path_resolution.item))
-                }
-
-                TraitPathResolutionMethod::TraitItem(item) => {
-                    let ident = HirIdent {
-                        location: path.location,
-                        id: item.definition,
-                        impl_kind: ImplKind::TraitItem(item),
-                    };
-                    Some(VariableResolution::Ident(ident, trait_path_resolution.item))
-                }
-
-                TraitPathResolutionMethod::MultipleTraitsInScope => {
-                    // An error has already been pushed, don't return an identifier
-                    None
-                }
-            };
-        }
-
-        // Case 3.
         // The location of variables or definitions we register (for LSP) must be that of the
         // path's last segment, as intermediate segments solve to other definitions.
         let location = path.last_ident().location();
@@ -553,6 +535,53 @@ impl Elaborator<'_> {
                 VariableResolution::Ident(hir_ident, Some(item))
             }
             IdentFromPath::TypeAlias(type_alias_id) => VariableResolution::TypeAlias(type_alias_id),
+        })
+    }
+
+    /// Resolve a path that has a prefix (more than one segment) to an item accessed *through* that
+    /// prefix. Returns `None` if the path names no such item, so the caller falls back to plain
+    /// value resolution.
+    fn resolve_variable_with_prefix(&mut self, path: &TypedPath) -> Option<PrefixedVariable> {
+        // A `Self`-prefixed associated item inside a trait impl, elaborated directly.
+        if let Some((expr_id, typ)) =
+            self.elaborate_variable_as_self_method_or_associated_constant(path)
+        {
+            return Some(PrefixedVariable::Resolved(VariableResolution::Expression(expr_id, typ)));
+        }
+
+        // A trait item reached through the prefix.
+        let trait_path_resolution = self.resolve_trait_generic_path(path)?;
+        self.push_errors(trait_path_resolution.errors);
+
+        Some(match trait_path_resolution.method {
+            TraitPathResolutionMethod::NotATraitMethod(func_id) => {
+                let ident = HirIdent {
+                    location: path.location,
+                    id: self.interner.function_definition_id(func_id),
+                    impl_kind: ImplKind::NotATraitMethod,
+                };
+                PrefixedVariable::Resolved(VariableResolution::Ident(
+                    ident,
+                    trait_path_resolution.item,
+                ))
+            }
+
+            TraitPathResolutionMethod::TraitItem(item) => {
+                let ident = HirIdent {
+                    location: path.location,
+                    id: item.definition,
+                    impl_kind: ImplKind::TraitItem(item),
+                };
+                PrefixedVariable::Resolved(VariableResolution::Ident(
+                    ident,
+                    trait_path_resolution.item,
+                ))
+            }
+
+            TraitPathResolutionMethod::MultipleTraitsInScope => {
+                // An error has already been pushed, don't return an identifier
+                PrefixedVariable::Errored
+            }
         })
     }
 

--- a/compiler/noirc_frontend/src/elaborator/variable.rs
+++ b/compiler/noirc_frontend/src/elaborator/variable.rs
@@ -27,10 +27,17 @@ use crate::{Kind, Type, TypeBindings, TypeVariable, TypeVariableId};
 use iter_extended::{btree_map, vecmap};
 use noirc_errors::{Located, Location};
 
-/// The result of [`Elaborator::resolve_variable`].
+/// The result of [`Elaborator::resolve_variable`]: what a path used as an expression resolves
+/// to. See [`Elaborator::resolve_variable`] for the full, ordered list of the path forms each
+/// variant covers.
 #[allow(clippy::large_enum_variant)]
 pub(crate) enum VariableResolution {
-    /// The path resolved to a variable or a definition.
+    /// The path was elaborated straight to an expression. This happens for the `Self::*` forms
+    /// handled inside a trait impl: an associated constant, an associated-type method, or a
+    /// method when `Self` is a primitive type.
+    Expression(ExprId, Type),
+    /// The path resolved to a local variable, a definition (global, function, enum-variant
+    /// global), or a trait item (method or associated constant).
     Ident(HirIdent, Option<PathResolutionItem>),
     /// The path resolved to a type alias that is numeric, infinitely recursive or one that errored.
     TypeAlias(TypeAliasId),
@@ -67,11 +74,6 @@ impl Elaborator<'_> {
     #[tracing::instrument(level = "trace", skip_all)]
     fn elaborate_variable_inner(&mut self, variable: Path) -> (ExprId, Type, bool, Location) {
         let variable = self.validate_path(variable);
-        if let Some((expr_id, typ)) =
-            self.elaborate_variable_as_self_method_or_associated_constant(&variable)
-        {
-            return (expr_id, typ, false, variable.location);
-        }
 
         let resolved_turbofish = variable.segments.last().unwrap().generics.clone();
 
@@ -86,6 +88,7 @@ impl Elaborator<'_> {
         let variable_resolution = self.resolve_variable(variable);
 
         let (hir_ident, item) = match variable_resolution {
+            Some(VariableResolution::Expression(id, typ)) => return (id, typ, false, location),
             Some(VariableResolution::TypeAlias(type_alias_id)) => {
                 // A type alias to a numeric generics is considered like a variable,
                 // but it is not a real variable so it does not resolve to a valid Identifier.
@@ -474,9 +477,31 @@ impl Elaborator<'_> {
         (id, numeric_type)
     }
 
-    /// Resolve a [`TypedPath`] to a [`HirIdent`] of either some trait method, or a local or global variable.
+    /// Resolve a [`TypedPath`] used as an expression to the item it names.
+    ///
+    /// This is the single place that enumerates every form a path-as-expression can take. The
+    /// forms are tried in the order below; the order is significant, as it decides which
+    /// interpretation wins when a path is ambiguous:
+    ///
+    /// 1. `Self::AssocType::method`, `Self::CONST`, or `Self::method` (primitive `Self`), inside
+    ///    a trait impl — elaborated directly to an expression
+    ///    (see [`Self::elaborate_variable_as_self_method_or_associated_constant`]).
+    /// 2. A trait item reached through `Self`, a trait, a concrete type, or an in-scope generic
+    ///    bound — e.g. `Self::item` in a trait definition, `Trait::method`, `Type::method`,
+    ///    `T::method` where `T: Trait`, or `Trait::CONST`
+    ///    (see [`Self::resolve_trait_generic_path`] for the individual forms).
+    /// 3. A local variable, a definition (global, function, enum-variant global), or a numeric
+    ///    type alias (see [`Self::get_ident_from_path`]).
     #[tracing::instrument(level = "trace", skip_all)]
     fn resolve_variable(&mut self, path: TypedPath) -> Option<VariableResolution> {
+        // Case 1
+        if let Some((expr_id, typ)) =
+            self.elaborate_variable_as_self_method_or_associated_constant(&path)
+        {
+            return Some(VariableResolution::Expression(expr_id, typ));
+        }
+
+        // Case 2
         if let Some(trait_path_resolution) = self.resolve_trait_generic_path(&path) {
             self.push_errors(trait_path_resolution.errors);
 
@@ -506,6 +531,7 @@ impl Elaborator<'_> {
             };
         }
 
+        // Case 3.
         // The location of variables or definitions we register (for LSP) must be that of the
         // path's last segment, as intermediate segments solve to other definitions.
         let location = path.last_ident().location();

--- a/compiler/noirc_frontend/src/elaborator/variable.rs
+++ b/compiler/noirc_frontend/src/elaborator/variable.rs
@@ -12,9 +12,7 @@ use crate::elaborator::TypedPath;
 use crate::elaborator::function_context::BindableTypeVariableKind;
 use crate::elaborator::path_resolution::PathResolutionItem;
 use crate::elaborator::patterns::{IdentFromPath, Variable};
-use crate::elaborator::types::{
-    SELF_TYPE_NAME, TraitPathResolution, TraitPathResolutionMethod, WildcardAllowed,
-};
+use crate::elaborator::types::{SELF_TYPE_NAME, WildcardAllowed};
 use crate::hir::def_collector::dc_crate::CompilationError;
 use crate::hir::resolution::errors::ResolverError;
 use crate::hir::type_check::TypeCheckError;
@@ -553,39 +551,6 @@ impl Elaborator<'_> {
 
         // A trait item reached through the prefix.
         self.resolve_trait_generic_path(path)
-    }
-
-    /// Turn a [`TraitPathResolution`] into the [`PrefixedVariable`] a prefixed path resolves to,
-    /// pushing the resolution's errors. An unresolvable trait method (`MultipleTraitsInScope`) has
-    /// already reported its error, so it becomes [`PrefixedVariable::Errored`] rather than an
-    /// identifier (and the caller must not fall back to value resolution).
-    pub(super) fn prefixed_variable_from_trait_resolution(
-        &mut self,
-        location: Location,
-        resolution: TraitPathResolution,
-    ) -> PrefixedVariable {
-        self.push_errors(resolution.errors);
-        let item = resolution.item;
-        match resolution.method {
-            TraitPathResolutionMethod::NotATraitMethod(func_id) => {
-                let ident = HirIdent {
-                    location,
-                    id: self.interner.function_definition_id(func_id),
-                    impl_kind: ImplKind::NotATraitMethod,
-                };
-                PrefixedVariable::Resolved(VariableResolution::Ident(ident, item))
-            }
-            TraitPathResolutionMethod::TraitItem(trait_item) => {
-                let ident = HirIdent {
-                    location,
-                    id: trait_item.definition,
-                    impl_kind: ImplKind::TraitItem(trait_item),
-                };
-                PrefixedVariable::Resolved(VariableResolution::Ident(ident, item))
-            }
-            // An error has already been pushed, don't return an identifier.
-            TraitPathResolutionMethod::MultipleTraitsInScope => PrefixedVariable::Errored,
-        }
     }
 
     /// Solve any generics that are part of the path before the function, for example:

--- a/compiler/noirc_frontend/src/elaborator/variable.rs
+++ b/compiler/noirc_frontend/src/elaborator/variable.rs
@@ -392,7 +392,7 @@ impl Elaborator<'_> {
     /// Returns `None` for any other shape (including a data-type `Self`, handled as a plain type
     /// prefix), so the caller falls back to resolving `Self` as a type.
     #[tracing::instrument(level = "trace", skip_all)]
-    pub(super) fn elaborate_variable_as_self_method_or_associated_constant(
+    pub(super) fn resolve_variable_as_self_method_or_associated_constant(
         &mut self,
         variable: &TypedPath,
         self_type: Type,
@@ -427,7 +427,7 @@ impl Elaborator<'_> {
     }
 
     /// The `Self::item` (single segment after `Self`) case of
-    /// [`Self::elaborate_variable_as_self_method_or_associated_constant`]: an associated constant
+    /// [`Self::resolve_variable_as_self_method_or_associated_constant`]: an associated constant
     /// (from the impl, or from the trait when the impl is missing it), or a method when `Self` is a
     /// primitive type. A data-type `Self` returns `None` so it is resolved as a plain type prefix.
     fn elaborate_self_associated_constant_or_primitive_method(
@@ -494,20 +494,21 @@ impl Elaborator<'_> {
     /// A path with a prefix (more than one segment) names an item accessed *through* that prefix,
     /// fully handled by [`Self::resolve_prefixed_variable`]. A single-segment path resolves in the
     /// current scope (a local variable, or a value item — global, function, enum-variant global,
-    /// numeric type alias) via [`Self::resolve_variable_in_scope`].
+    /// numeric type alias) via [`Self::resolve_unprefixed_variable`].
     #[tracing::instrument(level = "trace", skip_all)]
     fn resolve_variable(&mut self, path: TypedPath) -> Option<VariableResolution> {
         if path.segments.len() > 1 {
             self.resolve_prefixed_variable(path)
         } else {
-            self.resolve_variable_in_scope(path)
+            self.resolve_unprefixed_variable(path)
         }
     }
 
-    /// Resolve a path in the current scope to a local variable or a value item (global, function,
-    /// enum-variant global, numeric type alias), looked up across modules. Also serves as the
-    /// value fallback for a prefixed path whose last segment is not a method or trait item.
-    pub(super) fn resolve_variable_in_scope(
+    /// Resolve an unprefixed (single-segment) path to a local variable, or to a value item it
+    /// names (global, function, enum-variant global, numeric type alias). The counterpart to
+    /// [`Self::resolve_prefixed_variable`]; a prefixed path's value fallback uses
+    /// [`Self::resolve_value_item`], which skips the local-variable lookup.
+    pub(super) fn resolve_unprefixed_variable(
         &mut self,
         path: TypedPath,
     ) -> Option<VariableResolution> {
@@ -520,7 +521,34 @@ impl Elaborator<'_> {
         // This lookup allows support of such statements: let x = foo::bar::SOME_GLOBAL + 10;
         // If the expression is a singular indent, we search the resolver's current scope as normal.
         let ident_from_path = self.get_ident_from_path(path)?;
-        Some(match ident_from_path {
+        Some(self.variable_resolution_from_ident_from_path(ident_from_path, location))
+    }
+
+    /// Resolve a path's last segment as a value item (a global, function, enum-variant global,
+    /// trait constant, or numeric type alias). Unlike [`Self::resolve_unprefixed_variable`] this does
+    /// not look for a local variable, so it is the value fallback for a prefixed path: its last
+    /// segment is not a method or trait item, and a prefixed path can never name a local variable.
+    pub(super) fn resolve_value_item(&mut self, path: TypedPath) -> Option<VariableResolution> {
+        let location = path.last_ident().location();
+        match self.ident_from_value_item(path) {
+            Ok(ident_from_path) => {
+                Some(self.variable_resolution_from_ident_from_path(ident_from_path, location))
+            }
+            Err(error) => {
+                self.push_err(error);
+                None
+            }
+        }
+    }
+
+    /// Build the [`VariableResolution`] an already-resolved [`IdentFromPath`] denotes, registering
+    /// the reference (for LSP) along the way.
+    fn variable_resolution_from_ident_from_path(
+        &mut self,
+        ident_from_path: IdentFromPath,
+        location: Location,
+    ) -> VariableResolution {
+        match ident_from_path {
             IdentFromPath::Variable(variable) => {
                 self.handle_local_variable(&variable);
                 let hir_ident = HirIdent::non_trait_method(variable.ident.id, location);
@@ -532,7 +560,7 @@ impl Elaborator<'_> {
                 VariableResolution::Ident(hir_ident, Some(item))
             }
             IdentFromPath::TypeAlias(type_alias_id) => VariableResolution::TypeAlias(type_alias_id),
-        })
+        }
     }
 
     /// Solve any generics that are part of the path before the function, for example:

--- a/compiler/noirc_frontend/src/elaborator/variable.rs
+++ b/compiler/noirc_frontend/src/elaborator/variable.rs
@@ -43,27 +43,6 @@ pub(crate) enum VariableResolution {
     TypeAlias(TypeAliasId),
 }
 
-/// Outcome of [`Elaborator::resolve_variable_with_prefix`] for a path that has a prefix. A `None`
-/// result from that method means the path names no item accessed through its prefix, so the
-/// caller falls back to plain value resolution; a `Some` distinguishes the two handled outcomes.
-#[allow(clippy::large_enum_variant)]
-pub(super) enum PrefixedVariable {
-    /// The path resolved to this item.
-    Resolved(VariableResolution),
-    /// The path named a prefixed item but it could not be resolved unambiguously; an error was
-    /// already reported, so no value-resolution fallback should be attempted.
-    Errored,
-}
-
-impl PrefixedVariable {
-    fn into_option(self) -> Option<VariableResolution> {
-        match self {
-            PrefixedVariable::Resolved(resolution) => Some(resolution),
-            PrefixedVariable::Errored => None,
-        }
-    }
-}
-
 impl Elaborator<'_> {
     #[tracing::instrument(level = "trace", skip_all)]
     pub(super) fn elaborate_variable(&mut self, variable: Path) -> (ExprId, Type) {
@@ -500,20 +479,26 @@ impl Elaborator<'_> {
 
     /// Resolve a [`TypedPath`] used as an expression to the item it names.
     ///
-    /// A path with a prefix (more than one segment) may name an item accessed *through* that
-    /// prefix: a `Self`-prefixed associated item (elaborated directly to an expression), or a
-    /// trait item reached through `Self`, a trait, a concrete type, or an in-scope generic bound
-    /// (see [`Self::resolve_prefixed_variable`]). A single-segment path — or a prefixed path
-    /// that names no such item — resolves to a local variable, a definition (global, function,
-    /// enum-variant global), or a numeric type alias (see [`Self::get_ident_from_path`]).
+    /// A path with a prefix (more than one segment) names an item accessed *through* that prefix,
+    /// fully handled by [`Self::resolve_prefixed_variable`]. A single-segment path resolves in the
+    /// current scope (a local variable, or a value item — global, function, enum-variant global,
+    /// numeric type alias) via [`Self::resolve_variable_in_scope`].
     #[tracing::instrument(level = "trace", skip_all)]
     fn resolve_variable(&mut self, path: TypedPath) -> Option<VariableResolution> {
-        if path.segments.len() > 1
-            && let Some(resolution) = self.resolve_prefixed_variable(&path)
-        {
-            return resolution.into_option();
+        if path.segments.len() > 1 {
+            return self.resolve_prefixed_variable(&path);
         }
 
+        self.resolve_variable_in_scope(path)
+    }
+
+    /// Resolve a path in the current scope to a local variable or a value item (global, function,
+    /// enum-variant global, numeric type alias), looked up across modules. Also serves as the
+    /// value fallback for a prefixed path whose last segment is not a method or trait item.
+    pub(super) fn resolve_variable_in_scope(
+        &mut self,
+        path: TypedPath,
+    ) -> Option<VariableResolution> {
         // The location of variables or definitions we register (for LSP) must be that of the
         // path's last segment, as intermediate segments solve to other definitions.
         let location = path.last_ident().location();
@@ -522,8 +507,8 @@ impl Elaborator<'_> {
         // Otherwise, then it is referring to an Identifier
         // This lookup allows support of such statements: let x = foo::bar::SOME_GLOBAL + 10;
         // If the expression is a singular indent, we search the resolver's current scope as normal.
-        let ident_from_path = self.get_ident_from_path(path);
-        ident_from_path.map(|ident_from_path| match ident_from_path {
+        let ident_from_path = self.get_ident_from_path(path)?;
+        Some(match ident_from_path {
             IdentFromPath::Variable(variable) => {
                 self.handle_local_variable(&variable);
                 let hir_ident = HirIdent::non_trait_method(variable.ident.id, location);

--- a/compiler/noirc_frontend/src/elaborator/variable.rs
+++ b/compiler/noirc_frontend/src/elaborator/variable.rs
@@ -11,6 +11,7 @@ use crate::ast::{
 use crate::elaborator::TypedPath;
 use crate::elaborator::function_context::BindableTypeVariableKind;
 use crate::elaborator::path_resolution::PathResolutionItem;
+use crate::elaborator::path_resolution::TypedPathSegment;
 use crate::elaborator::patterns::{IdentFromPath, Variable};
 use crate::elaborator::types::{SELF_TYPE_NAME, WildcardAllowed};
 use crate::hir::def_collector::dc_crate::CompilationError;
@@ -21,7 +22,7 @@ use crate::hir_def::expr::{
 };
 use crate::node_interner::pusher::{HasLocation, PushedExpr};
 use crate::node_interner::{
-    DefinitionId, DefinitionInfo, DefinitionKind, ExprId, TraitImplKind, TypeAliasId,
+    DefinitionId, DefinitionInfo, DefinitionKind, ExprId, TraitImplId, TraitImplKind, TypeAliasId,
 };
 use crate::{Kind, Type, TypeBindings, TypeVariable, TypeVariableId};
 use iter_extended::{btree_map, vecmap};
@@ -378,67 +379,81 @@ impl Elaborator<'_> {
         }
     }
 
-    /// Checks whether `variable` is `Self::method_name`, `Self::AssociatedConstant`, or
-    /// `Self::AssociatedType::method_name` when we are inside a trait impl and `Self`
-    /// resolves to a primitive type.
+    /// Resolves the `Self::…` forms that only make sense inside a trait impl, where `Self` is a
+    /// concrete type with associated items. The segments *after* `Self` (the "rest") select the
+    /// form:
     ///
-    /// In the first case we elaborate this as if it were a [TypePath]
-    /// (for example, if `Self` is `u32` then we consider this the same as `u32::method_name`).
-    /// A regular path lookup won't work here for the same reason [TypePath] exists.
+    /// - `[AssociatedType, method]` — resolve the associated type, then elaborate the method on it.
+    /// - `[item]` — an associated constant (looked up for its value, later a literal), or, when
+    ///   `Self` is a primitive type, a method elaborated as if it were a [TypePath]
+    ///   (`u32::method_name`); a regular path lookup won't work, for the same reason [TypePath]
+    ///   exists.
     ///
-    /// In the second case we solve the associated constant by looking up its value, later
-    /// turning it into a literal.
-    ///
-    /// In the third case, we resolve the associated type first, then elaborate the method
-    /// call on that resolved type.
+    /// Returns `None` for any other shape (including a data-type `Self`, handled as a plain type
+    /// prefix), so the caller falls back to resolving `Self` as a type.
     #[tracing::instrument(level = "trace", skip_all)]
     pub(super) fn elaborate_variable_as_self_method_or_associated_constant(
         &mut self,
         variable: &TypedPath,
     ) -> Option<(ExprId, Type)> {
-        // The caller only reaches this for a `Self`-prefixed path with at least two segments
-        // (the `PathPrefixKind::SelfType` classification), so that is taken as a precondition.
-        let location = variable.location;
-        let name = variable.segments[1].ident.as_str();
-        let self_type = self.self_type.as_ref()?;
-        let trait_impl_id = &self.current_trait_impl?;
+        // Reached only for a `Self`-prefixed path with at least two segments. These forms need the
+        // impl's concrete `Self` and its associated items.
+        let self_type = self.self_type.clone()?;
+        let trait_impl_id = self.current_trait_impl?;
 
-        // Check for `Self::AssociatedType::method_name` (exactly 3 segments).
-        // Longer paths like `Self::AssocType::foo::bar` are not valid since associated types
-        // resolve to concrete types and you cannot chain further path segments after a method name.
-        if variable.segments.len() == 3 {
-            // Try to resolve the second segment as an associated type
-            if let Some(assoc_type) =
-                self.interner.find_associated_type_for_impl(*trait_impl_id, name).cloned()
-            {
-                let method_ident = variable.segments[2].ident.clone();
-                let typ_location = variable.segments[1].location;
-                // Extract already-resolved turbofish generics from the path segment
-                let resolved_generics = variable.segments[2].generics.as_ref().map(|generics| {
+        match &variable.segments[1..] {
+            [associated_type, method] => {
+                let associated_type = self
+                    .interner
+                    .find_associated_type_for_impl(trait_impl_id, associated_type.ident.as_str())
+                    .cloned()?;
+                // Extract already-resolved turbofish generics from the method segment.
+                let resolved_generics = method.generics.as_ref().map(|generics| {
                     generics.iter().map(|located| located.contents.clone()).collect()
                 });
-                return Some(self.elaborate_type_path_impl_with_resolved_generics(
-                    assoc_type,
-                    method_ident,
+                Some(self.elaborate_type_path_impl_with_resolved_generics(
+                    associated_type,
+                    method.ident.clone(),
                     resolved_generics,
-                    typ_location,
-                ));
+                    variable.segments[1].location,
+                ))
             }
-            // If it's not an associated type, fall through to let regular path resolution handle it
-            return None;
+            [item] => self.elaborate_self_associated_constant_or_primitive_method(
+                &self_type,
+                trait_impl_id,
+                item,
+                variable.location,
+                variable.segments[0].location,
+            ),
+            _ => None,
         }
+    }
 
-        // Check the `Self::AssociatedConstant` case when inside a trait impl (2 segments)
+    /// The `Self::item` (single segment after `Self`) case of
+    /// [`Self::elaborate_variable_as_self_method_or_associated_constant`]: an associated constant
+    /// (from the impl, or from the trait when the impl is missing it), or a method when `Self` is a
+    /// primitive type. A data-type `Self` returns `None` so it is resolved as a plain type prefix.
+    fn elaborate_self_associated_constant_or_primitive_method(
+        &mut self,
+        self_type: &Type,
+        trait_impl_id: TraitImplId,
+        item: &TypedPathSegment,
+        location: Location,
+        self_location: Location,
+    ) -> Option<(ExprId, Type)> {
+        let name = item.ident.as_str();
+
+        // The associated constant declared on the impl.
         if let Some((definition_id, numeric_type)) =
-            self.interner.get_trait_impl_associated_constant(*trait_impl_id, name).cloned()
+            self.interner.get_trait_impl_associated_constant(trait_impl_id, name).cloned()
         {
             return Some(self.intern_associated_constant(definition_id, numeric_type, location));
         }
 
-        // Check if the constant exists in the trait definition (even if impl is missing it).
-        // This prevents spurious "Could not resolve" errors inside trait methods when the impl is missing the constant,
-        // since the "missing associated constant" error is reported elsewhere.
-        if let Some(trait_impl) = self.interner.try_get_trait_implementation(*trait_impl_id) {
+        // The constant declared on the trait, even if the impl is missing it. This prevents a
+        // spurious "Could not resolve" inside trait methods; the "missing associated constant"
+        // error is reported elsewhere.
+        if let Some(trait_impl) = self.interner.try_get_trait_implementation(trait_impl_id) {
             let trait_id = trait_impl.borrow().trait_id;
             let trait_ = self.interner.get_trait(trait_id);
             if let Some(definition_id) = trait_.associated_constant_ids.get(name).copied() {
@@ -451,14 +466,17 @@ impl Elaborator<'_> {
             }
         }
 
-        // Check the `Self::method_name` case when `Self` is a primitive type (2 segments)
-        if matches!(self.self_type, Some(Type::DataType(..))) {
+        // A data-type `Self::method` is resolved as a plain type prefix, not here.
+        if matches!(self_type, Type::DataType(..)) {
             return None;
         }
 
-        let ident = variable.segments[1].ident.clone();
-        let typ_location = variable.segments[0].location;
-        Some(self.elaborate_type_path_impl(self_type.clone(), ident, None, typ_location))
+        Some(self.elaborate_type_path_impl(
+            self_type.clone(),
+            item.ident.clone(),
+            None,
+            self_location,
+        ))
     }
 
     /// Intern an identifier expression referring to an associated constant of the given type.

--- a/compiler/noirc_frontend/src/tests/expressions.rs
+++ b/compiler/noirc_frontend/src/tests/expressions.rs
@@ -551,3 +551,29 @@ fn does_not_trigger_unnecessary_mut_if_mut_self_method_is_called() {
     "#;
     assert_no_errors(src);
 }
+
+#[test]
+fn unresolved_path_prefix_reports_missing_segment() {
+    let src = r#"
+    fn main() {
+        let _ = nonexistent::foo();
+                ^^^^^^^^^^^ Could not resolve 'nonexistent' in path
+    }
+    "#;
+    check_errors(src);
+}
+
+#[test]
+fn value_used_as_path_prefix_reports_that_segment() {
+    // The prefix resolves (to a function) but a value can't carry an associated item, so the path
+    // names nothing; the error points at that segment.
+    let src = r#"
+    fn helper() {}
+
+    fn main() {
+        let _ = helper::foo();
+                ^^^^^^ Could not resolve 'helper' in path
+    }
+    "#;
+    check_errors(src);
+}

--- a/compiler/noirc_frontend/src/tests/traits/trait_qualified_paths.rs
+++ b/compiler/noirc_frontend/src/tests/traits/trait_qualified_paths.rs
@@ -630,3 +630,67 @@ fn generic_substitution_with_turbofish_trait_method() {
     "#;
     assert_no_errors(src);
 }
+
+#[test]
+fn unresolved_self_item_in_trait_definition_points_at_item() {
+    // In a trait definition `Self` is the trait itself, so `Self::nope` can only be a trait static
+    // method or associated constant. When it is neither, the error points at the item, not `Self`.
+    let src = r#"
+    trait MyTrait {
+        fn f() -> Field {
+            Self::nope()
+                  ^^^^ Could not resolve 'nope' in path
+        }
+    }
+
+    struct S {}
+
+    impl MyTrait for S {}
+
+    fn main() {
+        let _ = S::f();
+    }
+    "#;
+    check_errors(src);
+}
+
+#[test]
+fn unresolved_bounded_generic_item_points_at_item() {
+    // `T::nope` on a bounded generic must be a method or associated constant reached through a
+    // bound; when it is neither, the error points at the item, not the generic `T`.
+    let src = r#"
+    trait MyTrait {}
+
+    struct S {}
+
+    impl MyTrait for S {}
+
+    fn foo<T>() -> Field where T: MyTrait {
+        T::nope()
+           ^^^^ Could not resolve 'nope' in path
+    }
+
+    fn main() {
+        let _ = foo::<S>();
+    }
+    "#;
+    check_errors(src);
+}
+
+#[test]
+fn unresolved_trait_item_points_at_item() {
+    let src = r#"
+    trait MyTrait {}
+
+    struct S {}
+
+    impl MyTrait for S {}
+
+    fn main() {
+        let _ = S {};
+        MyTrait::nope()
+                 ^^^^ Could not resolve 'nope' in path
+    }
+    "#;
+    check_errors(src);
+}

--- a/compiler/noirc_frontend/src/usage_tracker.rs
+++ b/compiler/noirc_frontend/src/usage_tracker.rs
@@ -71,57 +71,24 @@ pub struct UsageTracker {
     /// type's method set — so they're tracked by id and removed when the method is called or
     /// otherwise referenced. The `Ident` is the method name, used to locate the unused warning.
     unused_impl_functions: HashMap<FuncId, Ident>,
-    /// A stack of resolution-mode frames. The top frame decides how removals from
-    /// `unused_items`/`unused_imports` are treated; an empty stack means they are committed (the
-    /// default outside any probe):
-    ///
-    /// * [`Journal::Speculative`] records every removal so it can be undone on rollback. This lets a
-    ///   speculative path-resolution probe (which marks segments as used/referenced while resolving)
-    ///   undo those marks when the path turns out not to be what it was probing for.
-    /// * [`Journal::Suspended`] commits removals unconditionally, used to run a committed side
-    ///   effect — e.g. resolving a function's [`FuncMeta`] — from inside a probe without its marks
-    ///   being rolled back when the probe fails.
-    ///
-    /// Frames nest and interleave freely: a probe may suspend, and a suspended resolution may itself
-    /// open a probe. Each frame is entered and exited in pairs — `begin`/`commit`/`rollback` for
-    /// speculative frames, `suspend`/`resume` for suspended ones — so the stay-balanced invariant is
-    /// what keeps the stack consistent.
+    /// A stack of [`Journal::Suspended`] frames. Each marks a region where removals from
+    /// `unused_items`/`unused_imports` are committed unconditionally, used to run a committed side
+    /// effect — e.g. resolving a function's [`FuncMeta`] — without its marks being rolled back.
     ///
     /// [`FuncMeta`]: crate::hir_def::function::FuncMeta
     journal: Vec<Journal>,
 }
 
-/// A single removal recorded during a speculative transaction, kept so it can be re-inserted on
-/// rollback.
-#[derive(Debug)]
-enum SpeculativeUndo {
-    Item(ModuleId, (Namespace, Ident), UnusedItem),
-    Import(ModuleId, (Ident, Location), HashSet<Namespace>),
-}
-
-/// A resolution-mode frame on the [`UsageTracker`]'s journal stack. The top frame determines how
-/// removals from the unused maps are treated; see [`UsageTracker::journal`].
+/// A resolution-mode frame on the [`UsageTracker`]'s journal stack.
 #[derive(Debug)]
 enum Journal {
-    /// Removals are committed unconditionally (not recorded for rollback).
+    /// Removals are committed unconditionally.
     Suspended,
-    /// Removals are recorded here so they can be undone if the probe is rolled back.
-    Speculative(Vec<SpeculativeUndo>),
-}
-
-/// Proof that a speculative transaction is open, returned by [`UsageTracker::begin_speculative`]
-/// and consumed by [`UsageTracker::commit_speculative`] / [`UsageTracker::rollback_speculative`].
-/// It can only be constructed here, so a transaction cannot be started without going through
-/// `begin_speculative`, and `#[must_use]` nudges callers to finish it. Prefer driving this through
-/// [`Elaborator::speculatively`](crate::elaborator::Elaborator) rather than by hand.
-#[must_use]
-pub(crate) struct SpeculativeTx {
-    _private: (),
 }
 
 /// Proof that a suspended frame is open, returned by [`UsageTracker::suspend_speculative`] and
-/// consumed by [`UsageTracker::resume_speculative`]. Like [`SpeculativeTx`], it can only be
-/// constructed here and `#[must_use]` nudges callers to pair the suspend with a resume.
+/// consumed by [`UsageTracker::resume_speculative`]. It can only be constructed here, and
+/// `#[must_use]` nudges callers to pair the suspend with a resume.
 #[must_use]
 pub(crate) struct SuspendTx {
     _private: (),
@@ -182,23 +149,12 @@ impl UsageTracker {
         name: &Ident,
         namespace: Namespace,
     ) {
-        let recording = matches!(self.journal.last(), Some(Journal::Speculative(_)));
         let Some(imports) = self.unused_imports.get_mut(&current_mod_id) else {
             return;
         };
-        let mut removed = Vec::new();
-        imports.retain(|(import_name, location), namespaces| {
-            let remove = import_name == name && namespaces.contains(&namespace);
-            if remove && recording {
-                removed.push(((import_name.clone(), *location), namespaces.clone()));
-            }
-            !remove
+        imports.retain(|(import_name, _location), namespaces| {
+            !(import_name == name && namespaces.contains(&namespace))
         });
-        if let Some(Journal::Speculative(undo)) = self.journal.last_mut() {
-            for (key, namespaces) in removed {
-                undo.push(SpeculativeUndo::Import(current_mod_id, key, namespaces));
-            }
-        }
     }
 
     /// Marks an item as being referenced. This doesn't always makes the item as used. For example
@@ -218,10 +174,8 @@ impl UsageTracker {
             return;
         }
 
-        let removed =
-            self.unused_items.get_mut(&current_mod_id).and_then(|items| items.remove_entry(&key));
-        if let Some((stored_key, item)) = removed {
-            self.record_item_removal(current_mod_id, stored_key, item);
+        if let Some(items) = self.unused_items.get_mut(&current_mod_id) {
+            items.remove(&key);
         }
     }
 
@@ -235,50 +189,8 @@ impl UsageTracker {
         self.mark_import_as_used(current_mod_id, name, namespace);
 
         let key = (namespace, name.clone());
-        let removed =
-            self.unused_items.get_mut(&current_mod_id).and_then(|items| items.remove_entry(&key));
-        if let Some((stored_key, item)) = removed {
-            self.record_item_removal(current_mod_id, stored_key, item);
-        }
-    }
-
-    /// While a speculative transaction is open, record an `unused_items` removal so it can be
-    /// restored on rollback. A no-op when no transaction is in progress.
-    ///
-    /// `key` must be the *stored* key returned by `remove_entry`, not the lookup key built from the
-    /// caller's ident. `Ident`'s `Eq`/`Hash` ignore location, so a lookup ident carries the
-    /// reference's location while the stored ident carries the definition's. Recording the stored
-    /// key keeps the restored entry pointing at the definition, so a later unused warning lands on
-    /// the definition rather than the (rolled-back) reference site.
-    fn record_item_removal(
-        &mut self,
-        module_id: ModuleId,
-        key: (Namespace, Ident),
-        item: UnusedItem,
-    ) {
-        if let Some(Journal::Speculative(undo)) = self.journal.last_mut() {
-            undo.push(SpeculativeUndo::Item(module_id, key, item));
-        }
-    }
-
-    /// Begin a speculative transaction by pushing a [`Journal::Speculative`] frame: until it is
-    /// committed or rolled back, every removal from `unused_items`/`unused_imports` made while it is
-    /// on top of the stack is recorded so it can be undone. Prefer [`Elaborator::speculatively`]
-    /// over calling this directly.
-    ///
-    /// [`Elaborator::speculatively`]: crate::elaborator::Elaborator
-    pub(crate) fn begin_speculative(&mut self) -> SpeculativeTx {
-        self.journal.push(Journal::Speculative(Vec::new()));
-        SpeculativeTx { _private: () }
-    }
-
-    /// Commit a speculative transaction, keeping every change made while it was open.
-    pub(crate) fn commit_speculative(&mut self, _tx: SpeculativeTx) {
-        match self.journal.pop() {
-            Some(Journal::Speculative(_)) => {}
-            other => {
-                panic!("commit_speculative expected a speculative frame on top, found {other:?}")
-            }
+        if let Some(items) = self.unused_items.get_mut(&current_mod_id) {
+            items.remove(&key);
         }
     }
 
@@ -301,23 +213,6 @@ impl UsageTracker {
             Some(Journal::Suspended) => {}
             other => {
                 panic!("resume_speculative expected a suspended frame on top, found {other:?}")
-            }
-        }
-    }
-
-    /// Roll back a speculative transaction, restoring every entry removed while it was open.
-    pub(crate) fn rollback_speculative(&mut self, _tx: SpeculativeTx) {
-        let Some(Journal::Speculative(undo)) = self.journal.pop() else {
-            panic!("rollback_speculative expected a speculative frame on top");
-        };
-        for entry in undo.into_iter().rev() {
-            match entry {
-                SpeculativeUndo::Item(module_id, key, item) => {
-                    self.unused_items.entry(module_id).or_default().insert(key, item);
-                }
-                SpeculativeUndo::Import(module_id, key, namespaces) => {
-                    self.unused_imports.entry(module_id).or_default().insert(key, namespaces);
-                }
             }
         }
     }

--- a/compiler/noirc_frontend/src/usage_tracker.rs
+++ b/compiler/noirc_frontend/src/usage_tracker.rs
@@ -71,27 +71,6 @@ pub struct UsageTracker {
     /// type's method set — so they're tracked by id and removed when the method is called or
     /// otherwise referenced. The `Ident` is the method name, used to locate the unused warning.
     unused_impl_functions: HashMap<FuncId, Ident>,
-    /// A stack of [`Journal::Suspended`] frames. Each marks a region where removals from
-    /// `unused_items`/`unused_imports` are committed unconditionally, used to run a committed side
-    /// effect — e.g. resolving a function's [`FuncMeta`] — without its marks being rolled back.
-    ///
-    /// [`FuncMeta`]: crate::hir_def::function::FuncMeta
-    journal: Vec<Journal>,
-}
-
-/// A resolution-mode frame on the [`UsageTracker`]'s journal stack.
-#[derive(Debug)]
-enum Journal {
-    /// Removals are committed unconditionally.
-    Suspended,
-}
-
-/// Proof that a suspended frame is open, returned by [`UsageTracker::suspend_speculative`] and
-/// consumed by [`UsageTracker::resume_speculative`]. It can only be constructed here, and
-/// `#[must_use]` nudges callers to pair the suspend with a resume.
-#[must_use]
-pub(crate) struct SuspendTx {
-    _private: (),
 }
 
 impl UsageTracker {
@@ -191,29 +170,6 @@ impl UsageTracker {
         let key = (namespace, name.clone());
         if let Some(items) = self.unused_items.get_mut(&current_mod_id) {
             items.remove(&key);
-        }
-    }
-
-    /// Suspend rollback recording by pushing a [`Journal::Suspended`] frame: while it is on top,
-    /// removals from the unused maps are committed unconditionally (never recorded for rollback).
-    /// Used to run a committed side effect — e.g. resolving a function's [`FuncMeta`], which
-    /// structurally strikes the function off the to-be-resolved list and so cannot be undone — from
-    /// inside a speculative probe without its usage-marks being rolled back when the probe fails.
-    /// Pair with [`resume_speculative`](Self::resume_speculative).
-    ///
-    /// [`FuncMeta`]: crate::hir_def::function::FuncMeta
-    pub(crate) fn suspend_speculative(&mut self) -> SuspendTx {
-        self.journal.push(Journal::Suspended);
-        SuspendTx { _private: () }
-    }
-
-    /// Resume after a [`suspend_speculative`](Self::suspend_speculative), popping its suspended frame.
-    pub(crate) fn resume_speculative(&mut self, _tx: SuspendTx) {
-        match self.journal.pop() {
-            Some(Journal::Suspended) => {}
-            other => {
-                panic!("resume_speculative expected a suspended frame on top, found {other:?}")
-            }
         }
     }
 


### PR DESCRIPTION


## Problem Resolved

No issue, just something I wanted to do for some time now.

## Summary of Changes

Variable path resolution (things like `foo`, `foo::bar::baz`, `Self::foo`, etc.) grew organically over time, handling more and more cases. These cases were spread throughout the code so it wasn't immediately clear how things work. It also happened that a single path was resolved multiple times, trying to see if it matches certain patterns or structures.

In my mind, a more correct way to do this was to solve each segment in turn and analyze each thing at each step. Checking with Claude, and asking how Rust works here, it turns out that if a path has more than one segment then we can resolve the path based on what the prefix and last segments are, where the prefix is everything except the last segment. This is what this PR does:
1. If a path has more than one segment, it checks what the prefix is. The prefix could be "Self" inside a trait, "Self" inside a trait impl, maybe a type, maybe a module, etc.
2. Then it goes to resolve the last segment based on that prefix

The intention of this PR was code clarity, so it's easier to see how path resolution works and, partially, to avoid doing redundant lookups. It turned out that we now don't do speculative lookups (we think that something might be a value when in reality it's a type) so the entire `Speculative` code that was recently added is no longer needed! 🎉 I think that could be a small prove that this refactor is in a good direction.

This PR also improves some "could not resolve" errors (the new tests).

I still feel like more refactors could be done here. For example when the prefix is a module we could directly look up the last segment inside that module. Instead, in many places we fallback to solving the entire path again, as a value. It's a bit redundant, but:

1. it's how it used to work before, kind of
2. it probably adds new logic instead of just moving things around
3. I didn't want to continue growing this PR as I'm thinking this is a good stop point

This could be done as a follow-up PR, though (I might try it)

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
