### PR TITLE
fix: Preserve fully-qualified trait call syntax if it clashes with inherent method

### DIFF
--- a/compiler/noirc_frontend/src/hir/printer/items/hir_def.rs
+++ b/compiler/noirc_frontend/src/hir/printer/items/hir_def.rs
@@ -424,23 +424,39 @@ impl ItemPrinter<'_, '_> {
 
         // Special case: assumed trait method
         if let ImplKind::TraitItem(trait_method) = &hir_ident.impl_kind {
-            let show_as_trait_as_path = if trait_method.assumed {
-                // Is this `self.foo()` where `self` is currently a trait?
-                // If so, show it as `self.foo()` instead of `Self::foo(self)`.
-                let method_on_trait_self =
-                    if let Type::NamedGeneric(NamedGeneric { name, .. }) =
-                        &trait_method.constraint.typ
-                    {
-                        name.to_string() == "Self"
-                    } else {
-                        false
-                    };
-                !method_on_trait_self
-            } else {
-                let trait_id = trait_method.constraint.trait_bound.trait_id;
-                let module_data = &self.def_maps[&self.module_id.krate][self.module_id.local_id];
-                module_data.find_trait_in_scope(trait_id).is_none()
+            // If the receiver type has an inherent method of the same name, neither the method-call
+            // sugar `foo.method()` nor the `Type::method(foo)` path form resolves back to this trait
+            // method — both prefer the inherent one. Only the fully-qualified `<Type as Trait>::method`
+            // form is faithful, so force it.
+            let shadowed_by_inherent = {
+                let instantiation_bindings =
+                    self.interner.get_instantiation_bindings(hir_call_expression.func);
+                let mut constraint = trait_method.constraint.clone();
+                constraint.apply_bindings(instantiation_bindings);
+                let self_type = constraint.typ.follow_bindings();
+                let method_name = self.interner.function_name(&func_id);
+                self.interner.lookup_direct_method(&self_type, method_name, false).is_some()
             };
+
+            let show_as_trait_as_path = shadowed_by_inherent
+                || if trait_method.assumed {
+                    // Is this `self.foo()` where `self` is currently a trait?
+                    // If so, show it as `self.foo()` instead of `Self::foo(self)`.
+                    let method_on_trait_self =
+                        if let Type::NamedGeneric(NamedGeneric { name, .. }) =
+                            &trait_method.constraint.typ
+                        {
+                            name.to_string() == "Self"
+                        } else {
+                            false
+                        };
+                    !method_on_trait_self
+                } else {
+                    let trait_id = trait_method.constraint.trait_bound.trait_id;
+                    let module_data =
+                        &self.def_maps[&self.module_id.krate][self.module_id.local_id];
+                    module_data.find_trait_in_scope(trait_id).is_none()
+                };
             if show_as_trait_as_path {
                 self.show_hir_call_as_trait_as_path(
                     hir_call_expression,
@@ -448,6 +464,7 @@ impl ItemPrinter<'_, '_> {
                     generics,
                     func_id,
                     trait_method,
+                    shadowed_by_inherent,
                 );
                 return true;
             }
@@ -521,6 +538,7 @@ impl ItemPrinter<'_, '_> {
         generics: Option<Vec<Type>>,
         func_id: FuncId,
         trait_method: &TraitItem,
+        force_fully_qualified: bool,
     ) {
         let instantiation_bindings =
             self.interner.get_instantiation_bindings(hir_call_expression.func);
@@ -529,9 +547,11 @@ impl ItemPrinter<'_, '_> {
 
         let trait_id = trait_method.constraint.trait_bound.trait_id;
         let module_data = &self.def_maps[&self.module_id.krate][self.module_id.local_id];
-        if module_data.find_trait_in_scope(trait_id).is_none() {
-            // It can happen that the trait is not in scope, for example if this call
-            // was generated via macros using `get_trait_impl -> methods`.
+        if force_fully_qualified || module_data.find_trait_in_scope(trait_id).is_none() {
+            // Print `<Type as Trait>::method`. This is required when the trait is not in scope (for
+            // example if this call was generated via macros using `get_trait_impl -> methods`), and
+            // when an inherent method of the same name would otherwise capture the unqualified
+            // `Type::method` form.
             self.push('<');
             self.show_type(&constraint.typ);
             self.push_str(" as ");

--- a/compiler/noirc_frontend/src/tests/expand.rs
+++ b/compiler/noirc_frontend/src/tests/expand.rs
@@ -557,8 +557,8 @@ fn expands_trait_method_call_shadowed_by_inherent_method() {
         let foo: Foo = Foo { };
         foo.method();
         foo.method();
-        foo.method();
-        foo.method();
+        <Foo as Trait>::method(foo);
+        <Foo as Trait>::method(foo);
     }
     ");
 }

--- a/compiler/noirc_frontend/src/tests/expand.rs
+++ b/compiler/noirc_frontend/src/tests/expand.rs
@@ -490,14 +490,19 @@ fn expands_trait_impl_calling_private_inherent_method_inside_module() {
     ");
 }
 
-/// A trait method and an inherent method can share a name. A method call (`foo.method()`) prefers
-/// the inherent method, so calling the trait method requires the disambiguated form
-/// `Trait::method(foo)`. The HIR printer must preserve that distinction: rendering the trait call
-/// back as `foo.method()` would make the expanded source re-resolve to the inherent method,
-/// silently changing which method runs.
+/// A trait method and an inherent method can share a name, and the four ways to call one resolve
+/// to different methods:
 ///
-/// This test pins the *buggy* output (both calls collapse to `foo.method()`) so the fix is visible
-/// as a snapshot change.
+/// - `foo.method()` and `Foo::method(foo)` both prefer the *inherent* method.
+/// - `Trait::method(foo)` and `<Foo as Trait>::method(foo)` select the *trait* method.
+///
+/// The HIR printer must keep each faithful. Rendering a trait call back as `foo.method()` (or
+/// `Foo::method(foo)`) would make the expanded source re-resolve to the inherent method, silently
+/// changing which method runs. The fully-qualified `<Foo as Trait>::method(foo)` is the only form
+/// that round-trips to the trait method regardless of the inherent one.
+///
+/// This test pins the *buggy* output (all four calls collapse to `foo.method()`) so the fix is
+/// visible as a snapshot change.
 #[test]
 fn expands_trait_method_call_shadowed_by_inherent_method() {
     let src = r#"
@@ -522,7 +527,9 @@ fn expands_trait_method_call_shadowed_by_inherent_method() {
     fn main() {
         let foo = Foo {};
         foo.method();
+        Foo::method(foo);
         Trait::method(foo);
+        <Foo as Trait>::method(foo);
     }
     "#;
     let expanded = assert_no_errors_and_to_string(src);
@@ -548,6 +555,8 @@ fn expands_trait_method_call_shadowed_by_inherent_method() {
 
     fn main() {
         let foo: Foo = Foo { };
+        foo.method();
+        foo.method();
         foo.method();
         foo.method();
     }

--- a/compiler/noirc_frontend/src/tests/expand.rs
+++ b/compiler/noirc_frontend/src/tests/expand.rs
@@ -489,3 +489,67 @@ fn expands_trait_impl_calling_private_inherent_method_inside_module() {
     }
     ");
 }
+
+/// A trait method and an inherent method can share a name. A method call (`foo.method()`) prefers
+/// the inherent method, so calling the trait method requires the disambiguated form
+/// `Trait::method(foo)`. The HIR printer must preserve that distinction: rendering the trait call
+/// back as `foo.method()` would make the expanded source re-resolve to the inherent method,
+/// silently changing which method runs.
+///
+/// This test pins the *buggy* output (both calls collapse to `foo.method()`) so the fix is visible
+/// as a snapshot change.
+#[test]
+fn expands_trait_method_call_shadowed_by_inherent_method() {
+    let src = r#"
+    trait Trait {
+        fn method(self);
+    }
+
+    struct Foo {}
+
+    impl Foo {
+        fn method(self) {
+            let _ = self;
+        }
+    }
+
+    impl Trait for Foo {
+        fn method(self) {
+            let _ = self;
+        }
+    }
+
+    fn main() {
+        let foo = Foo {};
+        foo.method();
+        Trait::method(foo);
+    }
+    "#;
+    let expanded = assert_no_errors_and_to_string(src);
+    insta::assert_snapshot!(expanded, @r"
+    trait Trait {
+        fn method(self);
+    }
+
+    struct Foo {
+    }
+
+    impl Foo {
+        fn method(self) {
+            let _: Self = self;
+        }
+    }
+
+    impl Trait for Foo {
+        fn method(self) {
+            let _: Self = self;
+        }
+    }
+
+    fn main() {
+        let foo: Foo = Foo { };
+        foo.method();
+        foo.method();
+    }
+    ");
+}

--- a/tooling/nargo_cli/tests/snapshots/execution_success/private_inherent_method_resolves_to_trait/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/private_inherent_method_resolves_to_trait/execute__tests__expanded.snap
@@ -32,6 +32,6 @@ mod impls {
 
 fn main() {
     assert(Foo {}.bar() == 2_u32);
-    assert(Foo {}.bar() == 2_u32);
+    assert(<Foo as Bar>::bar(Foo {}) == 2_u32);
     assert(impls::calls_inherent_bar(Foo {}) == 1_u32);
 }


### PR DESCRIPTION
## Problem Resolved

Noticed in https://github.com/noir-lang/noir/pull/13206 that `nargo expand` prints `std::validate::Validate::validate(foo)` as `foo.validate()` even if `Foo::validate` is an inherent method that would take precedence over it.

## Summary of Changes

Change `nargo expand` to look up shadowing inherent methods before sugaring trait method calls.

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
