### PR TITLE
fix: disallow `&mut (*x)` when x is not a mutable reference

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/ssa_gen/tests.rs
+++ b/compiler/noirc_evaluator/src/ssa/ssa_gen/tests.rs
@@ -1136,16 +1136,12 @@ fn can_reborrow_through_immutable_ref() {
     ");
 }
 
-/// `&mut *p` where `p` is an immutable `&u64` bound to a variable must still reborrow
-/// as a writable reference aliasing the original location, just like the parenthesized
-/// `&mut (*p)` form. The re-borrow simplification must not collapse to `p` and inherit
-/// its immutable type, which previously rejected `*p1 = 15`.
 #[test]
-fn mut_reborrow_through_immutable_ref_variable() {
+fn mut_reborrow_through_mutable_ref_variable() {
     let src = "
     fn main() {
         let mut f: u64 = 10;
-        let p = &f;
+        let p = &mut f;
         let p1 = &mut *p;
         *p1 = 15;
         assert(f == 15);

--- a/compiler/noirc_frontend/src/elaborator/expressions.rs
+++ b/compiler/noirc_frontend/src/elaborator/expressions.rs
@@ -673,6 +673,17 @@ impl Elaborator<'_> {
             HirExpression::MemberAccess(member_access) => {
                 self.check_can_mutate(member_access.lhs, location);
             }
+            HirExpression::Prefix(prefix)
+                if matches!(prefix.operator, UnaryOp::Dereference { .. }) =>
+            {
+                // &ref cannot be mutated
+                let typ = self.interner.id_type(prefix.rhs).follow_bindings();
+                if matches!(typ, Type::Reference(_, false)) {
+                    self.push_err(TypeCheckError::MutableReferenceBehindImmutableReference {
+                        location,
+                    });
+                }
+            }
             _ => (),
         }
     }

--- a/compiler/noirc_frontend/src/hir/type_check/errors.rs
+++ b/compiler/noirc_frontend/src/hir/type_check/errors.rs
@@ -127,6 +127,8 @@ pub enum TypeCheckError {
     MutableCaptureWithoutRef { name: String, location: Location },
     #[error("Mutable references to array indices are unsupported")]
     MutableReferenceToArrayElement { location: Location },
+    #[error("Cannot take a mutable reference to a value behind a `&` reference")]
+    MutableReferenceBehindImmutableReference { location: Location },
     #[error("No method named '{method_name}' found for type '{object_type}'")]
     UnresolvedMethodCall { method_name: String, object_type: Type, location: Location },
     #[error("Cannot invoke function field '{method_name}' on type '{object_type}' as a method")]
@@ -359,6 +361,7 @@ impl TypeCheckError {
             | TypeCheckError::CannotMutateImmutableVariable { location, .. }
             | TypeCheckError::MutableCaptureWithoutRef { location, .. }
             | TypeCheckError::MutableReferenceToArrayElement { location }
+            | TypeCheckError::MutableReferenceBehindImmutableReference { location }
             | TypeCheckError::UnresolvedMethodCall { location, .. }
             | TypeCheckError::CannotInvokeStructFieldFunctionType { location, .. }
             | TypeCheckError::IntegerSignedness { location, .. }
@@ -654,6 +657,9 @@ impl<'a> From<&'a TypeCheckError> for Diagnostic {
             ),
             TypeCheckError::MutableReferenceToArrayElement { location } => {
                 Diagnostic::simple_error("Mutable references to array elements are currently unsupported".into(), "Try storing the element in a fresh variable first".into(), *location)
+            },
+            TypeCheckError::MutableReferenceBehindImmutableReference { location } => {
+                Diagnostic::simple_error(error.to_string(), "A `&` reference grants read-only access to the value behind it".into(), *location)
             },
             TypeCheckError::TypeAnnotationsNeededForMethodCall { location } => {
                 let mut error = Diagnostic::simple_error(

--- a/compiler/noirc_frontend/src/tests/references.rs
+++ b/compiler/noirc_frontend/src/tests/references.rs
@@ -374,6 +374,57 @@ fn disallows_mutating_non_mutable_reference_inside_mutable_reference() {
 }
 
 #[test]
+fn disallows_mutable_reference_to_value_behind_immutable_reference() {
+    let src = r#"
+    fn main() {
+        let x: [Field; 2] = [1, 2];
+        let r = &x;
+        let m = &mut *r;
+                     ^^ Cannot take a mutable reference to a value behind a `&` reference
+                     ~~ A `&` reference grants read-only access to the value behind it
+        let _ = m;
+    }
+    "#;
+    check_errors(src);
+}
+
+#[test]
+fn disallows_mutable_reference_to_member_behind_immutable_reference() {
+    // Companion of `disallows_mutable_reference_to_value_behind_immutable_reference`:
+    // reaching through a field of the dereferenced value must not launder the upgrade.
+    let src = r#"
+    struct Foo {
+        x: Field,
+    }
+    fn main() {
+        let foo = Foo { x: 1 };
+        let r = &foo;
+        let m = &mut (*r).x;
+                     ^^^^^^ Cannot take a mutable reference to a value behind a `&` reference
+                     ~~~~~~ A `&` reference grants read-only access to the value behind it
+        let _ = m;
+    }
+    "#;
+    check_errors(src);
+}
+
+#[test]
+fn allows_reborrows_that_do_not_upgrade_mutability() {
+    // The two legal reborrow directions: `&mut *m` on a `&mut T` preserves mutability and
+    // `&*m` downgrades it. Only the upgrade (`&mut *r` on a `&T`) is banned.
+    let src = r#"
+    fn main() {
+        let mut x: [Field; 2] = [1, 2];
+        let m = &mut x;
+        let m2 = &mut *m;
+        let r: &[Field; 2] = &*m2;
+        assert((*r)[0] == 1);
+    }
+    "#;
+    assert_no_errors(src);
+}
+
+#[test]
 fn cannot_take_mut_ref_of_immutable_variable_in_deref() {
     let src = r#"
     fn main() {


### PR DESCRIPTION
## Problem Resolved

Resolves https://github.com/noir-lang/noir-claude/issues/1562

## Summary of Changes

The bug happened because we previously allowed `&mut (*x)` to be done even if `x` was not a mutable reference. This now behaves the same way as in Rust.

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
