### PR TITLE
fix: track progress of constrained Brillig call outputs

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/checks/check_for_missing_brillig_constraints.rs
+++ b/compiler/noirc_evaluator/src/ssa/checks/check_for_missing_brillig_constraints.rs
@@ -203,7 +203,7 @@ impl TaintedDescendants {
 
     /// Whether there are any unconstrained outputs left.
     /// Returns `true` if the call is fully constrained.
-    fn is_constrained(&self) -> bool {
+    fn is_fully_constrained(&self) -> bool {
         self.single_outputs.is_empty() && self.array_outputs.is_empty()
     }
 
@@ -790,7 +790,7 @@ impl Context {
                             self.max_ancestor_distance,
                         );
 
-                        let fully_constrained = tainted.is_constrained();
+                        let fully_constrained = tainted.is_fully_constrained();
                         if fully_constrained {
                             active_tainted.remove(id);
                         }

--- a/compiler/noirc_evaluator/src/ssa/checks/check_for_missing_brillig_constraints.rs
+++ b/compiler/noirc_evaluator/src/ssa/checks/check_for_missing_brillig_constraints.rs
@@ -220,7 +220,7 @@ impl TaintedDescendants {
     ///
     /// Returns `true` if at least one output was cleared by this call. Each output is
     /// cleared at most once (it is removed from its set when cleared), so this reflects
-    /// genuinely new progress, which the fixed-point loop in [`Self::constrain_tainted`]
+    /// genuinely new progress, which the fixed-point loop in [`Context::constrain_tainted`]
     /// uses to decide whether another walk is worthwhile.
     fn try_constrain(
         &mut self,

--- a/compiler/noirc_evaluator/src/ssa/checks/check_for_missing_brillig_constraints.rs
+++ b/compiler/noirc_evaluator/src/ssa/checks/check_for_missing_brillig_constraints.rs
@@ -202,6 +202,7 @@ impl TaintedDescendants {
     }
 
     /// Whether there are any unconstrained outputs left.
+    /// Returns `true` if the call is fully constrained.
     fn is_constrained(&self) -> bool {
         self.single_outputs.is_empty() && self.array_outputs.is_empty()
     }
@@ -217,7 +218,10 @@ impl TaintedDescendants {
     ///
     /// Any constrained output is added to the `all_constrained` set.
     ///
-    /// Return `true` if all outputs have been constrained.
+    /// Returns `true` if at least one output was cleared by this call. Each output is
+    /// cleared at most once (it is removed from its set when cleared), so this reflects
+    /// genuinely new progress, which the fixed-point loop in [`Self::constrain_tainted`]
+    /// uses to decide whether another walk is worthwhile.
     fn try_constrain(
         &mut self,
         constrained_values: &[ValueId],
@@ -251,6 +255,9 @@ impl TaintedDescendants {
             return false;
         }
 
+        // Set whenever an output is cleared below.
+        let mut progressed = false;
+
         // Remove any results that have been directly or indirectly constrained.
         self.single_outputs.retain(|output| {
             let constrained = constrained_values.iter().any(|value| {
@@ -259,6 +266,7 @@ impl TaintedDescendants {
 
             if constrained {
                 all_constrained.insert(*output);
+                progressed = true;
             }
 
             !constrained
@@ -293,6 +301,7 @@ impl TaintedDescendants {
 
                 if constrained {
                     all_constrained.extend(descendants.iter());
+                    progressed = true;
                 }
 
                 !constrained
@@ -302,7 +311,7 @@ impl TaintedDescendants {
             !index_outputs.is_empty()
         });
 
-        self.is_constrained()
+        progressed
     }
 
     /// Whether one of the constrained values:
@@ -707,13 +716,12 @@ impl Context {
         let mut all_constrained = ValueSet::new(&func.dfg);
 
         loop {
-            let before = self.tainted.len();
-            self.constrain_tainted_pass(func, all_functions, &mut all_constrained);
+            let progressed = self.constrain_tainted_pass(func, all_functions, &mut all_constrained);
 
-            // Re-walk only while we are still making progress and work remains. Fully
-            // constrained functions empty `tainted` in the first pass (no extra walk),
-            // and genuinely under-constrained ones make no progress and stop here too.
-            if self.tainted.is_empty() || self.tainted.len() == before {
+            // Re-walk only while we are still making progress and work remains.
+            // Fully constrained functions empty `tainted` in the first pass (no
+            // extra walk), and genuinely under-constrained ones make no progress and stop.
+            if self.tainted.is_empty() || !progressed {
                 break;
             }
         }
@@ -723,16 +731,20 @@ impl Context {
 
     /// A single Reverse Post Order walk attempting to constrain Brillig outputs,
     /// accumulating cleared outputs into `all_constrained`. See [`Self::constrain_tainted`].
+    ///
+    /// Returns `true` if at least one output was cleared during the walk.
     fn constrain_tainted_pass(
         &mut self,
         func: &Function,
         all_functions: &BTreeMap<FunctionId, Function>,
         all_constrained: &mut ValueSet,
-    ) {
+    ) -> bool {
         // Constraints on tainted output cannot be used to connect output to input.
         let mut all_tainted = ValueSet::new(&func.dfg);
         // Skip checks until we encounter the tainted instruction.
         let mut active_tainted = HashSet::new();
+        // Whether any output was cleared during this walk.
+        let mut progressed = false;
 
         // Traverse in Reverse Post Order, ie. top-down.
         for block_id in self.post_order.clone().into_iter().rev() {
@@ -769,7 +781,7 @@ impl Context {
                             return true;
                         }
 
-                        let constrained = tainted.try_constrain(
+                        progressed |= tainted.try_constrain(
                             &constrained_values,
                             parents,
                             equivalences,
@@ -778,15 +790,18 @@ impl Context {
                             self.max_ancestor_distance,
                         );
 
-                        if constrained {
+                        let fully_constrained = tainted.is_constrained();
+                        if fully_constrained {
                             active_tainted.remove(id);
                         }
 
-                        !constrained
+                        !fully_constrained
                     });
                 }
             }
         }
+
+        progressed
     }
 
     /// Every Brillig call not properly constrained should remain in the tainted set
@@ -1973,6 +1988,32 @@ mod tests {
             return v0
         }
         "#;
+
+        let ssa_level_warnings = check_for_missing_brillig_constraints_in_ssa(program);
+        assert_eq!(ssa_level_warnings.len(), 0);
+    }
+
+    #[test]
+    #[traced_test]
+    /// Multi-output variant of [`equivalence_before_pin_is_order_independent`]:
+    /// a single Brillig call returns two outputs, an equivalence between them is
+    /// seen before the constraint that pins the first output. Clearing the first
+    /// output leaves the call partially tainted, so the fixed-point loop must
+    /// re-walk (tracking cleared outputs, not whole calls) to clear the second.
+    fn multi_output_equivalence_before_pin_is_order_independent() {
+        let program = r#"
+    acir(inline) predicate_pure fn main f0 {
+      b0(v0: u32):
+        v1, v2 = call f1(v0) -> (u32, u32)
+        constrain v1 == v2
+        constrain v1 == v0
+        return
+    }
+    brillig(inline) pure fn f f1 {
+      b0(v0: u32):
+        return v0, v0
+    }
+    "#;
 
         let ssa_level_warnings = check_for_missing_brillig_constraints_in_ssa(program);
         assert_eq!(ssa_level_warnings.len(), 0);


### PR DESCRIPTION
## Problem Resolved

Resolves [claude box issue 1463](https://github.com/noir-lang/noir-claude/issues/1463)

## Summary of Changes
Track the progress for the fixed-point pass directly on what the pass computes (`all_constrained`).


## User Documentation

Check one:
- [X] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
