### PR TITLE
fix: Check return-type size in brillig

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/mod.rs
@@ -482,6 +482,22 @@ pub fn optimize_ssa_builder_into_acir(
         "Brillig Array Get and Set Optimizations",
     )])?;
 
+    // Enforce the return-value element limit on Brillig functions before code generation.
+    // Brillig arrays are allocated using `u32` addressing, so a function returning an array
+    // whose flattened size approaches `u32::MAX` overflows while reserving its memory. Reject
+    // such programs with a proper error here instead of panicking during Brillig generation.
+    //
+    // Functions returning a vector are skipped: a vector's length is only known at runtime, so
+    // its flattened size cannot be derived from the type, and it is not subject to this limit.
+    for func in builder.ssa().functions.values().filter(|func| func.runtime().is_brillig()) {
+        let returns_vector = func.returns().is_some_and(|returns| {
+            returns.iter().any(|value| func.dfg.type_of_value(*value).contains_vector_element())
+        });
+        if !returns_vector {
+            func.dfg.get_num_return_witnesses(func)?;
+        }
+    }
+
     let brillig = time("SSA to Brillig", options.print_codegen_timings, || {
         builder.ssa().to_brillig(&options.brillig_options)
     });

--- a/test_programs/compile_failure/regression_10522/Nargo.toml
+++ b/test_programs/compile_failure/regression_10522/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "regression_10522"
+version = "0.1.0"
+type = "bin"
+authors = [""]
+
+[dependencies]

--- a/test_programs/compile_failure/regression_10522/src/main.nr
+++ b/test_programs/compile_failure/regression_10522/src/main.nr
@@ -1,0 +1,12 @@
+type BigArray = [Field; 4294967295];
+
+#[oracle(void_to_array)]
+unconstrained fn void_to_array_oracle() -> BigArray {}
+
+unconstrained fn void_to_array() -> BigArray {
+    void_to_array_oracle()
+}
+
+unconstrained fn main() -> pub BigArray {
+    void_to_array()
+}

--- a/tooling/nargo_cli/tests/snapshots/compile_failure/regression_10522/execute__tests__stderr.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_failure/regression_10522/execute__tests__stderr.snap
@@ -1,0 +1,15 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: stderr
+---
+error: The return value has 4294967295 elements which exceeds the limit of 16777216
+   ┌─ src/main.nr:11:5
+   │
+11 │     void_to_array()
+   │     ---------------
+   │
+   = Call stack:
+     1: main
+             at src/main.nr:11:5
+
+Aborting due to 1 previous error

--- a/tooling/nargo_cli/tests/snapshots/compile_failure/regression_10524/execute__tests__stderr.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_failure/regression_10524/execute__tests__stderr.snap
@@ -3,15 +3,13 @@ source: tooling/nargo_cli/tests/execute.rs
 expression: stderr
 ---
 error: The return value has 4294967294 elements which exceeds the limit of 16777216
-   ┌─ src/main.nr:13:5
-   │  
-13 │ ╭     unsafe {
-14 │ │         void_to_array()
-15 │ │     }
-   │ ╰─────'
-   │  
-   = Call stack:
-     1: main
-             at src/main.nr:13:5
+  ┌─ src/main.nr:9:5
+  │
+9 │     void_to_array_oracle()
+  │     ----------------------
+  │
+  = Call stack:
+    1: void_to_array
+            at src/main.nr:9:5
 
 Aborting due to 1 previous error


### PR DESCRIPTION
## Problem Resolved

Resolves #10522

## Summary of Changes

Apply the existing brillig return-type size check before we actually convert to brillig so we don't potentially panic.

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
