### PR TITLE
feat(acir_gen): fold predicated constant-index array_set into AcirValue::Array

### DIFF
--- a/compiler/noirc_evaluator/src/acir/arrays.rs
+++ b/compiler/noirc_evaluator/src/acir/arrays.rs
@@ -375,8 +375,8 @@ impl Context<'_> {
                 // the stored element becomes `predicate * value + (1 - predicate) * dummy`: unchanged
                 // when the predicate is false. Folding it into the `AcirValue::Array` this way avoids
                 // initializing a memory block purely to read that dummy back out.
-                let dummy = array[index].clone();
-                let predicated_value = self.convert_array_set_store_value(&store_value, &dummy)?;
+                let predicated_value =
+                    self.convert_array_set_store_value(&store_value, &array[index])?;
                 let value = AcirValue::Array(array.update(index, predicated_value));
                 self.define_result(dfg, instruction, value);
                 Ok(true)

--- a/compiler/noirc_evaluator/src/acir/arrays.rs
+++ b/compiler/noirc_evaluator/src/acir/arrays.rs
@@ -362,9 +362,24 @@ impl Context<'_> {
                 let value = AcirValue::Array(array.update(index, store_value));
                 self.define_result(dfg, instruction, value);
                 Ok(true)
-            } else {
-                // If a predicate is applied however we must wait until runtime.
+            } else if contains_dynamic_array(&store_value) || contains_dynamic_array(&array[index])
+            {
+                // The predicated value mixes the store value with the existing element as a dummy
+                // (see below). We can only do this in-place while both are plain values; if either
+                // side holds a nested dynamic array we'd have to read it back out of a memory block,
+                // so we defer the whole operation to the runtime memory-op path instead.
                 Ok(false)
+            } else {
+                // A predicate is active, but the index is a known in-bounds constant, so we can still
+                // resolve the write at compile time. The existing element acts as the dummy value and
+                // the stored element becomes `predicate * value + (1 - predicate) * dummy`: unchanged
+                // when the predicate is false. Folding it into the `AcirValue::Array` this way avoids
+                // initializing a memory block purely to read that dummy back out.
+                let dummy = array[index].clone();
+                let predicated_value = self.convert_array_set_store_value(&store_value, &dummy)?;
+                let value = AcirValue::Array(array.update(index, predicated_value));
+                self.define_result(dfg, instruction, value);
+                Ok(true)
             }
         } else {
             // If the index is not out of range, we can optimistically perform the read at compile time
@@ -1343,6 +1358,18 @@ pub(super) fn calculate_element_type_sizes_array(
         total_size += element_type_sizes[index % element_types.len()].0;
     }
     flat_elem_type_sizes
+}
+
+/// Returns whether `value` contains an [`AcirValue::DynamicArray`] anywhere within it.
+///
+/// Such values are backed by a memory block rather than being held inline, so they cannot be
+/// folded into another [`AcirValue::Array`] without reading them back out of that block.
+fn contains_dynamic_array(value: &AcirValue) -> bool {
+    match value {
+        AcirValue::Var(_, _) => false,
+        AcirValue::Array(values) => values.iter().any(contains_dynamic_array),
+        AcirValue::DynamicArray(_) => true,
+    }
 }
 
 /// Calculates the total flattened size of an [`AcirValue`].

--- a/compiler/noirc_evaluator/src/acir/tests/arrays.rs
+++ b/compiler/noirc_evaluator/src/acir/tests/arrays.rs
@@ -187,15 +187,8 @@ fn predicated_constant_index_set_folds_without_memory_block() {
     private parameters: [w0, w1, w2, w3]
     public parameters: []
     return values: [w4]
-    INIT b0 = [w0, w1, w2]
     BLACKBOX::RANGE input: w3, bits: 1
-    ASSERT w5 = 0
-    READ w6 = b0[w5]
-    INIT b1 = [w0, w1, w2]
-    ASSERT w7 = w0*w3 - w3*w6 + w3 + w6
-    WRITE b1[w5] = w7
-    READ w8 = b1[w5]
-    ASSERT w4 = w8
+    ASSERT w4 = w0 + w3
     ");
 }
 

--- a/compiler/noirc_evaluator/src/acir/tests/arrays.rs
+++ b/compiler/noirc_evaluator/src/acir/tests/arrays.rs
@@ -160,6 +160,46 @@ fn constant_array_access_in_bounds() {
 }
 
 #[test]
+fn predicated_constant_index_set_folds_without_memory_block() {
+    // An `array_set` at a known in-bounds constant index under a predicate can be resolved at
+    // compile time: the stored element becomes `predicate * value + (1 - predicate) * old`, and a
+    // later constant-index read of the result folds to that element. Neither the set nor the read
+    // should require a memory block, so no `INIT`/`READ`/`WRITE` is emitted — the whole thing
+    // collapses to arithmetic on the input witnesses.
+    let src = "
+    acir(inline) fn main f0 {
+      b0(v0: [Field; 3], v1: u1):
+        v3 = array_get v0, index u32 0 -> Field
+        v5 = add v3, Field 1
+        enable_side_effects v1
+        v6 = array_set v0, index u32 0, value v5
+        enable_side_effects u1 1
+        v7 = array_get v6, index u32 0 -> Field
+        return v7
+    }
+    ";
+    let program = ssa_to_acir_program(src);
+
+    // `w0` is the original `v0[0]`, `w3` the predicate. The folded result is `v1 * (v0[0] + 1) +
+    // (1 - v1) * v0[0]` which simplifies to `v0[0] + v1`, returned directly with no memory ops.
+    assert_circuit_snapshot!(program, @r"
+    func 0
+    private parameters: [w0, w1, w2, w3]
+    public parameters: []
+    return values: [w4]
+    INIT b0 = [w0, w1, w2]
+    BLACKBOX::RANGE input: w3, bits: 1
+    ASSERT w5 = 0
+    READ w6 = b0[w5]
+    INIT b1 = [w0, w1, w2]
+    ASSERT w7 = w0*w3 - w3*w6 + w3 + w6
+    WRITE b1[w5] = w7
+    READ w8 = b1[w5]
+    ASSERT w4 = w8
+    ");
+}
+
+#[test]
 fn generates_memory_op_for_dynamic_read() {
     let src = "
     acir(inline) fn main f0 {


### PR DESCRIPTION
# Description

## Problem

A constant-index `array_set` executed under a predicate was deferred to the runtime memory-op path (`handle_constant_index` returned `Ok(false)` whenever side effects were not unconditionally enabled). That path reads the existing element back out of a memory block to use as the "dummy" value in `predicate * value + (1 - predicate) * dummy`, which forces the otherwise-foldable `AcirValue::Array` to be materialized as a `DynamicArray`. Once promoted, later constant-index reads of the result can no longer fold either, and a non-mutable set additionally copies the whole block.

For example, a struct-of-`Field` array conditionally updated at a few constant offsets and then read once at a constant index ended up with two memory blocks whose only purpose was to serve a single dummy read.

## Summary

Fold the predicated constant-index write at compile time: the existing element acts as the dummy, the stored element becomes `predicate * value + (1 - predicate) * old`, and the result stays an `AcirValue::Array`. This keeps the array inline so later constant-index reads still fold, and avoids initializing a memory block purely to read that dummy back out.

Falls back to the existing runtime path (`contains_dynamic_array` guard) when an element is itself a dynamic array, which would require a block read.

## Effect

The adversarial example collapses from two memory blocks + several read/write opcodes to pure arithmetic on the inputs:

```
BLACKBOX::RANGE input: w1280, bits: 1
ASSERT w1281 = w0 + w1280
BRILLIG CALL func: 0, predicate: 1, inputs: [w1281], outputs: [w1282]
ASSERT 0 = w1281*w1282 - 1
```

## Notes

- Split into a red commit (regression test capturing the pre-fix ACIR with the memory blocks) and a green commit (the fold + updated snapshot), per the repo's snapshot-regression convention.
- Existing predicated snapshots are unchanged: they use dynamic indices, which do not take the constant-index path.

## Additional Context

This is an independent ACIR-gen optimization. It is not stacked on any other branch.

## Documentation

- [x] No documentation needed (internal compiler change).

## PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
