### PR TITLE
fix: pin legacy ABI/artifact schema default to a fixed V1

### DIFF
--- a/tooling/noirc_abi/src/lib.rs
+++ b/tooling/noirc_abi/src/lib.rs
@@ -44,8 +44,12 @@ pub const MAIN_RETURN_NAME: &str = "return";
 /// The version of the ABI schema emitted by this version of Noir.
 pub const ABI_VERSION: u32 = 1;
 
+/// The schema version of ABI JSON written before `ABI_VERSION` existed. This is a historical
+/// fact about those files and must not change when `ABI_VERSION` is incremented.
+const LEGACY_ABI_VERSION: u32 = 1;
+
 const fn default_abi_version() -> u32 {
-    ABI_VERSION
+    LEGACY_ABI_VERSION
 }
 
 fn deserialize_abi_version<'de, D>(deserializer: D) -> Result<u32, D::Error>

--- a/tooling/noirc_abi/src/serialization.rs
+++ b/tooling/noirc_abi/src/serialization.rs
@@ -90,7 +90,7 @@ mod tests {
         });
 
         let abi: Abi = serde_json::from_value(serialized).unwrap();
-        assert_eq!(abi.abi_version, ABI_VERSION);
+        assert_eq!(abi.abi_version, 1);
     }
 
     #[test]

--- a/tooling/noirc_artifacts/src/lib.rs
+++ b/tooling/noirc_artifacts/src/lib.rs
@@ -20,8 +20,12 @@ pub mod ssa;
 /// The version of the artifact schema emitted by this version of Noir.
 pub const ARTIFACT_VERSION: u32 = 1;
 
+/// The schema version of artifact JSON written before `ARTIFACT_VERSION` existed. This is a
+/// historical fact about those files and must not change when `ARTIFACT_VERSION` is incremented.
+const LEGACY_ARTIFACT_VERSION: u32 = 1;
+
 pub(crate) const fn default_artifact_version() -> u32 {
-    ARTIFACT_VERSION
+    LEGACY_ARTIFACT_VERSION
 }
 
 pub(crate) fn deserialize_artifact_version<'de, D>(deserializer: D) -> Result<u32, D::Error>
@@ -129,13 +133,13 @@ mod tests {
         let program = program.as_object_mut().unwrap();
         program.remove("artifact_version");
         let program: ProgramArtifact = serde_json::from_value(program.clone().into()).unwrap();
-        assert_eq!(program.artifact_version, ARTIFACT_VERSION);
+        assert_eq!(program.artifact_version, 1);
 
         let mut contract = serde_json::to_value(contract_artifact()).unwrap();
         let contract = contract.as_object_mut().unwrap();
         contract.remove("artifact_version");
         let contract: ContractArtifact = serde_json::from_value(contract.clone().into()).unwrap();
-        assert_eq!(contract.artifact_version, ARTIFACT_VERSION);
+        assert_eq!(contract.artifact_version, 1);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`default_abi_version`/`default_artifact_version` (added in #13572) returned `ABI_VERSION`/`ARTIFACT_VERSION` — the version this build *emits* — as the default for versionless legacy JSON, instead of the fixed literal `1`. Both constants are `1` today so nothing is currently broken, but the first time either is bumped, a pre-#13572 legacy document (no version field) would be silently relabelled as the new version, while the byte-identical document with an explicit `"abi_version": 1"` would be rejected. The two `legacy_*_default_to_version_one` regression tests asserted against the same moving constant, so they'd stay green through that bump.

## Fix

Introduce `LEGACY_ABI_VERSION`/`LEGACY_ARTIFACT_VERSION`, fixed at `1`, and have the `default_*_version` functions return those instead of the emitted-version constant. Change the two existing tests to assert the literal `1` so they can actually fail if the mapping ever moves.

Out of scope: the version validators (`deserialize_abi_version`/`deserialize_artifact_version`) only accept a single current version, so once a version bump happens, explicit `"abi_version": 1"` documents will still be rejected — that's a separate multi-version-reading concern for whoever introduces version 2, not something this fix addresses.

## Test plan

- Verified RED: temporarily bumped `ABI_VERSION`/`ARTIFACT_VERSION` to `2` and confirmed `legacy_abi_defaults_to_version_one` / `legacy_artifacts_default_to_version_one` produced `2` instead of `1` against the pre-fix code.
- Applied the fix and re-verified with the constants still at `2` that both tests now correctly assert `1`.
- Reverted the constants back to `1` and ran the full `noirc_abi`/`noirc_artifacts` suites (34 tests, all passing).
- `cargo clippy -p noirc_abi -p noirc_artifacts --all-targets` and `cargo fmt --check` clean.