### PR TITLE
fix(brillig): emit a trap for unreachable terminators

### DIFF
--- a/compiler/noirc_evaluator/src/brillig/brillig_gen.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen.rs
@@ -110,6 +110,8 @@ pub(crate) fn gen_brillig_for(
 
 #[cfg(test)]
 mod entry_point {
+    use acvm::acir::brillig::Opcode as BrilligOpcode;
+
     use crate::{
         assert_artifact_snapshot,
         brillig::{
@@ -286,5 +288,37 @@ mod entry_point {
         59: sp[2] = u32 add sp[3], sp[5]
         60: return
         ");
+    }
+
+    #[test]
+    fn unreachable_terminator_keeps_jump_targets_in_range() {
+        let src = "
+        brillig(inline) fn main f0 {
+          b0(v0: u32):
+            constrain v0 == u32 7
+            unreachable
+        }
+        ";
+        let ssa = Ssa::from_str(src).unwrap();
+        let options = BrilligOptions::default();
+        let brillig = ssa.to_brillig(&options);
+
+        let args = vec![BrilligParameter::SingleAddr(32)];
+        let entry = gen_brillig_for(ssa.main(), &args, &brillig, &options).unwrap();
+
+        let len = entry.byte_code.len();
+        for (index, opcode) in entry.byte_code.iter().enumerate() {
+            let target = match opcode {
+                BrilligOpcode::Jump { location }
+                | BrilligOpcode::JumpIf { location, .. }
+                | BrilligOpcode::Call { location } => *location,
+                _ => continue,
+            };
+            assert!(
+                target < len,
+                "opcode {index} ({opcode:?}) targets {target}, \
+                 which is out of range for a program of {len} opcodes"
+            );
+        }
     }
 }

--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_block.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/brillig_block.rs
@@ -605,7 +605,7 @@ impl<'block, Registers: RegisterAllocator> BrilligBlock<'block, Registers> {
                 self.brillig_context.codegen_return(&return_registers);
             }
             TerminatorInstruction::Unreachable { .. } => {
-                // If we assume this is unreachable code then there's nothing to do here
+                self.brillig_context.codegen_trap();
             }
         }
     }

--- a/compiler/noirc_evaluator/src/brillig/brillig_gen/tests/memory.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_gen/tests/memory.rs
@@ -186,8 +186,8 @@ fn brillig_global_array_not_coalesced_with_block_param() {
     let brillig = ssa_to_brillig_artifacts(src);
     let main = &brillig.ssa_function_to_brillig[&Id::test_new(0)];
     // Key opcodes:
-    //   13: sp[2] = @68  — global g0 lives in global register @68, copied into sp[2] (param v3's slot)
-    //   15: return        — returns sp[1]; global and param use separate allocations (not coalesced)
+    //   19: sp[2] = @68  — global g0 lives in global register @68, copied into sp[2] (param v3's slot)
+    //   21: return        — returns sp[1]; global and param use separate allocations (not coalesced)
     assert_artifact_snapshot!(main, @r"
     fn main
      0: sp[3] = @1
@@ -201,14 +201,16 @@ fn brillig_global_array_not_coalesced_with_block_param() {
      8: @0 = sp[0]
      9: sp[4] = sp[8]
     10: jump if sp[4] to 0 // -> 12: f0/b1
-    11: jump to 0 // -> 17: f0/b2
+    11: jump to 0 // -> 19: f0/b2
     12: sp[2] = const bool 1 // f0/b1
     13: sp[3] = bool eq @69, sp[2]
     14: jump if sp[3] to 0 // -> 17: f0/b1/1
     15: sp[4] = const u32 0
     16: trap @[@1; sp[4]]
-    17: sp[2] = @68 // f0/b1/1, f0/b2
-    18: jump to 0 // -> 19: f0/b3
-    19: return // f0/b3
+    17: sp[2] = const u32 0 // f0/b1/1
+    18: trap @[@1; sp[2]]
+    19: sp[2] = @68 // f0/b2
+    20: jump to 0 // -> 21: f0/b3
+    21: return // f0/b3
     ");
 }

--- a/compiler/noirc_evaluator/src/brillig/brillig_ir/codegen_control_flow.rs
+++ b/compiler/noirc_evaluator/src/brillig/brillig_ir/codegen_control_flow.rs
@@ -186,6 +186,14 @@ impl<F: AcirField + DebugToString, Registers: RegisterAllocator> BrilligContext<
         self.enter_section(end_section);
     }
 
+    /// Emits an unconditional trap with empty error data (no error information).
+    pub(crate) fn codegen_trap(&mut self) {
+        let error_data = self.make_usize_constant_instruction(0_usize.into()).map(|size| {
+            HeapVector { pointer: ReservedRegisters::free_memory_pointer(), size: size.address }
+        });
+        self.trap_instruction(*error_data);
+    }
+
     /// Jump to a trap condition if `condition` is false.
     /// The trap will include the given message as error data.
     ///
@@ -204,12 +212,7 @@ impl<F: AcirField + DebugToString, Registers: RegisterAllocator> BrilligContext<
 
             // Special case: No error selector means completely empty error data
             let Some(error_selector) = error_selector else {
-                let error_data =
-                    ctx.make_usize_constant_instruction(0_usize.into()).map(|size| HeapVector {
-                        pointer: ReservedRegisters::free_memory_pointer(),
-                        size: size.address,
-                    });
-                ctx.trap_instruction(*error_data);
+                ctx.codegen_trap();
                 return;
             };
 


### PR DESCRIPTION
In reality the unreachable SSA instruction can never be triggered. That's why we didn't produce any brillig opcode in this case. However, it's probably safer to do a trap in this case. It slightly increases the number of opcodes in a program in this case, but it's always a small constant factor, and not for every program.

## Description

## Problem

Resolves https://github.com/noir-lang/noir-claude/issues/1541

Brillig codegen emitted no opcode for an `unreachable` terminator. When the block's last instruction is a `constrain`, its "assertion passed" section label is registered at the position of the next opcode to be emitted — which, with no terminator opcode following, is one past the end of the function's own code. The linker resolves that dangling label like any other, so the shipped `JumpIf` targets whatever bytecode happened to be linked next: another function's body, a shared procedure such as `RevertWithString`, or an index past the end of the whole program. Five programs in `test_programs` ship such a jump today; `execution_success/regression_5435` ships a jump target equal to its opcode count.

The edge is currently provably dead (every source-reachable `unreachable` sits behind a constrain over unequal constants), so no execution behavior changes — but the malformed address ships in real artifacts, and correctness rests on an unenforced upstream invariant.

## Summary

Emit a message-less trap for the `unreachable` terminator instead of nothing:

- Every section label stays in range by construction, so linked jump targets always point into the code they belong to.
- If an unreachability proof is ever wrong, execution now aborts loudly at the trap instead of silently transferring control into unrelated code.

The trap emission is extracted into a `codegen_trap` helper, reused by the existing empty-error-data constrain path (identical bytecode as before).

Cost: two opcodes (`const` + `trap`) per `unreachable` terminator, which by construction only appears on paths believed unreachable.

## Additional Context

Regression test: `unreachable_terminator_keeps_jump_targets_in_range` compiles the minimal reproduction (`constrain v0 == u32 7` followed by `unreachable`) and asserts every `Jump`/`JumpIf`/`Call` target in the linked program is in range. It fails on master with `JumpIf` targeting 17 in a 17-opcode program.

The updated `brillig_global_array_not_coalesced_with_block_param` snapshot shows the fix directly: the constrain's passed-edge label `f0/b1/1` previously resolved to the first opcode of the *next block* (`f0/b2`); it now lands on the trap inside its own block.

Verified locally: full `noirc_evaluator` suite (1921 tests) and the `nargo_cli` execution integration suite (9130 tests) pass; `regression_5435` now compiles with all jump targets in range and still executes successfully.

## PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)