### PR TITLE
fix(ssa): only restore unfit operands for signed checked arithmetic

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/interpreter/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/interpreter/mod.rs
@@ -1643,23 +1643,29 @@ macro_rules! apply_int_comparison_op {
     }};
 }
 
-/// "Restore" a value that escaped its type via an overflowing unchecked operation into the
-/// wrapped, in-range value that the ACIR and Brillig backends carry forward.
+/// "Restore" a signed value that escaped its type via an overflowing unchecked operation into the
+/// wrapped, in-range value that ACIR carries forward when lowering a checked signed op.
 ///
 /// An overflowing unchecked op leaves a [`value::Fitted::Unfit`] field that exceeds the operand's
-/// type (e.g. `unchecked_mul i32 i32::MAX, 2` yields the field `4294967294`). The backends do not
-/// keep that extended value: Brillig wraps in its fixed-width registers and ACIR truncates when
-/// lowering the consuming checked op, so both treat the operand as its `bit_size`-bit representative
-/// (`i32 -2`). Truncating here mirrors that, so a checked op over an `Unfit` operand evaluates
-/// consistently with the backends instead of erroring. Operands that already fit are returned
-/// unchanged.
+/// type (e.g. `unchecked_mul i32 i32::MAX, 2` yields the field `4294967294`). ACIR lowers a checked
+/// *signed* add/sub/mul by casting each operand to the unsigned type of the same width — i.e.
+/// truncating it to `bit_size` — before computing, so such an operand is reduced to its
+/// `bit_size`-bit representative there (`i32 -2`). Truncating a signed `Unfit` operand here mirrors
+/// that, so the checked op evaluates consistently with ACIR instead of erroring (noir-lang/noir-claude#1430).
+///
+/// Unsigned checked ops are lowered differently: ACIR keeps the operand as a field and
+/// range-constrains the *result*, so an out-of-range operand makes that range check fail and ACIR
+/// rejects the program. Unsigned `Unfit` operands are therefore left untouched so the checked op
+/// reports the overflow, matching that rejection — wrapping them would be unsound (an underflowed
+/// `unchecked_sub` carries `p - delta`, whose low `bit_size` bits are not the wrapped result, e.g.
+/// `0 - 10` as `u8` would give `247` rather than `246`). See noir-lang/noir-claude#1441.
+///
+/// Operands that already fit, and all unsigned operands, are returned unchanged.
 fn restore_unfit(value: NumericValue) -> IResult<NumericValue> {
     use value::Fitted::Unfit;
     use value::NumericValue::*;
 
-    let (U8(Unfit(field)) | U16(Unfit(field)) | U32(Unfit(field)) | U64(Unfit(field))
-    | U128(Unfit(field)) | I8(Unfit(field)) | I16(Unfit(field)) | I32(Unfit(field))
-    | I64(Unfit(field))) = value
+    let (I8(Unfit(field)) | I16(Unfit(field)) | I32(Unfit(field)) | I64(Unfit(field))) = value
     else {
         return Ok(value);
     };

--- a/compiler/noirc_evaluator/src/ssa/interpreter/tests/instructions.rs
+++ b/compiler/noirc_evaluator/src/ssa/interpreter/tests/instructions.rs
@@ -149,12 +149,19 @@ fn checked_signed_op_over_unfit_operand_wraps() {
     assert_eq!(value, Value::i32(3));
 }
 
-// Companion to [`checked_signed_op_over_unfit_operand_wraps`] exercising an unfit value that
-// exceeds the type's bit width (so wrapping must truncate modulo `2^bit_size`, not just
-// reinterpret): `unchecked_add u8 200, u8 100` yields 300, which wraps to `u8 44`.
+// Companion to [`checked_signed_op_over_unfit_operand_wraps`] for *unsigned* checked ops, and a
+// regression test for noir-lang/noir-claude#1441.
+//
+// Unlike the signed case, ACIR does not truncate the operand of an unsigned checked op: it keeps it
+// as a field and range-constrains the *result*, so an operand that overflowed/underflowed an
+// earlier unchecked op makes the range check fail and ACIR rejects the program. The interpreter must
+// therefore report the overflow rather than wrap the operand. Wrapping would diverge from ACIR and,
+// for underflow, would not even match Brillig: `0 - 10` carries the field `p - 10`, whose low 8 bits
+// are `247`, not the wrapped `246`.
 #[test]
-fn checked_unsigned_op_over_unfit_operand_wraps() {
-    let value = expect_value(
+fn checked_unsigned_op_over_unfit_operand_errors() {
+    // `unchecked_add u8 200, u8 100` yields 300 (> u8::MAX); the checked add must not wrap to 44.
+    let error = expect_error(
         "
         acir(inline) fn main f0 {
           b0():
@@ -164,7 +171,21 @@ fn checked_unsigned_op_over_unfit_operand_wraps() {
         }
     ",
     );
-    assert_eq!(value, Value::u8(44));
+    assert!(matches!(error, InterpreterError::Overflow { .. }));
+
+    // `unchecked_sub u8 0, u8 10` underflows; the checked add must not wrap (and in particular must
+    // not return `247` from truncating the field `p - 10`).
+    let error = expect_error(
+        "
+        acir(inline) fn main f0 {
+          b0():
+            v0 = unchecked_sub u8 0, u8 10
+            v1 = add v0, u8 0
+            return v1
+        }
+    ",
+    );
+    assert!(matches!(error, InterpreterError::Overflow { .. }));
 }
 
 #[test]


### PR DESCRIPTION
Fixes noir-lang/noir-claude#1441

## Background

[#13142](https://github.com/noir-lang/noir/pull/13142) added `restore_unfit`, which truncates a `Fitted::Unfit` operand to its bit size before checked integer arithmetic in the SSA interpreter, so a checked op over a value that overflowed an earlier unchecked op evaluates consistently with the backends instead of erroring (noir-lang/noir-claude#1430). That PR applied the restoration to **all** integer operands. The follow-up audit found it is only correct for **signed** ops.

## The bug

ACIR lowers checked signed and unsigned arithmetic differently:

- **Signed** checked add/sub/mul are lowered by `expand_signed_checks`, which casts each operand to the unsigned type of the same width — i.e. **truncates the operand** to `bit_size` — before computing. So `restore_unfit` (truncate the operand) matches ACIR.
- **Unsigned** checked add/sub/mul are lowered as field arithmetic with a **range check on the result** (no operand truncation). An operand that overflowed/underflowed an earlier unchecked op leaves the result out of range, so the range check fails and **ACIR rejects the program**.

By truncating unsigned operands too, `restore_unfit` made the interpreter *accept* (with a wrapped value) programs that ACIR rejects. Verified against real ACIR/Brillig execution:

| SSA | ACIR | Brillig | interpreter before this PR |
|---|---|---|---|
| `unchecked_sub u8 0, 10` → `add v, u8 0` | **rejects** | `246` | `247` (matched neither) |
| `unchecked_add u8 200, 100` → `add v, u8 0` | **rejects** | `44` | `44` (matched Brillig, not ACIR) |
| `unchecked_mul i32 MAX, 2` → `add v, i32 0` (#1430) | `-2` | `-2` | `-2` ✓ |

The underflow case was also numerically wrong even versus Brillig: `0 - 10` carries the field `p - 10`, and `(p - 10) mod 2⁸ = 247`, not the wrapped `246`, because `p` is not a multiple of `2^bit_size`.

## The fix

Restrict `restore_unfit` to **signed** operands (`i8`/`i16`/`i32`/`i64`). Unsigned `Unfit` operands are left untouched, so the checked op reports the overflow — matching ACIR's rejection — instead of wrapping. #1430's signed behavior is unchanged.

This keeps the SSA interpreter ACIR-faithful (its existing posture). Making it *also* Brillig-faithful for `brillig` functions (wrap instead of extend, keyed on the function's runtime) is a larger, separate improvement and is not attempted here.

## Testing

- `checked_signed_op_over_unfit_operand_wraps` (from #1430) still passes: baseline and post-`expand_signed_checks` interpretation both return `i32 -2`.
- `checked_unsigned_op_over_unfit_operand_wraps` (added in #13142, which incorrectly asserted `u8 44`) is replaced by `checked_unsigned_op_over_unfit_operand_errors`, covering both the overflow (`200 + 100`) and the #1441 underflow (`0 - 10`) cases, each now expecting an overflow error.
- Full `noirc_evaluator` suite passes; clippy + fmt clean.

## Not source-reachable

As with #1430, this requires hand-written / fuzzer SSA: signed and unsigned `unchecked_sub` underflow into a checked op is not produced by real Noir source (the frontend only emits unchecked ops where it has proven no overflow, and `checked_to_unchecked` only rewrites unsigned subtraction when the lhs is provably ≥ the rhs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
