### PR TITLE
fix(acir_gen): apply the fallback bias only where the index is gated

### DIFF
--- a/compiler/noirc_evaluator/src/acir/arrays.rs
+++ b/compiler/noirc_evaluator/src/acir/arrays.rs
@@ -448,7 +448,7 @@ impl Context<'_> {
     /// the result: the read targets a field of the element, and that same field also exists in
     /// element 0, at this offset, with exactly the result's layout.
     ///
-    /// [`Self::convert_array_operation_inputs`] biases the predicate-gated index by this offset
+    /// [`Self::get_flattened_index`] biases the predicate-gated index by this offset
     /// (`offset * (1 - predicate)`), so under a false predicate the read lands on that field of
     /// element 0 and is type-compatible by construction: no leaf of the result can end up
     /// holding a value wider than its declared type. The offset must be in flat slot units, the
@@ -490,12 +490,10 @@ impl Context<'_> {
     /// Returns the flat memory index to read/write at and, for `ArraySet`, the
     /// (predicated) value to store.
     ///
-    /// [`Self::get_flattened_index`] already gates the returned index by the side-effects
-    /// predicate when `is_safe_index = false`, so on a disabled branch the index
-    /// collapses to `0`. When `offset != 0` and `is_safe_index = false` we additionally
-    /// bias the disabled-branch fallback to `offset` by adding `offset * (1 - predicate)`,
-    /// so that the dummy value a disabled read returns is type-compatible with the read's
-    /// result type (see [`Self::compute_offset`]).
+    /// [`Self::get_flattened_index`] gates the returned index by the side-effects predicate
+    /// where necessary and biases the disabled-branch fallback to `offset`, so the dummy value
+    /// a disabled read returns is type-compatible with the read's result type
+    /// (see [`Self::compute_offset`]).
     fn convert_array_operation_inputs(
         &mut self,
         array_id: ValueId,
@@ -509,25 +507,20 @@ impl Context<'_> {
         let shift = ElementTypeSizesArrayShift::None;
         let index_var = self.convert_numeric_value(index, dfg)?;
         let is_safe_index = dfg.is_safe_index(index, array_id);
-        let mut index_var =
-            self.get_flattened_index(&array_typ, array_id, index_var, dfg, is_safe_index, shift)?;
+        let index_var = self.get_flattened_index(
+            &array_typ,
+            array_id,
+            index_var,
+            dfg,
+            is_safe_index,
+            shift,
+            offset,
+        )?;
 
         // Side-effects are always enabled so we do not need to do any predication
         if self.acir_context.is_constant_one(&self.current_side_effects_enabled_var) {
             let store_value = store_value.map(|store| self.convert_value(store, dfg));
             return Ok((index_var, store_value));
-        }
-
-        // Bias the disabled-branch fallback toward `offset` instead of `0`.
-        // `index_var` is already `raw_index * predicate` from `get_flattened_index`, so
-        // adding `offset * (1 - predicate)` yields `raw_index` when `predicate == 1` and
-        // `offset` when `predicate == 0` — without a second predicate multiplication.
-        if !is_safe_index && offset != 0 {
-            let one = self.acir_context.add_constant(FieldElement::one());
-            let not_pred = self.acir_context.sub_var(one, self.current_side_effects_enabled_var)?;
-            let offset_var = self.acir_context.add_constant(offset);
-            let offset_term = self.acir_context.mul_var(offset_var, not_pred)?;
-            index_var = self.acir_context.add_var(index_var, offset_term)?;
         }
 
         let new_value = store_value
@@ -1167,7 +1160,17 @@ impl Context<'_> {
     /// In some cases this requires consulting a side ["element type sizes"][Self::init_element_type_sizes_array]
     /// array to calculate offsets when elements have a non-homogenous layout.
     ///
+    /// When the index isn't statically known to be in range it is gated by the side-effects
+    /// predicate, and `fallback_offset * (1 - predicate)` is added on top, so that on a disabled
+    /// branch the access collapses to `fallback_offset` — a slot whose type is compatible with
+    /// the access (see [`Self::compute_offset`]). The bias's precondition is exactly "the index
+    /// collapses to `0` under a false predicate", so it is applied here, on the gated path and
+    /// nowhere else: an index that is not gated — a safe index, or a constant resolved through
+    /// the element-type-sizes table below — stays on its true slots whatever the predicate is,
+    /// and must not be biased.
+    ///
     /// See [self] for a more concrete example of how flattened indices are computed.
+    #[allow(clippy::too_many_arguments)]
     pub(super) fn get_flattened_index(
         &mut self,
         array_typ: &Type,
@@ -1176,6 +1179,7 @@ impl Context<'_> {
         dfg: &DataFlowGraph,
         is_safe_index: bool,
         shift: ElementTypeSizesArrayShift,
+        fallback_offset: usize,
     ) -> Result<AcirVar, RuntimeError> {
         // For a non-homogenous layout a statically-known, in-bounds index resolves to a fixed
         // flattened offset held in the element-type-sizes table. That offset is independent of the
@@ -1184,6 +1188,10 @@ impl Context<'_> {
         // use the original index here rather than the predicated one below, since gating can turn a
         // constant into a witness and hide its value. An out-of-bounds constant index (no table
         // entry) falls through to the runtime path, which defers the bounds failure to execution.
+        //
+        // This resolved index is in bounds and ungated (`is_safe_index` cannot see it: it holds
+        // vector indices to the vector's unknown semantic length, so it is `false` for every
+        // vector). The access reads the slots the program asked for, so no fallback bias applies.
         if array_has_constant_element_size(array_typ).is_none()
             && let Some(index) = self
                 .acir_context
@@ -1203,22 +1211,34 @@ impl Context<'_> {
         // (memory reads/writes, comparisons, etc.) would fail the ACVM bounds check on
         // a disabled branch with an OOB user-supplied index. `mul_var` constant-folds
         // when the predicate is `0` or `1`, so this is free in those cases.
-        let var_index = if is_safe_index {
-            var_index
-        } else {
+        let gated = !is_safe_index;
+        let var_index = if gated {
             self.acir_context.mul_var(var_index, self.current_side_effects_enabled_var)?
+        } else {
+            var_index
         };
 
-        if let Some(step_size) = array_has_constant_element_size(array_typ) {
+        let flat_index = if let Some(step_size) = array_has_constant_element_size(array_typ) {
             let step_size = self.acir_context.add_constant(step_size);
-            self.acir_context.mul_var(var_index, step_size)
+            self.acir_context.mul_var(var_index, step_size)?
         } else {
             let element_type_sizes =
                 self.init_element_type_sizes_array(array_typ, array_id, None, dfg, shift)?;
 
-            self.acir_context
-                .read_from_memory(element_type_sizes, &var_index)
-                .map_err(RuntimeError::from)
+            self.acir_context.read_from_memory(element_type_sizes, &var_index)?
+        };
+
+        // The gated flat index is `0` on a disabled branch; bias it to the fallback slot.
+        // `raw_index * predicate + fallback_offset * (1 - predicate)` yields the raw index when
+        // the predicate is `1` and `fallback_offset` when it is `0`.
+        if gated && fallback_offset != 0 {
+            let one = self.acir_context.add_constant(FieldElement::one());
+            let not_pred = self.acir_context.sub_var(one, self.current_side_effects_enabled_var)?;
+            let offset_var = self.acir_context.add_constant(fallback_offset);
+            let offset_term = self.acir_context.mul_var(offset_var, not_pred)?;
+            Ok(self.acir_context.add_var(flat_index, offset_term)?)
+        } else {
+            Ok(flat_index)
         }
     }
 

--- a/compiler/noirc_evaluator/src/acir/call/intrinsics/vector_ops.rs
+++ b/compiler/noirc_evaluator/src/acir/call/intrinsics/vector_ops.rs
@@ -272,6 +272,7 @@ impl Context<'_> {
                         dfg,
                         false,
                         ElementTypeSizesArrayShift::None,
+                        0,
                     )?
                 } else {
                     // A non-homogenous layout would otherwise resolve offsets through an
@@ -673,6 +674,7 @@ impl Context<'_> {
             dfg,
             is_safe_index,
             shift,
+            0,
         )?;
 
         // Determine the elements we need to write into our resulting dynamic array.
@@ -929,6 +931,7 @@ impl Context<'_> {
             dfg,
             is_safe_index,
             ElementTypeSizesArrayShift::None,
+            0,
         )?;
 
         // Fetch the values we are remove from the vector.

--- a/compiler/noirc_evaluator/src/acir/tests/arrays.rs
+++ b/compiler/noirc_evaluator/src/acir/tests/arrays.rs
@@ -891,9 +891,10 @@ fn predicated_constant_index_get_on_heterogeneous_vector() {
     // For a layout whose fields have differing flattened sizes,
     // [`Context::get_flattened_index`] resolves a constant index through the element-type-sizes
     // table into a flat offset that is already known to be in bounds, and therefore returns it
-    // ungated. `DataFlowGraph::is_safe_index` reports `false` for every vector, constant index
-    // or not, so the bias is added on top of that resolved offset instead of replacing a gated
-    // `0`.
+    // ungated — and unbiased, even though `DataFlowGraph::is_safe_index` reports `false` for
+    // every vector (it cannot see the vector's semantic length): a bias on top of that resolved
+    // offset would relocate the read to the wrong slots, or off the end of the block, exactly
+    // when the predicate is `0`.
     //
     // The vector holds two `(Field, [u8; 2])` items in six slots. Semi-flattened index `3` is
     // item 1's `[u8; 2]`, i.e. flat slot 4, and the read must stay on slots 4 and 5 whatever
@@ -912,8 +913,8 @@ fn predicated_constant_index_get_on_heterogeneous_vector() {
     }
     ";
     let program = ssa_to_acir_program(src);
-    // `w13 = -w1 + 5` reads slot 5 (and then slot 6, which does not exist) when the predicate
-    // `w1` is `0`. It should be the constant `4`, as it is on the array-typed counterpart.
+    // The index resolves to the constant `4` and both reads stay on slots 4 and 5 whatever the
+    // predicate is — identical to the array-typed counterpart below.
     assert_circuit_snapshot!(program, @r"
     func 0
     private parameters: [w0, w1, w2]
@@ -931,12 +932,10 @@ fn predicated_constant_index_get_on_heterogeneous_vector() {
     ASSERT w12 = 6
     INIT b1 = [w6, w10, w7, w8, w11, w12]
     WRITE b1[w9] = w2
-    ASSERT w13 = -w1 + 5
-    READ w14 = b1[w13]
-    ASSERT w15 = w13 + 1
-    READ w16 = b1[w15]
-    ASSERT w3 = w14
-    ASSERT w4 = w16
+    READ w13 = b1[w8]
+    READ w14 = b1[w11]
+    ASSERT w3 = w13
+    ASSERT w4 = w14
     ");
 }
 


### PR DESCRIPTION
Green half of #13471: turns its red tests green by moving the disabled-branch fallback bias from `convert_array_operation_inputs` into `get_flattened_index`, applied only on the path that gates the index by the side-effects predicate.

## Why this fix shape

The bias's precondition is *"the index collapses to 0 under a false predicate"*, and the only code that knows whether that happened is `get_flattened_index` — the gate and the bias now live at the same site, so the invariant is structural rather than a cross-function coincidence:

- the constant-index fast path resolves an in-bounds index through the element-type-sizes table and returns it **ungated → unbiased** (it reads the slots the program asked for, so there is nothing to relocate);
- a safe index is ungated → unbiased;
- the gated runtime path becomes `(index · predicate → flatten) + fallback_offset · (1 − predicate)`.

`is_safe_index` cannot stand in for "was gated": it reports `false` for every vector, constant index or not, which is exactly how the bias ended up on top of an ungated resolved offset (`true_offset + field_offset` on a disabled branch — wrong slots, or off the end of the block).

Of the three options suggested in the review: option 2 (skip the bias when the returned index is constant) encodes the precondition by proxy and silently breaks if the fast path ever changes shape; option 3 (extend `is_safe_index` to vectors) can't know the vector's semantic length and would also change predicate placement through `requires_acir_gen_predicate`. Option 1 is the honest one.

## Verification

- Both red `execution_success` programs flip green across the full inliner × Brillig matrix (32 subtests): the out-of-bounds one and the `Cannot satisfy constraint` one.
- The red-pinned vector ACIR snapshot flips to be shape-identical to its array counterpart: `READ b1[4]`, `READ b1[5]`, no predicate anywhere near the index. Test comments updated to describe the fixed behaviour.
- `cargo nextest run -p noirc_evaluator`: 1926 pass. Full `nargo_cli` execute suite: **9210/9210 pass, 0 skipped**. fmt + clippy clean.

Merging this into #13471 makes that PR a complete red → green unit that lands straight into #13466's branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)