### PR TITLE
chore: add per-ecosystem catch-all groups for minor/patch dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,15 @@ updates:
       core-actions:
         patterns:
           - "actions/**"
+      # Group assignment is first-match in definition order, so this catch-all
+      # only collects updates not claimed by a group above and must stay last.
+      actions-minor-and-patch:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"
+        patterns:
+          - "*"
 
   # Maintain dependencies for Rust crates
   - package-ecosystem: "cargo"
@@ -31,6 +40,17 @@ updates:
         patterns:
           - "p256"
           - "k256"
+      # Group assignment is first-match in definition order, so this catch-all
+      # only collects updates not claimed by a group above and must stay last.
+      # Note: 0.x bumps such as 0.4 -> 0.5 count as "minor" here even though
+      # cargo treats them as breaking; CI still gates the grouped PR.
+      cargo-minor-and-patch:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"
+        patterns:
+          - "*"
 
   # Enable version updates for npm
   - package-ecosystem: "npm"
@@ -82,3 +102,12 @@ updates:
           - "@types/chai"
           - "@types/mocha*"
           - "@types/sinon"
+      # Group assignment is first-match in definition order, so this catch-all
+      # only collects updates not claimed by a group above and must stay last.
+      npm-minor-and-patch:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"
+        patterns:
+          - "*"


### PR DESCRIPTION
## Description

## Problem

Dependabot currently opens an individual PR for every dependency outside the few named groups, which makes the weekly batch of updates time consuming to review and merge (e.g. 11 open cargo/npm PRs at time of writing).

## Summary

Adds a catch-all group per package ecosystem (`actions-minor-and-patch`, `cargo-minor-and-patch`, `npm-minor-and-patch`) that batches all minor and patch version updates not already claimed by a named group into a single weekly PR per ecosystem.

Notes:

- Group assignment is first-match in definition order, so the existing named groups (hardhat, webpack, arkworks, etc.) keep their current behavior; the catch-alls are defined last and only sweep up what's left.
- Major version updates outside the named groups still arrive as individual PRs.
- Groups are scoped to their ecosystem, so cargo and npm updates can never land in the same PR.
- Cargo caveat: Dependabot classifies `0.4 -> 0.5` bumps as "minor" even though cargo convention treats them as breaking, so such bumps will join the grouped cargo PR. CI still gates the batch; if this proves noisy the cargo catch-all can be narrowed to `patch` only.

## Additional Context

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.