### PR TITLE
fix(ssa): Handle header instruction remapping in `unrolling`

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/opt/unrolling.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/unrolling.rs
@@ -1244,16 +1244,19 @@ impl Loop {
         let termination_unproven = self.induction_step_may_miss_bound(function, unroll_into);
 
         let mut iterations = 0;
-        while let Some((context, loop_header_id)) =
-            self.unroll_header(function, unroll_into, &header_args, dom)?
-        {
-            (unroll_into, header_args) = context.unroll_loop_iteration(loop_header_id);
+        let exit_mapping = loop {
+            match self.unroll_header(function, unroll_into, &header_args, dom)? {
+                HeaderUnroll::Iterate(context, loop_header_id) => {
+                    (unroll_into, header_args) = context.unroll_loop_iteration(loop_header_id);
 
-            iterations += 1;
-            if termination_unproven && iterations >= unroll_limit {
-                return Err(CallStack::empty());
+                    iterations += 1;
+                    if termination_unproven && iterations >= unroll_limit {
+                        return Err(CallStack::empty());
+                    }
+                }
+                HeaderUnroll::Exit(mapping) => break mapping,
             }
-        }
+        };
 
         // Build a mapping from header params to their final values.
         // The caller is responsible for applying this mapping to blocks outside the loop.
@@ -1261,6 +1264,13 @@ impl Loop {
         if !header_params.is_empty() {
             mapping.batch_insert(&header_params, &header_args);
         }
+
+        // Header *instruction* results (not just parameters) can be referenced by blocks
+        // outside the loop, e.g. when constant folding's CSE points an exit block at an
+        // identical instruction that happens to live in the header. Redirect those references
+        // to their copies in the final unrolled header, otherwise they dangle once the
+        // original header block becomes unreachable.
+        mapping.extend(exit_mapping);
 
         Ok(mapping)
     }
@@ -1291,14 +1301,15 @@ impl Loop {
 
     /// Unrolls the header block of the loop. This is the block that dominates all other blocks in the
     /// loop and contains the jmpif instruction that lets us know if we should continue looping.
-    /// Returns Some((iteration context, `loop_header_id`)) if we should perform another iteration.
+    /// Returns [`HeaderUnroll::Iterate`] if we should perform another iteration, or
+    /// [`HeaderUnroll::Exit`] once the guard resolves to a block outside the loop.
     fn unroll_header<'a>(
         &'a self,
         function: &'a mut Function,
         unroll_into: BasicBlockId,
         header_args: &[ValueId],
         dom: &'a DominatorTree,
-    ) -> Result<Option<(LoopIteration<'a>, BasicBlockId)>, CallStack> {
+    ) -> Result<HeaderUnroll<'a>, CallStack> {
         // We insert into a fresh block first and move instructions into the unroll_into block later
         // only once we verify the jmpif instruction has a constant condition. If it does not, we can
         // just discard this fresh block and leave the loop unmodified.
@@ -1362,9 +1373,22 @@ impl Loop {
                     // in `source_block` and can unroll that into the destination.
                     let is_in_loop = self.blocks.contains(&context.source_block);
 
-                    Ok(is_in_loop
-                        .then_some(context)
-                        .map(|iteration_context| (iteration_context, loop_header_id)))
+                    if is_in_loop {
+                        Ok(HeaderUnroll::Iterate(context, loop_header_id))
+                    } else {
+                        // This final header evaluation flows to a block outside the loop. Map each
+                        // header instruction result to its copy in this last unrolled header so that
+                        // exit blocks referencing those results stay valid once the original header
+                        // block is dropped.
+                        let mut exit_mapping = ValueMapping::default();
+                        for instruction in context.dfg()[loop_header_id].instructions().to_vec() {
+                            for result in context.dfg().instruction_results(instruction).to_vec() {
+                                let resolved = context.inserter.resolve(result);
+                                exit_mapping.insert(result, resolved);
+                            }
+                        }
+                        Ok(HeaderUnroll::Exit(exit_mapping))
+                    }
                 } else {
                     // If this case is reached the loop either uses non-constant indices or we need
                     // another pass, such as mem2reg to resolve them to constants.
@@ -2065,6 +2089,16 @@ fn get_header_arguments(
         Some(terminator) => Err(dfg.get_call_stack(terminator.call_stack())),
         None => Err(CallStack::empty()),
     }
+}
+
+/// Outcome of unrolling a single evaluation of the loop header.
+enum HeaderUnroll<'a> {
+    /// The guard resolved to a block inside the loop: unroll another iteration with this context.
+    Iterate(LoopIteration<'a>, BasicBlockId),
+    /// The guard resolved to a block outside the loop, so unrolling is finished. Carries the
+    /// mapping from the header's instruction results to their values in the final unrolled copy
+    /// of the header, for redirecting references from blocks outside the loop.
+    Exit(ValueMapping),
 }
 
 /// The context object for each loop iteration.
@@ -4891,22 +4925,14 @@ mod tests {
         ");
     }
 
-    /// Documents that loop unrolling does NOT propagate instruction results defined
-    /// in the loop header (only block parameters) to exit blocks.
-    ///
-    /// If an instruction is hoisted into a loop header (e.g. by constant folding's CSE),
-    /// and the exit block references that instruction's result, unrolling will leave a
-    /// dangling reference because `Loop::unroll` only maps header parameters, not
-    /// instruction results.
-    ///
-    /// To fix this in the unrolling pass (if we ever want to allow hoisting into headers):
-    /// in `unroll_header`, on the final iteration (when `is_in_loop` is false), iterate
-    /// over header instruction results and add their resolved values from the inserter
-    /// to the `ValueMapping` returned by `unroll`.
+    /// A loop header can hold instruction results (not just block parameters) that are
+    /// referenced by exit blocks, e.g. when constant folding's CSE points an exit block at
+    /// an identical instruction already living in the header. Unrolling must redirect those
+    /// references to the final unrolled copy of the header instruction, otherwise the value
+    /// dangles once the original header block is dropped.
     #[test]
-    #[should_panic(expected = "should already be in scope")]
-    fn unroll_panics_on_header_instruction_results_referenced_by_exit_block() {
-        // Models the SSA after CSE hoists `mul v2, v2` into the loop header:
+    fn unroll_maps_header_instruction_results_referenced_by_exit_block() {
+        // Models the SSA after CSE points an exit block at `mul v2, v2` in the loop header:
         //   b1 header has v4 = mul v2, v2 (an instruction result, not a parameter)
         //   b2 loop body uses v4
         //   b3 exit block uses v4
@@ -4931,9 +4957,10 @@ mod tests {
         let (ssa, errors) = try_unroll_loops(ssa);
         assert!(errors.is_empty(), "Loop should unroll successfully");
 
-        // This panics because v4 (a header instruction result) was not mapped
-        // to its final-iteration value, leaving a dangling reference.
-        let _result = ssa.interpret(vec![Value::field(3u128.into())]);
+        // The exit block's `return v4` now reads the second iteration's squared value.
+        // With v0 = 3: iteration 1 squares to 9 (v5 = 10), iteration 2 squares 10 to 100.
+        let result = ssa.interpret(vec![Value::field(3u128.into())]);
+        assert_eq!(result, Ok(vec![Value::field(100u128.into())]));
     }
 }
 

--- a/test_programs/execution_success/unroll_loop_header_result_used_after_loop/Nargo.toml
+++ b/test_programs/execution_success/unroll_loop_header_result_used_after_loop/Nargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "unroll_loop_header_result_used_after_loop"
+type = "bin"
+authors = [""]
+
+[dependencies]

--- a/test_programs/execution_success/unroll_loop_header_result_used_after_loop/src/main.nr
+++ b/test_programs/execution_success/unroll_loop_header_result_used_after_loop/src/main.nr
@@ -1,0 +1,21 @@
+// Regression test: a loop header whose *instruction* result (here the `println`
+// type-descriptor array produced while evaluating the `while` condition) is also
+// referenced by a block outside the loop after CSE deduplicates the two identical
+// descriptors. Unrolling must redirect the exit block's reference to the final
+// unrolled copy of the header instruction, otherwise the value is left dangling.
+unconstrained fn main() {
+    let a: [u8; 3] = [1, 2, 3];
+    let mut i: u32 = 0;
+    while cond(a) {
+        if i == 0 {
+            break;
+        }
+        i += 1;
+    }
+    println(a);
+}
+
+unconstrained fn cond(a: [u8; 3]) -> bool {
+    println(a);
+    true
+}

--- a/tooling/nargo_cli/tests/snapshots/execution_success/unroll_loop_header_result_used_after_loop/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/unroll_loop_header_result_used_after_loop/execute__tests__expanded.snap
@@ -1,0 +1,18 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: expanded_code
+---
+unconstrained fn main() {
+    let a: [u8; 3] = [1_u8, 2_u8, 3_u8];
+    let mut i: u32 = 0_u32;
+    while cond(a) {
+        if i == 0_u32 { break; };
+        i = i + 1_u32;
+    }
+    println(a);
+}
+
+unconstrained fn cond(a: [u8; 3]) -> bool {
+    println(a);
+    true
+}

--- a/tooling/nargo_cli/tests/snapshots/execution_success/unroll_loop_header_result_used_after_loop/execute__tests__stdout.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/unroll_loop_header_result_used_after_loop/execute__tests__stdout.snap
@@ -1,0 +1,6 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: stdout
+---
+[1, 2, 3]
+[1, 2, 3]


### PR DESCRIPTION
## Problem Resolved

Resolves an issue found by the fuzzer in https://github.com/noir-lang/noir/actions/runs/28673202400/job/85042119100?pr=13256 :
```
NOIR_AST_FUZZER_SEED=0x11b1640200100000 cargo test -p noir_ast_fuzzer --test smoke
```

This resulted in the following error:
```
thread 'arb_program_can_be_executed' panicked at compiler/noirc_evaluator/src/ssa/opt/inlining.rs:327:17:
internal error: entered unreachable code: All Value::Instructions should already be known during inlining after creating the original inlined instruction. Unknown value v94 = Instruction { instruction: Id(27), position: 0, typ: Array([Numeric(Unsigned { bit_size: 8 })], SemanticLength(196)) }
```

The problem was that the exit block of a loop used a value from the header, which was not re-mapped, and the header go eliminated when the new unrolling logic from #13118 recognised the loop won't execute. 

### Minimal reproduction

```rust
unconstrained fn main() {
    let a: [u8; 3] = [1, 2, 3];
    let mut i: u32 = 0;
    while cond(a) {          // condition calls println -> descriptor make_array
        if i == 0 { break; }
        i += 1;
    }
    println(a);             // same descriptor after the loop
}
unconstrained fn cond(a: [u8; 3]) -> bool { println(a); true }
```

SSA just before unrolling (`Simplifying (2)`):

```
b0():
  v4 = make_array [u8 1, u8 2, u8 3]
  jmp b1(u32 0)
b1(v0: u32):                              // LOOP HEADER
  inc_rc v4
  v29 = make_array b"{...descriptor...}"  // header INSTRUCTION result
  call print(u1 1, v4, v29, u1 0)         // println(a) from cond()
  v33 = eq v0, u32 0
  jmpif v33 then: b2(), else: b3()        // i==0 -> exit b2, else continue b3
b2():                                     // EXIT block
  inc_rc v29                              // uses v29, defined in the HEADER
  call print(u1 1, v4, v29, u1 0)         // println(a) after the loop
  return
b3():
  v35 = unchecked_add v0, u32 1
  jmp b1(v35)                             // back-edge
```

### Root cause

`v29` is the `println` type-descriptor array. Two things put it in the header
and make an exit block depend on it:

1. The `while` condition is a function call (`cond`). After inlining, a
   `while`-condition is evaluated in the **loop header**, so `cond`'s body —
   including the descriptor `make_array v29` — lands in header `b1`.
2. Constant folding's **CSE** deduplicates the two identical descriptor
   `make_array`s (one in header `b1`, one in the after-loop `println` in `b2`).
   Because `b1` dominates `b2`, CSE keeps the header's `v29` and points `b2`'s
   use at it.

So the exit block `b2` references a **header instruction result**.

When `Loop::unroll` unrolls `b1`, the loop runs zero back-edges (`i == 0` exits
immediately). The header is evaluated once into the pre-header, control flows
to `b2`, and the original `b1`/`b3` become unreachable. On finishing, unrolling
builds a value remap for blocks outside the loop — **but only for header
*parameters* (`v0`), not header *instruction results* (`v29`)**. `b2` is left
pointing at `v29`, now defined in a dead block, so the next renumbering/inlining
pass finds a use with no definition in scope.

This was a latent, documented limitation (see the old `#[should_panic]` test
`unroll_panics_on_header_instruction_results_referenced_by_exit_block`).
PR #13118 rewrote induction-variable detection so this loop now unrolls where it
previously bailed out, which is what exposed the bug. Note PR #12044's guard
("prevent CSE from *hoisting into* loop headers") does not cover this case: the
instruction was already in the header, and CSE only redirected the exit block's
identical instruction at it.

## Summary of Changes

### Fix

In `compiler/noirc_evaluator/src/ssa/opt/unrolling.rs`: on the final header
evaluation (when the guard resolves to a block outside the loop), map each
header instruction result to its value in the final unrolled copy of the header
and add that to the `ValueMapping` that `unroll` returns. The caller already
applies that mapping to every block outside the loop, so exit-block references
are redirected to the live copy.

`unroll_header` now returns a small `HeaderUnroll { Iterate, Exit(ValueMapping) }`
enum instead of `Option<(LoopIteration, BasicBlockId)>` to carry that mapping out.


## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
