### PR TITLE
feat(brillig): Phase 1 — linear-scan register allocator

### DIFF
--- a/compiler/noirc_driver/src/lib.rs
+++ b/compiler/noirc_driver/src/lib.rs
@@ -369,6 +369,7 @@ impl CompileOptions {
                     self.max_scratch_space,
                 ),
                 copy_site_registry: None,
+                use_linear_scan_allocator: false,
             },
             print_codegen_timings: self.benchmark_codegen,
             emit_ssa: if self.emit_ssa { Some(package_build_path) } else { None },

--- a/compiler/noirc_evaluator/src/brillig/brillig_gen.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen.rs
@@ -8,6 +8,7 @@ pub(crate) mod brillig_globals;
 mod brillig_instructions;
 mod coalescing;
 pub(crate) mod constant_allocation;
+mod linear_scan;
 mod live_intervals;
 pub(crate) mod spill_manager;
 #[cfg(test)]

--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/allocator.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/allocator.rs
@@ -66,6 +66,12 @@ impl SpillSlot {
 pub(crate) enum Action {
     /// Store a register-resident value into its spill slot (the value leaves the map).
     Spill { value: ValueId, from: MemoryAddress, to: SpillSlot },
+    /// Store a register-resident value into its spill slot but *keep* it in its register (the map is
+    /// unchanged). Used by merge resolution: a value live across an edge whose successor expects it
+    /// in its slot is saved before the branch, while staying available for the block's own remaining
+    /// reads. The store is harmless on every outgoing edge (it targets the value's own slot and SSA
+    /// values are immutable), so it needs no critical-edge split.
+    Save { value: ValueId, from: MemoryAddress, to: SpillSlot },
     /// Load a spilled value from its slot into a register (the value enters the map at `into`).
     Reload { value: ValueId, from: SpillSlot, into: MemoryAddress },
     /// Register-to-register move (the value moves to `to` in the map). Produced by edge

--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/allocator.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/allocator.rs
@@ -211,7 +211,7 @@ pub(crate) struct GreedyAllocator<R: RegisterAllocator> {
 impl<R: RegisterAllocator> GreedyAllocator<R> {
     /// Build the greedy allocator with a shared handle to the register pool, plus the spill manager,
     /// coalescing map, liveness, and per-instruction last-use sets decided by
-    /// [`FunctionContext::new`](super::brillig_fn::FunctionContext::new).
+    /// [`FunctionContext::new_with_allocator`](super::brillig_fn::FunctionContext::new_with_allocator).
     pub(crate) fn new(
         pool: Rc<RefCell<R>>,
         spill_manager: Option<SpillManager>,

--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/allocator.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/allocator.rs
@@ -115,19 +115,28 @@ pub(crate) trait Allocator {
         dfg: &DataFlowGraph,
     ) -> (BrilligVariable, Vec<Action>);
 
-    /// Make an already-defined value register-resident and return its allocation, plus the actions
-    /// to get it there: a [`Action::Reload`] if it was spilled (and any [`Action::Spill`]s to free
-    /// a slot for it), or no actions if it is already resident.
-    fn use_variable(&mut self, value_id: ValueId) -> (BrilligVariable, Vec<Action>);
-
-    /// Ensure `n` registers are free for codegen to allocate scratch temporaries via its RAII path,
-    /// returning the spills that freed the room. The contract is "N slots are free", not "here are
-    /// the registers" — codegen owns the temporaries.
+    /// Make an already-defined value register-resident *at the point where instruction `at` uses it*
+    /// and return its allocation, plus the actions to get it there: a [`Action::Reload`] if it was
+    /// spilled (and any [`Action::Spill`]s to free a slot for it), a [`Action::Move`] if a splitting
+    /// allocator's plan places it in a different register at this point, or no actions if it is
+    /// already where it should be. `at` is `None` for a terminator operand: those are made resident
+    /// up front by [`Allocator::before_terminator`], so the use is a plain lookup.
     ///
-    /// This is the scratch half of the design's `before_instruction`; making the instruction's
-    /// operands resident up front (the other half) is still done lazily by the driver via
-    /// `use_variable`, so this takes an explicit count rather than an instruction id for now.
-    fn reserve_scratch(&mut self, scratch: usize) -> Vec<Action>;
+    /// The instruction id (rather than a bare value) is what lets a global-assignment allocator find
+    /// the program point and thus the value's planned register there; the greedy allocator, whose
+    /// homes do not vary by point, ignores it.
+    fn use_variable(
+        &mut self,
+        value_id: ValueId,
+        at: Option<InstructionId>,
+    ) -> (BrilligVariable, Vec<Action>);
+
+    /// Ensure `n` registers are free for codegen to allocate the scratch temporaries instruction
+    /// `at` needs via its RAII path, returning the spills that freed the room. The contract is "N
+    /// slots are free", not "here are the registers" — codegen owns the temporaries. The instruction
+    /// id lets a global-assignment allocator evict by that point's plan; greedy evicts by LRU and
+    /// ignores it.
+    fn reserve_scratch(&mut self, scratch: usize, at: Option<InstructionId>) -> Vec<Action>;
 
     /// Retire the values whose last use is `inst` now that it has been lowered: free their
     /// registers (returning them to the pool for reuse later in the block) and drop any bookkeeping.
@@ -362,7 +371,11 @@ impl<R: RegisterAllocator> Allocator for GreedyAllocator<R> {
         (variable, actions)
     }
 
-    fn use_variable(&mut self, value_id: ValueId) -> (BrilligVariable, Vec<Action>) {
+    fn use_variable(
+        &mut self,
+        value_id: ValueId,
+        _at: Option<InstructionId>,
+    ) -> (BrilligVariable, Vec<Action>) {
         if self.is_spilled(&value_id) {
             return self.reload_spilled_value(value_id);
         }
@@ -382,7 +395,7 @@ impl<R: RegisterAllocator> Allocator for GreedyAllocator<R> {
         (variable, Vec::new())
     }
 
-    fn reserve_scratch(&mut self, scratch: usize) -> Vec<Action> {
+    fn reserve_scratch(&mut self, scratch: usize, _at: Option<InstructionId>) -> Vec<Action> {
         self.make_room(scratch)
     }
 

--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_block.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_block.rs
@@ -261,6 +261,17 @@ impl<'block, Registers: RegisterAllocator> BrilligBlock<'block, Registers> {
                     pending_stores.push((to.offset(), from));
                     self.registers.remove(&value);
                 }
+                Action::Save { value, from, to } => {
+                    // Like a spill, but the value keeps its register — the map is unchanged.
+                    // Asserting it is at the reported register confirms the map never drifted from
+                    // the allocator's residency, the same guarantee `Prune` checks.
+                    debug_assert_eq!(
+                        self.registers.get(&value),
+                        Some(&from),
+                        "ICE: saved value {value} was not at its expected register in the map"
+                    );
+                    pending_stores.push((to.offset(), from));
+                }
                 Action::Reload { value, from, into } => {
                     if !pending_stores.is_empty() {
                         self.codegen_spill_stores(std::mem::take(&mut pending_stores));

--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_block.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_block.rs
@@ -53,6 +53,13 @@ pub(crate) struct BrilligBlock<'block, Registers: RegisterAllocator> {
     /// For example, liveness analysis for globals is unnecessary (and adds complexity),
     /// and instead globals live throughout the entirety of the program.
     pub(crate) building_globals: bool,
+
+    /// The instruction currently being lowered, or `None` while lowering a terminator (or during
+    /// block setup). Operand reads route this to [`Allocator::use_variable`] so a global-assignment
+    /// allocator can resolve the program point of the use; the greedy allocator ignores it. A
+    /// terminator's operands carry `None`: they are made resident up front by
+    /// [`Allocator::before_terminator`].
+    pub(crate) current_instruction: Option<InstructionId>,
 }
 
 impl<'block, Registers: RegisterAllocator> BrilligBlock<'block, Registers> {
@@ -84,6 +91,7 @@ impl<'block, Registers: RegisterAllocator> BrilligBlock<'block, Registers> {
             globals,
             hoisted_global_constants,
             building_globals: false,
+            current_instruction: None,
         };
 
         brillig_block.apply_actions(actions);
@@ -174,7 +182,7 @@ impl<'block, Registers: RegisterAllocator> BrilligBlock<'block, Registers> {
     /// anticipation of such need. The allocator decides which values to evict and returns the spill
     /// stores; the driver emits them.
     pub(crate) fn ensure_register_capacity(&mut self, n: usize) {
-        let actions = self.function_context.allocator.reserve_scratch(n);
+        let actions = self.function_context.allocator.reserve_scratch(n, self.current_instruction);
         self.apply_actions(actions);
     }
 
@@ -411,6 +419,12 @@ impl<'block, Registers: RegisterAllocator> BrilligBlock<'block, Registers> {
                 self.jmp(dfg, *destination, arguments);
             }
             TerminatorInstruction::Return { return_values, .. } => {
+                // Settle the return values into their planned registers before reading them, so a
+                // spilled or split return value is reloaded/moved once, up front. For greedy this is
+                // a no-op: a return block has no successors, so nothing crosses an edge.
+                let actions = self.function_context.allocator.before_terminator(self.block_id, dfg);
+                self.apply_actions(actions);
+
                 let return_registers = vecmap(return_values, |value_id| {
                     // Get the allocations of the values to be returned.
                     self.convert_ssa_value(*value_id, dfg)
@@ -554,6 +568,10 @@ impl<'block, Registers: RegisterAllocator> BrilligBlock<'block, Registers> {
         let call_stack_new_id = call_stacks.get_or_insert_locations(&call_stack);
         self.brillig_context.set_call_stack(call_stack_new_id);
 
+        // Operand reads during this instruction's lowering carry its id to the allocator, so a
+        // global-assignment allocator can resolve the program point of each use.
+        self.current_instruction = Some(instruction_id);
+
         self.initialize_constants(dfg, InstructionLocation::Instruction(instruction_id));
 
         match instruction {
@@ -632,6 +650,10 @@ impl<'block, Registers: RegisterAllocator> BrilligBlock<'block, Registers> {
             let actions = self.function_context.allocator.after_instruction(instruction_id);
             self.apply_actions(actions);
         }
+
+        // The instruction is fully lowered; later operand reads (terminator, next instruction's
+        // setup) must not attribute themselves to it.
+        self.current_instruction = None;
 
         // Clear the call stack; it only applied to this instruction.
         self.brillig_context.set_call_stack(CallStackId::root());
@@ -719,7 +741,10 @@ impl<'block, Registers: RegisterAllocator> BrilligBlock<'block, Registers> {
                 } else {
                     // Already-defined value: the allocator returns its register, reloading it
                     // (and spilling to make room) if it is currently spilled.
-                    let (var, actions) = self.function_context.allocator.use_variable(value_id);
+                    let (var, actions) = self
+                        .function_context
+                        .allocator
+                        .use_variable(value_id, self.current_instruction);
                     self.apply_actions(actions);
                     var
                 }
@@ -734,7 +759,10 @@ impl<'block, Registers: RegisterAllocator> BrilligBlock<'block, Registers> {
                     // defines each constant directly on first sight and reuses it afterwards.
                     // Globals never spill, so the register shadow is an exact "already defined" test.
                     if self.registers.contains_key(&value_id) {
-                        let (var, actions) = self.function_context.allocator.use_variable(value_id);
+                        let (var, actions) = self
+                            .function_context
+                            .allocator
+                            .use_variable(value_id, self.current_instruction);
                         self.apply_actions(actions);
                         var
                     } else {
@@ -747,7 +775,10 @@ impl<'block, Registers: RegisterAllocator> BrilligBlock<'block, Registers> {
                     // A non-global numeric constant is materialized at its allocation point by
                     // `initialize_constants` (which dominates all uses), so every reference here is
                     // just a use: the allocator returns its register, reloading it if it was spilled.
-                    let (var, actions) = self.function_context.allocator.use_variable(value_id);
+                    let (var, actions) = self
+                        .function_context
+                        .allocator
+                        .use_variable(value_id, self.current_instruction);
                     self.apply_actions(actions);
                     var
                 }

--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_call/brillig_vector_ops.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_call/brillig_vector_ops.rs
@@ -234,6 +234,7 @@ mod tests {
             globals,
             hoisted_global_constants,
             building_globals: false,
+            current_instruction: None,
         }
     }
 

--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_fn.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_fn.rs
@@ -161,11 +161,13 @@ impl<R: RegisterAllocator> FunctionContext<R> {
 
         let allocator = match linear_scan {
             Some(linear_scan) => {
-                // Reserve the low value-home band in the shared pool so codegen's scratch temporaries
-                // are drawn only from the registers above it and never collide with a value home.
+                // Reserve exactly the registers the plan uses for value homes, so codegen's scratch
+                // temporaries are drawn only from the registers above them (never colliding with a
+                // value home) while the frame's high-water mark stays as small as the values need —
+                // which keeps recursive call frames from ballooning.
                 {
                     let mut pool = pool.borrow_mut();
-                    for index in 0..linear_scan.value_capacity() {
+                    for index in 0..linear_scan.reserved_registers() {
                         pool.ensure_register_is_allocated(MemoryAddress::relative(assert_u32(
                             register_offset + index,
                         )));

--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_fn.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_fn.rs
@@ -9,6 +9,7 @@ use super::{
     allocator::{Allocator, GreedyAllocator},
     coalescing::CoalescingMap,
     constant_allocation::ConstantAllocation,
+    linear_scan::{FunctionAllocator, LinearScanAllocator},
     spill_manager::SpillManager,
     variable_liveness::VariableLiveness,
 };
@@ -40,9 +41,9 @@ pub(crate) struct FunctionContext<R: RegisterAllocator> {
     /// A `FunctionContext` is necessary for using a Brillig block's code gen, but sometimes
     /// such as with globals, we are not within a function and do not have a [`FunctionId`].
     function_id: Option<FunctionId>,
-    /// The register allocator: the register pool, the SSA-value → register cache, spill manager,
-    /// and coalescing map.
-    pub(crate) allocator: GreedyAllocator<R>,
+    /// The register allocator (greedy or linear-scan, chosen per function): the register pool, the
+    /// SSA-value → register cache, spill manager, and coalescing map.
+    pub(crate) allocator: FunctionAllocator<R>,
     /// The block ids of the function in Post Order.
     blocks: Vec<BasicBlockId>,
     /// Information on where to allocate constants
@@ -67,10 +68,26 @@ impl<R: RegisterAllocator> FunctionContext<R> {
     /// It can be tuned if it proves too aggressive or too conservative in practice.
     const SPILL_MARGIN: usize = 32;
 
+    /// Build a function context using the greedy allocator. Convenience wrapper over
+    /// [`Self::new_with_allocator`] for tests that don't select an allocator.
+    #[cfg(test)]
     pub(crate) fn new(
         function: &Function,
         max_stack_frame_size: usize,
         pool: Rc<RefCell<R>>,
+    ) -> Self {
+        Self::new_with_allocator(function, max_stack_frame_size, pool, false)
+    }
+
+    /// Build a function context, choosing the linear-scan allocator when `use_linear_scan` is set
+    /// and the greedy one otherwise. Both are constructed from the same liveness/coalescing/spill
+    /// inputs and hidden behind [`FunctionAllocator`], so the rest of codegen is agnostic to the
+    /// choice.
+    pub(crate) fn new_with_allocator(
+        function: &Function,
+        max_stack_frame_size: usize,
+        pool: Rc<RefCell<R>>,
+        use_linear_scan: bool,
     ) -> Self {
         let id = function.id();
 
@@ -113,9 +130,27 @@ impl<R: RegisterAllocator> FunctionContext<R> {
             }
         }
 
+        let allocator = if use_linear_scan {
+            FunctionAllocator::LinearScan(LinearScanAllocator::new(
+                pool,
+                spill_manager,
+                coalescing,
+                liveness,
+                last_uses,
+            ))
+        } else {
+            FunctionAllocator::Greedy(GreedyAllocator::new(
+                pool,
+                spill_manager,
+                coalescing,
+                liveness,
+                last_uses,
+            ))
+        };
+
         Self {
             function_id: Some(id),
-            allocator: GreedyAllocator::new(pool, spill_manager, coalescing, liveness, last_uses),
+            allocator,
             blocks: post_order,
             constant_allocation: constants,
         }
@@ -127,13 +162,13 @@ impl<R: RegisterAllocator> FunctionContext<R> {
     pub(crate) fn new_for_globals(pool: Rc<RefCell<R>>) -> Self {
         Self {
             function_id: None,
-            allocator: GreedyAllocator::new(
+            allocator: FunctionAllocator::Greedy(GreedyAllocator::new(
                 pool,
                 None,
                 CoalescingMap::default(),
                 VariableLiveness::default(),
                 HashMap::default(),
-            ),
+            )),
             blocks: Vec::new(),
             constant_allocation: ConstantAllocation::default(),
         }

--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_fn.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_fn.rs
@@ -2,6 +2,7 @@
 use std::cell::RefCell;
 use std::rc::Rc;
 
+use acvm::acir::brillig::MemoryAddress;
 use iter_extended::vecmap;
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 
@@ -14,6 +15,7 @@ use super::{
     variable_liveness::VariableLiveness,
 };
 use crate::{
+    brillig::assert_u32,
     brillig::brillig_ir::{
         artifact::BrilligParameter,
         brillig_variable::get_bit_size_from_ssa_type,
@@ -130,22 +132,54 @@ impl<R: RegisterAllocator> FunctionContext<R> {
             }
         }
 
-        let allocator = if use_linear_scan {
-            FunctionAllocator::LinearScan(LinearScanAllocator::new(
+        // The first usable register offset; the linear-scan plan's register indices are relative to
+        // it, and the low value-home band is reserved from it.
+        let register_offset = pool.borrow().start();
+
+        // Try the linear-scan allocator when selected; it declines (returns `None`) for functions
+        // whose pressure exceeds the value capacity (no pressure spilling yet), and we fall back to
+        // greedy so every function still compiles.
+        // Value homes get the low registers up to this capacity; the rest of the frame is reserved
+        // for scratch. Match greedy's `SPILL_MARGIN` cushion, since `min_live_count` under-counts the
+        // true scratch peak (parallel moves, on-demand constants). This makes tight frames decline
+        // linear scan and fall back to greedy, which is correct.
+        let value_capacity =
+            usable_registers.saturating_sub(liveness.min_live_count + Self::SPILL_MARGIN);
+        let linear_scan = use_linear_scan
+            .then(|| {
+                LinearScanAllocator::try_build(
+                    function,
+                    &liveness,
+                    &constants,
+                    &post_order,
+                    &last_uses,
+                    value_capacity,
+                    register_offset,
+                )
+            })
+            .flatten();
+
+        let allocator = match linear_scan {
+            Some(linear_scan) => {
+                // Reserve the low value-home band in the shared pool so codegen's scratch temporaries
+                // are drawn only from the registers above it and never collide with a value home.
+                {
+                    let mut pool = pool.borrow_mut();
+                    for index in 0..linear_scan.value_capacity() {
+                        pool.ensure_register_is_allocated(MemoryAddress::relative(assert_u32(
+                            register_offset + index,
+                        )));
+                    }
+                }
+                FunctionAllocator::LinearScan(linear_scan)
+            }
+            None => FunctionAllocator::Greedy(GreedyAllocator::new(
                 pool,
                 spill_manager,
                 coalescing,
                 liveness,
                 last_uses,
-            ))
-        } else {
-            FunctionAllocator::Greedy(GreedyAllocator::new(
-                pool,
-                spill_manager,
-                coalescing,
-                liveness,
-                last_uses,
-            ))
+            )),
         };
 
         Self {

--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_globals.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_globals.rs
@@ -332,6 +332,7 @@ impl Brillig {
             globals: &empty_globals,
             hoisted_global_constants: &HashMap::default(),
             building_globals: true,
+            current_instruction: None,
         };
 
         let hoisted_global_constants = brillig_block.compile_globals(

--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/constant_allocation.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/constant_allocation.rs
@@ -77,6 +77,19 @@ impl ConstantAllocation {
         Some(constants.as_ref())
     }
 
+    /// Every constant allocation as `(block, location, constants)` — the exact point where each
+    /// constant is materialized. Consumers that must align a constant's live range with where
+    /// codegen actually emits its `const` opcode (rather than the block entry) use this.
+    pub(crate) fn allocations(
+        &self,
+    ) -> impl Iterator<Item = (BasicBlockId, InstructionLocation, &[ValueId])> + '_ {
+        self.allocation_points.iter().flat_map(|(&block, locations)| {
+            locations
+                .iter()
+                .map(move |(&location, constants)| (block, location, constants.as_slice()))
+        })
+    }
+
     /// Visit all constant variables in the function and record their locations.
     fn collect_constant_usage(&mut self, func: &Function) {
         let mut record_if_constant =

--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/linear_scan.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/linear_scan.rs
@@ -117,10 +117,11 @@ struct RangeOf {
 /// hole on its own runtime path keeps one register (no spurious split), while a value dead across a
 /// *divergent-path* hole releases its register for another value to share during the hole.
 ///
-/// This function handles only the case that fits in `value_capacity` (no pressure spilling yet):
-/// it returns `None` if a program point needs more registers than are available, which the caller
-/// treats as "linear scan cannot place this function" and falls back. Pressure spilling to the
-/// fixed per-value slot is layered on next.
+/// Under register pressure (no free register at a point) it **spills the longest-lived interval** —
+/// an active one if it outlives the incoming range, else the incoming range — to that value's fixed
+/// spill slot, splitting the evicted value's timeline into a register segment then a slot segment.
+/// The resulting plan therefore mixes `Register` and `Slot` locations (a value can be both over its
+/// life). Returns `None` only when the entry parameters alone exceed `value_capacity`.
 #[allow(dead_code)]
 pub(crate) fn assign(
     ranges: &LiveRanges,
@@ -150,16 +151,20 @@ pub(crate) fn assign(
     // Free register indices available to non-parameter values (parameter indices are reserved).
     let mut free: std::collections::BTreeSet<usize> =
         (param_registers.len()..value_capacity).collect();
-    // Currently register-resident non-parameter ranges: (range end, register index).
-    let mut active: Vec<(ProgramPoint, usize)> = Vec::new();
+    // Currently register-resident non-parameter ranges: (range end, value, register index).
+    let mut active: Vec<(ProgramPoint, ValueId, usize)> = Vec::new();
     // A value's most recent register, so a later range can reclaim it when free.
     let mut previous_register: HashMap<ValueId, usize> = HashMap::default();
     let mut timeline: HashMap<ValueId, Vec<Segment>> = HashMap::default();
+    // The fixed spill slot of each value that is ever spilled. One slot per value (not yet packed
+    // across non-interfering values — a later refinement); reused across all of the value's spills.
+    let mut slots: HashMap<ValueId, usize> = HashMap::default();
+    let mut num_spill_slots = 0usize;
 
     for RangeOf { start, end, value } in intervals {
-        // Expire non-parameter ranges that ended strictly before this one begins, freeing their
-        // registers. Ranges touching at a point (`prev.end == start`) stay active — they interfere.
-        active.retain(|&(active_end, register)| {
+        // Expire ranges that ended strictly before this one begins, freeing their registers. Ranges
+        // touching at a point (`prev.end == start`) stay active — they interfere.
+        active.retain(|&(active_end, _, register)| {
             let expired = active_end < start;
             if expired {
                 free.insert(register);
@@ -167,26 +172,80 @@ pub(crate) fn assign(
             !expired
         });
 
-        let register = if let Some(&index) = param_registers.get(&value) {
-            // Fixed-interval parameter: always its reserved index, never drawn from `free`.
-            index
-        } else {
-            // Prefer the value's previous register (reclaim across a hole), else the lowest free one.
-            let register = match previous_register.get(&value) {
-                Some(&prev) if free.remove(&prev) => prev,
-                _ => *free.iter().next()?,
-            };
-            free.remove(&register);
-            active.push((end, register));
-            register
-        };
+        // Parameters are fixed intervals in their reserved register, never spilled.
+        if let Some(&index) = param_registers.get(&value) {
+            previous_register.insert(value, index);
+            timeline.entry(value).or_default().push(Segment {
+                start,
+                end,
+                location: Location::Register(index),
+            });
+            continue;
+        }
 
-        previous_register.insert(value, register);
-        timeline.entry(value).or_default().push(Segment {
-            start,
-            end,
-            location: Location::Register(register),
-        });
+        // Prefer the value's previous register (reclaim across a hole), else the lowest free one.
+        let reclaim = previous_register.get(&value).copied().filter(|prev| free.contains(prev));
+        if let Some(register) = reclaim.or_else(|| free.iter().next().copied()) {
+            free.remove(&register);
+            previous_register.insert(value, register);
+            active.push((end, value, register));
+            timeline.entry(value).or_default().push(Segment {
+                start,
+                end,
+                location: Location::Register(register),
+            });
+            continue;
+        }
+
+        // Pressure: no register is free. Evict the longest-lived interval — an active one if it
+        // outlives this range, else this range itself — to its value's spill slot. The evicted
+        // stretch lives in the slot; uses within it reload on demand.
+        let victim = active.iter().enumerate().max_by_key(|(_, (active_end, _, _))| *active_end);
+        match victim {
+            Some((position, &(active_end, active_value, active_register))) if active_end > end => {
+                // Split the active value's current register segment at `start`: register before,
+                // slot from `start` onward.
+                let slot = *slots.entry(active_value).or_insert_with(|| {
+                    let slot = num_spill_slots;
+                    num_spill_slots += 1;
+                    slot
+                });
+                let segments = timeline.get_mut(&active_value).expect("active value has segments");
+                let current = segments.last_mut().expect("active value has a live segment");
+                if current.start < start {
+                    current.end = start.pred();
+                    segments.push(Segment {
+                        start,
+                        end: active_end,
+                        location: Location::Slot(slot),
+                    });
+                } else {
+                    current.location = Location::Slot(slot);
+                }
+                active.remove(position);
+                // Hand the freed register to this range.
+                previous_register.insert(value, active_register);
+                active.push((end, value, active_register));
+                timeline.entry(value).or_default().push(Segment {
+                    start,
+                    end,
+                    location: Location::Register(active_register),
+                });
+            }
+            _ => {
+                // This range outlives every active one: spill it directly.
+                let slot = *slots.entry(value).or_insert_with(|| {
+                    let slot = num_spill_slots;
+                    num_spill_slots += 1;
+                    slot
+                });
+                timeline.entry(value).or_default().push(Segment {
+                    start,
+                    end,
+                    location: Location::Slot(slot),
+                });
+            }
+        }
     }
 
     // Keep each value's segments in point order.
@@ -194,7 +253,7 @@ pub(crate) fn assign(
         segments.sort_by_key(|seg| seg.start);
     }
 
-    Some(Plan { timeline, num_spill_slots: 0 })
+    Some(Plan { timeline, num_spill_slots })
 }
 
 /// The plan-based allocator: a **read-only** server over a precomputed [`Plan`].
@@ -608,9 +667,10 @@ mod assignment_tests {
     }
 
     #[test]
-    fn pressure_beyond_capacity_is_not_yet_placeable() {
-        // Five values are live at once; capacity 2 cannot hold them and pressure spilling is not
-        // implemented yet, so the scan reports the function as unplaceable.
+    fn pressure_spills_soundly() {
+        // Several values are live at once; capacity 2 cannot hold them all, so the scan spills the
+        // overflow to slots. The plan must still be sound (register-resident values never share a
+        // register over overlapping points) and at least one value must be spilled.
         let src = "
         brillig(inline) fn main f0 {
           b0(v0: Field, v1: Field):
@@ -623,10 +683,19 @@ mod assignment_tests {
         }
         ";
         let (ranges, ssa) = ranges_for(src);
-        assert!(
-            assign(&ranges, 2, &entry_params(&ssa)).is_none(),
-            "capacity 2 should be unplaceable without spilling"
-        );
+        let plan = assign(&ranges, 2, &entry_params(&ssa)).expect("spills rather than failing");
+        assert!(plan.num_spill_slots() > 0, "capacity 2 should force at least one spill");
+        assert_sound(&ranges, &plan, 2);
+
+        // Every value has a home at every point of its liveness (register or slot).
+        for (value, value_ranges) in ranges.iter() {
+            for range in value_ranges {
+                assert!(
+                    plan.location_at(value, range.start).is_some(),
+                    "value {value} has no location at the start of a live range"
+                );
+            }
+        }
     }
 
     #[test]

--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/linear_scan.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/linear_scan.rs
@@ -24,7 +24,7 @@ use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 
 use super::allocator::{Action, Allocator, GreedyAllocator, ParamHome};
 use super::coalescing::CoalescingMap;
-use super::live_intervals::{LiveInterval, LiveIntervals, ProgramPoint};
+use super::live_intervals::{LiveRanges, ProgramPoint};
 use super::spill_manager::SpillManager;
 use super::variable_liveness::VariableLiveness;
 use crate::brillig::brillig_ir::brillig_variable::BrilligVariable;
@@ -34,36 +34,59 @@ use crate::ssa::ir::dfg::DataFlowGraph;
 use crate::ssa::ir::instruction::InstructionId;
 use crate::ssa::ir::value::ValueId;
 
-/// The register or spill-slot home assigned to an SSA value for its entire lifetime.
+/// Where a value physically lives over one stretch of its lifetime.
 ///
-/// The fixed-home model gives each value exactly one location for its whole live range: a register
-/// (an index in `[0, value_capacity)` that codegen maps to a concrete `MemoryAddress`) or a spill
-/// slot. A value never changes home, so one that lives across a block boundary and got a register
-/// simply stays in it — no cross-block spill/reload. That is the reduction in spill traffic over the
-/// greedy allocator, which permanently spills every cross-block value once spilling is enabled.
-// The plan API is consumed by `LinearScanAllocator` in the next milestone; unused until then.
+/// A value's register can change over time (interval splitting under pressure), but its spill slot
+/// is fixed — spills are unbounded, so a value keeps one slot for the whole function and
+/// non-interfering values pack into shared slots. So only [`Location::Register`] varies point to
+/// point; a spilled value is always in its one slot.
 #[allow(dead_code)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum Home {
-    /// Register index in `[0, value_capacity)`.
+pub(crate) enum Location {
+    /// A register, identified by index in `[0, value_capacity)` (codegen maps it to a concrete
+    /// `MemoryAddress`).
     Register(usize),
-    /// Spill-slot offset.
-    Spill(usize),
+    /// The value's fixed spill slot (offset in the spill region).
+    Slot(usize),
 }
 
-/// A global register-allocation plan: the home of every value, plus the spill-slot count.
+/// One contiguous stretch `[start, end]` over which a value sits in a single [`Location`].
+///
+/// A value's timeline is a list of these. Consecutive segments with different locations are the
+/// split points where codegen emits a spill/reload/move; a gap between segments is a liveness hole
+/// (the value is dead there and its register is free for another value).
+#[allow(dead_code)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct Segment {
+    pub(crate) start: ProgramPoint,
+    pub(crate) end: ProgramPoint,
+    pub(crate) location: Location,
+}
+
+/// The global register-allocation plan: each value's location timeline, plus the spill-slot count.
+///
+/// Read-only once built. The allocator answers "where is `v` at point `P`" by finding the segment
+/// containing `P`, and derives the spill/reload/move actions at `P` from the segment boundaries.
 #[allow(dead_code)]
 #[derive(Debug, Default)]
 pub(crate) struct Plan {
-    homes: HashMap<ValueId, Home>,
+    timeline: HashMap<ValueId, Vec<Segment>>,
     num_spill_slots: usize,
 }
 
 #[allow(dead_code)]
 impl Plan {
-    /// The home assigned to `value`, or `None` if the value is not tracked (e.g. a global).
-    pub(crate) fn home(&self, value: ValueId) -> Option<Home> {
-        self.homes.get(&value).copied()
+    /// The value's location timeline (segments in point order), or empty if the value is untracked.
+    pub(crate) fn timeline(&self, value: ValueId) -> &[Segment] {
+        self.timeline.get(&value).map_or(&[], Vec::as_slice)
+    }
+
+    /// Where `value` lives at `point`, or `None` if it is dead there (in a hole) or untracked.
+    pub(crate) fn location_at(&self, value: ValueId, point: ProgramPoint) -> Option<Location> {
+        self.timeline(value)
+            .iter()
+            .find(|seg| seg.start <= point && point <= seg.end)
+            .map(|seg| seg.location)
     }
 
     /// The number of distinct spill slots the plan uses (0 if nothing spilled).
@@ -72,79 +95,76 @@ impl Plan {
     }
 }
 
-/// Compute the fixed-home assignment by linear scan (Poletto & Sarkar, "Linear Scan Register
-/// Allocation", 1999) over the value intervals, with a value-register capacity of `value_capacity`.
-///
-/// `value_capacity` is `usable_registers - min_live_count`. Reserving `min_live_count` registers
-/// leaves every instruction room for its working set (operands, result, and scratch, which reuse
-/// one another up to the per-instruction floor `min_live_count`), so bounding register-homed values
-/// to `value_capacity` at every point guarantees codegen never overflows the frame. Values that do
-/// not fit are spilled whole, evicting the furthest-`last_use` interval — the classic heuristic,
-/// applied globally because a fixed home cannot be split.
-#[allow(dead_code)]
-pub(crate) fn assign(intervals: &LiveIntervals, value_capacity: usize) -> Plan {
-    let sorted = intervals.intervals_by_def();
-
-    // Free register indices; kept as a stack with the lowest index on top so `pop` is deterministic.
-    let mut free: Vec<usize> = (0..value_capacity).rev().collect();
-    // Register-homed values still live, with their interval and assigned index.
-    let mut active: Vec<(ValueId, LiveInterval, usize)> = Vec::new();
-    let mut homes: HashMap<ValueId, Home> = HashMap::default();
-    let mut num_spill_slots = 0usize;
-
-    for (value, interval) in sorted {
-        // Free the registers of intervals that ended before this one begins.
-        expire(&mut active, &mut free, interval.def);
-
-        if let Some(index) = free.pop() {
-            homes.insert(value, Home::Register(index));
-            active.push((value, interval, index));
-            continue;
-        }
-
-        // The frame's value budget is full. Spill either the active value that lives longest — and
-        // give this value its register — or this value itself, whichever dies later.
-        let furthest = active
-            .iter()
-            .enumerate()
-            .max_by_key(|(_, (_, iv, _))| iv.last_use)
-            .map(|(pos, (v, iv, idx))| (pos, *v, iv.last_use, *idx));
-
-        match furthest {
-            Some((pos, spilled_value, spilled_last_use, index))
-                if spilled_last_use > interval.last_use =>
-            {
-                active.remove(pos);
-                homes.insert(spilled_value, Home::Spill(num_spill_slots));
-                num_spill_slots += 1;
-                homes.insert(value, Home::Register(index));
-                active.push((value, interval, index));
-            }
-            _ => {
-                homes.insert(value, Home::Spill(num_spill_slots));
-                num_spill_slots += 1;
-            }
-        }
-    }
-
-    Plan { homes, num_spill_slots }
+/// A `[start, end]` live range tagged with the value it belongs to — the unit the scan consumes.
+struct RangeOf {
+    start: ProgramPoint,
+    end: ProgramPoint,
+    value: ValueId,
 }
 
-/// Remove active intervals whose `last_use` is before `point`, returning their registers to `free`.
+/// Assign registers by linear scan over the hole-aware [`LiveRanges`], with a value-register
+/// capacity of `value_capacity`.
+///
+/// Each of a value's live ranges is scanned as a separate interval, but a value **reclaims its
+/// previous register** when a later range begins if that register is still free — so a value with a
+/// hole on its own runtime path keeps one register (no spurious split), while a value dead across a
+/// *divergent-path* hole releases its register for another value to share during the hole.
+///
+/// This function handles only the case that fits in `value_capacity` (no pressure spilling yet):
+/// it returns `None` if a program point needs more registers than are available, which the caller
+/// treats as "linear scan cannot place this function" and falls back. Pressure spilling to the
+/// fixed per-value slot is layered on next.
 #[allow(dead_code)]
-fn expire(
-    active: &mut Vec<(ValueId, LiveInterval, usize)>,
-    free: &mut Vec<usize>,
-    point: ProgramPoint,
-) {
-    active.retain(|(_, interval, index)| {
-        if interval.last_use < point {
-            free.push(*index);
-            false
-        } else {
-            true
-        }
-    });
+pub(crate) fn assign(ranges: &LiveRanges, value_capacity: usize) -> Option<Plan> {
+    // Flatten to one interval per (value, range), scanned in start order.
+    let mut intervals: Vec<RangeOf> = ranges
+        .iter()
+        .flat_map(|(value, list)| {
+            list.iter().map(move |range| RangeOf { start: range.start, end: range.end, value })
+        })
+        .collect();
+    intervals.sort_by_key(|r| (r.start, r.end, r.value));
+
+    let mut free: std::collections::BTreeSet<usize> = (0..value_capacity).collect();
+    // Currently register-resident ranges: (range end, value, register index).
+    let mut active: Vec<(ProgramPoint, ValueId, usize)> = Vec::new();
+    // A value's most recent register, so a later range can reclaim it when free.
+    let mut previous_register: HashMap<ValueId, usize> = HashMap::default();
+    let mut timeline: HashMap<ValueId, Vec<Segment>> = HashMap::default();
+
+    for RangeOf { start, end, value } in intervals {
+        // Expire ranges that ended strictly before this one begins, freeing their registers back to
+        // the pool. Ranges touching at a point (`prev.end == start`) stay active — they interfere.
+        active.retain(|&(active_end, _, register)| {
+            let expired = active_end < start;
+            if expired {
+                free.insert(register);
+            }
+            !expired
+        });
+
+        // Prefer the value's previous register (reclaim across a hole), else the lowest free one.
+        let register = match previous_register.get(&value) {
+            Some(&prev) if free.remove(&prev) => prev,
+            _ => *free.iter().next()?,
+        };
+        free.remove(&register);
+
+        previous_register.insert(value, register);
+        active.push((end, value, register));
+        timeline.entry(value).or_default().push(Segment {
+            start,
+            end,
+            location: Location::Register(register),
+        });
+    }
+
+    // Keep each value's segments in point order.
+    for segments in timeline.values_mut() {
+        segments.sort_by_key(|seg| seg.start);
+    }
+
+    Some(Plan { timeline, num_spill_slots: 0 })
 }
 
 /// The plan-based allocator. See the module docs; presently a delegating scaffold over
@@ -363,65 +383,53 @@ impl<R: RegisterAllocator> Allocator for FunctionAllocator<R> {
 
 #[cfg(test)]
 mod assignment_tests {
-    use super::{Home, Plan, assign};
+    use super::{Location, Plan, Segment, assign};
     use crate::brillig::brillig_gen::constant_allocation::ConstantAllocation;
-    use crate::brillig::brillig_gen::live_intervals::LiveIntervals;
+    use crate::brillig::brillig_gen::live_intervals::{LiveIntervals, LiveRanges};
     use crate::brillig::brillig_gen::variable_liveness::VariableLiveness;
     use crate::ssa::ir::post_order::PostOrder;
     use crate::ssa::ir::value::ValueId;
     use crate::ssa::ssa_gen::Ssa;
 
-    fn intervals_for(src: &str) -> LiveIntervals {
+    fn ranges_for(src: &str) -> (LiveRanges, Ssa) {
         let ssa = Ssa::from_str(src).unwrap();
         let func = ssa.main();
         let constants = ConstantAllocation::from_function(func);
         let liveness = VariableLiveness::from_function(func, &constants);
         let post_order = PostOrder::with_function(func).into_vec();
-        LiveIntervals::from_function(func, &liveness, &constants, &post_order)
+        let intervals = LiveIntervals::from_function(func, &liveness, &constants, &post_order);
+        (LiveRanges::from_intervals(&intervals, &liveness, &post_order), ssa)
     }
 
-    fn register_homes(intervals: &LiveIntervals, plan: &Plan) -> Vec<(ValueId, usize)> {
-        intervals
-            .intervals_by_def()
-            .into_iter()
-            .filter_map(|(v, _)| match plan.home(v) {
-                Some(Home::Register(index)) => Some((v, index)),
-                _ => None,
-            })
-            .collect()
+    fn segments_overlap(a: &Segment, b: &Segment) -> bool {
+        a.start <= b.end && b.start <= a.end
     }
 
-    fn spilled(intervals: &LiveIntervals, plan: &Plan) -> Vec<ValueId> {
-        intervals
-            .intervals_by_def()
-            .into_iter()
-            .filter_map(|(v, _)| matches!(plan.home(v), Some(Home::Spill(_))).then_some(v))
-            .collect()
-    }
-
-    /// The core soundness invariant: two values that interfere must never share a register index,
-    /// and every register index is within the capacity.
-    fn assert_sound(intervals: &LiveIntervals, plan: &Plan, capacity: usize) {
-        let homes = register_homes(intervals, plan);
-        for (i, &(a, ia)) in homes.iter().enumerate() {
-            assert!(ia < capacity, "register index {ia} exceeds capacity {capacity}");
-            for &(b, ib) in &homes[i + 1..] {
-                if ia == ib {
-                    assert!(
-                        !intervals.interferes(a, b),
-                        "interfering values {a} and {b} share register index {ia}"
-                    );
+    /// The core soundness invariant: no two register segments of *different* values that share a
+    /// register index overlap in program points (interfering values never co-occupy a register),
+    /// and every register index is within capacity. Also every value has at least one segment.
+    fn assert_sound(ranges: &LiveRanges, plan: &Plan, capacity: usize) {
+        let mut register_segments: Vec<(ValueId, Segment)> = Vec::new();
+        for (value, _) in ranges.iter() {
+            assert!(!plan.timeline(value).is_empty(), "value {value} has no timeline");
+            for seg in plan.timeline(value) {
+                if let Location::Register(index) = seg.location {
+                    assert!(index < capacity, "register index {index} exceeds capacity {capacity}");
+                    register_segments.push((value, *seg));
                 }
             }
         }
-        // Every value has a home.
-        for (v, _) in intervals.intervals_by_def() {
-            assert!(plan.home(v).is_some(), "value {v} has no home");
+        for (i, (va, sa)) in register_segments.iter().enumerate() {
+            for (vb, sb) in &register_segments[i + 1..] {
+                if va != vb && sa.location == sb.location && segments_overlap(sa, sb) {
+                    panic!("values {va} and {vb} share {:?} over overlapping ranges", sa.location);
+                }
+            }
         }
     }
 
     #[test]
-    fn ample_capacity_spills_nothing() {
+    fn no_pressure_assigns_registers_soundly() {
         let src = "
         brillig(inline) fn main f0 {
           b0(v0: Field):
@@ -431,15 +439,22 @@ mod assignment_tests {
             return v3
         }
         ";
-        let intervals = intervals_for(src);
-        let plan = assign(&intervals, 8);
-        assert_eq!(plan.num_spill_slots(), 0, "nothing should spill with ample capacity");
-        assert_sound(&intervals, &plan, 8);
+        let (ranges, _ssa) = ranges_for(src);
+        let plan = assign(&ranges, 8).expect("fits in 8 registers");
+        assert_eq!(plan.num_spill_slots(), 0);
+        assert_sound(&ranges, &plan, 8);
+        // Nothing is spilled: every segment is a register.
+        for (value, _) in ranges.iter() {
+            for seg in plan.timeline(value) {
+                assert!(matches!(seg.location, Location::Register(_)));
+            }
+        }
     }
 
     #[test]
-    fn tight_capacity_spills_the_overflow_soundly() {
-        // Several values are simultaneously live; a capacity of 2 forces spilling.
+    fn pressure_beyond_capacity_is_not_yet_placeable() {
+        // Five values are live at once; capacity 2 cannot hold them and pressure spilling is not
+        // implemented yet, so the scan reports the function as unplaceable.
         let src = "
         brillig(inline) fn main f0 {
           b0(v0: Field, v1: Field):
@@ -451,34 +466,15 @@ mod assignment_tests {
             return v6
         }
         ";
-        let intervals = intervals_for(src);
-        let plan = assign(&intervals, 2);
-        assert!(plan.num_spill_slots() > 0, "tight capacity should force spills");
-        assert_sound(&intervals, &plan, 2);
+        let (ranges, _ssa) = ranges_for(src);
+        assert!(assign(&ranges, 2).is_none(), "capacity 2 should be unplaceable without spilling");
     }
 
     #[test]
-    fn zero_capacity_spills_everything() {
-        let src = "
-        brillig(inline) fn main f0 {
-          b0(v0: Field):
-            v1 = add v0, Field 1
-            return v1
-        }
-        ";
-        let intervals = intervals_for(src);
-        let plan = assign(&intervals, 0);
-        let total = intervals.intervals_by_def().len();
-        assert_eq!(plan.num_spill_slots(), total, "with no registers every value spills");
-        assert!(register_homes(&intervals, &plan).is_empty());
-        assert_eq!(spilled(&intervals, &plan).len(), total);
-    }
-
-    #[test]
-    fn cross_block_value_keeps_its_register() {
-        // `v1` is live across the branch into both successors and the merge. With ample capacity the
-        // fixed-home model must keep it in a register the whole time — the behaviour greedy lacks
-        // (it would permanently spill it once spilling is on).
+    fn cross_block_value_gets_one_register() {
+        // `v1` is live across the branch into both successors and the merge. Linear scan keeps it in
+        // a single register the whole time — no cross-block spill/reload, the behaviour greedy lacks
+        // (it permanently spills every cross-block value once spilling is on).
         let src = "
         brillig(inline) fn main f0 {
           b0(v0: u1, v1: Field):
@@ -493,14 +489,24 @@ mod assignment_tests {
             return v4
         }
         ";
-        let intervals = intervals_for(src);
-        let plan = assign(&intervals, 8);
-        let ssa = Ssa::from_str(src).unwrap();
-        let v1 = ssa.main().dfg[ssa.main().entry_block()].parameters()[1];
-        assert!(
-            matches!(plan.home(v1), Some(Home::Register(_))),
-            "cross-block value should keep a register with ample capacity"
-        );
-        assert_sound(&intervals, &plan, 8);
+        let (ranges, ssa) = ranges_for(src);
+        let plan = assign(&ranges, 8).expect("fits in 8 registers");
+        let func = ssa.main();
+        let v1 = func.dfg[func.entry_block()].parameters()[1];
+
+        let segments = plan.timeline(v1);
+        assert!(!segments.is_empty(), "v1 should have a timeline");
+        let first = match segments[0].location {
+            Location::Register(index) => index,
+            Location::Slot(_) => panic!("v1 should be register-homed"),
+        };
+        for seg in segments {
+            assert_eq!(
+                seg.location,
+                Location::Register(first),
+                "v1 should keep one register across all its ranges"
+            );
+        }
+        assert_sound(&ranges, &plan, 8);
     }
 }

--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/linear_scan.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/linear_scan.rs
@@ -2,16 +2,21 @@
 //! `design/register_allocation.md`).
 //!
 //! Where [`GreedyAllocator`] makes spill/placement decisions *online* (LRU eviction as it runs),
-//! the linear-scan allocator computes a global assignment *up front* from the value
-//! [`LiveIntervals`](super::live_intervals::LiveIntervals) and then serves it as read-only queries.
-//! Both implement the same [`Allocator`] seam, so the driver ([`BrilligBlock`]) is identical for
-//! either; which one runs is chosen per function by [`FunctionAllocator`].
+//! the linear-scan allocator computes a global assignment *up front* from the value [`LiveRanges`]
+//! and then serves it as read-only queries. Both implement the same [`Allocator`] seam, so the
+//! driver ([`BrilligBlock`]) is identical for either; which one runs is chosen per function by
+//! [`FunctionAllocator`].
 //!
-//! **Scaffold status.** [`LinearScanAllocator`] currently delegates to [`GreedyAllocator`]. This
-//! lets the selection seam — the flag, the polymorphic [`FunctionContext`] field, construction, the
-//! globals `into_allocations` path — be exercised end-to-end and proven behavior-preserving before
-//! the plan-based internals land. Selecting linear scan today therefore reproduces greedy output
-//! exactly; the assignment pass replaces these delegations.
+//! **Pipeline.** [`assign`] runs linear scan over the hole-aware [`LiveRanges`] and produces a
+//! [`Plan`] — each value's location timeline. [`LinearScanAllocator`] is then a pure read-only server
+//! over that plan (no register pool, no online decisions): every trait method is a lookup returning
+//! where a value lives and the [`Action`]s to realize it.
+//!
+//! **Scope.** Only the no-pressure case is implemented: functions whose register pressure fits the
+//! value capacity, with every value in one register for its whole life. Functions that would need
+//! pressure spilling — or a split (a value in two registers) that requires a move the no-pressure
+//! allocator does not emit — decline in [`LinearScanAllocator::try_build`] and fall back to
+//! [`GreedyAllocator`]. Pressure spilling with reloads and edge resolution is the next step.
 //!
 //! [`BrilligBlock`]: super::brillig_block::BrilligBlock
 //! [`FunctionContext`]: super::brillig_fn::FunctionContext

--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/linear_scan.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/linear_scan.rs
@@ -24,11 +24,11 @@ use super::brillig_block_variables::compute_array_length;
 use super::constant_allocation::ConstantAllocation;
 use super::live_intervals::{LiveIntervals, LiveRanges, ProgramPoint};
 use super::variable_liveness::VariableLiveness;
-use crate::brillig::assert_u32;
 use crate::brillig::brillig_ir::brillig_variable::{
     BrilligArray, BrilligVariable, BrilligVector, SingleAddrVariable, get_bit_size_from_ssa_type,
 };
 use crate::brillig::brillig_ir::registers::RegisterAllocator;
+use crate::brillig::{assert_u32, assert_usize};
 use crate::ssa::ir::basic_block::BasicBlockId;
 use crate::ssa::ir::dfg::DataFlowGraph;
 use crate::ssa::ir::function::Function;
@@ -215,9 +215,10 @@ pub(crate) struct LinearScanAllocator {
     /// Each value's typed `BrilligVariable`, its register fixed by the plan. This is the final
     /// allocation map handed to the artifact via `into_allocations`.
     allocations: HashMap<ValueId, BrilligVariable>,
-    /// The number of low registers reserved for value homes (`usable - min_live_count`); codegen
-    /// keeps scratch above this band.
-    value_capacity: usize,
+    /// The number of low registers the plan actually uses for value homes — the reserved band
+    /// codegen keeps scratch above. Only the registers used (not the whole capacity) are reserved,
+    /// so the frame's high-water mark stays minimal (important for recursion depth).
+    reserved_registers: usize,
 }
 
 impl LinearScanAllocator {
@@ -246,27 +247,51 @@ impl LinearScanAllocator {
         let entry_params = function.dfg[function.entry_block()].parameters();
         let plan = assign(&ranges, value_capacity, entry_params)?;
 
-        // Materialize each value's typed variable at its planned (single, in the no-pressure case)
-        // register.
+        // Materialize each value's typed variable at its single planned register.
+        //
+        // The no-pressure allocator emits no spills, reloads, or moves, so it can only serve a plan
+        // where every value lives in exactly one register for its whole life. Register scarcity can
+        // still force a *split* even without slot spilling: when a value's register is reused during
+        // a divergent-path hole by another value whose range overlaps the first value's revival,
+        // reclaim fails and the value lands in a second register. Realizing a split needs a move on
+        // the revival edge, which only the pressure-aware allocator (with resolution) emits — so if
+        // any value's timeline is not a single register, decline and fall back to greedy.
         let mut allocations = HashMap::default();
         for (value, _) in ranges.iter() {
-            let register = match plan.timeline(value).first().map(|seg| seg.location) {
-                Some(Location::Register(index)) => {
-                    MemoryAddress::relative(assert_u32(register_offset + index))
-                }
-                // No pressure means no value is spill-homed; guard anyway.
-                _ => return None,
+            let segments = plan.timeline(value);
+            let Some(Location::Register(index)) = segments.first().map(|seg| seg.location) else {
+                return None;
             };
+            if segments.iter().any(|seg| seg.location != Location::Register(index)) {
+                return None;
+            }
+            let register = MemoryAddress::relative(assert_u32(register_offset + index));
             allocations.insert(value, typed_variable(function, value, register));
         }
 
-        Some(Self { plan, intervals, last_uses: last_uses.clone(), allocations, value_capacity })
+        // Reserve only the registers actually used, not the whole capacity: the highest value index
+        // plus one. Scratch sits above this band. Keeping the reservation tight keeps the frame's
+        // high-water mark minimal, which matters for recursion (each call frame is that size).
+        let reserved_registers = allocations
+            .values()
+            .map(|variable| assert_usize(variable.extract_register().unwrap_relative()))
+            .max()
+            .map_or(0, |max_offset| max_offset - register_offset + 1);
+
+        Some(Self {
+            plan,
+            intervals,
+            last_uses: last_uses.clone(),
+            allocations,
+            reserved_registers,
+        })
     }
 
-    /// The number of low registers the plan reserves for value homes. Codegen reserves the frame's
-    /// remaining (upper) registers for scratch, so scratch never collides with a value home.
-    pub(crate) fn value_capacity(&self) -> usize {
-        self.value_capacity
+    /// The number of low registers the plan actually uses for value homes. Codegen reserves exactly
+    /// these, keeping scratch above them, so scratch never collides with a value home and the frame
+    /// stays no larger than the values require.
+    pub(crate) fn reserved_registers(&self) -> usize {
+        self.reserved_registers
     }
 
     /// The final register allocations, consumed when handing the global allocations to the artifact.

--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/linear_scan.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/linear_scan.rs
@@ -16,22 +16,24 @@
 //! [`BrilligBlock`]: super::brillig_block::BrilligBlock
 //! [`FunctionContext`]: super::brillig_fn::FunctionContext
 
-use std::cell::RefCell;
-use std::rc::Rc;
-
 use acvm::acir::brillig::MemoryAddress;
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 
 use super::allocator::{Action, Allocator, GreedyAllocator, ParamHome};
-use super::coalescing::CoalescingMap;
-use super::live_intervals::{LiveRanges, ProgramPoint};
-use super::spill_manager::SpillManager;
+use super::brillig_block_variables::compute_array_length;
+use super::constant_allocation::ConstantAllocation;
+use super::live_intervals::{LiveIntervals, LiveRanges, ProgramPoint};
 use super::variable_liveness::VariableLiveness;
-use crate::brillig::brillig_ir::brillig_variable::BrilligVariable;
+use crate::brillig::assert_u32;
+use crate::brillig::brillig_ir::brillig_variable::{
+    BrilligArray, BrilligVariable, BrilligVector, SingleAddrVariable, get_bit_size_from_ssa_type,
+};
 use crate::brillig::brillig_ir::registers::RegisterAllocator;
 use crate::ssa::ir::basic_block::BasicBlockId;
 use crate::ssa::ir::dfg::DataFlowGraph;
+use crate::ssa::ir::function::Function;
 use crate::ssa::ir::instruction::InstructionId;
+use crate::ssa::ir::types::Type;
 use crate::ssa::ir::value::ValueId;
 
 /// Where a value physically lives over one stretch of its lifetime.
@@ -115,7 +117,22 @@ struct RangeOf {
 /// treats as "linear scan cannot place this function" and falls back. Pressure spilling to the
 /// fixed per-value slot is layered on next.
 #[allow(dead_code)]
-pub(crate) fn assign(ranges: &LiveRanges, value_capacity: usize) -> Option<Plan> {
+pub(crate) fn assign(
+    ranges: &LiveRanges,
+    value_capacity: usize,
+    entry_params: &[ValueId],
+) -> Option<Plan> {
+    // Entry-block parameters are pre-colored fixed intervals: the calling convention places argument
+    // `i` in register `i` (see `codegen_entry_point::allocate_function_arguments`), so the callee
+    // must read parameter `i` from register `i`. Reserve `[0, n_params)` for them, matching order,
+    // and never hand those indices to other values — over-reserving vs sharing a param's register
+    // after it dies, but correct and simple (register sharing for dead params is a later refinement).
+    let param_registers: HashMap<ValueId, usize> =
+        entry_params.iter().enumerate().map(|(index, &param)| (param, index)).collect();
+    if param_registers.len() > value_capacity {
+        return None;
+    }
+
     // Flatten to one interval per (value, range), scanned in start order.
     let mut intervals: Vec<RangeOf> = ranges
         .iter()
@@ -125,17 +142,19 @@ pub(crate) fn assign(ranges: &LiveRanges, value_capacity: usize) -> Option<Plan>
         .collect();
     intervals.sort_by_key(|r| (r.start, r.end, r.value));
 
-    let mut free: std::collections::BTreeSet<usize> = (0..value_capacity).collect();
-    // Currently register-resident ranges: (range end, value, register index).
-    let mut active: Vec<(ProgramPoint, ValueId, usize)> = Vec::new();
+    // Free register indices available to non-parameter values (parameter indices are reserved).
+    let mut free: std::collections::BTreeSet<usize> =
+        (param_registers.len()..value_capacity).collect();
+    // Currently register-resident non-parameter ranges: (range end, register index).
+    let mut active: Vec<(ProgramPoint, usize)> = Vec::new();
     // A value's most recent register, so a later range can reclaim it when free.
     let mut previous_register: HashMap<ValueId, usize> = HashMap::default();
     let mut timeline: HashMap<ValueId, Vec<Segment>> = HashMap::default();
 
     for RangeOf { start, end, value } in intervals {
-        // Expire ranges that ended strictly before this one begins, freeing their registers back to
-        // the pool. Ranges touching at a point (`prev.end == start`) stay active — they interfere.
-        active.retain(|&(active_end, _, register)| {
+        // Expire non-parameter ranges that ended strictly before this one begins, freeing their
+        // registers. Ranges touching at a point (`prev.end == start`) stay active — they interfere.
+        active.retain(|&(active_end, register)| {
             let expired = active_end < start;
             if expired {
                 free.insert(register);
@@ -143,15 +162,21 @@ pub(crate) fn assign(ranges: &LiveRanges, value_capacity: usize) -> Option<Plan>
             !expired
         });
 
-        // Prefer the value's previous register (reclaim across a hole), else the lowest free one.
-        let register = match previous_register.get(&value) {
-            Some(&prev) if free.remove(&prev) => prev,
-            _ => *free.iter().next()?,
+        let register = if let Some(&index) = param_registers.get(&value) {
+            // Fixed-interval parameter: always its reserved index, never drawn from `free`.
+            index
+        } else {
+            // Prefer the value's previous register (reclaim across a hole), else the lowest free one.
+            let register = match previous_register.get(&value) {
+                Some(&prev) if free.remove(&prev) => prev,
+                _ => *free.iter().next()?,
+            };
+            free.remove(&register);
+            active.push((end, register));
+            register
         };
-        free.remove(&register);
 
         previous_register.insert(value, register);
-        active.push((end, value, register));
         timeline.entry(value).or_default().push(Segment {
             start,
             end,
@@ -167,94 +192,185 @@ pub(crate) fn assign(ranges: &LiveRanges, value_capacity: usize) -> Option<Plan>
     Some(Plan { timeline, num_spill_slots: 0 })
 }
 
-/// The plan-based allocator. See the module docs; presently a delegating scaffold over
-/// [`GreedyAllocator`] pending the assignment pass.
-pub(crate) struct LinearScanAllocator<R: RegisterAllocator> {
-    inner: GreedyAllocator<R>,
+/// The plan-based allocator: a **read-only** server over a precomputed [`Plan`].
+///
+/// It holds no register pool and takes no online decisions — every method is a lookup into the plan
+/// (and the program-point maps in [`LiveIntervals`]) that returns where a value lives and the
+/// [`Action`]s to realize it. This is the endgame the design doc describes: "the allocator's methods
+/// become read-only queries over a precomputed plan".
+///
+/// **No-pressure scope.** This handles functions whose register pressure fits the value capacity
+/// (`usable - min_live_count`); [`Self::try_build`] returns `None` otherwise so the caller falls
+/// back to greedy. With no pressure every value keeps one register for its whole life, so there are
+/// no spills or reloads — `begin_block` seeds the register-resident values, `after_instruction`
+/// prunes the dead, and `resolve_edge` reports each parameter's register. Pressure spilling (splits,
+/// reloads, resolution) is layered on next.
+pub(crate) struct LinearScanAllocator {
+    /// The precomputed assignment (value location timelines).
+    plan: Plan,
+    /// Program-point maps, so `begin_block` can find a block's entry point.
+    intervals: LiveIntervals,
+    /// Values dying after each instruction, so `after_instruction` prunes them.
+    last_uses: HashMap<InstructionId, HashSet<ValueId>>,
+    /// Each value's typed `BrilligVariable`, its register fixed by the plan. This is the final
+    /// allocation map handed to the artifact via `into_allocations`.
+    allocations: HashMap<ValueId, BrilligVariable>,
+    /// The number of low registers reserved for value homes (`usable - min_live_count`); codegen
+    /// keeps scratch above this band.
+    value_capacity: usize,
 }
 
-impl<R: RegisterAllocator> LinearScanAllocator<R> {
-    /// Build the linear-scan allocator. Takes the same inputs as the greedy allocator so the two
-    /// are interchangeable at the construction site; the plan is derived from `liveness`.
-    pub(crate) fn new(
-        pool: Rc<RefCell<R>>,
-        spill_manager: Option<SpillManager>,
-        coalescing: CoalescingMap,
-        liveness: VariableLiveness,
-        last_uses: HashMap<InstructionId, HashSet<ValueId>>,
-    ) -> Self {
-        Self { inner: GreedyAllocator::new(pool, spill_manager, coalescing, liveness, last_uses) }
+impl LinearScanAllocator {
+    /// Build the plan and the read-only allocator, or `None` if the function does not fit
+    /// `value_capacity` without pressure spilling (the caller then falls back to greedy).
+    ///
+    /// `value_capacity` is the number of low registers usable for value homes; the caller reserves
+    /// the remaining upper registers for scratch (see [`FunctionContext`] — it sets the capacity to
+    /// `usable - (min_live_count + SPILL_MARGIN)`, leaving comfortable room for instruction scratch,
+    /// parallel-move temporaries, and on-demand constants that `min_live_count` under-counts).
+    /// `register_offset` is the first usable register offset (`Stack::START_OFFSET`), used to map a
+    /// plan register index to a frame-relative [`MemoryAddress`].
+    ///
+    /// [`FunctionContext`]: super::brillig_fn::FunctionContext
+    pub(crate) fn try_build(
+        function: &Function,
+        liveness: &VariableLiveness,
+        constants: &ConstantAllocation,
+        post_order: &[BasicBlockId],
+        last_uses: &HashMap<InstructionId, HashSet<ValueId>>,
+        value_capacity: usize,
+        register_offset: usize,
+    ) -> Option<Self> {
+        let intervals = LiveIntervals::from_function(function, liveness, constants, post_order);
+        let ranges = LiveRanges::from_intervals(&intervals, liveness, post_order);
+        let entry_params = function.dfg[function.entry_block()].parameters();
+        let plan = assign(&ranges, value_capacity, entry_params)?;
+
+        // Materialize each value's typed variable at its planned (single, in the no-pressure case)
+        // register.
+        let mut allocations = HashMap::default();
+        for (value, _) in ranges.iter() {
+            let register = match plan.timeline(value).first().map(|seg| seg.location) {
+                Some(Location::Register(index)) => {
+                    MemoryAddress::relative(assert_u32(register_offset + index))
+                }
+                // No pressure means no value is spill-homed; guard anyway.
+                _ => return None,
+            };
+            allocations.insert(value, typed_variable(function, value, register));
+        }
+
+        Some(Self { plan, intervals, last_uses: last_uses.clone(), allocations, value_capacity })
+    }
+
+    /// The number of low registers the plan reserves for value homes. Codegen reserves the frame's
+    /// remaining (upper) registers for scratch, so scratch never collides with a value home.
+    pub(crate) fn value_capacity(&self) -> usize {
+        self.value_capacity
     }
 
     /// The final register allocations, consumed when handing the global allocations to the artifact.
     pub(crate) fn into_allocations(self) -> HashMap<ValueId, BrilligVariable> {
-        self.inner.into_allocations()
+        self.allocations
     }
 
-    #[cfg(test)]
-    pub(crate) fn get_coalesced(&self, value_id: &ValueId) -> Option<ValueId> {
-        self.inner.get_coalesced(value_id)
-    }
-
-    #[cfg(test)]
-    pub(crate) fn liveness(&self) -> &VariableLiveness {
-        self.inner.liveness()
-    }
-
-    #[cfg(test)]
-    pub(crate) fn retire(&mut self, value_id: &ValueId) {
-        self.inner.retire(value_id);
+    /// The register a tracked value lives in (its home), panicking if it is untracked — every value
+    /// the driver defines or uses is in the plan.
+    fn register_of(&self, value: ValueId) -> MemoryAddress {
+        self.allocations
+            .get(&value)
+            .unwrap_or_else(|| panic!("ICE: linear-scan has no allocation for {value}"))
+            .extract_register()
     }
 }
 
-impl<R: RegisterAllocator> Allocator for LinearScanAllocator<R> {
+impl Allocator for LinearScanAllocator {
     fn begin_block(
         &mut self,
         block: BasicBlockId,
-        dfg: &DataFlowGraph,
+        _dfg: &DataFlowGraph,
     ) -> (Vec<(ValueId, MemoryAddress)>, Vec<Action>) {
-        self.inner.begin_block(block, dfg)
+        let entry = self.intervals.block_entry_point(block).expect("block has an entry point");
+        // Seed the shadow with every value register-resident at this block's entry.
+        let resident = self
+            .allocations
+            .iter()
+            .filter(|&(&value, _)| {
+                matches!(self.plan.location_at(value, entry), Some(Location::Register(_)))
+            })
+            .map(|(&value, variable)| (value, variable.extract_register()))
+            .collect();
+        (resident, Vec::new())
     }
 
     fn define_variable(
         &mut self,
         value_id: ValueId,
-        dfg: &DataFlowGraph,
+        _dfg: &DataFlowGraph,
     ) -> (BrilligVariable, Vec<Action>) {
-        self.inner.define_variable(value_id, dfg)
+        (self.allocations[&value_id], Vec::new())
     }
 
     fn use_variable(&mut self, value_id: ValueId) -> (BrilligVariable, Vec<Action>) {
-        self.inner.use_variable(value_id)
+        (self.allocations[&value_id], Vec::new())
     }
 
-    fn reserve_scratch(&mut self, scratch: usize) -> Vec<Action> {
-        self.inner.reserve_scratch(scratch)
+    fn reserve_scratch(&mut self, _scratch: usize) -> Vec<Action> {
+        // The plan reserved `min_live_count` upper registers for scratch, so there is always room;
+        // codegen allocates the temporaries from that band. Nothing to spill.
+        Vec::new()
     }
 
     fn after_instruction(&mut self, inst: InstructionId) -> Vec<Action> {
-        self.inner.after_instruction(inst)
+        let Some(dead) = self.last_uses.get(&inst) else {
+            return Vec::new();
+        };
+        dead.iter()
+            .filter(|value| self.allocations.contains_key(value))
+            .map(|&value| Action::Prune { value, register: self.register_of(value) })
+            .collect()
     }
 
-    fn before_terminator(&mut self, block: BasicBlockId, dfg: &DataFlowGraph) -> Vec<Action> {
-        self.inner.before_terminator(block, dfg)
+    fn before_terminator(&mut self, _block: BasicBlockId, _dfg: &DataFlowGraph) -> Vec<Action> {
+        // No pressure means no cross-edge value is spilled, so nothing to store before the branch.
+        Vec::new()
     }
 
     fn resolve_edge(
         &self,
-        pred: BasicBlockId,
+        _pred: BasicBlockId,
         succ: BasicBlockId,
         dfg: &DataFlowGraph,
     ) -> Vec<ParamHome> {
-        self.inner.resolve_edge(pred, succ, dfg)
+        dfg[succ]
+            .parameters()
+            .iter()
+            .map(|param| ParamHome::Register(self.register_of(*param)))
+            .collect()
     }
 
     fn spill_enabled(&self) -> bool {
-        self.inner.spill_enabled()
+        false
     }
 
     fn max_spill_offset(&self) -> usize {
-        self.inner.max_spill_offset()
+        0
+    }
+}
+
+/// Build a value's typed [`BrilligVariable`] at `register`, mirroring the greedy allocator's typed
+/// allocation but with the register fixed by the plan rather than pulled from a pool.
+fn typed_variable(function: &Function, value: ValueId, register: MemoryAddress) -> BrilligVariable {
+    let typ = function.dfg.type_of_value(value);
+    match typ.as_ref() {
+        Type::Numeric(_) | Type::Reference(..) | Type::Function => BrilligVariable::SingleAddr(
+            SingleAddrVariable::new(register, get_bit_size_from_ssa_type(&typ)),
+        ),
+        Type::Array(item_typ, elem_count) => BrilligVariable::BrilligArray(BrilligArray {
+            pointer: register,
+            size: compute_array_length(item_typ, *elem_count),
+        }),
+        Type::Vector(_) => BrilligVariable::BrilligVector(BrilligVector { pointer: register }),
     }
 }
 
@@ -264,9 +380,12 @@ impl<R: RegisterAllocator> Allocator for LinearScanAllocator<R> {
 /// which strategy is active. Keeping the choice in an enum (rather than `Box<dyn Allocator>`) lets
 /// the non-trait lifecycle methods (`into_allocations`, the test-only inspectors) stay off the
 /// [`Allocator`] trait, which is deliberately free of allocator-specific surface.
+// Exactly one instance exists per function, so the variant size gap does not matter; boxing would
+// add indirection on the hot allocator methods for no benefit.
+#[allow(clippy::large_enum_variant)]
 pub(crate) enum FunctionAllocator<R: RegisterAllocator> {
     Greedy(GreedyAllocator<R>),
-    LinearScan(LinearScanAllocator<R>),
+    LinearScan(LinearScanAllocator),
 }
 
 impl<R: RegisterAllocator> FunctionAllocator<R> {
@@ -278,11 +397,13 @@ impl<R: RegisterAllocator> FunctionAllocator<R> {
         }
     }
 
+    /// Greedy-only test inspectors. The tests that use them build greedy contexts (the default), so
+    /// the linear-scan arms are unreachable.
     #[cfg(test)]
     pub(crate) fn get_coalesced(&self, value_id: &ValueId) -> Option<ValueId> {
         match self {
             Self::Greedy(a) => a.get_coalesced(value_id),
-            Self::LinearScan(a) => a.get_coalesced(value_id),
+            Self::LinearScan(_) => panic!("get_coalesced is greedy-only"),
         }
     }
 
@@ -290,7 +411,7 @@ impl<R: RegisterAllocator> FunctionAllocator<R> {
     pub(crate) fn liveness(&self) -> &VariableLiveness {
         match self {
             Self::Greedy(a) => a.liveness(),
-            Self::LinearScan(a) => a.liveness(),
+            Self::LinearScan(_) => panic!("liveness is greedy-only"),
         }
     }
 
@@ -298,7 +419,7 @@ impl<R: RegisterAllocator> FunctionAllocator<R> {
     pub(crate) fn retire(&mut self, value_id: &ValueId) {
         match self {
             Self::Greedy(a) => a.retire(value_id),
-            Self::LinearScan(a) => a.retire(value_id),
+            Self::LinearScan(_) => panic!("retire is greedy-only"),
         }
     }
 }
@@ -405,6 +526,11 @@ mod assignment_tests {
         a.start <= b.end && b.start <= a.end
     }
 
+    fn entry_params(ssa: &Ssa) -> Vec<ValueId> {
+        let func = ssa.main();
+        func.dfg[func.entry_block()].parameters().to_vec()
+    }
+
     /// The core soundness invariant: no two register segments of *different* values that share a
     /// register index overlap in program points (interfering values never co-occupy a register),
     /// and every register index is within capacity. Also every value has at least one segment.
@@ -439,8 +565,8 @@ mod assignment_tests {
             return v3
         }
         ";
-        let (ranges, _ssa) = ranges_for(src);
-        let plan = assign(&ranges, 8).expect("fits in 8 registers");
+        let (ranges, ssa) = ranges_for(src);
+        let plan = assign(&ranges, 8, &entry_params(&ssa)).expect("fits in 8 registers");
         assert_eq!(plan.num_spill_slots(), 0);
         assert_sound(&ranges, &plan, 8);
         // Nothing is spilled: every segment is a register.
@@ -466,8 +592,11 @@ mod assignment_tests {
             return v6
         }
         ";
-        let (ranges, _ssa) = ranges_for(src);
-        assert!(assign(&ranges, 2).is_none(), "capacity 2 should be unplaceable without spilling");
+        let (ranges, ssa) = ranges_for(src);
+        assert!(
+            assign(&ranges, 2, &entry_params(&ssa)).is_none(),
+            "capacity 2 should be unplaceable without spilling"
+        );
     }
 
     #[test]
@@ -490,7 +619,7 @@ mod assignment_tests {
         }
         ";
         let (ranges, ssa) = ranges_for(src);
-        let plan = assign(&ranges, 8).expect("fits in 8 registers");
+        let plan = assign(&ranges, 8, &entry_params(&ssa)).expect("fits in 8 registers");
         let func = ssa.main();
         let v1 = func.dfg[func.entry_block()].parameters()[1];
 

--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/linear_scan.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/linear_scan.rs
@@ -280,13 +280,19 @@ impl Scan<'_> {
             return Some(register);
         }
         // Evict the evictable resident with the furthest next use (a value with no further use sorts
-        // furthest, so it is evicted first).
+        // furthest, so it is evicted first). Never evict a parameter, a value used at this point
+        // (`protected`), or a value defined at this point (its open segment starts here): spilling a
+        // just-defined value would close a zero-width register segment `[point, point - 1]` and lose
+        // the value's home. If that leaves no victim, the point genuinely needs more registers than
+        // exist, so `assign` declines (returns `None`) and the caller falls back to greedy.
         let victim = self
             .register_of
             .keys()
             .copied()
             .filter(|resident| {
-                !self.param_registers.contains_key(resident) && !protected.contains(resident)
+                !self.param_registers.contains_key(resident)
+                    && !protected.contains(resident)
+                    && self.open.get(resident).is_none_or(|&(start, _)| start != point)
             })
             .max_by_key(|&resident| {
                 let next = self.next_use(resident, point);
@@ -533,10 +539,24 @@ pub(crate) struct LinearScanAllocator {
     reserved_registers: usize,
     /// Number of spill slots the plan uses — the spill prologue's high-water mark (0 if none).
     num_spill_slots: usize,
+    /// Values whose plan location disagrees across *any* control-flow edge — the RPO-linear scan
+    /// carried a location over a non-CFG edge, so they don't physically arrive where the plan's
+    /// block entry says. Reconciled through the slot, uniformly at *every* boundary: such a value is
+    /// treated slot-resident at every block entry (excluded from the entry seed, reloaded on demand)
+    /// and saved to its slot before every terminator where it is register-resident. Making it slot-
+    /// canonical everywhere — rather than only on the diverging edge — keeps the property self-
+    /// consistent (a slot-resolved value's own exit location would otherwise shift and mislead its
+    /// successors). Every such value has a spill slot (`try_build` declines otherwise).
+    slot_boundary: HashSet<ValueId>,
     /// Residency mirror, reset from the plan at each block entry and evolved as actions are emitted:
     /// which register index holds each live value, and the inverse.
     register_of_value: HashMap<ValueId, usize>,
     value_in_register: HashMap<usize, ValueId>,
+    /// The function's entry block. Its live-in values are parameters that physically arrive in their
+    /// registers (placed by the caller, not by a predecessor's terminator), so a slot-canonical value
+    /// among them is seeded here — otherwise its slot would never be initialized before a later
+    /// reload. Non-entry blocks reconcile slot-canonical values through the slot instead.
+    entry_block: BasicBlockId,
 }
 
 impl LinearScanAllocator {
@@ -566,16 +586,6 @@ impl LinearScanAllocator {
         let entry_params = function.dfg[function.entry_block()].parameters();
         let mut plan = assign(&ranges, &use_points, value_capacity, entry_params)?;
         plan.entry_registers = block_entry_registers(&plan.timeline, &intervals, post_order);
-
-        // Scope: serve register-only plans (a value may change register across a hole; its data
-        // survives on the taken path, and `make_resident` re-seeds it). Decline plans that use a
-        // spill slot: pressure spilling needs the slot-canonical merge resolution (a value live on
-        // both branches of a merge but spilled on one), which is not yet implemented. Until then,
-        // fall back to greedy for those. Keeping register-resident values (including cross-block
-        // ones) in a register already beats greedy, which permanently spills every cross-block value.
-        if plan.num_spill_slots() > 0 {
-            return None;
-        }
 
         // Precompute, from the plan: each value's typed template at its definition register, each
         // spilled value's fixed slot, and the highest register index used (which fixes the reserved
@@ -610,6 +620,41 @@ impl LinearScanAllocator {
         let reserved_registers = max_register_index.map_or(0, |index| index + 1);
         let num_spill_slots = plan.num_spill_slots();
 
+        // Merge resolution. A non-parameter value live-in to a block whose plan location differs
+        // from its location at some predecessor's terminator was carried over a non-CFG edge by the
+        // RPO-linear scan, so it does not physically arrive where the plan's entry says. Reconcile
+        // it through its slot: the block treats it as slot-resident (reloaded on demand), and each
+        // predecessor saves it before branching. This needs the value to have a slot; if a divergent
+        // value has none (no register→register moves are emitted), decline and fall back to greedy.
+        let mut slot_boundary: HashSet<ValueId> = HashSet::default();
+        for &block in post_order {
+            let entry = intervals.block_entry_point(block).expect("block has an entry point");
+            let params: HashSet<ValueId> =
+                function.dfg[block].parameters().iter().copied().collect();
+            let predecessors: Vec<BasicBlockId> = liveness.cfg().predecessors(block).collect();
+            if predecessors.is_empty() {
+                continue;
+            }
+            for &value in liveness.get_live_in(&block) {
+                if params.contains(&value) || plan.timeline(value).is_empty() {
+                    continue;
+                }
+                let at_entry = plan.location_at(value, entry);
+                let divergent = predecessors.iter().any(|&pred| {
+                    let term = intervals.terminator_point(pred).expect("block has a terminator");
+                    plan.location_at(value, term) != at_entry
+                });
+                if divergent {
+                    // Reconciled through the slot; register-only divergence has no slot to route
+                    // through (no register-to-register moves are emitted), so decline it.
+                    if !value_slot.contains_key(&value) {
+                        return None;
+                    }
+                    slot_boundary.insert(value);
+                }
+            }
+        }
+
         Some(Self {
             plan,
             intervals,
@@ -619,6 +664,8 @@ impl LinearScanAllocator {
             register_offset,
             reserved_registers,
             num_spill_slots,
+            entry_block: function.entry_block(),
+            slot_boundary,
             register_of_value: HashMap::default(),
             value_in_register: HashMap::default(),
         })
@@ -742,15 +789,22 @@ impl Allocator for LinearScanAllocator {
         _dfg: &DataFlowGraph,
     ) -> (Vec<(ValueId, MemoryAddress)>, Vec<Action>) {
         // Reset the residency mirror to the plan's picture at this block's entry: the values the plan
-        // homes in a register there, read directly from the precomputed snapshot. The physical
-        // registers hold exactly these on entry — the plan is globally consistent and each incoming
-        // edge leaves cross-edge values where the successor expects them — so this is a lookup, not a
-        // decision.
+        // homes in a register there, read directly from the precomputed snapshot — except values that
+        // arrive inconsistently across incoming edges (`slot_boundary`), which are reconciled through
+        // their slot and so are treated slot-resident here (reloaded on demand at their first use).
+        // For the rest, the physical registers hold exactly these on entry, so this is a lookup.
         let snapshot = self.plan.registers_at_block_entry(block);
         self.register_of_value.clear();
         self.value_in_register.clear();
         let mut resident = Vec::with_capacity(snapshot.len());
         for (&value, &index) in &snapshot {
+            // A slot-canonical value is reloaded on demand rather than trusted to arrive in a
+            // register — except at the entry block, where it is a parameter that physically arrives
+            // in its register, so seeding it here lets `before_terminator` save it to its slot (the
+            // reload path in later blocks depends on that slot having been initialized).
+            if self.slot_boundary.contains(&value) && block != self.entry_block {
+                continue;
+            }
             self.register_of_value.insert(value, index);
             self.value_in_register.insert(index, value);
             resident.push((value, self.addr(index)));
@@ -848,6 +902,25 @@ impl Allocator for LinearScanAllocator {
             let index = self.register_index_at(value, point);
             actions.extend(self.make_resident(value, index, point));
         }
+
+        // Merge resolution: a value that some successor reconciles through its slot must hold the
+        // right data in that slot before we branch. Save each such value that is currently
+        // register-resident (a `Save` stores it but keeps its register, so it stays available for
+        // this block's own terminator reads). It is harmless on every outgoing edge — the store
+        // targets the value's own slot and SSA values are immutable — so no critical-edge split is
+        // needed. Values already spill-resident here need no save (their slot already holds them).
+        let mut to_save: Vec<(ValueId, usize)> = Vec::new();
+        for (&value, &index) in &self.register_of_value {
+            if self.slot_boundary.contains(&value) {
+                to_save.push((value, index));
+            }
+        }
+        to_save.sort_unstable();
+        to_save.dedup();
+        for (value, index) in to_save {
+            let slot = self.value_slot[&value];
+            actions.push(Action::Save { value, from: self.addr(index), to: SpillSlot(slot) });
+        }
         actions
     }
 
@@ -862,14 +935,25 @@ impl Allocator for LinearScanAllocator {
         dfg[succ]
             .parameters()
             .iter()
-            .map(|&param| match self.plan.location_at(param, entry) {
-                Some(Location::Register(index)) => ParamHome::Register(self.addr(index)),
-                Some(Location::Slot(slot)) => ParamHome::Slot(SpillSlot(slot)),
-                // The parameter is dead at its own block's entry: it is passed by a predecessor but
-                // never read in the block (e.g. only forwarded as a jmp argument earlier). The jmp
-                // still has to write it somewhere valid, so route it to the parameter's home (its
-                // definition register). The write is dead but harmless.
-                None => ParamHome::Register(self.templates[&param].extract_register()),
+            .map(|&param| {
+                // A slot-canonical parameter is reconciled through its slot at the block entry
+                // (`begin_block` excludes it from the entry seed and reloads it on demand), so the
+                // edge must deliver its incoming value to that slot — not to the plan's register,
+                // which the entry never reads. This is what makes a loop-carried value that is
+                // slot-canonical correct: each back-edge writes the fresh value to the slot the
+                // reload reads, rather than to a register the reload ignores.
+                if self.slot_boundary.contains(&param) {
+                    return ParamHome::Slot(SpillSlot(self.value_slot[&param]));
+                }
+                match self.plan.location_at(param, entry) {
+                    Some(Location::Register(index)) => ParamHome::Register(self.addr(index)),
+                    Some(Location::Slot(slot)) => ParamHome::Slot(SpillSlot(slot)),
+                    // The parameter is dead at its own block's entry: it is passed by a predecessor
+                    // but never read in the block (e.g. only forwarded as a jmp argument earlier).
+                    // The jmp still has to write it somewhere valid, so route it to the parameter's
+                    // home (its definition register). The write is dead but harmless.
+                    None => ParamHome::Register(self.templates[&param].extract_register()),
+                }
             })
             .collect()
     }

--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/linear_scan.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/linear_scan.rs
@@ -24,6 +24,7 @@ use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 
 use super::allocator::{Action, Allocator, GreedyAllocator, ParamHome};
 use super::coalescing::CoalescingMap;
+use super::live_intervals::{LiveInterval, LiveIntervals, ProgramPoint};
 use super::spill_manager::SpillManager;
 use super::variable_liveness::VariableLiveness;
 use crate::brillig::brillig_ir::brillig_variable::BrilligVariable;
@@ -32,6 +33,119 @@ use crate::ssa::ir::basic_block::BasicBlockId;
 use crate::ssa::ir::dfg::DataFlowGraph;
 use crate::ssa::ir::instruction::InstructionId;
 use crate::ssa::ir::value::ValueId;
+
+/// The register or spill-slot home assigned to an SSA value for its entire lifetime.
+///
+/// The fixed-home model gives each value exactly one location for its whole live range: a register
+/// (an index in `[0, value_capacity)` that codegen maps to a concrete `MemoryAddress`) or a spill
+/// slot. A value never changes home, so one that lives across a block boundary and got a register
+/// simply stays in it — no cross-block spill/reload. That is the reduction in spill traffic over the
+/// greedy allocator, which permanently spills every cross-block value once spilling is enabled.
+// The plan API is consumed by `LinearScanAllocator` in the next milestone; unused until then.
+#[allow(dead_code)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Home {
+    /// Register index in `[0, value_capacity)`.
+    Register(usize),
+    /// Spill-slot offset.
+    Spill(usize),
+}
+
+/// A global register-allocation plan: the home of every value, plus the spill-slot count.
+#[allow(dead_code)]
+#[derive(Debug, Default)]
+pub(crate) struct Plan {
+    homes: HashMap<ValueId, Home>,
+    num_spill_slots: usize,
+}
+
+#[allow(dead_code)]
+impl Plan {
+    /// The home assigned to `value`, or `None` if the value is not tracked (e.g. a global).
+    pub(crate) fn home(&self, value: ValueId) -> Option<Home> {
+        self.homes.get(&value).copied()
+    }
+
+    /// The number of distinct spill slots the plan uses (0 if nothing spilled).
+    pub(crate) fn num_spill_slots(&self) -> usize {
+        self.num_spill_slots
+    }
+}
+
+/// Compute the fixed-home assignment by linear scan (Poletto & Sarkar, "Linear Scan Register
+/// Allocation", 1999) over the value intervals, with a value-register capacity of `value_capacity`.
+///
+/// `value_capacity` is `usable_registers - min_live_count`. Reserving `min_live_count` registers
+/// leaves every instruction room for its working set (operands, result, and scratch, which reuse
+/// one another up to the per-instruction floor `min_live_count`), so bounding register-homed values
+/// to `value_capacity` at every point guarantees codegen never overflows the frame. Values that do
+/// not fit are spilled whole, evicting the furthest-`last_use` interval — the classic heuristic,
+/// applied globally because a fixed home cannot be split.
+#[allow(dead_code)]
+pub(crate) fn assign(intervals: &LiveIntervals, value_capacity: usize) -> Plan {
+    let sorted = intervals.intervals_by_def();
+
+    // Free register indices; kept as a stack with the lowest index on top so `pop` is deterministic.
+    let mut free: Vec<usize> = (0..value_capacity).rev().collect();
+    // Register-homed values still live, with their interval and assigned index.
+    let mut active: Vec<(ValueId, LiveInterval, usize)> = Vec::new();
+    let mut homes: HashMap<ValueId, Home> = HashMap::default();
+    let mut num_spill_slots = 0usize;
+
+    for (value, interval) in sorted {
+        // Free the registers of intervals that ended before this one begins.
+        expire(&mut active, &mut free, interval.def);
+
+        if let Some(index) = free.pop() {
+            homes.insert(value, Home::Register(index));
+            active.push((value, interval, index));
+            continue;
+        }
+
+        // The frame's value budget is full. Spill either the active value that lives longest — and
+        // give this value its register — or this value itself, whichever dies later.
+        let furthest = active
+            .iter()
+            .enumerate()
+            .max_by_key(|(_, (_, iv, _))| iv.last_use)
+            .map(|(pos, (v, iv, idx))| (pos, *v, iv.last_use, *idx));
+
+        match furthest {
+            Some((pos, spilled_value, spilled_last_use, index))
+                if spilled_last_use > interval.last_use =>
+            {
+                active.remove(pos);
+                homes.insert(spilled_value, Home::Spill(num_spill_slots));
+                num_spill_slots += 1;
+                homes.insert(value, Home::Register(index));
+                active.push((value, interval, index));
+            }
+            _ => {
+                homes.insert(value, Home::Spill(num_spill_slots));
+                num_spill_slots += 1;
+            }
+        }
+    }
+
+    Plan { homes, num_spill_slots }
+}
+
+/// Remove active intervals whose `last_use` is before `point`, returning their registers to `free`.
+#[allow(dead_code)]
+fn expire(
+    active: &mut Vec<(ValueId, LiveInterval, usize)>,
+    free: &mut Vec<usize>,
+    point: ProgramPoint,
+) {
+    active.retain(|(_, interval, index)| {
+        if interval.last_use < point {
+            free.push(*index);
+            false
+        } else {
+            true
+        }
+    });
+}
 
 /// The plan-based allocator. See the module docs; presently a delegating scaffold over
 /// [`GreedyAllocator`] pending the assignment pass.
@@ -244,5 +358,149 @@ impl<R: RegisterAllocator> Allocator for FunctionAllocator<R> {
             Self::Greedy(a) => a.max_spill_offset(),
             Self::LinearScan(a) => a.max_spill_offset(),
         }
+    }
+}
+
+#[cfg(test)]
+mod assignment_tests {
+    use super::{Home, Plan, assign};
+    use crate::brillig::brillig_gen::constant_allocation::ConstantAllocation;
+    use crate::brillig::brillig_gen::live_intervals::LiveIntervals;
+    use crate::brillig::brillig_gen::variable_liveness::VariableLiveness;
+    use crate::ssa::ir::post_order::PostOrder;
+    use crate::ssa::ir::value::ValueId;
+    use crate::ssa::ssa_gen::Ssa;
+
+    fn intervals_for(src: &str) -> LiveIntervals {
+        let ssa = Ssa::from_str(src).unwrap();
+        let func = ssa.main();
+        let constants = ConstantAllocation::from_function(func);
+        let liveness = VariableLiveness::from_function(func, &constants);
+        let post_order = PostOrder::with_function(func).into_vec();
+        LiveIntervals::from_function(func, &liveness, &constants, &post_order)
+    }
+
+    fn register_homes(intervals: &LiveIntervals, plan: &Plan) -> Vec<(ValueId, usize)> {
+        intervals
+            .intervals_by_def()
+            .into_iter()
+            .filter_map(|(v, _)| match plan.home(v) {
+                Some(Home::Register(index)) => Some((v, index)),
+                _ => None,
+            })
+            .collect()
+    }
+
+    fn spilled(intervals: &LiveIntervals, plan: &Plan) -> Vec<ValueId> {
+        intervals
+            .intervals_by_def()
+            .into_iter()
+            .filter_map(|(v, _)| matches!(plan.home(v), Some(Home::Spill(_))).then_some(v))
+            .collect()
+    }
+
+    /// The core soundness invariant: two values that interfere must never share a register index,
+    /// and every register index is within the capacity.
+    fn assert_sound(intervals: &LiveIntervals, plan: &Plan, capacity: usize) {
+        let homes = register_homes(intervals, plan);
+        for (i, &(a, ia)) in homes.iter().enumerate() {
+            assert!(ia < capacity, "register index {ia} exceeds capacity {capacity}");
+            for &(b, ib) in &homes[i + 1..] {
+                if ia == ib {
+                    assert!(
+                        !intervals.interferes(a, b),
+                        "interfering values {a} and {b} share register index {ia}"
+                    );
+                }
+            }
+        }
+        // Every value has a home.
+        for (v, _) in intervals.intervals_by_def() {
+            assert!(plan.home(v).is_some(), "value {v} has no home");
+        }
+    }
+
+    #[test]
+    fn ample_capacity_spills_nothing() {
+        let src = "
+        brillig(inline) fn main f0 {
+          b0(v0: Field):
+            v1 = add v0, Field 1
+            v2 = add v1, Field 2
+            v3 = add v2, Field 3
+            return v3
+        }
+        ";
+        let intervals = intervals_for(src);
+        let plan = assign(&intervals, 8);
+        assert_eq!(plan.num_spill_slots(), 0, "nothing should spill with ample capacity");
+        assert_sound(&intervals, &plan, 8);
+    }
+
+    #[test]
+    fn tight_capacity_spills_the_overflow_soundly() {
+        // Several values are simultaneously live; a capacity of 2 forces spilling.
+        let src = "
+        brillig(inline) fn main f0 {
+          b0(v0: Field, v1: Field):
+            v2 = add v0, v1
+            v3 = mul v0, v1
+            v4 = add v2, v3
+            v5 = mul v2, v3
+            v6 = add v4, v5
+            return v6
+        }
+        ";
+        let intervals = intervals_for(src);
+        let plan = assign(&intervals, 2);
+        assert!(plan.num_spill_slots() > 0, "tight capacity should force spills");
+        assert_sound(&intervals, &plan, 2);
+    }
+
+    #[test]
+    fn zero_capacity_spills_everything() {
+        let src = "
+        brillig(inline) fn main f0 {
+          b0(v0: Field):
+            v1 = add v0, Field 1
+            return v1
+        }
+        ";
+        let intervals = intervals_for(src);
+        let plan = assign(&intervals, 0);
+        let total = intervals.intervals_by_def().len();
+        assert_eq!(plan.num_spill_slots(), total, "with no registers every value spills");
+        assert!(register_homes(&intervals, &plan).is_empty());
+        assert_eq!(spilled(&intervals, &plan).len(), total);
+    }
+
+    #[test]
+    fn cross_block_value_keeps_its_register() {
+        // `v1` is live across the branch into both successors and the merge. With ample capacity the
+        // fixed-home model must keep it in a register the whole time — the behaviour greedy lacks
+        // (it would permanently spill it once spilling is on).
+        let src = "
+        brillig(inline) fn main f0 {
+          b0(v0: u1, v1: Field):
+            jmpif v0 then: b1(), else: b2()
+          b1():
+            v2 = add v1, Field 1
+            jmp b3(v2)
+          b2():
+            v3 = mul v1, Field 2
+            jmp b3(v3)
+          b3(v4: Field):
+            return v4
+        }
+        ";
+        let intervals = intervals_for(src);
+        let plan = assign(&intervals, 8);
+        let ssa = Ssa::from_str(src).unwrap();
+        let v1 = ssa.main().dfg[ssa.main().entry_block()].parameters()[1];
+        assert!(
+            matches!(plan.home(v1), Some(Home::Register(_))),
+            "cross-block value should keep a register with ample capacity"
+        );
+        assert_sound(&intervals, &plan, 8);
     }
 }

--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/linear_scan.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/linear_scan.rs
@@ -12,11 +12,12 @@
 //! over that plan (no register pool, no online decisions): every trait method is a lookup returning
 //! where a value lives and the [`Action`]s to realize it.
 //!
-//! **Scope.** Only the no-pressure case is implemented: functions whose register pressure fits the
-//! value capacity, with every value in one register for its whole life. Functions that would need
-//! pressure spilling — or a split (a value in two registers) that requires a move the no-pressure
-//! allocator does not emit — decline in [`LinearScanAllocator::try_build`] and fall back to
-//! [`GreedyAllocator`]. Pressure spilling with reloads and edge resolution is the next step.
+//! **Scope.** Functions whose register pressure fits the value capacity are served — including those
+//! that need pressure spilling (a value split register→slot→register, reloaded at its next use) and
+//! interval-splitting across holes. [`LinearScanAllocator::try_build`] declines (falls back to
+//! [`GreedyAllocator`]) only when [`assign`] cannot place the function at the capacity — e.g. a
+//! high-arity `MakeArray` whose elements the single-point plan counts as simultaneously live (the
+//! per-element sub-points that would stream them are a planned refinement).
 //!
 //! [`BrilligBlock`]: super::brillig_block::BrilligBlock
 //! [`FunctionContext`]: super::brillig_fn::FunctionContext
@@ -24,16 +25,16 @@
 use acvm::acir::brillig::MemoryAddress;
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 
-use super::allocator::{Action, Allocator, GreedyAllocator, ParamHome};
+use super::allocator::{Action, Allocator, GreedyAllocator, ParamHome, SpillSlot};
 use super::brillig_block_variables::compute_array_length;
 use super::constant_allocation::ConstantAllocation;
 use super::live_intervals::{LiveIntervals, LiveRanges, ProgramPoint};
 use super::variable_liveness::VariableLiveness;
+use crate::brillig::assert_u32;
 use crate::brillig::brillig_ir::brillig_variable::{
     BrilligArray, BrilligVariable, BrilligVector, SingleAddrVariable, get_bit_size_from_ssa_type,
 };
 use crate::brillig::brillig_ir::registers::RegisterAllocator;
-use crate::brillig::{assert_u32, assert_usize};
 use crate::ssa::ir::basic_block::BasicBlockId;
 use crate::ssa::ir::dfg::DataFlowGraph;
 use crate::ssa::ir::function::Function;
@@ -102,187 +103,349 @@ impl Plan {
     }
 }
 
-/// A `[start, end]` live range tagged with the value it belongs to — the unit the scan consumes.
-struct RangeOf {
-    start: ProgramPoint,
-    end: ProgramPoint,
-    value: ValueId,
+/// The use points of every value in increasing order: the program points where the value is an
+/// operand of an instruction or terminator. A spilled value must be reloaded to a register at each
+/// of these, and the furthest next use drives victim selection.
+pub(crate) fn compute_use_points(
+    function: &Function,
+    intervals: &LiveIntervals,
+    post_order: &[BasicBlockId],
+) -> HashMap<ValueId, Vec<ProgramPoint>> {
+    let mut uses: HashMap<ValueId, Vec<ProgramPoint>> = HashMap::default();
+    for &block in post_order {
+        for &inst in function.dfg[block].instructions() {
+            let point = intervals.instruction_point(inst).expect("instruction has a program point");
+            function.dfg[inst].for_each_value(|value| {
+                if super::variable_liveness::is_variable(value, &function.dfg) {
+                    uses.entry(value).or_default().push(point);
+                }
+            });
+        }
+        let point = intervals.terminator_point(block).expect("block has a terminator point");
+        function.dfg[block].unwrap_terminator().for_each_value(|value| {
+            if super::variable_liveness::is_variable(value, &function.dfg) {
+                uses.entry(value).or_default().push(point);
+            }
+        });
+    }
+    for points in uses.values_mut() {
+        points.sort_unstable();
+        points.dedup();
+    }
+    uses
 }
 
-/// Assign registers by linear scan over the hole-aware [`LiveRanges`], with a value-register
-/// capacity of `value_capacity`.
+/// The program points, increasing, at which the scan acts: where a live range begins or a value is
+/// used. Range *ends* are handled lazily (a value's register frees at the first event past its
+/// current range's end), so they need not be events themselves.
+fn event_points(
+    ranges: &LiveRanges,
+    use_points: &HashMap<ValueId, Vec<ProgramPoint>>,
+) -> Vec<ProgramPoint> {
+    let mut points: Vec<ProgramPoint> = ranges
+        .iter()
+        .flat_map(|(_, list)| list.iter().map(|range| range.start))
+        .chain(use_points.values().flatten().copied())
+        .collect();
+    points.sort_unstable();
+    points.dedup();
+    points
+}
+
+/// Mutable state of the linear scan, evolving as it walks program points. All decisions are made
+/// here; the result is the read-only [`Plan`] (`timeline`).
+struct Scan<'a> {
+    param_registers: &'a HashMap<ValueId, usize>,
+    use_points: &'a HashMap<ValueId, Vec<ProgramPoint>>,
+    /// Register indices currently free for non-parameter values.
+    free: std::collections::BTreeSet<usize>,
+    /// Currently register-resident values → their register index.
+    register_of: HashMap<ValueId, usize>,
+    /// Each currently-live value → the end of the range it is in (for lazy expiry).
+    range_end_of: HashMap<ValueId, ProgramPoint>,
+    /// A value's most recent register, so a later range reclaims it when free (no spurious split).
+    previous_register: HashMap<ValueId, usize>,
+    /// Each live value's open segment: (start point, location).
+    open: HashMap<ValueId, (ProgramPoint, Location)>,
+    /// The accumulated per-value location timeline (the plan being built).
+    timeline: HashMap<ValueId, Vec<Segment>>,
+    /// The fixed spill slot of each value that is ever spilled (one per value; packing is a later
+    /// refinement).
+    slot_of: HashMap<ValueId, usize>,
+    num_spill_slots: usize,
+}
+
+impl Scan<'_> {
+    /// The first use of `value` strictly after `point`, if any.
+    fn next_use(&self, value: ValueId, point: ProgramPoint) -> Option<ProgramPoint> {
+        let points = self.use_points.get(&value)?;
+        points.iter().copied().find(|&p| p > point)
+    }
+
+    /// The value's fixed spill slot, allocating one on first spill.
+    fn slot(&mut self, value: ValueId) -> usize {
+        if let Some(&slot) = self.slot_of.get(&value) {
+            return slot;
+        }
+        let slot = self.num_spill_slots;
+        self.num_spill_slots += 1;
+        self.slot_of.insert(value, slot);
+        slot
+    }
+
+    /// Close `value`'s open segment ending inclusively at `end`.
+    fn close_segment(&mut self, value: ValueId, end: ProgramPoint) {
+        if let Some((start, location)) = self.open.remove(&value) {
+            self.timeline.entry(value).or_default().push(Segment { start, end, location });
+        }
+    }
+
+    /// Spill a register-resident value to its slot at `point`: end its register segment just before
+    /// `point`, free the register, and open a slot segment. (Never called on a parameter.)
+    fn spill(&mut self, value: ValueId, point: ProgramPoint) -> usize {
+        let (start, location) =
+            self.open.remove(&value).expect("resident value has an open segment");
+        let Location::Register(register) = location else {
+            unreachable!("only register-resident values are spilled");
+        };
+        self.timeline.entry(value).or_default().push(Segment {
+            start,
+            end: point.pred(),
+            location,
+        });
+        self.register_of.remove(&value);
+        self.free.insert(register);
+        let slot = self.slot(value);
+        self.open.insert(value, (point, Location::Slot(slot)));
+        register
+    }
+
+    /// Expire currently-live values whose range has ended, closing each one's open segment at its
+    /// range end and returning its (non-parameter) register to the free set. With `strict`, only
+    /// ranges ending *before* `point` expire — values still needed at `point` stay resident. Without
+    /// it, ranges ending *at* `point` also expire; the scan runs this only *after* this point's
+    /// result has claimed a register, so an operand consumed here keeps its register through the
+    /// result's allocation and the result never aliases it.
+    fn expire(&mut self, point: ProgramPoint, strict: bool) {
+        let param_registers = self.param_registers;
+        let expired: Vec<ValueId> = self
+            .range_end_of
+            .iter()
+            .filter(|&(_, &end)| if strict { end < point } else { end <= point })
+            .map(|(&value, _)| value)
+            .collect();
+        for value in expired {
+            let end = self.range_end_of.remove(&value).expect("expiring value has a range end");
+            let register = self.register_of.remove(&value);
+            self.close_segment(value, end);
+            if let Some(register) = register
+                && !param_registers.contains_key(&value)
+            {
+                self.free.insert(register);
+            }
+        }
+    }
+
+    /// Allocate a register for `value` at `point`: reclaim its previous register if free, else the
+    /// lowest free one, else evict the resident whose next use is furthest (spilling it). Values in
+    /// `protected` (used at this very point, so needed now) and parameters are never evicted. Returns
+    /// `None` only if no register can be obtained.
+    fn allocate(
+        &mut self,
+        value: ValueId,
+        point: ProgramPoint,
+        protected: &HashSet<ValueId>,
+    ) -> Option<usize> {
+        if let Some(&previous) = self.previous_register.get(&value)
+            && self.free.remove(&previous)
+        {
+            return Some(previous);
+        }
+        if let Some(&register) = self.free.iter().next() {
+            self.free.remove(&register);
+            return Some(register);
+        }
+        // Evict the evictable resident with the furthest next use (a value with no further use sorts
+        // furthest, so it is evicted first).
+        let victim = self
+            .register_of
+            .keys()
+            .copied()
+            .filter(|resident| {
+                !self.param_registers.contains_key(resident) && !protected.contains(resident)
+            })
+            .max_by_key(|&resident| {
+                (self.next_use(resident, point).is_none(), self.next_use(resident, point), resident)
+            })?;
+        let register = self.spill(victim, point);
+        self.free.remove(&register);
+        Some(register)
+    }
+}
+
+/// Assign registers by linear scan over the hole-aware [`LiveRanges`], reloading spilled values at
+/// their uses (Wimmer-style interval splitting), with a value-register capacity of `value_capacity`.
 ///
-/// Each of a value's live ranges is scanned as a separate interval, but a value **reclaims its
-/// previous register** when a later range begins if that register is still free — so a value with a
-/// hole on its own runtime path keeps one register (no spurious split), while a value dead across a
-/// *divergent-path* hole releases its register for another value to share during the hole.
-///
-/// Under register pressure (no free register at a point) it **spills the longest-lived interval** —
-/// an active one if it outlives the incoming range, else the incoming range — to that value's fixed
-/// spill slot, splitting the evicted value's timeline into a register segment then a slot segment.
-/// The resulting plan therefore mixes `Register` and `Slot` locations (a value can be both over its
-/// life). Returns `None` only when the entry parameters alone exceed `value_capacity`.
+/// Walking program points in order: a value becomes resident when its live range begins (reclaiming
+/// its previous register across a hole when free — no spurious split); when a value is used while
+/// spilled it is reloaded into a register; and under pressure the resident whose next use is furthest
+/// is evicted to its fixed spill slot. A value's register may therefore change over its life (a
+/// register→slot→register split), which edge resolution reconciles at merges. Returns `None` only
+/// when a value cannot be given any register (e.g. the entry parameters already fill the capacity).
 #[allow(dead_code)]
 pub(crate) fn assign(
     ranges: &LiveRanges,
+    use_points: &HashMap<ValueId, Vec<ProgramPoint>>,
     value_capacity: usize,
     entry_params: &[ValueId],
 ) -> Option<Plan> {
     // Entry-block parameters are pre-colored fixed intervals: the calling convention places argument
     // `i` in register `i` (see `codegen_entry_point::allocate_function_arguments`), so the callee
-    // must read parameter `i` from register `i`. Reserve `[0, n_params)` for them, matching order,
-    // and never hand those indices to other values — over-reserving vs sharing a param's register
-    // after it dies, but correct and simple (register sharing for dead params is a later refinement).
+    // must read parameter `i` from register `i`. Reserve `[0, n_params)` for them, never handing
+    // those indices to other values.
     let param_registers: HashMap<ValueId, usize> =
         entry_params.iter().enumerate().map(|(index, &param)| (param, index)).collect();
     if param_registers.len() > value_capacity {
         return None;
     }
 
-    // Flatten to one interval per (value, range), scanned in start order.
-    let mut intervals: Vec<RangeOf> = ranges
-        .iter()
-        .flat_map(|(value, list)| {
-            list.iter().map(move |range| RangeOf { start: range.start, end: range.end, value })
-        })
-        .collect();
-    intervals.sort_by_key(|r| (r.start, r.end, r.value));
-
-    // Free register indices available to non-parameter values (parameter indices are reserved).
-    let mut free: std::collections::BTreeSet<usize> =
-        (param_registers.len()..value_capacity).collect();
-    // Currently register-resident non-parameter ranges: (range end, value, register index).
-    let mut active: Vec<(ProgramPoint, ValueId, usize)> = Vec::new();
-    // A value's most recent register, so a later range can reclaim it when free.
-    let mut previous_register: HashMap<ValueId, usize> = HashMap::default();
-    let mut timeline: HashMap<ValueId, Vec<Segment>> = HashMap::default();
-    // The fixed spill slot of each value that is ever spilled. One slot per value (not yet packed
-    // across non-interfering values — a later refinement); reused across all of the value's spills.
-    let mut slots: HashMap<ValueId, usize> = HashMap::default();
-    let mut num_spill_slots = 0usize;
-
-    for RangeOf { start, end, value } in intervals {
-        // Expire ranges that ended strictly before this one begins, freeing their registers. Ranges
-        // touching at a point (`prev.end == start`) stay active — they interfere.
-        active.retain(|&(active_end, _, register)| {
-            let expired = active_end < start;
-            if expired {
-                free.insert(register);
-            }
-            !expired
-        });
-
-        // Parameters are fixed intervals in their reserved register, never spilled.
-        if let Some(&index) = param_registers.get(&value) {
-            previous_register.insert(value, index);
-            timeline.entry(value).or_default().push(Segment {
-                start,
-                end,
-                location: Location::Register(index),
-            });
-            continue;
+    // Per-point range starts (value → that range's end) and the values used at each point.
+    let mut range_start_at: HashMap<ProgramPoint, Vec<(ValueId, ProgramPoint)>> =
+        HashMap::default();
+    for (value, list) in ranges.iter() {
+        for range in list {
+            range_start_at.entry(range.start).or_default().push((value, range.end));
         }
-
-        // Prefer the value's previous register (reclaim across a hole), else the lowest free one.
-        let reclaim = previous_register.get(&value).copied().filter(|prev| free.contains(prev));
-        if let Some(register) = reclaim.or_else(|| free.iter().next().copied()) {
-            free.remove(&register);
-            previous_register.insert(value, register);
-            active.push((end, value, register));
-            timeline.entry(value).or_default().push(Segment {
-                start,
-                end,
-                location: Location::Register(register),
-            });
-            continue;
+    }
+    let mut used_at: HashMap<ProgramPoint, HashSet<ValueId>> = HashMap::default();
+    for (&value, points) in use_points {
+        for &point in points {
+            used_at.entry(point).or_default().insert(value);
         }
+    }
 
-        // Pressure: no register is free. Evict the longest-lived interval — an active one if it
-        // outlives this range, else this range itself — to its value's spill slot. The evicted
-        // stretch lives in the slot; uses within it reload on demand.
-        let victim = active.iter().enumerate().max_by_key(|(_, (active_end, _, _))| *active_end);
-        match victim {
-            Some((position, &(active_end, active_value, active_register))) if active_end > end => {
-                // Split the active value's current register segment at `start`: register before,
-                // slot from `start` onward.
-                let slot = *slots.entry(active_value).or_insert_with(|| {
-                    let slot = num_spill_slots;
-                    num_spill_slots += 1;
-                    slot
-                });
-                let segments = timeline.get_mut(&active_value).expect("active value has segments");
-                let current = segments.last_mut().expect("active value has a live segment");
-                if current.start < start {
-                    current.end = start.pred();
-                    segments.push(Segment {
-                        start,
-                        end: active_end,
-                        location: Location::Slot(slot),
-                    });
-                } else {
-                    current.location = Location::Slot(slot);
+    let mut scan = Scan {
+        param_registers: &param_registers,
+        use_points,
+        free: (param_registers.len()..value_capacity).collect(),
+        register_of: HashMap::default(),
+        range_end_of: HashMap::default(),
+        previous_register: HashMap::default(),
+        open: HashMap::default(),
+        timeline: HashMap::default(),
+        slot_of: HashMap::default(),
+        num_spill_slots: 0,
+    };
+    let empty = HashSet::default();
+
+    for point in event_points(ranges, use_points) {
+        let protected = used_at.get(&point).unwrap_or(&empty);
+
+        // 1. Expire values whose current range ended strictly before this point, freeing their
+        //    registers. Values still used at this point stay resident.
+        scan.expire(point, true);
+
+        // 2. Uses here: a value used at this instruction must be register-resident. A currently
+        //    spilled operand is reloaded — its slot segment ends just before the use and it takes a
+        //    register.
+        if let Some(users) = used_at.get(&point) {
+            let mut users: Vec<ValueId> = users.iter().copied().collect();
+            users.sort_unstable();
+            for value in users {
+                if scan.register_of.contains_key(&value) || param_registers.contains_key(&value) {
+                    continue;
                 }
-                active.remove(position);
-                // Hand the freed register to this range.
-                previous_register.insert(value, active_register);
-                active.push((end, value, active_register));
-                timeline.entry(value).or_default().push(Segment {
-                    start,
-                    end,
-                    location: Location::Register(active_register),
-                });
-            }
-            _ => {
-                // This range outlives every active one: spill it directly.
-                let slot = *slots.entry(value).or_insert_with(|| {
-                    let slot = num_spill_slots;
-                    num_spill_slots += 1;
-                    slot
-                });
-                timeline.entry(value).or_default().push(Segment {
-                    start,
-                    end,
-                    location: Location::Slot(slot),
-                });
+                scan.close_segment(value, point.pred());
+                let register = scan.allocate(value, point, protected)?;
+                scan.register_of.insert(value, register);
+                scan.previous_register.insert(value, register);
+                scan.open.insert(value, (point, Location::Register(register)));
             }
         }
+
+        // 3. Ranges starting here: the value becomes live and is placed in a register. Parameters
+        //    take their fixed register. A result is placed *before* its instruction's dying operands
+        //    are freed (step 4), so it never reuses an operand's register — codegen claims the result
+        //    register before reading the operands, so the two must not alias. Operands used at this
+        //    point are `protected`, so the result never evicts one either.
+        if let Some(starts) = range_start_at.get(&point) {
+            let mut starts = starts.clone();
+            starts.sort_unstable_by_key(|(value, _)| *value);
+            for (value, range_end) in starts {
+                scan.range_end_of.insert(value, range_end);
+                if let Some(&index) = param_registers.get(&value) {
+                    scan.register_of.insert(value, index);
+                    scan.previous_register.insert(value, index);
+                    scan.open.insert(value, (point, Location::Register(index)));
+                    continue;
+                }
+                let register = scan.allocate(value, point, protected)?;
+                scan.register_of.insert(value, register);
+                scan.previous_register.insert(value, register);
+                scan.open.insert(value, (point, Location::Register(register)));
+            }
+        }
+
+        // 4. Expire operands consumed exactly at this point, freeing their registers — but only now
+        //    that this point's result has already claimed a distinct register.
+        scan.expire(point, false);
     }
 
-    // Keep each value's segments in point order.
-    for segments in timeline.values_mut() {
-        segments.sort_by_key(|seg| seg.start);
+    // Close every still-open segment at its range end.
+    let open_values: Vec<ValueId> = scan.open.keys().copied().collect();
+    for value in open_values {
+        let end = scan.range_end_of.get(&value).copied().unwrap_or_else(|| scan.open[&value].0);
+        scan.close_segment(value, end);
     }
 
-    Some(Plan { timeline, num_spill_slots })
+    for segments in scan.timeline.values_mut() {
+        segments.sort_by_key(|segment| segment.start);
+    }
+
+    Some(Plan { timeline: scan.timeline, num_spill_slots: scan.num_spill_slots })
 }
 
-/// The plan-based allocator: a **read-only** server over a precomputed [`Plan`].
+/// The plan-based allocator: a server that *realizes* a precomputed [`Plan`] at codegen time.
 ///
-/// It holds no register pool and takes no online decisions — every method is a lookup into the plan
-/// (and the program-point maps in [`LiveIntervals`]) that returns where a value lives and the
-/// [`Action`]s to realize it. This is the endgame the design doc describes: "the allocator's methods
-/// become read-only queries over a precomputed plan".
+/// It makes no online allocation decisions — [`assign`] already fixed where every value lives at
+/// every program point. What this does is keep a small **residency mirror** (which value occupies
+/// which register right now) and, at each definition and use, emit the [`Action`]s that move the
+/// register file from its current state to what the plan requires at that point: an [`Action::Reload`]
+/// to bring a spilled value back, an [`Action::Move`] when the plan splits a value into a different
+/// register, and an [`Action::Spill`] to evict whatever currently holds a register the plan is about
+/// to reuse. Residency is reset from the plan at each block entry, so a value's register is always a
+/// lookup, never a decision.
 ///
-/// **No-pressure scope.** This handles functions whose register pressure fits the value capacity
-/// (`usable - min_live_count`); [`Self::try_build`] returns `None` otherwise so the caller falls
-/// back to greedy. With no pressure every value keeps one register for its whole life, so there are
-/// no spills or reloads — `begin_block` seeds the register-resident values, `after_instruction`
-/// prunes the dead, and `resolve_edge` reports each parameter's register. Pressure spilling (splits,
-/// reloads, resolution) is layered on next.
+/// **No move cycles.** A register a value needs may be held by another value; since [`assign`]
+/// always evicts a live value to *its slot* (never to another register), the incumbent is simply
+/// spilled first — there is never a register-to-register displacement chain to untangle. A result
+/// never shares a register with its instruction's operands (codegen claims the result register
+/// before reading the operands), so defining a result never displaces a value about to be read.
 pub(crate) struct LinearScanAllocator {
-    /// The precomputed assignment (value location timelines).
+    /// The precomputed assignment: each value's location timeline.
     plan: Plan,
-    /// Program-point maps, so `begin_block` can find a block's entry point.
+    /// Program-point maps, so a block entry / instruction / terminator resolves to its point.
     intervals: LiveIntervals,
     /// Values dying after each instruction, so `after_instruction` prunes them.
     last_uses: HashMap<InstructionId, HashSet<ValueId>>,
-    /// Each value's typed `BrilligVariable`, its register fixed by the plan. This is the final
-    /// allocation map handed to the artifact via `into_allocations`.
-    allocations: HashMap<ValueId, BrilligVariable>,
-    /// The number of low registers the plan actually uses for value homes — the reserved band
-    /// codegen keeps scratch above. Only the registers used (not the whole capacity) are reserved,
-    /// so the frame's high-water mark stays minimal (important for recursion depth).
+    /// Each value's typed [`BrilligVariable`] at its *definition* register. The shape (bit size,
+    /// array length) is fixed; only the register varies, so a value is served at its current register
+    /// via [`BrilligVariable::with_register`]. Also the map handed to the artifact.
+    templates: HashMap<ValueId, BrilligVariable>,
+    /// Each value that is ever spilled → its fixed spill slot.
+    value_slot: HashMap<ValueId, usize>,
+    /// The first usable register offset; plan index `i` is the relative address `register_offset + i`.
+    register_offset: usize,
+    /// Low registers reserved for value homes (highest plan register index + 1); scratch sits above.
+    /// Only the registers used (not the whole capacity) are reserved, so the frame's high-water mark
+    /// stays minimal (important for recursion depth).
     reserved_registers: usize,
+    /// Number of spill slots the plan uses — the spill prologue's high-water mark (0 if none).
+    num_spill_slots: usize,
+    /// Residency mirror, reset from the plan at each block entry and evolved as actions are emitted:
+    /// which register index holds each live value, and the inverse.
+    register_of_value: HashMap<ValueId, usize>,
+    value_in_register: HashMap<usize, ValueId>,
 }
 
 impl LinearScanAllocator {
@@ -308,19 +471,21 @@ impl LinearScanAllocator {
     ) -> Option<Self> {
         let intervals = LiveIntervals::from_function(function, liveness, constants, post_order);
         let ranges = LiveRanges::from_intervals(&intervals, liveness, post_order);
+        let use_points = compute_use_points(function, &intervals, post_order);
         let entry_params = function.dfg[function.entry_block()].parameters();
-        let plan = assign(&ranges, value_capacity, entry_params)?;
+        let plan = assign(&ranges, &use_points, value_capacity, entry_params)?;
 
-        // Materialize each value's typed variable at its single planned register.
-        //
-        // The no-pressure allocator emits no spills, reloads, or moves, so it can only serve a plan
-        // where every value lives in exactly one register for its whole life. Register scarcity can
-        // still force a *split* even without slot spilling: when a value's register is reused during
-        // a divergent-path hole by another value whose range overlaps the first value's revival,
-        // reclaim fails and the value lands in a second register. Realizing a split needs a move on
-        // the revival edge, which only the pressure-aware allocator (with resolution) emits — so if
-        // any value's timeline is not a single register, decline and fall back to greedy.
-        let mut allocations = HashMap::default();
+        // Conservative scope: serve only plans where every value stays in **one register** for its
+        // whole life. Holes are fine — a value dead across a divergent branch and revived in the
+        // *same* register is served by re-seeding it at that register (its data survives on the
+        // taken path; see `make_resident`). What is declined is a value whose register *changes*:
+        // a register→register revival across a hole, or a register↔slot spill. Those need an
+        // edge/merge resolution phase (moves reconciling a split interval's location across control
+        // flow) that is implemented in the allocator methods below but not yet sound end to end —
+        // a linear scan over a non-linear CFG reuses the register on a divergent branch and lands
+        // the value elsewhere at the merge with nothing to reconcile them. Until that resolution is
+        // designed, decline and fall back to greedy. Even so, keeping cross-block values in one
+        // register already beats greedy, which permanently spills every cross-block value.
         for (value, _) in ranges.iter() {
             let segments = plan.timeline(value);
             let Some(Location::Register(index)) = segments.first().map(|seg| seg.location) else {
@@ -329,25 +494,52 @@ impl LinearScanAllocator {
             if segments.iter().any(|seg| seg.location != Location::Register(index)) {
                 return None;
             }
-            let register = MemoryAddress::relative(assert_u32(register_offset + index));
-            allocations.insert(value, typed_variable(function, value, register));
         }
 
-        // Reserve only the registers actually used, not the whole capacity: the highest value index
-        // plus one. Scratch sits above this band. Keeping the reservation tight keeps the frame's
-        // high-water mark minimal, which matters for recursion (each call frame is that size).
-        let reserved_registers = allocations
-            .values()
-            .map(|variable| assert_usize(variable.extract_register().unwrap_relative()))
-            .max()
-            .map_or(0, |max_offset| max_offset - register_offset + 1);
+        // Precompute, from the plan: each value's typed template at its definition register, each
+        // spilled value's fixed slot, and the highest register index used (which fixes the reserved
+        // value-home band). The template's register is the value's first register segment; codegen
+        // serves the value at its current register by rewriting that address via `with_register`.
+        let mut templates = HashMap::default();
+        let mut value_slot = HashMap::default();
+        let mut max_register_index: Option<usize> = None;
+        for (value, _) in ranges.iter() {
+            let segments = plan.timeline(value);
+            let def_index = segments.iter().find_map(|seg| match seg.location {
+                Location::Register(index) => Some(index),
+                Location::Slot(_) => None,
+            });
+            // Every tracked value is defined into a register before any spill, so a timeline with no
+            // register segment is malformed; decline rather than serve it.
+            let def_index = def_index?;
+            let register = MemoryAddress::relative(assert_u32(register_offset + def_index));
+            templates.insert(value, typed_variable(function, value, register));
+            for seg in segments {
+                match seg.location {
+                    Location::Register(index) => {
+                        max_register_index =
+                            Some(max_register_index.map_or(index, |current| current.max(index)));
+                    }
+                    Location::Slot(slot) => {
+                        value_slot.insert(value, slot);
+                    }
+                }
+            }
+        }
+        let reserved_registers = max_register_index.map_or(0, |index| index + 1);
+        let num_spill_slots = plan.num_spill_slots();
 
         Some(Self {
             plan,
             intervals,
             last_uses: last_uses.clone(),
-            allocations,
+            templates,
+            value_slot,
+            register_offset,
             reserved_registers,
+            num_spill_slots,
+            register_of_value: HashMap::default(),
+            value_in_register: HashMap::default(),
         })
     }
 
@@ -358,18 +550,107 @@ impl LinearScanAllocator {
         self.reserved_registers
     }
 
-    /// The final register allocations, consumed when handing the global allocations to the artifact.
+    /// The register allocations handed to the artifact: each value at its definition register. A
+    /// split value has several registers over its life; its definition register is the representative
+    /// the artifact metadata records.
     pub(crate) fn into_allocations(self) -> HashMap<ValueId, BrilligVariable> {
-        self.allocations
+        self.templates
     }
 
-    /// The register a tracked value lives in (its home), panicking if it is untracked — every value
-    /// the driver defines or uses is in the plan.
-    fn register_of(&self, value: ValueId) -> MemoryAddress {
-        self.allocations
-            .get(&value)
-            .unwrap_or_else(|| panic!("ICE: linear-scan has no allocation for {value}"))
-            .extract_register()
+    /// The relative memory address of plan register `index`.
+    fn addr(&self, index: usize) -> MemoryAddress {
+        MemoryAddress::relative(assert_u32(self.register_offset + index))
+    }
+
+    /// The typed variable for `value` served at register `index` (its fixed shape, this register).
+    fn var_at(&self, value: ValueId, index: usize) -> BrilligVariable {
+        self.templates[&value].with_register(self.addr(index))
+    }
+
+    /// The register index the plan places `value` in at `point`, panicking if the plan does not put
+    /// it in a register there — definitions and uses are always register-homed points.
+    fn register_index_at(&self, value: ValueId, point: ProgramPoint) -> usize {
+        match self.plan.location_at(value, point) {
+            Some(Location::Register(index)) => index,
+            other => panic!(
+                "ICE: linear-scan expected {value} in a register at {point:?}, got {other:?}"
+            ),
+        }
+    }
+
+    /// Record that `value` now occupies register `index`, updating both sides of the residency
+    /// mirror and clearing any stale inverse entry for the register `value` used to hold.
+    fn occupy(&mut self, value: ValueId, index: usize) {
+        if let Some(previous) = self.register_of_value.insert(value, index) {
+            self.value_in_register.remove(&previous);
+        }
+        self.value_in_register.insert(index, value);
+    }
+
+    /// Free register `index` for an incoming value at `point`, emitting the action to preserve its
+    /// current occupant. The plan reuses a register only by evicting its occupant to that occupant's
+    /// slot, so the occupant is spilled (a real store). The fallback [`Action::Prune`] covers only a
+    /// value the plan no longer homes here at all — bookkeeping so the driver's shadow stays exact.
+    /// Clears the occupant from the mirror either way.
+    fn free_register(&mut self, index: usize, point: ProgramPoint, actions: &mut Vec<Action>) {
+        let Some(occupant) = self.value_in_register.get(&index).copied() else {
+            return;
+        };
+        match self.plan.location_at(occupant, point) {
+            Some(Location::Slot(slot)) => {
+                actions.push(Action::Spill {
+                    value: occupant,
+                    from: self.addr(index),
+                    to: SpillSlot(slot),
+                });
+            }
+            _ => {
+                actions.push(Action::Prune { value: occupant, register: self.addr(index) });
+            }
+        }
+        self.register_of_value.remove(&occupant);
+        self.value_in_register.remove(&index);
+    }
+
+    /// Make `value` register-resident in register `index` for a use at `point`, returning the
+    /// actions to get it there: nothing if it is already there, otherwise free the target and bring
+    /// `value` in — a [`Action::Move`] from its current register, a [`Action::Reload`] from its slot
+    /// if it is currently spilled, or (for a value whose register never changes) nothing but a
+    /// re-seed of the residency mirror.
+    fn make_resident(&mut self, value: ValueId, index: usize, point: ProgramPoint) -> Vec<Action> {
+        if self.register_of_value.get(&value) == Some(&index) {
+            return Vec::new();
+        }
+        let mut actions = Vec::new();
+        self.free_register(index, point, &mut actions);
+        match self.register_of_value.get(&value).copied() {
+            Some(current) => {
+                actions.push(Action::Move {
+                    value,
+                    from: self.addr(current),
+                    to: self.addr(index),
+                });
+            }
+            None => {
+                // A currently-spilled value is reloaded from its slot. A value that is neither
+                // mirrored nor spilled is one whose plan register never changes, revived after a
+                // liveness hole: its data still sits in `index` on the path that reaches this use
+                // (the hole is a divergent branch that did not execute, so nothing overwrote the
+                // register there), so re-establishing the mirror entry below is enough — the pruning
+                // that dropped it happened on a branch this path did not take. (A value whose
+                // register *does* change across a hole cannot be served this way; `try_build`
+                // declines such plans.)
+                if let Some(slot) = self.value_slot.get(&value).copied() {
+                    actions.push(Action::Reload {
+                        value,
+                        from: SpillSlot(slot),
+                        into: self.addr(index),
+                    });
+                }
+            }
+        }
+        self.occupy(value, index);
+        actions
     }
 }
 
@@ -380,15 +661,27 @@ impl Allocator for LinearScanAllocator {
         _dfg: &DataFlowGraph,
     ) -> (Vec<(ValueId, MemoryAddress)>, Vec<Action>) {
         let entry = self.intervals.block_entry_point(block).expect("block has an entry point");
-        // Seed the shadow with every value register-resident at this block's entry.
-        let resident = self
-            .allocations
-            .iter()
-            .filter(|&(&value, _)| {
-                matches!(self.plan.location_at(value, entry), Some(Location::Register(_)))
+        // Reset the residency mirror to the plan's picture at this block's entry: every value the
+        // plan homes in a register there. The physical registers hold exactly these on entry — the
+        // plan is globally consistent and each incoming edge leaves cross-edge values where the
+        // successor expects them — so this is a lookup, not a decision.
+        let seeds: Vec<(ValueId, usize)> = self
+            .templates
+            .keys()
+            .copied()
+            .filter_map(|value| match self.plan.location_at(value, entry) {
+                Some(Location::Register(index)) => Some((value, index)),
+                _ => None,
             })
-            .map(|(&value, variable)| (value, variable.extract_register()))
             .collect();
+        self.register_of_value.clear();
+        self.value_in_register.clear();
+        let mut resident = Vec::with_capacity(seeds.len());
+        for (value, index) in seeds {
+            self.register_of_value.insert(value, index);
+            self.value_in_register.insert(index, value);
+            resident.push((value, self.addr(index)));
+        }
         (resident, Vec::new())
     }
 
@@ -397,16 +690,49 @@ impl Allocator for LinearScanAllocator {
         value_id: ValueId,
         _dfg: &DataFlowGraph,
     ) -> (BrilligVariable, Vec<Action>) {
-        (self.allocations[&value_id], Vec::new())
+        // The result is defined into its planned register at its definition point. Free that
+        // register first (spilling a live incumbent the plan evicts here, or pruning a dying operand
+        // whose register is handed off); the driver then writes the value into it. There is no
+        // reload/move for the value itself — it is freshly computed.
+        let def_point =
+            self.plan.timeline(value_id).first().expect("defined value has a segment").start;
+        let index = self.register_index_at(value_id, def_point);
+        let mut actions = Vec::new();
+        self.free_register(index, def_point, &mut actions);
+        self.occupy(value_id, index);
+        (self.var_at(value_id, index), actions)
     }
 
-    fn use_variable(&mut self, value_id: ValueId) -> (BrilligVariable, Vec<Action>) {
-        (self.allocations[&value_id], Vec::new())
+    fn use_variable(
+        &mut self,
+        value_id: ValueId,
+        at: Option<InstructionId>,
+    ) -> (BrilligVariable, Vec<Action>) {
+        match at {
+            Some(inst) => {
+                let point =
+                    self.intervals.instruction_point(inst).expect("instruction has a point");
+                let index = self.register_index_at(value_id, point);
+                let actions = self.make_resident(value_id, index, point);
+                (self.var_at(value_id, index), actions)
+            }
+            None => {
+                // Terminator operand: `before_terminator` made every terminator operand resident up
+                // front, so this is a plain lookup of the register it currently occupies.
+                let index = *self.register_of_value.get(&value_id).unwrap_or_else(|| {
+                    panic!("ICE: terminator operand {value_id} is not resident")
+                });
+                (self.var_at(value_id, index), Vec::new())
+            }
+        }
     }
 
-    fn reserve_scratch(&mut self, _scratch: usize) -> Vec<Action> {
-        // The plan reserved `min_live_count` upper registers for scratch, so there is always room;
-        // codegen allocates the temporaries from that band. Nothing to spill.
+    fn reserve_scratch(&mut self, _scratch: usize, _at: Option<InstructionId>) -> Vec<Action> {
+        // Nothing to do: `value_capacity` was sized as `usable - (min_live_count + SPILL_MARGIN)`,
+        // and `min_live_count` already folds in each instruction's `instruction_scratch_demand`
+        // (see `VariableLiveness`). So the registers above the reserved value band are provably free
+        // for codegen's scratch at every point — the reservation is made once at capacity time,
+        // rather than per instruction here.
         Vec::new()
     }
 
@@ -414,15 +740,42 @@ impl Allocator for LinearScanAllocator {
         let Some(dead) = self.last_uses.get(&inst) else {
             return Vec::new();
         };
-        dead.iter()
-            .filter(|value| self.allocations.contains_key(value))
-            .map(|&value| Action::Prune { value, register: self.register_of(value) })
-            .collect()
+        let dead: Vec<ValueId> =
+            dead.iter().copied().filter(|value| self.templates.contains_key(value)).collect();
+        let mut actions = Vec::new();
+        for value in dead {
+            // A register-resident dead value is dropped from the mirror, freeing its register (a
+            // dying value already handed off at a define was pruned there, so it is no longer in the
+            // mirror). A dead value that is currently spilled holds no register — nothing to prune.
+            if let Some(index) = self.register_of_value.remove(&value) {
+                self.value_in_register.remove(&index);
+                actions.push(Action::Prune { value, register: self.addr(index) });
+            }
+        }
+        actions
     }
 
-    fn before_terminator(&mut self, _block: BasicBlockId, _dfg: &DataFlowGraph) -> Vec<Action> {
-        // No pressure means no cross-edge value is spilled, so nothing to store before the branch.
-        Vec::new()
+    fn before_terminator(&mut self, block: BasicBlockId, dfg: &DataFlowGraph) -> Vec<Action> {
+        // Make every terminator operand resident in its planned register at the terminator point,
+        // before the operands are read. Terminator operands are bounded (condition, return values,
+        // jmp arguments), so — unlike a streaming `MakeArray` — they can all be made resident here.
+        let point = self.intervals.terminator_point(block).expect("block has a terminator point");
+        let mut operands: Vec<ValueId> = Vec::new();
+        dfg[block].unwrap_terminator().for_each_value(|value| {
+            if super::variable_liveness::is_variable(value, dfg)
+                && self.templates.contains_key(&value)
+            {
+                operands.push(value);
+            }
+        });
+        operands.sort_unstable();
+        operands.dedup();
+        let mut actions = Vec::new();
+        for value in operands {
+            let index = self.register_index_at(value, point);
+            actions.extend(self.make_resident(value, index, point));
+        }
+        actions
     }
 
     fn resolve_edge(
@@ -431,19 +784,29 @@ impl Allocator for LinearScanAllocator {
         succ: BasicBlockId,
         dfg: &DataFlowGraph,
     ) -> Vec<ParamHome> {
+        // Each successor parameter lives where the plan places it at the successor's entry point.
+        let entry = self.intervals.block_entry_point(succ).expect("block has an entry point");
         dfg[succ]
             .parameters()
             .iter()
-            .map(|param| ParamHome::Register(self.register_of(*param)))
+            .map(|&param| match self.plan.location_at(param, entry) {
+                Some(Location::Register(index)) => ParamHome::Register(self.addr(index)),
+                Some(Location::Slot(slot)) => ParamHome::Slot(SpillSlot(slot)),
+                // The parameter is dead at its own block's entry: it is passed by a predecessor but
+                // never read in the block (e.g. only forwarded as a jmp argument earlier). The jmp
+                // still has to write it somewhere valid, so route it to the parameter's home (its
+                // definition register). The write is dead but harmless.
+                None => ParamHome::Register(self.templates[&param].extract_register()),
+            })
             .collect()
     }
 
     fn spill_enabled(&self) -> bool {
-        false
+        self.num_spill_slots > 0
     }
 
     fn max_spill_offset(&self) -> usize {
-        0
+        self.num_spill_slots
     }
 }
 
@@ -536,17 +899,21 @@ impl<R: RegisterAllocator> Allocator for FunctionAllocator<R> {
         }
     }
 
-    fn use_variable(&mut self, value_id: ValueId) -> (BrilligVariable, Vec<Action>) {
+    fn use_variable(
+        &mut self,
+        value_id: ValueId,
+        at: Option<InstructionId>,
+    ) -> (BrilligVariable, Vec<Action>) {
         match self {
-            Self::Greedy(a) => a.use_variable(value_id),
-            Self::LinearScan(a) => a.use_variable(value_id),
+            Self::Greedy(a) => a.use_variable(value_id, at),
+            Self::LinearScan(a) => a.use_variable(value_id, at),
         }
     }
 
-    fn reserve_scratch(&mut self, scratch: usize) -> Vec<Action> {
+    fn reserve_scratch(&mut self, scratch: usize, at: Option<InstructionId>) -> Vec<Action> {
         match self {
-            Self::Greedy(a) => a.reserve_scratch(scratch),
-            Self::LinearScan(a) => a.reserve_scratch(scratch),
+            Self::Greedy(a) => a.reserve_scratch(scratch, at),
+            Self::LinearScan(a) => a.reserve_scratch(scratch, at),
         }
     }
 
@@ -593,24 +960,31 @@ impl<R: RegisterAllocator> Allocator for FunctionAllocator<R> {
 
 #[cfg(test)]
 mod assignment_tests {
-    use super::{Location, Plan, Segment, assign};
+    use super::{Location, Plan, Segment, assign, compute_use_points};
     use crate::brillig::brillig_gen::constant_allocation::ConstantAllocation;
-    use crate::brillig::brillig_gen::live_intervals::{LiveIntervals, LiveRanges};
+    use crate::brillig::brillig_gen::live_intervals::{LiveIntervals, LiveRanges, ProgramPoint};
     use crate::brillig::brillig_gen::variable_liveness::VariableLiveness;
     use crate::ssa::ir::post_order::PostOrder;
     use crate::ssa::ir::value::ValueId;
     use crate::ssa::ssa_gen::Ssa;
+    use rustc_hash::FxHashMap as HashMap;
 
-    fn ranges_for(src: &str) -> (LiveRanges, Ssa) {
+    fn ranges_for(src: &str) -> (LiveRanges, HashMap<ValueId, Vec<ProgramPoint>>, Ssa) {
         let ssa = Ssa::from_str(src).unwrap();
         let func = ssa.main();
         let constants = ConstantAllocation::from_function(func);
         let liveness = VariableLiveness::from_function(func, &constants);
         let post_order = PostOrder::with_function(func).into_vec();
         let intervals = LiveIntervals::from_function(func, &liveness, &constants, &post_order);
-        (LiveRanges::from_intervals(&intervals, &liveness, &post_order), ssa)
+        let ranges = LiveRanges::from_intervals(&intervals, &liveness, &post_order);
+        let use_points = compute_use_points(func, &intervals, &post_order);
+        (ranges, use_points, ssa)
     }
 
+    /// Inclusive overlap: two segments conflict if they share any point. A result defined at `p` and
+    /// an operand last-used at `p` both need a register at `p` — codegen claims the result register
+    /// before reading the operands, so they must not alias — hence sharing the boundary point `p` is
+    /// a genuine conflict, and `assign` gives them distinct registers.
     fn segments_overlap(a: &Segment, b: &Segment) -> bool {
         a.start <= b.end && b.start <= a.end
     }
@@ -654,8 +1028,9 @@ mod assignment_tests {
             return v3
         }
         ";
-        let (ranges, ssa) = ranges_for(src);
-        let plan = assign(&ranges, 8, &entry_params(&ssa)).expect("fits in 8 registers");
+        let (ranges, use_points, ssa) = ranges_for(src);
+        let plan =
+            assign(&ranges, &use_points, 8, &entry_params(&ssa)).expect("fits in 8 registers");
         assert_eq!(plan.num_spill_slots(), 0);
         assert_sound(&ranges, &plan, 8);
         // Nothing is spilled: every segment is a register.
@@ -668,12 +1043,16 @@ mod assignment_tests {
 
     #[test]
     fn pressure_spills_soundly() {
-        // Several values are live at once; capacity 2 cannot hold them all, so the scan spills the
-        // overflow to slots. The plan must still be sound (register-resident values never share a
-        // register over overlapping points) and at least one value must be spilled.
+        // `v2` and `v3` are defined up front and used by both `v4` and `v5`, so at the `mul v2, v3`
+        // point four non-parameter values are live at once: the operands `v2`, `v3`, the earlier
+        // result `v4` (used later by `v6`), and the result `v5` — and the result never reuses an
+        // operand's register. Two parameters take registers 0 and 1; capacity 5 leaves three
+        // non-parameter registers, one short, so the scan must spill one and reload it at its later
+        // use. No constants appear, so nothing piles up at the block entry. The plan must stay sound
+        // (no two register-resident values share a register over overlapping points).
         let src = "
         brillig(inline) fn main f0 {
-          b0(v0: Field, v1: Field):
+          b0(v0: u32, v1: u32):
             v2 = add v0, v1
             v3 = mul v0, v1
             v4 = add v2, v3
@@ -682,10 +1061,11 @@ mod assignment_tests {
             return v6
         }
         ";
-        let (ranges, ssa) = ranges_for(src);
-        let plan = assign(&ranges, 2, &entry_params(&ssa)).expect("spills rather than failing");
-        assert!(plan.num_spill_slots() > 0, "capacity 2 should force at least one spill");
-        assert_sound(&ranges, &plan, 2);
+        let (ranges, use_points, ssa) = ranges_for(src);
+        let plan =
+            assign(&ranges, &use_points, 5, &entry_params(&ssa)).expect("placeable at capacity 5");
+        assert!(plan.num_spill_slots() > 0, "capacity 5 should force at least one spill");
+        assert_sound(&ranges, &plan, 5);
 
         // Every value has a home at every point of its liveness (register or slot).
         for (value, value_ranges) in ranges.iter() {
@@ -717,8 +1097,9 @@ mod assignment_tests {
             return v4
         }
         ";
-        let (ranges, ssa) = ranges_for(src);
-        let plan = assign(&ranges, 8, &entry_params(&ssa)).expect("fits in 8 registers");
+        let (ranges, use_points, ssa) = ranges_for(src);
+        let plan =
+            assign(&ranges, &use_points, 8, &entry_params(&ssa)).expect("fits in 8 registers");
         let func = ssa.main();
         let v1 = func.dfg[func.entry_block()].parameters()[1];
 

--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/linear_scan.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/linear_scan.rs
@@ -1,0 +1,248 @@
+//! Linear-scan register allocation for Brillig (Phase 1 of the plan in
+//! `design/register_allocation.md`).
+//!
+//! Where [`GreedyAllocator`] makes spill/placement decisions *online* (LRU eviction as it runs),
+//! the linear-scan allocator computes a global assignment *up front* from the value
+//! [`LiveIntervals`](super::live_intervals::LiveIntervals) and then serves it as read-only queries.
+//! Both implement the same [`Allocator`] seam, so the driver ([`BrilligBlock`]) is identical for
+//! either; which one runs is chosen per function by [`FunctionAllocator`].
+//!
+//! **Scaffold status.** [`LinearScanAllocator`] currently delegates to [`GreedyAllocator`]. This
+//! lets the selection seam — the flag, the polymorphic [`FunctionContext`] field, construction, the
+//! globals `into_allocations` path — be exercised end-to-end and proven behavior-preserving before
+//! the plan-based internals land. Selecting linear scan today therefore reproduces greedy output
+//! exactly; the assignment pass replaces these delegations.
+//!
+//! [`BrilligBlock`]: super::brillig_block::BrilligBlock
+//! [`FunctionContext`]: super::brillig_fn::FunctionContext
+
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use acvm::acir::brillig::MemoryAddress;
+use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
+
+use super::allocator::{Action, Allocator, GreedyAllocator, ParamHome};
+use super::coalescing::CoalescingMap;
+use super::spill_manager::SpillManager;
+use super::variable_liveness::VariableLiveness;
+use crate::brillig::brillig_ir::brillig_variable::BrilligVariable;
+use crate::brillig::brillig_ir::registers::RegisterAllocator;
+use crate::ssa::ir::basic_block::BasicBlockId;
+use crate::ssa::ir::dfg::DataFlowGraph;
+use crate::ssa::ir::instruction::InstructionId;
+use crate::ssa::ir::value::ValueId;
+
+/// The plan-based allocator. See the module docs; presently a delegating scaffold over
+/// [`GreedyAllocator`] pending the assignment pass.
+pub(crate) struct LinearScanAllocator<R: RegisterAllocator> {
+    inner: GreedyAllocator<R>,
+}
+
+impl<R: RegisterAllocator> LinearScanAllocator<R> {
+    /// Build the linear-scan allocator. Takes the same inputs as the greedy allocator so the two
+    /// are interchangeable at the construction site; the plan is derived from `liveness`.
+    pub(crate) fn new(
+        pool: Rc<RefCell<R>>,
+        spill_manager: Option<SpillManager>,
+        coalescing: CoalescingMap,
+        liveness: VariableLiveness,
+        last_uses: HashMap<InstructionId, HashSet<ValueId>>,
+    ) -> Self {
+        Self { inner: GreedyAllocator::new(pool, spill_manager, coalescing, liveness, last_uses) }
+    }
+
+    /// The final register allocations, consumed when handing the global allocations to the artifact.
+    pub(crate) fn into_allocations(self) -> HashMap<ValueId, BrilligVariable> {
+        self.inner.into_allocations()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn get_coalesced(&self, value_id: &ValueId) -> Option<ValueId> {
+        self.inner.get_coalesced(value_id)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn liveness(&self) -> &VariableLiveness {
+        self.inner.liveness()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn retire(&mut self, value_id: &ValueId) {
+        self.inner.retire(value_id);
+    }
+}
+
+impl<R: RegisterAllocator> Allocator for LinearScanAllocator<R> {
+    fn begin_block(
+        &mut self,
+        block: BasicBlockId,
+        dfg: &DataFlowGraph,
+    ) -> (Vec<(ValueId, MemoryAddress)>, Vec<Action>) {
+        self.inner.begin_block(block, dfg)
+    }
+
+    fn define_variable(
+        &mut self,
+        value_id: ValueId,
+        dfg: &DataFlowGraph,
+    ) -> (BrilligVariable, Vec<Action>) {
+        self.inner.define_variable(value_id, dfg)
+    }
+
+    fn use_variable(&mut self, value_id: ValueId) -> (BrilligVariable, Vec<Action>) {
+        self.inner.use_variable(value_id)
+    }
+
+    fn reserve_scratch(&mut self, scratch: usize) -> Vec<Action> {
+        self.inner.reserve_scratch(scratch)
+    }
+
+    fn after_instruction(&mut self, inst: InstructionId) -> Vec<Action> {
+        self.inner.after_instruction(inst)
+    }
+
+    fn before_terminator(&mut self, block: BasicBlockId, dfg: &DataFlowGraph) -> Vec<Action> {
+        self.inner.before_terminator(block, dfg)
+    }
+
+    fn resolve_edge(
+        &self,
+        pred: BasicBlockId,
+        succ: BasicBlockId,
+        dfg: &DataFlowGraph,
+    ) -> Vec<ParamHome> {
+        self.inner.resolve_edge(pred, succ, dfg)
+    }
+
+    fn spill_enabled(&self) -> bool {
+        self.inner.spill_enabled()
+    }
+
+    fn max_spill_offset(&self) -> usize {
+        self.inner.max_spill_offset()
+    }
+}
+
+/// The allocator a [`FunctionContext`](super::brillig_fn::FunctionContext) runs, chosen per function.
+///
+/// Both variants implement [`Allocator`], so the driver dispatches through this enum without caring
+/// which strategy is active. Keeping the choice in an enum (rather than `Box<dyn Allocator>`) lets
+/// the non-trait lifecycle methods (`into_allocations`, the test-only inspectors) stay off the
+/// [`Allocator`] trait, which is deliberately free of allocator-specific surface.
+pub(crate) enum FunctionAllocator<R: RegisterAllocator> {
+    Greedy(GreedyAllocator<R>),
+    LinearScan(LinearScanAllocator<R>),
+}
+
+impl<R: RegisterAllocator> FunctionAllocator<R> {
+    /// The final register allocations, consumed when handing the global allocations to the artifact.
+    pub(crate) fn into_allocations(self) -> HashMap<ValueId, BrilligVariable> {
+        match self {
+            Self::Greedy(a) => a.into_allocations(),
+            Self::LinearScan(a) => a.into_allocations(),
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn get_coalesced(&self, value_id: &ValueId) -> Option<ValueId> {
+        match self {
+            Self::Greedy(a) => a.get_coalesced(value_id),
+            Self::LinearScan(a) => a.get_coalesced(value_id),
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn liveness(&self) -> &VariableLiveness {
+        match self {
+            Self::Greedy(a) => a.liveness(),
+            Self::LinearScan(a) => a.liveness(),
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn retire(&mut self, value_id: &ValueId) {
+        match self {
+            Self::Greedy(a) => a.retire(value_id),
+            Self::LinearScan(a) => a.retire(value_id),
+        }
+    }
+}
+
+impl<R: RegisterAllocator> Allocator for FunctionAllocator<R> {
+    fn begin_block(
+        &mut self,
+        block: BasicBlockId,
+        dfg: &DataFlowGraph,
+    ) -> (Vec<(ValueId, MemoryAddress)>, Vec<Action>) {
+        match self {
+            Self::Greedy(a) => a.begin_block(block, dfg),
+            Self::LinearScan(a) => a.begin_block(block, dfg),
+        }
+    }
+
+    fn define_variable(
+        &mut self,
+        value_id: ValueId,
+        dfg: &DataFlowGraph,
+    ) -> (BrilligVariable, Vec<Action>) {
+        match self {
+            Self::Greedy(a) => a.define_variable(value_id, dfg),
+            Self::LinearScan(a) => a.define_variable(value_id, dfg),
+        }
+    }
+
+    fn use_variable(&mut self, value_id: ValueId) -> (BrilligVariable, Vec<Action>) {
+        match self {
+            Self::Greedy(a) => a.use_variable(value_id),
+            Self::LinearScan(a) => a.use_variable(value_id),
+        }
+    }
+
+    fn reserve_scratch(&mut self, scratch: usize) -> Vec<Action> {
+        match self {
+            Self::Greedy(a) => a.reserve_scratch(scratch),
+            Self::LinearScan(a) => a.reserve_scratch(scratch),
+        }
+    }
+
+    fn after_instruction(&mut self, inst: InstructionId) -> Vec<Action> {
+        match self {
+            Self::Greedy(a) => a.after_instruction(inst),
+            Self::LinearScan(a) => a.after_instruction(inst),
+        }
+    }
+
+    fn before_terminator(&mut self, block: BasicBlockId, dfg: &DataFlowGraph) -> Vec<Action> {
+        match self {
+            Self::Greedy(a) => a.before_terminator(block, dfg),
+            Self::LinearScan(a) => a.before_terminator(block, dfg),
+        }
+    }
+
+    fn resolve_edge(
+        &self,
+        pred: BasicBlockId,
+        succ: BasicBlockId,
+        dfg: &DataFlowGraph,
+    ) -> Vec<ParamHome> {
+        match self {
+            Self::Greedy(a) => a.resolve_edge(pred, succ, dfg),
+            Self::LinearScan(a) => a.resolve_edge(pred, succ, dfg),
+        }
+    }
+
+    fn spill_enabled(&self) -> bool {
+        match self {
+            Self::Greedy(a) => a.spill_enabled(),
+            Self::LinearScan(a) => a.spill_enabled(),
+        }
+    }
+
+    fn max_spill_offset(&self) -> usize {
+        match self {
+            Self::Greedy(a) => a.max_spill_offset(),
+            Self::LinearScan(a) => a.max_spill_offset(),
+        }
+    }
+}

--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/linear_scan.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/linear_scan.rs
@@ -79,6 +79,11 @@ pub(crate) struct Segment {
 #[derive(Debug, Default)]
 pub(crate) struct Plan {
     timeline: HashMap<ValueId, Vec<Segment>>,
+    /// Per block, the values register-resident at its entry point → their register index. Stored as
+    /// `im` maps so the snapshots share structure across blocks; `begin_block` seeds the residency
+    /// mirror from its block's snapshot in O(live-at-entry), rather than scanning every value's
+    /// timeline (which is O(values) per block = quadratic over a whole function).
+    entry_registers: HashMap<BasicBlockId, im::HashMap<ValueId, usize>>,
     num_spill_slots: usize,
 }
 
@@ -87,6 +92,15 @@ impl Plan {
     /// The value's location timeline (segments in point order), or empty if the value is untracked.
     pub(crate) fn timeline(&self, value: ValueId) -> &[Segment] {
         self.timeline.get(&value).map_or(&[], Vec::as_slice)
+    }
+
+    /// The values register-resident at `block`'s entry, each mapped to its register index. Cheap to
+    /// clone (structural sharing).
+    pub(crate) fn registers_at_block_entry(
+        &self,
+        block: BasicBlockId,
+    ) -> im::HashMap<ValueId, usize> {
+        self.entry_registers.get(&block).cloned().unwrap_or_default()
     }
 
     /// Where `value` lives at `point`, or `None` if it is dead there (in a hole) or untracked.
@@ -275,7 +289,8 @@ impl Scan<'_> {
                 !self.param_registers.contains_key(resident) && !protected.contains(resident)
             })
             .max_by_key(|&resident| {
-                (self.next_use(resident, point).is_none(), self.next_use(resident, point), resident)
+                let next = self.next_use(resident, point);
+                (next.is_none(), next, resident)
             })?;
         let register = self.spill(victim, point);
         self.free.remove(&register);
@@ -345,6 +360,15 @@ pub(crate) fn assign(
         //    registers. Values still used at this point stay resident.
         scan.expire(point, true);
 
+        // A value whose live range *starts* at this point is defined here (an instruction result, or
+        // a constant materialized at its use — its def is the materialization point). It is handled
+        // by the range-starts step below, not reloaded as if it were a spilled operand; reloading it
+        // here would allocate it twice and leak its first register out of the free set.
+        let starts_here: HashSet<ValueId> = range_start_at
+            .get(&point)
+            .map(|starts| starts.iter().map(|(value, _)| *value).collect())
+            .unwrap_or_default();
+
         // 2. Uses here: a value used at this instruction must be register-resident. A currently
         //    spilled operand is reloaded — its slot segment ends just before the use and it takes a
         //    register.
@@ -352,7 +376,10 @@ pub(crate) fn assign(
             let mut users: Vec<ValueId> = users.iter().copied().collect();
             users.sort_unstable();
             for value in users {
-                if scan.register_of.contains_key(&value) || param_registers.contains_key(&value) {
+                if scan.register_of.contains_key(&value)
+                    || param_registers.contains_key(&value)
+                    || starts_here.contains(&value)
+                {
                     continue;
                 }
                 scan.close_segment(value, point.pred());
@@ -402,7 +429,71 @@ pub(crate) fn assign(
         segments.sort_by_key(|segment| segment.start);
     }
 
-    Some(Plan { timeline: scan.timeline, num_spill_slots: scan.num_spill_slots })
+    Some(Plan {
+        timeline: scan.timeline,
+        entry_registers: HashMap::default(),
+        num_spill_slots: scan.num_spill_slots,
+    })
+}
+
+/// Compute, per block, the values register-resident at its entry point (value → register index), as
+/// structurally-shared `im` maps. A single sweep over all register segments: a value enters the live
+/// set at a segment's start and leaves at its end + 1; the snapshot at a block-entry point is the
+/// live set there. This precomputes what `begin_block` would otherwise re-derive by scanning every
+/// value's timeline on each block.
+fn block_entry_registers(
+    timeline: &HashMap<ValueId, Vec<Segment>>,
+    intervals: &LiveIntervals,
+    post_order: &[BasicBlockId],
+) -> HashMap<BasicBlockId, im::HashMap<ValueId, usize>> {
+    use std::collections::BTreeMap;
+    // Register-segment enter/exit events, and the block-entry points to snapshot, keyed by point.
+    let mut enters: BTreeMap<ProgramPoint, Vec<(ValueId, usize)>> = BTreeMap::new();
+    let mut exits: BTreeMap<ProgramPoint, Vec<ValueId>> = BTreeMap::new();
+    for (&value, segments) in timeline {
+        for segment in segments {
+            if let Location::Register(index) = segment.location {
+                enters.entry(segment.start).or_default().push((value, index));
+                exits.entry(segment.end).or_default().push(value);
+            }
+        }
+    }
+    let mut entries_at: BTreeMap<ProgramPoint, Vec<BasicBlockId>> = BTreeMap::new();
+    for &block in post_order {
+        if let Some(point) = intervals.block_entry_point(block) {
+            entries_at.entry(point).or_default().push(block);
+        }
+    }
+
+    let mut points: Vec<ProgramPoint> =
+        enters.keys().chain(exits.keys()).chain(entries_at.keys()).copied().collect();
+    points.sort_unstable();
+    points.dedup();
+
+    // A segment `[start, end]` covers a point `p` iff `start <= p <= end`. Processing per point in
+    // the order enters → snapshot → exits keeps a value live for the snapshots at exactly its
+    // `[start, end]`: it is inserted before the snapshot at `start` and removed only after the
+    // snapshot at `end`.
+    let mut live: im::HashMap<ValueId, usize> = im::HashMap::new();
+    let mut result: HashMap<BasicBlockId, im::HashMap<ValueId, usize>> = HashMap::default();
+    for point in points {
+        if let Some(started) = enters.get(&point) {
+            for (value, index) in started {
+                live.insert(*value, *index);
+            }
+        }
+        if let Some(blocks) = entries_at.get(&point) {
+            for &block in blocks {
+                result.insert(block, live.clone());
+            }
+        }
+        if let Some(ended) = exits.get(&point) {
+            for value in ended {
+                live.remove(value);
+            }
+        }
+    }
+    result
 }
 
 /// The plan-based allocator: a server that *realizes* a precomputed [`Plan`] at codegen time.
@@ -473,27 +564,17 @@ impl LinearScanAllocator {
         let ranges = LiveRanges::from_intervals(&intervals, liveness, post_order);
         let use_points = compute_use_points(function, &intervals, post_order);
         let entry_params = function.dfg[function.entry_block()].parameters();
-        let plan = assign(&ranges, &use_points, value_capacity, entry_params)?;
+        let mut plan = assign(&ranges, &use_points, value_capacity, entry_params)?;
+        plan.entry_registers = block_entry_registers(&plan.timeline, &intervals, post_order);
 
-        // Conservative scope: serve only plans where every value stays in **one register** for its
-        // whole life. Holes are fine — a value dead across a divergent branch and revived in the
-        // *same* register is served by re-seeding it at that register (its data survives on the
-        // taken path; see `make_resident`). What is declined is a value whose register *changes*:
-        // a register→register revival across a hole, or a register↔slot spill. Those need an
-        // edge/merge resolution phase (moves reconciling a split interval's location across control
-        // flow) that is implemented in the allocator methods below but not yet sound end to end —
-        // a linear scan over a non-linear CFG reuses the register on a divergent branch and lands
-        // the value elsewhere at the merge with nothing to reconcile them. Until that resolution is
-        // designed, decline and fall back to greedy. Even so, keeping cross-block values in one
-        // register already beats greedy, which permanently spills every cross-block value.
-        for (value, _) in ranges.iter() {
-            let segments = plan.timeline(value);
-            let Some(Location::Register(index)) = segments.first().map(|seg| seg.location) else {
-                return None;
-            };
-            if segments.iter().any(|seg| seg.location != Location::Register(index)) {
-                return None;
-            }
+        // Scope: serve register-only plans (a value may change register across a hole; its data
+        // survives on the taken path, and `make_resident` re-seeds it). Decline plans that use a
+        // spill slot: pressure spilling needs the slot-canonical merge resolution (a value live on
+        // both branches of a merge but spilled on one), which is not yet implemented. Until then,
+        // fall back to greedy for those. Keeping register-resident values (including cross-block
+        // ones) in a register already beats greedy, which permanently spills every cross-block value.
+        if plan.num_spill_slots() > 0 {
+            return None;
         }
 
         // Precompute, from the plan: each value's typed template at its definition register, each
@@ -660,24 +741,16 @@ impl Allocator for LinearScanAllocator {
         block: BasicBlockId,
         _dfg: &DataFlowGraph,
     ) -> (Vec<(ValueId, MemoryAddress)>, Vec<Action>) {
-        let entry = self.intervals.block_entry_point(block).expect("block has an entry point");
-        // Reset the residency mirror to the plan's picture at this block's entry: every value the
-        // plan homes in a register there. The physical registers hold exactly these on entry — the
-        // plan is globally consistent and each incoming edge leaves cross-edge values where the
-        // successor expects them — so this is a lookup, not a decision.
-        let seeds: Vec<(ValueId, usize)> = self
-            .templates
-            .keys()
-            .copied()
-            .filter_map(|value| match self.plan.location_at(value, entry) {
-                Some(Location::Register(index)) => Some((value, index)),
-                _ => None,
-            })
-            .collect();
+        // Reset the residency mirror to the plan's picture at this block's entry: the values the plan
+        // homes in a register there, read directly from the precomputed snapshot. The physical
+        // registers hold exactly these on entry — the plan is globally consistent and each incoming
+        // edge leaves cross-edge values where the successor expects them — so this is a lookup, not a
+        // decision.
+        let snapshot = self.plan.registers_at_block_entry(block);
         self.register_of_value.clear();
         self.value_in_register.clear();
-        let mut resident = Vec::with_capacity(seeds.len());
-        for (value, index) in seeds {
+        let mut resident = Vec::with_capacity(snapshot.len());
+        for (&value, &index) in &snapshot {
             self.register_of_value.insert(value, index);
             self.value_in_register.insert(index, value);
             resident.push((value, self.addr(index)));

--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/linear_scan.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/linear_scan.rs
@@ -618,14 +618,12 @@ impl LinearScanAllocator {
             }
         }
         let reserved_registers = max_register_index.map_or(0, |index| index + 1);
-        let num_spill_slots = plan.num_spill_slots();
 
         // Merge resolution. A non-parameter value live-in to a block whose plan location differs
         // from its location at some predecessor's terminator was carried over a non-CFG edge by the
         // RPO-linear scan, so it does not physically arrive where the plan's entry says. Reconcile
         // it through its slot: the block treats it as slot-resident (reloaded on demand), and each
-        // predecessor saves it before branching. This needs the value to have a slot; if a divergent
-        // value has none (no register→register moves are emitted), decline and fall back to greedy.
+        // predecessor saves it before branching.
         let mut slot_boundary: HashSet<ValueId> = HashSet::default();
         for &block in post_order {
             let entry = intervals.block_entry_point(block).expect("block has an entry point");
@@ -645,15 +643,34 @@ impl LinearScanAllocator {
                     plan.location_at(value, term) != at_entry
                 });
                 if divergent {
-                    // Reconciled through the slot; register-only divergence has no slot to route
-                    // through (no register-to-register moves are emitted), so decline it.
-                    if !value_slot.contains_key(&value) {
-                        return None;
-                    }
                     slot_boundary.insert(value);
                 }
             }
         }
+
+        // A divergent value the plan never spilled has no slot to reconcile through: it stays in a
+        // register everywhere but lands in a *different* register across the diverging edges. The
+        // textbook fix (Wimmer & Franz §6) is a single register-to-register move on the diverging
+        // edge, but that needs critical-edge splitting — the move would clobber the predecessor's
+        // *other* successor — plus parallel-move cycle-breaking. Slot routing sidesteps both (a
+        // store to the value's own slot is harmless on every outgoing edge), so instead we give
+        // each such value a fresh slot and route it through that slot like every other
+        // slot-canonical value. This trades one move for a store+reload round-trip but reuses the
+        // slot machinery wholesale and needs no new edge handling. A future improvement could detect
+        // the pure register-to-register case and emit the move to avoid the round-trip; it would
+        // have to add the critical-edge/parallel-move handling this deliberately avoids.
+        //
+        // Slots are assigned in sorted value order so the spill-region layout is deterministic
+        // (`slot_boundary` is a `HashSet`, whose iteration order is not).
+        let mut next_slot = plan.num_spill_slots();
+        let mut slotless: Vec<ValueId> =
+            slot_boundary.iter().copied().filter(|value| !value_slot.contains_key(value)).collect();
+        slotless.sort_unstable();
+        for value in slotless {
+            value_slot.insert(value, next_slot);
+            next_slot += 1;
+        }
+        let num_spill_slots = next_slot;
 
         Some(Self {
             plan,

--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/live_intervals.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/live_intervals.rs
@@ -316,6 +316,15 @@ impl LiveIntervals {
         self.intervals.get(&value)
     }
 
+    /// All value intervals ordered by definition point (ties broken by `last_use`, then `ValueId`
+    /// for determinism). This is the order the linear-scan assignment consumes them in.
+    pub(crate) fn intervals_by_def(&self) -> Vec<(ValueId, LiveInterval)> {
+        let mut result: Vec<(ValueId, LiveInterval)> =
+            self.intervals.iter().map(|(&v, &iv)| (v, iv)).collect();
+        result.sort_by_key(|(v, iv)| (iv.def, iv.last_use, *v));
+        result
+    }
+
     /// Check whether two values' intervals overlap.
     pub(crate) fn interferes(&self, a: ValueId, b: ValueId) -> bool {
         match (self.intervals.get(&a), self.intervals.get(&b)) {

--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/live_intervals.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/live_intervals.rs
@@ -459,6 +459,12 @@ impl LiveRanges {
         self.ranges.get(&value).map_or(&[], Vec::as_slice)
     }
 
+    /// Every tracked value with its range list. Order is unspecified; callers that need a scan
+    /// order (e.g. by first range start) sort themselves.
+    pub(crate) fn iter(&self) -> impl Iterator<Item = (ValueId, &[LiveRange])> {
+        self.ranges.iter().map(|(&value, ranges)| (value, ranges.as_slice()))
+    }
+
     /// Whether `value` is live at `point` (i.e. `point` falls in one of its ranges, not a hole).
     pub(crate) fn is_live_at(&self, value: ValueId, point: ProgramPoint) -> bool {
         self.ranges(value).iter().any(|range| range.contains(point))

--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/live_intervals.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/live_intervals.rs
@@ -384,6 +384,112 @@ impl LiveIntervals {
     }
 }
 
+/// A single contiguous stretch of program points over which a value is live (inclusive on both
+/// ends). A value's full liveness is a *list* of these, separated by holes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct LiveRange {
+    pub(crate) start: ProgramPoint,
+    pub(crate) end: ProgramPoint,
+}
+
+impl LiveRange {
+    fn contains(&self, point: ProgramPoint) -> bool {
+        self.start <= point && point <= self.end
+    }
+
+    fn overlaps(&self, other: &LiveRange) -> bool {
+        self.start <= other.end && other.start <= self.end
+    }
+}
+
+/// Per-value liveness as a set of disjoint, sorted ranges that **preserves holes** — stretches of
+/// the program-point order where the value is dead even though it is live both before and after.
+///
+/// This is the precision [`LiveIntervals`] deliberately drops (it collapses to one `[def, last_use]`).
+/// The linear-scan allocator needs the holes: a value dead across a hole frees its register for a
+/// value that never co-resides with it (sharing "separated by a hole"), and only values that are
+/// *live but displaced* under register pressure are spilled. Without holes a linear scan would
+/// over-estimate pressure and lose to the greedy allocator, which already accounts for them.
+///
+/// Ranges are derived by punching holes into each value's contiguous `[def, last_use]`: a block
+/// whose whole point-range lies strictly inside the interval and in which the value is neither
+/// live-in nor live-out is a hole. (A value used or defined inside such an interior block is
+/// necessarily live-in there, so the live-in/live-out test alone identifies dead interior blocks.)
+#[derive(Debug, Default)]
+pub(crate) struct LiveRanges {
+    ranges: HashMap<ValueId, Vec<LiveRange>>,
+}
+
+impl LiveRanges {
+    /// Build the hole-aware ranges from the collapsed [`LiveIntervals`] and the block-granular
+    /// [`VariableLiveness`].
+    pub(crate) fn from_intervals(
+        intervals: &LiveIntervals,
+        liveness: &VariableLiveness,
+        post_order: &[BasicBlockId],
+    ) -> Self {
+        // Point-range of every block, so we can test "strictly interior to a value's interval".
+        let block_spans: Vec<(BasicBlockId, ProgramPoint, ProgramPoint)> = post_order
+            .iter()
+            .map(|&b| (b, intervals.block_entry_points[&b], intervals.terminator_points[&b]))
+            .collect();
+
+        let mut ranges = HashMap::default();
+        for (&value, interval) in &intervals.intervals {
+            let mut holes: Vec<(u32, u32)> = Vec::new();
+            for &(block, entry, term) in &block_spans {
+                let strictly_interior = entry.0 > interval.def.0 && term.0 < interval.last_use.0;
+                if !strictly_interior {
+                    continue;
+                }
+                let dead = !liveness.get_live_in(&block).contains(&value)
+                    && !liveness.get_live_out(&block).contains(&value);
+                if dead {
+                    holes.push((entry.0, term.0));
+                }
+            }
+            ranges.insert(value, subtract_holes(interval.def.0, interval.last_use.0, holes));
+        }
+
+        Self { ranges }
+    }
+
+    /// The live ranges of `value`, sorted and hole-separated, or empty if the value is untracked.
+    pub(crate) fn ranges(&self, value: ValueId) -> &[LiveRange] {
+        self.ranges.get(&value).map_or(&[], Vec::as_slice)
+    }
+
+    /// Whether `value` is live at `point` (i.e. `point` falls in one of its ranges, not a hole).
+    pub(crate) fn is_live_at(&self, value: ValueId, point: ProgramPoint) -> bool {
+        self.ranges(value).iter().any(|range| range.contains(point))
+    }
+
+    /// Whether two values' live ranges overlap at any point (true interference, holes respected).
+    pub(crate) fn interferes(&self, a: ValueId, b: ValueId) -> bool {
+        let (a_ranges, b_ranges) = (self.ranges(a), self.ranges(b));
+        a_ranges.iter().any(|ra| b_ranges.iter().any(|rb| ra.overlaps(rb)))
+    }
+}
+
+/// Carve the sorted, disjoint `holes` out of the inclusive span `[def, last_use]`, returning the
+/// remaining live ranges in order. Each hole lies strictly inside the span.
+fn subtract_holes(def: u32, last_use: u32, mut holes: Vec<(u32, u32)>) -> Vec<LiveRange> {
+    holes.sort_unstable();
+    let mut ranges = Vec::new();
+    let mut cursor = def;
+    for (hole_start, hole_end) in holes {
+        if hole_start > cursor {
+            ranges
+                .push(LiveRange { start: ProgramPoint(cursor), end: ProgramPoint(hole_start - 1) });
+        }
+        cursor = hole_end + 1;
+    }
+    if cursor <= last_use {
+        ranges.push(LiveRange { start: ProgramPoint(cursor), end: ProgramPoint(last_use) });
+    }
+    ranges
+}
+
 #[cfg(test)]
 mod tests {
     use crate::brillig::brillig_gen::constant_allocation::ConstantAllocation;
@@ -940,5 +1046,91 @@ mod register_pressure {
         // b3 has fewer (just v3).
         assert_eq!(p0, 3, "got {p0}");
         assert_eq!(p3, 1, "got {p3}");
+    }
+}
+
+#[cfg(test)]
+mod live_ranges {
+    use super::{LiveIntervals, LiveRanges};
+    use crate::brillig::brillig_gen::constant_allocation::ConstantAllocation;
+    use crate::brillig::brillig_gen::variable_liveness::VariableLiveness;
+    use crate::ssa::ir::post_order::PostOrder;
+    use crate::ssa::ssa_gen::Ssa;
+
+    fn build(src: &str) -> (LiveRanges, LiveIntervals, Ssa) {
+        let ssa = Ssa::from_str(src).unwrap();
+        let func = ssa.main();
+        let constants = ConstantAllocation::from_function(func);
+        let liveness = VariableLiveness::from_function(func, &constants);
+        let post_order = PostOrder::with_function(func).into_vec();
+        let intervals = LiveIntervals::from_function(func, &liveness, &constants, &post_order);
+        let ranges = LiveRanges::from_intervals(&intervals, &liveness, &post_order);
+        (ranges, intervals, ssa)
+    }
+
+    /// Straight-line code has no holes: every value's range list is a single range equal to its
+    /// collapsed `[def, last_use]` interval.
+    #[test]
+    fn straightline_has_no_holes() {
+        let src = "
+        brillig(inline) fn main f0 {
+          b0(v0: Field):
+            v1 = add v0, Field 1
+            v2 = add v1, Field 2
+            v3 = add v2, Field 3
+            return v3
+        }
+        ";
+        let (ranges, intervals, _ssa) = build(src);
+        for (value, interval) in intervals.intervals_by_def() {
+            let list = ranges.ranges(value);
+            assert_eq!(list.len(), 1, "value {value} should have a single range");
+            assert_eq!(list[0].start, interval.def, "value {value} range start");
+            assert_eq!(list[0].end, interval.last_use, "value {value} range end");
+        }
+    }
+
+    /// A value defined at entry and used only in a deep block, with a short sibling branch that is
+    /// dead for it and sorts early in RPO, must show a hole: the range list splits, and the value
+    /// reads as not-live at the dead branch's points even though they lie inside its collapsed
+    /// interval.
+    #[test]
+    fn dead_sibling_branch_is_a_hole() {
+        let src = "
+        brillig(inline) fn main f0 {
+          b0(v0: Field, v1: u1):
+            jmpif v1 then: b1(), else: b4()
+          b1():
+            jmp b2()
+          b2():
+            jmp b3()
+          b3():
+            v2 = add v0, Field 1
+            jmp b5(v2)
+          b4():
+            jmp b5(Field 0)
+          b5(v3: Field):
+            return v3
+        }
+        ";
+        let (ranges, intervals, ssa) = build(src);
+        let func = ssa.main();
+        let b0 = func.entry_block();
+        let v0 = func.dfg[b0].parameters()[0];
+
+        // v0 is used only in b3 (the deep branch); b4 is dead for v0 and RPO numbers it between b0
+        // and b3, so v0's liveness has a hole across b4.
+        let list = ranges.ranges(v0);
+        assert_eq!(
+            list.len(),
+            2,
+            "v0 should be split by a hole across the dead branch, got {list:?}"
+        );
+
+        // The collapsed interval spans the hole; the hole-aware ranges do not.
+        let interval = intervals.get(v0).unwrap();
+        assert_eq!(list[0].start, interval.def);
+        assert_eq!(list.last().unwrap().end, interval.last_use);
+        assert!(list[0].end < list[1].start, "the two ranges are separated by a gap");
     }
 }

--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/live_intervals.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/live_intervals.rs
@@ -38,7 +38,10 @@ use crate::ssa::ir::{
 
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 
-use super::{constant_allocation::ConstantAllocation, variable_liveness::VariableLiveness};
+use super::{
+    constant_allocation::{ConstantAllocation, InstructionLocation},
+    variable_liveness::VariableLiveness,
+};
 
 /// Monotonic index assigned to block entries, instructions, and terminators in RPO.
 ///
@@ -280,20 +283,29 @@ impl LiveIntervals {
         }
     }
 
-    /// Extend constant defs to their allocation block's entry point.
+    /// Set each constant's def to the program point where it is actually materialized.
     ///
-    /// Constants from `ConstantAllocation::allocated_in_block` are materialized
-    /// at specific block entries. We extend their def to match.
+    /// [`ConstantAllocation`] picks an allocation point for every constant — the common dominator of
+    /// its uses — and codegen emits the `const` opcode there (`initialize_constants`, at an
+    /// instruction or terminator location), *not* at the block entry. The def must match that point:
+    /// the interval seeded by [`Self::build_intervals`] starts at the block entry of the first block
+    /// that uses the constant, which is both too early (before materialization, in that block) and,
+    /// for a hoisted constant, in the wrong block entirely. Pinning the def to the materialization
+    /// point gives an accurate live range — so a value-register-pressure spill of a constant stores
+    /// data that has actually been computed, rather than garbage from before its `const` opcode ran.
     fn adjust_constant_defs(
         &mut self,
         constants: &ConstantAllocation,
-        post_order: &[BasicBlockId],
+        _post_order: &[BasicBlockId],
     ) {
-        for &block_id in post_order {
-            let entry_point = self.block_entry_points[&block_id];
-            for constant_id in constants.allocated_in_block(block_id) {
+        for (block_id, location, values) in constants.allocations() {
+            let point = match location {
+                InstructionLocation::Instruction(inst) => self.instruction_points[&inst],
+                InstructionLocation::Terminator => self.terminator_points[&block_id],
+            };
+            for &constant_id in values {
                 if let Some(interval) = self.intervals.get_mut(&constant_id) {
-                    interval.def = std::cmp::min(interval.def, entry_point);
+                    interval.def = point;
                 }
             }
         }
@@ -911,8 +923,6 @@ mod tests {
         let [b0, b1, b2, b3] = block_ids();
         assert_eq!(rpo, vec![b0, b1, b2, b3]);
 
-        let b0_entry = intervals.block_entry_point(b0).unwrap();
-
         let constants = ConstantAllocation::from_function(func);
 
         // Field 42 is used in both b1 and b2, so it should be allocated at b0
@@ -925,9 +935,14 @@ mod tests {
         );
         let constant_id = b0_constants[0];
 
-        // The constant's interval def should be at b0's entry.
+        // The constant's def should be where it is materialized: b0 has only a terminator (the
+        // `jmpif`), so it is allocated at b0's terminator, not b0's entry.
+        let b0_term = intervals.terminator_point(b0).unwrap();
         let iv = intervals.get(constant_id).expect("constant should have an interval");
-        assert_eq!(iv.def, b0_entry, "Field 42 def should be at b0 entry (common dominator)");
+        assert_eq!(
+            iv.def, b0_term,
+            "Field 42 def should be at b0's terminator (its materialization)"
+        );
 
         // RPO is [b0, b1, b2, b3], so b2 comes after b1.
         // Field 42's last_use should be at b2's instruction (the later use in RPO).
@@ -962,8 +977,6 @@ mod tests {
         let [b0, b1, b2, b3] = block_ids();
         assert_eq!(rpo, vec![b0, b1, b2, b3]);
 
-        let b0_entry = intervals.block_entry_point(b0).unwrap();
-
         let constants = ConstantAllocation::from_function(func);
 
         // u32 10 is used only inside the loop body (b2), but should be
@@ -972,9 +985,14 @@ mod tests {
         assert_eq!(b0_constants.len(), 1, "exactly one constant should be allocated in b0");
         let constant_id = b0_constants[0];
 
-        // The constant's def should be at b0's entry (hoisted).
+        // The constant's def should be where it is materialized: b0 has only a terminator (`jmp`),
+        // so it is hoisted to b0's terminator (outside the loop), not b0's entry.
+        let b0_term = intervals.terminator_point(b0).unwrap();
         let iv = intervals.get(constant_id).expect("u32 10 should have an interval");
-        assert_eq!(iv.def, b0_entry, "u32 10 def should be at b0 entry (hoisted outside loop)");
+        assert_eq!(
+            iv.def, b0_term,
+            "u32 10 def should be at b0's terminator (hoisted outside loop)"
+        );
 
         // The constant's last_use should be at b2's terminator: loop liveness
         // propagation keeps it live through the back-edge (b2 -> b1).
@@ -1004,11 +1022,13 @@ mod register_pressure {
         let (intervals, _ssa) = build_intervals(src);
 
         let pressure = intervals.max_register_pressure();
-        dbg!(pressure);
-        // We have a value and result for an addition and two constants declared at the beginning of the block.
+        // Each constant is live only from where it is materialized (its use), not from the block
+        // entry, so the peak is three: at `v1 = add v0, Field 1` the live values are `v0`, `Field 1`,
+        // and the fresh `v1`; likewise at the second add. (A block-entry model would inflate this to
+        // four by keeping both constants live from the start.)
         assert_eq!(
-            pressure, 4,
-            "need at least 2 values for the adds and 2 for the constants, got {pressure}"
+            pressure, 3,
+            "peak is an operand, a freshly-materialized constant, and the result, got {pressure}"
         );
     }
 

--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/live_intervals.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/live_intervals.rs
@@ -66,13 +66,11 @@ impl LiveInterval {
     }
 
     /// Check whether two intervals overlap (conservative interference).
-    #[cfg(test)]
     pub(crate) fn interferes(&self, other: &LiveInterval) -> bool {
         self.def <= other.last_use && other.def <= self.last_use
     }
 
     /// Check whether a program point falls within this interval.
-    #[cfg(test)]
     pub(crate) fn contains(&self, point: ProgramPoint) -> bool {
         self.def <= point && point <= self.last_use
     }
@@ -96,7 +94,6 @@ pub(crate) struct LiveIntervals {
     max_point: ProgramPoint,
 }
 
-#[cfg(test)]
 impl LiveIntervals {
     /// Build liveness intervals for a function.
     ///
@@ -315,13 +312,11 @@ impl LiveIntervals {
     }
 
     /// Look up the interval for a value.
-    #[cfg(test)]
     pub(crate) fn get(&self, value: ValueId) -> Option<&LiveInterval> {
         self.intervals.get(&value)
     }
 
     /// Check whether two values' intervals overlap.
-    #[cfg(test)]
     pub(crate) fn interferes(&self, a: ValueId, b: ValueId) -> bool {
         match (self.intervals.get(&a), self.intervals.get(&b)) {
             (Some(ia), Some(ib)) => ia.interferes(ib),
@@ -330,25 +325,21 @@ impl LiveIntervals {
     }
 
     /// Get the program point at a block's entry.
-    #[cfg(test)]
     pub(crate) fn block_entry_point(&self, block: BasicBlockId) -> Option<ProgramPoint> {
         self.block_entry_points.get(&block).copied()
     }
 
     /// Get the program point for an instruction.
-    #[cfg(test)]
     pub(crate) fn instruction_point(&self, inst: InstructionId) -> Option<ProgramPoint> {
         self.instruction_points.get(&inst).copied()
     }
 
     /// Get the program point for a block's terminator.
-    #[cfg(test)]
     pub(crate) fn terminator_point(&self, block: BasicBlockId) -> Option<ProgramPoint> {
         self.terminator_points.get(&block).copied()
     }
 
     /// Count how many value intervals are live at a given block's entry point.
-    #[cfg(test)]
     pub(crate) fn register_pressure_at_block(&self, block: BasicBlockId) -> usize {
         let Some(&entry) = self.block_entry_points.get(&block) else {
             return 0;
@@ -361,7 +352,6 @@ impl LiveIntervals {
     /// This is an approximation. We check at every assigned program point how many
     /// intervals are alive. For large functions a sweep-line algorithm would be
     /// more efficient, but this is adequate for diagnostic use.
-    #[cfg(test)]
     pub(crate) fn max_register_pressure(&self) -> usize {
         if self.intervals.is_empty() {
             return 0;

--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/live_intervals.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/live_intervals.rs
@@ -48,6 +48,14 @@ use super::{constant_allocation::ConstantAllocation, variable_liveness::Variable
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub(crate) struct ProgramPoint(u32);
 
+impl ProgramPoint {
+    /// The immediately-preceding program point (saturating at 0). Used to end a segment just before
+    /// a split point when a value is evicted at that point.
+    pub(crate) fn pred(self) -> ProgramPoint {
+        ProgramPoint(self.0.saturating_sub(1))
+    }
+}
+
 /// Conservative single-interval approximation of a value's liveness.
 ///
 /// Over-approximates for non-contiguous live ranges (sound for interference).

--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/tests/linear_scan.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/tests/linear_scan.rs
@@ -1,39 +1,35 @@
-//! Tests for the linear-scan allocator selection seam.
+//! End-to-end tests for the linear-scan allocator behind the `use_linear_scan_allocator` flag.
 //!
-//! While [`LinearScanAllocator`](crate::brillig::brillig_gen::linear_scan::LinearScanAllocator) is a
-//! delegating scaffold over the greedy allocator, selecting it must reproduce greedy bytecode
-//! exactly. These tests are the end-to-end proof that the seam — the `use_linear_scan_allocator`
-//! flag, the polymorphic `FunctionContext` allocator field, per-function construction, and the
-//! globals `into_allocations` path — routes correctly and is behavior-preserving. When the
-//! plan-based internals replace the delegation, the equality assertions become the pin that flags
-//! any divergence from greedy for review.
+//! The greedy and linear-scan allocators produce *different* bytecode (different register
+//! assignments, spill decisions), so these assert **execution-equivalence**: compiling a function
+//! with each allocator and running both on the same inputs must yield the same result. This is the
+//! real proof the whole linear-scan pipeline — assignment → read-only allocator → shadow-band
+//! scratch → driver — is correct, and it doubles as the regression pin against any future
+//! divergence. Functions whose pressure the linear-scan pass cannot yet place fall back to greedy
+//! internally, so equivalence holds for them trivially.
 
-use crate::{
-    brillig::{
-        BrilligOptions,
-        brillig_gen::tests::ssa_to_brillig_artifacts_with_options,
-        brillig_ir::{LayoutConfig, registers::MAX_SCRATCH_SPACE},
+use acvm::FieldElement;
+
+use crate::brillig::{
+    BrilligOptions,
+    brillig_gen::tests::execute_brillig_from_ssa_with_options,
+    brillig_ir::{
+        LayoutConfig,
+        registers::{MAX_SCRATCH_SPACE, MIN_STACK_FRAME_SIZE, NUM_STACK_FRAMES},
     },
-    ssa::ir::map::Id,
 };
 
-/// Compile `src` with the greedy allocator and again with the linear-scan allocator, and assert the
-/// pre-link bytecode of `main` (`f0`) is identical.
-fn assert_linear_scan_matches_greedy(src: &str, options: &BrilligOptions) {
-    let greedy = ssa_to_brillig_artifacts_with_options(src, options);
+/// Run `src` on `calldata` with the greedy allocator and again with the linear-scan allocator, and
+/// assert both return the same values.
+fn assert_execution_matches(src: &str, calldata: Vec<FieldElement>, options: &BrilligOptions) {
+    let greedy = execute_brillig_from_ssa_with_options(src, calldata.clone(), options);
     let linear_options = BrilligOptions { use_linear_scan_allocator: true, ..options.clone() };
-    let linear = ssa_to_brillig_artifacts_with_options(src, &linear_options);
-
-    let main = Id::test_new(0);
-    assert_eq!(
-        greedy.ssa_function_to_brillig[&main].byte_code,
-        linear.ssa_function_to_brillig[&main].byte_code,
-        "linear-scan allocator must reproduce greedy bytecode for {src}"
-    );
+    let linear = execute_brillig_from_ssa_with_options(src, calldata, &linear_options);
+    assert_eq!(greedy, linear, "linear-scan must match greedy execution for {src}");
 }
 
 #[test]
-fn seam_matches_greedy_no_spilling() {
+fn matches_greedy_no_spilling() {
     let src = "
     brillig(inline) fn main f0 {
       b0(v0: Field, v1: Field):
@@ -42,11 +38,16 @@ fn seam_matches_greedy_no_spilling() {
         return v3
     }
     ";
-    assert_linear_scan_matches_greedy(src, &BrilligOptions::default());
+    // v0=3, v1=7 -> v2=10, v3=30.
+    assert_execution_matches(
+        src,
+        vec![FieldElement::from(3u64), FieldElement::from(7u64)],
+        &BrilligOptions::default(),
+    );
 }
 
 #[test]
-fn seam_matches_greedy_across_blocks() {
+fn matches_greedy_across_blocks() {
     let src = "
     brillig(inline) fn main f0 {
       b0(v0: u32, v1: u32):
@@ -62,28 +63,39 @@ fn seam_matches_greedy_across_blocks() {
         return v5
     }
     ";
-    assert_linear_scan_matches_greedy(src, &BrilligOptions::default());
+    // v0=2 < v1=5 -> then: v3 = 2+5 = 7.
+    assert_execution_matches(
+        src,
+        vec![FieldElement::from(2u64), FieldElement::from(5u64)],
+        &BrilligOptions::default(),
+    );
+    // v0=9 >= v1=5 -> else: v4 = 9*5 = 45.
+    assert_execution_matches(
+        src,
+        vec![FieldElement::from(9u64), FieldElement::from(5u64)],
+        &BrilligOptions::default(),
+    );
 }
 
 #[test]
-fn seam_matches_greedy_with_spilling() {
-    // A tiny frame (4 slots -> 2 usable after the reserved prologue) forces the allocator down its
-    // spill path, so the seam is exercised where it does the most work.
+fn matches_greedy_with_frame_too_small_for_linear_scan() {
+    // At the minimal runnable frame the value capacity (`usable - min_live_count - SPILL_MARGIN`)
+    // saturates to zero, so the linear-scan pass declines and falls back to greedy. Greedy still
+    // runs at this frame, and execution must match.
     let src = "
     brillig(inline) fn main f0 {
-      b0(v0: u32, v1: u32, v2: u32, v3: u32):
-        v4 = unchecked_add v0, v1
-        v5 = unchecked_add v4, v0
-        v6 = unchecked_add v5, v2
-        v7 = unchecked_add v6, v1
-        jmp b1(v0, v1, v2, v3)
-      b1(v8: u32, v9: u32, v10: u32, v11: u32):
-        v12 = unchecked_add v0, v1
-        v13 = unchecked_add v12, v3
-        return v13
+      b0(v0: Field, v1: Field):
+        v2 = add v0, v1
+        v3 = mul v2, v0
+        return v3
     }
     ";
-    let layout = LayoutConfig::new(4, 16, MAX_SCRATCH_SPACE);
+    let layout = LayoutConfig::new(MIN_STACK_FRAME_SIZE, NUM_STACK_FRAMES, MAX_SCRATCH_SPACE);
     let options = BrilligOptions { layout, ..Default::default() };
-    assert_linear_scan_matches_greedy(src, &options);
+    // v0=3, v1=7 -> v2=10, v3=30.
+    assert_execution_matches(
+        src,
+        vec![FieldElement::from(3u64), FieldElement::from(7u64)],
+        &options,
+    );
 }

--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/tests/linear_scan.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/tests/linear_scan.rs
@@ -1,0 +1,89 @@
+//! Tests for the linear-scan allocator selection seam.
+//!
+//! While [`LinearScanAllocator`](crate::brillig::brillig_gen::linear_scan::LinearScanAllocator) is a
+//! delegating scaffold over the greedy allocator, selecting it must reproduce greedy bytecode
+//! exactly. These tests are the end-to-end proof that the seam — the `use_linear_scan_allocator`
+//! flag, the polymorphic `FunctionContext` allocator field, per-function construction, and the
+//! globals `into_allocations` path — routes correctly and is behavior-preserving. When the
+//! plan-based internals replace the delegation, the equality assertions become the pin that flags
+//! any divergence from greedy for review.
+
+use crate::{
+    brillig::{
+        BrilligOptions,
+        brillig_gen::tests::ssa_to_brillig_artifacts_with_options,
+        brillig_ir::{LayoutConfig, registers::MAX_SCRATCH_SPACE},
+    },
+    ssa::ir::map::Id,
+};
+
+/// Compile `src` with the greedy allocator and again with the linear-scan allocator, and assert the
+/// pre-link bytecode of `main` (`f0`) is identical.
+fn assert_linear_scan_matches_greedy(src: &str, options: &BrilligOptions) {
+    let greedy = ssa_to_brillig_artifacts_with_options(src, options);
+    let linear_options = BrilligOptions { use_linear_scan_allocator: true, ..options.clone() };
+    let linear = ssa_to_brillig_artifacts_with_options(src, &linear_options);
+
+    let main = Id::test_new(0);
+    assert_eq!(
+        greedy.ssa_function_to_brillig[&main].byte_code,
+        linear.ssa_function_to_brillig[&main].byte_code,
+        "linear-scan allocator must reproduce greedy bytecode for {src}"
+    );
+}
+
+#[test]
+fn seam_matches_greedy_no_spilling() {
+    let src = "
+    brillig(inline) fn main f0 {
+      b0(v0: Field, v1: Field):
+        v2 = add v0, v1
+        v3 = mul v2, v0
+        return v3
+    }
+    ";
+    assert_linear_scan_matches_greedy(src, &BrilligOptions::default());
+}
+
+#[test]
+fn seam_matches_greedy_across_blocks() {
+    let src = "
+    brillig(inline) fn main f0 {
+      b0(v0: u32, v1: u32):
+        v2 = lt v0, v1
+        jmpif v2 then: b1(), else: b2()
+      b1():
+        v3 = add v0, v1
+        jmp b3(v3)
+      b2():
+        v4 = mul v0, v1
+        jmp b3(v4)
+      b3(v5: u32):
+        return v5
+    }
+    ";
+    assert_linear_scan_matches_greedy(src, &BrilligOptions::default());
+}
+
+#[test]
+fn seam_matches_greedy_with_spilling() {
+    // A tiny frame (4 slots -> 2 usable after the reserved prologue) forces the allocator down its
+    // spill path, so the seam is exercised where it does the most work.
+    let src = "
+    brillig(inline) fn main f0 {
+      b0(v0: u32, v1: u32, v2: u32, v3: u32):
+        v4 = unchecked_add v0, v1
+        v5 = unchecked_add v4, v0
+        v6 = unchecked_add v5, v2
+        v7 = unchecked_add v6, v1
+        jmp b1(v0, v1, v2, v3)
+      b1(v8: u32, v9: u32, v10: u32, v11: u32):
+        v12 = unchecked_add v0, v1
+        v13 = unchecked_add v12, v3
+        return v13
+    }
+    ";
+    let layout = LayoutConfig::new(4, 16, MAX_SCRATCH_SPACE);
+    let options = BrilligOptions { layout, ..Default::default() };
+    assert_linear_scan_matches_greedy(src, &options);
+}

--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/tests/mod.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/tests/mod.rs
@@ -26,6 +26,7 @@ mod black_box;
 mod call;
 mod coalescing;
 mod jmp;
+mod linear_scan;
 mod memory;
 mod spill;
 mod truncate;

--- a/compiler/noirc_evaluator/src/brillig/brillig_ir.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_ir.rs
@@ -553,6 +553,7 @@ pub(crate) mod tests {
             show_opcode_advisories: false,
             layout: Default::default(),
             copy_site_registry: None,
+            use_linear_scan_allocator: false,
         };
         let mut context = BrilligContext::new("test", &options);
 
@@ -733,6 +734,7 @@ pub(crate) mod tests {
             show_opcode_advisories: false,
             layout: Default::default(),
             copy_site_registry: None,
+            use_linear_scan_allocator: false,
         };
         let mut context = BrilligContext::new("test", &options);
 
@@ -960,6 +962,7 @@ pub(crate) mod tests {
             show_opcode_advisories: false,
             layout: small_layout,
             copy_site_registry: None,
+            use_linear_scan_allocator: false,
         };
 
         let mut context: BrilligContext<FieldElement, Stack> =

--- a/compiler/noirc_evaluator/src/brillig/brillig_ir/codegen_stack.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_ir/codegen_stack.rs
@@ -274,6 +274,7 @@ mod tests {
             show_opcode_advisories: false,
             layout: LayoutConfig::default(),
             copy_site_registry: None,
+            use_linear_scan_allocator: false,
         };
         let mut context = BrilligContext::new("test", &options);
         context.enter_context(Label::function(FunctionId::test_new(0)));

--- a/compiler/noirc_evaluator/src/brillig/mod.rs
+++ b/compiler/noirc_evaluator/src/brillig/mod.rs
@@ -163,11 +163,15 @@ impl Brillig {
         let mut brillig_context = BrilligContext::new(func.name(), options);
 
         // The allocator shares the context's register pool, so build it after the context exists.
+        // `NOIR_BRILLIG_LINEAR_SCAN` is an A/B override for validation, forcing the linear-scan
+        // allocator corpus-wide without threading the option through every entry point.
+        let use_linear_scan =
+            options.use_linear_scan_allocator || std::env::var("NOIR_BRILLIG_LINEAR_SCAN").is_ok();
         let mut function_context = FunctionContext::new_with_allocator(
             func,
             options.layout.max_stack_frame_size(),
             brillig_context.registers_rc(),
-            options.use_linear_scan_allocator,
+            use_linear_scan,
         );
 
         brillig_context.enter_context(Label::function(func.id()));

--- a/compiler/noirc_evaluator/src/brillig/mod.rs
+++ b/compiler/noirc_evaluator/src/brillig/mod.rs
@@ -63,6 +63,9 @@ pub struct BrilligOptions {
     /// Shared registry for per-site array copy tracking. Populated (via `--count-array-copies`)
     /// to enable the copy-counting instrumentation; `None` leaves ordinary compilation untouched.
     pub copy_site_registry: Option<CopySiteRegistry>,
+    /// Select the linear-scan register allocator instead of the default greedy one. Off by default;
+    /// used to A/B the two allocators behind the pluggable `Allocator` seam.
+    pub use_linear_scan_allocator: bool,
 }
 
 /// Context structure for the Brillig pass.
@@ -160,10 +163,11 @@ impl Brillig {
         let mut brillig_context = BrilligContext::new(func.name(), options);
 
         // The allocator shares the context's register pool, so build it after the context exists.
-        let mut function_context = FunctionContext::new(
+        let mut function_context = FunctionContext::new_with_allocator(
             func,
             options.layout.max_stack_frame_size(),
             brillig_context.registers_rc(),
+            options.use_linear_scan_allocator,
         );
 
         brillig_context.enter_context(Label::function(func.id()));

--- a/tooling/nargo_cli/build.rs
+++ b/tooling/nargo_cli/build.rs
@@ -693,12 +693,35 @@ fn generate_brillig_small_stack_execution_success_tests(
     test_file: &mut File,
     test_data_dir: &Path,
 ) {
+    // Greedy allocator (the default) and the linear-scan allocator, each under a small stack frame
+    // where register pressure is highest. The linear-scan variant is what gives CI coverage of that
+    // allocator — nothing else runs it — so it must stay green as its capability grows.
+    generate_brillig_small_stack_variant(test_file, test_data_dir, Allocator::Greedy);
+    generate_brillig_small_stack_variant(test_file, test_data_dir, Allocator::LinearScan);
+}
+
+#[derive(Clone, Copy)]
+enum Allocator {
+    Greedy,
+    LinearScan,
+}
+
+fn generate_brillig_small_stack_variant(
+    test_file: &mut File,
+    test_data_dir: &Path,
+    allocator: Allocator,
+) {
     let test_type = "execution_success";
     let test_cases = read_test_cases(test_data_dir, test_type);
 
+    let (module_suffix, run_fn) = match allocator {
+        Allocator::Greedy => ("", "nargo_execute_brillig_small_stack"),
+        Allocator::LinearScan => ("linear_scan_", "nargo_execute_brillig_small_stack_linear_scan"),
+    };
+
     writeln!(
         test_file,
-        "mod brillig_small_stack_{test_type} {{
+        "mod brillig_small_stack_{module_suffix}{test_type} {{
         use super::*;
     "
     )
@@ -723,7 +746,7 @@ fn generate_brillig_small_stack_execution_success_tests(
             {should_panic}
             fn test_{test_name}() {{
                 let test_program_dir = PathBuf::from("{test_dir}");
-                nargo_execute_brillig_small_stack(test_program_dir);
+                {run_fn}(test_program_dir);
             }}
             "#
         )

--- a/tooling/nargo_cli/tests/execute.rs
+++ b/tooling/nargo_cli/tests/execute.rs
@@ -484,9 +484,23 @@ mod tests {
     }
 
     fn nargo_execute_brillig_small_stack(test_program_dir: PathBuf) {
+        nargo_execute_brillig_small_stack_with(test_program_dir, false);
+    }
+
+    /// Same as [`nargo_execute_brillig_small_stack`], but forces the linear-scan register allocator
+    /// (via `NOIR_BRILLIG_LINEAR_SCAN`) so CI exercises it. The small frame maximizes register
+    /// pressure, so this is where the allocator's placement and its greedy fallback are stressed.
+    fn nargo_execute_brillig_small_stack_linear_scan(test_program_dir: PathBuf) {
+        nargo_execute_brillig_small_stack_with(test_program_dir, true);
+    }
+
+    fn nargo_execute_brillig_small_stack_with(test_program_dir: PathBuf, linear_scan: bool) {
         let (mut nargo, target_dir) = setup_nargo(&test_program_dir);
         nargo.arg("execute").arg("--force").arg("--force-brillig");
         nargo.arg("--max-stack-frame-size").arg("64");
+        if linear_scan {
+            nargo.env("NOIR_BRILLIG_LINEAR_SCAN", "1");
+        }
 
         let skip_brillig_debug_assertions = IGNORED_BRILLIG_DEBUG_ASSERTIONS_TESTS
             .into_iter()


### PR DESCRIPTION
## Problem Resolved

Phase 1 of the register-allocation plan in #13302 (tracking issue #11638): a **linear-scan register allocator** for Brillig, running behind the pluggable `Allocator` seam extracted in Phase 0.5 (#13310).

> **Stacked on #13310.** This branch builds on the Phase 0.5 seam; please review/merge that first. The diff here is the Phase 1 additions.

> **Draft — full serving of splits and spills now implemented.** The allocator serves **pressure-spilled and interval-split plans**, not just single-register ones, via **slot-canonical merge resolution** (Wimmer & Franz §6), *including* register-to-register divergence. The only case still declined to greedy is **pressure beyond `value_capacity`** — a function needing more value registers than the frame leaves after the scratch haircut; greedy (which blanket-spills cross-block values) still covers those. This beats greedy on cross-block values — greedy permanently spills every value that crosses a block boundary; linear scan keeps it in a register where it can, spilling only where pressure forces it.

## What's landed

- **Interval-set liveness with holes** (`LiveRanges`): per-value liveness as a *list* of ranges, preserving the holes that `LiveIntervals` collapses. A hole is a divergent branch (dead-in **and** dead-out of an interior block), verified against Wimmer & Franz §3 — the `!live_out` clause is what distinguishes it from a straight-line gap. A value dead across a hole frees its register for a non-overlapping value.
- **The assignment** (`assign` → `Plan`): linear scan over the hole-aware ranges producing a per-value location timeline. Pre-colors entry-block parameters to their ABI registers; reclaims a value's previous register across a hole; and (for the pressure case) evicts the furthest-next-use value to a fixed slot and reloads it at its next use. A result never aliases its instruction's operands' registers (codegen claims the result register before reading operands).
- **The read-only allocator** (`LinearScanAllocator`): realizes the `Plan` at codegen time via a small residency mirror — every `Allocator` method is a lookup returning where a value lives and the `Action`s to get it there. For single-register plans this emits no moves; a value revived in the *same* register after a hole is re-seeded in the mirror (its data survives on the taken path). The seam's `use_variable`/`reserve_scratch` now take an `Option<InstructionId>` so a plan-based allocator can resolve the program point of a use; greedy ignores it.
- **Slot-canonical merge resolution**: a linear scan over a non-linear CFG can land a value in different locations on different incoming edges (pressure spilled it on one branch, kept it in a register on another). `try_build` computes the set of such **divergent** values and routes each through its spill slot *uniformly at every block boundary*: excluded from the block-entry seed (reloaded on demand), saved before every terminator (a new `Action::Save` that stores but keeps the register), and — when the value is a block parameter — delivered by `resolve_edge` to the slot rather than a register (this is what makes slot-canonical **loop-carried** values correct). Slot stores are harmless on every outgoing edge (own slot, SSA-immutable), so no critical-edge splitting is needed. A value in the same register on every edge pays nothing — only genuinely divergent values take the slot round-trip.
- **Constant live ranges fixed** (`adjust_constant_defs`): a constant's def is now its **materialization point** (the `ConstantAllocation` location), not the block entry — codegen materializes constants lazily at their use, so the old block-entry extension over-claimed liveness. This is a standalone correctness fix (first commit) and a prerequisite for spilling constants soundly.
- **Register-to-register divergence served via a fresh slot**: a divergent value the plan never spilled (no slot) stays in a register everywhere but lands in a *different* register across the diverging edges. The textbook fix is one register-to-register move on the diverging edge (Wimmer & Franz §6), but that needs critical-edge splitting (the move clobbers the predecessor's *other* successor) and parallel-move cycle-breaking. Instead we give the value a fresh spill slot and route it through the slot-canonical machinery — a store+reload round-trip, no new edge machinery. A future improvement can special-case the pure register-to-register divergence and emit the move.
- **Selection + fallback**: a `use_linear_scan_allocator` `BrilligOptions` flag (plus a `NOIR_BRILLIG_LINEAR_SCAN` env override for A/B and CI) chooses the allocator per function. The only functions the current scope cannot serve — pressure beyond `value_capacity` — **fall back to greedy**, so every function still compiles correctly.
- **CI coverage**: a new `brillig_small_stack_linear_scan_execution_success` test module runs the execution-success programs forced to Brillig at `--max-stack-frame-size 64` with the linear-scan allocator enabled — the small frame maximizes pressure, stressing placement and the greedy fallback. Nothing in CI ran linear scan before.
- **Scratch**: codegen draws scratch temporaries from the registers above the value band; only the registers the plan actually uses are reserved, keeping the frame's high-water mark minimal (matters for recursion).

## What's pending

- **Capacity-driven decline** (the last fallback): a function whose peak value pressure exceeds `value_capacity` (`usable − min_live_count − SPILL_MARGIN`) still falls back to greedy. Shrinking or retiring the static `SPILL_MARGIN` cushion — via shadow-backed dynamic scratch below — would remove most of these and is what would let greedy be retired entirely.
- **Shadow-backed dynamic scratch** (replaces the static reserved band): draw scratch from registers free at the current point (via the residency shadow) instead of a fixed band above the value homes, so the frame high-water mark is `max(live + scratch)` rather than `max(live) + max(scratch)`. Would also let `reserve_scratch` hand codegen an exact, plan-consistent temp set, turning the currently test-checked "scratch demand matches codegen" contract into a structural one.
- **Register-to-register move resolution** (optional efficiency): replace the slot round-trip for pure register-to-register divergence with a single edge move (needs critical-edge splitting + parallel moves).
- **Validation matrix** (frame-size sweep, spill/move deltas vs greedy).

## Validation

- `cargo nextest run -p noirc_evaluator` — **1847 passed** (greedy is the default; mainline unchanged). `cargo clippy` and `cargo fmt --check` clean.
- `NOIR_BRILLIG_LINEAR_SCAN=1 cargo nextest run -p nargo_cli --test execute --no-fail-fast` — **9574/9578 genuine passes, 0 serving bugs** (now with full spill/split serving enabled). The 4 diffs are cosmetic recursion-depth counts in expected-failure `stderr` snapshots (a different frame size overflows at a different depth), flag-on only and not in CI, not miscompilations.
- The new `brillig_small_stack_linear_scan_execution_success` module — **498/498**.
- Unit tests cover interval holes, assignment soundness (interfering values never share a register, including under pressure), cross-block register retention, and end-to-end execution-equivalence with greedy.

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.

## PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with `cargo fmt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

