### PR TITLE
fix: don't warn that a struct is never constructed if it's a field of…

### DIFF
--- a/compiler/noirc_frontend/src/elaborator/enums.rs
+++ b/compiler/noirc_frontend/src/elaborator/enums.rs
@@ -223,7 +223,9 @@ impl Elaborator<'_> {
         for (i, variant) in enum_def.variants.iter().enumerate() {
             let parameters = variant.item.parameters.as_ref();
             let types = parameters.map(|params| {
-                vecmap(params, |typ| self.resolve_type(typ.clone(), wildcard_allowed))
+                // `use_type` so a struct mentioned in a variant payload counts as constructed,
+                // for the same reason as struct fields (see `resolve_struct_fields`).
+                vecmap(params, |typ| self.use_type(typ.clone(), wildcard_allowed))
             });
             let name = variant.item.name.clone();
 

--- a/compiler/noirc_frontend/src/elaborator/structs.rs
+++ b/compiler/noirc_frontend/src/elaborator/structs.rs
@@ -169,7 +169,11 @@ impl Elaborator<'_> {
             let fields = vecmap(&unresolved.fields, |field| {
                 let visibility = field.item.visibility;
                 let name = field.item.name.clone();
-                let typ = this.resolve_type(field.item.typ.clone(), wildcard_allowed);
+                // `use_type` (not `resolve_type`) so that a struct mentioned as a field type
+                // counts as constructed: a value of this struct can't exist without a value of
+                // the field's type, so warning that the field's type is never constructed would
+                // be misleading (and Rust doesn't warn in this situation either).
+                let typ = this.use_type(field.item.typ.clone(), wildcard_allowed);
                 StructField { visibility, name, typ }
             });
             this.impl_trait_is_disallowed = previous_impl_trait_context;

--- a/compiler/noirc_frontend/src/tests/unused_items.rs
+++ b/compiler/noirc_frontend/src/tests/unused_items.rs
@@ -687,6 +687,39 @@ fn does_not_consider_struct_as_constructed_if_mentioned_in_function_argument() {
 }
 
 #[test]
+fn does_not_warn_on_struct_used_as_field_type_of_another_struct() {
+    // Mentioning a struct in a field of another type definition counts as using it, matching
+    // Rust, where a type reachable from a live struct's fields is not reported as dead code.
+    // (Rust goes further and propagates liveness, so a field type of a *dead* struct still
+    // warns; the tracker here is flat, so mention in any field silences the warning.)
+    let src = r#"
+    struct Foo {}
+
+    pub struct Gen<T> {
+        inner: Foo,
+        x: T,
+    }
+
+    fn main() {}
+    "#;
+    assert_no_errors(src);
+}
+
+#[test]
+fn does_not_warn_on_struct_used_in_enum_variant_payload() {
+    let src = r#"
+    struct Foo {}
+
+    pub enum Gen {
+        A(Foo),
+    }
+
+    fn main() {}
+    "#;
+    assert_no_errors(src);
+}
+
+#[test]
 fn allow_dead_code_on_unused_function() {
     let src = "
     #[allow(dead_code)]


### PR DESCRIPTION


## Problem Resolved

No issue.

## Summary of Changes

While working on the sparse array library I got a warning on an unused struct but it was actually used inside another struct. It seems our code didn't treat this case as used so I told Claude to fix it if that was indeed a bug (and it was).

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
