### PR TITLE
chore(brillig): Make `codegen_mov_registers_to_registers` general again and use it in `jmp`

### DIFF
--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_block.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_block.rs
@@ -611,10 +611,7 @@ impl<'block, Registers: RegisterAllocator> BrilligBlock<'block, Registers> {
     }
 
     fn jmp(&mut self, dfg: &DataFlowGraph, destination: BasicBlockId, arguments: &[ValueId]) {
-        let moves = self.jmp_setup(dfg, destination, arguments, None);
-        for (src, dst) in &moves {
-            self.brillig_context.mov_instruction(*dst, *src);
-        }
+        self.jmp_setup(dfg, destination, arguments, None);
 
         self.brillig_context
             .jump_instruction(self.create_block_label_for_current_function(destination));
@@ -622,19 +619,20 @@ impl<'block, Registers: RegisterAllocator> BrilligBlock<'block, Registers> {
 
     /// Lower a jmp/jmpif's parameter passing into Brillig instructions.
     ///
-    /// Spill-slot stores for params with eagerly-spilled destinations are emitted
-    /// directly here. Register-to-register moves are *returned* (not emitted) so
-    /// the caller can wrap them with a conditional move when lowering a `JmpIf`
-    /// then-branch. When `condition` is `Some(_)`, the spill-slot stores are also
-    /// guarded by the condition; this prevents a `JmpIf` else-branch from leaving a
-    /// then-arg in the then-destination param's spill slot.
+    /// Emits the spill-slot stores for params with eagerly-spilled destinations and the
+    /// register-to-register moves for the rest. The caller is left to emit the jump itself.
+    ///
+    /// `condition` selects between the two lowerings (see the parallel-move handling at the
+    /// end of the function) and, when `Some(_)`, also guards the spill-slot stores; this
+    /// prevents a `JmpIf` else-branch from leaving a then-arg in the then-destination param's
+    /// spill slot.
     fn jmp_setup(
         &mut self,
         dfg: &DataFlowGraph,
         destination: BasicBlockId,
         arguments: &[ValueId],
         condition: Option<MemoryAddress>,
-    ) -> Vec<(MemoryAddress, MemoryAddress)> {
+    ) {
         // Permanently spill non-param live-ins BEFORE the arg/param parallel moves.
         // The parallel moves may overwrite registers that hold values
         // we need to store to spill slots. By spilling first, we guarantee
@@ -678,20 +676,52 @@ impl<'block, Registers: RegisterAllocator> BrilligBlock<'block, Registers> {
             }
         }
 
-        // Block parameter assignments at a jmp must happen "simultaneously".
-        // A naive sequential loop can lose values when a source register
-        // is overwritten by an earlier move in the same batch. For example, with:
-        //   `jmp b1(v1, v2, u32 10)` where b1(v2, v3, v4):
-        // Sequential execution would:
-        //      1. mov reg(v2), reg(v1) — overwrites old v3
-        //      2. mov reg(v3), reg(v2) — reads the NEW v2 instead of old
-        // To prevent this, we save any source that would be overwritten into a
-        // temporary first.
-        let dest_set: HashSet<MemoryAddress> = moves.iter().map(|(_, d)| *d).collect();
+        // Block-parameter assignments at a jump happen "simultaneously": a source register
+        // may also be another param's destination, so emitting the moves naively in sequence
+        // can clobber a value before it is read. How we break that hazard differs between an
+        // unconditional and a conditional jump.
+        match condition {
+            None => self.codegen_unconditional_block_param_moves(moves),
+            Some(condition) => self.codegen_conditional_block_param_moves(moves, condition),
+        }
+    }
 
-        // `Allocated` automatically deallocates the register when dropped,
-        // so we collect the temporaries here to keep them alive until all
-        // moves have been emitted.
+    /// Lower the block-parameter moves of an unconditional `Jmp`.
+    ///
+    /// Every move is unconditional, so we hand the whole batch to the general parallel-move
+    /// solver: it orders the acyclic chains and breaks each cycle with a single temporary —
+    /// sometimes reusing an already-written destination as that scratch register, which is
+    /// only sound precisely because none of the writes are conditional.
+    fn codegen_unconditional_block_param_moves(
+        &mut self,
+        moves: Vec<(MemoryAddress, MemoryAddress)>,
+    ) {
+        let (sources, destinations): (Vec<_>, Vec<_>) = moves.into_iter().unzip();
+        self.brillig_context.codegen_mov_registers_to_registers(&sources, &destinations);
+    }
+
+    /// Lower the block-parameter moves of a `JmpIf` then-branch, guarded by `condition`.
+    ///
+    /// Every destination must be written with a `conditional_move` so that an else-taken
+    /// branch leaves it untouched. This rules out the general solver used for an
+    /// unconditional jump: it emits plain (unconditional) `mov`s and may reuse an
+    /// already-written destination as a cycle's scratch register — but under a false
+    /// condition that destination was never written, so reusing it would read stale data.
+    ///
+    /// Instead we save every source that is also a destination into a *fresh* temporary up
+    /// front. Copying into scratch unconditionally is harmless, and it guarantees each
+    /// conditional move reads the source's original value even after earlier moves have
+    /// (conditionally) overwritten destinations. This spends one temporary per such source
+    /// rather than one per cycle; teaching the solver to emit conditional moves so this path
+    /// can share it is left as a follow-up.
+    fn codegen_conditional_block_param_moves(
+        &mut self,
+        mut moves: Vec<(MemoryAddress, MemoryAddress)>,
+        condition: MemoryAddress,
+    ) {
+        // `Allocated` deallocates the register when dropped, so `temps` keeps them alive
+        // until all conditional moves have been emitted.
+        let dest_set: HashSet<MemoryAddress> = moves.iter().map(|(_, d)| *d).collect();
         let mut temps = Vec::new();
         for (src, _dst) in &mut moves {
             if dest_set.contains(src) {
@@ -701,7 +731,12 @@ impl<'block, Registers: RegisterAllocator> BrilligBlock<'block, Registers> {
                 temps.push(temp);
             }
         }
-        moves
+
+        for (src, dst) in &moves {
+            // The else_address is the same as the destination here to avoid modification if the
+            // condition is false.
+            self.brillig_context.conditional_move_instruction(condition, *src, *dst, *dst);
+        }
     }
 
     /// Conditionally move only the `then_arguments` of a jmpif terminator then
@@ -726,12 +761,7 @@ impl<'block, Registers: RegisterAllocator> BrilligBlock<'block, Registers> {
         then_destination: BasicBlockId,
         then_arguments: &[ValueId],
     ) {
-        let moves = self.jmp_setup(dfg, then_destination, then_arguments, Some(condition.address));
-        for (src, dst) in &moves {
-            // The else_address is the same as the destination here to avoid modification if the
-            // condition is false.
-            self.brillig_context.conditional_move_instruction(condition.address, *src, *dst, *dst);
-        }
+        self.jmp_setup(dfg, then_destination, then_arguments, Some(condition.address));
 
         self.brillig_context.jump_if_instruction(
             condition.address,

--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_block.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_block.rs
@@ -678,65 +678,12 @@ impl<'block, Registers: RegisterAllocator> BrilligBlock<'block, Registers> {
 
         // Block-parameter assignments at a jump happen "simultaneously": a source register
         // may also be another param's destination, so emitting the moves naively in sequence
-        // can clobber a value before it is read. How we break that hazard differs between an
-        // unconditional and a conditional jump.
-        match condition {
-            None => self.codegen_unconditional_block_param_moves(moves),
-            Some(condition) => self.codegen_conditional_block_param_moves(moves, condition),
-        }
-    }
-
-    /// Lower the block-parameter moves of an unconditional `Jmp`.
-    ///
-    /// Every move is unconditional, so we hand the whole batch to the general parallel-move
-    /// solver: it orders the acyclic chains and breaks each cycle with a single temporary —
-    /// sometimes reusing an already-written destination as that scratch register, which is
-    /// only sound precisely because none of the writes are conditional.
-    fn codegen_unconditional_block_param_moves(
-        &mut self,
-        moves: Vec<(MemoryAddress, MemoryAddress)>,
-    ) {
+        // can clobber a value before it is read. The general parallel-move solver orders the
+        // moves and breaks any cycle with a single temporary. When lowering a `JmpIf`
+        // then-branch (`condition` is `Some(_)`), it emits the destination writes as
+        // conditional moves so an else-taken branch leaves the params untouched.
         let (sources, destinations): (Vec<_>, Vec<_>) = moves.into_iter().unzip();
-        self.brillig_context.codegen_mov_registers_to_registers(&sources, &destinations);
-    }
-
-    /// Lower the block-parameter moves of a `JmpIf` then-branch, guarded by `condition`.
-    ///
-    /// Every destination must be written with a `conditional_move` so that an else-taken
-    /// branch leaves it untouched. This rules out the general solver used for an
-    /// unconditional jump: it emits plain (unconditional) `mov`s and may reuse an
-    /// already-written destination as a cycle's scratch register — but under a false
-    /// condition that destination was never written, so reusing it would read stale data.
-    ///
-    /// Instead we save every source that is also a destination into a *fresh* temporary up
-    /// front. Copying into scratch unconditionally is harmless, and it guarantees each
-    /// conditional move reads the source's original value even after earlier moves have
-    /// (conditionally) overwritten destinations. This spends one temporary per such source
-    /// rather than one per cycle; teaching the solver to emit conditional moves so this path
-    /// can share it is left as a follow-up.
-    fn codegen_conditional_block_param_moves(
-        &mut self,
-        mut moves: Vec<(MemoryAddress, MemoryAddress)>,
-        condition: MemoryAddress,
-    ) {
-        // `Allocated` deallocates the register when dropped, so `temps` keeps them alive
-        // until all conditional moves have been emitted.
-        let dest_set: HashSet<MemoryAddress> = moves.iter().map(|(_, d)| *d).collect();
-        let mut temps = Vec::new();
-        for (src, _dst) in &mut moves {
-            if dest_set.contains(src) {
-                let temp = self.brillig_context.allocate_register();
-                self.brillig_context.mov_instruction(*temp, *src);
-                *src = *temp;
-                temps.push(temp);
-            }
-        }
-
-        for (src, dst) in &moves {
-            // The else_address is the same as the destination here to avoid modification if the
-            // condition is false.
-            self.brillig_context.conditional_move_instruction(condition, *src, *dst, *dst);
-        }
+        self.brillig_context.codegen_mov_registers_to_registers(&sources, &destinations, condition);
     }
 
     /// Conditionally move only the `then_arguments` of a jmpif terminator then

--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/tests/jmp.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/tests/jmp.rs
@@ -1,0 +1,59 @@
+use crate::{
+    assert_artifact_snapshot, brillig::brillig_gen::tests::ssa_to_brillig_artifacts,
+    ssa::ir::map::Id,
+};
+
+/// A block that jumps to itself rotating its own parameters
+/// (`jmp b1(v5, v6, v7, v4)` where `b1(v4, v5, v6, v7)`) forms a cycle in the
+/// parameter-passing parallel move: every source register is also a destination
+/// register. The block-argument mover must break the cycle with temporaries.
+///
+/// This exercises how many temporaries and move opcodes that cycle costs. A
+/// general cycle-detecting solver rotates an N-cycle with a single temporary and
+/// N+1 moves; an inline "copy every source-that-is-a-destination to a fresh temp"
+/// strategy uses N temporaries and 2N moves.
+#[test]
+fn brillig_jmp_rotates_block_params_through_a_cycle() {
+    let src = "
+    brillig(inline) fn main f0 {
+      b0(v0: u32, v1: u32, v2: u32, v3: u32):
+        jmp b1(v0, v1, v2, v3)
+      b1(v4: u32, v5: u32, v6: u32, v7: u32):
+        v8 = lt v4, v5
+        jmpif v8 then: b2(), else: b3()
+      b2():
+        jmp b1(v5, v6, v7, v4)
+      b3():
+        return v4
+    }
+    ";
+
+    let brillig = ssa_to_brillig_artifacts(src);
+    let main = &brillig.ssa_function_to_brillig[&Id::test_new(0)];
+
+    // The rotation at `b2` (bytecode indices 8-15) copies all four sources into
+    // fresh temporaries (sp[2..5]) before writing the destinations: 8 moves, 4
+    // temporaries for a single 4-cycle.
+    assert_artifact_snapshot!(main, @r"
+    fn main
+     0: sp[6] = sp[2]
+     1: sp[7] = sp[3]
+     2: sp[8] = sp[4]
+     3: sp[9] = sp[5]
+     4: jump to 0 // -> 5: f0/b1
+     5: sp[2] = u32 lt sp[6], sp[7] // f0/b1
+     6: jump if sp[2] to 0 // -> 8: f0/b2
+     7: jump to 0 // -> 17: f0/b3
+     8: sp[2] = sp[7] // f0/b2
+     9: sp[3] = sp[8]
+    10: sp[4] = sp[9]
+    11: sp[5] = sp[6]
+    12: sp[6] = sp[2]
+    13: sp[7] = sp[3]
+    14: sp[8] = sp[4]
+    15: sp[9] = sp[5]
+    16: jump to 0 // -> 5: f0/b1
+    17: sp[2] = sp[6] // f0/b3
+    18: return
+    ");
+}

--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/tests/jmp.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/tests/jmp.rs
@@ -60,9 +60,10 @@ fn brillig_jmp_rotates_block_params_through_a_cycle() {
 /// then-branch parameter passing is a 4-cycle whose moves must be *conditional* so an
 /// else-taken branch leaves the params untouched.
 ///
-/// The general parallel-move solver only emits unconditional moves, so this path breaks
-/// the cycle inline by copying every source-that-is-a-destination into a fresh temporary
-/// before the conditional moves: 4 temporaries and 8 moves for the 4-cycle.
+/// The general parallel-move solver breaks the cycle by priming a single temporary with
+/// the loop entry (an unconditional copy into fresh scratch) and rotating the rest with
+/// conditional moves: 1 temporary and 5 moves for the 4-cycle. When the condition is
+/// false every conditional move is a no-op, so the params are left untouched.
 #[test]
 fn brillig_jmpif_rotates_block_params_through_a_cycle() {
     let src = "
@@ -80,9 +81,9 @@ fn brillig_jmpif_rotates_block_params_through_a_cycle() {
     let brillig = ssa_to_brillig_artifacts(src);
     let main = &brillig.ssa_function_to_brillig[&Id::test_new(0)];
 
-    // The conditional rotation at `b1` (bytecode indices 6-13) copies all four sources
-    // into fresh temporaries (sp[3..5], sp[10]) before the conditional moves: 8 moves,
-    // 4 temporaries for a single 4-cycle.
+    // The conditional rotation at `b1` (bytecode indices 6-10) primes one temporary
+    // (sp[3]) with the loop entry, then rotates the rest with conditional moves: 5 moves,
+    // 1 temporary for the 4-cycle.
     assert_artifact_snapshot!(main, @r"
     fn main
      0: sp[6] = sp[2]
@@ -91,17 +92,14 @@ fn brillig_jmpif_rotates_block_params_through_a_cycle() {
      3: sp[9] = sp[5]
      4: jump to 0 // -> 5: f0/b1
      5: sp[2] = u32 lt sp[6], sp[7] // f0/b1
-     6: sp[3] = sp[7]
-     7: sp[4] = sp[8]
-     8: sp[5] = sp[9]
-     9: sp[10] = sp[6]
-    10: sp[6] = if sp[2] then sp[3] else sp[6]
-    11: sp[7] = if sp[2] then sp[4] else sp[7]
-    12: sp[8] = if sp[2] then sp[5] else sp[8]
-    13: sp[9] = if sp[2] then sp[10] else sp[9]
-    14: jump if sp[2] to 0 // -> 5: f0/b1
-    15: jump to 0 // -> 16: f0/b2
-    16: sp[2] = sp[6] // f0/b2
-    17: return
+     6: sp[3] = sp[6]
+     7: sp[6] = if sp[2] then sp[7] else sp[6]
+     8: sp[7] = if sp[2] then sp[8] else sp[7]
+     9: sp[8] = if sp[2] then sp[9] else sp[8]
+    10: sp[9] = if sp[2] then sp[3] else sp[9]
+    11: jump if sp[2] to 0 // -> 5: f0/b1
+    12: jump to 0 // -> 13: f0/b2
+    13: sp[2] = sp[6] // f0/b2
+    14: return
     ");
 }

--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/tests/jmp.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/tests/jmp.rs
@@ -54,3 +54,54 @@ fn brillig_jmp_rotates_block_params_through_a_cycle() {
     15: return
     ");
 }
+
+/// Same rotation as [`brillig_jmp_rotates_block_params_through_a_cycle`], but reached
+/// through a `jmpif` then-branch (`jmpif v8 then: b1(v5, v6, v7, v4), else: ..`). The
+/// then-branch parameter passing is a 4-cycle whose moves must be *conditional* so an
+/// else-taken branch leaves the params untouched.
+///
+/// The general parallel-move solver only emits unconditional moves, so this path breaks
+/// the cycle inline by copying every source-that-is-a-destination into a fresh temporary
+/// before the conditional moves: 4 temporaries and 8 moves for the 4-cycle.
+#[test]
+fn brillig_jmpif_rotates_block_params_through_a_cycle() {
+    let src = "
+    brillig(inline) fn main f0 {
+      b0(v0: u32, v1: u32, v2: u32, v3: u32):
+        jmp b1(v0, v1, v2, v3)
+      b1(v4: u32, v5: u32, v6: u32, v7: u32):
+        v8 = lt v4, v5
+        jmpif v8 then: b1(v5, v6, v7, v4), else: b2()
+      b2():
+        return v4
+    }
+    ";
+
+    let brillig = ssa_to_brillig_artifacts(src);
+    let main = &brillig.ssa_function_to_brillig[&Id::test_new(0)];
+
+    // The conditional rotation at `b1` (bytecode indices 6-13) copies all four sources
+    // into fresh temporaries (sp[3..5], sp[10]) before the conditional moves: 8 moves,
+    // 4 temporaries for a single 4-cycle.
+    assert_artifact_snapshot!(main, @r"
+    fn main
+     0: sp[6] = sp[2]
+     1: sp[7] = sp[3]
+     2: sp[8] = sp[4]
+     3: sp[9] = sp[5]
+     4: jump to 0 // -> 5: f0/b1
+     5: sp[2] = u32 lt sp[6], sp[7] // f0/b1
+     6: sp[3] = sp[7]
+     7: sp[4] = sp[8]
+     8: sp[5] = sp[9]
+     9: sp[10] = sp[6]
+    10: sp[6] = if sp[2] then sp[3] else sp[6]
+    11: sp[7] = if sp[2] then sp[4] else sp[7]
+    12: sp[8] = if sp[2] then sp[5] else sp[8]
+    13: sp[9] = if sp[2] then sp[10] else sp[9]
+    14: jump if sp[2] to 0 // -> 5: f0/b1
+    15: jump to 0 // -> 16: f0/b2
+    16: sp[2] = sp[6] // f0/b2
+    17: return
+    ");
+}

--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/tests/jmp.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/tests/jmp.rs
@@ -31,9 +31,9 @@ fn brillig_jmp_rotates_block_params_through_a_cycle() {
     let brillig = ssa_to_brillig_artifacts(src);
     let main = &brillig.ssa_function_to_brillig[&Id::test_new(0)];
 
-    // The rotation at `b2` (bytecode indices 8-15) copies all four sources into
-    // fresh temporaries (sp[2..5]) before writing the destinations: 8 moves, 4
-    // temporaries for a single 4-cycle.
+    // The rotation at `b2` (bytecode indices 8-12) saves the loop entry into a
+    // single temporary (sp[2]) and rotates the rest in place: 5 moves, 1
+    // temporary for the 4-cycle.
     assert_artifact_snapshot!(main, @r"
     fn main
      0: sp[6] = sp[2]
@@ -43,17 +43,14 @@ fn brillig_jmp_rotates_block_params_through_a_cycle() {
      4: jump to 0 // -> 5: f0/b1
      5: sp[2] = u32 lt sp[6], sp[7] // f0/b1
      6: jump if sp[2] to 0 // -> 8: f0/b2
-     7: jump to 0 // -> 17: f0/b3
-     8: sp[2] = sp[7] // f0/b2
-     9: sp[3] = sp[8]
-    10: sp[4] = sp[9]
-    11: sp[5] = sp[6]
-    12: sp[6] = sp[2]
-    13: sp[7] = sp[3]
-    14: sp[8] = sp[4]
-    15: sp[9] = sp[5]
-    16: jump to 0 // -> 5: f0/b1
-    17: sp[2] = sp[6] // f0/b3
-    18: return
+     7: jump to 0 // -> 14: f0/b3
+     8: sp[2] = sp[6] // f0/b2
+     9: sp[6] = sp[7]
+    10: sp[7] = sp[8]
+    11: sp[8] = sp[9]
+    12: sp[9] = sp[2]
+    13: jump to 0 // -> 5: f0/b1
+    14: sp[2] = sp[6] // f0/b3
+    15: return
     ");
 }

--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/tests/mod.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/tests/mod.rs
@@ -25,6 +25,7 @@ mod binary;
 mod black_box;
 mod call;
 mod coalescing;
+mod jmp;
 mod memory;
 mod spill;
 mod truncate;

--- a/compiler/noirc_evaluator/src/brillig/brillig_ir/codegen_calls.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_ir/codegen_calls.rs
@@ -126,7 +126,7 @@ impl<F: AcirField + DebugToString, Registers: RegisterAllocator> BrilligContext<
             destinations.push(destination_register);
             sources.push(return_variable.extract_register());
         }
-        self.codegen_mov_registers_to_registers(&sources, &destinations);
+        self.codegen_mov_registers_to_registers(&sources, &destinations, None);
         self.return_instruction();
     }
 }

--- a/compiler/noirc_evaluator/src/brillig/brillig_ir/codegen_stack.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_ir/codegen_stack.rs
@@ -11,6 +11,10 @@ impl<F: AcirField + DebugToString, Registers: RegisterAllocator> BrilligContext<
     /// (and cycles broken with temporaries) so that every destination ends up holding the
     /// value its source held *before* any move was performed.
     ///
+    /// When `condition` is `Some(_)`, every destination is written with a `conditional_move`
+    /// guarded by that register, so the whole batch is a no-op when the condition is false;
+    /// with `None` the destinations are written unconditionally.
+    ///
     /// It assumes that:
     /// - every destination needs to be written at most once. Will panic if not.
     /// - sources and destinations are any addresses (relative registers or direct globals);
@@ -20,6 +24,7 @@ impl<F: AcirField + DebugToString, Registers: RegisterAllocator> BrilligContext<
         &mut self,
         sources: &[MemoryAddress],
         destinations: &[MemoryAddress],
+        condition: Option<MemoryAddress>,
     ) {
         assert_eq!(sources.len(), destinations.len(), "sources and destinations length must match");
         let n = sources.len();
@@ -64,6 +69,7 @@ impl<F: AcirField + DebugToString, Registers: RegisterAllocator> BrilligContext<
                     node,
                     sources[node],
                     destinations,
+                    condition,
                     &mut num_destinations,
                     &mut processed,
                 );
@@ -86,22 +92,30 @@ impl<F: AcirField + DebugToString, Registers: RegisterAllocator> BrilligContext<
                 return;
             }
         }
-        // All sinks and their parents have been processed, remaining nodes are part of a loop
-        // Check if a tail_candidate is a branch to a loop
-        for (entry, free) in tail_candidates {
-            let entry_idx = to_index(&dest_index, &entry).unwrap();
-            if num_destinations[entry_idx] == 1 {
-                // Use the branch as the temporary register for the loop
-                let free_register = from_index(destinations, free);
-                self.process_loop(
-                    entry_idx,
-                    &free_register,
-                    destinations,
-                    &dest_index,
-                    &mut num_destinations,
-                    sources,
-                    &mut processed,
-                );
+        // All sinks and their parents have been processed, remaining nodes are part of a loop.
+        // Check if a tail_candidate is a branch to a loop.
+        //
+        // This reuses an already-written destination (`free`) as the loop's scratch register.
+        // That is only sound when the writes are unconditional: under a false `condition` the
+        // move into `free` never happened, so it would hold stale data. When conditional, we
+        // skip this and let these loops fall through to the fresh-temporary path below.
+        if condition.is_none() {
+            for (entry, free) in tail_candidates {
+                let entry_idx = to_index(&dest_index, &entry).unwrap();
+                if num_destinations[entry_idx] == 1 {
+                    // Use the branch as the temporary register for the loop
+                    let free_register = from_index(destinations, free);
+                    self.process_loop(
+                        entry_idx,
+                        &free_register,
+                        destinations,
+                        &dest_index,
+                        condition,
+                        &mut num_destinations,
+                        sources,
+                        &mut processed,
+                    );
+                }
             }
         }
         if processed == n {
@@ -117,12 +131,15 @@ impl<F: AcirField + DebugToString, Registers: RegisterAllocator> BrilligContext<
                 // Unfortunately, we cannot use one register for all the loops
                 // when the sources do not have the same type
                 let temp_register = self.registers_mut().allocate_register();
+                // Prime the temporary with the loop entry unconditionally: it is fresh scratch,
+                // so writing it even when the condition is false is harmless.
                 self.mov_instruction(temp_register, src);
                 self.process_loop(
                     i,
                     &temp_register,
                     destinations,
                     &dest_index,
+                    condition,
                     &mut num_destinations,
                     sources,
                     &mut processed,
@@ -144,6 +161,7 @@ impl<F: AcirField + DebugToString, Registers: RegisterAllocator> BrilligContext<
         free: &MemoryAddress,
         destinations: &[MemoryAddress],
         dest_index: &HashMap<MemoryAddress, usize>,
+        condition: Option<MemoryAddress>,
         num_destinations: &mut [usize],
         source: &[MemoryAddress],
         processed: &mut usize,
@@ -154,25 +172,34 @@ impl<F: AcirField + DebugToString, Registers: RegisterAllocator> BrilligContext<
                 current,
                 source[current],
                 destinations,
+                condition,
                 num_destinations,
                 processed,
             );
             current = to_index(dest_index, &source[current]).unwrap();
         }
-        self.perform_movement(current, *free, destinations, num_destinations, processed);
+        self.perform_movement(current, *free, destinations, condition, num_destinations, processed);
     }
 
-    /// Generates a move opcode from 'src' to 'dest'.
+    /// Generates a move opcode from 'src' to 'dest'. When `condition` is `Some(_)`, the write
+    /// is a `conditional_move` guarded by it (leaving 'dest' unchanged when false); otherwise
+    /// it is an unconditional `mov`.
     fn perform_movement(
         &mut self,
         dest: usize,
         src: MemoryAddress,
         destinations: &[MemoryAddress],
+        condition: Option<MemoryAddress>,
         num_destinations: &mut [usize],
         processed: &mut usize,
     ) {
         let destination = from_index(destinations, dest);
-        self.mov_instruction(destination, src);
+        match condition {
+            None => self.mov_instruction(destination, src),
+            Some(condition) => {
+                self.conditional_move_instruction(condition, src, destination, destination);
+            }
+        }
         // set the node as 'processed'
         num_destinations[dest] = usize::MAX;
         *processed += 1;
@@ -263,7 +290,7 @@ mod tests {
             context.registers_mut().allocate_register();
         }
         let (sources, destinations) = movements_to_source_and_destinations(movements);
-        context.codegen_mov_registers_to_registers(&sources, &destinations);
+        context.codegen_mov_registers_to_registers(&sources, &destinations, None);
 
         let opcodes = context.into_artifact().byte_code;
 
@@ -389,24 +416,24 @@ mod tests {
         let mut context = create_context();
 
         // This should overflow the stack with recursive implementation
-        context.codegen_mov_registers_to_registers(&sources, &destinations);
+        context.codegen_mov_registers_to_registers(&sources, &destinations, None);
     }
 
     #[test]
     fn prop_mov_registers_to_registers() {
         const MEM_SIZE: usize = 10;
         arbtest::arbtest(|u| {
-            // Allocate more memory to allow for temporary variables.
-            let mut memory: Vec<u32> = vec![0; MEM_SIZE * 2];
+            // Room for the working slots, the condition register, and any temporaries.
+            let mut initial_memory: Vec<u32> = vec![0; MEM_SIZE * 3];
             // Fill the memory with some random numbers.
-            for slot in &mut memory {
+            for slot in &mut initial_memory {
                 *slot = u.arbitrary()?;
             }
 
             // Pick a random unique subset of the slots as destinations.
             let num_destinations = u.int_in_range(0..=MEM_SIZE)?;
 
-            // All potential memory slots; we can't address before the stack start.
+            // All potential source/destination slots; we can't address before the stack start.
             let all_indexes = (0..MEM_SIZE).map(|i| i + S).collect::<Vec<_>>();
 
             // Choose the destinations as a random unique subset of the slots (in an
@@ -425,39 +452,76 @@ mod tests {
                 sources.push(u.choose(&all_indexes).copied()?);
             }
 
-            // Take a snapshot of the source data; this is what we expect the destination to become.
-            let source_data = vecmap(&sources, |i| memory[*i]);
+            // A dedicated condition register just past the working slots, so it is never a
+            // source or destination and the mover's temporaries are allocated above it.
+            let condition_slot = S + MEM_SIZE;
 
-            // Generate the opcodes.
-            let opcodes = {
-                // Convert to MemoryAddress
-                let sources = vecmap(&sources, |i| MemoryAddress::relative(assert_u32(*i)));
-                let destinations =
-                    vecmap(&destinations, |i| MemoryAddress::relative(assert_u32(*i)));
+            // Exercise the same move set unconditionally, and conditionally with both a true
+            // and a false guard. A true (or absent) guard performs the moves; a false guard
+            // must leave every destination untouched.
+            for condition_value in [None, Some(true), Some(false)] {
+                let mut memory = initial_memory.clone();
+                if let Some(value) = condition_value {
+                    memory[condition_slot] = u32::from(value);
+                }
 
-                let mut context = create_context();
+                // Snapshots taken before the moves: what the destinations should become when
+                // the moves run, and what they must stay when a false guard suppresses them.
+                let source_data = vecmap(&sources, |i| memory[*i]);
+                let original_destination_data = vecmap(&destinations, |i| memory[*i]);
 
-                // Treat the memory we care about as pre-allocated, so temporary variables are created after them.
-                let all_registers = vecmap(all_indexes, |i| MemoryAddress::relative(assert_u32(i)));
-                context.set_allocated_registers(all_registers);
+                let condition_address =
+                    condition_value.map(|_| MemoryAddress::relative(assert_u32(condition_slot)));
 
-                context.codegen_mov_registers_to_registers(&sources, &destinations);
-                context.into_artifact().byte_code
-            };
+                // Generate the opcodes.
+                let opcodes = {
+                    // Convert to MemoryAddress
+                    let sources = vecmap(&sources, |i| MemoryAddress::relative(assert_u32(*i)));
+                    let destinations =
+                        vecmap(&destinations, |i| MemoryAddress::relative(assert_u32(*i)));
 
-            // Execute the opcodes.
-            for opcode in opcodes {
-                let Opcode::Mov { destination, source } = opcode else {
-                    unreachable!("only Mov expected");
+                    let mut context = create_context();
+
+                    // Pre-allocate the working slots and the condition register, so temporary
+                    // variables are created above them.
+                    let mut allocated =
+                        vecmap(&all_indexes, |i| MemoryAddress::relative(assert_u32(*i)));
+                    allocated.push(MemoryAddress::relative(assert_u32(condition_slot)));
+                    context.set_allocated_registers(allocated);
+
+                    context.codegen_mov_registers_to_registers(
+                        &sources,
+                        &destinations,
+                        condition_address,
+                    );
+                    context.into_artifact().byte_code
                 };
-                memory[assert_usize(destination.to_u32())] = memory[assert_usize(source.to_u32())];
+
+                // Execute the opcodes.
+                for opcode in opcodes {
+                    match opcode {
+                        Opcode::Mov { destination, source } => {
+                            memory[assert_usize(destination.to_u32())] =
+                                memory[assert_usize(source.to_u32())];
+                        }
+                        Opcode::ConditionalMov { destination, source_a, source_b, condition } => {
+                            let taken = memory[assert_usize(condition.to_u32())] != 0;
+                            let source = if taken { source_a } else { source_b };
+                            memory[assert_usize(destination.to_u32())] =
+                                memory[assert_usize(source.to_u32())];
+                        }
+                        other => unreachable!("only Mov/ConditionalMov expected, got {other:?}"),
+                    }
+                }
+
+                // Get the final values at the destination slots.
+                let destination_data = vecmap(&destinations, |i| memory[*i]);
+
+                match condition_value {
+                    None | Some(true) => assert_eq!(destination_data, source_data),
+                    Some(false) => assert_eq!(destination_data, original_destination_data),
+                }
             }
-
-            // Get the final values at the destination slots.
-            let destination_data = vecmap(&destinations, |i| memory[*i]);
-
-            // At the end the destination should have the same value as the source had.
-            assert_eq!(destination_data, source_data);
 
             Ok(())
         })

--- a/compiler/noirc_evaluator/src/brillig/brillig_ir/codegen_stack.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_ir/codegen_stack.rs
@@ -1,16 +1,20 @@
-use acvm::{AcirField, acir::brillig::MemoryAddress};
+use std::collections::HashMap;
 
-use crate::brillig::{assert_usize, brillig_ir::assert_u32};
+use acvm::{AcirField, acir::brillig::MemoryAddress};
 
 use super::{BrilligContext, debug_show::DebugToString, registers::RegisterAllocator};
 
 impl<F: AcirField + DebugToString, Registers: RegisterAllocator> BrilligContext<F, Registers> {
     /// Map sources to potentially multiple destinations.
     /// This function moves values from a set of registers to another set of registers.
+    /// The movement is treated as a set of simultaneous assignments: the moves are ordered
+    /// (and cycles broken with temporaries) so that every destination ends up holding the
+    /// value its source held *before* any move was performed.
+    ///
     /// It assumes that:
     /// - every destination needs to be written at most once. Will panic if not.
-    /// - destinations are relative addresses, starting from 1 and consecutively incremented by one. Will panic if not
-    /// - sources are any relative addresses, and can also be direct address to the global space. TODO: panic if not
+    /// - sources and destinations are any addresses (relative registers or direct globals);
+    ///   a source that is not also a destination is read as-is.
     /// - sources and destinations have same length. Will panic if not.
     pub(crate) fn codegen_mov_registers_to_registers(
         &mut self,
@@ -18,16 +22,23 @@ impl<F: AcirField + DebugToString, Registers: RegisterAllocator> BrilligContext<
         destinations: &[MemoryAddress],
     ) {
         assert_eq!(sources.len(), destinations.len(), "sources and destinations length must match");
-        let stack_start = self.registers().start();
         let n = sources.len();
+
+        // Map each destination address to its node index. Destinations must be unique,
+        // since every destination is written at most once.
+        let mut dest_index: HashMap<MemoryAddress, usize> = HashMap::with_capacity(n);
+        for (i, destination) in destinations.iter().enumerate() {
+            let previous = dest_index.insert(*destination, i);
+            assert!(previous.is_none(), "destination {destination:?} is written more than once");
+        }
+
         let mut processed = 0;
-        // Compute the number of destinations for each source node that is also a destination node (i.e within 0,..n-1) in the movement graph
+        // Count, for each node, how many *other* nodes read the value it writes (i.e. use its
+        // destination address as their source). A node with zero such readers is a sink and can
+        // be written immediately.
         let mut num_destinations = vec![0; n];
-        for i in 0..n {
-            // Check that destinations are relatives to 0,..,n-1
-            assert_eq!(to_index(&destinations[i], stack_start), Some(i));
-            if let Some(index) = to_index(&sources[i], stack_start)
-                && index < n
+        for (i, source) in sources.iter().enumerate() {
+            if let Some(index) = to_index(&dest_index, source)
                 && index != i
             {
                 num_destinations[index] += 1;
@@ -42,7 +53,7 @@ impl<F: AcirField + DebugToString, Registers: RegisterAllocator> BrilligContext<
             let mut node = i;
             // A sink has no child
             while num_destinations[node] == 0 {
-                if to_index(&sources[node], stack_start) == Some(node) {
+                if to_index(&dest_index, &sources[node]) == Some(node) {
                     //no-op: mark the node as processed
                     num_destinations[node] = usize::MAX;
                     processed += 1;
@@ -52,14 +63,12 @@ impl<F: AcirField + DebugToString, Registers: RegisterAllocator> BrilligContext<
                 self.perform_movement(
                     node,
                     sources[node],
-                    stack_start,
+                    destinations,
                     &mut num_destinations,
                     &mut processed,
                 );
                 // Follow the parent
-                if let Some(index) = to_index(&sources[node], stack_start)
-                    && index < n
-                {
+                if let Some(index) = to_index(&dest_index, &sources[node]) {
                     num_destinations[index] -= 1;
                     if num_destinations[index] > 0 {
                         // The parent node has another child, so we cannot process it yet.
@@ -80,13 +89,15 @@ impl<F: AcirField + DebugToString, Registers: RegisterAllocator> BrilligContext<
         // All sinks and their parents have been processed, remaining nodes are part of a loop
         // Check if a tail_candidate is a branch to a loop
         for (entry, free) in tail_candidates {
-            let entry_idx = to_index(&entry, stack_start).unwrap();
-            if entry_idx < n && num_destinations[entry_idx] == 1 {
+            let entry_idx = to_index(&dest_index, &entry).unwrap();
+            if num_destinations[entry_idx] == 1 {
                 // Use the branch as the temporary register for the loop
+                let free_register = from_index(destinations, free);
                 self.process_loop(
                     entry_idx,
-                    &from_index(free, stack_start),
-                    stack_start,
+                    &free_register,
+                    destinations,
+                    &dest_index,
                     &mut num_destinations,
                     sources,
                     &mut processed,
@@ -101,7 +112,7 @@ impl<F: AcirField + DebugToString, Registers: RegisterAllocator> BrilligContext<
         // since different loops may contain values of different types.
         for i in 0..n {
             if num_destinations[i] == 1 {
-                let src = from_index(i, stack_start);
+                let src = from_index(destinations, i);
                 // Copy the loop entry to a temporary register.
                 // Unfortunately, we cannot use one register for all the loops
                 // when the sources do not have the same type
@@ -110,7 +121,8 @@ impl<F: AcirField + DebugToString, Registers: RegisterAllocator> BrilligContext<
                 self.process_loop(
                     i,
                     &temp_register,
-                    stack_start,
+                    destinations,
+                    &dest_index,
                     &mut num_destinations,
                     sources,
                     &mut processed,
@@ -125,27 +137,29 @@ impl<F: AcirField + DebugToString, Registers: RegisterAllocator> BrilligContext<
 
     /// Generates mov opcodes corresponding to a loop, given a node from the loop (entry)
     /// and a register not in the loop that contains its value (free)
+    #[allow(clippy::too_many_arguments)]
     fn process_loop(
         &mut self,
         entry: usize,
         free: &MemoryAddress,
-        stack_start: usize,
+        destinations: &[MemoryAddress],
+        dest_index: &HashMap<MemoryAddress, usize>,
         num_destinations: &mut [usize],
         source: &[MemoryAddress],
         processed: &mut usize,
     ) {
         let mut current = entry;
-        while to_index(&source[current], stack_start).unwrap() != entry {
+        while to_index(dest_index, &source[current]).unwrap() != entry {
             self.perform_movement(
                 current,
                 source[current],
-                stack_start,
+                destinations,
                 num_destinations,
                 processed,
             );
-            current = to_index(&source[current], stack_start).unwrap();
+            current = to_index(dest_index, &source[current]).unwrap();
         }
-        self.perform_movement(current, *free, stack_start, num_destinations, processed);
+        self.perform_movement(current, *free, destinations, num_destinations, processed);
     }
 
     /// Generates a move opcode from 'src' to 'dest'.
@@ -153,11 +167,11 @@ impl<F: AcirField + DebugToString, Registers: RegisterAllocator> BrilligContext<
         &mut self,
         dest: usize,
         src: MemoryAddress,
-        stack_start: usize,
+        destinations: &[MemoryAddress],
         num_destinations: &mut [usize],
         processed: &mut usize,
     ) {
-        let destination = from_index(dest, stack_start);
+        let destination = from_index(destinations, dest);
         self.mov_instruction(destination, src);
         // set the node as 'processed'
         num_destinations[dest] = usize::MAX;
@@ -165,18 +179,17 @@ impl<F: AcirField + DebugToString, Registers: RegisterAllocator> BrilligContext<
     }
 }
 
-/// Map the address so that the first register of the stack will have index 0
-fn to_index(adr: &MemoryAddress, stack_start: usize) -> Option<usize> {
-    match adr {
-        MemoryAddress::Relative(size) => Some(assert_usize(*size) - stack_start),
-        MemoryAddress::Direct(_) => None,
-    }
+/// Look up the node index of an address that is one of the destinations, if any.
+/// Sources that are not destinations (e.g. globals or registers outside the destination set)
+/// return `None` and are treated as leaves in the movement graph.
+fn to_index(dest_index: &HashMap<MemoryAddress, usize>, adr: &MemoryAddress) -> Option<usize> {
+    dest_index.get(adr).copied()
 }
 
-/// Construct the register corresponding to the given mapped 'index'
-fn from_index(idx: usize, stack_start: usize) -> MemoryAddress {
+/// Recover the destination address of the given node index.
+fn from_index(destinations: &[MemoryAddress], idx: usize) -> MemoryAddress {
     assert!(idx != usize::MAX, "invalid index");
-    MemoryAddress::relative(assert_u32(idx + stack_start))
+    destinations[idx]
 }
 
 #[cfg(test)]
@@ -396,7 +409,15 @@ mod tests {
             // All potential memory slots; we can't address before the stack start.
             let all_indexes = (0..MEM_SIZE).map(|i| i + S).collect::<Vec<_>>();
 
-            let destinations: Vec<usize> = (0..num_destinations).map(|i| i + S).collect();
+            // Choose the destinations as a random unique subset of the slots (in an
+            // arbitrary order, not necessarily consecutive) to exercise the general
+            // any-source-to-any-destination mover.
+            let mut pool = all_indexes.clone();
+            let mut destinations = Vec::with_capacity(num_destinations);
+            for _ in 0..num_destinations {
+                let idx = u.int_in_range(0..=pool.len() - 1)?;
+                destinations.push(pool.swap_remove(idx));
+            }
 
             // Pick random sources for each destination (same source can be repeated).
             let mut sources = Vec::with_capacity(num_destinations);


### PR DESCRIPTION
## Problem Resolved

One of the phases in https://github.com/noir-lang/noir/pull/13302

https://github.com/noir-lang/noir/pull/10305 made this routine iterative, but also added a constraint that made it usable only for return values. This could have been used in linear scan during jumps; the current `jmp` handler used an ad-hoc method that grabs more temporary registers than the general routine would do to handle cycles. 

## Summary of Changes

* Refactor `codegen_mov_registers_to_registers` to remove the restriction that destinations have to be consecutive memory registers
* Update `codegen_mov_registers_to_registers` to handle a `condition` and emit `conditional_mov`.
* Call `codegen_mov_registers_to_registers` from `jmp_setup` 
* Added a before/after test to show that a block which rotates its parameters (a cycle) now requires just 1 temporary registers, instead of as many as there are parameters being passed.

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
