### PR TITLE
feat: Validate between SSA passes

### DIFF
--- a/compiler/noirc_driver/src/lib.rs
+++ b/compiler/noirc_driver/src/lib.rs
@@ -131,6 +131,11 @@ pub struct CompileOptions {
     #[arg(long, hide = true)]
     pub emit_ssa: bool,
 
+    /// Run the SSA validator after every optimization pass, to catch a pass that produces
+    /// malformed SSA. Intended for debugging and minimizing fuzzing failures.
+    #[arg(long, hide = true)]
+    pub validate_between_passes: bool,
+
     /// Only perform the minimum number of SSA passes.
     ///
     /// The purpose of this is to be able to debug fuzzing failures.
@@ -310,6 +315,7 @@ impl Default for CompileOptions {
             show_contract_fn: None,
             skip_ssa_pass: Vec::new(),
             emit_ssa: false,
+            validate_between_passes: false,
             minimal_ssa: false,
             show_brillig: false,
             show_brillig_opcode_advisories: false,
@@ -387,6 +393,7 @@ impl CompileOptions {
             max_specializations_per_fn: self.max_specializations_per_fn,
             skip_passes: self.skip_ssa_pass.clone(),
             ssa_logging_hide_unchanged: self.hide_unchanged_ssa,
+            validate_between_passes: self.validate_between_passes,
         }
     }
 }

--- a/compiler/noirc_evaluator/src/ssa/builder.rs
+++ b/compiler/noirc_evaluator/src/ssa/builder.rs
@@ -259,7 +259,7 @@ impl<'local> SsaBuilder<'local> {
         if !skip {
             self.ssa = time(&msg, self.print_codegen_timings, || pass(self.ssa))?;
             if self.validate_between_passes {
-                self.ssa = validate_ssa_or_err(self.ssa).map_err(|e| match e {
+                self.ssa = validate_ssa_or_err(self.ssa, false).map_err(|e| match e {
                     RuntimeError::SsaValidationError { message, call_stack } => {
                         RuntimeError::SsaValidationError {
                             message: format!("after '{msg}': {message}"),

--- a/compiler/noirc_evaluator/src/ssa/builder.rs
+++ b/compiler/noirc_evaluator/src/ssa/builder.rs
@@ -8,7 +8,7 @@ use noirc_frontend::monomorphization::ast::Program;
 
 use crate::errors::{RtResult, RuntimeError};
 
-use super::ssa_gen::generate_ssa;
+use super::ssa_gen::{generate_ssa, validate_ssa_or_err};
 use super::{SHOW_INVALID_SSA_ENV_KEY, Ssa, SsaLogging, should_show_invalid_ssa};
 
 type SsaPassResult = RtResult<Ssa>;
@@ -142,6 +142,10 @@ pub struct SsaBuilder<'local> {
     /// List of SSA pass message fragments that we want to skip, for testing purposes.
     skip_passes: Vec<String>,
 
+    /// Whether to run the full SSA validator after each pass, to catch a pass that turns
+    /// well-formed SSA into malformed SSA.
+    validate_between_passes: bool,
+
     /// Providing a file manager is optional - if provided it can be used to print source
     /// locations along with each ssa instructions when debugging.
     files: Option<&'local fm::FileManager>,
@@ -192,6 +196,7 @@ impl<'local> SsaBuilder<'local> {
             files,
             passed: Default::default(),
             skip_passes: Default::default(),
+            validate_between_passes: false,
         }
     }
 
@@ -206,6 +211,11 @@ impl<'local> SsaBuilder<'local> {
 
     pub fn with_skip_passes(mut self, skip_passes: Vec<String>) -> Self {
         self.skip_passes = skip_passes;
+        self
+    }
+
+    pub fn with_validate_between_passes(mut self, validate: bool) -> Self {
+        self.validate_between_passes = validate;
         self
     }
 
@@ -248,6 +258,17 @@ impl<'local> SsaBuilder<'local> {
 
         if !skip {
             self.ssa = time(&msg, self.print_codegen_timings, || pass(self.ssa))?;
+            if self.validate_between_passes {
+                self.ssa = validate_ssa_or_err(self.ssa).map_err(|e| match e {
+                    RuntimeError::SsaValidationError { message, call_stack } => {
+                        RuntimeError::SsaValidationError {
+                            message: format!("after '{msg}': {message}"),
+                            call_stack,
+                        }
+                    }
+                    other => other,
+                })?;
+            }
             Ok(self.print(&msg))
         } else {
             Ok(self)

--- a/compiler/noirc_evaluator/src/ssa/ir/dfg/simplify.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/dfg/simplify.rs
@@ -691,7 +691,7 @@ mod tests {
         ";
         let ssa = Ssa::from_str_simplifying(src).unwrap();
         let ssa = ssa.array_get_optimization();
-        crate::ssa::ssa_gen::validate_ssa(&ssa);
+        crate::ssa::ssa_gen::validate_ssa(&ssa, true);
     }
 
     #[test]

--- a/compiler/noirc_evaluator/src/ssa/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/mod.rs
@@ -167,6 +167,9 @@ pub struct SsaEvaluatorOptions {
 
     /// A list of SSA pass messages to skip, for testing purposes.
     pub skip_passes: Vec<String>,
+
+    /// Run the full SSA validator after each pass, to catch a pass that produces malformed SSA.
+    pub validate_between_passes: bool,
 }
 
 /// Defaults used in tests.
@@ -191,6 +194,7 @@ impl Default for SsaEvaluatorOptions {
             specialization_threshold: DEFAULT_SPECIALIZATION_THRESHOLD,
             max_specializations_per_fn: DEFAULT_MAX_SPECIALIZATIONS_PER_FN,
             skip_passes: Vec::new(),
+            validate_between_passes: false,
         }
     }
 }
@@ -456,7 +460,10 @@ pub fn optimize_ssa_builder_into_acir(
 ) -> Result<ArtifactsAndWarnings, RuntimeError> {
     let ssa_gen_span = span!(Level::TRACE, "ssa_generation");
     let ssa_gen_span_guard = ssa_gen_span.enter();
-    let builder = builder.with_skip_passes(options.skip_passes.clone()).run_passes(passes)?;
+    let builder = builder
+        .with_skip_passes(options.skip_passes.clone())
+        .with_validate_between_passes(options.validate_between_passes)
+        .run_passes(passes)?;
 
     drop(ssa_gen_span_guard);
 

--- a/compiler/noirc_evaluator/src/ssa/parser/into_ssa.rs
+++ b/compiler/noirc_evaluator/src/ssa/parser/into_ssa.rs
@@ -107,7 +107,7 @@ impl Translator {
 
         if validate {
             validate_stated_purities(&ssa, &stated_purities, &stated_purity_spans)?;
-            validate_ssa(&ssa);
+            validate_ssa(&ssa, true);
         }
 
         Ok(ssa)

--- a/compiler/noirc_evaluator/src/ssa/parser/into_ssa.rs
+++ b/compiler/noirc_evaluator/src/ssa/parser/into_ssa.rs
@@ -120,8 +120,12 @@ impl Translator {
     ) -> Result<Self, SsaError> {
         let mut purities = FunctionPurities::default();
 
-        // A FunctionBuilder must be created with a main Function, so here wer remove it
-        // from the parsed SSA to avoid adding it twice later on.
+        // A FunctionBuilder must be created with a main Function, so here we remove it
+        // from the parsed SSA to avoid adding it twice later on. There must be at least one
+        // function; otherwise the input was empty or contained only globals/comments.
+        if parsed_ssa.functions.is_empty() {
+            return Err(SsaError::NoFunctions);
+        }
         let main_function = parsed_ssa.functions.remove(0);
         let main_id = FunctionId::new(0);
         let mut builder = FunctionBuilder::new(main_function.external_name.clone(), main_id);

--- a/compiler/noirc_evaluator/src/ssa/parser/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/parser/mod.rs
@@ -106,6 +106,7 @@ impl Debug for SsaErrorWithSource {
         let span = self.error.span();
 
         let mut byte: usize = 0;
+        let mut printed_error = false;
         for line in self.src.lines() {
             let has_error =
                 byte <= span.start() as usize && span.end() as usize <= byte + line.len();
@@ -122,10 +123,18 @@ impl Debug for SsaErrorWithSource {
                 write!(f, "{}", " ".repeat(offset))?;
                 writeln!(f, "{}", self.error)?;
                 writeln!(f)?;
+                printed_error = true;
             }
 
             byte += line.len() + 1; // "+ 1" for the newline
         }
+
+        // No source line covered the error span (e.g. empty or whitespace-only input); still
+        // surface the message so the failure isn't reported as a blank error.
+        if !printed_error {
+            writeln!(f, "{}", self.error)?;
+        }
+
         Ok(())
     }
 }
@@ -156,6 +165,8 @@ pub(crate) enum SsaError {
         "Function '{function_name}' is declared as `{stated}` but its instructions compute `{computed}`"
     )]
     PurityMismatch { function_name: String, stated: Purity, computed: Purity, span: Span },
+    #[error("The SSA has no functions; expected at least a `main` function")]
+    NoFunctions,
 }
 
 impl SsaError {
@@ -172,6 +183,7 @@ impl SsaError {
             | SsaError::IllegalOffset(identifier, _) => identifier.span,
             SsaError::MismatchedReturnValues { returns, expected: _ } => returns[0].span,
             SsaError::PurityMismatch { span, .. } => *span,
+            SsaError::NoFunctions => Span::initial(),
         }
     }
 }

--- a/compiler/noirc_evaluator/src/ssa/parser/tests.rs
+++ b/compiler/noirc_evaluator/src/ssa/parser/tests.rs
@@ -21,6 +21,20 @@ fn assert_ssa_roundtrip(src: &str) {
 }
 
 #[test]
+fn functionless_input_errors_instead_of_panicking() {
+    // Regression: `into_ssa` used to `remove(0)` the (assumed) `main` function and panic with
+    // "removal index (is 0) should be < len (is 0)" when the parsed SSA had no functions at all,
+    // e.g. when an empty string is piped in from a failed upstream command.
+    for src in ["", "   ", "\n", "// just a comment\n"] {
+        let error = Ssa::from_str(src).err().expect("expected an error, not a panic");
+        assert!(
+            format!("{error:?}").contains("no functions"),
+            "expected a 'no functions' error for {src:?}, got: {error:?}"
+        );
+    }
+}
+
+#[test]
 fn test_empty_acir_function() {
     let src = "
         acir(inline) fn main f0 {

--- a/compiler/noirc_evaluator/src/ssa/ssa_gen/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/ssa_gen/mod.rs
@@ -136,17 +136,18 @@ pub fn generate_ssa(program: Program) -> Result<Ssa, RuntimeError> {
 
     let ssa = function_context.builder.finish();
 
-    validate_ssa_or_err(ssa)
+    validate_ssa_or_err(ssa, true)
 }
 
 /// Run the panicky validation, and try to turn it into a [`RuntimeError`] if it fails.
 ///
 /// On failure the SSA is printed when the `NOIR_SHOW_INVALID_SSA` env var is set.
-pub fn validate_ssa_or_err(ssa: Ssa) -> Result<Ssa, RuntimeError> {
+pub fn validate_ssa_or_err(ssa: Ssa, full: bool) -> Result<Ssa, RuntimeError> {
     // Temporarily take the hook, so we don't get the panic printout.
     let old_hook = std::panic::take_hook();
     std::panic::set_hook(Box::new(|_info| {}));
-    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| validate_ssa(&ssa)));
+    let result =
+        std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| validate_ssa(&ssa, full)));
     std::panic::set_hook(old_hook);
 
     if let Err(payload) = result {
@@ -171,9 +172,9 @@ pub fn validate_ssa_or_err(ssa: Ssa) -> Result<Ssa, RuntimeError> {
     }
 }
 
-pub fn validate_ssa(ssa: &Ssa) {
+pub fn validate_ssa(ssa: &Ssa, full: bool) {
     for function in ssa.functions.values() {
-        validate_function(function, ssa);
+        validate_function(function, ssa, full);
     }
 }
 

--- a/compiler/noirc_evaluator/src/ssa/ssa_gen/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/ssa_gen/mod.rs
@@ -140,7 +140,9 @@ pub fn generate_ssa(program: Program) -> Result<Ssa, RuntimeError> {
 }
 
 /// Run the panicky validation, and try to turn it into a [`RuntimeError`] if it fails.
-fn validate_ssa_or_err(ssa: Ssa) -> Result<Ssa, RuntimeError> {
+///
+/// On failure the SSA is printed when the `NOIR_SHOW_INVALID_SSA` env var is set.
+pub fn validate_ssa_or_err(ssa: Ssa) -> Result<Ssa, RuntimeError> {
     // Temporarily take the hook, so we don't get the panic printout.
     let old_hook = std::panic::take_hook();
     std::panic::set_hook(Box::new(|_info| {}));

--- a/compiler/noirc_evaluator/src/ssa/validation/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/validation/mod.rs
@@ -55,6 +55,17 @@ struct Validator<'f> {
     function: &'f Function,
     ssa: &'f Ssa,
 
+    /// Whether to run the full ruleset (`true`), as for freshly parsed input SSA and fully
+    /// codegen'd SSA, or only the rules that must hold at every point in the pipeline (`false`),
+    /// assuming we started from valid SSA and applied a single pass.
+    ///
+    /// The `false` (between-passes) mode skips rules that generated (and simplified) SSA satisfies
+    /// syntactically but that an optimization pass may legitimately break while staying semantically
+    /// valid — e.g. the narrowing-cast guard: a pass can prove a cast is in range by construction
+    /// without emitting a preceding `truncate`/`range_check` (which in ACIR would cost gates, since
+    /// a `Cast` is free).
+    full: bool,
+
     // State for validating narrowing casts.
     // Range checks are laid down in isolation and can make for safe casts
     // if they occurred before the value being cast to a smaller type.
@@ -67,10 +78,11 @@ struct Validator<'f> {
 }
 
 impl<'f> Validator<'f> {
-    fn new(function: &'f Function, ssa: &'f Ssa) -> Self {
+    fn new(function: &'f Function, ssa: &'f Ssa, full: bool) -> Self {
         Self {
             function,
             ssa,
+            full,
             range_checks: HashMap::default(),
             allocate_element_types: HashMap::default(),
         }
@@ -1136,7 +1148,12 @@ impl<'f> Validator<'f> {
         for block in PostOrder::with_function_from_entry(self.function).into_vec_reverse() {
             for instruction in self.function.dfg[block].instructions() {
                 self.track_allocate_and_check_load_store(*instruction);
-                self.validate_narrowing_cast_invariant(*instruction);
+                // The narrowing-cast guard is a property of generated/simplified SSA; a pass can
+                // produce a cast that's safe by construction without the syntactic guard, so it's
+                // only checked in the full ruleset (see the `full` field).
+                if self.full {
+                    self.validate_narrowing_cast_invariant(*instruction);
+                }
                 self.type_check_instruction(*instruction);
                 self.check_calls_in_unconstrained(*instruction);
                 self.check_calls_in_constrained(*instruction);
@@ -1190,8 +1207,8 @@ impl<'f> Validator<'f> {
 /// Validates that the [Function] is well formed.
 ///
 /// Panics on malformed functions.
-pub(crate) fn validate_function(function: &Function, ssa: &Ssa) {
-    let mut validator = Validator::new(function, ssa);
+pub(crate) fn validate_function(function: &Function, ssa: &Ssa, full: bool) {
+    let mut validator = Validator::new(function, ssa, full);
     validator.run();
 }
 
@@ -2799,7 +2816,7 @@ mod tests {
 
         let ssa = builder.finish();
 
-        Validator::new(&ssa.functions[&main_id], &ssa).run();
+        Validator::new(&ssa.functions[&main_id], &ssa, true).run();
     }
 
     #[test]

--- a/tooling/ast_fuzzer/fuzz/Cargo.toml
+++ b/tooling/ast_fuzzer/fuzz/Cargo.toml
@@ -71,3 +71,10 @@ path = "fuzz_targets/pass_vs_prev.rs"
 test = false
 doc = false
 bench = false
+
+[[bin]]
+name = "valid_after_pass"
+path = "fuzz_targets/valid_after_pass.rs"
+test = false
+doc = false
+bench = false

--- a/tooling/ast_fuzzer/fuzz/fuzz_targets/valid_after_pass.rs
+++ b/tooling/ast_fuzzer/fuzz/fuzz_targets/valid_after_pass.rs
@@ -1,0 +1,12 @@
+//! ```text
+//! cargo +nightly fuzz run valid_after_pass -- -runs=10000 -max_len=1048576 -len_control=0
+//! ```
+#![no_main]
+
+use libfuzzer_sys::arbitrary::Unstructured;
+use libfuzzer_sys::fuzz_target;
+use noir_ast_fuzzer_fuzz::targets::valid_after_pass;
+
+fuzz_target!(|data: &[u8]| {
+    valid_after_pass::fuzz(&mut Unstructured::new(data)).unwrap();
+});

--- a/tooling/ast_fuzzer/fuzz/src/targets/mod.rs
+++ b/tooling/ast_fuzzer/fuzz/src/targets/mod.rs
@@ -7,6 +7,7 @@ pub mod comptime_vs_brillig_nargo;
 pub mod min_vs_full;
 pub mod orig_vs_morph;
 pub mod pass_vs_prev;
+pub mod valid_after_pass;
 
 /// Create a default configuration instance, with some common flags randomized.
 fn default_config(u: &mut Unstructured) -> arbitrary::Result<Config> {

--- a/tooling/ast_fuzzer/fuzz/src/targets/valid_after_pass.rs
+++ b/tooling/ast_fuzzer/fuzz/src/targets/valid_after_pass.rs
@@ -1,0 +1,55 @@
+//! Verify that every SSA pass produces well-formed SSA.
+//!
+//! 1. generate an arbitrary AST
+//! 2. lower it to the initial SSA
+//! 3. run the primary pass pipeline one pass at a time
+//! 4. validate the SSA after each pass
+//!
+//! A failure means some pass turned valid SSA into malformed SSA — e.g. a pass
+//! that produces a `truncate` following a signed-integer `unchecked_sub`, which
+//! [`noirc_evaluator::ssa::ssa_gen::validate_ssa`] rejects. This is a bug
+//! independent of whether the interpreter or the backends happen to cope with it.
+//!
+//! This complements [`super::pass_vs_prev`], which checks that passes preserve
+//! *behavior*; here we check that they preserve *well-formed-ness*. Running the
+//! full validator after every pass is too costly to leave on for every
+//! compilation, but is affordable in a fuzzer.
+use crate::default_ssa_options;
+use arbitrary::Unstructured;
+use color_eyre::eyre;
+use noir_ast_fuzzer::{Config, arb_program};
+use noirc_evaluator::ssa::primary_passes;
+use noirc_evaluator::ssa::ssa_gen;
+
+pub fn fuzz(u: &mut Unstructured) -> eyre::Result<()> {
+    let config = Config { avoid_overflow: u.arbitrary()?, ..Config::default() };
+    let program = arb_program(u, config)?;
+
+    let ssa_options = default_ssa_options();
+    let passes = primary_passes(&ssa_options);
+
+    // `generate_ssa` already validates the initial SSA, so we only check each pass's output.
+    let mut ssa = ssa_gen::generate_ssa(program).expect("failed to generate initial SSA");
+
+    for pass in &passes {
+        ssa = pass.run(ssa).map_err(|e| eyre::eyre!("pass '{}' failed to run: {e}", pass.msg()))?;
+        // Prints the SSA when `NOIR_SHOW_INVALID_SSA` is set.
+        ssa = ssa_gen::validate_ssa_or_err(ssa)
+            .map_err(|e| eyre::eyre!("SSA invalid after '{}': {e}", pass.msg()))?;
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    /// ```ignore
+    /// NOIR_AST_FUZZER_SEED=0x6819c61400001000 \
+    /// RUST_LOG=debug \
+    /// cargo test -p noir_ast_fuzzer_fuzz valid_after_pass
+    /// ```
+    #[test]
+    fn fuzz_with_arbtest() {
+        crate::targets::tests::fuzz_with_arbtest(super::fuzz, 20000);
+    }
+}

--- a/tooling/ast_fuzzer/fuzz/src/targets/valid_after_pass.rs
+++ b/tooling/ast_fuzzer/fuzz/src/targets/valid_after_pass.rs
@@ -45,7 +45,7 @@ fn validate_each_pass(program: &Program) -> eyre::Result<()> {
     for pass in &passes {
         ssa = pass.run(ssa).map_err(|e| eyre::eyre!("pass '{}' failed to run: {e}", pass.msg()))?;
         // Prints the SSA when `NOIR_SHOW_INVALID_SSA` is set.
-        ssa = ssa_gen::validate_ssa_or_err(ssa)
+        ssa = ssa_gen::validate_ssa_or_err(ssa, false)
             .map_err(|e| eyre::eyre!("SSA invalid after '{}': {e}", pass.msg()))?;
     }
 

--- a/tooling/ast_fuzzer/fuzz/src/targets/valid_after_pass.rs
+++ b/tooling/ast_fuzzer/fuzz/src/targets/valid_after_pass.rs
@@ -17,19 +17,30 @@
 use crate::default_ssa_options;
 use arbitrary::Unstructured;
 use color_eyre::eyre;
-use noir_ast_fuzzer::{Config, arb_program};
+use noir_ast_fuzzer::{Config, DisplayAstAsNoir, arb_program};
 use noirc_evaluator::ssa::primary_passes;
 use noirc_evaluator::ssa::ssa_gen;
+use noirc_frontend::monomorphization::ast::Program;
 
 pub fn fuzz(u: &mut Unstructured) -> eyre::Result<()> {
     let config = Config { avoid_overflow: u.arbitrary()?, ..Config::default() };
     let program = arb_program(u, config)?;
 
+    let result = validate_each_pass(&program);
+    if result.is_err() {
+        // Show the AST as Noir so the failure can be replicated with other `nargo` tools.
+        eprintln!("---\nAST:\n{}", DisplayAstAsNoir(&program));
+    }
+    result
+}
+
+fn validate_each_pass(program: &Program) -> eyre::Result<()> {
     let ssa_options = default_ssa_options();
     let passes = primary_passes(&ssa_options);
 
     // `generate_ssa` already validates the initial SSA, so we only check each pass's output.
-    let mut ssa = ssa_gen::generate_ssa(program).expect("failed to generate initial SSA");
+    // Clone so `program` survives for the AST printout on failure.
+    let mut ssa = ssa_gen::generate_ssa(program.clone()).expect("failed to generate initial SSA");
 
     for pass in &passes {
         ssa = pass.run(ssa).map_err(|e| eyre::eyre!("pass '{}' failed to run: {e}", pass.msg()))?;

--- a/tooling/nargo_cli/build.rs
+++ b/tooling/nargo_cli/build.rs
@@ -969,7 +969,10 @@ fn generate_interpret_execution_success_tests(test_file: &mut File, test_data_di
             &test_name,
             &test_dir,
             "interpret",
-            "interpret_execution_success(nargo);",
+            r#"
+            nargo.arg("--validate-between-passes");
+            interpret_execution_success(nargo);
+            "#,
             &MatrixConfig {
                 vary_brillig: !IGNORED_BRILLIG_TESTS.contains(&test_name.as_str()),
                 vary_inliner: true,
@@ -1000,7 +1003,10 @@ fn generate_interpret_execution_failure_tests(test_file: &mut File, test_data_di
             &test_name,
             &test_dir,
             "interpret",
-            "interpret_execution_failure(nargo);",
+            r#"
+            nargo.arg("--validate-between-passes");
+            interpret_execution_failure(nargo);
+            "#,
             &MatrixConfig {
                 vary_brillig: !IGNORED_BRILLIG_TESTS.contains(&test_name.as_str()),
                 ..Default::default()

--- a/tooling/nargo_cli/src/cli/interpret_cmd.rs
+++ b/tooling/nargo_cli/src/cli/interpret_cmd.rs
@@ -166,7 +166,7 @@ pub(crate) fn run(args: InterpretCommand, workspace: Workspace) -> Result<(), Cl
                 .map_err(|e| CliError::Generic(format!("failed to run SSA pass {msg}: {e}")))?;
 
             if ssa_options.validate_between_passes {
-                ssa = validate_ssa_or_err(ssa)
+                ssa = validate_ssa_or_err(ssa, false)
                     .map_err(|e| CliError::Generic(format!("SSA invalid after {msg}: {e}")))?;
             }
 

--- a/tooling/nargo_cli/src/cli/interpret_cmd.rs
+++ b/tooling/nargo_cli/src/cli/interpret_cmd.rs
@@ -19,7 +19,7 @@ use noirc_errors::CustomDiagnostic;
 use noirc_evaluator::ssa::interpreter::InterpreterOptions;
 use noirc_evaluator::ssa::interpreter::value::{NumericValue, Value};
 use noirc_evaluator::ssa::ir::types::{NumericType, Type};
-use noirc_evaluator::ssa::ssa_gen::{Ssa, generate_ssa};
+use noirc_evaluator::ssa::ssa_gen::{Ssa, generate_ssa, validate_ssa_or_err};
 use noirc_evaluator::ssa::{SsaEvaluatorOptions, SsaLogging, primary_passes};
 use noirc_frontend::debug::DebugInstrumenter;
 use noirc_frontend::hir::ParsedFiles;
@@ -164,6 +164,11 @@ pub(crate) fn run(args: InterpretCommand, workspace: Workspace) -> Result<(), Cl
             ssa = ssa_pass
                 .run(ssa)
                 .map_err(|e| CliError::Generic(format!("failed to run SSA pass {msg}: {e}")))?;
+
+            if ssa_options.validate_between_passes {
+                ssa = validate_ssa_or_err(ssa)
+                    .map_err(|e| CliError::Generic(format!("SSA invalid after {msg}: {e}")))?;
+            }
 
             is_ok &= print_and_interpret_ssa(
                 ssa_options,

--- a/tooling/ssa_cli/src/cli/mod.rs
+++ b/tooling/ssa_cli/src/cli/mod.rs
@@ -1,14 +1,31 @@
 use std::io::{IsTerminal, Read};
 use std::path::PathBuf;
 
-use clap::{Args, Parser, Subcommand};
+use clap::{Args, Parser, Subcommand, ValueEnum};
 use color_eyre::eyre::{self, Context, bail};
 use const_format::formatcp;
 use noir_artifact_cli::commands::parse_and_normalize_path;
 use noir_artifact_cli::fs::artifact::write_to_file;
 use noirc_driver::CompileOptions;
 use noirc_errors::{println_to_stderr, println_to_stdout};
-use noirc_evaluator::ssa::{SsaEvaluatorOptions, SsaPass, primary_passes, ssa_gen::Ssa};
+use noirc_evaluator::ssa::{
+    SsaEvaluatorOptions, SsaPass, primary_passes,
+    ssa_gen::{Ssa, validate_ssa_or_err},
+};
+
+/// Which validation ruleset to run on the source SSA.
+#[derive(ValueEnum, Clone, Copy, Debug, Default, PartialEq, Eq)]
+enum ValidationMode {
+    /// Skip validation entirely. Use to test how invalid input behaves.
+    Off,
+    /// Run every rule. Appropriate for hand-written input SSA or fully optimized SSA.
+    #[default]
+    Full,
+    /// Run only the rules that must hold at every point in the pipeline, assuming the SSA is the
+    /// result of applying a pass to already-valid SSA. Use this to validate the output of
+    /// `transform`, so a pass's provably-safe-but-syntactically-unguarded output isn't rejected.
+    AfterPass,
+}
 
 mod interpret_cmd;
 mod transform_cmd;
@@ -36,11 +53,13 @@ struct SsaArgs {
     #[clap(long, short, global = true, value_parser = parse_and_normalize_path)]
     source_path: Option<PathBuf>,
 
-    /// Turn off validation of the source SSA.
+    /// Which validation ruleset to run on the source SSA.
     ///
-    /// This can be used to test how invalid input behaves.
-    #[clap(long, global = true, default_value_t = false)]
-    no_validate: bool,
+    /// `off` skips validation (to test how invalid input behaves); `full` runs every rule;
+    /// `after-pass` runs only the rules that hold between passes, which is
+    /// what you want when validating the output of `transform`.
+    #[clap(long, global = true, value_enum, default_value_t = ValidationMode::Full)]
+    validation_mode: ValidationMode,
 }
 
 #[derive(Subcommand, Clone, Debug)]
@@ -60,7 +79,7 @@ pub(crate) fn start_cli() -> eyre::Result<()> {
 
     let ssa = || {
         let src = read_source(args.source_path)?;
-        parse_ssa(&src, !args.no_validate)
+        parse_ssa(&src, args.validation_mode)
     };
 
     match command {
@@ -120,16 +139,30 @@ fn write_output(output: &str, path: Option<PathBuf>) -> eyre::Result<()> {
 ///
 /// If parsing fails, print errors to `stderr` and return a failure.
 ///
-/// If validation is enabled, any semantic error causes a panic.
-fn parse_ssa(src: &str, validate: bool) -> eyre::Result<Ssa> {
-    let result = if validate { Ssa::from_str(src) } else { Ssa::from_str_no_validation(src) };
-    match result {
-        Ok(ssa) => Ok(ssa),
+/// A semantic error under `Full` or `AfterPass` causes a panic. `mode` selects whether to skip
+/// validation, run the full ruleset, or run only the between-passes subset (see [`ValidationMode`]).
+fn parse_ssa(src: &str, mode: ValidationMode) -> eyre::Result<Ssa> {
+    // Running the full ruleset while parsing gives source-annotated error spans; otherwise parse
+    // without validation and run the chosen ruleset explicitly.
+    let result = if mode == ValidationMode::Full {
+        Ssa::from_str(src)
+    } else {
+        Ssa::from_str_no_validation(src)
+    };
+    let ssa = match result {
+        Ok(ssa) => ssa,
         Err(source_with_errors) => {
             println_to_stderr!("{source_with_errors:?}");
             bail!("Failed to parse the SSA.")
         }
+    };
+
+    if mode == ValidationMode::AfterPass {
+        return validate_ssa_or_err(ssa, false)
+            .wrap_err("SSA failed the between-passes validation");
     }
+
+    Ok(ssa)
 }
 
 /// List of the SSA passes in the primary pipeline, enriched with their "step"

--- a/tooling/ssa_executor/src/compiler.rs
+++ b/tooling/ssa_executor/src/compiler.rs
@@ -42,7 +42,7 @@ pub fn optimize_ssa_into_acir(
         }
     }));
     let result = std::panic::catch_unwind(AssertUnwindSafe(|| {
-        validate_ssa(&ssa);
+        validate_ssa(&ssa, true);
 
         let builder = SsaBuilder::from_ssa(
             ssa,

--- a/tooling/ssa_executor/src/lib.rs
+++ b/tooling/ssa_executor/src/lib.rs
@@ -20,7 +20,7 @@ pub fn execute_ssa(
     let ssa = Ssa::from_str(&ssa);
     match ssa {
         Ok(ssa) => {
-            validate_ssa(&ssa);
+            validate_ssa(&ssa, true);
 
             let compiled_program = compile_from_ssa(ssa, &compile_options);
             match compiled_program {


### PR DESCRIPTION
## Problem Resolved

Inspired by https://github.com/noir-lang/noir/pull/13232#issuecomment-4856800269

https://github.com/noir-lang/noir-claude/issues/1441 adds a test with a handcrafted malformed SSA on which the SSA interpreter didn't work correctly. The SSA was malformed in the sense that the compiler would never generate it, but it wasn't rejected by the SSA validator. The results before and after the `expand_signed_checks` pass were different. 

What was interesting about it was that the SSA produced by the `expand_signed_checks` _would_ be rejected by the SSA validator, which raises the question whether we should reject the input SSA as well. 

We never promised that all SSA passes would produce valid SSA output, however if we pass such SSA to the `ssa_cli` commands then by default they do get validated, unless the `--no-validate` option is used. 

I thought it would be nice to test whether we maintain validity on well-formed input SSA.

### Example

```console
❯ printf '%s\n' 'acir(inline) fn main f0 {
    b0():
      v0 = unchecked_sub i8 0, i8 10
      v1 = add v0, i8 0
      return v1
  }' | cargo run -q -p noir_ssa_cli -- transform --ssa-pass "expand" | cargo run -q -p noir_ssa_cli -- check

thread 'main' panicked at compiler/noirc_evaluator/src/ssa/validation/mod.rs:380:21:
Truncate follows a signed integer-typed unchecked Sub, which may underflow. Use Field arithmetic with an explicit 2^bit_size addition before the Sub to prevent integer underflow, then Truncate the Field result.
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

```

## Summary of Changes

* Add a `valid_after_pass` AST fuzzer target to check that passing an arbitrary AST through SSA passes and validating after each succeeds (it doesn't)
* Add a `--validate-between-passes` option to `CompileOptions` so we can use it with `nargo compile|execute|interpret`
* Replace `--no-validate` with `--validation-mode=off|full|after-pass` in the `noir-ssa-cli`
* Add a `full` flag to the SSA `Validator` that can turn off certain rules that only apply to the initial SSA, but not between passes
* Enable testing with `--validate-betwene-passes` for the integration tests that use the SSA interpreter - it's a natural fit there to validate after each pass, since we also execute after each pass.

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
