### PR TITLE
chore: resolve builtin/foreign attribute names to a shared enum

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/ir/instruction.rs
+++ b/compiler/noirc_evaluator/src/ssa/ir/instruction.rs
@@ -9,6 +9,7 @@ use acvm::{
 };
 use iter_extended::vecmap;
 use noirc_frontend::hir_def::types::Type as HirType;
+use noirc_frontend::shared::Builtin;
 
 use crate::ssa::{ir::integer::IntegerConstant, opt::pure::Purity};
 
@@ -323,39 +324,52 @@ impl Intrinsic {
     /// Lookup an Intrinsic by name and return it if found.
     /// If there is no such intrinsic by that name, None is returned.
     ///
-    /// `noirc_frontend::ownership::builtin_supports_clone_elision` keeps a name-based
-    /// copy of the clone-elision classification of these intrinsics (it cannot depend
-    /// on this crate). When adding or reclassifying a name here, update it as well;
+    /// This is only used where a name arrives as text (e.g. the SSA parser); the
+    /// compilation pipeline resolves names to [`Builtin`] once, in the frontend,
+    /// and maps them here via [`Self::from_builtin`].
+    pub(crate) fn lookup(name: &str) -> Option<Intrinsic> {
+        Builtin::lookup(name).and_then(Self::from_builtin)
+    }
+
+    /// Map a frontend [`Builtin`] to the [`Intrinsic`] implementing it, or `None`
+    /// for builtins that never reach SSA (comptime-only builtins, and those the
+    /// monomorphizer evaluates away).
+    ///
+    /// `noirc_frontend::ownership::builtin_supports_clone_elision` keeps its own
+    /// clone-elision classification of these builtins (it cannot depend on this
+    /// crate). When adding or reclassifying a builtin here, update it as well;
     /// `ownership_clone_elision_list_matches_intrinsic_purity` in `ssa_gen::tests`
     /// checks the two agree.
-    pub(crate) fn lookup(name: &str) -> Option<Intrinsic> {
-        match name {
-            "array_len" => Some(Intrinsic::ArrayLen),
-            "array_as_str_unchecked" => Some(Intrinsic::ArrayAsStrUnchecked),
-            "as_vector" => Some(Intrinsic::AsVector),
-            "assert_constant" => Some(Intrinsic::AssertConstant),
-            "static_assert" => Some(Intrinsic::StaticAssert),
-            "apply_range_constraint" => Some(Intrinsic::ApplyRangeConstraint),
-            "vector_push_back" => Some(Intrinsic::VectorPushBack),
-            "vector_push_front" => Some(Intrinsic::VectorPushFront),
-            "vector_pop_back" => Some(Intrinsic::VectorPopBack),
-            "vector_pop_front" => Some(Intrinsic::VectorPopFront),
-            "vector_insert" => Some(Intrinsic::VectorInsert),
-            "vector_remove" => Some(Intrinsic::VectorRemove),
-            "str_as_bytes" => Some(Intrinsic::StrAsBytes),
-            "to_le_radix" => Some(Intrinsic::ToRadix(Endian::Little)),
-            "to_be_radix" => Some(Intrinsic::ToRadix(Endian::Big)),
-            "to_le_bits" => Some(Intrinsic::ToBits(Endian::Little)),
-            "to_be_bits" => Some(Intrinsic::ToBits(Endian::Big)),
-            "as_witness" => Some(Intrinsic::AsWitness),
-            "is_unconstrained" => Some(Intrinsic::IsUnconstrained),
-            "derive_pedersen_generators" => Some(Intrinsic::DerivePedersenGenerators),
-            "field_less_than" => Some(Intrinsic::FieldLessThan),
-            "black_box" => Some(Intrinsic::Hint(Hint::BlackBox)),
-            "array_refcount" => Some(Intrinsic::ArrayRefCount),
-            "vector_refcount" => Some(Intrinsic::VectorRefCount),
+    pub(crate) fn from_builtin(builtin: Builtin) -> Option<Intrinsic> {
+        match builtin {
+            Builtin::ArrayLen => Some(Intrinsic::ArrayLen),
+            Builtin::ArrayAsStrUnchecked => Some(Intrinsic::ArrayAsStrUnchecked),
+            Builtin::AsVector => Some(Intrinsic::AsVector),
+            Builtin::AssertConstant => Some(Intrinsic::AssertConstant),
+            Builtin::StaticAssert => Some(Intrinsic::StaticAssert),
+            Builtin::ApplyRangeConstraint => Some(Intrinsic::ApplyRangeConstraint),
+            Builtin::VectorPushBack => Some(Intrinsic::VectorPushBack),
+            Builtin::VectorPushFront => Some(Intrinsic::VectorPushFront),
+            Builtin::VectorPopBack => Some(Intrinsic::VectorPopBack),
+            Builtin::VectorPopFront => Some(Intrinsic::VectorPopFront),
+            Builtin::VectorInsert => Some(Intrinsic::VectorInsert),
+            Builtin::VectorRemove => Some(Intrinsic::VectorRemove),
+            Builtin::StrAsBytes => Some(Intrinsic::StrAsBytes),
+            Builtin::ToLeRadix => Some(Intrinsic::ToRadix(Endian::Little)),
+            Builtin::ToBeRadix => Some(Intrinsic::ToRadix(Endian::Big)),
+            Builtin::ToLeBits => Some(Intrinsic::ToBits(Endian::Little)),
+            Builtin::ToBeBits => Some(Intrinsic::ToBits(Endian::Big)),
+            Builtin::AsWitness => Some(Intrinsic::AsWitness),
+            Builtin::IsUnconstrained => Some(Intrinsic::IsUnconstrained),
+            Builtin::DerivePedersenGenerators => Some(Intrinsic::DerivePedersenGenerators),
+            Builtin::FieldLessThan => Some(Intrinsic::FieldLessThan),
+            Builtin::BlackBoxHint => Some(Intrinsic::Hint(Hint::BlackBox)),
+            Builtin::ArrayRefcount => Some(Intrinsic::ArrayRefCount),
+            Builtin::VectorRefcount => Some(Intrinsic::VectorRefCount),
 
-            other => BlackBoxFunc::lookup(other).map(Intrinsic::BlackBox),
+            Builtin::BlackBox(func) => Some(Intrinsic::BlackBox(func)),
+
+            _ => None,
         }
     }
 }

--- a/compiler/noirc_evaluator/src/ssa/ssa_gen/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/ssa_gen/mod.rs
@@ -257,10 +257,10 @@ impl FunctionContext<'_> {
             ast::Definition::Oracle { name, pure } => {
                 self.builder.import_foreign_function(name, *pure).into()
             }
-            ast::Definition::Builtin(name) | ast::Definition::LowLevel(name) => {
-                match self.builder.import_intrinsic(name) {
-                    Some(builtin) => builtin.into(),
-                    None => panic!("No builtin function named '{name}' found"),
+            ast::Definition::Builtin(builtin) | ast::Definition::LowLevel(builtin) => {
+                match Intrinsic::from_builtin(*builtin) {
+                    Some(intrinsic) => self.builder.import_intrinsic_id(intrinsic).into(),
+                    None => panic!("No builtin function named '{builtin}' found"),
                 }
             }
         }

--- a/compiler/noirc_evaluator/src/ssa/ssa_gen/tests.rs
+++ b/compiler/noirc_evaluator/src/ssa/ssa_gen/tests.rs
@@ -458,54 +458,38 @@ fn pure_builtin_call_with_mutating_sibling_arg_keeps_clone() {
 }
 
 /// The ownership pass decides clone elision in `noirc_frontend`, which cannot see
-/// [`Intrinsic`]: it keeps its own name-based copy of the classification. This test
-/// pins the two lists together so a new or reclassified intrinsic cannot silently
-/// diverge from the frontend's view.
+/// [`Intrinsic`](crate::ssa::ir::instruction::Intrinsic): it keeps its own copy of
+/// the classification. This test pins the two together over every [`Builtin`] so a
+/// new or reclassified builtin cannot silently diverge from the frontend's view.
 #[test]
 fn ownership_clone_elision_list_matches_intrinsic_purity() {
+    use crate::ssa::ir::instruction::Intrinsic;
     use crate::ssa::opt::pure::Purity;
     use acvm::acir::BlackBoxFunc;
     use noirc_frontend::ownership::builtin_supports_clone_elision;
+    use noirc_frontend::shared::Builtin;
     use strum::IntoEnumIterator;
 
-    // Keep in sync with the names recognized by `Intrinsic::lookup`.
-    let intrinsic_names = [
-        "array_len",
-        "array_as_str_unchecked",
-        "as_vector",
-        "assert_constant",
-        "static_assert",
-        "apply_range_constraint",
-        "vector_push_back",
-        "vector_push_front",
-        "vector_pop_back",
-        "vector_pop_front",
-        "vector_insert",
-        "vector_remove",
-        "str_as_bytes",
-        "to_le_radix",
-        "to_be_radix",
-        "to_le_bits",
-        "to_be_bits",
-        "as_witness",
-        "is_unconstrained",
-        "derive_pedersen_generators",
-        "field_less_than",
-        "black_box",
-        "array_refcount",
-        "vector_refcount",
-    ];
-    let blackbox_names = BlackBoxFunc::iter().map(|func| func.name().to_string());
-
-    for name in intrinsic_names.into_iter().map(String::from).chain(blackbox_names) {
-        let intrinsic = crate::ssa::ir::instruction::Intrinsic::lookup(&name)
-            .unwrap_or_else(|| panic!("`{name}` should be a known intrinsic"));
-        let elidable = !intrinsic.unsafe_for_clone_elision_in_brillig()
-            && matches!(intrinsic.purity(), Purity::Pure | Purity::PureWithPredicate);
+    // `Builtin::iter` skips the strum-disabled `BlackBox` variant, so chain the
+    // callable black box functions explicitly.
+    let black_boxes = BlackBoxFunc::iter()
+        .filter(|func| Builtin::lookup(func.name()).is_some())
+        .map(Builtin::BlackBox);
+    for builtin in Builtin::iter().chain(black_boxes) {
+        // Builtins that never reach SSA generation have no runtime call whose clone
+        // could be elided; those that do must agree with `Intrinsic`'s purity and
+        // aliasing classification.
+        let elidable = match Intrinsic::from_builtin(builtin) {
+            Some(intrinsic) => {
+                !intrinsic.unsafe_for_clone_elision_in_brillig()
+                    && matches!(intrinsic.purity(), Purity::Pure | Purity::PureWithPredicate)
+            }
+            None => false,
+        };
         assert_eq!(
-            builtin_supports_clone_elision(&name),
+            builtin_supports_clone_elision(builtin),
             elidable,
-            "`builtin_supports_clone_elision` disagrees with `Intrinsic`'s classification of `{name}`",
+            "`builtin_supports_clone_elision` disagrees with `Intrinsic`'s classification of `{builtin}`",
         );
     }
 }

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter.rs
@@ -55,7 +55,7 @@ use crate::monomorphization::{
     undo_instantiation_bindings,
 };
 use crate::node_interner::GlobalValue;
-use crate::shared::{ForeignCall, Signedness};
+use crate::shared::{Builtin, ForeignCall, Signedness};
 use crate::token::{FmtStrFragment, Tokens};
 use crate::{
     Shared, Type, TypeBindings,
@@ -330,10 +330,18 @@ impl<'local, 'interner> Interpreter<'local, 'interner> {
         let func_attrs = &attributes.function()
             .expect("all builtin functions must contain a function attribute which contains the opcode which it links to").kind;
 
-        if let Some(builtin) = func_attrs.builtin() {
-            self.call_builtin(builtin.clone().as_str(), arguments, return_type, location)
-        } else if let Some(foreign) = func_attrs.foreign() {
-            self.call_foreign(foreign.clone().as_str(), arguments, return_type, location)
+        if let Some(name) = func_attrs.builtin() {
+            let Some(builtin) = Builtin::lookup(name) else {
+                let item = format!("Comptime evaluation for builtin function '{name}'");
+                return Err(InterpreterError::Unimplemented { item, location });
+            };
+            self.call_builtin(builtin, arguments, return_type, location)
+        } else if let Some(name) = func_attrs.foreign() {
+            let Some(foreign) = Builtin::lookup(name) else {
+                let item = format!("Comptime evaluation for foreign function '{name}'");
+                return Err(InterpreterError::Unimplemented { item, location });
+            };
+            self.call_foreign(foreign, arguments, return_type, location)
         } else if let Some(oracle) = func_attrs.oracle() {
             if let Some(ForeignCall::Print) = ForeignCall::lookup(oracle) {
                 self.print_oracle(&arguments)

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin.rs
@@ -13,9 +13,9 @@ use builtin_helpers::{
     check_function_not_yet_resolved, check_one_argument, check_return_type_shape,
     check_three_arguments, check_two_arguments, get_bool, get_expr, get_field, get_format_string,
     get_function_def, get_location, get_module, get_quoted, get_trait_constraint, get_trait_def,
-    get_trait_impl, get_type, get_type_id, get_typed_expr, get_u32, get_unresolved_type,
-    get_vector, has_builtin_attribute, has_named_attribute, hir_pattern_to_tokens, new_binary_op,
-    new_unary_op, parse, quote_ident, type_shape, visibility_to_quoted,
+    get_trait_impl, get_type, get_type_id, get_typed_expr, get_u32, get_vector,
+    has_builtin_attribute, has_named_attribute, hir_pattern_to_tokens, new_binary_op, new_unary_op,
+    parse, quote_ident, type_shape, visibility_to_quoted,
 };
 use fm::FileMap;
 use imbl::Vector;
@@ -29,10 +29,10 @@ use crate::{
     Kind, QuotedType, Shared, Type, TypeBindings,
     ast::{
         ArrayLiteral, ConstrainKind, Expression, ExpressionKind, ForRange, IntegerBitSize, LValue,
-        Literal, Pattern, Statement, StatementKind, UnresolvedTypeData, UnsafeExpression,
+        Literal, Pattern, Statement, StatementKind, UnsafeExpression,
     },
     elaborator::{
-        ElaborateReason, Elaborator, PrimitiveType,
+        ElaborateReason, Elaborator,
         types::{WildcardAllowed, WildcardDisallowedContext},
     },
     hir::{
@@ -56,7 +56,7 @@ use crate::{
     },
     node_interner::{NodeInterner, TraitImplKind},
     parser::{Parser, StatementOrExpressionOrLValue},
-    shared::Signedness,
+    shared::{Builtin, Signedness},
     token::{LocatedToken, SecondaryAttribute, SecondaryAttributeKind, Token},
 };
 
@@ -70,7 +70,7 @@ pub(crate) mod builtin_helpers;
 impl Interpreter<'_, '_> {
     pub(super) fn call_builtin(
         &mut self,
-        name: &str,
+        builtin: Builtin,
         arguments: Vec<(Value, Location)>,
         return_type: Type,
         location: Location,
@@ -78,63 +78,73 @@ impl Interpreter<'_, '_> {
         let call_stack = &self.elaborator.interpreter_call_stack().clone();
         let expected_return_shape = type_shape(&return_type);
         let interner = &mut self.elaborator.interner;
-        let result = match name {
-            "apply_range_constraint" => apply_range_constraint(arguments, location, call_stack),
-            "array_as_str_unchecked" => array_as_str_unchecked(arguments, location),
-            "array_len" => array_len(arguments, location),
-            "array_refcount" => Ok(Value::u32(0)),
-            "assert_constant" => Ok(Value::Unit),
-            "as_vector" => as_vector(arguments, location),
-            "as_witness" => as_witness(arguments, location),
-            "black_box" => black_box(arguments, location),
-            "checked_transmute" => checked_transmute(arguments, return_type, location),
-            "ctstring_append" => ctstring_append(arguments, location),
-            "ctstring_eq" => eq_item(arguments, location, get_ctstring),
-            "ctstring_hash" => hash_item(arguments, location, get_ctstring),
-            "derive_pedersen_generators" => derive_generators(arguments, return_type, location),
-            "expr_as_array" => expr_as_array(interner, arguments, return_type, location),
-            "expr_as_assert" => expr_as_assert(interner, arguments, return_type, location),
-            "expr_as_assert_eq" => expr_as_assert_eq(interner, arguments, return_type, location),
-            "expr_as_assign" => expr_as_assign(interner, arguments, return_type, location),
-            "expr_as_binary_op" => expr_as_binary_op(interner, arguments, return_type, location),
-            "expr_as_block" => expr_as_block(interner, arguments, return_type, location),
-            "expr_as_bool" => expr_as_bool(interner, arguments, return_type, location),
-            "expr_as_cast" => expr_as_cast(interner, arguments, return_type, location),
-            "expr_as_comptime" => expr_as_comptime(interner, arguments, return_type, location),
-            "expr_as_constructor" => {
+        let result = match builtin {
+            Builtin::ApplyRangeConstraint => {
+                apply_range_constraint(arguments, location, call_stack)
+            }
+            Builtin::ArrayAsStrUnchecked => array_as_str_unchecked(arguments, location),
+            Builtin::ArrayLen => array_len(arguments, location),
+            Builtin::ArrayRefcount => Ok(Value::u32(0)),
+            Builtin::AssertConstant => Ok(Value::Unit),
+            Builtin::AsVector => as_vector(arguments, location),
+            Builtin::AsWitness => as_witness(arguments, location),
+            Builtin::BlackBoxHint => black_box(arguments, location),
+            Builtin::CheckedTransmute => checked_transmute(arguments, return_type, location),
+            Builtin::CtstringAppend => ctstring_append(arguments, location),
+            Builtin::CtstringEq => eq_item(arguments, location, get_ctstring),
+            Builtin::CtstringHash => hash_item(arguments, location, get_ctstring),
+            Builtin::DerivePedersenGenerators => {
+                derive_generators(arguments, return_type, location)
+            }
+            Builtin::ExprAsArray => expr_as_array(interner, arguments, return_type, location),
+            Builtin::ExprAsAssert => expr_as_assert(interner, arguments, return_type, location),
+            Builtin::ExprAsAssertEq => {
+                expr_as_assert_eq(interner, arguments, return_type, location)
+            }
+            Builtin::ExprAsAssign => expr_as_assign(interner, arguments, return_type, location),
+            Builtin::ExprAsBinaryOp => {
+                expr_as_binary_op(interner, arguments, return_type, location)
+            }
+            Builtin::ExprAsBlock => expr_as_block(interner, arguments, return_type, location),
+            Builtin::ExprAsBool => expr_as_bool(interner, arguments, return_type, location),
+            Builtin::ExprAsCast => expr_as_cast(interner, arguments, return_type, location),
+            Builtin::ExprAsComptime => expr_as_comptime(interner, arguments, return_type, location),
+            Builtin::ExprAsConstructor => {
                 expr_as_constructor(interner, arguments, return_type, location)
             }
-            "expr_as_for" => expr_as_for(interner, arguments, return_type, location),
-            "expr_as_for_range" => expr_as_for_range(interner, arguments, return_type, location),
-            "expr_as_function_call" => {
+            Builtin::ExprAsFor => expr_as_for(interner, arguments, return_type, location),
+            Builtin::ExprAsForRange => {
+                expr_as_for_range(interner, arguments, return_type, location)
+            }
+            Builtin::ExprAsFunctionCall => {
                 expr_as_function_call(interner, arguments, return_type, location)
             }
-            "expr_as_if" => expr_as_if(interner, arguments, return_type, location),
-            "expr_as_index" => expr_as_index(interner, arguments, return_type, location),
-            "expr_as_integer" => expr_as_integer(interner, arguments, return_type, location),
-            "expr_as_lambda" => expr_as_lambda(interner, arguments, return_type, location),
-            "expr_as_let" => expr_as_let(interner, arguments, return_type, location),
-            "expr_as_member_access" => {
+            Builtin::ExprAsIf => expr_as_if(interner, arguments, return_type, location),
+            Builtin::ExprAsIndex => expr_as_index(interner, arguments, return_type, location),
+            Builtin::ExprAsInteger => expr_as_integer(interner, arguments, return_type, location),
+            Builtin::ExprAsLambda => expr_as_lambda(interner, arguments, return_type, location),
+            Builtin::ExprAsLet => expr_as_let(interner, arguments, return_type, location),
+            Builtin::ExprAsMemberAccess => {
                 expr_as_member_access(interner, arguments, return_type, location)
             }
-            "expr_as_method_call" => {
+            Builtin::ExprAsMethodCall => {
                 expr_as_method_call(interner, arguments, return_type, location)
             }
-            "expr_as_repeated_element_array" => {
+            Builtin::ExprAsRepeatedElementArray => {
                 expr_as_repeated_element_array(interner, arguments, return_type, location)
             }
-            "expr_as_repeated_element_vector" => {
+            Builtin::ExprAsRepeatedElementVector => {
                 expr_as_repeated_element_vector(interner, arguments, return_type, location)
             }
-            "expr_as_vector" => expr_as_vector(interner, arguments, return_type, location),
-            "expr_as_tuple" => expr_as_tuple(interner, arguments, return_type, location),
-            "expr_as_unary_op" => expr_as_unary_op(interner, arguments, return_type, location),
-            "expr_as_unsafe" => expr_as_unsafe(interner, arguments, return_type, location),
-            "expr_has_semicolon" => expr_has_semicolon(interner, arguments, location),
-            "expr_is_break" => expr_is_break(interner, arguments, location),
-            "expr_is_continue" => expr_is_continue(interner, arguments, location),
-            "expr_resolve" => expr_resolve(self, arguments, location),
-            "is_unconstrained" => {
+            Builtin::ExprAsVector => expr_as_vector(interner, arguments, return_type, location),
+            Builtin::ExprAsTuple => expr_as_tuple(interner, arguments, return_type, location),
+            Builtin::ExprAsUnaryOp => expr_as_unary_op(interner, arguments, return_type, location),
+            Builtin::ExprAsUnsafe => expr_as_unsafe(interner, arguments, return_type, location),
+            Builtin::ExprHasSemicolon => expr_has_semicolon(interner, arguments, location),
+            Builtin::ExprIsBreak => expr_is_break(interner, arguments, location),
+            Builtin::ExprIsContinue => expr_is_continue(interner, arguments, location),
+            Builtin::ExprResolve => expr_resolve(self, arguments, location),
+            Builtin::IsUnconstrained => {
                 // When in coverage mode, have the comptime interpreter treat `is_unconstrained` the same
                 // way it's treated in ACIR and Brillig. Usually unconstrained code is faster and that's why
                 // in non-coverage mode we want to go through the fastest path, but in coverage mode it's fine
@@ -145,157 +155,168 @@ impl Interpreter<'_, '_> {
                     Ok(Value::Bool(true))
                 }
             }
-            "field_less_than" => field_less_than(arguments, location),
-            "issue_error" => issue_diagnostic(self, arguments, location, false),
-            "issue_warning" => issue_diagnostic(self, arguments, location, true),
-            "location_eq" => eq_item(arguments, location, get_location),
-            "location_hash" => hash_item(arguments, location, get_location),
-            "fmtstr_as_ctstring" => {
+            Builtin::FieldLessThan => field_less_than(arguments, location),
+            Builtin::IssueError => issue_diagnostic(self, arguments, location, false),
+            Builtin::IssueWarning => issue_diagnostic(self, arguments, location, true),
+            Builtin::LocationEq => eq_item(arguments, location, get_location),
+            Builtin::LocationHash => hash_item(arguments, location, get_location),
+            Builtin::FmtstrAsCtstring => {
                 fmtstr_as_ctstring(interner, self.elaborator.files, arguments, location)
             }
-            "fmtstr_quoted_contents" => {
+            Builtin::FmtstrQuotedContents => {
                 fmtstr_quoted_contents(interner, self.elaborator.files, arguments, location)
             }
-            "fresh_type_variable" => fresh_type_variable(interner),
-            "function_def_as_typed_expr" => function_def_as_typed_expr(self, arguments, location),
-            "function_def_body" => function_def_body(self, arguments, location),
-            "function_def_disable" => function_def_disable(self, arguments, location),
-            "function_def_eq" => eq_item(arguments, location, get_function_def),
-            "function_def_has_builtin_attribute" => {
+            Builtin::FreshTypeVariable => fresh_type_variable(interner),
+            Builtin::FunctionDefAsTypedExpr => {
+                function_def_as_typed_expr(self, arguments, location)
+            }
+            Builtin::FunctionDefBody => function_def_body(self, arguments, location),
+            Builtin::FunctionDefDisable => function_def_disable(self, arguments, location),
+            Builtin::FunctionDefEq => eq_item(arguments, location, get_function_def),
+            Builtin::FunctionDefHasBuiltinAttribute => {
                 function_def_has_attribute(interner, arguments, location, true)
             }
-            "function_def_has_named_attribute" => {
+            Builtin::FunctionDefHasNamedAttribute => {
                 function_def_has_attribute(interner, arguments, location, false)
             }
-            "function_def_named_attribute_args" => {
+            Builtin::FunctionDefNamedAttributeArgs => {
                 function_def_named_attribute_args(interner, arguments, location)
             }
-            "function_def_hash" => hash_item(arguments, location, get_function_def),
-            "function_def_is_unconstrained" => {
+            Builtin::FunctionDefHash => hash_item(arguments, location, get_function_def),
+            Builtin::FunctionDefIsUnconstrained => {
                 function_def_is_unconstrained(self, arguments, location)
             }
-            "function_def_location" => function_def_location(self.elaborator, arguments, location),
-            "function_def_module" => function_def_module(interner, arguments, location),
-            "function_def_name" => function_def_name(interner, arguments, location),
-            "function_def_parameters" => function_def_parameters(self, arguments, location),
-            "function_def_return_type" => function_def_return_type(self, arguments, location),
-            "function_def_visibility" => function_def_visibility(interner, arguments, location),
-            "module_child_modules" => module_child_modules(self, arguments, location),
-            "module_eq" => eq_item(arguments, location, get_module),
-            "module_functions" => module_functions(self, arguments, location),
-            "module_has_builtin_attribute" => module_has_attribute(self, arguments, location, true),
-            "module_has_named_attribute" => module_has_attribute(self, arguments, location, false),
-            "module_named_attribute_args" => module_named_attribute_args(self, arguments, location),
-            "module_hash" => hash_item(arguments, location, get_module),
-            "module_is_contract" => module_is_contract(self, arguments, location),
-            "module_location" => module_location(interner, arguments, location),
-            "module_name" => module_name(interner, arguments, location),
-            "module_parent" => module_parent(self, arguments, return_type, location),
-            "module_structs" => module_structs(self, arguments, location),
-            "modulus_be_bits" => modulus_be_bits(&arguments, location),
-            "modulus_be_bytes" => modulus_be_bytes(&arguments, location),
-            "modulus_le_bits" => modulus_le_bits(&arguments, location),
-            "modulus_le_bytes" => modulus_le_bytes(&arguments, location),
-            "modulus_num_bits" => modulus_num_bits(&arguments, location),
-            "quoted_as_expr" => quoted_as_expr(self.elaborator, arguments, return_type, location),
-            "quoted_as_module" => quoted_as_module(self, arguments, return_type, location),
-            "quoted_as_trait_constraint" => quoted_as_trait_constraint(self, arguments, location),
-            "quoted_as_type" => quoted_as_type(self, arguments, location),
-            "quoted_eq" => {
+            Builtin::FunctionDefLocation => {
+                function_def_location(self.elaborator, arguments, location)
+            }
+            Builtin::FunctionDefModule => function_def_module(interner, arguments, location),
+            Builtin::FunctionDefName => function_def_name(interner, arguments, location),
+            Builtin::FunctionDefParameters => function_def_parameters(self, arguments, location),
+            Builtin::FunctionDefReturnType => function_def_return_type(self, arguments, location),
+            Builtin::FunctionDefVisibility => {
+                function_def_visibility(interner, arguments, location)
+            }
+            Builtin::ModuleChildModules => module_child_modules(self, arguments, location),
+            Builtin::ModuleEq => eq_item(arguments, location, get_module),
+            Builtin::ModuleFunctions => module_functions(self, arguments, location),
+            Builtin::ModuleHasBuiltinAttribute => {
+                module_has_attribute(self, arguments, location, true)
+            }
+            Builtin::ModuleHasNamedAttribute => {
+                module_has_attribute(self, arguments, location, false)
+            }
+            Builtin::ModuleNamedAttributeArgs => {
+                module_named_attribute_args(self, arguments, location)
+            }
+            Builtin::ModuleHash => hash_item(arguments, location, get_module),
+            Builtin::ModuleIsContract => module_is_contract(self, arguments, location),
+            Builtin::ModuleLocation => module_location(interner, arguments, location),
+            Builtin::ModuleName => module_name(interner, arguments, location),
+            Builtin::ModuleParent => module_parent(self, arguments, return_type, location),
+            Builtin::ModuleStructs => module_structs(self, arguments, location),
+            Builtin::ModulusBeBits => modulus_be_bits(&arguments, location),
+            Builtin::ModulusBeBytes => modulus_be_bytes(&arguments, location),
+            Builtin::ModulusLeBits => modulus_le_bits(&arguments, location),
+            Builtin::ModulusLeBytes => modulus_le_bytes(&arguments, location),
+            Builtin::ModulusNumBits => modulus_num_bits(&arguments, location),
+            Builtin::QuotedAsExpr => {
+                quoted_as_expr(self.elaborator, arguments, return_type, location)
+            }
+            Builtin::QuotedAsModule => quoted_as_module(self, arguments, return_type, location),
+            Builtin::QuotedAsTraitConstraint => {
+                quoted_as_trait_constraint(self, arguments, location)
+            }
+            Builtin::QuotedAsType => quoted_as_type(self, arguments, location),
+            Builtin::QuotedEq => {
                 quoted_eq(self.elaborator.interner, self.elaborator.files, arguments, location)
             }
-            "quoted_hash" => {
+            Builtin::QuotedHash => {
                 quoted_hash(self.elaborator.interner, self.elaborator.files, arguments, location)
             }
-            "quoted_location" => quoted_location(arguments, return_type, location),
-            "quoted_tokens" => quoted_tokens(arguments, location),
-            "vector_insert" => vector_insert(arguments, location, call_stack),
-            "vector_pop_back" => vector_pop_back(arguments, location, call_stack),
-            "vector_pop_front" => vector_pop_front(arguments, location, call_stack),
-            "vector_push_back" => vector_push_back(arguments, location),
-            "vector_push_front" => vector_push_front(arguments, location),
-            "vector_refcount" => Ok(Value::u32(0)),
-            "vector_remove" => vector_remove(arguments, location, call_stack),
-            "static_assert" => {
+            Builtin::QuotedLocation => quoted_location(arguments, return_type, location),
+            Builtin::QuotedTokens => quoted_tokens(arguments, location),
+            Builtin::VectorInsert => vector_insert(arguments, location, call_stack),
+            Builtin::VectorPopBack => vector_pop_back(arguments, location, call_stack),
+            Builtin::VectorPopFront => vector_pop_front(arguments, location, call_stack),
+            Builtin::VectorPushBack => vector_push_back(arguments, location),
+            Builtin::VectorPushFront => vector_push_front(arguments, location),
+            Builtin::VectorRefcount => Ok(Value::u32(0)),
+            Builtin::VectorRemove => vector_remove(arguments, location, call_stack),
+            Builtin::StaticAssert => {
                 static_assert(interner, self.elaborator.files, arguments, location, call_stack)
             }
-            "str_as_bytes" => str_as_bytes(arguments, location),
-            "str_as_ctstring" => str_as_ctstring(arguments, location),
-            "to_be_radix" => to_be_radix(arguments, return_type, location, call_stack),
-            "to_le_radix" => to_le_radix(arguments, return_type, location, call_stack),
-            "to_be_bits" => to_be_bits(arguments, return_type, location, call_stack),
-            "to_le_bits" => to_le_bits(arguments, return_type, location, call_stack),
-            "trait_constraint_eq" => eq_item(arguments, location, get_trait_constraint),
-            "trait_constraint_hash" => hash_item(arguments, location, get_trait_constraint),
-            "trait_def_as_trait_constraint" => {
+            Builtin::StrAsBytes => str_as_bytes(arguments, location),
+            Builtin::StrAsCtstring => str_as_ctstring(arguments, location),
+            Builtin::ToBeRadix => to_be_radix(arguments, return_type, location, call_stack),
+            Builtin::ToLeRadix => to_le_radix(arguments, return_type, location, call_stack),
+            Builtin::ToBeBits => to_be_bits(arguments, return_type, location, call_stack),
+            Builtin::ToLeBits => to_le_bits(arguments, return_type, location, call_stack),
+            Builtin::TraitConstraintEq => eq_item(arguments, location, get_trait_constraint),
+            Builtin::TraitConstraintHash => hash_item(arguments, location, get_trait_constraint),
+            Builtin::TraitDefAsTraitConstraint => {
                 trait_def_as_trait_constraint(interner, arguments, location)
             }
-            "trait_def_eq" => eq_item(arguments, location, get_trait_def),
-            "trait_def_hash" => hash_item(arguments, location, get_trait_def),
-            "trait_def_location" => trait_def_location(interner, arguments, location),
-            "trait_impl_methods" => trait_impl_methods(interner, arguments, location),
-            "trait_impl_trait_generic_args" => {
+            Builtin::TraitDefEq => eq_item(arguments, location, get_trait_def),
+            Builtin::TraitDefHash => hash_item(arguments, location, get_trait_def),
+            Builtin::TraitDefLocation => trait_def_location(interner, arguments, location),
+            Builtin::TraitImplMethods => trait_impl_methods(interner, arguments, location),
+            Builtin::TraitImplTraitGenericArgs => {
                 trait_impl_trait_generic_args(interner, arguments, location)
             }
-            "type_as_array" => type_as_array(arguments, return_type, location),
-            "type_as_constant" => type_as_constant(arguments, return_type, location),
-            "type_as_integer" => type_as_integer(arguments, return_type, location),
-            "type_as_mutable_reference" => {
+            Builtin::TypeAsArray => type_as_array(arguments, return_type, location),
+            Builtin::TypeAsConstant => type_as_constant(arguments, return_type, location),
+            Builtin::TypeAsInteger => type_as_integer(arguments, return_type, location),
+            Builtin::TypeAsMutableReference => {
                 type_as_mutable_reference(arguments, return_type, location)
             }
-            "type_as_vector" => type_as_vector(arguments, return_type, location),
-            "type_as_str" => type_as_str(arguments, return_type, location),
-            "type_as_data_type" => type_as_data_type(arguments, return_type, location),
-            "type_as_tuple" => type_as_tuple(arguments, return_type, location),
-            "type_def_add_abi" => type_def_add_abi(self, arguments, location),
-            "type_def_as_type" => type_def_as_type(interner, arguments, location),
-            "type_def_as_type_with_generics" => {
+            Builtin::TypeAsVector => type_as_vector(arguments, return_type, location),
+            Builtin::TypeAsStr => type_as_str(arguments, return_type, location),
+            Builtin::TypeAsDataType => type_as_data_type(arguments, return_type, location),
+            Builtin::TypeAsTuple => type_as_tuple(arguments, return_type, location),
+            Builtin::TypeDefAddAbi => type_def_add_abi(self, arguments, location),
+            Builtin::TypeDefAsType => type_def_as_type(interner, arguments, location),
+            Builtin::TypeDefAsTypeWithGenerics => {
                 type_def_as_type_with_generics(interner, arguments, return_type, location)
             }
-            "type_def_eq" => eq_item(arguments, location, get_type_id),
-            "type_def_fields" => type_def_fields(self, arguments, location, call_stack),
-            "type_def_fields_as_written" => type_def_fields_as_written(self, arguments, location),
-            "type_def_generics" => type_def_generics(interner, arguments, return_type, location),
-            "type_def_has_builtin_attribute" => {
+            Builtin::TypeDefEq => eq_item(arguments, location, get_type_id),
+            Builtin::TypeDefFields => type_def_fields(self, arguments, location, call_stack),
+            Builtin::TypeDefFieldsAsWritten => {
+                type_def_fields_as_written(self, arguments, location)
+            }
+            Builtin::TypeDefGenerics => {
+                type_def_generics(interner, arguments, return_type, location)
+            }
+            Builtin::TypeDefHasBuiltinAttribute => {
                 type_def_has_attribute(interner, arguments, location, true)
             }
-            "type_def_has_named_attribute" => {
+            Builtin::TypeDefHasNamedAttribute => {
                 type_def_has_attribute(interner, arguments, location, false)
             }
-            "type_def_named_attribute_args" => {
+            Builtin::TypeDefNamedAttributeArgs => {
                 type_def_named_attribute_args(interner, arguments, location)
             }
-            "type_def_hash" => hash_item(arguments, location, get_type_id),
-            "type_def_location" => type_def_location(interner, arguments, location),
-            "type_def_module" => type_def_module(self, arguments, location),
-            "type_def_name" => type_def_name(interner, arguments, location),
-            "type_eq" => eq_item(arguments, location, get_type),
-            "type_get_trait_impl" => {
+            Builtin::TypeDefHash => hash_item(arguments, location, get_type_id),
+            Builtin::TypeDefLocation => type_def_location(interner, arguments, location),
+            Builtin::TypeDefModule => type_def_module(self, arguments, location),
+            Builtin::TypeDefName => type_def_name(interner, arguments, location),
+            Builtin::TypeEq => eq_item(arguments, location, get_type),
+            Builtin::TypeGetTraitImpl => {
                 type_get_trait_impl(interner, arguments, return_type, location)
             }
-            "type_hash" => hash_item(arguments, location, get_type),
-            "type_implements" => type_implements(interner, arguments, location),
-            "type_is_bool" => type_is_bool(arguments, location),
-            "type_is_field" => type_is_field(arguments, location),
-            "type_is_unit" => type_is_unit(arguments, location),
-            "type_of" => type_of(arguments, location),
-            "typed_expr_as_function_definition" => {
+            Builtin::TypeHash => hash_item(arguments, location, get_type),
+            Builtin::TypeImplements => type_implements(interner, arguments, location),
+            Builtin::TypeIsBool => type_is_bool(arguments, location),
+            Builtin::TypeIsField => type_is_field(arguments, location),
+            Builtin::TypeIsUnit => type_is_unit(arguments, location),
+            Builtin::TypeOf => type_of(arguments, location),
+            Builtin::TypedExprAsFunctionDefinition => {
                 typed_expr_as_function_definition(interner, arguments, return_type, location)
             }
-            "typed_expr_get_type" => {
+            Builtin::TypedExprGetType => {
                 typed_expr_get_type(interner, arguments, return_type, location)
             }
-            "typed_expr_location" => typed_expr_location(interner, arguments, location),
-            "unresolved_type_as_mutable_reference" => {
-                unresolved_type_as_mutable_reference(interner, arguments, return_type, location)
-            }
-            "unresolved_type_as_vector" => {
-                unresolved_type_as_vector(interner, arguments, return_type, location)
-            }
-            "unresolved_type_is_bool" => unresolved_type_is_bool(interner, arguments, location),
-            "unresolved_type_is_field" => unresolved_type_is_field(interner, arguments, location),
-            "unresolved_type_is_unit" => unresolved_type_is_unit(interner, arguments, location),
-            "zeroed" => {
+            Builtin::TypedExprLocation => typed_expr_location(interner, arguments, location),
+            Builtin::Zeroed => {
                 // Resolve any deferred struct fields or enum variants in the
                 // return type so `zeroed` returns a real `Value::Struct`/`Enum`
                 // instead of an opaque `Value::Zeroed` placeholder when called
@@ -304,7 +325,7 @@ impl Interpreter<'_, '_> {
                 Ok(zeroed(return_type, location))
             }
             _ => {
-                let item = format!("Comptime evaluation for builtin function '{name}'");
+                let item = format!("Comptime evaluation for builtin function '{builtin}'");
                 Err(InterpreterError::Unimplemented { item, location })
             }
         }?;
@@ -1531,119 +1552,6 @@ fn typed_expr_get_type(
     } else {
         None
     };
-    Ok(option(return_type, option_value, location))
-}
-
-// fn as_mutable_reference(self) -> Option<UnresolvedType>
-fn unresolved_type_as_mutable_reference(
-    interner: &NodeInterner,
-    arguments: Vec<(Value, Location)>,
-    return_type: Type,
-    location: Location,
-) -> IResult<Value> {
-    unresolved_type_as(interner, arguments, return_type, location, |typ| {
-        if let UnresolvedTypeData::Reference(typ, true) = typ {
-            Some(Value::UnresolvedType(typ.typ))
-        } else {
-            None
-        }
-    })
-}
-
-// fn as_vector(self) -> Option<UnresolvedType>
-fn unresolved_type_as_vector(
-    interner: &NodeInterner,
-    arguments: Vec<(Value, Location)>,
-    return_type: Type,
-    location: Location,
-) -> IResult<Value> {
-    unresolved_type_as(interner, arguments, return_type, location, |typ| {
-        if let UnresolvedTypeData::Vector(typ) = typ {
-            Some(Value::UnresolvedType(typ.typ))
-        } else {
-            None
-        }
-    })
-}
-
-// fn is_bool(self) -> bool
-fn unresolved_type_is_bool(
-    interner: &NodeInterner,
-    arguments: Vec<(Value, Location)>,
-    location: Location,
-) -> IResult<Value> {
-    let self_argument = check_one_argument(arguments, location)?;
-    let typ = get_unresolved_type(interner, self_argument)?;
-
-    // TODO: we should resolve the type here instead of just checking the name
-    // See https://github.com/noir-lang/noir/issues/8505
-    let UnresolvedTypeData::Named(path, generics, _) = typ else {
-        return Ok(Value::Bool(false));
-    };
-    if !generics.is_empty() {
-        return Ok(Value::Bool(false));
-    }
-    let Some(ident) = path.as_ident() else {
-        return Ok(Value::Bool(false));
-    };
-    let Some(primitive_type) = PrimitiveType::lookup_by_name(ident.as_str()) else {
-        return Ok(Value::Bool(false));
-    };
-    Ok(Value::Bool(primitive_type == PrimitiveType::Bool))
-}
-
-// fn is_field(self) -> bool
-fn unresolved_type_is_field(
-    interner: &NodeInterner,
-    arguments: Vec<(Value, Location)>,
-    location: Location,
-) -> IResult<Value> {
-    let self_argument = check_one_argument(arguments, location)?;
-    let typ = get_unresolved_type(interner, self_argument)?;
-
-    // TODO: we should resolve the type here instead of just checking the name
-    // See https://github.com/noir-lang/noir/issues/8505
-    let UnresolvedTypeData::Named(path, generics, _) = typ else {
-        return Ok(Value::Bool(false));
-    };
-    if !generics.is_empty() {
-        return Ok(Value::Bool(false));
-    }
-    let Some(ident) = path.as_ident() else {
-        return Ok(Value::Bool(false));
-    };
-    let Some(primitive_type) = PrimitiveType::lookup_by_name(ident.as_str()) else {
-        return Ok(Value::Bool(false));
-    };
-    Ok(Value::Bool(primitive_type == PrimitiveType::Field))
-}
-
-// fn is_unit(self) -> bool
-fn unresolved_type_is_unit(
-    interner: &NodeInterner,
-    arguments: Vec<(Value, Location)>,
-    location: Location,
-) -> IResult<Value> {
-    let self_argument = check_one_argument(arguments, location)?;
-    let typ = get_unresolved_type(interner, self_argument)?;
-    Ok(Value::Bool(matches!(typ, UnresolvedTypeData::Unit)))
-}
-
-// Helper function for implementing the `unresolved_type_as_...` functions.
-fn unresolved_type_as<F>(
-    interner: &NodeInterner,
-    arguments: Vec<(Value, Location)>,
-    return_type: Type,
-    location: Location,
-    f: F,
-) -> IResult<Value>
-where
-    F: FnOnce(UnresolvedTypeData) -> Option<Value>,
-{
-    let value = check_one_argument(arguments, location)?;
-    let typ = get_unresolved_type(interner, value)?;
-
-    let option_value = f(typ);
     Ok(option(return_type, option_value, location))
 }
 

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin/builtin_helpers.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter/builtin/builtin_helpers.rs
@@ -25,10 +25,7 @@ use crate::parser::{Parser, ParserError};
 use crate::token::{Keyword, LocatedToken, SecondaryAttributeKind};
 use crate::{
     QuotedType, Type,
-    ast::{
-        BlockExpression, ExpressionKind, Ident, IntegerBitSize, LValue, Pattern, StatementKind,
-        UnresolvedTypeData,
-    },
+    ast::{BlockExpression, ExpressionKind, Ident, IntegerBitSize, LValue, Pattern, StatementKind},
     hir::{
         comptime::{
             Interpreter, InterpreterError, Value,
@@ -440,23 +437,6 @@ pub(crate) fn get_quoted((value, location): (Value, Location)) -> IResult<Rc<Vec
     match value {
         Value::Quoted(tokens) => Ok(tokens),
         value => type_mismatch(value, Type::Quoted(QuotedType::Quoted), location),
-    }
-}
-
-pub(crate) fn get_unresolved_type(
-    interner: &NodeInterner,
-    (value, location): (Value, Location),
-) -> IResult<UnresolvedTypeData> {
-    match value {
-        Value::UnresolvedType(typ) => {
-            if let UnresolvedTypeData::Interned(id) = typ {
-                let typ = interner.get_unresolved_type_data(id).clone();
-                Ok(typ)
-            } else {
-                Ok(typ)
-            }
-        }
-        value => type_mismatch(value, Type::Quoted(QuotedType::UnresolvedType), location),
     }
 }
 

--- a/compiler/noirc_frontend/src/hir/comptime/interpreter/foreign.rs
+++ b/compiler/noirc_frontend/src/hir/comptime/interpreter/foreign.rs
@@ -1,6 +1,9 @@
 //! The foreign function counterpart to `interpreter/builtin.rs`, defines how to call
 //! all foreign functions available to the interpreter.
-use acvm::{BlackBoxResolutionError, FieldElement, blackbox_solver::BlackBoxFunctionSolver};
+use acvm::{
+    BlackBoxResolutionError, FieldElement, acir::BlackBoxFunc,
+    blackbox_solver::BlackBoxFunctionSolver,
+};
 use bn254_blackbox_solver::Bn254BlackBoxSolver; // Currently locked to only bn254!
 use imbl::{Vector, vector};
 use noirc_errors::Location;
@@ -14,6 +17,7 @@ use crate::{
             builtin::builtin_helpers::to_byte_array, builtin_helpers::check_argument_count,
         },
     },
+    shared::Builtin,
 };
 
 use super::{
@@ -28,12 +32,12 @@ use super::{
 impl Interpreter<'_, '_> {
     pub(super) fn call_foreign(
         &self,
-        name: &str,
+        foreign: Builtin,
         arguments: Vec<(Value, Location)>,
         return_type: Type,
         location: Location,
     ) -> IResult<Value> {
-        call_foreign(name, arguments, return_type, location)
+        call_foreign(foreign, arguments, return_type, location)
     }
 }
 
@@ -41,42 +45,46 @@ impl Interpreter<'_, '_> {
 ///
 /// Similar to `evaluate_black_box` in `brillig_vm`.
 fn call_foreign(
-    name: &str,
+    foreign: Builtin,
     args: Vec<(Value, Location)>,
     return_type: Type,
     location: Location,
 ) -> IResult<Value> {
     let expected_return_shape = type_shape(&return_type);
-    let result = match name {
-        "aes128_encrypt" => aes128_encrypt(args, location),
-        "blake2s" => blake_hash(args, location, acvm::blackbox_solver::blake2s),
-        "blake3" => blake_hash(args, location, acvm::blackbox_solver::blake3),
-        // cSpell:disable-next-line
-        "ecdsa_secp256k1" => {
+    let result = match foreign {
+        Builtin::BlackBox(BlackBoxFunc::AES128Encrypt) => aes128_encrypt(args, location),
+        Builtin::BlackBox(BlackBoxFunc::Blake2s) => {
+            blake_hash(args, location, acvm::blackbox_solver::blake2s)
+        }
+        Builtin::BlackBox(BlackBoxFunc::Blake3) => {
+            blake_hash(args, location, acvm::blackbox_solver::blake3)
+        }
+        Builtin::BlackBox(BlackBoxFunc::EcdsaSecp256k1) => {
             ecdsa_secp256_verify(args, location, acvm::blackbox_solver::ecdsa_secp256k1_verify)
         }
-        // cSpell:disable-next-line
-        "ecdsa_secp256r1" => {
+        Builtin::BlackBox(BlackBoxFunc::EcdsaSecp256r1) => {
             ecdsa_secp256_verify(args, location, acvm::blackbox_solver::ecdsa_secp256r1_verify)
         }
-        "embedded_curve_add" => embedded_curve_add(args, return_type, location),
-        "multi_scalar_mul" => multi_scalar_mul(args, return_type, location),
-        "poseidon2_permutation" => poseidon2_permutation(args, location),
-        "poseidon2_config_state_size" => poseidon2_config_state_size(&args, location),
-        "keccakf1600" => keccakf1600(args, location),
-        "sha256_compression" => sha256_compression(args, location),
-        _ => {
-            let explanation = match name {
-                "and" | "xor" => "It should be turned into a binary operation.".into(),
-                "recursive_aggregation" => "A proof cannot be verified at comptime.".into(),
-                _ => {
-                    let item = format!("Comptime evaluation for foreign function '{name}'");
-                    return Err(InterpreterError::Unimplemented { item, location });
-                }
-            };
-
-            let item = format!("Attempting to evaluate foreign function '{name}'");
+        Builtin::BlackBox(BlackBoxFunc::EmbeddedCurveAdd) => {
+            embedded_curve_add(args, return_type, location)
+        }
+        Builtin::BlackBox(BlackBoxFunc::MultiScalarMul) => {
+            multi_scalar_mul(args, return_type, location)
+        }
+        Builtin::BlackBox(BlackBoxFunc::Poseidon2Permutation) => {
+            poseidon2_permutation(args, location)
+        }
+        Builtin::Poseidon2ConfigStateSize => poseidon2_config_state_size(&args, location),
+        Builtin::BlackBox(BlackBoxFunc::Keccakf1600) => keccakf1600(args, location),
+        Builtin::BlackBox(BlackBoxFunc::Sha256Compression) => sha256_compression(args, location),
+        Builtin::BlackBox(BlackBoxFunc::RecursiveAggregation) => {
+            let item = format!("Attempting to evaluate foreign function '{foreign}'");
+            let explanation = "A proof cannot be verified at comptime.".into();
             Err(InterpreterError::InvalidInComptimeContext { item, location, explanation })
+        }
+        _ => {
+            let item = format!("Comptime evaluation for foreign function '{foreign}'");
+            Err(InterpreterError::Unimplemented { item, location })
         }
     }?;
 
@@ -125,7 +133,7 @@ fn get_aes128_block(
 
 fn aes128_error(reason: String, location: Location) -> InterpreterError {
     InterpreterError::BlackBoxError(
-        BlackBoxResolutionError::Failed(acvm::acir::BlackBoxFunc::AES128Encrypt, reason),
+        BlackBoxResolutionError::Failed(BlackBoxFunc::AES128Encrypt, reason),
         location,
     )
 }
@@ -353,14 +361,17 @@ mod tests {
         let mut not_implemented = Vec::new();
 
         for blackbox in BlackBoxFunc::iter() {
-            // There's no implementation for RANGE as it's actually a builtin function,
-            // and in the comptime interpreter it's not transformed to a foreign function call
-            if blackbox == BlackBoxFunc::RANGE {
+            // AND, XOR and RANGE are not callable functions — the compiler emits their
+            // opcodes from binary operations, casts and range checks — so they have no
+            // `Builtin` variant and cannot reach `call_foreign`.
+            if matches!(blackbox, BlackBoxFunc::AND | BlackBoxFunc::XOR | BlackBoxFunc::RANGE) {
                 continue;
             }
 
             let name = blackbox.name();
-            match call_foreign(name, Vec::new(), Type::Unit, no_location) {
+            let builtin = crate::shared::Builtin::lookup(name)
+                .unwrap_or_else(|| panic!("`{name}` has no `Builtin` variant"));
+            match call_foreign(builtin, Vec::new(), Type::Unit, no_location) {
                 Ok(_) => {
                     // Exists and works with no args (unlikely)
                 }

--- a/compiler/noirc_frontend/src/monomorphization/ast.rs
+++ b/compiler/noirc_frontend/src/monomorphization/ast.rs
@@ -14,7 +14,10 @@ use crate::{
     shared::Signedness,
     token::Attributes,
 };
-use crate::{shared::Visibility, token::FunctionAttributeKind};
+use crate::{
+    shared::{Builtin, Visibility},
+    token::FunctionAttributeKind,
+};
 use serde::{Deserialize, Serialize};
 
 use super::HirType;
@@ -214,8 +217,8 @@ pub enum Definition {
     Local(LocalId),
     Global(GlobalId),
     Function(FuncId),
-    Builtin(String),
-    LowLevel(String),
+    Builtin(Builtin),
+    LowLevel(Builtin),
     /// A foreign/externally-defined unconstrained function.
     ///
     /// `pure` is `true` when the user marked the oracle declaration with

--- a/compiler/noirc_frontend/src/monomorphization/builtin.rs
+++ b/compiler/noirc_frontend/src/monomorphization/builtin.rs
@@ -13,7 +13,7 @@ use crate::{
         errors::MonomorphizationError,
     },
     node_interner::{self, ExprId},
-    shared::{Signedness, Visibility},
+    shared::{Builtin, Signedness, Visibility},
     token::FmtStrFragment,
 };
 
@@ -32,6 +32,19 @@ enum HandledOpcode {
 }
 
 impl Monomorphizer<'_> {
+    /// Resolve a `#[builtin]`/`#[foreign]` attribute name to its [`Builtin`], erroring
+    /// on names the compiler does not implement (previously an unknown name survived
+    /// to SSA generation and panicked there).
+    pub(super) fn lookup_builtin(
+        name: &str,
+        location: Location,
+    ) -> Result<Builtin, MonomorphizationError> {
+        Builtin::lookup(name).ok_or_else(|| MonomorphizationError::UnknownBuiltin {
+            name: name.to_string(),
+            location,
+        })
+    }
+
     /// Try to evaluate certain builtin functions (just the function itself) given their type.
     /// All builtins are function types, so the evaluated result will always be a new function or None.
     ///
@@ -41,7 +54,7 @@ impl Monomorphizer<'_> {
     #[expect(clippy::too_many_arguments)]
     pub(super) fn try_evaluate_builtin(
         &mut self,
-        opcode_string: &str,
+        builtin: Builtin,
         typ: Type,
         turbofish_generics: Vec<Type>,
         bindings_key: CanonicalBindings,
@@ -49,7 +62,7 @@ impl Monomorphizer<'_> {
         id: node_interner::FuncId,
         location: Location,
     ) -> Result<Option<FuncId>, MonomorphizationError> {
-        let Some(opcode) = HandledOpcode::parse(opcode_string) else { return Ok(None) };
+        let Some(opcode) = HandledOpcode::from_builtin(builtin) else { return Ok(None) };
 
         let (parameter_types, return_type, env, unconstrained) = match typ {
             Type::Function(parameters, ret, env, unconstrained) => {
@@ -99,7 +112,7 @@ impl Monomorphizer<'_> {
             new_function_id,
             Function {
                 id: new_function_id,
-                name: opcode_string.to_string(),
+                name: builtin.name().to_string(),
                 parameters,
                 body,
                 return_type: converted_return_type,
@@ -344,7 +357,7 @@ impl Monomorphizer<'_> {
         {
             let location = self.interner.expr_location(expr_id);
 
-            return Ok(Some(match HandledOpcode::parse(opcode) {
+            return Ok(Some(match HandledOpcode::from_builtin(*opcode) {
                 Some(HandledOpcode::CheckedTransmute) => {
                     assert_eq!(arguments.len(), 1);
                     let parameter_type = self.interner.id_type(arguments[0]).follow_bindings();
@@ -401,16 +414,16 @@ impl Monomorphizer<'_> {
 }
 
 impl HandledOpcode {
-    fn parse(opcode: &str) -> Option<Self> {
-        match opcode {
-            "checked_transmute" => Some(Self::CheckedTransmute),
-            "modulus_be_bits" => Some(Self::ModulusBeBits),
-            "modulus_be_bytes" => Some(Self::ModulusBeBytes),
-            "modulus_le_bits" => Some(Self::ModulusLeBits),
-            "modulus_le_bytes" => Some(Self::ModulusLeBytes),
-            "modulus_num_bits" => Some(Self::ModulusNumBits),
-            "poseidon2_config_state_size" => Some(Self::Poseidon2ConfigStateSize),
-            "zeroed" => Some(Self::Zeroed),
+    fn from_builtin(builtin: Builtin) -> Option<Self> {
+        match builtin {
+            Builtin::CheckedTransmute => Some(Self::CheckedTransmute),
+            Builtin::ModulusBeBits => Some(Self::ModulusBeBits),
+            Builtin::ModulusBeBytes => Some(Self::ModulusBeBytes),
+            Builtin::ModulusLeBits => Some(Self::ModulusLeBits),
+            Builtin::ModulusLeBytes => Some(Self::ModulusLeBytes),
+            Builtin::ModulusNumBits => Some(Self::ModulusNumBits),
+            Builtin::Poseidon2ConfigStateSize => Some(Self::Poseidon2ConfigStateSize),
+            Builtin::Zeroed => Some(Self::Zeroed),
             _ => None,
         }
     }

--- a/compiler/noirc_frontend/src/monomorphization/errors.rs
+++ b/compiler/noirc_frontend/src/monomorphization/errors.rs
@@ -38,6 +38,7 @@ pub enum MonomorphizationError {
     ReturnLimitExceeded { num_elements: u64, max_elements: u64, location: Location },
     ComplexType { complexity: usize, max_complexity: usize, location: Location },
     CannotUseFunctionAsValue { name: String, location: Location },
+    UnknownBuiltin { name: String, location: Location },
     GlobalContainsFunctionPointer { typ: String, location: Location },
     CalledDisabledFunction { name: String, location: Location },
 }
@@ -80,6 +81,7 @@ impl MonomorphizationError {
             | MonomorphizationError::ReturnLimitExceeded { location, .. }
             | MonomorphizationError::ComplexType { location, .. }
             | MonomorphizationError::CannotUseFunctionAsValue { location, .. }
+            | MonomorphizationError::UnknownBuiltin { location, .. }
             | MonomorphizationError::GlobalContainsFunctionPointer { location, .. }
             | MonomorphizationError::CalledDisabledFunction { location, .. } => *location,
             MonomorphizationError::InterpreterError(error) => error.location(),
@@ -256,6 +258,11 @@ impl From<MonomorphizationError> for CustomDiagnostic {
                     "`{name}` cannot be used as a function value; it must be called directly"
                 );
                 let secondary = "Used as a value here".to_string();
+                return CustomDiagnostic::simple_error(message, secondary, *location);
+            }
+            MonomorphizationError::UnknownBuiltin { name, location } => {
+                let message = format!("`{name}` is not a builtin function known to the compiler");
+                let secondary = "Called here".to_string();
                 return CustomDiagnostic::simple_error(message, secondary, *location);
             }
             MonomorphizationError::GlobalContainsFunctionPointer { typ, location } => {

--- a/compiler/noirc_frontend/src/monomorphization/mod.rs
+++ b/compiler/noirc_frontend/src/monomorphization/mod.rs
@@ -54,7 +54,7 @@ use crate::hir::type_check::NoMatchingImplFoundError;
 use crate::lint::Lint;
 use crate::node_interner::{ExprId, GlobalValue, ImplSearchErrorKind, TraitItemId};
 use crate::recursion::TypeRecursionContext;
-use crate::shared::{ForeignCall, Visibility};
+use crate::shared::{Builtin, ForeignCall, Visibility};
 use crate::token::FunctionAttributeKind;
 use crate::{
     Kind, Type, TypeBinding, TypeBindings,
@@ -482,12 +482,12 @@ impl<'interner> Monomorphizer<'interner> {
                         let opcode = attribute.kind.foreign().expect(
                             "ICE: function marked as foreign, but attribute kind does not match this",
                         );
-                        let opcode = opcode.clone();
                         let location = self.interner.expr_location(&expr_id);
+                        let opcode = Self::lookup_builtin(opcode, location)?;
 
                         if evaluate_builtin {
                             match self.try_evaluate_builtin(
-                                &opcode,
+                                opcode,
                                 typ,
                                 turbofish_generics,
                                 bindings_key,
@@ -507,12 +507,12 @@ impl<'interner> Monomorphizer<'interner> {
                         let opcode = attribute.kind.builtin().expect(
                             "ICE: function marked as builtin, but attribute kind does not match this",
                         );
-                        let opcode = opcode.clone();
                         let location = self.interner.expr_location(&expr_id);
+                        let opcode = Self::lookup_builtin(opcode, location)?;
 
                         if evaluate_builtin {
                             match self.try_evaluate_builtin(
-                                &opcode,
+                                opcode,
                                 typ,
                                 turbofish_generics,
                                 bindings_key,
@@ -2396,9 +2396,7 @@ impl<'interner> Monomorphizer<'interner> {
                 // The second argument is expected to always be an ident
                 self.append_printable_type_info(&hir_arguments[1], &mut arguments);
             }
-            if let Definition::Builtin(name) = &ident.definition
-                && name.as_str() == "static_assert"
-            {
+            if let Definition::Builtin(Builtin::StaticAssert) = &ident.definition {
                 // static_assert can take any type for the `message` argument.
                 // Here we append printable type info so we can know how to turn that argument
                 // into a human-readable string.
@@ -3263,7 +3261,7 @@ impl<'interner> Monomorphizer<'interner> {
 /// direct calls.
 fn special_function_name(definition: &Definition) -> Option<&str> {
     match definition {
-        Definition::Builtin(name) if name == "static_assert" => Some(name),
+        Definition::Builtin(builtin @ Builtin::StaticAssert) => Some(builtin.name()),
         Definition::Oracle { name, .. }
             if matches!(ForeignCall::lookup(name), Some(ForeignCall::Print)) =>
         {

--- a/compiler/noirc_frontend/src/monomorphization/printer.rs
+++ b/compiler/noirc_frontend/src/monomorphization/printer.rs
@@ -3,6 +3,7 @@
 use crate::{
     ast::UnaryOp,
     monomorphization::ast::{Ident, Literal},
+    shared::Builtin,
 };
 
 use super::ast::{
@@ -583,10 +584,10 @@ impl AstPrinter {
                 // Builtins that are written as methods in Noir source have to be printed that
                 // way, or the printed program does not parse back: `as_bytes(s)` is not a
                 // function in scope, `s.as_bytes()` is.
-                Definition::Builtin(s)
-                    if s.starts_with("array")
-                        || s.starts_with("vector")
-                        || matches!(s.as_str(), "as_vector" | "str_as_bytes") =>
+                Definition::Builtin(builtin)
+                    if builtin.name().starts_with("array")
+                        || builtin.name().starts_with("vector")
+                        || matches!(builtin, Builtin::AsVector | Builtin::StrAsBytes) =>
                 {
                     Some(SpecialCall::Object(name.clone()))
                 }

--- a/compiler/noirc_frontend/src/monomorphization/proxies.rs
+++ b/compiler/noirc_frontend/src/monomorphization/proxies.rs
@@ -364,7 +364,7 @@ mod tests {
             f(true);
         }
 
-        #[builtin(foo)]
+        #[builtin(black_box)]
         pub fn foo<T>(x: T) -> T {}
         ";
 
@@ -387,19 +387,19 @@ mod tests {
         }
         #[inline_always]
         fn foo_proxy$f3(p0$l0: Field) -> Field {
-            foo$foo(p0$l0)
+            foo$black_box(p0$l0)
         }
         #[inline_always]
         unconstrained fn foo_proxy$f4(p0$l0: Field) -> Field {
-            foo$foo(p0$l0)
+            foo$black_box(p0$l0)
         }
         #[inline_always]
         fn foo_proxy$f5(p0$l0: bool) -> bool {
-            foo$foo(p0$l0)
+            foo$black_box(p0$l0)
         }
         #[inline_always]
         unconstrained fn foo_proxy$f6(p0$l0: bool) -> bool {
-            foo$foo(p0$l0)
+            foo$black_box(p0$l0)
         }
         ");
     }

--- a/compiler/noirc_frontend/src/monomorphization/tests.rs
+++ b/compiler/noirc_frontend/src/monomorphization/tests.rs
@@ -1989,3 +1989,28 @@ fn constrained_fn_value_in_unconstrained_fn_target_control() {
     }
     ");
 }
+
+#[test]
+fn errors_on_unknown_builtin_name() {
+    // The name in a `#[builtin]`/`#[foreign]` attribute is free-form at parse time;
+    // it is resolved to `shared::Builtin` when a call to it is monomorphized. A name
+    // the compiler does not implement must produce a diagnostic here rather than
+    // surviving to SSA generation and panicking there.
+    let src = r#"
+    #[builtin(not_a_real_builtin)]
+    pub fn not_a_real_builtin() {}
+
+    fn main() {
+        not_a_real_builtin();
+    }
+    "#;
+    let err = get_monomorphized_with_options(
+        src,
+        GetProgramOptions { root_and_stdlib: true, ..Default::default() },
+    )
+    .unwrap_err();
+    assert!(
+        matches!(&err, MonomorphizationError::UnknownBuiltin { name, .. } if name == "not_a_real_builtin"),
+        "expected UnknownBuiltin, got: {err:?}"
+    );
+}

--- a/compiler/noirc_frontend/src/ownership/clone_elision.rs
+++ b/compiler/noirc_frontend/src/ownership/clone_elision.rs
@@ -18,37 +18,36 @@
 //! callee would read the mutated buffer. The clone on an argument is therefore
 //! kept unless every later argument of the same call is side-effect-free.
 
-use acvm::acir::BlackBoxFunc;
 use rustc_hash::FxHashSet as HashSet;
 
 use crate::monomorphization::ast::{Call, Definition, Expression, FuncId, Literal, Program};
+use crate::shared::Builtin;
 
-/// Return whether a call to the builtin or low level function with the given name
-/// allows the `Clone` around its array arguments to be elided: the callee must
-/// neither modify the input nor return an alias of it that a later Brillig mutation
-/// could observe.
+/// Return whether a call to the given builtin or low level function allows the
+/// `Clone` around its array arguments to be elided: the callee must neither modify
+/// the input nor return an alias of it that a later Brillig mutation could observe.
 ///
 /// This mirrors `Intrinsic::purity` and `Intrinsic::unsafe_for_clone_elision_in_brillig`
 /// in `noirc_evaluator`, which cannot be used here directly since `noirc_frontend` cannot
 /// depend on `noirc_evaluator`. A test in `noirc_evaluator` (`ssa::ssa_gen::tests`) checks
-/// that this function agrees with them for every intrinsic name.
-pub fn builtin_supports_clone_elision(name: &str) -> bool {
-    match name {
+/// that this function agrees with them for every builtin.
+pub fn builtin_supports_clone_elision(builtin: Builtin) -> bool {
+    match builtin {
         // Pure or predicate-pure builtins that neither modify their array arguments
         // nor return an alias of them.
-        "array_len"
-        | "as_vector"
-        | "assert_constant"
-        | "static_assert"
-        | "apply_range_constraint"
-        | "to_le_radix"
-        | "to_be_radix"
-        | "to_le_bits"
-        | "to_be_bits"
-        | "as_witness"
-        | "is_unconstrained"
-        | "derive_pedersen_generators"
-        | "field_less_than" => true,
+        Builtin::ArrayLen
+        | Builtin::AsVector
+        | Builtin::AssertConstant
+        | Builtin::StaticAssert
+        | Builtin::ApplyRangeConstraint
+        | Builtin::ToLeRadix
+        | Builtin::ToBeRadix
+        | Builtin::ToLeBits
+        | Builtin::ToBeBits
+        | Builtin::AsWitness
+        | Builtin::IsUnconstrained
+        | Builtin::DerivePedersenGenerators
+        | Builtin::FieldLessThan => true,
 
         // Vector mutators may write through their input pointer in place when the
         // copy-on-write reference count is 1. `str_as_bytes` and
@@ -56,21 +55,26 @@ pub fn builtin_supports_clone_elision(name: &str) -> bool {
         // input, so a later mutation of the result could corrupt the source.
         // `black_box` is deliberately opaque to the optimizer, and reference count
         // reads are ordering-dependent on the rc traffic around them.
-        "vector_push_back"
-        | "vector_push_front"
-        | "vector_pop_back"
-        | "vector_pop_front"
-        | "vector_insert"
-        | "vector_remove"
-        | "str_as_bytes"
-        | "array_as_str_unchecked"
-        | "black_box"
-        | "array_refcount"
-        | "vector_refcount" => false,
+        Builtin::VectorPushBack
+        | Builtin::VectorPushFront
+        | Builtin::VectorPopBack
+        | Builtin::VectorPopFront
+        | Builtin::VectorInsert
+        | Builtin::VectorRemove
+        | Builtin::StrAsBytes
+        | Builtin::ArrayAsStrUnchecked
+        | Builtin::BlackBoxHint
+        | Builtin::ArrayRefcount
+        | Builtin::VectorRefcount => false,
 
-        // Blackbox functions (hashes, curve operations, signature verification, and
-        // bitwise AND/XOR) only read their inputs and return fresh outputs.
-        other => BlackBoxFunc::lookup(other).is_some(),
+        // Black box functions (hashes, curve operations, signature verification)
+        // only read their inputs and return fresh outputs.
+        Builtin::BlackBox(_) => true,
+
+        // Anything else is either evaluated away before SSA generation
+        // (comptime-only and monomorphizer-handled builtins) or unknown;
+        // conservatively keep the clone.
+        _ => false,
     }
 }
 
@@ -120,8 +124,8 @@ pub fn find_oracle_wrappers(program: &Program) -> HashSet<FuncId> {
 /// elided (sibling arguments permitting, see [`elide_clones_in_call_arguments`]).
 fn callee_preserves_array_arguments(func: &Expression, oracle_wrappers: &HashSet<FuncId>) -> bool {
     match callee_definition(func) {
-        Some(Definition::Builtin(name) | Definition::LowLevel(name)) => {
-            builtin_supports_clone_elision(name)
+        Some(Definition::Builtin(builtin) | Definition::LowLevel(builtin)) => {
+            builtin_supports_clone_elision(*builtin)
         }
         Some(Definition::Oracle { .. }) => true,
         Some(Definition::Function(func_id)) => oracle_wrappers.contains(func_id),

--- a/compiler/noirc_frontend/src/shared/builtin.rs
+++ b/compiler/noirc_frontend/src/shared/builtin.rs
@@ -1,0 +1,267 @@
+use acvm::acir::BlackBoxFunc;
+use serde::{Deserialize, Serialize};
+use strum_macros::{AsRefStr, EnumIter, EnumString};
+
+/// A function the compiler implements, declared in the standard library with the
+/// `#[builtin(name)]` or `#[foreign(name)]` attribute.
+///
+/// The two attribute kinds share a single flat namespace: by the time a call is
+/// dispatched, builtin and foreign ("low level") functions are treated identically,
+/// so this enum covers both. Oracle (`#[oracle]`) names are deliberately *not* here:
+/// they are an open, user-extensible namespace and stay strings.
+///
+/// Attribute parsing keeps the name as a free-form string (so malformed or unknown
+/// names still parse and error later, with a real diagnostic); the string is resolved
+/// to this enum where the function is actually consumed: the comptime interpreter,
+/// the monomorphizer, and (via `Definition::Builtin`/`Definition::LowLevel`) SSA
+/// generation.
+#[derive(
+    Debug,
+    Copy,
+    Clone,
+    PartialEq,
+    Eq,
+    Hash,
+    Serialize,
+    Deserialize,
+    AsRefStr,
+    EnumString,
+    EnumIter
+)]
+#[strum(serialize_all = "snake_case")]
+pub enum Builtin {
+    // Runtime intrinsics: reach SSA generation and map to `Intrinsic` in noirc_evaluator.
+    ApplyRangeConstraint,
+    ArrayAsStrUnchecked,
+    ArrayLen,
+    ArrayRefcount,
+    AsVector,
+    AsWitness,
+    AssertConstant,
+    #[strum(serialize = "black_box")]
+    BlackBoxHint,
+    DerivePedersenGenerators,
+    FieldLessThan,
+    IsUnconstrained,
+    StaticAssert,
+    StrAsBytes,
+    ToBeBits,
+    ToBeRadix,
+    ToLeBits,
+    ToLeRadix,
+    VectorInsert,
+    VectorPopBack,
+    VectorPopFront,
+    VectorPushBack,
+    VectorPushFront,
+    VectorRefcount,
+    VectorRemove,
+
+    // Evaluated during monomorphization (see `HandledOpcode`); never reach SSA.
+    CheckedTransmute,
+    ModulusBeBits,
+    ModulusBeBytes,
+    ModulusLeBits,
+    ModulusLeBytes,
+    ModulusNumBits,
+    Zeroed,
+
+    // Comptime-only builtins, dispatched by the comptime interpreter.
+    CtstringAppend,
+    CtstringEq,
+    CtstringHash,
+    ExprAsArray,
+    ExprAsAssert,
+    ExprAsAssertEq,
+    ExprAsAssign,
+    ExprAsBinaryOp,
+    ExprAsBlock,
+    ExprAsBool,
+    ExprAsCast,
+    ExprAsComptime,
+    ExprAsConstructor,
+    ExprAsFor,
+    ExprAsForRange,
+    ExprAsFunctionCall,
+    ExprAsIf,
+    ExprAsIndex,
+    ExprAsInteger,
+    ExprAsLambda,
+    ExprAsLet,
+    ExprAsMemberAccess,
+    ExprAsMethodCall,
+    ExprAsRepeatedElementArray,
+    ExprAsRepeatedElementVector,
+    ExprAsTuple,
+    ExprAsUnaryOp,
+    ExprAsUnsafe,
+    ExprAsVector,
+    ExprHasSemicolon,
+    ExprIsBreak,
+    ExprIsContinue,
+    ExprResolve,
+    FmtstrAsCtstring,
+    FmtstrQuotedContents,
+    FreshTypeVariable,
+    FunctionDefAsTypedExpr,
+    FunctionDefBody,
+    FunctionDefDisable,
+    FunctionDefEq,
+    FunctionDefHasBuiltinAttribute,
+    FunctionDefHasNamedAttribute,
+    FunctionDefHash,
+    FunctionDefIsUnconstrained,
+    FunctionDefLocation,
+    FunctionDefModule,
+    FunctionDefName,
+    FunctionDefNamedAttributeArgs,
+    FunctionDefParameters,
+    FunctionDefReturnType,
+    FunctionDefVisibility,
+    IssueError,
+    IssueWarning,
+    LocationEq,
+    LocationHash,
+    ModuleChildModules,
+    ModuleEq,
+    ModuleFunctions,
+    ModuleHasBuiltinAttribute,
+    ModuleHasNamedAttribute,
+    ModuleHash,
+    ModuleIsContract,
+    ModuleLocation,
+    ModuleName,
+    ModuleNamedAttributeArgs,
+    ModuleParent,
+    ModuleStructs,
+    QuotedAsExpr,
+    QuotedAsModule,
+    QuotedAsTraitConstraint,
+    QuotedAsType,
+    QuotedEq,
+    QuotedHash,
+    QuotedLocation,
+    QuotedTokens,
+    StrAsCtstring,
+    TraitConstraintEq,
+    TraitConstraintHash,
+    TraitDefAsTraitConstraint,
+    TraitDefEq,
+    TraitDefHash,
+    TraitDefLocation,
+    TraitImplMethods,
+    TraitImplTraitGenericArgs,
+    TypeAsArray,
+    TypeAsConstant,
+    TypeAsDataType,
+    TypeAsInteger,
+    TypeAsMutableReference,
+    TypeAsStr,
+    TypeAsTuple,
+    TypeAsVector,
+    TypeDefAddAbi,
+    TypeDefAsType,
+    TypeDefAsTypeWithGenerics,
+    TypeDefEq,
+    TypeDefFields,
+    TypeDefFieldsAsWritten,
+    TypeDefGenerics,
+    TypeDefHasBuiltinAttribute,
+    TypeDefHasNamedAttribute,
+    TypeDefHash,
+    TypeDefLocation,
+    TypeDefModule,
+    TypeDefName,
+    TypeDefNamedAttributeArgs,
+    TypeEq,
+    TypeGetTraitImpl,
+    TypeHash,
+    TypeImplements,
+    TypeIsBool,
+    TypeIsField,
+    TypeIsUnit,
+    TypeOf,
+    TypedExprAsFunctionDefinition,
+    TypedExprGetType,
+    TypedExprLocation,
+
+    // Foreign (`#[foreign]`) functions that are not ACIR black box functions.
+    Poseidon2ConfigStateSize,
+
+    /// A foreign (`#[foreign]`) function implemented as an ACIR black box function
+    /// (hashes, curve operations, signature verification). Excluded from the strum
+    /// derives because of its payload; [`Self::lookup`] and [`Self::name`] handle it
+    /// explicitly.
+    #[strum(disabled)]
+    BlackBox(BlackBoxFunc),
+}
+
+impl Builtin {
+    /// Resolve a `#[builtin(name)]` / `#[foreign(name)]` attribute name.
+    /// Returns `None` for names the compiler does not implement.
+    pub fn lookup(name: &str) -> Option<Self> {
+        name.parse().ok().or_else(|| {
+            let func = BlackBoxFunc::lookup(name)?;
+            // AND, XOR and RANGE are not callable functions: the compiler emits their
+            // opcodes from binary operations, casts and range checks.
+            let callable =
+                !matches!(func, BlackBoxFunc::AND | BlackBoxFunc::XOR | BlackBoxFunc::RANGE);
+            callable.then_some(Self::BlackBox(func))
+        })
+    }
+
+    /// The name this builtin is declared with, i.e. the inverse of [`Self::lookup`].
+    pub fn name(&self) -> &str {
+        match self {
+            Self::BlackBox(func) => func.name(),
+            other => other.as_ref(),
+        }
+    }
+}
+
+impl std::fmt::Display for Builtin {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str(self.name())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use strum::IntoEnumIterator;
+
+    use super::Builtin;
+    use acvm::acir::BlackBoxFunc;
+
+    #[test]
+    fn name_round_trips_through_lookup() {
+        // `Builtin::iter` skips the strum-disabled `BlackBox` variant, so chain the
+        // callable black box functions explicitly.
+        let black_boxes = BlackBoxFunc::iter()
+            .filter(|func| Builtin::lookup(func.name()).is_some())
+            .map(Builtin::BlackBox);
+        for builtin in Builtin::iter().chain(black_boxes) {
+            assert_eq!(
+                Builtin::lookup(builtin.name()),
+                Some(builtin),
+                "`{builtin:?}` does not round-trip through its name `{}`",
+                builtin.name()
+            );
+        }
+    }
+
+    #[test]
+    fn black_box_funcs_resolve_to_builtins() {
+        for func in BlackBoxFunc::iter() {
+            // AND, XOR and RANGE are not callable functions: the compiler emits their
+            // opcodes from binary operations, casts and range checks, so their names
+            // do not resolve.
+            let expected =
+                if matches!(func, BlackBoxFunc::AND | BlackBoxFunc::XOR | BlackBoxFunc::RANGE) {
+                    None
+                } else {
+                    Some(Builtin::BlackBox(func))
+                };
+            assert_eq!(Builtin::lookup(func.name()), expected);
+        }
+    }
+}

--- a/compiler/noirc_frontend/src/shared/mod.rs
+++ b/compiler/noirc_frontend/src/shared/mod.rs
@@ -3,10 +3,12 @@
 //! This is done to avoid each IR from needing to have its own definition of elementary types
 //! while avoiding one IR being embedded within another.
 
+mod builtin;
 mod foreign_calls;
 mod signedness;
 mod visibility;
 
+pub use builtin::Builtin;
 pub use foreign_calls::ForeignCall;
 pub use signedness::Signedness;
 pub use visibility::Visibility;

--- a/design/clone_elision.md
+++ b/design/clone_elision.md
@@ -49,14 +49,14 @@ keeps the clone, which is always sound (at worst a wasted copy).
 
 ## The duplicated builtin classification
 
-`builtin_supports_clone_elision` in the frontend is a name-based copy of
-information that canonically lives in `noirc_evaluator`
-(`Intrinsic::purity` and `Intrinsic::unsafe_for_clone_elision_in_brillig`),
-because the crate dependency only goes the other way. The duplication is
-deliberate and small; the test
-`ownership_clone_elision_list_matches_intrinsic_purity` in
-`noirc_evaluator`'s `ssa_gen::tests` asserts the two classifications agree for
-every intrinsic name, so they cannot drift silently.
+`builtin_supports_clone_elision` in the frontend duplicates information that
+canonically lives in `noirc_evaluator` (`Intrinsic::purity` and
+`Intrinsic::unsafe_for_clone_elision_in_brillig`), because the crate
+dependency only goes the other way. Both sides are keyed on the shared
+`noirc_frontend::shared::Builtin` enum, and the test
+`ownership_clone_elision_list_matches_intrinsic_purity` in `noirc_evaluator`'s
+`ssa_gen::tests` iterates every `Builtin` variant and asserts the two
+classifications agree, so they cannot drift silently.
 
 Notable entries: vector mutators are excluded because they may write through
 their input pointer in place at reference count 1; `str_as_bytes` and

--- a/tooling/ast_fuzzer/src/program/func.rs
+++ b/tooling/ast_fuzzer/src/program/func.rs
@@ -21,7 +21,7 @@ use noirc_frontend::{
             Parameters, Program, Type, While,
         },
     },
-    shared::{Signedness, Visibility},
+    shared::{Builtin, Signedness, Visibility},
     token::FmtStrFragment,
 };
 
@@ -2595,7 +2595,7 @@ impl<'a> FunctionContext<'a> {
     fn call_array_len(&mut self, array_or_vector: Expression, typ: Type) -> Expression {
         let func_ident = Ident {
             location: None,
-            definition: Definition::Builtin("array_len".to_string()),
+            definition: Definition::Builtin(Builtin::ArrayLen),
             mutable: false,
             name: "len".to_string(),
             typ: Rc::new(Type::Function(
@@ -2618,7 +2618,7 @@ impl<'a> FunctionContext<'a> {
     fn call_str_as_bytes(&mut self, value: Expression, len: u32, bytes_type: Type) -> Expression {
         let func_ident = Ident {
             location: None,
-            definition: Definition::Builtin("str_as_bytes".to_string()),
+            definition: Definition::Builtin(Builtin::StrAsBytes),
             mutable: false,
             name: "as_bytes".to_string(),
             typ: Rc::new(Type::Function(
@@ -2646,7 +2646,7 @@ impl<'a> FunctionContext<'a> {
     ) -> Expression {
         let func_ident = Ident {
             location: None,
-            definition: Definition::Builtin("as_vector".to_string()),
+            definition: Definition::Builtin(Builtin::AsVector),
             mutable: false,
             name: "as_vector".to_string(),
             typ: Rc::new(Type::Function(
@@ -2668,14 +2668,18 @@ impl<'a> FunctionContext<'a> {
     /// Construct a `Call` to one of the `vector_*` builtin functions.
     fn call_vector_builtin(
         &mut self,
-        name: &str,
+        builtin: Builtin,
         return_type: Type,
         arg_types: Vec<Type>,
         args: Vec<Expression>,
     ) -> Expression {
+        let name = builtin
+            .name()
+            .strip_prefix("vector_")
+            .expect("call_vector_builtin expects a vector_* builtin");
         let func_ident = Ident {
             location: None,
-            definition: Definition::Builtin(format!("vector_{name}")),
+            definition: Definition::Builtin(builtin),
             mutable: false,
             name: name.to_string(),
             typ: Rc::new(Type::Function(
@@ -2704,7 +2708,7 @@ impl<'a> FunctionContext<'a> {
         item: Expression,
     ) -> Expression {
         self.call_vector_builtin(
-            if is_front { "push_front" } else { "push_back" },
+            if is_front { Builtin::VectorPushFront } else { Builtin::VectorPushBack },
             vector_type.clone(),
             vec![vector_type, item_type],
             vec![vector, item],
@@ -2725,7 +2729,7 @@ impl<'a> FunctionContext<'a> {
             vec![vector_type.clone(), item_type]
         };
         self.call_vector_builtin(
-            if is_front { "pop_front" } else { "pop_back" },
+            if is_front { Builtin::VectorPopFront } else { Builtin::VectorPopBack },
             Type::Tuple(return_fields),
             vec![vector_type],
             vec![vector],
@@ -2741,7 +2745,7 @@ impl<'a> FunctionContext<'a> {
         idx: Expression,
     ) -> Expression {
         self.call_vector_builtin(
-            "remove",
+            Builtin::VectorRemove,
             Type::Tuple(vec![vector_type.clone(), item_type]),
             vec![vector_type, types::U32],
             vec![vector, idx],
@@ -2758,7 +2762,7 @@ impl<'a> FunctionContext<'a> {
         item: Expression,
     ) -> Expression {
         self.call_vector_builtin(
-            "insert",
+            Builtin::VectorInsert,
             Type::Tuple(vec![vector_type.clone()]),
             vec![vector_type, types::U32, item_type],
             vec![vector, idx, item],


### PR DESCRIPTION
Stacked on #13520 — the first three commits are that PR; review only the last commit here.

## Problem

The name in a `#[builtin(name)]`/`#[foreign(name)]` attribute was carried as a `String` through the whole pipeline and re-matched textually at every consumer: the comptime interpreter's ~150-arm dispatch, the monomorphizer's `HandledOpcode`, `Definition::Builtin`/`LowLevel`, `Intrinsic::lookup` in SSA generation, and the ownership pass's clone-elision list (added in #13520). Nothing tied these tables together except one test, and an unknown name silently survived to SSA generation where it **panicked**.

## Change

Builtin/foreign names now resolve once to `noirc_frontend::shared::Builtin` — a single enum (the two attribute kinds share one namespace at consumption) covering all 148 stdlib `#[builtin]` names and the 12 `#[foreign]` names, grouped by consumer: SSA intrinsics, monomorphizer-evaluated, comptime-only. The ACIR black box functions are not repeated as variants: they nest as `Builtin::BlackBox(BlackBoxFunc)`, so acvm's enum stays the single source of those names and a new black box function is a `Builtin` by construction. `strum` derives provide `lookup`/`name`/`iter` for the unit variants (the payload variant is `#[strum(disabled)]` and handled explicitly), with a round-trip test.

Attribute tokens still hold free-form strings, so malformed or unknown names parse normally; resolution happens at the semantic boundaries:

- the comptime interpreter's `call_special` (then `call_builtin`/`call_foreign` match enum variants),
- the monomorphizer when constructing `Definition::Builtin(Builtin)`/`LowLevel(Builtin)`,
- SSA generation maps `Builtin` → `Intrinsic` via the new `Intrinsic::from_builtin` (`Intrinsic::lookup(&str)` remains only for the SSA text parser).

Oracle (`#[oracle]`) names stay strings deliberately: they are an open, user-extensible namespace.

## Behavior changes

- Calling a builtin whose name the compiler doesn't implement is now a proper `MonomorphizationError::UnknownBuiltin` diagnostic (with test); previously it was an SSA-gen `panic!`.
- The five `unresolved_type_*` comptime dispatch arms and their helpers are deleted: stdlib no longer declares those builtins, and only stdlib may declare builtins, so they were unreachable.
- `BlackBoxFunc::AND`/`XOR`/`RANGE` are filtered out of `Builtin::lookup`: they are not callable functions (the compiler emits their opcodes from binary ops, casts and range checks), so names like `#[foreign(and)]` — never declared anywhere — now error like any unknown name.

## Follow-on wins

- The clone-elision sync test from #13520 now iterates `Builtin::iter()` exhaustively instead of a hand-maintained name list, and `builtin_supports_clone_elision` matches variants.
- One test adapted: the proxies test used a fabricated `#[builtin(foo)]`, which the new diagnostic rightly rejects; it now uses the real generic builtin `black_box` and tests the same instantiation behavior.

## Validation

`noirc_frontend` + `noirc_evaluator` (4192 tests), the full `nargo_cli --test execute` suite (9350 tests), stdlib tests (431 × 9 configs), AST fuzzer smoke, clippy, and the enum round-trip/black-box coverage tests all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)