### PR TITLE
chore: use config size for poseidon2

### DIFF
--- a/noir_stdlib/src/hash/poseidon2.nr
+++ b/noir_stdlib/src/hash/poseidon2.nr
@@ -1,7 +1,9 @@
 use crate::default::Default;
-use crate::hash::Hasher;
+use crate::hash::{Hasher, POSEIDON2_CONFIG_STATE_SIZE};
 
-global RATE: u32 = 3;
+// Sponge capacity in field elements: It must match the backend's Poseidon2 parameter.
+global CAPACITY: u32 = 1;
+global RATE: u32 = POSEIDON2_CONFIG_STATE_SIZE - CAPACITY;
 
 pub(crate) struct Poseidon2Hasher {
     _state: [Field],
@@ -15,14 +17,15 @@ impl Hasher for Poseidon2Hasher {
     fn finish_ref(&self) -> Field {
         let input_length = self._state.len();
         let iv: Field = (input_length as Field) * 18446744073709551616; // iv = (self._state.len() << 64)
-        let mut state = [0, 0, 0, iv];
+        let mut state = [0; POSEIDON2_CONFIG_STATE_SIZE];
+        state[RATE] = iv;
 
         // These for-loops can run for a dynamic number of iterations, however
         // this is not an issue in practice as this code is only reachable within a `comptime` context
         for i in 0..input_length / RATE {
-            state[0] += self._state[i * RATE];
-            state[1] += self._state[i * RATE + 1];
-            state[2] += self._state[i * RATE + 2];
+            for j in 0..RATE {
+                state[j] += self._state[i * RATE + j];
+            }
             state = super::poseidon2_permutation(state);
         }
 
@@ -48,6 +51,18 @@ impl Default for Poseidon2Hasher {
 mod test {
     use crate::hash::Hasher;
     use super::Poseidon2Hasher;
+
+    // Test the exact output of Poseidon2. This catches any change to the parameters.
+    #[test]
+    unconstrained fn finish_ref_matches_known_digest() {
+        let mut a = Poseidon2Hasher { _state: [].as_vector() };
+        a.write(1);
+        a.write(2);
+        a.write(3);
+        a.write(4);
+        a.write(5);
+        assert(a.finish() == 0x2247be7014a54d17342a7ef677f58d28877780d203860396967f5d0a18d259db);
+    }
 
     // The residual block absorbs the unabsorbed tail elements. If it instead
     // re-absorbed the prefix, mutating the trailing `len % RATE` elements would


### PR DESCRIPTION
## Problem Resolved

Resolves #11064

## Summary of Changes
Small change to use the config size instead of hardcoding the rate, and then use it also for the state in the implementation.
The security parameter is still hardcoded, but I added a test which check an exact output so any change of parameter is caught.

Most of the issue is not relevant anymore, while the parameters are still hardcoded, they are coming from the same config, and the documentation does not advertise configurable parameters.


## User Documentation

Check one:
- [X] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
