### PR TITLE
fix: check module visibility for TypedExpr

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/path_resolution.rs
+++ b/compiler/noirc_frontend/src/elaborator/path_resolution.rs
@@ -648,8 +648,13 @@ impl Elaborator<'_> {
         // Use the caller's module if set, else the module the lookup started in.
         let visibility_module = self.caller_module.unwrap_or(self.module_id());
 
+        // The first segment's visibility is computed with the same module the rest of
+        // the path's visibility is checked against (`visibility_module`). When resolving on behalf
+        // of a caller (e.g. `Expr::resolve` with a foreign function scope), that is the caller's
+        // module, not the module the lookup happens to run in — otherwise a private first segment
+        // that is only locally visible in the foreign scope would be wrongly exempted.
         let first_segment_is_always_visible =
-            first_segment_is_always_visible(&path, self.module_id(), starting_module);
+            first_segment_is_always_visible(&path, visibility_module, starting_module);
 
         // The current module and module ID as we resolve path segments
         let mut current_module_id = starting_module;

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
@@ -47,7 +47,7 @@ use crate::{
             value::{ExprValue, FormatStringFragment, TypedExpr},
         },
         def_map::{ModuleDefId, ModuleId, fully_qualified_module_path},
-        resolution::visibility::item_in_module_is_visible,
+        resolution::visibility::{item_in_module_is_visible, module_is_visible},
     },
     hir_def::{
         expr::{HirExpression, HirIdent, HirLiteral, ImplKind, TraitItem},
@@ -2679,12 +2679,20 @@ fn function_def_as_typed_expr(
         let defining_module = interpreter.elaborator.interner.function_module(func_id);
         let visibility = interpreter.elaborator.interner.function_visibility(func_id);
         let caller_module = interpreter.elaborator.module_id();
-        if !item_in_module_is_visible(
+        // Check both function visibility and module visibility:  a `pub` function in a private
+        // module is not reachable.
+        let visible = item_in_module_is_visible(
             interpreter.elaborator.def_maps,
             caller_module,
             defining_module,
             visibility,
-        ) {
+        ) && module_is_visible(
+            defining_module,
+            caller_module,
+            interpreter.elaborator.interner,
+            interpreter.elaborator.def_maps,
+        );
+        if !visible {
             let name = interpreter.elaborator.interner.function_name(&func_id).to_string();
             let defining_module = fully_qualified_module_path(
                 interpreter.elaborator.def_maps,

--- a/compiler/noirc_frontend/src/hir/resolution/visibility.rs
+++ b/compiler/noirc_frontend/src/hir/resolution/visibility.rs
@@ -45,6 +45,31 @@ pub fn item_in_module_is_visible(
     }
 }
 
+/// Returns true if `module` and every one of its ancestor modules (up to, but not including,
+/// the crate root) are visible from `current_module`.
+///
+/// This mimics the behavior of path resolution, which checks the visibility of each module
+/// segment as it walks a path.
+pub fn module_is_visible(
+    module: ModuleId,
+    current_module: ModuleId,
+    interner: &NodeInterner,
+    def_maps: &DefMaps,
+) -> bool {
+    // Each module's visibility is declared in its parent, so we check it against the parent just
+    // as path resolution checks a segment's visibility against the module it lives in. The crate
+    // root has no parent and is always reachable (it is entered via the extern prelude).
+    let mut module = module;
+    while let Some(parent) = module.parent(def_maps) {
+        let visibility = module_def_id_visibility(ModuleDefId::ModuleId(module), interner);
+        if !item_in_module_is_visible(def_maps, current_module, parent, visibility) {
+            return false;
+        }
+        module = parent;
+    }
+    true
+}
+
 /// Returns true if `current` is a (potentially nested) child module of `target`.
 /// This is also true if `current == target`.
 fn module_is_descendant_of_target(

--- a/compiler/noirc_frontend/src/tests/metaprogramming.rs
+++ b/compiler/noirc_frontend/src/tests/metaprogramming.rs
@@ -2516,6 +2516,9 @@ const META_API_STDLIB: &str = r#"
         #[builtin(module_functions)]
         pub comptime fn functions(self) -> [FunctionDefinition] {}
 
+        #[builtin(module_child_modules)]
+        pub comptime fn child_modules(self) -> [Module] {}
+
         #[builtin(module_named_attribute_args)]
         pub comptime fn named_attribute_args<let N: u32>(self, _name: str<N>) -> [[Quoted]] {}
     }
@@ -2596,6 +2599,116 @@ fn comptime_as_typed_expr_visibility() {
         };
 
         assert(victim::read(hijacked_vault) == 31337);
+    }
+    "#;
+    check_errors_with_stdlib(src, [META_API_STDLIB]);
+}
+
+/// A `pub fn` inside a private module is not reachable from outside that module through a
+/// normal path (the enclosing module is private), so it must not be reachable through
+/// `as_typed_expr` either. Checking only the function's own visibility misses the private
+/// enclosing module.
+#[test]
+fn comptime_as_typed_expr_visibility_through_private_module() {
+    let src = r#"
+    mod victim {
+        pub struct Vault {
+            secret: Field,
+        }
+
+        pub fn new() -> Vault {
+            Vault { secret: 1 }
+        }
+
+        pub fn read(v: Vault) -> Field {
+            v.secret
+        }
+
+        mod priv_mod {
+            use super::Vault;
+
+            pub fn set_secret(mut v: Vault, new_secret: Field) -> Vault {
+                v.secret = new_secret;
+                v
+            }
+        }
+    }
+
+    fn main() {
+        let original_vault = victim::new();
+            ^^^^^^^^^^^^^^ unused variable original_vault
+            ~~~~~~~~~~~~~~ unused variable
+
+        let hijacked_vault = comptime {
+            let victim_module = quote { victim }.as_module().unwrap();
+            let mut found = Option::none();
+            for m in victim_module.child_modules() {
+                for f in m.functions() {
+                    if quoted_eq(f.name(), quote { set_secret }) {
+                        found = Option::some(f);
+                    }
+                }
+            }
+            let set_secret = found.unwrap();
+            let set_secret_expr = set_secret.as_typed_expr();
+                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ Function `set_secret` is private
+                                  ~~~~~~~~~~~~~~~~~~~~~~~~~~ `set_secret` is declared in `victim::priv_mod`
+            quote { $set_secret_expr(original_vault, 31337) }
+        };
+
+        assert(victim::read(hijacked_vault) == 31337);
+    }
+    "#;
+    check_errors_with_stdlib(src, [META_API_STDLIB]);
+}
+
+/// The private-module check must not over-restrict: a `pub fn` inside a `pub mod` is reachable
+/// through a normal path, so it must remain reachable through `as_typed_expr` as well.
+#[test]
+fn comptime_as_typed_expr_visibility_through_public_module() {
+    let src = r#"
+    mod victim {
+        pub struct Vault {
+            secret: Field,
+        }
+
+        pub fn new() -> Vault {
+            Vault { secret: 1 }
+        }
+
+        pub fn read(v: Vault) -> Field {
+            v.secret
+        }
+
+        pub mod pub_mod {
+            use super::Vault;
+
+            pub fn set_secret(mut v: Vault, new_secret: Field) -> Vault {
+                v.secret = new_secret;
+                v
+            }
+        }
+    }
+
+    fn main() {
+        let original_vault = victim::new();
+
+        let updated_vault = comptime {
+            let victim_module = quote { victim }.as_module().unwrap();
+            let mut found = Option::none();
+            for m in victim_module.child_modules() {
+                for f in m.functions() {
+                    if quoted_eq(f.name(), quote { set_secret }) {
+                        found = Option::some(f);
+                    }
+                }
+            }
+            let set_secret = found.unwrap();
+            let set_secret_expr = set_secret.as_typed_expr();
+            quote { $set_secret_expr(original_vault, 31337) }
+        };
+
+        assert(victim::read(updated_vault) == 31337);
     }
     "#;
     check_errors_with_stdlib(src, [META_API_STDLIB]);

--- a/compiler/noirc_frontend/src/tests/metaprogramming.rs
+++ b/compiler/noirc_frontend/src/tests/metaprogramming.rs
@@ -3717,3 +3717,32 @@ fn spliced_bare_generic_field_type_rebinds_in_generated_impl() {
     "#;
     check_errors_with_stdlib(src, [META_API_STDLIB]);
 }
+
+/// `Expr::resolve` with a foreign function scope must judge visibility from the caller's module,
+/// including the first path segment. A `pub` item inside a private module of the foreign scope is
+/// reachable there as a plain first segment, but it must not become reachable from the caller.
+#[test]
+fn comptime_resolve_first_segment_visibility() {
+    let src = r#"
+    mod victim {
+        pub fn foreign_scope() {}
+
+        mod secret_mod {
+            pub struct Leaked { pub x: Field }
+        }
+    }
+
+    fn main() {
+        let leaked = comptime {
+            let victim_module = quote { victim }.as_module().unwrap();
+            let expr = quote { secret_mod::Leaked { x: 5 } }.as_expr().unwrap().resolve(Option::some(victim_module.functions()[0]));
+                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ While evaluating `Expr::resolve`
+                               ^^^^^^^^^^ secret_mod is private and not visible from the current module
+                               ~~~~~~~~~~ secret_mod is private
+            quote { $expr.x }
+        };
+        assert(leaked == 5);
+    }
+    "#;
+    check_errors_with_stdlib(src, [META_API_STDLIB]);
+}


### PR DESCRIPTION
## Problem Resolved

Resolves Veridise audit report group9 issue 865: [Quoted TypedExpr can ignore visibility](https://app.audithub.dev/app/organizations/161/projects/600/project-viewer?version=1408&issueId=865)


## Summary of Changes
Check the full path of the function module.


## User Documentation

Check one:
- [X] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
