### PR TITLE
fix(ci): pass a real ref when dispatching publish-es-packages

### DIFF
--- a/.github/workflows/publish-nightly.yml
+++ b/.github/workflows/publish-nightly.yml
@@ -27,4 +27,4 @@ jobs:
         with:
           workflow: publish-es-packages.yml
           token: ${{ secrets.NOIR_REPO_TOKEN }}
-          inputs: "{ \"noir-ref\": \"${{ env.GITHUB_REF }}\", \"npm-tag\": \"nightly\" }"
+          inputs: "{ \"noir-ref\": \"${{ github.ref }}\", \"npm-tag\": \"nightly\" }"


### PR DESCRIPTION
## Problem

`publish-nightly.yml` passes `${{ env.GITHUB_REF }}` as the `noir-ref` input when dispatching `publish-es-packages.yml`:

```yaml
inputs: "{ \"noir-ref\": \"${{ env.GITHUB_REF }}\", \"npm-tag\": \"nightly\" }"
```

The [`env` context](https://docs.github.com/en/actions/learn-github-actions/contexts#env-context) only contains variables declared via an `env:` key in the workflow, job, or step. It does **not** expose the runner's default environment variables such as `GITHUB_REF`. This workflow declares no `env:` block, so the expression evaluates to an empty string.

## Why it went unnoticed

`publish-es-packages.yml` declares `default: "master"` for `noir-ref`, so the empty value fell back to `master` — which is what the scheduled nightly wanted anyway.

The fallback is directly observable in the dispatched runs, since that workflow's `run-name` interpolates the input. Every nightly-dispatched run reads:

> Publish ES Packages from **master** under @nightly tag.

and never `from refs/heads/master`. For contrast, a manual dispatch with a genuine value reads `from v1.0.0-beta.22`.

## Fix

Use `github.ref`, so the dispatched run tracks the ref the nightly actually ran from instead of silently relying on the default.

## Note

This is not the cause of the current nightly failures. Those are `Bad credentials` (HTTP 401) from an expired `NOIR_REPO_TOKEN` — `publish-nightly` has failed every night since 2026-06-03, and `bump-aztec-packages-commit` (the other consumer of that secret) since 2026-06-08. That secret needs regenerating separately; it is not something this PR can address.
