### PR TITLE
chore: remove old assignees from templates

### DIFF
--- a/.github/ACVM_NOT_PUBLISHABLE.md
+++ b/.github/ACVM_NOT_PUBLISHABLE.md
@@ -1,11 +1,11 @@
 ---
 title: "ACVM crates are not publishable"
-assignees: TomAFrench, Savio-Sou
+assignees: TomAFrench
 ---
 
 The ACVM crates are currently unpublishable, making a release will NOT push our crates to crates.io.
 
-This is likely due to a crate we depend on bumping its MSRV above our own. Our lockfile is not taken into account when publishing to crates.io (as people downloading our crate don't use it) so we need to be able to use the most up-to-date versions of our dependencies (including transient dependencies) specified. 
+This is likely due to a crate we depend on bumping its MSRV above our own. Our lockfile is not taken into account when publishing to crates.io (as people downloading our crate don't use it) so we need to be able to use the most up-to-date versions of our dependencies (including transient dependencies) specified.
 
 Check the [MSRV check]({{env.WORKFLOW_URL}}) workflow for details.
 

--- a/.github/ACVM_PUBLISH_FAILED.md
+++ b/.github/ACVM_PUBLISH_FAILED.md
@@ -1,6 +1,6 @@
 ---
 title: "ACVM crates failed to publish"
-assignees: TomAFrench, Savio-Sou
+assignees: TomAFrench
 ---
 
 The {{env.CRATE_VERSION}} release of the ACVM crates failed.

--- a/.github/CRATES_IO_PUBLISH_FAILED.md
+++ b/.github/CRATES_IO_PUBLISH_FAILED.md
@@ -1,6 +1,6 @@
 ---
 title: "ACVM crates failed to publish"
-assignees: TomAFrench, Savio-Sou
+assignees: TomAFrench
 ---
 
 The {{env.CRATE_VERSION}} release of the ACVM crates failed.

--- a/.github/DEAD_LINKS_IN_DOCS.md
+++ b/.github/DEAD_LINKS_IN_DOCS.md
@@ -1,6 +1,5 @@
 ---
 title: "Docs contains dead links"
-assignees: signorecello, catmcgee, critesjosh, jzaki, Savio-Sou
 labels: documentation
 ---
 

--- a/.github/JS_PUBLISH_FAILED.md
+++ b/.github/JS_PUBLISH_FAILED.md
@@ -1,6 +1,6 @@
 ---
 title: "JS packages failed to publish"
-assignees: TomAFrench, Savio-Sou
+assignees: TomAFrench
 labels: js
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -186,8 +186,6 @@ When we are ready to release the version, we approve and squash the release pull
 
 We aim to have every documentation version matching the versions of Noir. However, to avoid unnecessary build time and size to the existent documentation, they aren't currently released alongside the stable releases, and instead are released ad-hoc.
 
-Please contact any member of the DevRel[^1] team if you believe a new docs version should be cut.
-
 ### Documentation structure
 
 The Noir documentation is versioned according to the [Docusaurus documentation](https://docusaurus.io/docs/versioning). In the `versioned_docs` and `versioned_sidebars` folders you will find the docs and configs for the previous versions. If any change needs to be made to older versions, please do them in those folders.
@@ -230,5 +228,3 @@ Release Please would generate add the following to the Changelog:
 
 * **optimizer:** Compile Boolean to u1
 ```
-
-[^1]: Currently, @critesjosh, @catmcgee and @signorecello. For Noir documentation, it is recommended to tag @signorecello


### PR DESCRIPTION
## Problem Resolved

Resolves <!-- Link to GitHub Issue -->

## Summary of Changes



## User Documentation

Check one:
- [ ] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
