### PR TITLE
feat(brillig): represent reference count as a unique/shared boolean

### DIFF
--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_call/code_gen_call.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_call/code_gen_call.rs
@@ -387,19 +387,17 @@ impl<Registers: RegisterAllocator> BrilligBlock<'_, Registers> {
                         let array = self.convert_ssa_value(arguments[0], dfg);
                         let [result] = dfg.instruction_result(instruction_id);
 
-                        let destination = self.define_variable(result, dfg);
-                        let destination = destination.extract_register();
+                        let destination = self.define_variable(result, dfg).extract_single_addr();
                         let array = array.extract_register();
-                        self.brillig_context.load_instruction(destination, array);
+                        self.codegen_load_rc_flag(destination, array);
                     }
                     Intrinsic::VectorRefCount => {
                         let array = self.convert_ssa_value(arguments[1], dfg);
                         let [result] = dfg.instruction_result(instruction_id);
 
-                        let destination = self.define_variable(result, dfg);
-                        let destination = destination.extract_register();
+                        let destination = self.define_variable(result, dfg).extract_single_addr();
                         let array = array.extract_register();
-                        self.brillig_context.load_instruction(destination, array);
+                        self.codegen_load_rc_flag(destination, array);
                     }
                     Intrinsic::ApplyRangeConstraint => {
                         unreachable!(

--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_instructions/brillig_memory.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_instructions/brillig_memory.rs
@@ -435,14 +435,22 @@ impl<Registers: RegisterAllocator> BrilligBlock<'_, Registers> {
         let array_or_vector = self.convert_ssa_value(value, dfg);
         let array_register = array_or_vector.extract_register();
 
-        let rc_register = self.brillig_context.codegen_read_rc(array_register);
+        // The reference count is a "unique / shared" boolean and only ever moves towards
+        // shared, so this is a single store with no read-modify-write.
+        self.brillig_context.codegen_mark_rc_shared(array_register);
+    }
 
-        // Ensure we're not incrementing from 0 back to 1
-        if self.brillig_context.enable_debug_assertions() {
-            self.codegen_assert_rc_neq_zero(rc_register.address);
-        }
-
-        self.brillig_context.codegen_increment_rc(array_register, rc_register.address);
+    /// Load the `u1` "unique / shared" reference-count flag of `array` and widen it into
+    /// `destination`, the integer type returned by the `array_refcount` / `vector_refcount`
+    /// intrinsics.
+    pub(crate) fn codegen_load_rc_flag(
+        &mut self,
+        destination: SingleAddrVariable,
+        array: MemoryAddress,
+    ) {
+        let flag = self.brillig_context.allocate_single_addr_bool();
+        self.brillig_context.load_instruction(flag.address, array);
+        self.brillig_context.cast_instruction(destination, *flag);
     }
     pub(crate) fn codegen_decrement_rc(&mut self, value: ValueId, dfg: &DataFlowGraph) {
         let array_or_vector = self.convert_ssa_value(value, dfg);

--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/tests/black_box.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/tests/black_box.rs
@@ -21,7 +21,7 @@ fn brillig_blake2s() {
     0: sp[3] = @1
     1: sp[4] = const u32 33
     2: @1 = u32 add @1, sp[4]
-    3: sp[3] = indirect const u32 1
+    3: sp[3] = indirect const bool 1
     4: sp[4] = u32 add sp[2], @2
     5: sp[5] = u32 add sp[3], @2
     6: blake2s(message: [sp[4]; 10], output: [sp[5]; 32])
@@ -47,7 +47,7 @@ fn brillig_blake3() {
     0: sp[3] = @1
     1: sp[4] = const u32 33
     2: @1 = u32 add @1, sp[4]
-    3: sp[3] = indirect const u32 1
+    3: sp[3] = indirect const bool 1
     4: sp[4] = u32 add sp[2], @2
     5: sp[5] = u32 add sp[3], @2
     6: blake3(message: [sp[4]; 10], output: [sp[5]; 32])
@@ -74,7 +74,7 @@ fn brillig_keccakf1600() {
     0: sp[3] = @1
     1: sp[4] = const u32 26
     2: @1 = u32 add @1, sp[4]
-    3: sp[3] = indirect const u32 1
+    3: sp[3] = indirect const bool 1
     4: sp[4] = u32 add sp[2], @2
     5: sp[5] = u32 add sp[3], @2
     6: keccakf1600(input: [sp[4]; 25], output: [sp[5]; 25])
@@ -154,7 +154,7 @@ fn brillig_multi_scalar_mul() {
      1: sp[5] = @1
      2: sp[6] = const u32 3
      3: @1 = u32 add @1, sp[6]
-     4: sp[5] = indirect const u32 1
+     4: sp[5] = indirect const bool 1
      5: sp[6] = u32 add sp[2], @2
      6: sp[7] = u32 add sp[3], @2
      7: sp[8] = u32 add sp[5], @2
@@ -183,7 +183,7 @@ fn brillig_embedded_curve_add() {
     1: sp[7] = @1
     2: sp[8] = const u32 3
     3: @1 = u32 add @1, sp[8]
-    4: sp[7] = indirect const u32 1
+    4: sp[7] = indirect const bool 1
     5: sp[8] = u32 add sp[7], @2
     6: embedded_curve_add(input1_x: sp[2], input1_y: sp[3], input2_x: sp[4], input2_y: sp[5], result: [sp[8]; 2])
     7: sp[2] = sp[7]
@@ -209,7 +209,7 @@ fn brillig_poseidon2_permutation() {
     0: sp[3] = @1
     1: sp[4] = const u32 5
     2: @1 = u32 add @1, sp[4]
-    3: sp[3] = indirect const u32 1
+    3: sp[3] = indirect const bool 1
     4: sp[4] = u32 add sp[2], @2
     5: sp[5] = u32 add sp[3], @2
     6: poseidon2_permutation(message: [sp[4]; 4], output: [sp[5]; 4])
@@ -235,7 +235,7 @@ fn brillig_sha256_compression() {
      0: sp[4] = @1
      1: sp[5] = const u32 9
      2: @1 = u32 add @1, sp[5]
-     3: sp[4] = indirect const u32 1
+     3: sp[4] = indirect const bool 1
      4: sp[5] = u32 add sp[2], @2
      5: sp[6] = u32 add sp[3], @2
      6: sp[7] = u32 add sp[4], @2
@@ -263,7 +263,7 @@ fn brillig_aes128_encrypt() {
      0: sp[5] = @1
      1: sp[6] = const u32 17
      2: @1 = u32 add @1, sp[6]
-     3: sp[5] = indirect const u32 1
+     3: sp[5] = indirect const bool 1
      4: sp[6] = u32 add sp[2], @2
      5: sp[7] = u32 add sp[3], @2
      6: sp[8] = u32 add sp[4], @2

--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/tests/call.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/tests/call.rs
@@ -90,7 +90,7 @@ fn brillig_as_vector() {
      3: sp[5] = @1
      4: sp[6] = const u32 4
      5: @1 = u32 add @1, sp[6]
-     6: sp[5] = indirect const u32 1
+     6: sp[5] = indirect const bool 1
      7: sp[6] = u32 add sp[5], @2
      8: sp[7] = sp[6]
      9: store sp[2] at sp[7]
@@ -104,7 +104,7 @@ fn brillig_as_vector() {
     17: sp[6] = u32 add sp[4], sp[7]
     18: sp[3] = @1
     19: @1 = u32 add @1, sp[6]
-    20: sp[3] = indirect const u32 1
+    20: sp[3] = indirect const bool 1
     21: sp[6] = u32 add sp[3], @2
     22: store sp[4] at sp[6]
     23: sp[6] = u32 add sp[6], @2
@@ -140,7 +140,7 @@ fn brillig_to_bits() {
      2: sp[3] = @1
      3: sp[6] = const u32 9
      4: @1 = u32 add @1, sp[6]
-     5: sp[3] = indirect const u32 1
+     5: sp[3] = indirect const bool 1
      6: sp[6] = u32 add sp[3], @2
      7: sp[7] = const u32 8
      8: to_radix(input: sp[2], radix: sp[4], num_limbs: sp[7], output_pointer: sp[6], output_bits: sp[5])
@@ -186,7 +186,7 @@ fn brillig_to_radix() {
      1: sp[4] = @1
      2: sp[6] = const u32 9
      3: @1 = u32 add @1, sp[6]
-     4: sp[4] = indirect const u32 1
+     4: sp[4] = indirect const bool 1
      5: sp[6] = u32 add sp[4], @2
      6: sp[7] = const u32 8
      7: to_radix(input: sp[2], radix: sp[3], num_limbs: sp[7], output_pointer: sp[6], output_bits: sp[5])
@@ -241,7 +241,7 @@ fn brillig_array_ref_count() {
      3: sp[5] = @1
      4: sp[6] = const u32 4
      5: @1 = u32 add @1, sp[6]
-     6: sp[5] = indirect const u32 1
+     6: sp[5] = indirect const bool 1
      7: sp[6] = u32 add sp[5], @2
      8: sp[7] = sp[6]
      9: store sp[2] at sp[7]
@@ -249,8 +249,9 @@ fn brillig_array_ref_count() {
     11: store sp[3] at sp[7]
     12: sp[7] = u32 add sp[7], @2
     13: store sp[4] at sp[7]
-    14: sp[2] = load sp[5]
-    15: return
+    14: sp[3] = load sp[5]
+    15: sp[2] = cast sp[3] to u32
+    16: return
     ");
 }
 
@@ -277,7 +278,7 @@ fn brillig_vector_ref_count() {
      3: sp[5] = @1
      4: sp[6] = const u32 4
      5: @1 = u32 add @1, sp[6]
-     6: sp[5] = indirect const u32 1
+     6: sp[5] = indirect const bool 1
      7: sp[6] = u32 add sp[5], @2
      8: sp[7] = sp[6]
      9: store sp[2] at sp[7]
@@ -291,7 +292,7 @@ fn brillig_vector_ref_count() {
     17: sp[6] = u32 add sp[4], sp[7]
     18: sp[3] = @1
     19: @1 = u32 add @1, sp[6]
-    20: sp[3] = indirect const u32 1
+    20: sp[3] = indirect const bool 1
     21: sp[6] = u32 add sp[3], @2
     22: store sp[4] at sp[6]
     23: sp[6] = u32 add sp[6], @2
@@ -303,8 +304,9 @@ fn brillig_vector_ref_count() {
     29: @4 = sp[6]
     30: @5 = sp[4]
     31: call 0 // -> MemCopy
-    32: sp[4] = load sp[3]
-    33: sp[2] = sp[4]
-    34: return
+    32: sp[5] = load sp[3]
+    33: sp[4] = cast sp[5] to u32
+    34: sp[2] = sp[4]
+    35: return
     ");
 }

--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/tests/memory.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/tests/memory.rs
@@ -25,7 +25,7 @@ fn brillig_array_get() {
      3: sp[6] = @1
      4: sp[7] = const u32 4
      5: @1 = u32 add @1, sp[7]
-     6: sp[6] = indirect const u32 1
+     6: sp[6] = indirect const bool 1
      7: sp[7] = u32 add sp[6], @2
      8: sp[8] = sp[7]
      9: store sp[3] at sp[8]
@@ -64,7 +64,7 @@ fn brillig_array_set() {
      3: sp[6] = @1
      4: sp[7] = const u32 4
      5: @1 = u32 add @1, sp[7]
-     6: sp[6] = indirect const u32 1
+     6: sp[6] = indirect const bool 1
      7: sp[7] = u32 add sp[6], @2
      8: sp[8] = sp[7]
      9: store sp[3] at sp[8]
@@ -112,7 +112,7 @@ fn brillig_array_with_rc_ops() {
      3: sp[5] = @1
      4: sp[6] = const u32 4
      5: @1 = u32 add @1, sp[6]
-     6: sp[5] = indirect const u32 1
+     6: sp[5] = indirect const bool 1
      7: sp[6] = u32 add sp[5], @2
      8: sp[7] = sp[6]
      9: store sp[2] at sp[7]
@@ -120,23 +120,21 @@ fn brillig_array_with_rc_ops() {
     11: store sp[3] at sp[7]
     12: sp[7] = u32 add sp[7], @2
     13: store sp[4] at sp[7]
-    14: sp[2] = load sp[5]
-    15: sp[2] = u32 add sp[2], @2
-    16: store sp[2] at sp[5]
-    17: sp[2] = const u32 0
-    18: sp[3] = const u32 99
-    19: @3 = sp[5]
-    20: @4 = const u32 4
-    21: call 0 // -> ArrayCopy
-    22: sp[4] = @5
-    23: sp[6] = u32 add sp[4], @2
-    24: sp[7] = u32 add sp[6], sp[2]
-    25: store sp[3] at sp[7]
-    26: sp[5] = u32 add sp[4], @2
-    27: sp[3] = u32 add sp[5], sp[2]
-    28: sp[3] = load sp[3]
-    29: sp[2] = sp[3]
-    30: return
+    14: sp[5] = indirect const bool 0
+    15: sp[2] = const u32 0
+    16: sp[3] = const u32 99
+    17: @3 = sp[5]
+    18: @4 = const u32 4
+    19: call 0 // -> ArrayCopy
+    20: sp[4] = @5
+    21: sp[6] = u32 add sp[4], @2
+    22: sp[7] = u32 add sp[6], sp[2]
+    23: store sp[3] at sp[7]
+    24: sp[5] = u32 add sp[4], @2
+    25: sp[3] = u32 add sp[5], sp[2]
+    26: sp[3] = load sp[3]
+    27: sp[2] = sp[3]
+    28: return
     ");
 }
 

--- a/compiler/noirc_evaluator/src/brillig/brillig_ir/codegen_binary.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_ir/codegen_binary.rs
@@ -1,6 +1,6 @@
 use acvm::{AcirField, acir::brillig::MemoryAddress};
 
-use crate::brillig::brillig_ir::{brillig_variable::SingleAddrVariable, registers::Allocated};
+use crate::brillig::brillig_ir::brillig_variable::SingleAddrVariable;
 
 use super::{
     BrilligContext, ReservedRegisters, debug_show::DebugToString, instructions::BrilligBinaryOp,
@@ -32,16 +32,6 @@ impl<F: AcirField + DebugToString, Registers: RegisterAllocator> BrilligContext<
             let const_register = self.make_usize_constant_instruction(F::from(constant));
             self.memory_op_instruction(operand, const_register.address, destination, op);
         }
-    }
-
-    /// Utility method to check if the value at a memory address equals one.
-    pub(crate) fn codegen_usize_equals_one(
-        &mut self,
-        operand: SingleAddrVariable,
-    ) -> Allocated<SingleAddrVariable, Registers> {
-        let is_one = self.allocate_single_addr_bool();
-        self.codegen_usize_op(operand.address, is_one.address, BrilligBinaryOp::Equals, 1);
-        is_one
     }
 
     /// Emit overflow check for addition: traps if `lhs > result` (i.e., overflow occurred).

--- a/compiler/noirc_evaluator/src/brillig/brillig_ir/codegen_memory.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_ir/codegen_memory.rs
@@ -16,6 +16,18 @@ use super::{
     registers::RegisterAllocator,
 };
 
+/// The reference-count slot of an array or vector holds a boolean rather than a count:
+/// the value only ever distinguishes "uniquely owned" from "shared", which is all the
+/// copy-on-write decision needs. Because no `dec_rc` is ever emitted, the slot only moves
+/// from [`RC_UNIQUE`] to [`RC_SHARED`] (via `inc_rc`) and back to [`RC_UNIQUE`] when a fresh
+/// copy is made — it never has to be incremented or compared against a count.
+///
+/// [`RC_UNIQUE`] is `1` and [`RC_SHARED`] is `0` so that copy-on-write can branch on the slot
+/// directly: a unique array/vector is "truthy" and may be mutated in place, a shared one is
+/// "falsy" and must be copied.
+pub(crate) const RC_UNIQUE: usize = 1;
+pub(crate) const RC_SHARED: usize = 0;
+
 pub(crate) struct VectorMetaData<Registers: RegisterAllocator> {
     pub(crate) rc: Allocated<SingleAddrVariable, Registers>,
     pub(crate) size: Allocated<SingleAddrVariable, Registers>,
@@ -332,12 +344,13 @@ impl<F: AcirField + DebugToString, Registers: RegisterAllocator> BrilligContext<
         }
     }
 
-    /// Returns a variable holding the ref-count of a given array or vector.
+    /// Returns a variable holding the `u1` "unique / shared" reference-count flag of a given
+    /// array or vector.
     pub(crate) fn codegen_read_rc(
         &mut self,
         pointer: MemoryAddress,
     ) -> Allocated<SingleAddrVariable, Registers> {
-        let result = self.allocate_single_addr_usize();
+        let result = self.allocate_single_addr_bool();
         self.load_instruction(result.address, pointer);
         result
     }
@@ -450,7 +463,8 @@ impl<F: AcirField + DebugToString, Registers: RegisterAllocator> BrilligContext<
         vector: BrilligVector,
         semantic_length_and_item_size: Option<(MemoryAddress, MemoryAddress)>,
     ) -> VectorMetaData<Registers> {
-        let rc = self.allocate_single_addr_usize();
+        // The reference-count slot holds a `u1` "unique / shared" flag, not a count.
+        let rc = self.allocate_single_addr_bool();
         let size = self.allocate_single_addr_usize();
         let capacity = self.allocate_single_addr_usize();
         let items_pointer = self.allocate_single_addr_usize();
@@ -550,15 +564,17 @@ impl<F: AcirField + DebugToString, Registers: RegisterAllocator> BrilligContext<
             .checked_add(offsets::ARRAY_META_COUNT)
             .expect("Array size overflow: array is too large to be allocated in Brillig");
         self.codegen_allocate_immediate_mem(array.pointer, assert_usize(size));
-        self.codegen_initialize_rc(array.pointer, 1);
+        self.codegen_initialize_rc(array.pointer, RC_UNIQUE);
     }
 
-    /// Initialize the reference counter for an array or vector.
+    /// Initialize the reference-count slot for an array or vector.
     /// This should only be used internally in the array and vector initialization methods.
     ///
-    /// The RC is in the 0th slot of the memory allocated for the array or vector.
+    /// The slot is in the 0th position of the memory allocated for the array or vector. It holds
+    /// a `u1` "unique / shared" flag rather than a count (see [`RC_UNIQUE`] / [`RC_SHARED`]) so
+    /// that the copy-on-write decision can branch on it directly without a comparison.
     pub(crate) fn codegen_initialize_rc(&mut self, pointer: MemoryAddress, rc: usize) {
-        self.indirect_const_instruction(pointer, BRILLIG_MEMORY_ADDRESSING_BIT_SIZE, rc.into());
+        self.indirect_const_instruction(pointer, 1, rc.into());
     }
 
     /// Decrement the ref-count by 1.
@@ -579,37 +595,14 @@ impl<F: AcirField + DebugToString, Registers: RegisterAllocator> BrilligContext<
         // self.store_instruction(pointer, rc);
     }
 
-    /// Increment the ref-count by 1.
+    /// Mark an array or vector as shared so that a subsequent `array_set` copies it
+    /// rather than mutating it in place.
     ///
-    /// The inputs are:
-    /// * the `pointer` to the array/vector
-    /// * the `rc` address of the vector where we have the current RC loaded already
-    ///
-    /// # Safety
-    ///
-    /// ### RC Overflow Limitation
-    ///
-    /// This operation uses wrapping arithmetic and does not check for overflow.
-    /// If the reference count were to reach `u32::MAX` (4,294,967,295) and be
-    /// incremented, it would wrap to 0. A subsequent increment would make it 1,
-    /// which would cause the copy-on-write logic (`rc == 1`) to incorrectly
-    /// treat a shared array/vector as uniquely owned, leading to in-place
-    /// mutation of shared data (memory corruption / unsoundness).
-    ///
-    /// This is an accepted theoretical limitation because:
-    /// - Triggering overflow requires 2^32 (~4.3 billion) RC increments on a
-    ///   single array/vector, which is practically unreachable in any realistic
-    ///   Noir program.
-    /// - Unlike free memory pointer (FMP) updates (which are checked in the VM), RC values are stored
-    ///   at arbitrary heap addresses, and the incremented result is written back to that address.
-    ///   They are not operating on the [FMP][ReservedRegisters::free_memory_pointer()].
-    /// - Adding runtime overflow checks would require ~3 extra opcodes per RC
-    ///   increment, which is unacceptable overhead for a theoretical issue.
-    pub(crate) fn codegen_increment_rc(&mut self, pointer: MemoryAddress, rc: MemoryAddress) {
-        // Modify the RC (it's on the stack, or scratch space).
-        self.codegen_usize_op_in_place(rc, BrilligBinaryOp::Add, 1);
-        // Write it back onto the heap.
-        self.store_instruction(pointer, rc);
+    /// The reference-count slot holds a boolean (see [`RC_UNIQUE`] / [`RC_SHARED`]), and
+    /// because no `dec_rc` is ever emitted the slot only moves from unique to shared. So
+    /// marking it shared is an unconditional store of a constant — no read, no arithmetic.
+    pub(crate) fn codegen_mark_rc_shared(&mut self, pointer: MemoryAddress) {
+        self.codegen_initialize_rc(pointer, RC_SHARED);
     }
 
     /// Initializes a vector, allocating memory on the heap to store its representation and initializing the reference counter, size and capacity.
@@ -652,7 +645,7 @@ impl<F: AcirField + DebugToString, Registers: RegisterAllocator> BrilligContext<
         capacity: SingleAddrVariable,
     ) {
         // Write RC
-        self.codegen_initialize_rc(vector.pointer, 1);
+        self.codegen_initialize_rc(vector.pointer, RC_UNIQUE);
 
         // Write size
         let write_pointer = self.allocate_register();

--- a/compiler/noirc_evaluator/src/brillig/brillig_ir/procedures/array_copy.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_ir/procedures/array_copy.rs
@@ -4,6 +4,7 @@ use super::ProcedureId;
 use crate::brillig::brillig_ir::{
     BrilligContext,
     brillig_variable::{BrilligArray, SingleAddrVariable},
+    codegen_memory::RC_UNIQUE,
     debug_show::DebugToString,
     registers::{RegisterAllocator, ScratchSpace},
 };
@@ -51,13 +52,13 @@ pub(super) fn compile_array_copy_procedure<F: AcirField + DebugToString>(
     let [source_array_pointer_arg, source_array_memory_size_arg, destination_array_pointer_return] =
         brillig_context.allocate_scratch_registers();
 
+    // The reference-count slot is a "unique / shared" boolean, so we can branch on it
+    // directly: unique (truthy) means we can mutate in place, shared (falsy) means copy.
     let rc = brillig_context.codegen_read_rc(source_array_pointer_arg);
 
-    let is_rc_one = brillig_context.codegen_usize_equals_one(*rc);
-
-    brillig_context.codegen_branch(is_rc_one.address, |ctx, cond| {
-        if cond {
-            // Reference count is 1, we can mutate the array directly
+    brillig_context.codegen_branch(rc.address, |ctx, is_unique| {
+        if is_unique {
+            // Uniquely owned, we can mutate the array directly.
             ctx.mov_instruction(destination_array_pointer_return, source_array_pointer_arg);
         } else {
             // We need to copy the array; allocate the required space on the heap.
@@ -73,13 +74,8 @@ pub(super) fn compile_array_copy_procedure<F: AcirField + DebugToString>(
                 destination_array_pointer_return,
                 SingleAddrVariable::new_usize(source_array_memory_size_arg),
             );
-            // Then set the new RC to 1.
-            ctx.codegen_initialize_rc(destination_array_pointer_return, 1);
-
-            // Decrease the original ref count now that this copy is no longer pointing to it.
-            // Copying an array is a potential implicit side effect of setting an item by index through a mutable variable;
-            // we won't end up with two handles to the array, so we can split the RC between the old and the new.
-            ctx.codegen_decrement_rc(source_array_pointer_arg, rc.address);
+            // The fresh copy is uniquely owned. The source stays marked as shared.
+            ctx.codegen_initialize_rc(destination_array_pointer_return, RC_UNIQUE);
 
             // Increase our array copy counter if that flag is set
             if ctx.count_array_copies() {

--- a/compiler/noirc_evaluator/src/brillig/brillig_ir/procedures/mod.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_ir/procedures/mod.rs
@@ -186,24 +186,23 @@ mod tests {
         insta::assert_snapshot!(artifact_string, @r"
         fn ArrayCopy
          0: @6 = load @3
-         1: @7 = u32 eq @6, @2
-         2: jump if @7 to 17
-         3: @5 = @1
-         4: @1 = u32 add @1, @4
-         5: @9 = u32 add @3, @4
-         6: @10 = @3
-         7: @11 = @5
-         8: jump to 13
-         9: @8 = load @10
-        10: store @8 at @11
+         1: jump if @6 to 16
+         2: @5 = @1
+         3: @1 = u32 add @1, @4
+         4: @8 = u32 add @3, @4
+         5: @9 = @3
+         6: @10 = @5
+         7: jump to 12
+         8: @7 = load @9
+         9: store @7 at @10
+        10: @9 = u32 add @9, @2
         11: @10 = u32 add @10, @2
-        12: @11 = u32 add @11, @2
-        13: @12 = u32 lt @10, @9
-        14: jump if @12 to 9
-        15: @5 = indirect const u32 1
-        16: jump to 18
-        17: @5 = @3
-        18: return
+        12: @11 = u32 lt @9, @8
+        13: jump if @11 to 8
+        14: @5 = indirect const bool 1
+        15: jump to 17
+        16: @5 = @3
+        17: return
         ");
     }
 }

--- a/compiler/noirc_evaluator/src/brillig/brillig_ir/procedures/prepare_vector_push.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_ir/procedures/prepare_vector_push.rs
@@ -202,11 +202,10 @@ pub(crate) fn reallocate_vector_for_insertion<
         does_capacity_fit.address,
         |brillig_context, does_capacity_fit| {
             if does_capacity_fit {
-                // We can only reuse the source vector if the ref-count is 1.
-                let is_rc_one = brillig_context.codegen_usize_equals_one(source_rc);
-
-                brillig_context.codegen_branch(is_rc_one.address, |brillig_context, is_rc_one| {
-                    if is_rc_one {
+                // We can only reuse the source vector if it is uniquely owned. The
+                // reference-count slot is a "unique / shared" boolean, so we branch on it directly.
+                brillig_context.codegen_branch(source_rc.address, |brillig_context, is_unique| {
+                    if is_unique {
                         // We can insert in place, so we can just move the source pointer to the destination pointer and update the length
                         brillig_context
                             .mov_instruction(target_vector.pointer, source_vector.pointer);

--- a/compiler/noirc_evaluator/src/brillig/brillig_ir/procedures/vector_copy.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_ir/procedures/vector_copy.rs
@@ -6,6 +6,7 @@ use crate::brillig::{
     brillig_ir::{
         BrilligBinaryOp, BrilligContext,
         brillig_variable::BrilligVector,
+        codegen_memory::RC_UNIQUE,
         debug_show::DebugToString,
         registers::{RegisterAllocator, ScratchSpace},
     },
@@ -44,13 +45,13 @@ pub(super) fn compile_vector_copy_procedure<F: AcirField + DebugToString>(
     let source_vector = BrilligVector { pointer: source_vector_pointer_arg };
     let target_vector = BrilligVector { pointer: destination_vector_pointer_return };
 
+    // The reference-count slot is a "unique / shared" boolean, so we can branch on it
+    // directly: unique (truthy) means we can mutate in place, shared (falsy) means copy.
     let rc = brillig_context.codegen_read_vector_rc(source_vector);
 
-    let is_rc_one = brillig_context.codegen_usize_equals_one(*rc);
-
-    brillig_context.codegen_branch(is_rc_one.address, |ctx, cond| {
-        if cond {
-            // Reference count is 1, we can mutate the vector directly; just the the destination to equal the source.
+    brillig_context.codegen_branch(rc.address, |ctx, is_unique| {
+        if is_unique {
+            // Uniquely owned, we can mutate the vector directly; just set the destination to equal the source.
             ctx.mov_instruction(target_vector.pointer, source_vector.pointer);
         } else {
             // Allocate the memory for the new vector.
@@ -65,13 +66,8 @@ pub(super) fn compile_vector_copy_procedure<F: AcirField + DebugToString>(
             // Copy the entire source vector, including metadata and items.
             ctx.codegen_mem_copy(source_vector.pointer, target_vector.pointer, *allocation_size);
 
-            // Then reset the new RC to 1.
-            ctx.codegen_initialize_rc(target_vector.pointer, 1);
-
-            // Decrease the original ref count now that this copy is no longer pointing to it.
-            // Copying a vector this way is an implicit side effect of setting an item by index through a mutable variable;
-            // unlike with pop and push, we won't end up with a new vector handle, so we can split the RC between the old and the new.
-            ctx.codegen_decrement_rc(source_vector.pointer, rc.address);
+            // The fresh copy is uniquely owned. The source stays marked as shared.
+            ctx.codegen_initialize_rc(target_vector.pointer, RC_UNIQUE);
 
             // Increase our array copy counter if that flag is set
             if ctx.count_array_copies() {

--- a/compiler/noirc_evaluator/src/brillig/brillig_ir/procedures/vector_pop_back.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_ir/procedures/vector_pop_back.rs
@@ -78,15 +78,14 @@ pub(super) fn compile_vector_pop_back_procedure<F: AcirField + DebugToString>(
         BrilligBinaryOp::Sub,
     );
 
+    // The reference-count slot is a "unique / shared" boolean, so we branch on it directly.
     let rc = brillig_context.codegen_read_vector_rc(source_vector);
-
-    let is_rc_one = brillig_context.codegen_usize_equals_one(*rc);
 
     let source_vector_items_pointer =
         brillig_context.codegen_make_vector_items_pointer(source_vector);
 
-    brillig_context.codegen_branch(is_rc_one.address, |brillig_context, is_rc_one| {
-        if is_rc_one {
+    brillig_context.codegen_branch(rc.address, |brillig_context, is_unique| {
+        if is_unique {
             // We can reuse the source vector, updating its length
             brillig_context.mov_instruction(target_vector.pointer, source_vector.pointer);
             brillig_context.codegen_update_vector_size(target_vector, *target_size);

--- a/compiler/noirc_evaluator/src/brillig/brillig_ir/procedures/vector_pop_front.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_ir/procedures/vector_pop_front.rs
@@ -73,10 +73,9 @@ pub(super) fn compile_vector_pop_front_procedure<F: AcirField + DebugToString>(
         BrilligBinaryOp::Sub,
     );
 
-    let is_rc_one = brillig_context.codegen_usize_equals_one(*source_rc);
-
-    brillig_context.codegen_branch(is_rc_one.address, |brillig_context, is_rc_one| {
-        if is_rc_one {
+    // The reference-count slot is a "unique / shared" boolean, so we branch on it directly.
+    brillig_context.codegen_branch(source_rc.address, |brillig_context, is_unique| {
+        if is_unique {
             // We reuse the source vector, moving the metadata to the right (decreasing capacity)
             // Set the target vector pointer to be the source plus the number of popped items.
             brillig_context.memory_op_instruction(

--- a/compiler/noirc_evaluator/src/brillig/brillig_ir/procedures/vector_remove.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_ir/procedures/vector_remove.rs
@@ -63,9 +63,8 @@ pub(super) fn compile_vector_remove_procedure<F: AcirField + DebugToString>(
         BrilligBinaryOp::Sub,
     );
 
+    // The reference-count slot is a "unique / shared" boolean, so we branch on it directly.
     let rc = brillig_context.codegen_read_vector_rc(source_vector);
-
-    let is_rc_one = brillig_context.codegen_usize_equals_one(*rc);
 
     let source_vector_items_pointer =
         brillig_context.codegen_make_vector_items_pointer(source_vector);
@@ -74,8 +73,8 @@ pub(super) fn compile_vector_remove_procedure<F: AcirField + DebugToString>(
     let target_vector_items_pointer = brillig_context.allocate_register();
 
     // Set up the target vector up to the index.
-    brillig_context.codegen_branch(is_rc_one.address, |brillig_context, is_rc_one| {
-        if is_rc_one {
+    brillig_context.codegen_branch(rc.address, |brillig_context, is_unique| {
+        if is_unique {
             // We can reuse the source vector: update its length and set the items pointer to be the source.
             brillig_context.mov_instruction(target_vector.pointer, source_vector.pointer);
             brillig_context.codegen_update_vector_size(target_vector, *target_size);

--- a/compiler/noirc_evaluator/src/ssa/interpreter/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/interpreter/mod.rs
@@ -1174,12 +1174,10 @@ impl<'ssa, W: Write> Interpreter<'ssa, W> {
     fn interpret_inc_rc(&self, value_id: ValueId) -> IResult<()> {
         if self.in_unconstrained_context() {
             let array = self.lookup_array_or_vector(value_id, "inc_rc")?;
-            let mut rc = array.rc.borrow_mut();
-            if *rc == 0 {
-                let value = array.to_string();
-                return Err(InterpreterError::IncRcRevive { value_id, value });
-            }
-            *rc += 1;
+            // The reference count is a "unique (1) / shared (0)" boolean rather than a
+            // count: `inc_rc` marks the array/vector as shared so a later `array_set`
+            // copies instead of mutating in place. It never has to be incremented.
+            *array.rc.borrow_mut() = 0;
         }
         Ok(())
     }

--- a/compiler/noirc_evaluator/src/ssa/interpreter/tests/instructions.rs
+++ b/compiler/noirc_evaluator/src/ssa/interpreter/tests/instructions.rs
@@ -1226,8 +1226,10 @@ fn array_set_with_offset() {
     let v0 = values[0].as_array_or_vector().unwrap();
     let v1 = values[1].as_array_or_vector().unwrap();
 
-    assert_eq!(*v0.rc.borrow(), 2, "1+1-0; the copy of v1 does not decrease the RC of v0");
-    assert_eq!(*v1.rc.borrow(), 1);
+    // The reference count is a "unique (1) / shared (0)" flag: `inc_rc` marked v0 as shared,
+    // and the copy made for v1 leaves v0 shared while v1 is a fresh, uniquely-owned array.
+    assert_eq!(*v0.rc.borrow(), 0, "v0 stays shared");
+    assert_eq!(*v1.rc.borrow(), 1, "v1 is uniquely owned");
 
     let one = from_constant(1u32.into(), NumericType::NativeField);
     let two = from_constant(2u32.into(), NumericType::NativeField);
@@ -1291,7 +1293,9 @@ fn increment_rc() {
     ",
     );
     let array = value.as_array_or_vector().unwrap();
-    assert_eq!(*array.rc.borrow(), 4);
+    // The reference count is a "unique (1) / shared (0)" flag rather than a count, so any number
+    // of `inc_rc` instructions just leave the array marked as shared.
+    assert_eq!(*array.rc.borrow(), 0);
 }
 
 #[test]

--- a/compiler/noirc_evaluator/src/ssa/opt/constant_folding/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/constant_folding/mod.rs
@@ -2932,8 +2932,8 @@ mod test {
     fn do_not_deduplicate_call_with_inc_rc() {
         // This test ensures that a function which mutates an array pointer is marked impure.
         // This protects against future deduplication passes incorrectly assuming purity.
-        // The increasing RC numbers reflect the current expectation that the RC of the
-        // original array does not get decremented when a copy is made.
+        // The reference count is a "unique (1) / shared (0)" flag: the array starts uniquely
+        // owned, and the `inc_rc` inside `f1` marks it shared.
         let src = r#"
         brillig(inline) fn main f0 {
           b0(v0: u32):
@@ -2942,10 +2942,10 @@ mod test {
             constrain v5 == u32 1
             v8 = call f1(v3) -> [Field; 2]
             v9 = call array_refcount(v3) -> u32
-            constrain v9 == u32 2
+            constrain v9 == u32 0
             v11 = call f1(v3) -> [Field; 2]
             v12 = call array_refcount(v3) -> u32
-            constrain v12 == u32 3
+            constrain v12 == u32 0
             inc_rc v3
             v15 = array_set v3, index v0, value Field 9
             return v3, v15


### PR DESCRIPTION

## Problem Resolved

No issue.

## Summary of Changes

I was just curious about the performance implications of not having a counter for RC since we only ever increment it, so we could keep it as a boolean. It's based on top of https://github.com/noir-lang/noir/pull/12977 . Not meant to be merged, but... if we ever decide that `dec_rc` is definitely not something that we'll want to keep, then it's something to consider...

## User Documentation

Check one:
- [ ] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
