### PR TITLE
fix: check intermediate path segment visibility against its declaring module

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/path_resolution.rs
+++ b/compiler/noirc_frontend/src/elaborator/path_resolution.rs
@@ -653,6 +653,10 @@ impl Elaborator<'_> {
 
             let current_module_id_is_type;
 
+            // The module `prev_segment` is declared in (its visibility is checked against this),
+            // captured before stepping `current_module_id` into the module/type it refers to.
+            let prev_segment_module_id = current_module_id;
+
             (current_module_id, current_module_id_is_type, intermediate_item) = match typ {
                 ModuleDefId::ModuleId(id) => {
                     if prev_segment_generics.is_some() {
@@ -713,7 +717,7 @@ impl Elaborator<'_> {
                 || item_in_module_is_visible(
                     self.def_maps,
                     visibility_module,
-                    current_module_id,
+                    prev_segment_module_id,
                     visibility,
                 ))
             {

--- a/compiler/noirc_frontend/src/tests/visibility.rs
+++ b/compiler/noirc_frontend/src/tests/visibility.rs
@@ -1611,3 +1611,27 @@ fn errors_when_two_inherent_methods_with_same_name_exist_in_different_modules() 
     "#;
     check_errors(src);
 }
+
+#[test]
+fn private_module_is_accessible_from_within_its_parent() {
+    // A private module's public items are reachable from the module it is declared in (and that
+    // module's descendants), exactly like any other private item. Here `inner` is private to
+    // `outer`, and `outer::bar` (inside `outer`) accesses `inner::foo` through a fully-qualified
+    // path. This is allowed in Rust, but is currently rejected with "inner is private".
+    let src = r#"
+    mod outer {
+        mod inner {
+            pub fn foo() {}
+        }
+
+        pub fn bar() {
+            crate::outer::inner::foo();
+        }
+    }
+
+    fn main() {
+        outer::bar();
+    }
+    "#;
+    assert_no_errors(src);
+}

--- a/tooling/nargo_cli/tests/snapshots/compile_failure/interned_crate_binary/execute__tests__stderr.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_failure/interned_crate_binary/execute__tests__stderr.snap
@@ -7,16 +7,6 @@ error: fun is private and not visible from the current module
    │
 11 │                 $crate::fun::my_public_fn_that_cannot_be_imported();
    │                         --- fun is private
-   ·
-18 │ #[derive(Foo)]
-   │ -------------- While running this function attribute
-   │
-
-error: fun is private and not visible from the current module
-   ┌─ interned_crate_library/src/lib.nr:11:25
-   │
-11 │                 $crate::fun::my_public_fn_that_cannot_be_imported();
-   │                         --- fun is private
    │
    ┌─ src/main.nr:4:1
    │
@@ -24,4 +14,4 @@ error: fun is private and not visible from the current module
    │ -------------- While running this function attribute
    │
 
-Aborting due to 2 previous errors
+Aborting due to 1 previous error


### PR DESCRIPTION
## Summary

Fixes #13203.

A private item is visible from the module it is declared in and that module's descendants. The visibility check for an **intermediate** path segment was run against the **segment's own module** instead of the module it is **declared in**, so a private intermediate module was treated as usable only from inside itself, not from its parent module.

This rejected valid code such as:

```rust
mod outer {
    mod inner {
        pub fn foo() {}
    }

    pub fn bar() {
        crate::outer::inner::foo(); // was: error "inner is private"
    }
}
```

The leaf segment is already checked against its declaring module; this makes the intermediate check consistent with it (capture the declaring module before stepping `current_module_id` into the module/type the segment refers to).

## Changes

- `resolve_name_in_module`: check an intermediate segment's visibility against its declaring module, not the module it refers to.
- Add a regression test (`private_module_is_accessible_from_within_its_parent`).
- Update the `interned_crate_binary` snapshot: a `$crate::`-qualified path to a private item now resolves **within the defining crate** (matching that test's own comment, *"works in the crate it was defined in"*) while still being rejected **from another crate**.

## Notes

The bug mostly surfaced on fully-qualified (`crate::`) and `$crate`-qualified (macro-generated) paths; the first-segment-always-visible shortcut hid it for ordinary paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)