### PR TITLE
chore: Simplify `SpillManager`

### DIFF
--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_block.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_block.rs
@@ -369,7 +369,7 @@ impl<'block, Registers: RegisterAllocator> BrilligBlock<'block, Registers> {
         // Ask the spill_manager for the LRU variable, and then spill it.
         let victim_id = {
             let sm = self.function_context.spill_manager.as_ref().unwrap();
-            sm.lru_victim(&self.variables).expect("No values available to spill")
+            sm.lru_victim().expect("No values available to spill")
         };
         self.spill_value(victim_id, false, true);
     }
@@ -381,7 +381,7 @@ impl<'block, Registers: RegisterAllocator> BrilligBlock<'block, Registers> {
     fn spill_lru_values(&mut self, k: usize) {
         let victims = {
             let sm = self.function_context.spill_manager.as_ref().unwrap();
-            sm.lru_victims(k, &self.variables)
+            sm.lru_victims(k)
         };
         if victims.is_empty() {
             return;
@@ -430,14 +430,14 @@ impl<'block, Registers: RegisterAllocator> BrilligBlock<'block, Registers> {
         // Update SSA mapping to point to new register
         self.function_context.ssa_value_allocations.insert(value_id, new_var);
 
-        // The slot is kept (the emitted load may re-execute in a loop iteration, so its data
-        // must stay valid); the value is back in a register, which we record by re-adding it to
-        // the available set below. Touch it as most-recently-used.
-        self.function_context.spill_manager.as_mut().unwrap().touch(value_id);
-
         // Re-add to available variables (was removed during spill); this is what marks the value
         // as no longer spilled now that it holds a register again.
         self.variables.add_available(value_id);
+
+        // The slot is kept (the emitted load may re-execute in a loop iteration, so its data must
+        // stay valid). The value is back in a register (added just above), so touch it as MRU —
+        // which `touch` asserts.
+        self.function_context.spill_manager.as_mut().unwrap().touch(value_id, &self.variables);
 
         new_var
     }
@@ -493,7 +493,7 @@ impl<'block, Registers: RegisterAllocator> BrilligBlock<'block, Registers> {
             dfg,
         );
         if let Some(sm) = self.function_context.spill_manager.as_mut() {
-            sm.touch(value_id);
+            sm.touch(value_id, &self.variables);
         }
         var
     }
@@ -1017,7 +1017,7 @@ impl<'block, Registers: RegisterAllocator> BrilligBlock<'block, Registers> {
                     }
                     let var = self.variables.get_allocation(self.function_context, value_id);
                     if let Some(sm) = self.function_context.spill_manager.as_mut() {
-                        sm.touch(value_id);
+                        sm.touch(value_id, &self.variables);
                     }
                     var
                 }
@@ -1034,7 +1034,7 @@ impl<'block, Registers: RegisterAllocator> BrilligBlock<'block, Registers> {
                 if self.variables.is_allocated(&value_id) {
                     let var = self.variables.get_allocation(self.function_context, value_id);
                     if let Some(sm) = self.function_context.spill_manager.as_mut() {
-                        sm.touch(value_id);
+                        sm.touch(value_id, &self.variables);
                     }
                     var
                 } else if dfg.is_global(value_id) {

--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_block.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_block.rs
@@ -181,9 +181,20 @@ impl<'block, Registers: RegisterAllocator> BrilligBlock<'block, Registers> {
         self.function_context.spill_manager.is_some()
     }
 
-    /// Returns `true` if the given value is currently spilled.
+    /// Returns `true` if the given value is currently spilled (has a slot and is not in a register).
     fn is_spilled(&self, value_id: &ValueId) -> bool {
-        self.function_context.spill_manager.as_ref().is_some_and(|sm| sm.is_spilled(value_id))
+        self.function_context
+            .spill_manager
+            .as_ref()
+            .is_some_and(|sm| sm.is_spilled(value_id, &self.variables))
+    }
+
+    /// Returns `true` if the value was transiently spilled and is currently reloaded into a register.
+    fn is_transient_reloaded(&self, value_id: &ValueId) -> bool {
+        self.function_context
+            .spill_manager
+            .as_ref()
+            .is_some_and(|sm| sm.is_transient_reloaded(value_id, &self.variables))
     }
 
     /// Check if allocating `n` more registers would exceed the stack frame limit.
@@ -271,21 +282,20 @@ impl<'block, Registers: RegisterAllocator> BrilligBlock<'block, Registers> {
     /// whose registers don't yet contain the final value.
     /// The Jmp terminators write the value directly into the slot later.
     pub(crate) fn spill_value(&mut self, value_id: ValueId, permanent: bool, emit_store: bool) {
-        let sm = self
-            .function_context
-            .spill_manager
-            .as_mut()
-            .expect("ICE: spill_value called without spill manager");
-
         // For a permanent spill, try to promote an existing record first.
-        // ensure_permanent_spill() modifies the record, so capture the pre-call state first.
         if permanent {
-            // A TransientReloaded value holds a register that must be freed when promoted to
-            // a permanent spill. Values already in PermanentReloaded state must not have their
-            // register freed here — they may still be live (e.g. the condition register of a
-            // jmpif instruction when spill_non_param_live_ins fires multiple times).
-            let was_transient_reloaded = sm.is_transient_reloaded(&value_id);
-            if sm.ensure_permanent_spill(&value_id) {
+            // A reloaded transient value holds a register that must be freed when promoted to a
+            // permanent spill. A value not currently in a register must not have its register
+            // freed here — it may still be live (e.g. the condition register of a jmpif when
+            // spill_non_param_live_ins fires multiple times). Capture this before promoting.
+            let was_transient_reloaded = self.is_transient_reloaded(&value_id);
+            let promoted = self
+                .function_context
+                .spill_manager
+                .as_mut()
+                .expect("ICE: spill_value called without spill manager")
+                .ensure_permanent_spill(&value_id);
+            if promoted {
                 if was_transient_reloaded {
                     self.variables.remove_variable(
                         &value_id,
@@ -297,17 +307,20 @@ impl<'block, Registers: RegisterAllocator> BrilligBlock<'block, Registers> {
             }
         }
 
-        if sm.is_spilled(&value_id) {
+        if self.is_spilled(&value_id) {
             return;
         }
 
         let var = *self.function_context.ssa_value_allocations.get(&value_id).unwrap();
+        let sm = self.function_context.spill_manager.as_mut().unwrap();
         let prior_offset = sm.get_spill_offset(&value_id);
         let offset = prior_offset.unwrap_or_else(|| sm.allocate_spill_offset());
         if permanent {
             sm.record_permanent_spill(value_id, offset, var);
         } else {
-            sm.record_spill(value_id, offset, var);
+            // `value_id` is still in a register here (we free it below), so record_spill's
+            // double-spill assert sees a legitimate spill.
+            sm.record_spill(value_id, offset, var, &self.variables);
         }
 
         // Only store when we've just allocated the slot. If the value already had a slot,
@@ -354,8 +367,10 @@ impl<'block, Registers: RegisterAllocator> BrilligBlock<'block, Registers> {
     /// Spill the least-recently-used value to the spill region
     fn spill_lru_value(&mut self) {
         // Ask the spill_manager for the LRU variable, and then spill it.
-        let sm = self.function_context.spill_manager.as_mut().unwrap();
-        let victim_id = sm.lru_victim().expect("No values available to spill");
+        let victim_id = {
+            let sm = self.function_context.spill_manager.as_ref().unwrap();
+            sm.lru_victim(&self.variables).expect("No values available to spill")
+        };
         self.spill_value(victim_id, false, true);
     }
 
@@ -364,21 +379,25 @@ impl<'block, Registers: RegisterAllocator> BrilligBlock<'block, Registers> {
     /// Batched version of [`Self::spill_lru_value`]. Each `record_spill` drops its value from
     /// the LRU, and the stores are emitted together so they can share address computations.
     fn spill_lru_values(&mut self, k: usize) {
-        let sm = self.function_context.spill_manager.as_ref().unwrap();
-        let victims = sm.lru_victims(k);
+        let victims = {
+            let sm = self.function_context.spill_manager.as_ref().unwrap();
+            sm.lru_victims(k, &self.variables)
+        };
         if victims.is_empty() {
             return;
         }
 
         // Record each spill and collect the stores that must be emitted. A value that
-        // already has a slot keeps it and does not need a store.
+        // already has a slot keeps it and does not need a store. The victims are still in
+        // registers at this point (freed in the loop below), so record_spill's double-spill
+        // assert sees legitimate spills.
         let mut stores = Vec::with_capacity(victims.len());
         for value_id in &victims {
             let var = *self.function_context.ssa_value_allocations.get(value_id).unwrap();
             let sm = self.function_context.spill_manager.as_mut().unwrap();
             let prior_offset = sm.get_spill_offset(value_id);
             let offset = prior_offset.unwrap_or_else(|| sm.allocate_spill_offset());
-            sm.record_spill(*value_id, offset, var);
+            sm.record_spill(*value_id, offset, var, &self.variables);
             if prior_offset.is_none() {
                 stores.push((offset, var.extract_register()));
             }
@@ -396,8 +415,10 @@ impl<'block, Registers: RegisterAllocator> BrilligBlock<'block, Registers> {
         // Ensure capacity for the reload register (may trigger another spill)
         self.ensure_register_capacity(1);
 
-        let sm = self.function_context.spill_manager.as_ref().unwrap();
-        let spill_record = *sm.get_spill(&value_id).unwrap();
+        let spill_record = {
+            let sm = self.function_context.spill_manager.as_ref().unwrap();
+            *sm.get_spill(&value_id, &self.variables).unwrap()
+        };
 
         let new_reg = self.brillig_context.allocate_register().detach();
 
@@ -409,13 +430,13 @@ impl<'block, Registers: RegisterAllocator> BrilligBlock<'block, Registers> {
         // Update SSA mapping to point to new register
         self.function_context.ssa_value_allocations.insert(value_id, new_var);
 
-        // Unmark spilled (don't free the slot). The emitted Brillig load opcodes may
-        // re-execute at runtime in a loop iteration, so the slot data must remain valid.
-        let sm = self.function_context.spill_manager.as_mut().unwrap();
-        sm.unmark_spilled(&value_id);
-        sm.touch(value_id);
+        // The slot is kept (the emitted load may re-execute in a loop iteration, so its data
+        // must stay valid); the value is back in a register, which we record by re-adding it to
+        // the available set below. Touch it as most-recently-used.
+        self.function_context.spill_manager.as_mut().unwrap().touch(value_id);
 
-        // Re-add to available variables (was removed during spill)
+        // Re-add to available variables (was removed during spill); this is what marks the value
+        // as no longer spilled now that it holds a register again.
         self.variables.add_available(value_id);
 
         new_var

--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_block.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_block.rs
@@ -369,7 +369,7 @@ impl<'block, Registers: RegisterAllocator> BrilligBlock<'block, Registers> {
         // Ask the spill_manager for the LRU variable, and then spill it.
         let victim_id = {
             let sm = self.function_context.spill_manager.as_ref().unwrap();
-            sm.lru_victim().expect("No values available to spill")
+            sm.lru_victim(&self.variables).expect("No values available to spill")
         };
         self.spill_value(victim_id, false, true);
     }
@@ -381,7 +381,7 @@ impl<'block, Registers: RegisterAllocator> BrilligBlock<'block, Registers> {
     fn spill_lru_values(&mut self, k: usize) {
         let victims = {
             let sm = self.function_context.spill_manager.as_ref().unwrap();
-            sm.lru_victims(k)
+            sm.lru_victims(k, &self.variables)
         };
         if victims.is_empty() {
             return;

--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_block.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_block.rs
@@ -932,11 +932,10 @@ impl<'block, Registers: RegisterAllocator> BrilligBlock<'block, Registers> {
                         );
                         if let Some(sm) = self.function_context.spill_manager.as_mut() {
                             // A value can reach this branch while still owning a spill slot: a
-                            // transiently spilled value that was reloaded into a register
-                            // (TransientReloaded) is no longer `is_spilled`, yet its slot stays
-                            // reserved. Release it so the offset returns to the free list. For a
-                            // value with no spill record, or a permanently spilled one, this is a
-                            // no-op.
+                            // transiently spilled value that was reloaded into a register is no
+                            // longer spilled, yet its transient slot stays reserved. Release it so
+                            // the offset returns to the free list. For a value with no spill
+                            // record, or a permanently spilled one, this is a no-op.
                             sm.remove_spill(dead_variable);
                         }
                     }

--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_block_variables.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_block_variables.rs
@@ -38,6 +38,7 @@ use crate::{
 };
 
 use super::brillig_fn::FunctionContext;
+use super::spill_manager::RegisterState;
 
 /// Tracks SSA variables that have a register currently allocated and usable during
 /// Brillig compilation of a block.
@@ -56,6 +57,14 @@ use super::brillig_fn::FunctionContext;
 #[derive(Debug, Default)]
 pub(crate) struct BlockVariables {
     available_variables: HashSet<ValueId>,
+}
+
+/// The spill manager consults the set of register-resident values through this trait;
+/// "available" (has a register allocated right now) is exactly "in a register".
+impl RegisterState for BlockVariables {
+    fn is_in_register(&self, value_id: &ValueId) -> bool {
+        self.is_allocated(value_id)
+    }
 }
 
 impl BlockVariables {

--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/spill_manager.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/spill_manager.rs
@@ -265,9 +265,18 @@ impl SpillManager {
         self.records.get(value_id).is_some_and(|r| r.permanent)
     }
 
-    /// Move a value to the back of the LRU (most recently used).
-    /// If the value isn't tracked yet, add it.
-    pub(crate) fn touch(&mut self, value_id: ValueId) {
+    /// Move a value to the back of the LRU (most recently used), inserting it if absent.
+    ///
+    /// The value must currently be in a register: the LRU only ever holds register-resident
+    /// values (a definition or a reload is the only way one enters). Asserting that here keeps a
+    /// spilled value from ever entering the LRU, which is what lets [`Self::lru_victim`] hand back
+    /// its oldest entry without re-checking — a spilled value can only get in through an erroneous
+    /// touch, and this catches it at the source.
+    pub(crate) fn touch(&mut self, value_id: ValueId, registers: &impl RegisterState) {
+        assert!(
+            registers.is_in_register(&value_id),
+            "touched {value_id} which is not in a register"
+        );
         self.lru.touch(value_id);
     }
 
@@ -314,31 +323,16 @@ impl SpillManager {
 
     /// Return the least recently used value tracked in the LRU, or `None` if it is empty.
     ///
-    /// Recording a spill drops the value from the LRU (see `record_spill`), so by the time we
-    /// pick a victim every tracked value is in a register. The `assert!` guards that invariant:
-    /// handing back a spilled value would be a bug, since re-spilling it frees no register.
-    pub(crate) fn lru_victim(&self, registers: &impl RegisterState) -> Option<ValueId> {
-        let victim = self.lru.iter().next();
-        assert!(
-            victim.is_none_or(|v| !self.is_spilled(&v, registers)),
-            "lru_victim returned a spilled value: {victim:?}"
-        );
-        victim
+    /// Every tracked value is in a register — [`Self::touch`] only admits register-resident
+    /// values and spills/deaths drop them — so the oldest entry is always a valid eviction
+    /// candidate, with no spill check needed here.
+    pub(crate) fn lru_victim(&self) -> Option<ValueId> {
+        self.lru.iter().next()
     }
 
-    /// Batched version of [`Self::lru_victim`]
-    ///
-    /// Return up to `k` least-recently-used values, asserting that they are not currently spilled,
-    /// ordered least-recently-used first.
-    pub(crate) fn lru_victims(&self, k: usize, registers: &impl RegisterState) -> Vec<ValueId> {
-        let victims: Vec<ValueId> = self.lru.iter().take(k).collect();
-        for victim in &victims {
-            assert!(
-                !self.is_spilled(victim, registers),
-                "lru_victim returned a spilled value: {victim:?}"
-            );
-        }
-        victims
+    /// Batched version of [`Self::lru_victim`]: the `k` least-recently-used values, oldest first.
+    pub(crate) fn lru_victims(&self, k: usize) -> Vec<ValueId> {
+        self.lru.iter().take(k).collect()
     }
 
     /// Record that a value has been spilled to a transient slot, dropping it from the LRU since
@@ -567,44 +561,45 @@ mod tests {
     #[test]
     fn lru_ordering_and_victim_selection() {
         let mut sm = SpillManager::new();
-        let regs = MockRegisters::default();
+        let mut regs = MockRegisters::default();
         let v0 = Id::test_new(0);
         let v1 = Id::test_new(1);
         let v2 = Id::test_new(2);
 
-        // Touch v0, v1, v2 in order. LRU order: [v0, v1, v2]
-        sm.touch(v0);
-        sm.touch(v1);
-        sm.touch(v2);
+        // Touch v0, v1, v2 in order (all in registers). LRU order: [v0, v1, v2]
+        for v in [v0, v1, v2] {
+            regs.allocate(v);
+            sm.touch(v, &regs);
+        }
 
         // Victim should be v0 (least recently used)
-        assert_eq!(sm.lru_victim(&regs), Some(v0));
+        assert_eq!(sm.lru_victim(), Some(v0));
 
         // Touch v0 again, making it most recent. LRU order: [v1, v2, v0]
-        sm.touch(v0);
+        sm.touch(v0, &regs);
 
         // Victim should now be v1
-        assert_eq!(sm.lru_victim(&regs), Some(v1));
+        assert_eq!(sm.lru_victim(), Some(v1));
     }
 
     #[test]
     fn lru_victims_returns_the_k_least_recently_used() {
         let mut sm = SpillManager::new();
-        let regs = MockRegisters::default();
+        let mut regs = MockRegisters::default();
         let v0 = Id::test_new(0);
         let v1 = Id::test_new(1);
         let v2 = Id::test_new(2);
         let v3 = Id::test_new(3);
 
-        sm.touch(v0);
-        sm.touch(v1);
-        sm.touch(v2);
-        sm.touch(v3);
+        for v in [v0, v1, v2, v3] {
+            regs.allocate(v);
+            sm.touch(v, &regs);
+        }
 
         // The `k` least-recently-used, oldest first.
-        assert_eq!(sm.lru_victims(2, &regs), vec![v0, v1]);
+        assert_eq!(sm.lru_victims(2), vec![v0, v1]);
         // `k` larger than the tracked set returns everything.
-        assert_eq!(sm.lru_victims(10, &regs), vec![v0, v1, v2, v3]);
+        assert_eq!(sm.lru_victims(10), vec![v0, v1, v2, v3]);
     }
 
     #[test]
@@ -618,7 +613,7 @@ mod tests {
         // All three are in registers and tracked in the LRU.
         for v in [v0, v1, v2] {
             regs.allocate(v);
-            sm.touch(v);
+            sm.touch(v, &regs);
         }
 
         // Spill v0: record_spill drops it from the LRU, then its register is freed.
@@ -634,14 +629,14 @@ mod tests {
         assert!(!sm.has_permanent_slot(&v0)); // it is a transient slot
 
         // v0 is no longer tracked, so the next-oldest live value is the victim.
-        assert_eq!(sm.lru_victim(&regs), Some(v1));
+        assert_eq!(sm.lru_victim(), Some(v1));
     }
 
     #[test]
-    #[should_panic(expected = "returned a spilled value")]
-    fn lru_victim_rejects_a_spilled_oldest_value() {
-        // A spilled value can only re-enter the LRU through an erroneous `touch`; `lru_victim`
-        // must catch that rather than hand back a value whose re-spill would free no register.
+    #[should_panic(expected = "is not in a register")]
+    fn touch_rejects_a_value_not_in_a_register() {
+        // The LRU must only ever hold register-resident values. Touching a spilled value is the
+        // only way a spilled value could enter it, and `touch` catches that at the source.
         let mut sm = SpillManager::new();
         let mut regs = MockRegisters::default();
         let v0 = Id::test_new(0);
@@ -649,10 +644,9 @@ mod tests {
         regs.allocate(v0);
         let offset = sm.allocate_spill_offset();
         sm.record_spill(v0, offset, test_var(0), &regs);
-        regs.free(v0); // v0 is now spilled (has a slot, not in a register)
-        sm.touch(v0); // erroneously re-track it
+        regs.free(v0); // v0 is now spilled (out of a register)
 
-        let _ = sm.lru_victim(&regs);
+        sm.touch(v0, &regs); // touching a value that is not in a register panics
     }
 
     #[test]
@@ -688,26 +682,27 @@ mod tests {
     #[test]
     fn remove_from_lru() {
         let mut sm = SpillManager::new();
-        let regs = MockRegisters::default();
+        let mut regs = MockRegisters::default();
         let v0 = Id::test_new(0);
         let v1 = Id::test_new(1);
         let v2 = Id::test_new(2);
 
-        sm.touch(v0);
-        sm.touch(v1);
-        sm.touch(v2);
+        for v in [v0, v1, v2] {
+            regs.allocate(v);
+            sm.touch(v, &regs);
+        }
 
         // Remove v1 from LRU entirely. LRU order: [v0, v2]
         sm.remove_from_lru(&v1);
 
         // Victim should be v0 (v1 is absent)
-        assert_eq!(sm.lru_victim(&regs), Some(v0));
+        assert_eq!(sm.lru_victim(), Some(v0));
 
         // Touch v0, making it most recent. LRU order: [v2, v0]
-        sm.touch(v0);
+        sm.touch(v0, &regs);
 
         // Victim should be v2 (v1 is absent, v0 was touched)
-        assert_eq!(sm.lru_victim(&regs), Some(v2));
+        assert_eq!(sm.lru_victim(), Some(v2));
     }
 
     #[test]
@@ -733,8 +728,8 @@ mod tests {
         assert_eq!(sm.get_permanent_spill_offset(&v0), Some(0));
 
         // While reloaded (in a register) the value is a normal eviction candidate.
-        sm.touch(v0);
-        assert_eq!(sm.lru_victim(&regs), Some(v0));
+        sm.touch(v0, &regs);
+        assert_eq!(sm.lru_victim(), Some(v0));
 
         // Block entry resets the register state (was `restore_permanent_spills`): no longer resident.
         regs.free(v0);
@@ -748,7 +743,7 @@ mod tests {
         // Slot is NOT freed (no slot in free list)
         assert!(sm.free_spill_slots.is_empty());
         // The dead value was dropped from the LRU, so it is no longer an eviction candidate.
-        assert_eq!(sm.lru_victim(&regs), None);
+        assert_eq!(sm.lru_victim(), None);
     }
 
     #[test]
@@ -776,7 +771,7 @@ mod tests {
         assert!(sm.is_spilled(&v0, &regs));
         assert!(sm.free_spill_slots.is_empty());
         // Although still `is_spilled`, the dead value must not be returned by the LRU.
-        assert_eq!(sm.lru_victim(&regs), None);
+        assert_eq!(sm.lru_victim(), None);
     }
 
     #[test]
@@ -896,12 +891,12 @@ mod tests {
         regs.allocate(v0);
         let off = sm.allocate_spill_offset();
         sm.record_permanent_spill(v0, off, test_var(0));
-        sm.touch(v0);
+        sm.touch(v0, &regs);
         assert!(!sm.is_transient_reloaded(&v0, &regs)); // it is permanent, not transient
-        assert_eq!(sm.lru_victim(&regs), Some(v0));
+        assert_eq!(sm.lru_victim(), Some(v0));
 
         // ensure_permanent_spill drops it from the LRU, so it is no longer a victim.
         assert!(sm.ensure_permanent_spill(&v0));
-        assert_eq!(sm.lru_victim(&regs), None);
+        assert_eq!(sm.lru_victim(), None);
     }
 }

--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/spill_manager.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/spill_manager.rs
@@ -154,10 +154,13 @@ pub(crate) struct SpillRecord {
 /// Values are ordered by the time they were last touched: the least-recently-used value is
 /// the first element of `order`, the most-recently-used the last.
 ///
-/// Invariant: when `SpillManager::lru_victim` consults the LRU, no tracked value is spilled.
-/// The methods that record a spill (`record_spill`, `record_permanent_spill`,
-/// `ensure_permanent_spill`) drop the value from the LRU, so the order only ever yields values
-/// that are in a register. `lru_victim` asserts it.
+/// Invariant: the LRU only ever holds register-resident values, so `SpillManager::lru_victim`
+/// never hands back a spilled one. It is guarded at both ends: `SpillManager::touch` (the only
+/// way a value enters) asserts the value is in a register, and every method that moves a value
+/// out of a register — the slot-recording methods (`record_spill`, `record_permanent_spill`,
+/// `ensure_permanent_spill`) and `remove_spill` — drops it from the LRU. `lru_victim` re-checks
+/// this as a backstop, so a future spill path that forgets to remove trips immediately rather
+/// than silently dishing out a spilled value.
 #[derive(Default)]
 struct Lru {
     /// Logical clock, incremented once per `touch`. Strictly increasing, so no two entries
@@ -345,16 +348,25 @@ impl SpillManager {
 
     /// Return the least recently used value tracked in the LRU, or `None` if it is empty.
     ///
-    /// Every tracked value is in a register — [`Self::touch`] only admits register-resident
-    /// values and spills/deaths drop them — so the oldest entry is always a valid eviction
-    /// candidate, with no spill check needed here.
-    pub(crate) fn lru_victim(&self) -> Option<ValueId> {
-        self.lru.iter().next()
+    /// A single-victim [`Self::lru_victims`], so the same spilled-value backstop applies.
+    pub(crate) fn lru_victim(&self, registers: &impl RegisterState) -> Option<ValueId> {
+        self.lru_victims(1, registers).first().copied()
     }
 
-    /// Batched version of [`Self::lru_victim`]: the `k` least-recently-used values, oldest first.
-    pub(crate) fn lru_victims(&self, k: usize) -> Vec<ValueId> {
-        self.lru.iter().take(k).collect()
+    /// Return the `k` least-recently-used values, oldest first.
+    ///
+    /// The LRU only holds register-resident values (see the [`Lru`] invariant), so these are all
+    /// valid eviction candidates. The `assert!` is a backstop: it re-checks that we never hand
+    /// back a spilled value, catching any future spill path that fails to drop it from the LRU.
+    pub(crate) fn lru_victims(&self, k: usize, registers: &impl RegisterState) -> Vec<ValueId> {
+        let victims: Vec<ValueId> = self.lru.iter().take(k).collect();
+        for victim in &victims {
+            assert!(
+                !self.is_spilled(victim, registers),
+                "lru_victim returned a spilled value: {victim:?}"
+            );
+        }
+        victims
     }
 
     /// Record that a value has been spilled to a transient slot, dropping it from the LRU since
@@ -595,13 +607,13 @@ mod tests {
         }
 
         // Victim should be v0 (least recently used)
-        assert_eq!(sm.lru_victim(), Some(v0));
+        assert_eq!(sm.lru_victim(&regs), Some(v0));
 
         // Touch v0 again, making it most recent. LRU order: [v1, v2, v0]
         sm.touch(v0, &regs);
 
         // Victim should now be v1
-        assert_eq!(sm.lru_victim(), Some(v1));
+        assert_eq!(sm.lru_victim(&regs), Some(v1));
     }
 
     #[test]
@@ -619,9 +631,9 @@ mod tests {
         }
 
         // The `k` least-recently-used, oldest first.
-        assert_eq!(sm.lru_victims(2), vec![v0, v1]);
+        assert_eq!(sm.lru_victims(2, &regs), vec![v0, v1]);
         // `k` larger than the tracked set returns everything.
-        assert_eq!(sm.lru_victims(10), vec![v0, v1, v2, v3]);
+        assert_eq!(sm.lru_victims(10, &regs), vec![v0, v1, v2, v3]);
     }
 
     #[test]
@@ -651,7 +663,7 @@ mod tests {
         assert!(!sm.has_permanent_slot(&v0)); // it is a transient slot
 
         // v0 is no longer tracked, so the next-oldest live value is the victim.
-        assert_eq!(sm.lru_victim(), Some(v1));
+        assert_eq!(sm.lru_victim(&regs), Some(v1));
     }
 
     #[test]
@@ -669,6 +681,25 @@ mod tests {
         regs.free(v0); // v0 is now spilled (out of a register)
 
         sm.touch(v0, &regs); // touching a value that is not in a register panics
+    }
+
+    #[test]
+    #[should_panic(expected = "returned a spilled value")]
+    fn lru_victim_rejects_a_spilled_value() {
+        // Backstop for the invariant "the LRU never holds a spilled value". If a value ends up
+        // spilled while still tracked (forced here by re-touching it and then freeing its
+        // register), `lru_victim` must trip rather than hand it out.
+        let mut sm = SpillManager::new();
+        let mut regs = MockRegisters::default();
+        let v0 = Id::test_new(0);
+
+        regs.allocate(v0);
+        let off = sm.allocate_spill_offset();
+        sm.record_spill(v0, off, test_var(0), &regs); // transient slot; dropped from the LRU
+        sm.touch(v0, &regs); // still in a register, so this re-tracks it in the LRU
+        regs.free(v0); // now spilled (has a slot, not in a register) yet still in the LRU
+
+        let _ = sm.lru_victim(&regs);
     }
 
     #[test]
@@ -718,13 +749,13 @@ mod tests {
         sm.remove_from_lru(&v1);
 
         // Victim should be v0 (v1 is absent)
-        assert_eq!(sm.lru_victim(), Some(v0));
+        assert_eq!(sm.lru_victim(&regs), Some(v0));
 
         // Touch v0, making it most recent. LRU order: [v2, v0]
         sm.touch(v0, &regs);
 
         // Victim should be v2 (v1 is absent, v0 was touched)
-        assert_eq!(sm.lru_victim(), Some(v2));
+        assert_eq!(sm.lru_victim(&regs), Some(v2));
     }
 
     #[test]
@@ -751,7 +782,7 @@ mod tests {
 
         // While reloaded (in a register) the value is a normal eviction candidate.
         sm.touch(v0, &regs);
-        assert_eq!(sm.lru_victim(), Some(v0));
+        assert_eq!(sm.lru_victim(&regs), Some(v0));
 
         // Block entry resets the register state (was `restore_permanent_spills`): no longer resident.
         regs.free(v0);
@@ -765,7 +796,7 @@ mod tests {
         // Slot is NOT freed (no slot in free list)
         assert!(sm.free_spill_slots.is_empty());
         // The dead value was dropped from the LRU, so it is no longer an eviction candidate.
-        assert_eq!(sm.lru_victim(), None);
+        assert_eq!(sm.lru_victim(&regs), None);
     }
 
     #[test]
@@ -793,7 +824,7 @@ mod tests {
         assert!(sm.is_spilled(&v0, &regs));
         assert!(sm.free_spill_slots.is_empty());
         // Although still `is_spilled`, the dead value must not be returned by the LRU.
-        assert_eq!(sm.lru_victim(), None);
+        assert_eq!(sm.lru_victim(&regs), None);
     }
 
     #[test]
@@ -915,10 +946,10 @@ mod tests {
         sm.record_permanent_spill(v0, off, test_var(0));
         sm.touch(v0, &regs);
         assert!(!sm.is_transient_reloaded(&v0, &regs)); // it is permanent, not transient
-        assert_eq!(sm.lru_victim(), Some(v0));
+        assert_eq!(sm.lru_victim(&regs), Some(v0));
 
         // ensure_permanent_spill drops it from the LRU, so it is no longer a victim.
         assert!(sm.ensure_permanent_spill(&v0));
-        assert_eq!(sm.lru_victim(), None);
+        assert_eq!(sm.lru_victim(&regs), None);
     }
 }

--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/spill_manager.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/spill_manager.rs
@@ -50,42 +50,31 @@
 use std::collections::BTreeSet;
 use std::collections::hash_map::Entry;
 
-use itertools::Itertools;
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 
 use crate::brillig::brillig_ir::brillig_variable::BrilligVariable;
 use crate::ssa::ir::value::ValueId;
 
-/// Lifecycle state of a spill record.
+/// The register-allocation state the spill manager consults but does not own.
 ///
-/// Transitions:
-/// - First eviction → `Transient` or `Permanent`
-/// - Reloaded into a register → `TransientReloaded` or `PermanentReloaded`
-/// - Evicted again by LRU → back to `Transient` or `Permanent`
-/// - Block boundary → `PermanentReloaded` becomes `Permanent`; `Transient` must not survive
-#[derive(Clone, Copy, PartialEq, Eq, Debug)]
-pub(crate) enum SpillStatus {
-    /// Within-block spill: value is in the spill slot, not in a register.
-    Transient,
-    /// Was transiently spilled then reloaded into a register.
-    /// The spill slot is still allocated and the register holds the live value.
-    TransientReloaded,
-    /// Permanent spill: the slot is the source of truth across block boundaries.
-    /// Value is not currently in a register.
-    Permanent,
-    /// Permanently spilled, but currently also loaded into a register.
-    /// The slot remains authoritative; the register is a transient copy.
-    PermanentReloaded,
-}
-
-impl SpillStatus {
-    /// Whether the value is currently in memory rather than a register.
-    fn is_spilled(self) -> bool {
-        matches!(self, SpillStatus::Transient | SpillStatus::Permanent)
-    }
+/// The manager tracks which values have a heap slot and whether that slot is transient or
+/// permanent; whether a value is *currently* in a register is owned elsewhere — by
+/// [`BlockVariables`] in real codegen, or by a mock in tests — and injected through this trait.
+/// Together they answer "is this value currently spilled": it has a slot and is not in a
+/// register (see [`SpillManager::is_spilled`]).
+///
+/// [`BlockVariables`]: super::brillig_block_variables::BlockVariables
+pub(crate) trait RegisterState {
+    /// Whether `value_id` currently occupies a register.
+    fn is_in_register(&self, value_id: &ValueId) -> bool;
 }
 
 /// Tracks register values that have been spilled to the spill region in heap memory.
+///
+/// The manager owns only *slot* bookkeeping (which values have a heap slot, and whether that
+/// slot is transient or permanent) plus the LRU. It deliberately does not track whether a value
+/// is currently in a register — that is owned by the register allocator and reached through
+/// [`RegisterState`]. "Currently spilled" is derived: `has_slot(v) && !is_in_register(v)`.
 ///
 /// See the [module docs][self] for an overview of when and how the spill manager is used.
 pub(crate) struct SpillManager {
@@ -101,14 +90,39 @@ pub(crate) struct SpillManager {
     max_spill_offset: usize,
 }
 
+/// A heap slot reserved for a spilled value.
+///
+/// # Value lifecycle
+///
+/// A value's state is the combination of its *slot* (tracked here: none, transient, or
+/// permanent) and whether it is *currently in a register* (tracked by [`RegisterState`], not
+/// stored here). "Spilled" means it has a slot but is not in a register. The combinations —
+/// and the names the former `SpillStatus` enum gave them — are:
+///
+/// | slot      | in register | former name         | meaning                                       |
+/// |-----------|-------------|---------------------|-----------------------------------------------|
+/// | none      | yes         | (no record)         | normal value, lives only in a register        |
+/// | transient | no          | `Transient`         | within-block spill, awaiting reload           |
+/// | transient | yes         | `TransientReloaded` | reloaded; transient slot still reserved       |
+/// | permanent | no          | `Permanent`         | cross-block spill, heap slot is authoritative |
+/// | permanent | yes         | `PermanentReloaded` | reloaded; permanent slot still authoritative  |
+///
+/// Transitions:
+/// - First eviction → gains a transient slot (or, across a block boundary, a permanent one);
+///   the register is freed.
+/// - Reloaded into a register, or evicted again by the LRU → purely a [`RegisterState`] change;
+///   the slot itself is unchanged.
+/// - Block boundary → the register state resets (nothing is in a register); permanent slots
+///   persist while transient slots must not survive.
 #[derive(Clone, Copy)]
 pub(crate) struct SpillRecord {
     /// Offset relative to the per-frame heap-allocated spill region base.
     pub(crate) offset: usize,
     /// Original variable (for type/register info on reload).
     pub(crate) variable: BrilligVariable,
-    /// Current lifecycle state of this spill record.
-    pub(crate) status: SpillStatus,
+    /// Whether the slot is permanent (reserved for the rest of the function, the source of
+    /// truth across block boundaries) rather than transient (freed when the value dies).
+    permanent: bool,
 }
 
 /// Least-recently-used tracker over local SSA values, keyed by a monotonic touch clock.
@@ -164,6 +178,21 @@ impl Lru {
         self.last_used.clear();
         self.order.clear();
     }
+
+    /// Insert `values` as equally — and least — recently used (one shared clock tick).
+    ///
+    /// Because `order` is keyed by `(clock, value_id)`, entries sharing a clock are ordered by
+    /// [`ValueId`], so the caller need not pre-sort to get a deterministic ordering.
+    fn seed(&mut self, values: impl IntoIterator<Item = ValueId>) {
+        self.clock += 1;
+        let clock = self.clock;
+        for value_id in values {
+            if let Some(previous) = self.last_used.insert(value_id, clock) {
+                self.order.remove(&(previous, value_id));
+            }
+            self.order.insert((clock, value_id));
+        }
+    }
 }
 
 impl SpillManager {
@@ -179,39 +208,61 @@ impl SpillManager {
 
     /// Prepare spill state for a new block.
     ///
-    /// 1. Asserts that no transient spills leaked from the previous block
-    ///    (only `Permanent` and `PermanentReloaded` records may survive).
-    /// 2. Restores permanently-spilled values by marking them as currently spilled.
-    /// 3. Removes spilled values from the live-in set (they have no register).
-    /// 4. Updates the LRU: rebuilds the LRU from the live-in set in [`ValueId`] order.
+    /// 1. Asserts that no *live-in* value carries a transient slot. A value that lives across a
+    ///    block boundary must be permanently spilled (transient slots are within-block), so a
+    ///    transient slot for a live-in value signals a leak. A leftover transient slot for a
+    ///    value that is *not* live-in (e.g. one that died at the terminator after being
+    ///    reloaded for it) is a benign within-block artifact and is tolerated.
+    /// 2. Removes permanently-spilled values from the live-in set: the register state is reset
+    ///    at block entry, so these must be reloaded before use.
+    /// 3. Rebuilds the LRU from the surviving live-in set.
+    ///
+    /// All three steps run *before* the block's register state exists — `BrilligBlock::compile_block`
+    /// builds the new `BlockVariables` and resets the registers only after `begin_block` returns
+    /// — so they decide purely from slot state and the live-in set, never from [`RegisterState`]
+    /// (which has no valid value to consult here).
     pub(crate) fn begin_block(&mut self, live_in: &mut HashSet<ValueId>) {
-        // No transient spills should survive across block boundaries.
+        // A live-in value must be permanently spilled; only a transient slot for one is a leak.
         assert!(
-            self.records.values().all(|r| r.status != SpillStatus::Transient),
-            "Transient spill leaked across block boundary"
+            !self.records.iter().any(|(v, r)| !r.permanent && live_in.contains(v)),
+            "Transient spill leaked across block boundary: {:?}",
+            self.records
+                .iter()
+                .filter(|(v, r)| !r.permanent && live_in.contains(v))
+                .map(|(v, _)| *v)
+                .collect::<Vec<_>>()
         );
-        self.restore_permanent_spills();
-        live_in.retain(|v| !self.is_spilled(v));
+        live_in.retain(|v| !self.has_permanent_slot(v));
         self.reset_lru_for_block(live_in);
     }
 
-    /// Check if a value is currently spilled (in memory, not in a register).
-    pub(crate) fn is_spilled(&self, value_id: &ValueId) -> bool {
-        self.get_spill(value_id).is_some()
+    /// Whether a value is currently spilled: it has a heap slot but is not in a register.
+    pub(crate) fn is_spilled(&self, value_id: &ValueId, registers: &impl RegisterState) -> bool {
+        self.has_slot(value_id) && !registers.is_in_register(value_id)
     }
 
-    /// Check if a value was transiently spilled and has since been reloaded into a register.
-    pub(crate) fn is_transient_reloaded(&self, value_id: &ValueId) -> bool {
-        matches!(self.records.get(value_id), Some(r) if r.status == SpillStatus::TransientReloaded)
+    /// Whether a value was transiently spilled and has since been reloaded into a register.
+    pub(crate) fn is_transient_reloaded(
+        &self,
+        value_id: &ValueId,
+        registers: &impl RegisterState,
+    ) -> bool {
+        self.has_transient_slot(value_id) && registers.is_in_register(value_id)
     }
 
-    /// Check if a value has a permanent spill slot.
-    #[cfg(test)]
+    /// Whether a value has any heap slot (transient or permanent).
+    fn has_slot(&self, value_id: &ValueId) -> bool {
+        self.records.contains_key(value_id)
+    }
+
+    /// Whether a value has a transient heap slot.
+    fn has_transient_slot(&self, value_id: &ValueId) -> bool {
+        self.records.get(value_id).is_some_and(|r| !r.permanent)
+    }
+
+    /// Whether a value has a permanent heap slot.
     pub(crate) fn has_permanent_slot(&self, value_id: &ValueId) -> bool {
-        matches!(
-            self.records.get(value_id),
-            Some(r) if matches!(r.status, SpillStatus::Permanent | SpillStatus::PermanentReloaded)
-        )
+        self.records.get(value_id).is_some_and(|r| r.permanent)
     }
 
     /// Move a value to the back of the LRU (most recently used).
@@ -227,24 +278,18 @@ impl SpillManager {
 
     /// Remove a (dead) value from spill tracking and from the LRU.
     ///
-    /// Transient slots are freed for reuse. Permanent slots are never freed — they must remain
-    /// valid across all blocks — so a permanently-spilled value keeps its record and is left in
-    /// the `Permanent` state (its register, if any, was already freed by the caller). Either
-    /// way the value is dropped from the LRU, since a value that is gone must never be an
-    /// eviction candidate.
+    /// A transient slot is reclaimed to the free list. A permanent slot is never freed — it must
+    /// remain valid across all blocks — so the record is kept. Either way the value is dropped
+    /// from the LRU, since a value that is gone must never be an eviction candidate.
     ///
     /// TODO(<https://github.com/noir-lang/noir/issues/11695>) - Free globally dead permanent spill slots
     pub(crate) fn remove_spill(&mut self, value_id: &ValueId) {
-        if let Entry::Occupied(mut entry) = self.records.entry(*value_id) {
-            match entry.get().status {
-                SpillStatus::Permanent | SpillStatus::PermanentReloaded => {
-                    entry.get_mut().status = SpillStatus::Permanent;
-                }
-                SpillStatus::Transient | SpillStatus::TransientReloaded => {
-                    let record = entry.remove();
-                    self.free_spill_slots.push(record.offset);
-                }
-            }
+        // A transient slot is reclaimed; a permanent slot is kept (never freed).
+        if let Entry::Occupied(entry) = self.records.entry(*value_id)
+            && !entry.get().permanent
+        {
+            let record = entry.remove();
+            self.free_spill_slots.push(record.offset);
         }
         self.remove_from_lru(value_id);
     }
@@ -272,10 +317,10 @@ impl SpillManager {
     /// Recording a spill drops the value from the LRU (see `record_spill`), so by the time we
     /// pick a victim every tracked value is in a register. The `assert!` guards that invariant:
     /// handing back a spilled value would be a bug, since re-spilling it frees no register.
-    pub(crate) fn lru_victim(&self) -> Option<ValueId> {
+    pub(crate) fn lru_victim(&self, registers: &impl RegisterState) -> Option<ValueId> {
         let victim = self.lru.iter().next();
         assert!(
-            victim.is_none_or(|v| !self.is_spilled(&v)),
+            victim.is_none_or(|v| !self.is_spilled(&v, registers)),
             "lru_victim returned a spilled value: {victim:?}"
         );
         victim
@@ -285,90 +330,91 @@ impl SpillManager {
     ///
     /// Return up to `k` least-recently-used values, asserting that they are not currently spilled,
     /// ordered least-recently-used first.
-    pub(crate) fn lru_victims(&self, k: usize) -> Vec<ValueId> {
-        let victims = self.lru.iter().take(k).collect();
+    pub(crate) fn lru_victims(&self, k: usize, registers: &impl RegisterState) -> Vec<ValueId> {
+        let victims: Vec<ValueId> = self.lru.iter().take(k).collect();
         for victim in &victims {
-            assert!(!self.is_spilled(victim), "lru_victim returned a spilled value: {victim:?}");
+            assert!(
+                !self.is_spilled(victim, registers),
+                "lru_victim returned a spilled value: {victim:?}"
+            );
         }
         victims
     }
 
-    /// Record that a value has been spilled, dropping it from the LRU since a value living in
-    /// its heap slot must never be an eviction candidate.
+    /// Record that a value has been spilled to a transient slot, dropping it from the LRU since
+    /// a value living in its heap slot must never be an eviction candidate.
     ///
-    /// If the value already has a record (e.g., it was reloaded and then
-    /// re-evicted by LRU), this updates the existing record:
-    /// - `PermanentReloaded`: transitions back to `Permanent` (slot data is still valid).
-    /// - `TransientReloaded`: transitions back to `Transient`, updating the variable.
+    /// If the value already has a slot (e.g. it was reloaded and is now being re-evicted), the
+    /// existing slot is kept — including its kind, so a permanent slot stays permanent — and only
+    /// the variable is refreshed.
+    ///
+    /// # Precondition
+    /// `value_id` must still be in a register when this is called: the caller frees its register
+    /// only *after* recording the spill. That ordering is what makes the double-spill assert
+    /// meaningful — an already-spilled value (has a slot and is not in a register) trips it, while
+    /// a legitimate re-eviction of a reloaded value passes because it is still in a register here.
     pub(crate) fn record_spill(
         &mut self,
         value_id: ValueId,
         offset: usize,
         variable: BrilligVariable,
+        registers: &impl RegisterState,
     ) {
-        assert!(!self.is_spilled(&value_id), "Double-spill of {value_id}");
-        let record = self.records.entry(value_id).or_insert(SpillRecord {
-            offset,
-            variable,
-            status: SpillStatus::Transient,
-        });
-        // Always preserve the offset, so we don't leak free slots.
-        assert_eq!(offset, record.offset, "Spill of {value_id} orphaned existing slot");
-        match record.status {
-            SpillStatus::PermanentReloaded => {
-                // Re-evicting a permanently-spilled value: keep permanent, slot data is valid.
-                record.status = SpillStatus::Permanent;
-            }
-            SpillStatus::TransientReloaded | SpillStatus::Transient => {
-                record.status = SpillStatus::Transient;
-                record.variable = variable;
-            }
-            SpillStatus::Permanent => {
-                unreachable!(
-                    "record_spill called on a Permanent record — is_spilled should have caught this as a double-spill"
+        assert!(!self.is_spilled(&value_id, registers), "Double-spill of {value_id}");
+        match self.records.entry(value_id) {
+            Entry::Occupied(mut entry) => {
+                // Always preserve the offset, so we don't leak free slots.
+                assert_eq!(
+                    offset,
+                    entry.get().offset,
+                    "Spill of {value_id} orphaned existing slot"
                 );
+                entry.get_mut().variable = variable;
+            }
+            Entry::Vacant(entry) => {
+                entry.insert(SpillRecord { offset, variable, permanent: false });
             }
         }
         self.remove_from_lru(&value_id);
     }
 
-    /// Get the spill record for a value if it is currently spilled and is not in a register.
-    pub(crate) fn get_spill(&self, value_id: &ValueId) -> Option<&SpillRecord> {
-        self.records.get(value_id).filter(|r| r.status.is_spilled())
+    /// Get the spill record for a value if it is currently spilled (has a slot and is not in a
+    /// register).
+    pub(crate) fn get_spill(
+        &self,
+        value_id: &ValueId,
+        registers: &impl RegisterState,
+    ) -> Option<&SpillRecord> {
+        self.records.get(value_id).filter(|_| !registers.is_in_register(value_id))
     }
 
-    /// Rebuild `lru_order` for a new block from scratch, retaining only live-in
-    /// values that are not currently spilled, in deterministic ValueId order.
+    /// Rebuild the LRU for a new block from the surviving live-in set.
     ///
-    /// This discards any ordering carried over from the previous block, which is sound while
-    /// spilling is enabled: every value live across a block boundary is permanently spilled
-    /// before its block is entered (block parameters via `convert_block_params`, other
-    /// live-ins via `spill_non_param_live_ins`), so no non-spilled value is ever carried over
-    /// and there is no recency order to preserve. The `debug_assert!` enforces that premise.
+    /// Called only from [`Self::begin_block`], after permanently-spilled values have been removed
+    /// from `live_in`. Like `begin_block`, it runs before the block's register state exists, so it
+    /// is register-free.
     ///
-    /// If a future register allocator (<https://github.com/noir-lang/noir/issues/11638>) lets
-    /// values stay in registers across blocks, the assert will fire — at which point the
-    /// surviving entries' previous-block order is a real eviction hint and should be preserved
-    /// here rather than re-sorted by `ValueId`.
+    /// The `debug_assert!` is a trip-wire: today every value live across a block boundary is
+    /// permanently spilled, so nothing live-in survives in the carried-over LRU. If a future
+    /// register allocator (<https://github.com/noir-lang/noir/issues/11638>) keeps live values in
+    /// registers across blocks it fires — a signal that re-seeding by `ValueId` discards a real
+    /// previous-block recency ordering we should be preserving instead.
     fn reset_lru_for_block(&mut self, live_in: &HashSet<ValueId>) {
         debug_assert!(
-            !self.lru.iter().any(|v| live_in.contains(&v) && !self.is_spilled(&v)),
-            "cross-block LRU carryover is non-empty; preserve the previous block's order instead of re-sorting: {:?}",
+            !self.lru.iter().any(|v| live_in.contains(&v)),
+            "cross-block LRU carryover is non-empty; preserve the previous block's order instead of re-seeding: {:?}",
             self.lru.iter().collect::<Vec<_>>()
         );
-        let seed: Vec<ValueId> =
-            live_in.iter().copied().filter(|v| !self.is_spilled(v)).sorted().collect();
         self.lru.clear();
-        for value_id in seed {
-            self.lru.touch(value_id);
-        }
+        // Seed every surviving live-in as equally least-recently-used; the LRU orders them by
+        // `ValueId`, so no explicit sort is needed.
+        self.lru.seed(live_in.iter().copied());
     }
 
     /// Record a value as permanently spilled, dropping it from the LRU (like [`Self::record_spill`]).
     ///
-    /// If the value already has a transient spill record, it is promoted to `Permanent`.
-    /// The permanent record ensures consistency regardless of what happens during
-    /// block processing.
+    /// If the value already has a transient spill slot, it is promoted to permanent.
+    /// The permanent slot ensures consistency regardless of what happens during block processing.
     pub(crate) fn record_permanent_spill(
         &mut self,
         value_id: ValueId,
@@ -379,19 +425,16 @@ impl SpillManager {
             .entry(value_id)
             .and_modify(|record| {
                 assert_eq!(record.offset, offset);
-                record.status = SpillStatus::Permanent;
+                record.permanent = true;
                 record.variable = variable;
             })
-            .or_insert(SpillRecord { offset, variable, status: SpillStatus::Permanent });
+            .or_insert(SpillRecord { offset, variable, permanent: true });
         self.remove_from_lru(&value_id);
     }
 
     /// Get the permanent spill slot offset for a value, if any.
     pub(crate) fn get_permanent_spill_offset(&self, value_id: &ValueId) -> Option<usize> {
-        self.records
-            .get(value_id)
-            .filter(|r| matches!(r.status, SpillStatus::Permanent | SpillStatus::PermanentReloaded))
-            .map(|r| r.offset)
+        self.records.get(value_id).filter(|r| r.permanent).map(|r| r.offset)
     }
 
     /// Get the spill slot offset for a value, if any.
@@ -402,48 +445,11 @@ impl SpillManager {
         self.records.get(value_id).map(|r| r.offset)
     }
 
-    /// Re-mark permanently-spilled values as currently spilled at block entry.
+    /// Promote an existing spill record to a permanent slot, dropping it from the LRU.
     ///
-    /// A reload in a previous block sets the status to `PermanentReloaded`, but the
-    /// value must be reloaded again in every block that uses it (since the
-    /// permanent spill slot is always the source of truth).
-    ///
-    /// Unlike the other spill transitions, this does not drop the affected values from the
-    /// LRU: it runs only from `begin_block`, which rebuilds the LRU wholesale via
-    /// `reset_lru_for_block` immediately afterwards, so any per-value removal here would be
-    /// redundant.
-    pub(crate) fn restore_permanent_spills(&mut self) {
-        for record in self.records.values_mut() {
-            if record.status == SpillStatus::PermanentReloaded {
-                record.status = SpillStatus::Permanent;
-            }
-        }
-    }
-
-    /// Mark a spilled value as reloaded into a register, without freeing the spill slot.
-    ///
-    /// - `Transient` → `TransientReloaded`
-    /// - `Permanent` → `PermanentReloaded`
-    ///
-    /// The slot's data must remain valid because the reload code may execute
-    /// again in a loop iteration. Only `remove_spill` (used when the value is
-    /// truly dead) should free the slot.
-    pub(crate) fn unmark_spilled(&mut self, value_id: &ValueId) {
-        let record = self.records.get_mut(value_id).expect("No record for value");
-        record.status = match record.status {
-            SpillStatus::Transient => SpillStatus::TransientReloaded,
-            SpillStatus::Permanent => SpillStatus::PermanentReloaded,
-            _ => panic!("Expected record not to be spilled, but was {:?}", record.status),
-        };
-    }
-
-    /// Promote an existing spill record to `Permanent`: the heap slot becomes the value's
-    /// authoritative copy, so it is also dropped from the LRU (an in-memory value must never
-    /// be an eviction victim).
-    ///
-    /// This updates spill bookkeeping only. A `*Reloaded` value still physically occupies a
-    /// register at this point; whether that register is freed or kept alive is the caller's
-    /// decision — see `BrilligBlock::spill_value`.
+    /// The permanent slot becomes the value's authoritative copy across block boundaries. This
+    /// updates slot bookkeeping only; whether the value still occupies a register is the caller's
+    /// concern — see `BrilligBlock::spill_value`.
     ///
     /// # Returns
     /// * `true` — a record already existed, so the value already owns a permanent slot; the
@@ -454,7 +460,7 @@ impl SpillManager {
         let Some(record) = self.records.get_mut(value_id) else {
             return false;
         };
-        record.status = SpillStatus::Permanent;
+        record.permanent = true;
         self.remove_from_lru(value_id);
         true
     }
@@ -469,10 +475,40 @@ mod tests {
         ssa::ir::map::Id,
     };
 
-    use super::{Lru, SpillManager, SpillStatus};
+    use rustc_hash::FxHashSet;
+
+    use super::{Lru, RegisterState, SpillManager};
+    use crate::ssa::ir::value::ValueId;
 
     fn test_var(n: u32) -> BrilligVariable {
         BrilligVariable::SingleAddr(SingleAddrVariable::new(MemoryAddress::relative(n), 32))
+    }
+
+    /// Stand-in for the register allocator the spill manager consults but does not own.
+    ///
+    /// Tests drive this explicitly to mirror what `BrilligBlock` does to the real registers:
+    /// `allocate` is "a register now holds the value" (e.g. a reload, formerly `unmark_spilled`),
+    /// and `free` is "the register was released" (e.g. after a spill, or the block-entry reset
+    /// that formerly went through `restore_permanent_spills`).
+    #[derive(Default)]
+    struct MockRegisters {
+        in_register: FxHashSet<ValueId>,
+    }
+
+    impl RegisterState for MockRegisters {
+        fn is_in_register(&self, value_id: &ValueId) -> bool {
+            self.in_register.contains(value_id)
+        }
+    }
+
+    impl MockRegisters {
+        fn allocate(&mut self, value_id: ValueId) {
+            self.in_register.insert(value_id);
+        }
+
+        fn free(&mut self, value_id: ValueId) {
+            self.in_register.remove(&value_id);
+        }
     }
 
     #[test]
@@ -531,6 +567,7 @@ mod tests {
     #[test]
     fn lru_ordering_and_victim_selection() {
         let mut sm = SpillManager::new();
+        let regs = MockRegisters::default();
         let v0 = Id::test_new(0);
         let v1 = Id::test_new(1);
         let v2 = Id::test_new(2);
@@ -541,18 +578,19 @@ mod tests {
         sm.touch(v2);
 
         // Victim should be v0 (least recently used)
-        assert_eq!(sm.lru_victim(), Some(v0));
+        assert_eq!(sm.lru_victim(&regs), Some(v0));
 
         // Touch v0 again, making it most recent. LRU order: [v1, v2, v0]
         sm.touch(v0);
 
         // Victim should now be v1
-        assert_eq!(sm.lru_victim(), Some(v1));
+        assert_eq!(sm.lru_victim(&regs), Some(v1));
     }
 
     #[test]
     fn lru_victims_returns_the_k_least_recently_used() {
         let mut sm = SpillManager::new();
+        let regs = MockRegisters::default();
         let v0 = Id::test_new(0);
         let v1 = Id::test_new(1);
         let v2 = Id::test_new(2);
@@ -564,70 +602,79 @@ mod tests {
         sm.touch(v3);
 
         // The `k` least-recently-used, oldest first.
-        assert_eq!(sm.lru_victims(2), vec![v0, v1]);
+        assert_eq!(sm.lru_victims(2, &regs), vec![v0, v1]);
         // `k` larger than the tracked set returns everything.
-        assert_eq!(sm.lru_victims(10), vec![v0, v1, v2, v3]);
+        assert_eq!(sm.lru_victims(10, &regs), vec![v0, v1, v2, v3]);
     }
 
     #[test]
     fn spilling_removes_value_from_lru_so_it_is_not_a_victim() {
         let mut sm = SpillManager::new();
+        let mut regs = MockRegisters::default();
         let v0 = Id::test_new(0);
         let v1 = Id::test_new(1);
         let v2 = Id::test_new(2);
 
-        sm.touch(v0);
-        sm.touch(v1);
-        sm.touch(v2);
+        // All three are in registers and tracked in the LRU.
+        for v in [v0, v1, v2] {
+            regs.allocate(v);
+            sm.touch(v);
+        }
 
-        // `record_spill` itself drops the value from the LRU.
+        // Spill v0: record_spill drops it from the LRU, then its register is freed.
         let offset = sm.allocate_spill_offset();
-        sm.record_spill(v0, offset, test_var(0));
+        sm.record_spill(v0, offset, test_var(0), &regs);
+        regs.free(v0);
 
-        assert!(sm.is_spilled(&v0));
-        assert!(!sm.is_spilled(&v1));
+        assert!(sm.is_spilled(&v0, &regs));
+        assert!(!sm.is_spilled(&v1, &regs));
 
-        let record = sm.get_spill(&v0).unwrap();
+        let record = sm.get_spill(&v0, &regs).unwrap();
         assert_eq!(record.offset, 0);
-        assert_eq!(record.status, SpillStatus::Transient);
+        assert!(!sm.has_permanent_slot(&v0)); // it is a transient slot
 
         // v0 is no longer tracked, so the next-oldest live value is the victim.
-        assert_eq!(sm.lru_victim(), Some(v1));
+        assert_eq!(sm.lru_victim(&regs), Some(v1));
     }
 
     #[test]
     #[should_panic(expected = "returned a spilled value")]
     fn lru_victim_rejects_a_spilled_oldest_value() {
-        // Recording a spill drops the value from the LRU, so a spilled value can only re-enter
-        // it through an erroneous `touch`. `lru_victim` must catch that rather than hand back a
-        // value whose re-spill would free no register.
+        // A spilled value can only re-enter the LRU through an erroneous `touch`; `lru_victim`
+        // must catch that rather than hand back a value whose re-spill would free no register.
         let mut sm = SpillManager::new();
+        let mut regs = MockRegisters::default();
         let v0 = Id::test_new(0);
 
+        regs.allocate(v0);
         let offset = sm.allocate_spill_offset();
-        sm.record_spill(v0, offset, test_var(0));
-        sm.touch(v0);
+        sm.record_spill(v0, offset, test_var(0), &regs);
+        regs.free(v0); // v0 is now spilled (has a slot, not in a register)
+        sm.touch(v0); // erroneously re-track it
 
-        let _ = sm.lru_victim();
+        let _ = sm.lru_victim(&regs);
     }
 
     #[test]
     fn spill_slot_allocation_and_reuse() {
         let mut sm = SpillManager::new();
+        let mut regs = MockRegisters::default();
         let v0 = Id::test_new(0);
         let v1 = Id::test_new(1);
 
         // Allocate two slots: offsets 0 and 1
+        regs.allocate(v0);
+        regs.allocate(v1);
         let off0 = sm.allocate_spill_offset();
-        sm.record_spill(v0, off0, test_var(0));
+        sm.record_spill(v0, off0, test_var(0), &regs);
         let off1 = sm.allocate_spill_offset();
-        sm.record_spill(v1, off1, test_var(1));
+        sm.record_spill(v1, off1, test_var(1), &regs);
         assert_eq!(off0, 0);
         assert_eq!(off1, 1);
 
-        // Free slot 0 by removing the spill
+        // Free slot 0 by removing the spill (the value died).
         sm.remove_spill(&v0);
-        assert!(!sm.is_spilled(&v0));
+        assert!(!sm.is_spilled(&v0, &regs));
 
         // Next allocation should reuse freed slot 0
         let off_reused = sm.allocate_spill_offset();
@@ -641,6 +688,7 @@ mod tests {
     #[test]
     fn remove_from_lru() {
         let mut sm = SpillManager::new();
+        let regs = MockRegisters::default();
         let v0 = Id::test_new(0);
         let v1 = Id::test_new(1);
         let v2 = Id::test_new(2);
@@ -653,103 +701,110 @@ mod tests {
         sm.remove_from_lru(&v1);
 
         // Victim should be v0 (v1 is absent)
-        assert_eq!(sm.lru_victim(), Some(v0));
+        assert_eq!(sm.lru_victim(&regs), Some(v0));
 
         // Touch v0, making it most recent. LRU order: [v2, v0]
         sm.touch(v0);
 
         // Victim should be v2 (v1 is absent, v0 was touched)
-        assert_eq!(sm.lru_victim(), Some(v2));
+        assert_eq!(sm.lru_victim(&regs), Some(v2));
     }
 
     #[test]
     fn permanent_spill_lifecycle() {
         let mut sm = SpillManager::new();
+        let mut regs = MockRegisters::default();
         let v0 = Id::test_new(0);
 
-        // Allocate and record a permanent spill
+        // The value starts in a register, then is permanently spilled (register then freed).
+        regs.allocate(v0);
         let off = sm.allocate_spill_offset();
         sm.record_permanent_spill(v0, off, test_var(0));
+        regs.free(v0);
         assert_eq!(off, 0);
-        assert!(sm.is_spilled(&v0));
+        assert!(sm.is_spilled(&v0, &regs));
         assert!(sm.has_permanent_slot(&v0));
         assert_eq!(sm.get_permanent_spill_offset(&v0), Some(0));
 
-        // Unmark spilled (reload) — record stays, slot stays
-        sm.unmark_spilled(&v0);
-        assert!(!sm.is_spilled(&v0));
+        // Reload: a register is allocated again (was `unmark_spilled`); the slot stays.
+        regs.allocate(v0);
+        assert!(!sm.is_spilled(&v0, &regs));
         assert!(sm.has_permanent_slot(&v0));
         assert_eq!(sm.get_permanent_spill_offset(&v0), Some(0));
 
         // While reloaded (in a register) the value is a normal eviction candidate.
         sm.touch(v0);
-        assert_eq!(sm.lru_victim(), Some(v0));
+        assert_eq!(sm.lru_victim(&regs), Some(v0));
 
-        // Restore permanent spills (block entry) — re-marks as spilled
-        sm.restore_permanent_spills();
-        assert!(sm.is_spilled(&v0));
+        // Block entry resets the register state (was `restore_permanent_spills`): no longer resident.
+        regs.free(v0);
+        assert!(sm.is_spilled(&v0, &regs));
 
-        // Remove spill on a permanent record — keeps the record and slot, stays `Permanent`.
+        // The value dies: the permanent slot is kept, but it is dropped from the LRU.
         sm.remove_spill(&v0);
-        assert!(sm.is_spilled(&v0));
+        assert!(sm.is_spilled(&v0, &regs));
         // Permanent record still exists
         assert!(sm.has_permanent_slot(&v0));
         // Slot is NOT freed (no slot in free list)
         assert!(sm.free_spill_slots.is_empty());
         // The dead value was dropped from the LRU, so it is no longer an eviction candidate.
-        assert_eq!(sm.lru_victim(), None);
+        assert_eq!(sm.lru_victim(&regs), None);
     }
 
     #[test]
     fn promote_transient_to_permanent() {
         let mut sm = SpillManager::new();
+        let mut regs = MockRegisters::default();
         let v0 = Id::test_new(0);
 
-        // Record a transient spill
+        // Transient spill: in a register, then spilled (register freed).
+        regs.allocate(v0);
         let off = sm.allocate_spill_offset();
-        sm.record_spill(v0, off, test_var(0));
-        assert!(sm.is_spilled(&v0));
+        sm.record_spill(v0, off, test_var(0), &regs);
+        regs.free(v0);
+        assert!(sm.is_spilled(&v0, &regs));
         assert!(!sm.has_permanent_slot(&v0));
 
         // Promote to permanent via ensure_permanent_spill
         assert!(sm.ensure_permanent_spill(&v0));
-        assert!(sm.is_spilled(&v0));
+        assert!(sm.is_spilled(&v0, &regs));
         assert!(sm.has_permanent_slot(&v0));
         assert_eq!(sm.get_permanent_spill_offset(&v0), Some(0));
 
-        // Removing a promoted permanent spill keeps it `Permanent` and does NOT free the slot.
+        // Removing a promoted permanent spill keeps the slot and does NOT free it.
         sm.remove_spill(&v0);
-        assert!(sm.is_spilled(&v0));
+        assert!(sm.is_spilled(&v0, &regs));
         assert!(sm.free_spill_slots.is_empty());
         // Although still `is_spilled`, the dead value must not be returned by the LRU.
-        assert_eq!(sm.lru_victim(), None);
+        assert_eq!(sm.lru_victim(&regs), None);
     }
 
     #[test]
-    fn ensure_permanent_spill_for_not_spilled() {
+    fn ensure_permanent_spill_returns_true_when_a_record_exists() {
         let mut sm = SpillManager::new();
+        let regs = MockRegisters::default();
         let v0 = Id::test_new(0);
 
-        // Record a transient spill
+        // A transient spill record exists; ensure_permanent_spill promotes it and returns true.
         let off = sm.allocate_spill_offset();
-        sm.record_spill(v0, off, test_var(0));
-        sm.unmark_spilled(&v0);
-
+        sm.record_spill(v0, off, test_var(0), &regs);
         assert!(sm.ensure_permanent_spill(&v0), "expect true because the record exists");
+        assert!(sm.has_permanent_slot(&v0));
     }
 
     #[test]
     #[should_panic(expected = "Transient spill leaked across block boundary")]
     fn begin_block_panics_on_transient_spill_leak() {
         let mut sm = SpillManager::new();
+        let regs = MockRegisters::default();
         let v0 = Id::test_new(0);
 
-        // Record a transient spill (not permanent), leave it currently spilled
+        // A live-in value carrying only a transient slot is a leak (it should be permanent).
         let off = sm.allocate_spill_offset();
-        sm.record_spill(v0, off, test_var(0));
+        sm.record_spill(v0, off, test_var(0), &regs);
 
-        // begin_block should panic because a transient spill is still active
-        let mut live_in = rustc_hash::FxHashSet::default();
+        let mut live_in = FxHashSet::default();
+        live_in.insert(v0);
         sm.begin_block(&mut live_in);
     }
 
@@ -757,98 +812,96 @@ mod tests {
     #[should_panic(expected = "Double-spill")]
     fn record_spill_panics_on_double_spill() {
         let mut sm = SpillManager::new();
+        let mut regs = MockRegisters::default();
         let v0 = Id::test_new(0);
 
+        regs.allocate(v0);
         let off = sm.allocate_spill_offset();
-        sm.record_spill(v0, off, test_var(0));
+        sm.record_spill(v0, off, test_var(0), &regs);
+        regs.free(v0); // spilling frees the register; v0 is now spilled
 
-        // Attempting to spill v0 again without unmark/remove should panic
+        // Spilling v0 again while it is already spilled (out of a register) is a double-spill.
         let off2 = sm.allocate_spill_offset();
-        sm.record_spill(v0, off2, test_var(0));
+        sm.record_spill(v0, off2, test_var(0), &regs);
     }
 
     #[test]
     #[should_panic(expected = "orphaned existing slot")]
     fn record_spill_panics_on_orphaned_slot() {
         let mut sm = SpillManager::new();
+        let mut regs = MockRegisters::default();
         let v0 = Id::test_new(0);
 
+        regs.allocate(v0);
         let off = sm.allocate_spill_offset();
-        sm.record_spill(v0, off, test_var(0));
-
-        sm.unmark_spilled(&v0);
-
+        sm.record_spill(v0, off, test_var(0), &regs);
         assert_eq!(sm.get_spill_offset(&v0), Some(off));
 
-        // Attempting to spill v0 again with a different offset should panic.
+        // v0 stays in a register (re-eviction), so this passes the double-spill check, but a
+        // different offset orphans the existing slot.
         let off2 = sm.allocate_spill_offset();
-        sm.record_spill(v0, off2, test_var(0));
+        sm.record_spill(v0, off2, test_var(0), &regs);
     }
 
     #[test]
-    fn record_spill_of_unmarked_with_same_offset() {
+    fn record_spill_of_reloaded_value_with_same_offset() {
         let mut sm = SpillManager::new();
+        let mut regs = MockRegisters::default();
         let v0 = Id::test_new(0);
 
+        regs.allocate(v0);
         let off = sm.allocate_spill_offset();
-        sm.record_spill(v0, off, test_var(0));
-        sm.unmark_spilled(&v0);
-        sm.record_spill(v0, off, test_var(1)); // Different BrilligVariable to show it's not checked.
+        sm.record_spill(v0, off, test_var(0), &regs);
+        // v0 stays in a register (reloaded); re-recording the same offset is fine.
+        sm.record_spill(v0, off, test_var(1), &regs); // Different BrilligVariable to show it's not checked.
     }
 
     #[test]
     fn ensure_permanent_spill_all_branches() {
         let mut sm = SpillManager::new();
+        let regs = MockRegisters::default();
         let v0 = Id::test_new(0);
         let v1 = Id::test_new(1);
-        let v2 = Id::test_new(2);
         let v3 = Id::test_new(3);
 
         // Case 1: No record -> returns false
         assert!(!sm.ensure_permanent_spill(&v3));
 
-        // Case 2: Permanent -> returns true, stays Permanent
+        // Case 2: Already permanent -> returns true, stays permanent
         let off0 = sm.allocate_spill_offset();
         sm.record_permanent_spill(v0, off0, test_var(0));
-        assert_eq!(sm.records[&v0].status, SpillStatus::Permanent);
+        assert!(sm.has_permanent_slot(&v0));
         assert!(sm.ensure_permanent_spill(&v0));
-        assert_eq!(sm.records[&v0].status, SpillStatus::Permanent);
+        assert!(sm.has_permanent_slot(&v0));
 
-        // Case 3: Transient -> returns true, promoted to Permanent
+        // Case 3: Transient -> returns true, promoted to permanent
         let off1 = sm.allocate_spill_offset();
-        sm.record_spill(v1, off1, test_var(1));
-        assert_eq!(sm.records[&v1].status, SpillStatus::Transient);
+        sm.record_spill(v1, off1, test_var(1), &regs);
+        assert!(!sm.has_permanent_slot(&v1));
         assert!(sm.ensure_permanent_spill(&v1));
-        assert_eq!(sm.records[&v1].status, SpillStatus::Permanent);
-
-        // Case 4: PermanentReloaded -> returns true, re-marked as Permanent
-        let off2 = sm.allocate_spill_offset();
-        sm.record_permanent_spill(v2, off2, test_var(2));
-        sm.unmark_spilled(&v2);
-        assert_eq!(sm.records[&v2].status, SpillStatus::PermanentReloaded);
-        assert!(sm.ensure_permanent_spill(&v2));
-        assert_eq!(sm.records[&v2].status, SpillStatus::Permanent);
+        assert!(sm.has_permanent_slot(&v1));
     }
 
-    /// Promoting a `PermanentReloaded` value back to `Permanent` must drop it from the LRU,
-    /// otherwise a spilled value lingers as an eviction candidate. In real codegen this
-    /// happens for a JmpIf condition that is re-spilled by `spill_non_param_live_ins` and
-    /// then reloaded, with `ensure_register_capacity` querying `lru_victim` in between.
+    /// Promoting a reloaded permanent value back to spilled must drop it from the LRU, otherwise
+    /// a spilled value lingers as an eviction candidate. In real codegen this happens for a
+    /// JmpIf condition re-spilled by `spill_non_param_live_ins` then reloaded, with
+    /// `ensure_register_capacity` querying `lru_victim` in between.
     #[test]
     fn ensure_permanent_spill_drops_reloaded_value_from_lru() {
         let mut sm = SpillManager::new();
+        let mut regs = MockRegisters::default();
         let v0 = Id::test_new(0);
 
+        // Permanent slot, currently reloaded (in a register) and tracked in the LRU.
+        regs.allocate(v0);
         let off = sm.allocate_spill_offset();
         sm.record_permanent_spill(v0, off, test_var(0));
-        sm.unmark_spilled(&v0); // PermanentReloaded: currently in a register
-        sm.touch(v0); // tracked in the LRU
+        sm.touch(v0);
+        assert!(!sm.is_transient_reloaded(&v0, &regs)); // it is permanent, not transient
+        assert_eq!(sm.lru_victim(&regs), Some(v0));
 
-        assert!(!sm.is_transient_reloaded(&v0));
+        // ensure_permanent_spill drops it from the LRU, so it is no longer a victim.
         assert!(sm.ensure_permanent_spill(&v0));
-        assert!(sm.is_spilled(&v0));
-
-        // The value is spilled again, so it must no longer be an eviction candidate.
-        assert_eq!(sm.lru_victim(), None);
+        assert_eq!(sm.lru_victim(&regs), None);
     }
 }

--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/spill_manager.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/spill_manager.rs
@@ -104,26 +104,38 @@ pub(crate) struct SpillManager {
 ///
 /// # Value lifecycle
 ///
-/// A value's state is the combination of its *slot* (tracked here: none, transient, or
-/// permanent) and whether it is *currently in a register* (tracked by [`RegisterState`], not
-/// stored here). "Spilled" means it has a slot but is not in a register. The combinations —
-/// and the names the former `SpillStatus` enum gave them — are:
+/// A value's state is the combination of its *slot* — none, transient, or permanent, tracked
+/// here — and whether it is *currently in a register*, which is owned by the register allocator
+/// ([`RegisterState`]) and not stored here. A value is "spilled" when it has a slot but is not
+/// in a register. There are five combinations; a `SpillRecord` exists only for the four with a
+/// slot:
 ///
-/// | slot      | in register | former name         | meaning                                       |
-/// |-----------|-------------|---------------------|-----------------------------------------------|
-/// | none      | yes         | (no record)         | normal value, lives only in a register        |
-/// | transient | no          | `Transient`         | within-block spill, awaiting reload           |
-/// | transient | yes         | `TransientReloaded` | reloaded; transient slot still reserved       |
-/// | permanent | no          | `Permanent`         | cross-block spill, heap slot is authoritative |
-/// | permanent | yes         | `PermanentReloaded` | reloaded; permanent slot still authoritative  |
+/// | slot      | in register | meaning                                                     |
+/// |-----------|-------------|-------------------------------------------------------------|
+/// | none      | yes         | normal value — lives only in a register, has no record      |
+/// | transient | no          | spilled within the block, awaiting reload                   |
+/// | transient | yes         | reloaded, but the transient slot is still reserved          |
+/// | permanent | no          | spilled across blocks; the heap slot is the source of truth |
+/// | permanent | yes         | reloaded, but the permanent slot is still authoritative     |
 ///
-/// Transitions:
-/// - First eviction → gains a transient slot (or, across a block boundary, a permanent one);
-///   the register is freed.
-/// - Reloaded into a register, or evicted again by the LRU → purely a [`RegisterState`] change;
-///   the slot itself is unchanged.
-/// - Block boundary → the register state resets (nothing is in a register); permanent slots
-///   persist while transient slots must not survive.
+/// Movement between rows:
+///
+/// - **Spill** (registers run out): a value in a register gains a slot and its register is
+///   freed. Within a block it gets a *transient* slot (`record_spill`); a value that must
+///   survive to another block gets a *permanent* slot instead (`record_permanent_spill`).
+/// - **Reload** (a spilled value is used again): it is loaded back into a register, moving to
+///   the "in register" row of the *same* slot kind. The slot is kept — the emitted load may
+///   re-run in a loop iteration — so nothing is re-allocated.
+/// - **Re-eviction**: a reloaded value the LRU picks again has its register freed, dropping back
+///   to the "not in register" row and reusing its existing slot.
+/// - **Promotion** (`ensure_permanent_spill`): a transient value that turns out to live across a
+///   block boundary is promoted to a permanent slot (transient → permanent, same residence).
+/// - **Block boundary**: the register file is reset, so every value is momentarily "not in a
+///   register" — the reloaded rows collapse onto their spilled rows. Transient slots must not
+///   survive for a live-in value (`begin_block` asserts this); permanent slots persist as the
+///   cross-block source of truth.
+/// - **Death** (`remove_spill`): at a value's last use a transient slot is freed and the value
+///   leaves the table, while a permanent slot is kept for the rest of the function.
 #[derive(Clone, Copy)]
 pub(crate) struct SpillRecord {
     /// Offset relative to the per-frame heap-allocated spill region base.

--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/spill_manager.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/spill_manager.rs
@@ -19,30 +19,40 @@
 //! _permanent_ spills: their slot is reserved for the remainder of the function and every
 //! use reloads from it.
 //!
+//! The manager owns only this *slot* bookkeeping plus an LRU eviction order. Whether a value is
+//! currently in a register is owned by the register allocator ([`BlockVariables`]) and read
+//! through the [`RegisterState`] trait; "currently spilled" is *derived* as having a slot while
+//! not in a register, never stored.
+//!
 //! Transient slots are freed as soon as the value dies; permanent slots are never freed
 //! (see <https://github.com/noir-lang/noir/issues/11695>). Each block begins with
-//! [`SpillManager::begin_block`], which (a) asserts no transient spills leaked from the
-//! previous block, (b) re-marks permanent slots as "currently spilled" so their owners
-//! must reload before use, and (c) rebuilds the LRU with this block's live-in set.
+//! [`SpillManager::begin_block`], which (a) asserts no live-in value carries a transient slot
+//! (values living across a boundary must be permanently spilled), and (b) rebuilds the LRU from
+//! this block's live-in set. It consults no [`RegisterState`]: the block's registers are reset
+//! by the caller immediately afterwards, so a permanently-spilled value is automatically "not in
+//! a register" at entry.
 //!
 //! # Per-use flow
 //!
 //! The code generator calls into the spill manager at a small number of well-defined points:
 //!
 //! - Before making room for a fresh value, [`BrilligBlock::ensure_register_capacity`] asks
-//!   [`SpillManager::lru_victim`] for the least-recently-used non-spilled value and spills
-//!   it via [`BrilligBlock::spill_value`]. That emits the store and frees the register.
-//! - When a spilled value is needed, [`BrilligBlock::reload_spilled_value`] allocates a
-//!   fresh register, emits the load, and calls [`SpillManager::unmark_spilled`] to record
-//!   that the value is once again in a register (the slot still holds a valid copy).
-//! - When a value is used, [`SpillManager::touch`] bumps it to the most-recently-used end
-//!   of the LRU, so that freshly-loaded and just-produced values aren't the first victims
-//!   of the next eviction.
-//! - When a value dies, [`SpillManager::remove_spill`] frees its transient slot (permanent
-//!   slots are kept for the rest of the function).
+//!   [`SpillManager::lru_victim`] for the least-recently-used value (the LRU only ever holds
+//!   register-resident values) and spills it via [`BrilligBlock::spill_value`]. That emits the
+//!   store, records the slot, and frees the register.
+//! - When a spilled value is needed, [`BrilligBlock::reload_spilled_value`] allocates a fresh
+//!   register and emits the load; re-adding the value to the register set is what marks it no
+//!   longer spilled (the slot is kept, since the load may re-execute in a loop iteration).
+//! - When a value is used, [`SpillManager::touch`] bumps it to the most-recently-used end of
+//!   the LRU, so that freshly-loaded and just-produced values aren't the first victims of the
+//!   next eviction. `touch` also asserts the value is in a register, keeping spilled values out
+//!   of the LRU at the source.
+//! - When a value dies, [`SpillManager::remove_spill`] frees its transient slot (permanent slots
+//!   are kept for the rest of the function) and drops it from the LRU.
 //!
 //! [`VariableLiveness::max_live_count`]: super::variable_liveness::VariableLiveness::max_live_count
 //! [`LayoutConfig`]: crate::brillig::brillig_ir::LayoutConfig
+//! [`BlockVariables`]: super::brillig_block_variables::BlockVariables
 //! [`BrilligBlock::ensure_register_capacity`]: super::brillig_block::BrilligBlock::ensure_register_capacity
 //! [`BrilligBlock::spill_value`]: super::brillig_block::BrilligBlock::spill_value
 //! [`BrilligBlock::reload_spilled_value`]: super::brillig_block::BrilligBlock::reload_spilled_value

--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/tests/spill.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/tests/spill.rs
@@ -31,17 +31,15 @@ fn spill_region_size(bytecode: &str) -> u32 {
 /// takes 5 parameters, so codegen spills from the first instruction. As the chain
 /// is evaluated, several values are transiently spilled, reloaded into a register
 /// for a single use, and then die — all within `b0`. At the moment such a value
-/// dies it is in the `TransientReloaded` state: the live value is in a register
-/// and its spill slot is still allocated.
+/// dies it has a transient slot but is back in a register, so it is not currently
+/// spilled.
 ///
-/// `convert_ssa_instruction`'s dead-variable cleanup decides what to do via
-/// `is_spilled`, which is `true` only for `Transient`/`Permanent`. A
-/// `TransientReloaded` value matches neither, so cleanup takes the
-/// register-freeing branch and never calls `remove_spill`: the `SpillRecord`
-/// lingers in `records` and its offset is never pushed back onto
-/// `free_spill_slots`. The next `allocate_spill_offset` bumps `next_spill_offset`
-/// instead of reusing the dead slot, so `max_spill_offset` — and the spill region
-/// the prologue reserves on every call — grows by one for each such pattern.
+/// `convert_ssa_instruction`'s dead-variable cleanup must still call `remove_spill`
+/// for it; otherwise the `SpillRecord` lingers in `records` and its offset is never
+/// pushed back onto `free_spill_slots`. The next `allocate_spill_offset` then bumps
+/// `next_spill_offset` instead of reusing the dead slot, so `max_spill_offset` — and
+/// the spill region the prologue reserves on every call — grows by one for each such
+/// pattern.
 ///
 /// The leak has no soundness impact — the skipped offset is never reused
 /// incorrectly — so it is purely a memory-footprint regression. Here the true

--- a/cspell.json
+++ b/cspell.json
@@ -280,6 +280,7 @@
         "rangemap",
         "rawstr",
         "refcount",
+        "regs",
         "replacen",
         "repr",
         "reqwest",


### PR DESCRIPTION
## Problem Resolved

While working on https://github.com/noir-lang/noir/pull/13128 I added an assertion that victims found in the LRU are always non-spilled. @jfecher contributed a test in https://github.com/noir-lang/noir/pull/13128#discussion_r3493060086 that showed this invariant does not hold on all programs. We fixed it so it does, by moving the removal from the LRU into the `SpillManager`, to make sure it's always called. 

The fact that I missed this highlighted how difficult it was to understand the ways the `SpillManager` worked. As it stands today, the `SpillManager` is rather anaemic, driven mostly by `BrilligBlock`. It doesn't really "manage", doesn't fully own its invariants, rather, it keeps records, its methods serve to synchronise parts of its state with a source of truth that lives elsewhere. For example `unmark_spill` happens when we reload a value into registers, so the manager can mark its records accordingly, but what does or doesn't live in registers we already know from `BrilligBlock::variables`.

I pointed this out during the original review, and Maxim confirmed it was sort of deliberate. We tried to simplify the model during the review (e.g. adding flags to represent state), but since it was merged, it already underwent additional changes to try and make it easier to understand: for example in https://github.com/noir-lang/noir/pull/12391 we went from 2 flags to 4 states.

This PR tries to simplify the `SpillManger` by removing the synchronisation between the `BlockVariables` and its `SpillRecord`s: instead of reflecting whether a value is in the registers using the `*Reloaded` states, we make the registers available for query to the manager.

## Summary of Changes

* Remove `SpillStatus` and replace `SpillRecord::status` with `SpillRecord::permanent`: which shows whether the spill slot is transient (`false`) or permanent (`true`). 
* Add a `RegisterState` trait with an `is_in_register` method to indicate whether a particular value is currently in the registers
* Use parameter injection to pass a `RegisterState` implementation to the `SpillManager` methods that need it.
* Redefine `SpillManager::is_spilled(v)` as `has_slot(v) && !is_in_register(v)`
* Assert in `SpillManager::touch` that the value being touch is in the registers. Remove the assertion that the value is not spilled from the `lru_victim` methods. This way we have a true invariant that the LRU only contains values which can be evicted, and any violation is caught at the source.
* Remove `SpillManager::unmark_spill`: we no longer have to let it know that we reloaded something, it's simply reflected in the `RegisterState`
* Remove `SpillManager::restore_permanent_spill`: if something was permanent, it's still permanent; whether it's in the registry no longer reflected in the manager.
* Use a `MockRegister` in the tests to preserve the test scenarios (e.g. `unmark_spill` is now `reg.allocate(...)` and `record_spill` is followed by `reg.free(...)`). 
* Add `Lru::seed` to simplify resetting the LRU to a list of values ordered by ID

These changes make it clear which part of the state is owned by the `SpillManager` and which parts are just used by it, while reducing the chance of being out of sync.

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
