### PR TITLE
fix(ssa): keep preserved reference aliases across a scalar array_set

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/opt/alias_analysis.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/alias_analysis.rs
@@ -771,6 +771,17 @@ impl AliasAnalysisContext {
                 Instruction::ArraySet { array, value, .. } => {
                     let new_array = function.dfg.instruction_result::<1>(*instruction_id)[0];
 
+                    // An `array_set` replaces a single element, so the result preserves every
+                    // reference field the original array held apart from the overwritten one.
+                    // The result therefore inherits the original array's whole reference graph,
+                    // which also covers the case where the written value is a scalar and carries
+                    // no references of its own.
+                    if function.dfg.type_of_value(*array).contains_reference() {
+                        let array_g = GlobalValueId::new(function, *array);
+                        let new_array_g = GlobalValueId::new(function, new_array);
+                        self.merge_alias(array_g, new_array_g);
+                    }
+
                     // Field-insensitive: the array is merged with its elements (and the index is not used)
                     self.merge_reference(function, *value, new_array);
                     // The original array is merged with the new one transitively through the value, because they share elements:

--- a/compiler/noirc_evaluator/src/ssa/opt/load_store_forwarding.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/load_store_forwarding.rs
@@ -221,7 +221,11 @@ fn forward_loads_and_stores_in_block(
 mod tests {
     use crate::{
         assert_ssa_snapshot,
-        ssa::{opt::assert_ssa_does_not_change, ssa_gen::Ssa},
+        ssa::{
+            interpreter::value::Value,
+            opt::{assert_pass_does_not_affect_execution, assert_ssa_does_not_change},
+            ssa_gen::Ssa,
+        },
     };
 
     #[test]
@@ -1846,5 +1850,50 @@ mod tests {
             return
         }
         ");
+    }
+
+    /// Regression for noir-claude#1362: a scalar `array_set` on a composite
+    /// element preserves the element's reference fields, and a call through
+    /// such a preserved reference must invalidate a cached load of the value it
+    /// points to.
+    ///
+    /// The array holds `(Field, &mut Field)` elements. `array_set` overwrites
+    /// only tuple field 0, so field 1 still holds the original `v0` reference.
+    /// `call f1(v3)` stores `Field 1` through that reference, so the final
+    /// `load v0` observes `Field 1`: alias analysis keeps the preserved
+    /// reference in the result's alias graph, so Load-Store Forwarding treats
+    /// the call as reaching `v0` and keeps the load live.
+    ///
+    /// `assert_pass_does_not_affect_execution` interprets `main` before and
+    /// after the pass and asserts the results match, pinning that the pass
+    /// preserves the `Field 1` outcome.
+    #[test]
+    fn preserves_reference_field_of_composite_array_set_across_call() {
+        let src = "
+        brillig(inline) fn main f0 {
+          b0():
+            v0 = allocate -> &mut Field
+            store Field 0 at v0
+            v1 = make_array [Field 7, v0] : [(Field, &mut Field); 1]
+            v2 = array_set v1, index u32 0, value Field 99
+            v3 = array_get v2, index u32 1 -> &mut Field
+            call f1(v3)
+            v4 = load v0 -> Field
+            return v4
+        }
+        brillig(inline) fn f1 f1 {
+          b0(v0: &mut Field):
+            store Field 1 at v0
+            return
+        }
+        ";
+        let ssa = Ssa::from_str(src).unwrap();
+
+        let (_, result) =
+            assert_pass_does_not_affect_execution(ssa, vec![], |ssa| ssa.load_store_forwarding());
+
+        // The call stores `Field 1` through the preserved reference, so the
+        // final load returns it.
+        assert_eq!(result.unwrap(), vec![Value::field(1_u128.into())]);
     }
 }

--- a/test_programs/execution_success/regression_nc1362/Nargo.toml
+++ b/test_programs/execution_success/regression_nc1362/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "regression_nc1362"
+version = "0.1.0"
+type = "bin"
+authors = [""]
+
+[dependencies]

--- a/test_programs/execution_success/regression_nc1362/src/main.nr
+++ b/test_programs/execution_success/regression_nc1362/src/main.nr
@@ -1,0 +1,17 @@
+// Regression for noir-claude#1362: a scalar `array_set` on a composite element
+// (here tuple field 0) preserves the element's other fields, including a `&mut`
+// reference field (tuple field 1). A store made through that preserved
+// reference is observed by a later read of the referenced value.
+unconstrained fn set_ref(r: &mut Field) {
+    *r = 1;
+}
+
+unconstrained fn main() {
+    let mut x: Field = 0;
+    let r = &mut x;
+    let mut arr: [(Field, &mut Field); 1] = [(7, r)];
+    arr[0].0 = 99; // scalar array_set on tuple field 0; field 1 keeps `r`
+    let rr = arr[0].1; // preserved reference field
+    set_ref(rr); // stores 1 through the reference into `x`
+    assert(x == 1);
+}

--- a/tooling/nargo_cli/tests/snapshots/execution_success/regression_nc1362/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/regression_nc1362/execute__tests__expanded.snap
@@ -1,0 +1,17 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: expanded_code
+---
+unconstrained fn set_ref(r: &mut Field) {
+    *r = 1_Field;
+}
+
+unconstrained fn main() {
+    let mut x: Field = 0_Field;
+    let r: &mut Field = &mut x;
+    let mut arr: [(Field, &mut Field); 1] = [(7_Field, r)];
+    arr[0_u32].0 = 99_Field;
+    let rr: &mut Field = arr[0_u32].1;
+    set_ref(rr);
+    assert(x == 1_Field);
+}

--- a/tooling/nargo_cli/tests/snapshots/execution_success/regression_nc1362/execute__tests__stdout.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/regression_nc1362/execute__tests__stdout.snap
@@ -1,0 +1,5 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: stdout
+---
+


### PR DESCRIPTION
## Problem

`alias_analysis` modeled an `ArraySet` result only through the value being written. When an array element is a flattened tuple/struct and the update changes only a **scalar** field, the written value carries no references, so the three `merge_reference`/`join_reference` calls are all no-ops and the result inherits **none** of the reference fields the original array preserved.

`load_store_forwarding` then sees a call made through one of those preserved references as unrelated to a cached load of the value it points to, and forwards a stale value — a semantic-preservation bug: one optimizer pass changes the program's result.

This is reproducible from ordinary unconstrained Noir source (no `unsafe`, no hand-written SSA):

```rust
unconstrained fn set_ref(r: &mut Field) {
    *r = 1;
}

unconstrained fn main() {
    let mut x: Field = 0;
    let r = &mut x;
    let mut arr: [(Field, &mut Field); 1] = [(7, r)];
    arr[0].0 = 99;      // scalar array_set on tuple field 0
    let rr = arr[0].1;  // preserved reference field
    set_ref(rr);        // stores 1 through the reference into x
    assert(x == 1);     // fails before this fix (x is read as 0)
}
```

Fixes noir-lang/noir-claude#1362.

## Fix

In the `ArraySet` arm of `alias_analysis`, when the array type contains references, `merge_alias` the original array with the result so the result inherits the original array's whole reference graph — independent of whether the written value carries references. This mirrors how the existing `IfElse` arm already merges reference-carrying operands. `merge_alias` only widens aliasing, so it is a conservative, sound over-approximation.

## Regression coverage

- An SSA-level unit test in `load_store_forwarding.rs` using `assert_pass_does_not_affect_execution` (asserts the pass preserves the `Field 1` result).
- `execution_success/regression_nc1362`, reproducing the miscompilation end-to-end from Noir source.

## Verification

- Full `noirc_evaluator` unit suite passes (1962), including all alias-analysis and load-store-forwarding tests.
- Reference/array/mutable-reference execution integration tests pass with no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)