### PR TITLE
feat(ssa): remove truncate of values bounded by a bitwise AND with a constant mask

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/opt/remove_truncate_after_range_check.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/remove_truncate_after_range_check.rs
@@ -2,20 +2,30 @@
 //! have a `range_check` on them, where the checked range is less or equal than
 //! the bits to truncate (the truncate isn't needed then as it won't change the
 //! underlying value).
+//!
+//! The same bound is also learned from a bitwise `and` with a constant mask:
+//! every bit set in the result must also be set in the mask, so the result fits
+//! in the mask's bit length (`x & 123` fits in 7 bits, since `123 < 2^7`).
 
+use acvm::AcirField;
 use rustc_hash::FxHashMap as HashMap;
 
 use crate::ssa::{
     ir::{
-        cfg::ControlFlowGraph, dom::DominatorTree, function::Function, instruction::Instruction,
-        post_order::PostOrder, value::ValueId,
+        cfg::ControlFlowGraph,
+        dom::DominatorTree,
+        function::Function,
+        instruction::{Binary, BinaryOp, Instruction},
+        post_order::PostOrder,
+        value::ValueId,
     },
     ssa_gen::Ssa,
 };
 
 impl Ssa {
     /// Removes `truncate` instructions that happen on values that
-    /// have a `range_check` on them, where the checked range is less or equal than
+    /// have a `range_check` on them (or are the result of a bitwise `and` with
+    /// a constant mask), where the known bound is less or equal than
     /// the bits to truncate.
     pub(crate) fn remove_truncate_after_range_check(mut self) -> Self {
         for function in self.functions.values_mut() {
@@ -58,6 +68,31 @@ impl Function {
                             }
                         })
                         .or_insert(*max_bit_size);
+                }
+                // A bitwise `and` with a constant mask bounds the result to the mask's
+                // bit length: every bit set in the result must also be set in the mask,
+                // so `result < 2^bits(mask)`. This holds for non-contiguous masks too
+                // (`x & 0b101` is bounded by 3 bits, the mask's highest set bit).
+                // Masks of the form `2^n - 1` are usually canonicalized to `truncate`
+                // by `simplify_binary` before this pass runs, but other constant masks
+                // (e.g. `x & 123`) reach here as `and` instructions (see issue #8628).
+                Instruction::Binary(Binary { lhs, rhs, operator: BinaryOp::And }) => {
+                    let lhs_constant = context.dfg.get_numeric_constant(*lhs);
+                    let rhs_constant = context.dfg.get_numeric_constant(*rhs);
+                    // A fully-constant `and` is folded elsewhere; a non-constant mask
+                    // gives no bound.
+                    if let (Some(mask), None) | (None, Some(mask)) = (lhs_constant, rhs_constant) {
+                        let mask_bit_size = mask.num_bits();
+                        let [result] = context.dfg.instruction_result(instruction_id);
+                        range_checks
+                            .entry(result)
+                            .and_modify(|current_max| {
+                                if mask_bit_size < *current_max {
+                                    *current_max = mask_bit_size;
+                                }
+                            })
+                            .or_insert(mask_bit_size);
+                    }
                 }
                 // If this is a truncate instruction, check if there's a range check for that same value
                 Instruction::Truncate { value, bit_size, .. } => {
@@ -146,6 +181,142 @@ mod tests {
             range_check v0 to 64 bits
             v1 = truncate v0 to 32 bits, max_bit_size: 254
             return v1
+        }
+        ";
+        assert_ssa_does_not_change(src, Ssa::remove_truncate_after_range_check);
+    }
+
+    #[test]
+    fn removes_truncate_after_and_with_constant_mask() {
+        // 123 = 0b1111011 fits in 7 bits, so truncating the masked value
+        // to 8 bits cannot change it.
+        let src = "
+        acir(inline) pure fn main f0 {
+          b0(v0: u64):
+            v2 = and v0, u64 123
+            jmp b1() // Make sure the optimization is applied across dominated blocks
+          b1():
+            v3 = truncate v2 to 8 bits, max_bit_size: 64
+            v4 = cast v3 as u8
+            return v4
+        }
+        ";
+
+        let ssa = Ssa::from_str(src).unwrap();
+        let ssa = ssa.remove_truncate_after_range_check();
+        assert_ssa_snapshot!(ssa, @r"
+        acir(inline) pure fn main f0 {
+          b0(v0: u64):
+            v2 = and v0, u64 123
+            jmp b1()
+          b1():
+            v3 = cast v2 as u8
+            return v3
+        }
+        ");
+    }
+
+    #[test]
+    fn removes_truncate_after_and_with_non_contiguous_mask_up_to_highest_set_bit() {
+        // 5 = 0b101: the bound is the mask's bit *length* (3), not its
+        // number of set bits, so truncating to 3 bits is removable.
+        let src = "
+        acir(inline) pure fn main f0 {
+          b0(v0: u64):
+            v2 = and v0, u64 5
+            v3 = truncate v2 to 3 bits, max_bit_size: 64
+            return v3
+        }
+        ";
+
+        let ssa = Ssa::from_str(src).unwrap();
+        let ssa = ssa.remove_truncate_after_range_check();
+        assert_ssa_snapshot!(ssa, @r"
+        acir(inline) pure fn main f0 {
+          b0(v0: u64):
+            v2 = and v0, u64 5
+            return v2
+        }
+        ");
+    }
+
+    #[test]
+    fn does_not_remove_truncate_below_the_masks_highest_set_bit() {
+        // 5 = 0b101 has only two bits set but is *not* bounded by 2 bits
+        // (x & 5 can be 4 or 5), so truncating to 2 bits must be kept.
+        let src = "
+        acir(inline) pure fn main f0 {
+          b0(v0: u64):
+            v2 = and v0, u64 5
+            v3 = truncate v2 to 2 bits, max_bit_size: 64
+            return v3
+        }
+        ";
+        assert_ssa_does_not_change(src, Ssa::remove_truncate_after_range_check);
+    }
+
+    #[test]
+    fn does_not_remove_truncate_after_and_with_non_constant_mask() {
+        let src = "
+        acir(inline) pure fn main f0 {
+          b0(v0: u64, v1: u64):
+            v2 = and v0, v1
+            v3 = truncate v2 to 8 bits, max_bit_size: 64
+            return v3
+        }
+        ";
+        assert_ssa_does_not_change(src, Ssa::remove_truncate_after_range_check);
+    }
+
+    #[test]
+    fn does_not_remove_truncate_after_and_with_mask_wider_than_truncation() {
+        // 0x1fb needs 9 bits, so an 8-bit truncation of the masked value
+        // can still change it.
+        let src = "
+        acir(inline) pure fn main f0 {
+          b0(v0: u64):
+            v2 = and v0, u64 507
+            v3 = truncate v2 to 8 bits, max_bit_size: 64
+            return v3
+        }
+        ";
+        assert_ssa_does_not_change(src, Ssa::remove_truncate_after_range_check);
+    }
+
+    #[test]
+    fn does_not_remove_truncate_after_and_with_mask_spanning_the_type_width() {
+        // 0x8000000000000075 needs 64 bits (and is not of the form 2^n - 1,
+        // so it is not canonicalized to a truncation), giving no useful bound
+        // for a 32-bit truncation.
+        let src = "
+        acir(inline) pure fn main f0 {
+          b0(v0: u64):
+            v2 = and v0, u64 9223372036854775925
+            v3 = truncate v2 to 32 bits, max_bit_size: 64
+            return v3
+        }
+        ";
+        assert_ssa_does_not_change(src, Ssa::remove_truncate_after_range_check);
+    }
+
+    #[test]
+    fn does_not_remove_truncate_in_block_not_dominated_by_the_previous_block() {
+        // The pass's known-bounds map is cleared when the traversal moves to a
+        // block that is not dominated by the previously visited one (b1 does
+        // not dominate b2 here), so the bound learned for v3 in b0 is
+        // conservatively dropped and the truncate in b2 is kept, mirroring the
+        // pass's existing dominance discipline for range checks.
+        let src = "
+        acir(inline) pure fn main f0 {
+          b0(v0: u64, v1: u1):
+            v3 = and v0, u64 123
+            jmpif v1 then: b1(), else: b2()
+          b1():
+            v5 = and v0, u64 42
+            jmp b2()
+          b2():
+            v6 = truncate v3 to 8 bits, max_bit_size: 64
+            return v6
         }
         ";
         assert_ssa_does_not_change(src, Ssa::remove_truncate_after_range_check);

--- a/compiler/noirc_evaluator/src/ssa/opt/remove_truncate_after_range_check.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/remove_truncate_after_range_check.rs
@@ -4,8 +4,7 @@
 //! underlying value).
 //!
 //! The same bound is also learned from a bitwise `and` with a constant mask:
-//! every bit set in the result must also be set in the mask, so the result fits
-//! in the mask's bit length (`x & 123` fits in 7 bits, since `123 < 2^7`).
+//! the result fits in the mask's bit length (`x & 123` fits in 7 bits, since `123 < 2^7`).
 
 use acvm::AcirField;
 use rustc_hash::FxHashMap as HashMap;
@@ -69,13 +68,9 @@ impl Function {
                         })
                         .or_insert(*max_bit_size);
                 }
-                // A bitwise `and` with a constant mask bounds the result to the mask's
-                // bit length: every bit set in the result must also be set in the mask,
-                // so `result < 2^bits(mask)`. This holds for non-contiguous masks too
-                // (`x & 0b101` is bounded by 3 bits, the mask's highest set bit).
-                // Masks of the form `2^n - 1` are usually canonicalized to `truncate`
-                // by `simplify_binary` before this pass runs, but other constant masks
-                // (e.g. `x & 123`) reach here as `and` instructions (see issue #8628).
+                // An `and` with a constant mask bounds the result to the mask's bit length
+                // (its highest set bit, so non-contiguous masks work too): every bit set
+                // in the result must also be set in the mask, hence `result < 2^bits(mask)`.
                 Instruction::Binary(Binary { lhs, rhs, operator: BinaryOp::And }) => {
                     let lhs_constant = context.dfg.get_numeric_constant(*lhs);
                     let rhs_constant = context.dfg.get_numeric_constant(*rhs);
@@ -301,11 +296,8 @@ mod tests {
 
     #[test]
     fn does_not_remove_truncate_in_block_not_dominated_by_the_previous_block() {
-        // The pass's known-bounds map is cleared when the traversal moves to a
-        // block that is not dominated by the previously visited one (b1 does
-        // not dominate b2 here), so the bound learned for v3 in b0 is
-        // conservatively dropped and the truncate in b2 is kept, mirroring the
-        // pass's existing dominance discipline for range checks.
+        // b1 does not dominate b2, so the known-bounds map is cleared and the bound
+        // learned for v3 in b0 is conservatively dropped, keeping the truncate in b2.
         let src = "
         acir(inline) pure fn main f0 {
           b0(v0: u64, v1: u1):

--- a/test_programs/execution_success/truncate_after_and_mask/Nargo.toml
+++ b/test_programs/execution_success/truncate_after_and_mask/Nargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "truncate_after_and_mask"
+type = "bin"
+authors = [""]
+
+[dependencies]

--- a/test_programs/execution_success/truncate_after_and_mask/Prover.toml
+++ b/test_programs/execution_success/truncate_after_and_mask/Prover.toml
@@ -1,0 +1,8 @@
+# x = 0x123456789abcddf5 (bit 8 set so that `x & 0x1ab` = 417 exceeds 8 bits)
+# y = 0xcafebabe
+x = 1311768467463790069
+y = 3405691582
+expected_a = 113
+expected_b = 161
+expected_c = 4660
+expected_kept = 161

--- a/test_programs/execution_success/truncate_after_and_mask/src/main.nr
+++ b/test_programs/execution_success/truncate_after_and_mask/src/main.nr
@@ -1,13 +1,7 @@
-// A bitwise AND with a constant mask bounds the result to the mask's bit
-// length, so a subsequent truncation to at least that many bits is redundant
-// and can be removed (issue #8628): `x & 123` fits in 7 bits, so the truncate
-// emitted for the `as u8` cast cannot change the value.
-//
-// Masks of the form `2^n - 1` (like `0xff`) are canonicalized to `truncate`
-// earlier in SSA and never reach the pass as `and`, so the masks here are
-// deliberately not of that form. The `& 0x1ab` case is bounded by 9 bits, so
-// its 8-bit truncation is semantically active and must be kept (for the input
-// in Prover.toml, `x & 0x1ab` is 417 and the cast must reduce it to 161).
+// An AND with a constant mask bounds the result to the mask's bit length, so a
+// truncation to at least that many bits is redundant and removable (issue #8628).
+// Masks of the form `2^n - 1` are canonicalized to `truncate` before the pass runs,
+// so the masks here are deliberately not of that form.
 fn main(x: u64, y: u32, expected_a: u8, expected_b: u8, expected_c: u16, expected_kept: u8) {
     // 123 = 0b111_1011 fits in 7 bits: the 8-bit truncate is removable.
     let a = (x & 123) as u8;

--- a/test_programs/execution_success/truncate_after_and_mask/src/main.nr
+++ b/test_programs/execution_success/truncate_after_and_mask/src/main.nr
@@ -1,0 +1,27 @@
+// A bitwise AND with a constant mask bounds the result to the mask's bit
+// length, so a subsequent truncation to at least that many bits is redundant
+// and can be removed (issue #8628): `x & 123` fits in 7 bits, so the truncate
+// emitted for the `as u8` cast cannot change the value.
+//
+// Masks of the form `2^n - 1` (like `0xff`) are canonicalized to `truncate`
+// earlier in SSA and never reach the pass as `and`, so the masks here are
+// deliberately not of that form. The `& 0x1ab` case is bounded by 9 bits, so
+// its 8-bit truncation is semantically active and must be kept (for the input
+// in Prover.toml, `x & 0x1ab` is 417 and the cast must reduce it to 161).
+fn main(x: u64, y: u32, expected_a: u8, expected_b: u8, expected_c: u16, expected_kept: u8) {
+    // 123 = 0b111_1011 fits in 7 bits: the 8-bit truncate is removable.
+    let a = (x & 123) as u8;
+    assert(a == expected_a);
+
+    // Non-contiguous 8-bit mask 0xab = 0b1010_1011: the 8-bit truncate is removable.
+    let b = (x & 0xab) as u8;
+    assert(b == expected_b);
+
+    // Non-contiguous 13-bit mask on a u32: the 16-bit truncate is removable.
+    let c = (y & 0x1234) as u16;
+    assert(c == expected_c);
+
+    // 9-bit mask 0x1ab: NOT removable for an 8-bit cast; must keep the truncation.
+    let kept = (x & 0x1ab) as u8;
+    assert(kept == expected_kept);
+}

--- a/tooling/nargo_cli/tests/snapshots/execution_success/truncate_after_and_mask/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/truncate_after_and_mask/execute__tests__expanded.snap
@@ -1,0 +1,14 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: expanded_code
+---
+fn main(x: u64, y: u32, expected_a: u8, expected_b: u8, expected_c: u16, expected_kept: u8) {
+    let a: u8 = (x & 123_u64) as u8;
+    assert(a == expected_a);
+    let b: u8 = (x & 171_u64) as u8;
+    assert(b == expected_b);
+    let c: u16 = (y & 4660_u32) as u16;
+    assert(c == expected_c);
+    let kept: u8 = (x & 427_u64) as u8;
+    assert(kept == expected_kept);
+}

--- a/tooling/nargo_cli/tests/snapshots/execution_success/truncate_after_and_mask/execute__tests__stdout.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/truncate_after_and_mask/execute__tests__stdout.snap
@@ -1,0 +1,5 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: stdout
+---
+


### PR DESCRIPTION
# Description

This change was developed with support from generative AI; I am reviewing it as the PR author before requesting maintainer review.

## Summary

Extends the `remove_truncate_after_range_check` SSA pass to also learn value bounds from a bitwise `and` with a constant mask, as suggested in #8628: every bit set in `x & mask` must also be set in `mask`, so the result fits in the mask's bit *length* (highest set bit — non-contiguous masks work too), and a later `truncate` to at least that many bits is removable. Masks of the form `2^n - 1` are already canonicalized to `truncate` before the pass, so this fires exactly on the remaining constant masks (e.g. `x & 123`, the issue's original shape). The pass's existing bound map and dominance discipline are reused unchanged.

Measured on the new `truncate_after_and_mask` fixture (`bb 5.0.0-nightly.20260522`, `bb gates -s ultra_honk`):

| Metric | before | after |
|---|---:|---:|
| ACIR opcodes (`main`) | 28 | 16 |
| UltraHonk `circuit_size` | 4112 | 4112 |
| Σ attributed gates | 2873 | 2858 |

Caveat: on small circuits the backend `circuit_size` is pinned by the AND gadget's lookup-table floor, so the win is in ACIR opcodes, witnesses and Brillig hint work (each removed truncate deletes a full euclidean-division lowering), not UltraHonk gates; noir benchmarks and an 11-program external corpus are unchanged.

<details>
<summary>Full bound derivation, guard conditions and measurement notes</summary>

### The bound rule (each point tested)

- **Bit length, not popcount**: `x & 0b101` can be `4` or `5`, so it is bounded by 3 bits (the mask's highest set bit), not by its 2 set bits. Truncating the masked value to 3 bits is removable; truncating it to 2 bits is not (both tested).
- **Constant mask only**: a non-constant mask gives no bound (tested non-firing).
- **Mask at least as wide as the truncation** gives no useful bound (tested non-firing, including a mask spanning the full type width).
- **Soundness is representation-level and type-independent**: SSA `and` is bitwise on the numeric representations (two's complement for signed types), and `truncate` operates on the same representation, so `result < 2^bits(mask)` is a sound over-approximation for any numeric type. In practice the operands are unsigned integers.
- **Dominance discipline unchanged**: the learned bound lives in the same map as range-check bounds and is dropped by the same clearing rule when the traversal moves to a non-dominated block (tested non-firing). For `and`-derived bounds this is conservative rather than necessary — SSA guarantees any use of the `and` result is dominated by its definition.

### Interaction with `and`-canonicalization

Masks of the form `2^n - 1` (e.g. `x & 0xff`) never reach this pass as `and`: `simplify_binary` canonicalizes them to `truncate` at insertion time (the second observation in #8628). The fixture and SSA tests deliberately use non-`2^n - 1` masks.

### Performance detail

Each removed `truncate` deletes a full euclidean-division lowering at ACIR-gen (`truncate_var` → `euclidean_division_var` by `2^bits`): a Brillig quotient hint call, two range checks (one dropped again by the ACVM optimizer for power-of-two divisors) and the recomposition/bound constraints — net 4 ACIR opcodes per truncate on the fixture. The consuming `cast` is a pure witness reinterpret at ACIR-gen.

On this small fixture the first `and` opcode alone is attributed 2742 gates (bitwise lookup tables), and the removed range checks ride on already-present range tables, so the backend total does not move — only the attributed per-opcode sum drops. A scaling probe with 10 masked casts (not committed) shows the same shape: 67 → 29 ACIR opcodes with `circuit_size` unchanged. Since any circuit exercising this optimization necessarily contains an `and`, the table floor is always paid. The upstream CI gates-diff on the real benchmark circuits is the arbiter for gate-level impact.

Regression checks, before vs after (ACIR opcodes, `nargo info --force`):

- noir benchmarks: `sha512_100_bytes` 13173 → 13173, `semaphore_depth_10` 5699 → 5699, `bench_eddsa_poseidon` 4147 → 4147, `bench_poseidon2_hash_100` 202 → 202 (unchanged)
- an 11-program external corpus of real ZK circuits (fixed-point/IEEE-754 filter and scan kernels, 65–22313 opcodes): all unchanged — real-world code overwhelmingly masks with `2^n - 1`, which is already canonicalized before this pass
- compile time/memory on `sha512_100_bytes` (3 runs each): ~2.2s / ~180MB before and after (unchanged within noise)

### Validation

- New SSA-level tests in the pass: positive removal across a dominated block, non-contiguous-mask bound at the highest set bit (removable at 3 bits, kept at 2 bits), non-constant mask non-firing, mask wider than the truncation non-firing, mask spanning the type width non-firing, dominance-clearing non-firing
- `cargo nextest run -p noirc_evaluator` passes (the pre-existing `ssa::interpreter::tests::infinite_recursion` stack-overflow failure reproduces identically on unpatched master on this machine, so it is environmental); no existing SSA snapshots changed
- `nargo execute` and `nargo execute --force-brillig` on the new fixture: witness solves against externally-computed expected values, including the kept-truncation control (`x & 0x1ab = 417` must reduce to `161` through the cast)
- `cargo fmt` / `cargo clippy` clean

</details>

Resolves #8628

## Documentation

- [x] No documentation needed (internal SSA optimization).

cc @jeswr for author review.
