### PR TITLE
fix: check intermediate `use` segment visibility against its declaring module

### DIFF
--- a/compiler/noirc_frontend/src/hir/resolution/import.rs
+++ b/compiler/noirc_frontend/src/hir/resolution/import.rs
@@ -484,6 +484,10 @@ impl<'def_maps, 'usage_tracker, 'references_tracker>
 
             self.add_reference(typ, last_segment.location, last_segment.ident.is_self_type_name());
 
+            // The module `last_segment` is declared in (its visibility is checked against this),
+            // captured before stepping `current_module_id` into the module it refers to.
+            let last_segment_module_id = current_module_id;
+
             // In the type namespace, only a module can be navigated through in a path. A type's
             // associated items (methods, and for enums their variants) can't be imported through
             // it, matching Rust: `use Type::method` is rejected. Such items remain reachable via a
@@ -519,7 +523,7 @@ impl<'def_maps, 'usage_tracker, 'references_tracker>
             };
 
             if !((first_segment_is_always_visible && index == 0)
-                || self.item_in_module_is_visible(current_module_id, visibility))
+                || self.item_in_module_is_visible(last_segment_module_id, visibility))
             {
                 errors.push(PathResolutionError::Private(last_ident.clone()));
             }

--- a/compiler/noirc_frontend/src/tests/visibility.rs
+++ b/compiler/noirc_frontend/src/tests/visibility.rs
@@ -1635,3 +1635,29 @@ fn private_module_is_accessible_from_within_its_parent() {
     "#;
     assert_no_errors(src);
 }
+
+#[test]
+fn use_path_can_access_private_intermediate_module_from_within_its_parent() {
+    // The `use` resolver must apply the same intermediate-segment visibility rule as qualified
+    // paths: a private module is reachable from the module it is declared in. Here `inner` is
+    // private to `outer`, so `use crate::outer::inner::foo;` inside `outer` is valid (the direct
+    // path `crate::outer::inner::foo()` already compiles). This was rejected as "inner is private".
+    let src = r#"
+    mod outer {
+        mod inner {
+            pub fn foo() {}
+        }
+
+        use crate::outer::inner::foo;
+
+        pub fn bar() {
+            foo();
+        }
+    }
+
+    fn main() {
+        outer::bar();
+    }
+    "#;
+    assert_no_errors(src);
+}


### PR DESCRIPTION



## Problem Resolved

Resolves https://github.com/noir-lang/noir-claude/issues/1449

## Summary of Changes

Same fix as https://github.com/noir-lang/noir/pull/13204 but for imports.

Later on I might try to see if path lookups and imports could be unified somehow...

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
