### PR TITLE
fix(fmt): terminate line comments before appending more output to the line

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3385,6 +3385,7 @@ dependencies = [
  "color-eyre",
  "env_logger",
  "libfuzzer-sys",
+ "nargo_fmt",
  "noir_ast_fuzzer",
  "noirc_abi",
  "noirc_evaluator",

--- a/tooling/ast_fuzzer/fuzz/Cargo.toml
+++ b/tooling/ast_fuzzer/fuzz/Cargo.toml
@@ -18,6 +18,7 @@ libfuzzer-sys.workspace = true
 strum.workspace = true
 
 acir.workspace = true
+nargo_fmt.workspace = true
 noirc_abi.workspace = true
 noirc_evaluator.workspace = true
 noirc_frontend.workspace = true
@@ -75,6 +76,13 @@ bench = false
 [[bin]]
 name = "valid_after_pass"
 path = "fuzz_targets/valid_after_pass.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "fmt_line_comments"
+path = "fuzz_targets/fmt_line_comments.rs"
 test = false
 doc = false
 bench = false

--- a/tooling/ast_fuzzer/fuzz/fuzz_targets/fmt_line_comments.rs
+++ b/tooling/ast_fuzzer/fuzz/fuzz_targets/fmt_line_comments.rs
@@ -1,0 +1,12 @@
+//! ```text
+//! cargo +nightly fuzz run fmt_line_comments
+//! ```
+#![no_main]
+
+use libfuzzer_sys::arbitrary::Unstructured;
+use libfuzzer_sys::fuzz_target;
+use noir_ast_fuzzer_fuzz::targets::fmt_line_comments;
+
+fuzz_target!(|data: &[u8]| {
+    fmt_line_comments::fuzz(&mut Unstructured::new(data)).unwrap();
+});

--- a/tooling/ast_fuzzer/fuzz/src/targets/fmt_line_comments.rs
+++ b/tooling/ast_fuzzer/fuzz/src/targets/fmt_line_comments.rs
@@ -1,0 +1,95 @@
+//! Verify that line comments never cause the formatter to swallow code.
+//!
+//! The AST fuzzer generates a valid program, which is formatted once to establish a normalized
+//! baseline. We then insert a line comment at a fuzz-selected token boundary, format again, and
+//! require the non-comment token stream to remain equal to the baseline. This catches both invalid
+//! formatter output and the more dangerous case where swallowed code still parses.
+
+use arbitrary::Unstructured;
+use color_eyre::eyre;
+use nargo_fmt::{Config as FormatterConfig, format};
+use noir_ast_fuzzer::{DisplayAstAsNoir, arb_program};
+use noirc_frontend::{lexer::Lexer, parser, token::Token};
+
+use super::default_config;
+
+pub fn fuzz(u: &mut Unstructured) -> eyre::Result<()> {
+    let config = default_config(u)?;
+    let program = arb_program(u, config)?;
+    let source = DisplayAstAsNoir(&program).to_string();
+    let Some(baseline) = try_format(&source) else { return Ok(()) };
+
+    let mut boundaries = significant_token_boundaries(&baseline);
+    boundaries.pop(); // A comment after the final token cannot swallow code.
+    if boundaries.is_empty() {
+        return Ok(());
+    }
+
+    let boundary = boundaries[u.choose_index(boundaries.len())?];
+    let mut with_comment = baseline.clone();
+    with_comment.insert_str(boundary, " // fuzzed line comment\n");
+
+    // A newline is not valid at every token boundary. Invalid mutations do not exercise the
+    // formatter and are discarded like other unsuitable fuzz inputs.
+    let Some(formatted) = try_format(&with_comment) else { return Ok(()) };
+
+    let expected_tokens = significant_tokens(&baseline);
+    let actual_tokens = significant_tokens(&formatted);
+    if actual_tokens != expected_tokens {
+        eyre::bail!(
+            "formatter changed code tokens after a line comment at byte {boundary}\n\
+             baseline:\n{baseline}\nwith comment:\n{with_comment}\nformatted:\n{formatted}"
+        );
+    }
+
+    Ok(())
+}
+
+fn try_format(source: &str) -> Option<String> {
+    let (parsed_module, errors) = parser::parse_program_with_dummy_file(source);
+    if errors.iter().any(|error| !error.is_warning()) {
+        return None;
+    }
+    Some(format(source, parsed_module, &FormatterConfig::default()))
+}
+
+fn significant_token_boundaries(source: &str) -> Vec<usize> {
+    Lexer::new_with_dummy_file(source)
+        .skip_comments(true)
+        .skip_whitespaces(true)
+        .filter_map(|token| {
+            let token = token.expect("formatter output should lex");
+            (!matches!(token.token(), Token::EOF)).then(|| token.span().end() as usize)
+        })
+        .collect()
+}
+
+fn significant_tokens(source: &str) -> Vec<Token> {
+    let tokens: Vec<_> = Lexer::new_with_dummy_file(source)
+        .skip_comments(true)
+        .skip_whitespaces(true)
+        .map(|token| token.expect("formatter output should lex").into_token())
+        .collect();
+
+    // A comment can make a group multiline, in which case the formatter may add a trailing comma.
+    // Ignore those layout-only tokens while checking that all source code survived.
+    (0..tokens.len())
+        .filter_map(|index| {
+            let token = &tokens[index];
+            let is_layout_comma = *token == Token::Comma
+                && matches!(
+                    tokens.get(index + 1),
+                    Some(Token::RightParen | Token::RightBracket | Token::RightBrace)
+                );
+            (!is_layout_comma).then(|| token.clone())
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn fuzz_with_arbtest() {
+        crate::targets::tests::fuzz_with_arbtest(super::fuzz, 1000);
+    }
+}

--- a/tooling/ast_fuzzer/fuzz/src/targets/mod.rs
+++ b/tooling/ast_fuzzer/fuzz/src/targets/mod.rs
@@ -4,6 +4,7 @@ use noir_ast_fuzzer::Config;
 pub mod acir_vs_brillig;
 pub mod comptime_vs_brillig_direct;
 pub mod comptime_vs_brillig_nargo;
+pub mod fmt_line_comments;
 pub mod min_vs_full;
 pub mod orig_vs_morph;
 pub mod pass_vs_prev;

--- a/tooling/nargo_fmt/src/chunks.rs
+++ b/tooling/nargo_fmt/src/chunks.rs
@@ -925,12 +925,15 @@ impl<'a> Formatter<'a> {
             match chunk {
                 Chunk::Text(text_chunk, _) => {
                     self.write(&text_chunk.string);
+                    self.protect_open_line_comment();
                 }
                 Chunk::TrailingComment(text_chunk, _) => {
                     self.write(&text_chunk.string);
+                    self.protect_open_line_comment();
                 }
                 Chunk::LeadingComment(text_chunk) => {
                     self.write(&text_chunk.string);
+                    self.protect_open_line_comment();
                     self.write_space_without_skipping_whitespace_and_comments();
                 }
                 Chunk::Group(chunks) => self.format_chunk_group_impl(chunks),
@@ -1291,6 +1294,10 @@ impl<'a> Formatter<'a> {
                 inside_block_comment = false;
             }
         }
+
+        // `str::lines()` above drops the chunk's final newline, so a `//` comment on
+        // the chunk's last line is left unterminated in the buffer here.
+        self.protect_open_line_comment();
     }
 
     /// Returns a new `GroupTag` that is unique compared to other `new_group_tag` calls.

--- a/tooling/nargo_fmt/src/formatter.rs
+++ b/tooling/nargo_fmt/src/formatter.rs
@@ -312,8 +312,59 @@ impl<'a> Formatter<'a> {
     }
 
     /// Writes a string to the buffer.
+    ///
+    /// A `//` comment is terminated only by a newline, so if the current line ends
+    /// inside one, appending anything to it would silently turn that text into part
+    /// of the comment. When the buffer says the current line needs its comment
+    /// terminated, break the line first so the text that follows stays code.
     pub(crate) fn write(&mut self, str: &str) {
+        if self.buffer.line_comment_needs_termination()
+            && !str.starts_with('\n')
+            && !str.trim().is_empty()
+        {
+            self.buffer.trim_spaces();
+            self.buffer.write("\n");
+            self.write_indentation();
+            self.buffer.write(str.trim_start_matches(' '));
+            return;
+        }
+
         self.buffer.write(str);
+    }
+
+    /// Checks whether the buffer's current line ends inside a `//` line comment and,
+    /// if so, flags it so that any text appended to that line triggers a line break
+    /// first (see `write`). Chunk text is written without its final newline (that
+    /// newline, if any, is the enclosing layout's decision), so this must be called
+    /// after writing a chunk's text to protect a comment that ends it.
+    pub(crate) fn protect_open_line_comment(&mut self) {
+        let line = self.buffer.current_line();
+        if !line.contains("//") {
+            return;
+        }
+
+        // Lex the line to check that the `//` really starts a comment (as opposed to,
+        // say, appearing inside a string literal). A line comment always extends to
+        // the end of the input, so finding one means the line ends inside it.
+        let lexer = Lexer::new_with_dummy_file(line).skip_comments(false).skip_whitespaces(false);
+        for token in lexer {
+            match token {
+                Ok(token) => {
+                    if matches!(token.token(), Token::LineComment(..)) {
+                        self.buffer.set_line_comment_needs_termination();
+                        return;
+                    }
+                }
+                // The line is not lexable on its own (for example, it could end in the
+                // middle of a multiline string literal). Err on the side of breaking
+                // the line: a spurious break only perturbs layout, while a missed one
+                // comments out code.
+                Err(_) => {
+                    self.buffer.set_line_comment_needs_termination();
+                    return;
+                }
+            }
+        }
     }
 
     pub(crate) fn current_line_width(&self) -> usize {

--- a/tooling/nargo_fmt/src/formatter/buffer.rs
+++ b/tooling/nargo_fmt/src/formatter/buffer.rs
@@ -8,6 +8,11 @@ pub(crate) struct Buffer {
     /// How many characters we've written so far in the current line
     /// (useful to avoid exceeding the configurable maximum)
     current_line_width: usize,
+
+    /// Whether the current line ends inside a `//` line comment that a newline must
+    /// terminate before anything else is appended to the line (otherwise whatever
+    /// is appended would become part of the comment).
+    line_comment_needs_termination: bool,
 }
 
 impl Buffer {
@@ -27,7 +32,19 @@ impl Buffer {
         self.buffer.ends_with(' ')
     }
 
+    /// Returns the contents of the current (last) line in the buffer.
+    pub(crate) fn current_line(&self) -> &str {
+        match self.buffer.rfind('\n') {
+            Some(index) => &self.buffer[index + 1..],
+            None => &self.buffer,
+        }
+    }
+
     pub(crate) fn write(&mut self, str: &str) {
+        if str.contains('\n') {
+            self.line_comment_needs_termination = false;
+        }
+
         self.buffer.push_str(str);
 
         if str.ends_with('\n') {
@@ -35,6 +52,14 @@ impl Buffer {
         } else {
             self.current_line_width += str.chars().count();
         }
+    }
+
+    pub(crate) fn line_comment_needs_termination(&self) -> bool {
+        self.line_comment_needs_termination
+    }
+
+    pub(crate) fn set_line_comment_needs_termination(&mut self) {
+        self.line_comment_needs_termination = true;
     }
 
     /// Trim spaces from the end of the buffer.

--- a/tooling/nargo_fmt/src/formatter/expression.rs
+++ b/tooling/nargo_fmt/src/formatter/expression.rs
@@ -2719,6 +2719,47 @@ let     x   =    1   +    2 ;
     }
 
     #[test]
+    fn format_lambda_with_comment_between_parameters_and_body() {
+        // Regression test for https://github.com/noir-lang/noir-claude/issues/1646:
+        // the comment's terminating newline was dropped, so the lambda body was
+        // swallowed into the comment while the program still compiled.
+        let src = "fn main(x: Field, y: Field) {
+    let check = |v| // every checked value must equal y
+{ assert(v == y); };
+    check(x);
+}
+";
+        let expected = "fn main(x: Field, y: Field) {
+    let check = |v| // every checked value must equal y
+    { assert(v == y); };
+    check(x);
+}
+";
+        assert_format(src, expected);
+    }
+
+    #[test]
+    fn format_lambda_as_last_call_argument_with_comment_between_parameters_and_body() {
+        // Regression test for https://github.com/noir-lang/noir-claude/issues/1646.
+        // A lambda as the last call argument is formatted through a fast path that
+        // writes the group in one line, which is a separate way for the comment's
+        // terminating newline to be lost.
+        let src = "fn main() {
+    foo(1, |x| // doubles the input
+    {
+        x * 2
+    });
+}
+";
+        let expected = "fn main() {
+    foo(1, |x| // doubles the input
+    x * 2);
+}
+";
+        assert_format(src, expected);
+    }
+
+    #[test]
     fn format_lambda_as_last_call_argument() {
         let src = "global x = foo(1, |x| { 1; 2 });";
         let expected = "global x = foo(1, |x| {

--- a/tooling/nargo_fmt/src/formatter/statement.rs
+++ b/tooling/nargo_fmt/src/formatter/statement.rs
@@ -514,6 +514,46 @@ mod tests {
     }
 
     #[test]
+    fn format_let_statement_with_comment_after_let_keyword() {
+        // Regression test for https://github.com/noir-lang/noir-claude/issues/1646:
+        // the comment's terminating newline was dropped, so the rest of the
+        // statement was swallowed into the comment and no longer parsed.
+        let src = "fn main() {
+    let // C1
+    mut x: Field = 1;
+    assert(x == 1);
+}
+";
+        let expected = "fn main() {
+    let // C1
+    mut x: Field = 1;
+    assert(x == 1);
+}
+";
+        assert_format(src, expected);
+    }
+
+    #[test]
+    fn format_let_statement_with_comment_between_unsafe_and_block() {
+        // Regression test for https://github.com/noir-lang/noir-claude/issues/1646.
+        let src = "fn main(x: Field) {
+    let y = unsafe // Safety: no constraints needed
+    {
+        helper(x)
+    };
+    assert(y == x);
+}
+";
+        let expected = "fn main(x: Field) {
+    let y = unsafe // Safety: no constraints needed
+    { helper(x) };
+    assert(y == x);
+}
+";
+        assert_format(src, expected);
+    }
+
+    #[test]
     fn format_let_statement_with_long_type() {
         let src = " fn foo() {
         let  some_variable: ThisIsAReallyLongType  = 123;
@@ -623,6 +663,28 @@ mod tests {
         let src = " fn foo() { x  + =  2 ; } ";
         let expected = "fn foo() {
     x += 2;
+}
+";
+        assert_format(src, expected);
+    }
+
+    #[test]
+    fn format_op_assign_with_comment_after_operator() {
+        // Regression test for https://github.com/noir-lang/noir-claude/issues/1646:
+        // the comment's terminating newline was dropped, so the right-hand side
+        // was swallowed into the comment.
+        let src = "fn main() {
+    let mut total = 0;
+    total += // running sum
+        1 * 2;
+    assert(total == 2);
+}
+";
+        let expected = "fn main() {
+    let mut total = 0;
+    total += // running sum
+    1 * 2;
+    assert(total == 2);
 }
 ";
         assert_format(src, expected);

--- a/tooling/nargo_fmt/src/lib.rs
+++ b/tooling/nargo_fmt/src/lib.rs
@@ -116,3 +116,45 @@ pub(crate) fn assert_formatter_changes_with_config(src: &str, config: Config) {
 
     assert_ne!(result, src, "idempotent check failed");
 }
+
+#[cfg(test)]
+mod line_comment_regression_tests {
+    use test_case::test_case;
+
+    use super::assert_format;
+
+    #[test_case(
+        "use // import the hash function\nstd::hash::pedersen_hash;\n";
+        "use keyword"
+    )]
+    #[test_case(
+        "fn main(x: Field) {\n    let mut y = 0;\n    y = // copy x\n    x;\n}\n";
+        "assignment operator"
+    )]
+    #[test_case(
+        "fn main(condition: bool) {\n    if // select a branch\n    condition {\n        assert(true);\n    }\n}\n";
+        "if keyword"
+    )]
+    #[test_case(
+        "fn main() {\n    for i in 0..2 // iterate twice\n    {\n        assert(i < 2);\n    }\n}\n";
+        "for loop before body"
+    )]
+    #[test_case(
+        "global // public constant\nANSWER: Field = 42;\n";
+        "global keyword"
+    )]
+    #[test_case(
+        "fn main() {\n    comptime // evaluate during compilation\n    {\n        assert(true);\n    }\n}\n";
+        "comptime keyword"
+    )]
+    fn format_line_comment_before_code_boundary_is_unchanged(src: &str) {
+        assert_format(src, src);
+    }
+
+    #[test]
+    fn format_line_comment_after_function_parameter_modifier() {
+        let src = "fn main(mut // keep parameter mutable\nx: Field) {}\n";
+        let expected = "fn main(\n    mut // keep parameter mutable\n    x: Field,\n) {}\n";
+        assert_format(src, expected);
+    }
+}


### PR DESCRIPTION
## Description

## Problem

The formatter could emit a `//` line comment without its terminating newline and keep writing on the same line, so the code that followed was swallowed into the comment. `nargo fmt` rewrites files in place and prints nothing while doing so, and the corruption usually shows up as output that no longer parses — but in the worst case the corrupted output still compiles:

```noir
fn main(x: Field, y: Field) {
    let check = |v| // every checked value must equal y
{ assert(v == y); };

    println("checking");
    check(x);
}
```

One `nargo fmt` pass turned this into

```noir
    let check = |v| // every checked value must equal y{ assert(v == y); };
```

which still compiles, but the `assert` is now commentary: the compiled ACIR loses its `ASSERT` opcode and a program written to reject its inputs accepts them.

There are two paths with this defect:

- `write_chunk_lines` splits a chunk's text with `str::lines()`, which drops a trailing newline, and writes newlines only *between* the resulting lines — so a chunk ending in `// comment\n` leaves the buffer's current line inside the comment.
- `format_chunk_group_in_one_line` writes chunk text with no newline handling at all, and is reachable for newline-bearing chunks through the lambda-as-last-expression fast path (e.g. `foo(1, |x| // comment` followed by the body swallowed the body).

## Solution

Enforce the invariant at append time instead of patching each writer: after writing chunk text, if the buffer's current line ends inside a `//` line comment, flag it (`Buffer::line_comment_needs_termination`); `Formatter::write` then breaks the line before appending any non-whitespace text to a flagged line, and any write containing a newline clears the flag.

The check lexes the buffer's current line, so `//` inside a string literal doesn't count. If the line isn't lexable on its own (e.g. it ends mid-multiline-string), it errs toward flagging: a spurious break only perturbs layout, while a missed one comments out code.

Two simpler designs don't work, for the record:

- Restoring the dropped newline at the end of `write_chunk_lines` unconditionally breaks ~45 existing tests: for a trailing comment at the end of a block, the caller already writes its own newline before `}`, so restoration double-breaks. Only append-time enforcement can tell "the next writer will break the line" apart from "the next writer will append".
- A universal guard that lexes the current line on every write breaks ~344 tests, because the comment writers themselves emit `//` and the comment body as separate writes. Hence the flag is set only where a completed chunk of text has been replayed into the buffer.

## Commits

The first commit adds the five regression tests (which fail on `master`), the second adds the fix. Please don't squash locally when reviewing; the PR itself is squash-merged as usual.

## Verification

- The five new tests cover the trigger positions from the issue: lambda body after a comment (the silent constraint-dropping case), lambda as last call argument (the one-line fast path), and comments after `let`, `+=`, and `unsafe`.
- Full `nargo_fmt` suite passes (615 tests, including the idempotence checks), plus `nargo_expand` and `noir_lsp` suites.
- `just format-noir` reports no changes: no committed Noir source is reformatted by this fix.
- End-to-end: the repro above now formats correctly, `nargo execute` still fails with `Cannot satisfy constraint` after formatting, and the output is a fixed point.

Fixes https://github.com/noir-lang/noir-claude/issues/1646

🤖 Generated with [Claude Code](https://claude.com/claude-code)