### PR TITLE
chore: left-overs audit's maintainability improvements

### DIFF
--- a/acvm-repo/acir/src/circuit/black_box_functions.rs
+++ b/acvm-repo/acir/src/circuit/black_box_functions.rs
@@ -107,6 +107,77 @@ impl BlackBoxFunc {
             | BlackBoxFunc::Sha256Compression => false,
         }
     }
+
+    /// This function will return the number of inputs that a blackbox function
+    /// expects. Returning `None` if there is no expectation.
+    pub fn expected_input_size(&self) -> Option<usize> {
+        match self {
+            // Bitwise opcodes will take in 2 parameters
+            BlackBoxFunc::AND | BlackBoxFunc::XOR => Some(2),
+
+            // All of the hash/cipher methods will take in a
+            // variable number of inputs.
+            BlackBoxFunc::AES128Encrypt | BlackBoxFunc::Blake2s | BlackBoxFunc::Blake3 => None,
+
+            BlackBoxFunc::Keccakf1600 => Some(25),
+            // The permutation takes a fixed number of inputs, but the inputs length depends on the proving system implementation.
+            BlackBoxFunc::Poseidon2Permutation => None,
+
+            // SHA256 compression requires 16 u32s as input message and 8 u32s for the hash state.
+            BlackBoxFunc::Sha256Compression => Some(24),
+            // Can only apply a range constraint to one
+            // witness at a time.
+            BlackBoxFunc::RANGE => Some(1),
+
+            // 64 bytes for the signature, 32 bytes for the hashed message,
+            // and 32 bytes each for the x and y coordinates of the public key, plus a predicate.
+            BlackBoxFunc::EcdsaSecp256k1 | BlackBoxFunc::EcdsaSecp256r1 => Some(161),
+
+            // Inputs for multi scalar multiplication is an arbitrary number of [point, scalar] pairs.
+            BlackBoxFunc::MultiScalarMul => None,
+
+            // Recursive aggregation has a variable number of inputs
+            BlackBoxFunc::RecursiveAggregation => None,
+
+            // Addition over the embedded curve: inputs are coordinates (x1,y1) and (x2,y2) of the Grumpkin points
+            // to add, plus a predicate to conditionally perform the addition.
+            BlackBoxFunc::EmbeddedCurveAdd => Some(5),
+        }
+    }
+
+    /// This function will return the number of outputs that a blackbox function
+    /// expects. Returning `None` if there is no expectation.
+    pub fn expected_output_size(&self) -> Option<usize> {
+        match self {
+            // Bitwise opcodes will return 1 parameter which is the output
+            // or the operation.
+            BlackBoxFunc::AND | BlackBoxFunc::XOR => Some(1),
+
+            // 32 byte hash algorithms
+            BlackBoxFunc::Blake2s | BlackBoxFunc::Blake3 => Some(32),
+
+            BlackBoxFunc::Keccakf1600 => Some(25),
+            // The permutation returns a fixed number of outputs, equals to the inputs length which depends on the proving system implementation.
+            BlackBoxFunc::Poseidon2Permutation => None,
+
+            BlackBoxFunc::Sha256Compression => Some(8),
+
+            BlackBoxFunc::RANGE => Some(0),
+
+            // Signature verification algorithms will return a boolean
+            BlackBoxFunc::EcdsaSecp256k1 | BlackBoxFunc::EcdsaSecp256r1 => Some(1),
+
+            // Output of operations over the embedded curve
+            // will be 2 field elements representing the point, i.e. (x,y)
+            BlackBoxFunc::MultiScalarMul | BlackBoxFunc::EmbeddedCurveAdd => Some(2),
+
+            // Recursive aggregation has no output
+            BlackBoxFunc::RecursiveAggregation => Some(0),
+
+            // AES encryption returns a variable number of outputs
+            BlackBoxFunc::AES128Encrypt => None,
+        }
+    }
 }
 
 #[cfg(test)]

--- a/compiler/noirc_evaluator/src/acir/acir_context/generated_acir/mod.rs
+++ b/compiler/noirc_evaluator/src/acir/acir_context/generated_acir/mod.rs
@@ -721,77 +721,6 @@ impl<F: AcirField> GeneratedAcir<F> {
     }
 }
 
-/// This function will return the number of inputs that a blackbox function
-/// expects. Returning `None` if there is no expectation.
-fn black_box_func_expected_input_size(name: BlackBoxFunc) -> Option<usize> {
-    match name {
-        // Bitwise opcodes will take in 2 parameters
-        BlackBoxFunc::AND | BlackBoxFunc::XOR => Some(2),
-
-        // All of the hash/cipher methods will take in a
-        // variable number of inputs.
-        BlackBoxFunc::AES128Encrypt | BlackBoxFunc::Blake2s | BlackBoxFunc::Blake3 => None,
-
-        BlackBoxFunc::Keccakf1600 => Some(25),
-        // The permutation takes a fixed number of inputs, but the inputs length depends on the proving system implementation.
-        BlackBoxFunc::Poseidon2Permutation => None,
-
-        // SHA256 compression requires 16 u32s as input message and 8 u32s for the hash state.
-        BlackBoxFunc::Sha256Compression => Some(24),
-        // Can only apply a range constraint to one
-        // witness at a time.
-        BlackBoxFunc::RANGE => Some(1),
-
-        // 64 bytes for the signature, 32 bytes for the hashed message,
-        // and 32 bytes each for the x and y coordinates of the public key, plus a predicate.
-        BlackBoxFunc::EcdsaSecp256k1 | BlackBoxFunc::EcdsaSecp256r1 => Some(161),
-
-        // Inputs for multi scalar multiplication is an arbitrary number of [point, scalar] pairs.
-        BlackBoxFunc::MultiScalarMul => None,
-
-        // Recursive aggregation has a variable number of inputs
-        BlackBoxFunc::RecursiveAggregation => None,
-
-        // Addition over the embedded curve: inputs are coordinates (x1,y1) and (x2,y2) of the Grumpkin points
-        // to add, plus a predicate to conditionally perform the addition.
-        BlackBoxFunc::EmbeddedCurveAdd => Some(5),
-    }
-}
-
-/// This function will return the number of outputs that a blackbox function
-/// expects. Returning `None` if there is no expectation.
-fn black_box_expected_output_size(name: BlackBoxFunc) -> Option<usize> {
-    match name {
-        // Bitwise opcodes will return 1 parameter which is the output
-        // or the operation.
-        BlackBoxFunc::AND | BlackBoxFunc::XOR => Some(1),
-
-        // 32 byte hash algorithms
-        BlackBoxFunc::Blake2s | BlackBoxFunc::Blake3 => Some(32),
-
-        BlackBoxFunc::Keccakf1600 => Some(25),
-        // The permutation returns a fixed number of outputs, equals to the inputs length which depends on the proving system implementation.
-        BlackBoxFunc::Poseidon2Permutation => None,
-
-        BlackBoxFunc::Sha256Compression => Some(8),
-
-        BlackBoxFunc::RANGE => Some(0),
-
-        // Signature verification algorithms will return a boolean
-        BlackBoxFunc::EcdsaSecp256k1 | BlackBoxFunc::EcdsaSecp256r1 => Some(1),
-
-        // Output of operations over the embedded curve
-        // will be 2 field elements representing the point, i.e. (x,y)
-        BlackBoxFunc::MultiScalarMul | BlackBoxFunc::EmbeddedCurveAdd => Some(2),
-
-        // Recursive aggregation has no output
-        BlackBoxFunc::RecursiveAggregation => Some(0),
-
-        // AES encryption returns a variable number of outputs
-        BlackBoxFunc::AES128Encrypt => None,
-    }
-}
-
 /// Checks that the number of inputs being used to call the blackbox function
 /// is correct according to the function definition.
 ///
@@ -808,7 +737,7 @@ fn black_box_expected_output_size(name: BlackBoxFunc) -> Option<usize> {
 /// fn sha256<N>(_input : [u8; N]) -> [u8; 32] {}
 /// ``
 fn intrinsics_check_inputs(name: BlackBoxFunc, input_count: usize) {
-    let Some(expected_num_inputs) = black_box_func_expected_input_size(name) else {
+    let Some(expected_num_inputs) = name.expected_input_size() else {
         return;
     };
 
@@ -840,7 +769,7 @@ fn intrinsics_check_inputs(name: BlackBoxFunc, input_count: usize) {
 /// ) -> [Field; N] {}
 /// ``
 fn intrinsics_check_outputs(name: BlackBoxFunc, output_count: usize) {
-    let Some(expected_num_outputs) = black_box_expected_output_size(name) else {
+    let Some(expected_num_outputs) = name.expected_output_size() else {
         return;
     };
 

--- a/compiler/noirc_evaluator/src/acir/acir_context/mod.rs
+++ b/compiler/noirc_evaluator/src/acir/acir_context/mod.rs
@@ -107,9 +107,15 @@ impl<F: AcirField> AcirContext<F> {
 
     /// Returns the constant represented by the given variable.
     ///
-    /// Panics: if the variable does not represent a constant.
-    pub(crate) fn constant(&self, var: AcirVar) -> &F {
-        self.vars[&var].as_constant().expect("ICE - expected the variable to be a constant value")
+    /// Error if the variable does not represent a constant.
+    pub(crate) fn constant(&self, var: &AcirVar, name: String) -> Result<&F, RuntimeError> {
+        match self.vars.get(var) {
+            Some(AcirVarData::Const(field)) => Ok(field),
+            _ => Err(RuntimeError::InternalError(InternalError::NotAConstant {
+                name,
+                call_stack: self.get_call_stack(),
+            })),
+        }
     }
 
     /// Adds a Variable to the context, whose exact value is resolved at runtime.
@@ -247,29 +253,33 @@ impl<F: AcirField> AcirContext<F> {
 
     /// True if the given `AcirVar` refers to a constant one value
     pub(crate) fn is_constant_one(&self, var: &AcirVar) -> bool {
-        match self.vars[var] {
-            AcirVarData::Const(field) => field.is_one(),
+        match self.vars.get(var) {
+            Some(AcirVarData::Const(field)) => field.is_one(),
             _ => false,
         }
     }
 
     /// True if the given `AcirVar` refers to a constant value
     pub(crate) fn is_constant(&self, var: &AcirVar) -> bool {
-        matches!(self.vars[var], AcirVarData::Const(_))
+        matches!(self.vars.get(var), Some(AcirVarData::Const(_)))
     }
 
     /// Adds a new Variable to context whose value will
     /// be constrained to be the negation of `var`.
     ///
     /// Note: `Variables` are immutable.
-    pub(crate) fn neg_var(&mut self, var: AcirVar) -> AcirVar {
-        let var_data = &self.vars[&var];
+    pub(crate) fn neg_var(&mut self, var: AcirVar) -> Result<AcirVar, RuntimeError> {
+        let Some(var_data) = self.vars.get(&var) else {
+            return Err(RuntimeError::InternalError(InternalError::UndeclaredAcirVar {
+                call_stack: self.get_call_stack(),
+            }));
+        };
         let result_data = if let AcirVarData::Const(constant) = var_data {
             AcirVarData::Const(-*constant)
         } else {
             AcirVarData::Expr(-var_data.to_expression().as_ref())
         };
-        self.add_data(result_data)
+        Ok(self.add_data(result_data))
     }
 
     /// Adds a new Variable to context whose value will
@@ -279,7 +289,11 @@ impl<F: AcirField> AcirContext<F> {
         var: AcirVar,
         predicate: AcirVar,
     ) -> Result<AcirVar, RuntimeError> {
-        let var_data = &self.vars[&var];
+        let Some(var_data) = self.vars.get(&var) else {
+            return Err(RuntimeError::InternalError(InternalError::UndeclaredAcirVar {
+                call_stack: self.get_call_stack(),
+            }));
+        };
         let inverted_var = if let AcirVarData::Const(constant) = var_data {
             // Note that this will return a 0 if the inverse is not available
             self.add_data(AcirVarData::Const(constant.inverse()))
@@ -612,8 +626,16 @@ impl<F: AcirField> AcirContext<F> {
     /// Adds a new Variable to context whose value will
     /// be constrained to be the multiplication of `lhs` and `rhs`
     pub(crate) fn mul_var(&mut self, lhs: AcirVar, rhs: AcirVar) -> Result<AcirVar, RuntimeError> {
-        let lhs_data = self.vars[&lhs].clone();
-        let rhs_data = self.vars[&rhs].clone();
+        let Some(lhs_data) = self.vars.get(&lhs).cloned() else {
+            return Err(RuntimeError::InternalError(InternalError::UndeclaredAcirVar {
+                call_stack: self.get_call_stack(),
+            }));
+        };
+        let Some(rhs_data) = self.vars.get(&rhs).cloned() else {
+            return Err(RuntimeError::InternalError(InternalError::UndeclaredAcirVar {
+                call_stack: self.get_call_stack(),
+            }));
+        };
 
         let result = match (lhs_data, rhs_data) {
             // (x * 1) == (1 * x) == x
@@ -693,7 +715,7 @@ impl<F: AcirField> AcirContext<F> {
     /// Adds a new Variable to context whose value will
     /// be constrained to be the subtraction of `lhs` and `rhs`
     pub(crate) fn sub_var(&mut self, lhs: AcirVar, rhs: AcirVar) -> Result<AcirVar, RuntimeError> {
-        let neg_rhs = self.neg_var(rhs);
+        let neg_rhs = self.neg_var(rhs)?;
         self.add_var(lhs, neg_rhs)
     }
 
@@ -1233,15 +1255,10 @@ impl<F: AcirField> AcirContext<F> {
         limb_count: SemanticLength,
         result_element_type: NumericType,
     ) -> Result<AcirValue, RuntimeError> {
-        let radix = match self.vars[&radix_var].as_constant() {
-            Some(radix) => radix.try_into_u128().expect("expected radix to fit within a u128"),
-            None => {
-                return Err(RuntimeError::InternalError(InternalError::NotAConstant {
-                    name: "radix".to_string(),
-                    call_stack: self.get_call_stack(),
-                }));
-            }
-        };
+        let radix = self
+            .constant(&radix_var, "radix".to_string())?
+            .try_into_u128()
+            .expect("expected radix to fit within a u128");
 
         // Match the assertions of `Field::to_le_radix` and `Field::to_be_radix`.
         assert!(2 <= radix);
@@ -1518,17 +1535,6 @@ enum AcirVarData<F> {
     Witness(Witness),
     Expr(Expression<F>),
     Const(F),
-}
-
-impl<F> AcirVarData<F> {
-    /// Returns a `FieldElement`, if the underlying `AcirVarData`
-    /// represents a constant.
-    pub(crate) fn as_constant(&self) -> Option<&F> {
-        if let AcirVarData::Const(field) = self {
-            return Some(field);
-        }
-        None
-    }
 }
 
 impl<F: AcirField> AcirVarData<F> {

--- a/compiler/noirc_evaluator/src/acir/call/mod.rs
+++ b/compiler/noirc_evaluator/src/acir/call/mod.rs
@@ -279,7 +279,11 @@ impl Context<'_> {
             if let Type::Vector(elements_type) = &*result_type {
                 let error = "ICE - cannot get vector length when converting vector to AcirValue";
                 let len = values.last().expect(error).borrow_var().expect(error);
-                let len = self.acir_context.constant(len).to_u128();
+                let len = self
+                    .acir_context
+                    .constant(&len, "len".to_string())
+                    .expect("ICE - expected the variable to be a constant value")
+                    .to_u128();
                 let mut element_values = im::Vector::new();
                 for _ in 0..len {
                     for element_type in elements_type.iter() {


### PR DESCRIPTION
## Problem Resolved

Resolves #11056 

## Summary of Changes
Follow-up on the fix #12597, where I missed the issues about BlackBox inputs and AcirVar get:
1. The AcirContext.vars field is frequently accessed using brackets (e.g. self.vars[i]), rather than using the provided .get()method. This can cause unhelpful panics at compilation time in the case that a variable does not exist for whatever reason.

2. The black_box_func_expected_input_size() and black_box_expected_output_size() functions return the number of expected inputs and outputs attached to a blackbox function call. However, these functions are defined in compiler/noirc_evaluator/src/acir/acir_context/generated_acir/mod.rs rather than acvm-repo/acir/src/circuit/black_box_functions.rs where the list of blackbox functions is defined, or acvm-repo/acir/src/circuit/opcodes/black_box_function_call.rs where the call structs are defined. This could lead to issues if the blackbox functions structs are updated without propagating the changes to the expected inputs and outputs.


## User Documentation

Check one:
- [X] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
