### PR TITLE
fix: don't deduplicate vector intrinsics in brillig

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/opt/constant_folding/mod.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/constant_folding/mod.rs
@@ -841,11 +841,18 @@ fn can_be_deduplicated(instruction: &Instruction, dfg: &DataFlowGraph) -> CanBeD
         | DecrementRc { .. } => CanBeDeduplicated::Never,
 
         Call { func, .. } => match dfg[*func] {
-            Value::Intrinsic(intrinsic) => match intrinsic.purity() {
-                Purity::Pure => CanBeDeduplicated::Always,
-                Purity::PureWithPredicate => CanBeDeduplicated::UnderSamePredicate,
-                Purity::Impure => CanBeDeduplicated::Never,
-            },
+            Value::Intrinsic(intrinsic) => {
+                // Similar to the ArraySet case below: in Brillig vector intrinsics might mutate a vector in-place
+                if dfg.runtime().is_brillig() && intrinsic.mutates_array_operand_in_brillig() {
+                    CanBeDeduplicated::Never
+                } else {
+                    match intrinsic.purity() {
+                        Purity::Pure => CanBeDeduplicated::Always,
+                        Purity::PureWithPredicate => CanBeDeduplicated::UnderSamePredicate,
+                        Purity::Impure => CanBeDeduplicated::Never,
+                    }
+                }
+            }
             // A call to a user-defined function from an ACIR caller lowers to a predicated
             // `Opcode::Call` or `Opcode::BrilligCall`, which leaves the callee's outputs
             // unconstrained when the predicate is disabled. `DataFlowGraph::purity_of` already
@@ -3888,5 +3895,48 @@ mod test {
         }
         ";
         assert_ssa_does_not_change(src, |ssa| ssa.fold_constants(MIN_ITER));
+    }
+
+    #[test_case("vector_push_front(v11, v12, u8 8)")]
+    #[test_case("vector_push_back(v11, v12, u8 8)")]
+    #[test_case("vector_pop_front(v11, v12)")]
+    #[test_case("vector_pop_back(v11, v12)")]
+    #[test_case("vector_insert(v11, v12, u32 1, u8 8)")]
+    #[test_case("vector_remove(v11, v12, u32 1)")]
+    fn does_not_deduplicate_possibly_mutable_vector_intrinsics_in_brillig(intrinsic: &'static str) {
+        let src = format!(
+            "
+        brillig(inline) predicate_pure fn main f0 {{
+          b0(v0: [u8; 2], v1: u1, v2: u1):
+            v6, v7 = call as_vector(v0) -> (u32, [u8])
+            v11, v12 = call vector_push_front(u32 2, v7, u8 9) -> (u32, [u8])
+            jmpif v1 then: b1(), else: b2()
+          b1():
+            v14, v15 = call {intrinsic} -> (u32, [u8])
+            v17 = lt u32 0, v14
+            constrain v17 == u1 1
+            v19 = array_get v15, index u32 0 -> u8
+            jmp b3(v19)
+          b2():
+            jmpif v2 then: b4(), else: b5()
+          b3(v3: u8):
+            return v3
+          b4():
+            v20, v21 = call {intrinsic} -> (u32, [u8])
+            v22 = lt u32 0, v20
+            constrain v22 == u1 1
+            v23 = array_get v21, index u32 0 -> u8
+            jmp b6(v23)
+          b5():
+            v24 = lt u32 0, v11
+            constrain v24 == u1 1
+            v25 = array_get v12, index u32 0 -> u8
+            jmp b6(v25)
+          b6(v4: u8):
+            jmp b3(v4)
+        }}
+        "
+        );
+        assert_ssa_does_not_change(&src, |ssa| ssa.fold_constants_using_constraints(MIN_ITER));
     }
 }

--- a/test_programs/execution_success/regression_claude_1721/Nargo.toml
+++ b/test_programs/execution_success/regression_claude_1721/Nargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "regression_claude_1721"
+version = "0.1.0"
+type = "bin"
+authors = [""]
+
+[dependencies]

--- a/test_programs/execution_success/regression_claude_1721/Prover.toml
+++ b/test_programs/execution_success/regression_claude_1721/Prover.toml
@@ -1,0 +1,4 @@
+arr = [1, 2]
+c1 = false
+c2 = false
+return = 9

--- a/test_programs/execution_success/regression_claude_1721/src/main.nr
+++ b/test_programs/execution_success/regression_claude_1721/src/main.nr
@@ -1,0 +1,13 @@
+fn main(arr: [u8; 2], c1: bool, c2: bool) -> pub u8 {
+    let v: [u8] = arr.as_vector();
+    let v1: [u8] = v.push_front(9);
+    if c1 {
+        let w: [u8] = v1.push_front(8);
+        w[0]
+    } else if c2 {
+        let w: [u8] = v1.push_front(8);
+        w[0]
+    } else {
+        v1[0]
+    }
+}

--- a/tooling/nargo_cli/tests/snapshots/execution_success/regression_claude_1721/execute__tests__expanded.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/regression_claude_1721/execute__tests__expanded.snap
@@ -1,0 +1,17 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: expanded_code
+---
+fn main(arr: [u8; 2], c1: bool, c2: bool) -> pub u8 {
+    let v: [u8] = arr.as_vector();
+    let v1: [u8] = v.push_front(9_u8);
+    if c1 {
+        let w: [u8] = v1.push_front(8_u8);
+        w[0_u32]
+    } else if c2 {
+        let w: [u8] = v1.push_front(8_u8);
+        w[0_u32]
+    } else {
+        v1[0_u32]
+    }
+}

--- a/tooling/nargo_cli/tests/snapshots/execution_success/regression_claude_1721/execute__tests__stdout.snap
+++ b/tooling/nargo_cli/tests/snapshots/execution_success/regression_claude_1721/execute__tests__stdout.snap
@@ -1,0 +1,5 @@
+---
+source: tooling/nargo_cli/tests/execute.rs
+expression: stdout
+---
+[regression_claude_1721] Circuit output: 9


### PR DESCRIPTION
## Problem Resolved

Resolves https://github.com/noir-lang/noir-claude/issues/1721

## Summary of Changes

Similar to how we don't de-duplicate `array_set` in Brillig because it might be mutating an array, here we stop de-duplicating vector intrinsics that might mutate the passed vector.

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
