### PR TITLE
chore: bundle playwright deps into a dedicated dependabot group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -102,6 +102,11 @@ updates:
           - "@types/chai"
           - "@types/mocha*"
           - "@types/sinon"
+      # Playwright bumps are coupled to browser/docker image versions and need
+      # coordinated handling, so they are bundled separately from the catch-all.
+      playwright:
+        patterns:
+          - "*playwright*"
       # Group assignment is first-match in definition order, so this catch-all
       # only collects updates not claimed by a group above and must stay last.
       npm-minor-and-patch:


### PR DESCRIPTION
## Description

## Problem

Since #13336, playwright-related dependencies are swept into the `npm-minor-and-patch` catch-all group. Playwright bumps are coupled to browser/docker image versions and need coordinated handling, so batching them with unrelated updates causes issues.

## Summary

Adds a dedicated `playwright` group (matching `*playwright*`, i.e. `@playwright/test` and `@web/test-runner-playwright`) ahead of the catch-all. Since group assignment is first-match in definition order, playwright updates now always arrive bundled in their own PR — including major bumps — and never join the catch-all batch.

## Additional Context

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.