### PR TITLE
fix: repair dead documentation links

### DIFF
--- a/docs/docs/guides/how_to_use_oracles.md
+++ b/docs/docs/guides/how_to_use_oracles.md
@@ -112,7 +112,7 @@ In general, computing square roots is computationally more expensive than multip
 
 :::
 
-Now, we should write the correspondent RPC server, starting with the [default JSON-RPC 2.0 boilerplate](https://www.npmjs.com/package/json-rpc-2.0#example):
+Now, we should write the correspondent RPC server, starting with the [default JSON-RPC 2.0 boilerplate](https://github.com/shogowada/json-rpc-2.0):
 
 ```js
 import { JSONRPCServer } from "json-rpc-2.0";
@@ -249,7 +249,7 @@ const { witness } = await noir.execute(input, foreignCallHandler);
 
 :::tip
 
-If you're in a NoirJS environment running your RPC server together with a frontend app, you'll probably hit a familiar problem in full-stack development: requests being blocked by [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) policy. For development only, you can simply install and use the [`cors` npm package](https://www.npmjs.com/package/cors) to get around the problem:
+If you're in a NoirJS environment running your RPC server together with a frontend app, you'll probably hit a familiar problem in full-stack development: requests being blocked by [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) policy. For development only, you can simply install and use the [`cors` package](https://github.com/expressjs/cors) to get around the problem:
 
 ```bash
 yarn add cors

--- a/docs/docs/guides/thinking_in_circuits.md
+++ b/docs/docs/guides/thinking_in_circuits.md
@@ -214,4 +214,4 @@ Note: When used incorrectly it will create **less** efficient circuits (higher g
 
 ## References
 - Guillaume's ["`Crypdoku`" talk](https://www.youtube.com/watch?v=MrQyzuogxgg) (Jun'23)
-- [Idiomatic Noir](https://www.vlayer.xyz/blog/idiomatic-noir-part-1-collections) blog post
+- [Idiomatic Noir](https://www.vlayer.xyz/blog) blog posts

--- a/docs/docs/project_structure/crates_and_packages.md
+++ b/docs/docs/project_structure/crates_and_packages.md
@@ -23,7 +23,7 @@ _Library crates_ don't have a `main` function and they don't compile down to ACI
 
 #### Contracts
 
-Contract crates are similar to binary crates in that they compile to ACIR which you can create proofs against. They are different in that they do not have a single `main` function, but are a collection of functions to be deployed to the [Aztec network](https://aztec.network). You can learn more about the technical details of Aztec in the [monorepo](https://github.com/AztecProtocol/aztec-packages) or contract [examples](https://github.com/AztecProtocol/aztec-packages/tree/master/noir-projects/noir-contracts/contracts).
+Contract crates are similar to binary crates in that they compile to ACIR which you can create proofs against. They are different in that they do not have a single `main` function, but are a collection of functions to be deployed to the [Aztec network](https://aztec.network). You can learn more about the technical details of Aztec in the [monorepo](https://github.com/AztecProtocol/aztec-packages) or contract [examples](https://github.com/AztecProtocol/aztec-packages/tree/next/docs/examples/contracts).
 
 ### Crate Root
 


### PR DESCRIPTION
## Summary

Fixes #13404 by repairing the stale external documentation links reported by the repository's `Check Markdown links` workflow:

- replace npm package pages that returned checker-blocked 403 responses with the maintained GitHub repositories
- update the Aztec contract examples link from the removed `master/noir-projects/noir-contracts/contracts` path to the current `next/docs/examples/contracts` path
- point the vlayer reference at the current blog index after the old article URL began returning 404

The change is limited to the three docs references identified by the linked workflow run.

## Validation

- `npx --yes markdown-link-check docs/docs/guides/how_to_use_oracles.md --config docs/link-check.config.json -q`
- `npx --yes markdown-link-check docs/docs/guides/thinking_in_circuits.md --config docs/link-check.config.json -q`
- `npx --yes markdown-link-check docs/docs/project_structure/crates_and_packages.md --config docs/link-check.config.json -q`
- `git diff --check`

The focused link checks pass on commit `d310b52`. The repository contribution guide asks for the `documentation` label; the fork token cannot add repository labels, so the changed paths and PR scope make the required category explicit for the maintainer.

Let me know what you think.