### PR TITLE
fix: Check that arrays in the ABI do not exceed the witness size limit

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/ir/dfg.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/dfg.rs
@@ -177,11 +177,10 @@ impl From<GlobalsGraph> for DataFlowGraph {
 }
 
 /// Maximum number of elements allowed for return values, or for some arrays.
-/// This limit prevents hangings or out-of-memory issues when dealing with very large arrays.
-/// 2^24 = 16,777,216 witnesses.
-/// In practice, the number of witnesses is limited by the CRS size, which is usually around 2^20.
-/// So this limit should not interfere with real use cases.
-pub(crate) const MAX_ELEMENTS: usize = 1 << 24;
+///
+/// Defined in `noirc_frontend` alongside the entry point input-size check that shares it;
+/// see [`MAX_ELEMENTS`] for the full rationale.
+pub(crate) use noirc_frontend::monomorphization::ast::MAX_ELEMENTS;
 
 impl DataFlowGraph {
     /// Runtime type of the function.

--- a/compiler/noirc_frontend/src/monomorphization/ast.rs
+++ b/compiler/noirc_frontend/src/monomorphization/ast.rs
@@ -570,6 +570,18 @@ pub enum Type {
     ),
 }
 
+/// Maximum number of flattened field elements allowed at an entry point boundary,
+/// i.e. for a parameter or a return value.
+///
+/// This limit prevents hangs or out-of-memory issues when dealing with very large arrays:
+/// flattened sizes approaching `u32::MAX` cannot be represented, since Brillig arrays are
+/// heap-allocated using `u32` addressing and ACIR/data-bus construction reserves one witness
+/// per flattened element.
+///
+/// 2^24 = 16,777,216 witnesses. In practice the number of witnesses is limited by the CRS size,
+/// which is usually around 2^20, so this limit should not interfere with real use cases.
+pub const MAX_ELEMENTS: usize = 1 << 24;
+
 impl Type {
     pub fn flatten(&self) -> Vec<Type> {
         match self {

--- a/compiler/noirc_frontend/src/monomorphization/errors.rs
+++ b/compiler/noirc_frontend/src/monomorphization/errors.rs
@@ -34,6 +34,7 @@ pub enum MonomorphizationError {
     ReferenceParameterToOracle { typ: String, location: Location },
     VectorWithNestedArrayReturnedFromOracle { typ: String, location: Location },
     InvalidTypeForEntryPoint { invalid_type: InvalidType, location: Location },
+    InputLimitExceeded { num_elements: u64, max_elements: u64, location: Location },
     ComplexType { complexity: usize, max_complexity: usize, location: Location },
     CannotUseFunctionAsValue { name: String, location: Location },
     GlobalContainsFunctionPointer { typ: String, location: Location },
@@ -74,6 +75,7 @@ impl MonomorphizationError {
             | MonomorphizationError::ReferenceParameterToOracle { location, .. }
             | MonomorphizationError::VectorWithNestedArrayReturnedFromOracle { location, .. }
             | MonomorphizationError::InvalidTypeForEntryPoint { location, .. }
+            | MonomorphizationError::InputLimitExceeded { location, .. }
             | MonomorphizationError::ComplexType { location, .. }
             | MonomorphizationError::CannotUseFunctionAsValue { location, .. }
             | MonomorphizationError::GlobalContainsFunctionPointer { location, .. }
@@ -229,6 +231,11 @@ impl From<MonomorphizationError> for CustomDiagnostic {
                 diagnostic.add_note("Note: vectors, references, empty arrays, empty strings, or any type containing them may not be used in main, contract functions, test functions, fuzz functions or foldable functions.".to_string());
                 invalid_type.add_to_diagnostic(*location, &mut diagnostic);
                 return diagnostic;
+            }
+            MonomorphizationError::InputLimitExceeded { num_elements, max_elements, .. } => {
+                format!(
+                    "An input parameter has {num_elements} elements which exceeds the limit of {max_elements}"
+                )
             }
             MonomorphizationError::ComplexType { complexity, max_complexity, location } => {
                 let message = format!(

--- a/compiler/noirc_frontend/src/monomorphization/errors.rs
+++ b/compiler/noirc_frontend/src/monomorphization/errors.rs
@@ -35,6 +35,7 @@ pub enum MonomorphizationError {
     VectorWithNestedArrayReturnedFromOracle { typ: String, location: Location },
     InvalidTypeForEntryPoint { invalid_type: InvalidType, location: Location },
     InputLimitExceeded { num_elements: u64, max_elements: u64, location: Location },
+    ReturnLimitExceeded { num_elements: u64, max_elements: u64, location: Location },
     ComplexType { complexity: usize, max_complexity: usize, location: Location },
     CannotUseFunctionAsValue { name: String, location: Location },
     GlobalContainsFunctionPointer { typ: String, location: Location },
@@ -76,6 +77,7 @@ impl MonomorphizationError {
             | MonomorphizationError::VectorWithNestedArrayReturnedFromOracle { location, .. }
             | MonomorphizationError::InvalidTypeForEntryPoint { location, .. }
             | MonomorphizationError::InputLimitExceeded { location, .. }
+            | MonomorphizationError::ReturnLimitExceeded { location, .. }
             | MonomorphizationError::ComplexType { location, .. }
             | MonomorphizationError::CannotUseFunctionAsValue { location, .. }
             | MonomorphizationError::GlobalContainsFunctionPointer { location, .. }
@@ -235,6 +237,11 @@ impl From<MonomorphizationError> for CustomDiagnostic {
             MonomorphizationError::InputLimitExceeded { num_elements, max_elements, .. } => {
                 format!(
                     "An input parameter has {num_elements} elements which exceeds the limit of {max_elements}"
+                )
+            }
+            MonomorphizationError::ReturnLimitExceeded { num_elements, max_elements, .. } => {
+                format!(
+                    "The return value has {num_elements} elements which exceeds the limit of {max_elements}"
                 )
             }
             MonomorphizationError::ComplexType { complexity, max_complexity, location } => {

--- a/compiler/noirc_frontend/src/monomorphization/mod.rs
+++ b/compiler/noirc_frontend/src/monomorphization/mod.rs
@@ -194,14 +194,6 @@ type CanonicalBindings = Vec<(TypeVariableId, HirType)>;
 
 const MAX_TYPE_COMPLEXITY: usize = 100_000;
 
-/// Maximum number of field elements an entry point parameter may flatten into.
-///
-/// This mirrors the return-value limit (`MAX_ELEMENTS`) enforced in `noirc_evaluator`: inputs
-/// whose flattened size approaches `u32::MAX` cannot be represented, since Brillig arrays are
-/// heap-allocated using `u32` addressing and data-bus/ACIR construction reserves one slot per
-/// flattened element. Rejecting them here produces a clean error before those later stages.
-const MAX_ENTRY_POINT_FIELD_COUNT: u64 = 1 << 24;
-
 /// Number of field elements needed to represent `typ` as a flattened entry point parameter.
 ///
 /// Computed with saturating `u64` arithmetic so that sizes beyond `u32::MAX` are reported as a
@@ -700,14 +692,15 @@ impl<'interner> Monomorphizer<'interner> {
         let is_entry_point =
             (!self.force_unconstrained && inline_type.is_entry_point()) || id == Program::main_id();
         if is_entry_point {
+            let max_elements = ast::MAX_ELEMENTS as u64;
             for (pattern, typ, _visibility) in &func_parameters.0 {
                 let location = pattern.location();
                 let num_elements =
                     entry_point_field_count_saturating(&Self::convert_type(typ, location)?);
-                if num_elements > MAX_ENTRY_POINT_FIELD_COUNT {
+                if num_elements > max_elements {
                     return Err(MonomorphizationError::InputLimitExceeded {
                         num_elements,
-                        max_elements: MAX_ENTRY_POINT_FIELD_COUNT,
+                        max_elements,
                         location,
                     });
                 }

--- a/compiler/noirc_frontend/src/monomorphization/mod.rs
+++ b/compiler/noirc_frontend/src/monomorphization/mod.rs
@@ -194,6 +194,38 @@ type CanonicalBindings = Vec<(TypeVariableId, HirType)>;
 
 const MAX_TYPE_COMPLEXITY: usize = 100_000;
 
+/// Maximum number of field elements an entry point parameter may flatten into.
+///
+/// This mirrors the return-value limit (`MAX_ELEMENTS`) enforced in `noirc_evaluator`: inputs
+/// whose flattened size approaches `u32::MAX` cannot be represented, since Brillig arrays are
+/// heap-allocated using `u32` addressing and data-bus/ACIR construction reserves one slot per
+/// flattened element. Rejecting them here produces a clean error before those later stages.
+const MAX_ENTRY_POINT_FIELD_COUNT: u64 = 1 << 24;
+
+/// Number of field elements needed to represent `typ` as a flattened entry point parameter.
+///
+/// Computed with saturating `u64` arithmetic so that sizes beyond `u32::MAX` are reported as a
+/// clean limit error rather than overflowing: [`ast::Type::entry_point_field_count`] panics on
+/// `u32` overflow. Types that cannot appear as entry point parameters contribute nothing; they
+/// are rejected separately by the entry point validity checks.
+fn entry_point_field_count_saturating(typ: &ast::Type) -> u64 {
+    match typ {
+        ast::Type::Field | ast::Type::Integer(..) | ast::Type::Bool => 1,
+        ast::Type::Array(length, element) => {
+            u64::from(*length).saturating_mul(entry_point_field_count_saturating(element))
+        }
+        ast::Type::String(length) => u64::from(*length),
+        ast::Type::Tuple(fields) => {
+            fields.iter().map(entry_point_field_count_saturating).fold(0, u64::saturating_add)
+        }
+        ast::Type::FmtString(..)
+        | ast::Type::Unit
+        | ast::Type::Vector(_)
+        | ast::Type::Reference(..)
+        | ast::Type::Function(..) => 0,
+    }
+}
+
 /// Starting from the given `main` function, monomorphize the entire program,
 /// replacing all references to type variables and `NamedGenerics` with concrete
 /// types, duplicating definitions as necessary to do so.
@@ -658,6 +690,27 @@ impl<'interner> Monomorphizer<'interner> {
                     invalid_type,
                     location,
                 });
+            }
+        }
+
+        // Reject entry point parameters whose flattened size exceeds the limit. Enforcing it here
+        // fails fast before data-bus construction and Brillig array allocation, which assume the
+        // flattened size is `u32`-representable. `is_entry_point` is only finalized in
+        // `into_program`, so recompute the same condition here.
+        let is_entry_point =
+            (!self.force_unconstrained && inline_type.is_entry_point()) || id == Program::main_id();
+        if is_entry_point {
+            for (pattern, typ, _visibility) in &func_parameters.0 {
+                let location = pattern.location();
+                let num_elements =
+                    entry_point_field_count_saturating(&Self::convert_type(typ, location)?);
+                if num_elements > MAX_ENTRY_POINT_FIELD_COUNT {
+                    return Err(MonomorphizationError::InputLimitExceeded {
+                        num_elements,
+                        max_elements: MAX_ENTRY_POINT_FIELD_COUNT,
+                        location,
+                    });
+                }
             }
         }
 

--- a/compiler/noirc_frontend/src/monomorphization/mod.rs
+++ b/compiler/noirc_frontend/src/monomorphization/mod.rs
@@ -705,6 +705,18 @@ impl<'interner> Monomorphizer<'interner> {
                     });
                 }
             }
+
+            let num_elements = entry_point_field_count_saturating(&Self::convert_type(
+                return_target_type,
+                return_type_location,
+            )?);
+            if num_elements > max_elements {
+                return Err(MonomorphizationError::ReturnLimitExceeded {
+                    num_elements,
+                    max_elements,
+                    location: return_type_location,
+                });
+            }
         }
 
         // If `convert_type` fails here it is most likely because of generics at the

--- a/compiler/noirc_frontend/src/tests.rs
+++ b/compiler/noirc_frontend/src/tests.rs
@@ -8,6 +8,7 @@ mod bound_checks;
 mod cast;
 mod control_flow;
 mod deeply_nested;
+mod entry_point_size;
 mod enums;
 mod expand;
 mod expressions;

--- a/compiler/noirc_frontend/src/tests/entry_point_size.rs
+++ b/compiler/noirc_frontend/src/tests/entry_point_size.rs
@@ -1,0 +1,66 @@
+//! Tests for the flattened-size limit enforced on entry point parameters during
+//! monomorphization. Inputs whose flattened field count exceeds the limit are rejected
+//! here so that later stages (data-bus construction, Brillig array allocation) don't have
+//! to cope with sizes that approach `u32::MAX`.
+
+use crate::test_utils::get_monomorphized;
+use crate::tests::check_monomorphization_error;
+
+#[test]
+fn rejects_large_array_input_to_main() {
+    let src = r#"
+    fn main(_arr: [Field; 4294967295]) {}
+            ^^^^ An input parameter has 4294967295 elements which exceeds the limit of 16777216
+    "#;
+    check_monomorphization_error(src);
+}
+
+#[test]
+fn rejects_large_array_input_to_unconstrained_main() {
+    let src = r#"
+    unconstrained fn main(_arr: [Field; 4294967295]) {}
+                          ^^^^ An input parameter has 4294967295 elements which exceeds the limit of 16777216
+    "#;
+    check_monomorphization_error(src);
+}
+
+/// A nested array whose element product overflows `u32` must produce a clean error rather
+/// than panicking in the `u32`-based `Type::entry_point_field_count`.
+#[test]
+fn rejects_nested_array_input_overflowing_u32() {
+    // 65536 * 65536 == 2^32 == 4294967296, which overflows u32.
+    let src = r#"
+    fn main(_arr: [[Field; 65536]; 65536]) {}
+            ^^^^ An input parameter has 4294967296 elements which exceeds the limit of 16777216
+    "#;
+    check_monomorphization_error(src);
+}
+
+/// The limit applies to the whole flattened parameter, so an aggregate that individually
+/// stays small but sums past the limit is still rejected.
+#[test]
+fn rejects_tuple_input_containing_large_array() {
+    // 4294967295 elements for the array + 1 for the trailing Field.
+    let src = r#"
+    fn main(_input: ([Field; 4294967295], Field)) {}
+            ^^^^^^ An input parameter has 4294967296 elements which exceeds the limit of 16777216
+    "#;
+    check_monomorphization_error(src);
+}
+
+#[test]
+fn accepts_array_input_at_the_limit() {
+    let src = r#"
+    fn main(_arr: [Field; 16777216]) {}
+    "#;
+    assert!(get_monomorphized(src).is_ok(), "an input of exactly the limit should be accepted");
+}
+
+#[test]
+fn rejects_array_input_just_over_the_limit() {
+    let src = r#"
+    fn main(_arr: [Field; 16777217]) {}
+            ^^^^ An input parameter has 16777217 elements which exceeds the limit of 16777216
+    "#;
+    check_monomorphization_error(src);
+}

--- a/compiler/noirc_frontend/src/tests/entry_point_size.rs
+++ b/compiler/noirc_frontend/src/tests/entry_point_size.rs
@@ -3,7 +3,7 @@
 //! here so that later stages (data-bus construction, Brillig array allocation) don't have
 //! to cope with sizes that approach `u32::MAX`.
 
-use crate::test_utils::get_monomorphized;
+use crate::test_utils::{get_monomorphized, get_monomorphized_with_stdlib, stdlib_src};
 use crate::tests::check_monomorphization_error;
 
 #[test]
@@ -97,4 +97,45 @@ fn accepts_array_return_at_the_limit() {
     }
     "#;
     assert!(get_monomorphized(src).is_ok(), "a return of exactly the limit should be accepted");
+}
+
+/// The check only fires for the entry points that monomorphization marks as such: `main` and
+/// fold functions. A generic `unconstrained` function called from ACIR becomes a Brillig entry
+/// point per instantiation (here `mk_array::<10>` and `mk_array::<4294967295>`), with `N` only
+/// known at monomorphization — yet it is a plain `brillig(inline)` function, not flagged as an
+/// entry point, so its oversized return is NOT rejected here. It would fail later during codegen.
+///
+/// `zeroed()` produces the array without materializing a literal, so the test isolates the
+/// return-type boundary from the separate interior-allocation gap.
+#[test]
+fn generic_unconstrained_entry_point_return_is_not_checked() {
+    let src = r#"
+    unconstrained fn mk_array<let N: u32>() -> [u64; N] {
+        zeroed()
+    }
+    fn main() {
+        // Safety: test
+        let _a = unsafe { mk_array::<10>() };
+        // Safety: test
+        let _b = unsafe { mk_array::<4294967295>() };
+    }
+    "#;
+    let result = get_monomorphized_with_stdlib(src, &[stdlib_src::ZEROED]);
+    assert!(result.is_ok(), "generic Brillig entry point return is not rejected: {result:?}");
+}
+
+/// A non-entry Brillig function returning a huge array is an interior allocation, not a circuit
+/// boundary, so it is NOT rejected by this check (it would fail later during Brillig codegen).
+#[test]
+fn non_entry_brillig_return_is_not_checked() {
+    let src = r#"
+    unconstrained fn helper() -> [u64; 4294967295] {
+        zeroed()
+    }
+    unconstrained fn main() {
+        let _ = helper();
+    }
+    "#;
+    let result = get_monomorphized_with_stdlib(src, &[stdlib_src::ZEROED]);
+    assert!(result.is_ok(), "non-entry Brillig return is not rejected: {result:?}");
 }

--- a/compiler/noirc_frontend/src/tests/entry_point_size.rs
+++ b/compiler/noirc_frontend/src/tests/entry_point_size.rs
@@ -64,3 +64,37 @@ fn rejects_array_input_just_over_the_limit() {
     "#;
     check_monomorphization_error(src);
 }
+
+/// The same limit applies to the circuit's output (return value), independent of whether the
+/// program is ACIR or Brillig.
+#[test]
+fn rejects_large_array_return_from_main() {
+    let src = r#"
+    fn main() -> pub [Field; 4294967295] {
+                     ^^^^^^^^^^^^^^^^^^^ The return value has 4294967295 elements which exceeds the limit of 16777216
+        [0; 4294967295]
+    }
+    "#;
+    check_monomorphization_error(src);
+}
+
+#[test]
+fn rejects_large_array_return_from_unconstrained_main() {
+    let src = r#"
+    unconstrained fn main() -> pub [Field; 4294967295] {
+                                   ^^^^^^^^^^^^^^^^^^^ The return value has 4294967295 elements which exceeds the limit of 16777216
+        [0; 4294967295]
+    }
+    "#;
+    check_monomorphization_error(src);
+}
+
+#[test]
+fn accepts_array_return_at_the_limit() {
+    let src = r#"
+    unconstrained fn main() -> pub [Field; 16777216] {
+        [0; 16777216]
+    }
+    "#;
+    assert!(get_monomorphized(src).is_ok(), "a return of exactly the limit should be accepted");
+}

--- a/tooling/nargo_cli/tests/snapshots/compile_failure/regression_10524/execute__tests__stderr.snap
+++ b/tooling/nargo_cli/tests/snapshots/compile_failure/regression_10524/execute__tests__stderr.snap
@@ -3,15 +3,10 @@ source: tooling/nargo_cli/tests/execute.rs
 expression: stderr
 ---
 error: The return value has 4294967294 elements which exceeds the limit of 16777216
-   ┌─ src/main.nr:13:5
-   │  
-13 │ ╭     unsafe {
-14 │ │         void_to_array()
-15 │ │     }
-   │ ╰─────'
-   │  
-   = Call stack:
-     1: main
-             at src/main.nr:13:5
+   ┌─ src/main.nr:12:18
+   │
+12 │ fn main() -> pub BigArray {
+   │                  --------
+   │
 
 Aborting due to 1 previous error


### PR DESCRIPTION
## Problem Resolved

While reviewing #13250 I noticed that if we use `BigArray` as an input, the compiler hangs. It happened to want to allocate a `Vec` with 4 billion elements in SSA-gen for the databus visibility.

## Summary of Changes

Check during monomorphization that none of the entry-point input/output parameters would generate more witnesses than what #11279 allowed for results.

This does not include internal call boundaries, for example:
* an `unconstrained` helper function called from another `unconstrained` one: these would probably be inlined and become internal allocations
* an `unconstrained` function called from a constrained one: these are covered by the checks in #11279 which makes sure we are not trying to return values from Brillig to ACIR which would exceed the witness count limit

Checking whether internal array allocations can cause panics during Brillig gen is left for #13250 which is aiming to resolve #10522

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
