### PR TITLE
chore: speed up stdlib test

### DIFF
--- a/noir_stdlib/src/array/quicksort.nr
+++ b/noir_stdlib/src/array/quicksort.nr
@@ -122,8 +122,8 @@ mod test {
 
     #[test]
     fn test_already_sorted_ascending_with_one_out_of_order() {
-        let mut arr: [u32; 1000] = [0; 1000];
-        for i in 0..1000 {
+        let mut arr: [u32; 100] = [0; 100];
+        for i in 0..100 {
             arr[i] = i as u32;
         }
         arr[0] = 2;


### PR DESCRIPTION
## Problem Resolved

No issue.

## Summary of Changes

Stdlib tests are pretty fast except `test_already_sorted_ascending_with_one_out_of_order` which takes a long time to compile (or run, not sure) because it uses a 1000-length array. The test works the same way if it has a length of 100, but it runs much faster. 

## User Documentation

Check one:
- [x] No user documentation needed.
- [ ] Documented in _docs/_.
- [ ] **[For Experimental Features]** Documentation tracking issue created: <!-- Link to GitHub Issue -->

## PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
