### PR TITLE
fix(nargo): show `--show-output` output for parameterized (fuzzed) tests

### DIFF
--- a/tooling/greybox_fuzzer/src/lib.rs
+++ b/tooling/greybox_fuzzer/src/lib.rs
@@ -38,6 +38,7 @@ use types::{
     SuccessfulCaseOutcome,
 };
 
+use noirc_abi::InputMap;
 use noirc_artifacts::program::ProgramArtifact;
 use rand::prelude::*;
 use rand::{Rng, SeedableRng};
@@ -48,6 +49,12 @@ use std::io::Write;
 use termcolor::{Color, ColorSpec, WriteColor};
 
 const FOREIGN_CALL_FAILURE_SUBSTRING: &str = "Failed calling external resolver.";
+
+/// Returns an arbitrary input from the corpus, used as a representative passing input so a single
+/// execution's output can be shown for `nargo test --show-output`.
+fn representative_case(corpus: &Corpus) -> Option<InputMap> {
+    corpus.get_current_discovered_testcases().first().map(|testcase| testcase.value().clone())
+}
 
 /// We aim the number of testcases per round so one round takes these many microseconds
 const SINGLE_FUZZING_ROUND_TARGET_TIME: u128 = 100_000u128;
@@ -970,13 +977,13 @@ impl<
                 last_metric_check = time_tracker.elapsed();
                 // Check if we've exceeded the timeout
                 if self.timeout > 0 && time_tracker.elapsed() >= Duration::from_secs(self.timeout) {
-                    return FuzzTestResult::Success;
+                    return FuzzTestResult::Success(representative_case(&corpus));
                 }
                 // Check if we've exceeded the maximum number of executions
                 if self.max_executions > 0
                     && self.metrics.processed_testcase_count >= self.max_executions
                 {
-                    return FuzzTestResult::Success;
+                    return FuzzTestResult::Success(representative_case(&corpus));
                 }
             }
 
@@ -1002,7 +1009,9 @@ impl<
 
         // Parse the execution result and convert it to the FuzzTestResult
         match fuzz_res {
-            HarnessExecutionOutcome::Case(_) => FuzzTestResult::Success,
+            HarnessExecutionOutcome::Case(SuccessfulCaseOutcome { case, .. }) => {
+                FuzzTestResult::Success(Some(case))
+            }
             HarnessExecutionOutcome::Discrepancy(DiscrepancyOutcome {
                 case_id: _,
                 exit_reason: status,

--- a/tooling/greybox_fuzzer/src/lib.rs
+++ b/tooling/greybox_fuzzer/src/lib.rs
@@ -975,13 +975,10 @@ impl<
                 }
                 self.metrics.refresh_round();
                 last_metric_check = time_tracker.elapsed();
-                // Check if we've exceeded the timeout
-                if self.timeout > 0 && time_tracker.elapsed() >= Duration::from_secs(self.timeout) {
-                    return FuzzTestResult::Success(representative_case(&corpus));
-                }
-                // Check if we've exceeded the maximum number of executions
-                if self.max_executions > 0
-                    && self.metrics.processed_testcase_count >= self.max_executions
+                // Check if we've exceeded the timeout or if we've exceeded the maximum number of executions
+                if (self.timeout > 0 && time_tracker.elapsed() >= Duration::from_secs(self.timeout))
+                    || (self.max_executions > 0
+                        && self.metrics.processed_testcase_count >= self.max_executions)
                 {
                     return FuzzTestResult::Success(representative_case(&corpus));
                 }

--- a/tooling/greybox_fuzzer/src/types.rs
+++ b/tooling/greybox_fuzzer/src/types.rs
@@ -16,8 +16,10 @@ pub struct ProgramFailureResult {
 #[derive(Debug)]
 /// The outcome of a fuzz test
 pub enum FuzzTestResult {
-    /// If the program has been executed properly and no failures have been found
-    Success,
+    /// If the program has been executed properly and no failures have been found.
+    /// Carries a representative passing input (when available) so a single execution's
+    /// output can be shown for `nargo test --show-output`.
+    Success(Option<InputMap>),
     /// If we've discovered a failing testcase
     ProgramFailure(ProgramFailureResult),
 

--- a/tooling/nargo/src/ops/fuzz.rs
+++ b/tooling/nargo/src/ops/fuzz.rs
@@ -77,6 +77,7 @@ pub fn run_fuzzing_harness<'a, B, F, E>(
     context: &mut Context,
     fuzzing_harness: &FuzzingHarness,
     show_output: bool,
+    output_sink: Box<dyn std::io::Write + 'a>,
     package_name: String,
     compile_config: &CompileOptions,
     fuzz_folder_config: &FuzzFolderConfig,
@@ -221,7 +222,26 @@ where
 
             let result = fuzzer.fuzz();
             match result {
-                FuzzTestResult::Success => FuzzingRunStatus::ExecutionPass,
+                FuzzTestResult::Success(maybe_input) => {
+                    // Re-run a single representative input so `--show-output` can display the
+                    // output of one execution, mirroring tests without arguments. The many
+                    // executions during fuzzing itself intentionally discard their output.
+                    if let (Some(input_map), Some(acir_program)) = (maybe_input, &acir_program_copy)
+                        && let Ok(initial_witness) = acir_program.abi.encode(&input_map, None)
+                    {
+                        let foreign_call_executor =
+                            build_foreign_call_executor(output_sink, layers::Unhandled);
+                        let mut foreign_call_executor =
+                            TestForeignCallExecutor::new(foreign_call_executor);
+                        let _ = execute_program(
+                            &acir_program.program,
+                            initial_witness,
+                            &B::default(),
+                            &mut foreign_call_executor,
+                        );
+                    }
+                    FuzzingRunStatus::ExecutionPass
+                }
                 FuzzTestResult::ProgramFailure(program_failure_result) => {
                     // Collect failing callstack
                     let unwrapped_acir_program = acir_program_copy.unwrap();
@@ -230,7 +250,7 @@ where
                         .encode(&program_failure_result.counterexample, None)
                         .unwrap();
                     let foreign_call_executor =
-                        build_foreign_call_executor(output(show_output), layers::Unhandled);
+                        build_foreign_call_executor(output_sink, layers::Unhandled);
                     let mut foreign_call_executor =
                         TestForeignCallExecutor::new(foreign_call_executor);
                     // Execute the program with the failing witness
@@ -267,12 +287,19 @@ where
                                 .encode(&program_failure_result.counterexample, None)
                                 .unwrap();
 
+                            // The ACIR re-execution above already captured this input's output
+                            // into `output_sink`, so discard the Brillig re-execution's output to
+                            // avoid showing it twice.
+                            let brillig_foreign_call_executor =
+                                build_foreign_call_executor(output(false), layers::Unhandled);
+                            let mut brillig_foreign_call_executor =
+                                TestForeignCallExecutor::new(brillig_foreign_call_executor);
                             // Execute the program with the failing witness
                             let execution_failure = execute_program(
                                 &unwrapped_brillig_program.program,
                                 initial_witness,
                                 &B::default(),
-                                &mut foreign_call_executor,
+                                &mut brillig_foreign_call_executor,
                             );
                             match execution_failure {
                                 Err(err) => FuzzingRunStatus::ExecutionFailure {

--- a/tooling/nargo/src/ops/test.rs
+++ b/tooling/nargo/src/ops/test.rs
@@ -71,9 +71,10 @@ where
     E: ForeignCallExecutor<FieldElement>,
 {
     if test_function.has_arguments {
-        fuzz_test::<B, F, E>(
+        fuzz_test::<W, B, F, E>(
             context,
             test_function,
+            output,
             package_name,
             config,
             fuzz_config,
@@ -183,23 +184,26 @@ where
 }
 
 /// Runs the fuzzer on a test function. This assumes the function has arguments.
-pub fn fuzz_test<'a, B, F, E>(
+pub fn fuzz_test<'a, W, B, F, E>(
     context: &mut Context,
     test_function: &TestFunction,
+    output: W,
     package_name: String,
     config: &CompileOptions,
     fuzz_config: FuzzConfig,
     build_foreign_call_executor: F,
 ) -> TestStatus
 where
+    W: std::io::Write + 'a,
     B: BlackBoxFunctionSolver<FieldElement> + Default,
     F: Fn(Box<dyn std::io::Write + 'a>, layers::Unhandled) -> E + Sync,
     E: ForeignCallExecutor<FieldElement>,
 {
     match compile_no_check(context, config, test_function.id, None, false) {
-        Ok(_) => fuzz_test_impl::<B, F, E>(
+        Ok(_) => fuzz_test_impl::<W, B, F, E>(
             context,
             test_function,
+            output,
             package_name,
             config,
             fuzz_config,
@@ -209,15 +213,17 @@ where
     }
 }
 
-fn fuzz_test_impl<'a, B, F, E>(
+fn fuzz_test_impl<'a, W, B, F, E>(
     context: &mut Context,
     test_function: &TestFunction,
+    output: W,
     package_name: String,
     config: &CompileOptions,
     fuzz_config: FuzzConfig,
     build_foreign_call_executor: F,
 ) -> TestStatus
 where
+    W: std::io::Write + 'a,
     B: BlackBoxFunctionSolver<FieldElement> + Default,
     F: Fn(Box<dyn std::io::Write + 'a>, layers::Unhandled) -> E + Sync,
     E: ForeignCallExecutor<FieldElement>,
@@ -256,12 +262,13 @@ where
     };
     let fuzz_execution_config = fuzz_config.execution_config;
 
-    // TODO: show output?
-    let show_output = false;
     let fuzz_result = run_fuzzing_harness::<B, _, _>(
         context,
         &fuzzing_harness,
-        show_output,
+        // The many executions during fuzzing discard their output; only the single
+        // representative re-run inside `run_fuzzing_harness` writes to `output`.
+        false,
+        Box::new(output),
         package_name,
         config,
         &fuzz_folder_config,

--- a/tooling/nargo_cli/src/cli/fuzz_cmd.rs
+++ b/tooling/nargo_cli/src/cli/fuzz_cmd.rs
@@ -322,10 +322,13 @@ fn run_fuzzing_harness<S: BlackBoxFunctionSolver<FieldElement> + Default>(
         context.get_all_fuzzing_harnesses_in_crate_matching(&crate_id, &pattern);
     let (_, fuzzing_harness) = fuzzing_harnesses.first().expect("Fuzzing harness should exist");
 
+    let output_sink: Box<dyn Write> =
+        if show_output { Box::new(std::io::stdout()) } else { Box::new(std::io::empty()) };
     nargo::ops::run_fuzzing_harness::<S, _, _>(
         &mut context,
         fuzzing_harness,
         show_output,
+        output_sink,
         package_name.clone(),
         compile_options,
         fuzz_folder_config,

--- a/tooling/nargo_cli/tests/fuzz_show_output.rs
+++ b/tooling/nargo_cli/tests/fuzz_show_output.rs
@@ -1,0 +1,57 @@
+//! Integration test for `nargo test --show-output` on parameterized (fuzzed) tests.
+//!
+//! A test with arguments is executed by the greybox fuzzer rather than a single run. Its
+//! `println` output must still be surfaced under `--show-output` (for a single representative
+//! execution), matching the behavior of tests without arguments. See issue #8194.
+
+use assert_cmd::prelude::*;
+use predicates::prelude::*;
+use std::process::Command;
+
+use assert_fs::TempDir;
+use assert_fs::fixture::ChildPath;
+use assert_fs::prelude::{FileWriteStr, PathChild};
+
+/// A parameterized test prints a constant marker, so the assertion is deterministic regardless of
+/// which input the fuzzer settles on.
+const MAIN_WITH_FUZZED_TEST: &str = "\
+fn main() {}
+
+#[test]
+fn prints(_x: u8) {
+    println(\"fuzz output marker\");
+}
+";
+
+fn new_project(test_dir: &TempDir, project_name: &str) -> ChildPath {
+    #[allow(deprecated)]
+    let mut cmd = Command::cargo_bin("nargo").unwrap();
+    cmd.current_dir(test_dir).arg("new").arg(project_name);
+    cmd.assert().success();
+
+    let project_dir = test_dir.child(project_name);
+    project_dir.child("src").child("main.nr").write_str(MAIN_WITH_FUZZED_TEST).unwrap();
+    project_dir
+}
+
+#[test]
+fn show_output_prints_output_for_parameterized_test() {
+    let test_dir = TempDir::new().unwrap();
+    let project_dir = new_project(&test_dir, "fuzz_show_output");
+
+    #[allow(deprecated)]
+    let mut cmd = Command::cargo_bin("nargo").unwrap();
+    cmd.current_dir(&project_dir).arg("test").arg("--show-output").arg("--exact").arg("prints");
+    cmd.assert().success().stdout(predicate::str::contains("fuzz output marker"));
+}
+
+#[test]
+fn without_show_output_no_output_for_parameterized_test() {
+    let test_dir = TempDir::new().unwrap();
+    let project_dir = new_project(&test_dir, "fuzz_no_show_output");
+
+    #[allow(deprecated)]
+    let mut cmd = Command::cargo_bin("nargo").unwrap();
+    cmd.current_dir(&project_dir).arg("test").arg("--exact").arg("prints");
+    cmd.assert().success().stdout(predicate::str::contains("fuzz output marker").not());
+}


### PR DESCRIPTION
# Description

## Problem

Resolves #8194

`nargo test --show-output` prints `println` output for tests **without** arguments, but shows nothing for **parameterized** tests (e.g. `#[test] fn t(x: u8) { println(x); }`), which are dispatched to the greybox fuzzer instead of a single execution.

## Summary

The fuzz path in `fuzz_test_impl` hardcoded `let show_output = false;` and never forwarded the caller's capture buffer into `run_fuzzing_harness`, so every fuzz execution wrote to `std::io::empty()` and the output was dropped.

Since a fuzzed test runs many times, printing every iteration would be extremely noisy. Following the guidance from the earlier (closed) attempt in #8206 — *"restrict to only the last instance… from a user perspective it always looks like it just ran once with some value"* — this PR shows the output of a **single representative execution**:

- **on success**, a representative passing input (surfaced from the fuzzer's corpus / last successful case);
- **on failure**, the counterexample.

The many per-iteration fuzz executions stay silent. This mirrors how a no-argument test shows its single run's output.

### Changes
- `greybox_fuzzer`: `FuzzTestResult::Success` now carries `Option<InputMap>` (a representative passing input).
- `nargo/ops/fuzz.rs`: `run_fuzzing_harness` takes an `output_sink` used only for one deterministic re-execution; the Brillig counterexample re-run discards its output so failures aren't printed twice.
- `nargo/ops/test.rs`: threads the capture buffer through `run_or_fuzz_test → fuzz_test → fuzz_test_impl`.
- `nargo_cli/src/cli/fuzz_cmd.rs`: `nargo fuzz` behavior preserved.
- Adds an integration test (`tooling/nargo_cli/tests/fuzz_show_output.rs`) asserting a parameterized test's output appears with `--show-output` and not without.

## Additional Context

Example after this change:

```
$ nargo test --show-output
[pkg] Running 1 test function
[pkg] Testing test_with_args ... ok
--- test_with_args stdout ---
with-args output
-----------------------------
[pkg] 1 test passed
```

## Documentation

Check one:
- [x] No documentation needed.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with Prettier and/or `cargo fmt` on default settings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)