### PR TITLE
feat(cli): accept `--bytecode-path` and `--abi-path` as alternative to `--artifact-path`

### DIFF
--- a/tooling/artifact_cli/src/commands/execute_cmd.rs
+++ b/tooling/artifact_cli/src/commands/execute_cmd.rs
@@ -8,6 +8,7 @@ use crate::{
     Artifact,
     errors::CliError,
     execution::{self, ExecutionResults},
+    fs::artifact::load_program_from_parts,
 };
 use nargo::foreign_calls::{
     DefaultForeignCallBuilder, OracleResolverUrl, layers, transcript::ReplayForeignCallExecutor,
@@ -19,8 +20,18 @@ use super::parse_and_normalize_path;
 #[derive(Debug, Clone, Args)]
 pub struct ExecuteCommand {
     /// Path to the JSON build artifact (either a program or a contract).
-    #[clap(long, short, value_parser = parse_and_normalize_path)]
-    pub artifact_path: PathBuf,
+    #[clap(long, short, conflicts_with_all = ["bytecode_path", "abi_path"], value_parser = parse_and_normalize_path)]
+    pub artifact_path: Option<PathBuf>,
+
+    /// Path to the raw bytecode file (gzip-compressed), as an alternative to
+    /// `--artifact-path`. Must be used together with `--abi-path`.
+    #[clap(long, conflicts_with = "artifact_path", requires = "abi_path", value_parser = parse_and_normalize_path)]
+    pub bytecode_path: Option<PathBuf>,
+
+    /// Path to the ABI file (JSON), as an alternative to `--artifact-path`.
+    /// Must be used together with `--bytecode-path`.
+    #[clap(long, conflicts_with = "artifact_path", requires = "bytecode_path", value_parser = parse_and_normalize_path)]
+    pub abi_path: Option<PathBuf>,
 
     /// Path to the Prover.toml (or .json) file which contains the inputs and the
     /// optional return value in ABI format.
@@ -69,24 +80,55 @@ pub struct ExecuteCommand {
 }
 
 pub fn run(args: ExecuteCommand) -> Result<(), CliError> {
-    let artifact = Artifact::read_from_file(&args.artifact_path)?;
-    let artifact_name = args.artifact_path.file_stem().and_then(|s| s.to_str()).unwrap_or_default();
+    let (circuit, circuit_name): (CompiledProgram, String) =
+        match (&args.artifact_path, &args.bytecode_path, &args.abi_path) {
+            (Some(artifact_path), None, None) => {
+                let artifact = Artifact::read_from_file(artifact_path)?;
+                let artifact_name =
+                    artifact_path.file_stem().and_then(|s| s.to_str()).unwrap_or_default();
 
-    let (circuit, circuit_name): (CompiledProgram, String) = match artifact {
-        Artifact::Program(program) => (program.into(), artifact_name.to_string()),
-        Artifact::Contract(contract) => {
-            let names = || contract.functions.iter().map(|f| f.name.clone()).collect::<Vec<_>>();
+                match artifact {
+                    Artifact::Program(program) => (program.into(), artifact_name.to_string()),
+                    Artifact::Contract(contract) => {
+                        let names = || {
+                            contract.functions.iter().map(|f| f.name.clone()).collect::<Vec<_>>()
+                        };
 
-            let Some(ref name) = args.contract_fn else {
-                return Err(CliError::MissingContractFn { names: names() });
-            };
-            let Some(program) = contract.function_as_compiled_program(name) else {
-                return Err(CliError::UnknownContractFn { name: name.clone(), names: names() });
-            };
+                        let Some(ref name) = args.contract_fn else {
+                            return Err(CliError::MissingContractFn { names: names() });
+                        };
+                        let Some(program) = contract.function_as_compiled_program(name) else {
+                            return Err(CliError::UnknownContractFn {
+                                name: name.clone(),
+                                names: names(),
+                            });
+                        };
 
-            (program, format!("{artifact_name}::{name}"))
-        }
-    };
+                        (program, format!("{artifact_name}::{name}"))
+                    }
+                }
+            }
+            (None, Some(bytecode_path), Some(abi_path)) => {
+                if args.contract_fn.is_some() {
+                    return Err(CliError::Generic(
+                        "--contract-fn cannot be used with --bytecode-path".to_string(),
+                    ));
+                }
+                let circuit_name = bytecode_path
+                    .file_stem()
+                    .and_then(|s| s.to_str())
+                    .unwrap_or_default()
+                    .to_string();
+                let program = load_program_from_parts(bytecode_path, abi_path)?;
+                (program, circuit_name)
+            }
+            _ => {
+                return Err(CliError::Generic(
+                    "provide either --artifact-path or both --bytecode-path and --abi-path"
+                        .to_string(),
+                ));
+            }
+        };
 
     execute_program(
         &circuit,

--- a/tooling/artifact_cli/src/errors.rs
+++ b/tooling/artifact_cli/src/errors.rs
@@ -96,4 +96,7 @@ pub enum CliError {
 
     #[error("Failed to save contract '{0}':\n{1}")]
     FailedToSaveContract(String, Box<CliError>),
+
+    #[error("{0}")]
+    Generic(String),
 }

--- a/tooling/artifact_cli/src/fs/artifact.rs
+++ b/tooling/artifact_cli/src/fs/artifact.rs
@@ -1,11 +1,16 @@
+use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
+
+use acvm::FieldElement;
+use acvm::acir::circuit::Program;
+use noirc_abi::Abi;
 
 use crate::{
     Artifact,
     errors::{CliError, FilesystemError},
 };
 use noirc_artifacts::contract::ContractArtifact;
-use noirc_artifacts::program::ProgramArtifact;
+use noirc_artifacts::program::{CompiledProgram, ProgramArtifact};
 use noirc_driver::CrateName;
 use serde::de::Error;
 
@@ -83,6 +88,37 @@ fn save_build_artifact_to_file<T: ?Sized + serde::Serialize>(
     let bytes = serde_json::to_vec(build_artifact)?;
     write_to_file(&bytes, &artifact_path)?;
     Ok(artifact_path)
+}
+
+/// Load a [`CompiledProgram`] from separate bytecode and ABI files.
+///
+/// The bytecode file contains the raw gzip-compressed program (the same binary format
+/// produced by [`Program::serialize_program`]). The ABI file is plain JSON.
+///
+/// Debug symbols and source maps are not available in this mode, so error
+/// diagnostics will not include source-level stack traces.
+pub fn load_program_from_parts(
+    bytecode_path: &Path,
+    abi_path: &Path,
+) -> Result<CompiledProgram, CliError> {
+    let bytecode_bytes = std::fs::read(bytecode_path).map_err(|e| {
+        FilesystemError::InvalidBytecodeFile(bytecode_path.to_path_buf(), e.to_string())
+    })?;
+    let program = Program::<FieldElement>::deserialize_program(&bytecode_bytes)?;
+
+    let abi_bytes = std::fs::read(abi_path)
+        .map_err(|e| FilesystemError::InvalidInputFile(abi_path.to_path_buf(), e.to_string()))?;
+    let abi: Abi = serde_json::from_slice(&abi_bytes)?;
+
+    Ok(CompiledProgram {
+        noir_version: String::new(),
+        hash: 0,
+        program,
+        abi,
+        debug: vec![],
+        file_map: BTreeMap::new(),
+        warnings: vec![],
+    })
 }
 
 /// Create the parent directory if needed and write the bytes to a file.

--- a/tooling/nargo_cli/src/cli/execute_cmd.rs
+++ b/tooling/nargo_cli/src/cli/execute_cmd.rs
@@ -88,7 +88,9 @@ pub(crate) fn run(args: ExecuteCommand, workspace: Workspace) -> Result<(), CliE
         let prover_file = package.root_dir.join(&args.prover_name).with_extension("toml");
 
         let cmd = noir_artifact_cli::commands::execute_cmd::ExecuteCommand {
-            artifact_path: program_artifact_path,
+            artifact_path: Some(program_artifact_path),
+            bytecode_path: None,
+            abi_path: None,
             prover_file,
             overwrite_return: args.overwrite_return,
             output_dir: Some(workspace.target_directory_path()),


### PR DESCRIPTION

## Problem Resolved

No issue.

## Summary of Changes

Callers that already hold bytecode and ABI separately can now pass them directly to `noir-execute` instead of assembling and writing a combined 25 MB artifact JSON. The bytecode file is the raw gzip-compressed program (same binary format as `Program::serialize_program`), and the ABI file is plain JSON. Debug symbols are unavailable in this mode, so error diagnostics omit source-level stack traces while the error itself is still reported.

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
