### PR TITLE
feat(wasm): export `deserializeWitness` and `deserializeWitnessStack` from `noirc_abi_wasm`

### DIFF
--- a/tooling/noirc_abi_wasm/src/js_witness_stack.rs
+++ b/tooling/noirc_abi_wasm/src/js_witness_stack.rs
@@ -1,0 +1,58 @@
+use acvm::{FieldElement, acir::native_types::WitnessStack};
+use js_sys::{Array, Map, Object};
+use wasm_bindgen::prelude::{JsValue, wasm_bindgen};
+
+use crate::JsWitnessMap;
+
+#[wasm_bindgen(typescript_custom_section)]
+const WITNESS_STACK: &'static str = r#"
+export type StackItem = {
+    index: number;
+    witness: WitnessMap;
+}
+
+export type WitnessStack = Array<StackItem>;
+"#;
+
+// WitnessStack
+#[wasm_bindgen]
+extern "C" {
+    #[wasm_bindgen(extends = Array, js_name = "WitnessStack", typescript_type = "WitnessStack")]
+    #[derive(Clone, Debug, PartialEq)]
+    pub type JsWitnessStack;
+
+    #[wasm_bindgen(constructor, js_class = "Array")]
+    pub fn new() -> JsWitnessStack;
+
+    #[wasm_bindgen(extends = Object, js_name = "StackItem", typescript_type = "StackItem")]
+    #[derive(Clone, Debug, PartialEq)]
+    pub type JsStackItem;
+
+    #[wasm_bindgen(constructor, js_class = "Object")]
+    pub fn new() -> JsStackItem;
+}
+
+impl Default for JsWitnessStack {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl From<WitnessStack<FieldElement>> for JsWitnessStack {
+    fn from(mut witness_stack: WitnessStack<FieldElement>) -> Self {
+        let js_witness_stack = JsWitnessStack::new();
+        while let Some(stack_item) = witness_stack.pop() {
+            let js_map = JsWitnessMap::from(stack_item.witness);
+            let js_index = JsValue::from_f64(stack_item.index.into());
+
+            let entry_map = Map::new();
+            entry_map.set(&JsValue::from_str("index"), &js_index);
+            entry_map.set(&JsValue::from_str("witness"), &js_map);
+            let stack_item = Object::from_entries(&entry_map).unwrap();
+
+            js_witness_stack.push(&stack_item);
+        }
+        // `reverse()` returns an `Array` so we have to wrap it
+        JsWitnessStack { obj: js_witness_stack.reverse() }
+    }
+}

--- a/tooling/noirc_abi_wasm/src/lib.rs
+++ b/tooling/noirc_abi_wasm/src/lib.rs
@@ -24,9 +24,11 @@ use wasm_bindgen::{JsValue, prelude::wasm_bindgen};
 
 mod errors;
 mod js_witness_map;
+mod js_witness_stack;
 
 use errors::JsAbiError;
 use js_witness_map::JsWitnessMap;
+use js_witness_stack::JsWitnessStack;
 
 #[wasm_bindgen(typescript_custom_section)]
 const INPUT_MAP: &'static str = r#"
@@ -170,6 +172,24 @@ pub fn serialize_witness(witness_map: JsWitnessMap) -> Result<Vec<u8>, JsAbiErro
     let witness_stack: WitnessStack<FieldElement> = converted_witness.into();
     let output = witness_stack.serialize();
     output.map_err(|_| JsAbiError::new("Failed to serialize witness stack".to_string()))
+}
+
+#[wasm_bindgen(js_name = deserializeWitness)]
+pub fn deserialize_witness(bytes: Vec<u8>) -> Result<JsWitnessMap, JsAbiError> {
+    console_error_panic_hook::set_once();
+    let mut witness_stack =
+        WitnessStack::deserialize(bytes.as_slice()).map_err(|err| err.to_string())?;
+    let witness =
+        witness_stack.pop().expect("Should have at least one witness on the stack").witness;
+    Ok(witness.into())
+}
+
+#[wasm_bindgen(js_name = deserializeWitnessStack)]
+pub fn deserialize_witness_stack(bytes: Vec<u8>) -> Result<JsWitnessStack, JsAbiError> {
+    console_error_panic_hook::set_once();
+    let witness_stack =
+        WitnessStack::deserialize(bytes.as_slice()).map_err(|err| err.to_string())?;
+    Ok(witness_stack.into())
 }
 
 #[wasm_bindgen(js_name = abiDecodeError)]


### PR DESCRIPTION


## Problem Resolved

No issue.

## Summary of Changes

The crate already exports `serializeWitness` but no inverse, forcing consumers to hand-roll a msgpack decoder. Add `deserializeWitness` (returns the main function's `WitnessMap`) and `deserializeWitnessStack` (returns the full `WitnessStack`), mirroring the `decompressWitness` / `decompressWitnessStack` pattern already present in `acvm_js`.

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
