### PR TITLE
chore: ignore quick-xml RUSTSEC-2026-0194/0195 advisories

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -8,6 +8,12 @@ yanked = "warn"
 ignore = [
     "RUSTSEC-2024-0388", # derivative unmaintained
     "RUSTSEC-2024-0436", # paste unmaintained
+    # quick-xml DoS on attacker-controlled XML (quadratic attribute checks / unbounded
+    # namespace allocations). Only reachable via inferno's flamegraph handling in
+    # noir_profiler and pprof, which never parse untrusted XML. No inferno release on a
+    # fixed quick-xml (>= 0.41.0) exists yet; drop these once one does.
+    "RUSTSEC-2026-0194",
+    "RUSTSEC-2026-0195",
 ]
 
 # This section is considered when running `cargo deny check bans`.


### PR DESCRIPTION
# Description

## Problem

Two quick-xml advisories published today ([RUSTSEC-2026-0194](https://rustsec.org/advisories/RUSTSEC-2026-0194), [RUSTSEC-2026-0195](https://rustsec.org/advisories/RUSTSEC-2026-0195)) fail the `deny` CI job on every PR (e.g. [this run](https://github.com/noir-lang/noir/actions/runs/28673131359/job/85040727870)).

## Summary

Both are DoS vectors when parsing attacker-controlled XML. quick-xml only enters our tree through `inferno`'s flamegraph handling (in `noir_profiler` and `pprof`), which never parses untrusted XML, so the advisories are ignored with a comment. There is no `inferno` release on a fixed quick-xml (>= 0.41.0) yet — the ignores should be dropped once one exists.

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Changes in _docs/_ included in this PR.
- [ ] **[For Experimental Features]** Changes in _docs/_ to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)