### PR TITLE
feat(ssa): simplify single-limb `to_bits`/`to_radix` to a range constraint

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/ir/dfg/simplify/call.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/dfg/simplify/call.rs
@@ -56,8 +56,7 @@ pub(super) fn simplify_call(
 
     let simplified_result = match intrinsic {
         Intrinsic::ToBits(endian) => {
-            // TODO: simplify to a range constraint if `limb_count == 1`
-            if let (Some(constant_args), Some(return_type)) = (constant_args, return_type) {
+            if let (Some(constant_args), Some(return_type)) = (&constant_args, return_type) {
                 let field = constant_args[0];
                 let Type::Array(_, limb_count) = return_type else {
                     unreachable!("ICE: Intrinsic::ToRadix return type must be array")
@@ -71,13 +70,23 @@ pub(super) fn simplify_call(
                         call_stack,
                     )
                 })
+            } else if let Some(return_type) = return_type {
+                // The value is not constant: a single-limb decomposition is just a range
+                // constraint on the value.
+                simplify_single_limb_decomposition(
+                    dfg,
+                    arguments[0],
+                    2,
+                    return_type,
+                    block,
+                    call_stack,
+                )
             } else {
                 SimplifyResult::None
             }
         }
         Intrinsic::ToRadix(endian) => {
-            // TODO: simplify to a range constraint if `limb_count == 1`
-            if let (Some(constant_args), Some(return_type)) = (constant_args, return_type) {
+            if let (Some(constant_args), Some(return_type)) = (&constant_args, return_type) {
                 let field = constant_args[0];
                 let radix = constant_args[1].to_u128() as u32;
                 let Type::Array(_, limb_count) = return_type else {
@@ -92,6 +101,20 @@ pub(super) fn simplify_call(
                         call_stack,
                     )
                 })
+            } else if let (Some(return_type), Some(radix)) =
+                (return_type, dfg.get_numeric_constant(arguments[1]))
+            {
+                // The value is not constant here (`constant_args` requires every argument
+                // to be constant, and the radix is): a single-limb decomposition of it is
+                // just a range constraint on the value.
+                simplify_single_limb_decomposition(
+                    dfg,
+                    arguments[0],
+                    radix.to_u128(),
+                    return_type,
+                    block,
+                    call_stack,
+                )
             } else {
                 SimplifyResult::None
             }
@@ -648,6 +671,67 @@ fn simplify_constant_to_radix(
     }
 }
 
+/// Simplify a `to_bits`/`to_radix` call that decomposes into a single limb to a range
+/// constraint.
+///
+/// A radix decomposition into `N` limbs constrains each limb to `[0, radix)` and constrains
+/// the weighted limb sum to reconstruct the input exactly (failing with "Field failed to
+/// decompose into specified `N` limbs" otherwise). With `N == 1` the weighted sum is the
+/// limb itself, so the decomposition constrains exactly `value < radix` and returns
+/// `[value]`. This emits the equivalent `range_check value to log2(radix) bits` followed by
+/// a cast of the value to the limb type, avoiding the decomposition's fresh limb witness,
+/// its Brillig limb hint and the recomposition constraint. Endianness is irrelevant for a
+/// single limb, so both endian variants take this path.
+///
+/// The rewrite only fires for a constant power-of-two radix in `2..=256`: a
+/// non-power-of-two bound (reachable in Brillig, where any radix in `2..=256` is accepted
+/// at runtime) is not expressible as a bit-size range check. Constant values never reach
+/// this function; they are constant-folded (or, when they do not fit, left to fail with
+/// the decomposition's own semantics).
+///
+/// The range check is inserted *before* the cast on purpose:
+/// - the narrowing-cast invariant (see `validation::Validator`) accepts a cast whose input
+///   was previously range-checked to fit the destination type, and
+/// - when the call executes under a predicate, `flatten_cfg` replaces a range-checked
+///   value with its predicated form (`predicate * value`) for the rest of the branch
+///   (issue #8617), which remaps the cast input too. The returned limb therefore stays
+///   zero — in range for its type — when the predicate is off, exactly like the
+///   decomposition's limb (whose input argument would have been multiplied by the
+///   predicate, while its limb range checks are emitted unconditionally).
+fn simplify_single_limb_decomposition(
+    dfg: &mut DataFlowGraph,
+    value: ValueId,
+    radix: u128,
+    return_type: &Type,
+    block: BasicBlockId,
+    call_stack: CallStackId,
+) -> SimplifyResult {
+    let Type::Array(element_types, limb_count) = return_type else {
+        unreachable!("ICE: Intrinsic::ToRadix return type must be array")
+    };
+    if limb_count.0 != 1 {
+        return SimplifyResult::None;
+    }
+    if !(2..=256).contains(&radix) || !radix.is_power_of_two() {
+        return SimplifyResult::None;
+    }
+    let [Type::Numeric(limb_type)] = element_types.as_slice() else {
+        return SimplifyResult::None;
+    };
+
+    let max_bit_size = radix.ilog2();
+    // Keep the decomposition's failure message for the equivalent range constraint.
+    let assert_message = Some("Field failed to decompose into specified 1 limbs".to_string());
+    let range_check = Instruction::RangeCheck { value, max_bit_size, assert_message };
+    dfg.insert_instruction_and_results(range_check, block, None, call_stack);
+
+    let cast = Instruction::Cast(value, *limb_type);
+    let limb = dfg.insert_instruction_and_results(cast, block, None, call_stack).first();
+
+    let array = make_array(dfg, im::Vector::unit(limb), return_type.clone(), block, call_stack);
+    SimplifyResult::SimplifiedTo(array)
+}
+
 pub(crate) fn constant_to_radix(
     endian: Endian,
     field: FieldElement,
@@ -1070,6 +1154,176 @@ mod tests {
     fn constant_to_radix_rejects_non_zero_value_with_zero_limbs() {
         let limbs = constant_to_radix(Endian::Little, FieldElement::from(5u128), 256, 0);
         assert_eq!(limbs, None);
+    }
+
+    #[test]
+    fn single_limb_to_le_radix_simplifies_to_range_check() {
+        let src = "
+        acir(inline) fn main f0 {
+          b0(v0: Field):
+            v1 = call to_le_radix(v0, u32 256) -> [u8; 1]
+            return v1
+        }
+        ";
+        let ssa = Ssa::from_str_simplifying(src).unwrap();
+        assert_ssa_snapshot!(ssa, @r#"
+        acir(inline) fn main f0 {
+          b0(v0: Field):
+            range_check v0 to 8 bits, "Field failed to decompose into specified 1 limbs"
+            v1 = cast v0 as u8
+            v2 = make_array [v1] : [u8; 1]
+            return v2
+        }
+        "#);
+    }
+
+    #[test]
+    fn single_limb_to_be_radix_simplifies_to_range_check() {
+        // Endianness is irrelevant for a single limb: identical to the little-endian case.
+        let src = "
+        acir(inline) fn main f0 {
+          b0(v0: Field):
+            v1 = call to_be_radix(v0, u32 256) -> [u8; 1]
+            return v1
+        }
+        ";
+        let ssa = Ssa::from_str_simplifying(src).unwrap();
+        assert_ssa_snapshot!(ssa, @r#"
+        acir(inline) fn main f0 {
+          b0(v0: Field):
+            range_check v0 to 8 bits, "Field failed to decompose into specified 1 limbs"
+            v1 = cast v0 as u8
+            v2 = make_array [v1] : [u8; 1]
+            return v2
+        }
+        "#);
+    }
+
+    #[test]
+    fn single_limb_to_le_bits_simplifies_to_range_check() {
+        let src = "
+        acir(inline) fn main f0 {
+          b0(v0: Field):
+            v1 = call to_le_bits(v0) -> [u1; 1]
+            return v1
+        }
+        ";
+        let ssa = Ssa::from_str_simplifying(src).unwrap();
+        assert_ssa_snapshot!(ssa, @r#"
+        acir(inline) fn main f0 {
+          b0(v0: Field):
+            range_check v0 to 1 bits, "Field failed to decompose into specified 1 limbs"
+            v1 = cast v0 as u1
+            v2 = make_array [v1] : [u1; 1]
+            return v2
+        }
+        "#);
+    }
+
+    #[test]
+    fn single_limb_to_be_bits_simplifies_to_range_check() {
+        // Endianness is irrelevant for a single limb: identical to the little-endian case.
+        let src = "
+        acir(inline) fn main f0 {
+          b0(v0: Field):
+            v1 = call to_be_bits(v0) -> [u1; 1]
+            return v1
+        }
+        ";
+        let ssa = Ssa::from_str_simplifying(src).unwrap();
+        assert_ssa_snapshot!(ssa, @r#"
+        acir(inline) fn main f0 {
+          b0(v0: Field):
+            range_check v0 to 1 bits, "Field failed to decompose into specified 1 limbs"
+            v1 = cast v0 as u1
+            v2 = make_array [v1] : [u1; 1]
+            return v2
+        }
+        "#);
+    }
+
+    #[test]
+    fn single_limb_to_radix_with_radix_two_range_checks_one_bit() {
+        let src = "
+        acir(inline) fn main f0 {
+          b0(v0: Field):
+            v1 = call to_le_radix(v0, u32 2) -> [u8; 1]
+            return v1
+        }
+        ";
+        let ssa = Ssa::from_str_simplifying(src).unwrap();
+        assert_ssa_snapshot!(ssa, @r#"
+        acir(inline) fn main f0 {
+          b0(v0: Field):
+            range_check v0 to 1 bits, "Field failed to decompose into specified 1 limbs"
+            v1 = cast v0 as u8
+            v2 = make_array [v1] : [u8; 1]
+            return v2
+        }
+        "#);
+    }
+
+    #[test]
+    fn constant_single_limb_to_radix_still_constant_folds() {
+        // A constant value takes the constant-folding path, not the range-constraint one.
+        let src = "
+        acir(inline) fn main f0 {
+          b0():
+            v1 = call to_le_radix(Field 3, u32 256) -> [u8; 1]
+            return v1
+        }
+        ";
+        let ssa = Ssa::from_str_simplifying(src).unwrap();
+        assert_ssa_snapshot!(ssa, @"
+        acir(inline) fn main f0 {
+          b0():
+            v1 = make_array [u8 3] : [u8; 1]
+            return v1
+        }
+        ");
+    }
+
+    #[test]
+    fn multi_limb_to_radix_is_not_simplified() {
+        let src = "
+        acir(inline) fn main f0 {
+          b0(v0: Field):
+            v3 = call to_le_radix(v0, u32 256) -> [u8; 2]
+            return v3
+        }
+        ";
+        let ssa = Ssa::from_str_simplifying(src).unwrap();
+        assert_normalized_ssa_equals(ssa, src);
+    }
+
+    #[test]
+    fn single_limb_to_radix_with_non_power_of_two_radix_is_not_simplified() {
+        // A non-power-of-two radix (reachable in Brillig, where any radix in 2..=256 is
+        // accepted at runtime) is not expressible as a bit-size range check.
+        let src = "
+        brillig(inline) fn main f0 {
+          b0(v0: Field):
+            v3 = call to_le_radix(v0, u32 10) -> [u8; 1]
+            return v3
+        }
+        ";
+        let ssa = Ssa::from_str_simplifying(src).unwrap();
+        assert_normalized_ssa_equals(ssa, src);
+    }
+
+    #[test]
+    fn single_limb_to_radix_with_non_constant_radix_is_not_simplified() {
+        // The radix must be constant to know the range check's bit size (a non-constant
+        // radix is only reachable in Brillig).
+        let src = "
+        brillig(inline) fn main f0 {
+          b0(v0: Field, v1: u32):
+            v3 = call to_le_radix(v0, v1) -> [u8; 1]
+            return v3
+        }
+        ";
+        let ssa = Ssa::from_str_simplifying(src).unwrap();
+        assert_normalized_ssa_equals(ssa, src);
     }
 
     #[test]

--- a/compiler/noirc_evaluator/src/ssa/ir/dfg/simplify/call.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/dfg/simplify/call.rs
@@ -104,9 +104,8 @@ pub(super) fn simplify_call(
             } else if let (Some(return_type), Some(radix)) =
                 (return_type, dfg.get_numeric_constant(arguments[1]))
             {
-                // The value is not constant here (`constant_args` requires every argument
-                // to be constant, and the radix is): a single-limb decomposition of it is
-                // just a range constraint on the value.
+                // The value is not constant (`constant_args` requires every argument to be
+                // constant) but the radix is: the single-limb rewrite still applies.
                 simplify_single_limb_decomposition(
                     dfg,
                     arguments[0],
@@ -671,33 +670,20 @@ fn simplify_constant_to_radix(
     }
 }
 
-/// Simplify a `to_bits`/`to_radix` call that decomposes into a single limb to a range
-/// constraint.
+/// Simplify a `to_bits`/`to_radix` call that decomposes into a single limb: with one limb
+/// the decomposition constrains exactly `value < radix` and returns `[value]`, so it is
+/// replaced by the equivalent `range_check value to log2(radix) bits` (same failure
+/// message) plus a cast to the limb type. Endianness is irrelevant for a single limb.
 ///
-/// A radix decomposition into `N` limbs constrains each limb to `[0, radix)` and constrains
-/// the weighted limb sum to reconstruct the input exactly (failing with "Field failed to
-/// decompose into specified `N` limbs" otherwise). With `N == 1` the weighted sum is the
-/// limb itself, so the decomposition constrains exactly `value < radix` and returns
-/// `[value]`. This emits the equivalent `range_check value to log2(radix) bits` followed by
-/// a cast of the value to the limb type, avoiding the decomposition's fresh limb witness,
-/// its Brillig limb hint and the recomposition constraint. Endianness is irrelevant for a
-/// single limb, so both endian variants take this path.
+/// Only fires for a constant power-of-two radix in `2..=256`: any other bound (reachable
+/// in Brillig, where the radix is a runtime value in `2..=256`) is not expressible as a
+/// bit-size range check. Constant values are constant-folded before reaching this.
 ///
-/// The rewrite only fires for a constant power-of-two radix in `2..=256`: a
-/// non-power-of-two bound (reachable in Brillig, where any radix in `2..=256` is accepted
-/// at runtime) is not expressible as a bit-size range check. Constant values never reach
-/// this function; they are constant-folded (or, when they do not fit, left to fail with
-/// the decomposition's own semantics).
-///
-/// The range check is inserted *before* the cast on purpose:
-/// - the narrowing-cast invariant (see `validation::Validator`) accepts a cast whose input
-///   was previously range-checked to fit the destination type, and
-/// - when the call executes under a predicate, `flatten_cfg` replaces a range-checked
-///   value with its predicated form (`predicate * value`) for the rest of the branch
-///   (issue #8617), which remaps the cast input too. The returned limb therefore stays
-///   zero — in range for its type — when the predicate is off, exactly like the
-///   decomposition's limb (whose input argument would have been multiplied by the
-///   predicate, while its limb range checks are emitted unconditionally).
+/// The range check is inserted *before* the cast on purpose: it justifies the narrowing
+/// cast (see `validation::Validator`), and under a predicate `flatten_cfg` remaps the
+/// range-checked value — and thus the cast input — to `predicate * value` (issue #8617),
+/// so the returned limb stays zero (in range) when the predicate is off, exactly like the
+/// decomposition's limb.
 fn simplify_single_limb_decomposition(
     dfg: &mut DataFlowGraph,
     value: ValueId,

--- a/compiler/noirc_evaluator/src/ssa/opt/constant_folding/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/constant_folding/mod.rs
@@ -2543,13 +2543,13 @@ mod test {
         // After EnableSideEffectsIf removal:
         brillig(inline) fn main f0 {
           b0(v0: Field, v1: Field, v2: u1):
-            v7 = call to_be_radix(v0, u32 256) -> [u8; 1]    // `a.to_be_radix(256)`;
+            v7 = call to_be_radix(v0, u32 256) -> [u8; 2]    // `a.to_be_radix(256)`;
             inc_rc v7
-            v8 = call to_be_radix(v0, u32 256) -> [u8; 1]    // duplicate load of `a`
+            v8 = call to_be_radix(v0, u32 256) -> [u8; 2]    // duplicate load of `a`
             inc_rc v8
             v9 = cast v2 as Field                            // `if c { a.to_be_radix(256) }`
             v10 = mul v0, v9                                 // attaching `c` to `a`
-            v11 = call to_be_radix(v10, u32 256) -> [u8; 1]  // calling `to_radix(c * a)`
+            v11 = call to_be_radix(v10, u32 256) -> [u8; 2]  // calling `to_radix(c * a)`
             inc_rc v11
             return
         }
@@ -2560,13 +2560,13 @@ mod test {
         assert_ssa_snapshot!(ssa, @r"
         brillig(inline) fn main f0 {
           b0(v0: Field, v1: Field, v2: u1):
-            v5 = call to_be_radix(v0, u32 256) -> [u8; 1]
+            v5 = call to_be_radix(v0, u32 256) -> [u8; 2]
             inc_rc v5
             inc_rc v5
             inc_rc v5
             v6 = cast v2 as Field
             v7 = mul v0, v6
-            v8 = call to_be_radix(v7, u32 256) -> [u8; 1]
+            v8 = call to_be_radix(v7, u32 256) -> [u8; 2]
             inc_rc v8
             return
         }

--- a/compiler/noirc_evaluator/src/ssa/opt/remove_bit_shifts.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/remove_bit_shifts.rs
@@ -695,18 +695,17 @@ mod tests {
                 v6 = lt v4, u64 64
                 constrain v6 == u1 1, "attempt to bit-shift with overflow"
                 v8 = cast v1 as Field
-                v10 = call to_le_bits(v8) -> [u1; 1]
-                v12 = array_get v10, index u32 0 -> u1
-                v13 = not v12
-                v14 = cast v12 as Field
-                v15 = cast v13 as Field
-                v17 = mul Field 2, v14
-                v18 = add v15, v17
-                v19 = cast v0 as Field
-                v20 = mul v19, v18
-                v21 = truncate v20 to 64 bits, max_bit_size: 65
-                v22 = cast v21 as u64
-                return v22
+                v9 = make_array [v1] : [u1; 1]
+                v10 = not v1
+                v11 = cast v1 as Field
+                v12 = cast v10 as Field
+                v14 = mul Field 2, v11
+                v15 = add v12, v14
+                v16 = cast v0 as Field
+                v17 = mul v16, v15
+                v18 = truncate v17 to 64 bits, max_bit_size: 65
+                v19 = cast v18 as u64
+                return v19
             }
             "#);
         }

--- a/test_programs/execution_success/to_radix_single_limb/Nargo.toml
+++ b/test_programs/execution_success/to_radix_single_limb/Nargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "to_radix_single_limb"
+type = "bin"
+authors = [""]
+
+[dependencies]

--- a/test_programs/execution_success/to_radix_single_limb/Prover.toml
+++ b/test_programs/execution_success/to_radix_single_limb/Prover.toml
@@ -1,0 +1,9 @@
+# x fits in one byte, b in one bit; y = 0x1234 needs two bytes (and is the
+# non-fitting input for the predicated single-limb decomposition, disabled by
+# `cond = false`).
+x = 250
+b = 1
+y = 4660
+cond = false
+expected_byte = 250
+expected_bit = true

--- a/test_programs/execution_success/to_radix_single_limb/src/main.nr
+++ b/test_programs/execution_success/to_radix_single_limb/src/main.nr
@@ -1,0 +1,33 @@
+// A `to_bits`/`to_radix` decomposition into a single limb constrains exactly
+// `value < radix` and returns `[value]` (the one-limb reconstruction sum is the
+// identity), so the SSA simplifies it to a range check plus a cast instead of
+// a full decomposition (limb witness + Brillig limb hint + recomposition).
+//
+// Endianness is irrelevant for a single limb: both orders are exercised and
+// must return the same limb.
+fn main(x: Field, b: Field, y: Field, cond: bool, expected_byte: u8, expected_bit: bool) {
+    // Single-limb byte decompositions: simplified to an 8-bit range check on `x`.
+    let le_byte: [u8; 1] = x.to_le_bytes();
+    assert(le_byte[0] == expected_byte);
+    let be_byte: [u8; 1] = x.to_be_bytes();
+    assert(be_byte[0] == expected_byte);
+
+    // Single-limb bit decompositions: simplified to a 1-bit range check on `b`.
+    let le_bit: [bool; 1] = b.to_le_bits();
+    assert(le_bit[0] == expected_bit);
+    let be_bit: [bool; 1] = b.to_be_bits();
+    assert(be_bit[0] == expected_bit);
+
+    // Two-limb control: must keep the full decomposition.
+    let two_bytes: [u8; 2] = y.to_le_bytes();
+    assert(two_bytes[0] as Field + two_bytes[1] as Field * 256 == y);
+
+    // Predicated single-limb decomposition of a value that does NOT fit in one
+    // byte: with `cond = false` the emitted range check is predicated off and
+    // must not fail (`flatten_cfg` replaces the range-checked value with its
+    // predicated form for the rest of the branch, issue #8617).
+    if cond {
+        let bad_byte: [u8; 1] = y.to_le_bytes();
+        assert(bad_byte[0] == expected_byte);
+    }
+}

--- a/test_programs/execution_success/to_radix_single_limb/src/main.nr
+++ b/test_programs/execution_success/to_radix_single_limb/src/main.nr
@@ -1,10 +1,6 @@
-// A `to_bits`/`to_radix` decomposition into a single limb constrains exactly
-// `value < radix` and returns `[value]` (the one-limb reconstruction sum is the
-// identity), so the SSA simplifies it to a range check plus a cast instead of
-// a full decomposition (limb witness + Brillig limb hint + recomposition).
-//
-// Endianness is irrelevant for a single limb: both orders are exercised and
-// must return the same limb.
+// A single-limb `to_bits`/`to_radix` decomposition constrains exactly `value < radix`
+// and returns `[value]`, so the SSA simplifies it to a range check plus a cast.
+// Endianness is irrelevant for a single limb: both orders must return the same limb.
 fn main(x: Field, b: Field, y: Field, cond: bool, expected_byte: u8, expected_bit: bool) {
     // Single-limb byte decompositions: simplified to an 8-bit range check on `x`.
     let le_byte: [u8; 1] = x.to_le_bytes();
@@ -22,10 +18,9 @@ fn main(x: Field, b: Field, y: Field, cond: bool, expected_byte: u8, expected_bi
     let two_bytes: [u8; 2] = y.to_le_bytes();
     assert(two_bytes[0] as Field + two_bytes[1] as Field * 256 == y);
 
-    // Predicated single-limb decomposition of a value that does NOT fit in one
-    // byte: with `cond = false` the emitted range check is predicated off and
-    // must not fail (`flatten_cfg` replaces the range-checked value with its
-    // predicated form for the rest of the branch, issue #8617).
+    // Predicated single-limb decomposition of a value that does NOT fit in one byte:
+    // with `cond = false` the emitted range check is predicated off (issue #8617)
+    // and must not fail.
     if cond {
         let bad_byte: [u8; 1] = y.to_le_bytes();
         assert(bad_byte[0] == expected_byte);

--- a/tooling/nargo_cli/tests/snapshots/execution_success/to_radix_single_limb/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/to_radix_single_limb/execute__tests__expanded.snap
@@ -1,0 +1,20 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: expanded_code
+---
+fn main(x: Field, b: Field, y: Field, cond: bool, expected_byte: u8, expected_bit: bool) {
+    let le_byte: [u8; 1] = x.to_le_bytes();
+    assert(le_byte[0_u32] == expected_byte);
+    let be_byte: [u8; 1] = x.to_be_bytes();
+    assert(be_byte[0_u32] == expected_byte);
+    let le_bit: [bool; 1] = b.to_le_bits();
+    assert(le_bit[0_u32] == expected_bit);
+    let be_bit: [bool; 1] = b.to_be_bits();
+    assert(be_bit[0_u32] == expected_bit);
+    let two_bytes: [u8; 2] = y.to_le_bytes();
+    assert(((two_bytes[0_u32] as Field) + ((two_bytes[1_u32] as Field) * 256_Field)) == y);
+    if cond {
+        let bad_byte: [u8; 1] = y.to_le_bytes();
+        assert(bad_byte[0_u32] == expected_byte);
+    }
+}

--- a/tooling/nargo_cli/tests/snapshots/execution_success/to_radix_single_limb/execute__tests__stdout.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/to_radix_single_limb/execute__tests__stdout.snap
@@ -1,0 +1,5 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: stdout
+---
+


### PR DESCRIPTION
# Description

This change was developed with support from generative AI; I am reviewing it as the PR author before requesting maintainer review.

## Summary

Resolves the two in-code TODOs in `simplify_call` (`// TODO: simplify to a range constraint if limb_count == 1`, on the `ToBits` and `ToRadix` arms). A single-limb radix decomposition constrains exactly `value < radix` and returns `[value]`, so it is replaced by `range_check value to log2(radix) bits` (same failure message) + a cast to the limb type + `make_array`, dropping the fresh limb witness, the Brillig limb hint and the recomposition constraint. Fires only for a constant power-of-two radix in `2..=256`; endianness is irrelevant for a single limb. The range check is inserted *before* the cast so the narrowing-cast validator and `flatten_cfg`'s predication of range-checked values (#8617) both compose — the predicated adversarial case is covered by the existing `to_le_bytes` test and the new fixture.

Measured on the new `to_radix_single_limb` fixture (`bb 5.0.0-nightly.20260522`, `bb gates -s ultra_honk`):

| Metric | before | after |
|---|---:|---:|
| ACIR opcodes (`main`) | 28 | 15 |
| UltraHonk `circuit_size` | 89 | 80 |
| Σ attributed gates | 73 | 64 |

Caveat: the eliminated limb's range check is replaced by an equivalent one on the input, so the backend saving per site is small (one witness, one `AssertZero`, one Brillig call) — the win is ACIR opcodes, witness-generation work and dropping the `directive_to_radix` bytecode artifact when no other decomposition remains; noir benchmarks and an 8-program external corpus are unchanged.

<details>
<summary>Full guard-condition derivation, predication analysis and measurement notes</summary>

### Semantics

A radix decomposition into `N` limbs constrains each limb to `[0, radix)` (an unconditional per-limb range constraint in `radix_le_decompose`) and constrains the weighted limb sum to reconstruct the input exactly, failing with `"Field failed to decompose into specified N limbs"` otherwise. With `N == 1` the weighted sum is the limb itself. The failure message is preserved, and the Brillig VM's `to_be_radix` fails with the same message under the same condition, so failure semantics match in both runtimes.

### Guard conditions (each with a test)

- **Single limb only**: `limb_count` comes from the array return type, so it is always compile-time constant; multi-limb decompositions are untouched (tested non-firing). The "non-constant count" guard therefore lives on the **radix**: a non-constant radix (reachable in Brillig, where `to_le_radix` takes a runtime radix) gives no bit size and never fires (tested non-firing).
- **Constant power-of-two radix in `2..=256` only**: a non-power-of-two bound — legal in Brillig — is not expressible as a bit-size range check (tested non-firing on a Brillig function with radix 10). In ACIR the stdlib already `static_assert`s these radix conditions.
- **Non-constant value only**: a constant value keeps the existing constant-folding path (tested), and a constant value that does not fit keeps the decomposition's own solve-time failure semantics.
- **Endianness is irrelevant for a single limb**: `to_le_*` and `to_be_*` produce identical SSA (both tested; the snapshots are byte-identical).

### Predication safety (the subtle part)

The decomposition's per-limb range checks are emitted **unconditionally** at ACIR-gen, while `flatten_cfg` predicates the *input* (`handle_intrinsic_side_effects` multiplies the field argument by the branch condition), so under a false predicate the old limb is `decompose(0) = 0` — always in range for its type. A naive `cast value` replacement would break that invariant: a `u8`-typed SSA value holding an out-of-range field element (dead under a false predicate) can still make the circuit unsatisfiable downstream, e.g. through an unsigned `Lt`, whose internal comparison division is *not* predicated and range-checks its quotient.

The replacement therefore inserts the `range_check` **before** the cast, which composes with two existing mechanisms:

- `flatten_cfg`'s `RangeCheck` handling (issue #8617) replaces the range-checked value with its predicated form (`predicate * value`) *for the rest of the branch*, which remaps the cast input too — so the returned limb is `predicate * value`: exactly the old limb, and zero (in range) when the predicate is off;
- the narrowing-cast validator (`validation::Validator`) accepts a cast whose input was previously range-checked to fit the destination type, so the emitted SSA satisfies the existing cast invariant.

The existing `execution_success/to_le_bytes` test contains exactly the adversarial shape — `if cond { let bad: [u8; 1] = x.to_le_bytes(); }` with `x = 2040124` and `cond = false` — and passes in all harness variants; the new fixture includes the same shape.

### Performance detail

The fixture exercises single-limb `to_le_bytes`/`to_be_bytes`/`to_le_bits`/`to_be_bits` on witness inputs, a two-limb control that must keep the full decomposition, and a predicated non-fitting single-limb decomposition disabled by `cond = false`. A minimal one-site probe (not committed) shows the per-site shape: 5 → 3 ACIR opcodes, `circuit_size` 69 → 68, and the program's 17-opcode `directive_to_radix` unconstrained function disappears entirely when no other decomposition remains.

One knock-on improvement appears in an existing snapshot: the dynamic `shl`-by-`u1` lowering (`remove_bit_shifts`) internally emits a 1-limb `to_le_bits` whose replacement now folds away completely — the range check self-eliminates (the value is provably 1 bit) and the cast chain folds back to the original `u1` — so that lowering loses its whole bit-decomposition (snapshot updated in this PR).

Regression checks, before vs after (ACIR opcodes, `nargo info --force`):

- noir benchmarks: `sha512_100_bytes` 13173 → 13173, `semaphore_depth_10` 5699 → 5699, `bench_eddsa_poseidon` 4147 → 4147, `bench_poseidon2_hash_100` 202 → 202 (unchanged)
- an 8-program external corpus of real ZK circuits (fixed-point filter/scan kernels, 65–22313 opcodes): all unchanged — real code rarely decomposes into a single limb explicitly
- compile time/memory on `sha512_100_bytes` (3 runs each): ~1.9s / ~175–180MB before and after (unchanged within noise)

### Validation

- New SSA-level tests in `simplify/call.rs`: positive single-limb simplification for `to_le_radix`/`to_be_radix` (radix 256), `to_le_bits`/`to_be_bits`, and radix 2 (1-bit check with a `u8` limb); constant-value single-limb still constant-folds; non-firing for multi-limb, non-power-of-two radix (Brillig) and non-constant radix (Brillig)
- `constant_folding::deduplicates_side_effecting_intrinsics` switched from `[u8; 1]` to `[u8; 2]` so it keeps testing intrinsic-*call* deduplication (single-limb calls no longer survive to that pass)
- `cargo nextest run -p noirc_evaluator`: 1837/1838 passed (the pre-existing `ssa::interpreter::tests::infinite_recursion` SIGABRT reproduces identically on unpatched master on this machine, so it is environmental)
- `nargo_cli` execution harness: all 16 generated variants of the new fixture pass (ACIR + `--force-brillig` × inliner settings, minimal, interpreter, comptime, expand), plus all 138 decomposition/bit-shift-related execution tests (`to_le_bytes`, `to_be_bytes`, `to_bits`, `to_radix`, `bit_shifts`, …)
- `nargo execute` and `nargo execute --force-brillig` on the new fixture directly: witness solves, including the predicated non-fitting single-limb case
- `cargo fmt` / `cargo clippy` clean

</details>

## Documentation

- [x] No documentation needed (internal SSA simplification).

cc @jeswr for author review.
