### PR TITLE
chore(ssa): Reject `call` if callee can return alias to array arg and no `inc_rc` exists on input

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/validation/rc_invariant/call.rs
+++ b/compiler/noirc_evaluator/src/ssa/validation/rc_invariant/call.rs
@@ -323,4 +323,87 @@ mod tests {
             "the call argument is a &mut reference, not an array value, so it is not a COW hazard",
         );
     }
+
+    /// Regression for noir-lang/noir-claude#1443. `identity` (`f1`) does not
+    /// mutate its argument, so `callee_may_mutate_args` is `false`; but by
+    /// returning `v0` unchanged it makes the call result `v1` an **alias** of
+    /// `v0`. The caller then `array_set v1` (mutating `v0`'s storage in place at
+    /// RC 1) and reads `v0` afterwards, observing the mutation. The frontend
+    /// would emit an `inc_rc v0` before the call (`v0` is reused), so this SSA
+    /// is malformed. The call verifier must not skip a callee that may return an
+    /// alias of an array input — `returns_arg_alias` — and so flags the reused
+    /// `v0`.
+    #[test]
+    fn end_to_end_callee_returns_input_alias_mutated_by_caller_is_rejected() {
+        let src = r#"
+            brillig(inline) fn main f0 {
+              b0():
+                v0 = make_array [Field 1, Field 2] : [Field; 2]
+                v1 = call f1(v0) -> [Field; 2]
+                v2 = array_set v1, index u32 0, value Field 9
+                v3 = array_get v0, index u32 0 -> Field
+                return v3
+            }
+            brillig(inline) fn identity f1 {
+              b0(v0: [Field; 2]):
+                return v0
+            }"#;
+        assert_verifier_rejects(src);
+    }
+
+    /// The well-formed counterpart of
+    /// [`end_to_end_callee_returns_input_alias_mutated_by_caller_is_rejected`]:
+    /// the `inc_rc v0` the ownership pass emits before the reused call argument
+    /// is present, so the later `array_set` copies rather than mutating `v0` in
+    /// place and the read of `v0` is sound. Accepted.
+    #[test]
+    fn end_to_end_callee_returns_input_alias_with_inc_rc_is_accepted() {
+        let src = r#"
+            brillig(inline) fn main f0 {
+              b0():
+                v0 = make_array [Field 1, Field 2] : [Field; 2]
+                inc_rc v0
+                v1 = call f1(v0) -> [Field; 2]
+                v2 = array_set v1, index u32 0, value Field 9
+                v3 = array_get v0, index u32 0 -> Field
+                return v3
+            }
+            brillig(inline) fn identity f1 {
+              b0(v0: [Field; 2]):
+                return v0
+            }"#;
+        assert_verifier_accepts_because(
+            src,
+            "the reused argument is protected by a preceding inc_rc",
+        );
+    }
+
+    /// Soundness guard for `returns_arg_alias`: a callee that returns a *fresh*
+    /// array (here a foreign-call result, the shape of an oracle wrapper that
+    /// returns an array) does **not** alias its input. Even though the caller
+    /// reuses the argument with no `inc_rc` — which the frontend legitimately
+    /// elides for oracle wrappers — there is no aliasing hazard, so the call
+    /// verifier must skip it and accept. A coarser "returns any array" rule
+    /// would have falsely flagged this.
+    #[test]
+    fn end_to_end_callee_returns_fresh_array_reused_arg_is_accepted() {
+        let src = r#"
+            brillig(inline) fn main f0 {
+              b0():
+                v0 = make_array [Field 1, Field 2] : [Field; 2]
+                v1 = call f1(v0) -> [Field; 2]
+                v2 = array_set v1, index u32 0, value Field 9
+                v3 = array_get v0, index u32 0 -> Field
+                return v3
+            }
+            brillig(inline) fn wrapper f1 {
+              b0(v0: [Field; 2]):
+                v1 = call my_oracle(v0) -> [Field; 2]
+                return v1
+            }"#;
+        assert_verifier_accepts_because(
+            src,
+            "the callee returns a fresh foreign-call result, not an alias of its input",
+        );
+    }
 }

--- a/compiler/noirc_evaluator/src/ssa/validation/rc_invariant/call.rs
+++ b/compiler/noirc_evaluator/src/ssa/validation/rc_invariant/call.rs
@@ -40,11 +40,11 @@ pub(crate) fn verify(ssa: &Ssa) -> RtResult<()> {
     // may mutate one in place, *or* may hand back an alias of one that the
     // caller then mutates (e.g. an identity function — see [#1443]). Either way,
     // reusing the argument without a protecting `inc_rc` is a hazard. Both
-    // summaries cover every function, so we can index them directly.
+    // summaries cover every function, so indexing them is safe (and asserts we
+    // computed a value for every callee).
     //
     // [#1443]: https://github.com/noir-lang/noir-claude/issues/1443
-    let needs_check: HashMap<FunctionId, bool> =
-        ssa.functions.keys().map(|id| (*id, may_mutate[id] || returns_arg_alias[id])).collect();
+    let needs_check = |callee: FunctionId| may_mutate[&callee] || returns_arg_alias[&callee];
 
     for function in ssa.functions.values() {
         verify_function(function, &needs_check)?;
@@ -58,7 +58,7 @@ pub(crate) fn verify(ssa: &Ssa) -> RtResult<()> {
 /// treats each array-typed argument as an all-index in-place mutation and runs
 /// the shared coverage + forward walk: a forward-reachable aliased read with no
 /// protecting `inc_rc` is a hazard.
-fn verify_function(function: &Function, needs_check: &HashMap<FunctionId, bool>) -> RtResult<()> {
+fn verify_function(function: &Function, needs_check: &impl Fn(FunctionId) -> bool) -> RtResult<()> {
     if !function.runtime().is_brillig() {
         return Ok(());
     }
@@ -136,15 +136,15 @@ fn verify_function(function: &Function, needs_check: &HashMap<FunctionId, bool>)
 /// of one. Mirrors `ssa_gen`'s `can_modify_args`: foreign calls only read their
 /// inputs and return fresh results; pure builtins that are safe for clone
 /// elision do neither; an unresolved/dynamic callee is assumed to need
-/// checking; and a known function is looked up in the combined call-graph
-/// summary (`may_mutate || returns_arg_alias`).
+/// checking; and a known function is decided by `needs_check`, which combines
+/// the two call-graph summaries (`may_mutate || returns_arg_alias`).
 fn callee_needs_arg_check(
     function: &Function,
     func: ValueId,
-    needs_check: &HashMap<FunctionId, bool>,
+    needs_check: &impl Fn(FunctionId) -> bool,
 ) -> bool {
     match &function.dfg[func] {
-        Value::Function(callee) => needs_check.get(callee).copied().unwrap_or(true),
+        Value::Function(callee) => needs_check(*callee),
         Value::Intrinsic(intrinsic) => intrinsic_may_mutate_args(*intrinsic),
         Value::ForeignFunction { .. } => false,
         _ => true,
@@ -238,7 +238,7 @@ fn compute_may_mutate_args(ssa: &Ssa) -> HashMap<FunctionId, bool> {
             if may_mutate[&id] {
                 return false;
             }
-            let now = callees[&id].iter().any(|c| may_mutate.get(c).copied().unwrap_or(true));
+            let now = callees[&id].iter().any(|c| may_mutate[c]);
             if now {
                 may_mutate.insert(id, true);
             }

--- a/compiler/noirc_evaluator/src/ssa/validation/rc_invariant/call.rs
+++ b/compiler/noirc_evaluator/src/ssa/validation/rc_invariant/call.rs
@@ -12,14 +12,15 @@
 //! sources, and gated on whether the callee can modify its arguments (mirroring
 //! `can_modify_args` in `ssa_gen`).
 
-use rustc_hash::FxHashMap as HashMap;
+use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 
 use crate::{
     errors::{RtResult, RuntimeError},
     ssa::{
         ir::{
+            basic_block::BasicBlockId,
             function::{Function, FunctionId},
-            instruction::{Instruction, Intrinsic},
+            instruction::{Instruction, Intrinsic, TerminatorInstruction},
             value::{Value, ValueId},
         },
         opt::pure::Purity,
@@ -33,18 +34,31 @@ use super::Context;
 /// `ssa`. See the module docs for the invariant.
 pub(crate) fn verify(ssa: &Ssa) -> RtResult<()> {
     let may_mutate = compute_may_mutate_args(ssa);
+    let returns_arg_alias = compute_returns_arg_alias(ssa);
+
+    // A user-function call must have its array arguments checked if the callee
+    // may mutate one in place, *or* may hand back an alias of one that the
+    // caller then mutates (e.g. an identity function — see [#1443]). Either way,
+    // reusing the argument without a protecting `inc_rc` is a hazard. Both
+    // summaries cover every function, so we can index them directly.
+    //
+    // [#1443]: https://github.com/noir-lang/noir-claude/issues/1443
+    let needs_check: HashMap<FunctionId, bool> =
+        ssa.functions.keys().map(|id| (*id, may_mutate[id] || returns_arg_alias[id])).collect();
+
     for function in ssa.functions.values() {
-        verify_function(function, &may_mutate)?;
+        verify_function(function, &needs_check)?;
     }
     Ok(())
 }
 
 /// Per-function check. Skips ACIR functions (the invariant only applies to
 /// Brillig, where a callee may mutate an argument in place). For every `call`
-/// whose callee may mutate its arguments, treats each array-typed argument as
-/// an all-index in-place mutation and runs the shared coverage + forward walk:
-/// a forward-reachable aliased read with no protecting `inc_rc` is a hazard.
-fn verify_function(function: &Function, may_mutate: &HashMap<FunctionId, bool>) -> RtResult<()> {
+/// whose callee may mutate an argument or return an alias of one (`needs_check`),
+/// treats each array-typed argument as an all-index in-place mutation and runs
+/// the shared coverage + forward walk: a forward-reachable aliased read with no
+/// protecting `inc_rc` is a hazard.
+fn verify_function(function: &Function, needs_check: &HashMap<FunctionId, bool>) -> RtResult<()> {
     if !function.runtime().is_brillig() {
         return Ok(());
     }
@@ -59,12 +73,13 @@ fn verify_function(function: &Function, may_mutate: &HashMap<FunctionId, bool>) 
             };
 
             // Mirror `ssa_gen`'s `can_modify_args`: a callee that provably
-            // cannot mutate its arguments (a foreign call, a pure builtin, or a
-            // non-mutating function) has its argument clones elided by the
-            // ownership pass, so a reused argument legitimately carries no
-            // `inc_rc`. Skipping such calls is what keeps this check from
-            // flagging well-formed SSA.
-            if !callee_may_mutate_args(function, *func, may_mutate) {
+            // cannot mutate an argument *or* hand back an alias of one (a
+            // foreign call, a pure builtin, or a function that neither mutates
+            // an argument nor returns an alias of one) has its argument clones
+            // elided by the ownership pass, so a reused argument legitimately
+            // carries no `inc_rc`. Skipping such calls is what keeps this check
+            // from flagging well-formed SSA.
+            if !callee_needs_arg_check(function, *func, needs_check) {
                 continue;
             }
 
@@ -98,7 +113,8 @@ fn verify_function(function: &Function, may_mutate: &HashMap<FunctionId, bool>) 
                 let message = format!(
                     "call in function {} passes array {arg} that is read again as {} on a \
                      forward path with no preceding `inc_rc`; if the callee mutates the argument \
-                     in place the mutation would be observable through that alias",
+                     in place, or returns an alias of it that is then mutated, the mutation would \
+                     be observable through that alias",
                     function.name(),
                     hit.value,
                 );
@@ -115,18 +131,20 @@ fn verify_function(function: &Function, may_mutate: &HashMap<FunctionId, bool>) 
     Ok(())
 }
 
-/// Whether the callee referenced by `func` may mutate an array argument in a
-/// way observable to the caller. Mirrors `ssa_gen`'s `can_modify_args`:
-/// foreign calls only read their inputs; pure builtins that are safe for clone
-/// elision cannot mutate; an unresolved/dynamic callee is assumed to be able
-/// to; and a known function is looked up in the call-graph summary.
-fn callee_may_mutate_args(
+/// Whether a call to the callee referenced by `func` needs its array arguments
+/// checked — i.e. the callee may mutate an argument in place or return an alias
+/// of one. Mirrors `ssa_gen`'s `can_modify_args`: foreign calls only read their
+/// inputs and return fresh results; pure builtins that are safe for clone
+/// elision do neither; an unresolved/dynamic callee is assumed to need
+/// checking; and a known function is looked up in the combined call-graph
+/// summary (`may_mutate || returns_arg_alias`).
+fn callee_needs_arg_check(
     function: &Function,
     func: ValueId,
-    may_mutate: &HashMap<FunctionId, bool>,
+    needs_check: &HashMap<FunctionId, bool>,
 ) -> bool {
     match &function.dfg[func] {
-        Value::Function(callee) => may_mutate.get(callee).copied().unwrap_or(true),
+        Value::Function(callee) => needs_check.get(callee).copied().unwrap_or(true),
         Value::Intrinsic(intrinsic) => intrinsic_may_mutate_args(*intrinsic),
         Value::ForeignFunction { .. } => false,
         _ => true,
@@ -196,6 +214,147 @@ fn compute_may_mutate_args(ssa: &Ssa) -> HashMap<FunctionId, bool> {
     }
 
     may_mutate
+}
+
+/// Compute, for every function, whether it may return an array value that
+/// aliases one of its array parameters — e.g. an identity function that returns
+/// its input unchanged. Such a call hands the caller an alias of the argument,
+/// so an in-place mutation of the *result* mutates the *argument's* storage; the
+/// call must be checked even when the callee does not itself mutate.
+///
+/// Distinct from "returns any array": a callee that returns a *fresh* array (a
+/// `make_array`, or a foreign/intrinsic-call result — the shape of an oracle
+/// wrapper) is not flagged, so its caller's clone-elided arguments stay
+/// accepted. Propagated to a fixed point over the call graph because the
+/// alias property flows through `Value::Function` call results.
+fn compute_returns_arg_alias(ssa: &Ssa) -> HashMap<FunctionId, bool> {
+    let mut returns_arg_alias: HashMap<FunctionId, bool> =
+        ssa.functions.keys().map(|id| (*id, false)).collect();
+
+    // Monotonic fixed point: a function only ever flips from false to true, and
+    // `function_returns_arg_alias` reads the current map for callee results.
+    let mut changed = true;
+    while changed {
+        changed = false;
+        for function in ssa.functions.values() {
+            if returns_arg_alias[&function.id()] {
+                continue;
+            }
+            if function_returns_arg_alias(function, &returns_arg_alias) {
+                returns_arg_alias.insert(function.id(), true);
+                changed = true;
+            }
+        }
+    }
+
+    returns_arg_alias
+}
+
+/// Whether `function` returns an array value that may alias one of its array
+/// parameters, given the current `returns_arg_alias` summary for resolving
+/// callee results.
+///
+/// Computes the set of *parameter-derived* values to a fixed point: an array
+/// parameter, a block parameter threaded from one, an `array_set` of one, or a
+/// `Value::Function` call result whose callee `returns_arg_alias` and is fed a
+/// parameter-derived argument. `make_array`, foreign-call and intrinsic results
+/// are fresh and stop the trace. The function returns an arg alias iff any
+/// returned value is parameter-derived.
+fn function_returns_arg_alias(
+    function: &Function,
+    returns_arg_alias: &HashMap<FunctionId, bool>,
+) -> bool {
+    let dfg = &function.dfg;
+
+    // Incoming block-parameter arguments per destination block, to thread
+    // parameter-derived-ness across edges.
+    let mut incoming: HashMap<BasicBlockId, Vec<Vec<ValueId>>> = HashMap::default();
+    for block_id in function.reachable_blocks() {
+        match dfg[block_id].terminator() {
+            Some(TerminatorInstruction::Jmp { destination, arguments, .. }) => {
+                incoming.entry(*destination).or_default().push(arguments.clone());
+            }
+            Some(TerminatorInstruction::JmpIf {
+                then_destination,
+                then_arguments,
+                else_destination,
+                else_arguments,
+                ..
+            }) => {
+                incoming.entry(*then_destination).or_default().push(then_arguments.clone());
+                incoming.entry(*else_destination).or_default().push(else_arguments.clone());
+            }
+            _ => {}
+        }
+    }
+
+    // Seed with the function's array-value parameters (entry block parameters).
+    let entry = function.entry_block();
+    let mut param_derived: HashSet<ValueId> = dfg
+        .block_parameters(entry)
+        .iter()
+        .copied()
+        .filter(|&p| dfg.type_of_value(p).is_array())
+        .collect();
+
+    let mut changed = true;
+    while changed {
+        changed = false;
+
+        for block_id in function.reachable_blocks() {
+            // Block parameters fed a parameter-derived argument on some edge.
+            if let Some(edges) = incoming.get(&block_id) {
+                let params = dfg.block_parameters(block_id);
+                for (i, &param) in params.iter().enumerate() {
+                    if param_derived.contains(&param) {
+                        continue;
+                    }
+                    // Check any of the incoming edges for arguments which are derived from function inputs.
+                    let fed = edges
+                        .iter()
+                        .any(|args| args.get(i).is_some_and(|a| param_derived.contains(a)));
+                    if fed {
+                        param_derived.insert(param);
+                        changed = true;
+                    }
+                }
+            }
+
+            for instruction_id in dfg[block_id].instructions() {
+                let propagate = match &dfg[*instruction_id] {
+                    // An array_set result shares the operand's storage.
+                    Instruction::ArraySet { array, .. } => param_derived.contains(array),
+                    // A call result aliases an argument only if the callee
+                    // returns an arg alias and is fed a parameter-derived
+                    // argument. Foreign/intrinsic results are fresh.
+                    Instruction::Call { func, arguments } => match &dfg[*func] {
+                        Value::Function(callee) => {
+                            returns_arg_alias[callee]
+                                && arguments.iter().any(|a| param_derived.contains(a))
+                        }
+                        _ => false,
+                    },
+                    _ => false,
+                };
+                if propagate {
+                    for &result in dfg.instruction_results(*instruction_id) {
+                        if dfg.type_of_value(result).is_array() && param_derived.insert(result) {
+                            changed = true;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // Check if the return block contains a value that was derived from the inputs.
+    function.reachable_blocks().iter().any(|&block_id| {
+        matches!(
+            dfg[block_id].terminator(),
+            Some(TerminatorInstruction::Return { return_values, .. })
+                if return_values.iter().any(|v| param_derived.contains(v))
+        )
+    })
 }
 
 #[cfg(test)]

--- a/compiler/noirc_evaluator/src/ssa/validation/rc_invariant/call.rs
+++ b/compiler/noirc_evaluator/src/ssa/validation/rc_invariant/call.rs
@@ -324,6 +324,12 @@ fn function_returns_arg_alias(
                 let propagate = match &dfg[*instruction_id] {
                     // An array_set result shares the operand's storage.
                     Instruction::ArraySet { array, .. } => param_derived.contains(array),
+                    // A *nested* array_get returns a sub-array that shares the
+                    // source's storage (a brillig array_get on a nested array
+                    // aliases rather than copies). The `is_array` gate on the
+                    // result below restricts this to the nested case — a
+                    // non-nested get yields a scalar and propagates nothing.
+                    Instruction::ArrayGet { array, .. } => param_derived.contains(array),
                     // A call result aliases an argument only if the callee
                     // returns an arg alias and is fed a parameter-derived
                     // argument. Foreign/intrinsic results are fresh.
@@ -564,5 +570,30 @@ mod tests {
             src,
             "the callee returns a fresh foreign-call result, not an alias of its input",
         );
+    }
+
+    /// `returns_arg_alias` must trace through a **nested** `array_get`: a brillig
+    /// `array_get` on a nested array returns a sub-array that *aliases* the
+    /// source's storage (the same "the input was moved" case `pure.rs` models).
+    /// Here `f1` returns `v0[0]`, an alias of its nested-array input; the caller
+    /// `array_set`s that result (mutating the input's storage in place) and then
+    /// reads the input. With no `inc_rc` on the reused argument the verifier must
+    /// reject.
+    #[test]
+    fn end_to_end_callee_returns_nested_array_get_alias_is_rejected() {
+        let src = r#"
+            brillig(inline) fn main f0 {
+              b0(v0: [[u8; 3]; 2]):
+                v1 = call f1(v0) -> [u8; 3]
+                v2 = array_set v1, index u32 0, value u8 9
+                v3 = array_get v0, index u32 0 -> [u8; 3]
+                return v3
+            }
+            brillig(inline) fn nested_identity f1 {
+              b0(v0: [[u8; 3]; 2]):
+                v1 = array_get v0, index u32 0 -> [u8; 3]
+                return v1
+            }"#;
+        assert_verifier_rejects(src);
     }
 }

--- a/compiler/noirc_evaluator/src/ssa/validation/rc_invariant/call.rs
+++ b/compiler/noirc_evaluator/src/ssa/validation/rc_invariant/call.rs
@@ -159,6 +159,22 @@ fn intrinsic_may_mutate_args(intrinsic: Intrinsic) -> bool {
         || !matches!(intrinsic.purity(), Purity::Pure | Purity::PureWithPredicate)
 }
 
+/// Run `update` over every function until a full round makes no change, then
+/// return the final state. `update` receives each function and a mutable
+/// reference to the state, mutates it in place, and returns whether it changed
+/// anything; returning `false` short-circuits a function whose contribution is
+/// already settled. The caller keeps whichever part of the final state it needs.
+fn fixpoint<S>(ssa: &Ssa, mut state: S, mut update: impl FnMut(&Function, &mut S) -> bool) -> S {
+    let mut changed = true;
+    while changed {
+        changed = false;
+        for function in ssa.functions.values() {
+            changed |= update(function, &mut state);
+        }
+    }
+    state
+}
+
 /// Compute, for every function, whether a call to it may mutate the storage of
 /// one of its array arguments observably to the caller.
 ///
@@ -199,21 +215,19 @@ fn compute_may_mutate_args(ssa: &Ssa) -> HashMap<FunctionId, bool> {
         callees.insert(function.id(), calls);
     }
 
-    let mut changed = true;
-    while changed {
-        changed = false;
-        for (&id, callee_ids) in &callees {
-            if may_mutate[&id] {
-                continue;
-            }
-            if callee_ids.iter().any(|c| may_mutate.get(c).copied().unwrap_or(true)) {
-                may_mutate.insert(id, true);
-                changed = true;
-            }
+    // Propagate: a function may-mutate if any callee may-mutate. The pre-built
+    // callee list lets each round avoid re-scanning instruction bodies.
+    fixpoint(ssa, may_mutate, |function, may_mutate| {
+        let id = function.id();
+        if may_mutate[&id] {
+            return false;
         }
-    }
-
-    may_mutate
+        let now = callees[&id].iter().any(|c| may_mutate.get(c).copied().unwrap_or(true));
+        if now {
+            may_mutate.insert(id, true);
+        }
+        now
+    })
 }
 
 /// Compute, for every function, whether it may return an array value that
@@ -228,26 +242,22 @@ fn compute_may_mutate_args(ssa: &Ssa) -> HashMap<FunctionId, bool> {
 /// accepted. Propagated to a fixed point over the call graph because the
 /// alias property flows through `Value::Function` call results.
 fn compute_returns_arg_alias(ssa: &Ssa) -> HashMap<FunctionId, bool> {
-    let mut returns_arg_alias: HashMap<FunctionId, bool> =
+    let returns_arg_alias: HashMap<FunctionId, bool> =
         ssa.functions.keys().map(|id| (*id, false)).collect();
 
     // Monotonic fixed point: a function only ever flips from false to true, and
     // `function_returns_arg_alias` reads the current map for callee results.
-    let mut changed = true;
-    while changed {
-        changed = false;
-        for function in ssa.functions.values() {
-            if returns_arg_alias[&function.id()] {
-                continue;
-            }
-            if function_returns_arg_alias(function, &returns_arg_alias) {
-                returns_arg_alias.insert(function.id(), true);
-                changed = true;
-            }
+    fixpoint(ssa, returns_arg_alias, |function, returns_arg_alias| {
+        let id = function.id();
+        if returns_arg_alias[&id] {
+            return false;
         }
-    }
-
-    returns_arg_alias
+        let now = function_returns_arg_alias(function, returns_arg_alias);
+        if now {
+            returns_arg_alias.insert(id, true);
+        }
+        now
+    })
 }
 
 /// Whether `function` returns an array value that may alias one of its array

--- a/compiler/noirc_evaluator/src/ssa/validation/rc_invariant/call.rs
+++ b/compiler/noirc_evaluator/src/ssa/validation/rc_invariant/call.rs
@@ -255,10 +255,12 @@ fn compute_may_mutate_args(ssa: &Ssa) -> HashMap<FunctionId, bool> {
 /// call must be checked even when the callee does not itself mutate.
 ///
 /// Distinct from "returns any array": a callee that returns a *fresh* array (a
-/// `make_array`, or a foreign/intrinsic-call result — the shape of an oracle
-/// wrapper) is not flagged, so its caller's clone-elided arguments stay
-/// accepted. Propagated to a fixed point over the call graph because the
-/// alias property flows through `Value::Function` call results.
+/// `make_array`, or a foreign-call result — the shape of an oracle wrapper that
+/// returns an array) is not flagged, so its caller's clone-elided arguments stay
+/// accepted. Propagated to a fixed point over the call graph because the alias
+/// property flows through `Value::Function` call results. (Alias-returning
+/// intrinsics such as the vector mutators are left to `may_mutate` — see
+/// [`function_returns_arg_alias`].)
 fn compute_returns_arg_alias(ssa: &Ssa) -> HashMap<FunctionId, bool> {
     // Monotonic fixed point: every function starts `false`; one only ever flips
     // to true, and `function_returns_arg_alias` reads the current map to resolve
@@ -287,10 +289,13 @@ fn compute_returns_arg_alias(ssa: &Ssa) -> HashMap<FunctionId, bool> {
 /// callee results.
 ///
 /// Computes the set of *parameter-derived* values to a fixed point: an array
-/// parameter, a block parameter threaded from one, an `array_set` of one, or a
-/// `Value::Function` call result whose callee `returns_arg_alias` and is fed a
-/// parameter-derived argument. `make_array`, foreign-call and intrinsic results
-/// are fresh and stop the trace. The function returns an arg alias iff any
+/// parameter, a block parameter threaded from one, an `array_set` or nested
+/// `array_get` of one, or a `Value::Function` call result whose callee
+/// `returns_arg_alias` and is fed a parameter-derived argument. `make_array` and
+/// foreign-call results stop the trace (genuinely fresh). Intrinsic results also
+/// stop the trace here — the alias-returning ones
+/// (`unsafe_for_clone_elision_in_brillig`) are instead covered by `may_mutate`,
+/// since calling one sets that flag. The function returns an arg alias iff any
 /// returned value is parameter-derived.
 fn function_returns_arg_alias(
     function: &Function,
@@ -362,9 +367,21 @@ fn function_returns_arg_alias(
                     // result below restricts this to the nested case — a
                     // non-nested get yields a scalar and propagates nothing.
                     Instruction::ArrayGet { array, .. } => param_derived.contains(array),
-                    // A call result aliases an argument only if the callee
-                    // returns an arg alias and is fed a parameter-derived
-                    // argument. Foreign/intrinsic results are fresh.
+                    // A user-function call result aliases an argument only if
+                    // the callee returns an arg alias and is fed a
+                    // parameter-derived argument.
+                    //
+                    // Foreign-call results are genuinely fresh (oracles copy
+                    // across the boundary). Intrinsic results are *not* always
+                    // fresh — the `unsafe_for_clone_elision_in_brillig`
+                    // intrinsics (vector mutators, `str_as_bytes`,
+                    // `array_as_str_unchecked`) return an alias of their input —
+                    // but we deliberately don't trace through them here: calling
+                    // one already makes the function `may_mutate`
+                    // (`intrinsic_may_mutate_args`), so `needs_check` flags it
+                    // via that summary. This pass only has to cover the gap
+                    // `may_mutate` misses: a non-mutating function that passes an
+                    // input straight back.
                     Instruction::Call { func, arguments } => match &dfg[*func] {
                         Value::Function(callee) => {
                             returns_arg_alias[callee]

--- a/compiler/noirc_evaluator/src/ssa/validation/rc_invariant/call.rs
+++ b/compiler/noirc_evaluator/src/ssa/validation/rc_invariant/call.rs
@@ -159,12 +159,24 @@ fn intrinsic_may_mutate_args(intrinsic: Intrinsic) -> bool {
         || !matches!(intrinsic.purity(), Purity::Pure | Purity::PureWithPredicate)
 }
 
-/// Run `update` over every function until a full round makes no change, then
-/// return the final state. `update` receives each function and a mutable
-/// reference to the state, mutates it in place, and returns whether it changed
-/// anything; returning `false` short-circuits a function whose contribution is
-/// already settled. The caller keeps whichever part of the final state it needs.
-fn fixpoint<S>(ssa: &Ssa, mut state: S, mut update: impl FnMut(&Function, &mut S) -> bool) -> S {
+/// Populate per-function state with `init`, then run `update` over every
+/// function until a full round makes no change, and return the final state.
+///
+/// `init` receives each function and a mutable reference to the
+/// default-initialized state to fill in that function's entry. `update`
+/// likewise receives each function and the state, mutates it in place, and
+/// returns whether it changed anything; returning `false` short-circuits a
+/// function whose contribution is already settled. The caller keeps whichever
+/// part of the final state it needs.
+fn fixpoint<S: Default>(
+    ssa: &Ssa,
+    mut init: impl FnMut(&Function, &mut S),
+    mut update: impl FnMut(&Function, &mut S) -> bool,
+) -> S {
+    let mut state = S::default();
+    for function in ssa.functions.values() {
+        init(function, &mut state);
+    }
     let mut changed = true;
     while changed {
         changed = false;
@@ -187,47 +199,53 @@ fn fixpoint<S>(ssa: &Ssa, mut state: S, mut update: impl FnMut(&Function, &mut S
 /// never trips the check on well-formed SSA. Propagated to a fixed point over
 /// the call graph.
 fn compute_may_mutate_args(ssa: &Ssa) -> HashMap<FunctionId, bool> {
-    let mut may_mutate: HashMap<FunctionId, bool> = HashMap::default();
-    let mut callees: HashMap<FunctionId, Vec<FunctionId>> = HashMap::default();
-
-    for function in ssa.functions.values() {
-        let mut base = false;
-        let mut calls = Vec::new();
-        for block_id in function.reachable_blocks() {
-            for instruction_id in function.dfg[block_id].instructions() {
-                match &function.dfg[*instruction_id] {
-                    Instruction::ArraySet { .. } | Instruction::Store { .. } => base = true,
-                    Instruction::Call { func, .. } => match &function.dfg[*func] {
-                        Value::Function(callee) => calls.push(*callee),
-                        Value::Intrinsic(intrinsic) => {
-                            base |= intrinsic_may_mutate_args(*intrinsic);
-                        }
-                        // Foreign calls only read their inputs.
-                        Value::ForeignFunction { .. } => {}
-                        // An unresolved or dynamic callee: assume the worst.
-                        _ => base = true,
-                    },
-                    _ => {}
+    let (may_mutate, _callees) = fixpoint(
+        ssa,
+        // Initialize the state to each function's own (non-propagated) may-mutate flag,
+        // plus its callee list. The callee list, built once by `init`, lets the propagation
+        // rounds avoid re-scanning instruction bodies.
+        |function,
+         (may_mutate, callees): &mut (
+            HashMap<FunctionId, bool>,
+            HashMap<FunctionId, Vec<FunctionId>>,
+        )| {
+            let mut base = false;
+            let mut calls = Vec::new();
+            for block_id in function.reachable_blocks() {
+                for instruction_id in function.dfg[block_id].instructions() {
+                    match &function.dfg[*instruction_id] {
+                        Instruction::ArraySet { .. } | Instruction::Store { .. } => base = true,
+                        Instruction::Call { func, .. } => match &function.dfg[*func] {
+                            Value::Function(callee) => calls.push(*callee),
+                            Value::Intrinsic(intrinsic) => {
+                                base |= intrinsic_may_mutate_args(*intrinsic);
+                            }
+                            // Foreign calls only read their inputs.
+                            Value::ForeignFunction { .. } => {}
+                            // An unresolved or dynamic callee: assume the worst.
+                            _ => base = true,
+                        },
+                        _ => {}
+                    }
                 }
             }
-        }
-        may_mutate.insert(function.id(), base);
-        callees.insert(function.id(), calls);
-    }
-
-    // Propagate: a function may-mutate if any callee may-mutate. The pre-built
-    // callee list lets each round avoid re-scanning instruction bodies.
-    fixpoint(ssa, may_mutate, |function, may_mutate| {
-        let id = function.id();
-        if may_mutate[&id] {
-            return false;
-        }
-        let now = callees[&id].iter().any(|c| may_mutate.get(c).copied().unwrap_or(true));
-        if now {
-            may_mutate.insert(id, true);
-        }
-        now
-    })
+            may_mutate.insert(function.id(), base);
+            callees.insert(function.id(), calls);
+        },
+        // Propagate: a function may-mutate if any callee may-mutate.
+        |function, (may_mutate, callees)| {
+            let id = function.id();
+            if may_mutate[&id] {
+                return false;
+            }
+            let now = callees[&id].iter().any(|c| may_mutate.get(c).copied().unwrap_or(true));
+            if now {
+                may_mutate.insert(id, true);
+            }
+            now
+        },
+    );
+    may_mutate
 }
 
 /// Compute, for every function, whether it may return an array value that
@@ -242,22 +260,26 @@ fn compute_may_mutate_args(ssa: &Ssa) -> HashMap<FunctionId, bool> {
 /// accepted. Propagated to a fixed point over the call graph because the
 /// alias property flows through `Value::Function` call results.
 fn compute_returns_arg_alias(ssa: &Ssa) -> HashMap<FunctionId, bool> {
-    let returns_arg_alias: HashMap<FunctionId, bool> =
-        ssa.functions.keys().map(|id| (*id, false)).collect();
-
-    // Monotonic fixed point: a function only ever flips from false to true, and
-    // `function_returns_arg_alias` reads the current map for callee results.
-    fixpoint(ssa, returns_arg_alias, |function, returns_arg_alias| {
-        let id = function.id();
-        if returns_arg_alias[&id] {
-            return false;
-        }
-        let now = function_returns_arg_alias(function, returns_arg_alias);
-        if now {
-            returns_arg_alias.insert(id, true);
-        }
-        now
-    })
+    // Monotonic fixed point: every function starts `false`; one only ever flips
+    // to true, and `function_returns_arg_alias` reads the current map to resolve
+    // callee results.
+    fixpoint(
+        ssa,
+        |function, returns_arg_alias: &mut HashMap<FunctionId, bool>| {
+            returns_arg_alias.insert(function.id(), false);
+        },
+        |function, returns_arg_alias| {
+            let id = function.id();
+            if returns_arg_alias[&id] {
+                return false;
+            }
+            let now = function_returns_arg_alias(function, returns_arg_alias);
+            if now {
+                returns_arg_alias.insert(id, true);
+            }
+            now
+        },
+    )
 }
 
 /// Whether `function` returns an array value that may alias one of its array

--- a/cspell.json
+++ b/cspell.json
@@ -129,6 +129,7 @@
         "fixarray",
         "fixint",
         "fixmap",
+        "fixpoint",
         "flamegraph",
         "Flamegraph",
         "Flamegraphing",


### PR DESCRIPTION
## Problem Resolved

Resolves https://github.com/noir-lang/noir-claude/issues/1443

## Summary of Changes

Changes `rc_invariant::call` to reject SSA as malformed if:
* there is a `call` with an array argument, and 
* the callee can return an alias to its array argument, and 
* the array is later accessed in the caller (read or write)
* there is no `inc_rc` on the array to protect it

Added a `fixpoint` helper to support the new `compute_returns_arg_alias` and existing `compute_may_mutate_args` functions. 

`compute_returns_arg_alias` traces through the instructions and computes which outputs are derived from inputs. When inspecting a `Call` instruction it looks at the callee to check if it can return an alias, but only for normal functions; intrinsics are redundant with the existing `may_mutate_args` property, which already takes `intrinsic_may_mutate_args` into account.

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
