### PR TITLE
feat: add pub helper to get scratch space range

### DIFF
--- a/compiler/noirc_evaluator/src/brillig/brillig_ir/registers.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_ir/registers.rs
@@ -30,7 +30,7 @@
 use std::{
     cell::{Ref, RefCell, RefMut},
     collections::BTreeSet,
-    ops::{Deref, DerefMut},
+    ops::{Deref, DerefMut, Range},
     rc::Rc,
 };
 
@@ -90,6 +90,15 @@ impl LayoutConfig {
 
     pub(crate) fn max_scratch_space(&self) -> usize {
         self.max_scratch_space
+    }
+
+    /// Memory region occupied by the scratch space:
+    /// `{reserved} [scratch space] {globals} {entry point} {stack} {heap}`.
+    ///
+    /// Returns the range of memory addresses reserved for scratch space.
+    /// Is public so external consumers can re-use the same scratch space layout.
+    pub fn scratch_space_range(&self) -> Range<usize> {
+        ScratchSpace::start()..ScratchSpace::end_with_layout(self)
     }
 
     /// Start of the entry point region:


### PR DESCRIPTION
It's helpful to enable external brillig consumers to query the bounds of the scratch space to allocate locals arising from custom procedures/routines.