### PR TITLE
fix: derive force_unconstrained per position instead of pass-wide

### DIFF
--- a/compiler/noirc_frontend/src/monomorphization/mod.rs
+++ b/compiler/noirc_frontend/src/monomorphization/mod.rs
@@ -180,10 +180,10 @@ pub struct Monomorphizer<'interner> {
     /// from a pair of `(constrained, unconstrained)` to `(unconstrained, unconstrained)`, so that
     /// a constrained caller dispatching through slot `.0` still runs the unconstrained version.
     ///
-    /// This is a property of the *position* being monomorphized, not of the pass, so it must be
-    /// re-derived at every position with a known target type rather than only ever set. A nested
-    /// binding carrying its own constrained `fn` type does not flow into the enclosing
-    /// `unconstrained fn` slot and must not inherit the forcing.
+    /// This is a property of the position being monomorphized, not of the pass: it holds for the
+    /// value stored into that slot and for nothing else. A binding nested inside that value's
+    /// expression carries its own type and its own slot, so it is monomorphized under its own
+    /// value of this field.
     force_unconstrained: bool,
 }
 
@@ -837,17 +837,19 @@ impl<'interner> Monomorphizer<'interner> {
     }
 
     /// Monomorphize an expression.
-    /// Monomorphize an expression in a position that does not produce the enclosing position's
-    /// value. Any function value built here occupies no `unconstrained fn(..)` slot of its own,
-    /// so it keeps the runtime its own type declares.
     pub(crate) fn expr(&mut self, expr: ExprId) -> Result<ast::Expression, MonomorphizationError> {
         self.expr_with_force_unconstrained(expr, false)
     }
 
-    /// Monomorphize an expression that produces the enclosing position's value -- a block's
-    /// trailing expression, or an `if`/`match` branch. An `unconstrained fn(..)` target on that
-    /// enclosing position applies here too, because this is the value that lands in the slot.
-    fn expr_forwarding(&mut self, expr: ExprId) -> Result<ast::Expression, MonomorphizationError> {
+    /// Monomorphize an expression in tail position, meaning its value becomes the value of the
+    /// expression containing it: a block's trailing expression, or an `if` or `match` branch.
+    ///
+    /// Only such an expression inherits the containing position's `force_unconstrained`, because
+    /// it is the one that produces the value stored into that position's slot.
+    fn expr_in_tail_position(
+        &mut self,
+        expr: ExprId,
+    ) -> Result<ast::Expression, MonomorphizationError> {
         use ast::Expression::Literal;
         use ast::Literal::*;
 
@@ -1015,10 +1017,10 @@ impl<'interner> Monomorphizer<'interner> {
 
             HirExpression::If(if_expr) => {
                 let condition = Box::new(self.expr(if_expr.condition)?);
-                let consequence = Box::new(self.expr_forwarding(if_expr.consequence)?);
+                let consequence = Box::new(self.expr_in_tail_position(if_expr.consequence)?);
                 let else_ = if_expr
                     .alternative
-                    .map(|alt| self.expr_forwarding(alt))
+                    .map(|alt| self.expr_in_tail_position(alt))
                     .transpose()?
                     .map(Box::new);
 
@@ -1214,23 +1216,22 @@ impl<'interner> Monomorphizer<'interner> {
         self.expr_with_force_unconstrained(expr, forced)
     }
 
-    /// Monomorphize `expr` with `force_unconstrained` set to `forced`, restoring the previous
-    /// value afterwards.
+    /// Monomorphize `expr` as the value of a position that is forced unconstrained when `forced`,
+    /// then restore the caller's own forcing.
     ///
-    /// `forced` is assigned rather than or-ed into the current value: a position whose target type
-    /// is not `unconstrained fn(..)` clears the forcing inherited from an enclosing position, since
-    /// the value it produces does not flow into that enclosing `unconstrained fn` slot. Restoring
-    /// afterwards keeps the enclosing position forced, so a `let` earlier in a forced block does
-    /// not unforce the block's terminal expression.
+    /// `forced` describes this position alone, so it replaces the caller's value for the duration
+    /// rather than adding to it. Restoring on the way out is what lets a block hold a mix: a `let`
+    /// with a constrained type is monomorphized unforced, while the block's trailing expression
+    /// still sees the target that applies to the block as a whole.
     ///
-    /// `--force-brillig` is a program-wide property and always wins.
+    /// `--force-brillig` applies to every function in the program, so it always forces.
     fn expr_with_force_unconstrained(
         &mut self,
         expr: ExprId,
         forced: bool,
     ) -> Result<ast::Expression, MonomorphizationError> {
         let old = std::mem::replace(&mut self.force_unconstrained, self.force_brillig || forced);
-        let result = self.expr_forwarding(expr);
+        let result = self.expr_in_tail_position(expr);
         self.force_unconstrained = old;
         result
     }
@@ -1346,15 +1347,13 @@ impl<'interner> Monomorphizer<'interner> {
         &mut self,
         statement_ids: Vec<StmtId>,
     ) -> Result<ast::Expression, MonomorphizationError> {
-        // A block's value comes from a trailing expression statement, so that statement is the
-        // only one that inherits an enclosing `unconstrained fn(..)` target. Every other statement
-        // goes through `expr`, which clears it.
+        // Only a trailing expression statement produces the block's value.
         let last_index = statement_ids.len().wrapping_sub(1);
         let stmts = try_vecmap(statement_ids.into_iter().enumerate(), |(index, id)| {
             if index == last_index
                 && let HirStatement::Expression(expr) = self.interner.statement(&id)
             {
-                return self.expr_forwarding(expr);
+                return self.expr_in_tail_position(expr);
             }
             self.statement(id)
         });
@@ -3050,7 +3049,7 @@ impl<'interner> Monomorphizer<'interner> {
         }
 
         match match_expr {
-            HirMatch::Success(id) => self.expr_forwarding(id),
+            HirMatch::Success(id) => self.expr_in_tail_position(id),
             HirMatch::Failure { .. } => {
                 let false_ = Box::new(ast::Expression::Literal(ast::Literal::Bool(false)));
                 let msg = "match failure";
@@ -3066,7 +3065,7 @@ impl<'interner> Monomorphizer<'interner> {
             }
             HirMatch::Guard { cond, body, otherwise } => {
                 let condition = Box::new(self.expr(cond)?);
-                let consequence = Box::new(self.expr_forwarding(body)?);
+                let consequence = Box::new(self.expr_in_tail_position(body)?);
                 let alternative = Some(Box::new(self.match_expr(*otherwise, expr_id)?));
                 let typ = Self::convert_type(&result_type, location)?;
                 Ok(ast::Expression::If(ast::If { condition, consequence, alternative, typ }))

--- a/compiler/noirc_frontend/src/monomorphization/mod.rs
+++ b/compiler/noirc_frontend/src/monomorphization/mod.rs
@@ -837,7 +837,17 @@ impl<'interner> Monomorphizer<'interner> {
     }
 
     /// Monomorphize an expression.
+    /// Monomorphize an expression in a position that does not produce the enclosing position's
+    /// value. Any function value built here occupies no `unconstrained fn(..)` slot of its own,
+    /// so it keeps the runtime its own type declares.
     pub(crate) fn expr(&mut self, expr: ExprId) -> Result<ast::Expression, MonomorphizationError> {
+        self.expr_with_force_unconstrained(expr, false)
+    }
+
+    /// Monomorphize an expression that produces the enclosing position's value -- a block's
+    /// trailing expression, or an `if`/`match` branch. An `unconstrained fn(..)` target on that
+    /// enclosing position applies here too, because this is the value that lands in the slot.
+    fn expr_forwarding(&mut self, expr: ExprId) -> Result<ast::Expression, MonomorphizationError> {
         use ast::Expression::Literal;
         use ast::Literal::*;
 
@@ -1005,9 +1015,12 @@ impl<'interner> Monomorphizer<'interner> {
 
             HirExpression::If(if_expr) => {
                 let condition = Box::new(self.expr(if_expr.condition)?);
-                let consequence = Box::new(self.expr(if_expr.consequence)?);
-                let else_ =
-                    if_expr.alternative.map(|alt| self.expr(alt)).transpose()?.map(Box::new);
+                let consequence = Box::new(self.expr_forwarding(if_expr.consequence)?);
+                let else_ = if_expr
+                    .alternative
+                    .map(|alt| self.expr_forwarding(alt))
+                    .transpose()?
+                    .map(Box::new);
 
                 let location = self.interner.expr_location(&expr);
                 let frontend_type = self.interner.id_type(expr);
@@ -1217,7 +1230,7 @@ impl<'interner> Monomorphizer<'interner> {
         forced: bool,
     ) -> Result<ast::Expression, MonomorphizationError> {
         let old = std::mem::replace(&mut self.force_unconstrained, self.force_brillig || forced);
-        let result = self.expr(expr);
+        let result = self.expr_forwarding(expr);
         self.force_unconstrained = old;
         result
     }
@@ -1333,7 +1346,18 @@ impl<'interner> Monomorphizer<'interner> {
         &mut self,
         statement_ids: Vec<StmtId>,
     ) -> Result<ast::Expression, MonomorphizationError> {
-        let stmts = try_vecmap(statement_ids, |id| self.statement(id));
+        // A block's value comes from a trailing expression statement, so that statement is the
+        // only one that inherits an enclosing `unconstrained fn(..)` target. Every other statement
+        // goes through `expr`, which clears it.
+        let last_index = statement_ids.len().wrapping_sub(1);
+        let stmts = try_vecmap(statement_ids.into_iter().enumerate(), |(index, id)| {
+            if index == last_index
+                && let HirStatement::Expression(expr) = self.interner.statement(&id)
+            {
+                return self.expr_forwarding(expr);
+            }
+            self.statement(id)
+        });
         stmts.map(ast::Expression::Block)
     }
 
@@ -3026,7 +3050,7 @@ impl<'interner> Monomorphizer<'interner> {
         }
 
         match match_expr {
-            HirMatch::Success(id) => self.expr(id),
+            HirMatch::Success(id) => self.expr_forwarding(id),
             HirMatch::Failure { .. } => {
                 let false_ = Box::new(ast::Expression::Literal(ast::Literal::Bool(false)));
                 let msg = "match failure";
@@ -3042,7 +3066,7 @@ impl<'interner> Monomorphizer<'interner> {
             }
             HirMatch::Guard { cond, body, otherwise } => {
                 let condition = Box::new(self.expr(cond)?);
-                let consequence = Box::new(self.expr(body)?);
+                let consequence = Box::new(self.expr_forwarding(body)?);
                 let alternative = Some(Box::new(self.match_expr(*otherwise, expr_id)?));
                 let typ = Self::convert_type(&result_type, location)?;
                 Ok(ast::Expression::If(ast::If { condition, consequence, alternative, typ }))

--- a/compiler/noirc_frontend/src/monomorphization/mod.rs
+++ b/compiler/noirc_frontend/src/monomorphization/mod.rs
@@ -171,9 +171,19 @@ pub struct Monomorphizer<'interner> {
     /// constrained function called from this context to be monomorphized as unconstrained too.
     in_unconstrained_function: bool,
 
-    /// Set to true to force every function to be unconstrained.
-    /// Note that this also changes the first-class function representation
-    /// from a pair of `(constrained, unconstrained)` to `(unconstrained, unconstrained)`
+    /// Set to true to force every function in the program to be unconstrained (`--force-brillig`).
+    /// This is fixed for the whole pass; `force_unconstrained` is derived from it.
+    force_brillig: bool,
+
+    /// Set to true while monomorphizing an expression whose target slot is typed
+    /// `unconstrained fn(..)`. Note that this also changes the first-class function representation
+    /// from a pair of `(constrained, unconstrained)` to `(unconstrained, unconstrained)`, so that
+    /// a constrained caller dispatching through slot `.0` still runs the unconstrained version.
+    ///
+    /// This is a property of the *position* being monomorphized, not of the pass, so it must be
+    /// re-derived at every position with a known target type rather than only ever set. A nested
+    /// binding carrying its own constrained `fn` type does not flow into the enclosing
+    /// `unconstrained fn` slot and must not inherit the forcing.
     force_unconstrained: bool,
 }
 
@@ -299,6 +309,7 @@ impl<'interner> Monomorphizer<'interner> {
             debug_type_tracker,
             debug_crate_id,
             in_unconstrained_function: force_unconstrained,
+            force_brillig: force_unconstrained,
             force_unconstrained,
         }
     }
@@ -388,7 +399,7 @@ impl<'interner> Monomorphizer<'interner> {
             self.debug_type_tracker.extract_vars_and_types();
 
         for f in &mut functions {
-            let is_acir_entry_point = !self.force_unconstrained && f.inline_type.is_entry_point();
+            let is_acir_entry_point = !self.force_brillig && f.inline_type.is_entry_point();
             f.is_entry_point = is_acir_entry_point || f.id == Program::main_id();
         }
 
@@ -692,7 +703,7 @@ impl<'interner> Monomorphizer<'interner> {
         // flattened size is `u32`-representable. `is_entry_point` is only finalized in
         // `into_program`, so recompute the same condition here.
         let is_entry_point =
-            (!self.force_unconstrained && inline_type.is_entry_point()) || id == Program::main_id();
+            (!self.force_brillig && inline_type.is_entry_point()) || id == Program::main_id();
         if is_entry_point {
             let max_elements = ast::MAX_ELEMENTS as u64;
             for (pattern, typ, _visibility) in &func_parameters.0 {
@@ -1186,14 +1197,29 @@ impl<'interner> Monomorphizer<'interner> {
         expr: ExprId,
         target_type: &Type,
     ) -> Result<ast::Expression, MonomorphizationError> {
-        if matches!(target_type.follow_bindings(), Type::Function(_, _, _, true)) {
-            let old = std::mem::replace(&mut self.force_unconstrained, true);
-            let result = self.expr(expr);
-            self.force_unconstrained = old;
-            result
-        } else {
-            self.expr(expr)
-        }
+        let forced = matches!(target_type.follow_bindings(), Type::Function(_, _, _, true));
+        self.expr_with_force_unconstrained(expr, forced)
+    }
+
+    /// Monomorphize `expr` with `force_unconstrained` set to `forced`, restoring the previous
+    /// value afterwards.
+    ///
+    /// `forced` is assigned rather than or-ed into the current value: a position whose target type
+    /// is not `unconstrained fn(..)` clears the forcing inherited from an enclosing position, since
+    /// the value it produces does not flow into that enclosing `unconstrained fn` slot. Restoring
+    /// afterwards keeps the enclosing position forced, so a `let` earlier in a forced block does
+    /// not unforce the block's terminal expression.
+    ///
+    /// `--force-brillig` is a program-wide property and always wins.
+    fn expr_with_force_unconstrained(
+        &mut self,
+        expr: ExprId,
+        forced: bool,
+    ) -> Result<ast::Expression, MonomorphizationError> {
+        let old = std::mem::replace(&mut self.force_unconstrained, self.force_brillig || forced);
+        let result = self.expr(expr);
+        self.force_unconstrained = old;
+        result
     }
 
     fn constructor(
@@ -2308,19 +2334,12 @@ impl<'interner> Monomorphizer<'interner> {
                 // of the unconstrained variant, being itself unconstrained, we can generate a pair of
                 // two unconstrained functions, and avoid potential illegal passing of mutable references
                 // from constrained to unconstrained code in a lambda that we know will never be called.
-                let expr = match typ {
+                let forced = matches!(
+                    typ,
                     Type::Function(_, _, _, lambda_unconstrained)
-                        if *lambda_unconstrained || *callee_unconstrained =>
-                    {
-                        let old_force_unconstrained =
-                            std::mem::replace(&mut self.force_unconstrained, true);
-                        let expr = self.expr(*id)?;
-                        self.force_unconstrained = old_force_unconstrained;
-                        expr
-                    }
-                    _ => self.expr(*id)?,
-                };
-                arguments.push(expr);
+                        if *lambda_unconstrained || *callee_unconstrained
+                );
+                arguments.push(self.expr_with_force_unconstrained(*id, forced)?);
             }
         } else {
             for id in &call.arguments {

--- a/compiler/noirc_frontend/src/monomorphization/tests.rs
+++ b/compiler/noirc_frontend/src/monomorphization/tests.rs
@@ -1883,27 +1883,28 @@ fn constrained_fn_value_nested_in_unconstrained_fn_target_keeps_mixed_pair() {
     }
     "#;
     let program = get_monomorphized(src).unwrap();
-    // The snapshot below is WRONG and records the buggy output. `g$l2` is
-    // `(compute$f1, compute$f1)` -- both halves are the same function, and `compute$f1` is
-    // emitted `unconstrained` -- so `g$l2.0(x$l0)` lowers to a Brillig call from constrained
-    // code and `x * x` never becomes a constraint. A correct lowering binds `g$l2` to a mixed
-    // pair with a constrained slot `.0`, as in
-    // `constrained_fn_value_in_unconstrained_fn_target_control` below.
+    // `g$l2` is a mixed pair and slot `.0` -- the one `g$l2.0(x$l0)` selects from constrained
+    // code -- is the constrained `compute$f1`, so `x * x` becomes an ACIR constraint. `dummy`,
+    // which does occupy the `unconstrained fn` slot, is still forced to a
+    // `(unconstrained, unconstrained)` pair.
     insta::assert_snapshot!(program, @r"
     fn main$f0(x$l0: u32) -> pub u32 {
         let mut r$l1 = 0;
         let _f$l3 = {
-            let g$l2 = (compute$f1, compute$f1);
+            let g$l2 = (compute$f1, compute$f2);
             r$l1 = g$l2.0(x$l0);
-            (dummy$f2, dummy$f2)
+            (dummy$f3, dummy$f3)
         };
         r$l1
     }
-    unconstrained fn compute$f1(x$l4: u32) -> u32 {
+    fn compute$f1(x$l4: u32) -> u32 {
         (x$l4 * x$l4)
     }
-    unconstrained fn dummy$f2(x$l5: u32) -> u32 {
-        x$l5
+    unconstrained fn compute$f2(x$l5: u32) -> u32 {
+        (x$l5 * x$l5)
+    }
+    unconstrained fn dummy$f3(x$l6: u32) -> u32 {
+        x$l6
     }
     ");
 }

--- a/compiler/noirc_frontend/src/monomorphization/tests.rs
+++ b/compiler/noirc_frontend/src/monomorphization/tests.rs
@@ -1927,20 +1927,19 @@ fn lambda_in_if_condition_of_unconstrained_fn_target_is_not_forced() {
     }
     "#;
     let program = get_monomorphized(src).unwrap();
-    // The snapshot below is WRONG and records the buggy output. Both halves of the lambda pair
-    // are `unconstrained`, so the condition is computed in Brillig and `y * y` is unconstrained
-    // even though the call is made from constrained code. A correct lowering emits a constrained
-    // `fn lambda$f1` and calls it without the `unsafe` wrapper.
+    // The condition calls the constrained `lambda$f1` directly, with no `unsafe` wrapper, so
+    // `y * y` is constrained. The branches, which do produce the value occupying the
+    // `unconstrained fn` slot, are still forced to `(dummy$f3, dummy$f3)`.
     insta::assert_snapshot!(program, @r"
     fn main$f0(x$l0: u32) -> pub u32 {
-        let _f$l3 = if (unsafe { lambda$f1(x$l0) } == 9) {
+        let _f$l3 = if (lambda$f1(x$l0) == 9) {
             (dummy$f3, dummy$f3)
         } else {
             (dummy$f3, dummy$f3)
         };
         x$l0
     }
-    unconstrained fn lambda$f1(y$l1: u32) -> u32 {
+    fn lambda$f1(y$l1: u32) -> u32 {
         (y$l1 * y$l1)
     }
     unconstrained fn lambda$f2(y$l2: u32) -> u32 {

--- a/compiler/noirc_frontend/src/monomorphization/tests.rs
+++ b/compiler/noirc_frontend/src/monomorphization/tests.rs
@@ -1856,3 +1856,136 @@ fn zeroed_array_of_references_does_not_alias() {
     }
     ");
 }
+
+#[test]
+fn constrained_fn_value_nested_in_unconstrained_fn_target_keeps_mixed_pair() {
+    // A `let` whose declared type is `unconstrained fn(..)` forces every function value in its
+    // initializer to be built as an `(unconstrained, unconstrained)` pair, so that a constrained
+    // caller dispatching through slot `.0` still runs Brillig. That is correct for the value that
+    // occupies the slot -- here `dummy`.
+    //
+    // It must not extend to `g`, which is a separate binding with its own, constrained, `fn` type
+    // and never flows into that slot. `g` must stay a mixed `(constrained, unconstrained)` pair so
+    // that `g(x)` -- a call from constrained code with no `unsafe` -- selects the constrained
+    // specialization of `compute` and its `x * x` becomes an ACIR constraint.
+    let src = r#"
+    fn compute(x: u32) -> u32 { x * x }
+    unconstrained fn dummy(x: u32) -> u32 { x }
+
+    fn main(x: u32) -> pub u32 {
+        let mut r: u32 = 0;
+        let _f: unconstrained fn(u32) -> u32 = {
+            let g: fn(u32) -> u32 = compute;
+            r = g(x);
+            dummy
+        };
+        r
+    }
+    "#;
+    let program = get_monomorphized(src).unwrap();
+    // The snapshot below is WRONG and records the buggy output. `g$l2` is
+    // `(compute$f1, compute$f1)` -- both halves are the same function, and `compute$f1` is
+    // emitted `unconstrained` -- so `g$l2.0(x$l0)` lowers to a Brillig call from constrained
+    // code and `x * x` never becomes a constraint. A correct lowering binds `g$l2` to a mixed
+    // pair with a constrained slot `.0`, as in
+    // `constrained_fn_value_in_unconstrained_fn_target_control` below.
+    insta::assert_snapshot!(program, @r"
+    fn main$f0(x$l0: u32) -> pub u32 {
+        let mut r$l1 = 0;
+        let _f$l3 = {
+            let g$l2 = (compute$f1, compute$f1);
+            r$l1 = g$l2.0(x$l0);
+            (dummy$f2, dummy$f2)
+        };
+        r$l1
+    }
+    unconstrained fn compute$f1(x$l4: u32) -> u32 {
+        (x$l4 * x$l4)
+    }
+    unconstrained fn dummy$f2(x$l5: u32) -> u32 {
+        x$l5
+    }
+    ");
+}
+
+#[test]
+fn lambda_in_if_condition_of_unconstrained_fn_target_is_not_forced() {
+    // An `if` condition does not produce the value that lands in the enclosing `unconstrained fn`
+    // slot -- only the branches do. A lambda built in the condition is therefore an ordinary
+    // constrained function value, and `(|y| y * y)(x)` must be constrained.
+    //
+    // If it is forced, the comparison feeding the `if` becomes a free witness, so every assertion
+    // inside a branch is predicated on a value the prover chooses and can be made vacuous.
+    let src = r#"
+    unconstrained fn dummy(y: u32) -> u32 { y }
+
+    fn main(x: u32) -> pub u32 {
+        let _f: unconstrained fn(u32) -> u32 =
+            if (|y: u32| y * y)(x) == 9 { dummy } else { dummy };
+        x
+    }
+    "#;
+    let program = get_monomorphized(src).unwrap();
+    // The snapshot below is WRONG and records the buggy output. Both halves of the lambda pair
+    // are `unconstrained`, so the condition is computed in Brillig and `y * y` is unconstrained
+    // even though the call is made from constrained code. A correct lowering emits a constrained
+    // `fn lambda$f1` and calls it without the `unsafe` wrapper.
+    insta::assert_snapshot!(program, @r"
+    fn main$f0(x$l0: u32) -> pub u32 {
+        let _f$l3 = if (unsafe { lambda$f1(x$l0) } == 9) {
+            (dummy$f3, dummy$f3)
+        } else {
+            (dummy$f3, dummy$f3)
+        };
+        x$l0
+    }
+    unconstrained fn lambda$f1(y$l1: u32) -> u32 {
+        (y$l1 * y$l1)
+    }
+    unconstrained fn lambda$f2(y$l2: u32) -> u32 {
+        (y$l2 * y$l2)
+    }
+    unconstrained fn dummy$f3(y$l4: u32) -> u32 {
+        y$l4
+    }
+    ");
+}
+
+#[test]
+fn constrained_fn_value_in_unconstrained_fn_target_control() {
+    // Control for `constrained_fn_value_nested_in_unconstrained_fn_target_keeps_mixed_pair`:
+    // the identical program with the `unconstrained fn` ascription removed. `g` is bound to a
+    // mixed pair whose slot `.0` is the constrained `compute$f1`, so `x * x` is constrained.
+    // This is the shape the forced case must also produce for its nested `g` binding.
+    let src = r#"
+    fn compute(x: u32) -> u32 { x * x }
+
+    fn main(x: u32) -> pub u32 {
+        let mut r: u32 = 0;
+        let _f: u32 = {
+            let g: fn(u32) -> u32 = compute;
+            r = g(x);
+            0
+        };
+        r
+    }
+    "#;
+    let program = get_monomorphized(src).unwrap();
+    insta::assert_snapshot!(program, @r"
+    fn main$f0(x$l0: u32) -> pub u32 {
+        let mut r$l1 = 0;
+        let _f$l3 = {
+            let g$l2 = (compute$f1, compute$f2);
+            r$l1 = g$l2.0(x$l0);
+            0
+        };
+        r$l1
+    }
+    fn compute$f1(x$l4: u32) -> u32 {
+        (x$l4 * x$l4)
+    }
+    unconstrained fn compute$f2(x$l5: u32) -> u32 {
+        (x$l5 * x$l5)
+    }
+    ");
+}

--- a/test_programs/execution_success/stored_unconstrained_fn_regression/src/main.nr
+++ b/test_programs/execution_success/stored_unconstrained_fn_regression/src/main.nr
@@ -23,6 +23,23 @@ fn get_choose() -> unconstrained fn(u32) -> u32 {
     choose
 }
 
+/// Returns 1 when compiled as a constrained function, 100 when compiled as an unconstrained one.
+fn probe() -> u32 {
+    if is_unconstrained() {
+        100
+    } else {
+        1
+    }
+}
+
+fn other(x: u32) -> u32 {
+    x + 200
+}
+
+fn takes_unconstrained_fn(_f: unconstrained fn(u32) -> u32, r: u32) -> u32 {
+    r
+}
+
 fn pick(cond: bool) -> unconstrained fn(u32) -> u32 {
     if cond {
         choose
@@ -62,4 +79,65 @@ fn main() {
 
     // 7. function return whose body is a block with a terminal function reference
     assert_eq(call_unc(block_return(), 7), 107);
+
+    // Cases 8-12 cover the other direction: an `unconstrained fn` target must force only the
+    // value that occupies the slot. A function value nested inside the same expression that
+    // carries its own constrained type, or that sits in a position not producing the slot's
+    // value, keeps the runtime its own type declares.
+    //
+    // Each case compares against `probe()` called from `main` directly, so the expectation
+    // tracks the runtime `main` itself was compiled for. That is 1 normally, and 100 under
+    // `--force-brillig`, where every function in the program is legitimately unconstrained.
+    let expected = probe();
+
+    // 8. nested `let` with its own constrained `fn` type, inside a forced `let` RHS
+    let mut a: u32 = 0;
+    let _a: unconstrained fn(u32) -> u32 = {
+        let g: fn() -> u32 = probe;
+        a = g();
+        choose
+    };
+    assert_eq(a, expected);
+
+    // 9. unannotated lambda inside a forced `let` RHS
+    let mut b: u32 = 0;
+    let _b: unconstrained fn(u32) -> u32 = {
+        let g = || if is_unconstrained() { 100 } else { 1 };
+        b = g();
+        choose
+    };
+    assert_eq(b, expected);
+
+    // 10. call argument whose parameter type is `unconstrained fn`
+    let mut c: u32 = 0;
+    let _c = takes_unconstrained_fn(
+        {
+            let g: fn() -> u32 = probe;
+            c = g();
+            choose
+        },
+        0,
+    );
+    assert_eq(c, expected);
+
+    // 11. struct constructor field
+    let mut d: u32 = 0;
+    let _d = Holder {
+        f: {
+            let g: fn() -> u32 = probe;
+            d = g();
+            choose
+        },
+    };
+    assert_eq(d, expected);
+
+    // 12. `if` condition -- the branches produce the slot's value, the condition does not, so a
+    // lambda built in the condition matches `main`'s runtime and `choose` is selected. Forcing
+    // the condition's lambda would select `other` instead, giving 208.
+    let cond_probe: unconstrained fn(u32) -> u32 = if (|| probe())() == expected {
+        choose
+    } else {
+        other
+    };
+    assert_eq(call_unc(cond_probe, 8), 108);
 }

--- a/tooling/nargo_cli/tests/snapshots/execution_success/stored_unconstrained_fn_regression/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/stored_unconstrained_fn_regression/execute__tests__expanded.snap
@@ -27,6 +27,23 @@ fn get_choose() -> unconstrained fn(u32) -> u32 {
     choose
 }
 
+/// Returns 1 when compiled as a constrained function, 100 when compiled as an unconstrained one.
+fn probe() -> u32 {
+    if is_unconstrained() {
+        100_u32
+    } else {
+        1_u32
+    }
+}
+
+fn other(x: u32) -> u32 {
+    x + 200_u32
+}
+
+fn takes_unconstrained_fn(_f: unconstrained fn(u32) -> u32, r: u32) -> u32 {
+    r
+}
+
 fn pick(cond: bool) -> unconstrained fn(u32) -> u32 {
     if cond {
         choose
@@ -53,4 +70,44 @@ fn main() {
     assert(call_unc(h, 5_u32) == 105_u32);
     assert(call_unc(pick(true), 6_u32) == 106_u32);
     assert(call_unc(block_return(), 7_u32) == 107_u32);
+    let expected: u32 = probe();
+    let mut a: u32 = 0_u32;
+    let _a: unconstrained fn(u32) -> u32 = {
+        let g: fn() -> u32 = probe;
+        a = g();
+        choose
+    };
+    assert(a == expected);
+    let mut b: u32 = 0_u32;
+    let _b: unconstrained fn(u32) -> u32 = {
+        let g: fn() -> u32 = || -> u32 if is_unconstrained() { 100_u32 } else { 1_u32 };
+        b = g();
+        choose
+    };
+    assert(b == expected);
+    let mut c: u32 = 0_u32;
+    let _c: u32 = takes_unconstrained_fn(
+        {
+            let g: fn() -> u32 = probe;
+            c = g();
+            choose
+        },
+        0_u32,
+    );
+    assert(c == expected);
+    let mut d: u32 = 0_u32;
+    let _d: Holder = Holder {
+        f: {
+            let g: fn() -> u32 = probe;
+            d = g();
+            choose
+        },
+    };
+    assert(d == expected);
+    let cond_probe: unconstrained fn(u32) -> u32 = if (|| -> u32 probe())() == expected {
+        choose
+    } else {
+        other
+    };
+    assert(call_unc(cond_probe, 8_u32) == 108_u32);
 }


### PR DESCRIPTION
## Problem Resolved

Resolves https://github.com/noir-lang/noir-claude/issues/1539

`Monomorphizer::force_unconstrained` was a single field doing two unrelated jobs: the program-wide
`--force-brillig` flag, and a per-position marker meaning "this subtree targets an
`unconstrained fn(..)` slot". Because the global must never become false mid-pass, the marker could
only ever be *set*, never cleared.

So once forcing turned on for an expression whose target slot is typed `unconstrained fn(..)`, it
stayed on for that expression's entire subtree — including nested bindings that carry their own,
constrained, `fn` type and never reach that slot. Every function value beneath was built as an
`(unconstrained, unconstrained)` pair, and a constrained caller reading slot `.0` then ran Brillig
for a function the source declares constrained.

Since Brillig output is prover-supplied hint data the verifier never checks, the computation
disappears from the constraint system. Given:

```noir
fn compute(x: u32) -> u32 { x * x }
unconstrained fn dummy(x: u32) -> u32 { x }

fn main(x: u32) -> pub u32 {
    let mut r: u32 = 0;
    let _f: unconstrained fn(u32) -> u32 = {
        let g: fn(u32) -> u32 = compute;   // declared constrained; no `unsafe` anywhere
        r = g(x);
        dummy
    };
    assert(r < 1000000);
    r + x
}
```

the emitted ACIR contains no `ASSERT w2 = w0*w0` — `w2` is a free witness the prover picks. The
same program with the `unconstrained fn` ascription removed emits that constraint as opcode 1.
`nargo compile --deny-warnings` exits `0` with no diagnostic.

Two notes on scope beyond the filed issue:

- The `function_call` argument branch matches `*lambda_unconstrained || *callee_unconstrained`, so
  passing a **constrained** `fn`-typed argument to an unconstrained callee also forced the whole
  argument subtree. That path sits inside `unsafe`, but nothing there would lead a developer to
  expect an unrelated constrained computation in the argument expression to lose its constraints.
- Re-deriving the flag only at positions with a known target type is **not sufficient**. An `if`
  condition has no target type, so a lambda built there stays forced:

  ```noir
  let _f: unconstrained fn(u32) -> u32 =
      if (|y: u32| y * y)(x) == 9 { assert(x == 3); dummy } else { dummy };
  ```

  This compiles to `ASSERT 0 = w0*w4 - 3*w4`, where `w4` derives from the free witness the Brillig
  call returns — a prover picks a value making the predicate zero and `assert(x == 3)` vacuous.

Reachability requires an **indirect** call. Direct calls are immune: `extract_function`
early-returns with `use_current_runtime = true` and bypasses the pair mechanism entirely. A `fn`-typed
variable or a lambda must be built *and* called inside the forced subtree, which is why the
reproductions look contrived — that shape is load-bearing, not incidental.

## Summary of Changes

**Split the two responsibilities.** `force_brillig` holds the program-wide flag and is what the
entry-point checks in `into_program` and `function_body` read. `force_unconstrained` is now purely
per-position and is *assigned* at each position with a known target type rather than or-ed into
whatever was already there, so a position whose target is not `unconstrained fn(..)` clears the
forcing inherited from an enclosing one. Restoring the previous value afterwards is what preserves
[#12831](https://github.com/noir-lang/noir/pull/12831): a `let` earlier in a forced block does not
unforce the block's terminal expression. This also collapses the duplicated sticky-flag logic in
`function_call` into the same helper, so both entry points share one mechanism.

**Invert the default** rather than enumerate more positions to clear. `expr` now clears the flag and
`expr_forwarding` retains it. Only positions that genuinely produce the enclosing position's value
forward it: a block's trailing expression statement, `if` consequence and alternative, and `match`
arm bodies. Every other sub-expression is correct by construction instead of by enumeration.

**Tests.** The first commit records the buggy output as snapshots so the defect keeps a
machine-readable fingerprint in history, then each fix commit flips its own. Coverage is at two
levels: monomorphization snapshots asserting the `(constrained, unconstrained)` pair shape directly,
plus cases 8–12 in `stored_unconstrained_fn_regression` asserting end-to-end dispatch. Scenarios 1–7
there already pin the opposite direction, so both sides of the mechanism are now guarded.

Each fix commit is independently justified by a failing test: against the unfixed monomorphizer case
8 fails, and with only the per-position derivation applied case 12 fails.

One trap worth recording for anyone extending these tests — `execution_success` programs also run
under a `forcebrillig_true` matrix variant, where every function *is* legitimately unconstrained. An
`is_unconstrained()` probe must therefore be compared against `probe()` called from `main` rather
than a literal, or the `--force-brillig` variants break.

No breaking changes: this only removes forcing that was never intended to apply.

Verified locally: 2226 `noirc_frontend`, 9130 `nargo_cli --test execute` (including all
`forcebrillig_true` variants), 431 stdlib tests, `cargo clippy`, `cargo fmt`, and `just format-noir`
all clean. `--force-brillig` still lowers the whole program to Brillig.

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
