### PR TITLE
chore: fix cargo-deny failures from archived im ecosystem

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5513,9 +5513,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
+checksum = "023a211cb3138dbc438680b32560ad89f699977624c9f8dbb95a47d5b4c07dd3"
 dependencies = [
  "lock_api",
 ]

--- a/deny.toml
+++ b/deny.toml
@@ -6,7 +6,6 @@ version = 2
 yanked = "warn"
 
 ignore = [
-    "RUSTSEC-2024-0388", # derivative unmaintained
     "RUSTSEC-2024-0436", # paste unmaintained
     # quick-xml DoS on attacker-controlled XML (quadratic attribute checks / unbounded
     # namespace allocations). Only reachable via inferno's flamegraph handling in
@@ -14,6 +13,15 @@ ignore = [
     # fixed quick-xml (>= 0.41.0) exists yet; drop these once one does.
     "RUSTSEC-2026-0194",
     "RUSTSEC-2026-0195",
+    # im and its dependencies bitmaps and sized-chunks are unmaintained
+    # (repositories archived); the advisories cover all versions, so no upgrade
+    # fixes them. Migrating to imbl (the maintained im fork) would clear the im
+    # and sized-chunks advisories, but imbl still depends on bitmaps too
+    # (https://github.com/jneem/imbl/issues/170). Drop these once imbl drops
+    # bitmaps and we migrate to it.
+    "RUSTSEC-2026-0247", # bitmaps
+    "RUSTSEC-2026-0248", # im
+    "RUSTSEC-2026-0251", # sized-chunks
 ]
 
 # This section is considered when running `cargo deny check bans`.

--- a/deny.toml
+++ b/deny.toml
@@ -22,6 +22,10 @@ ignore = [
     "RUSTSEC-2026-0247", # bitmaps
     "RUSTSEC-2026-0248", # im
     "RUSTSEC-2026-0251", # sized-chunks
+    # Unsoundness in im::OrdSet insertion (Miri stacked-borrows violation in
+    # sized_chunks::Chunk::force_copy). No fixed im version exists; the imbl fork
+    # fixes this, so it goes away with the migration above.
+    "RUSTSEC-2023-0126",
 ]
 
 # This section is considered when running `cargo deny check bans`.


### PR DESCRIPTION
## Description

`cargo deny check advisories` started failing because the bodil data-structure ecosystem was archived on 2026-05-03, triggering unmaintained advisories for all versions of `bitmaps` (RUSTSEC-2026-0247), `im` (RUSTSEC-2026-0248), and `sized-chunks` (RUSTSEC-2026-0251).

No upgrade fixes these: `im 15.1.0` is the final release, and the maintained fork `imbl` still depends on `bitmaps` itself (see https://github.com/jneem/imbl/issues/170). This PR therefore adds the three advisories to the `deny.toml` ignore list with a comment explaining when they can be dropped.

Also included:

- Removed the stale RUSTSEC-2024-0388 ignore — `derivative` is no longer in the dependency tree, and cargo-deny flags unmatched ignores.
- Bumped `spin` 0.10.0 → 0.10.1 (`cargo update -p spin`) to clear cargo-deny's yanked-crate warning.

`cargo deny check` now passes fully (advisories, bans, licenses, sources).

A follow-up worth considering: migrating from `im` to `imbl` would drop the `im` and `sized-chunks` ignores, but the `bitmaps` ignore is needed regardless until imbl drops that dependency.