### PR TITLE
chore: replace zkhash Poseidon2 cross-check with hardcoded test vectors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,8 +40,8 @@ name = "acir_field"
 version = "1.0.0-beta.23"
 dependencies = [
  "ark-bls12-381",
- "ark-bn254 0.6.0",
- "ark-ff 0.6.0",
+ "ark-bn254",
+ "ark-ff",
  "cfg-if",
  "criterion",
  "hex",
@@ -59,8 +59,8 @@ dependencies = [
  "acir",
  "acvm_blackbox_solver",
  "ark-bls12-381",
- "ark-bn254 0.6.0",
- "ark-ff 0.6.0",
+ "ark-bn254",
+ "ark-ff",
  "bn254_blackbox_solver",
  "brillig_vm",
  "criterion",
@@ -83,12 +83,12 @@ version = "1.0.0-beta.23"
 dependencies = [
  "acir",
  "aes",
- "blake2 0.11.0-rc.6",
+ "blake2",
  "blake3",
  "cbc",
  "criterion",
  "k256",
- "keccak 0.2.0",
+ "keccak",
  "log",
  "p256",
  "pprof",
@@ -314,21 +314,10 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be2ede2c0c96fa37d5d3484e8a59fec566c4a52b8c84bf993eaa6c67d7225a4c"
 dependencies = [
- "ark-ec 0.6.0",
- "ark-ff 0.6.0",
- "ark-serialize 0.6.0",
- "ark-std 0.6.0",
-]
-
-[[package]]
-name = "ark-bn254"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a22f4561524cd949590d78d7d4c5df8f592430d221f7f3c9497bbafd8972120f"
-dependencies = [
- "ark-ec 0.4.2",
- "ark-ff 0.4.2",
- "ark-std 0.4.0",
+ "ark-ec",
+ "ark-ff",
+ "ark-serialize",
+ "ark-std",
 ]
 
 [[package]]
@@ -337,26 +326,9 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6bc66f96ebe2a17a499475b4f94791d379817592ef494171586967ffdc6f95db"
 dependencies = [
- "ark-ec 0.6.0",
- "ark-ff 0.6.0",
- "ark-std 0.6.0",
-]
-
-[[package]]
-name = "ark-ec"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "defd9a439d56ac24968cca0571f598a61bc8c55f71d50a89cda591cb750670ba"
-dependencies = [
- "ark-ff 0.4.2",
- "ark-poly 0.4.2",
- "ark-serialize 0.4.2",
- "ark-std 0.4.0",
- "derivative",
- "hashbrown 0.13.2",
- "itertools 0.10.5",
- "num-traits",
- "zeroize",
+ "ark-ec",
+ "ark-ff",
+ "ark-std",
 ]
 
 [[package]]
@@ -366,10 +338,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8352a2b2aedf6ba2cc38f7520fc51191d518dde96175c729af19f2d059f191c4"
 dependencies = [
  "ahash",
- "ark-ff 0.6.0",
- "ark-poly 0.6.0",
- "ark-serialize 0.6.0",
- "ark-std 0.6.0",
+ "ark-ff",
+ "ark-poly",
+ "ark-serialize",
+ "ark-std",
  "educe",
  "fnv",
  "hashbrown 0.17.0",
@@ -382,49 +354,19 @@ dependencies = [
 
 [[package]]
 name = "ark-ff"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec847af850f44ad29048935519032c33da8aa03340876d351dfab5660d2966ba"
-dependencies = [
- "ark-ff-asm 0.4.2",
- "ark-ff-macros 0.4.2",
- "ark-serialize 0.4.2",
- "ark-std 0.4.0",
- "derivative",
- "digest 0.10.7",
- "itertools 0.10.5",
- "num-bigint",
- "num-traits",
- "paste",
- "rustc_version",
- "zeroize",
-]
-
-[[package]]
-name = "ark-ff"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7a806ac6c8307b929df4645776290a50ee2aac754ad09d8bdf73391309e43af"
 dependencies = [
- "ark-ff-asm 0.6.0",
- "ark-ff-macros 0.6.0",
- "ark-serialize 0.6.0",
- "ark-std 0.6.0",
+ "ark-ff-asm",
+ "ark-ff-macros",
+ "ark-serialize",
+ "ark-std",
  "digest 0.10.7",
  "educe",
  "num-bigint",
  "num-traits",
  "zeroize",
-]
-
-[[package]]
-name = "ark-ff-asm"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed4aa4fe255d0bc6d79373f7e31d2ea147bcf486cba1be5ba7ea85abdb92348"
-dependencies = [
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -435,19 +377,6 @@ checksum = "1479009684adc073dff49a1025d3a7065b317a9ead25aaaca38cdc70058ba8a2"
 dependencies = [
  "quote",
  "syn 2.0.118",
-]
-
-[[package]]
-name = "ark-ff-macros"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7abe79b0e4288889c4574159ab790824d0033b9fdcb2a112a3182fac2e514565"
-dependencies = [
- "num-bigint",
- "num-traits",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -469,23 +398,10 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2c969a12ceed8881e5c66277dabd3e7a5aa2c72c9370f3f42eca3f2dd33a21a"
 dependencies = [
- "ark-bn254 0.6.0",
- "ark-ec 0.6.0",
- "ark-ff 0.6.0",
- "ark-std 0.6.0",
-]
-
-[[package]]
-name = "ark-poly"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d320bfc44ee185d899ccbadfa8bc31aab923ce1558716e1997a1e74057fe86bf"
-dependencies = [
- "ark-ff 0.4.2",
- "ark-serialize 0.4.2",
- "ark-std 0.4.0",
- "derivative",
- "hashbrown 0.13.2",
+ "ark-bn254",
+ "ark-ec",
+ "ark-ff",
+ "ark-std",
 ]
 
 [[package]]
@@ -495,24 +411,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75f55af10b672002b8d953e230282c51206842e20e5791a94432219b4201de5c"
 dependencies = [
  "ahash",
- "ark-ff 0.6.0",
- "ark-serialize 0.6.0",
- "ark-std 0.6.0",
+ "ark-ff",
+ "ark-serialize",
+ "ark-std",
  "educe",
  "fnv",
  "hashbrown 0.17.0",
-]
-
-[[package]]
-name = "ark-serialize"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adb7b85a02b83d2f22f89bd5cac66c9c89474240cb6207cb1efc16d098e822a5"
-dependencies = [
- "ark-serialize-derive 0.4.2",
- "ark-std 0.4.0",
- "digest 0.10.7",
- "num-bigint",
 ]
 
 [[package]]
@@ -521,21 +425,10 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a74dd304fd536fb95d0a328e72be759209cc496a9da094c5bc56e5fea4f9e86b"
 dependencies = [
- "ark-serialize-derive 0.6.0",
- "ark-std 0.6.0",
+ "ark-serialize-derive",
+ "ark-std",
  "digest 0.10.7",
  "num-bigint",
-]
-
-[[package]]
-name = "ark-serialize-derive"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae3281bc6d0fd7e549af32b52511e1302185bd688fd3359fa36423346ff682ea"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -547,16 +440,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.118",
-]
-
-[[package]]
-name = "ark-std"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
-dependencies = [
- "num-traits",
- "rand 0.8.6",
 ]
 
 [[package]]
@@ -732,44 +615,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "bitvec"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
-dependencies = [
- "funty",
- "radium",
- "tap",
- "wyz",
-]
-
-[[package]]
-name = "blake2"
-version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
-dependencies = [
- "digest 0.10.7",
-]
-
-[[package]]
 name = "blake2"
 version = "0.11.0-rc.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "061f1a09225e328e1ffbb378d2d49923c0ca5fee19fb5ac1cc9c1e9d52b93690"
 dependencies = [
  "digest 0.11.3",
-]
-
-[[package]]
-name = "blake2b_simd"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b79834656f71332577234b50bfc009996f7449e0c056884e6a02492ded0ca2f3"
-dependencies = [
- "arrayref",
- "arrayvec",
- "constant_time_eq",
 ]
 
 [[package]]
@@ -814,37 +665,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "bls12_381"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3c196a77437e7cc2fb515ce413a6401291578b5afc8ecb29a3c7ab957f05941"
-dependencies = [
- "ff 0.12.1",
- "group 0.12.1",
- "pairing",
- "rand_core 0.6.4",
- "subtle",
-]
-
-[[package]]
 name = "bn254_blackbox_solver"
 version = "1.0.0-beta.23"
 dependencies = [
  "acir",
  "acvm_blackbox_solver",
- "ark-bn254 0.4.0",
- "ark-bn254 0.6.0",
- "ark-ec 0.6.0",
- "ark-ff 0.4.2",
- "ark-ff 0.6.0",
+ "ark-bn254",
+ "ark-ec",
+ "ark-ff",
  "ark-grumpkin",
  "criterion",
  "hex",
  "itertools 0.15.0",
  "num-bigint",
  "pprof",
- "proptest",
- "zkhash",
 ]
 
 [[package]]
@@ -926,12 +760,6 @@ name = "bytemuck"
 version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
-
-[[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -1562,17 +1390,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "derivative"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "derive_arbitrary"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1597,7 +1414,6 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
  "crypto-common 0.1.7",
- "subtle",
 ]
 
 [[package]]
@@ -1729,8 +1545,8 @@ dependencies = [
  "crypto-bigint",
  "crypto-common 0.2.2",
  "digest 0.11.3",
- "ff 0.14.0",
- "group 0.14.0",
+ "ff",
+ "group",
  "hybrid-array",
  "pem-rfc7468",
  "pkcs8",
@@ -1879,28 +1695,6 @@ dependencies = [
 
 [[package]]
 name = "ff"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d013fc25338cc558c5c2cfbad646908fb23591e2404481826742b651c9af7160"
-dependencies = [
- "bitvec",
- "rand_core 0.6.4",
- "subtle",
-]
-
-[[package]]
-name = "ff"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
-dependencies = [
- "bitvec",
- "rand_core 0.6.4",
- "subtle",
-]
-
-[[package]]
-name = "ff"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1f686ab92a9fb0eaf188f6c6c87b89490baa6fdb0db4544ba4dc47f7942489f"
@@ -2018,12 +1812,6 @@ checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "funty"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
@@ -2214,34 +2002,11 @@ dependencies = [
 
 [[package]]
 name = "group"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dfbfb3a6cfbd390d5c9564ab283a0349b9b9fcd46a706c1eb10e0db70bfbac7"
-dependencies = [
- "ff 0.12.1",
- "memuse",
- "rand_core 0.6.4",
- "subtle",
-]
-
-[[package]]
-name = "group"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
-dependencies = [
- "ff 0.13.1",
- "rand_core 0.6.4",
- "subtle",
-]
-
-[[package]]
-name = "group"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fd1a1c7a5206c5b7a3f5a0d7ccd3ff85d0c8f5133d62a02680255b0004af5f4"
 dependencies = [
- "ff 0.14.0",
+ "ff",
  "rand_core 0.10.1",
  "subtle",
 ]
@@ -2277,42 +2042,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "halo2"
-version = "0.1.0-beta.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a23c779b38253fe1538102da44ad5bd5378495a61d2c4ee18d64eaa61ae5995"
-dependencies = [
- "halo2_proofs",
-]
-
-[[package]]
-name = "halo2_proofs"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e925780549adee8364c7f2b685c753f6f3df23bde520c67416e93bf615933760"
-dependencies = [
- "blake2b_simd",
- "ff 0.12.1",
- "group 0.12.1",
- "pasta_curves 0.4.1",
- "rand_core 0.6.4",
- "rayon",
-]
-
-[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-
-[[package]]
-name = "hashbrown"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
-dependencies = [
- "ahash",
-]
 
 [[package]]
 name = "hashbrown"
@@ -3069,20 +2802,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "jubjub"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a575df5f985fe1cd5b2b05664ff6accfc46559032b954529fd225a2168d27b0f"
-dependencies = [
- "bitvec",
- "bls12_381",
- "ff 0.12.1",
- "group 0.12.1",
- "rand_core 0.6.4",
- "subtle",
-]
-
-[[package]]
 name = "k256"
 version = "0.14.0-rc.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3095,15 +2814,6 @@ dependencies = [
  "sha2 0.11.0",
  "signature",
  "wnaf",
-]
-
-[[package]]
-name = "keccak"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
-dependencies = [
- "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -3156,9 +2866,6 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-dependencies = [
- "spin 0.9.8",
-]
 
 [[package]]
 name = "lcov"
@@ -3317,12 +3024,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "memuse"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d97bbf43eb4f088f8ca469930cde17fa036207c9a5e02ccc5107c4e8b17c964"
-
-[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3428,7 +3129,7 @@ name = "nargo_cli"
 version = "1.0.0-beta.23"
 dependencies = [
  "acvm",
- "ark-bn254 0.6.0",
+ "ark-bn254",
  "assert_cmd",
  "assert_fs",
  "async-lsp",
@@ -4282,15 +3983,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pairing"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "135590d8bdba2b31346f9cd1fb2a912329f5135e832a4f422942eb6ead8b6b3b"
-dependencies = [
- "group 0.12.1",
-]
-
-[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4311,36 +4003,6 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "windows-link",
-]
-
-[[package]]
-name = "pasta_curves"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cc65faf8e7313b4b1fbaa9f7ca917a0eed499a9663be71477f87993604341d8"
-dependencies = [
- "blake2b_simd",
- "ff 0.12.1",
- "group 0.12.1",
- "lazy_static",
- "rand 0.8.6",
- "static_assertions",
- "subtle",
-]
-
-[[package]]
-name = "pasta_curves"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3e57598f73cc7e1b2ac63c79c517b31a0877cd7c402cdcaa311b5208de7a095"
-dependencies = [
- "blake2b_simd",
- "ff 0.13.1",
- "group 0.13.0",
- "lazy_static",
- "rand 0.8.6",
- "static_assertions",
- "subtle",
 ]
 
 [[package]]
@@ -4574,7 +4236,7 @@ dependencies = [
  "nix 0.26.4",
  "once_cell",
  "smallvec",
- "spin 0.10.0",
+ "spin",
  "symbolic-demangle",
  "tempfile",
  "thiserror 2.0.18",
@@ -4651,7 +4313,7 @@ checksum = "2db02b39ea98560a1fec81df6266f3c1ef7fdde06ac5ef17f69aee6101602630"
 dependencies = [
  "crypto-bigint",
  "crypto-common 0.2.2",
- "ff 0.14.0",
+ "ff",
  "rand_core 0.10.1",
  "subtle",
  "zeroize",
@@ -4767,12 +4429,6 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
-
-[[package]]
-name = "radium"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "radix_trie"
@@ -5688,16 +5344,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha3"
-version = "0.10.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77fd7028345d415a4034cf8777cd4f8ab1851274233b45f84e3d955502d93874"
-dependencies = [
- "digest 0.10.7",
- "keccak 0.1.6",
-]
-
-[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5850,12 +5496,6 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
-
-[[package]]
-name = "spin"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
@@ -5922,12 +5562,6 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
-
-[[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "str-buf"
@@ -6038,12 +5672,6 @@ dependencies = [
  "quote",
  "syn 2.0.118",
 ]
-
-[[package]]
-name = "tap"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "target-triple"
@@ -7464,8 +7092,8 @@ version = "0.14.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1dd5ee3ed0cacf709ec8681413bf22da12190f5b9a9d1ecc853eb62fae5fd8c"
 dependencies = [
- "ff 0.14.0",
- "group 0.14.0",
+ "ff",
+ "group",
  "hybrid-array",
 ]
 
@@ -7481,15 +7109,6 @@ name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
-
-[[package]]
-name = "wyz"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
-dependencies = [
- "tap",
-]
 
 [[package]]
 name = "xdg"
@@ -7572,20 +7191,6 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
-dependencies = [
- "zeroize_derive",
-]
-
-[[package]]
-name = "zeroize_derive"
-version = "1.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.118",
-]
 
 [[package]]
 name = "zerotrie"
@@ -7618,33 +7223,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.118",
-]
-
-[[package]]
-name = "zkhash"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4352d1081da6922701401cdd4cbf29a2723feb4cfabb5771f6fee8e9276da1c7"
-dependencies = [
- "ark-ff 0.4.2",
- "ark-std 0.4.0",
- "bitvec",
- "blake2 0.10.6",
- "bls12_381",
- "byteorder",
- "cfg-if",
- "group 0.12.1",
- "group 0.13.0",
- "halo2",
- "hex",
- "jubjub",
- "lazy_static",
- "pasta_curves 0.5.1",
- "rand 0.8.6",
- "serde",
- "sha2 0.10.9",
- "sha3",
- "subtle",
 ]
 
 [[package]]

--- a/acvm-repo/bn254_blackbox_solver/Cargo.toml
+++ b/acvm-repo/bn254_blackbox_solver/Cargo.toml
@@ -34,13 +34,6 @@ pprof = { version = "^0.15.0", features = [
     "frame-pointer",
     "criterion",
 ] }
-proptest.workspace = true
-
-zkhash = { version = "^0.2.0", default-features = false }
-ark-bn254-v04 = { package = "ark-bn254", version = "^0.4.0", default-features = false, features = [
-    "curve",
-] }
-ark-ff-v04 = { package = "ark-ff", version = "^0.4.0", default-features = false }
 
 [[bench]]
 name = "criterion"

--- a/acvm-repo/bn254_blackbox_solver/src/poseidon2.rs
+++ b/acvm-repo/bn254_blackbox_solver/src/poseidon2.rs
@@ -124,103 +124,101 @@ impl Poseidon2<'_> {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
+    use super::poseidon2_permutation;
+    use crate::poseidon2_constants::field_from_hex;
 
-    use acir::AcirField;
-
-    use proptest::prelude::*;
-    use proptest::result::maybe_ok;
-
-    use super::{FieldElement, poseidon2_permutation};
-    use crate::poseidon2_constants::{POSEIDON2_CONFIG, field_from_hex};
-
+    /// Cross-check vectors against an independent Poseidon2 implementation.
+    ///
+    /// The expected outputs were generated with the `zkhash` crate v0.2.0
+    /// (<https://github.com/HorizenLabs/poseidon2>), instantiating its
+    /// `Poseidon2` permutation with the parameters from
+    /// `crate::poseidon2_constants::POSEIDON2_CONFIG` (t = 4, d = 5) and
+    /// feeding it the inputs below.
     #[test]
-    fn smoke_test() {
-        let inputs = [FieldElement::zero(); 4];
-        let result = poseidon2_permutation(&inputs).expect("should successfully permute");
-
-        let expected_result = [
-            field_from_hex("18DFB8DC9B82229CFF974EFEFC8DF78B1CE96D9D844236B496785C698BC6732E"),
-            field_from_hex("095C230D1D37A246E8D2D5A63B165FE0FADE040D442F61E25F0590E5FB76F839"),
-            field_from_hex("0BB9545846E1AFA4FA3C97414A60A20FC4949F537A68CCECA34C5CE71E28AA59"),
-            field_from_hex("18A4F34C9C6F99335FF7638B82AEED9018026618358873C982BBDDE265B2ED6D"),
-        ];
-        assert_eq!(result, expected_result);
-    }
-
-    fn into_old_ark_field<T, U>(field: T) -> U
-    where
-        T: AcirField,
-        U: ark_ff_v04::PrimeField,
-    {
-        U::from_be_bytes_mod_order(&field.to_be_bytes())
-    }
-
-    fn into_new_ark_field<T, U>(field: T) -> U
-    where
-        T: ark_ff_v04::PrimeField,
-        U: ark_ff::PrimeField,
-    {
-        use zkhash::ark_ff::BigInteger;
-
-        U::from_be_bytes_mod_order(&field.into_bigint().to_bytes_be())
-    }
-
-    fn run_both_poseidon2_permutations(
-        inputs: Vec<FieldElement>,
-    ) -> (Vec<ark_bn254::Fr>, Vec<ark_bn254::Fr>) {
-        let poseidon2_t = POSEIDON2_CONFIG.t as usize;
-        let poseidon2_d = 5;
-        let rounds_f = POSEIDON2_CONFIG.rounds_f as usize;
-        let rounds_p = POSEIDON2_CONFIG.rounds_p as usize;
-        let mat_internal_diag_m_1: Vec<ark_bn254_v04::Fr> =
-            POSEIDON2_CONFIG.internal_matrix_diagonal.into_iter().map(into_old_ark_field).collect();
-        let mat_internal = vec![];
-        let round_constants: Vec<Vec<ark_bn254_v04::Fr>> = POSEIDON2_CONFIG
-            .round_constant
-            .into_iter()
-            .map(|fields| fields.into_iter().map(into_old_ark_field).collect())
-            .collect();
-
-        let external_poseidon2 = zkhash::poseidon2::poseidon2::Poseidon2::new(&Arc::new(
-            zkhash::poseidon2::poseidon2_params::Poseidon2Params::new(
-                poseidon2_t,
-                poseidon2_d,
-                rounds_f,
-                rounds_p,
-                &mat_internal_diag_m_1,
-                &mat_internal,
-                &round_constants,
+    fn matches_external_reference_implementation() {
+        let cases: [([&str; 4], [&str; 4]); 5] = [
+            // all zeroes
+            (
+                [
+                    "0000000000000000000000000000000000000000000000000000000000000000",
+                    "0000000000000000000000000000000000000000000000000000000000000000",
+                    "0000000000000000000000000000000000000000000000000000000000000000",
+                    "0000000000000000000000000000000000000000000000000000000000000000",
+                ],
+                [
+                    "18DFB8DC9B82229CFF974EFEFC8DF78B1CE96D9D844236B496785C698BC6732E",
+                    "095C230D1D37A246E8D2D5A63B165FE0FADE040D442F61E25F0590E5FB76F839",
+                    "0BB9545846E1AFA4FA3C97414A60A20FC4949F537A68CCECA34C5CE71E28AA59",
+                    "18A4F34C9C6F99335FF7638B82AEED9018026618358873C982BBDDE265B2ED6D",
+                ],
             ),
-        ));
+            // sequential small values
+            (
+                [
+                    "0000000000000000000000000000000000000000000000000000000000000000",
+                    "0000000000000000000000000000000000000000000000000000000000000001",
+                    "0000000000000000000000000000000000000000000000000000000000000002",
+                    "0000000000000000000000000000000000000000000000000000000000000003",
+                ],
+                [
+                    "01BD538C2EE014ED5141B29E9AE240BF8DB3FE5B9A38629A9647CF8D76C01737",
+                    "239B62E7DB98AA3A2A8F6A0D2FA1709E7A35959AA6C7034814D9DAA90CBAC662",
+                    "04CBB44C61D928ED06808456BF758CBF0C18D1E15A7B6DBC8245FA7515D5E3CB",
+                    "2E11C5CFF2A22C64D01304B778D78F6998EFF1AB73163A35603F54794C30847A",
+                ],
+            ),
+            // u128::MAX in every lane
+            (
+                [
+                    "00000000000000000000000000000000ffffffffffffffffffffffffffffffff",
+                    "00000000000000000000000000000000ffffffffffffffffffffffffffffffff",
+                    "00000000000000000000000000000000ffffffffffffffffffffffffffffffff",
+                    "00000000000000000000000000000000ffffffffffffffffffffffffffffffff",
+                ],
+                [
+                    "1452D1D69A606FB2F6AFF10FA4C73EA7486AC4BD59B3557B52311EFFB283A261",
+                    "2433004A0EDE6798EF76B637F9E2A0EAB454D70B7433A9AB18512D5A980890A9",
+                    "05A2ECD90756DD7DBD1840B0F252E490A73594CD103B56F6A3B1ADD8F38449BE",
+                    "1D5B91141464C8B36F830F33B7BA06BEA37D309A7A5E63A91100BB23C55168F1",
+                ],
+            ),
+            // p - 1 (largest field element) in every lane
+            (
+                [
+                    "30644E72E131A029B85045B68181585D2833E84879B9709143E1F593F0000000",
+                    "30644E72E131A029B85045B68181585D2833E84879B9709143E1F593F0000000",
+                    "30644E72E131A029B85045B68181585D2833E84879B9709143E1F593F0000000",
+                    "30644E72E131A029B85045B68181585D2833E84879B9709143E1F593F0000000",
+                ],
+                [
+                    "1B18E6CA21A1E9B15D65F0B5861EDE5FF20DB8FA3722531823D0C817D69D945D",
+                    "0AFB50EA6867B1CB2D9D1EAC935AF746BC7A780E181A1E6AE9B768C9CBA68878",
+                    "0A521A22CA614E65B877D0676652FB60E90A11B462F9846A08E811D95272A9D8",
+                    "2369F077784E0AEA99EE3DC6B7B01612AF7F80D7F08B755F9F116E2885EE367F",
+                ],
+            ),
+            // arbitrary full-width distinct values
+            (
+                [
+                    "123456789ABCDEF00FEDCBA987654321123456789ABCDEF00FEDCBA987654321",
+                    "2718281828459045235360287471352662497757247093699959574966967627",
+                    "1414213562373095048801688724209698078569671875376948073176679737",
+                    "0B172182839274F8E5D4C3B2A1908070605040302010FFEEDDCCBBAA99887766",
+                ],
+                [
+                    "1C68B20A2080BCC11A2B6F38A46F8270C3CE1DCD40CF8A16626E1CC936E90D56",
+                    "22FDAD6F2E2AED646BE444EFB2AE2EAACD49F0440C846F4882F8B013C01C792C",
+                    "1726C0B52C59E7008DBB710A8D3046214257D997A6E7870F46E7DFE5C6729378",
+                    "03B4A4B3B3694B4EFAF50186E75062F30D3FF4B73D95CAB554763B7E19DE8BA0",
+                ],
+            ),
+        ];
 
-        let result =
-            poseidon2_permutation(&inputs).unwrap().into_iter().map(|x| x.into_repr()).collect();
-
-        let expected_result = external_poseidon2.permutation(
-            &inputs.into_iter().map(into_old_ark_field).collect::<Vec<ark_bn254_v04::Fr>>(),
-        );
-        (result, expected_result.into_iter().map(into_new_ark_field).collect())
-    }
-
-    prop_compose! {
-        // Use both `u128` and hex proptest strategies
-        fn field_element()
-            (u128_or_hex in maybe_ok(any::<u128>(), "[0-9a-f]{64}"))
-            -> FieldElement
-        {
-            match u128_or_hex {
-                Ok(number) => FieldElement::from(number),
-                Err(hex) => FieldElement::from_hex(&hex).expect("should accept any 32 byte hex string"),
-            }
-        }
-    }
-
-    proptest! {
-        #[test]
-        fn poseidon2_permutation_matches_external_impl(inputs in proptest::collection::vec(field_element(), 4)) {
-            let (result, expected_result) = run_both_poseidon2_permutations(inputs);
-            prop_assert_eq!(result, expected_result);
+        for (inputs, expected) in cases {
+            let inputs = inputs.map(field_from_hex);
+            let expected = expected.map(field_from_hex);
+            let result = poseidon2_permutation(&inputs).expect("should successfully permute");
+            assert_eq!(result, expected, "mismatch for inputs {inputs:?}");
         }
     }
 }


### PR DESCRIPTION
## Description

## Problem

`bn254_blackbox_solver` cross-checks its Poseidon2 permutation against the `zkhash` reference implementation via a proptest. `zkhash` is pinned to arkworks 0.4 and has had no release since v0.2.0 (July 2024), which keeps a full duplicate set of ark 0.4 crates in `Cargo.lock` alongside the ark 0.6 set used by the workspace, with no upgrade path.

## Summary

- Replaces the proptest cross-check with a fixed-vector test. The expected outputs were generated with `zkhash` v0.2.0 (instantiated with `POSEIDON2_CONFIG` parameters) immediately before its removal, so the vectors carry the same independent-implementation provenance; this is recorded in the test's doc comment.
- Vectors cover: all zeros (folded in from the former `smoke_test`), sequential small values, `u128::MAX` lanes, `p - 1` lanes, and arbitrary full-width values.
- Drops the `zkhash`, `ark-bn254-v04`, `ark-ff-v04` and (now unused) `proptest` dev-dependencies, pruning ~420 lines from `Cargo.lock` including the entire duplicate ark 0.4 set.

## Additional Context

Trade-off: we lose the "live" property-based comparison against an independent implementation in exchange for frozen outputs from that same implementation. Both ends of the permutation parameter space plus random full-width values are pinned, and any regression in the permutation would show up as a vector mismatch.

## Documentation

Check one:
- [x] No documentation needed.
- [ ] Documentation included in this PR.
- [ ] **[For Experimental Features]** Documentation to be submitted in a separate PR.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.