### PR TITLE
feat: carry `#[allow(constant_return)]` through SSA to its emission site

### DIFF
--- a/compiler/noirc_driver/src/lib.rs
+++ b/compiler/noirc_driver/src/lib.rs
@@ -17,7 +17,7 @@ use noirc_artifacts::contract::{CompiledContract, CompiledContractOutputs, Contr
 use noirc_artifacts::debug::{DebugFile, DebugInfo, FunctionLocation};
 use noirc_artifacts::program::CompiledProgram;
 use noirc_artifacts::ssa::{InternalBug, InternalWarning, SsaReport};
-use noirc_errors::{CustomDiagnostic, Location};
+use noirc_errors::CustomDiagnostic;
 use noirc_evaluator::brillig::brillig_ir::{
     LayoutConfig, MAX_SCRATCH_SPACE, MAX_STACK_FRAME_SIZE, MIN_SCRATCH_SPACE, MIN_STACK_FRAME_SIZE,
     NUM_STACK_FRAMES,
@@ -941,11 +941,6 @@ pub fn compile_no_check(
         )?
     };
 
-    // Drop backend warnings the user silenced with a scoped `#[allow(...)]`. This is baked into
-    // the artifact (rather than applied when reporting) so every consumer of `warnings` — nargo,
-    // the wasm bindings, tooling — observes the same silenced set.
-    let warnings = filter_allowed_ssa_warnings(context, warnings);
-
     let abi = gen_abi(context, &main_function, return_visibility, error_types);
     let file_map = filter_relevant_files(&debug, &context.file_manager, &context.parsed_files);
 
@@ -996,29 +991,6 @@ fn drop_silenced_warnings(
         .into_iter()
         .filter(|diagnostic| !options.silence_warnings || !diagnostic.is_warning())
         .collect()
-}
-
-/// Drops the SSA warnings the user opted out of with a scoped `#[allow(...)]`.
-///
-/// Backend warnings such as `constant_return` are raised during ACIR generation, after
-/// source attributes are gone, so an `#[allow]` can only be honored by matching the
-/// warning's call stack against the body spans of the functions that carry the attribute.
-fn filter_allowed_ssa_warnings(context: &Context, warnings: Vec<SsaReport>) -> Vec<SsaReport> {
-    let allow_constant_return = context.def_interner.function_bodies_allowing("constant_return");
-    warnings
-        .into_iter()
-        .filter(|warning| !ssa_warning_is_allowed(warning, &allow_constant_return))
-        .collect()
-}
-
-fn ssa_warning_is_allowed(warning: &SsaReport, allow_constant_return: &[Location]) -> bool {
-    match warning {
-        SsaReport::Warning(InternalWarning::ConstantReturn { call_stack }) => call_stack
-            .as_ref()
-            .iter()
-            .any(|location| allow_constant_return.iter().any(|body| body.contains(location))),
-        _ => false,
-    }
 }
 
 fn ssa_report_to_custom_diagnostic(error: SsaReport) -> CustomDiagnostic {

--- a/compiler/noirc_driver/tests/allow_warnings.rs
+++ b/compiler/noirc_driver/tests/allow_warnings.rs
@@ -1,9 +1,9 @@
 //! Integration tests for silencing backend/SSA warnings with a scoped `#[allow(...)]`.
 //!
 //! The `constant_return` warning is produced during ACIR generation, long after source
-//! attributes are available, so honoring an `#[allow(constant_return)]` requires matching
-//! the warning's call stack back to the annotated function. These tests exercise that path
-//! end-to-end.
+//! attributes are available, so honoring an `#[allow(constant_return)]` requires carrying
+//! the attribute through monomorphization and SSA generation down to the ACIR entry point
+//! that would emit the warning. These tests exercise that path end-to-end.
 
 use std::path::Path;
 
@@ -60,6 +60,68 @@ fn allow_of_a_different_lint_does_not_silence_constant_return() {
     assert!(
         warnings.iter().any(|warning| warning.message.contains("constant")),
         "expected the constant_return warning to survive an unrelated allow, got {warnings:?}"
+    );
+}
+
+#[test]
+fn allow_constant_return_on_main_silences_a_constant_from_an_inlined_helper() {
+    // The constant flows out of an inlined helper, but the return belongs to `main`,
+    // so annotating `main` is what silences the warning.
+    let source = r#"
+    fn helper() -> Field { 1 }
+
+    #[allow(constant_return)]
+    fn main() -> pub Field { helper() }
+    "#;
+    let warnings = compile_warnings(source);
+    assert!(warnings.is_empty(), "expected no warnings, got {warnings:?}");
+}
+
+#[test]
+fn fold_function_with_constant_return_warns() {
+    let source = r#"
+    #[fold]
+    fn folded() -> Field { 1 }
+
+    fn main(x: Field) -> pub Field { folded() + x }
+    "#;
+    let warnings = compile_warnings(source);
+    assert!(
+        warnings.iter().any(|warning| warning.message.contains("constant")),
+        "expected a constant_return warning from the fold function, got {warnings:?}"
+    );
+}
+
+#[test]
+fn allow_constant_return_on_fold_function_silences_its_warning() {
+    // `#[fold]` functions are separate ACIR entry points and warn independently of `main`,
+    // so the attribute must silence the warning when placed on the fold function itself.
+    let source = r#"
+    #[fold]
+    #[allow(constant_return)]
+    fn folded() -> Field { 1 }
+
+    fn main(x: Field) -> pub Field { folded() + x }
+    "#;
+    let warnings = compile_warnings(source);
+    assert!(warnings.is_empty(), "expected no warnings, got {warnings:?}");
+}
+
+#[test]
+fn allow_constant_return_on_main_does_not_silence_a_fold_function() {
+    // The attribute is scoped to the annotated function, so annotating `main` must not
+    // leak into the fold function's own entry point.
+    let source = r#"
+    #[fold]
+    fn folded() -> Field { 1 }
+
+    #[allow(constant_return)]
+    fn main(x: Field) -> pub Field { folded() + x }
+    "#;
+    let warnings = compile_warnings(source);
+    assert!(
+        warnings.iter().any(|warning| warning.message.contains("constant")),
+        "expected the fold function's constant_return warning to survive, got {warnings:?}"
     );
 }
 

--- a/compiler/noirc_evaluator/src/acir/mod.rs
+++ b/compiler/noirc_evaluator/src/acir/mod.rs
@@ -659,7 +659,7 @@ impl<'a> Context<'a> {
         }
 
         let call_stack = dfg.call_stack_data.get_call_stack(call_stack);
-        let warnings = if has_constant_return {
+        let warnings = if has_constant_return && !dfg.allow_constant_return {
             vec![SsaReport::Warning(InternalWarning::ConstantReturn { call_stack })]
         } else {
             Vec::new()

--- a/compiler/noirc_evaluator/src/ssa/function_builder/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/function_builder/mod.rs
@@ -98,6 +98,7 @@ impl FunctionBuilder {
         this.current_function.set_runtime(function.runtime());
         this.current_function.dfg.set_function_purities(this.purities.clone());
         this.set_allow_malformed_simplify(function.dfg.allow_malformed_simplify);
+        this.current_function.dfg.allow_constant_return = function.dfg.allow_constant_return;
         this
     }
 

--- a/compiler/noirc_evaluator/src/ssa/ir/dfg.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/dfg.rs
@@ -124,6 +124,11 @@ pub(crate) struct DataFlowGraph {
     /// Indicate whether the Brillig array index offset optimizations have been performed.
     pub(crate) brillig_arrays_offset: bool,
 
+    /// When `true`, the `constant_return` warning is not emitted if this function is an
+    /// ACIR entry point whose return value is constant. Set from a
+    /// `#[allow(constant_return)]` attribute on the source function.
+    pub(crate) allow_constant_return: bool,
+
     /// When `false` (the default), a `simplify_*` routine that detects malformed input — SSA that
     /// could not arise from well-formed compilation — panics via [`bail_malformed!`][crate::ssa::ir::dfg::simplify::bail_malformed].
     /// When `true`, those routines instead emit a trace and decline to simplify, leaving the

--- a/compiler/noirc_evaluator/src/ssa/ir/function.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/function.rs
@@ -134,6 +134,7 @@ impl Function {
         new_function.set_globals(another.dfg.globals.clone());
         new_function.dfg.set_function_purities(another.dfg.function_purities.clone());
         new_function.dfg.brillig_arrays_offset = another.dfg.brillig_arrays_offset;
+        new_function.dfg.allow_constant_return = another.dfg.allow_constant_return;
         new_function
     }
 

--- a/compiler/noirc_evaluator/src/ssa/ssa_gen/context.rs
+++ b/compiler/noirc_evaluator/src/ssa/ssa_gen/context.rs
@@ -186,6 +186,7 @@ impl<'a> FunctionContext<'a> {
         } else {
             self.builder.new_function(func.name.clone(), id, func.inline_type);
         }
+        self.builder.current_function.dfg.allow_constant_return = func.allow_constant_return;
 
         self.add_parameters_to_scope(&func.parameters);
     }

--- a/compiler/noirc_evaluator/src/ssa/ssa_gen/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/ssa_gen/mod.rs
@@ -74,6 +74,8 @@ pub fn generate_ssa(program: Program) -> Result<Ssa, RuntimeError> {
     };
     let mut function_context =
         FunctionContext::new(main.name.clone(), &main.parameters, main_runtime, &context, globals);
+    function_context.builder.current_function.dfg.allow_constant_return =
+        main.allow_constant_return;
 
     // Generate the call_data bus from the relevant parameters. We create it *before* processing the function body
     let call_data = function_context.builder.call_data_bus(is_databus);

--- a/compiler/noirc_frontend/src/monomorphization/ast.rs
+++ b/compiler/noirc_frontend/src/monomorphization/ast.rs
@@ -542,6 +542,11 @@ pub struct Function {
     pub unconstrained: bool,
     pub inline_type: InlineType,
     pub is_entry_point: bool,
+
+    /// True if the source function was annotated with `#[allow(constant_return)]`,
+    /// which silences the `constant_return` warning raised during ACIR generation
+    /// when this function is an ACIR entry point whose return value is constant.
+    pub allow_constant_return: bool,
 }
 
 /// Compared to `hir_def::types::Type`, this monomorphized Type has:

--- a/compiler/noirc_frontend/src/monomorphization/builtin.rs
+++ b/compiler/noirc_frontend/src/monomorphization/builtin.rs
@@ -107,6 +107,7 @@ impl Monomorphizer<'_> {
                 unconstrained: is_unconstrained,
                 inline_type: InlineType::InlineAlways,
                 is_entry_point: false,
+                allow_constant_return: false,
             },
         );
         let typ = Type::Function(parameter_types, return_type, env, unconstrained);
@@ -309,6 +310,7 @@ impl Monomorphizer<'_> {
             unconstrained,
             inline_type: InlineType::default(),
             is_entry_point: false,
+            allow_constant_return: false,
         };
         self.push_function(id, function);
 

--- a/compiler/noirc_frontend/src/monomorphization/mod.rs
+++ b/compiler/noirc_frontend/src/monomorphization/mod.rs
@@ -653,6 +653,7 @@ impl<'interner> Monomorphizer<'interner> {
         };
 
         let attributes = self.interner.function_attributes(&f);
+        let allow_constant_return = attributes.has_allow("constant_return");
         let mut inline_type = InlineType::from(attributes);
         let unconstrained = self.in_unconstrained_function;
         if unconstrained {
@@ -737,6 +738,7 @@ impl<'interner> Monomorphizer<'interner> {
             unconstrained,
             inline_type,
             is_entry_point: false,
+            allow_constant_return,
         };
 
         self.push_function(id, function);
@@ -2758,6 +2760,7 @@ impl<'interner> Monomorphizer<'interner> {
             unconstrained: self.in_unconstrained_function,
             inline_type: InlineType::default(),
             is_entry_point: false,
+            allow_constant_return: false,
         };
         self.push_function(id, function);
 
@@ -2883,6 +2886,7 @@ impl<'interner> Monomorphizer<'interner> {
             unconstrained: self.in_unconstrained_function,
             inline_type: InlineType::default(),
             is_entry_point: false,
+            allow_constant_return: false,
         };
         self.push_function(constrained_id, lambda_fn.clone());
 

--- a/compiler/noirc_frontend/src/monomorphization/proxies.rs
+++ b/compiler/noirc_frontend/src/monomorphization/proxies.rs
@@ -280,6 +280,7 @@ fn make_proxy(id: FuncId, ident: Ident, unconstrained: bool) -> Function {
         unconstrained,
         inline_type: InlineType::InlineAlways,
         is_entry_point: false, // This only matters for creating artifacts
+        allow_constant_return: false,
     }
 }
 

--- a/compiler/noirc_frontend/src/node_interner/function.rs
+++ b/compiler/noirc_frontend/src/node_interner/function.rs
@@ -209,20 +209,4 @@ impl NodeInterner {
     pub fn function_attributes(&self, func_id: &FuncId) -> &Attributes {
         &self.function_modifiers[func_id].attributes
     }
-
-    /// Returns the body [`Location`] of every function annotated with `#[allow(<name>)]`.
-    ///
-    /// Diagnostics produced after monomorphization (for example the `constant_return`
-    /// warning raised during ACIR generation) cannot inspect source attributes at the
-    /// point they are emitted. Matching such a diagnostic's call stack against these
-    /// spans recovers the `#[allow]` that should silence it.
-    pub fn function_bodies_allowing(&self, name: &'static str) -> Vec<Location> {
-        self.function_modifiers
-            .iter()
-            .filter(|(_, modifiers)| modifiers.attributes.has_allow(name))
-            .filter_map(|(func_id, _)| {
-                self.function(func_id).try_as_expr().map(|body| self.expr_location(&body))
-            })
-            .collect()
-    }
 }

--- a/design/lints.md
+++ b/design/lints.md
@@ -1,0 +1,46 @@
+# Lints and warning control
+
+## Silencing backend warnings with `#[allow(...)]`
+
+Most warnings are emitted by the frontend, where the attributes of the item being
+checked are directly available, so `#[allow(...)]` can be honored at the emission
+site. Some warnings, however, are only discovered by the backend — for example
+`constant_return` ("Return variable contains a constant value"), which is detected
+during ACIR generation when an entry point's return value turns out to be constant.
+By that point source attributes are long gone.
+
+For these warnings, the attribute is resolved in the frontend and carried through
+the pipeline as a flag on the function:
+
+- monomorphization reads the attribute from the interner and stores it on the
+  monomorphized `ast::Function` (e.g. `allow_constant_return`);
+- SSA generation copies it onto the SSA function's `DataFlowGraph`, next to other
+  per-function metadata such as the runtime;
+- the emission site (ACIR generation for `constant_return`) checks the flag on the
+  function it is converting and simply never constructs the warning.
+
+The alternative — emitting the warning unconditionally and filtering it out in
+`noirc_driver` by matching the warning's call stack against the body spans of
+annotated functions — was rejected (see PR #13399 review). Filtering after the fact
+spreads lint policy across the pipeline, and matching by source location is fragile
+under inlining: a call stack can point into a different function than the one whose
+return is being reported.
+
+Consequences of the flag-based design:
+
+- The warning never exists in any artifact, so every consumer (`nargo`, the wasm
+  bindings, anything reading `CompiledProgram.warnings`) observes the same silenced
+  set, and `--deny-warnings` has nothing to deny. Item-level `#[allow]` therefore
+  wins over the global flag by construction.
+- The attribute is scoped to the annotated function's identity, not its source
+  span. Each ACIR entry point (`main` and every `#[fold]` function) warns and is
+  silenced independently.
+- The flag is deliberately **not** part of the SSA text syntax: hand-written SSA in
+  tests always has it unset. It must, however, be preserved wherever a pass rebuilds
+  a function from an existing one (`Function::clone_signature`,
+  `FunctionBuilder::from_existing`).
+
+The general lint framework — a lint registry, `#[warn]`/`#[deny]`/`#[expect]`
+levels, validation of unknown lint names — is tracked in issue #7460 and is expected
+to build on the same principle: resolve lint levels in the frontend, honor them at
+the emission site.

--- a/tooling/ast_fuzzer/src/program/mod.rs
+++ b/tooling/ast_fuzzer/src/program/mod.rs
@@ -390,6 +390,7 @@ impl Context {
             unconstrained: decl.unconstrained,
             inline_type: decl.inline_type,
             is_entry_point: id == FuncId(0), // we only need main as an entry point
+            allow_constant_return: false,
         };
         self.functions.insert(id, func);
         Ok(())

--- a/tooling/ast_fuzzer/src/program/rewrite/mod.rs
+++ b/tooling/ast_fuzzer/src/program/rewrite/mod.rs
@@ -231,5 +231,6 @@ fn make_print_wrapper(
         unconstrained: true,
         inline_type: InlineType::default(),
         is_entry_point: false,
+        allow_constant_return: false,
     }
 }

--- a/tooling/ast_fuzzer/src/program/tests.rs
+++ b/tooling/ast_fuzzer/src/program/tests.rs
@@ -39,6 +39,7 @@ fn generate_ssa_from_body(body: Expression) -> ssa_gen::Ssa {
         unconstrained: false,
         inline_type: InlineType::Inline,
         is_entry_point: false,
+        allow_constant_return: false,
     };
 
     let program = Program {
@@ -149,6 +150,7 @@ fn test_recursion_limit_rewrite() {
             unconstrained,
             inline_type: InlineType::InlineAlways,
             is_entry_point: false,
+            allow_constant_return: false,
         };
 
         ctx.function_declarations.insert(
@@ -354,6 +356,7 @@ fn test_wrap_oracle_prints_in_functions() {
         unconstrained: false,
         inline_type: InlineType::default(),
         is_entry_point: true,
+        allow_constant_return: false,
     };
 
     ctx.functions.insert(FuncId(0), main_func);


### PR DESCRIPTION
## Description

## Problem

Resolves the review concern on #13399 ([comment](https://github.com/noir-lang/noir/pull/13399#issuecomment-5070017064)): filtering the `constant_return` warning in `noirc_driver` after the fact spreads lint policy across the pipeline, and matching by call-stack location is fragile under inlining.

## Summary

Replaces the driver-level filtering with a boolean carried on the function all the way to the warning's emission site:

- **Monomorphization** reads `#[allow(constant_return)]` from the interner (right where `InlineType` is already derived from attributes) and stores `allow_constant_return` on the monomorphized `ast::Function`.
- **SSA generation** copies it onto the function's `DataFlowGraph`, next to `runtime`. It is preserved by `Function::clone_signature` and `FunctionBuilder::from_existing`, the two paths that rebuild a function from an existing one (`normalize_value_ids`, inlining).
- **ACIR generation** checks the flag in `convert_ssa_return` and never constructs the warning for an annotated entry point.

The `filter_allowed_ssa_warnings` / `ssa_warning_is_allowed` machinery in `noirc_driver` and `NodeInterner::function_bodies_allowing` are removed.

A note on the "we'd end up with potentially 4 filtering methods" concern: `ConstantReturn` is the only `InternalWarning`, and it has exactly one emission site — `convert_ssa_return`, reached only from `convert_acir_main`. Brillig generation never emits it (the `InternalBug` reports come from the SSA-level underconstrained checks, not from codegen). With the flag checked at that single site, no filtering method exists anywhere.

## Semantics

The attribute is scoped to the annotated function's **identity**, not its source span:

- Each ACIR entry point (`main` and every `#[fold]` function) warns and is silenced independently; an `#[allow]` on `main` cannot leak into a fold function even if post-inlining call stacks point across function bodies.
- Because the warning is never constructed, every consumer of `CompiledProgram.warnings` (nargo, wasm bindings, tooling) observes the same silenced set, and item-level `#[allow]` wins over `--deny-warnings` by construction — same behavior as the base PR, without the post-hoc filter.
- The flag is deliberately **not** part of the SSA text syntax; hand-written SSA always has it unset.

The decision is recorded in `design/lints.md`.

## Tests

The base PR's four end-to-end tests pass unchanged (they test behavior, not mechanism). Added four more in `compiler/noirc_driver/tests/allow_warnings.rs`:

- a constant flowing out of an *inlined helper* is silenced by annotating `main` (the return belongs to `main`);
- a `#[fold]` function with a constant return warns;
- `#[allow(constant_return)]` on the fold function silences its warning;
- `#[allow(constant_return)]` on `main` does **not** silence the fold function's warning.

`noirc_frontend` + `noirc_evaluator` + `noirc_driver` test suites pass (4117 tests), `noir_ast_fuzzer` smoke test passes, workspace `cargo check --all-targets` and `clippy` clean.

Part of #13396. Part of epic #7460. Refs #12323.

🤖 Generated with [Claude Code](https://claude.com/claude-code)