### PR TITLE
feat(ssa): simplify unsigned div/mod by constants exceeding the dividend's maximum

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/ir/dfg.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/dfg.rs
@@ -569,14 +569,21 @@ impl DataFlowGraph {
         match self[value] {
             Value::Instruction { instruction, .. } => {
                 let value_bit_size = self.type_of_value(value).bit_size();
-                if let Instruction::Cast(original_value, _) = self[instruction] {
-                    let original_bit_size = self.get_value_max_num_bits(original_value);
-                    // We might have cast e.g. `u1` to `u8` to be able to do arithmetic,
-                    // in which case we want to recover the original smaller bit size;
-                    // OTOH if we cast down, then we don't need the higher original size.
-                    value_bit_size.min(original_bit_size)
-                } else {
-                    value_bit_size
+                match self[instruction] {
+                    Instruction::Cast(original_value, _) => {
+                        let original_bit_size = self.get_value_max_num_bits(original_value);
+                        // We might have cast e.g. `u1` to `u8` to be able to do arithmetic,
+                        // in which case we want to recover the original smaller bit size;
+                        // OTOH if we cast down, then we don't need the higher original size.
+                        value_bit_size.min(original_bit_size)
+                    }
+                    Instruction::Truncate { value: original_value, bit_size, .. } => {
+                        // A truncation bounds its result to `bit_size` bits, and the result
+                        // can never require more bits than the value being truncated.
+                        let original_bit_size = self.get_value_max_num_bits(original_value);
+                        value_bit_size.min(bit_size).min(original_bit_size)
+                    }
+                    _ => value_bit_size,
                 }
             }
 

--- a/compiler/noirc_evaluator/src/ssa/ir/dfg/simplify/binary.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/dfg/simplify/binary.rs
@@ -156,6 +156,16 @@ pub(super) fn simplify_binary(
                     operator: BinaryOp::Mul { unchecked: false },
                 }));
             }
+            // An unsigned division by a constant strictly greater than the maximum possible
+            // value of `lhs` always produces zero. A zero divisor is never greater than the
+            // (non-negative) maximum, so division-by-zero semantics are preserved.
+            if lhs_type.is_unsigned()
+                && let Some(rhs_value) = rhs_value
+                && constant_exceeds_max_value(dfg, lhs, rhs_value)
+            {
+                let zero = dfg.make_constant(FieldElement::zero(), lhs_type);
+                return SimplifyResult::SimplifiedTo(zero);
+            }
         }
         BinaryOp::Mod => {
             if rhs_is_one {
@@ -163,6 +173,16 @@ pub(super) fn simplify_binary(
                 return SimplifyResult::SimplifiedTo(zero);
             }
             if lhs_type.is_unsigned() {
+                // An unsigned modulo by a constant strictly greater than the maximum possible
+                // value of `lhs` leaves `lhs` unchanged. A zero modulus is never greater than
+                // the (non-negative) maximum, so division-by-zero semantics are preserved.
+                // This is checked before the power-of-two rewrite below so that an oversized
+                // power-of-two modulus simplifies to `lhs` instead of a redundant truncation.
+                if let Some(rhs_value) = rhs_value
+                    && constant_exceeds_max_value(dfg, lhs, rhs_value)
+                {
+                    return SimplifyResult::SimplifiedTo(lhs);
+                }
                 // lhs % 2**bit_size is equivalent to truncating `lhs` to `bit_size` bits.
                 // We then convert to a truncation for consistency, allowing more optimizations.
                 if let Some(modulus) = rhs_value {
@@ -358,6 +378,20 @@ fn can_simplify_arithmetic_identity(
     }
 }
 
+/// Whether `constant` is strictly greater than the maximum value that the unsigned `value`
+/// can possibly take.
+///
+/// The maximum is derived from [`DataFlowGraph::get_value_max_num_bits`], which refines the
+/// type's bit width using the value's definition (e.g. an upcast keeps its source width and a
+/// truncation bounds the result to the truncated width). A value of `max_bits` bits is at most
+/// `2^max_bits - 1`, so the comparison is strict: a constant equal to the maximum never counts
+/// as exceeding it.
+fn constant_exceeds_max_value(dfg: &DataFlowGraph, value: ValueId, constant: FieldElement) -> bool {
+    let max_bits = dfg.get_value_max_num_bits(value);
+    let max_value = if max_bits >= 128 { u128::MAX } else { (1u128 << max_bits) - 1 };
+    constant.to_u128() > max_value
+}
+
 #[cfg(test)]
 mod tests {
     use crate::{
@@ -506,6 +540,182 @@ mod tests {
             return v0
         }
         ");
+    }
+
+    #[test]
+    fn simplifies_unsigned_div_by_constant_exceeding_upcast_max_to_zero() {
+        // `v1` comes from a `u8` so it is at most 255; dividing by 256 always yields 0.
+        let src = "
+        acir(inline) fn main f0 {
+          b0(v0: u8):
+            v1 = cast v0 as u32
+            v2 = div v1, u32 256
+            return v2
+        }
+        ";
+        let ssa = Ssa::from_str_simplifying(src).unwrap();
+        assert_ssa_snapshot!(ssa, @r"
+        acir(inline) fn main f0 {
+          b0(v0: u8):
+            v1 = cast v0 as u32
+            return u32 0
+        }
+        ");
+    }
+
+    #[test]
+    fn simplifies_unsigned_mod_by_constant_exceeding_upcast_max_to_lhs() {
+        // `v1` comes from a `u8` so it is at most 255; taking it modulo 300 is a no-op.
+        let src = "
+        acir(inline) fn main f0 {
+          b0(v0: u8):
+            v1 = cast v0 as u32
+            v2 = mod v1, u32 300
+            return v2
+        }
+        ";
+        let ssa = Ssa::from_str_simplifying(src).unwrap();
+        assert_ssa_snapshot!(ssa, @r"
+        acir(inline) fn main f0 {
+          b0(v0: u8):
+            v1 = cast v0 as u32
+            return v1
+        }
+        ");
+    }
+
+    #[test]
+    fn simplifies_unsigned_mod_by_oversized_power_of_two_to_lhs_not_truncation() {
+        // An oversized modulus that happens to be a power of two simplifies to `lhs`
+        // directly rather than to a redundant truncation.
+        let src = "
+        acir(inline) fn main f0 {
+          b0(v0: u8):
+            v1 = cast v0 as u32
+            v2 = mod v1, u32 256
+            return v2
+        }
+        ";
+        let ssa = Ssa::from_str_simplifying(src).unwrap();
+        assert_ssa_snapshot!(ssa, @r"
+        acir(inline) fn main f0 {
+          b0(v0: u8):
+            v1 = cast v0 as u32
+            return v1
+        }
+        ");
+    }
+
+    #[test]
+    fn simplifies_unsigned_div_by_constant_exceeding_truncated_max_to_zero() {
+        // `v1` is truncated to 8 bits so it is at most 255; dividing by 300 always yields 0.
+        let src = "
+        acir(inline) fn main f0 {
+          b0(v0: u32):
+            v1 = truncate v0 to 8 bits, max_bit_size: 32
+            v2 = div v1, u32 300
+            return v2
+        }
+        ";
+        let ssa = Ssa::from_str_simplifying(src).unwrap();
+        assert_ssa_snapshot!(ssa, @r"
+        acir(inline) fn main f0 {
+          b0(v0: u32):
+            v1 = truncate v0 to 8 bits, max_bit_size: 32
+            return u32 0
+        }
+        ");
+    }
+
+    #[test]
+    fn does_not_simplify_unsigned_div_by_constant_equal_to_max() {
+        // Strict boundary: `v1` can reach 255, so `255 / 255 == 1` and the rule must not fire.
+        let src = "
+        acir(inline) fn main f0 {
+          b0(v0: u8):
+            v1 = cast v0 as u32
+            v2 = div v1, u32 255
+            return v2
+        }
+        ";
+        let ssa = Ssa::from_str_simplifying(src).unwrap();
+        assert_normalized_ssa_equals(ssa, src);
+    }
+
+    #[test]
+    fn does_not_simplify_unsigned_mod_by_constant_equal_to_max() {
+        // Strict boundary: `v1` can reach 255, so `255 % 255 == 0` and the rule must not fire.
+        let src = "
+        acir(inline) fn main f0 {
+          b0(v0: u8):
+            v1 = cast v0 as u32
+            v2 = mod v1, u32 255
+            return v2
+        }
+        ";
+        let ssa = Ssa::from_str_simplifying(src).unwrap();
+        assert_normalized_ssa_equals(ssa, src);
+    }
+
+    #[test]
+    fn does_not_simplify_unsigned_div_by_type_width_constant() {
+        // Without a refined bound, `v0` can be as large as any `u8` constant, so the
+        // rule can never fire at the type's own width.
+        let src = "
+        acir(inline) fn main f0 {
+          b0(v0: u8):
+            v1 = div v0, u8 255
+            return v1
+        }
+        ";
+        let ssa = Ssa::from_str_simplifying(src).unwrap();
+        assert_normalized_ssa_equals(ssa, src);
+    }
+
+    #[test]
+    fn does_not_simplify_unsigned_div_by_zero() {
+        // Division by zero must keep its failure semantics even though `v1` is bounded.
+        let src = "
+        acir(inline) fn main f0 {
+          b0(v0: u8):
+            v1 = cast v0 as u32
+            v2 = div v1, u32 0
+            return v2
+        }
+        ";
+        let ssa = Ssa::from_str_simplifying(src).unwrap();
+        assert_normalized_ssa_equals(ssa, src);
+    }
+
+    #[test]
+    fn does_not_simplify_unsigned_mod_by_zero() {
+        // Modulo by zero must keep its failure semantics even though `v1` is bounded.
+        let src = "
+        acir(inline) fn main f0 {
+          b0(v0: u8):
+            v1 = cast v0 as u32
+            v2 = mod v1, u32 0
+            return v2
+        }
+        ";
+        let ssa = Ssa::from_str_simplifying(src).unwrap();
+        assert_normalized_ssa_equals(ssa, src);
+    }
+
+    #[test]
+    fn does_not_simplify_signed_div_by_constant_exceeding_upcast_width() {
+        // The rule is unsigned-only: a sign-extended `i8` can be negative, so its
+        // magnitude is not bounded by its source bit width.
+        let src = "
+        acir(inline) fn main f0 {
+          b0(v0: i8):
+            v1 = cast v0 as i16
+            v2 = div v1, i16 300
+            return v2
+        }
+        ";
+        let ssa = Ssa::from_str_simplifying(src).unwrap();
+        assert_normalized_ssa_equals(ssa, src);
     }
 
     #[test]

--- a/compiler/noirc_evaluator/src/ssa/ir/dfg/simplify/binary.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/dfg/simplify/binary.rs
@@ -156,9 +156,9 @@ pub(super) fn simplify_binary(
                     operator: BinaryOp::Mul { unchecked: false },
                 }));
             }
-            // An unsigned division by a constant strictly greater than the maximum possible
-            // value of `lhs` always produces zero. A zero divisor is never greater than the
-            // (non-negative) maximum, so division-by-zero semantics are preserved.
+            // An unsigned division by a constant greater than the maximum possible value of
+            // `lhs` is always zero. A zero divisor never exceeds the maximum, so
+            // division-by-zero semantics are preserved.
             if lhs_type.is_unsigned()
                 && let Some(rhs_value) = rhs_value
                 && constant_exceeds_max_value(dfg, lhs, rhs_value)
@@ -173,11 +173,10 @@ pub(super) fn simplify_binary(
                 return SimplifyResult::SimplifiedTo(zero);
             }
             if lhs_type.is_unsigned() {
-                // An unsigned modulo by a constant strictly greater than the maximum possible
-                // value of `lhs` leaves `lhs` unchanged. A zero modulus is never greater than
-                // the (non-negative) maximum, so division-by-zero semantics are preserved.
-                // This is checked before the power-of-two rewrite below so that an oversized
-                // power-of-two modulus simplifies to `lhs` instead of a redundant truncation.
+                // An unsigned modulo by a constant greater than the maximum possible value of
+                // `lhs` leaves `lhs` unchanged (a zero modulus never exceeds the maximum, so
+                // division-by-zero semantics are preserved). Checked before the power-of-two
+                // rewrite below to avoid simplifying to a redundant truncation instead.
                 if let Some(rhs_value) = rhs_value
                     && constant_exceeds_max_value(dfg, lhs, rhs_value)
                 {
@@ -379,13 +378,10 @@ fn can_simplify_arithmetic_identity(
 }
 
 /// Whether `constant` is strictly greater than the maximum value that the unsigned `value`
-/// can possibly take.
+/// can possibly take, per [`DataFlowGraph::get_value_max_num_bits`].
 ///
-/// The maximum is derived from [`DataFlowGraph::get_value_max_num_bits`], which refines the
-/// type's bit width using the value's definition (e.g. an upcast keeps its source width and a
-/// truncation bounds the result to the truncated width). A value of `max_bits` bits is at most
-/// `2^max_bits - 1`, so the comparison is strict: a constant equal to the maximum never counts
-/// as exceeding it.
+/// A value of `max_bits` bits can reach `2^max_bits - 1`, so the comparison is strict:
+/// a constant equal to the maximum does not count as exceeding it.
 fn constant_exceeds_max_value(dfg: &DataFlowGraph, value: ValueId, constant: FieldElement) -> bool {
     let max_bits = dfg.get_value_max_num_bits(value);
     let max_value = if max_bits >= 128 { u128::MAX } else { (1u128 << max_bits) - 1 };

--- a/test_programs/execution_success/div_mod_by_oversized_constant/Nargo.toml
+++ b/test_programs/execution_success/div_mod_by_oversized_constant/Nargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "div_mod_by_oversized_constant"
+type = "bin"
+authors = [""]
+
+[dependencies]

--- a/test_programs/execution_success/div_mod_by_oversized_constant/Prover.toml
+++ b/test_programs/execution_success/div_mod_by_oversized_constant/Prover.toml
@@ -1,0 +1,9 @@
+# x = 200, y = 0x12345 (masked = 0x45 = 69)
+x = 200
+y = 74565
+expected_q = 0
+expected_r = 200
+expected_masked_q = 0
+expected_masked_r = 69
+expected_small_q = 2
+expected_small_r = 0

--- a/test_programs/execution_success/div_mod_by_oversized_constant/src/main.nr
+++ b/test_programs/execution_success/div_mod_by_oversized_constant/src/main.nr
@@ -1,0 +1,29 @@
+// Unsigned division/modulo where the constant divisor is strictly greater than the
+// maximum possible value of the dividend: `wide` and `masked` are provably at most
+// 255, so `/ 1000`, `% 1000`, `/ 300` and `% 300` are compile-time simplifiable to
+// `0` / the dividend. The `/ 100` and `% 100` cases are NOT simplifiable (100 is
+// within the dividend's range) and must keep full division semantics.
+fn main(
+    x: u8,
+    y: u32,
+    expected_q: u32,
+    expected_r: u32,
+    expected_masked_q: u32,
+    expected_masked_r: u32,
+    expected_small_q: u32,
+    expected_small_r: u32,
+) {
+    // Upcast-bounded dividend: at most 8 bits.
+    let wide = x as u32;
+    assert(wide / 1000 == expected_q);
+    assert(wide % 1000 == expected_r);
+
+    // Mask-bounded dividend: at most 8 bits.
+    let masked = y & 0xff;
+    assert(masked / 300 == expected_masked_q);
+    assert(masked % 300 == expected_masked_r);
+
+    // In-range divisor: must not be simplified away.
+    assert(wide / 100 == expected_small_q);
+    assert(wide % 100 == expected_small_r);
+}

--- a/tooling/nargo_cli/tests/snapshots/execution_success/div_mod_by_oversized_constant/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/div_mod_by_oversized_constant/execute__tests__expanded.snap
@@ -1,0 +1,23 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: expanded_code
+---
+fn main(
+    x: u8,
+    y: u32,
+    expected_q: u32,
+    expected_r: u32,
+    expected_masked_q: u32,
+    expected_masked_r: u32,
+    expected_small_q: u32,
+    expected_small_r: u32,
+) {
+    let wide: u32 = x as u32;
+    assert((wide / 1000_u32) == expected_q);
+    assert((wide % 1000_u32) == expected_r);
+    let masked: u32 = y & 255_u32;
+    assert((masked / 300_u32) == expected_masked_q);
+    assert((masked % 300_u32) == expected_masked_r);
+    assert((wide / 100_u32) == expected_small_q);
+    assert((wide % 100_u32) == expected_small_r);
+}

--- a/tooling/nargo_cli/tests/snapshots/execution_success/div_mod_by_oversized_constant/execute__tests__stdout.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/div_mod_by_oversized_constant/execute__tests__stdout.snap
@@ -1,0 +1,5 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: stdout
+---
+


### PR DESCRIPTION
# Description

This change was developed with support from generative AI; I am reviewing it as the PR author before requesting maintainer review.

## Summary

Simplifies unsigned `div`/`mod` by a constant strictly greater than the dividend's maximum possible value: the quotient is always `0` and the remainder is the dividend, so the whole division circuit is removed. The bound comes from the existing `DataFlowGraph::get_value_max_num_bits`, minimally extended to look through `Truncate` (mirroring `checked_to_unchecked`), which covers upcasts (`x as u32` from a `u8`) and masked values (`x & 0xff`, canonicalized to a truncate). Division-by-zero semantics are preserved and the rule is unsigned-only; signed and `Field` values never fire.

Measured on the new `div_mod_by_oversized_constant` fixture (`bb 5.0.0-nightly.20260522`, `bb gates -s ultra_honk`):

| Metric | before | after |
|---|---:|---:|
| ACIR opcodes (`main`) | 54 | 28 |
| UltraHonk `circuit_size` | 3843 | 3725 |

Caveats: the fixture keeps in-range control divisions, so shared range-table machinery stays in the circuit and the absolute gate delta is modest; noir benchmarks and a 13-program external corpus are unchanged. Independent of the #12780/#12781 range-analysis stack — if that lands first, its rule subsumes this one.

<details>
<summary>Full guard-condition derivation, measurements and validation</summary>

### Guard conditions (derived from the SSA semantics)

- **Unsigned only**: a sign-extended signed value is not magnitude-bounded by its source bit width, so the rule never fires for signed or `Field` types (`Field` division is already rewritten to multiplication by the inverse).
- **Strict inequality**: a value of `max_bits` bits is at most `2^max_bits - 1`, so the rule requires `C > 2^max_bits - 1`. `C == max(lhs)` must not fire (`255 / 255 == 1`), and there is a boundary test proving it does not.
- **Division-by-zero preserved**: a zero divisor is never strictly greater than the (non-negative) maximum, so `lhs / 0` and `lhs % 0` are untouched and keep their failure semantics (tested).
- At the type's own width the rule can never fire, because a constant of the same type cannot exceed the type's maximum — it only triggers when the operand has a provably narrower range (upcast/truncation/mask).
- The `mod` rule is checked before the existing power-of-two-modulus → truncate rewrite, so an oversized power-of-two modulus simplifies to `lhs` directly instead of a redundant truncation.

### Performance detail

The fixture uses u8-upcast and `& 0xff`-masked u32 dividends with `/ 1000`, `% 1000`, `/ 300`, `% 300`, plus in-range `/ 100`, `% 100` controls that must not simplify. Each eliminated euclidean division removes a Brillig quotient/remainder hint call, two range checks and the recomposition/bound constraints. Circuits where the eliminated division is at a wider bit width, or in flattened branches, save proportionally more.

Regression checks, before vs after (ACIR opcodes, `nargo info --force`):

- noir benchmarks: `sha512_100_bytes` 13173 → 13173, `semaphore_depth_10` 5699 → 5699, `bench_eddsa_poseidon` 4147 → 4147, `bench_poseidon2_hash_100` 202 → 202 (unchanged)
- a 13-program external corpus of real ZK circuits (fixed-point/IEEE-754 filter and scan kernels, 65–22313 opcodes): all unchanged
- compile time/memory on `sha512_100_bytes`: 2.30s/181MB → 2.28s/181MB (unchanged)

### Validation

- `cargo nextest run -p noirc_evaluator`: 1838 passed (the pre-existing `interpreter::tests::infinite_recursion` stack-overflow failure reproduces identically on unpatched master on this machine, so it is environmental)
- New SSA-level tests in `simplify/binary.rs`: positive upcast/truncate div and mod simplifications, oversized power-of-two modulus, strict-boundary (`C == max`) non-firing for div and mod, type-width non-firing, div/mod-by-zero non-firing, signed non-firing
- `nargo execute` and `nargo execute --force-brillig` on the new fixture: witness checks pass against externally-computed expected quotients/remainders (including the non-simplified in-range control divisions)
- `cargo fmt` / `cargo clippy` clean; no existing SSA snapshots changed

### Relationship to #12781

#12781 implements the same simplification theme stacked on the #12780 constraint-derived range-analysis stack. This PR is an independent, self-contained re-derivation: the bound source is the existing definition-local `get_value_max_num_bits` walk (plus the small `Truncate` extension mirroring `checked_to_unchecked`), so the diff stands alone. If #12780/#12781 land first, the rule there subsumes this one (with a strictly stronger bound source); if a minimal standalone version is preferred, this one has no prerequisites.

</details>

## Documentation

- [x] No documentation needed (internal SSA simplification).

cc @jeswr for author review.
