### PR TITLE
feat(docs): add Aztec Matomo tracker with consent gating

### DIFF
--- a/docs/src/components/Matomo/matomo.jsx
+++ b/docs/src/components/Matomo/matomo.jsx
@@ -28,6 +28,19 @@ export default function useMatomo() {
   const trackerUrl = `${urlBase}matomo.php`;
   const srcUrl = `${urlBase}matomo.js`;
 
+  // Additional Aztec Labs tracker (site 23) that receives the same events as
+  // the Noir tracker, for cross-domain analytics across the Aztec and Noir
+  // web properties.
+  const azteclabsTrackerUrl = "https://azteclabs.matomo.cloud/matomo.php";
+  const azteclabsSiteId = "23";
+  const crossDomainList = [
+    "*.aztec.network",
+    "*.docs.aztec.network",
+    "*.noir-lang.org",
+    "*.play.aztec-labs.com",
+    "*.testnet.aztec.network",
+  ];
+
   window._paq = window._paq || [];
 
   // Debug logging
@@ -48,10 +61,30 @@ export default function useMatomo() {
   }, []);
 
   useEffect(() => {
+    // Gate all tracking and cookies behind explicit opt-in. Nothing is sent
+    // and no cookies — including the cross-domain visitor id — are set until
+    // consent is granted through the banner.
+    pushInstruction("requireConsent");
     pushInstruction("setTrackerUrl", trackerUrl);
     pushInstruction("setSiteId", getSiteId(env));
     if (env !== "prod") {
       pushInstruction("setSecureCookie", false);
+    }
+
+    // Report to the shared Aztec Labs Matomo instance in addition to the Noir
+    // instance. A single matomo.js dispatches every subsequent _paq command —
+    // consent, trackPageView and the settings above — to both trackers, so the
+    // Aztec Labs tracker is gated by the same consent as the Noir tracker.
+    pushInstruction("addTracker", azteclabsTrackerUrl, azteclabsSiteId);
+    pushInstruction("setDomains", crossDomainList);
+    pushInstruction("enableCrossDomainLinking");
+    pushInstruction("enableLinkTracking");
+
+    // Re-apply a stored opt-in so returning visitors who already accepted are
+    // tracked without seeing the banner again. Refusal or no prior choice
+    // leaves tracking blocked by requireConsent.
+    if (localStorage.getItem("matomoConsent") === "true") {
+      pushInstruction("rememberConsentGiven");
     }
 
     const doc = document;
@@ -74,6 +107,9 @@ export default function useMatomo() {
 
   const optIn = () => {
     pushInstruction("rememberConsentGiven");
+    // Record the page the user opted in on; the initial page view was
+    // suppressed by requireConsent before consent existed.
+    pushInstruction("trackPageView");
     localStorage.setItem("matomoConsent", true);
     setShowBanner(false);
   };


### PR DESCRIPTION
## Summary

Adds the shared Aztec Matomo instance (`azteclabs.matomo.cloud`, site `23`) as a **second tracker alongside** the existing Noir instance (`noirlang.matomo.cloud`), with cross-domain linking across the Aztec and Noir web properties. Reporting to both instances is done with a single `matomo.js` via `addTracker`, so no second script is injected and the page-view logic isn't duplicated.

It also **hard-gates all analytics behind explicit consent**, which the previous setup did not do.

## Changes (all in `docs/src/components/Matomo/matomo.jsx`)

- **Dual tracking** — register `azteclabs` site 23 via `addTracker`; add `setDomains`, `enableCrossDomainLinking`, and `enableLinkTracking`.
- **Consent gating** — push `requireConsent` at bootstrap so nothing is tracked, no cookies are set, and no cross-domain visitor id (`pk_vid`) is created until the user accepts the cookie banner.
- **Returning visitors** — a stored opt-in (`localStorage.matomoConsent === "true"`) is re-applied on load so accepted users aren't re-prompted.
- **Opt-in page view** — accepting now fires `trackPageView`, capturing the landing page whose initial view was suppressed by `requireConsent`.

## Behavior change (please note)

Because Matomo's `_paq` queue fans out to all trackers, the consent gate and the link/cross-domain settings also apply to the **existing Noir tracker**. Net effect: the Noir tracker is now consent-gated (page views are no longer sent before opt-in) and also tracks outbound links. This is stricter/more GDPR-compliant than before, but it does reduce analytics volume from users who never interact with the banner.

## Verification

- No test harness exists for the docs analytics hook (no jest/jsdom in `docs/`), so no automated test was added.
- ESLint / docs build were not run locally (toolchain not installed in the working checkout).
- Manual check: `cd docs && yarn install && yarn dev`, then confirm no `*/matomo.php` requests fire before clicking **I accept**, and that after accepting requests go to **both** `noirlang.matomo.cloud/matomo.php` and `azteclabs.matomo.cloud/matomo.php`.
