### PR TITLE
chore(evaluator): rename misleading "scratch" identifiers in brillig gen

### DIFF
--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_instructions/brillig_binary.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_instructions/brillig_binary.rs
@@ -110,27 +110,22 @@ impl<Registers: RegisterAllocator> BrilligBlock<'_, Registers> {
         right: SingleAddrVariable,
         result: SingleAddrVariable,
     ) {
-        let scratch_var_i = self.brillig_context.allocate_single_addr(left.bit_size);
-        let scratch_var_j = self.brillig_context.allocate_single_addr(left.bit_size);
+        let quotient = self.brillig_context.allocate_single_addr(left.bit_size);
+        let product = self.brillig_context.allocate_single_addr(left.bit_size);
 
-        // i = left / right
+        // quotient = left / right
         self.brillig_context.convert_signed_division(
             left,
             right,
-            *scratch_var_i,
+            *quotient,
             SignedDivisionOperator::Mod,
         );
 
-        // j = i * right
-        self.brillig_context.binary_instruction(
-            *scratch_var_i,
-            right,
-            *scratch_var_j,
-            BrilligBinaryOp::Mul,
-        );
+        // product = quotient * right
+        self.brillig_context.binary_instruction(*quotient, right, *product, BrilligBinaryOp::Mul);
 
-        // result_register = left - j
-        self.brillig_context.binary_instruction(left, *scratch_var_j, result, BrilligBinaryOp::Sub);
+        // result_register = left - product
+        self.brillig_context.binary_instruction(left, *product, result, BrilligBinaryOp::Sub);
     }
 
     fn mod_by_zero_check(&mut self, right: SingleAddrVariable) {

--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/variable_liveness.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/variable_liveness.rs
@@ -381,8 +381,8 @@ impl VariableLiveness {
     /// and remove dead variables from `last_uses`. Record the highest count.
     ///
     /// On top of the live SSA values, allocated constants, and `MakeArray` elements, this
-    /// adds a per-instruction upper bound on the transient scratch registers the code
-    /// generator allocates (see [`instruction_scratch_demand`]).
+    /// adds a per-instruction upper bound on the transient registers the code
+    /// generator allocates (see [`instruction_transient_register_demand`]).
     ///
     /// # Safety
     /// This remains a lower bound, not an exact live count: some transients are not
@@ -424,12 +424,13 @@ impl VariableLiveness {
                 let results = func.dfg.instruction_results(*instruction_id);
                 live_set.extend(results.iter().copied());
 
-                // The code generator also allocates transient scratch registers while
+                // The code generator also allocates transient registers while
                 // lowering this instruction (overflow checks, address arithmetic, call
                 // setup). They are live simultaneously with the operands and results, so
                 // include them in the peak rather than relying solely on the spill margin.
-                let scratch = instruction_scratch_demand(instruction, &func.dfg);
-                max_count = max_count.max(live_set.len() + scratch);
+                let transient_registers =
+                    instruction_transient_register_demand(instruction, &func.dfg);
+                max_count = max_count.max(live_set.len() + transient_registers);
 
                 // Subtract variables that die after this instruction.
                 if let Some(dead) = last_uses.get(instruction_id) {
@@ -457,7 +458,7 @@ impl VariableLiveness {
     }
 }
 
-/// Upper bound on the temporary scratch registers the Brillig code generator allocates
+/// Upper bound on the transient registers the Brillig code generator allocates
 /// while lowering a single instruction (not counting the SSA values tracked by the live set).
 ///
 /// [`compute_max_live_count`] counts live SSA values, allocated constants, and `MakeArray`
@@ -471,9 +472,9 @@ impl VariableLiveness {
 ///
 /// [`compute_max_live_count`]: VariableLiveness::compute_max_live_count
 /// [`FunctionContext::SPILL_MARGIN`]: crate::brillig::brillig_gen::brillig_fn::FunctionContext::SPILL_MARGIN
-fn instruction_scratch_demand(instruction: &Instruction, dfg: &DataFlowGraph) -> usize {
+fn instruction_transient_register_demand(instruction: &Instruction, dfg: &DataFlowGraph) -> usize {
     match instruction {
-        Instruction::Binary(binary) => binary_op_scratch_demand(binary, dfg),
+        Instruction::Binary(binary) => binary_op_transient_register_demand(binary, dfg),
         // Call setup allocates a `stack_size_register` held across the call sequence.
         Instruction::Call { .. } => 1,
         // Memory accesses compute the target address into a temporary register before the
@@ -485,14 +486,14 @@ fn instruction_scratch_demand(instruction: &Instruction, dfg: &DataFlowGraph) ->
     }
 }
 
-/// Peak number of scratch registers held simultaneously while lowering a signed division,
+/// Peak number of transient registers held simultaneously while lowering a signed division,
 /// modulo, or arithmetic right shift.
-const SIGNED_DIVISION_SCRATCH: usize = 8;
+const SIGNED_DIVISION_TRANSIENT_REGISTERS: usize = 8;
 
-/// Peak number of scratch registers held simultaneously while lowering a [`Binary`]
+/// Peak number of transient registers held simultaneously while lowering a [`Binary`]
 /// instruction. The hard-coded values used here are validated in the test
-/// `binary_scratch_demand_matches_codegen`
-fn binary_op_scratch_demand(binary: &Binary, dfg: &DataFlowGraph) -> usize {
+/// `binary_transient_register_demand_matches_codegen`
+fn binary_op_transient_register_demand(binary: &Binary, dfg: &DataFlowGraph) -> usize {
     let (is_field, is_signed) = match dfg.type_of_value(binary.lhs).as_ref() {
         Type::Numeric(NumericType::Signed { .. }) => (false, true),
         Type::Numeric(NumericType::Unsigned { .. }) => (false, false),
@@ -502,16 +503,16 @@ fn binary_op_scratch_demand(binary: &Binary, dfg: &DataFlowGraph) -> usize {
 
     match binary.operator {
         // Signed division performs an unsigned division, compute absolute values and signs
-        BinaryOp::Div if is_signed => SIGNED_DIVISION_SCRATCH,
-        // Signed modulo wraps the signed division with two extra scratch registers.
-        BinaryOp::Mod if is_signed => SIGNED_DIVISION_SCRATCH + 2,
+        BinaryOp::Div if is_signed => SIGNED_DIVISION_TRANSIENT_REGISTERS,
+        // Signed modulo wraps the signed division with two extra transient registers.
+        BinaryOp::Mod if is_signed => SIGNED_DIVISION_TRANSIENT_REGISTERS + 2,
         // Unsigned (non-field) modulo emits a divisor-is-nonzero pre-check.
         BinaryOp::Mod if !is_field => 2,
         // Signed comparison biases both operands before an unsigned comparison.
         BinaryOp::Lt if is_signed => 3,
         // Arithmetic right shift on signed values reuses the signed-division expansion plus
         // the shift-overflow check and sign-handling temporaries.
-        BinaryOp::Shr if is_signed => SIGNED_DIVISION_SCRATCH + 4,
+        BinaryOp::Shr if is_signed => SIGNED_DIVISION_TRANSIENT_REGISTERS + 4,
         // Bit shifts emit an overflow check (a predicate plus the bit-width constant).
         BinaryOp::Shl | BinaryOp::Shr => 2,
         // Checked unsigned arithmetic emits an overflow check after the operation.
@@ -1149,10 +1150,10 @@ mod tests {
     }
 
     #[test]
-    fn max_live_count_accounts_for_signed_comparison_scratch() {
+    fn max_live_count_accounts_for_signed_comparison_transients() {
         // Ensure that `liveness.max_live_count` is properly computed for `lt` instruction.
         // We know that the expected value 6 is correct thanks
-        // to `binary_scratch_demand_matches_codegen()` test
+        // to `binary_transient_register_demand_matches_codegen()` test
 
         let src = "
         brillig(inline) fn main f0 {
@@ -1168,19 +1169,19 @@ mod tests {
 
         assert_eq!(
             liveness.max_live_count, 6,
-            "expected live set (v0,v1,v2 = 3) + signed-compare scratch (3) = 6, got {}",
+            "expected live set (v0,v1,v2 = 3) + signed-compare transients (3) = 6, got {}",
             liveness.max_live_count
         );
     }
 
     #[test]
-    fn max_live_count_accounts_for_call_setup_scratch() {
+    fn max_live_count_accounts_for_call_setup_transients() {
         // Lowering a call allocates a `stack_size_register` that is held across the call
         // setup/teardown (see `codegen_call` in `brillig_ir`). It is not an SSA value, so
         // the raw live-set count misses it.
         //
         // Live set at the call is {v0, v1} = 2 (the argument is still live, plus the
-        // result). The call scratch demand adds 1, for a peak of 3.
+        // result). The call transient demand adds 1, for a peak of 3.
         let src = "
         brillig(inline) fn main f0 {
           b0(v0: u32):
@@ -1199,13 +1200,13 @@ mod tests {
 
         assert_eq!(
             liveness.max_live_count, 3,
-            "expected live set (v0,v2 = 2) + call scratch (1) = 3, got {}",
+            "expected live set (v0,v2 = 2) + call transients (1) = 3, got {}",
             liveness.max_live_count
         );
     }
 
     #[test]
-    fn max_live_count_accounts_for_store_address_scratch() {
+    fn max_live_count_accounts_for_store_address_transients() {
         // Lowering a store computes the target address into a temporary register (see
         // `codegen_store_with_offset` in `brillig_ir`). That address temporary is not an
         // SSA value, so the raw live-set count misses it.
@@ -1227,7 +1228,7 @@ mod tests {
 
         assert_eq!(
             liveness.max_live_count, 3,
-            "expected live set (v0,v1 = 2) + store address scratch (1) = 3, got {}",
+            "expected live set (v0,v1 = 2) + store address transient (1) = 3, got {}",
             liveness.max_live_count
         );
     }
@@ -1239,24 +1240,24 @@ mod tests {
         crate::brillig::brillig_check::max_relative_register(&main.byte_code)
     }
 
-    /// The scratch `instruction_scratch_demand` predicts for the first instruction of `src`'s
-    /// entry block.
-    fn predicted_scratch(src: &str) -> usize {
+    /// The transient register count `instruction_transient_register_demand` predicts for the
+    /// first instruction of `src`'s entry block.
+    fn predicted_transient_registers(src: &str) -> usize {
         let ssa = Ssa::from_str(src).unwrap();
         let func = ssa.main();
         let entry = func.entry_block();
         let instruction_id = func.dfg[entry].instructions()[0];
-        super::instruction_scratch_demand(&func.dfg[instruction_id], &func.dfg)
+        super::instruction_transient_register_demand(&func.dfg[instruction_id], &func.dfg)
     }
 
     #[test]
-    fn binary_scratch_demand_matches_codegen() {
-        // Ensure that the hardcoded `instruction_scratch_demand` for binary operations
+    fn binary_transient_register_demand_matches_codegen() {
+        // Ensure that the hardcoded `instruction_transient_register_demand` for binary operations
         // correspond to real allocations made by the code-gen.
         // To compute the real allocations, we brillig-gen from a SSA function having
         // exactly one binary instruction, and get the highest written register.
         // We then compare it to an `unchecked_add` that does not need any additional register.
-        // This real allocation is then checked against the `instruction_scratch_demand` function.
+        // This real allocation is then checked against the `instruction_transient_register_demand` function.
         // So this test ensure the hardcoded function is correct against real binary operations.
         let baseline = measured_register_peak(
             "brillig(inline) fn main f0 {
@@ -1293,7 +1294,7 @@ mod tests {
             );
 
             let measured = measured_register_peak(&src) - baseline;
-            let predicted = predicted_scratch(&src);
+            let predicted = predicted_transient_registers(&src);
 
             if measured != predicted {
                 mismatches.push(format!(
@@ -1304,7 +1305,7 @@ mod tests {
 
         assert!(
             mismatches.is_empty(),
-            "binary scratch demand drifted from codegen:\n  {}",
+            "binary transient register demand drifted from codegen:\n  {}",
             mismatches.join("\n  "),
         );
     }

--- a/compiler/noirc_evaluator/src/brillig/brillig_ir/instructions.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_ir/instructions.rs
@@ -183,17 +183,17 @@ impl<F: AcirField + DebugToString, Registers: RegisterAllocator> BrilligContext<
         let bit_size = left.bit_size;
         assert!(bit_size != BitSize::Field.to_u32::<F>(), "Attempt to modulo fields");
 
-        let scratch_var_i = self.allocate_single_addr(bit_size);
-        let scratch_var_j = self.allocate_single_addr(bit_size);
+        let quotient = self.allocate_single_addr(bit_size);
+        let product = self.allocate_single_addr(bit_size);
 
-        // i = left / right
-        self.binary(left, right, *scratch_var_i, BrilligBinaryOp::UnsignedDiv);
+        // quotient = left / right
+        self.binary(left, right, *quotient, BrilligBinaryOp::UnsignedDiv);
 
-        // j = i * right
-        self.binary(*scratch_var_i, right, *scratch_var_j, BrilligBinaryOp::Mul);
+        // product = quotient * right
+        self.binary(*quotient, right, *product, BrilligBinaryOp::Mul);
 
-        // result_register = left - j
-        self.binary(left, *scratch_var_j, result, BrilligBinaryOp::Sub);
+        // result_register = left - product
+        self.binary(left, *product, result, BrilligBinaryOp::Sub);
     }
 
     fn binary_result_bit_size(operation: BrilligBinaryOp, arguments_bit_size: u32) -> u32 {


### PR DESCRIPTION
## Summary

"Scratch space" in Brillig codegen refers to a specific, fixed region of Brillig memory: the `ScratchSpace` register allocator (starting right after the reserved registers) used for **procedure argument/return passing** and **procedure-local temporaries**.

Several unrelated identifiers reused the word "scratch" for ordinary *transient registers* (short-lived stack/register allocations made while lowering an instruction). This collides with the `ScratchSpace` concept and makes the code harder to reason about and grep. This PR renames them; there is **no behavior change**.

## Changes

**`variable_liveness.rs`** — these compute an upper bound on the transient *allocated (stack) registers* held while lowering an instruction (feeding max-live-count / stack-frame sizing), which has nothing to do with the scratch memory region:
- `instruction_scratch_demand` → `instruction_transient_register_demand`
- `binary_op_scratch_demand` → `binary_op_transient_register_demand`
- `SIGNED_DIVISION_SCRATCH` → `SIGNED_DIVISION_TRANSIENT_REGISTERS`
- test/helper names (`binary_scratch_demand_matches_codegen`, `predicted_scratch`, `max_live_count_accounts_for_*_scratch`) and comments updated to match.

**Signed & unsigned modulo lowering** (`brillig_binary.rs`, `instructions.rs`):
- `scratch_var_i` / `scratch_var_j` → `quotient` / `product`, naming the temporaries after what they actually hold (`quotient = left / right`, `product = quotient * right`, `result = left - product`).

## Testing

- `cargo build -p noirc_evaluator` — clean.
- `cargo nextest run -p noirc_evaluator variable_liveness` — 24/24 pass, including the renamed `binary_transient_register_demand_matches_codegen` (which exercises `mod` on i32/u32, covering the renamed modulo temporaries).