### PR TITLE
chore(fmt): replace the line-comment termination guard with faithful newline re-emission

### DIFF
--- a/tooling/nargo_fmt/src/chunks.rs
+++ b/tooling/nargo_fmt/src/chunks.rs
@@ -924,16 +924,16 @@ impl<'a> Formatter<'a> {
         for chunk in group.chunks {
             match chunk {
                 Chunk::Text(text_chunk, _) => {
+                    self.write_indentation();
                     self.write(&text_chunk.string);
-                    self.protect_open_line_comment();
                 }
                 Chunk::TrailingComment(text_chunk, _) => {
+                    self.write_indentation();
                     self.write(&text_chunk.string);
-                    self.protect_open_line_comment();
                 }
                 Chunk::LeadingComment(text_chunk) => {
+                    self.write_indentation();
                     self.write(&text_chunk.string);
-                    self.protect_open_line_comment();
                     self.write_space_without_skipping_whitespace_and_comments();
                 }
                 Chunk::Group(chunks) => self.format_chunk_group_impl(chunks),
@@ -976,6 +976,7 @@ impl<'a> Formatter<'a> {
             match chunk {
                 Chunk::Text(text_chunk, verbatim) => {
                     if verbatim {
+                        self.write_indentation();
                         self.write(&text_chunk.string);
                     } else if text_chunk.has_newlines {
                         self.write_chunk_lines(&text_chunk.string, false);
@@ -991,9 +992,9 @@ impl<'a> Formatter<'a> {
                         {
                             self.write_line_without_skipping_whitespace_and_comments();
                             self.increase_indentation();
-                            self.write_indentation();
                             increased_indentation += 1;
                         }
+                        self.write_indentation();
                         self.write(&text_chunk.string);
                     }
                 }
@@ -1083,6 +1084,11 @@ impl<'a> Formatter<'a> {
         });
         let string = text_chunk.string;
 
+        // The lambda's parameter list may have ended the line (for example with a
+        // `//` comment's terminating newline), leaving us at a fresh line that needs
+        // indentation (`write_indentation` is a no-op mid-line).
+        self.write_indentation();
+
         // Don't remove the braces if the lambda's body is a Semi expression.
         if string.ends_with("; }") || string.ends_with("; },") {
             self.write(&string);
@@ -1107,6 +1113,11 @@ impl<'a> Formatter<'a> {
         // The logic involves checking whether each line is part of a line or block comment
         // and wrapping those accordingly.
         let mut inside_block_comment = false;
+
+        // The previous chunk may have ended the line (for example with a `//` comment's
+        // terminating newline), in which case this chunk's first line starts fresh and
+        // needs indentation (`write_indentation` is a no-op mid-line).
+        self.write_indentation();
 
         let lines: Vec<_> = string.lines().collect();
 
@@ -1295,9 +1306,15 @@ impl<'a> Formatter<'a> {
             }
         }
 
-        // `str::lines()` above drops the chunk's final newline, so a `//` comment on
-        // the chunk's last line is left unterminated in the buffer here.
-        self.protect_open_line_comment();
+        // `str::lines()` above drops a final newline, but that newline is meaningful:
+        // in particular it may be the one that terminates a `//` comment on the chunk's
+        // last line, and anything appended to that line would become part of the
+        // comment. Re-emit it (`write_line_without_...` is a no-op if the line already
+        // ended, so writers that break the line themselves are unaffected).
+        if string.ends_with('\n') {
+            self.trim_spaces();
+            self.write_line_without_skipping_whitespace_and_comments();
+        }
     }
 
     /// Returns a new `GroupTag` that is unique compared to other `new_group_tag` calls.

--- a/tooling/nargo_fmt/src/formatter.rs
+++ b/tooling/nargo_fmt/src/formatter.rs
@@ -312,59 +312,8 @@ impl<'a> Formatter<'a> {
     }
 
     /// Writes a string to the buffer.
-    ///
-    /// A `//` comment is terminated only by a newline, so if the current line ends
-    /// inside one, appending anything to it would silently turn that text into part
-    /// of the comment. When the buffer says the current line needs its comment
-    /// terminated, break the line first so the text that follows stays code.
     pub(crate) fn write(&mut self, str: &str) {
-        if self.buffer.line_comment_needs_termination()
-            && !str.starts_with('\n')
-            && !str.trim().is_empty()
-        {
-            self.buffer.trim_spaces();
-            self.buffer.write("\n");
-            self.write_indentation();
-            self.buffer.write(str.trim_start_matches(' '));
-            return;
-        }
-
         self.buffer.write(str);
-    }
-
-    /// Checks whether the buffer's current line ends inside a `//` line comment and,
-    /// if so, flags it so that any text appended to that line triggers a line break
-    /// first (see `write`). Chunk text is written without its final newline (that
-    /// newline, if any, is the enclosing layout's decision), so this must be called
-    /// after writing a chunk's text to protect a comment that ends it.
-    pub(crate) fn protect_open_line_comment(&mut self) {
-        let line = self.buffer.current_line();
-        if !line.contains("//") {
-            return;
-        }
-
-        // Lex the line to check that the `//` really starts a comment (as opposed to,
-        // say, appearing inside a string literal). A line comment always extends to
-        // the end of the input, so finding one means the line ends inside it.
-        let lexer = Lexer::new_with_dummy_file(line).skip_comments(false).skip_whitespaces(false);
-        for token in lexer {
-            match token {
-                Ok(token) => {
-                    if matches!(token.token(), Token::LineComment(..)) {
-                        self.buffer.set_line_comment_needs_termination();
-                        return;
-                    }
-                }
-                // The line is not lexable on its own (for example, it could end in the
-                // middle of a multiline string literal). Err on the side of breaking
-                // the line: a spurious break only perturbs layout, while a missed one
-                // comments out code.
-                Err(_) => {
-                    self.buffer.set_line_comment_needs_termination();
-                    return;
-                }
-            }
-        }
     }
 
     pub(crate) fn current_line_width(&self) -> usize {

--- a/tooling/nargo_fmt/src/formatter/buffer.rs
+++ b/tooling/nargo_fmt/src/formatter/buffer.rs
@@ -8,11 +8,6 @@ pub(crate) struct Buffer {
     /// How many characters we've written so far in the current line
     /// (useful to avoid exceeding the configurable maximum)
     current_line_width: usize,
-
-    /// Whether the current line ends inside a `//` line comment that a newline must
-    /// terminate before anything else is appended to the line (otherwise whatever
-    /// is appended would become part of the comment).
-    line_comment_needs_termination: bool,
 }
 
 impl Buffer {
@@ -32,19 +27,7 @@ impl Buffer {
         self.buffer.ends_with(' ')
     }
 
-    /// Returns the contents of the current (last) line in the buffer.
-    pub(crate) fn current_line(&self) -> &str {
-        match self.buffer.rfind('\n') {
-            Some(index) => &self.buffer[index + 1..],
-            None => &self.buffer,
-        }
-    }
-
     pub(crate) fn write(&mut self, str: &str) {
-        if str.contains('\n') {
-            self.line_comment_needs_termination = false;
-        }
-
         self.buffer.push_str(str);
 
         if str.ends_with('\n') {
@@ -52,14 +35,6 @@ impl Buffer {
         } else {
             self.current_line_width += str.chars().count();
         }
-    }
-
-    pub(crate) fn line_comment_needs_termination(&self) -> bool {
-        self.line_comment_needs_termination
-    }
-
-    pub(crate) fn set_line_comment_needs_termination(&mut self) {
-        self.line_comment_needs_termination = true;
     }
 
     /// Trim spaces from the end of the buffer.


### PR DESCRIPTION
I thought #13480 was a bit hacky so I told Claude about this and it said that there's a larger refactor that could be done that would be better. It did it and then it realized it was not that big, and it was actually simpler than the other fix... so here's that PR.

To add a bit more to this: the problem was that when writing a line comment that ended in a newline, that newline was trimmed because we used the `lines()` Rust method which removes it. I told Claude "why don't we keep that final newline in addition to write the lines calling `lines()`" and it said it tried it but 45 tests failed so it wasn't straight-forward. It turns out that that was the proper solution, but for some reason it also added some extra indentations that broke those tests. This PR has the proper fix.

## Description

## Problem

Follow-up to #13480, which fixed `nargo fmt` swallowing the code that follows a `//` line comment (noir-lang/noir-claude#1646). That fix guarded the symptom: a buffer flag marks a line that ends inside an open `//` comment, and `Formatter::write` breaks the line before appending non-whitespace text to it. It works, but it is reactive — it re-derives "this line ends in a comment" by lexing buffer text the formatter itself produced, and its correctness depends on `protect_open_line_comment()` being called at every chunk-replay completion point.

## Solution

Fix the root cause instead: `write_chunk_lines` splits chunk text with `str::lines()`, which drops a trailing newline — the newline that terminates a `//` comment on the chunk's last line. Re-emit it.

The reason this wasn't done in #13480 is that callers after a chunk write their own line breaks, and re-emitting looked like it would double-break. It doesn't: the line/space/indentation writers already have ensure-semantics (`write_line_without_skipping_whitespace_and_comments` no-ops if the line is already broken; `write_indentation` no-ops mid-line), so those callers are unaffected. What was actually missing is the mirror-image assumption: chunk-text writers assumed they never start on a fresh line, so text written right after a terminated comment landed at column 0. This PR gives those write sites a `write_indentation()` call (a no-op mid-line): both group writers, `write_chunk_lines`' first line, and `format_lambda_body_removing_braces` — a fourth bare chunk-text writer that the guard covered only incidentally (everything funnels through `Formatter::write`).

With the newline re-emitted at the source, the guard is dead weight and is deleted: no buffer flag, no line re-lexing, no per-site protect calls. Net −59 lines.

## Behavior

Formatter output is unchanged: the full `nargo_fmt` suite — including the twelve line-comment swallowing regression tests from #13480 and #13491 — passes without modification, and `just format-noir` reports no changes across `noir_stdlib` and `test_programs`.

## Verification

- All 622 `nargo_fmt` tests pass unmodified.
- The `fmt_line_comments` fuzz target's deterministic case set passes (`CI=1 cargo test -p noir_ast_fuzzer_fuzz fmt_line_comments`).
- End-to-end: the original issue's repro formats correctly, keeps its `assert` (still fails with `Cannot satisfy constraint`), and is a fixed point.
- Nondeterministic `fmt_line_comments` runs surface pre-existing `Expected token …` lexer-surfing panics (`formatter.rs:174/248`); seed replays confirm they are byte-identical with and without this change — that's the separate panic bug class scoped out of noir-lang/noir-claude#1646, not comment swallowing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)