### PR TITLE
fix(ci): clear stale Criterion baselines before running ACVM benchmarks

### DIFF
--- a/.github/workflows/reports.yml
+++ b/.github/workflows/reports.yml
@@ -36,7 +36,11 @@ jobs:
           save-if: ${{ github.event_name != 'merge_group' }}
 
       - name: Run ACVM benchmarks
+        # `target/criterion` must not survive from the cache: rust-cache's cleanup can strip
+        # the files inside it while keeping the directories, and Criterion errors mid-output
+        # on such a hollow baseline, which breaks the bencher-format parsing below.
         run: |
+          rm -rf target/criterion
           cargo bench -p acvm -- --output-format bencher | tee acvm-bench.txt
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Problem Resolved

The `Reports / Rust Benchmarks` job has been failing on every branch (including `master` pushes) since ~13:14 UTC today with:

```
##[error]No benchmark result was found in .../acvm-bench.txt. Benchmark output was 'test purely_sequential_opcodes ... Criterion.rs ERROR: error: Failed to access file ".../target/criterion/purely_sequential_opcodes/base/sample.json": No such file or directory
```

## Root cause

#13484 bumped `Swatinem/rust-cache` to v2.9.2, which inverted the default in its target-dir cleanup classification. Previously, a `target/` subdirectory without Cargo's target-dir markers was treated as a profile dir and its contents were **wiped wholesale** before saving the cache — so `target/criterion` never made it into the cache and Criterion always started fresh. In v2.9.2, a directory without `build`/`.fingerprint`/`deps` is instead **recursed into**, deleting files while keeping directories:

```js
// old: isNestedTarget = exists(CACHEDIR.TAG) || exists(.rustc_info.json); else → profile (wiped)
// new: isProfile = name == "tests" || exists(build) || exists(.fingerprint) || exists(deps); else → recurse
```

`target/criterion` matches neither, so the saved cache now contains a hollow skeleton: `criterion/<bench>/base/` directories exist but `sample.json` and friends are deleted. On the next run Criterion sees the `base/` directory, concludes a saved baseline exists, fails to load it, and prints `Criterion.rs ERROR:` lines in the middle of its bencher output — which breaks the single-line `test NAME ... bench: N ns/iter` format that `github-action-benchmark` parses, so it reports "No benchmark result was found" and fails the job.

This also explains the ~2h delay between the bump merging (11:25 UTC) and failures starting (~13:14 UTC): the first runs after the bump restored caches saved by the *old* action version (no criterion state — fine), then saved the first poisoned cache; everything after that restores the skeleton and fails.

## Summary of Changes

Delete `target/criterion` before running `cargo bench`. Baselines restored from CI caches were never meaningful across runners (the old rust-cache behavior effectively discarded them anyway), and this makes the job immune to whatever state the cache carries — including if the upstream cleanup behavior changes again.

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)