### PR TITLE
feat(ssa): validate u1 unchecked add/sub canonicality in ACIR

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/ir/dfg/simplify.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/dfg/simplify.rs
@@ -639,7 +639,10 @@ mod tests {
     use crate::{
         assert_ssa_snapshot,
         ssa::{
-            opt::{assert_normalized_ssa_equals, assert_ssa_does_not_change_after_simplifying},
+            opt::{
+                assert_normalized_ssa_equals, assert_ssa_does_not_change_after_simplifying,
+                assert_ssa_does_not_change_after_simplifying_no_validation,
+            },
             ssa_gen::Ssa,
         },
     };
@@ -1158,6 +1161,9 @@ mod tests {
 
     /// `u1` is not exempt: in ACIR `unchecked_add u1 1, 1` is the field value 2, so a
     /// `range_check ... to 1 bits` on its result is load-bearing and must survive.
+    ///
+    /// The validator rejects this `unchecked_add` of unrelated `u1` values outright, so the
+    /// parse skips validation: the simplifier must stay conservative even for such SSA.
     #[test]
     fn range_check_after_unchecked_add_u1_is_preserved_in_acir() {
         let src = "
@@ -1168,11 +1174,14 @@ mod tests {
             return v2
         }
         ";
-        assert_ssa_does_not_change_after_simplifying(src);
+        assert_ssa_does_not_change_after_simplifying_no_validation(src);
     }
 
     /// `unchecked_sub u1 0, 1` underflows to a field-negative (near-modulus) value in ACIR, so a
     /// `range_check ... to 1 bits` on its result must not be removed.
+    ///
+    /// The validator rejects this possibly-underflowing `u1` `unchecked_sub` outright, so the
+    /// parse skips validation: the simplifier must stay conservative even for such SSA.
     #[test]
     fn range_check_after_unchecked_sub_u1_is_preserved_in_acir() {
         let src = "
@@ -1183,7 +1192,7 @@ mod tests {
             return v2
         }
         ";
-        assert_ssa_does_not_change_after_simplifying(src);
+        assert_ssa_does_not_change_after_simplifying_no_validation(src);
     }
 
     /// `unchecked_mul u1` genuinely stays a single bit (0*0, 0*1, 1*1), so a
@@ -1211,6 +1220,9 @@ mod tests {
     /// A `u1`-typed `unchecked_mul` stays a single bit only when its operands do: here the lhs is
     /// an `unchecked_add u1` that can hold the field value 2 in ACIR (1 + 1), and multiplying by
     /// `v1 = 1` preserves it, so the `range_check ... to 1 bits` is load-bearing and must survive.
+    ///
+    /// The validator rejects this `unchecked_add` of unrelated `u1` values outright, so the
+    /// parse skips validation: the simplifier must stay conservative even for such SSA.
     #[test]
     fn range_check_after_unchecked_mul_of_wide_u1_operand_is_preserved_in_acir() {
         let src = "
@@ -1222,7 +1234,7 @@ mod tests {
             return v3
         }
         ";
-        assert_ssa_does_not_change_after_simplifying(src);
+        assert_ssa_does_not_change_after_simplifying_no_validation(src);
     }
 
     /// Same as the previous test but with the wide value laundered through one more `u1` Mul
@@ -1240,6 +1252,6 @@ mod tests {
             return v5
         }
         ";
-        assert_ssa_does_not_change_after_simplifying(src);
+        assert_ssa_does_not_change_after_simplifying_no_validation(src);
     }
 }

--- a/compiler/noirc_evaluator/src/ssa/opt/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/mod.rs
@@ -72,7 +72,12 @@ use crate::ssa::{
 /// is equal to the expected string. Normalization is done so the IDs don't
 /// shift depending on whether temporary intermediate values were created.
 #[cfg(test)]
-pub(crate) fn assert_normalized_ssa_equals(mut ssa: Ssa, expected: &str) {
+pub(crate) fn assert_normalized_ssa_equals(ssa: Ssa, expected: &str) {
+    assert_normalized_ssa_equals_impl(ssa, expected, true);
+}
+
+#[cfg(test)]
+fn assert_normalized_ssa_equals_impl(mut ssa: Ssa, expected: &str, validate: bool) {
     use crate::{ssa::Ssa, trim_comments_from_lines, trim_leading_whitespace_from_lines};
 
     // Clean up the expected SSA a bit
@@ -82,7 +87,9 @@ pub(crate) fn assert_normalized_ssa_equals(mut ssa: Ssa, expected: &str) {
     // First check if `expected` is valid SSA by parsing it, otherwise
     // the comparison will always fail but it won't be clear that it's because
     // expected is not valid.
-    let mut expected_ssa = match Ssa::from_str(&expected) {
+    let expected_parse_result =
+        if validate { Ssa::from_str(&expected) } else { Ssa::from_str_no_validation(&expected) };
+    let mut expected_ssa = match expected_parse_result {
         Ok(ssa) => ssa,
         Err(err) => {
             panic!("`expected` argument of `assert_ssa_equals` is not valid SSA:\n{err:?}")
@@ -163,6 +170,15 @@ pub(crate) fn assert_ssa_does_not_change(src: &str, pass: impl FnOnce(Ssa) -> Ss
 pub(crate) fn assert_ssa_does_not_change_after_simplifying(src: &str) {
     let ssa = Ssa::from_str_simplifying(src).unwrap();
     assert_normalized_ssa_equals(ssa, src);
+}
+
+/// Same as [assert_ssa_does_not_change_after_simplifying] but skips SSA validation: for
+/// deliberately non-canonical SSA that the validator rejects, to check that the simplifier
+/// stays conservative for it as defense in depth.
+#[cfg(test)]
+pub(crate) fn assert_ssa_does_not_change_after_simplifying_no_validation(src: &str) {
+    let ssa = Ssa::from_str_impl(src, true, false, false).unwrap();
+    assert_normalized_ssa_equals_impl(ssa, src, false);
 }
 
 /// Assert that running a certain pass on the SSA does not change the execution result.

--- a/compiler/noirc_evaluator/src/ssa/validation/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/validation/mod.rs
@@ -295,6 +295,56 @@ impl<'f> Validator<'f> {
                          produce a forbidden Truncate of the unchecked Sub."
                     );
                 }
+
+                // In ACIR, unchecked arithmetic is field arithmetic, so an `unchecked_add` of two
+                // `u1` values can produce the non-canonical value 2, breaking the invariant that a
+                // `u1` holds 0 or 1 (which other rewrites, e.g. `b*b = b`, rely on). The only `u1`
+                // `unchecked_add` the compiler emits is the value merger's `c*x + !c*y` (possibly
+                // simplified), whose opposing guards make the operands disjoint and the sum
+                // canonical. Require that provable disjointness.
+                //
+                // Full mode only: passes can legitimately erode the structural witness while
+                // preserving canonicality — e.g. "Constant Folding using constraints" can learn
+                // `c == 0` from a constrain and fold the `!c*y` product to a bare `y`, leaving
+                // `unchecked_add (c*x), y` whose disjointness is constraint-based and invisible
+                // to a local syntactic check.
+                if self.full
+                    && matches!(operator, BinaryOp::Add { unchecked: true })
+                    && self.function.runtime().is_acir()
+                    && *lhs_type == Type::bool()
+                    && !u1_unchecked_add_operands_are_disjoint(dfg, *lhs, *rhs)
+                {
+                    panic!(
+                        "ACIR `unchecked_add` on `u1` values may produce the non-canonical value 2; \
+                         it is only valid when its operands are guarded by opposing boolean conditions \
+                         (`c*x + !c*y`, as emitted by the value merger) or one operand is zero"
+                    );
+                }
+
+                // Similarly, an ACIR `unchecked_sub` of `u1` values can underflow to a
+                // field-negative (near-modulus) value. The only `u1` `unchecked_sub` the compiler
+                // emits comes from `checked_to_unchecked`, which requires the lhs to be a constant
+                // at least as large as the rhs's maximum value. Full mode only, like the
+                // `unchecked_add` rule above: a pass can replace one operand with a
+                // constraint-derived equivalent value, erasing a structural no-underflow witness
+                // (e.g. `lhs == rhs`) without breaking canonicality.
+                if self.full
+                    && matches!(operator, BinaryOp::Sub { unchecked: true })
+                    && self.function.runtime().is_acir()
+                    && *lhs_type == Type::bool()
+                {
+                    let lhs_is_max =
+                        dfg.get_numeric_constant(*lhs).is_some_and(|constant| constant.is_one());
+                    let rhs_is_zero =
+                        dfg.get_numeric_constant(*rhs).is_some_and(|constant| constant.is_zero());
+                    if !(lhs_is_max || rhs_is_zero || lhs == rhs) {
+                        panic!(
+                            "ACIR `unchecked_sub` on `u1` values may underflow to a field-negative \
+                             value; it is only valid when it provably cannot underflow (the lhs is \
+                             the constant 1, the rhs is zero, or both operands are the same value)"
+                        );
+                    }
+                }
             }
             Instruction::ArrayGet { array, index, .. }
             | Instruction::ArraySet { array, index, .. } => {
@@ -1232,6 +1282,60 @@ fn defined_by_unchecked_signed_sub(dfg: &DataFlowGraph, value: ValueId) -> bool 
     } else {
         false
     }
+}
+
+/// Whether the operands of an ACIR `u1` `unchecked_add` are provably disjoint — at most one can be
+/// nonzero — which keeps the sum canonical (0 or 1).
+///
+/// This recognizes the shape the value merger emits: each operand is a tree of `u1`
+/// multiplications (or a bare value), and some factor of one operand is the boolean negation of a
+/// factor of the other. When the negated factor is 1 the other operand contains a 0 factor and
+/// vanishes; when it is 0 its own operand vanishes. A constant 0 operand is also accepted.
+fn u1_unchecked_add_operands_are_disjoint(dfg: &DataFlowGraph, lhs: ValueId, rhs: ValueId) -> bool {
+    let is_zero = |value| dfg.get_numeric_constant(value).is_some_and(|c| c.is_zero());
+    if is_zero(lhs) || is_zero(rhs) {
+        return true;
+    }
+
+    let lhs_factors = collect_u1_mul_factors(dfg, lhs);
+    let rhs_factors = collect_u1_mul_factors(dfg, rhs);
+
+    let has_factor_negated_in = |factors: &HashSet<ValueId>, other: &HashSet<ValueId>| {
+        factors.iter().any(|factor| {
+            if let Value::Instruction { instruction, .. } = dfg[*factor]
+                && let Instruction::Not(inner) = dfg[instruction]
+            {
+                other.contains(&inner)
+            } else {
+                false
+            }
+        })
+    };
+
+    has_factor_negated_in(&lhs_factors, &rhs_factors)
+        || has_factor_negated_in(&rhs_factors, &lhs_factors)
+}
+
+/// Multiplicative factors of `value`: the values in its `Mul` tree, recursing through `u1`
+/// multiplication results. Intermediate products count as factors too — if any value in the tree
+/// is zero the whole product is zero — so an opposing condition can be matched at any level (e.g.
+/// `remove_if_else` negates a whole condition product, not its leaves).
+fn collect_u1_mul_factors(dfg: &DataFlowGraph, value: ValueId) -> HashSet<ValueId> {
+    let mut factors = HashSet::default();
+    let mut worklist = vec![value];
+    while let Some(value) = worklist.pop() {
+        if !factors.insert(value) {
+            continue;
+        }
+        if let Value::Instruction { instruction, .. } = dfg[value]
+            && let Instruction::Binary(Binary { lhs, rhs, operator: BinaryOp::Mul { .. } }) =
+                dfg[instruction]
+        {
+            worklist.push(lhs);
+            worklist.push(rhs);
+        }
+    }
+    factors
 }
 
 /// Validates that the [Function] is well formed.
@@ -3272,5 +3376,173 @@ mod tests {
         ";
         let ssa = Ssa::from_str_no_validation(src).unwrap();
         super::validate_terminators(ssa.main());
+    }
+
+    #[test]
+    #[should_panic(expected = "guarded by opposing boolean conditions")]
+    fn disallows_acir_u1_unchecked_add_of_unrelated_values() {
+        // In ACIR, `unchecked_add` is field arithmetic: adding two unrelated `u1` values can
+        // produce the non-canonical value 2, breaking the invariant that `u1` holds 0 or 1.
+        let src = "
+        acir(inline) fn main f0 {
+          b0(v0: u1, v1: u1):
+            v2 = unchecked_add v0, v1
+            return v2
+        }
+        ";
+        let _ = Ssa::from_str(src).unwrap();
+    }
+
+    #[test]
+    fn allows_acir_u1_unchecked_add_of_value_merger_shape() {
+        // The flattening value merger emits `c*a + !c*b`: the products are guarded by opposing
+        // conditions, so at most one is nonzero and the sum stays 0 or 1.
+        let src = "
+        acir(inline) fn main f0 {
+          b0(v0: u1, v1: u1, v2: u1):
+            v3 = not v0
+            v4 = unchecked_mul v0, v1
+            v5 = unchecked_mul v3, v2
+            v6 = unchecked_add v4, v5
+            return v6
+        }
+        ";
+        let _ = Ssa::from_str(src).unwrap();
+    }
+
+    #[test]
+    fn allows_acir_u1_unchecked_add_with_bare_condition_operand() {
+        // `if c { true } else { b }`: the `c*1` product simplifies to the bare condition `c`,
+        // which is its own guard opposing the `!c` factor on the other side.
+        let src = "
+        acir(inline) fn main f0 {
+          b0(v0: u1, v1: u1):
+            v2 = not v0
+            v3 = unchecked_mul v2, v1
+            v4 = unchecked_add v0, v3
+            return v4
+        }
+        ";
+        let _ = Ssa::from_str(src).unwrap();
+    }
+
+    #[test]
+    fn allows_acir_u1_unchecked_add_with_nested_condition_products() {
+        // Nested ifs guard each side with a *product* of conditions: `(c1*c2)*a + (c1*!c2)*b`.
+        // The opposing pair (`c2` vs `!c2`) is found among the operands' multiplicative factors.
+        let src = "
+        acir(inline) fn main f0 {
+          b0(v0: u1, v1: u1, v2: u1, v3: u1):
+            v4 = unchecked_mul v0, v1
+            v5 = not v1
+            v6 = unchecked_mul v0, v5
+            v7 = unchecked_mul v4, v2
+            v8 = unchecked_mul v6, v3
+            v9 = unchecked_add v7, v8
+            return v9
+        }
+        ";
+        let _ = Ssa::from_str(src).unwrap();
+    }
+
+    #[test]
+    #[should_panic(expected = "only valid when it provably cannot underflow")]
+    fn disallows_acir_u1_unchecked_sub_that_may_underflow() {
+        // In ACIR, `unchecked_sub u1 0, 1` underflows to a field-negative (near-modulus) value,
+        // breaking the invariant that a `u1` holds 0 or 1.
+        let src = "
+        acir(inline) fn main f0 {
+          b0(v0: u1, v1: u1):
+            v2 = unchecked_sub v0, v1
+            return v2
+        }
+        ";
+        let _ = Ssa::from_str(src).unwrap();
+    }
+
+    #[test]
+    fn allows_acir_u1_unchecked_sub_from_one() {
+        // `checked_to_unchecked` converts `sub u1 1, x` to unchecked: 1 is the maximum value of
+        // the rhs's type, so the subtraction cannot underflow.
+        let src = "
+        acir(inline) fn main f0 {
+          b0(v0: u1):
+            v1 = unchecked_sub u1 1, v0
+            return v1
+        }
+        ";
+        let _ = Ssa::from_str(src).unwrap();
+    }
+
+    #[test]
+    fn allows_acir_u1_unchecked_sub_of_zero() {
+        let src = "
+        acir(inline) fn main f0 {
+          b0(v0: u1):
+            v1 = unchecked_sub v0, u1 0
+            return v1
+        }
+        ";
+        let _ = Ssa::from_str(src).unwrap();
+    }
+
+    #[test]
+    fn allows_brillig_u1_unchecked_sub() {
+        // In Brillig, unchecked arithmetic wraps to the type width, so the result stays canonical.
+        let src = "
+        brillig(inline) fn main f0 {
+          b0(v0: u1, v1: u1):
+            v2 = unchecked_sub v0, v1
+            return v2
+        }
+        ";
+        let _ = Ssa::from_str(src).unwrap();
+    }
+
+    #[test]
+    fn allows_brillig_u1_unchecked_add() {
+        // In Brillig, unchecked arithmetic wraps to the type width, so the result stays canonical.
+        let src = "
+        brillig(inline) fn main f0 {
+          b0(v0: u1, v1: u1):
+            v2 = unchecked_add v0, v1
+            return v2
+        }
+        ";
+        let _ = Ssa::from_str(src).unwrap();
+    }
+
+    #[test]
+    fn allows_acir_u1_unchecked_add_with_constant_zero_operand() {
+        let src = "
+        acir(inline) fn main f0 {
+          b0(v0: u1):
+            v1 = unchecked_add v0, u1 0
+            return v1
+        }
+        ";
+        let _ = Ssa::from_str(src).unwrap();
+    }
+
+    #[test]
+    fn allows_eroded_u1_unchecked_add_between_passes() {
+        // Found by the `valid_after_pass` fuzzer: "Constant Folding using constraints" learns
+        // `v0 == 0` from the constrain and folds the merger's `!v0 * y` product to a bare `y`,
+        // leaving an `unchecked_add` whose disjointness witness is constraint-based rather than
+        // structural. Between passes (`full = false`) the canonicality rules are skipped, so this
+        // must validate.
+        let src = "
+        acir(inline) fn main f0 {
+          b0(v0: u1, v1: u1, v2: u1):
+            enable_side_effects v0
+            constrain u1 0 == v0
+            enable_side_effects u1 1
+            v3 = unchecked_mul v0, v1
+            v4 = unchecked_add v3, v2
+            return v4
+        }
+        ";
+        let ssa = Ssa::from_str_no_validation(src).unwrap();
+        crate::ssa::ssa_gen::validate_ssa(&ssa, false);
     }
 }


### PR DESCRIPTION
## Description

In ACIR, unchecked arithmetic is field arithmetic, so a `u1` unchecked add/sub can produce a non-canonical value (`unchecked_add u1 1, 1` is the field value 2; `unchecked_sub u1 0, 1` is field-negative). A non-canonical `u1` breaks the 0/1 invariant that algebraic rewrites rely on — e.g. `b*b = b` via `DataFlowGraph::is_boolean_value` — which is the miscompile surface reported in noir-lang/noir-claude#1509 (only reachable from hand-written/tool-generated SSA; no Noir source route exists).

The compiler only ever emits these instructions in shapes that are canonical by construction:

- the value merger's `c*x + !c*y`, where the opposing guards make the operands disjoint, and
- `checked_to_unchecked`'s subs, converted only with a proof they cannot underflow.

The SSA validator now enforces exactly those shapes, so validator-accepted SSA cannot mint a non-canonical `u1`:

- **`unchecked_add` on `u1`** requires a constant-0 operand or *opposing multiplicative factors*: some factor of one operand must be the `Not` of a factor of the other, matched anywhere in each operand's `Mul` tree. Intermediate products count as factors too, since `remove_if_else` negates a whole condition product rather than its leaves.
- **`unchecked_sub` on `u1`** requires a lhs of constant 1, a rhs of constant 0, or equal operands.

Brillig is exempt (unchecked arithmetic wraps to the type width there). Both rules run in **full validation mode only** — freshly parsed SSA, the surface where non-compiler SSA enters. Between passes the structural witness can be legitimately eroded while canonicality is preserved: the `valid_after_pass` fuzzer (seed `0x994fb39600100000`) found "Constant Folding using constraints" learning `c == 0` from a constrain and folding the `!c*y` product to a bare `y`. That shape is pinned by the `allows_eroded_u1_unchecked_add_between_passes` regression test.

The pre-existing `range_check_after_unchecked_*` regression tests keep guarding the simplifier's conservatism for these shapes as defense in depth (the validator does not run between passes in release compiles); they now parse with validation disabled via the new `assert_ssa_does_not_change_after_simplifying_no_validation` helper.

## Test coverage

11 new validator tests: rejected shapes (unrelated-operand add, possibly-underflowing sub) plus the accepted family (merger shape, bare-condition operand, nested condition products, constant operands, `1 - x` sub, Brillig add/sub, eroded between-passes shape).

🤖 Generated with [Claude Code](https://claude.com/claude-code)