### PR TITLE
fix(ssa): preserve predicated vector state after OOB

### DIFF
--- a/compiler/noirc_evaluator/src/ssa/opt/remove_unreachable_instructions.rs
+++ b/compiler/noirc_evaluator/src/ssa/opt/remove_unreachable_instructions.rs
@@ -366,8 +366,12 @@ impl Function {
                     } else {
                         // We will never use the results (the constraint fails if the side effects are enabled),
                         // but we need them to make the rest of the SSA valid even if the side effects are off.
+                        // Keep processing later instructions normally. Replacing the rest of a predicated
+                        // vector update with defaults can leak a zero semantic length past the predicate
+                        // boundary and turn a later, correctly guarded bounds check into an unconditional
+                        // failure. Each later failing array operation will insert its own guarded constraint.
                         remove_and_replace_with_defaults(context, func_id, block_id);
-                        Reachability::UnreachableUnderPredicate
+                        Reachability::Reachable
                     };
                 }
                 Instruction::Call { func, arguments } if context.dfg.runtime().is_acir() => {

--- a/test_programs/execution_success/conditional_vector_push_dead_branch/Nargo.toml
+++ b/test_programs/execution_success/conditional_vector_push_dead_branch/Nargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "conditional_vector_push_dead_branch"
+type = "bin"
+authors = [""]
+
+[dependencies]

--- a/test_programs/execution_success/conditional_vector_push_dead_branch/Prover.toml
+++ b/test_programs/execution_success/conditional_vector_push_dead_branch/Prover.toml
@@ -1,0 +1,1 @@
+flag = false

--- a/test_programs/execution_success/conditional_vector_push_dead_branch/src/main.nr
+++ b/test_programs/execution_success/conditional_vector_push_dead_branch/src/main.nr
@@ -1,0 +1,16 @@
+fn main(flag: bool) -> pub Field {
+    let mut out = 0;
+
+    if flag {
+        let mut values: [(Field, Field)] = @[(1, 2)];
+        if flag {
+            values = values.push_back(values[1]);
+        }
+        if flag {
+            values = values.push_back(values[1]);
+        }
+        out = values[0].0;
+    }
+
+    out
+}


### PR DESCRIPTION
Closes #13457. A constant-false bounds check inside a runtime-disabled branch marked the rest of the block `UnreachableUnderPredicate`, and the defaults that follow leak a zero semantic length past the predicate boundary, so a later correctly guarded check folds to an unconditional failure. `--force-brillig` returns `0` on the same program, so it is only the ACIR path that overconstrains.

Returning `Reachable` gives up two behaviours and not one. Later instructions are no longer replaced with defaults, and the predicate no longer lands in `unreachable_predicates`. I could not measure a cost for either. A dead branch carrying a loop and eight further pushes past the OOB compiles to 9 ACIR opcodes with and without this. I left the `VectorPopBack`/`VectorPopFront` arm below untouched because I have no reproducer for it.
