### PR TITLE
ci: bind workflow/composite inputs via env before shell

### DIFF
--- a/.github/actions/download-binary/action.yml
+++ b/.github/actions/download-binary/action.yml
@@ -15,7 +15,10 @@ runs:
 
     - name: Set ${{ inputs.name }} on PATH
       shell: bash
+      env:
+        BINARY_NAME: ${{ inputs.name }}
+        WORKSPACE: ${{ github.workspace }}
       run: |
-        binary="${{ github.workspace }}/${{ inputs.name }}/${{ inputs.name }}"
-        chmod +x $binary
-        echo "$(dirname $binary)" >> $GITHUB_PATH
+        binary="${WORKSPACE}/${BINARY_NAME}/${BINARY_NAME}"
+        chmod +x "$binary"
+        echo "$(dirname "$binary")" >> "$GITHUB_PATH"

--- a/.github/actions/install-playwright/action.yml
+++ b/.github/actions/install-playwright/action.yml
@@ -28,8 +28,11 @@ runs:
     - name: Install Playwright browsers
       if: steps.playwright-cache.outputs.cache-hit != 'true'
       uses: ./.github/actions/retry
+      env:
+        PLAYWRIGHT_VERSION: ${{ inputs.playwright-version }}
+        PLAYWRIGHT_BROWSERS: ${{ inputs.browsers }}
       with:
-        run: timeout 240 npx -y playwright@${{ inputs.playwright-version }} install ${{ inputs.browsers }}
+        run: timeout 240 npx -y playwright@"$PLAYWRIGHT_VERSION" install $PLAYWRIGHT_BROWSERS
 
     # GitHub-hosted Ubuntu runner images already ship Chromium's system
     # libraries, so `install-deps` is only needed for engines like WebKit.

--- a/.github/workflows/publish-es-packages.yml
+++ b/.github/workflows/publish-es-packages.yml
@@ -169,11 +169,15 @@ jobs:
 
       - name: Prepare nightly version
         if: ${{ inputs.npm-tag != 'latest' }}
+        env:
+          NPM_TAG: ${{ inputs.npm-tag }}
         run: |
-          yarn nightly:version -- .${{ inputs.npm-tag }}
+          yarn nightly:version -- ".${NPM_TAG}"
 
       - name: Publish ES Packages
-        run: yarn publish:all --provenance --access public --tag ${{ inputs.npm-tag }}
+        env:
+          NPM_TAG: ${{ inputs.npm-tag }}
+        run: yarn publish:all --provenance --access public --tag "$NPM_TAG"
 
       # Raise an issue if any package failed to publish
       - name: Alert on failed publish


### PR DESCRIPTION
## Summary
- Bind `inputs.npm-tag` through `env:` before nightly version / publish shell steps in `publish-es-packages.yml`.
- Bind Playwright version/browsers through `env:` before the install command in `install-playwright`.
- Bind binary name / workspace through `env:` before PATH setup in `download-binary`.
- Same class as GitHub’s documented script-injection guidance for interpolating workflow/composite inputs into `run:` scripts.

## Test plan
- [ ] ES package publish with non-latest npm-tag still versions and publishes correctly
- [ ] Playwright install still installs requested browsers
- [ ] download-binary still adds the artifact binary to PATH


Made with [Cursor](https://cursor.com)