### PR TITLE
fix: Make `FunctionDefinition` coercion in meta-attributes work with inherent methods

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/mod.rs
+++ b/compiler/noirc_frontend/src/elaborator/mod.rs
@@ -115,6 +115,7 @@ mod variable;
 mod visibility;
 
 use self::traits::check_trait_impl_method_matches_declaration;
+use self::variable::VariableResolution;
 use fm::FileMap;
 use function_context::FunctionContext;
 use noirc_errors::Location;
@@ -810,7 +811,7 @@ impl<'context> Elaborator<'context> {
     #[tracing::instrument(level = "trace", skip_all)]
     fn resolve_function_by_path(&mut self, path: TypedPath) -> Option<FuncId> {
         let location = path.location;
-        match self.resolve_path_or_error(path, PathResolutionTarget::Value) {
+        match self.resolve_path_or_error(path.clone(), PathResolutionTarget::Value) {
             Ok(item) => {
                 if let Some(func_id) = item.function_id() {
                     Some(func_id)
@@ -825,6 +826,14 @@ impl<'context> Elaborator<'context> {
                 }
             }
             Err(error) => {
+                // A `Type::method` path (an inherent or trait-impl method) is not resolvable as a
+                // value path, but it resolves the same way the expression `Type::method` does. Try
+                // that before surfacing the original path-resolution error.
+                if let Some(VariableResolution::Ident(_, Some(item))) = self.resolve_variable(path)
+                    && let Some(func_id) = item.function_id()
+                {
+                    return Some(func_id);
+                }
                 self.push_err(error);
                 None
             }

--- a/compiler/noirc_frontend/src/elaborator/variable.rs
+++ b/compiler/noirc_frontend/src/elaborator/variable.rs
@@ -523,7 +523,7 @@ impl Elaborator<'_> {
     /// current scope (a local variable, or a value item — global, function, enum-variant global,
     /// numeric type alias) via [`Self::resolve_unprefixed_variable`].
     #[tracing::instrument(level = "trace", skip_all)]
-    fn resolve_variable(&mut self, path: TypedPath) -> Option<VariableResolution> {
+    pub(super) fn resolve_variable(&mut self, path: TypedPath) -> Option<VariableResolution> {
         if path.segments.len() > 1 {
             self.resolve_prefixed_variable(path)
         } else {

--- a/compiler/noirc_frontend/src/tests/metaprogramming.rs
+++ b/compiler/noirc_frontend/src/tests/metaprogramming.rs
@@ -3324,6 +3324,29 @@ fn meta_attribute_coerces_function_path_to_function_definition() {
 }
 
 #[test]
+fn meta_attribute_coerces_inherent_method_path_to_function_definition() {
+    // https://github.com/noir-lang/noir/issues/13186
+    // An inherent method path (`Type::method`) is not resolvable as a plain value path the way a
+    // free function is, but it must still coerce to a `FunctionDefinition` argument — mirroring how
+    // the expression `Type::method` resolves to that method.
+    let src = r#"
+    pub struct Foo {}
+
+    impl Foo {
+        pub fn check(_self: &Self) {}
+    }
+
+    #[validate(Foo::check)]
+    pub fn target() {}
+
+    comptime fn validate(_f: FunctionDefinition, _method: FunctionDefinition) {}
+
+    fn main() {}
+    "#;
+    assert_no_errors(src);
+}
+
+#[test]
 fn meta_attribute_function_definition_argument_can_be_inspected() {
     // The coerced `FunctionDefinition` is a real definition whose signature can be inspected,
     // which is the point of accepting it as `FunctionDefinition` rather than `Quoted`.


### PR DESCRIPTION
## Problem Resolved

Extracts a fix from https://github.com/noir-lang/noir/pull/13198

## Summary of Changes

Fixes passing inherent methods as `FunctionDefinition` in meta-attributes.

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
