### PR TITLE
feat(ssa): check purity contracts during SSA interpretation

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/interpreter/errors.rs
+++ b/compiler/noirc_evaluator/src/ssa/interpreter/errors.rs
@@ -82,7 +82,7 @@ pub enum InterpreterError {
     )]
     PurityViolation { function: FunctionId, function_name: String, purity: String, reason: String },
     /// An intrinsic mutated its vector operand in place without being listed in
-    /// [Intrinsic::mutates_array_operand_in_brillig]. Purity analysis relies on that
+    /// `Intrinsic::mutates_array_operand_in_brillig`. Purity analysis relies on that
     /// list to classify callers, so an unlisted mutator silently poisons every
     /// containing function's recorded purity.
     #[error(

--- a/compiler/noirc_evaluator/src/ssa/interpreter/errors.rs
+++ b/compiler/noirc_evaluator/src/ssa/interpreter/errors.rs
@@ -81,6 +81,14 @@ pub enum InterpreterError {
         "purity violation: function {function} ({function_name}) is recorded as {purity} but {reason}"
     )]
     PurityViolation { function: FunctionId, function_name: String, purity: String, reason: String },
+    /// An intrinsic mutated its vector operand in place without being listed in
+    /// [Intrinsic::mutates_array_operand_in_brillig]. Purity analysis relies on that
+    /// list to classify callers, so an unlisted mutator silently poisons every
+    /// containing function's recorded purity.
+    #[error(
+        "purity violation: intrinsic {intrinsic} mutated its vector operand in place but is not marked as a vector mutator"
+    )]
+    IntrinsicPurityViolation { intrinsic: Intrinsic },
 }
 
 impl InterpreterError {

--- a/compiler/noirc_evaluator/src/ssa/interpreter/errors.rs
+++ b/compiler/noirc_evaluator/src/ssa/interpreter/errors.rs
@@ -75,6 +75,36 @@ pub enum InterpreterError {
     OutOfBudget { steps: usize },
     #[error("Stack overflow in 'fn {} {}'", .call_stack.last().unwrap().1, .call_stack.last().unwrap().0)]
     StackOverflow { call_stack: Vec<(FunctionId, String)> },
+    /// A function behaved in a way its recorded purity forbids. This indicates a bug
+    /// in purity analysis, or in an SSA pass that invalidated its results.
+    #[error(
+        "purity violation: function {function} ({function_name}) is recorded as {purity} but {reason}"
+    )]
+    PurityViolation { function: FunctionId, function_name: String, purity: String, reason: String },
+}
+
+impl InterpreterError {
+    /// Whether this error is a failure of the interpreted program's own semantics
+    /// (a failed assertion, overflow, division by zero, ...) as opposed to an
+    /// artifact of interpretation (step budget, missing oracle, malformed SSA).
+    ///
+    /// Only these failures are purity violations when they escape a function
+    /// recorded as [Pure][crate::ssa::opt::pure::Purity::Pure]: a `Pure` function
+    /// must never fail, since passes may remove or reorder calls to it.
+    pub(super) fn is_execution_failure(&self) -> bool {
+        matches!(
+            self,
+            InterpreterError::ConstrainEqFailed { .. }
+                | InterpreterError::ConstrainNeFailed { .. }
+                | InterpreterError::StaticAssertFailed { .. }
+                | InterpreterError::RangeCheckFailed { .. }
+                | InterpreterError::DivisionByZero { .. }
+                | InterpreterError::Overflow { .. }
+                | InterpreterError::PoppedFromEmptyVector { .. }
+                | InterpreterError::IndexOutOfBounds { .. }
+                | InterpreterError::ReachedTheUnreachable
+        )
+    }
 }
 
 /// These errors can only result from interpreting malformed SSA

--- a/compiler/noirc_evaluator/src/ssa/interpreter/intrinsics.rs
+++ b/compiler/noirc_evaluator/src/ssa/interpreter/intrinsics.rs
@@ -525,12 +525,17 @@ impl<W: Write> Interpreter<'_, W> {
     /// When mutating in place the returned vector shares its backing store with `vector`, so any
     /// other handle to the same vector observes the mutation as well — exactly as in Brillig when
     /// the reference count is 1 and the ownership pass did not insert a protecting `inc_rc`.
+    ///
+    /// `intrinsic` is the operation on whose behalf the mutation happens; it must declare
+    /// itself a mutator (see [check_intrinsic_mutation_label]).
     fn update_vector_elements<R>(
         &self,
+        intrinsic: Intrinsic,
         vector: ArrayValue,
         f: impl FnOnce(&mut Vec<Value>) -> IResult<R>,
     ) -> IResult<(R, Value)> {
         if self.vector_mutates_in_place(&vector) {
+            check_intrinsic_mutation_label(intrinsic)?;
             self.check_purity_on_mutation(
                 vector.elements.as_ptr() as StorageIdentity,
                 "a vector intrinsic writing through its input vector",
@@ -552,23 +557,24 @@ impl<W: Write> Interpreter<'_, W> {
 
         let new_values = try_vecmap(args.iter().skip(2), |arg| self.lookup(*arg))?;
 
-        let (_, new_vector) = self.update_vector_elements(vector, |elements| {
-            // The vector might contain more elements than its length.
-            // We need to either insert before the extras, overwrite, or remove them.
-            // We could remove any extras and then append:
-            //  elements.truncate(width * length as usize);
-            // But the way some SSA passes work is that they assume we *always* grow the vector capacity,
-            // so instead of truncating, we append as well as overwrite.
-            let end_index = width * (length as usize);
-            let push_only = end_index == elements.len();
-            for (i, value) in new_values.into_iter().enumerate() {
-                if !push_only {
-                    elements[end_index + i] = value.clone();
+        let (_, new_vector) =
+            self.update_vector_elements(Intrinsic::VectorPushBack, vector, |elements| {
+                // The vector might contain more elements than its length.
+                // We need to either insert before the extras, overwrite, or remove them.
+                // We could remove any extras and then append:
+                //  elements.truncate(width * length as usize);
+                // But the way some SSA passes work is that they assume we *always* grow the vector capacity,
+                // so instead of truncating, we append as well as overwrite.
+                let end_index = width * (length as usize);
+                let push_only = end_index == elements.len();
+                for (i, value) in new_values.into_iter().enumerate() {
+                    if !push_only {
+                        elements[end_index + i] = value.clone();
+                    }
+                    elements.push(value);
                 }
-                elements.push(value);
-            }
-            Ok(())
-        })?;
+                Ok(())
+            })?;
 
         let new_length = Value::u32(length + 1);
         Ok(vec![new_length, new_vector])
@@ -581,12 +587,13 @@ impl<W: Write> Interpreter<'_, W> {
 
         let new_values = try_vecmap(args.iter().skip(2), |arg| self.lookup(*arg))?;
 
-        let (_, new_vector) = self.update_vector_elements(vector, |elements| {
-            let mut prefixed = new_values;
-            prefixed.append(elements);
-            *elements = prefixed;
-            Ok(())
-        })?;
+        let (_, new_vector) =
+            self.update_vector_elements(Intrinsic::VectorPushFront, vector, |elements| {
+                let mut prefixed = new_values;
+                prefixed.append(elements);
+                *elements = prefixed;
+                Ok(())
+            })?;
 
         let new_length = Value::u32(length + 1);
         Ok(vec![new_length, new_vector])
@@ -612,11 +619,12 @@ impl<W: Write> Interpreter<'_, W> {
         let width = vector.element_types.len();
         let last_index = width * (length as usize - 1);
 
-        let (popped_elements, new_vector) = self.update_vector_elements(vector, |elements| {
-            let popped = elements[last_index..last_index + width].to_vec();
-            elements.truncate(elements.len() - width);
-            Ok(popped)
-        })?;
+        let (popped_elements, new_vector) =
+            self.update_vector_elements(Intrinsic::VectorPopBack, vector, |elements| {
+                let popped = elements[last_index..last_index + width].to_vec();
+                elements.truncate(elements.len() - width);
+                Ok(popped)
+            })?;
 
         let new_length = Value::u32(length - 1);
         let mut results = vec![new_length, new_vector];
@@ -637,9 +645,10 @@ impl<W: Write> Interpreter<'_, W> {
 
         let width = vector.element_types.len();
 
-        let (mut results, new_vector) = self.update_vector_elements(vector, |elements| {
-            Ok(elements.drain(0..width).collect::<Vec<_>>())
-        })?;
+        let (mut results, new_vector) =
+            self.update_vector_elements(Intrinsic::VectorPopFront, vector, |elements| {
+                Ok(elements.drain(0..width).collect::<Vec<_>>())
+            })?;
 
         let new_length = Value::u32(length - 1);
         results.push(new_length);
@@ -656,13 +665,14 @@ impl<W: Write> Interpreter<'_, W> {
 
         let new_values = try_vecmap(args.iter().skip(3), |arg| self.lookup(*arg))?;
 
-        let (_, new_vector) = self.update_vector_elements(vector, |elements| {
-            let start = index as usize * width;
-            for (offset, value) in new_values.into_iter().enumerate() {
-                elements.insert(start + offset, value);
-            }
-            Ok(())
-        })?;
+        let (_, new_vector) =
+            self.update_vector_elements(Intrinsic::VectorInsert, vector, |elements| {
+                let start = index as usize * width;
+                for (offset, value) in new_values.into_iter().enumerate() {
+                    elements.insert(start + offset, value);
+                }
+                Ok(())
+            })?;
 
         let new_length = Value::u32(length + 1);
         Ok(vec![new_length, new_vector])
@@ -683,9 +693,10 @@ impl<W: Write> Interpreter<'_, W> {
         let width = vector.element_types.len();
         let index = index as usize * width;
 
-        let (removed, new_vector) = self.update_vector_elements(vector, |elements| {
-            Ok(elements.drain(index..index + width).collect::<Vec<_>>())
-        })?;
+        let (removed, new_vector) =
+            self.update_vector_elements(Intrinsic::VectorRemove, vector, |elements| {
+                Ok(elements.drain(index..index + width).collect::<Vec<_>>())
+            })?;
 
         let new_length = Value::u32(length - 1);
         let mut results = vec![new_length, new_vector];
@@ -774,6 +785,21 @@ impl<W: Write> Interpreter<'_, W> {
         }
 
         Ok(Vec::new())
+    }
+}
+
+/// Checks that an intrinsic about to write through its input vector's backing store
+/// declares itself a mutator via [Intrinsic::mutates_array_operand_in_brillig].
+///
+/// Purity analysis uses that list to classify functions containing intrinsic calls,
+/// so an intrinsic that mutates without being listed silently poisons the recorded
+/// purity of every function it appears in. Checking at the moment of mutation keeps
+/// the list and the interpreter's (Brillig-mirroring) behavior from drifting apart.
+pub(super) fn check_intrinsic_mutation_label(intrinsic: Intrinsic) -> IResult<()> {
+    if intrinsic.mutates_array_operand_in_brillig() {
+        Ok(())
+    } else {
+        Err(InterpreterError::IntrinsicPurityViolation { intrinsic })
     }
 }
 

--- a/compiler/noirc_evaluator/src/ssa/interpreter/intrinsics.rs
+++ b/compiler/noirc_evaluator/src/ssa/interpreter/intrinsics.rs
@@ -12,7 +12,10 @@ use crate::ssa::ir::{
     value::ValueId,
 };
 
-use super::{ArrayValue, IResult, IResults, InternalError, Interpreter, InterpreterError, Value};
+use super::{
+    ArrayValue, IResult, IResults, InternalError, Interpreter, InterpreterError, Value,
+    value::StorageIdentity,
+};
 
 impl<W: Write> Interpreter<'_, W> {
     pub(super) fn call_intrinsic(
@@ -528,6 +531,10 @@ impl<W: Write> Interpreter<'_, W> {
         f: impl FnOnce(&mut Vec<Value>) -> IResult<R>,
     ) -> IResult<(R, Value)> {
         if self.vector_mutates_in_place(&vector) {
+            self.check_purity_on_mutation(
+                vector.elements.as_ptr() as StorageIdentity,
+                "a vector intrinsic writing through its input vector",
+            )?;
             let result = f(&mut vector.elements.borrow_mut())?;
             Ok((result, Value::ArrayOrVector(vector)))
         } else {

--- a/compiler/noirc_evaluator/src/ssa/interpreter/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/interpreter/mod.rs
@@ -515,6 +515,11 @@ impl<'ssa, W: Write> Interpreter<'ssa, W> {
     /// observable by that call's caller, which both [Purity::Pure] and
     /// [Purity::PureWithPredicate] forbid. Storage allocated during the call is not
     /// in any scope's set, so local mutations pass freely.
+    ///
+    /// Callers only invoke this for writes that are genuinely observable under the
+    /// current runtime's semantics: constrained-context `array_set`s marked mutable
+    /// are exempt, since they merely reuse the backing store of an array value
+    /// proven dead, under ACIR's value semantics.
     fn check_purity_on_mutation(&self, storage: StorageIdentity, what: &str) -> IResult<()> {
         for context in self.call_stack.iter().rev() {
             let Some(scope) = &context.pure_scope else { continue };
@@ -1294,10 +1299,18 @@ impl<'ssa, W: Write> Interpreter<'ssa, W> {
             }
 
             if should_mutate {
-                self.check_purity_on_mutation(
-                    array.elements.as_ptr() as StorageIdentity,
-                    "an in-place array_set",
-                )?;
+                // In a constrained context arrays have value semantics: an in-place write
+                // here only reuses the backing store of an array value that the Mutable
+                // Array Set Optimizations pass proved dead, so it is not a caller-visible
+                // mutation and purity analysis rightly ignores it. Only in Brillig, where
+                // the reference count governs genuine sharing, is writing through
+                // argument-reachable storage observable by the caller.
+                if self.in_unconstrained_context() {
+                    self.check_purity_on_mutation(
+                        array.elements.as_ptr() as StorageIdentity,
+                        "an in-place array_set",
+                    )?;
+                }
                 array.elements.borrow_mut()[index as usize] = value;
                 Value::ArrayOrVector(array)
             } else {

--- a/compiler/noirc_evaluator/src/ssa/interpreter/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/interpreter/mod.rs
@@ -18,13 +18,14 @@ use crate::ssa::ir::{
     printer::display_binary,
     types::NumericType,
 };
+use crate::ssa::opt::pure::Purity;
 use acvm::{AcirField, FieldElement};
 use errors::{InternalError, InterpreterError, MAX_UNSIGNED_BIT_SIZE};
 use iter_extended::{try_vecmap, vecmap};
 use itertools::Itertools;
 use noirc_frontend::Shared;
-use rustc_hash::FxHashMap as HashMap;
-use value::{ArrayValue, NumericValue, ReferenceValue};
+use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
+use value::{ArrayValue, NumericValue, ReferenceValue, StorageIdentity};
 
 pub mod errors;
 mod intrinsics;
@@ -52,6 +53,11 @@ pub(crate) struct Interpreter<'ssa, W> {
 
     /// Number of instructions and terminators executed.
     step_counter: usize,
+
+    /// Storage identities of every array or reference defined by global instructions.
+    /// Globals are visible everywhere, so mutating their storage inside a function
+    /// whose purity forbids caller-visible side effects is always a violation.
+    global_storage: HashSet<StorageIdentity>,
 }
 
 #[derive(Debug, Clone, Copy, Default)]
@@ -76,19 +82,51 @@ struct CallContext {
     /// expected to have no effect if there are no such instructions or if the code
     /// being executed is an unconstrained function.
     side_effects_enabled: bool,
+
+    /// Present when the called function's recorded purity is [Purity::Pure] or
+    /// [Purity::PureWithPredicate], both of which forbid mutating caller-visible
+    /// memory. Absent for `Impure` functions and when no purity analysis has run.
+    pure_scope: Option<PureScope>,
+}
+
+/// The purity contract the interpreter enforces for the duration of one call.
+///
+/// A violation can only stem from a bug in purity analysis or in an SSA pass that
+/// invalidated its results, so the interpreter reports it as an
+/// [InterpreterError::PurityViolation] rather than treating it as program behavior.
+struct PureScope {
+    /// The purity recorded for the called function, as observed by its caller
+    /// (see [DataFlowGraph::purity_of]).
+    purity: Purity,
+
+    /// Storage identities of everything reachable from the call's arguments at
+    /// entry. An in-place write to any of these during the call is observable by
+    /// the caller, which both `Pure` and `PureWithPredicate` forbid.
+    argument_storage: HashSet<StorageIdentity>,
+
+    /// Clones of the arguments, held only to keep the collected storage alive for
+    /// the duration of the call so that a freed allocation's address cannot be
+    /// reused by unrelated storage and trigger a false violation.
+    _argument_keepalive: Vec<Value>,
 }
 
 impl CallContext {
-    fn new(called_function: FunctionId) -> Self {
+    fn new(called_function: FunctionId, pure_scope: Option<PureScope>) -> Self {
         Self {
             called_function: Some(called_function),
             scope: Default::default(),
             side_effects_enabled: true,
+            pure_scope,
         }
     }
 
     fn global_context() -> Self {
-        Self { called_function: None, scope: Default::default(), side_effects_enabled: true }
+        Self {
+            called_function: None,
+            scope: Default::default(),
+            side_effects_enabled: true,
+            pure_scope: None,
+        }
     }
 }
 
@@ -134,7 +172,14 @@ impl<'ssa, W: Write> Interpreter<'ssa, W> {
         output: W,
     ) -> Self {
         let call_stack = vec![CallContext::global_context()];
-        Self { functions, call_stack, options, output, step_counter: 0 }
+        Self {
+            functions,
+            call_stack,
+            options,
+            output,
+            step_counter: 0,
+            global_storage: HashSet::default(),
+        }
     }
 
     pub(crate) fn functions(&self) -> &BTreeMap<FunctionId, Function> {
@@ -263,6 +308,13 @@ impl<'ssa, W: Write> Interpreter<'ssa, W> {
             };
             self.define(global_id, value)?;
         }
+
+        let mut global_storage = HashSet::default();
+        for value in self.global_scope().values() {
+            value.collect_storage_identities(&mut global_storage);
+        }
+        self.global_storage = global_storage;
+
         Ok(())
     }
 
@@ -283,8 +335,49 @@ impl<'ssa, W: Write> Interpreter<'ssa, W> {
     ///
     /// Unlike `interpret_function` this does not reset the state;
     /// it is meant to be used for internal calls.
-    fn call_function(&mut self, function_id: FunctionId, mut arguments: Vec<Value>) -> IResults {
-        self.call_stack.push(CallContext::new(function_id));
+    ///
+    /// If the called function has a recorded purity, its behavior is checked against
+    /// the contract that purity promises: `Pure` and `PureWithPredicate` functions
+    /// must not mutate caller-visible memory (enforced at each in-place write via
+    /// [Self::check_purity_on_mutation]), and `Pure` functions additionally must not
+    /// fail, since passes are free to deduplicate or remove calls to them.
+    fn call_function(&mut self, function_id: FunctionId, arguments: Vec<Value>) -> IResults {
+        // The function's purity as its caller observes it; the innermost frame is
+        // still the caller here. For a top-level call there is no caller, so the
+        // callee's own runtime provides the (identity) projection.
+        let caller_id = self.call_context().called_function.unwrap_or(function_id);
+        let purity = self.functions[&caller_id].dfg.purity_of(function_id);
+
+        let pure_scope = purity.filter(|purity| *purity != Purity::Impure).map(|purity| {
+            let mut argument_storage = HashSet::default();
+            for argument in &arguments {
+                argument.collect_storage_identities(&mut argument_storage);
+            }
+            PureScope { purity, argument_storage, _argument_keepalive: arguments.clone() }
+        });
+
+        let result = self.call_function_inner(function_id, arguments, pure_scope);
+
+        if purity == Some(Purity::Pure)
+            && let Err(error) = &result
+            && error.is_execution_failure()
+        {
+            return Err(self.purity_violation(
+                function_id,
+                Purity::Pure,
+                format!("it failed with: {error}"),
+            ));
+        }
+        result
+    }
+
+    fn call_function_inner(
+        &mut self,
+        function_id: FunctionId,
+        mut arguments: Vec<Value>,
+        pure_scope: Option<PureScope>,
+    ) -> IResults {
+        self.call_stack.push(CallContext::new(function_id, pure_scope));
 
         if self.call_stack.len() >= MAX_INTERPRETER_CALL_STACK_SIZE {
             let call_stack = self
@@ -400,6 +493,57 @@ impl<'ssa, W: Write> Interpreter<'ssa, W> {
         }
 
         Ok(return_values)
+    }
+
+    fn purity_violation(
+        &self,
+        function: FunctionId,
+        purity: Purity,
+        reason: String,
+    ) -> InterpreterError {
+        InterpreterError::PurityViolation {
+            function,
+            function_name: self.functions[&function].name().to_string(),
+            purity: purity.to_string(),
+            reason,
+        }
+    }
+
+    /// Check an in-place write to `storage` against every active purity scope.
+    ///
+    /// Writing to storage reachable from a call's arguments (or from a global) is
+    /// observable by that call's caller, which both [Purity::Pure] and
+    /// [Purity::PureWithPredicate] forbid. Storage allocated during the call is not
+    /// in any scope's set, so local mutations pass freely.
+    fn check_purity_on_mutation(&self, storage: StorageIdentity, what: &str) -> IResult<()> {
+        for context in self.call_stack.iter().rev() {
+            let Some(scope) = &context.pure_scope else { continue };
+            if scope.argument_storage.contains(&storage) || self.global_storage.contains(&storage) {
+                let function = context
+                    .called_function
+                    .expect("purity scopes only exist on function call frames");
+                let reason = format!("it mutated caller-visible memory ({what})");
+                return Err(self.purity_violation(function, scope.purity, reason));
+            }
+        }
+        Ok(())
+    }
+
+    /// Check an executed foreign function call against every active purity scope.
+    ///
+    /// A foreign call is an observable side effect, so it is forbidden inside any
+    /// function whose recorded purity is not `Impure` (even a `#[pure]` oracle makes
+    /// its caller at most `PureWithPredicate`, and the only foreign function the
+    /// interpreter executes, `print`, is not a pure oracle).
+    fn check_purity_on_foreign_call(&self, name: &str) -> IResult<()> {
+        for context in self.call_stack.iter().rev() {
+            let Some(scope) = &context.pure_scope else { continue };
+            let function =
+                context.called_function.expect("purity scopes only exist on function call frames");
+            let reason = format!("it called foreign function `{name}`");
+            return Err(self.purity_violation(function, scope.purity, reason));
+        }
+        Ok(())
     }
 
     fn lookup(&self, id: ValueId) -> IResult<Value> {
@@ -852,7 +996,10 @@ impl<'ssa, W: Write> Interpreter<'ssa, W> {
                 Value::ForeignFunction(name) if self.options.no_foreign_calls => {
                     return Err(InterpreterError::UnknownForeignFunctionCall { name });
                 }
-                Value::ForeignFunction(name) if name == "print" => self.call_print(arguments)?,
+                Value::ForeignFunction(name) if name == "print" => {
+                    self.check_purity_on_foreign_call(&name)?;
+                    self.call_print(arguments)?
+                }
                 Value::ForeignFunction(name) => {
                     return Err(InterpreterError::UnknownForeignFunctionCall { name });
                 }
@@ -1016,6 +1163,11 @@ impl<'ssa, W: Write> Interpreter<'ssa, W> {
             println!("store {value} at {address}");
         }
 
+        self.check_purity_on_mutation(
+            reference_address.element.as_ptr() as StorageIdentity,
+            "a store through a reference",
+        )?;
+
         *reference_address.element.borrow_mut() = Some(value);
 
         Ok(())
@@ -1142,6 +1294,10 @@ impl<'ssa, W: Write> Interpreter<'ssa, W> {
             }
 
             if should_mutate {
+                self.check_purity_on_mutation(
+                    array.elements.as_ptr() as StorageIdentity,
+                    "an in-place array_set",
+                )?;
                 array.elements.borrow_mut()[index as usize] = value;
                 Value::ArrayOrVector(array)
             } else {

--- a/compiler/noirc_evaluator/src/ssa/interpreter/tests/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/interpreter/tests/mod.rs
@@ -29,6 +29,7 @@ use super::{Ssa, Value};
 mod black_box;
 mod instructions;
 mod intrinsics;
+mod purity;
 
 #[track_caller]
 fn executes_with_no_errors(src: &str) {

--- a/compiler/noirc_evaluator/src/ssa/interpreter/tests/purity.rs
+++ b/compiler/noirc_evaluator/src/ssa/interpreter/tests/purity.rs
@@ -215,6 +215,33 @@ fn pure_function_may_mutate_local_memory() {
 }
 
 #[test]
+fn acir_in_place_array_set_on_a_parameter_is_not_a_purity_violation() {
+    // In a constrained context arrays have value semantics: the Mutable Array Set
+    // Optimizations pass marks an `array_set` mutable when the old array value is
+    // dead, so the in-place write only reuses that value's backing store. It is not
+    // a caller-visible mutation, and the function legitimately stays
+    // `predicate_pure` under the real analysis.
+    let src = r#"
+        acir(inline) fn main f0 {
+          b0():
+            v3 = make_array [Field 1, Field 2] : [Field; 2]
+            v5 = call f1(v3) -> Field
+            constrain v5 == Field 5
+            return
+        }
+        acir(inline) fn set_first f1 {
+          b0(v0: [Field; 2]):
+            v4 = array_set mut v0, index u32 0, value Field 5
+            v6 = array_get v4, index u32 0 -> Field
+            return v6
+        }
+    "#;
+    let ssa = Ssa::from_str(src).unwrap().purity_analysis();
+    let result = ssa.interpret(Vec::new());
+    assert!(result.is_ok(), "expected success, got {result:?}");
+}
+
+#[test]
 fn in_place_vector_mutation_requires_the_mutator_label() {
     // Every intrinsic the interpreter mutates a vector through must declare itself in
     // `Intrinsic::mutates_array_operand_in_brillig`: purity analysis classifies the

--- a/compiler/noirc_evaluator/src/ssa/interpreter/tests/purity.rs
+++ b/compiler/noirc_evaluator/src/ssa/interpreter/tests/purity.rs
@@ -9,8 +9,8 @@
 use std::sync::Arc;
 
 use crate::ssa::{
-    interpreter::{IResults, errors::InterpreterError},
-    ir::function::FunctionId,
+    interpreter::{IResults, errors::InterpreterError, intrinsics::check_intrinsic_mutation_label},
+    ir::{function::FunctionId, instruction::Intrinsic},
     opt::pure::{FunctionPurities, Purity},
 };
 
@@ -212,6 +212,35 @@ fn pure_function_may_mutate_local_memory() {
     "#;
     let result = interpret_with_injected_purities(src, &[(1, Purity::Pure)], Vec::new());
     assert!(result.is_ok(), "expected success, got {result:?}");
+}
+
+#[test]
+fn in_place_vector_mutation_requires_the_mutator_label() {
+    // Every intrinsic the interpreter mutates a vector through must declare itself in
+    // `Intrinsic::mutates_array_operand_in_brillig`: purity analysis classifies the
+    // containing function from that list, so an unlisted mutator would silently
+    // poison recorded purities. The six vector mutators pass; a non-mutator is
+    // rejected at the moment of mutation.
+    let mutators = [
+        Intrinsic::VectorPushBack,
+        Intrinsic::VectorPushFront,
+        Intrinsic::VectorPopBack,
+        Intrinsic::VectorPopFront,
+        Intrinsic::VectorInsert,
+        Intrinsic::VectorRemove,
+    ];
+    for intrinsic in mutators {
+        assert!(check_intrinsic_mutation_label(intrinsic).is_ok());
+    }
+
+    let result = check_intrinsic_mutation_label(Intrinsic::ArrayLen);
+    assert!(
+        matches!(
+            result,
+            Err(InterpreterError::IntrinsicPurityViolation { intrinsic: Intrinsic::ArrayLen })
+        ),
+        "expected an intrinsic purity violation, got {result:?}"
+    );
 }
 
 #[test]

--- a/compiler/noirc_evaluator/src/ssa/interpreter/tests/purity.rs
+++ b/compiler/noirc_evaluator/src/ssa/interpreter/tests/purity.rs
@@ -1,0 +1,237 @@
+//! Tests for the interpreter's purity-contract checks: a function whose recorded
+//! [Purity] is `Pure` or `PureWithPredicate` must behave accordingly during
+//! interpretation, or the interpreter reports a [InterpreterError::PurityViolation].
+//!
+//! Violations can only arise from a bug in purity analysis (or in a pass that
+//! invalidates its results), so these tests inject hand-crafted purities instead of
+//! running the real analysis, which would classify the functions correctly.
+
+use std::sync::Arc;
+
+use crate::ssa::{
+    interpreter::{IResults, errors::InterpreterError},
+    ir::function::FunctionId,
+    opt::pure::{FunctionPurities, Purity},
+};
+
+use super::{Ssa, Value};
+
+/// Interpret `src` with explicitly chosen purities instead of the computed ones,
+/// simulating a buggy or stale purity analysis.
+fn interpret_with_injected_purities(
+    src: &str,
+    purities: &[(u32, Purity)],
+    args: Vec<Value>,
+) -> IResults {
+    let mut ssa = Ssa::from_str(src).unwrap();
+
+    let mut map = FunctionPurities::default();
+    for (id, purity) in purities {
+        map.insert_purity(FunctionId::new(*id), *purity);
+    }
+    for function in ssa.functions.values() {
+        if function.runtime().is_brillig() {
+            map.insert_brillig_function(function.id());
+        }
+    }
+
+    let map = Arc::new(map);
+    for function in ssa.functions.values_mut() {
+        function.dfg.set_function_purities(map.clone());
+    }
+    ssa.interpret(args)
+}
+
+#[track_caller]
+fn expect_purity_violation(result: IResults, reason_fragment: &str) {
+    match result {
+        Err(InterpreterError::PurityViolation { reason, .. }) => {
+            assert!(
+                reason.contains(reason_fragment),
+                "expected purity violation reason to contain {reason_fragment:?}, got {reason:?}"
+            );
+        }
+        other => panic!("expected a purity violation, got {other:?}"),
+    }
+}
+
+#[test]
+fn pure_function_that_fails_is_a_purity_violation() {
+    // f1 is really `PureWithPredicate` (it contains a constrain); marking it `Pure`
+    // simulates an analysis bug. A `Pure` function must never fail: DIE may remove
+    // an unused call to it, which would erase the failure.
+    let src = r#"
+        acir(inline) fn main f0 {
+          b0():
+            call f1(u1 0)
+            return
+        }
+        acir(inline) fn assert_true f1 {
+          b0(v0: u1):
+            constrain v0 == u1 1
+            return
+        }
+    "#;
+    let result = interpret_with_injected_purities(src, &[(1, Purity::Pure)], Vec::new());
+    expect_purity_violation(result, "failed");
+}
+
+#[test]
+fn predicate_pure_function_that_fails_is_not_a_purity_violation() {
+    // `PureWithPredicate` functions are allowed to fail; the failure must surface
+    // unchanged.
+    let src = r#"
+        acir(inline) fn main f0 {
+          b0():
+            call f1(u1 0)
+            return
+        }
+        acir(inline) fn assert_true f1 {
+          b0(v0: u1):
+            constrain v0 == u1 1
+            return
+        }
+    "#;
+    let result =
+        interpret_with_injected_purities(src, &[(1, Purity::PureWithPredicate)], Vec::new());
+    assert!(
+        matches!(result, Err(InterpreterError::ConstrainEqFailed { .. })),
+        "expected the plain constrain failure, got {result:?}"
+    );
+}
+
+#[test]
+fn pure_function_mutating_argument_array_in_place_is_a_purity_violation() {
+    // In Brillig an `array_set` on an array whose reference count is 1 mutates the
+    // backing store in place, so the caller's copy observes the write. A function
+    // doing this to one of its parameters cannot be `Pure` (or `PureWithPredicate`).
+    let src = r#"
+        brillig(inline) fn main f0 {
+          b0():
+            v2 = make_array [Field 1, Field 2] : [Field; 2]
+            v4 = call f1(v2) -> [Field; 2]
+            return
+        }
+        brillig(inline) fn set_first f1 {
+          b0(v0: [Field; 2]):
+            v3 = array_set mut v0, index u32 0, value Field 5
+            return v3
+        }
+    "#;
+    let result = interpret_with_injected_purities(src, &[(1, Purity::Pure)], Vec::new());
+    expect_purity_violation(result, "mutated");
+}
+
+#[test]
+fn predicate_pure_function_mutating_argument_vector_in_place_is_a_purity_violation() {
+    // Vector-mutator intrinsics write through the input vector's backing store when
+    // its reference count is 1. Mutation of caller-visible memory is forbidden for
+    // `PureWithPredicate` functions too, not just `Pure` ones.
+    let src = r#"
+        brillig(inline) fn main f0 {
+          b0():
+            v3 = make_array [Field 1, Field 2] : [Field]
+            v5, v6 = call f1(u32 2, v3) -> (u32, [Field])
+            return
+        }
+        brillig(inline) fn push f1 {
+          b0(v0: u32, v1: [Field]):
+            v4, v5 = call vector_push_back(v0, v1, Field 3) -> (u32, [Field])
+            return v4, v5
+        }
+    "#;
+    let result =
+        interpret_with_injected_purities(src, &[(1, Purity::PureWithPredicate)], Vec::new());
+    expect_purity_violation(result, "mutated");
+}
+
+#[test]
+fn pure_function_storing_through_argument_reference_is_a_purity_violation() {
+    // Functions taking references are always `Impure`; marking one `Pure` simulates
+    // an analysis bug. A store through a caller-provided reference is caller-visible.
+    let src = r#"
+        brillig(inline) fn main f0 {
+          b0():
+            v1 = allocate -> &mut Field
+            store Field 1 at v1
+            call f1(v1)
+            return
+        }
+        brillig(inline) fn set_ref f1 {
+          b0(v0: &mut Field):
+            store Field 2 at v0
+            return
+        }
+    "#;
+    let result = interpret_with_injected_purities(src, &[(1, Purity::Pure)], Vec::new());
+    expect_purity_violation(result, "mutated");
+}
+
+#[test]
+fn pure_function_calling_foreign_function_is_a_purity_violation() {
+    // Even a `#[pure]` oracle makes its caller at most `PureWithPredicate`, so a
+    // foreign call inside a `Pure` function is always a contract violation.
+    let src = r#"
+        brillig(inline) fn main f0 {
+          b0():
+            call f1(Field 7)
+            return
+        }
+        brillig(inline) fn print_it f1 {
+          b0(v0: Field):
+            v3 = make_array b"{\"kind\":\"field\"}"
+            call print(u1 1, v0, v3, u1 0)
+            return
+        }
+    "#;
+    let result = interpret_with_injected_purities(src, &[(1, Purity::Pure)], Vec::new());
+    expect_purity_violation(result, "foreign function");
+}
+
+#[test]
+fn pure_function_may_mutate_local_memory() {
+    // Local allocations and local arrays are invisible to the caller: mutating them
+    // is allowed in a `Pure` function even though the same instructions on a
+    // parameter would be a violation.
+    let src = r#"
+        brillig(inline) fn main f0 {
+          b0():
+            v1 = call f1() -> Field
+            return v1
+        }
+        brillig(inline) fn local_mutations f1 {
+          b0():
+            v1 = allocate -> &mut Field
+            store Field 1 at v1
+            store Field 2 at v1
+            v4 = make_array [Field 1, Field 2] : [Field; 2]
+            v7 = array_set mut v4, index u32 0, value Field 5
+            v9 = load v1 -> Field
+            return v9
+        }
+    "#;
+    let result = interpret_with_injected_purities(src, &[(1, Purity::Pure)], Vec::new());
+    assert!(result.is_ok(), "expected success, got {result:?}");
+}
+
+#[test]
+fn computed_purities_hold_on_a_pure_call_chain() {
+    // End-to-end sanity: run the real purity analysis and interpret; correctly
+    // classified functions must not trip the checks.
+    let src = r#"
+        acir(inline) fn main f0 {
+          b0(v0: Field):
+            v2 = call f1(v0) -> Field
+            constrain v2 == Field 6
+            return
+        }
+        acir(inline) fn double f1 {
+          b0(v0: Field):
+            v1 = add v0, v0
+            return v1
+        }
+    "#;
+    let ssa = Ssa::from_str(src).unwrap().purity_analysis();
+    let result = ssa.interpret(vec![Value::field(3_u32.into())]);
+    assert!(result.is_ok(), "expected success, got {result:?}");
+}

--- a/compiler/noirc_evaluator/src/ssa/interpreter/value.rs
+++ b/compiler/noirc_evaluator/src/ssa/interpreter/value.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use acvm::{AcirField, FieldElement, acir::brillig::lengths::SemanticLength};
 use iter_extended::{try_vecmap, vecmap};
 use noirc_frontend::Shared;
+use rustc_hash::FxHashSet as HashSet;
 
 use crate::{
     brillig::{assert_u32, assert_usize},
@@ -101,7 +102,46 @@ impl ArrayValue {
     }
 }
 
+/// An address identifying a `Shared` storage cell (an array's elements or a
+/// reference's pointee), used purely for identity comparisons: an in-place write to
+/// a cell is observable through every handle whose storage identity is equal.
+pub(crate) type StorageIdentity = *const ();
+
 impl Value {
+    /// Collects the [StorageIdentity] of every storage cell reachable from this value,
+    /// recursing through array elements and reference contents.
+    ///
+    /// The set answers "which memory could an in-place write make visible through
+    /// this value": it is captured from a call's arguments on entry to a function
+    /// whose recorded purity forbids mutating caller-visible memory, and checked
+    /// against on every in-place write. The caller must keep the value (or a clone
+    /// of it) alive for as long as the set is used, so that none of the collected
+    /// allocations can be freed and their addresses reused.
+    pub(crate) fn collect_storage_identities(&self, identities: &mut HashSet<StorageIdentity>) {
+        match self {
+            Value::Numeric(_)
+            | Value::Function(_)
+            | Value::Intrinsic(_)
+            | Value::ForeignFunction(_) => (),
+            Value::Reference(reference) => {
+                // The insertion check also breaks cycles (a reference stored inside
+                // an array it points to).
+                if identities.insert(reference.element.as_ptr() as StorageIdentity)
+                    && let Some(element) = reference.element.borrow().as_ref()
+                {
+                    element.collect_storage_identities(identities);
+                }
+            }
+            Value::ArrayOrVector(array) => {
+                if identities.insert(array.elements.as_ptr() as StorageIdentity) {
+                    for element in array.elements.borrow().iter() {
+                        element.collect_storage_identities(identities);
+                    }
+                }
+            }
+        }
+    }
+
     #[allow(unused)]
     pub(crate) fn get_type(&self) -> Type {
         match self {

--- a/compiler/noirc_frontend/src/hir_def/types.rs
+++ b/compiler/noirc_frontend/src/hir_def/types.rs
@@ -959,6 +959,13 @@ impl<T> Shared<T> {
         Shared(Rc::new(RefCell::new(thing)))
     }
 
+    /// A pointer identifying the shared allocation itself, for identity comparisons.
+    /// Two `Shared` handles observe each other's mutations exactly when their
+    /// `as_ptr` results are equal (note that `PartialEq` compares contents instead).
+    pub fn as_ptr(&self) -> *const T {
+        self.0.as_ptr()
+    }
+
     pub fn borrow(&self) -> std::cell::Ref<T> {
         self.0.borrow()
     }


### PR DESCRIPTION
It should probably be better to merge https://github.com/noir-lang/noir/pull/13493 before reviewing this.

## Description

### Problem

Purity analysis classifies every function as `Pure`, `PureWithPredicate`, or `Impure`, and LICM, DIE, and constant-folding deduplication act on those results — but nothing verified that a function's actual behavior matches its recorded purity. This contract has silently broken four times recently, each one a miscompilation or near-miss:

- a vector mutator hoisted by LICM out of its loop (fixed in #13445),
- a vector-mutator wrapper function classified `predicate_pure` and deduplicated,
- function purities lost while cloning functions (fixed in #13493),
- Brillig functions calling a vector mutator on an array input considered pure (#13479, merged just days ago).

All of these were found late, by a fuzzer roll or corpus luck, because the existing oracle (`pass_vs_prev` differential testing) only fires on the *consequence*: a pass has to actually exploit the wrong purity **and** the divergence has to reach an output. For the LICM bug that meant aligning spare vector capacity, a specific loop shape, and no pre-loop use of the vector.

### Summary

The SSA interpreter now enforces the purity contract on every interpreted call — firing on the *precondition* (recorded purity contradicts observed behavior) instead, deterministically, on any program that exercises the misclassified function:

- **`Pure` and `PureWithPredicate` functions must not mutate caller-visible memory.** On call entry the storage identities reachable from the arguments are captured (via a new `Shared::as_ptr` — `Shared`'s `PartialEq` compares contents, not identity); every in-place write (store through a reference, mutable `array_set`, vector intrinsics writing through their input) and every global's storage is checked against the active scopes. Local allocations are in no scope's set, so local mutation passes freely, matching purity analysis' "local mutations are not impure" rule.
- **`Pure` functions must not fail**: execution failures escaping a `Pure` call (failed constraints, overflow, division by zero, out-of-bounds indexing, ...) are violations, since passes may deduplicate or remove such calls. Interpretation artifacts (step budget, missing oracles, malformed SSA) are excluded.
- **Foreign calls are forbidden** inside any function with a recorded non-`Impure` purity.
- **Intrinsic mutation labels are validated** (second commit): the interpreter's in-place vector mutation point requires the intrinsic to be listed in `Intrinsic::mutates_array_operand_in_brillig`. That list is an input to purity analysis, so an unlisted mutator poisons every containing function's recorded purity without any function-level contract observably breaking — exactly the LICM-bug shape, which the function-level checks alone cannot see.

Violations surface as `InterpreterError::PurityViolation` / `IntrinsicPurityViolation`, naming the offending function or intrinsic and its recorded contract. Purity is observed through the caller's runtime (`DataFlowGraph::purity_of`), matching what optimization passes see; when no purity analysis has run, the checks are skipped.

### Value

The interpreter runs inside every `assert_pass_does_not_affect_execution` SSA pass unit test, `nargo interpret` (after every pass), and both fuzzers — so drift between purity analysis and actual behavior now fails loudly at every one of those points, with the cause named, instead of waiting for a pass to miscompile and a divergence to be bisected. Three of the four historical bugs above would have been caught directly at the misclassification stage (the wrapper bug, #13479, and the dangerous direction of the purity-cloning bug); the intrinsic-label check covers the remaining bare-intrinsic shape (the LICM bug).

### Verification

- Red-green: the five violation tests failed before the implementation (wrong purities are injected via `FunctionPurities`, since the SSA parser validates hand-written annotations); the intrinsic-label wiring was verified end-to-end by temporarily unlisting `VectorPushBack`, which makes the existing in-place push test fail with `IntrinsicPurityViolation`.
- False-positive sweep, all clean: full `noirc_evaluator` suite (1968 tests), `nargo_cli` interpret test, AST fuzzer smoke test, and aztec-packages protocol circuits (private-kernel-inner, rollup-tx-base-private) under `nargo interpret`.
- Performance: interleaved release-build timing of `nargo interpret --force` on those circuits shows no measurable overhead (private-kernel-inner 10.06s → 10.10s; rollup-tx-base-private within noise in both directions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)