### PR TITLE
chore(brillig): Assert that the stack frame is large enough for the max number of registers needed by any instruction

### DIFF
--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_fn.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_fn.rs
@@ -5,6 +5,7 @@ use crate::{
     brillig::brillig_ir::{
         artifact::BrilligParameter,
         brillig_variable::{BrilligVariable, get_bit_size_from_ssa_type},
+        registers::Stack,
     },
     ssa::ir::{
         basic_block::BasicBlockId,
@@ -82,6 +83,20 @@ impl FunctionContext {
         let post_order = PostOrder::with_function(function).into_vec();
         let constants = ConstantAllocation::from_function(function);
         let liveness = VariableLiveness::from_function(function, &constants);
+
+        // A single instruction's operands and scratch registers must all be resident at once;
+        // no amount of spilling can lower it in a frame that cannot hold them. Enforce that floor
+        // up front with a clear diagnostic, rather than letting codegen hit the reactive
+        // "Stack frame too deep" panic once an allocation overflows. The floor is compared against
+        // the *usable* slots — the frame minus the reserved prologue slots.
+        let usable_registers = max_stack_frame_size.saturating_sub(Stack::START_OFFSET);
+        assert!(
+            liveness.min_live_count <= usable_registers,
+            "Brillig function {id} has an instruction that needs at least {} registers, but only \
+             {usable_registers} are usable in a frame of max_stack_frame_size {max_stack_frame_size}",
+            liveness.min_live_count,
+        );
+
         let needs_spill_support =
             liveness.max_live_count + Self::SPILL_MARGIN >= max_stack_frame_size;
 
@@ -171,5 +186,42 @@ impl FunctionContext {
     /// Iterate blocks in Reverse Post Order.
     pub(crate) fn reverse_post_order(&self) -> impl ExactSizeIterator<Item = BasicBlockId> {
         self.blocks.iter().copied().rev()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::FunctionContext;
+    use crate::ssa::ssa_gen::Ssa;
+
+    // A signed `lt` needs max(2 inputs, 1 result) + 3 scratch = 5 usable registers at once,
+    // none of which can be spilled around.
+    const SIGNED_LT: &str = "
+        brillig(inline) fn main f0 {
+          b0(v0: i32, v1: i32):
+            v2 = lt v0, v1
+            return v2
+        }
+        ";
+
+    #[test]
+    #[should_panic(expected = "needs at least 5 registers, but only 4 are usable")]
+    fn new_asserts_frame_fits_per_instruction_floor() {
+        // Frame 6 leaves only 4 usable slots (2 are reserved for the prologue), one short of
+        // the floor, so `new` must reject the layout up front instead of deferring to the
+        // "Stack frame too deep" panic during codegen.
+        let ssa = Ssa::from_str(SIGNED_LT).unwrap();
+        FunctionContext::new(ssa.main(), 6);
+    }
+
+    #[test]
+    fn new_accepts_frame_when_the_floor_fits_the_usable_slots() {
+        // Frame 7 leaves 5 usable slots, exactly the floor, so the assertion passes.
+        // (`new` validates only this per-instruction lower bound; because `min_live_count`
+        // under-counts by the result count for scratch-bearing instructions, full codegen of
+        // this `lt` actually needs one more slot — that residual is left to the codegen panic.)
+        let ssa = Ssa::from_str(SIGNED_LT).unwrap();
+        let ctx = FunctionContext::new(ssa.main(), 7);
+        assert_eq!(ctx.liveness.min_live_count, 5);
     }
 }

--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/variable_liveness.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/variable_liveness.rs
@@ -468,7 +468,7 @@ impl VariableLiveness {
                 // Per-instruction register floor. Inputs and scratch must be resident together;
                 // results reuse operand registers (see the field docs), so they are folded in
                 // with `max` rather than added on top.
-                let num_inputs = variables_used_in_instruction(instruction, &func.dfg).len();
+                let num_inputs = instruction_min_inputs(instruction, &func.dfg);
                 min_count = min_count.max(num_inputs.max(results.len()) + scratch);
 
                 // Subtract variables that die after this instruction.
@@ -495,6 +495,22 @@ impl VariableLiveness {
 
     pub(super) fn cfg(&self) -> &ControlFlowGraph {
         &self.cfg
+    }
+}
+
+/// Number of distinct input variables that must be register-resident *simultaneously* to lower
+/// an instruction — the input contribution to the per-instruction register floor.
+///
+/// For most instructions this is every distinct operand (they feed a single Brillig opcode). The
+/// exception is [`Instruction::MakeArray`]: its elements are written to the heap one at a time
+/// (see `codegen_make_array` and `initialize_constant_array`), so they are never all
+/// register-resident at once — no matter how large the array literal is. The only path holding
+/// more than one element simultaneously is the repeating-item runtime loop, which materializes a
+/// single item's subitems (`subitem_to_repeat_variables`), bounded by the per-item type count.
+fn instruction_min_inputs(instruction: &Instruction, dfg: &DataFlowGraph) -> usize {
+    match instruction {
+        Instruction::MakeArray { typ, .. } => typ.element_types().len(),
+        _ => variables_used_in_instruction(instruction, dfg).len(),
     }
 }
 
@@ -1531,6 +1547,32 @@ mod tests {
         assert_eq!(
             liveness.min_live_count, 1,
             "repeated operand counts once and result reuses it: max(1, 1) = 1, got {}",
+            liveness.min_live_count
+        );
+    }
+
+    #[test]
+    fn min_live_count_does_not_scale_with_make_array_length() {
+        // `MakeArray` writes its elements to the heap one at a time, so they are never all
+        // register-resident together. The floor must not grow with the element count, otherwise a
+        // large array literal would spuriously exceed the frame (regression: `brillig_large_array`
+        // failed to compile). For a scalar-element array the per-item type count is 1.
+        let src = "
+        brillig(inline) fn main f0 {
+          b0():
+            v0 = make_array [u32 0, u32 1, u32 2, u32 3, u32 4, u32 5, u32 6, u32 7, u32 8, u32 9] : [u32; 10]
+            return v0
+        }
+        ";
+        let ssa = Ssa::from_str(src).unwrap();
+        let func = ssa.main();
+        let constants = ConstantAllocation::from_function(func);
+        let liveness = VariableLiveness::from_function(func, &constants);
+
+        assert_eq!(
+            liveness.min_live_count, 1,
+            "make_array of 10 scalars streams one element at a time, so the floor is the per-item \
+             type count (1), not the element count; got {}",
             liveness.min_live_count
         );
     }

--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/variable_liveness.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/variable_liveness.rs
@@ -126,6 +126,32 @@ pub(crate) struct VariableLiveness {
     /// The maximum number of variables simultaneously live at any point in the function.
     /// Computed after `last_uses` by walking each block instruction-by-instruction.
     pub(crate) max_live_count: usize,
+    /// A lower bound on the number of *usable* stack-frame registers required to lower any
+    /// single instruction in the function, i.e.
+    /// `max over instructions of (max(inputs, results) + scratch)`.
+    ///
+    /// An instruction's input variables and transient scratch registers (see
+    /// [`instruction_scratch_demand`]) must be register-resident at the same program point;
+    /// no allocator can spill around them, because you cannot evict an operand you are about
+    /// to read. The results are counted with `max(inputs, results)` rather than added on top
+    /// of the inputs: a result can take over an operand's register in place — the Brillig
+    /// binary opcode reads both sources before writing the destination, and a live operand it
+    /// overwrites is first preserved in a spill slot — so results and inputs share registers.
+    ///
+    /// This makes `min_live_count` a floor that a valid [`LayoutConfig`][layout] must leave room
+    /// for in each frame, after the reserved [`Stack::START_OFFSET`][start] slots. It is a
+    /// deliberate *lower* bound: for an instruction whose scratch outlives the operation (e.g. an
+    /// overflow check that reads operands and result together), the true floor is up to `results`
+    /// higher, because there the result does *not* reuse an operand register. Under-counting is the
+    /// safe direction — the assertion built on this never rejects a frame that codegen could
+    /// actually handle; the residual gap falls through to the reactive "Stack frame too deep" panic.
+    ///
+    /// Whereas [`Self::max_live_count`] drives the *decision to enable* spilling,
+    /// `min_live_count` is that per-instruction floor.
+    ///
+    /// [layout]: crate::brillig::brillig_ir::LayoutConfig
+    /// [start]: crate::brillig::brillig_ir::registers::Stack::START_OFFSET
+    pub(crate) min_live_count: usize,
 }
 
 impl VariableLiveness {
@@ -146,7 +172,7 @@ impl VariableLiveness {
             .compute_block_param_definitions(func, &loops.dom)
             .compute_live_in_of_blocks(func, constants, back_edges)
             .compute_last_uses(func)
-            .compute_max_live_count(func, constants)
+            .compute_live_count(func, constants)
     }
 
     /// The set of values that are alive before the block starts executing.
@@ -373,7 +399,9 @@ impl VariableLiveness {
         self
     }
 
-    /// Compute [`VariableLiveness::max_live_count`].
+    /// Compute [`VariableLiveness::max_live_count`] and [`VariableLiveness::min_live_count`].
+    ///
+    /// ### `max_live_count`
     ///
     /// Walk each block instruction-by-instruction, tracking the set of variables
     /// simultaneously alive: start with `live_in` plus block param definitions,
@@ -384,13 +412,19 @@ impl VariableLiveness {
     /// adds a per-instruction upper bound on the transient scratch registers the code
     /// generator allocates (see [`instruction_scratch_demand`]).
     ///
+    /// ### `min_live_count`
+    ///
+    /// The same walk also computes [`VariableLiveness::min_live_count`], the per-instruction
+    /// register floor: at each instruction `max(distinct inputs, results) + scratch`.
+    ///
     /// # Safety
     /// This remains a lower bound, not an exact live count: some transients are not
     /// attributed per-instruction. Consumers of the max live count are expected to keep
     /// some extra margin to account for those.
     /// See this example [spill margin][crate::brillig::brillig_gen::FunctionContext::SPILL_MARGIN].
-    fn compute_max_live_count(mut self, func: &Function, constants: &ConstantAllocation) -> Self {
+    fn compute_live_count(mut self, func: &Function, constants: &ConstantAllocation) -> Self {
         let mut max_count: usize = 0;
+        let mut min_count: usize = 0;
 
         for block_id in func.reachable_blocks() {
             let block = &func.dfg[block_id];
@@ -431,6 +465,12 @@ impl VariableLiveness {
                 let scratch = instruction_scratch_demand(instruction, &func.dfg);
                 max_count = max_count.max(live_set.len() + scratch);
 
+                // Per-instruction register floor. Inputs and scratch must be resident together;
+                // results reuse operand registers (see the field docs), so they are folded in
+                // with `max` rather than added on top.
+                let num_inputs = variables_used_in_instruction(instruction, &func.dfg).len();
+                min_count = min_count.max(num_inputs.max(results.len()) + scratch);
+
                 // Subtract variables that die after this instruction.
                 if let Some(dead) = last_uses.get(instruction_id) {
                     for d in dead {
@@ -449,6 +489,7 @@ impl VariableLiveness {
         }
 
         self.max_live_count = max_count;
+        self.min_live_count = min_count;
         self
     }
 
@@ -460,7 +501,7 @@ impl VariableLiveness {
 /// Upper bound on the temporary scratch registers the Brillig code generator allocates
 /// while lowering a single instruction (not counting the SSA values tracked by the live set).
 ///
-/// [`compute_max_live_count`] counts live SSA values, allocated constants, and `MakeArray`
+/// [`compute_live_count`] counts live SSA values, allocated constants, and `MakeArray`
 /// elements. The code generator additionally allocates short-lived registers that never
 /// appear as SSA values — overflow/range-check predicates, address-arithmetic temporaries,
 /// and call setup registers. These are live at the same program point as the instruction's
@@ -469,7 +510,7 @@ impl VariableLiveness {
 /// The result is a conservative upper bound added on top of the live set. It does not cover
 /// everything, the rest been handled by [`FunctionContext::SPILL_MARGIN`].
 ///
-/// [`compute_max_live_count`]: VariableLiveness::compute_max_live_count
+/// [`compute_live_count`]: VariableLiveness::compute_live_count
 /// [`FunctionContext::SPILL_MARGIN`]: crate::brillig::brillig_gen::brillig_fn::FunctionContext::SPILL_MARGIN
 fn instruction_scratch_demand(instruction: &Instruction, dfg: &DataFlowGraph) -> usize {
     match instruction {
@@ -1353,7 +1394,7 @@ mod tests {
     fn max_live_count_counts_terminator_constants() {
         // A constant used in multiple branches whose common dominator is a block that
         // doesn't itself use the constant is allocated at the dominator's terminator.
-        // The `InstructionLocation::Terminator` branch of compute_max_live_count was
+        // The `InstructionLocation::Terminator` branch of compute_live_count was
         // previously untested.
         //
         // b0 has four block params live through the jmpif. If the terminator branch
@@ -1409,6 +1450,88 @@ mod tests {
             liveness.max_live_count, 3,
             "peak should be {{prev, const, new}} = 3; got {} (did dead values carry over?)",
             liveness.max_live_count
+        );
+    }
+
+    #[test]
+    fn min_live_count_is_per_instruction_floor_not_the_peak() {
+        // Many values are simultaneously live across this chain (high `max_live_count`),
+        // but every individual instruction only touches two inputs (the result reuses an
+        // operand register), so the per-instruction floor stays at 2 regardless of how much
+        // lives around it.
+        let src = "
+        brillig(inline) fn main f0 {
+          b0(v0: u32, v1: u32, v2: u32, v3: u32, v4: u32):
+            v5 = unchecked_add v0, v1
+            v6 = unchecked_add v2, v3
+            v7 = unchecked_add v4, v5
+            v8 = unchecked_add v6, v7
+            return v8
+        }
+        ";
+        let ssa = Ssa::from_str(src).unwrap();
+        let func = ssa.main();
+        let constants = ConstantAllocation::from_function(func);
+        let liveness = VariableLiveness::from_function(func, &constants);
+
+        assert_eq!(
+            liveness.min_live_count, 2,
+            "each add needs max(2 inputs, 1 result) = 2; got {}",
+            liveness.min_live_count
+        );
+        assert!(
+            liveness.max_live_count > liveness.min_live_count,
+            "this shape should keep many values live at once, so the peak ({}) must exceed \
+             the per-instruction floor ({})",
+            liveness.max_live_count,
+            liveness.min_live_count
+        );
+    }
+
+    #[test]
+    fn min_live_count_includes_instruction_scratch() {
+        // A signed `lt` biases both operands before an unsigned comparison, allocating 3
+        // scratch registers (validated by `binary_scratch_demand_matches_codegen`). The
+        // floor is max(2 inputs, 1 result) + 3 scratch = 5.
+        let src = "
+        brillig(inline) fn main f0 {
+          b0(v0: i32, v1: i32):
+            v2 = lt v0, v1
+            return v2
+        }
+        ";
+        let ssa = Ssa::from_str(src).unwrap();
+        let func = ssa.main();
+        let constants = ConstantAllocation::from_function(func);
+        let liveness = VariableLiveness::from_function(func, &constants);
+
+        assert_eq!(
+            liveness.min_live_count, 5,
+            "expected max(2 inputs, 1 result) + 3 signed-compare scratch = 5, got {}",
+            liveness.min_live_count
+        );
+    }
+
+    #[test]
+    fn min_live_count_deduplicates_repeated_operands() {
+        // `add v0, v0` reads a single distinct input, and the result reuses that operand
+        // register, so the floor is max(1 input, 1 result) = 1. The input set is deduplicated.
+        let src = "
+        brillig(inline) fn main f0 {
+          b0(v0: u32):
+            v1 = unchecked_add v0, v0
+            return v1
+        }
+        ";
+        let ssa = Ssa::from_str(src).unwrap();
+        let func = ssa.main();
+        let constants = ConstantAllocation::from_function(func);
+        let liveness = VariableLiveness::from_function(func, &constants);
+
+        assert_eq!(
+            liveness.min_live_count, 1,
+            "repeated operand counts once and result reuses it: max(1, 1) = 1, got {}",
+            liveness.min_live_count
         );
     }
 

--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/variable_liveness.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/variable_liveness.rs
@@ -538,6 +538,11 @@ fn instruction_scratch_demand(instruction: &Instruction, dfg: &DataFlowGraph) ->
         Instruction::Store { .. } | Instruction::ArrayGet { .. } | Instruction::ArraySet { .. } => {
             1
         }
+        // `codegen_make_array` reserves `ensure_register_capacity(4)`: the result register plus
+        // three transient temporaries (items_pointer, write_pointer, and codegen temps used while
+        // writing the elements). The result is an SSA value already counted in the live set, so the
+        // scratch demand on top of it is 3.
+        Instruction::MakeArray { .. } => 3,
         _ => 0,
     }
 }
@@ -1556,7 +1561,8 @@ mod tests {
         // `MakeArray` writes its elements to the heap one at a time, so they are never all
         // register-resident together. The floor must not grow with the element count, otherwise a
         // large array literal would spuriously exceed the frame (regression: `brillig_large_array`
-        // failed to compile). For a scalar-element array the per-item type count is 1.
+        // failed to compile). It is a fixed `max(per-item type count, result) + scratch`: for a
+        // scalar-element array `max(1, 1) + 3 = 4`, independent of the element count.
         let src = "
         brillig(inline) fn main f0 {
           b0():
@@ -1570,9 +1576,9 @@ mod tests {
         let liveness = VariableLiveness::from_function(func, &constants);
 
         assert_eq!(
-            liveness.min_live_count, 1,
-            "make_array of 10 scalars streams one element at a time, so the floor is the per-item \
-             type count (1), not the element count; got {}",
+            liveness.min_live_count, 4,
+            "make_array of 10 scalars streams one element at a time, so the floor is \
+             max(1 per-item, 1 result) + 3 scratch = 4, independent of the 10 elements; got {}",
             liveness.min_live_count
         );
     }
@@ -1625,13 +1631,13 @@ mod tests {
         let constants = ConstantAllocation::from_function(func);
         let liveness = VariableLiveness::from_function(func, &constants);
 
-        // Peak: v0, v1, v2 (live-in params) + v3 (result) = 4
-        // The elements are already in the live set as block params, but
-        // the result register is allocated simultaneously during codegen.
+        // Peak: v0, v1, v2 (live-in params) + v3 (result) = 4 SSA values, plus the 3 transient
+        // temporaries `codegen_make_array` reserves (items_pointer, write_pointer, codegen temp),
+        // which `instruction_scratch_demand` accounts for = 7.
         assert_eq!(
-            liveness.max_live_count, 4,
-            "MakeArray peak must include the result register: \
-             3 element params + 1 result = 4, got {}",
+            liveness.max_live_count, 7,
+            "MakeArray peak must include the result register and its codegen scratch: \
+             3 element params + 1 result + 3 scratch = 7, got {}",
             liveness.max_live_count
         );
     }
@@ -1673,12 +1679,13 @@ mod tests {
         // Plain chain: peak is {previous, constant, new_result} = 3.
         assert_eq!(peak(plain_chain), 3, "plain chain peak should be 3");
 
-        // With MakeArray: v1 and v2 can no longer die early because they are elements,
-        // so by `v3 = add v2, Field 3` the live set is {v1, v2, Field 3, v3} = 4.
+        // With MakeArray: v1 and v2 can no longer die early because they are elements, so the peak
+        // moves to the MakeArray itself — its live set {v1, v2, v3, v4} = 4 plus the 3 transient
+        // temporaries `codegen_make_array` reserves = 7.
         assert_eq!(
             peak(with_make_array),
-            4,
-            "MakeArray keeps elements live, raising the peak to 4"
+            7,
+            "MakeArray keeps elements live and adds codegen scratch, raising the peak to 7"
         );
 
         assert!(

--- a/compiler/noirc_evaluator/src/brillig/brillig_ir/registers.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_ir/registers.rs
@@ -174,7 +174,7 @@ impl Stack {
     /// Number of reserved slots at the start of each stack frame:
     /// - `sp[0]`: previous stack pointer
     /// - `sp[1]`: per-frame spill base pointer
-    const START_OFFSET: usize = 2;
+    pub(crate) const START_OFFSET: usize = 2;
 
     pub(crate) fn new(layout: LayoutConfig) -> Self {
         Self { storage: DeallocationListAllocator::new(Self::START_OFFSET), layout }


### PR DESCRIPTION
## Problem Resolved

One of the tasks the design doc proposed in https://github.com/noir-lang/noir/pull/13302

### Goal

Convert the latent, reactive `"Stack frame too deep"` panic in `Stack::allocate_register`
into an upfront diagnostic. An instruction's operands and scratch registers must all be
register-resident at the same program point — no allocator can spill around them — so there
is a hard lower bound on `max_stack_frame_size`. If the layout is configured below that bound
we should say so clearly instead of failing deep inside codegen once an allocation overflows.


## Summary of Changes

Three files (`+182 / -7`):

- **`compiler/noirc_evaluator/src/brillig/brillig_gen/variable_liveness.rs`**
  - New field `VariableLiveness::min_live_count`, computed in the same walk as
    `max_live_count` (`compute_max_live_count`).
  - Per instruction: `max(distinct inputs, results) + scratch`, folded with `max` across all
    instructions. `scratch` comes from the existing `instruction_scratch_demand`.
  - Inputs come from `instruction_min_inputs`: for most instructions the distinct operands from
    `variables_used_in_instruction` (a `HashSet`, so repeated operands like `add v0, v0` count
    once; function values excluded). **`MakeArray` is an exception — see below.**
  - Four unit tests: floor is per-instruction (not the peak), scratch is included, operands
    are deduplicated, and the floor does not scale with `MakeArray` length.

- **`compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_fn.rs`**
  - `FunctionContext::new` now asserts
    `min_live_count <= max_stack_frame_size - Stack::START_OFFSET`
    with a clear message ("needs at least N registers, but only M are usable …").
  - Two tests: the assertion fires for a signed `lt` in a too-small frame; it accepts a frame
    whose usable slots meet the floor.

- **`compiler/noirc_evaluator/src/brillig/brillig_ir/registers.rs`**
  - `Stack::START_OFFSET` made `pub(crate)` so the floor can be compared against *usable*
    slots (`frame − START_OFFSET`), not the raw frame. `START_OFFSET = 2` (`sp[0]` = previous
    stack pointer, `sp[1]` = per-frame spill base pointer).


### Why `max(inputs, results) + scratch`, and why against usable slots

The first draft used `inputs + results + scratch <= max_stack_frame_size` (matching the
design doc's shorthand). Review pushed back: comparing against the *full* frame rather than
the *usable* slots relies on the reserved-slot count (2) coincidentally covering the
over-count, with no real relationship to why a result can reuse an input register.

To settle it, a frame-size sweep measured the smallest frame each single instruction compiles
in without the `"Stack frame too deep"` panic (usable = frame − 2):

| instruction   | inputs | results | scratch | usable floor | `i+r+s` | `max(i,r)+s` |
| ------------- | ------ | ------- | ------- | ------------ | ------- | ------------ |
| checked add   | 2      | 1       | 1       | **4**        | 4       | 3            |
| checked mul   | 2      | 1       | 4       | **7**        | 7       | 6            |
| signed lt     | 2      | 1       | 3       | **6**        | 6       | 5            |
| signed div    | 2      | 1       | 8       | **11**       | 11      | 10           |
| array_get     | 2      | 1       | 1       | **4**        | 4       | 3            |

Findings:

1. For every instruction that *actually panics* (scratch-bearing), the true usable floor is
   `inputs + results + scratch` exactly — the result does **not** reuse an operand register
   when there is a post-op check/scratch that keeps operands and result live together.
2. Trivial ops (`unchecked_add`, `store`) never panic; they silently emit
   possibly-fragile code at absurdly small frames, so their apparent floor of 1 is an artifact,
   not a real capability. Result-register reuse (the "alias trick") happens only here.
3. The original `i+r+s <= frame` had a real **false negative**: signed `lt` panics at frame 7,
   but `6 <= 7` passed the assertion. The `+START_OFFSET` slack was masking under-configuration.

The exact rule `i+r+s <= frame − START_OFFSET` would be tightest, but it breaks two existing
compile-only regression tests that deliberately use sub-floor frames — notably
`brillig_spill_does_not_cause_transient_spill_leak`, whose bug *requires* the frame-4
("2-register layout") to reproduce, so bumping it is not an option.

Decision: `max(inputs, results) + scratch` compared against `frame − START_OFFSET`. Rationale:

- **Principled** — compares a reuse-aware demand against the actually-usable slots.
- **Safe** — it is a *lower bound* on the true floor. For an assertion, false positives
  (rejecting a frame codegen could handle → breaking valid compilation) are far worse than
  false negatives (missing a bad config → falling through to the existing panic, i.e. status
  quo). Under-counting is the safe direction.
- **Keeps all tests green.**

Documented caveat: `max(i,r)+s` under-counts the true floor by `results` (≈1) for
scratch-bearing instructions, because the "results reuse operands" assumption is empirically
false when scratch is present. So the assertion catches gross under-configuration but leaves a
±1 gap to the existing codegen panic. `FunctionContext::new` therefore validates only this
floor, not full register pressure.

### The `MakeArray` exception: streamed inputs

`MakeArray` breaks the "all operands must be register-resident together" assumption: its
elements are written to the heap **one at a time** (`codegen_make_array` →
`initialize_constant_array_comptime` converts and stores each element in turn; the repeating-item
runtime loop only ever materializes a single item's subitems, `subitem_to_repeat_variables`). So
a large array literal never needs all of its elements in registers at once.

Counting every distinct element as a simultaneous input therefore massively over-stated the floor
and caused a false positive: `test_programs/execution_success/brillig_large_array` failed to
compile (`min_live_count` exceeded the frame). Fix: `instruction_min_inputs` special-cases
`MakeArray` to `typ.element_types().len()` — the per-item subitem count (1 for a scalar array,
tuple-arity for tuple arrays), which is the true simultaneous bound and matches the size of
`subitem_to_repeat_variables`. Regression test: `min_live_count_does_not_scale_with_make_array_length`;
verified against all 16 `brillig_large_array` variants (including the small-stack one).

**Is `MakeArray` the only exception?** It is the only instruction whose operands are streamed to
the **heap** rather than held in registers, so it is the only one where the distinct-operand
count over-states the floor. (`Call` also marshals many arguments, but into contiguous
**stack-frame** slots that `codegen_call` already bounds-checks separately, so counting those is
not a false-positive source.)

**`MakeArray` scratch.** `codegen_make_array` reserves `ensure_register_capacity(4)` = the result
register plus three transient temporaries (items_pointer, write_pointer, codegen temp). The result
is an SSA value already counted in the live set, so `instruction_scratch_demand` returns **3** for
`MakeArray`, consistent with how it accounts for every other instruction's codegen temporaries.
The floor for a scalar-element array is therefore `max(1 per-item, 1 result) + 3 = 4`, matching the
`ensure_register_capacity(4)` reservation, and independent of the element count.

This scratch also feeds `max_live_count`, so two `max_live_count` `MakeArray` tests move from
`4` → `7` (their earlier expectation counted the elements + result but omitted the codegen
temporaries). `brillig_spill_batch_reduces_consecutive_spill_opcodes` (a `MakeArray` at exactly 4
usable slots) still passes — floor `4 ≤ 4` — confirming this is not a false positive.

### The result-register reuse mechanism (and a needless spill it exposes)

How two live-through operands and a result fit in only 2 usable registers:

- `codegen_binary` allocates the **result register first**, then reloads operands, then emits
  the op (`brillig_binary.rs`).
- Where inputs are reloaded: `convert_ssa_binary` → `convert_ssa_single_addr_value`
  (`brillig_block.rs:1069`) → `convert_ssa_value` (`brillig_block.rs:982`), whose
  `is_spilled` → `reload_spilled_value` (`brillig_block.rs:417`) emits the spill-slot load.
- `spill_value` (`brillig_block.rs:288`) **stores the value to a slot, then frees the
  register** — the value survives in memory.
- With only 2 usable slots the pre-allocated result register necessarily coincides with one
  operand's register at emit time; the alias is safe because a Brillig binary opcode reads
  both sources *before* writing the destination.

#### Needless spill of the empty result register

Real codegen of `v2 = v0 + v1` at frame=4 (2 usable slots, both operands live-through):

```
 3: store sp[2] at sp[1]          ## (1) spill INPUT v0  → free a slot for the result register
 6: store sp[3] at @<slot 1>      ##     spill INPUT v1  → free a slot to reload v0
 7: sp[3] = load  sp[1]           ##     reload v0 into sp[3]      (left operand)
10: store sp[2] at @<slot 2>      ## (2) spill the RESULT register sp[2] — it holds no data yet!
13: sp[2] = load  @<slot 1>       ##     reload v1 into sp[2]      (right operand)
14: sp[2] = add   sp[3], sp[2]    ## (3) v2 = v0 + v1 → sp[2] (the result register)
```

Trace:

1. The result register is allocated first; `ensure_register_capacity` spills the LRU value,
   which is input `v0` (line 3). Result `v2` takes `sp[2]`.
2. Reloading the second operand needs a slot back. At that point registers hold
   `{v2 (result, empty), v0 (just reloaded)}`; the LRU victim is `v2`, so line 10 **stores the
   result register while it contains no live data**.
3. Line 14 overwrites that register with the actual sum.

So lines 8–10 (`const` + `add` + `store`) are ~3 wasted opcodes spilling an empty register.
Root cause: the victim choice uses LRU **recency**, not **next use** — `v2`'s next use is
imminent (line 14) but its last touch is older than `v0`'s reload, so the recency proxy wrongly
ranks the about-to-be-written result as the coldest register.

This is exactly the behavior the design doc targets: the plan-based allocator reserves room for
inputs + results + scratch together (`before_instruction`) so results draw a pre-reserved slot
and never evict a sibling, and its furthest-next-use victim rule cannot evict them (their next
use is immediate). It is wasteful, not incorrect — the stale transient-spill record is cleaned
up by machinery already covered by `brillig_spill_does_not_cause_transient_spill_leak` and
`..._reclaims_slot_when_it_dies`.

Possible cheap follow-up (independent of the allocator rewrite): teach `spill_value` to skip
the store when the victim is a defined-but-not-yet-written result.


## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.


