### PR TITLE
feat: ship noir-execute in release tarballs

### DIFF
--- a/justfile
+++ b/justfile
@@ -75,6 +75,7 @@ build-bins: install-binstall
     {{ cargo }} build --package nargo_cli --release --target={{ target }} --no-default-features
     {{ cargo }} build --package noir_profiler --release --target={{ target }} --no-default-features
     {{ cargo }} build --package noir_inspector --release --target={{ target }} --no-default-features
+    {{ cargo }} build --package noir_artifact_cli --release --target={{ target }} --no-default-features
 
 # Package release artifacts
 [linux]
@@ -83,6 +84,7 @@ package: build-bins
     cp ./target/{{ target }}/release/nargo ./dist/nargo
     cp ./target/{{ target }}/release/noir-profiler ./dist/noir-profiler
     cp ./target/{{ target }}/release/noir-inspector ./dist/noir-inspector
+    cp ./target/{{ target }}/release/noir-execute ./dist/noir-execute
     # TODO(https://github.com/noir-lang/noir/issues/7445): Remove the separate nargo binary
     tar -czf nargo-{{ target }}.tar.gz -C dist nargo
     tar -czf noir-{{ target }}.tar.gz -C dist .
@@ -94,6 +96,7 @@ package: build-bins
     cp ./target/{{ target }}/release/nargo ./dist/nargo
     cp ./target/{{ target }}/release/noir-profiler ./dist/noir-profiler
     cp ./target/{{ target }}/release/noir-inspector ./dist/noir-inspector
+    cp ./target/{{ target }}/release/noir-execute ./dist/noir-execute
 
     # TODO(https://github.com/noir-lang/noir/issues/7445): Remove the separate nargo binary
     7z a -ttar -so -an ./dist/nargo | 7z a -si ./nargo-{{ target }}.tar.gz


### PR DESCRIPTION


## Problem Resolved

No issue, but `noir-execute` was missing from the distributed binary.

## Summary of Changes

Add noir_artifact_cli to the build and packaging steps so that the noir-execute binary is included alongside nargo, noir-profiler, and noir-inspector in the noir-<target>.tar.gz release artifacts.

I wonder if the name should be `noir-executor`...? Because the others are `noir-profiler` and `noir-inspector`. It's maybe a minor thing, but for consistency's sake...

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
