### PR TITLE
fix: warn on never-mutated `mut` function parameters

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/function.rs
+++ b/compiler/noirc_frontend/src/elaborator/function.rs
@@ -744,7 +744,9 @@ impl Elaborator<'_> {
         for parameter in &func_meta.parameter_idents {
             let name = self.interner.definition_name(parameter.id).to_owned();
             let warn_if_unused = !(func_meta.trait_impl.is_some() && name == "self");
-            let warn_if_not_mutated = false;
+            // The unnecessary-mut check only considers definitions that are actually mutable,
+            // so this is a no-op for parameters without `mut`.
+            let warn_if_not_mutated = true;
             // We allow shadowing here because there's no outer scope to shadow
             // (duplicate parameter names were already checked in `resolve_function_parameters`)
             let allow_shadowing = true;

--- a/compiler/noirc_frontend/src/tests/arrays.rs
+++ b/compiler/noirc_frontend/src/tests/arrays.rs
@@ -152,7 +152,7 @@ fn array_length_overflow_during_monomorphization() {
 #[test]
 fn constant_index_out_of_bounds() {
     let src = r#"
-    fn main(a: u32, mut c: [u32; 2]) {
+    fn main(a: u32, c: [u32; 2]) {
         if (a == c[0]) {
             assert((c[0] == 12));
         } else if (a == c[1]) {

--- a/compiler/noirc_frontend/src/tests/functions.rs
+++ b/compiler/noirc_frontend/src/tests/functions.rs
@@ -515,6 +515,8 @@ fn rejects_mutable_tuple_pattern_in_main_param() {
     fn main(mut (a, b): pub (Field, Field)) -> pub Field {
             ^^^^^^^^^^ Entry point parameter must use a simple identifier pattern
             ~~~~~~~~~~ Destructuring patterns are not allowed here; bind to a name and destructure inside the body
+                 ^ variable does not need to be mutable
+                    ^ variable does not need to be mutable
         a + b
     }
     "#;
@@ -742,4 +744,91 @@ fn error_on_empty_composite_array_param_and_out_of_bounds_index() {
     }
     "#;
     check_errors(src);
+}
+
+#[test]
+fn warns_on_unnecessary_mut_function_parameter() {
+    let src = r#"
+    fn foo(mut x: Field) -> Field {
+               ^ variable does not need to be mutable
+        x
+    }
+
+    fn main() {
+        assert(foo(1) == 1);
+    }
+    "#;
+    check_errors(src);
+}
+
+#[test]
+fn warns_on_unnecessary_mut_self_parameter() {
+    let src = r#"
+    struct Counter {
+        count: Field,
+    }
+
+    impl Counter {
+        fn count(mut self) -> Field {
+                     ^^^^ variable does not need to be mutable
+            self.count
+        }
+    }
+
+    fn main() {
+        let counter = Counter { count: 1 };
+        assert(counter.count() == 1);
+    }
+    "#;
+    check_errors(src);
+}
+
+#[test]
+fn does_not_warn_on_mutated_mut_function_parameter() {
+    let src = r#"
+    fn foo(mut x: Field) -> Field {
+        x = x + 1;
+        x
+    }
+
+    fn main() {
+        assert(foo(1) == 2);
+    }
+    "#;
+    assert_no_errors(src);
+}
+
+#[test]
+fn does_not_warn_on_unnecessary_mut_parameter_with_underscore_name() {
+    let src = r#"
+    fn foo(mut _x: Field) -> Field {
+        1
+    }
+
+    fn main() {
+        assert(foo(1) == 1);
+    }
+    "#;
+    assert_no_errors(src);
+}
+
+#[test]
+fn does_not_warn_on_unmutated_mut_reference_self_parameter() {
+    let src = r#"
+    struct Counter {
+        count: Field,
+    }
+
+    impl Counter {
+        fn count(&mut self) -> Field {
+            self.count
+        }
+    }
+
+    fn main() {
+        let mut counter = Counter { count: 1 };
+        assert(counter.count() == 1);
+    }
+    "#;
+    assert_no_errors(src);
 }

--- a/noir_stdlib/src/collections/bounded_vec.nr
+++ b/noir_stdlib/src/collections/bounded_vec.nr
@@ -578,7 +578,7 @@ impl<T, let MaxLen: u32> BoundedVec<T, MaxLen> {
     /// let vec: BoundedVec<u32, 4> = BoundedVec::from_parts([1, 2, 3, 0], 3);
     /// assert_eq(vec.len(), 3);
     /// ```
-    pub fn from_parts(mut array: [T; MaxLen], len: u32) -> Self {
+    pub fn from_parts(array: [T; MaxLen], len: u32) -> Self {
         assert(len <= MaxLen);
         BoundedVec { storage: array, len }
     }

--- a/tooling/nargo_cli/tests/snapshots/execution_failure/brillig_mem_layout_regression/execute__tests__acir_stderr.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_failure/brillig_mem_layout_regression/execute__tests__acir_stderr.snap
@@ -2,6 +2,13 @@
 source: tooling/nargo_cli/tests/execute.rs
 expression: stderr
 ---
+warning: variable does not need to be mutable
+   ┌─ src/main.nr:39:9
+   │
+39 │     mut b: (Field, &mut u128, (bool, bool, u8), (Field, u8), [i64; 4]),
+   │         -
+   │
+
 error: Assertion failed: Stack too deep
    ┌─ src/main.nr:44:15
    │

--- a/tooling/nargo_cli/tests/snapshots/execution_failure/brillig_mem_layout_regression/execute__tests__brillig_stderr.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_failure/brillig_mem_layout_regression/execute__tests__brillig_stderr.snap
@@ -2,6 +2,13 @@
 source: tooling/nargo_cli/tests/execute.rs
 expression: stderr
 ---
+warning: variable does not need to be mutable
+   ┌─ src/main.nr:39:9
+   │
+39 │     mut b: (Field, &mut u128, (bool, bool, u8), (Field, u8), [i64; 4]),
+   │         -
+   │
+
 error: Assertion failed: Stack too deep
    ┌─ src/main.nr:44:15
    │

--- a/tooling/nargo_cli/tests/snapshots/execution_failure/brillig_mem_layout_regression/execute__tests__comptime_stderr.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_failure/brillig_mem_layout_regression/execute__tests__comptime_stderr.snap
@@ -2,6 +2,13 @@
 source: tooling/nargo_cli/tests/execute.rs
 expression: stderr
 ---
+warning: variable does not need to be mutable
+   ┌─ src/main.nr:39:9
+   │
+39 │     mut b: (Field, &mut u128, (bool, bool, u8), (Field, u8), [i64; 4]),
+   │         -
+   │
+
 error: Comptime Evaluation Depth Overflow
    ┌─ src/main.nr:42:5
    │  

--- a/tooling/nargo_cli/tests/snapshots/execution_failure/dyn_index_fail_nested_array/execute__tests__acir_stderr.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_failure/dyn_index_fail_nested_array/execute__tests__acir_stderr.snap
@@ -2,6 +2,13 @@
 source: tooling/nargo_cli/tests/execute.rs
 expression: stderr
 ---
+warning: variable does not need to be mutable
+  ┌─ src/main.nr:6:13
+  │
+6 │ fn main(mut x: [Foo; 3], y: pub u32) {
+  │             -
+  │
+
 error: Assertion failed: Index out of bounds, array has size 3, but index was 4
   ┌─ src/main.nr:7:12
   │

--- a/tooling/nargo_cli/tests/snapshots/execution_failure/dyn_index_fail_nested_array/execute__tests__brillig_stderr.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_failure/dyn_index_fail_nested_array/execute__tests__brillig_stderr.snap
@@ -2,6 +2,13 @@
 source: tooling/nargo_cli/tests/execute.rs
 expression: stderr
 ---
+warning: variable does not need to be mutable
+  ┌─ src/main.nr:6:13
+  │
+6 │ fn main(mut x: [Foo; 3], y: pub u32) {
+  │             -
+  │
+
 error: Assertion failed: Index out of bounds
   ┌─ src/main.nr:7:12
   │

--- a/tooling/nargo_cli/tests/snapshots/execution_failure/dyn_index_fail_nested_array/execute__tests__comptime_stderr.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_failure/dyn_index_fail_nested_array/execute__tests__comptime_stderr.snap
@@ -2,6 +2,13 @@
 source: tooling/nargo_cli/tests/execute.rs
 expression: stderr
 ---
+warning: variable does not need to be mutable
+  ┌─ src/main.nr:6:13
+  │
+6 │ fn main(mut x: [Foo; 3], y: pub u32) {
+  │             -
+  │
+
 error: Index out of bounds: 4 is out of bounds for the array of length 3
   ┌─ src/main.nr:7:12
   │

--- a/tooling/nargo_cli/tests/snapshots/execution_failure/regression_8231/execute__tests__acir_stderr.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_failure/regression_8231/execute__tests__acir_stderr.snap
@@ -2,6 +2,27 @@
 source: tooling/nargo_cli/tests/execute.rs
 expression: stderr
 ---
+warning: variable does not need to be mutable
+   ┌─ src/main.nr:20:15
+   │
+20 │ fn func_1(mut a: u64, mut b: [bool; 1], mut c: [bool; 1]) -> (i64, [bool; 1]) {
+   │               -
+   │
+
+warning: variable does not need to be mutable
+   ┌─ src/main.nr:20:27
+   │
+20 │ fn func_1(mut a: u64, mut b: [bool; 1], mut c: [bool; 1]) -> (i64, [bool; 1]) {
+   │                           -
+   │
+
+warning: variable does not need to be mutable
+   ┌─ src/main.nr:20:45
+   │
+20 │ fn func_1(mut a: u64, mut b: [bool; 1], mut c: [bool; 1]) -> (i64, [bool; 1]) {
+   │                                             -
+   │
+
 warning: Return variable contains a constant value
    ┌─ src/main.nr:14:5
    │  

--- a/tooling/nargo_cli/tests/snapshots/execution_failure/regression_8231/execute__tests__brillig_stderr.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_failure/regression_8231/execute__tests__brillig_stderr.snap
@@ -2,6 +2,27 @@
 source: tooling/nargo_cli/tests/execute.rs
 expression: stderr
 ---
+warning: variable does not need to be mutable
+   ┌─ src/main.nr:20:15
+   │
+20 │ fn func_1(mut a: u64, mut b: [bool; 1], mut c: [bool; 1]) -> (i64, [bool; 1]) {
+   │               -
+   │
+
+warning: variable does not need to be mutable
+   ┌─ src/main.nr:20:27
+   │
+20 │ fn func_1(mut a: u64, mut b: [bool; 1], mut c: [bool; 1]) -> (i64, [bool; 1]) {
+   │                           -
+   │
+
+warning: variable does not need to be mutable
+   ┌─ src/main.nr:20:45
+   │
+20 │ fn func_1(mut a: u64, mut b: [bool; 1], mut c: [bool; 1]) -> (i64, [bool; 1]) {
+   │                                             -
+   │
+
 error: Assertion failed: attempt to add with overflow
    ┌─ src/main.nr:29:21
    │

--- a/tooling/nargo_cli/tests/snapshots/execution_failure/regression_8231/execute__tests__comptime_stderr.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_failure/regression_8231/execute__tests__comptime_stderr.snap
@@ -2,6 +2,27 @@
 source: tooling/nargo_cli/tests/execute.rs
 expression: stderr
 ---
+warning: variable does not need to be mutable
+   ┌─ src/main.nr:20:15
+   │
+20 │ fn func_1(mut a: u64, mut b: [bool; 1], mut c: [bool; 1]) -> (i64, [bool; 1]) {
+   │               -
+   │
+
+warning: variable does not need to be mutable
+   ┌─ src/main.nr:20:27
+   │
+20 │ fn func_1(mut a: u64, mut b: [bool; 1], mut c: [bool; 1]) -> (i64, [bool; 1]) {
+   │                           -
+   │
+
+warning: variable does not need to be mutable
+   ┌─ src/main.nr:20:45
+   │
+20 │ fn func_1(mut a: u64, mut b: [bool; 1], mut c: [bool; 1]) -> (i64, [bool; 1]) {
+   │                                             -
+   │
+
 error: Attempt to add with overflow
    ┌─ src/main.nr:29:21
    │


### PR DESCRIPTION
## Description

### Problem

`VariableDoesNotNeedToBeMutable` never fired for function parameters: `fn foo(mut x: Field)` with `x` never mutated produced no warning, even though the same binding as a `let` or a lambda parameter would warn.

### Summary

The cause was a one-line inconsistency: `define_function_meta` elaborates parameter patterns with `warn_if_not_mutated: true`, but when `elaborate_function` reintroduces the stored parameter idents into the body's scope, the flag was hard-coded to `false` — so the body-scope check that produces the warning never considered parameters. This PR passes the flag through.

Safety of the change:
- The unnecessary-mut check only considers definitions that are actually mutable, so parameters without `mut` are unaffected.
- Method calls that auto-take `&mut self` mark the receiver as mutated (`check_can_mutate`), so `mut` parameters that exist to enable such calls do not warn — verified against `trait_method_mut_self` and the generic `impl SomeTrait` patterns.
- `_`-prefixed names are skipped, same as for `let` bindings.
- `mut self` warns (like Rust's `unused_mut`); `&mut self` does not (the binding itself is immutable).

### Fallout the new warning surfaced

- **A genuine stdlib leftover**: `BoundedVec::from_parts` kept `mut` on its array parameter from a since-removed zeroing loop (the deprecation note on `from_parts_unchecked` records that removal). The `mut` is now dropped.
- Two frontend test fixtures had incidental never-mutated `mut` params; one dropped the `mut`, the other (`rejects_mutable_tuple_pattern_in_main_param`) now annotates the two new warnings.
- Three fuzzer-derived `execution_failure` programs (`regression_8231`, `dyn_index_fail_nested_array`, `brillig_mem_layout_regression`) keep their unnecessary `mut`s — removing them would change SSA allocations, which is what those repros exercise — so their stderr snapshots now include the warnings.

### Interaction with #13390

`nargo check --fix` (#13390) removes unnecessary `mut`s and its pattern-visitor already handles parameters; that branch carries a characterization test asserting parameters produce no warning. Whichever PR lands second should flip that test to assert the `mut` is removed (the test's comment says exactly this).

### Test coverage

Five new frontend tests: warns for a never-mutated `mut` parameter and for `mut self`; no warning when the parameter is mutated, `_`-prefixed, or `&mut self`. Full suites pass: `noirc_frontend` (2218), `noir_lsp` (350), stdlib tests, and the entire `nargo_cli` execute suite (9114).