### PR TITLE
fix(acir): guard empty vector pop/remove on the semantic length

### DIFF
--- a/compiler/noirc_evaluator/src/acir/call/intrinsics/vector_ops.rs
+++ b/compiler/noirc_evaluator/src/acir/call/intrinsics/vector_ops.rs
@@ -386,8 +386,14 @@ impl Context<'_> {
         let vector_type = dfg.type_of_value(vector_contents_id);
         self.check_vector_result_count("vector_pop_back", result_ids, &vector_type)?;
 
-        // Check if we're trying to pop from a known empty vector.
-        if self.has_zero_length(vector_contents_id, dfg) {
+        let vector_length_var = vector_length_value.clone().into_var()?;
+
+        // Check if we're trying to pop from a known empty vector: one whose backing store
+        // is empty, or one whose semantic length is known to be zero (its backing store may
+        // still be non-empty padding in that case).
+        if self.has_zero_length(vector_contents_id, dfg)
+            || self.vector_length_is_known_zero(dfg, vector_length_id, vector_length_var)
+        {
             // Make sure this code is disabled, or fail with the empty-vector pop message.
             let msg = "Attempt to pop from an empty vector".to_string();
             self.acir_context.assert_zero_var(self.current_side_effects_enabled_var, msg)?;
@@ -449,6 +455,25 @@ impl Context<'_> {
         results.append(&mut popped_elements);
 
         Ok(results)
+    }
+
+    /// Whether the vector's semantic length is known to be zero at this point: either the
+    /// SSA value is the constant zero, or its ACIR expression has folded to zero (which
+    /// happens when the side-effects predicate it was multiplied by collapsed to a
+    /// constant). The backing store cannot answer this question — merging branch arms of
+    /// unequal lengths pads the shorter arm, so a semantically empty vector may still have
+    /// a non-empty backing store, and `has_zero_length` inspects that backing store.
+    fn vector_length_is_known_zero(
+        &self,
+        dfg: &DataFlowGraph,
+        vector_length_id: ValueId,
+        vector_length_var: AcirVar,
+    ) -> bool {
+        let length_const = dfg.get_numeric_constant(vector_length_id).or_else(|| {
+            let expr = self.acir_context.var_to_expression(vector_length_var).ok()?;
+            expr.to_const().copied()
+        });
+        length_const.is_some_and(|length| length.is_zero())
     }
 
     /// Compute the new vector length after popping one value from it.
@@ -547,8 +572,14 @@ impl Context<'_> {
         self.check_vector_result_count("vector_pop_front", result_ids, &vector_type)?;
         let element_size = vector_type.element_size();
 
-        // Check if we're trying to pop from a known empty vector.
-        if self.has_zero_length(vector_contents_id, dfg) {
+        let vector_length_var = vector_length_value.clone().into_var()?;
+
+        // Check if we're trying to pop from a known empty vector: one whose backing store
+        // is empty, or one whose semantic length is known to be zero (its backing store may
+        // still be non-empty padding in that case).
+        if self.has_zero_length(vector_contents_id, dfg)
+            || self.vector_length_is_known_zero(dfg, vector_length_id, vector_length_var)
+        {
             // Make sure this code is disabled, or fail with the empty-vector pop message.
             let msg = "Attempt to pop from an empty vector".to_string();
             self.acir_context.assert_zero_var(self.current_side_effects_enabled_var, msg)?;
@@ -873,8 +904,13 @@ impl Context<'_> {
         let vector_typ = dfg.type_of_value(vector_contents);
         self.check_vector_result_count("vector_remove", result_ids, &vector_typ)?;
 
-        // Check if we're trying to remove from an empty vector
-        if self.has_zero_length(vector_contents, dfg) {
+        // Check if we're trying to remove from a known empty vector: one whose backing store
+        // is empty, or one whose semantic length is known to be zero (its backing store may
+        // still be non-empty padding in that case). Without the semantic-length check a length
+        // that has folded to zero reaches the `sub_var(length, 1)` below and produces `p - 1`.
+        if self.has_zero_length(vector_contents, dfg)
+            || self.vector_length_is_known_zero(dfg, arguments[0], vector_length)
+        {
             // Make sure this code is disabled, or fail with "Index out of bounds".
             let msg = "Index out of bounds, vector has size 0".to_string();
             self.acir_context.assert_zero_var(self.current_side_effects_enabled_var, msg)?;

--- a/test_programs/execution_success/vector_ops_collapsed_predicate/Nargo.toml
+++ b/test_programs/execution_success/vector_ops_collapsed_predicate/Nargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "vector_ops_collapsed_predicate"
+type = "bin"
+authors = [""]
+
+[dependencies]

--- a/test_programs/execution_success/vector_ops_collapsed_predicate/Prover.toml
+++ b/test_programs/execution_success/vector_ops_collapsed_predicate/Prover.toml
@@ -1,0 +1,4 @@
+g0 = true
+d = false
+i = 0
+return = 0

--- a/test_programs/execution_success/vector_ops_collapsed_predicate/src/main.nr
+++ b/test_programs/execution_success/vector_ops_collapsed_predicate/src/main.nr
@@ -1,0 +1,23 @@
+// Popping from a statically-empty slice inside a conditional collapses the branch
+// predicate to a constant zero at the ACIR level (the empty-pop assertion pins it),
+// which in turn folds the length of an unrelated, still-live slice to a constant zero.
+// A subsequent `remove` on that slice must not turn the folded length into `0 - 1` in
+// the field: `push_back` consumes the result as a `u32` length, and the compiler must
+// not crash converting it. With `g0 = true` the branch is inactive and `main` returns 0.
+fn main(g0: bool, d: bool, i: u32) -> pub Field {
+    let v = @[1];
+    let mut w = @[1];
+    if d {
+        w = w.push_back(5);
+    }
+    let mut out = 0;
+    if !g0 {
+        let (v2, _a) = v.remove(i);
+        let (_v3, _b) = v2.pop_back();
+        let (w2, _c) = w.pop_back();
+        let (w3, _e) = w2.remove(i);
+        let w4 = w3.push_back(9);
+        out = w4[0];
+    }
+    out
+}

--- a/tooling/nargo_cli/tests/snapshots/execution_success/vector_ops_collapsed_predicate/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/vector_ops_collapsed_predicate/execute__tests__expanded.snap
@@ -1,0 +1,19 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: expanded_code
+---
+fn main(g0: bool, d: bool, i: u32) -> pub Field {
+    let v: [Field] = @[1_Field];
+    let mut w: [Field] = @[1_Field];
+    if d { w = w.push_back(5_Field); };
+    let mut out: Field = 0_Field;
+    if !g0 {
+        let (v2, _a): ([Field], Field) = v.remove(i);
+        let (_v3, _b): ([Field], Field) = v2.pop_back();
+        let (w2, _c): ([Field], Field) = w.pop_back();
+        let (w3, _e): ([Field], Field) = w2.remove(i);
+        let w4: [Field] = w3.push_back(9_Field);
+        out = w4[0_u32];
+    };
+    out
+}

--- a/tooling/nargo_cli/tests/snapshots/execution_success/vector_ops_collapsed_predicate/execute__tests__stdout.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/vector_ops_collapsed_predicate/execute__tests__stdout.snap
@@ -1,0 +1,5 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: stdout
+---
+[vector_ops_collapsed_predicate] Circuit output: 0x00


### PR DESCRIPTION
## Summary

Fixes a compiler crash (and latent miscompilation) when a `pop_back`/`pop_front`/`remove` intrinsic is applied to a vector whose **semantic length** is zero but whose **backing store** is not.

acir_gen decided emptiness with `has_zero_length`, which inspects the backing store. But a slice's backing store can be non-empty while its semantic length is zero — merging two branch arms of unequal length pads the shorter arm. In that state the empty-vector arm was skipped and the new length was computed as `0 - 1 = p - 1` in the field; `convert_vector_push_back` then aborted the compiler in `FieldElement::to_u128` ("field element too large for u128").

The zero length is not always visible in the SSA. An empty-vector assertion can collapse the side-effects predicate to a constant zero *during ACIR generation*, and the predicate multiplication then folds a live vector's length to zero while its SSA value stays dynamic — so no SSA pass can see it. The new `vector_length_is_known_zero` helper checks both the SSA constant and the folded ACIR expression, and the three converters take the empty arm when **either** the backing store or the semantic length is known to be zero.

## Changes

- `convert_vector_pop_back` / `convert_vector_pop_front` / `convert_vector_remove` now key their empty check on the semantic length as well as the backing store, via the new `vector_length_is_known_zero` helper.

## Testing

- New regression program `vector_ops_collapsed_predicate` reproduces the predicate-collapse crash end to end; it panicked the compiler before this change and now compiles and executes across the ACIR, Brillig, and interpreter variants.
- The active (predicate-enabled) empty case still fails at runtime with `Failed assertion` rather than returning padding — soundness preserved.
- All existing `noirc_evaluator` vector tests pass; `acir_vs_brillig`, `min_vs_full`, `orig_vs_morph`, and `comptime_vs_brillig_nargo` AST-fuzzer targets pass.

## Status

Draft: opening for review of the approach. The Brillig `update_vector_length` wrapping-`Sub` and the SSA interpreter's `vector_remove` guard are related but separate surfaces (source programs reach them only through their own ssa_gen checks); this PR scopes to the ACIR generation path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
