### PR TITLE
fix(ssa): don't leak exit-destination param mappings out of loop unrolling

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/opt/unrolling.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/unrolling.rs
@@ -2284,9 +2284,19 @@ impl<'f> LoopIteration<'f> {
                 // independent predecessor carrying a different argument, and its parameters
                 // must be preserved so the join body runs once over the merged parameter;
                 // specializing would copy the body for this edge and drop it for the others.
+                //
+                // It must also be restricted to destinations inside the loop. A destination
+                // outside the loop is the exit edge: its body is never inlined by this
+                // iteration, so the mapping would never be consulted here, but it *would* be
+                // exported by `Loop::unroll` via `into_value_mapping` and applied to every
+                // reachable block. If the exit edge carries arguments into a later loop's
+                // header, that would freeze the later loop's parameters at this edge's values
+                // throughout the function, corrupting that loop.
                 let folding_block_dominates_destination =
                     self.dom.dominates(folding_block, original_destination);
-                if folding_block_dominates_destination {
+                if folding_block_dominates_destination
+                    && self.loop_.blocks.contains(&original_destination)
+                {
                     let destination_params = self.dfg().block_parameters(destination).to_vec();
                     for (param, arg) in destination_params.iter().zip(&arguments) {
                         self.inserter.map_value(*param, *arg);
@@ -4755,7 +4765,7 @@ mod tests {
           b0(v0: u32):
             jmp b1(u32 50)
           b1(v1: u32):
-            return u32 50
+            return v1
         }
         ");
     }
@@ -4941,6 +4951,54 @@ mod tests {
             },
         );
         assert_eq!(result, Ok(vec![Value::field(100u128.into())]));
+    }
+
+    /// The value mapping `Loop::unroll` exports for post-loop replacement must not
+    /// rewrite blocks that belong to a *different* loop.
+    ///
+    /// When the final iteration folds the header's `jmpif` exit edge and that edge
+    /// carries arguments into a parameterized destination, `handle_jmpif` maps the
+    /// destination's block parameters to this edge's arguments. That specialization is
+    /// only valid local to the folded edge: if the destination is a later loop's header,
+    /// exporting it freezes that loop's parameters at their first-iteration values in
+    /// every reachable block, so its guard becomes constant, simplification folds the
+    /// header's `jmpif` into a `jmp`, and the next unrolling attempt hits the
+    /// "Expected loop header to terminate in a JmpIf" unreachable.
+    #[test]
+    fn unroll_direct_exit_to_next_loop_header_preserves_second_loop_final_value() {
+        // Two sibling loops: the first (header b1) accumulates Field 5 once and its exit
+        // edge jumps *directly* into the second loop's header b4, passing the accumulator
+        // and the second loop's initial counter as arguments. The second loop (header b4)
+        // then accumulates Field 10 once, so the program returns 0 + 5 + 10 = 15.
+        let src = "
+        acir(inline) fn main f0 {
+          b0():
+            jmp b1(u32 0, Field 0)
+          b1(v0: u32, v1: Field):
+            v2 = eq v0, u32 1
+            jmpif v2 then: b4(v1, u32 0), else: b2()
+          b2():
+            v3 = add v1, Field 5
+            v4 = unchecked_add v0, u32 1
+            jmp b1(v4, v3)
+          b4(v5: Field, v6: u32):
+            v7 = eq v6, u32 1
+            jmpif v7 then: b6(v5), else: b5()
+          b5():
+            v8 = add v5, Field 10
+            v9 = unchecked_add v6, u32 1
+            jmp b4(v8, v9)
+          b6(v10: Field):
+            return v10
+        }
+        ";
+
+        let (_, result) =
+            assert_pass_does_not_affect_execution(Ssa::from_str(src).unwrap(), vec![], |ssa| {
+                ssa.unroll_loops_iteratively(None, MAX_UNROLL_ITERATIONS, FORCE_UNROLL_THRESHOLD)
+                    .unwrap()
+            });
+        assert_eq!(result, Ok(vec![Value::field(15u128.into())]));
     }
 }
 


### PR DESCRIPTION
## Description

### Problem

Resolves https://github.com/noir-lang/noir-claude/issues/1484

After #13245, `Loop::unroll` exports the final `FunctionInserter`'s entire value map and `unroll_loops_iteratively` applies it to every reachable block. That map also contains the destination block-parameter specializations `handle_jmpif` records when folding the header's exit `jmpif`. If the exit edge carries arguments directly into a later loop's header, those leaked entries freeze the later loop's parameters at their entry values throughout the function: its guard becomes constant, simplification folds its header's `jmpif` into a `jmp`, and the retry in `unroll_loops_iteratively` panics with `Expected loop header to terminate in a JmpIf to the loop body, but found Jmp ...`.

Note this is not reachable from Noir source code: the frontend only emits argument-less `jmpif` edges (a loop exit always goes through an argless `loop_end` block, and the next loop's header receives its arguments via a plain `jmp`), and no SSA pass introduces `jmpif` arguments. The shape can only be written by hand or through the SSA parser (`noir-ssa`, unit tests) — but it's still good to fix so unrolling is correct on all valid SSA.

### Summary

Restrict `handle_jmpif`'s destination-param specialization to destinations inside the loop. The specialization only exists so a folded `jmpif`'s destination body resolves correctly when inlined, which never happens for the exit edge (the destination is outside the loop), so on that edge the entries were never consumed — they only leaked out through the exported mapping. With the guard, the exported map contains only the header params and header instruction results that post-loop code actually needs remapped (the #13245 fix), and its regression test keeps passing.

### Additional Context

The `unroll_with_body_block_params` snapshot loses the constant previously propagated into the exit block by this same leak; the exit block now keeps its parameter (`return v1` reached via `jmp b1(u32 50)`), which is semantically identical and resolved by constant folding later in the pipeline.

Added the regression test `unroll_direct_exit_to_next_loop_header_preserves_second_loop_final_value` with the two-loop SSA from the issue: it ICE'd before the fix and now unrolls to `Field 15`, matching the interpreter.

## Documentation

Check one:

- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
