### PR TITLE
feat: version ABI and artifact schemas

### DIFF
--- a/compiler/noirc_driver/src/abi_gen.rs
+++ b/compiler/noirc_driver/src/abi_gen.rs
@@ -4,7 +4,8 @@ use acvm::AcirField;
 use acvm::acir::circuit::ErrorSelector;
 use iter_extended::vecmap;
 use noirc_abi::{
-    Abi, AbiErrorType, AbiParameter, AbiReturnType, AbiType, AbiValue, AbiVisibility, Sign,
+    ABI_VERSION, Abi, AbiErrorType, AbiParameter, AbiReturnType, AbiType, AbiValue, AbiVisibility,
+    Sign,
 };
 use noirc_errors::Location;
 use noirc_evaluator::ErrorType;
@@ -34,7 +35,7 @@ pub fn gen_abi(
         .into_iter()
         .map(|(selector, typ)| (selector, build_abi_error_type(context, typ)))
         .collect();
-    Abi { parameters, return_type, error_types }
+    Abi { abi_version: ABI_VERSION, parameters, return_type, error_types }
 }
 
 // Get the Span of the root crate's main function, or else a dummy span if that fails

--- a/compiler/wasm/src/compile.rs
+++ b/compiler/wasm/src/compile.rs
@@ -30,7 +30,6 @@ export type ContractOutputsArtifact = {
 
 export type ContractArtifact = {
     artifact_version: 1;
-    artifact_kind: 'contract';
     noir_version: string;
     name: string;
     functions: Array<any>;
@@ -40,7 +39,6 @@ export type ContractArtifact = {
 
 export type ProgramArtifact = {
     artifact_version: 1;
-    artifact_kind: 'program';
     noir_version: string;
     hash: number;
     abi: any;

--- a/compiler/wasm/src/compile.rs
+++ b/compiler/wasm/src/compile.rs
@@ -29,6 +29,8 @@ export type ContractOutputsArtifact = {
 }
 
 export type ContractArtifact = {
+    artifact_version: 1;
+    artifact_kind: 'contract';
     noir_version: string;
     name: string;
     functions: Array<any>;
@@ -37,6 +39,8 @@ export type ContractArtifact = {
 };
 
 export type ProgramArtifact = {
+    artifact_version: 1;
+    artifact_kind: 'program';
     noir_version: string;
     hash: number;
     abi: any;

--- a/compiler/wasm/src/types/noir_artifact.ts
+++ b/compiler/wasm/src/types/noir_artifact.ts
@@ -76,6 +76,10 @@ export interface NoirFunctionEntry {
  * The compilation result of an Noir contract.
  */
 export interface ContractArtifact {
+  /** Version of the serialized artifact schema. */
+  artifact_version: 1;
+  /** Identifies this as a contract artifact. */
+  artifact_kind: 'contract';
   /** The name of the contract. */
   name: string;
   /** Version of noir used for the build. */
@@ -95,6 +99,10 @@ export interface ContractArtifact {
  * The compilation result of an Noir contract.
  */
 export interface ProgramArtifact {
+  /** Version of the serialized artifact schema. */
+  artifact_version: 1;
+  /** Identifies this as a program artifact. */
+  artifact_kind: 'program';
   /** Version of noir used for the build. */
   noir_version: string;
   /** The hash of the circuit. */

--- a/compiler/wasm/src/types/noir_artifact.ts
+++ b/compiler/wasm/src/types/noir_artifact.ts
@@ -78,8 +78,6 @@ export interface NoirFunctionEntry {
 export interface ContractArtifact {
   /** Version of the serialized artifact schema. */
   artifact_version: 1;
-  /** Identifies this as a contract artifact. */
-  artifact_kind: 'contract';
   /** The name of the contract. */
   name: string;
   /** Version of noir used for the build. */
@@ -101,8 +99,6 @@ export interface ContractArtifact {
 export interface ProgramArtifact {
   /** Version of the serialized artifact schema. */
   artifact_version: 1;
-  /** Identifies this as a program artifact. */
-  artifact_kind: 'program';
   /** Version of noir used for the build. */
   noir_version: string;
   /** The hash of the circuit. */

--- a/tooling/ast_fuzzer/src/abi.rs
+++ b/tooling/ast_fuzzer/src/abi.rs
@@ -28,7 +28,12 @@ pub fn program_abi(program: &Program) -> Abi {
         }),
     };
 
-    Abi { parameters, return_type, error_types: BTreeMap::default() }
+    Abi {
+        abi_version: noirc_abi::ABI_VERSION,
+        parameters,
+        return_type,
+        error_types: BTreeMap::default(),
+    }
 }
 
 /// Check if a type is valid as an ABI parameter for the `main` function.

--- a/tooling/noir_codegen/test/index.test.ts
+++ b/tooling/noir_codegen/test/index.test.ts
@@ -128,6 +128,7 @@ it('codegens a callable function with no return value', async () => {
 it('codegens `Promise<void>` for functions with no return value', () => {
   const program: CompiledCircuit = {
     abi: {
+      abi_version: 1,
       parameters: [{ name: 'x', type: { kind: 'integer', sign: 'unsigned', width: 64 }, visibility: 'private' }],
       return_type: null,
       error_types: {},

--- a/tooling/noir_codegen/test/typings_generator.test.ts
+++ b/tooling/noir_codegen/test/typings_generator.test.ts
@@ -5,6 +5,7 @@ import { codegen } from '../src/index.js';
 it('marks InputMap as a type-only import', () => {
   const program = {
     abi: {
+      abi_version: 1,
       parameters: [],
       return_type: null,
       error_types: {},

--- a/tooling/noir_js_types/src/types.ts
+++ b/tooling/noir_js_types/src/types.ts
@@ -99,6 +99,7 @@ export interface DebugInfo {
 export type WitnessMap = Map<number, string>;
 
 export type Abi = {
+  abi_version: 1;
   parameters: AbiParameter[];
   return_type: { abi_type: AbiType; visibility: Visibility } | null;
   error_types: Partial<Record<string, AbiErrorType>>;

--- a/tooling/noirc_abi/Cargo.toml
+++ b/tooling/noirc_abi/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "noirc_abi"
+publish = false
 version.workspace = true
 authors.workspace = true
 edition.workspace = true

--- a/tooling/noirc_abi/src/arbitrary.rs
+++ b/tooling/noirc_abi/src/arbitrary.rs
@@ -147,6 +147,14 @@ prop_compose! {
             let parameters  = vecmap(&parameters_with_values, |(param, _)| param.clone());
             let input_map = btree_map(parameters_with_values, |(param, value)| (param.name, value));
 
-            (Abi { parameters, return_type, error_types: BTreeMap::default() }, input_map)
+            (
+                Abi {
+                    abi_version: crate::ABI_VERSION,
+                    parameters,
+                    return_type,
+                    error_types: BTreeMap::default(),
+                },
+                input_map,
+            )
     }
 }

--- a/tooling/noirc_abi/src/input_parser/json.rs
+++ b/tooling/noirc_abi/src/input_parser/json.rs
@@ -321,6 +321,7 @@ mod tests {
     fn try_from_json_tuple_array_length_mismatch() {
         let typ = AbiType::Tuple { fields: vec![AbiType::Field, AbiType::Field] };
         let abi = Abi {
+            abi_version: crate::ABI_VERSION,
             parameters: vec![AbiParameter {
                 name: "input".to_string(),
                 typ,

--- a/tooling/noirc_abi/src/input_parser/mod.rs
+++ b/tooling/noirc_abi/src/input_parser/mod.rs
@@ -258,6 +258,7 @@ mod serialization_tests {
     #[test]
     fn serialization_round_trip() {
         let abi = Abi {
+            abi_version: crate::ABI_VERSION,
             parameters: vec![
                 AbiParameter {
                     name: "foo".into(),

--- a/tooling/noirc_abi/src/input_parser/toml.rs
+++ b/tooling/noirc_abi/src/input_parser/toml.rs
@@ -315,6 +315,7 @@ mod tests {
     fn suggests_wrapping_large_numbers_in_double_quotes() {
         let typ = AbiType::Field;
         let abi = Abi {
+            abi_version: crate::ABI_VERSION,
             parameters: vec![AbiParameter {
                 name: "input".to_string(),
                 typ,
@@ -332,6 +333,7 @@ mod tests {
     fn suggests_wrapping_large_hex_numbers_in_double_quotes() {
         let typ = AbiType::Field;
         let abi = Abi {
+            abi_version: crate::ABI_VERSION,
             parameters: vec![AbiParameter {
                 name: "input".to_string(),
                 typ,
@@ -349,6 +351,7 @@ mod tests {
     fn try_from_toml_tuple_array_length_mismatch() {
         let typ = AbiType::Tuple { fields: vec![AbiType::Field, AbiType::Field] };
         let abi = Abi {
+            abi_version: crate::ABI_VERSION,
             parameters: vec![AbiParameter {
                 name: "input".to_string(),
                 typ,

--- a/tooling/noirc_abi/src/lib.rs
+++ b/tooling/noirc_abi/src/lib.rs
@@ -1,6 +1,11 @@
 #![forbid(unsafe_code)]
 #![cfg_attr(not(test), warn(unused_crate_dependencies, unused_extern_crates))]
 
+//! Types for Noir's serialized ABI format.
+//!
+//! The serialized format is the compatibility boundary. This crate's Rust API is an internal
+//! implementation detail and may change between Noir releases.
+
 use acvm::{
     AcirField, FieldElement,
     acir::{
@@ -16,7 +21,7 @@ use noirc_printable_type::{
     PrintableType, PrintableValue, PrintableValueDisplay, decode_printable_value,
     decode_string_value,
 };
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 use std::borrow::Borrow;
 use std::{collections::BTreeMap, str};
 // This is the ABI used to bridge the different TOML formats for the initial
@@ -35,6 +40,27 @@ mod serialization;
 pub type InputMap = BTreeMap<String, InputValue>;
 
 pub const MAIN_RETURN_NAME: &str = "return";
+
+/// The version of the ABI schema emitted by this version of Noir.
+pub const ABI_VERSION: u32 = 1;
+
+const fn default_abi_version() -> u32 {
+    ABI_VERSION
+}
+
+fn deserialize_abi_version<'de, D>(deserializer: D) -> Result<u32, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let version = u32::deserialize(deserializer)?;
+    if version == ABI_VERSION {
+        Ok(version)
+    } else {
+        Err(serde::de::Error::custom(format!(
+            "unsupported ABI schema version {version}; expected {ABI_VERSION}"
+        )))
+    }
+}
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "lowercase")]
@@ -171,14 +197,29 @@ pub struct AbiReturnType {
     pub visibility: AbiVisibility,
 }
 
-#[derive(Clone, Debug, Default, Serialize, Deserialize, Hash)]
+#[derive(Clone, Debug, Serialize, Deserialize, Hash)]
 #[cfg_attr(test, derive(arbitrary::Arbitrary))]
 pub struct Abi {
+    /// The version of the serialized ABI schema.
+    #[serde(default = "default_abi_version", deserialize_with = "deserialize_abi_version")]
+    #[cfg_attr(test, proptest(strategy = "proptest::prelude::Just(ABI_VERSION)"))]
+    pub abi_version: u32,
     /// An ordered list of the arguments to the program's `main` function, specifying their types and visibility.
     pub parameters: Vec<AbiParameter>,
     pub return_type: Option<AbiReturnType>,
     #[cfg_attr(test, proptest(strategy = "proptest::prelude::Just(BTreeMap::from([]))"))]
     pub error_types: BTreeMap<ErrorSelector, AbiErrorType>,
+}
+
+impl Default for Abi {
+    fn default() -> Self {
+        Self {
+            abi_version: ABI_VERSION,
+            parameters: Vec::new(),
+            return_type: None,
+            error_types: BTreeMap::new(),
+        }
+    }
 }
 
 impl Abi {
@@ -536,7 +577,8 @@ mod tests {
     use proptest::prelude::*;
 
     use crate::{
-        Abi, AbiParameter, AbiType, AbiVisibility, Sign, arbitrary::arb_abi_and_input_map,
+        ABI_VERSION, Abi, AbiParameter, AbiType, AbiVisibility, Sign,
+        arbitrary::arb_abi_and_input_map,
     };
 
     proptest! {
@@ -552,6 +594,7 @@ mod tests {
 
     fn abi_with_single_param(typ: AbiType) -> Abi {
         Abi {
+            abi_version: ABI_VERSION,
             parameters: vec![AbiParameter {
                 name: "x".to_string(),
                 typ,

--- a/tooling/noirc_abi/src/serialization.rs
+++ b/tooling/noirc_abi/src/serialization.rs
@@ -73,7 +73,38 @@ where
 
 #[cfg(test)]
 mod tests {
-    use crate::{AbiParameter, AbiType, AbiVisibility, Sign};
+    use crate::{ABI_VERSION, Abi, AbiParameter, AbiType, AbiVisibility, Sign};
+
+    #[test]
+    fn abi_schema_version_serialization() {
+        let serialized = serde_json::to_value(Abi::default()).unwrap();
+        assert_eq!(serialized["abi_version"], ABI_VERSION);
+    }
+
+    #[test]
+    fn legacy_abi_defaults_to_version_one() {
+        let serialized = serde_json::json!({
+            "parameters": [],
+            "return_type": null,
+            "error_types": {},
+        });
+
+        let abi: Abi = serde_json::from_value(serialized).unwrap();
+        assert_eq!(abi.abi_version, ABI_VERSION);
+    }
+
+    #[test]
+    fn unsupported_abi_schema_version_is_rejected() {
+        let serialized = serde_json::json!({
+            "abi_version": ABI_VERSION + 1,
+            "parameters": [],
+            "return_type": null,
+            "error_types": {},
+        });
+
+        let error = serde_json::from_value::<Abi>(serialized).unwrap_err();
+        assert!(error.to_string().contains("unsupported ABI schema version"));
+    }
 
     #[test]
     fn abi_parameter_serialization() {

--- a/tooling/noirc_abi_wasm/test/shared/abi_encode.ts
+++ b/tooling/noirc_abi_wasm/test/shared/abi_encode.ts
@@ -1,6 +1,7 @@
 import { Abi, InputMap } from '@noir-lang/noirc_abi';
 
 export const abi: Abi = {
+  abi_version: 1,
   parameters: [
     { name: 'foo', type: { kind: 'field' }, visibility: 'private' },
     {

--- a/tooling/noirc_abi_wasm/test/shared/array_as_field.ts
+++ b/tooling/noirc_abi_wasm/test/shared/array_as_field.ts
@@ -1,6 +1,7 @@
 import { Abi, InputMap } from '@noir-lang/noirc_abi';
 
 export const abi: Abi = {
+  abi_version: 1,
   parameters: [
     {
       name: 'foo',

--- a/tooling/noirc_abi_wasm/test/shared/decode_error.ts
+++ b/tooling/noirc_abi_wasm/test/shared/decode_error.ts
@@ -10,6 +10,7 @@ export const SAMPLE_FMT_STRING = 'hello {a}';
 export const SAMPLE_STRING = 'hello world';
 
 export const abi: Abi = {
+  abi_version: 1,
   parameters: [
     {
       name: 'foo',

--- a/tooling/noirc_abi_wasm/test/shared/field_as_array.ts
+++ b/tooling/noirc_abi_wasm/test/shared/field_as_array.ts
@@ -1,6 +1,7 @@
 import { Abi, InputMap } from '@noir-lang/noirc_abi';
 
 export const abi: Abi = {
+  abi_version: 1,
   parameters: [
     {
       name: 'foo',

--- a/tooling/noirc_abi_wasm/test/shared/structs.ts
+++ b/tooling/noirc_abi_wasm/test/shared/structs.ts
@@ -9,6 +9,7 @@ export type MyNestedStruct = {
 };
 
 export const abi: Abi = {
+  abi_version: 1,
   parameters: [
     {
       name: 'struct_arg',

--- a/tooling/noirc_abi_wasm/test/shared/uint_overflow.ts
+++ b/tooling/noirc_abi_wasm/test/shared/uint_overflow.ts
@@ -1,6 +1,7 @@
 import { Abi, InputMap } from '@noir-lang/noirc_abi';
 
 export const abi: Abi = {
+  abi_version: 1,
   parameters: [
     {
       name: 'foo',

--- a/tooling/noirc_abi_wasm/test/shared/unsafe_integer.ts
+++ b/tooling/noirc_abi_wasm/test/shared/unsafe_integer.ts
@@ -1,6 +1,7 @@
 import { Abi } from '@noir-lang/noirc_abi';
 
 export const abi: Abi = {
+  abi_version: 1,
   parameters: [
     {
       name: 'foo',

--- a/tooling/noirc_artifacts/Cargo.toml
+++ b/tooling/noirc_artifacts/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "noirc_artifacts"
 description = "Definitions of Nargo's build artifacts"
+publish = false
 version.workspace = true
 authors.workspace = true
 edition.workspace = true

--- a/tooling/noirc_artifacts/src/contract.rs
+++ b/tooling/noirc_artifacts/src/contract.rs
@@ -13,25 +13,8 @@ use crate::{
 };
 
 use super::{
-    ArtifactKind, default_artifact_version, deserialize_artifact_version, deserialize_hash,
-    serialize_hash,
+    default_artifact_version, deserialize_artifact_version, deserialize_hash, serialize_hash,
 };
-
-const fn default_contract_artifact_kind() -> ArtifactKind {
-    ArtifactKind::Contract
-}
-
-fn deserialize_contract_artifact_kind<'de, D>(deserializer: D) -> Result<ArtifactKind, D::Error>
-where
-    D: serde::Deserializer<'de>,
-{
-    let kind = ArtifactKind::deserialize(deserializer)?;
-    if kind == ArtifactKind::Contract {
-        Ok(kind)
-    } else {
-        Err(serde::de::Error::custom("expected a contract artifact"))
-    }
-}
 
 #[derive(Clone, Serialize, Deserialize, Debug)]
 pub struct ContractOutputsArtifact {
@@ -54,13 +37,6 @@ pub struct ContractArtifact {
     )]
     pub artifact_version: u32,
 
-    /// Identifies this as a contract artifact.
-    #[serde(
-        default = "default_contract_artifact_kind",
-        deserialize_with = "deserialize_contract_artifact_kind"
-    )]
-    pub artifact_kind: ArtifactKind,
-
     /// Version of noir used to compile this contract
     pub noir_version: String,
     /// The name of the contract.
@@ -77,7 +53,6 @@ impl From<CompiledContract> for ContractArtifact {
     fn from(contract: CompiledContract) -> Self {
         ContractArtifact {
             artifact_version: super::ARTIFACT_VERSION,
-            artifact_kind: ArtifactKind::Contract,
             noir_version: contract.noir_version,
             name: contract.name,
             functions: contract.functions.into_iter().map(ContractFunctionArtifact::from).collect(),

--- a/tooling/noirc_artifacts/src/contract.rs
+++ b/tooling/noirc_artifacts/src/contract.rs
@@ -12,7 +12,26 @@ use crate::{
     ssa::SsaReport,
 };
 
-use super::{deserialize_hash, serialize_hash};
+use super::{
+    ArtifactKind, default_artifact_version, deserialize_artifact_version, deserialize_hash,
+    serialize_hash,
+};
+
+const fn default_contract_artifact_kind() -> ArtifactKind {
+    ArtifactKind::Contract
+}
+
+fn deserialize_contract_artifact_kind<'de, D>(deserializer: D) -> Result<ArtifactKind, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let kind = ArtifactKind::deserialize(deserializer)?;
+    if kind == ArtifactKind::Contract {
+        Ok(kind)
+    } else {
+        Err(serde::de::Error::custom("expected a contract artifact"))
+    }
+}
 
 #[derive(Clone, Serialize, Deserialize, Debug)]
 pub struct ContractOutputsArtifact {
@@ -28,6 +47,20 @@ impl From<CompiledContractOutputs> for ContractOutputsArtifact {
 
 #[derive(Clone, Serialize, Deserialize, Debug)]
 pub struct ContractArtifact {
+    /// Version of the serialized artifact schema.
+    #[serde(
+        default = "default_artifact_version",
+        deserialize_with = "deserialize_artifact_version"
+    )]
+    pub artifact_version: u32,
+
+    /// Identifies this as a contract artifact.
+    #[serde(
+        default = "default_contract_artifact_kind",
+        deserialize_with = "deserialize_contract_artifact_kind"
+    )]
+    pub artifact_kind: ArtifactKind,
+
     /// Version of noir used to compile this contract
     pub noir_version: String,
     /// The name of the contract.
@@ -43,6 +76,8 @@ pub struct ContractArtifact {
 impl From<CompiledContract> for ContractArtifact {
     fn from(contract: CompiledContract) -> Self {
         ContractArtifact {
+            artifact_version: super::ARTIFACT_VERSION,
+            artifact_kind: ArtifactKind::Contract,
             noir_version: contract.noir_version,
             name: contract.name,
             functions: contract.functions.into_iter().map(ContractFunctionArtifact::from).collect(),

--- a/tooling/noirc_artifacts/src/lib.rs
+++ b/tooling/noirc_artifacts/src/lib.rs
@@ -9,7 +9,7 @@
 //! The serialized format is the compatibility boundary. This crate's Rust API is an internal
 //! implementation detail and may change between Noir releases.
 
-use serde::{Deserialize, Deserializer, Serialize, Serializer, de::Visitor};
+use serde::{Deserialize, Deserializer, Serializer, de::Visitor};
 
 pub mod contract;
 pub mod debug;
@@ -36,14 +36,6 @@ where
             "unsupported artifact schema version {version}; expected {ARTIFACT_VERSION}"
         )))
     }
-}
-
-/// Identifies which artifact schema a serialized artifact contains.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "lowercase")]
-pub enum ArtifactKind {
-    Program,
-    Contract,
 }
 
 /// Serialize `hash` as `String`, so that it doesn't get truncated in Javascript.
@@ -93,7 +85,7 @@ mod tests {
     use noirc_abi::Abi;
 
     use crate::{
-        ARTIFACT_VERSION, ArtifactKind,
+        ARTIFACT_VERSION,
         contract::{ContractArtifact, ContractOutputsArtifact},
         debug::ProgramDebugInfo,
         program::ProgramArtifact,
@@ -102,7 +94,6 @@ mod tests {
     fn program_artifact() -> ProgramArtifact {
         ProgramArtifact {
             artifact_version: ARTIFACT_VERSION,
-            artifact_kind: ArtifactKind::Program,
             noir_version: "1.0.0".to_owned(),
             hash: 0,
             abi: Abi::default(),
@@ -115,7 +106,6 @@ mod tests {
     fn contract_artifact() -> ContractArtifact {
         ContractArtifact {
             artifact_version: ARTIFACT_VERSION,
-            artifact_kind: ArtifactKind::Contract,
             noir_version: "1.0.0".to_owned(),
             name: "contract".to_owned(),
             functions: Vec::new(),
@@ -125,33 +115,27 @@ mod tests {
     }
 
     #[test]
-    fn artifact_schema_markers_are_serialized() {
+    fn artifact_schema_version_is_serialized() {
         let program = serde_json::to_value(program_artifact()).unwrap();
         assert_eq!(program["artifact_version"], ARTIFACT_VERSION);
-        assert_eq!(program["artifact_kind"], "program");
 
         let contract = serde_json::to_value(contract_artifact()).unwrap();
         assert_eq!(contract["artifact_version"], ARTIFACT_VERSION);
-        assert_eq!(contract["artifact_kind"], "contract");
     }
 
     #[test]
-    fn legacy_artifacts_default_to_version_one_and_their_expected_kind() {
+    fn legacy_artifacts_default_to_version_one() {
         let mut program = serde_json::to_value(program_artifact()).unwrap();
         let program = program.as_object_mut().unwrap();
         program.remove("artifact_version");
-        program.remove("artifact_kind");
         let program: ProgramArtifact = serde_json::from_value(program.clone().into()).unwrap();
         assert_eq!(program.artifact_version, ARTIFACT_VERSION);
-        assert_eq!(program.artifact_kind, ArtifactKind::Program);
 
         let mut contract = serde_json::to_value(contract_artifact()).unwrap();
         let contract = contract.as_object_mut().unwrap();
         contract.remove("artifact_version");
-        contract.remove("artifact_kind");
         let contract: ContractArtifact = serde_json::from_value(contract.clone().into()).unwrap();
         assert_eq!(contract.artifact_version, ARTIFACT_VERSION);
-        assert_eq!(contract.artifact_kind, ArtifactKind::Contract);
     }
 
     #[test]
@@ -161,14 +145,5 @@ mod tests {
 
         let error = serde_json::from_value::<ProgramArtifact>(artifact).unwrap_err();
         assert!(error.to_string().contains("unsupported artifact schema version"));
-    }
-
-    #[test]
-    fn wrong_artifact_kind_is_rejected() {
-        let mut artifact = serde_json::to_value(program_artifact()).unwrap();
-        artifact["artifact_kind"] = "contract".into();
-
-        let error = serde_json::from_value::<ProgramArtifact>(artifact).unwrap_err();
-        assert!(error.to_string().contains("expected a program artifact"));
     }
 }

--- a/tooling/noirc_artifacts/src/lib.rs
+++ b/tooling/noirc_artifacts/src/lib.rs
@@ -6,14 +6,45 @@
 //! These artifacts are intended to remain independent of any applications being built on top of Noir.
 //! Should any projects require/desire a different artifact format, it's expected that they will write a transformer
 //! to generate them using these artifacts as a starting point.
+//! The serialized format is the compatibility boundary. This crate's Rust API is an internal
+//! implementation detail and may change between Noir releases.
 
-use serde::{Deserializer, Serializer, de::Visitor};
+use serde::{Deserialize, Deserializer, Serialize, Serializer, de::Visitor};
 
 pub mod contract;
 pub mod debug;
 mod debug_vars;
 pub mod program;
 pub mod ssa;
+
+/// The version of the artifact schema emitted by this version of Noir.
+pub const ARTIFACT_VERSION: u32 = 1;
+
+pub(crate) const fn default_artifact_version() -> u32 {
+    ARTIFACT_VERSION
+}
+
+pub(crate) fn deserialize_artifact_version<'de, D>(deserializer: D) -> Result<u32, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let version = u32::deserialize(deserializer)?;
+    if version == ARTIFACT_VERSION {
+        Ok(version)
+    } else {
+        Err(serde::de::Error::custom(format!(
+            "unsupported artifact schema version {version}; expected {ARTIFACT_VERSION}"
+        )))
+    }
+}
+
+/// Identifies which artifact schema a serialized artifact contains.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ArtifactKind {
+    Program,
+    Contract,
+}
 
 /// Serialize `hash` as `String`, so that it doesn't get truncated in Javascript.
 fn serialize_hash<S>(hash: &u64, s: S) -> Result<S::Ok, S::Error>
@@ -52,4 +83,92 @@ where
         }
     }
     deserializer.deserialize_any(StringOrU64)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::{BTreeMap, HashMap};
+
+    use acvm::{FieldElement, acir::circuit::Program};
+    use noirc_abi::Abi;
+
+    use crate::{
+        ARTIFACT_VERSION, ArtifactKind,
+        contract::{ContractArtifact, ContractOutputsArtifact},
+        debug::ProgramDebugInfo,
+        program::ProgramArtifact,
+    };
+
+    fn program_artifact() -> ProgramArtifact {
+        ProgramArtifact {
+            artifact_version: ARTIFACT_VERSION,
+            artifact_kind: ArtifactKind::Program,
+            noir_version: "1.0.0".to_owned(),
+            hash: 0,
+            abi: Abi::default(),
+            bytecode: Program::<FieldElement>::default(),
+            debug_symbols: ProgramDebugInfo::default(),
+            file_map: BTreeMap::new(),
+        }
+    }
+
+    fn contract_artifact() -> ContractArtifact {
+        ContractArtifact {
+            artifact_version: ARTIFACT_VERSION,
+            artifact_kind: ArtifactKind::Contract,
+            noir_version: "1.0.0".to_owned(),
+            name: "contract".to_owned(),
+            functions: Vec::new(),
+            outputs: ContractOutputsArtifact { structs: HashMap::new(), globals: HashMap::new() },
+            file_map: BTreeMap::new(),
+        }
+    }
+
+    #[test]
+    fn artifact_schema_markers_are_serialized() {
+        let program = serde_json::to_value(program_artifact()).unwrap();
+        assert_eq!(program["artifact_version"], ARTIFACT_VERSION);
+        assert_eq!(program["artifact_kind"], "program");
+
+        let contract = serde_json::to_value(contract_artifact()).unwrap();
+        assert_eq!(contract["artifact_version"], ARTIFACT_VERSION);
+        assert_eq!(contract["artifact_kind"], "contract");
+    }
+
+    #[test]
+    fn legacy_artifacts_default_to_version_one_and_their_expected_kind() {
+        let mut program = serde_json::to_value(program_artifact()).unwrap();
+        let program = program.as_object_mut().unwrap();
+        program.remove("artifact_version");
+        program.remove("artifact_kind");
+        let program: ProgramArtifact = serde_json::from_value(program.clone().into()).unwrap();
+        assert_eq!(program.artifact_version, ARTIFACT_VERSION);
+        assert_eq!(program.artifact_kind, ArtifactKind::Program);
+
+        let mut contract = serde_json::to_value(contract_artifact()).unwrap();
+        let contract = contract.as_object_mut().unwrap();
+        contract.remove("artifact_version");
+        contract.remove("artifact_kind");
+        let contract: ContractArtifact = serde_json::from_value(contract.clone().into()).unwrap();
+        assert_eq!(contract.artifact_version, ARTIFACT_VERSION);
+        assert_eq!(contract.artifact_kind, ArtifactKind::Contract);
+    }
+
+    #[test]
+    fn unsupported_artifact_schema_version_is_rejected() {
+        let mut artifact = serde_json::to_value(program_artifact()).unwrap();
+        artifact["artifact_version"] = (ARTIFACT_VERSION + 1).into();
+
+        let error = serde_json::from_value::<ProgramArtifact>(artifact).unwrap_err();
+        assert!(error.to_string().contains("unsupported artifact schema version"));
+    }
+
+    #[test]
+    fn wrong_artifact_kind_is_rejected() {
+        let mut artifact = serde_json::to_value(program_artifact()).unwrap();
+        artifact["artifact_kind"] = "contract".into();
+
+        let error = serde_json::from_value::<ProgramArtifact>(artifact).unwrap_err();
+        assert!(error.to_string().contains("expected a program artifact"));
+    }
 }

--- a/tooling/noirc_artifacts/src/program.rs
+++ b/tooling/noirc_artifacts/src/program.rs
@@ -11,10 +11,43 @@ use crate::debug::DebugInfo;
 use crate::debug::ProgramDebugInfo;
 use crate::ssa::SsaReport;
 
-use super::{deserialize_hash, serialize_hash};
+use super::{
+    ArtifactKind, default_artifact_version, deserialize_artifact_version, deserialize_hash,
+    serialize_hash,
+};
+
+const fn default_program_artifact_kind() -> ArtifactKind {
+    ArtifactKind::Program
+}
+
+fn deserialize_program_artifact_kind<'de, D>(deserializer: D) -> Result<ArtifactKind, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let kind = ArtifactKind::deserialize(deserializer)?;
+    if kind == ArtifactKind::Program {
+        Ok(kind)
+    } else {
+        Err(serde::de::Error::custom("expected a program artifact"))
+    }
+}
 
 #[derive(Clone, Serialize, Deserialize, Debug)]
 pub struct ProgramArtifact {
+    /// Version of the serialized artifact schema.
+    #[serde(
+        default = "default_artifact_version",
+        deserialize_with = "deserialize_artifact_version"
+    )]
+    pub artifact_version: u32,
+
+    /// Identifies this as a program artifact.
+    #[serde(
+        default = "default_program_artifact_kind",
+        deserialize_with = "deserialize_program_artifact_kind"
+    )]
+    pub artifact_kind: ArtifactKind,
+
     pub noir_version: String,
 
     /// Hash of the monomorphized program from which this [`ProgramArtifact`] was compiled.
@@ -44,6 +77,8 @@ pub struct ProgramArtifact {
 impl From<CompiledProgram> for ProgramArtifact {
     fn from(compiled_program: CompiledProgram) -> Self {
         ProgramArtifact {
+            artifact_version: super::ARTIFACT_VERSION,
+            artifact_kind: ArtifactKind::Program,
             hash: compiled_program.hash,
             abi: compiled_program.abi,
             noir_version: compiled_program.noir_version,

--- a/tooling/noirc_artifacts/src/program.rs
+++ b/tooling/noirc_artifacts/src/program.rs
@@ -12,25 +12,8 @@ use crate::debug::ProgramDebugInfo;
 use crate::ssa::SsaReport;
 
 use super::{
-    ArtifactKind, default_artifact_version, deserialize_artifact_version, deserialize_hash,
-    serialize_hash,
+    default_artifact_version, deserialize_artifact_version, deserialize_hash, serialize_hash,
 };
-
-const fn default_program_artifact_kind() -> ArtifactKind {
-    ArtifactKind::Program
-}
-
-fn deserialize_program_artifact_kind<'de, D>(deserializer: D) -> Result<ArtifactKind, D::Error>
-where
-    D: serde::Deserializer<'de>,
-{
-    let kind = ArtifactKind::deserialize(deserializer)?;
-    if kind == ArtifactKind::Program {
-        Ok(kind)
-    } else {
-        Err(serde::de::Error::custom("expected a program artifact"))
-    }
-}
 
 #[derive(Clone, Serialize, Deserialize, Debug)]
 pub struct ProgramArtifact {
@@ -40,13 +23,6 @@ pub struct ProgramArtifact {
         deserialize_with = "deserialize_artifact_version"
     )]
     pub artifact_version: u32,
-
-    /// Identifies this as a program artifact.
-    #[serde(
-        default = "default_program_artifact_kind",
-        deserialize_with = "deserialize_program_artifact_kind"
-    )]
-    pub artifact_kind: ArtifactKind,
 
     pub noir_version: String,
 
@@ -78,7 +54,6 @@ impl From<CompiledProgram> for ProgramArtifact {
     fn from(compiled_program: CompiledProgram) -> Self {
         ProgramArtifact {
             artifact_version: super::ARTIFACT_VERSION,
-            artifact_kind: ArtifactKind::Program,
             hash: compiled_program.hash,
             abi: compiled_program.abi,
             noir_version: compiled_program.noir_version,

--- a/tooling/profiler/src/cli/execution_flamegraph_cmd.rs
+++ b/tooling/profiler/src/cli/execution_flamegraph_cmd.rs
@@ -226,6 +226,8 @@ mod tests {
         let prover_toml_path = temp_dir.path().join("Prover.toml");
 
         let artifact = ProgramArtifact {
+            artifact_version: noirc_artifacts::ARTIFACT_VERSION,
+            artifact_kind: noirc_artifacts::ArtifactKind::Program,
             noir_version: "0.0.0".to_string(),
             hash: 27,
             abi: noirc_abi::Abi::default(),

--- a/tooling/profiler/src/cli/execution_flamegraph_cmd.rs
+++ b/tooling/profiler/src/cli/execution_flamegraph_cmd.rs
@@ -227,7 +227,6 @@ mod tests {
 
         let artifact = ProgramArtifact {
             artifact_version: noirc_artifacts::ARTIFACT_VERSION,
-            artifact_kind: noirc_artifacts::ArtifactKind::Program,
             noir_version: "0.0.0".to_string(),
             hash: 27,
             abi: noirc_abi::Abi::default(),

--- a/tooling/profiler/src/cli/gates_flamegraph_cmd.rs
+++ b/tooling/profiler/src/cli/gates_flamegraph_cmd.rs
@@ -182,6 +182,8 @@ mod tests {
         let artifact_path = temp_dir.path().join("test.json");
 
         let artifact = ProgramArtifact {
+            artifact_version: noirc_artifacts::ARTIFACT_VERSION,
+            artifact_kind: noirc_artifacts::ArtifactKind::Program,
             noir_version: "0.0.0".to_string(),
             hash: 27,
             abi: noirc_abi::Abi::default(),

--- a/tooling/profiler/src/cli/gates_flamegraph_cmd.rs
+++ b/tooling/profiler/src/cli/gates_flamegraph_cmd.rs
@@ -183,7 +183,6 @@ mod tests {
 
         let artifact = ProgramArtifact {
             artifact_version: noirc_artifacts::ARTIFACT_VERSION,
-            artifact_kind: noirc_artifacts::ArtifactKind::Program,
             noir_version: "0.0.0".to_string(),
             hash: 27,
             abi: noirc_abi::Abi::default(),

--- a/tooling/profiler/src/cli/opcodes_flamegraph_cmd.rs
+++ b/tooling/profiler/src/cli/opcodes_flamegraph_cmd.rs
@@ -196,7 +196,6 @@ mod tests {
 
         let artifact = ProgramArtifact {
             artifact_version: noirc_artifacts::ARTIFACT_VERSION,
-            artifact_kind: noirc_artifacts::ArtifactKind::Program,
             noir_version: "0.0.0".to_string(),
             hash: 27,
             abi: noirc_abi::Abi::default(),
@@ -254,7 +253,6 @@ mod tests {
 
         let artifact = ProgramArtifact {
             artifact_version: noirc_artifacts::ARTIFACT_VERSION,
-            artifact_kind: noirc_artifacts::ArtifactKind::Program,
             noir_version: "0.0.0".to_string(),
             hash: 27,
             abi: noirc_abi::Abi::default(),

--- a/tooling/profiler/src/cli/opcodes_flamegraph_cmd.rs
+++ b/tooling/profiler/src/cli/opcodes_flamegraph_cmd.rs
@@ -195,6 +195,8 @@ mod tests {
         let artifact_path = temp_dir.path().join("test.json");
 
         let artifact = ProgramArtifact {
+            artifact_version: noirc_artifacts::ARTIFACT_VERSION,
+            artifact_kind: noirc_artifacts::ArtifactKind::Program,
             noir_version: "0.0.0".to_string(),
             hash: 27,
             abi: noirc_abi::Abi::default(),
@@ -251,6 +253,8 @@ mod tests {
         ];
 
         let artifact = ProgramArtifact {
+            artifact_version: noirc_artifacts::ARTIFACT_VERSION,
+            artifact_kind: noirc_artifacts::ArtifactKind::Program,
             noir_version: "0.0.0".to_string(),
             hash: 27,
             abi: noirc_abi::Abi::default(),

--- a/tooling/ssa_cli/src/cli/interpret_cmd.rs
+++ b/tooling/ssa_cli/src/cli/interpret_cmd.rs
@@ -120,7 +120,12 @@ fn abi_from_ssa(ssa: &Ssa) -> Abi {
         .filter(|ts| !ts.is_empty())
         .map(|types| AbiReturnType { abi_type: abi_type_from_multi_ssa(&types), visibility });
 
-    Abi { parameters, return_type, error_types: Default::default() }
+    Abi {
+        abi_version: noirc_abi::ABI_VERSION,
+        parameters,
+        return_type,
+        error_types: Default::default(),
+    }
 }
 
 /// Create an ABI type from multiple SSA types, for example when multiple values are returned, or appear in arrays.

--- a/tooling/ssa_executor/src/compiler.rs
+++ b/tooling/ssa_executor/src/compiler.rs
@@ -88,7 +88,12 @@ pub fn compile_from_artifacts(artifacts: ArtifactsAndWarnings) -> CompiledProgra
         hash: 1, // const hash, doesn't matter in this case
         program,
         debug,
-        abi: Abi { parameters: vec![], return_type: None, error_types: BTreeMap::new() },
+        abi: Abi {
+            abi_version: noirc_abi::ABI_VERSION,
+            parameters: vec![],
+            return_type: None,
+            error_types: BTreeMap::new(),
+        },
         file_map,
         noir_version: NOIR_ARTIFACT_VERSION_STRING.to_string(),
         warnings,


### PR DESCRIPTION
## Summary

- add `abi_version: 1` to serialized ABIs
- add `artifact_version: 1` to serialized program and contract artifacts
- treat existing unversioned JSON as V1 while rejecting unsupported versions
- update Rust constructors, WASM declarations, and TypeScript types
- mark `noirc_abi` and `noirc_artifacts` as non-publishable because the serialized formats, rather than their Rust APIs, are the compatibility boundary

This implements the versioning portion of the [1.0 artifact schema proposal](https://gist.github.com/asterite/2e675cd0c24cba4aaee785355ea5582f#redesign-and-version-abi-and-artifact-schemas).

## Compatibility

Existing unversioned ABI and artifact JSON remains readable and is interpreted as V1. Existing consumers that only read compiler output continue to work because the change is additive. Rust or TypeScript consumers that construct these structs or object literals must add the new version fields; this is the intentional pre-1.0 source-level break that establishes the versioned format.

## Testing

- `cargo test -p noirc_abi -p noirc_artifacts`
- `cargo check -p noirc_driver -p noir_wasm -p noir_ast_fuzzer -p noir_ssa_cli -p noir_ssa_executor -p noir_profiler -p noir_artifact_cli -p noirc_abi_wasm`
- `cargo test -p noir_artifact_cli -p noir_profiler`
- `cargo fmt --all -- --check`
- `git diff --check`
- `yarn workspace @noir-lang/types build`
- `yarn workspace @noir-lang/noir_codegen build`
- compiled fresh program and contract fixtures with Nargo and verified their V1 markers