### PR TITLE
fix: do not inline in vector ops with dynamic array

### DIFF
--- a/compiler/noirc_evaluator/src/acir/acir_context/mod.rs
+++ b/compiler/noirc_evaluator/src/acir/acir_context/mod.rs
@@ -87,7 +87,9 @@ impl<F: AcirField> AcirContext<F> {
     pub(crate) fn extract_witnesses(&self, inputs: &[AcirValue]) -> Vec<Witness> {
         inputs
             .iter()
-            .flat_map(|value| value.clone().flatten())
+            .flat_map(|value| {
+                value.clone().flatten().expect("ICE: cannot extract witnesses from a dynamic array")
+            })
             .map(|value| {
                 self.vars
                     .get(&value.0)

--- a/compiler/noirc_evaluator/src/acir/arrays.rs
+++ b/compiler/noirc_evaluator/src/acir/arrays.rs
@@ -537,7 +537,10 @@ impl Context<'_> {
             ) => {
                 let dummy_values = dummy_values
                     .into_iter()
-                    .flat_map(|val| val.clone().flatten())
+                    .map(|val| val.clone().flatten())
+                    .collect::<Result<Vec<_>, _>>()?
+                    .into_iter()
+                    .flatten()
                     .map(|(var, typ)| AcirValue::Var(var, typ))
                     .collect::<Vec<_>>();
 

--- a/compiler/noirc_evaluator/src/acir/call/intrinsics/vector_ops.rs
+++ b/compiler/noirc_evaluator/src/acir/call/intrinsics/vector_ops.rs
@@ -15,14 +15,19 @@ use super::Context;
 
 /// Flattens a vector's contents to its scalar vars when they are still known inline.
 ///
-/// Returns `Some` for an [`AcirValue::Array`] (whose elements are held directly) and `None` for an
-/// [`AcirValue::DynamicArray`], which is backed by a memory block and must be read from it. The
-/// result indexes positionally into the vector's flattened memory layout.
+/// Returns `Some` for an [`AcirValue::Array`] whose elements are all held directly, and `None` for
+/// an [`AcirValue::DynamicArray`], which is backed by a memory block and must be read from it. A
+/// `None` is also returned when the outer array holds a nested [`AcirValue::DynamicArray`] element
+/// (which makes [`AcirValue::flatten`] fail), since that element's scalars only exist in the
+/// backing memory block; in that case the whole read falls back to the memory block. The result
+/// indexes positionally into the vector's flattened memory layout.
 fn flattened_inline_source(value: &AcirValue) -> Option<Vec<AcirVar>> {
     match value {
-        AcirValue::Array(_) => {
-            Some(value.clone().flatten().into_iter().map(|(var, _typ)| var).collect())
-        }
+        AcirValue::Array(_) => value
+            .clone()
+            .flatten()
+            .ok()
+            .map(|flat| flat.into_iter().map(|(var, _typ)| var).collect()),
         AcirValue::Var(_, _) | AcirValue::DynamicArray(_) => None,
     }
 }

--- a/compiler/noirc_evaluator/src/acir/mod.rs
+++ b/compiler/noirc_evaluator/src/acir/mod.rs
@@ -338,7 +338,10 @@ impl<'a> Context<'a> {
 
         let return_witnesses: Vec<Witness> = output_values
             .iter()
-            .flat_map(|value| value.clone().flatten())
+            .map(|value| value.clone().flatten())
+            .collect::<Result<Vec<_>, _>>()?
+            .into_iter()
+            .flatten()
             .map(|(value, _)| self.acir_context.var_to_witness(value))
             .collect::<Result<_, _>>()?;
 

--- a/compiler/noirc_evaluator/src/acir/tests/intrinsics.rs
+++ b/compiler/noirc_evaluator/src/acir/tests/intrinsics.rs
@@ -1293,3 +1293,21 @@ fn vector_remove_with_wrong_result_count_is_an_error() {
         "unexpected error message: {message}"
     );
 }
+
+#[test]
+fn vector_pop_back_nested_dynamic_inner_array_regression() {
+    let src = "
+    acir(inline) fn main f0 {
+      b0(v0: u32, v1: Field, v2: Field, v3: Field, v4: Field):
+        v5 = make_array [v1, v2] : [Field; 2]
+        v6 = array_set v5, index v0, value v3
+        v7 = make_array [v3, v4] : [Field; 2]
+        v8 = make_array [v6, v7] : [[Field; 2]]
+        v10, v11, v12 = call vector_pop_back(u32 2, v8) -> (u32, [[Field; 2]], [Field; 2])
+        return v12
+    }
+    ";
+
+    try_ssa_to_acir(src)
+        .expect("nested dynamic arrays inside an inline outer vector should compile");
+}

--- a/compiler/noirc_evaluator/src/acir/types.rs
+++ b/compiler/noirc_evaluator/src/acir/types.rs
@@ -182,16 +182,25 @@ impl AcirValue {
 
     /// Fetch a flat list of ([`AcirVar`], [`AcirType`]).
     ///
-    /// # Panics
-    /// If [`AcirValue::DynamicArray`] is supplied or an inner element of an [`AcirValue::Array`].
-    /// This is because an [`AcirValue::DynamicArray`] is simply a pointer to an array
-    /// and fetching its internal [`AcirValue::Var`] would require laying down opcodes to read its content.
-    /// This method should only be used where dynamic arrays are not a possible type.
-    pub(super) fn flatten(self) -> Vec<(AcirVar, NumericType)> {
+    /// Returns an error if [`AcirValue::DynamicArray`] is supplied or is an inner element of an
+    /// [`AcirValue::Array`]. This is because an [`AcirValue::DynamicArray`] is simply a pointer to
+    /// an array and fetching its internal [`AcirValue::Var`] would require laying down opcodes to
+    /// read its content. This method should only be used where dynamic arrays are not a possible
+    /// type, or where a dynamic array can be handled by falling back to reading its memory block.
+    pub(super) fn flatten(self) -> Result<Vec<(AcirVar, NumericType)>, InternalError> {
         match self {
-            AcirValue::Var(var, typ) => vec![(var, typ)],
-            AcirValue::Array(array) => array.into_iter().flat_map(AcirValue::flatten).collect(),
-            AcirValue::DynamicArray(_) => unimplemented!("Cannot flatten a dynamic array"),
+            AcirValue::Var(var, typ) => Ok(vec![(var, typ)]),
+            AcirValue::Array(array) => {
+                let mut flattened = Vec::new();
+                for value in array {
+                    flattened.extend(value.flatten()?);
+                }
+                Ok(flattened)
+            }
+            AcirValue::DynamicArray(_) => Err(InternalError::General {
+                message: "Cannot flatten a dynamic array".to_string(),
+                call_stack: CallStack::empty(),
+            }),
         }
     }
 }


### PR DESCRIPTION
## Problem Resolved

Resolves [claudebox issue 1459](https://github.com/noir-lang/noir-claude/issues/1459)

## Summary of Changes
No inline source for dynamic arrays, or nested dynamic arrays. 


## User Documentation

Check one:
- [X] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
