### PR TITLE
fix(comptime): array incorrectly displayed as vector

### DIFF
--- a/compiler/noirc_frontend/src/hir/comptime/display.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/display.rs
@@ -863,7 +863,7 @@ fn remove_interned_in_literal(interner: &NodeInterner, literal: Literal) -> Lite
             Literal::Array(remove_interned_in_array_literal(interner, array_literal))
         }
         Literal::Vector(array_literal) => {
-            Literal::Array(remove_interned_in_array_literal(interner, array_literal))
+            Literal::Vector(remove_interned_in_array_literal(interner, array_literal))
         }
         Literal::Bool(_)
         | Literal::Integer(..)

--- a/test_programs/compile_success_empty/regression_1456_vector_expr_display/Nargo.toml
+++ b/test_programs/compile_success_empty/regression_1456_vector_expr_display/Nargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "regression_1456_vector_expr_display"
+type = "bin"
+authors = [""]
+
+[dependencies]

--- a/test_programs/compile_success_empty/regression_1456_vector_expr_display/src/main.nr
+++ b/test_programs/compile_success_empty/regression_1456_vector_expr_display/src/main.nr
@@ -1,0 +1,37 @@
+// Regression test for https://github.com/noir-lang/noir-claude/issues/1456
+//
+// Reflecting a vector literal `@[...]` through `Quoted::as_expr()`, interpolating it into a
+// format string with `f"{expr}"`, and re-lexing via `.quoted_contents()` must preserve the
+// vector spelling `@[...]` rather than lowering it to a fixed-array literal `[...]`. Otherwise
+// the regenerated source takes `[Field; N]` trait dispatch instead of `[Field]` dispatch.
+
+comptime fn unquote(code: Quoted) -> Quoted {
+    code
+}
+
+comptime fn render_expr_to_code(code: Quoted) -> Quoted {
+    let expr = code.as_expr().unwrap();
+    f"{expr}".quoted_contents()
+}
+
+trait Kind {
+    fn kind(self) -> Field;
+}
+impl Kind for [Field] {
+    fn kind(self) -> Field {
+        1
+    }
+}
+impl<let N: u32> Kind for [Field; N] {
+    fn kind(self) -> Field {
+        2
+    }
+}
+
+fn main() {
+    let direct = unquote!(quote { @[1, 2, 3] }).kind();
+    assert(direct == 1);
+
+    let via_generated_source = render_expr_to_code!(quote { @[1, 2, 3] }).kind();
+    assert(via_generated_source == 1);
+}

--- a/tooling/nargo_cli/tests/snapshots/compile_success_empty/regression_1456_vector_expr_display/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_success_empty/regression_1456_vector_expr_display/execute__tests__expanded.snap
@@ -1,0 +1,35 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: expanded_code
+---
+comptime fn unquote(code: Quoted) -> Quoted {
+    code
+}
+
+comptime fn render_expr_to_code(code: Quoted) -> Quoted {
+    let expr: Expr = code.as_expr().unwrap();
+    f"{expr}".quoted_contents()
+}
+
+trait Kind {
+    fn kind(self) -> Field;
+}
+
+impl Kind for [Field] {
+    fn kind(self) -> Field {
+        1_Field
+    }
+}
+
+impl<let N: u32> Kind for [Field; N] {
+    fn kind(self) -> Field {
+        2_Field
+    }
+}
+
+fn main() {
+    let direct: Field = { @[1_Field, 2_Field, 3_Field] }.kind();
+    assert(direct == 1_Field);
+    let via_generated_source: Field = { @[1_Field, 2_Field, 3_Field] }.kind();
+    assert(via_generated_source == 1_Field);
+}


### PR DESCRIPTION
## Problem Resolved

Resolves https://github.com/noir-lang/noir-claude/issues/1456

## Summary of Changes

Fixes a small copy-paste bug where an array was being transformed into a vector.

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
