### PR TITLE
chore: Ensure some Brillig functions called from ACIR are not pure pass through or constant in tests

### DIFF
--- a/test_programs/execution_success/brillig_identity_function/src/main.nr
+++ b/test_programs/execution_success/brillig_identity_function/src/main.nr
@@ -22,14 +22,16 @@ fn main(x: Field) {
     }
 }
 
+// `black_box` keeps each body from being recognized as a pure pass-through, so the
+// ACIR→Brillig call survives optimization and the round-trip is actually exercised.
 unconstrained fn identity(x: Field) -> Field {
-    x
+    std::hint::black_box(x)
 }
 
 unconstrained fn identity_array(arr: [Field; 2]) -> [Field; 2] {
-    arr
+    std::hint::black_box(arr)
 }
 
 unconstrained fn identity_struct(s: myStruct) -> myStruct {
-    s
+    std::hint::black_box(s)
 }

--- a/test_programs/execution_success/immutable_ref_to_unconstrained/src/main.nr
+++ b/test_programs/execution_success/immutable_ref_to_unconstrained/src/main.nr
@@ -1,5 +1,7 @@
+// `black_box` keeps the body from being recognized as a pure pass-through, so the
+// ACIR→Brillig call survives optimization and the immutable reference is actually read.
 unconstrained fn read_ref(r: &Field) -> Field {
-    *r
+    std::hint::black_box(*r)
 }
 
 unconstrained fn read_ref_struct(r: &Foo) -> u32 {
@@ -16,8 +18,10 @@ fn main(x: pub Field, y: pub u32) {
     let result = unsafe { read_ref(&x) };
     assert_eq(result, x);
 
-    let foo = Foo { x: 1, y: [2, 3, 4] };
+    // `foo` is built from a witness so the compiler cannot fold the read away at
+    // compile time, forcing the struct to be read back through the reference at runtime.
+    let foo = Foo { x: y, y: [y, y, y] };
     // Safety:
     let result = unsafe { read_ref_struct(&foo) };
-    assert_eq(result, y);
+    assert_eq(result, y * 4);
 }

--- a/tooling/nargo_cli/tests/snapshots/execution_success/brillig_identity_function/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/brillig_identity_function/execute__tests__expanded.snap
@@ -23,13 +23,13 @@ fn main(x: Field) {
 }
 
 unconstrained fn identity(x: Field) -> Field {
-    x
+    std::hint::black_box(x)
 }
 
 unconstrained fn identity_array(arr: [Field; 2]) -> [Field; 2] {
-    arr
+    std::hint::black_box(arr)
 }
 
 unconstrained fn identity_struct(s: myStruct) -> myStruct {
-    s
+    std::hint::black_box(s)
 }

--- a/tooling/nargo_cli/tests/snapshots/execution_success/immutable_ref_to_unconstrained/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/immutable_ref_to_unconstrained/execute__tests__expanded.snap
@@ -3,7 +3,7 @@ source: tooling/nargo_cli/tests/execute.rs
 expression: expanded_code
 ---
 unconstrained fn read_ref(r: &Field) -> Field {
-    *r
+    std::hint::black_box(*r)
 }
 
 unconstrained fn read_ref_struct(r: &Foo) -> u32 {
@@ -19,8 +19,8 @@ fn main(x: pub Field, y: pub u32) {
     // Safety: comment added by `nargo expand`
     let result: Field = unsafe { read_ref(&x) };
     assert(result == x);
-    let foo: Foo = Foo { x: 1_u32, y: [2_u32, 3_u32, 4_u32] };
+    let foo: Foo = Foo { x: y, y: [y, y, y] };
     // Safety: comment added by `nargo expand`
     let result: u32 = unsafe { read_ref_struct(&foo) };
-    assert(result == y);
+    assert(result == (y * 4_u32));
 }


### PR DESCRIPTION
## Problem Resolved

Follow up for https://github.com/noir-lang/noir/pull/13196#issuecomment-4865892303

## Summary of Changes

Changes two tests to make them immune to the https://github.com/noir-lang/noir/pull/13196 pass or something similar. 

The assumption is that the test author wanted the ACIR-to-Brillig call to be exercised, and just happened to use identity functions and constant structs, which ended up being optimised away, removing the coverage for these features.

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
