### PR TITLE
fix(debugger): allow debugging tests in library packages

### DIFF
--- a/tooling/nargo_cli/src/cli/dap_cmd.rs
+++ b/tooling/nargo_cli/src/cli/dap_cmd.rs
@@ -130,8 +130,8 @@ fn load_and_compile_project(
         .ok_or(LoadError::Generic(workspace_not_found_error_msg(project_folder, package)))?;
     let package = workspace
         .into_iter()
-        .find(|p| p.is_binary() || p.is_contract())
-        .ok_or(LoadError::Generic("No matching binary or contract packages found in workspace. Only these packages can be debugged.".into()))?;
+        .find(|p| p.is_binary() || p.is_contract() || (test_name.is_some() && p.is_library()))
+        .ok_or(LoadError::Generic("No matching packages found in workspace.".into()))?;
 
     let (compiled_program, test_def) = match test_name {
         None => {
@@ -209,10 +209,6 @@ fn loop_uninitialized_dap<R: Read, W: Write>(mut server: Server<R, W>) -> Result
                     .get("oracleResolver")
                     .and_then(|v| v.as_str())
                     .map(String::from);
-
-                eprintln!("Project folder: {project_folder}");
-                eprintln!("Package: {}", package.unwrap_or("(default)"));
-                eprintln!("Prover name: {prover_name}");
 
                 let compile_options = compile_options_for_debugging(
                     generate_acir,


### PR DESCRIPTION

## Problem Resolved

No issue.

## Summary of Changes

The DAP debugger only accepted binary and contract packages, rejecting library packages with "No matching binary or contract packages found". Tests can exist in any package type, so accept library packages when a test name is provided.


## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
